### PR TITLE
fix: ES module imports for Node.js compatibility

### DIFF
--- a/scripts/fix-imports.js
+++ b/scripts/fix-imports.js
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+/**
+ * Fix ES Module Imports - Add .js extensions to relative imports
+ *
+ * This script adds .js extensions to all relative imports in TypeScript source files
+ * to ensure proper ES module resolution in Node.js.
+ *
+ * Example:
+ *   Before: import { foo } from '../bar';
+ *   After:  import { foo } from '../bar.js';
+ */
+
+import { readFileSync, writeFileSync, readdirSync, statSync } from 'fs';
+import { join, extname } from 'path';
+
+/**
+ * Recursively find all TypeScript files in a directory
+ */
+function findTypeScriptFiles(dir, fileList = []) {
+  const files = readdirSync(dir);
+
+  for (const file of files) {
+    const filePath = join(dir, file);
+    const stat = statSync(filePath);
+
+    if (stat.isDirectory()) {
+      // Skip node_modules and dist
+      if (file !== 'node_modules' && file !== 'dist') {
+        findTypeScriptFiles(filePath, fileList);
+      }
+    } else if (extname(file) === '.ts' && !file.endsWith('.d.ts')) {
+      fileList.push(filePath);
+    }
+  }
+
+  return fileList;
+}
+
+/**
+ * Fix imports in a single file
+ */
+function fixImportsInFile(filePath) {
+  let content = readFileSync(filePath, 'utf-8');
+  let modified = false;
+
+  // Pattern to match relative imports without .js extension
+  // Matches: from './foo' or from '../foo' or from '../../foo'
+  // But not: from './foo.js' or from 'external-package'
+  const importPattern = /from ['"](\.\.[\/\\](?:[^'"]+)|\.\/(?:[^'"]+))(?<!\.js)['"]/g;
+
+  const newContent = content.replace(importPattern, (match, importPath) => {
+    // Don't add .js if it already has an extension
+    if (importPath.endsWith('.js') ||
+        importPath.endsWith('.json') ||
+        importPath.endsWith('.node')) {
+      return match;
+    }
+
+    modified = true;
+    return `from '${importPath}.js'`;
+  });
+
+  if (modified) {
+    writeFileSync(filePath, newContent, 'utf-8');
+    console.log(`✓ Fixed imports in: ${filePath}`);
+    return 1;
+  }
+
+  return 0;
+}
+
+// Main execution
+const srcDir = 'src';
+console.log('Finding TypeScript files...');
+const tsFiles = findTypeScriptFiles(srcDir);
+console.log(`Found ${tsFiles.length} TypeScript files`);
+
+console.log('\nFixing imports...');
+let fixedCount = 0;
+
+for (const file of tsFiles) {
+  fixedCount += fixImportsInFile(file);
+}
+
+console.log(`\n✅ Fixed ${fixedCount} files`);
+console.log('✅ All imports now have .js extensions for proper ES module resolution');

--- a/src/core/globals.ts
+++ b/src/core/globals.ts
@@ -5,8 +5,8 @@
  * and ensure consistent tracking across the application.
  */
 
-import { TokenCounter } from './token-counter';
-import { MetricsCollector } from './metrics';
+import { TokenCounter } from './token-counter.js';
+import { MetricsCollector } from './metrics.js';
 
 /**
  * Global token counter instance shared across all tools

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -25,7 +25,6 @@ import {
   getSmartAstGrepTool,
   SMART_AST_GREP_TOOL_DEFINITION,
 } from '../tools/code-analysis/smart-ast-grep.js';
-import type { SmartAstGrepOptions } from '../tools/code-analysis/smart-ast-grep.js';
 import {
   getCacheAnalyticsTool,
   CACHE_ANALYTICS_TOOL_DEFINITION,

--- a/src/tools/advanced-caching/cache-analytics.ts
+++ b/src/tools/advanced-caching/cache-analytics.ts
@@ -17,9 +17,9 @@
  * Token Reduction Target: 88%+
  */
 
-import { CacheEngine } from '../../core/cache-engine';
-import { TokenCounter } from '../../core/token-counter';
-import { MetricsCollector } from '../../core/metrics';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { TokenCounter } from '../../core/token-counter.js';
+import { MetricsCollector } from '../../core/metrics.js';
 import { EventEmitter } from 'events';
 import { writeFileSync } from 'fs';
 

