### PR TITLE
feat(analytics): auto-record token savings + get_optimization_report

### DIFF
--- a/src/analytics/record-tool-analytics.ts
+++ b/src/analytics/record-tool-analytics.ts
@@ -1,0 +1,204 @@
+/**
+ * Auto-recording bridge between the MCP tool dispatcher and the AnalyticsManager.
+ *
+ * Every token-optimizer tool returns its result as a JSON string inside an MCP
+ * `content[].text` block. Most optimization tools include a savings triplet
+ * (original tokens, optimized tokens, tokens saved) under one of a handful of
+ * well-known field names. This module extracts that triplet from a tool result
+ * and records it, so the analytics breakdown tools (`get_hook_analytics`,
+ * `get_action_analytics`, `get_mcp_server_analytics`, `export_analytics`,
+ * `get_optimization_report`) have real data instead of always returning zeros.
+ *
+ * It is intentionally best-effort: a tool whose result has no recognizable
+ * savings triplet is silently skipped, and any parsing/storage error is
+ * swallowed so recording can never break a tool call.
+ */
+
+import type { AnalyticsManager } from './analytics-manager.js';
+import type { HookPhase } from './analytics-types.js';
+
+/** MCP tool result shape (the parts we read). */
+interface McpToolResult {
+  content?: Array<{ type?: string; text?: string }>;
+  isError?: boolean;
+}
+
+/** A normalized savings measurement extracted from a tool result. */
+export interface SavingsTriplet {
+  originalTokens: number;
+  optimizedTokens: number;
+  tokensSaved: number;
+}
+
+const VALID_HOOK_PHASES: readonly HookPhase[] = [
+  'PreToolUse',
+  'PostToolUse',
+  'SessionStart',
+  'PreCompact',
+  'UserPromptSubmit',
+  'Unknown',
+];
+
+// Field-name aliases seen across the 70+ tools. Order matters: the first present
+// numeric field wins.
+const ORIGINAL_KEYS = [
+  'originalTokens',
+  'originalTokenCount',
+  'tokensBefore',
+  'beforeTokens',
+  'inputTokens',
+];
+const OPTIMIZED_KEYS = [
+  'optimizedTokens',
+  'compressedTokens',
+  'cachedTokens',
+  'tokensAfter',
+  'afterTokens',
+  'outputTokens',
+];
+const SAVED_KEYS = ['tokensSaved', 'savedTokens', 'tokens_saved', 'tokenSavings'];
+
+// Containers a triplet is commonly nested inside.
+const NESTED_CONTAINERS = [
+  'metadata',
+  'stats',
+  'statistics',
+  'summary',
+  'optimization',
+  'tokenAnalysis',
+  'tokens',
+  'result',
+  'data',
+];
+
+function firstNumber(
+  obj: Record<string, unknown>,
+  keys: string[]
+): number | undefined {
+  for (const k of keys) {
+    const v = obj[k];
+    if (typeof v === 'number' && Number.isFinite(v)) return v;
+  }
+  return undefined;
+}
+
+/** Try to read a savings triplet directly off one object (no recursion). */
+function tripletFrom(obj: Record<string, unknown>): SavingsTriplet | null {
+  const original = firstNumber(obj, ORIGINAL_KEYS);
+  const optimized = firstNumber(obj, OPTIMIZED_KEYS);
+  const saved = firstNumber(obj, SAVED_KEYS);
+
+  // Need enough to reconstruct the triplet. Accept any two of the three, or
+  // (original + saved) / (original + optimized) / (optimized + saved).
+  const known = [original, optimized, saved].filter(
+    (n): n is number => typeof n === 'number'
+  ).length;
+  if (known < 2) {
+    // Special case: an explicit savings value alone is still meaningful.
+    if (typeof saved === 'number' && typeof original === 'number') {
+      // handled below; unreachable here since that's 2 known
+    }
+    return null;
+  }
+
+  let o = original;
+  let opt = optimized;
+  let s = saved;
+
+  if (o === undefined && opt !== undefined && s !== undefined) o = opt + s;
+  if (opt === undefined && o !== undefined && s !== undefined) opt = o - s;
+  if (s === undefined && o !== undefined && opt !== undefined) s = o - opt;
+
+  if (o === undefined || opt === undefined || s === undefined) return null;
+
+  // Sanity: no negative token counts; ignore no-op records with nothing saved
+  // AND nothing measured (pure noise), but keep genuine 0-savings measurements.
+  if (o < 0 || opt < 0) return null;
+  if (o === 0 && opt === 0) return null;
+
+  return { originalTokens: o, optimizedTokens: opt, tokensSaved: s };
+}
+
+/**
+ * Extract a savings triplet from a parsed tool-result payload, checking the
+ * top level first, then one level of common nested containers.
+ */
+export function extractSavings(payload: unknown): SavingsTriplet | null {
+  if (!payload || typeof payload !== 'object') return null;
+  const obj = payload as Record<string, unknown>;
+
+  const top = tripletFrom(obj);
+  if (top) return top;
+
+  for (const key of NESTED_CONTAINERS) {
+    const child = obj[key];
+    if (child && typeof child === 'object' && !Array.isArray(child)) {
+      const nested = tripletFrom(child as Record<string, unknown>);
+      if (nested) return nested;
+    }
+  }
+  return null;
+}
+
+/** Resolve the current hook phase from the environment (set by hook launchers). */
+export function currentHookPhase(): HookPhase {
+  const raw = process.env.TOKEN_OPTIMIZER_HOOK_PHASE;
+  if (raw && (VALID_HOOK_PHASES as readonly string[]).includes(raw)) {
+    return raw as HookPhase;
+  }
+  return 'Unknown';
+}
+
+/**
+ * Best-effort: record the savings from a single MCP tool result. Never throws.
+ *
+ * @param manager   the shared AnalyticsManager
+ * @param toolName  the tool that produced the result (e.g. "smart_read")
+ * @param result    the MCP result object returned by the tool handler
+ */
+export async function recordToolAnalytics(
+  manager: AnalyticsManager,
+  toolName: string,
+  result: McpToolResult
+): Promise<void> {
+  try {
+    if (!result || result.isError) return;
+    const text = result.content?.find((c) => c?.type !== 'image')?.text;
+    if (!text) return;
+
+    let payload: unknown;
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      return; // non-JSON output (e.g. raw text) — nothing to record
+    }
+
+    // Don't record failures the tool reported in-band.
+    if (
+      payload &&
+      typeof payload === 'object' &&
+      (payload as Record<string, unknown>).success === false
+    ) {
+      return;
+    }
+
+    const savings = extractSavings(payload);
+    if (!savings) return;
+
+    const sessionId =
+      process.env.TOKEN_OPTIMIZER_SESSION_ID ||
+      (payload as Record<string, unknown>).sessionId as string | undefined;
+
+    await manager.track({
+      hookPhase: currentHookPhase(),
+      toolName,
+      mcpServer: 'token-optimizer',
+      originalTokens: savings.originalTokens,
+      optimizedTokens: savings.optimizedTokens,
+      tokensSaved: savings.tokensSaved,
+      ...(sessionId ? { sessionId } : {}),
+    });
+  } catch {
+    // Analytics must never break a tool call.
+  }
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -132,6 +132,11 @@ import {
   EXPORT_ANALYTICS_TOOL_DEFINITION,
 } from '../tools/analytics/export-analytics.js';
 import {
+  getOptimizationReportTool,
+  GET_OPTIMIZATION_REPORT_TOOL_DEFINITION,
+} from '../tools/analytics/get-optimization-report.js';
+import { recordToolAnalytics } from '../analytics/record-tool-analytics.js';
+import {
   OptimizationStorageTool,
   OPTIMIZATION_STORAGE_TOOL_DEFINITION,
 } from '../tools/optimization-storage-tool.js';
