### PR TITLE
feat(packaging): claude code plugin + gemini/codex/opencode/copilot integrations

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "token-optimizer",
+  "owner": {
+    "name": "ooples",
+    "url": "https://github.com/ooples"
+  },
+  "metadata": {
+    "description": "Marketplace hosting the token-optimizer plugin for Claude Code.",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "token-optimizer",
+      "source": "./plugin",
+      "description": "Context-window optimization (caching, compression, smart file tooling) as an MCP server + usage skill + auto-optimization hooks."
+    }
+  ]
+}

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,19 @@
+# Token optimization (Gemini CLI)
+
+This extension adds the `token-optimizer` MCP server. Its tools cut context/token
+usage 60–90% via caching, diffing, and compression. Prefer them:
+
+- **`smart_read`** instead of reading a file directly when the file is **large**
+  (>~400 lines / >25 KB) or already read this session — re-reads return a **diff**.
+- **`smart_glob`** instead of a content grep on a **big/unknown tree** — returns
+  **paths only**; read only what you need.
+- **`smart_edit`** on **large files** — returns a compact diff, not the whole file.
+- **`optimize_session`** when context fills up; **`get_session_stats`** for savings.
+- **`get_optimization_report`** to show the user total tokens saved with a full
+  breakdown by action/hook/server (returns a ready-to-display `formatted` summary).
+- **`optimize_text`** to stash bulky text out-of-context under a key.
+  **`compress_text`** is at-rest byte compression only — its base64 output usually
+  costs *more* tokens, so never put it back into context.
+- **`count_tokens`** to measure a chunk first.
+
+Small files / one-off reads: built-in reading is fine — don't add overhead.

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -1,0 +1,98 @@
+# Publishing token-optimizer to plugin marketplaces & registries
+
+token-optimizer is fundamentally an **MCP server** (`@ooples/token-optimizer-mcp`
+on npm) plus a **Claude Code plugin** (`./plugin`) and per-CLI integration
+configs (`./integrations`). This guide covers getting it *listed* in each
+ecosystem's discovery surface.
+
+Legend: ✅ done in-repo · ⏳ requires a manual/interactive step you must run.
+
+## 1. Official MCP Registry — covers Copilot CLI, Codex, OpenCode, and any MCP client
+
+The [official MCP Registry](https://registry.modelcontextprotocol.io/) is the
+shared metadata registry backed by Anthropic, GitHub, Microsoft, and PulseMCP.
+Publishing here makes the server discoverable across every MCP-aware tool
+(GitHub's registry mirrors from it). Codex and OpenCode have no separate
+marketplace — they consume MCP servers via config, so the registry is their
+discovery path.
+
+- ✅ `package.json` carries the ownership marker `"mcpName": "io.github.ooples/token-optimizer-mcp"`.
+- ✅ `server.json` (repo root) declares the scoped npm package, version, stdio
+  transport, and the optional `TOKEN_OPTIMIZER_CACHE_DIR` env var.
+- ✅ **PUBLISHED** — `io.github.ooples/token-optimizer-mcp v5.0.1` is live on
+  <https://registry.modelcontextprotocol.io> (verify:
+  `curl -s "https://registry.modelcontextprotocol.io/v0/servers?search=token-optimizer"`).
+- **Re-publishing on each future npm release** (non-interactive; `gh` must be
+  authenticated as `ooples`):
+  ```bash
+  # 0. server.json "version" must equal a PUBLISHED npm version carrying mcpName:
+  npm view @ooples/token-optimizer-mcp@<ver> mcpName   # -> io.github.ooples/token-optimizer-mcp
+  # 1. Get the publisher CLI (macOS/Linux: brew install mcp-publisher; Windows:
+  #    download mcp-publisher_windows_amd64.tar.gz from the registry releases).
+  # 2. Authenticate with the gh token (no browser needed):
+  mcp-publisher login github --token "$(gh auth token)"
+  # 3. Publish (reads ./server.json):
+  mcp-publisher publish
+  ```
+  Notes learned in practice: `description` must be **≤ 100 chars** or the
+  registry returns 422; keep `server.json` `version` in lockstep with npm.
+
+## 2. Claude Code
+
+The repo **is** a marketplace: `.claude-plugin/marketplace.json` lists the
+`token-optimizer` plugin under `./plugin`. `claude plugin validate ./plugin`
+passes.
+
+- **Self-host (no approval):** once the plugin is on the default branch,
+  ```
+  /plugin marketplace add ooples/token-optimizer-mcp
+  /plugin install token-optimizer@token-optimizer
+  ```
+- ⏳ **Community marketplace** (`claude-community`) — the realistic public listing:
+  1. Run `claude plugin validate ./plugin` (the review pipeline runs the same check).
+  2. Submit via the Console form: <https://platform.claude.com/plugins/submit>
+     (individual authors), or the claude.ai form
+     <https://claude.ai/admin-settings/directory/submissions/plugins/new>
+     (needs a Team/Enterprise org + directory-management access).
+  3. On approval it's pinned to a commit SHA in
+     [`anthropics/claude-plugins-community`](https://github.com/anthropics/claude-plugins-community);
+     the catalog syncs nightly.
+- **Official marketplace** (`claude-plugins-official`): curated by Anthropic at
+  its discretion. **No application process** — the submission form does not add
+  here. If they list it, you can prompt users via
+  [plugin hints](https://code.claude.com/docs/en/plugin-hints).
+- ⏳ **Prerequisite:** merge the packaging PR so `plugin/` and
+  `.claude-plugin/marketplace.json` land on `master` (the submission/self-host
+  flows read the default branch).
+
+## 3. Gemini CLI — auto-indexed gallery (no form)
+
+The [Gemini extension gallery](https://www.geminicliextensions.com/browse)
+crawls public GitHub repos daily; there is nothing to submit.
+
+- ✅ Repo is public.
+- ✅ GitHub topic `gemini-cli-extension` added (the crawler keys off this).
+- ✅ `gemini-extension.json` + `GEMINI.md` placed at the **repo root** (the
+  crawler requires the manifest at the absolute root or a release-archive root).
+- ⏳ **Tag a release** so the crawler picks it up:
+  ```bash
+  git tag v5.0.2 && git push origin v5.0.2
+  ```
+  It appears in the gallery on the next daily crawl if validation passes.
+
+## 4. GitHub Copilot CLI / Codex / OpenCode
+
+No dedicated plugin store of their own — they load MCP servers from config
+(`~/.copilot/mcp-config.json`, `~/.codex/config.toml`,
+`opencode.json`; see `integrations/`). Discovery comes from **the MCP Registry
+(step 1)**. Ready-to-copy configs live in `integrations/`.
+
+## Quick status
+
+| Target | In-repo prep | Manual step remaining |
+| --- | --- | --- |
+| MCP Registry | ✅ `server.json`, `mcpName` | ✅ **PUBLISHED (v5.0.1 live)** |
+| Claude Code (self-host) | ✅ marketplace.json, validate passes | merge packaging PR to `master` |
+| Claude Code (community) | ✅ validate passes | submit via Console form (needs your login) |
+| Gemini gallery | ✅ topic + root manifest | `git tag` a release (after merge) |
+| Copilot / Codex / OpenCode | ✅ `integrations/*` configs | ✅ (covered by the MCP Registry) |

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,12 @@
+{
+  "name": "token-optimizer",
+  "version": "5.0.2",
+  "description": "Context-window optimization tools (caching, compression, smart file tooling) for the Gemini CLI.",
+  "mcpServers": {
+    "token-optimizer": {
+      "command": "npx",
+      "args": ["-y", "@ooples/token-optimizer-mcp@latest"]
+    }
+  },
+  "contextFileName": "GEMINI.md"
+}

--- a/integrations/AGENTS.md
+++ b/integrations/AGENTS.md
@@ -1,0 +1,25 @@
+# Token optimization (for Codex, OpenCode, and other AGENTS.md-aware agents)
+
+This project provides a `token-optimizer` MCP server whose tools cut context/token
+usage 60–90% via caching, diffing, and compression. When the MCP server is
+configured (see the integration READMEs), prefer these tools:
+
+- **`smart_read`** instead of reading a file directly when the file is **large**
+  (>~400 lines / >25 KB) or you have **already read it** this session — on
+  re-reads it returns only a **diff**, often a few tokens instead of the whole file.
+- **`smart_glob`** instead of a content grep when searching a **big/unknown tree**
+  — it returns **paths only** with filtering/pagination; read only what you need.
+- **`smart_edit`** instead of a raw edit on **large files** — returns a compact
+  unified diff rather than echoing the file.
+- **`optimize_session`** when context is filling up; **`get_session_stats`** to see
+  tokens saved.
+- **`get_optimization_report`** to show the user how much they've saved — total
+  tokens saved, overall %, and a breakdown by action/hook/server. It returns a
+  ready-to-display `formatted` summary; show that when the user asks about savings.
+- **`optimize_text`** to stash bulky text out-of-context under a key (retrieve
+  later). **`compress_text`** is byte-compression for **at-rest storage only** —
+  its base64 output usually costs *more* LLM tokens, so never feed it back into
+  context.
+- **`count_tokens`** to measure a chunk before deciding how to handle it.
+
+Small files / one-off reads: the built-in tools are fine — don't add overhead.

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -1,0 +1,98 @@
+# Using token-optimizer across AI agents
+
+The token-optimizer MCP server works with any MCP-capable agent. This folder has
+ready-to-use config for the major CLIs. The MCP **server** is identical
+everywhere (`npx -y @ooples/token-optimizer-mcp@latest`); what differs per tool is
+the config file and how each one loads instructions ("skills").
+
+| Agent | MCP config | Instructions ("skill") |
+| --- | --- | --- |
+| **Claude Code** | `../plugin` (full plugin: MCP + skill + hooks) | `skills/token-optimization/SKILL.md` |
+| **Gemini CLI** | `gemini/gemini-extension.json` | `gemini/GEMINI.md` |
+| **OpenAI Codex** | `codex/config.toml` | `AGENTS.md` |
+| **OpenCode** | `opencode/opencode.json` | `AGENTS.md` |
+| **GitHub Copilot CLI** | `copilot/mcp-config.json` | `AGENTS.md` |
+
+Prereq for all: Node.js (so `npx` can run the server). First run downloads
+`@ooples/token-optimizer-mcp`; subsequent runs are cached.
+
+> Getting token-optimizer **listed** in each ecosystem's marketplace/registry
+> (MCP Registry, Claude Code community marketplace, Gemini extension gallery)?
+> See [`../docs/PUBLISHING.md`](../docs/PUBLISHING.md).
+
+## Claude Code (native plugin — richest)
+
+The repo root is a plugin marketplace; the plugin lives in `../plugin` (MCP +
+the `token-optimization` skill + a cross-platform large-read hook).
+
+```bash
+# Try it locally:
+claude --plugin-dir ./plugin
+
+# Or install via the marketplace:
+/plugin marketplace add ooples/token-optimizer-mcp
+/plugin install token-optimizer@token-optimizer
+```
+
+Optional hook env vars: `TOKEN_OPTIMIZER_REDIRECT_LARGE_READS=true` (deny large
+built-in Reads and steer to `smart_read`), `TOKEN_OPTIMIZER_LARGE_READ_BYTES`
+(threshold, default 25600).
+
+## Gemini CLI
+
+```bash
+# Install as a Gemini extension:
+mkdir -p ~/.gemini/extensions/token-optimizer
+cp gemini/gemini-extension.json gemini/GEMINI.md ~/.gemini/extensions/token-optimizer/
+# Restart the Gemini CLI; verify the server with: /mcp
+```
+
+Alternatively add the `mcpServers` block from `gemini-extension.json` to
+`~/.gemini/settings.json`.
+
+> **Gemini hooks caveat:** if you also wire up hooks in `~/.gemini/settings.json`,
+> Gemini CLI uses its **own** event names — `BeforeTool` / `AfterTool`, *not*
+> Claude Code's `PreToolUse` / `PostToolUse`. An unknown event name is silently
+> dropped (`Hook registry initialized with 0 hook entries`) and the MCP tools
+> keep working, but the hook never fires. MCP tool names match as
+> `mcp_<server>_<tool>` in a hook `matcher`.
+
+## OpenAI Codex
+
+```bash
+# 1) Merge the MCP server into your Codex config:
+cat codex/config.toml >> ~/.codex/config.toml
+# 2) Add the guidance so Codex knows when to use the tools:
+cat AGENTS.md >> ~/.codex/AGENTS.md   # or your project's AGENTS.md
+```
+
+## OpenCode
+
+```bash
+# Drop both files into your project (or ~/.config/opencode/):
+cp opencode/opencode.json AGENTS.md ./
+# opencode.json references ./AGENTS.md via "instructions".
+```
+
+## GitHub Copilot CLI
+
+```bash
+# Add the MCP server to your global Copilot config:
+cp copilot/mcp-config.json ~/.copilot/mcp-config.json
+# Or, for a single session without touching the global config:
+copilot --additional-mcp-config @copilot/mcp-config.json
+# Guidance: append AGENTS.md so Copilot knows when to use the tools:
+cat AGENTS.md >> AGENTS.md   # in your project root
+```
+
+Verify: the Copilot log (`~/.copilot/logs/`) shows
+`MCP client for token-optimizer connected`.
+
+## Notes
+
+- **Compression is model-invoked.** No agent can transparently rewrite a built-in
+  read's output (see anthropics/claude-code#32105), so the agent must *call*
+  `smart_read`/`smart_glob`/etc. The skill/AGENTS.md/GEMINI.md files teach it when.
+- **`compress_text` is at-rest only** — its base64 output usually has more tokens
+  than the input; use `optimize_text` (by key) to stash content out of context.
+- Pin a version by replacing `@latest` with a specific version in any config.

--- a/integrations/codex/config.toml
+++ b/integrations/codex/config.toml
@@ -1,0 +1,10 @@
+# OpenAI Codex CLI — token-optimizer MCP server.
+# Merge this into ~/.codex/config.toml (Codex reads MCP servers under
+# [mcp_servers.<name>]). Then add the guidance from ../AGENTS.md to your
+# project's AGENTS.md (or ~/.codex/AGENTS.md) so Codex knows when to use them.
+
+[mcp_servers.token-optimizer]
+command = "npx"
+args = ["-y", "@ooples/token-optimizer-mcp@latest"]
+# Optional: point the cache somewhere stable.
+# env = { TOKEN_OPTIMIZER_CACHE_DIR = "~/.token-optimizer-cache" }

--- a/integrations/copilot/mcp-config.json
+++ b/integrations/copilot/mcp-config.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "token-optimizer": {
+      "type": "local",
+      "command": "npx",
+      "args": ["-y", "@ooples/token-optimizer-mcp@latest"],
+      "tools": ["*"]
+    }
+  }
+}

--- a/integrations/gemini/GEMINI.md
+++ b/integrations/gemini/GEMINI.md
@@ -1,0 +1,19 @@
+# Token optimization (Gemini CLI)
+
+This extension adds the `token-optimizer` MCP server. Its tools cut context/token
+usage 60–90% via caching, diffing, and compression. Prefer them:
+
+- **`smart_read`** instead of reading a file directly when the file is **large**
+  (>~400 lines / >25 KB) or already read this session — re-reads return a **diff**.
+- **`smart_glob`** instead of a content grep on a **big/unknown tree** — returns
+  **paths only**; read only what you need.
+- **`smart_edit`** on **large files** — returns a compact diff, not the whole file.
+- **`optimize_session`** when context fills up; **`get_session_stats`** for savings.
+- **`get_optimization_report`** to show the user total tokens saved with a full
+  breakdown by action/hook/server (returns a ready-to-display `formatted` summary).
+- **`optimize_text`** to stash bulky text out-of-context under a key.
+  **`compress_text`** is at-rest byte compression only — its base64 output usually
+  costs *more* tokens, so never put it back into context.
+- **`count_tokens`** to measure a chunk first.
+
+Small files / one-off reads: built-in reading is fine — don't add overhead.

--- a/integrations/gemini/gemini-extension.json
+++ b/integrations/gemini/gemini-extension.json
@@ -1,0 +1,12 @@
+{
+  "name": "token-optimizer",
+  "version": "5.0.2",
+  "description": "Context-window optimization tools (caching, compression, smart file tooling) for the Gemini CLI.",
+  "mcpServers": {
+    "token-optimizer": {
+      "command": "npx",
+      "args": ["-y", "@ooples/token-optimizer-mcp@latest"]
+    }
+  },
+  "contextFileName": "GEMINI.md"
+}

--- a/integrations/opencode/opencode.json
+++ b/integrations/opencode/opencode.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "token-optimizer": {
+      "type": "local",
+      "command": ["npx", "-y", "@ooples/token-optimizer-mcp@latest"],
+      "enabled": true
+    }
+  },
+  "instructions": ["./AGENTS.md"]
+}

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "token-optimizer",
+  "description": "Intelligent context-window optimization: caching, compression, and smart file tooling that cut token usage 60-90%. Bundles the token-optimizer MCP server plus a usage skill and automatic-optimization hooks.",
+  "version": "5.0.2",
+  "author": {
+    "name": "ooples"
+  },
+  "homepage": "https://github.com/ooples/token-optimizer-mcp#readme",
+  "repository": "https://github.com/ooples/token-optimizer-mcp",
+  "license": "MIT",
+  "keywords": [
+    "token-optimization",
+    "context-window",
+    "caching",
+    "compression",
+    "mcp"
+  ]
+}

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/large-read-advisor.mjs\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugin/hooks/large-read-advisor.mjs
+++ b/plugin/hooks/large-read-advisor.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/**
+ * Cross-platform PreToolUse hook: steer large built-in `Read` calls toward the
+ * token-optimizer `smart_read` MCP tool (cached/diffed, far fewer tokens).
+ *
+ * Runs on macOS/Linux/Windows (plain Node, no shell/PowerShell). It reads the
+ * hook payload as JSON on stdin and:
+ *   - default: emits a NON-blocking `additionalContext` nudge for large reads.
+ *   - if TOKEN_OPTIMIZER_REDIRECT_LARGE_READS=true: DENIES the large read so the
+ *     model uses smart_read instead (off by default — never breaks workflows).
+ *
+ * Why not transparently compress the Read? Claude Code's hook contract can't
+ * replace a built-in tool's output (see anthropics/claude-code#32105), so the
+ * only lever is to advise/deny at PreToolUse. Small reads pass through untouched.
+ */
+import { statSync } from 'node:fs';
+
+const THRESHOLD_BYTES = Number(process.env.TOKEN_OPTIMIZER_LARGE_READ_BYTES) || 25_600; // ~25 KB
+const REDIRECT = process.env.TOKEN_OPTIMIZER_REDIRECT_LARGE_READS === 'true';
+
+function readStdin() {
+  return new Promise((resolve) => {
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (c) => (data += c));
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', () => resolve(data));
+  });
+}
+
+function allow() {
+  // No decision — let normal permission flow proceed.
+  process.exit(0);
+}
+
+const raw = await readStdin();
+let payload;
+try {
+  payload = JSON.parse(raw);
+} catch {
+  allow();
+}
+
+if (!payload || payload.tool_name !== 'Read') allow();
+
+const filePath = payload.tool_input?.file_path;
+if (!filePath) allow();
+
+let size = 0;
+try {
+  const st = statSync(filePath);
+  if (!st.isFile()) allow();
+  size = st.size;
+} catch {
+  allow(); // unreadable/nonexistent — nothing to advise
+}
+
+if (size < THRESHOLD_BYTES) allow();
+
+const kb = Math.round(size / 1024);
+if (REDIRECT) {
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: `This file is ${kb} KB. Use the smart_read MCP tool (smart_read with path="${filePath}") for a cached/diffed, token-optimized read instead of the built-in Read.`,
+      },
+    })
+  );
+  process.exit(0);
+}
+
+// Default: non-blocking nudge.
+process.stdout.write(
+  JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      additionalContext: `Tip: ${filePath} is ${kb} KB. Consider the smart_read MCP tool (cached/diffed) to save tokens on large or repeat reads.`,
+    },
+  })
+);
+process.exit(0);