--- a/src/tools/advanced-caching/cache-benchmark.ts
+++ b/src/tools/advanced-caching/cache-benchmark.ts
@@ -22,9 +22,9 @@ import { createHash, randomBytes } from 'crypto';
 import { writeFileSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
-import { CacheEngine } from '../../core/cache-engine';
-import { TokenCounter } from '../../core/token-counter';
-import { MetricsCollector } from '../../core/metrics';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { TokenCounter } from '../../core/token-counter.js';
+import { MetricsCollector } from '../../core/metrics.js';
 
 // ===== Type Definitions =====
 

--- a/src/tools/advanced-caching/cache-compression.ts
+++ b/src/tools/advanced-caching/cache-compression.ts
@@ -31,10 +31,10 @@ import {
   brotliDecompress,
   constants,
 } from 'zlib';
-import { CacheEngine } from '../../core/cache-engine';
-import { TokenCounter } from '../../core/token-counter';
-import { generateCacheKey } from '../shared/hash-utils';
-import { MetricsCollector } from '../../core/metrics';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { TokenCounter } from '../../core/token-counter.js';
+import { generateCacheKey } from '../shared/hash-utils.js';
+import { MetricsCollector } from '../../core/metrics.js';
 
 // Promisify compression functions
 const gzipAsync = promisify(gzip);

--- a/src/tools/advanced-caching/cache-invalidation.ts
+++ b/src/tools/advanced-caching/cache-invalidation.ts
@@ -13,11 +13,11 @@
  */
 
 import { createHash } from 'crypto';
-import { CacheEngine } from '../../core/cache-engine';
-import { TokenCounter } from '../../core/token-counter';
-import { MetricsCollector } from '../../core/metrics';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { TokenCounter } from '../../core/token-counter.js';
+import { MetricsCollector } from '../../core/metrics.js';
 import { EventEmitter } from 'events';
-import { CacheInvalidationEvent } from '../../core/types';
+import { CacheInvalidationEvent } from '../../core/types.js';
 
 export type InvalidationStrategy =
   | 'immediate'

--- a/src/tools/advanced-caching/cache-optimizer.ts
+++ b/src/tools/advanced-caching/cache-optimizer.ts
@@ -14,9 +14,9 @@
  * - Token reduction optimization (86%+ target)
  */
 
-import { CacheEngine } from '../../core/cache-engine';
-import { TokenCounter } from '../../core/token-counter';
-import { MetricsCollector } from '../../core/metrics';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { TokenCounter } from '../../core/token-counter.js';
+import { MetricsCollector } from '../../core/metrics.js';
 import { EventEmitter } from 'events';
 
 export type EvictionStrategy =

--- a/src/tools/advanced-caching/cache-partition.ts
+++ b/src/tools/advanced-caching/cache-partition.ts
@@ -23,9 +23,9 @@
 
 import { createHash } from 'crypto';
 import { EventEmitter } from 'events';
-import { CacheEngine } from '../../core/cache-engine';
-import { TokenCounter } from '../../core/token-counter';
-import { MetricsCollector } from '../../core/metrics';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { TokenCounter } from '../../core/token-counter.js';
+import { MetricsCollector } from '../../core/metrics.js';
 
 export interface CachePartitionOptions {
   operation:

--- a/src/tools/advanced-caching/cache-replication.ts
+++ b/src/tools/advanced-caching/cache-replication.ts
@@ -19,10 +19,10 @@
  */
 
 import { EventEmitter } from 'events';
-import { CacheEngine } from '../../core/cache-engine';
-import { TokenCounter } from '../../core/token-counter';
-import { MetricsCollector } from '../../core/metrics';
-import { generateCacheKey } from '../shared/hash-utils';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { TokenCounter } from '../../core/token-counter.js';
+import { MetricsCollector } from '../../core/metrics.js';
+import { generateCacheKey } from '../shared/hash-utils.js';
 import { createHash } from 'crypto';
 
 /**

--- a/src/tools/advanced-caching/cache-warmup.ts
+++ b/src/tools/advanced-caching/cache-warmup.ts
@@ -21,9 +21,9 @@
  * 6. status - Get warming status
  */
 
-import { CacheEngine } from '../../core/cache-engine';
-import { TokenCounter } from '../../core/token-counter';
-import { MetricsCollector } from '../../core/metrics';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { TokenCounter } from '../../core/token-counter.js';
+import { MetricsCollector } from '../../core/metrics.js';
 import { EventEmitter } from 'events';
 
 export type WarmupStrategy =

--- a/src/tools/advanced-caching/index.ts
+++ b/src/tools/advanced-caching/index.ts
@@ -18,7 +18,7 @@ export {
   type CompressionRecommendation,
   type BenchmarkResult,
   type CompressionConfig,
-} from './cache-compression';
+} from './cache-compression.js';
 
 // Cache Benchmark Tool
 export {
@@ -37,7 +37,7 @@ export {
   type LatencyMetrics,
   type ThroughputMetrics,
   type ReportFormat,
-} from './cache-benchmark';
+} from './cache-benchmark.js';
 
 // Cache Analytics Tool
 // Note: Implementation pending - exports temporarily removed

--- a/src/tools/advanced-caching/predictive-cache.ts
+++ b/src/tools/advanced-caching/predictive-cache.ts
@@ -1,8 +1,8 @@
 /** * PredictiveCache - ML-Based Predictive Caching (Track 2D) * * Token Reduction Target: 91%+ (highest in Track 2D) * Lines: 1,580+ * * Features: * - Time-series forecasting (ARIMA-like, exponential smoothing) * - Pattern recognition (clustering for access patterns) * - Collaborative filtering (predict based on similar keys) * - Neural networks (LSTM-like sequence prediction) * - Model compression (quantization, pruning) * - Automatic cache warming * - Model export/import (JSON, binary, ONNX-like format) * * Operations: * 1. train - Train prediction model on access patterns * 2. predict - Predict upcoming cache needs * 3. auto-warm - Automatically warm cache based on predictions * 4. evaluate - Evaluate prediction accuracy * 5. retrain - Retrain model with new data * 6. export-model - Export trained model * 7. import-model - Import pre-trained model * * TODO: Current implementation provides basic prediction capabilities. * Consider enhancing with: * - Real statistical confidence intervals instead of random confidence values * - More sophisticated pattern detection algorithms (e.g., seasonal decomposition) * - Integration with actual cache access logs for better training data * - A/B testing framework to validate prediction accuracy * - Dynamic threshold adjustment based on observed performance */
 
-import { CacheEngine } from '../../core/cache-engine';
-import { TokenCounter } from '../../core/token-counter';
-import { MetricsCollector } from '../../core/metrics';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { TokenCounter } from '../../core/token-counter.js';
+import { MetricsCollector } from '../../core/metrics.js';
 import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { EventEmitter } from 'events';
 

--- a/src/tools/advanced-caching/smart-cache.ts
+++ b/src/tools/advanced-caching/smart-cache.ts
@@ -1,8 +1,8 @@
 /** * SmartCache - Advanced Cache Management * * Track 2D - Tool #1: Comprehensive cache management (90%+ token reduction) * * Capabilities: * - Multi-tier caching (L1: Memory, L2: Disk, L3: Remote) * - 6 eviction strategies: LRU, LFU, FIFO, TTL, size-based, hybrid * - Cache stampede prevention with mutex locks * - Automatic tier promotion/demotion * - Write-through/write-back modes * - Batch operations with atomic guarantees * * Token Reduction Strategy: * - Cache metadata compression (95% reduction) * - Entry deduplication across tiers (92% reduction) * - Incremental state exports (delta-based, 94% reduction) * - Compressed statistics aggregation (93% reduction) */
 
-import { CacheEngine } from '../../core/cache-engine';
-import { TokenCounter } from '../../core/token-counter';
-import { MetricsCollector } from '../../core/metrics';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { TokenCounter } from '../../core/token-counter.js';
+import { MetricsCollector } from '../../core/metrics.js';
 import { LRUCache } from 'lru-cache';
 import { EventEmitter } from 'events';
 

--- a/src/tools/api-database/index.ts
+++ b/src/tools/api-database/index.ts
@@ -15,13 +15,13 @@ export {
   type CachingStrategy,
   type InvalidationPattern,
   type CacheAnalysis,
-} from './smart-cache-api';
+} from './smart-cache-api.js';
 
 export {
   SmartApiFetch,
   runSmartApiFetch,
   SMART_API_FETCH_TOOL_DEFINITION,
-} from './smart-api-fetch';
+} from './smart-api-fetch.js';
 
 export {
   SmartSchema,
@@ -43,7 +43,7 @@ export {
   type SchemaIssue,
   type MissingIndex as SchemaMissingIndex,
   type SchemaDiff,
-} from './smart-schema';
+} from './smart-schema.js';
 
 export {
   SmartREST,
@@ -56,7 +56,7 @@ export {
   type ResourceGroup,
   type HealthIssue,
   type RateLimit,
-} from './smart-rest';
+} from './smart-rest.js';
 
 export {
   SmartORM,
@@ -69,7 +69,7 @@ export {
   type EagerLoadingSuggestion,
   type QueryReduction,
   type IndexSuggestion,
-} from './smart-orm';
+} from './smart-orm.js';
 
 export {
   SmartSql,
@@ -85,7 +85,7 @@ export {
   type ValidationError,
   type Validation,
   type HistoryEntry,
-} from './smart-sql';
+} from './smart-sql.js';
 
 export {
   SmartDatabase,
@@ -109,7 +109,7 @@ export {
   type PoolInfo,
   type SlowQuery,
   type BatchResult,
-} from './smart-database';
+} from './smart-database.js';
 
 export {
   SmartWebSocket,
@@ -119,7 +119,7 @@ export {
   type SmartWebSocketResult,
   type Message,
   type MessageType,
-} from './smart-websocket';
+} from './smart-websocket.js';
 
 export {
   SmartGraphQL,
@@ -135,7 +135,7 @@ export {
   type QueryAnalysis as GraphQLQueryAnalysis,
   type Optimizations,
   type SchemaInfo,
-} from './smart-graphql';
+} from './smart-graphql.js';
 
 export {
   SmartMigration,
@@ -148,4 +148,4 @@ export {
   type MigrationStatus,
   type MigrationHistoryEntry,
   type RollbackResult,
-} from './smart-migration';
+} from './smart-migration.js';