@@ -383,6 +388,7 @@ const getHookAnalytics = getHookAnalyticsTool(analyticsManager);
 const getActionAnalytics = getActionAnalyticsTool(analyticsManager);
 const getMcpServerAnalytics = getMcpServerAnalyticsTool(analyticsManager);
 const exportAnalytics = getExportAnalyticsTool(analyticsManager);
+const getOptimizationReport = getOptimizationReportTool(analyticsManager);
 const optimizationStorage = new OptimizationStorageTool();
 
 // #120: load user config (creates ~/.token-optimizer/config.json with
@@ -731,6 +737,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       GET_ACTION_ANALYTICS_TOOL_DEFINITION,
       GET_MCP_SERVER_ANALYTICS_TOOL_DEFINITION,
       EXPORT_ANALYTICS_TOOL_DEFINITION,
+      GET_OPTIMIZATION_REPORT_TOOL_DEFINITION,
       OPTIMIZATION_STORAGE_TOOL_DEFINITION,
       CONTEXT_DELTA_TOOL_DEFINITION,
     ],
@@ -738,7 +745,9 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
 });
 
 // Handle tool calls
-server.setRequestHandler(CallToolRequestSchema, async (request) => {
+async function handleToolCall(request: {
+  params: { name: string; arguments?: unknown };
+}) {
   const { name } = request.params;
 
   // Validate tool arguments using Zod schemas. The validated (and, for tightened
@@ -2356,6 +2365,13 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
       }
 
+      case 'get_optimization_report': {
+        const result = await getOptimizationReport(args as any);
+        return {
+          content: [{ type: 'text', text: result }],
+        };
+      }
+
       default:
         throw new Error(`Unknown tool: ${name}`);
     }
@@ -2372,6 +2388,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       isError: true,
     };
   }
