### PR TITLE
feat: register 5 file-operations tools (smart-edit, smart-glob, smart-grep, smart-read, smart-write)

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -220,6 +220,13 @@ import type { SmartWriteOptions } from '../tools/file-operations/smart-write.js'
 import type { SmartEditOptions } from '../tools/file-operations/smart-edit.js';
 import type { SmartGlobOptions } from '../tools/file-operations/smart-glob.js';
 import type { SmartGrepOptions } from '../tools/file-operations/smart-grep.js';
+// Tool handler argument types
+type SmartReadArgs = { path: string } & SmartReadOptions;
+type SmartWriteArgs = { path: string; content: string } & SmartWriteOptions;
+type SmartEditArgs = { path: string; operations: any[] } & SmartEditOptions;
+type SmartGlobArgs = { pattern: string } & SmartGlobOptions;
+type SmartGrepArgs = { pattern: string } & SmartGrepOptions;
+
 
 // Configuration constants
 const COMPRESSION_CONFIG = {
@@ -1804,8 +1811,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'smart_read': {
-        const { path: filePath, ...options } = args as any;
-        const result = await smartRead.read(filePath, options as SmartReadOptions);
+        const { path: filePath, ...options } = args as unknown as SmartReadArgs;
+        const result = await smartRead.read(filePath, options);
         return {
           content: [
             {
@@ -1817,8 +1824,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'smart_write': {
-        const { path: filePath, content, ...options } = args as any;
-        const result = await smartWrite.write(filePath, content, options as SmartWriteOptions);
+        const { path: filePath, content, ...options } = args as unknown as SmartWriteArgs;
+        const result = await smartWrite.write(filePath, content, options);
         return {
           content: [
             {
@@ -1830,8 +1837,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'smart_edit': {
-        const { path: filePath, operations, ...options } = args as any;
-        const result = await smartEdit.edit(filePath, operations, options as SmartEditOptions);
+        const { path: filePath, operations, ...options } = args as unknown as SmartEditArgs;
+        const result = await smartEdit.edit(filePath, operations, options);
         return {
           content: [
             {
@@ -1843,8 +1850,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'smart_glob': {
-        const { pattern, ...options } = args as any;
-        const result = await smartGlob.glob(pattern, options as SmartGlobOptions);
+        const { pattern, ...options } = args as unknown as SmartGlobArgs;
+        const result = await smartGlob.glob(pattern, options);
         return {
           content: [
             {
@@ -1856,8 +1863,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'smart_grep': {
-        const { pattern, ...options } = args as any;
-        const result = await smartGrep.grep(pattern, options as SmartGrepOptions);
+        const { pattern, ...options } = args as unknown as SmartGrepArgs;
+        const result = await smartGrep.grep(pattern, options);
         return {
           content: [
             {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -217,13 +217,19 @@ import type { SmartStatusOptions } from '../tools/file-operations/smart-status.j
 import type { SmartLogOptions } from '../tools/file-operations/smart-log.js';
 import type { SmartReadOptions } from '../tools/file-operations/smart-read.js';
 import type { SmartWriteOptions } from '../tools/file-operations/smart-write.js';
-import type { SmartEditOptions } from '../tools/file-operations/smart-edit.js';
+import type {
+  SmartEditOptions,
+  EditOperation,
+} from '../tools/file-operations/smart-edit.js';
 import type { SmartGlobOptions } from '../tools/file-operations/smart-glob.js';
 import type { SmartGrepOptions } from '../tools/file-operations/smart-grep.js';
 // Tool handler argument types
 type SmartReadArgs = { path: string } & SmartReadOptions;
 type SmartWriteArgs = { path: string; content: string } & SmartWriteOptions;
-type SmartEditArgs = { path: string; operations: any[] } & SmartEditOptions;
+type SmartEditArgs = {
+  path: string;
+  operations: EditOperation | EditOperation[];
+} & SmartEditOptions;
 type SmartGlobArgs = { pattern: string } & SmartGlobOptions;
 type SmartGrepArgs = { pattern: string } & SmartGrepOptions;
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -227,7 +227,6 @@ type SmartEditArgs = { path: string; operations: any[] } & SmartEditOptions;
 type SmartGlobArgs = { pattern: string } & SmartGlobOptions;
 type SmartGrepArgs = { pattern: string } & SmartGrepOptions;
 
-
 // Configuration constants
 const COMPRESSION_CONFIG = {
   MIN_SIZE_THRESHOLD: 500, // bytes - minimum size before attempting compression
@@ -1824,7 +1823,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'smart_write': {
-        const { path: filePath, content, ...options } = args as unknown as SmartWriteArgs;
+        const {
+          path: filePath,
+          content,
+          ...options
+        } = args as unknown as SmartWriteArgs;
         const result = await smartWrite.write(filePath, content, options);
         return {
           content: [
@@ -1837,7 +1840,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'smart_edit': {
-        const { path: filePath, operations, ...options } = args as unknown as SmartEditArgs;
+        const {
+          path: filePath,
+          operations,
+          ...options
+        } = args as unknown as SmartEditArgs;
         const result = await smartEdit.edit(filePath, operations, options);
         return {
           content: [

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -184,6 +184,26 @@ import {
   getSmartLogTool,
   SMART_LOG_TOOL_DEFINITION,
 } from '../tools/file-operations/smart-log.js';
+import {
+  getSmartReadTool,
+  SMART_READ_TOOL_DEFINITION,
+} from '../tools/file-operations/smart-read.js';
+import {
+  getSmartWriteTool,
+  SMART_WRITE_TOOL_DEFINITION,
+} from '../tools/file-operations/smart-write.js';
+import {
+  getSmartEditTool,
+  SMART_EDIT_TOOL_DEFINITION,
+} from '../tools/file-operations/smart-edit.js';
+import {
+  getSmartGlobTool,
+  SMART_GLOB_TOOL_DEFINITION,
+} from '../tools/file-operations/smart-glob.js';
+import {
+  getSmartGrepTool,
+  SMART_GREP_TOOL_DEFINITION,
+} from '../tools/file-operations/smart-grep.js';
 import { parseSessionLog } from './session-log-parser.js';
 import fs from 'fs';
 import path from 'path';
@@ -195,6 +215,11 @@ import type { SmartBranchOptions } from '../tools/file-operations/smart-branch.j
 import type { SmartMergeOptions } from '../tools/file-operations/smart-merge.js';
 import type { SmartStatusOptions } from '../tools/file-operations/smart-status.js';
 import type { SmartLogOptions } from '../tools/file-operations/smart-log.js';
+import type { SmartReadOptions } from '../tools/file-operations/smart-read.js';
+import type { SmartWriteOptions } from '../tools/file-operations/smart-write.js';
+import type { SmartEditOptions } from '../tools/file-operations/smart-edit.js';
+import type { SmartGlobOptions } from '../tools/file-operations/smart-glob.js';
+import type { SmartGrepOptions } from '../tools/file-operations/smart-grep.js';
 
 // Configuration constants
 const COMPRESSION_CONFIG = {
@@ -274,6 +299,11 @@ const smartBranch = getSmartBranchTool(cache, tokenCounter, metrics);
 const smartMerge = getSmartMergeTool(cache, tokenCounter, metrics);
 const smartStatus = getSmartStatusTool(cache, tokenCounter, metrics);
 const smartLog = getSmartLogTool(cache, tokenCounter, metrics);
+const smartRead = getSmartReadTool(cache, tokenCounter, metrics);
+const smartWrite = getSmartWriteTool(cache, tokenCounter, metrics);
+const smartEdit = getSmartEditTool(cache, tokenCounter, metrics);
+const smartGlob = getSmartGlobTool(cache, tokenCounter, metrics);
+const smartGrep = getSmartGrepTool(cache, tokenCounter, metrics);
 
 // Create MCP server
 const server = new Server(
@@ -539,6 +569,11 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       SMART_MERGE_TOOL_DEFINITION,
       SMART_STATUS_TOOL_DEFINITION,
       SMART_LOG_TOOL_DEFINITION,
+      SMART_READ_TOOL_DEFINITION,
+      SMART_WRITE_TOOL_DEFINITION,
+      SMART_EDIT_TOOL_DEFINITION,
+      SMART_GLOB_TOOL_DEFINITION,
+      SMART_GREP_TOOL_DEFINITION,
     ],
   };
 });
@@ -1758,6 +1793,71 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case 'smart_log': {
         const options = args as SmartLogOptions;
         const result = await smartLog.log(options);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'smart_read': {
+        const { path: filePath, ...options } = args as any;
+        const result = await smartRead.read(filePath, options as SmartReadOptions);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'smart_write': {
+        const { path: filePath, content, ...options } = args as any;
+        const result = await smartWrite.write(filePath, content, options as SmartWriteOptions);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'smart_edit': {
+        const { path: filePath, operations, ...options } = args as any;
+        const result = await smartEdit.edit(filePath, operations, options as SmartEditOptions);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'smart_glob': {
+        const { pattern, ...options } = args as any;
+        const result = await smartGlob.glob(pattern, options as SmartGlobOptions);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'smart_grep': {
+        const { pattern, ...options } = args as any;
+        const result = await smartGrep.grep(pattern, options as SmartGrepOptions);
         return {
           content: [
             {


### PR DESCRIPTION
PR Title: feat: register 5 file-operations tools (smart-edit, smart-glob, smart-grep, smart-read, smart-write)

PR Body:
## Summary
Registers 5 essential file-operations tools in the MCP server:
- **smart-read**: Read files with 80% token reduction through intelligent caching and diff-based updates
- **smart-write**: Write files with 85% token reduction through verification and change tracking
- **smart-edit**: Edit files with 90% token reduction through line-based operations and diff-only output
- **smart-glob**: Search files with glob patterns and 75% token reduction through path-only results
- **smart-grep**: Search file contents with 80% token reduction through match-only output

## Changes Made
1. ✅ Added imports for 5 factory functions and TOOL_DEFINITIONs
2. ✅ Initialized 5 tool instances with (cache, tokenCounter, metrics)
3. ✅ Added 5 TOOL_DEFINITIONs to tools array in ListToolsRequestSchema
4. ✅ Added 5 case handlers in CallToolRequestSchema switch statement
5. ✅ Build passes with no errors

## Tool Descriptions

### smart-read
- Diff-based updates (send only changes)
- Automatic chunking for large files
- Syntax-aware truncation
- Cache integration with git awareness
- 80% token reduction

### smart-write
- Verify before write (skip if content identical)
- Atomic operations (temporary file + rename)
- Automatic formatting (prettier/eslint integration)
- Change tracking (report only changes made)
- 85% token reduction

### smart-edit
- Line-based editing (edit only specific ranges, not full file)
- Return only diffs (show changes, not entire file content)
- Pattern-based replacement (regex/search-replace)
- Multi-edit batching (apply multiple edits in one operation)
- 90% token reduction

### smart-glob
- Path-only results (no file content unless requested)
- Smart pagination (limit results, return counts)
- Cached pattern results (reuse glob results)
- Metadata filtering (filter before returning)
- 75% token reduction

### smart-grep
- Match-only output (line numbers + matched text, not full files)
- Context line control (configurable before/after lines)
- Pattern caching (reuse search results)
- Result pagination (limit matches returned)
- 80% token reduction

## Quality Checks
- ✅ All 5 tools imported correctly
- ✅ All 5 tools initialized with proper dependencies
- ✅ All 5 TOOL_DEFINITIONs in tools array
- ✅ All 5 case handlers in switch
- ✅ Build passes with no errors
- ✅ Commit follows conventional commits (lowercase)

## Test Plan
- [x] Build succeeds with npm run build
- [ ] Verify tools are listed when MCP server starts
- [ ] Test each tool with basic operations
- [ ] Verify token reduction metrics are tracked

---
Branch: feat/register-file-operations-remaining
Base: master
Repository: ooples/token-optimizer-mcp
URL: https://github.com/ooples/token-optimizer-mcp/pull/new/feat/register-file-operations-remaining