--- a/src/tools/api-database/smart-api-fetch.ts
+++ b/src/tools/api-database/smart-api-fetch.ts
@@ -10,9 +10,9 @@
  * - Token-optimized output
  */
 
-import { CacheEngine } from '../../core/cache-engine';
-import type { TokenCounter } from '../../core/token-counter';
-import type { MetricsCollector } from '../../core/metrics';
+import { CacheEngine } from '../../core/cache-engine.js';
+import type { TokenCounter } from '../../core/token-counter.js';
+import type { MetricsCollector } from '../../core/metrics.js';
 import { createHash } from 'crypto';
 
 interface SmartApiFetchOptions {

--- a/src/tools/api-database/smart-cache-api.ts
+++ b/src/tools/api-database/smart-cache-api.ts
@@ -11,9 +11,9 @@
  */
 
 import { createHash } from 'crypto';
-import { CacheEngine } from '../../core/cache-engine';
-import type { TokenCounter } from '../../core/token-counter';
-import type { MetricsCollector } from '../../core/metrics';
+import { CacheEngine } from '../../core/cache-engine.js';
+import type { TokenCounter } from '../../core/token-counter.js';
+import type { MetricsCollector } from '../../core/metrics.js';
 
 // ===== Type Definitions =====
 

--- a/src/tools/api-database/smart-database.ts
+++ b/src/tools/api-database/smart-database.ts
@@ -22,15 +22,15 @@ import { createHash } from 'crypto';
 import {
   CacheEngine,
   CacheEngine as CacheEngineClass,
-} from '../../core/cache-engine';
+} from '../../core/cache-engine.js';
 import {
   TokenCounter,
   TokenCounter as TokenCounterClass,
-} from '../../core/token-counter';
+} from '../../core/token-counter.js';
 import {
   MetricsCollector,
   MetricsCollector as MetricsCollectorClass,
-} from '../../core/metrics';
+} from '../../core/metrics.js';
 
 // ============================================================================
 // Type Definitions

--- a/src/tools/api-database/smart-graphql.ts
+++ b/src/tools/api-database/smart-graphql.ts
@@ -11,10 +11,10 @@
  * - Token-optimized output
  */
 
-import { CacheEngine } from '../../core/cache-engine';
-import { globalTokenCounter, globalMetricsCollector } from '../../core/globals';
-import type { TokenCounter } from '../../core/token-counter';
-import type { MetricsCollector } from '../../core/metrics';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { globalTokenCounter, globalMetricsCollector } from '../../core/globals.js';
+import type { TokenCounter } from '../../core/token-counter.js';
+import type { MetricsCollector } from '../../core/metrics.js';
 import { createHash } from 'crypto';
 
 interface SmartGraphQLOptions {

--- a/src/tools/api-database/smart-migration.test.ts
+++ b/src/tools/api-database/smart-migration.test.ts
@@ -8,10 +8,10 @@ import {
   SmartMigration,
   getSmartMigration,
   runSmartMigration,
-} from './smart-migration';
-import { CacheEngine } from '../../core/cache-engine';
-import { TokenCounter } from '../../core/token-counter';
-import { MetricsCollector } from '../../core/metrics';
+} from './smart-migration.js';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { TokenCounter } from '../../core/token-counter.js';
+import { MetricsCollector } from '../../core/metrics.js';
 import { tmpdir } from 'os';
 import { join } from 'path';
 

--- a/src/tools/api-database/smart-migration.ts
+++ b/src/tools/api-database/smart-migration.ts
@@ -22,9 +22,9 @@ import { createHash } from 'crypto';
 import {
   CacheEngine,
   CacheEngine as CacheEngineClass,
-} from '../../core/cache-engine';
-import { TokenCounter } from '../../core/token-counter';
-import { MetricsCollector } from '../../core/metrics';
+} from '../../core/cache-engine.js';
+import { TokenCounter } from '../../core/token-counter.js';
+import { MetricsCollector } from '../../core/metrics.js';
 
 // ============================================================================
 // Type Definitions

--- a/src/tools/api-database/smart-orm.ts
+++ b/src/tools/api-database/smart-orm.ts
@@ -11,9 +11,9 @@
  * - Generated SQL inspection
  */
 
-import { CacheEngine } from '../../core/cache-engine';
-import type { TokenCounter } from '../../core/token-counter';
-import type { MetricsCollector } from '../../core/metrics';
+import { CacheEngine } from '../../core/cache-engine.js';
+import type { TokenCounter } from '../../core/token-counter.js';
+import type { MetricsCollector } from '../../core/metrics.js';
 import { createHash } from 'crypto';
 
 export type ORMType =

--- a/src/tools/api-database/smart-rest.ts
+++ b/src/tools/api-database/smart-rest.ts
@@ -12,9 +12,9 @@
 import { createHash } from 'crypto';
 
 // Core imports
-import { CacheEngine } from '../../core/cache-engine';
-import type { TokenCounter } from '../../core/token-counter';
-import type { MetricsCollector } from '../../core/metrics';
+import { CacheEngine } from '../../core/cache-engine.js';
+import type { TokenCounter } from '../../core/token-counter.js';
+import type { MetricsCollector } from '../../core/metrics.js';
 
 export interface SmartRESTOptions {
   // API specification

--- a/src/tools/api-database/smart-schema.test.ts
+++ b/src/tools/api-database/smart-schema.test.ts
@@ -4,10 +4,10 @@
  */
 
 import { describe, it, expect, beforeEach } from '@jest/globals';
-import { SmartSchema, getSmartSchema, runSmartSchema } from './smart-schema';
-import { CacheEngine } from '../../core/cache-engine';
-import { TokenCounter } from '../../core/token-counter';
-import { MetricsCollector } from '../../core/metrics';
+import { SmartSchema, getSmartSchema, runSmartSchema } from './smart-schema.js';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { TokenCounter } from '../../core/token-counter.js';
+import { MetricsCollector } from '../../core/metrics.js';
 import { tmpdir } from 'os';
 import { join } from 'path';
 

--- a/src/tools/api-database/smart-schema.ts
+++ b/src/tools/api-database/smart-schema.ts
@@ -21,10 +21,10 @@ import { createHash } from 'crypto';
 import {
   CacheEngine,
   CacheEngine as CacheEngineClass,
-} from '../../core/cache-engine';
-import { TokenCounter } from '../../core/token-counter';
-import { MetricsCollector } from '../../core/metrics';
-import { generateCacheKey } from '../shared/hash-utils';
+} from '../../core/cache-engine.js';
+import { TokenCounter } from '../../core/token-counter.js';
+import { MetricsCollector } from '../../core/metrics.js';
+import { generateCacheKey } from '../shared/hash-utils.js';
 
 // ============================================================================
 // Type Definitions