+}
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const result = await handleToolCall(request);
+  // Best-effort: feed savings into analytics so the report/breakdown tools have
+  // real data. Never blocks meaningfully or breaks the tool call.
+  await recordToolAnalytics(analyticsManager, request.params.name, result);
+  return result;
 });
 
 // Helper to run cleanup operations with error handling

--- a/src/tools/analytics/get-optimization-report.ts
+++ b/src/tools/analytics/get-optimization-report.ts
@@ -1,0 +1,193 @@
+/**
+ * MCP tool: get_optimization_report
+ *
+ * One-stop, user-facing summary of everything token-optimizer has saved:
+ * total tokens saved, overall savings %, and full breakdowns by action (tool),
+ * by hook phase, and by MCP server. Returns both a structured object (for
+ * programmatic use / dashboards) and a pre-rendered `formatted` text report so
+ * any agent can show the user a clean summary without post-processing.
+ */
+
+import type { AnalyticsManager } from '../../analytics/analytics-manager.js';
+import type { AggregatedStats } from '../../analytics/analytics-types.js';
+
+export const GET_OPTIMIZATION_REPORT_TOOL_DEFINITION = {
+  name: 'get_optimization_report',
+  description:
+    'Get a complete token-savings report: total tokens saved, overall savings %, and full breakdowns by action/tool, by hook phase, and by MCP server. Returns structured data plus a ready-to-display formatted text summary. Use this to show the user how much context/token budget token-optimizer has saved them.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      startDate: {
+        type: 'string',
+        description:
+          'Optional start date filter in ISO 8601 format (e.g., 2025-01-01T00:00:00Z)',
+      },
+      endDate: {
+        type: 'string',
+        description:
+          'Optional end date filter in ISO 8601 format (e.g., 2025-12-31T23:59:59Z)',
+      },
+      sessionId: {
+        type: 'string',
+        description:
+          'Optional session ID to scope the report to a single session.',
+      },
+      topN: {
+        type: 'number',
+        description:
+          'Limit each breakdown to the top N rows by tokens saved (default: 10).',
+      },
+    },
+  },
+} as const;
+
+function num(n: number): string {
+  return Math.round(n).toLocaleString('en-US');
+}
+
+function pct(n: number): string {
+  return `${n.toFixed(1)}%`;
+}
+
+/** Approximate USD saved, assuming input-token pricing (~$3 / 1M tokens). */
+function approxCost(tokens: number): string {
+  const usd = (tokens / 1_000_000) * 3;
+  if (usd < 0.01) return '<$0.01';
+  return `$${usd.toFixed(2)}`;
+}
+
+function bar(fraction: number, width = 20): string {
+  const filled = Math.max(0, Math.min(width, Math.round(fraction * width)));
+  return '█'.repeat(filled) + '░'.repeat(width - filled);
+}
+
+function renderTable(
+  title: string,
+  rows: AggregatedStats[],
+  topN: number
+): string {
+  if (rows.length === 0) return `${title}\n  (no data yet)\n`;
+  const shown = rows.slice(0, topN);
+  const maxSaved = Math.max(...shown.map((r) => r.totalTokensSaved), 1);
+  const nameW = Math.max(4, ...shown.map((r) => r.name.length));
+
+  const lines = shown.map((r) => {
+    const name = r.name.padEnd(nameW);
+    const saved = num(r.totalTokensSaved).padStart(10);
+    const savePct = pct(r.savingsPercentage).padStart(7);
+    const ops = String(r.totalOperations).padStart(5);
+    return `  ${name}  ${saved}  ${savePct}  ${ops}  ${bar(
+      r.totalTokensSaved / maxSaved
+    )}`;
+  });
+
+  const header = `  ${'name'.padEnd(nameW)}  ${'saved'.padStart(
+    10
+  )}  ${'save%'.padStart(7)}  ${'ops'.padStart(5)}`;
+  const extra =
+    rows.length > topN ? `\n  ... and ${rows.length - topN} more\n` : '\n';
+  return `${title}\n${header}\n${lines.join('\n')}\n${extra}`;
+}
+
+export function getOptimizationReportTool(analyticsManager: AnalyticsManager) {
+  return async (args: {
+    startDate?: string;
+    endDate?: string;
+    sessionId?: string;
+    topN?: number;
+  }): Promise<string> => {
+    try {
+      const topN = args.topN && args.topN > 0 ? args.topN : 10;
+      const range = { startDate: args.startDate, endDate: args.endDate };
+
+      const [hook, action, server, totalCount] = await Promise.all([
+        analyticsManager.getHookAnalytics(range),
+        analyticsManager.getActionAnalytics(range),
+        analyticsManager.getServerAnalytics(range),
+        analyticsManager.count(),
+      ]);
+
+      // If scoped to a session, recompute the summary from filtered entries.
+      let summary = action.summary;
+      let byAction = action.byAction;
+      if (args.sessionId) {
+        const entries = await analyticsManager.getEntries({
+          sessionId: args.sessionId,
+          startDate: args.startDate,
+          endDate: args.endDate,
+        });
+        const totalOriginalTokens = entries.reduce(
+          (s, e) => s + e.originalTokens,
+          0
+        );
+        const totalOptimizedTokens = entries.reduce(
+          (s, e) => s + e.optimizedTokens,
+          0
+        );
+        const totalTokensSaved = entries.reduce((s, e) => s + e.tokensSaved, 0);
+        summary = {
+          totalOperations: entries.length,
+          totalTokensSaved,
+          totalOriginalTokens,
+          totalOptimizedTokens,
+        };
+      }
+
+      const savingsPercentage =
+        summary.totalOriginalTokens > 0
+          ? (summary.totalTokensSaved / summary.totalOriginalTokens) * 100
+          : 0;
+
+      const scope = args.sessionId
+        ? `session ${args.sessionId}`
+        : `${args.startDate || 'all time'} → ${args.endDate || 'present'}`;
+
+      const formatted = [
+        '╔══ Token Optimizer — Savings Report ══╗',
+        `  scope: ${scope}`,
+        '',
+        `  ✨ Total tokens saved : ${num(
+          summary.totalTokensSaved
+        )}  (~${approxCost(summary.totalTokensSaved)} @ $3/1M)`,
+        `  \u{1F4E5} Original tokens    : ${num(summary.totalOriginalTokens)}`,
+        `  \u{1F4E6} After optimization : ${num(summary.totalOptimizedTokens)}`,
+        `  \u{1F4C9} Overall reduction  : ${pct(savingsPercentage)}  ${bar(
+          savingsPercentage / 100
+        )}`,
+        `  \u{1F527} Operations tracked : ${num(
+          summary.totalOperations
+        )}  (${num(totalCount)} all-time)`,
+        '',
+        renderTable('▸ By action (tool)', byAction, topN),
+        renderTable('▸ By hook phase', hook.byHook, topN),
+        renderTable('▸ By MCP server', server.byServer, topN),
+      ].join('\n');
+
+      return JSON.stringify(
+        {
+          success: true,
+          scope,
+          summary: { ...summary, savingsPercentage },
+          approxUsdSaved: approxCost(summary.totalTokensSaved),
+          byAction,
+          byHook: hook.byHook,
+          byServer: server.byServer,
+          formatted,
+        },
+        null,
+        2
+      );
+    } catch (error) {
+      return JSON.stringify(
+        {
+          success: false,
+          error:
+            error instanceof Error ? error.message : 'Unknown error occurred',
+        },
+        null,
+        2
+      );
+    }
+  };
+}

