### PR TITLE
ci: add HOL plugin scanner for awesome-codex-plugins listing

### DIFF
--- a/.github/workflows/hol-plugin-scanner.yml
+++ b/.github/workflows/hol-plugin-scanner.yml
@@ -1,0 +1,33 @@
+name: HOL Plugin Scanner
+
+# Security scan required by the awesome-codex-plugins community directory
+# (hashgraph-online). Scans the Codex plugin bundle and must score >= 80/130
+# with no high-severity findings. Third-party action pinned to a commit SHA.
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    name: HOL Plugin Scanner
+    runs-on: ubuntu-latest
+    # Skip on release-please PRs (they only bump version/changelog).
+    if: ${{ !startsWith(github.head_ref, 'release-please') }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: HOL Plugin Scanner
+        uses: hashgraph-online/ai-plugin-scanner-action@8f0a503ca2a70c1968a9a883e11fdff5737b7909 # v1 (v1.2.514)
+        with:
+          plugin_dir: "integrations/codex/plugin"
+          mode: scan
+          min_score: 80
+          fail_on_severity: high
+          format: sarif
+          upload_sarif: true


### PR DESCRIPTION
Required prerequisite for submitting to the [awesome-codex-plugins](https://github.com/hashgraph-online/awesome-codex-plugins) directory: the plugin repo must run `hashgraph-online/ai-plugin-scanner-action` in CI and score ≥80/130 with no high-severity findings.

- Scans the Codex plugin bundle (`integrations/codex/plugin`).
- Third-party action **pinned to commit `8f0a503`** (v1 / v1.2.514) for supply-chain safety, not a floating tag.
- Skipped on release-please PRs.

Once this passes on `master`, I'll submit the one-line PR to awesome-codex-plugins with the run URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)