### PR TITLE
fix: add missing items schema to array tool parameters (#153)

### DIFF
--- a/src/tools/advanced-caching/cache-warmup.ts
+++ b/src/tools/advanced-caching/cache-warmup.ts
@@ -1573,6 +1573,17 @@ export const CACHE_WARMUP_TOOL_DEFINITION = {
       accessHistory: {
         type: 'array',
         description: 'Access history for pattern-based warmup',
+        items: {
+          type: 'object',
+          properties: {
+            key: { type: 'string' },
+            timestamp: { type: 'number' },
+            accessCount: { type: 'number' },
+            category: { type: 'string' },
+            metadata: { type: 'object', additionalProperties: true },
+          },
+          required: ['key', 'timestamp', 'accessCount'],
+        },
       },
       minAccessCount: {
         type: 'number',

--- a/src/tools/api-database/smart-database.ts
+++ b/src/tools/api-database/smart-database.ts
@@ -1838,6 +1838,9 @@ export const SMART_DATABASE_TOOL_DEFINITION = {
       params: {
         type: 'array',
         description: 'Query parameters for prepared statements',
+        items: {
+          type: ['string', 'number', 'boolean', 'null'],
+        },
       },
       timeout: {
         type: 'number',

--- a/src/tools/intelligence/anomaly-explainer.ts
+++ b/src/tools/intelligence/anomaly-explainer.ts
@@ -1682,6 +1682,15 @@ export const ANOMALYEXPLAINERTOOL = {
       historicalData: {
         type: 'array',
         description: 'Historical metric data for baseline analysis',
+        items: {
+          type: 'object',
+          properties: {
+            timestamp: { type: 'number' },
+            value: { type: 'number' },
+            metadata: { type: 'object', additionalProperties: true },
+          },
+          required: ['timestamp', 'value'],
+        },
       },
       hypothesis: {
         type: 'string',
@@ -1690,6 +1699,16 @@ export const ANOMALYEXPLAINERTOOL = {
       events: {
         type: 'array',
         description: 'Related system events',
+        items: {
+          type: 'object',
+          properties: {
+            timestamp: { type: 'number' },
+            type: { type: 'string' },
+            description: { type: 'string' },
+            severity: { type: 'string' },
+          },
+          required: ['timestamp', 'type', 'description'],
+        },
       },
       useCache: {
         type: 'boolean',

--- a/src/tools/intelligence/knowledge-graph.ts
+++ b/src/tools/intelligence/knowledge-graph.ts
@@ -1836,10 +1836,29 @@ export const KNOWLEDGE_GRAPH_TOOL_DEFINITION = {
       entities: {
         type: 'array',
         description: 'Entities to add to graph (for build-graph)',
+        items: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+            type: { type: 'string' },
+            properties: { type: 'object', additionalProperties: true },
+          },
+          required: ['id', 'type', 'properties'],
+        },
       },
       relations: {
         type: 'array',
         description: 'Relations between entities (for build-graph)',
+        items: {
+          type: 'object',
+          properties: {
+            from: { type: 'string' },
+            to: { type: 'string' },
+            type: { type: 'string' },
+            properties: { type: 'object', additionalProperties: true },
+          },
+          required: ['from', 'to', 'type'],
+        },
       },
       pattern: {
         type: 'object',


### PR DESCRIPTION
## Summary
- Fixes MCP schema validation error that prevented `cache_warmup` (and five sibling tools) from being called: `"array schema missing items"`.
- Audited every `type: 'array'` schema in `src/tools/**` and `src/server/**`; found 6 missing `items` definitions across 4 tool files. All fixed.

## Fixed schemas
| Tool | Parameter | File |
|---|---|---|
| `cache_warmup` | `accessHistory` | `src/tools/advanced-caching/cache-warmup.ts` |
| `smart_database` | `params` | `src/tools/api-database/smart-database.ts` |
| `anomaly_explainer` | `historicalData` | `src/tools/intelligence/anomaly-explainer.ts` |
| `anomaly_explainer` | `events` | `src/tools/intelligence/anomaly-explainer.ts` |
| `knowledge_graph` | `entities` | `src/tools/intelligence/knowledge-graph.ts` |
| `knowledge_graph` | `relations` | `src/tools/intelligence/knowledge-graph.ts` |

Each `items` schema was derived from the existing TypeScript interfaces (e.g., `AccessHistoryEntry`) so runtime validation matches what the tool implementation already accepts.

Closes #153

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] Audit script confirms all 12 `type: 'array'` tool-definition schemas now have `items`
- [ ] MCP client can call `cache_warmup` without the `invalid_function_parameters` error