--- a/src/tools/api-database/smart-sql.ts
+++ b/src/tools/api-database/smart-sql.ts
@@ -10,9 +10,9 @@
  * - Token-optimized output with intelligent caching
  */
 
-import { CacheEngine } from '../../core/cache-engine';
-import { TokenCounter } from '../../core/token-counter';
-import { MetricsCollector } from '../../core/metrics';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { TokenCounter } from '../../core/token-counter.js';
+import { MetricsCollector } from '../../core/metrics.js';
 import { createHash } from 'crypto';
 
 export interface SmartSqlOptions {

--- a/src/tools/api-database/smart-websocket.ts
+++ b/src/tools/api-database/smart-websocket.ts
@@ -12,9 +12,9 @@
  */
 
 import { createHash } from 'crypto';
-import { CacheEngine } from '../../core/cache-engine';
-import { TokenCounter } from '../../core/token-counter';
-import { MetricsCollector } from '../../core/metrics';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { TokenCounter } from '../../core/token-counter.js';
+import { MetricsCollector } from '../../core/metrics.js';
 
 // ============================================================================
 // Type Definitions

--- a/src/tools/build-systems/index.ts
+++ b/src/tools/build-systems/index.ts
@@ -10,28 +10,28 @@ export {
   getSmartTestTool,
   runSmartTest,
   SMART_TEST_TOOL_DEFINITION,
-} from './smart-test';
+} from './smart-test.js';
 export {
   SmartBuild,
   getSmartBuildTool,
   runSmartBuild,
   SMART_BUILD_TOOL_DEFINITION,
-} from './smart-build';
+} from './smart-build.js';
 export {
   SmartLint,
   getSmartLintTool,
   runSmartLint,
   SMART_LINT_TOOL_DEFINITION,
-} from './smart-lint';
+} from './smart-lint.js';
 export {
   SmartTypeCheck,
   getSmartTypeCheckTool,
   runSmartTypeCheck,
   SMART_TYPECHECK_TOOL_DEFINITION,
-} from './smart-typecheck';
+} from './smart-typecheck.js';
 export {
   SmartProcesses,
   getSmartProcessesTool,
   runSmartProcesses,
   SMART_PROCESSES_TOOL_DEFINITION,
-} from './smart-processes';
+} from './smart-processes.js';

--- a/src/tools/build-systems/smart-build.ts
+++ b/src/tools/build-systems/smart-build.ts
@@ -9,9 +9,9 @@
  */
 
 import { spawn } from 'child_process';
-import { CacheEngine } from '../../core/cache-engine';
-import { TokenCounter } from '../../core/token-counter';
-import { MetricsCollector } from '../../core/metrics';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { TokenCounter } from '../../core/token-counter.js';
+import { MetricsCollector } from '../../core/metrics.js';
 import { createHash } from 'crypto';
 import { readFileSync, existsSync, readdirSync, statSync } from 'fs';
 import { join } from 'path';

--- a/src/tools/build-systems/smart-docker.ts
+++ b/src/tools/build-systems/smart-docker.ts
@@ -9,7 +9,7 @@
  */
 
 import { spawn } from 'child_process';
-import { CacheEngine } from '../../core/cache-engine';
+import { CacheEngine } from '../../core/cache-engine.js';
 import { createHash } from 'crypto';
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';

--- a/src/tools/build-systems/smart-install.ts
+++ b/src/tools/build-systems/smart-install.ts
@@ -9,7 +9,7 @@
  */
 
 import { spawn } from 'child_process';
-import { CacheEngine } from '../../core/cache-engine';
+import { CacheEngine } from '../../core/cache-engine.js';
 import { createHash } from 'crypto';
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';

--- a/src/tools/build-systems/smart-lint.ts
+++ b/src/tools/build-systems/smart-lint.ts
@@ -9,9 +9,9 @@
  */
 
 import { spawn } from 'child_process';
-import { CacheEngine } from '../../core/cache-engine';
-import { TokenCounter } from '../../core/token-counter';
-import { MetricsCollector } from '../../core/metrics';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { TokenCounter } from '../../core/token-counter.js';
+import { MetricsCollector } from '../../core/metrics.js';
 import { createHash } from 'crypto';
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';

--- a/src/tools/build-systems/smart-logs.ts
+++ b/src/tools/build-systems/smart-logs.ts
@@ -9,7 +9,7 @@
  */
 
 import { spawn } from 'child_process';
-import { CacheEngine } from '../../core/cache-engine';
+import { CacheEngine } from '../../core/cache-engine.js';
 import { createHash } from 'crypto';
 import { existsSync } from 'fs';
 import { join } from 'path';

--- a/src/tools/build-systems/smart-network.ts
+++ b/src/tools/build-systems/smart-network.ts
@@ -10,7 +10,7 @@
  */
 
 import { spawn } from 'child_process';
-import { CacheEngine } from '../../core/cache-engine';
+import { CacheEngine } from '../../core/cache-engine.js';
 import { createHash } from 'crypto';
 import { homedir } from 'os';
 import { join } from 'path';

--- a/src/tools/build-systems/smart-processes.ts
+++ b/src/tools/build-systems/smart-processes.ts
@@ -10,9 +10,9 @@
 
 import { exec } from 'child_process';
 import { promisify } from 'util';
-import { CacheEngine } from '../../core/cache-engine';
-import { TokenCounter } from '../../core/token-counter';
-import { MetricsCollector } from '../../core/metrics';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { TokenCounter } from '../../core/token-counter.js';
+import { MetricsCollector } from '../../core/metrics.js';
 import { join } from 'path';
 import { homedir, cpus, totalmem } from 'os';
 

--- a/src/tools/build-systems/smart-system-metrics.ts
+++ b/src/tools/build-systems/smart-system-metrics.ts
@@ -9,7 +9,7 @@
  */
 
 import { spawn } from 'child_process';
-import { CacheEngine } from '../../core/cache-engine';
+import { CacheEngine } from '../../core/cache-engine.js';
 import { createHash } from 'crypto';
 import { homedir } from 'os';
 import { join } from 'path';

--- a/src/tools/build-systems/smart-test.ts
+++ b/src/tools/build-systems/smart-test.ts
@@ -9,9 +9,9 @@
  */
 
 import { spawn } from 'child_process';
-import { CacheEngine } from '../../core/cache-engine';
-import { TokenCounter } from '../../core/token-counter';
-import { MetricsCollector } from '../../core/metrics';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { TokenCounter } from '../../core/token-counter.js';
+import { MetricsCollector } from '../../core/metrics.js';
 import { createHash } from 'crypto';
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';

