### PR TITLE
fix(US-BF-005): Fix ModelMetrics type incompatibility

### DIFF
--- a/src/tools/advanced-caching/predictive-cache.ts
+++ b/src/tools/advanced-caching/predictive-cache.ts
@@ -76,7 +76,7 @@ export interface PredictiveCacheResult {
   operation: string;
   data: {
     predictions?: Prediction[];
-    metrics?: ModelMetrics;
+    metrics?: ModelMetrics | null;
     patterns?: AccessPattern[];
     modelExport?: string;
     warmedKeys?: string[];


### PR DESCRIPTION
## User Story
References: US-BF-005 from ~/.claude/user-stories/token-optimizer-mcp/bug_fixes/us-bf-005-fix-type-incompatibility-for-modelmetrics-in-predictive-cache-ts.md

## Summary
Fixed type incompatibility where `ModelMetrics | null` was not assignable to `ModelMetrics | undefined`. Updated the PredictiveCacheResult interface to explicitly accept `ModelMetrics | null` to match the trainingMetrics property type.

## Changes Made
- Changed `metrics?: ModelMetrics;` to `metrics?: ModelMetrics | null;` in PredictiveCacheResult interface

## Files Modified
- src/tools/advanced-caching/predictive-cache.ts

## Acceptance Criteria
- [x] TypeScript compiler no longer reports TS2322 error for ModelMetrics
- [x] Application compiles successfully for predictive-cache.ts

## Verification
- [x] Modified file builds with zero errors
- [x] All acceptance criteria met
- [x] Changes scoped to user story only
- [x] No other files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)