### PR TITLE
fix: close gap-analysis findings (smart-read contract, package name, latency, context-guard, residuals)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
 
           MESSAGE="New release: token-optimizer-mcp v${VERSION}\n"
           MESSAGE="${MESSAGE}Release notes: ${RELEASE_URL}\n"
-          MESSAGE="${MESSAGE}npm: https://www.npmjs.com/package/token-optimizer-mcp/v/${VERSION}"
+          MESSAGE="${MESSAGE}npm: https://www.npmjs.com/package/@ooples/token-optimizer-mcp/v/${VERSION}"
 
           echo "message<<EOF" >> $GITHUB_OUTPUT
           echo -e "$MESSAGE" >> $GITHUB_OUTPUT
@@ -145,7 +145,7 @@ jobs:
 
             Version:       v${{ needs.release.outputs.new_release_version }}
             Release notes: ${{ steps.release_notes.outputs.release_url }}
-            npm:           https://www.npmjs.com/package/token-optimizer-mcp/v/${{ needs.release.outputs.new_release_version }}
+            npm:           https://www.npmjs.com/package/@ooples/token-optimizer-mcp/v/${{ needs.release.outputs.new_release_version }}
 
             — automated by the release pipeline
 
@@ -188,4 +188,4 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Version: ${{ needs.release.outputs.new_release_version }}" >> $GITHUB_STEP_SUMMARY
           echo "Release URL: ${{ steps.release_notes.outputs.release_url }}" >> $GITHUB_STEP_SUMMARY
