### PR TITLE
fix: correct branch name in install-hooks script from main to master

### DIFF
--- a/install-hooks.ps1
+++ b/install-hooks.ps1
@@ -18,7 +18,7 @@ $CLAUDE_SETTINGS = "$env:USERPROFILE\.claude\settings.json"
 $CLAUDE_STATE = "$env:USERPROFILE\.claude.json"
 $MCP_CONFIG = "$env:APPDATA\Claude\claude_desktop_config.json"
 
-$REPO_URL = "https://raw.githubusercontent.com/ooples/token-optimizer-mcp/main/hooks"
+$REPO_URL = "https://raw.githubusercontent.com/ooples/token-optimizer-mcp/master/hooks"
 
 # ============================================================
 # Helper Functions


### PR DESCRIPTION
## Summary
Fixes the install-hooks.ps1 script to use the correct branch name ( instead of ) when downloading hook files from GitHub.

## Problem
The install-hooks.ps1 script was attempting to download hook files from the  branch, but the repository uses  as the default branch. This caused all GitHub downloads to fail with 404 errors:

```
[ERROR] Failed to download https://raw.githubusercontent.com/ooples/token-optimizer-mcp/main/hooks/dispatcher.ps1: The remote server returned an error: (404) Not Found.
```

The installer would then fall back to copying from local npm package files, which worked but added unnecessary error messages and delays.

## Changes
- Updated `REPO_URL` in install-hooks.ps1 line 21
- Changed from: `https://raw.githubusercontent.com/ooples/token-optimizer-mcp/main/hooks`
- Changed to: `https://raw.githubusercontent.com/ooples/token-optimizer-mcp/master/hooks`

## Verification
Tested all three hook file URLs with `master` branch - all return **200 OK**:
- ✅ `dispatcher.ps1`
- ✅ `handlers/token-optimizer-orchestrator.ps1`
- ✅ `helpers/invoke-mcp.ps1`

## Impact
- ✅ Eliminates 404 errors during installation
- ✅ Reduces installation time by successfully downloading from GitHub
- ✅ Improves user experience with cleaner installation logs
- ✅ No functional changes - fallback mechanism still works if GitHub is unavailable

## Testing
Confirmed the corrected URLs work before making this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)