--- a/src/tools/build-systems/smart-typecheck.ts
+++ b/src/tools/build-systems/smart-typecheck.ts
@@ -9,9 +9,9 @@
  */
 
 import { spawn } from 'child_process';
-import { CacheEngine } from '../../core/cache-engine';
-import { MetricsCollector } from '../../core/metrics';
-import { TokenCounter } from '../../core/token-counter';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { MetricsCollector } from '../../core/metrics.js';
+import { TokenCounter } from '../../core/token-counter.js';
 import { createHash } from 'crypto';
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';

--- a/src/tools/code-analysis/index.ts
+++ b/src/tools/code-analysis/index.ts
@@ -9,7 +9,7 @@ export {
   getSmartTypeScriptTool,
   runSmartTypescript,
   SMART_TYPESCRIPT_TOOL_DEFINITION,
-} from './smart-typescript';
+} from './smart-typescript.js';
 
 export {
   SmartAstGrepTool,
@@ -19,7 +19,7 @@ export {
   type SmartAstGrepOptions,
   type SmartAstGrepResult,
   type AstMatch,
-} from './smart-ast-grep';
+} from './smart-ast-grep.js';
 
 // SmartAmbiance - Implementation pending
 // Note: Exports temporarily removed until implementation is complete
@@ -31,7 +31,7 @@ export {
   SMART_SECURITY_TOOL_DEFINITION,
   type SmartSecurityOptions,
   type SmartSecurityOutput,
-} from './smart-security';
+} from './smart-security.js';
 
 export {
   SmartDependenciesTool,
@@ -46,7 +46,7 @@ export {
   type CircularDependency,
   type UnusedDependency,
   type DependencyImpact,
-} from './smart-dependencies';
+} from './smart-dependencies.js';
 
 export {
   SmartSymbolsTool,
@@ -56,7 +56,7 @@ export {
   type SmartSymbolsOptions,
   type SmartSymbolsResult,
   type SymbolInfo,
-} from './smart-symbols';
+} from './smart-symbols.js';
 
 export {
   SmartComplexityTool,
@@ -67,7 +67,7 @@ export {
   type SmartComplexityResult,
   type ComplexityMetrics,
   type FunctionComplexity,
-} from './smart-complexity';
+} from './smart-complexity.js';
 
 export {
   SmartRefactorTool,
@@ -77,7 +77,7 @@ export {
   type SmartRefactorOptions,
   type SmartRefactorResult,
   type RefactorSuggestion,
-} from './smart-refactor';
+} from './smart-refactor.js';
 
 export {
   SmartImportsTool,
@@ -89,7 +89,7 @@ export {
   type ImportInfo,
   type ImportOptimization,
   type CircularDependency as ImportCircularDependency,
-} from './smart-imports';
+} from './smart-imports.js';
 
 export {
   SmartExportsTool,
@@ -101,4 +101,4 @@ export {
   type ExportInfo,
   type ExportDependency,
   type ExportOptimization,
-} from './smart-exports';
+} from './smart-exports.js';

--- a/src/tools/code-analysis/smart-ast-grep.ts
+++ b/src/tools/code-analysis/smart-ast-grep.ts
@@ -14,10 +14,10 @@
 import { execSync } from 'child_process';
 import { existsSync, statSync, readdirSync } from 'fs';
 import { join, relative } from 'path';
-import { CacheEngine } from '../../core/cache-engine';
-import { TokenCounter } from '../../core/token-counter';
-import { MetricsCollector } from '../../core/metrics';
-import { hashFile } from '../shared/hash-utils';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { TokenCounter } from '../../core/token-counter.js';
+import { MetricsCollector } from '../../core/metrics.js';
+import { hashFile } from '../shared/hash-utils.js';
 
 export interface SmartAstGrepOptions {
   // Pattern options

--- a/src/tools/code-analysis/smart-complexity.ts
+++ b/src/tools/code-analysis/smart-complexity.ts
@@ -11,9 +11,9 @@ import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 import { createHash } from 'crypto';
-import { CacheEngine } from '../../core/cache-engine';
-import { MetricsCollector } from '../../core/metrics';
-import { TokenCounter } from '../../core/token-counter';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { MetricsCollector } from '../../core/metrics.js';
+import { TokenCounter } from '../../core/token-counter.js';
 
 export interface SmartComplexityOptions {
   filePath?: string;

--- a/src/tools/code-analysis/smart-dependencies.ts
+++ b/src/tools/code-analysis/smart-dependencies.ts
@@ -19,10 +19,10 @@ import { parse as parseBabel } from '@babel/parser';
 import pkg from 'glob';
 const { globSync } = pkg;
 import { relative, resolve, dirname, extname, join } from 'path';
-import { CacheEngine } from '../../core/cache-engine';
-import { TokenCounter } from '../../core/token-counter';
-import { MetricsCollector } from '../../core/metrics';
-import { hashFileMetadata, generateCacheKey } from '../shared/hash-utils';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { TokenCounter } from '../../core/token-counter.js';
+import { MetricsCollector } from '../../core/metrics.js';
+import { hashFileMetadata, generateCacheKey } from '../shared/hash-utils.js';
 
 /**
  * Represents an import in a file

--- a/src/tools/code-analysis/smart-exports.ts
+++ b/src/tools/code-analysis/smart-exports.ts
@@ -12,9 +12,9 @@ import { createHash } from 'crypto';
 import { join } from 'path';
 import { homedir } from 'os';
 import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
-import { CacheEngine } from '../../core/cache-engine';
-import { MetricsCollector } from '../../core/metrics';
-import { TokenCounter } from '../../core/token-counter';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { MetricsCollector } from '../../core/metrics.js';
+import { TokenCounter } from '../../core/token-counter.js';
 
 /**
  * Export statement information
@@ -694,7 +694,7 @@ export class SmartExportsTool {
             before:
               'export const a = ...\nexport const b = ...\nexport const c = ...',
             after:
-              "// In module.ts:\nconst a = ...\nconst b = ...\nexport { a, b };\n\n// In index.ts:\nexport { a, b } from './module';",
+              "// In module.ts:\nconst a = ...\nconst b = ...\nexport { a, b };\n\n// In index.ts:\nexport { a, b } from './module.js';",
           },
           impact: {
             readability: 'high',

--- a/src/tools/code-analysis/smart-imports.ts
+++ b/src/tools/code-analysis/smart-imports.ts
@@ -12,9 +12,9 @@ import { createHash } from 'crypto';
 import { join } from 'path';
 import { homedir } from 'os';
 import { existsSync, readFileSync } from 'fs';
-import { CacheEngine } from '../../core/cache-engine';
-import { MetricsCollector } from '../../core/metrics';
-import { TokenCounter } from '../../core/token-counter';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { MetricsCollector } from '../../core/metrics.js';
+import { TokenCounter } from '../../core/token-counter.js';
 
 /**
  * Import statement information

--- a/src/tools/code-analysis/smart-refactor.ts
+++ b/src/tools/code-analysis/smart-refactor.ts
@@ -11,13 +11,13 @@ import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 import { createHash } from 'crypto';
-import { CacheEngine } from '../../core/cache-engine';
-import { MetricsCollector } from '../../core/metrics';
-import { TokenCounter } from '../../core/token-counter';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { MetricsCollector } from '../../core/metrics.js';
+import { TokenCounter } from '../../core/token-counter.js';
 import {
   SmartComplexityTool,
   getSmartComplexityTool,
-} from './smart-complexity';
+} from './smart-complexity.js';
 
 export interface SmartRefactorOptions {
   filePath?: string;

--- a/src/tools/code-analysis/smart-security.ts
+++ b/src/tools/code-analysis/smart-security.ts
@@ -9,9 +9,9 @@
  * - <1 hour full scan requirement for daily TTL
  */
 
-import { CacheEngine } from '../../core/cache-engine';
-import { MetricsCollector } from '../../core/metrics';
-import { TokenCounter } from '../../core/token-counter';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { MetricsCollector } from '../../core/metrics.js';
+import { TokenCounter } from '../../core/token-counter.js';
 import { createHash } from 'crypto';
 import { readFileSync, existsSync, statSync, readdirSync } from 'fs';
 import { join, relative, extname } from 'path';

--- a/src/tools/code-analysis/smart-symbols.ts
+++ b/src/tools/code-analysis/smart-symbols.ts
@@ -9,9 +9,9 @@
  * - 75-85% token reduction through summarization
  */
 
-import { CacheEngine } from '../../core/cache-engine';
-import { MetricsCollector } from '../../core/metrics';
-import { TokenCounter } from '../../core/token-counter';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { MetricsCollector } from '../../core/metrics.js';
+import { TokenCounter } from '../../core/token-counter.js';
 import { createHash } from 'crypto';
 import { readFileSync, existsSync } from 'fs';
 import { join, relative } from 'path';

--- a/src/tools/code-analysis/smart-typescript.ts
+++ b/src/tools/code-analysis/smart-typescript.ts
@@ -9,9 +9,9 @@
  * - Provides actionable type error summaries
  */
 
-import { CacheEngine } from '../../core/cache-engine';
-import { MetricsCollector } from '../../core/metrics';
-import { TokenCounter } from '../../core/token-counter';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { MetricsCollector } from '../../core/metrics.js';
+import { TokenCounter } from '../../core/token-counter.js';
 import { createHash } from 'crypto';
 import { readFileSync, existsSync, statSync } from 'fs';
 import { join, relative, dirname } from 'path';

--- a/src/tools/configuration/index.ts
+++ b/src/tools/configuration/index.ts
@@ -9,14 +9,14 @@ export {
   SmartPackageJson,
   runSmartPackageJson,
   SMART_PACKAGE_JSON_TOOL_DEFINITION,
-} from './smart-package-json';
+} from './smart-package-json.js';
 
 export {
   SmartConfigReadTool,
   getSmartConfigReadTool,
   runSmartConfigRead,
   SMART_CONFIG_READ_TOOL_DEFINITION,
-} from './smart-config-read';
+} from './smart-config-read.js';
 
 // SmartEnv - Implementation pending
 // SmartWorkflow - Implementation pending
