### PR TITLE
fix: remove unused SmartAstGrepOptions import

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -25,7 +25,6 @@ import {
   getSmartAstGrepTool,
   SMART_AST_GREP_TOOL_DEFINITION,
 } from '../tools/code-analysis/smart-ast-grep.js';
-import type { SmartAstGrepOptions } from '../tools/code-analysis/smart-ast-grep.js';
 import {
   getCacheAnalyticsTool,
   CACHE_ANALYTICS_TOOL_DEFINITION,


### PR DESCRIPTION
## Summary
Removes unused `SmartAstGrepOptions` type import that was causing TypeScript build error.

## Issue
- TypeScript error: `error TS6133: 'SmartAstGrepOptions' is declared but its value is never read`
- File: `src/server/index.ts` line 28
- Introduced in PR #72

## Changes
- Removed unused type import: `import type { SmartAstGrepOptions } from '../tools/code-analysis/smart-ast-grep.js';`

## Verification
- Build passes with 0 errors: `npm run build`
- No other references to `SmartAstGrepOptions` in the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>