### PR TITLE
fix: repair broken PowerShell hooks and 5 MCP tool bugs (15 user-reported issues)

### DIFF
--- a/hooks/dispatcher.ps1
+++ b/hooks/dispatcher.ps1
@@ -5,9 +5,13 @@
 [CmdletBinding()]
 param([string]$Phase = "")
 
-$HANDLERS_DIR = "C:\Users\cheat\.claude-global\hooks\handlers"
-$LOG_FILE = "C:\Users\cheat\.claude-global\hooks\logs\dispatcher.log"
-$ORCHESTRATOR = "$HANDLERS_DIR\token-optimizer-orchestrator.ps1"
+# Resolve every path relative to THIS script so the hooks work for any user
+# and any install location. NEVER hardcode a developer profile — that breaks
+# the hooks for everyone but the original dev machine. dispatcher.ps1 lives
+# at the hooks root, so $PSScriptRoot is the hooks root.
+$HANDLERS_DIR = Join-Path $PSScriptRoot "handlers"
+$LOG_FILE = Join-Path $PSScriptRoot "logs\dispatcher.log"
+$ORCHESTRATOR = Join-Path $HANDLERS_DIR "token-optimizer-orchestrator.ps1"
 
 # Load the shared logging helper defensively: a missing/malformed helper
 # must not kill the dispatcher for every hook phase. Fall back to a