--- a/src/tools/analytics/index.ts
+++ b/src/tools/analytics/index.ts
@@ -21,3 +21,8 @@ export {
   getExportAnalyticsTool,
   EXPORT_ANALYTICS_TOOL_DEFINITION,
 } from './export-analytics.js';
+
+export {
+  getOptimizationReportTool,
+  GET_OPTIMIZATION_REPORT_TOOL_DEFINITION,
+} from './get-optimization-report.js';

--- a/src/validation/tool-schemas.ts
+++ b/src/validation/tool-schemas.ts
@@ -514,6 +514,30 @@ export const ExportAnalyticsSchema = z.object({
     .describe('Optional filter by MCP server name'),
 });
 
+// 71b. get_optimization_report
+export const GetOptimizationReportSchema = z.object({
+  startDate: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?Z$/)
+    .optional()
+    .describe('Optional start date filter in ISO 8601 format'),
+  endDate: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?Z$/)
+    .optional()
+    .describe('Optional end date filter in ISO 8601 format'),
+  sessionId: z
+    .string()
+    .optional()
+    .describe('Optional session ID to scope the report to a single session'),
+  topN: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe('Limit each breakdown to the top N rows (default 10)'),
+});
+
 // 72. optimization_storage — discriminated union keyed on `operation` so
 // the zod validator rejects a `store` request missing the required
 // payload fields at validateToolArgs time, instead of after dispatch.