@@ -25,7 +25,7 @@ export {
 export {
   runSmartTsconfig,
   SMART_TSCONFIG_TOOL_DEFINITION,
-} from './smart-tsconfig';
+} from './smart-tsconfig.js';
 
 export type {
   SmartConfigReadOptions,
@@ -35,6 +35,6 @@ export type {
   ConfigSchemaProperty,
   ConfigValidationError,
   ConfigDiff,
-} from './smart-config-read';
+} from './smart-config-read.js';
 
 // SmartWorkflow types - Implementation pending

--- a/src/tools/configuration/smart-config-read.ts
+++ b/src/tools/configuration/smart-config-read.ts
@@ -13,11 +13,11 @@
 import { readFileSync, existsSync, statSync } from 'fs';
 import { parse as parseYAML } from 'yaml';
 import { parse as parseTOML } from '@iarna/toml';
-import { CacheEngine } from '../../core/cache-engine';
-import { TokenCounter } from '../../core/token-counter';
-import { MetricsCollector } from '../../core/metrics';
-import { hashFile, generateCacheKey } from '../shared/hash-utils';
-import { compress, decompress } from '../shared/compression-utils';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { TokenCounter } from '../../core/token-counter.js';
+import { MetricsCollector } from '../../core/metrics.js';
+import { hashFile, generateCacheKey } from '../shared/hash-utils.js';
+import { compress, decompress } from '../shared/compression-utils.js';
 import { homedir } from 'os';
 import { join } from 'path';
 

--- a/src/tools/configuration/smart-package-json.ts
+++ b/src/tools/configuration/smart-package-json.ts
@@ -14,9 +14,9 @@ import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { createHash } from 'crypto';
 import { execSync } from 'child_process';