--- a/plugin/skills/token-optimization/SKILL.md
+++ b/plugin/skills/token-optimization/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: token-optimization
+description: Use the token-optimizer MCP tools to reduce context/token usage when reading, searching, or editing files, or when the context window is filling up. Trigger when reading large files, re-reading files already seen, searching a big/unknown tree, making edits to large files, or when you need to store bulky output out-of-context.
+---
+
+# Token optimization
+
+This project ships a `token-optimizer` MCP server whose tools cut context usage
+60–90% via caching, diffing, and compression. Prefer them over the built-in
+tools in the situations below. All tools are model-invoked — you must call them;
+nothing rewrites the built-in `Read`/`Grep` output automatically.
+
+## When to use which tool
+
+- **`smart_read`** instead of `Read` when a file is **large** (roughly >400
+  lines / >25 KB) or you have **read it before this session**. It caches file
+  content and, on re-reads, returns only a **diff** of what changed — often a
+  handful of tokens instead of the whole file. Pass `path`; optionally
+  `enableCache`, `diffMode`, `maxSize`, `includeMetadata`.
+
+- **`smart_glob`** instead of `Grep`/`Glob` for finding files in a **big or
+  unfamiliar tree**. It returns **paths only** (no content) with filtering,
+  sorting, and pagination — a fraction of the tokens of listing with content.
+  Pass `pattern` (e.g. `src/**/*.ts`) and optionally `cwd`, `extensions`,
+  `limit`.
+
+- **`smart_edit`** instead of `Edit` for **large files**: it applies the edit
+  and returns a compact unified **diff** rather than echoing the whole file.
+  (For very small files a plain `Edit` is fine — smart_edit's diff overhead is
+  only worth it once the file is sizeable.)
+
+- **`optimize_session`** / **`get_session_stats`** when the **context window is
+  filling up** or after a burst of file operations. `optimize_session`
+  batch-compresses prior file operations and stores them out-of-context;
+  `get_session_stats` reports tokens saved so far.
+
+- **`get_optimization_report`** when the user asks **how much they've saved**
+  (or to show it proactively). Returns total tokens saved, overall savings %,
+  approximate cost saved, and a full breakdown **by action, by hook phase, and
+  by MCP server**, plus a pre-rendered `formatted` text summary you can display
+  as-is. (The per-tool `get_hook_analytics` / `get_action_analytics` /
+  `get_mcp_server_analytics` / `export_analytics` tools give the raw dimensions.)
+
+- **`count_tokens`** to measure how expensive a chunk of text is before you
+  decide how to handle it.
+
+## Storing bulky content out of context
+
+- **`optimize_text`** — compress a large text blob under a `key` and keep it in
+  the external cache instead of your context; retrieve it later by key. Reports
+  `tokensSaved`. Good for logs, large outputs, or reference material you don't
+  need inline right now.
+
+- **`compress_text`** — Brotli+base64 compression. **Byte** reduction only:
+  the base64 output usually has **more** LLM tokens than the input, so use it
+  for **at-rest storage/caching, not for putting back into context.** The tool
+  returns `increasesTokens` + a warning when that's the case.
+
+## Rules of thumb
+
+1. Reading a big file or one you've seen before → `smart_read`.
+2. Searching a large/unknown tree → `smart_glob` (paths first, read only what
+   you need).
+3. Editing a large file → `smart_edit`.
+4. Context getting tight → `optimize_session`, then continue.
+5. Need to stash bulky output → `optimize_text` (by key), not `compress_text`
+   into context.
+6. Small files/one-off reads → the built-in tools are fine; don't add overhead.

