### PR TITLE
ci: skip redundant checks on release-please PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
   lint-and-format:
     name: Lint and Format Check
     runs-on: ubuntu-latest
+    # Skip redundant CI on release-please PRs: the version/changelog bump only
+    # contains changes already validated in the PRs that were merged. Skipped
+    # jobs still satisfy required status checks (unlike workflow-level filters).
+    if: ${{ !startsWith(github.head_ref, 'release-please') }}
     timeout-minutes: 10
 
     steps:
@@ -47,6 +51,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.head_ref, 'release-please') }}
     timeout-minutes: 10
 
     steps:
@@ -87,6 +92,7 @@ jobs:
   test:
     name: Test (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.head_ref, 'release-please') }}
     timeout-minutes: 15
 
     strategy:
@@ -150,6 +156,7 @@ jobs:
   performance-benchmarks:
     name: Performance Benchmarks
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.head_ref, 'release-please') }}
     timeout-minutes: 15
     permissions:
       contents: read
@@ -230,6 +237,7 @@ jobs:
   integration-test:
     name: Integration Tests
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.head_ref, 'release-please') }}
     timeout-minutes: 15
     needs: build
 
@@ -302,7 +310,10 @@ jobs:
     name: All Checks Passed
     runs-on: ubuntu-latest
     needs: [lint-and-format, build, test, performance-benchmarks, integration-test]
-    if: always()
+    # always() so a real failure is still reported, but skip entirely on
+    # release-please PRs (its deps are skipped there, which would otherwise fail
+    # the != "success" checks below).
+    if: ${{ always() && !startsWith(github.head_ref, 'release-please') }}
 
     steps:
       - name: Check all job statuses

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -16,6 +16,8 @@ jobs:
   commitlint:
     name: Lint Commit Messages
     runs-on: ubuntu-latest
+    # Skip on release-please PRs: the release commit is auto-generated.
+    if: ${{ !startsWith(github.head_ref, 'release-please') }}
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -19,6 +19,8 @@ jobs:
   bundle-size:
     name: Bundle Size Analysis
     runs-on: ubuntu-latest
+    # Skip on release-please PRs (only bump version/changelog already validated on merge).
+    if: ${{ !startsWith(github.head_ref, 'release-please') }}
     timeout-minutes: 10
     permissions:
       contents: read
@@ -121,6 +123,7 @@ jobs:
   security-audit:
     name: Security Audit
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.head_ref, 'release-please') }}
     timeout-minutes: 10
     permissions:
       contents: read
@@ -228,6 +231,7 @@ jobs:
   license-compliance:
     name: License Compliance
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.head_ref, 'release-please') }}
     timeout-minutes: 10
     permissions:
       contents: read
@@ -325,6 +329,7 @@ jobs:
   dependency-vulnerabilities:
     name: Dependency Vulnerability Scan
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.head_ref, 'release-please') }}
     timeout-minutes: 10
 
     steps:
@@ -375,6 +380,7 @@ jobs:
   code-quality:
     name: Code Quality Metrics
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.head_ref, 'release-please') }}
     timeout-minutes: 10
 
     steps:


### PR DESCRIPTION
## Why

release-please PRs (like #184) only change `package.json` / `package-lock.json` / `CHANGELOG.md` / manifest — content that **already passed the full CI suite** in the PRs that were merged. Re-running Tests ×3, Build, Integration, Performance, Security, Bundle Size, etc. on them is duplicated compute (mirrors the AiDotNet setup).

## What

Guard every PR-triggered job with `if: ${{ !startsWith(github.head_ref, 'release-please') }}` across **ci.yml**, **quality-gates.yml**, and **commitlint.yml**.

**Why job-level `if:` and not a workflow-level branch filter:** a skipped *job* still emits a check-run with conclusion `skipped`, which **satisfies** required status checks. A workflow-level `branches-ignore`/filter would omit the check entirely, leaving each required check stuck on "Expected — waiting for status" and **blocking** the release PR forever. This is the key footgun this PR avoids.

The `All Checks Passed` aggregator is skipped too (otherwise its `needs.*.result != "success"` gate would fail on the skipped deps), while keeping `always()` so genuine PRs still surface failures.

Regular PRs and pushes to `master` are unaffected (`head_ref` is empty on push, and `push` is already filtered to `master`).

## Validation note

This PR itself runs the **full** suite (it's not a release-please PR — correct). The definitive proof is the *next* release-please PR skipping cleanly; skipped-jobs-satisfy-required-checks is the documented mechanism, and I'll confirm it live on the next release cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)