-          echo "npm URL: https://www.npmjs.com/package/token-optimizer-mcp/v/${{ needs.release.outputs.new_release_version }}" >> $GITHUB_STEP_SUMMARY
+          echo "npm URL: https://www.npmjs.com/package/@ooples/token-optimizer-mcp/v/${{ needs.release.outputs.new_release_version }}" >> $GITHUB_STEP_SUMMARY

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -151,7 +151,7 @@
       {
         "assets": [],
         "draftRelease": false,
-        "successComment": "This ${issue.pull_request ? 'PR is included' : 'issue has been resolved'} in version ${nextRelease.version}. :tada:\n\nThe release is available on:\n- [GitHub release](https://github.com/ooples/token-optimizer-mcp/releases/tag/v${nextRelease.version})\n- [npm package (@latest dist-tag)](https://www.npmjs.com/package/token-optimizer-mcp/v/${nextRelease.version})\n\nYour **semantic-release** bot :package::rocket:",
+        "successComment": "This ${issue.pull_request ? 'PR is included' : 'issue has been resolved'} in version ${nextRelease.version}. :tada:\n\nThe release is available on:\n- [GitHub release](https://github.com/ooples/token-optimizer-mcp/releases/tag/v${nextRelease.version})\n- [npm package (@latest dist-tag)](https://www.npmjs.com/package/@ooples/token-optimizer-mcp/v/${nextRelease.version})\n\nYour **semantic-release** bot :package::rocket:",
         "failComment": false,
         "failTitle": false,
         "labels": [

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -29,6 +29,29 @@ hooks/
 
 3. The hooks will automatically find the CLI wrapper using relative paths.
 
+## File-read compression: what actually works
+
+Claude Code's hook contract limits how file-read output can be compressed. Know
+these rules before expecting "every Read is automatically compressed":
+
+- **Built-in `Read` — cannot be transparently compressed.** A `PreToolUse` hook
+  can only allow/deny/ask or rewrite a tool's *input*; it cannot replace output.
+  `PostToolUse.updatedToolOutput` is **ignored for built-in tools** (see
+  [anthropics/claude-code#32105](https://github.com/anthropics/claude-code/issues/32105)).
+  So there is no supported way to swap a normal `Read`'s content for a compressed
+  version.
+- **MCP file reads — compressed transparently.** For `mcp__filesystem__read_file`
+  / `read_text_file`, the hook substitutes `smart_read`'s cached/diffed/truncated
+  content via the supported `PostToolUse.updatedMCPToolOutput` field.
+- **`smart_read` MCP tool — always available.** Call `smart_read` directly for a
+  token-optimized read of any file; it returns compressed content regardless of
+  the hook limitations above.
+- **Opt-in large-`Read` redirect (off by default).** Set
+  `TOKEN_OPTIMIZER_REDIRECT_LARGE_READS=true` to have the hook deny built-in
+  `Read` for files at/over `TOKEN_OPTIMIZER_LARGE_READ_BYTES` (default 50 KB) and
+  steer the model to `smart_read`. Off by default so it never disrupts edit
+  workflows.
+
 ## How It Works
 
 ### Hook Flow

--- a/hooks/dispatcher.ps1
+++ b/hooks/dispatcher.ps1
@@ -75,12 +75,33 @@ try {
     # ============================================================
     if ($Phase -eq "PreToolUse") {
 
-        # NOTE: smart_read substitution intentionally does NOT run here.
-        # Claude Code's PreToolUse contract can only allow/deny/ask or rewrite
-        # a tool's INPUT (updatedInput) — it CANNOT let a tool run and replace
-        # its OUTPUT. The only supported way to serve cached/compressed content
-        # in place of a plain Read is PostToolUse `updatedToolOutput`, so the
-        # smart_read handling lives in the PostToolUse phase below.
+        # NOTE: transparent smart_read substitution for the BUILT-IN Read tool
+        # is impossible — PreToolUse cannot replace output, and PostToolUse
+        # `updatedToolOutput` is ignored for built-in tools
+        # (anthropics/claude-code#32105). Transparent substitution only works
+        # for the MCP file-read tools (handled in PostToolUse below).
+
+        # 1. OPT-IN large-Read redirect (built-in Read only, OFF by default).
+        #    Since we cannot compress a built-in Read's output, the next best
+        #    thing is to steer big reads to the smart_read MCP tool, whose
+        #    output IS compressed (cached/diffed/truncated). Enable by setting
+        #    TOKEN_OPTIMIZER_REDIRECT_LARGE_READS=true. Off by default so it
+        #    never disrupts normal edit workflows.
+        if ($toolName -eq "Read" -and $env:TOKEN_OPTIMIZER_REDIRECT_LARGE_READS -eq 'true') {
+            $readPath = $data.tool_input.file_path
+            if ($readPath -and (Test-Path -LiteralPath $readPath -PathType Leaf)) {
+                # Threshold in bytes (default 51200 = 50KB); configurable.
+                $thresholdBytes = 51200
+                if ($env:TOKEN_OPTIMIZER_LARGE_READ_BYTES) {
+                    [int]::TryParse($env:TOKEN_OPTIMIZER_LARGE_READ_BYTES, [ref]$thresholdBytes) | Out-Null
+                }
+                $sizeBytes = (Get-Item -LiteralPath $readPath).Length
+                if ($sizeBytes -ge $thresholdBytes) {
+                    Write-Log "[REDIRECT] Large Read ($sizeBytes bytes) -> smart_read: $readPath"
+                    Block-Tool -Reason "This file is large ($([Math]::Round($sizeBytes/1KB)) KB). Use the smart_read MCP tool (smart_read with path='$readPath') for a token-optimized, cached/diffed read instead of the built-in Read."
+                }
+            }
+        }
 
         # 2. Context Guard - Check if we're approaching token limit
         & powershell -NoProfile -ExecutionPolicy Bypass -File $ORCHESTRATOR -Phase "PreToolUse" -Action "context-guard" -InputJsonFile $tempFile
@@ -163,13 +184,15 @@ try {
     if ($Phase -eq "PostToolUse") {
         $phaseStart = Get-Date
 
-        # 0. SMART READ SUBSTITUTION (Read only)
-        #    Replace the plain Read result with smart_read's cached/diffed/
-        #    optimized content via the supported PostToolUse `updatedToolOutput`
-        #    mechanism. This is the ONLY hook contract that lets us change what
-        #    content actually reaches the model. The orchestrator writes the
-        #    replacement JSON to its stdout and exits 2 as a "substitute" signal.
-        if ($toolName -eq "Read") {
+        # 0. SMART READ SUBSTITUTION (MCP file-read tools ONLY)
+        #    Claude Code's `updatedToolOutput` does NOT work for BUILT-IN tools
+        #    like Read (anthropics/claude-code#32105 — closed, not implemented);
+        #    only `updatedMCPToolOutput` works, and only for MCP tools. So the
+        #    one place we can transparently swap in compressed content is the
+        #    MCP filesystem read tools. Built-in Read cannot be substituted —
+        #    it is handled (opt-in) at PreToolUse, and users can always call the
+        #    smart_read MCP tool directly for compressed reads.
+        if ($toolName -in @("mcp__filesystem__read_file", "mcp__filesystem__read_text_file")) {
             $smartReadOutput = & powershell -NoProfile -ExecutionPolicy Bypass -File $ORCHESTRATOR -Phase "PostToolUse" -Action "smart-read" -InputJsonFile $tempFile
             $smartReadExit = $LASTEXITCODE
             if ($smartReadExit -eq 2 -and $smartReadOutput) {
@@ -178,7 +201,7 @@ try {
                 & powershell -NoProfile -ExecutionPolicy Bypass -File $ORCHESTRATOR -Phase "PostToolUse" -Action "log-operation" -InputJsonFile $tempFile | Out-Null
                 & powershell -NoProfile -ExecutionPolicy Bypass -File $ORCHESTRATOR -Phase "PostToolUse" -Action "session-track" -InputJsonFile $tempFile | Out-Null
 
-                # Relay the orchestrator's updatedToolOutput JSON verbatim and
+                # Relay the orchestrator's updatedMCPToolOutput JSON verbatim and
                 # exit 0 — PostToolUse only parses stdout JSON on exit 0 (exit 2
                 # would merely surface stderr and cannot substitute output).
                 [Console]::Out.Write(($smartReadOutput -join "`n"))
@@ -187,11 +210,11 @@ try {
                 if (Test-Path $tempFile) {
                     Remove-Item -Path $tempFile -Force -ErrorAction SilentlyContinue
                 }
-                Write-Log "[SMART-READ] Substituted Read output via PostToolUse updatedToolOutput"
+                Write-Log "[SMART-READ] Substituted MCP file-read output via updatedMCPToolOutput"
                 exit 0
             }
             # smart_read miss/failure: fall through to normal handling so the
-            # plain Read result is preserved and still logged/optimized.
+            # original result is preserved and still logged/optimized.
         }
 
         # 1. Log ALL tool operations to operations-{sessionId}.csv

--- a/hooks/handlers/token-optimizer-orchestrator.ps1
+++ b/hooks/handlers/token-optimizer-orchestrator.ps1
@@ -809,19 +809,12 @@ function Handle-ContextGuard {
                 $session.lastOptimized = $session.totalOperations
                 $session | ConvertTo-Json | Out-File $SESSION_FILE -Encoding UTF8
             } else {
-                # BLOCK with standard response so dispatcher exits with 2
-                $blockResponse = @{
-                    continue = $false
-                    stopReason = "context guard block"
-                    hookSpecificOutput = @{
-                        hookEventName = "PreToolUse"
-                        reason = "optimize_session failed at FORCE_THRESHOLD"
-                        sessionId = $session.sessionId
-                        usagePercent = [Math]::Round($percentage * 100, 1)
-                    }
-                } | ConvertTo-Json -Depth 10 -Compress
-                Write-Output $blockResponse
-                [Console]::Out.Flush(); [Console]::Error.Flush()
+                # Signal the dispatcher to block (exit 2). Do NOT write a
+                # response here: the dispatcher owns the block and emits the
+                # correct PreToolUse deny schema via Block-Tool. Writing our own
+                # JSON to stdout would leak into the dispatcher's stdout and
+                # collide with Block-Tool's response.
+                Write-Log "Context guard: optimize_session failed at FORCE_THRESHOLD - signalling block" "WARN"
                 return 2
             }
 
@@ -2250,8 +2243,12 @@ function Handle-SmartRead {
         $data = $InputJson | ConvertFrom-Json
         $toolName = $data.tool_name
 
-        # Intercept Read, mcp__filesystem__read_file, and mcp__filesystem__read_text_file
-        if ($toolName -notin @("Read", "mcp__filesystem__read_file", "mcp__filesystem__read_text_file")) {
+        # Intercept ONLY the MCP filesystem read tools. Output substitution is
+        # not possible for the built-in Read tool (updatedToolOutput is ignored
+        # for built-in tools — anthropics/claude-code#32105); only MCP tools
+        # support updatedMCPToolOutput. Built-in Read is steered to smart_read
+        # via the opt-in PreToolUse redirect in the dispatcher instead.
+        if ($toolName -notin @("mcp__filesystem__read_file", "mcp__filesystem__read_text_file")) {
             return
         }
 
@@ -2276,7 +2273,10 @@ function Handle-SmartRead {
             includeMetadata = $true
         }
         $argsJson = $mcpArgs | ConvertTo-Json -Compress
-        $resultJson = & "$HELPERS_DIR\invoke-mcp.ps1" -Tool "smart_read" -ArgumentsJson $argsJson
+        # This runs on every intercepted read, so it must be fast: daemon-only
+        # (no slow npx fallback) with a short connect timeout. A missing daemon
+        # then fails fast and we simply leave the original result untouched.
+        $resultJson = & "$HELPERS_DIR\invoke-mcp.ps1" -Tool "smart_read" -ArgumentsJson $argsJson -DaemonOnly -ConnectTimeoutMs 1500
         $result = if ($resultJson) { $resultJson | ConvertFrom-Json } else { $null }
 
         # Check for errors - if MCP call failed, allow fallback to plain Read
@@ -2329,27 +2329,25 @@ function Handle-SmartRead {
                 Write-Log "context_delta update skipped: $($_.Exception.Message)" 'DEBUG'
             }
 
-            # Substitute the Read's result with smart_read's optimized content
-            # using the PostToolUse `updatedToolOutput` contract. PreToolUse
-            # CANNOT replace a tool's output — only PostToolUse can — so this
-            # runs in the PostToolUse phase and hands Claude Code the smaller
-            # (cached / diffed / truncated) text in place of the raw file.
-            $optimizedText = if ($result.content) {
-                ($result.content | ForEach-Object { $_.text }) -join "`n"
-            } else {
-                $null
-            }
-
-            if (-not $optimizedText) {
-                Write-Log "smart_read produced empty content for $filePath - falling back to plain Read" "WARN"
+            # Substitute the MCP read tool's result with smart_read's optimized
+            # content using `updatedMCPToolOutput` (the ONLY output-substitution
+            # contract Claude Code supports, and only for MCP tools — see
+            # anthropics/claude-code#32105). The replacement must MATCH the MCP
+            # tool's output schema, i.e. a CallToolResult { content: [...] }, so
+            # we hand back smart_read's content array (cached/diffed/truncated).
+            if (-not $result.content) {
+                Write-Log "smart_read produced empty content for $filePath - leaving original result" "WARN"
                 return 0
             }
 
             $substituteResponse = @{
                 hookSpecificOutput = @{
                     hookEventName = "PostToolUse"
-                    # updatedToolOutput REPLACES the tool result returned to Claude.
-                    updatedToolOutput = $optimizedText
+                    # Replaces the MCP tool result returned to Claude. Shape must
+                    # match the tool's output (a CallToolResult content array).
+                    updatedMCPToolOutput = @{
+                        content = $result.content
+                    }
                 }
             } | ConvertTo-Json -Depth 10 -Compress
 
@@ -2430,7 +2428,14 @@ if ($MyInvocation.InvocationName -ne '.') {
                 }
             }
             "context-guard" {
-                Handle-ContextGuard -InputJson $InputJson
+                # Same #5-class fix as smart-read: convert the function's
+                # return 2 into a real exit code so the dispatcher's
+                # `$LASTEXITCODE -eq 2` check fires and the token-budget block
+                # actually engages (previously it never did).
+                $guardCode = Handle-ContextGuard -InputJson $InputJson
+                if (($guardCode | Select-Object -Last 1) -eq 2) {
+                    exit 2
+                }
             }
             "periodic-optimize" {
                 Handle-PeriodicOptimize -InputJson $InputJson

--- a/hooks/helpers/invoke-mcp.ps1
+++ b/hooks/helpers/invoke-mcp.ps1
@@ -14,7 +14,17 @@ param(
     [string]$ArgumentsJson = "{}",
 
     [Parameter(Mandatory=$false)]
-    [string]$ServerName = "token-optimizer"
+    [string]$ServerName = "token-optimizer",
+
+    # Skip the (slow) npx fallback entirely. Latency-sensitive per-tool hook
+    # paths (e.g. per-read substitution) set this so a missing daemon fails
+    # fast instead of paying npx spawn + package download on every call.
+    [Parameter(Mandatory=$false)]
+    [switch]$DaemonOnly,
+
+    # Named-pipe connect timeout in ms. Short for interactive per-tool paths.
+    [Parameter(Mandatory=$false)]
+    [int]$ConnectTimeoutMs = 5000
 )
 
 $profileRoot = $env:USERPROFILE
@@ -101,7 +111,8 @@ function Log-Performance {
 function Invoke-MCPViaDaemon {
     param(
         [string]$Tool,
-        $ToolArguments
+        $ToolArguments,
+        [int]$ConnectTimeoutMs = 5000
     )
 
     try {
@@ -129,8 +140,9 @@ function Invoke-MCPViaDaemon {
         $pipe = New-Object System.IO.Pipes.NamedPipeClientStream(".", "token-optimizer-daemon", "InOut")
 
         try {
-            # Connect with 5 second timeout
-            $pipe.Connect(5000)
+            # Connect with the caller-supplied timeout (short for interactive
+            # per-tool paths so a missing daemon fails fast).
+            $pipe.Connect($ConnectTimeoutMs)
 
             # Write request
             $writer = New-Object System.IO.StreamWriter($pipe)
@@ -234,7 +246,10 @@ function Invoke-MCPViaNpx {
         # kill the tree. npx is a .cmd shim on Windows, so go via cmd.exe.
         $psi = New-Object System.Diagnostics.ProcessStartInfo
         $psi.FileName = "cmd.exe"
-        $psi.Arguments = "/c npx -y token-optimizer-mcp@latest"
+        # Use the SCOPED package name. The unscoped `token-optimizer-mcp` on npm
+        # is a stale 2.x publish; the current server ships as
+        # `@ooples/token-optimizer-mcp` (its bin is still `token-optimizer-mcp`).
+        $psi.Arguments = "/c npx -y @ooples/token-optimizer-mcp@latest"
         $psi.RedirectStandardInput = $true
         $psi.RedirectStandardOutput = $true
         $psi.RedirectStandardError = $true
@@ -305,13 +320,20 @@ function Invoke-MCPViaNpx {
 $mcpStart = Get-Date
 
 # Try daemon first (fast path)
-$result = Invoke-MCPViaDaemon -Tool $Tool -ToolArguments $Arguments
+$result = Invoke-MCPViaDaemon -Tool $Tool -ToolArguments $Arguments -ConnectTimeoutMs $ConnectTimeoutMs
 
-# Fallback to npx if daemon unavailable
+# Fallback to npx if daemon unavailable — UNLESS the caller opted out. The
+# npx fallback spawns a fresh server (slow) and is inappropriate for
+# latency-sensitive per-tool paths, which pass -DaemonOnly.
 if ($null -eq $result) {
-    Write-Log "Daemon unavailable, using npx fallback" "WARN"
-    $result = Invoke-MCPViaNpx -Tool $Tool -ToolArguments $Arguments
-    $server = "npx"
+    if ($DaemonOnly) {
+        Write-Log "Daemon unavailable and -DaemonOnly set; skipping npx fallback" "WARN"
+        $server = "none"
+    } else {
+        Write-Log "Daemon unavailable, using npx fallback" "WARN"
+        $result = Invoke-MCPViaNpx -Tool $Tool -ToolArguments $Arguments
+        $server = "npx"
+    }
 } else {
     $server = "daemon"
 }

--- a/src/tools/build-systems/smart-build.ts
+++ b/src/tools/build-systems/smart-build.ts
@@ -119,6 +119,7 @@ export class SmartBuild {
   private cache: CacheEngine;
   private cacheNamespace = 'smart_build';
   private projectRoot: string;
+  private readonly defaultProjectRoot: string;
 
   constructor(
     cache: CacheEngine,
@@ -127,7 +128,8 @@ export class SmartBuild {
     projectRoot?: string
   ) {
     this.cache = cache;
-    this.projectRoot = projectRoot || process.cwd();
+    this.defaultProjectRoot = projectRoot || process.cwd();
+    this.projectRoot = this.defaultProjectRoot;
   }
 
   /**
@@ -138,9 +140,9 @@ export class SmartBuild {
     // as a singleton (with the server's own cwd), so without this the
     // projectRoot argument was silently ignored and the build ran in the
     // wrong directory — reporting success:false with 0 files on a clean build.
-    if (options.projectRoot) {
-      this.projectRoot = options.projectRoot;
-    }
+    // Resolve from the constructor default each call so omitting projectRoot
+    // reverts to the default instead of stickily keeping a prior call's value.
+    this.projectRoot = options.projectRoot || this.defaultProjectRoot;
     const {
       force = false,
       watch = false,

--- a/src/tools/build-systems/smart-lint.ts
+++ b/src/tools/build-systems/smart-lint.ts
@@ -152,6 +152,7 @@ export class SmartLint {
   private cache: CacheEngine;
   private cacheNamespace = 'smart_lint';
   private projectRoot: string;
+  private readonly defaultProjectRoot: string;
   private ignoredIssuesKey = 'ignored_issues';
 
   constructor(
@@ -161,7 +162,8 @@ export class SmartLint {
     projectRoot?: string
   ) {
     this.cache = cache;
-    this.projectRoot = projectRoot || process.cwd();
+    this.defaultProjectRoot = projectRoot || process.cwd();
+    this.projectRoot = this.defaultProjectRoot;
   }
 
   /**
@@ -172,9 +174,9 @@ export class SmartLint {
     // as a singleton (with the server's own cwd), so without this the
     // projectRoot argument was silently ignored and eslint ran in the wrong
     // directory (where it isn't installed, triggering an npx auto-download).
-    if (options.projectRoot) {
-      this.projectRoot = options.projectRoot;
-    }
+    // Resolve from the constructor default each call so omitting projectRoot
+    // reverts to the default instead of stickily keeping a prior call's value.
+    this.projectRoot = options.projectRoot || this.defaultProjectRoot;
     const {
       files = 'src',
       force = false,

--- a/src/tools/build-systems/smart-test.ts
+++ b/src/tools/build-systems/smart-test.ts
@@ -134,6 +134,7 @@ export class SmartTest {
   private cache: CacheEngine;
   private cacheNamespace = 'smart_test';
   private projectRoot: string;
+  private readonly defaultProjectRoot: string;
 
   constructor(
     cache: CacheEngine,
@@ -142,7 +143,8 @@ export class SmartTest {
     projectRoot?: string
   ) {
     this.cache = cache;
-    this.projectRoot = projectRoot || process.cwd();
+    this.defaultProjectRoot = projectRoot || process.cwd();
+    this.projectRoot = this.defaultProjectRoot;
   }
 
   /**
@@ -153,9 +155,9 @@ export class SmartTest {
     // as a singleton (with the server's own cwd), so without this the
     // projectRoot argument was silently ignored and npm ran in an unrelated
     // directory — failing with ENOENT instead of running the project's tests.
-    if (options.projectRoot) {
-      this.projectRoot = options.projectRoot;
-    }
+    // Resolve from the constructor default each call so omitting projectRoot
+    // reverts to the default instead of stickily keeping a prior call's value.
+    this.projectRoot = options.projectRoot || this.defaultProjectRoot;
     const {
       pattern,
       onlyChanged = false,

--- a/src/tools/build-systems/smart-typecheck.ts
+++ b/src/tools/build-systems/smart-typecheck.ts
@@ -112,6 +112,7 @@ export class SmartTypeCheck {
   private cache: CacheEngine;
   private cacheNamespace = 'smart_typecheck';
   private projectRoot: string;
+  private readonly defaultProjectRoot: string;
 
   constructor(
     cache: CacheEngine,
@@ -120,7 +121,8 @@ export class SmartTypeCheck {
     projectRoot?: string
   ) {
     this.cache = cache;
-    this.projectRoot = projectRoot || process.cwd();
+    this.defaultProjectRoot = projectRoot || process.cwd();
+    this.projectRoot = this.defaultProjectRoot;
   }
 
   /**
@@ -133,9 +135,9 @@ export class SmartTypeCheck {
     // as a singleton (with the server's own cwd), so without this the
     // projectRoot argument was silently ignored and tsc ran in the wrong
     // directory — reporting success:false with 0 files on a clean project.
-    if (options.projectRoot) {
-      this.projectRoot = options.projectRoot;
-    }
+    // Resolve from the constructor default each call so omitting projectRoot
+    // reverts to the default instead of stickily keeping a prior call's value.
+    this.projectRoot = options.projectRoot || this.defaultProjectRoot;
     const {
       force = false,
       watch = false,

--- a/src/tools/file-operations/smart-edit.ts
+++ b/src/tools/file-operations/smart-edit.ts
@@ -143,6 +143,9 @@ export class SmartEditTool {
       // Check if content actually changed
       if (editedContent === originalContent) {
         const duration = Date.now() - startTime;
+        // Clamp so a tiny unchanged file (< 50 tokens) never reports a
+        // misleading negative saving.
+        const unchangedSaved = Math.max(0, originalTokens - 50);
 
         this.metrics.record({
           operation: 'smart_edit',
@@ -150,7 +153,7 @@ export class SmartEditTool {
           inputTokens: 50, // Minimal tokens for "no changes" message
           outputTokens: 0,
           cachedTokens: 0,
-          savedTokens: originalTokens - 50,
+          savedTokens: unchangedSaved,
           success: true,
           cacheHit: false,
         });
@@ -164,7 +167,7 @@ export class SmartEditTool {
             linesChanged: 0,
             originalLines: originalLines.length,
             finalLines: editedLines.length,
-            tokensSaved: originalTokens - 50,
+            tokensSaved: unchangedSaved,
             tokenCount: 50,
             originalTokenCount: originalTokens,
             compressionRatio: 50 / originalTokens,


### PR DESCRIPTION
Stacked on top of #175 (base = its branch) so the diff stays focused on the gap fixes. **Retarget to master once #175 merges.**

Addresses every gap from the post-#175 review, plus all recommended next steps.

## Smart-read — the #5/#6/#7 story, definitively resolved
Research settled the open question: **`updatedToolOutput` does NOT work for built-in tools like `Read`** (anthropics/claude-code#32105 — closed, not implemented). Only `updatedMCPToolOutput` works, and only for MCP tools. #175 used the right idea but targeted a field Claude Code ignores for built-in Read, so substitution never engaged. Fix:
- **MCP file reads** (`mcp__filesystem__read_file`/`read_text_file`): transparent compression via the supported `updatedMCPToolOutput`, matching the `CallToolResult` schema.
- **Built-in `Read`**: an **opt-in, size-gated PreToolUse redirect** to `smart_read` (`TOKEN_OPTIMIZER_REDIRECT_LARGE_READS`, off by default; `TOKEN_OPTIMIZER_LARGE_READ_BYTES` default 50 KB). Never disrupts edit workflows.
- **`smart_read` MCP tool** stays the always-available compression path.
- Limitation documented in `hooks/README.md`.

## Latency
- `invoke-mcp.ps1` gains `-DaemonOnly` + `-ConnectTimeoutMs`. The per-read path uses daemon-only + a 1.5 s connect timeout, so a missing daemon fails fast instead of paying npx spawn on every read.

## Package name (was pointing at a stale package)
- npx fallback now fetches **`@ooples/token-optimizer-mcp@latest`** (current scoped package) instead of the stale unscoped `token-optimizer-mcp@2.x`.
- Release notification URLs (`.releaserc.json`, `release.yml`) point at the scoped npm page.

## Context guard
- Propagate `Handle-ContextGuard`'s `return 2` to a real exit code so the token-budget block actually engages (same #5-class bug), and drop the stray `Write-Output` that leaked block-JSON into the dispatcher's stdout.

## Tool residuals
- `projectRoot` is no longer **sticky** across singleton calls in `smart_typecheck`/`build`/`test`/`lint` (resolve from a captured constructor default each call).
- `smart_edit` clamps the "unchanged" path so tiny files never report a negative `tokensSaved`.

## Verification (toolchain repaired via clean `npm ci`)
- `tsc --noEmit`: clean.
- `eslint src`: **0 errors** (pre-existing warnings only).
- `jest`: **655 passed, 1 skipped, 38 suites** — all green.
- `npm run build`: clean.
- All hook scripts parse in PowerShell 5.1 and run end-to-end with clean stdout.
- `smart_glob **/*.ts` over `src` → **165** (matches `find`); `smart_log` oneline leaks no body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)