@@ -627,6 +651,7 @@ export const toolSchemaMap: Record<string, z.ZodType<any>> = {
   get_action_analytics: GetActionAnalyticsSchema,
   get_mcp_server_analytics: GetMcpServerAnalyticsSchema,
   export_analytics: ExportAnalyticsSchema,
+  get_optimization_report: GetOptimizationReportSchema,
   optimization_storage: OptimizationStorageSchema,
   context_delta: ContextDeltaSchema,
 };

--- a/tests/unit/analytics/record-tool-analytics.test.ts
+++ b/tests/unit/analytics/record-tool-analytics.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Unit tests for the analytics auto-recording bridge.
+ */
+
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import {
+  extractSavings,
+  recordToolAnalytics,
+  currentHookPhase,
+} from '../../../src/analytics/record-tool-analytics.js';
+import { AnalyticsManager } from '../../../src/analytics/analytics-manager.js';
+import { SqliteAnalyticsStorage } from '../../../src/analytics/analytics-storage.js';
+import path from 'path';
+import os from 'os';
+
+function mcpResult(payload: unknown, isError = false) {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(payload) }],
+    isError,
+  };
+}
+
+describe('extractSavings', () => {
+  it('reads the canonical optimize_text triplet', () => {
+    expect(
+      extractSavings({
+        originalTokens: 2001,
+        compressedTokens: 60,
+        tokensSaved: 1941,
+      })
+    ).toEqual({ originalTokens: 2001, optimizedTokens: 60, tokensSaved: 1941 });
+  });
+
+  it('reconstructs a missing member from the other two', () => {
+    // only original + saved present → optimized = original - saved
+    expect(extractSavings({ originalTokens: 100, tokensSaved: 30 })).toEqual({
+      originalTokens: 100,
+      optimizedTokens: 70,
+      tokensSaved: 30,
+    });
+  });
+
+  it('accepts optimizedTokens alias and derives savings', () => {
+    expect(
+      extractSavings({ originalTokens: 100, optimizedTokens: 40 })
+    ).toEqual({ originalTokens: 100, optimizedTokens: 40, tokensSaved: 60 });
+  });
+
+  it('finds a triplet nested one level deep', () => {
+    expect(
+      extractSavings({
+        success: true,
+        metadata: { originalTokens: 500, tokensSaved: 450 },
+      })
+    ).toEqual({ originalTokens: 500, optimizedTokens: 50, tokensSaved: 450 });
+  });
+
+  it('returns null when there is no measurable triplet', () => {
+    expect(extractSavings({ tokens: 2001, characters: 9000 })).toBeNull();
+    expect(extractSavings({ success: true, message: 'ok' })).toBeNull();
+    expect(extractSavings(null)).toBeNull();
+    expect(extractSavings('a string')).toBeNull();
+  });
+
+  it('rejects impossible negative counts', () => {
+    expect(
+      extractSavings({ originalTokens: -5, optimizedTokens: 1 })
+    ).toBeNull();
+  });
+
+  it('keeps genuine zero-savings measurements out (pure noise) but real ones in', () => {
+    // both zero → noise
+    expect(
+      extractSavings({ originalTokens: 0, optimizedTokens: 0, tokensSaved: 0 })
+    ).toBeNull();
+    // real measurement that happened to save nothing
+    expect(
+      extractSavings({ originalTokens: 50, optimizedTokens: 50, tokensSaved: 0 })
+    ).toEqual({ originalTokens: 50, optimizedTokens: 50, tokensSaved: 0 });
+  });
+});
+
+describe('currentHookPhase', () => {
+  it('defaults to Unknown and honors a valid env override', () => {
+    delete process.env.TOKEN_OPTIMIZER_HOOK_PHASE;
+    expect(currentHookPhase()).toBe('Unknown');
+    process.env.TOKEN_OPTIMIZER_HOOK_PHASE = 'PostToolUse';
+    expect(currentHookPhase()).toBe('PostToolUse');
+    process.env.TOKEN_OPTIMIZER_HOOK_PHASE = 'bogus';
+    expect(currentHookPhase()).toBe('Unknown');
+    delete process.env.TOKEN_OPTIMIZER_HOOK_PHASE;
+  });
+});
+
+describe('recordToolAnalytics', () => {
+  let manager: AnalyticsManager;
+
+  beforeEach(() => {
+    const dbPath = path.join(os.tmpdir(), `rec-analytics-${Date.now()}-${Math.round(performance.now())}.db`);
+    manager = new AnalyticsManager(new SqliteAnalyticsStorage(dbPath));
+  });
+
+  it('records a savings triplet from a real tool result', async () => {
+    await recordToolAnalytics(
+      manager,
+      'smart_read',
+      mcpResult({ originalTokens: 1000, optimizedTokens: 100, tokensSaved: 900 })
+    );
+    const action = await manager.getActionAnalytics();
+    expect(action.summary.totalOperations).toBe(1);
+    expect(action.summary.totalTokensSaved).toBe(900);
+    expect(action.byAction[0].name).toBe('smart_read');
+  });
+
+  it('does not record error results, in-band failures, or non-JSON output', async () => {
+    await recordToolAnalytics(
+      manager,
+      'smart_read',
+      mcpResult({ originalTokens: 1, optimizedTokens: 0, tokensSaved: 1 }, true)
+    );
+    await recordToolAnalytics(
+      manager,
+      'smart_read',
+      mcpResult({ success: false, originalTokens: 1000, tokensSaved: 900 })
+    );
+    await recordToolAnalytics(manager, 'x', {
+      content: [{ type: 'text', text: 'not json' }],
+    });
+    await recordToolAnalytics(manager, 'count_tokens', mcpResult({ tokens: 2001 }));
+    expect(await manager.count()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Problem

The analytics breakdown tools (`get_hook_analytics`, `get_action_analytics`, `get_mcp_server_analytics`, `export_analytics`) were fully wired into the server, but **`AnalyticsManager.track()` was never called anywhere in the codebase**. The store had no writers, so every breakdown always returned zeros — there was no way to show a user how many tokens token-optimizer actually saved them.

Verified empirically against the running server before the fix: `get_hook_analytics` / `get_action_analytics` → `totalTokensSaved: 0`.

## What this does

1. **Auto-recording bridge** (`src/analytics/record-tool-analytics.ts`) — wraps the central tool dispatcher so every tool call feeds its savings into `AnalyticsManager.track()`. A robust normalizer extracts the `originalTokens / optimizedTokens / tokensSaved` triplet from any tool result (field-name aliases + one level of nesting), reconstructing a missing member from the other two. It skips error results, in-band `{success:false}`, non-JSON output, and pure-noise zero rows. It **never throws** — analytics can't break a tool call. Hook phase is read from `TOKEN_OPTIMIZER_HOOK_PHASE` (set by hook launchers), defaulting to `Unknown`.

2. **`get_optimization_report`** (new tool) — one call returns total tokens saved, overall savings %, approx USD saved, and full breakdowns **by action / by hook / by MCP server**, plus a ready-to-display `formatted` text report with bars. This is the "great UX" surface an agent can show the user.

3. **Zod schema** for the new tool + **unit tests** for the normalizer, hook-phase resolution, and recording guards (10 new tests, all green).

## Verification

End-to-end against the real server (MCP stdio): recording an `optimize_text` + `smart_read` sequence produced a correct non-zero breakdown, e.g.:

```
✨ Total tokens saved : 59,530  (~$0.18 @ $3/1M)
📉 Overall reduction  : 95.4%  ███████████████████░
▸ By action (tool)
  smart_read         50,720    94.9%      5  ████████████████████
  optimize_text       8,810    97.9%      3  ███░░░░░░░░░░░░░░░░░
```

(Test rows were cleared from the analytics DB afterward.)

## Notes

- Recording is best-effort and additive; no existing tool behavior changes.
- The 3 existing analytics tools + CSV export now return real data automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)