### PR TITLE
chore(registry): bump MCP Registry manifest to 5.1.1

### DIFF
--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/ooples/token-optimizer-mcp",
     "source": "github"
   },
-  "version": "5.0.1",
+  "version": "5.1.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@ooples/token-optimizer-mcp",
-      "version": "5.0.1",
+      "version": "5.1.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Keeps `server.json` in sync with npm 5.1.1 and the live registry entry (re-published to `io.github.ooples/token-optimizer-mcp@5.1.1`). Registry was stale at 5.0.1.