### PR TITLE
fix(US-BF-035): Correct TokenCountResult usage in sentiment-analysis.ts

### DIFF
--- a/src/tools/intelligence/sentiment-analysis.ts
+++ b/src/tools/intelligence/sentiment-analysis.ts
@@ -481,7 +481,7 @@ export class SentimentAnalysisTool {
           const cachedResult = JSON.parse(cached);
           const tokensSaved = this.tokenCounter.count(
             JSON.stringify(cachedResult),
-          );
+          ).tokens;
 
           this.metrics.record({
             operation: `sentiment-analysis:${options.operation}`,


### PR DESCRIPTION
## Summary
Fixed TypeScript compilation error in `sentiment-analysis.ts` by correctly accessing the `.tokens` property of `TokenCountResult` objects instead of treating them as numbers.

## Changes Made
- Modified line 484 in `src/tools/intelligence/sentiment-analysis.ts` to access `.tokens` property from the `TokenCountResult` returned by `tokenCounter.count()`

## Issue Fixed
Resolved TS2322 type errors on lines 493-494 where `TokenCountResult` was being assigned to properties expecting `number` type.

## Testing
- TypeScript compilation verified - specific errors on lines 493-494 are now resolved
- No new errors introduced

## Acceptance Criteria Met
- [x] TypeScript compiler no longer reports TS2322 errors related to `TokenCountResult` to `number` type mismatches
- [x] The `tokens` property of `TokenCountResult` is correctly accessed
- [x] The application compiles successfully

## References
- User Story: US-BF-035

🤖 Generated with [Claude Code](https://claude.com/claude-code)