### PR TITLE
fix(US-BF-007): Add required operation property to SmartCacheOptions

### DIFF
--- a/src/tools/advanced-caching/smart-cache.ts
+++ b/src/tools/advanced-caching/smart-cache.ts
@@ -845,7 +845,7 @@ export class SmartCacheTool extends EventEmitter {
       }
     }
 
-    const stats = await this.getStats({});
+    const stats = await this.getStats({ operation: "stats" });
     return { stats: stats.stats };
   }
 


### PR DESCRIPTION
## Summary
- Fixed TS2345 compilation error in smart-cache.ts by adding the required `operation` property to SmartCacheOptions instantiation
- Changed `await this.getStats({})` to `await this.getStats({ operation: "stats" })`

## Changes Made
- **src/tools/advanced-caching/smart-cache.ts**: Added missing `operation: "stats"` property to SmartCacheOptions object on line 848

## Acceptance Criteria Met
✅ TypeScript compiler no longer reports TS2345 error related to SmartCacheOptions instantiation  
✅ Application compiles successfully

## Test Plan
- [x] Verified TypeScript compilation passes for the modified file
- [x] Confirmed TS2345 error is no longer present in build output

## References
- User Story: US-BF-007

🤖 Generated with [Claude Code](https://claude.com/claude-code)