@@ -71,17 +75,12 @@ try {
     # ============================================================
     if ($Phase -eq "PreToolUse") {
 
-        # 1. SMART READ - Use smart_read MCP tool for cached file reads (CRITICAL FOR TOKEN SAVINGS!)
-        # This replaces plain Read with intelligent caching, diffing, and truncation
-        # Must run BEFORE user enforcers to ensure caching takes priority
-        if ($toolName -eq "Read") {
-            & powershell -NoProfile -ExecutionPolicy Bypass -File $ORCHESTRATOR -Phase "PreToolUse" -Action "smart-read" -InputJsonFile $tempFile
-            if ($LASTEXITCODE -eq 2) {
-                # smart_read succeeded - blocks plain Read and returns cached/optimized content
-                exit 2
-            }
-            # If smart_read failed, allow plain Read to proceed
-        }
+        # NOTE: smart_read substitution intentionally does NOT run here.
+        # Claude Code's PreToolUse contract can only allow/deny/ask or rewrite
+        # a tool's INPUT (updatedInput) — it CANNOT let a tool run and replace
+        # its OUTPUT. The only supported way to serve cached/compressed content
+        # in place of a plain Read is PostToolUse `updatedToolOutput`, so the
+        # smart_read handling lives in the PostToolUse phase below.
 
         # 2. Context Guard - Check if we're approaching token limit
         & powershell -NoProfile -ExecutionPolicy Bypass -File $ORCHESTRATOR -Phase "PreToolUse" -Action "context-guard" -InputJsonFile $tempFile
@@ -163,6 +162,37 @@ try {
     # ============================================================
     if ($Phase -eq "PostToolUse") {
         $phaseStart = Get-Date
+
+        # 0. SMART READ SUBSTITUTION (Read only)
+        #    Replace the plain Read result with smart_read's cached/diffed/
+        #    optimized content via the supported PostToolUse `updatedToolOutput`
+        #    mechanism. This is the ONLY hook contract that lets us change what
+        #    content actually reaches the model. The orchestrator writes the
+        #    replacement JSON to its stdout and exits 2 as a "substitute" signal.
+        if ($toolName -eq "Read") {
+            $smartReadOutput = & powershell -NoProfile -ExecutionPolicy Bypass -File $ORCHESTRATOR -Phase "PostToolUse" -Action "smart-read" -InputJsonFile $tempFile
+            $smartReadExit = $LASTEXITCODE
+            if ($smartReadExit -eq 2 -and $smartReadOutput) {
+                # Still record the operation for session analytics. Suppress any
+                # stdout from these so it can't corrupt the JSON we relay.
+                & powershell -NoProfile -ExecutionPolicy Bypass -File $ORCHESTRATOR -Phase "PostToolUse" -Action "log-operation" -InputJsonFile $tempFile | Out-Null
+                & powershell -NoProfile -ExecutionPolicy Bypass -File $ORCHESTRATOR -Phase "PostToolUse" -Action "session-track" -InputJsonFile $tempFile | Out-Null
+
+                # Relay the orchestrator's updatedToolOutput JSON verbatim and
+                # exit 0 — PostToolUse only parses stdout JSON on exit 0 (exit 2
+                # would merely surface stderr and cannot substitute output).
+                [Console]::Out.Write(($smartReadOutput -join "`n"))
+                [Console]::Out.Flush()
+
+                if (Test-Path $tempFile) {
+                    Remove-Item -Path $tempFile -Force -ErrorAction SilentlyContinue
+                }
+                Write-Log "[SMART-READ] Substituted Read output via PostToolUse updatedToolOutput"
+                exit 0
+            }
+            # smart_read miss/failure: fall through to normal handling so the
+            # plain Read result is preserved and still logged/optimized.
+        }
 
         # 1. Log ALL tool operations to operations-{sessionId}.csv
         #    This is CRITICAL for session-level optimization

--- a/hooks/handlers/token-optimizer-orchestrator.ps1
+++ b/hooks/handlers/token-optimizer-orchestrator.ps1
@@ -12,14 +12,23 @@ param(
 
 # Dot-source helpers BEFORE any logging — Write-Log must exist before
 # the first use below.
-$HELPERS_DIR = "C:\Users\cheat\.claude-global\hooks\helpers"
-$INVOKE_MCP = "$HELPERS_DIR\invoke-mcp.ps1"
-$LOG_FILE = "C:\Users\cheat\.claude-global\hooks\logs\token-optimizer-orchestrator.log"
-$SESSION_FILE = "C:\Users\cheat\.claude-global\hooks\data\current-session.txt"
-. "$PSScriptRoot\..\helpers\logging.ps1"
-. "$PSScriptRoot\..\helpers\config.ps1"
-. "$PSScriptRoot\..\helpers\gzip.ps1"
-. "$PSScriptRoot\..\helpers\context-delta.ps1"
+#
+# Resolve every path relative to THIS script so the hooks work for any
+# user and any install location. NEVER hardcode a developer profile
+# (e.g. C:\Users\cheat\...) — that breaks the hooks for everyone else.
+# This script lives in <hooks-root>\handlers, so the hooks root is the
+# parent of $PSScriptRoot.
+$HOOKS_ROOT = Split-Path -Parent $PSScriptRoot
+$HELPERS_DIR = Join-Path $HOOKS_ROOT "helpers"
+$INVOKE_MCP = Join-Path $HELPERS_DIR "invoke-mcp.ps1"
+$LOG_FILE = Join-Path $HOOKS_ROOT "logs\token-optimizer-orchestrator.log"
+$OPERATIONS_DIR = Join-Path $HOOKS_ROOT "data"
+# $SESSION_FILE is resolved per-session below, once the hook payload
+# (which carries the real Claude Code session_id) has been read.
+. (Join-Path $HELPERS_DIR "logging.ps1")
+. (Join-Path $HELPERS_DIR "config.ps1")
+. (Join-Path $HELPERS_DIR "gzip.ps1")
+. (Join-Path $HELPERS_DIR "context-delta.ps1")
 
 # DIAGNOSTIC: Log script version/load time to verify latest version is being used
 $SCRIPT_VERSION = Get-Date -Format 'yyyyMMdd.HHmmss'
@@ -35,12 +44,37 @@ if ($InputJsonFile -and (Test-Path $InputJsonFile)) {
         Write-Log "Failed to read InputJsonFile: $($_.Exception.Message)" "ERROR"
     }
 }
-$OPERATIONS_DIR = "C:\Users\cheat\.claude-global\hooks\data"
+# Resolve the session file from the REAL Claude Code session id carried in
+# the hook payload (field: session_id). Keying state per-session stops
+# concurrent/sequential Claude Code sessions from sharing one counter file,
+# and lets get_session_stats / transcript analytics match on the same id.
+# Falls back to a shared default only when the payload carries no session id.
+$SessionId = $null
+if ($InputJson) {
+    try {
+        $SessionId = ($InputJson | ConvertFrom-Json).session_id
+    } catch {
+        $SessionId = $null
+    }
+}
+if ($SessionId) {
+    # Strip anything that isn't filename-safe.
+    $safeSessionId = ($SessionId -replace '[^A-Za-z0-9._-]', '_')
+    $SESSION_FILE = Join-Path $OPERATIONS_DIR "session-$safeSessionId.txt"
+} else {
+    $SESSION_FILE = Join-Path $OPERATIONS_DIR "current-session.txt"
+}
+# Ensure the data directory exists before any session read/write.
+if (-not (Test-Path $OPERATIONS_DIR)) {
+    New-Item -ItemType Directory -Path $OPERATIONS_DIR -Force | Out-Null
+}
 
-# PERFORMANCE FIX: Prefer local dev path if not already set
+# PERFORMANCE FIX: Prefer local dev path if not already set.
+# NOTE: $HOME is a read-only PowerShell automatic variable — assigning to it
+# throws "Cannot overwrite variable HOME". Use a distinct local name.
 if (-not $env:TOKEN_OPTIMIZER_DEV_PATH) {
-  $home = $env:USERPROFILE; if (-not $home) { $home = (Get-Item "~").FullName }
-  $env:TOKEN_OPTIMIZER_DEV_PATH = (Join-Path $home "source\repos\token-optimizer-mcp")
+  $profileHome = $env:USERPROFILE; if (-not $profileHome) { $profileHome = (Get-Item "~").FullName }
+  $env:TOKEN_OPTIMIZER_DEV_PATH = (Join-Path $profileHome "source\repos\token-optimizer-mcp")
 }
 
 # PERFORMANCE OPTIMIZATION: In-memory session state (50-70ms -> <10ms)
@@ -218,7 +252,11 @@ if (-not ('TokenCounter' -as [type])) {
 
     # Primary method: try API first, fall back to estimation
     [int] CountTokens([string]$text, [string]$contentType) {
-        # Check cache first (using content hash as key with proper disposal)
+        # Check cache first (using content hash as key with proper disposal).
+        # Initialize $textHash before the try so PowerShell's class definite-
+        # assignment analysis sees it assigned on every path (otherwise the
+        # whole file fails to parse: "Variable is not assigned in the method").
+        $textHash = ""
         $sha256 = [System.Security.Cryptography.SHA256]::Create()
         try {
             $textHash = [System.BitConverter]::ToString(
@@ -318,6 +356,11 @@ if (-not ('TokenCounter' -as [type])) {
                 return $baseRatio
             }
         }
+        # Unreachable (the switch has a default), but PowerShell's class method
+        # analysis does not treat a switch as exhaustive, so without a trailing
+        # return the whole file fails to parse: "Not all code path returns
+        # value within method".
+        return $baseRatio
     }
 
     # Content type detection based on file extension or tool name
@@ -329,6 +372,8 @@ if (-not ('TokenCounter' -as [type])) {
             '^(Read|Grep|Bash)$' { return "code" }
             default { return "text" }
         }
+        # Guaranteed return so the class parses (see EstimateTokens above).
+        return "text"
     }
 
     # Get cache statistics
@@ -550,8 +595,12 @@ function Initialize-Session {
     $session = Get-SessionInfo
 
     if (-not $session) {
-        # If file doesn't exist or is empty/corrupt, create a new session
-        $sessionId = [guid]::NewGuid().ToString()
+        # If file doesn't exist or is empty/corrupt, create a new session.
+        # Prefer the REAL Claude Code session id (parsed from the hook payload
+        # into $script:SessionId) so operations-<sessionId>.csv and
+        # get_session_stats line up with the actual session. Only mint a
+        # random GUID when the payload carried no session id.
+        $sessionId = if ($script:SessionId) { $script:SessionId } else { [guid]::NewGuid().ToString() }
         $sessionStart = Get-Date -Format "yyyyMMdd-HHmmss"
 
         # PHASE 4 FIX: Enhanced stats tracking
@@ -717,7 +766,7 @@ function Handle-OptimizeSession {
             min_token_threshold = 30
         }
         $argsJson = $mcpArgs | ConvertTo-Json -Compress
-        $resultJson = & "$HELPERS_DIR\invoke-mcp.ps1" -Tool "mcp__token-optimizer__optimize_session" -ArgumentsJson $argsJson
+        $resultJson = & "$HELPERS_DIR\invoke-mcp.ps1" -Tool "optimize_session" -ArgumentsJson $argsJson
         $result = if ($resultJson) { $resultJson | ConvertFrom-Json } else { $null }
 
         if ($result) {
@@ -752,7 +801,7 @@ function Handle-ContextGuard {
                 min_token_threshold = 30
             }
             $argsJson = $mcpArgs | ConvertTo-Json -Compress
-            $resultJson = & "$HELPERS_DIR\invoke-mcp.ps1" -Tool "mcp__token-optimizer__optimize_session" -ArgumentsJson $argsJson
+            $resultJson = & "$HELPERS_DIR\invoke-mcp.ps1" -Tool "optimize_session" -ArgumentsJson $argsJson
             $result = if ($resultJson) { $resultJson | ConvertFrom-Json } else { $null }
 
             if ($result) {
@@ -788,7 +837,7 @@ function Handle-ContextGuard {
                     min_token_threshold = 30
                 }
                 $argsJson = $mcpArgs | ConvertTo-Json -Compress
-                $resultJson = & "$HELPERS_DIR\invoke-mcp.ps1" -Tool "mcp__token-optimizer__optimize_session" -ArgumentsJson $argsJson
+                $resultJson = & "$HELPERS_DIR\invoke-mcp.ps1" -Tool "optimize_session" -ArgumentsJson $argsJson
                 $result = if ($resultJson) { $resultJson | ConvertFrom-Json } else { $null }
 
                 if ($result) {
@@ -822,7 +871,7 @@ function Handle-PeriodicOptimize {
             min_token_threshold = 30
         }
         $argsJson = $mcpArgs | ConvertTo-Json -Compress
-        $resultJson = & "$HELPERS_DIR\invoke-mcp.ps1" -Tool "mcp__token-optimizer__optimize_session" -ArgumentsJson $argsJson
+        $resultJson = & "$HELPERS_DIR\invoke-mcp.ps1" -Tool "optimize_session" -ArgumentsJson $argsJson
         $result = if ($resultJson) { $resultJson | ConvertFrom-Json } else { $null }
 
         if ($result) {
@@ -849,7 +898,7 @@ function Handle-CacheWarmup {
             maxConcurrency = 5
         }
         $argsJson = $mcpArgs | ConvertTo-Json -Compress
-        $resultJson = & "$HELPERS_DIR\invoke-mcp.ps1" -Tool "mcp__token-optimizer__cache_warmup" -ArgumentsJson $argsJson
+        $resultJson = & "$HELPERS_DIR\invoke-mcp.ps1" -Tool "cache_warmup" -ArgumentsJson $argsJson
         $result = if ($resultJson) { $resultJson | ConvertFrom-Json } else { $null }
 
         if ($result) {
@@ -876,7 +925,7 @@ function Handle-SessionReport {
             sessionId = $session.sessionId
         }
         $argsJson = $mcpArgs | ConvertTo-Json -Compress
-        $statsJson = & "$HELPERS_DIR\invoke-mcp.ps1" -Tool "mcp__token-optimizer__get_session_stats" -ArgumentsJson $argsJson
+        $statsJson = & "$HELPERS_DIR\invoke-mcp.ps1" -Tool "get_session_stats" -ArgumentsJson $argsJson
         $stats = if ($statsJson) { $statsJson | ConvertFrom-Json } else { $null }
 
         if ($stats) {
@@ -884,11 +933,11 @@ function Handle-SessionReport {
 
             # Generate project-level analysis
             $mcpArgs = @{
-                projectPath = "C:\Users\cheat\.claude-global\hooks"
+                projectPath = $HOOKS_ROOT
                 costPerMillionTokens = 30
             }
             $argsJson = $mcpArgs | ConvertTo-Json -Compress
-            $analysisJson = & "$HELPERS_DIR\invoke-mcp.ps1" -Tool "mcp__token-optimizer__analyze_project_tokens" -ArgumentsJson $argsJson
+            $analysisJson = & "$HELPERS_DIR\invoke-mcp.ps1" -Tool "analyze_project_tokens" -ArgumentsJson $argsJson
             $analysis = if ($analysisJson) { $analysisJson | ConvertFrom-Json } else { $null }
 
             if ($analysis) {
@@ -2248,9 +2297,13 @@ function Handle-SmartRead {
 
             Write-Log "$fromCache - ${isDiff}: $filePath ($tokens tokens, saved $tokensSaved)" "INFO"
 
-            # FIX: Update session tokens with the tokens from smart_read
+            # FIX: Update session tokens with the tokens from smart_read.
+            # Discard the returned session object ($null = ...) so it does not
+            # leak into this function's pipeline output — the caller captures
+            # our return value ($code = Handle-SmartRead ...) to read the exit
+            # signal, and a stray object there would corrupt that check.
             if ($tokens -ne "unknown") {
-                Update-SessionOperation -TokensDelta $tokens
+                $null = Update-SessionOperation -TokensDelta $tokens
                 Write-Log "Updated session totalTokens by $tokens" "DEBUG"
             }
 
@@ -2276,24 +2329,39 @@ function Handle-SmartRead {
                 Write-Log "context_delta update skipped: $($_.Exception.Message)" 'DEBUG'
             }
 
-            # Return smart_read result and block plain Read
-            $blockResponse = @{
-                continue = $false
-                stopReason = "smart_read success"
+            # Substitute the Read's result with smart_read's optimized content
+            # using the PostToolUse `updatedToolOutput` contract. PreToolUse
+            # CANNOT replace a tool's output — only PostToolUse can — so this
+            # runs in the PostToolUse phase and hands Claude Code the smaller
+            # (cached / diffed / truncated) text in place of the raw file.
+            $optimizedText = if ($result.content) {
+                ($result.content | ForEach-Object { $_.text }) -join "`n"
+            } else {
+                $null
+            }
+
+            if (-not $optimizedText) {
+                Write-Log "smart_read produced empty content for $filePath - falling back to plain Read" "WARN"
+                return 0
+            }
+
+            $substituteResponse = @{
                 hookSpecificOutput = @{
-                    hookEventName = "PreToolUse"
-                    smartRead = $true
-                    filePath = $filePath
-                    content = $result.content
-                    metadata = $result.metadata
+                    hookEventName = "PostToolUse"
+                    # updatedToolOutput REPLACES the tool result returned to Claude.
+                    updatedToolOutput = $optimizedText
                 }
             } | ConvertTo-Json -Depth 10 -Compress
 
-            Write-Output $blockResponse
-            # PHASE 1 FIX: Flush output before exit to prevent freezing
+            # #6: write straight to the console stream, NOT Write-Output. When
+            # the dispatch site captures this function's value
+            # (`$code = Handle-SmartRead ...`), Write-Output would be swallowed
+            # into that variable and never reach stdout. [Console]::Out bypasses
+            # the pipeline so the JSON is emitted regardless of how we're called.
+            [Console]::Out.Write($substituteResponse)
             [Console]::Out.Flush()
             [Console]::Error.Flush()
-            return 2  # BUGFIX: Return instead of exit to avoid terminating dispatcher
+            return 2  # Signal to the caller: a replacement result was emitted.
 
         } else {
             # FAILED - Allow plain Read to proceed
@@ -2337,16 +2405,29 @@ function Cleanup-Session {
 # Main execution - Only run if script is executed directly (not dot-sourced)
 # When dot-sourced by dispatcher.ps1, this block is skipped and only functions are loaded
 if ($MyInvocation.InvocationName -ne '.') {
-    # Initialize session at the very start of the script execution
-    # This loads the latest state from file into $script:CurrentSession
-    Initialize-Session
+    # Initialize session at the very start of the script execution.
+    # This loads the latest state from file into $script:CurrentSession.
+    # Discard the returned session object ($null = ...) — otherwise it is
+    # emitted to stdout and would corrupt the JSON we relay for the
+    # PostToolUse smart-read `updatedToolOutput` substitution.
+    $null = Initialize-Session
 
     try {
         Write-Log "Phase: $Phase, Action: $Action" "INFO"
 
         switch ($Action) {
             "smart-read" {
-                Handle-SmartRead -InputJson $InputJson
+                # #5: capture the return and convert it into a REAL process exit
+                # code. The old code did `return 2` from the function but the
+                # switch always fell through to `exit 0`, so the dispatcher's
+                # `$LASTEXITCODE -eq 2` check never fired and substitution never
+                # engaged. Now exit 2 propagates to the dispatcher as the signal
+                # that a replacement tool result was written to stdout.
+                $smartReadCode = Handle-SmartRead -InputJson $InputJson
+                if ($smartReadCode -eq 2) {
+                    [Console]::Out.Flush()
+                    exit 2
+                }
             }
             "context-guard" {
                 Handle-ContextGuard -InputJson $InputJson
@@ -2384,7 +2465,7 @@ if ($MyInvocation.InvocationName -ne '.') {
                         Remove-Item -Path $InputJsonFile -Force -ErrorAction Stop
                         Write-Log "BACKGROUND: Cleaned up temp file after optimization: $InputJsonFile" "DEBUG"
                     } catch {
-                        Write-Log "BACKGROUND: Failed to cleanup temp file $InputJsonFile: $($_.Exception.Message)" "WARN"
+                        Write-Log "BACKGROUND: Failed to cleanup temp file ${InputJsonFile}: $($_.Exception.Message)" "WARN"
                     }
                 }
             }

--- a/hooks/helpers/invoke-mcp.ps1
+++ b/hooks/helpers/invoke-mcp.ps1
@@ -169,21 +169,55 @@ function Invoke-MCPViaDaemon {
 function Invoke-MCPViaNpx {
     param(
         [string]$Tool,
-        $ToolArguments
+        $ToolArguments,
+        [int]$TimeoutMs = 20000
     )
 
+    # token-optimizer-mcp is a LONG-RUNNING stdio MCP server. The old fallback
+    # piped a single bare tools/call into `npx ... token-optimizer-mcp` with no
+    # MCP initialize handshake, never closed stdin, and had no timeout — so the
+    # server sat waiting for more stdin and NEVER exited. That hung every hook
+    # (i.e. every user turn) forever and left orphaned node/npx processes.
+    #
+    # This version:
+    #   1. Sends the full stdio lifecycle: initialize -> notifications/initialized
+    #      -> tools/call, one JSON-RPC message per line.
+    #   2. CLOSES stdin (EOF) so the server's stdio transport shuts down and the
+    #      process exits on its own.
+    #   3. Enforces a hard timeout and force-kills the whole process tree
+    #      (cmd -> npx -> node) via taskkill /T if it ever overruns.
+    $proc = $null
     try {
         Write-Log "Invoking MCP via npx (fallback): $Tool" "DEBUG"
 
-        # Ensure ToolArguments is a proper object
         if ($null -eq $ToolArguments) {
             $ToolArguments = @{}
         }
 
-        # Build MCP protocol request
-        $request = @{
+        if (-not (Get-Command npx -ErrorAction SilentlyContinue)) {
+            Write-Log "npx not found on PATH; cannot use npx fallback" "ERROR"
+            return $null
+        }
+
+        $initReq = @{
             jsonrpc = "2.0"
-            id = [guid]::NewGuid().ToString()
+            id = 1
+            method = "initialize"
+            params = @{
+                protocolVersion = "2024-11-05"
+                capabilities = @{}
+                clientInfo = @{ name = "token-optimizer-hooks"; version = "1.0.0" }
+            }
+        } | ConvertTo-Json -Depth 10 -Compress
+
+        $initializedNote = @{
+            jsonrpc = "2.0"
+            method = "notifications/initialized"
+        } | ConvertTo-Json -Compress
+
+        $callReq = @{
+            jsonrpc = "2.0"
+            id = 2
             method = "tools/call"
             params = @{
                 name = $Tool
@@ -191,34 +225,79 @@ function Invoke-MCPViaNpx {
             }
         } | ConvertTo-Json -Depth 10 -Compress
 
-        Write-Log "npx request: $request" "DEBUG"
+        $stdinPayload = "$initReq`n$initializedNote`n$callReq`n"
+        Write-Log "npx tools/call request: $callReq" "DEBUG"
 
-        # Invoke via npx (fallback method)
         $env:TOKEN_OPTIMIZER_CACHE_DIR = "$env:USERPROFILE\.token-optimizer-cache"
 
-        $result = $request | cmd /c npx -y token-optimizer-mcp@latest 2>&1
+        # Launch through a real Process we control so we can time it out and
+        # kill the tree. npx is a .cmd shim on Windows, so go via cmd.exe.
+        $psi = New-Object System.Diagnostics.ProcessStartInfo
+        $psi.FileName = "cmd.exe"
+        $psi.Arguments = "/c npx -y token-optimizer-mcp@latest"
+        $psi.RedirectStandardInput = $true
+        $psi.RedirectStandardOutput = $true
+        $psi.RedirectStandardError = $true
+        $psi.UseShellExecute = $false
+        $psi.CreateNoWindow = $true
 
-        if ($LASTEXITCODE -ne 0) {
-            Write-Log "npx call failed with exit code $LASTEXITCODE" "ERROR"
-            Write-Log "Output: $result" "ERROR"
+        $proc = [System.Diagnostics.Process]::Start($psi)
+
+        # Drain stdout/stderr asynchronously so a full pipe buffer can't
+        # deadlock the child while we wait.
+        $stdoutTask = $proc.StandardOutput.ReadToEndAsync()
+        $stderrTask = $proc.StandardError.ReadToEndAsync()
+
+        # Send the lifecycle and CLOSE stdin — this is what lets the server exit.
+        $proc.StandardInput.Write($stdinPayload)
+        $proc.StandardInput.Close()
+
+        if (-not $proc.WaitForExit($TimeoutMs)) {
+            Write-Log "npx MCP call timed out after ${TimeoutMs}ms; killing process tree $($proc.Id)" "ERROR"
+            # PS 5.1 / .NET Framework has no Process.Kill(bool) tree overload,
+            # so use taskkill /T to take out cmd -> npx -> node together.
+            try { & taskkill /PID $proc.Id /T /F 2>$null | Out-Null } catch {}
             return $null
         }
 
-        Write-Log "npx result: $result" "DEBUG"
+        $stdout = $stdoutTask.GetAwaiter().GetResult()
+        $stderr = $stderrTask.GetAwaiter().GetResult()
 
-        # Parse JSON response
-        $response = $result | ConvertFrom-Json
-
-        if ($response.error) {
-            Write-Log "MCP error: $($response.error.message)" "ERROR"
-            return $null
+        if ($proc.ExitCode -ne 0) {
+            Write-Log "npx exited with code $($proc.ExitCode): $stderr" "ERROR"
         }
 
-        return $response.result
+        # The server emits one JSON-RPC message per line. Return the result for
+        # our tools/call (id = 2); ignore the initialize response (id = 1).
+        foreach ($line in ($stdout -split "`n")) {
+            $trimmed = $line.Trim()
+            if (-not $trimmed.StartsWith("{")) { continue }
+            try {
+                $obj = $trimmed | ConvertFrom-Json
+            } catch {
+                continue
+            }
+            if ($obj.id -eq 2) {
+                if ($obj.error) {
+                    Write-Log "MCP error: $($obj.error.message)" "ERROR"
+                    return $null
+                }
+                return $obj.result
+            }
+        }
+
+        Write-Log "npx fallback returned no tools/call response" "WARN"
+        return $null
 
     } catch {
         Write-Log "npx invocation failed: $($_.Exception.Message)" "ERROR"
         return $null
+    } finally {
+        # Never leave an orphaned process behind, even on early return/throw.
+        if ($proc -and -not $proc.HasExited) {
+            try { & taskkill /PID $proc.Id /T /F 2>$null | Out-Null } catch {}
+        }
+        if ($proc) { $proc.Dispose() }
     }
 }
 

--- a/hooks/helpers/invoke-token-optimizer.ps1
+++ b/hooks/helpers/invoke-token-optimizer.ps1
@@ -10,9 +10,16 @@ param(
     [hashtable]$Arguments
 )
 
-$LOG_FILE = "C:\Users\cheat\.claude-global\hooks\logs\token-optimizer-calls.log"
+# Resolve paths relative to this script — never hardcode a developer profile.
+# This script lives in <hooks-root>\helpers.
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
-$repoRoot = Split-Path -Parent (Split-Path -Parent $scriptDir)
+$hooksRoot = Split-Path -Parent $scriptDir
+$repoRoot = Split-Path -Parent $hooksRoot
+$logDir = Join-Path $hooksRoot "logs"
+if (-not (Test-Path $logDir)) {
+    New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+}
+$LOG_FILE = Join-Path $logDir "token-optimizer-calls.log"
 $CLI_WRAPPER = Join-Path $repoRoot "cli-wrapper.mjs"
 
 function Write-Log {

--- a/install-hooks.ps1
+++ b/install-hooks.ps1
@@ -107,11 +107,20 @@ function Install-HooksFiles {
         return
     }
 
-    # Download hooks files
+    # Download hooks files.
+    # IMPORTANT: the orchestrator dot-sources logging.ps1, config.ps1, gzip.ps1
+    # and context-delta.ps1 at startup, and both the orchestrator and
+    # context-delta.ps1 call invoke-mcp.ps1 at runtime. If ANY of these is
+    # missing, every hook invocation dies with "Write-Log is not recognized"
+    # (etc.), so ALL of them must be downloaded — not just the dispatcher trio.
     $files = @(
         @{ Source = "$REPO_URL/dispatcher.ps1"; Dest = "$HOOKS_DIR\dispatcher.ps1" },
         @{ Source = "$REPO_URL/handlers/token-optimizer-orchestrator.ps1"; Dest = "$HOOKS_DIR\handlers\token-optimizer-orchestrator.ps1" },
-        @{ Source = "$REPO_URL/helpers/invoke-mcp.ps1"; Dest = "$HOOKS_DIR\helpers\invoke-mcp.ps1" }
+        @{ Source = "$REPO_URL/helpers/invoke-mcp.ps1"; Dest = "$HOOKS_DIR\helpers\invoke-mcp.ps1" },
+        @{ Source = "$REPO_URL/helpers/logging.ps1"; Dest = "$HOOKS_DIR\helpers\logging.ps1" },
+        @{ Source = "$REPO_URL/helpers/config.ps1"; Dest = "$HOOKS_DIR\helpers\config.ps1" },
+        @{ Source = "$REPO_URL/helpers/gzip.ps1"; Dest = "$HOOKS_DIR\helpers\gzip.ps1" },
+        @{ Source = "$REPO_URL/helpers/context-delta.ps1"; Dest = "$HOOKS_DIR\helpers\context-delta.ps1" }
     )
 
     foreach ($file in $files) {
@@ -159,8 +168,14 @@ function Configure-ClaudeSettings {
         @{}
     }
 
-    # Add hooks configuration
-    $hookCommand = "powershell.exe -File $HOOKS_DIR\dispatcher.ps1 -Phase"
+    # Add hooks configuration.
+    # The command must be shell-safe: Claude Code may run hook commands through
+    # bash (e.g. when Git Bash is on PATH), where an UNQUOTED Windows path has
+    # its backslashes silently stripped, corrupting the path. So quote the
+    # dispatcher path. Also pass -NoProfile (don't load the user's PS profile)
+    # and -ExecutionPolicy Bypass (so the hook runs regardless of local policy).
+    $dispatcherPath = Join-Path $HOOKS_DIR "dispatcher.ps1"
+    $hookCommand = "powershell.exe -NoProfile -ExecutionPolicy Bypass -File `"$dispatcherPath`" -Phase"
 
     $settings.hooks = @{
         PreToolUse = @(
@@ -408,11 +423,16 @@ function Test-Installation {
 
     $issues = @()
 
-    # Check hooks files exist
+    # Check hooks files exist (including every helper the orchestrator
+    # dot-sources — a missing helper breaks every hook invocation).
     $requiredFiles = @(
         "$HOOKS_DIR\dispatcher.ps1",
         "$HOOKS_DIR\handlers\token-optimizer-orchestrator.ps1",
-        "$HOOKS_DIR\helpers\invoke-mcp.ps1"
+        "$HOOKS_DIR\helpers\invoke-mcp.ps1",
+        "$HOOKS_DIR\helpers\logging.ps1",
+        "$HOOKS_DIR\helpers\config.ps1",
+        "$HOOKS_DIR\helpers\gzip.ps1",
+        "$HOOKS_DIR\helpers\context-delta.ps1"
     )
 
     foreach ($file in $requiredFiles) {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -520,7 +520,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       {
         name: 'compress_text',
         description:
-          'Compress text using Brotli compression. Returns compressed text as base64 string.',
+          'Compress text using Brotli, returned as a base64 string. Intended for AT-REST STORAGE/caching (reduces bytes ~50%). NOTE: base64 tokenizes poorly, so the output usually has MORE LLM tokens than the input — do NOT feed the result into a model context expecting savings. The response includes originalTokens/compressedTokens and a warning when the output would increase tokens.',
         inputSchema: {
           type: 'object',
           properties: {
@@ -973,11 +973,35 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const { text, quality } = args as { text: string; quality?: number };
         const result = compression.compressToBase64(text, { quality });
 
+        // Brotli+base64 reduces BYTES (~50%) but base64 tokenizes poorly, so
+        // the output usually has MORE LLM tokens than the input. Surface both
+        // token counts and a warning so callers don't feed the result back
+        // into a model context expecting savings — this tool is for at-rest
+        // storage, not for shrinking context.
+        const originalTokens = tokenCounter.count(text).tokens;
+        const compressedTokens = tokenCounter.count(result.compressed).tokens;
+        const increasesTokens = compressedTokens >= originalTokens;
+
         return {
           content: [
             {
               type: 'text',
-              text: JSON.stringify(result, null, 2),
+              text: JSON.stringify(
+                {
+                  ...result,
+                  originalTokens,
+                  compressedTokens,
+                  increasesTokens,
+                  ...(increasesTokens
+                    ? {
+                        warning:
+                          'Base64 output has MORE LLM tokens than the input. This tool reduces BYTES for at-rest storage/caching; do NOT inject the result into a model context expecting token savings (use optimize_text with a cache key for that).',
+                      }
+                    : {}),
+                },
+                null,
+                2
+              ),
             },
           ],
         };

--- a/src/tools/build-systems/smart-build.ts
+++ b/src/tools/build-systems/smart-build.ts
@@ -134,6 +134,13 @@ export class SmartBuild {
    * Run build with smart caching and output reduction
    */
   async run(options: SmartBuildOptions = {}): Promise<SmartBuildOutput> {
+    // Honor a per-call projectRoot. The MCP server constructs this tool ONCE
+    // as a singleton (with the server's own cwd), so without this the
+    // projectRoot argument was silently ignored and the build ran in the
+    // wrong directory — reporting success:false with 0 files on a clean build.
+    if (options.projectRoot) {
+      this.projectRoot = options.projectRoot;
+    }
     const {
       force = false,
       watch = false,
@@ -211,7 +218,9 @@ export class SmartBuild {
       // tsconfig path) cannot be reinterpreted by a shell. On Windows npx is a
       // .cmd shim that must be named explicitly when not using a shell.
       const npx = process.platform === 'win32' ? 'npx.cmd' : 'npx';
-      const tsc = spawn(npx, ['tsc', ...args], {
+      // --no-install: use only a locally/globally installed tsc rather than
+      // letting npx silently download typescript from the registry.
+      const tsc = spawn(npx, ['--no-install', 'tsc', ...args], {
         cwd: this.projectRoot,
         shell: false,
         windowsHide: true,

--- a/src/tools/build-systems/smart-lint.ts
+++ b/src/tools/build-systems/smart-lint.ts
@@ -168,6 +168,13 @@ export class SmartLint {
    * Run lint with smart caching and output reduction
    */
   async run(options: SmartLintOptions = {}): Promise<SmartLintOutput> {
+    // Honor a per-call projectRoot. The MCP server constructs this tool ONCE
+    // as a singleton (with the server's own cwd), so without this the
+    // projectRoot argument was silently ignored and eslint ran in the wrong
+    // directory (where it isn't installed, triggering an npx auto-download).
+    if (options.projectRoot) {
+      this.projectRoot = options.projectRoot;
+    }
     const {
       files = 'src',
       force = false,
@@ -222,7 +229,11 @@ export class SmartLint {
       // SECURITY: argv mode (shell:false) so caller-controlled file paths are
       // passed verbatim to eslint and cannot be reinterpreted by a shell.
       const npx = process.platform === 'win32' ? 'npx.cmd' : 'npx';
-      const eslint = spawn(npx, ['eslint', ...args], {
+      // --no-install: use only a locally/globally installed eslint. Without it,
+      // npx SILENTLY DOWNLOADS eslint from the registry when it isn't found —
+      // an unexpected network install the user never asked for. Now it fails
+      // cleanly instead, and the caller can install eslint deliberately.
+      const eslint = spawn(npx, ['--no-install', 'eslint', ...args], {
         cwd: this.projectRoot,
         shell: false,
         windowsHide: true,

--- a/src/tools/build-systems/smart-test.ts
+++ b/src/tools/build-systems/smart-test.ts
@@ -149,6 +149,13 @@ export class SmartTest {
    * Run tests with smart caching and output reduction
    */
   async run(options: SmartTestOptions = {}): Promise<SmartTestOutput> {
+    // Honor a per-call projectRoot. The MCP server constructs this tool ONCE
+    // as a singleton (with the server's own cwd), so without this the
+    // projectRoot argument was silently ignored and npm ran in an unrelated
+    // directory — failing with ENOENT instead of running the project's tests.
+    if (options.projectRoot) {
+      this.projectRoot = options.projectRoot;
+    }
     const {
       pattern,
       onlyChanged = false,

--- a/src/tools/build-systems/smart-typecheck.ts
+++ b/src/tools/build-systems/smart-typecheck.ts
@@ -129,6 +129,13 @@ export class SmartTypeCheck {
   async run(
     options: SmartTypeCheckOptions = {}
   ): Promise<SmartTypeCheckOutput> {
+    // Honor a per-call projectRoot. The MCP server constructs this tool ONCE
+    // as a singleton (with the server's own cwd), so without this the
+    // projectRoot argument was silently ignored and tsc ran in the wrong
+    // directory — reporting success:false with 0 files on a clean project.
+    if (options.projectRoot) {
+      this.projectRoot = options.projectRoot;
+    }
     const {
       force = false,
       watch = false,
@@ -191,7 +198,9 @@ export class SmartTypeCheck {
       // SECURITY: argv mode (shell:false) so caller-controlled args are passed
       // verbatim and cannot be reinterpreted by a shell.
       const npx = process.platform === 'win32' ? 'npx.cmd' : 'npx';
-      const tsc = spawn(npx, ['tsc', ...args], {
+      // --no-install: use only a locally/globally installed tsc rather than
+      // letting npx silently download typescript from the registry.
+      const tsc = spawn(npx, ['--no-install', 'tsc', ...args], {
         cwd: this.projectRoot,
         shell: false,
         windowsHide: true,

--- a/src/tools/file-operations/smart-edit.ts
+++ b/src/tools/file-operations/smart-edit.ts
@@ -120,6 +120,16 @@ export class SmartEditTool {
       const originalLines = originalContent.split('\n');
       const originalTokens = this.tokenCounter.count(originalContent).tokens;
 
+      // Small-file guard: for tiny files the unified-diff + metadata payload
+      // costs MORE tokens than it saves, making smart_edit net-negative (a
+      // 6-line edit reported tokensSaved: -130). Mirror the compression
+      // MIN_SIZE_THRESHOLD (500 bytes): below it, don't return the diff so the
+      // response stays minimal. The edit itself is still applied normally.
+      const SMALL_FILE_BYTES = 500;
+      const isSmallFile =
+        Buffer.byteLength(originalContent, opts.encoding) < SMALL_FILE_BYTES;
+      const effectiveReturnDiff = opts.returnDiff && !isSmallFile;
+
       // Normalize operations to array
       const ops = Array.isArray(operations) ? operations : [operations];
 
@@ -172,17 +182,19 @@ export class SmartEditTool {
         filePath,
         opts.contextLines
       );
-      const diffTokens = opts.returnDiff
+      const diffTokens = effectiveReturnDiff
         ? this.tokenCounter.count(diff.unifiedDiff).tokens
         : this.tokenCounter.count(editedContent).tokens;
 
       // If dry run, return preview without applying
       if (opts.dryRun) {
         const duration = Date.now() - startTime;
-        const tokensSaved =
+        const tokensSaved = Math.max(
+          0,
           originalTokens +
-          this.tokenCounter.count(editedContent).tokens -
-          diffTokens;
+            this.tokenCounter.count(editedContent).tokens -
+            diffTokens
+        );
 
         this.metrics.record({
           operation: 'smart_edit',
@@ -212,7 +224,7 @@ export class SmartEditTool {
             verified: opts.verifyBeforeApply,
             wasBackedUp: false,
           },
-          diff: opts.returnDiff ? diff : undefined,
+          diff: effectiveReturnDiff ? diff : undefined,
           preview: editedContent,
         };
       }
@@ -235,7 +247,8 @@ export class SmartEditTool {
 
       // Record metrics
       const duration = Date.now() - startTime;
-      const tokensSaved = originalTokens - diffTokens;
+      // Clamp so a small/expensive edit never reports a misleading negative.
+      const tokensSaved = Math.max(0, originalTokens - diffTokens);
 
       this.metrics.record({
         operation: 'smart_edit',
@@ -265,7 +278,7 @@ export class SmartEditTool {
           verified: opts.verifyBeforeApply,
           wasBackedUp: opts.createBackup,
         },
-        diff: opts.returnDiff ? diff : undefined,
+        diff: effectiveReturnDiff ? diff : undefined,
       };
     } catch (error) {
       const duration = Date.now() - startTime;

--- a/src/tools/file-operations/smart-glob.ts
+++ b/src/tools/file-operations/smart-glob.ts
@@ -13,7 +13,7 @@
 
 import { globSync } from 'glob';
 import { statSync, readFileSync } from 'fs';
-import { relative, basename, extname, join } from 'path';
+import { relative, basename, extname, join, isAbsolute } from 'path';
 import { homedir } from 'os';
 import { CacheEngine } from '../../core/cache-engine.js';
 import { TokenCounter } from '../../core/token-counter.js';
@@ -174,7 +174,17 @@ export class SmartGlobTool {
 
       for (const filePath of matches) {
         try {
-          const stats = statSync(filePath);
+          // globSync returns paths relative to opts.cwd when absolute:false.
+          // statSync resolves relative paths against process.cwd(), NOT
+          // opts.cwd — so when a caller passes a cwd different from the MCP
+          // server's process cwd, EVERY statSync throws and every file is
+          // skipped, yielding 0 matches for a directory that actually has
+          // files. Resolve against opts.cwd for all filesystem access while
+          // keeping the caller-facing display path (filePath) unchanged.
+          const absPath = isAbsolute(filePath)
+            ? filePath
+            : join(opts.cwd, filePath);
+          const stats = statSync(absPath);
           const isFile = stats.isFile();
           const isDir = stats.isDirectory();
 
@@ -205,17 +215,18 @@ export class SmartGlobTool {
           let metadata: FileMetadata | undefined;
           if (opts.includeMetadata) {
             metadata = {
-              path: filePath,
-              relativePath: relative(opts.cwd, filePath),
-              name: basename(filePath),
-              extension: extname(filePath),
+              path: absPath,
+              relativePath: relative(opts.cwd, absPath),
+              name: basename(absPath),
+              extension: extname(absPath),
               size: stats.size,
               modified: stats.mtime,
               type: isFile ? 'file' : 'directory',
-              fileType: isFile ? detectFileType(filePath) : undefined,
+              fileType: isFile ? detectFileType(absPath) : undefined,
             };
           }
 
+          // Keep the caller-facing display path (respects opts.absolute).
           files.push({ path: filePath, metadata });
         } catch {
           // Skip files we can't access
@@ -242,10 +253,15 @@ export class SmartGlobTool {
       // Add content if requested (and files are small enough)
       if (opts.includeContent) {
         for (let i = 0; i < results.length; i++) {
-          const filePath =
+          const displayPath =
             typeof results[i] === 'string'
               ? (results[i] as string)
               : (results[i] as FileMetadata).path;
+          // Resolve against opts.cwd so content reads work when the display
+          // path is relative (same root cause as the statSync fix above).
+          const filePath = isAbsolute(displayPath)
+            ? displayPath
+            : join(opts.cwd, displayPath);
 
           try {
             const stats = statSync(filePath);

--- a/src/tools/file-operations/smart-log.ts
+++ b/src/tools/file-operations/smart-log.ts
@@ -422,11 +422,18 @@ export class SmartLogTool {
         author,
         email,
         date: new Date(dateStr),
-        message: subject + (body ? '\n\n' + body.trim() : ''),
+        // `message` must honor `format`. Previously it ALWAYS concatenated the
+        // full body, so `oneline` still returned multi-paragraph bodies (and
+        // the reported token savings did not reflect what was actually sent).
+        // For oneline, mirror `git log --oneline`: subject only.
+        message:
+          opts.format === 'oneline'
+            ? subject
+            : subject + (body ? '\n\n' + body.trim() : ''),
         subject,
       };
 
-      // Add body if format is not oneline
+      // Add body only when the format actually includes it (not oneline).
       if (opts.format !== 'oneline' && body.trim()) {
         commit.body = body.trim();
       }


### PR DESCRIPTION
Addresses 15 critical user-reported issues across the PowerShell hooks and the MCP tools. Reported env: Windows 10, PowerShell 5.1, Node 24/npm 11, package 5.0.2.

## Root cause found (not in the original list, but why the hooks appeared totally broken)
`hooks/handlers/token-optimizer-orchestrator.ps1` **failed to parse in PowerShell 5.1** — an invalid `$InputJsonFile:` token plus two non-exhaustive `class` methods (`switch` isn't treated as exhaustive) and a possibly-unassigned `$textHash`. Since the dispatcher runs the orchestrator as a separate `-File` process, it exited with a parse error on **every** hook invocation, so no token-optimizer hook ever actually ran. Fixed; verified it now parses and executes end-to-end (clean stdout, correct exit codes).

## PowerShell hooks (#1–#10)
- **#1** Resolve every path from `$PSScriptRoot` instead of the hardcoded `C:\Users\cheat\...` developer profile (dispatcher, orchestrator, invoke-token-optimizer) — 7 sites + the `projectPath`.
- **#2** `install-hooks.ps1` now downloads every dot-sourced helper (`logging`, `config`, `gzip`, `context-delta`), not just the dispatcher trio, and verifies them.
- **#3** Hook commands are shell-safe: quoted dispatcher path + `-NoProfile -ExecutionPolicy Bypass`.
- **#4** Stop assigning the read-only `$HOME` automatic variable.
- **#5/#6/#7** PreToolUse **cannot** substitute a tool's output (confirmed against the current hook docs — only `permissionDecision`/`updatedInput`). Moved smart-read substitution to **PostToolUse `updatedToolOutput`**, write via `[Console]::Out` (survives value-capture), and propagate the exit code so substitution actually engages.
- **#8** The npx MCP fallback hung forever (no initialize handshake, stdin never closed, no timeout — orphaning node processes and freezing every user turn). Now sends a proper `initialize` → `initialized` → `tools/call` sequence, **closes stdin (EOF)**, and hard-times-out with a `taskkill /T` tree kill.
- **#9** Call MCP tools by bare name (`optimize_session`, `cache_warmup`, `get_session_stats`, `analyze_project_tokens`) instead of the unrecognized `mcp__token-optimizer__` prefix.
- **#10** Key session state to the **real Claude Code `session_id`** from the hook payload instead of a random GUID in one shared file. Verified: produces `session-<id>.txt` with the correct id.

## MCP tools (#11–#15)
- **#11** `smart_glob` returned 0 for a dir with matching files: `globSync` yields paths relative to `opts.cwd` but `statSync` resolved them against `process.cwd()`, so every stat threw. Resolve against `opts.cwd`. **Verified: `**/*.ts` over `src` now returns 165 (matches `find`), up from 0.**
- **#12** `smart_log` ignored `format:"oneline"` — `message` always concatenated the full body. Now honors format. **Verified: 0 body leakage on oneline.**
- **#13** `smart_typecheck`/`build`/`test`/`lint` ignored `projectRoot` (singleton tools used their own cwd). `run()` now honors `options.projectRoot`. Also `npx --no-install` so they never silently download eslint/tsc.
- **#14** `smart_edit` was net-negative on small files (a 6-line edit reported `tokensSaved: -130`). Added a 500-byte small-file guard (mirrors the compression threshold) that drops the diff payload, and clamped `tokensSaved` to be non-negative.
- **#15** `compress_text` base64 reduces bytes but increases LLM tokens. Now reports `originalTokens`/`compressedTokens` + a `warning` when it would increase tokens, and documents it as at-rest storage only.

## Release automation
The user asked about release setup: it's already fully configured via **semantic-release** (not release-please) — `.releaserc.json` + `.github/workflows/release.yml`, all plugins/deps/scripts/`publishConfig` present. No change needed; adding release-please would duplicate it.

## Verification
- `tsc --noEmit`: clean (exit 0).
- All modified PowerShell files parse in PS 5.1; orchestrator runs end-to-end with clean stdout and correct per-session file/exit code.
- Functional: smart_glob 165 matches; smart_log oneline no body leak.
- No existing tests cover the changed code paths (full `test:coverage` runs in CI via `npm ci`; local `node_modules` here is partial so lint/jest were not run locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)