### PR TITLE
fix(US-BF-034): Import createHash from crypto in knowledge-graph.ts

### DIFF
--- a/src/tools/intelligence/knowledge-graph.ts
+++ b/src/tools/intelligence/knowledge-graph.ts
@@ -19,6 +19,7 @@
  * - Ranking caching (92% reduction, 15-min TTL)
  */
 
+import { createHash } from "crypto";
 import { CacheEngine } from "../../core/cache-engine";
 import { TokenCounter } from "../../core/token-counter";
 import { MetricsCollector } from "../../core/metrics";


### PR DESCRIPTION
## Summary
- Added missing import statement for `createHash` function from Node.js crypto module
- Resolves TS2304 compilation error in `knowledge-graph.ts`

## Changes
- **src/tools/intelligence/knowledge-graph.ts**: Added `import { createHash } from "crypto";` at the top of the file

## Testing
- Verified that TS2304 error for `createHash` in `knowledge-graph.ts` is resolved
- Build no longer reports "Cannot find name 'createHash'" error for this file

## Acceptance Criteria
- ✅ TypeScript compiler no longer reports TS2304 error for `createHash` in `knowledge-graph.ts`
- ✅ The `createHash` function is correctly imported from the `crypto` module

## References
- User Story: US-BF-034

🤖 Generated with [Claude Code](https://claude.com/claude-code)