### PR TITLE
ci(release): stop branch pushes; rely on GitHub release notes

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -48,13 +48,6 @@
       }
     ],
     [
-      "@semantic-release/changelog",
-      {
-        "changelogFile": "CHANGELOG.md",
-        "changelogTitle": "# Changelog\n\nAll notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines."
-      }
-    ],
-    [
       "@semantic-release/npm",
       {
         "npmPublish": false
@@ -64,8 +57,7 @@
       "@semantic-release/github",
       {
         "assets": [
-          { "path": "dist/**", "label": "Distribution files" },
-          { "path": "CHANGELOG.md", "label": "Changelog" }
+          { "path": "dist/**", "label": "Distribution files" }
         ],
         "successComment": "This ${issue.pull_request ? 'PR is included' : 'issue has been resolved'} in version ${nextRelease.version}. :tada:\n\nThe release is available on:\n- [GitHub release](${releaseUrl})\n- [npm package (@latest dist-tag)](https://www.npmjs.com/package/token-optimizer-mcp/v/${nextRelease.version})\n\nYour **semantic-release** bot :package::rocket:",
         "failComment": false,
@@ -73,13 +65,7 @@
         "labels": ["released"],
         "releasedLabels": ["released<%= nextRelease.channel ? `-${nextRelease.channel}` : '' %>"]
       }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["CHANGELOG.md", "package.json", "package-lock.json"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      }
     ]
   ]
 }
+


### PR DESCRIPTION
This hardens the release pipeline against branch protection failures:

- Remove `@semantic-release/git` to avoid direct pushes to `master` (blocked by rules: PR-only changes, required checks, signed commits).
- Remove `@semantic-release/changelog` and the `CHANGELOG.md` release asset; rely on GitHub Releases for notes.
- Keep GitHub release + tag creation and `dist/**` assets upload.

Outcome: Semantic Release will no longer attempt `git push HEAD:master`, preventing GH013 violations and making releases dependable under branch protections.

No runtime code changes.