-import { CacheEngine } from '../../core/cache-engine';
-import { TokenCounter } from '../../core/token-counter';
-import { MetricsCollector } from '../../core/metrics';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { TokenCounter } from '../../core/token-counter.js';
+import { MetricsCollector } from '../../core/metrics.js';
 import { homedir } from 'os';
 
 interface PackageMetadata {

--- a/src/tools/configuration/smart-tsconfig.ts
+++ b/src/tools/configuration/smart-tsconfig.ts
@@ -13,10 +13,10 @@ import { readFile } from 'fs/promises';
 import { resolve, dirname, join } from 'path';
 import { existsSync } from 'fs';
 import { homedir } from 'os';
-import { CacheEngine } from '../../core/cache-engine';
-import { globalMetricsCollector } from '../../core/globals';
-import { TokenCounter } from '../../core/token-counter';
-import { hashContent, generateCacheKey } from '../shared/hash-utils';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { globalMetricsCollector } from '../../core/globals.js';
+import { TokenCounter } from '../../core/token-counter.js';
+import { hashContent, generateCacheKey } from '../shared/hash-utils.js';
 
 // ==================== Type Definitions ====================
 

--- a/src/tools/dashboard-monitoring/alert-manager.ts
+++ b/src/tools/dashboard-monitoring/alert-manager.ts
@@ -19,9 +19,9 @@
  * - Silence state compression (90% reduction)
  */
 
-import { CacheEngine } from '../../core/cache-engine';
-import { TokenCounter } from '../../core/token-counter';
-import { MetricsCollector } from '../../core/metrics';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { TokenCounter } from '../../core/token-counter.js';
+import { MetricsCollector } from '../../core/metrics.js';
 import { createHash } from 'crypto';
 
 // ============================================================================

--- a/src/tools/dashboard-monitoring/custom-widget.ts
+++ b/src/tools/dashboard-monitoring/custom-widget.ts
@@ -11,10 +11,10 @@
  * - Aggressive caching for templates and configurations
  */
 
-import { CacheEngine } from '../../core/cache-engine';
-import { TokenCounter } from '../../core/token-counter';
-import { MetricsCollector } from '../../core/metrics';
-import { compress, decompress } from '../shared/compression-utils';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { TokenCounter } from '../../core/token-counter.js';
+import { MetricsCollector } from '../../core/metrics.js';
+import { compress, decompress } from '../shared/compression-utils.js';
 import { createHash } from 'crypto';
 
 // Type definitions

--- a/src/tools/dashboard-monitoring/data-visualizer.ts
+++ b/src/tools/dashboard-monitoring/data-visualizer.ts
@@ -6,9 +6,9 @@
  * Operations: 8 (create-chart, update-chart, export-chart, create-heatmap, create-timeline, create-network-graph, create-sankey, animate)
  */
 
-import { CacheEngine } from '../../core/cache-engine';
-import { TokenCounter } from '../../core/token-counter';
-import { MetricsCollector } from '../../core/metrics';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { TokenCounter } from '../../core/token-counter.js';
+import { MetricsCollector } from '../../core/metrics.js';
 import { createHash } from 'crypto';
 
 // ============================================================================

--- a/src/tools/dashboard-monitoring/health-monitor.ts
+++ b/src/tools/dashboard-monitoring/health-monitor.ts
@@ -16,10 +16,10 @@
  * 8. get-impact - Analyze impact of service failures
  */
 
-import { CacheEngine } from '../../core/cache-engine';
-import { TokenCounter } from '../../core/token-counter';
-import { MetricsCollector } from '../../core/metrics';
-import { generateCacheKey } from '../shared/hash-utils';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { TokenCounter } from '../../core/token-counter.js';
+import { MetricsCollector } from '../../core/metrics.js';
+import { generateCacheKey } from '../shared/hash-utils.js';
 import { createHash } from 'crypto';
 
 // ============================================================================

--- a/src/tools/dashboard-monitoring/log-dashboard.ts
+++ b/src/tools/dashboard-monitoring/log-dashboard.ts
@@ -17,9 +17,9 @@
  * Target Lines: 1,540
  */
 
-import { CacheEngine } from '../../core/cache-engine';
-import { TokenCounter } from '../../core/token-counter';
-import { MetricsCollector } from '../../core/metrics';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { TokenCounter } from '../../core/token-counter.js';
+import { MetricsCollector } from '../../core/metrics.js';
 import { createHash } from 'crypto';
 import * as fs from 'fs';
 import { EventEmitter } from 'events';

--- a/src/tools/dashboard-monitoring/metric-collector.ts
+++ b/src/tools/dashboard-monitoring/metric-collector.ts
@@ -23,9 +23,9 @@
  * 8. purge - Remove old metrics data
  */
 
-import { CacheEngine } from '../../core/cache-engine';
-import { TokenCounter } from '../../core/token-counter';
-import { MetricsCollector as CoreMetricsCollector } from '../../core/metrics';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { TokenCounter } from '../../core/token-counter.js';
+import { MetricsCollector as CoreMetricsCollector } from '../../core/metrics.js';
 import { createHash } from 'crypto';
 
 // ============================================================================

--- a/src/tools/dashboard-monitoring/monitoring-integration.ts
+++ b/src/tools/dashboard-monitoring/monitoring-integration.ts
@@ -17,9 +17,9 @@
  * Token Reduction Target: 87%+
  */
 
-import { CacheEngine } from '../../core/cache-engine';
-import { TokenCounter } from '../../core/token-counter';
-import { MetricsCollector } from '../../core/metrics';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { TokenCounter } from '../../core/token-counter.js';
+import { MetricsCollector } from '../../core/metrics.js';
 import { createHash } from 'crypto';
 
 // ============================================================================

--- a/src/tools/file-operations/index.ts
+++ b/src/tools/file-operations/index.ts
@@ -2,13 +2,13 @@
  * File Operations Tools - Token-Optimized File I/O
  */
 
-export * from './smart-read';
-export * from './smart-write';
-export * from './smart-edit';
-export * from './smart-glob';
-export * from './smart-grep';
-export * from './smart-status';
-export * from './smart-diff';
-export * from './smart-log';
-export * from './smart-branch';
-export * from './smart-merge';
+export * from './smart-read.js';
+export * from './smart-write.js';
+export * from './smart-edit.js';
+export * from './smart-glob.js';
+export * from './smart-grep.js';
+export * from './smart-status.js';
+export * from './smart-diff.js';
+export * from './smart-log.js';
+export * from './smart-branch.js';
+export * from './smart-merge.js';

--- a/src/tools/intelligence/index.ts
+++ b/src/tools/intelligence/index.ts
@@ -13,10 +13,10 @@ export {
   KnowledgeGraphTool,
   getKnowledgeGraphTool,
   KNOWLEDGE_GRAPH_TOOL_DEFINITION,
-} from './knowledge-graph';
+} from './knowledge-graph.js';
 
 // Export types for incomplete tools - temporarily removed
 export type {
   KnowledgeGraphOptions,
   KnowledgeGraphResult,
-} from './knowledge-graph';
+} from './knowledge-graph.js';

--- a/src/tools/intelligence/knowledge-graph.ts
+++ b/src/tools/intelligence/knowledge-graph.ts
@@ -20,9 +20,9 @@
  */
 
 import { createHash } from 'crypto';
-import { CacheEngine } from '../../core/cache-engine';
-import { TokenCounter } from '../../core/token-counter';
-import { MetricsCollector } from '../../core/metrics';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { TokenCounter } from '../../core/token-counter.js';
+import { MetricsCollector } from '../../core/metrics.js';
 import graphlibPkg from 'graphlib';
 const { Graph, alg } = graphlibPkg;
 import {

--- a/src/tools/intelligence/sentiment-analysis.ts
+++ b/src/tools/intelligence/sentiment-analysis.ts
@@ -21,9 +21,9 @@
  * - Emotion classifier caching (93% reduction, infinite TTL)
  */
 
-import { CacheEngine } from '../../core/cache-engine';
-import { TokenCounter } from '../../core/token-counter';
-import { MetricsCollector } from '../../core/metrics';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { TokenCounter } from '../../core/token-counter.js';
+import { MetricsCollector } from '../../core/metrics.js';
 import { createHash } from 'crypto';
 
 // NLP libraries (to be installed: natural, compromise)

--- a/src/tools/output-formatting/index.ts
+++ b/src/tools/output-formatting/index.ts
@@ -26,4 +26,4 @@ export {
   type FormatResult,
   type LanguageDetectionResult,
   type ThemeApplicationResult,
-} from './smart-pretty';
+} from './smart-pretty.js';

--- a/src/tools/output-formatting/smart-pretty.ts
+++ b/src/tools/output-formatting/smart-pretty.ts
@@ -20,11 +20,11 @@
 import hljs from 'highlight';
 import { format as prettierFormat } from 'prettier';
 import chalk from 'chalk';
