### PR TITLE
chore(deps): bump transitive ajv from 6.12.6 to 6.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -708,9 +708,9 @@
       }
     },
     "node_modules/@commitlint/config-validator/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3748,9 +3748,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Supersedes #158 and #159. Both dependabot PRs had lockfile conflicts that weren't auto-resolved.

`ajv` is a **transitive dependency** (reached through `@modelcontextprotocol/sdk` and `eslint`), so this is a lockfile-only update produced via `npm update ajv --package-lock-only`.

## Security
Picks up the fix for ajv's `$data` ReDoS exploit in the form of the new `regExp` option — see [ajv-validator/ajv@b552ed6](https://github.com/ajv-validator/ajv/commit/b552ed66191eb338498df3196065c777e3bb71f2).

Closes #158
Closes #159

## Test plan
- [ ] CI: Build, Tests, Lint pass