### PR TITLE
fix(US-BF-008): Fix argument count mismatch in smart-api-fetch.ts

### DIFF
--- a/src/tools/api-database/smart-api-fetch.ts
+++ b/src/tools/api-database/smart-api-fetch.ts
@@ -427,7 +427,7 @@ export class SmartApiFetch {
     }
 
     try {
-      const result = JSON.parse(cached.toString('utf-8')) as SmartApiFetchResult;
+      const result = JSON.parse(cached) as SmartApiFetchResult;
 
       // Check if cache is still valid
       const age = (Date.now() - result.timestamp) / 1000;


### PR DESCRIPTION
## Summary
- Fixed TS2554 error in `smart-api-fetch.ts` at line 430
- Removed invalid argument `'utf-8'` from `toString()` call on a string
- Since `cache.get()` returns `string | null`, the cached value can be used directly without calling `toString()`

## Changes Made
- **File**: `src/tools/api-database/smart-api-fetch.ts`
  - Line 430: Changed `JSON.parse(cached.toString('utf-8'))` to `JSON.parse(cached)`
  - Reason: The `toString()` method on strings expects 0 arguments, but was being called with 1

## Test Plan
- [x] TypeScript compilation no longer reports TS2554 error for smart-api-fetch.ts
- [x] Build process completes without errors specific to this file
- [x] The fix maintains the same functionality (parsing the cached JSON string)

## Acceptance Criteria
- [x] The TypeScript compiler does not report TS2554 error in `smart-api-fetch.ts`
- [x] The application compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)