### PR TITLE
fix(cache): self-heal from a corrupt database file on every retry

### DIFF
--- a/src/core/cache-engine.ts
+++ b/src/core/cache-engine.ts
@@ -6,6 +6,23 @@ import os from 'os';
 import { IEmbeddingGenerator } from '../interfaces/IEmbeddingGenerator.js';
 import { IVectorStore } from '../interfaces/IVectorStore.js';
 
+/**
+ * Whether an error from opening/initializing SQLite indicates the database file
+ * is corrupt or not a valid database (e.g. a partially-written file, or a
+ * non-DB file left at the path). Such a file can be safely deleted and
+ * recreated, so callers use this to decide whether to self-heal on retry.
+ */
+function isCorruptDatabaseError(err: unknown): boolean {
+  if (!err) return false;
+  const code = (err as { code?: string }).code ?? '';
+  const message = err instanceof Error ? err.message : String(err);
+  return (
+    code === 'SQLITE_NOTADB' ||
+    code === 'SQLITE_CORRUPT' ||
+    /not a database|file is encrypted|is not a database|malformed/i.test(message)
+  );
+}
+
 export interface CacheEntry {
   key: string;
   value: string;
@@ -107,23 +124,27 @@ export class CacheEngine {
 
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       try {
-        // First attempt: use requested path
-        // Second attempt: try cleaning up corrupted files and retry
-        // PHASE 1 FIX: Removed tmpdir fallback - was causing 0% cache hit rate
-        // Third attempt: fail loudly instead of falling back to ephemeral temp location
+        // First attempt: use requested path as-is.
+        // Any later attempt: if the previous failure was a corrupt/invalid DB
+        // file (e.g. SQLITE_NOTADB from a partial write or a stray non-DB file),
+        // delete the DB and its WAL/SHM sidecars so this attempt recreates a
+        // fresh database. This runs on EVERY retry (not just attempt 2) so a
+        // single failed delete doesn't strand the remaining attempts.
+        // PHASE 1 FIX: Removed tmpdir fallback - was causing 0% cache hit rate.
         const dbPathToUse = finalDbPath;
 
-        // If this is attempt 2, try to clean up corrupted files
-        if (attempt === 2 && fs.existsSync(finalDbPath)) {
-          try {
-            fs.unlinkSync(finalDbPath);
-            // Also remove WAL files
-            const walPath = `${finalDbPath}-wal`;
-            const shmPath = `${finalDbPath}-shm`;
-            if (fs.existsSync(walPath)) fs.unlinkSync(walPath);
-            if (fs.existsSync(shmPath)) fs.unlinkSync(shmPath);
-          } catch {
-            // If we can't clean up, attempt 3 will fail with an error (no tmpdir fallback)
+        if (attempt > 1 && isCorruptDatabaseError(lastError)) {
+          for (const p of [
+            finalDbPath,
+            `${finalDbPath}-wal`,
+            `${finalDbPath}-shm`,
+          ]) {
+            try {
+              if (fs.existsSync(p)) fs.unlinkSync(p);
+            } catch {
+              // Best-effort: if a sidecar can't be removed, the open below may
+              // still fail and we fall through to the next attempt / final error.
+            }
           }
         }
 

--- a/tests/unit/cache-engine-corruption.test.ts
+++ b/tests/unit/cache-engine-corruption.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Regression tests: CacheEngine must self-heal from a corrupt / invalid SQLite
+ * database file instead of failing to construct.
+ *
+ * A partially-written file, a crashed process, or a stray non-DB file at the
+ * cache path makes better-sqlite3 throw SQLITE_NOTADB on open. Previously the
+ * recovery (delete + recreate) only ran on the 2nd of 3 attempts, so a single
+ * failed delete stranded the remaining attempt and construction threw. Now the
+ * corrupt DB + WAL/SHM sidecars are removed on every retry.
+ */
+
+import { describe, it, expect, afterEach } from '@jest/globals';
+import { CacheEngine } from '../../src/core/cache-engine.js';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+describe('CacheEngine corrupt-database self-heal', () => {
+  const dirs: string[] = [];
+  const engines: CacheEngine[] = [];
+
+  afterEach(() => {
+    while (engines.length) {
+      try {
+        engines.pop()?.close();
+      } catch {
+        // already closed
+      }
+    }
+    while (dirs.length) {
+      const d = dirs.pop();
+      if (d) {
+        try {
+          rmSync(d, { recursive: true, force: true });
+        } catch {
+          // OS reclaims later on Windows
+        }
+      }
+    }
+  });
+
+  function tempDbPath(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'token-optimizer-corrupt-'));
+    dirs.push(dir);
+    return join(dir, 'cache.db');
+  }
+
+  function open(dbPath: string): CacheEngine {
+    const engine = new CacheEngine(dbPath, 100);
+    engines.push(engine);
+    return engine;
+  }
+
+  it('recovers when the database file is not a valid SQLite database', () => {
+    const dbPath = tempDbPath();
+    // Simulate a corrupt / partially-written DB: a non-empty, non-SQLite file.
+    writeFileSync(dbPath, 'this is definitely not a sqlite database header');
+
+    // Construction must not throw — the invalid file is deleted and recreated.
+    const engine = open(dbPath);
+
+    // ...and the engine is fully usable afterwards.
+    expect(engine.getDatabasePath()).toBe(dbPath);
+    engine.set('k', 'hello world', 11, 11);
+    expect(engine.get('k')).toBe('hello world');
+    expect(engine.getStats().totalEntries).toBe(1);
+  });
+
+  it('recovers when stale WAL/SHM sidecars accompany a corrupt db', () => {
+    const dbPath = tempDbPath();
+    writeFileSync(dbPath, 'corrupt-main');
+    writeFileSync(`${dbPath}-wal`, 'stale-wal');
+    writeFileSync(`${dbPath}-shm`, 'stale-shm');
+
+    const engine = open(dbPath);
+    engine.set('a', 'b', 1, 1);
+    expect(engine.get('a')).toBe('b');
+  });
+});


### PR DESCRIPTION
## Why

While debugging the v5.1.0 publish failure, the root cause under it was `CacheEngine` throwing `Failed to initialize persistent cache database after 3 attempts` on `SQLITE_NOTADB`. That happens when the SQLite file is invalid — a partial write, a crash mid-write, or a stray non-DB file at the cache path.

The existing recovery (delete + recreate) only ran on **attempt 2**. If that delete didn't take, **attempt 3 had no cleanup** → construction threw. That's why the full suite collapsed in the `npm publish` sandbox (plain `npm test` = unlimited Jest workers, more contention) while it self-healed locally and in CI (`test:ci` caps `--maxWorkers=2`).

## Fix

- New `isCorruptDatabaseError()` guard (`SQLITE_NOTADB` / `SQLITE_CORRUPT` / "not a database" / "malformed").
- Remove the corrupt DB **and its WAL/SHM sidecars before every retry** when the prior error looks like corruption — not just attempt 2. So a single failed delete no longer strands the remaining attempts.
- This also makes `CacheEngine` resilient for **real users** whose `cache.db` gets corrupted by a crash.

## Tests

New `tests/unit/cache-engine-corruption.test.ts`: writes a non-DB file (and stale WAL/SHM) at the cache path and asserts `CacheEngine` constructs and works. Full suite locally: **674 passed** (+2), build + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)