### PR TITLE
fix(release): recognize existing vX.Y.Z tags in release-please

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch: {} # allow manual re-runs (gh workflow run release.yml)
 
 permissions:
   contents: write

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,7 @@
       "release-type": "node",
       "changelog-path": "CHANGELOG.md",
       "include-v-in-tag": true,
+      "include-component-in-tag": false,
       "bump-minor-pre-major": false,
       "draft": false,
       "prerelease": false


### PR DESCRIPTION
The first release-please run after the migration failed to produce a correct release PR for two reasons; this fixes the config one.

**Symptom (from the run logs):** `⚠ Found release tag with component '', but not configured in manifest` (×many), then it considered all **626 commits** and proposed **6.0.0** instead of a bump from the real `5.0.1` baseline.

**Cause:** release-please defaults to a tag component derived from the package name (`token-optimizer-mcp-vX.Y.Z`), which doesn't match the repo's existing `vX.Y.Z` tags. So it never found `v5.0.1` and treated the repo as unreleased.

**Fix:** `"include-component-in-tag": false` → tag format is `vX.Y.Z`, matching the existing tags. release-please now anchors to `v5.0.1` and computes the next version from commits since then.

The two *mechanism* blockers were fixed separately at the repo level (not in this diff): enabled "Allow GitHub Actions to create and approve pull requests", and excluded the `release-please--*` branches from the `~ALL` ruleset (which required signed commits / PRs and was blocking the bot's release branch).

After this merges, the `Release` workflow will open the correct release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)