--- a/server.json
+++ b/server.json
@@ -1,23 +1,23 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.ooples/token-optimizer-mcp",
-  "description": "Intelligent token optimization achieving 95%+ reduction through caching, compression, and 80+ tools",
+  "description": "Context-window optimization: caching, compression & smart file tools that cut tokens 60-90%.",
   "repository": {
     "url": "https://github.com/ooples/token-optimizer-mcp",
     "source": "github"
   },
-  "version": "2.0.0",
+  "version": "5.0.1",
   "packages": [
     {
       "registryType": "npm",
-      "identifier": "token-optimizer-mcp",
-      "version": "2.0.0",
+      "identifier": "@ooples/token-optimizer-mcp",
+      "version": "5.0.1",
       "transport": {
         "type": "stdio"
       },
       "environmentVariables": [
         {
-          "description": "Directory path for cache storage (optional, defaults to ~/.token-optimizer-cache)",
+          "description": "Directory path for cache storage (optional, defaults to ~/.token-optimizer-mcp)",
           "isRequired": false,
           "format": "string",
           "isSecret": false,

--- a/src/analytics/record-tool-analytics.ts
+++ b/src/analytics/record-tool-analytics.ts
@@ -56,7 +56,12 @@ const OPTIMIZED_KEYS = [
   'afterTokens',
   'outputTokens',
 ];
-const SAVED_KEYS = ['tokensSaved', 'savedTokens', 'tokens_saved', 'tokenSavings'];
+const SAVED_KEYS = [
+  'tokensSaved',
+  'savedTokens',
+  'tokens_saved',
+  'tokenSavings',
+];
 
 // Containers a triplet is commonly nested inside.
 const NESTED_CONTAINERS = [
@@ -187,7 +192,7 @@ export async function recordToolAnalytics(
 
     const sessionId =
       process.env.TOKEN_OPTIMIZER_SESSION_ID ||
-      (payload as Record<string, unknown>).sessionId as string | undefined;
+      ((payload as Record<string, unknown>).sessionId as string | undefined);
 
     await manager.track({
       hookPhase: currentHookPhase(),


### PR DESCRIPTION
Packages token-optimizer for use across MCP-capable agents — bundling the MCP server **plus** skills/instructions and hooks, per platform.

## Claude Code plugin (`plugin/`)
Validated with `claude plugin validate ./plugin` → **✔ passed**.
- `.claude-plugin/plugin.json` manifest + repo-root `.claude-plugin/marketplace.json` (repo doubles as a marketplace)
- `.mcp.json` → runs the server via `npx -y @ooples/token-optimizer-mcp@latest`
- `skills/token-optimization/SKILL.md` → **model-invoked** guidance on when to reach for `smart_read` / `smart_glob` / `smart_edit` / `optimize_session` / `optimize_text` (the "more than MCP" piece)
- `hooks/hooks.json` + `hooks/large-read-advisor.mjs` → a **cross-platform, pure-Node** PreToolUse hook that nudges large built-in `Read`s toward `smart_read`; opt-in hard redirect via `TOKEN_OPTIMIZER_REDIRECT_LARGE_READS=true`

Install: `claude --plugin-dir ./plugin`, or `/plugin marketplace add ooples/token-optimizer-mcp` then `/plugin install token-optimizer@token-optimizer`.

## Other agents (`integrations/`)
Same MCP server, per-tool config + a "skill-equivalent" instructions file:
- **Gemini CLI** — `gemini/gemini-extension.json` + `gemini/GEMINI.md`
- **OpenAI Codex** — `codex/config.toml` (`[mcp_servers.token-optimizer]`) + shared `AGENTS.md`
- **OpenCode** — `opencode/opencode.json` (`mcp` local + `instructions`) + shared `AGENTS.md`
- `integrations/README.md` — copy-paste install per platform

## Design notes
- The plugin lives in a **subdirectory**, not the repo root, so it never collides with the developer's local `.mcp.json`.
- Compression is **model-invoked everywhere**: no agent can transparently replace a built-in read's output (anthropics/claude-code#32105), so the skill/AGENTS/GEMINI files teach *when* to call the tools rather than pretending it's automatic.
- The existing PowerShell hooks are untouched (kept for current Windows users); the new hook is the portable path.

## Verification
`claude plugin validate` passes · all JSON/TOML parse · the Node hook parses and behaves (nudge on large files, deny in redirect mode, silent on small). Kept out of the commit: the developer's secret-bearing `.mcp.json` (handled separately in #179).

🤖 Generated with [Claude Code](https://claude.com/claude-code)