### PR TITLE
fix: sync package.json version with releases and add git plugin

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -140,6 +140,13 @@
       }
     ],
     [
+      "@semantic-release/git",
+      {
+        "assets": ["package.json", "package-lock.json", "CHANGELOG.md"],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ],
+    [
       "@semantic-release/github",
       {
         "assets": [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "token-optimizer-mcp",
-  "version": "2.12.1",
+  "name": "@ooples/token-optimizer-mcp",
+  "version": "5.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "token-optimizer-mcp",
-      "version": "2.12.1",
+      "name": "@ooples/token-optimizer-mcp",
+      "version": "5.0.1",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.20.0",
@@ -20,6 +21,7 @@
         "tiktoken": "^1.0.22"
       },
       "bin": {
+        "token-optimizer-daemon": "dist/server/daemon.js",
         "token-optimizer-mcp": "dist/server/index.js"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ooples/token-optimizer-mcp",
-  "version": "3.1.0",
+  "version": "5.0.1",
   "mcpName": "io.github.ooples/token-optimizer-mcp",
   "description": "Intelligent context window optimization for Claude Code - store content externally via caching and compression, freeing up your context window for what matters",
   "main": "dist/server/index.js",


### PR DESCRIPTION
## 🔧 Fix: Version Synchronization

This PR fixes the version mismatch between `package.json` and actual releases.

### 📊 Current Problem

| Location | Version | Status |
|----------|---------|--------|
| npm registry | v5.0.1 | ✅ Correct |
| GitHub releases | v5.0.1 | ✅ Correct |
| package.json | 3.1.0 | ❌ Out of sync |

### 🛠️ Changes

#### 1. Added @semantic-release/git Plugin
**File**: `.releaserc.json`

```json
{
  "@semantic-release/git": {
    "assets": ["package.json", "package-lock.json", "CHANGELOG.md"],
    "message": "chore(release): ${nextRelease.version} [skip ci]"
  }
}
```

**Why**: The git plugin commits version updates back to the repository after each release.

**Result**: Future releases will automatically update package.json in the repo.

#### 2. Updated package.json Version
**File**: `package.json`
- **Before**: `"version": "3.1.0"`
- **After**: `"version": "5.0.1"`

**Why**: Sync with actual published version.

#### 3. Updated package-lock.json
**File**: `package-lock.json`
- Updated to reflect new version

---

### 🔍 Root Cause Analysis

The semantic-release configuration was **missing the git plugin**, which is responsible for committing version changes back to the repository.

**What was happening:**
1. ✅ semantic-release created git tags (v5.0.1)
2. ✅ semantic-release published to npm (v5.0.1)
3. ✅ semantic-release created GitHub releases (v5.0.1)
4. ❌ **No commit updating package.json in the repo**

**Flow after this fix:**
```
Merge to master
    ↓
semantic-release analyzes commits
    ↓
Determines version bump (5.0.2)
    ↓
Updates package.json to 5.0.2
    ↓
Commits change with "chore(release): 5.0.2 [skip ci]"
    ↓
Creates git tag v5.0.2
    ↓
Publishes to npm
    ↓
Creates GitHub release
```

---

### ✅ Testing

**Before this PR:**
```bash
$ cat package.json | grep version
"version": "3.1.0"

$ gh release list | head -1
v5.0.1  Latest  v5.0.1  2025-11-02
```
❌ Mismatch!

**After this PR:**
```bash
$ cat package.json | grep version
"version": "5.0.1"

$ gh release list | head -1
v5.0.1  Latest  v5.0.1  2025-11-02
```
✅ Synchronized!

---

### 📝 Notes

- The `[skip ci]` flag prevents infinite loops (release → commit → release → ...)
- The git plugin is **already installed** in devDependencies (`@semantic-release/git: ^10.0.1`)
- Future version bumps will be automatic

---

### 🎯 Impact

- **Developers**: package.json now shows correct version
- **CI/CD**: Releases will commit version changes automatically
- **Users**: No impact (functionality unchanged)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>