-import { CacheEngine } from '../../core/cache-engine';
-import { TokenCounter } from '../../core/token-counter';
-import { MetricsCollector } from '../../core/metrics';
-import { compress, decompress } from '../shared/compression-utils';
-import { hashContent, generateCacheKey } from '../shared/hash-utils';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { TokenCounter } from '../../core/token-counter.js';
+import { MetricsCollector } from '../../core/metrics.js';
+import { compress, decompress } from '../shared/compression-utils.js';
+import { hashContent, generateCacheKey } from '../shared/hash-utils.js';
 import { homedir } from 'os';
 import { join } from 'path';
 

--- a/src/tools/system-operations/index.ts
+++ b/src/tools/system-operations/index.ts
@@ -13,7 +13,7 @@ export {
   type ProcessInfo,
   type ProcessTreeNode,
   type ResourceSnapshot,
-} from './smart-process';
+} from './smart-process.js';
 
 export {
   SmartService,
@@ -26,7 +26,7 @@ export {
   type ServiceInfo,
   type HealthCheck,
   type DependencyGraph,
-} from './smart-service';
+} from './smart-service.js';
 
 // SmartNetwork - Implementation pending
 // SmartCleanup - Implementation pending
@@ -46,7 +46,7 @@ export {
   type ACLEntry,
   type SecurityIssue,
   type SecurityAuditReport,
-} from './smart-user';
+} from './smart-user.js';
 
 // SmartArchive - Implementation pending
 // Note: Exports temporarily removed until implementation is complete
@@ -67,4 +67,4 @@ export {
   type ExecutionRecord,
   type NextRunPrediction,
   type ScheduleValidation,
-} from './smart-cron';
+} from './smart-cron.js';

--- a/src/tools/system-operations/smart-cron.ts
+++ b/src/tools/system-operations/smart-cron.ts
@@ -16,12 +16,12 @@
  * - Compressed schedule analysis (87% reduction)
  */
 
-import { CacheEngine } from '../../core/cache-engine';
-import { TokenCounter } from '../../core/token-counter';
-import { MetricsCollector } from '../../core/metrics';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { TokenCounter } from '../../core/token-counter.js';
+import { MetricsCollector } from '../../core/metrics.js';
 import { exec } from 'child_process';
 import { promisify } from 'util';
-import { generateCacheKey } from '../shared/hash-utils';
+import { generateCacheKey } from '../shared/hash-utils.js';
 import * as crypto from 'crypto';
 
 const execAsync = promisify(exec);

--- a/src/tools/system-operations/smart-process.ts
+++ b/src/tools/system-operations/smart-process.ts
@@ -15,9 +15,9 @@
 import { spawn, ChildProcess } from 'child_process';
 import { promisify } from 'util';
 import { exec } from 'child_process';
-import { CacheEngine } from '../../core/cache-engine';
-import { TokenCounter } from '../../core/token-counter';
-import { MetricsCollector } from '../../core/metrics';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { TokenCounter } from '../../core/token-counter.js';
+import { MetricsCollector } from '../../core/metrics.js';
 
 const execAsync = promisify(exec);
 

--- a/src/tools/system-operations/smart-service.ts
+++ b/src/tools/system-operations/smart-service.ts
@@ -16,9 +16,9 @@
  * - Compressed dependency graphs (88% reduction)
  */
 
-import { CacheEngine } from '../../core/cache-engine';
-import { TokenCounter } from '../../core/token-counter';
-import { MetricsCollector } from '../../core/metrics';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { TokenCounter } from '../../core/token-counter.js';
+import { MetricsCollector } from '../../core/metrics.js';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 import * as crypto from 'crypto';

--- a/src/tools/system-operations/smart-user.ts
+++ b/src/tools/system-operations/smart-user.ts
@@ -16,9 +16,9 @@
  * - Compressed ACL trees (88% reduction)
  */
 
-import { CacheEngine } from '../../core/cache-engine';
-import { TokenCounter } from '../../core/token-counter';
-import { MetricsCollector } from '../../core/metrics';
+import { CacheEngine } from '../../core/cache-engine.js';
+import { TokenCounter } from '../../core/token-counter.js';
+import { MetricsCollector } from '../../core/metrics.js';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 import * as crypto from 'crypto';

--- a/src/utils/cache-helper.ts
+++ b/src/utils/cache-helper.ts
@@ -3,8 +3,8 @@
  * Provides consistent caching interface across all tools
  */
 
-import { CacheEngine } from '../core/cache-engine';
-import { compress, decompress } from '../tools/shared/compression-utils';
+import { CacheEngine } from '../core/cache-engine.js';
+import { compress, decompress } from '../tools/shared/compression-utils.js';
 
 /**
  * Get cached content with automatic decompression


### PR DESCRIPTION
## Summary

Resolves ES module import errors that prevented users from installing and running the token-optimizer MCP server. This fix ensures all relative imports have explicit `.js` file extensions as required by Node.js ES module resolution.

**Root Cause:**
Node.js ES modules require explicit `.js` extensions for relative imports. TypeScript was compiling imports without extensions, causing `ERR_MODULE_NOT_FOUND` errors at runtime.

**Solution:**
- Created `scripts/fix-imports.js` automation script to add `.js` extensions
- Updated 69 source files with 181+ import fixes across all tool categories
- No changes to `tsconfig.json` needed - source files now have proper extensions

## Changes Made

### Files Affected
- ✅ 69 TypeScript source files updated
- ✅ 181+ import statements fixed
- ✅ New automation script: `scripts/fix-imports.js`

### Categories Updated
- Advanced caching tools (12 files)
- API & database tools (13 files)  
- Build systems tools (10 files)
- Code analysis tools (10 files)
- Configuration tools (4 files)
- Dashboard monitoring tools (7 files)
- File operations tools (1 file)
- Intelligence tools (3 files)
- System operations tools (5 files)
- Output formatting tools (2 files)
- Core utilities (2 files)

## Testing Performed

### Build Verification
```bash
npm run clean && npm run build
# ✅ SUCCESS - No TypeScript errors
```

### Runtime Verification
```bash
node dist/server/index.js
# ✅ SUCCESS - No ERR_MODULE_NOT_FOUND errors
```

### MCP Protocol Verification
```bash
echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0.0"}}}' | node dist/server/index.js
# ✅ SUCCESS - Returns proper initialization response
```

### Sample Import Fix
**Before:**
```typescript
import { CacheEngine } from '../../core/cache-engine';
import { TokenCounter } from '../../core/token-counter';
```

**After:**
```typescript
import { CacheEngine } from '../../core/cache-engine.js';
import { TokenCounter } from '../../core/token-counter.js';
```

## Impact

✅ **Users can now install and run the MCP server successfully**
- No more `ERR_MODULE_NOT_FOUND` errors
- All ES module imports resolve correctly
- MCP protocol initialization works as expected
- All 55+ smart tools load properly

## Future Maintenance

The `scripts/fix-imports.js` script can be reused if new files are added without proper `.js` extensions:

```bash
node scripts/fix-imports.js
```

## Related Issues

Fixes installation errors related to ES module resolution in Node.js v18+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)