### PR TITLE
fix(plugins): track plugin .mcp.json + add native Codex plugin packaging

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,22 @@
+{
+  "name": "token-optimizer",
+  "interface": {
+    "displayName": "Token Optimizer"
+  },
+  "plugins": [
+    {
+      "name": "token-optimizer",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/ooples/token-optimizer-mcp.git",
+        "path": "./integrations/codex/plugin",
+        "ref": "master"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_USE"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -41,10 +41,12 @@ coverage/
 .mcpregistry_github_token
 .mcpregistry_registry_token
 
-# Local MCP server config — may contain project secrets (Supabase/Postgres
-# tokens etc.). MUST NOT be committed. A committed copy previously leaked
-# credentials to the public repo; keep this local-only from now on.
-.mcp.json
+# Local MCP server config at the repo root — may contain project secrets
+# (Supabase/Postgres tokens etc.). MUST NOT be committed. A committed copy
+# previously leaked credentials to the public repo; keep this local-only.
+# Anchored to the root so plugin MCP manifests (plugin/.mcp.json,
+# integrations/**/.mcp.json — npx-only, no secrets) can still be tracked.
+/.mcp.json
 worktrees/
  
 # Local development configs and logs

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -59,6 +59,20 @@ Alternatively add the `mcpServers` block from `gemini-extension.json` to
 
 ## OpenAI Codex
 
+**Native plugin (richest — bundles the MCP server + skill via Codex's plugin system):**
+
+```bash
+# Add this repo as a Codex plugin marketplace, then install:
+codex plugin marketplace add ooples/token-optimizer-mcp
+codex plugin install token-optimizer@token-optimizer
+```
+
+The plugin lives in `codex/plugin/` (`.codex-plugin/plugin.json` + `.mcp.json` +
+the `token-optimization` skill); the repo-root `.agents/plugins/marketplace.json`
+makes the repo an installable Codex marketplace.
+
+**Or just the MCP server + guidance (no plugin system):**
+
 ```bash
 # 1) Merge the MCP server into your Codex config:
 cat codex/config.toml >> ~/.codex/config.toml

--- a/integrations/codex/plugin/.codex-plugin/plugin.json
+++ b/integrations/codex/plugin/.codex-plugin/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "token-optimizer",
+  "version": "5.1.2",
+  "description": "Context-window optimization: caching, compression, and smart file tooling that cut token usage 60-90%.",
+  "author": {
+    "name": "ooples",
+    "url": "https://github.com/ooples"
+  },
+  "homepage": "https://github.com/ooples/token-optimizer-mcp#readme",
+  "repository": "https://github.com/ooples/token-optimizer-mcp",
+  "license": "MIT",
+  "keywords": [
+    "token-optimization",
+    "context-window",
+    "caching",
+    "compression",
+    "mcp"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Token Optimizer",
+    "shortDescription": "Cut token usage 60-90% with caching, compression, and smart file tools.",
+    "longDescription": "Bundles the token-optimizer MCP server plus a usage skill. smart_read returns diffs on re-reads, smart_glob returns paths only, optimize_session stashes bulky output out-of-context, and get_optimization_report shows total tokens saved.",
+    "developerName": "ooples",
+    "category": "Productivity",
+    "capabilities": ["Read", "Write"],
+    "websiteURL": "https://github.com/ooples/token-optimizer-mcp",
+    "defaultPrompt": [
+      "Use token-optimizer smart_read to re-read this large file as a diff.",
+      "Show my token savings with get_optimization_report."
+    ]
+  }
+}

--- a/integrations/codex/plugin/.mcp.json
+++ b/integrations/codex/plugin/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcp_servers": {
+    "token-optimizer": {
+      "command": "npx",
+      "args": ["-y", "@ooples/token-optimizer-mcp@latest"]
+    }
+  }
+}

--- a/integrations/codex/plugin/skills/token-optimization/SKILL.md
+++ b/integrations/codex/plugin/skills/token-optimization/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: token-optimization
+description: Use the token-optimizer MCP tools to reduce context/token usage when reading, searching, or editing files, or when the context window is filling up. Trigger when reading large files, re-reading files already seen, searching a big/unknown tree, making edits to large files, or when you need to store bulky output out-of-context.
+---
+
+# Token optimization
+
+This plugin ships a `token-optimizer` MCP server whose tools cut context usage
+60–90% via caching, diffing, and compression. Prefer them over the built-in
+tools in the situations below. All tools are model-invoked — you must call them;
+nothing rewrites the built-in read/grep output automatically.
+
+## When to use which tool
+
+- **`smart_read`** instead of a plain file read when a file is **large**
+  (roughly >400 lines / >25 KB) or you have **read it before this session**. It
+  caches file content and, on re-reads, returns only a **diff** of what changed
+  — often a handful of tokens instead of the whole file. Pass `path`; optionally
+  `enableCache`, `diffMode`, `maxSize`, `includeMetadata`.
+
+- **`smart_glob`** instead of a content grep for finding files in a **big or
+  unfamiliar tree**. It returns **paths only** (no content) with filtering,
+  sorting, and pagination — a fraction of the tokens of listing with content.
+  Pass `pattern` (e.g. `src/**/*.ts`) and optionally `cwd`, `extensions`,
+  `limit`.
+
+- **`smart_edit`** instead of a raw edit for **large files**: it applies the
+  edit and returns a compact unified **diff** rather than echoing the whole
+  file. (For very small files a plain edit is fine — smart_edit's diff overhead
+  is only worth it once the file is sizeable.)
+
+- **`optimize_session`** / **`get_session_stats`** when the **context window is
+  filling up** or after a burst of file operations. `optimize_session`
+  batch-compresses prior file operations and stores them out-of-context;
+  `get_session_stats` reports tokens saved so far.
+
+- **`get_optimization_report`** when the user asks **how much they've saved**
+  (or to show it proactively). Returns total tokens saved, overall savings %,
+  approximate cost saved, and a full breakdown **by action, by hook phase, and
+  by MCP server**, plus a pre-rendered `formatted` text summary you can display
+  as-is.
+
+- **`count_tokens`** to measure how expensive a chunk of text is before you
+  decide how to handle it.
+
+## Storing bulky content out of context
+
+- **`optimize_text`** — compress a large text blob under a `key` and keep it in
+  the external cache instead of your context; retrieve it later by key. Reports
+  `tokensSaved`. Good for logs, large outputs, or reference material you don't
+  need inline right now.
+
+- **`compress_text`** — Brotli+base64 compression. **Byte** reduction only:
+  the base64 output usually has **more** LLM tokens than the input, so use it
+  for **at-rest storage/caching, not for putting back into context.** The tool
+  returns `increasesTokens` + a warning when that's the case.
+
+## Rules of thumb
+
+1. Reading a big file or one you've seen before → `smart_read`.
+2. Searching a large/unknown tree → `smart_glob` (paths first, read only what
+   you need).
+3. Editing a large file → `smart_edit`.
+4. Context getting tight → `optimize_session`, then continue.
+5. Need to stash bulky output → `optimize_text` (by key), not `compress_text`
+   into context.
+6. Small files/one-off reads → the built-in tools are fine; don't add overhead.

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "token-optimizer": {
+      "command": "npx",
+      "args": ["-y", "@ooples/token-optimizer-mcp@latest"],
+      "env": {}
+    }
+  }
+}


### PR DESCRIPTION
## Two things (same root cause: `.mcp.json` handling)

### 1. Fix: the Claude Code plugin was missing its `.mcp.json` on master
The `.mcp.json` gitignore rule (added during the credential cleanup) was **unanchored**, so it silently ignored *every* `.mcp.json` — including `plugin/.mcp.json`. That file was never committed, so the Claude Code plugin on master (the one just submitted to the community marketplace) had **no MCP server declaration**.

Fix: anchor the rule to `/​.mcp.json` (root only) — the secret-bearing root file stays ignored, while plugin manifests (npx-only, no secrets) are tracked. Recovered `plugin/.mcp.json`.

### 2. Feature: native Codex plugin packaging
Mirrors the Claude Code plugin so token-optimizer installs via Codex's plugin system:
- `integrations/codex/plugin/.codex-plugin/plugin.json` — Codex manifest
- `integrations/codex/plugin/.mcp.json` — MCP server (`mcp_servers`, npx)
- `integrations/codex/plugin/skills/token-optimization/SKILL.md` — usage skill
- `.agents/plugins/marketplace.json` — repo → installable Codex marketplace

**Verified:** `codex plugin marketplace add .` + `codex plugin list` → `token-optimizer@token-optimizer` available.

> Note: the Claude community submission was made before this fix, so its plugin was missing `.mcp.json`. Once this merges, master is correct and a re-sync/re-submit picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)