### PR TITLE
feat(server): complete Windows stdio orphan-leak fix (tests + unified lifecycle + daemon/dashboard)

### DIFF
--- a/src/server/daemon.ts
+++ b/src/server/daemon.ts
@@ -222,6 +222,8 @@ async function sendToMCPServer(request: any): Promise<any> {
  * Handle incoming request from PowerShell hook via IPC
  */
 async function handleIPCRequest(data: string): Promise<string> {
+  // Any request counts as activity — push back the idle self-exit.
+  resetIdleTimer();
   const startTime = Date.now();
 
   let request: any;
@@ -296,6 +298,33 @@ async function handleIPCRequest(data: string): Promise<string> {
 
 let shuttingDown = false;
 
+// Idle self-exit. Unlike the stdio MCP server, the daemon does NOT read stdin,
+// so it can't use the stdin-close "parent is gone" signal — and on Windows a
+// killed parent sends no signal. An orphaned daemon (plus its MCP child) would
+// otherwise leak ~100 MB forever. So shut down after a stretch of no IPC
+// requests; the next client transparently respawns the daemon. It's a singleton
+// per socket, so at most one can exist, but this bounds even that one.
+// Set TOKEN_OPTIMIZER_DAEMON_IDLE_MS=0 to disable (keep a persistent daemon).
+const IDLE_TIMEOUT_MS = (() => {
+  const raw = process.env.TOKEN_OPTIMIZER_DAEMON_IDLE_MS;
+  if (raw === undefined || raw === '') return 30 * 60 * 1000; // default 30 min
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? n : 30 * 60 * 1000;
+})();
+let idleTimer: NodeJS.Timeout | null = null;
+
+function resetIdleTimer(): void {
+  if (IDLE_TIMEOUT_MS <= 0) return; // disabled: persistent daemon
+  if (idleTimer) clearTimeout(idleTimer);
+  idleTimer = setTimeout(() => {
+    console.error(
+      `[DAEMON] Idle for ${IDLE_TIMEOUT_MS}ms with no requests — self-terminating to avoid an orphaned daemon`
+    );
+    shutdown();
+  }, IDLE_TIMEOUT_MS);
+  // Intentionally NOT unref'd: we WANT this timer to fire and stop an idle daemon.
+}
+
 /**
  * Graceful shutdown
  */
@@ -304,6 +333,11 @@ function shutdown(): void {
   shuttingDown = true;
 
   console.error('[DAEMON] Shutting down gracefully...');
+
+  if (idleTimer) {
+    clearTimeout(idleTimer);
+    idleTimer = null;
+  }
 
   // Kill MCP server
   if (mcpProcess) {
@@ -378,6 +412,9 @@ function startDaemon(): void {
 
     // Write PID file for process management
     fs.writeFileSync(PID_FILE, process.pid.toString());
+
+    // Start the idle self-exit clock (no-op if disabled via env).
+    resetIdleTimer();
 
     console.error('[DAEMON] Daemon ready');
   });

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2,6 +2,7 @@
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { installShutdownHandlers } from './lifecycle.js';
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
@@ -2418,35 +2419,10 @@ async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
 
-  // Cleanup on exit - Note: the signal handlers use try-catch blocks
-  // to ensure cleanup continues even if disposal fails
-  process.on('SIGINT', () => {
-    cleanup().finally(() => process.exit(0));
-  });
-
-  process.on('SIGTERM', () => {
-    cleanup().finally(() => process.exit(0));
-  });
-
-  // Windows stdio lifecycle fix: a stdio MCP server MUST exit when its parent
-  // (the MCP client, e.g. Claude Code) dies. On Windows a killed parent sends
-  // NO SIGTERM to the child, so the SIGINT/SIGTERM handlers above never fire on
-  // orphaning. The only reliable signal is the stdin stream closing/ending/
-  // erroring (the client's pipe write-end goes away). Without this the process
-  // leaks forever: the prune timer is unref'd (does not pin the loop), but the
-  // StdioServerTransport's active stdin read handle keeps the process alive.
-  // Idempotent: stdin can emit both 'end' and 'close' (and 'error') for a single
-  // disconnect, so guard against re-entry — cleanup()+exit must run exactly once,
-  // otherwise the handlers race (concurrent cleanup, double process.exit).
-  let stdinClosing = false;
-  const exitOnStdinClose = () => {
-    if (stdinClosing) return;
-    stdinClosing = true;
-    cleanup().finally(() => process.exit(0));
-  };
-  process.stdin.on('end', exitOnStdinClose);
-  process.stdin.on('close', exitOnStdinClose);
-  process.stdin.on('error', exitOnStdinClose);
+  // All termination paths (SIGINT/SIGTERM/SIGHUP + stdin end/close/error) run
+  // through one guarded shutdown. See ./lifecycle.ts for the full rationale
+  // (the stdin handlers are the Windows orphan-leak fix from PR #177).
+  installShutdownHandlers({ cleanup });
 }
 
 main().catch((error) => {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2435,7 +2435,13 @@ async function main() {
   // erroring (the client's pipe write-end goes away). Without this the process
   // leaks forever: the prune timer is unref'd (does not pin the loop), but the
   // StdioServerTransport's active stdin read handle keeps the process alive.
+  // Idempotent: stdin can emit both 'end' and 'close' (and 'error') for a single
+  // disconnect, so guard against re-entry — cleanup()+exit must run exactly once,
+  // otherwise the handlers race (concurrent cleanup, double process.exit).
+  let stdinClosing = false;
   const exitOnStdinClose = () => {
+    if (stdinClosing) return;
+    stdinClosing = true;
     cleanup().finally(() => process.exit(0));
   };
   process.stdin.on('end', exitOnStdinClose);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2427,6 +2427,20 @@ async function main() {
   process.on('SIGTERM', () => {
     cleanup().finally(() => process.exit(0));
   });
+
+  // Windows stdio lifecycle fix: a stdio MCP server MUST exit when its parent
+  // (the MCP client, e.g. Claude Code) dies. On Windows a killed parent sends
+  // NO SIGTERM to the child, so the SIGINT/SIGTERM handlers above never fire on
+  // orphaning. The only reliable signal is the stdin stream closing/ending/
+  // erroring (the client's pipe write-end goes away). Without this the process
+  // leaks forever: the prune timer is unref'd (does not pin the loop), but the
+  // StdioServerTransport's active stdin read handle keeps the process alive.
+  const exitOnStdinClose = () => {
+    cleanup().finally(() => process.exit(0));
+  };
+  process.stdin.on('end', exitOnStdinClose);
+  process.stdin.on('close', exitOnStdinClose);
+  process.stdin.on('error', exitOnStdinClose);
 }
 
 main().catch((error) => {

--- a/src/server/lifecycle.ts
+++ b/src/server/lifecycle.ts
@@ -1,0 +1,62 @@
+/**
+ * Process lifecycle wiring for the stdio MCP server.
+ *
+ * Extracted into its own side-effect-free module so the shutdown logic can be
+ * unit-tested in isolation, without importing (and booting) the whole server.
+ */
+
+export interface ShutdownDeps {
+  /** Runs the actual resource cleanup. Must be safe to call once. */
+  cleanup: () => Promise<void>;
+  /** Signal/exit target. Defaults to the real `process`; injectable for tests. */
+  proc?: NodeJS.EventEmitter & { exit: (code?: number) => void };
+  /** stdin stream. Defaults to `process.stdin`; injectable for tests. */
+  stdin?: NodeJS.EventEmitter;
+}
+
+/**
+ * Wire every process-termination path to a single guarded shutdown so that
+ * cleanup() + exit run EXACTLY ONCE.
+ *
+ * Why one guard for all paths: they race each other. A signal can arrive while
+ * stdin is closing, and stdin itself can emit both 'end' and 'close' (plus
+ * 'error') for a single disconnect. Without a shared guard, cleanup() runs
+ * concurrently and process.exit() is called more than once.
+ *
+ * Why the stdin handlers (the core fix, PR #177): a stdio MCP server MUST exit
+ * when its parent (the MCP client, e.g. Claude Code) dies. On Windows a killed
+ * parent sends NO signal to the child, so SIGINT/SIGTERM never fire on
+ * orphaning. The only reliable "parent is gone" signal is stdin closing/ending/
+ * erroring (the client's pipe write-end goes away). Without it the process
+ * leaks forever: the prune timer is unref'd (does not pin the loop), but
+ * StdioServerTransport's active stdin read handle keeps the process alive.
+ */
+export function installShutdownHandlers(deps: ShutdownDeps): void {
+  const proc = deps.proc ?? process;
+  const stdin = deps.stdin ?? process.stdin;
+
+  let shuttingDown = false;
+  const shutdown = (reason: string) => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    // stderr, not stdout — stdout is the MCP JSON-RPC channel.
+    console.error(`[token-optimizer] shutting down (${reason})`);
+    // Swallow any cleanup failure (log it) so a rejecting cleanup can never
+    // surface as an unhandled rejection, then exit unconditionally. Wrapping in
+    // Promise.resolve().then also absorbs a synchronous throw from cleanup().
+    Promise.resolve()
+      .then(() => deps.cleanup())
+      .catch((err) =>
+        console.error('[token-optimizer] cleanup error during shutdown:', err)
+      )
+      .finally(() => proc.exit(0));
+  };
+
+  proc.on('SIGINT', () => shutdown('SIGINT'));
+  proc.on('SIGTERM', () => shutdown('SIGTERM'));
+  proc.on('SIGHUP', () => shutdown('SIGHUP')); // Unix: controlling terminal/parent closed
+
+  stdin.on('end', () => shutdown('stdin end'));
+  stdin.on('close', () => shutdown('stdin close'));
+  stdin.on('error', () => shutdown('stdin error'));
+}

--- a/src/server/web-server.ts
+++ b/src/server/web-server.ts
@@ -428,11 +428,29 @@ app.get('/', (_req, res) => {
 
 // Start server
 export function startWebServer() {
-  app.listen(PORT, () => {
+  const server = app.listen(PORT, () => {
     console.log(
       `Token Optimizer Dashboard running on http://localhost:${PORT}`
     );
   });
+
+  // Graceful shutdown: the dashboard previously had NO lifecycle handlers, so a
+  // SIGINT/SIGTERM left the HTTP listener dangling instead of closing cleanly.
+  // Route both signals through one guarded close, and force-exit if connections
+  // don't drain promptly.
+  let shuttingDown = false;
+  const shutdown = (reason: string) => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    console.log(`[dashboard] shutting down (${reason})`);
+    const force = setTimeout(() => process.exit(0), 5000);
+    force.unref();
+    server.close(() => process.exit(0));
+  };
+  process.on('SIGINT', () => shutdown('SIGINT'));
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+
+  return server;
 }
 
 // Start server if this file is run directly

--- a/tests/unit/server/lifecycle.test.ts
+++ b/tests/unit/server/lifecycle.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for the stdio server shutdown lifecycle (PR #177 + completion).
+ *
+ * Verifies that every termination path (stdin end/close/error, SIGINT/SIGTERM/
+ * SIGHUP) routes through one guarded shutdown that runs cleanup() and exits
+ * EXACTLY ONCE — including when multiple events fire for a single disconnect,
+ * which is the race the idempotency guard exists to prevent.
+ */
+
+import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
+import { EventEmitter } from 'events';
+import { installShutdownHandlers } from '../../../src/server/lifecycle.js';
+
+type MockProc = EventEmitter & { exit: jest.Mock };
+
+function makeProc(): MockProc {
+  const proc = new EventEmitter() as MockProc;
+  proc.exit = jest.fn();
+  return proc;
+}
+
+const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+describe('installShutdownHandlers', () => {
+  let errSpy: jest.SpiedFunction<typeof console.error>;
+
+  beforeEach(() => {
+    // Shutdown logs a line to stderr; keep test output clean.
+    errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errSpy.mockRestore();
+  });
+
+  it('exits with code 0 when stdin ends (the core #177 fix)', async () => {
+    const proc = makeProc();
+    const stdin = new EventEmitter();
+    const cleanup = jest.fn(async () => {});
+
+    installShutdownHandlers({ cleanup, proc, stdin });
+    stdin.emit('end');
+    await flush();
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(proc.exit).toHaveBeenCalledTimes(1);
+    expect(proc.exit).toHaveBeenCalledWith(0);
+  });
+
+  it('runs cleanup + exit EXACTLY ONCE when stdin emits end, then close, then error', async () => {
+    const proc = makeProc();
+    const stdin = new EventEmitter();
+    const cleanup = jest.fn(async () => {});
+
+    installShutdownHandlers({ cleanup, proc, stdin });
+    // A single disconnect can surface as several events.
+    stdin.emit('end');
+    stdin.emit('close');
+    stdin.emit('error', new Error('broken pipe'));
+    await flush();
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(proc.exit).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(['SIGINT', 'SIGTERM', 'SIGHUP'])(
+    'shuts down cleanly on %s',
+    async (signal) => {
+      const proc = makeProc();
+      const stdin = new EventEmitter();
+      const cleanup = jest.fn(async () => {});
+
+      installShutdownHandlers({ cleanup, proc, stdin });
+      proc.emit(signal);
+      await flush();
+
+      expect(cleanup).toHaveBeenCalledTimes(1);
+      expect(proc.exit).toHaveBeenCalledWith(0);
+    }
+  );
+
+  it('a signal racing a stdin close still cleans up exactly once', async () => {
+    const proc = makeProc();
+    const stdin = new EventEmitter();
+    const cleanup = jest.fn(async () => {});
+
+    installShutdownHandlers({ cleanup, proc, stdin });
+    proc.emit('SIGTERM');
+    stdin.emit('close');
+    await flush();
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(proc.exit).toHaveBeenCalledTimes(1);
+  });
+
+  it('still exits(0) even if cleanup rejects', async () => {
+    const proc = makeProc();
+    const stdin = new EventEmitter();
+    const cleanup = jest.fn(async () => {
+      throw new Error('cleanup failed');
+    });
+
+    installShutdownHandlers({ cleanup, proc, stdin });
+    stdin.emit('error', new Error('pipe gone'));
+    await flush();
+
+    expect(proc.exit).toHaveBeenCalledWith(0);
+  });
+});


### PR DESCRIPTION
Completes @deadczarvc's **#177** (their first contribution — nice catch). Their fix is correct and is included here with authorship preserved (commits `f62c9f1`, `d657384`); this PR finishes the gaps found in review so the whole orphan-leak family is closed and locked in with tests.

> If you prefer, merge #177 first and I'll rebase this to just the delta — but this branch already contains their commits, so merging this alone lands everything.

## What #177 got right
On Windows a killed parent sends **no signal** to the child, and `StdioServerTransport`'s active stdin read handle pins the event loop, so an orphaned stdio server runs forever. Exiting on stdin `end`/`close`/`error` is the correct, reliable fix. Their follow-up even added an idempotency guard for the stdin double-fire.

## What this adds
- **Automated tests** (`tests/unit/server/lifecycle.test.ts`) — the PR had none. Covers: exits(0) on stdin end; cleanup+exit **exactly once** across end/close/error; SIGINT/SIGTERM/SIGHUP; a signal racing a stdin close; and surviving a rejecting `cleanup()`. Also verified the **real built server exits 0 on stdin EOF** end-to-end.
- **Unified, testable lifecycle** — extracted the wiring into a side-effect-free `src/server/lifecycle.ts` (`installShutdownHandlers`) and routed **SIGINT/SIGTERM/SIGHUP *and* stdin events through one guarded shutdown**. #177's guard covered only stdin, so a signal racing a stdin close (or `end`+`close` for one disconnect) could still run `cleanup()` twice and call `process.exit` twice. Also hardened against a rejecting `cleanup()` that would otherwise become an unhandled rejection (latent in the original — benign only because `process.exit` is synchronous).
- **Daemon orphan bound** (`daemon.ts`) — the daemon doesn't read stdin, so #177's mechanism can't apply; an orphaned daemon + its MCP child (~100 MB) would linger. Added an inactivity self-exit (`TOKEN_OPTIMIZER_DAEMON_IDLE_MS`, default 30 min, `0` to disable), reset per IPC request, cleared on shutdown.
- **Dashboard lifecycle** (`web-server.ts`) — had **no** signal handlers at all; added guarded SIGINT/SIGTERM graceful HTTP close with a force-exit fallback.

## Verification
- `tsc --noEmit` clean · `eslint src` **0 errors** · `jest` **662 passed / 1 skipped, 39 suites** (incl. 7 new) · `npm run build` clean.
- Real `node dist/server/index.js` exits **code 0** on stdin EOF within seconds.

## Note for the author (@deadczarvc)
Great root-cause analysis and a clean, minimal fix — genuinely strong for a first PR. The only things missing were tests and the adjacent processes (daemon/dashboard) that share the same lifecycle gap; those are handled here. This also complements the client-side npx orphan mitigation from #175 (server-side self-exit is the deeper fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)