### PR TITLE
fix: remove unused preservefirst variable

### DIFF
--- a/src/modules/DeduplicationModule.ts
+++ b/src/modules/DeduplicationModule.ts
@@ -187,7 +187,7 @@ export class DeduplicationModule implements IOptimizationModule {
       .filter((s) => s.trim().length > 0);
     const minLength = this.options?.minSentenceLength ?? 5;
     const caseSensitive = this.options?.caseSensitive ?? true;
-    const preserveFirst = this.options?.preserveFirst ?? true;
+    // Note: preserveFirst option exists but only true is currently implemented
 
     const seen = new Set<string>();
     const result: string[] = [];


### PR DESCRIPTION
## Issue

PR #96 merged with a TypeScript build error that was missed in CI:
```
error TS6133: 'preserveFirst' is declared but its value is never read.
```

## Root Cause

When simplifying the duplicate-handling code to document that `preserveFirst=false` isn't implemented, we removed the code branches that used the variable but left the variable declaration.

## Fix

Removed the unused variable declaration and replaced it with a comment explaining the limitation.

## Testing

- ✅ TypeScript build passes
- ✅ Existing tests pass (deduplication behavior unchanged)

## Related

- Fixes build failure from #96
- Follow-up improvements tracked in #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)