### PR TITLE
feat: add native token-optimizer hooks across CLIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,19 +17,28 @@ Token Optimizer is a local [Model Context Protocol](https://modelcontextprotocol
 
 ## Installation
 
-Every client launches the same stdio server—`npx -y @ooples/token-optimizer-mcp@latest`—but stores its MCP configuration and agent instructions differently.
+Every client launches the same stdio server—`npx -y @ooples/token-optimizer-mcp@latest`—but each client has its own instruction and lifecycle APIs. The ready-made integrations below use those native APIs; they do not pretend Claude Code's seven-phase PowerShell hook system is portable unchanged.
 
-| Client             | Fastest setup                                                                                                | Verify                            |
-| ------------------ | ------------------------------------------------------------------------------------------------------------ | --------------------------------- |
-| Codex              | `codex mcp add token-optimizer -- npx -y @ooples/token-optimizer-mcp@latest`                                 | `codex mcp get token-optimizer`   |
-| Claude Code        | `claude mcp add --transport stdio --scope user token-optimizer -- npx -y @ooples/token-optimizer-mcp@latest` | `claude mcp get token-optimizer`  |
-| GitHub Copilot CLI | `copilot mcp add token-optimizer -- npx -y @ooples/token-optimizer-mcp@latest`                               | `copilot mcp get token-optimizer` |
-| Gemini CLI         | `gemini mcp add --scope user token-optimizer npx -y @ooples/token-optimizer-mcp@latest`                      | `gemini mcp list`                 |
-| OpenCode           | Add the `mcp` block below to `opencode.json`                                                                 | `opencode mcp list`               |
+| Client             | Fastest MCP setup                                                                                            | Best-experience integration                          |
+| ------------------ | ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
+| Codex              | `codex mcp add token-optimizer -- npx -y @ooples/token-optimizer-mcp@latest`                                 | Codex plugin: MCP + skill + lifecycle hooks          |
+| Claude Code        | `claude mcp add --transport stdio --scope user token-optimizer -- npx -y @ooples/token-optimizer-mcp@latest` | Claude plugin: MCP + skill + large-read hook         |
+| GitHub Copilot CLI | `copilot mcp add token-optimizer -- npx -y @ooples/token-optimizer-mcp@latest`                               | `AGENTS.md` + repository lifecycle hooks             |
+| Gemini CLI         | `gemini mcp add --scope user token-optimizer npx -y @ooples/token-optimizer-mcp@latest`                      | Gemini extension: MCP + context + lifecycle hooks    |
+| OpenCode           | Add the `mcp` block below to `opencode.json`                                                                 | `AGENTS.md` + local plugin + compaction preservation |
 
 ### Codex
 
-#### 1. Add the MCP server
+#### 1. Add the MCP server or native plugin
+
+For the best experience, install the Codex plugin. It bundles the MCP server, the token-optimization skill, session guidance, and a large-read hook:
+
+```bash
+codex plugin marketplace add ooples/token-optimizer-mcp
+codex plugin add token-optimizer@token-optimizer
+```
+
+Review and trust the bundled hooks with `/hooks`, then start a new conversation. If you prefer an MCP-only installation, use:
 
 ```bash
 codex mcp add token-optimizer -- npx -y @ooples/token-optimizer-mcp@latest
@@ -54,9 +63,13 @@ codex mcp list
 
 Start a new Codex conversation after installation so the new tools are discovered. In an interactive CLI session, `/mcp` shows the tools available to the conversation.
 
-#### 3. Tell Codex when to use it
+#### 3. Add optimization guidance and hooks
 
-MCP registration makes the tools available; it does not transparently replace Codex's built-in file tools. Add the guidance from [`integrations/AGENTS.md`](./integrations/AGENTS.md) to your project `AGENTS.md`, or start with this smaller rule:
+The plugin supplies both automatically. For an MCP-only installation, add the guidance from [`integrations/AGENTS.md`](./integrations/AGENTS.md) to a project or global `AGENTS.md`. A ready-made standalone hook is also available under [`integrations/codex/hooks`](./integrations/codex/hooks); merge its `hooks.json` into `~/.codex/hooks.json`, copy the script to `~/.codex/hooks/`, and review it once with `/hooks`.
+
+The Codex hook injects guidance at `SessionStart`, advises on large first-class read calls, and can block those reads when `TOKEN_OPTIMIZER_REDIRECT_LARGE_READS=true`. Shell commands such as `cat` or `Get-Content` are exposed to hooks as `Bash`, so the hook does not try to parse and rewrite arbitrary shell syntax. The `AGENTS.md`/skill guidance remains important.
+
+If you prefer a smaller instruction block:
 
 ```markdown
 ## Token optimization
@@ -70,6 +83,8 @@ Use the token-optimizer MCP for large or repeated reads:
 
 Use normal tools for small, one-off operations.
 ```
+
+See the current [Codex hooks documentation](https://learn.chatgpt.com/docs/hooks.md) for hook trust, matching, and tool-coverage details.
 
 #### Equivalent manual Codex configuration
 
@@ -167,9 +182,25 @@ copilot mcp list
 
 Inside an interactive Copilot session, `/mcp show token-optimizer` displays the connection status and available tools.
 
-#### 3. Add optimization guidance
+#### 3. Add optimization guidance and hooks
 
-Keep [`integrations/AGENTS.md`](./integrations/AGENTS.md) as the repository's `AGENTS.md`, or adapt the same guidance into `.github/copilot-instructions.md`. See [GitHub's Copilot CLI MCP guide](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers).
+Keep [`integrations/AGENTS.md`](./integrations/AGENTS.md) as the repository's `AGENTS.md`, or adapt the same guidance into `.github/copilot-instructions.md`.
+
+For native lifecycle integration, copy the ready-made repository hooks into your project:
+
+```bash
+mkdir -p .github/hooks
+cp integrations/copilot/.github/hooks/token-optimizer* .github/hooks/
+```
+
+```powershell
+New-Item -ItemType Directory -Force .github/hooks | Out-Null
+Copy-Item integrations/copilot/.github/hooks/token-optimizer* .github/hooks/
+```
+
+The hooks inject optimization guidance at `sessionStart`, add a model-visible suggestion after a large `view`, and—when `TOKEN_OPTIMIZER_REDIRECT_LARGE_READS=true`—deny a large built-in read so Copilot retries with `smart_read`. Partial reads and files below 25 KB pass through unchanged. Repository hooks work without overwriting user-level files; global hooks can instead be placed in `~/.copilot/hooks/` with their script paths adjusted for that directory.
+
+Restart Copilot CLI after changing hook files. See GitHub's official [MCP setup guide](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers) and [hooks reference](https://docs.github.com/en/copilot/reference/hooks-reference).
 
 ### Gemini CLI
 
@@ -196,9 +227,17 @@ gemini extensions list
 
 Run `/mcp` inside Gemini CLI to inspect the connection. Restart Gemini CLI after installing or updating the extension.
 
-#### 3. Add optimization guidance
+#### 3. Add optimization guidance and hooks
 
-Direct MCP users should copy [`GEMINI.md`](./GEMINI.md) into the project or merge its rules into an existing `GEMINI.md`. Extension users receive that context file with the extension. See the official [Gemini MCP guide](https://geminicli.com/docs/tools/mcp-server/) and [extension guide](https://geminicli.com/docs/extensions/reference/).
+Direct MCP users should copy [`GEMINI.md`](./GEMINI.md) into the project or merge its rules into an existing `GEMINI.md`. Extension users receive that context file plus native hooks automatically.
+
+The extension's `SessionStart` hook injects optimization guidance. Its `AfterTool` hook notices full-file `read_file` results over 25 KB and suggests `smart_read`. To make Gemini automatically replace those large results with a token-optimizer tail call, configure the extension setting **Automatic large-read routing** as `true`:
+
+```bash
+gemini extensions config token-optimizer
+```
+
+Automatic routing uses Gemini's native `tailToolCallRequest`: the `smart_read` result replaces the built-in read result before it reaches the model. Partial reads remain unchanged. Restart Gemini CLI after installing, updating, or reconfiguring the extension. See the official [Gemini MCP guide](https://geminicli.com/docs/tools/mcp-server/), [extension guide](https://geminicli.com/docs/extensions/reference/), and [hooks reference](https://geminicli.com/docs/hooks/reference/).
 
 ### OpenCode
 
@@ -230,9 +269,21 @@ opencode mcp list
 
 The output shows configured servers and their connection status.
 
-#### 3. Add optimization guidance
+#### 3. Add optimization guidance and the local plugin
 
-Copy [`integrations/AGENTS.md`](./integrations/AGENTS.md) to the project as `AGENTS.md`; the `instructions` entry above loads it. See the [OpenCode MCP guide](https://opencode.ai/docs/mcp-servers/).
+Copy [`integrations/AGENTS.md`](./integrations/AGENTS.md) to the project as `AGENTS.md`; the `instructions` entry above loads it. Then copy the ready-made local plugin:
+
+```bash
+mkdir -p .opencode/plugins
+cp integrations/opencode/.opencode/plugins/token-optimizer.js .opencode/plugins/
+```
+
+```powershell
+New-Item -ItemType Directory -Force .opencode/plugins | Out-Null
+Copy-Item integrations/opencode/.opencode/plugins/token-optimizer.js .opencode/plugins/
+```
+
+The plugin preserves Token Optimizer usage state in OpenCode's compaction prompt. Set `TOKEN_OPTIMIZER_REDIRECT_LARGE_READS=true` to make its `tool.execute.before` hook reject full-file reads over 25 KB and steer the agent to `smart_read`; small and partial reads pass normally. Restart OpenCode after adding the plugin. See the official [OpenCode MCP guide](https://opencode.ai/docs/mcp-servers/) and [plugin hook guide](https://opencode.ai/docs/plugins/).
 
 ### Generic MCP configuration
 
@@ -617,6 +668,20 @@ get_session_stats({});
 
 ### Architecture and Global Hooks
 
+#### Native client lifecycle coverage
+
+The MCP server is identical in every client, but lifecycle APIs are not. The repository ships client-native adapters instead of copying Claude event names into tools that would silently ignore them.
+
+| Client             | Native integration events                   | Default behavior                                   | Optional strict behavior                                   |
+| ------------------ | ------------------------------------------- | -------------------------------------------------- | ---------------------------------------------------------- |
+| Codex              | `SessionStart`, `PreToolUse`                | Inject guidance; advise on large first-class reads | Deny large reads and steer to `smart_read`                 |
+| Claude Code        | `PreToolUse` plus optional global pipeline  | Advise on large reads                              | Deny and steer; global install adds the seven phases below |
+| GitHub Copilot CLI | `sessionStart`, `preToolUse`, `postToolUse` | Inject guidance; advise after large `view` calls   | Deny large `view` calls and steer to `smart_read`          |
+| Gemini CLI         | `SessionStart`, `AfterTool`                 | Inject guidance; advise after large `read_file`    | Tail-call `smart_read` and replace the built-in result     |
+| OpenCode           | `tool.execute.before`, compaction hook      | Preserve optimization guidance during compaction   | Reject large full-file reads and steer to `smart_read`     |
+
+Strict behavior is enabled with `TOKEN_OPTIMIZER_REDIRECT_LARGE_READS=true` and uses a 25,600-byte threshold by default. Override the threshold with `TOKEN_OPTIMIZER_LARGE_READ_BYTES`. Partial reads pass through because they may already be more efficient than a full cached read.
+
 #### Analytics workflow and storage
 
 <details>
@@ -665,7 +730,7 @@ export_analytics({
 
 #### Global Hooks System (7-Phase Optimization)
 
-This pipeline applies to the optional Claude Code global-hook installation. MCP-only installations in Codex, Copilot, Gemini, OpenCode, and other clients expose model-invoked tools but do not transparently intercept built-in operations.
+This complete seven-phase pipeline applies to the optional Claude Code global-hook installation. Codex, Copilot, Gemini, and OpenCode use the smaller native adapters above because their event names, payloads, and result-replacement capabilities differ.
 
 When global hooks are installed, token-optimizer-mcp runs automatically on **every tool call**:
 
@@ -795,11 +860,11 @@ await analyze_project_tokens({
 
 Token Optimizer works with stdio-capable MCP clients and includes first-party setup guidance for:
 
-- **OpenAI Codex** - MCP configuration plus AGENTS.md guidance
+- **OpenAI Codex** - Direct MCP setup or the bundled plugin, skill, and hooks
 - **Claude Code** - Direct MCP setup or the bundled plugin, skill, and hooks
-- **GitHub Copilot CLI** - User or repository MCP configuration
-- **Google Gemini CLI** - Direct MCP setup or the bundled extension
-- **OpenCode** - Local MCP configuration plus AGENTS.md instructions
+- **GitHub Copilot CLI** - MCP configuration, AGENTS.md guidance, and repository hooks
+- **Google Gemini CLI** - Direct MCP setup or the bundled context-and-hooks extension
+- **OpenCode** - Local MCP configuration, AGENTS.md instructions, and compaction plugin
 - **Claude Desktop**, **Cursor**, **Cline**, and **Windsurf** - Standard MCP JSON configuration
 
 See [Installation](#installation) for the supported commands and configuration files.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -8,5 +8,19 @@
       "args": ["-y", "@ooples/token-optimizer-mcp@latest"]
     }
   },
+  "settings": [
+    {
+      "name": "Automatic large-read routing",
+      "description": "Set to true to replace large built-in read results with token-optimizer smart_read results.",
+      "envVar": "TOKEN_OPTIMIZER_REDIRECT_LARGE_READS",
+      "sensitive": false
+    },
+    {
+      "name": "Large-read threshold in bytes",
+      "description": "Optional byte threshold for large-read guidance and routing (default 25600).",
+      "envVar": "TOKEN_OPTIMIZER_LARGE_READ_BYTES",
+      "sensitive": false
+    }
+  ],
   "contextFileName": "GEMINI.md"
 }

--- a/hooks/gemini-token-optimizer-advisor.mjs
+++ b/hooks/gemini-token-optimizer-advisor.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+
+import { statSync } from 'node:fs';
+import { isAbsolute, resolve } from 'node:path';
+
+const mode = process.argv[2];
+const threshold =
+  Number(process.env.TOKEN_OPTIMIZER_LARGE_READ_BYTES) || 25_600;
+const redirect = process.env.TOKEN_OPTIMIZER_REDIRECT_LARGE_READS === 'true';
+
+const guidance =
+  'Use the token-optimizer MCP for large or repeated operations: smart_read for large/repeated files, smart_glob or smart_grep for noisy searches, optimize_text for bulky output, optimize_session before context gets tight, and get_optimization_report for savings. Built-in tools remain appropriate for small one-off operations.';
+
+function readStdin() {
+  return new Promise((resolveInput) => {
+    let input = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => (input += chunk));
+    process.stdin.on('end', () => resolveInput(input));
+    process.stdin.on('error', () => resolveInput(input));
+  });
+}
+
+function isPartialRead(args) {
+  return ['offset', 'limit', 'start_line', 'end_line'].some(
+    (key) => args[key] !== undefined
+  );
+}
+
+const raw = await readStdin();
+let payload;
+try {
+  payload = JSON.parse(raw);
+} catch {
+  process.exit(0);
+}
+
+if (mode === 'session-start') {
+  process.stdout.write(
+    JSON.stringify({ hookSpecificOutput: { additionalContext: guidance } })
+  );
+  process.exit(0);
+}
+
+if (mode !== 'after-read' || payload?.tool_name !== 'read_file') {
+  process.exit(0);
+}
+
+const args = payload.tool_input ?? {};
+if (isPartialRead(args)) process.exit(0);
+
+const requestedPath = args.file_path;
+if (typeof requestedPath !== 'string' || requestedPath.length === 0) {
+  process.exit(0);
+}
+
+const absolutePath = isAbsolute(requestedPath)
+  ? requestedPath
+  : resolve(payload.cwd || process.cwd(), requestedPath);
+
+let size;
+try {
+  const stats = statSync(absolutePath);
+  if (!stats.isFile() || stats.size < threshold) process.exit(0);
+  size = stats.size;
+} catch {
+  process.exit(0);
+}
+
+const kb = Math.round(size / 1024);
+const message = `${absolutePath} is ${kb} KB. Token Optimizer can cache it and return only diffs on repeat reads.`;
+
+if (redirect) {
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        tailToolCallRequest: {
+          name: 'mcp_token-optimizer_smart_read',
+          args: { path: absolutePath },
+        },
+      },
+    })
+  );
+} else {
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        additionalContext: `Token Optimizer suggestion: ${message} Use smart_read for this file on the next read.`,
+      },
+    })
+  );
+}

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,31 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "name": "token-optimizer-session-guidance",
+            "command": "node \"${extensionPath}${/}hooks${/}gemini-token-optimizer-advisor.mjs\" session-start",
+            "timeout": 5000,
+            "description": "Load token-optimizer guidance into the Gemini session."
+          }
+        ]
+      }
+    ],
+    "AfterTool": [
+      {
+        "matcher": "read_file",
+        "hooks": [
+          {
+            "type": "command",
+            "name": "token-optimizer-large-read",
+            "command": "node \"${extensionPath}${/}hooks${/}gemini-token-optimizer-advisor.mjs\" after-read",
+            "timeout": 5000,
+            "description": "Advise on large reads or replace them with smart_read when automatic routing is enabled."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -1,112 +1,153 @@
-# Using token-optimizer across AI agents
+# Native CLI integrations
 
-The token-optimizer MCP server works with any MCP-capable agent. This folder has
-ready-to-use config for the major CLIs. The MCP **server** is identical
-everywhere (`npx -y @ooples/token-optimizer-mcp@latest`); what differs per tool is
-the config file and how each one loads instructions ("skills").
+Token Optimizer runs the same MCP server in every client:
 
-| Agent | MCP config | Instructions ("skill") |
-| --- | --- | --- |
-| **Claude Code** | `../plugin` (full plugin: MCP + skill + hooks) | `skills/token-optimization/SKILL.md` |
-| **Gemini CLI** | `gemini/gemini-extension.json` | `gemini/GEMINI.md` |
-| **OpenAI Codex** | `codex/config.toml` | `AGENTS.md` |
-| **OpenCode** | `opencode/opencode.json` | `AGENTS.md` |
-| **GitHub Copilot CLI** | `copilot/mcp-config.json` | `AGENTS.md` |
+```text
+npx -y @ooples/token-optimizer-mcp@latest
+```
 
-Prereq for all: Node.js (so `npx` can run the server). First run downloads
-`@ooples/token-optimizer-mcp`; subsequent runs are cached.
+What differs is how each CLI loads instructions and lifecycle hooks. This
+directory contains ready-made, client-native configurations; Claude Code's
+seven-phase PowerShell hook system is documented separately and is not copied
+unchanged into clients with different event contracts.
 
-> Getting token-optimizer **listed** in each ecosystem's marketplace/registry
-> (MCP Registry, Claude Code community marketplace, Gemini extension gallery)?
-> See [`../docs/PUBLISHING.md`](../docs/PUBLISHING.md).
+| Client             | MCP configuration                   | Guidance                    | Native lifecycle integration                     |
+| ------------------ | ----------------------------------- | --------------------------- | ------------------------------------------------ |
+| Codex              | `codex/config.toml` or Codex plugin | `AGENTS.md` or plugin skill | `codex/hooks/` or plugin `hooks/hooks.json`      |
+| Claude Code        | `../plugin/.mcp.json`               | Plugin skill                | Plugin large-read hook; optional global pipeline |
+| GitHub Copilot CLI | `copilot/mcp-config.json`           | `AGENTS.md`                 | `copilot/.github/hooks/`                         |
+| Gemini CLI         | `gemini/gemini-extension.json`      | `gemini/GEMINI.md`          | `gemini/hooks/`                                  |
+| OpenCode           | `opencode/opencode.json`            | `AGENTS.md`                 | `opencode/.opencode/plugins/`                    |
 
-## Claude Code (native plugin — richest)
+Prerequisite: Node.js 18 or newer so `npx` can launch the server. The first
+launch downloads the package; later launches use the local npm cache.
 
-The repo root is a plugin marketplace; the plugin lives in `../plugin` (MCP +
-the `token-optimization` skill + a cross-platform large-read hook).
+## Codex
+
+Recommended: install the native plugin, which bundles MCP, the optimization
+skill, session guidance, and large-read hooks.
 
 ```bash
-# Try it locally:
-claude --plugin-dir ./plugin
+codex plugin marketplace add ooples/token-optimizer-mcp
+codex plugin add token-optimizer@token-optimizer
+```
 
-# Or install via the marketplace:
+Review and trust the plugin hooks with `/hooks`, then start a new conversation.
+The marketplace points to `integrations/codex/plugin/`.
+
+For an MCP-only installation:
+
+```bash
+codex mcp add token-optimizer -- npx -y @ooples/token-optimizer-mcp@latest
+```
+
+Add `AGENTS.md` at project scope or append its contents once to
+`~/.codex/AGENTS.md`. If you also want lifecycle hooks, copy
+`codex/hooks/token-optimizer-advisor.mjs` to `~/.codex/hooks/` and merge
+`codex/hooks/hooks.json` into `~/.codex/hooks.json`; do not overwrite unrelated
+hooks already present. Review and trust the new definition with `/hooks`.
+
+The hooks inject guidance at `SessionStart` and advise on first-class large read
+tools. Codex exposes shell reads such as `cat` or `Get-Content` as `Bash`, so the
+adapter deliberately does not parse and rewrite arbitrary shell commands.
+
+## Claude Code
+
+The repository root is a Claude plugin marketplace. The plugin bundles the MCP
+server, optimization skill, and cross-platform large-read hook.
+
+```text
 /plugin marketplace add ooples/token-optimizer-mcp
 /plugin install token-optimizer@token-optimizer
+/reload-plugins
 ```
 
-Optional hook env vars: `TOKEN_OPTIMIZER_REDIRECT_LARGE_READS=true` (deny large
-built-in Reads and steer to `smart_read`), `TOKEN_OPTIMIZER_LARGE_READ_BYTES`
-(threshold, default 25600).
-
-## Gemini CLI
-
-```bash
-# Install as a Gemini extension:
-mkdir -p ~/.gemini/extensions/token-optimizer
-cp gemini/gemini-extension.json gemini/GEMINI.md ~/.gemini/extensions/token-optimizer/
-# Restart the Gemini CLI; verify the server with: /mcp
-```
-
-Alternatively add the `mcpServers` block from `gemini-extension.json` to
-`~/.gemini/settings.json`.
-
-> **Gemini hooks caveat:** if you also wire up hooks in `~/.gemini/settings.json`,
-> Gemini CLI uses its **own** event names — `BeforeTool` / `AfterTool`, *not*
-> Claude Code's `PreToolUse` / `PostToolUse`. An unknown event name is silently
-> dropped (`Hook registry initialized with 0 hook entries`) and the MCP tools
-> keep working, but the hook never fires. MCP tool names match as
-> `mcp_<server>_<tool>` in a hook `matcher`.
-
-## OpenAI Codex
-
-**Native plugin (richest — bundles the MCP server + skill via Codex's plugin system):**
-
-```bash
-# Add this repo as a Codex plugin marketplace, then install:
-codex plugin marketplace add ooples/token-optimizer-mcp
-codex plugin install token-optimizer@token-optimizer
-```
-
-The plugin lives in `codex/plugin/` (`.codex-plugin/plugin.json` + `.mcp.json` +
-the `token-optimization` skill); the repo-root `.agents/plugins/marketplace.json`
-makes the repo an installable Codex marketplace.
-
-**Or just the MCP server + guidance (no plugin system):**
-
-```bash
-# 1) Merge the MCP server into your Codex config:
-cat codex/config.toml >> ~/.codex/config.toml
-# 2) Add the guidance so Codex knows when to use the tools:
-cat AGENTS.md >> ~/.codex/AGENTS.md   # or your project's AGENTS.md
-```
-
-## OpenCode
-
-```bash
-# Drop both files into your project (or ~/.config/opencode/):
-cp opencode/opencode.json AGENTS.md ./
-# opencode.json references ./AGENTS.md via "instructions".
-```
+For local development, run `claude --plugin-dir ./plugin`. The separate global
+installer and complete seven-phase hook architecture remain documented in
+[`../docs/HOOKS-INSTALLATION.md`](../docs/HOOKS-INSTALLATION.md) and the main
+README.
 
 ## GitHub Copilot CLI
 
+Add the MCP server:
+
 ```bash
-# Add the MCP server to your global Copilot config:
-cp copilot/mcp-config.json ~/.copilot/mcp-config.json
-# Or, for a single session without touching the global config:
-copilot --additional-mcp-config @copilot/mcp-config.json
-# Guidance: append AGENTS.md so Copilot knows when to use the tools:
-cat AGENTS.md >> AGENTS.md   # in your project root
+copilot mcp add token-optimizer -- npx -y @ooples/token-optimizer-mcp@latest
 ```
 
-Verify: the Copilot log (`~/.copilot/logs/`) shows
-`MCP client for token-optimizer connected`.
+If that command is unavailable in an older release, merge the server from
+`copilot/mcp-config.json` into `~/.copilot/mcp-config.json`.
+
+Add `AGENTS.md` to the repository, then copy the native repository hooks:
+
+```bash
+mkdir -p /path/to/project/.github/hooks
+cp copilot/.github/hooks/token-optimizer* /path/to/project/.github/hooks/
+```
+
+The hooks inject session guidance, advise after a large `view`, and provide an
+opt-in `preToolUse` redirect. Repository hooks are easier to install safely than
+overwriting user hooks.
+
+## Gemini CLI
+
+Recommended: install the extension, which bundles MCP, `GEMINI.md`, and native
+`SessionStart`/`AfterTool` hooks.
+
+```bash
+gemini extensions install https://github.com/ooples/token-optimizer-mcp --auto-update
+```
+
+The standalone files under `gemini/` have the same structure if you want to
+package the integration separately. Direct MCP setup is also available:
+
+```bash
+gemini mcp add --scope user token-optimizer npx -y @ooples/token-optimizer-mcp@latest
+```
+
+By default, the `AfterTool` hook suggests `smart_read` after a large full-file
+read. Run `gemini extensions config token-optimizer` and set **Automatic
+large-read routing** to `true` to use Gemini's native `tailToolCallRequest`; the
+`smart_read` result then replaces the built-in result before it reaches the
+model.
+
+## OpenCode
+
+Copy or merge the MCP configuration and instructions into a project:
+
+```bash
+cp opencode/opencode.json /path/to/project/
+cp AGENTS.md /path/to/project/
+mkdir -p /path/to/project/.opencode/plugins
+cp opencode/.opencode/plugins/token-optimizer.js /path/to/project/.opencode/plugins/
+```
+
+The local plugin preserves Token Optimizer guidance during context compaction.
+Its strict large-read redirect is opt-in because OpenCode's before-hook blocks
+the original tool rather than transparently replacing its result.
+
+## Hook behavior and controls
+
+All adapters are fail-open for malformed payloads, missing files, small files,
+and partial reads. The default threshold is 25,600 bytes.
+
+- `TOKEN_OPTIMIZER_REDIRECT_LARGE_READS=true` enables strict native routing.
+- `TOKEN_OPTIMIZER_LARGE_READ_BYTES=<bytes>` changes the threshold.
+- Codex and Copilot deny the large built-in read so the agent retries with
+  `smart_read`.
+- Gemini replaces the result with an MCP tail call.
+- OpenCode rejects the built-in read with a `smart_read` instruction.
+
+The environment variables are optional. Default mode injects guidance without
+blocking normal operations.
 
 ## Notes
 
-- **Compression is model-invoked.** No agent can transparently rewrite a built-in
-  read's output (see anthropics/claude-code#32105), so the agent must *call*
-  `smart_read`/`smart_glob`/etc. The skill/AGENTS.md/GEMINI.md files teach it when.
-- **`compress_text` is at-rest only** — its base64 output usually has more tokens
-  than the input; use `optimize_text` (by key) to stash content out of context.
-- Pin a version by replacing `@latest` with a specific version in any config.
+- `smart_read` is most useful for large files and repeat reads because cached
+  re-reads return diffs.
+- `optimize_text` stores bulky content outside context. `compress_text` is
+  byte-oriented Brotli/base64 storage and can increase LLM token count if its
+  encoded output is put back into context.
+- Pin a version by replacing `@latest` in any configuration.
+- Marketplace and registry publishing steps are in
+  [`../docs/PUBLISHING.md`](../docs/PUBLISHING.md).

--- a/integrations/codex/hooks/hooks.json
+++ b/integrations/codex/hooks/hooks.json
@@ -1,0 +1,33 @@
+{
+  "description": "Load token-optimizer guidance and steer large file reads toward smart_read.",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$HOME/.codex/hooks/token-optimizer-advisor.mjs\"",
+            "commandWindows": "node \"$env:USERPROFILE\\.codex\\hooks\\token-optimizer-advisor.mjs\"",
+            "timeout": 5,
+            "statusMessage": "Loading token-optimizer guidance"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Read|read_file|view_file",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$HOME/.codex/hooks/token-optimizer-advisor.mjs\"",
+            "commandWindows": "node \"$env:USERPROFILE\\.codex\\hooks\\token-optimizer-advisor.mjs\"",
+            "timeout": 5,
+            "statusMessage": "Checking large read"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrations/codex/hooks/token-optimizer-advisor.mjs
+++ b/integrations/codex/hooks/token-optimizer-advisor.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+
+import { statSync } from 'node:fs';
+import { isAbsolute, resolve } from 'node:path';
+
+const DEFAULT_THRESHOLD_BYTES = 25_600;
+const threshold =
+  Number(process.env.TOKEN_OPTIMIZER_LARGE_READ_BYTES) ||
+  DEFAULT_THRESHOLD_BYTES;
+const redirect = process.env.TOKEN_OPTIMIZER_REDIRECT_LARGE_READS === 'true';
+
+const guidance =
+  'Use the token-optimizer MCP for large or repeated operations: smart_read for large/repeated files, smart_glob or smart_grep for noisy searches, optimize_text for bulky output, optimize_session before context gets tight, and get_optimization_report for savings. Built-in tools remain appropriate for small one-off operations.';
+
+function readStdin() {
+  return new Promise((resolveInput) => {
+    let input = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => (input += chunk));
+    process.stdin.on('end', () => resolveInput(input));
+    process.stdin.on('error', () => resolveInput(input));
+  });
+}
+
+function emit(hookEventName, output) {
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName,
+        ...output,
+      },
+    })
+  );
+}
+
+function parseArgs(value) {
+  if (value && typeof value === 'object') return value;
+  if (typeof value !== 'string') return {};
+  try {
+    return JSON.parse(value);
+  } catch {
+    return {};
+  }
+}
+
+function isPartialRead(args) {
+  return [
+    'offset',
+    'limit',
+    'lineStart',
+    'lineEnd',
+    'start_line',
+    'end_line',
+  ].some((key) => args[key] !== undefined);
+}
+
+function largeRead(payload) {
+  const args = parseArgs(payload.tool_input);
+  if (isPartialRead(args)) return undefined;
+
+  const requestedPath = args.file_path ?? args.filePath ?? args.path;
+  if (typeof requestedPath !== 'string' || requestedPath.length === 0) {
+    return undefined;
+  }
+
+  const absolutePath = isAbsolute(requestedPath)
+    ? requestedPath
+    : resolve(payload.cwd || process.cwd(), requestedPath);
+
+  try {
+    const stats = statSync(absolutePath);
+    if (!stats.isFile() || stats.size < threshold) return undefined;
+    return { absolutePath, size: stats.size };
+  } catch {
+    return undefined;
+  }
+}
+
+const raw = await readStdin();
+let payload;
+try {
+  payload = JSON.parse(raw);
+} catch {
+  process.exit(0);
+}
+
+const event = payload?.hook_event_name;
+if (event === 'SessionStart') {
+  emit(event, { additionalContext: guidance });
+  process.exit(0);
+}
+
+if (event !== 'PreToolUse') process.exit(0);
+
+const read = largeRead(payload);
+if (!read) process.exit(0);
+
+const kb = Math.round(read.size / 1024);
+const message = `${read.absolutePath} is ${kb} KB. Use token-optimizer smart_read with path="${read.absolutePath}" so repeat reads return cached diffs instead of the full file.`;
+
+if (redirect) {
+  emit(event, {
+    permissionDecision: 'deny',
+    permissionDecisionReason: message,
+  });
+} else {
+  emit(event, { additionalContext: `Token Optimizer suggestion: ${message}` });
+}

--- a/integrations/codex/plugin/hooks/hooks.json
+++ b/integrations/codex/plugin/hooks/hooks.json
@@ -1,0 +1,33 @@
+{
+  "description": "Load token-optimizer guidance and steer large file reads toward smart_read.",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/hooks/token-optimizer-advisor.mjs\"",
+            "commandWindows": "node \"$env:PLUGIN_ROOT\\hooks\\token-optimizer-advisor.mjs\"",
+            "timeout": 5,
+            "statusMessage": "Loading token-optimizer guidance"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Read|read_file|view_file",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/hooks/token-optimizer-advisor.mjs\"",
+            "commandWindows": "node \"$env:PLUGIN_ROOT\\hooks\\token-optimizer-advisor.mjs\"",
+            "timeout": 5,
+            "statusMessage": "Checking large read"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrations/codex/plugin/hooks/token-optimizer-advisor.mjs
+++ b/integrations/codex/plugin/hooks/token-optimizer-advisor.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+
+import { statSync } from 'node:fs';
+import { isAbsolute, resolve } from 'node:path';
+
+const DEFAULT_THRESHOLD_BYTES = 25_600;
+const threshold =
+  Number(process.env.TOKEN_OPTIMIZER_LARGE_READ_BYTES) ||
+  DEFAULT_THRESHOLD_BYTES;
+const redirect = process.env.TOKEN_OPTIMIZER_REDIRECT_LARGE_READS === 'true';
+
+const guidance =
+  'Use the token-optimizer MCP for large or repeated operations: smart_read for large/repeated files, smart_glob or smart_grep for noisy searches, optimize_text for bulky output, optimize_session before context gets tight, and get_optimization_report for savings. Built-in tools remain appropriate for small one-off operations.';
+
+function readStdin() {
+  return new Promise((resolveInput) => {
+    let input = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => (input += chunk));
+    process.stdin.on('end', () => resolveInput(input));
+    process.stdin.on('error', () => resolveInput(input));
+  });
+}
+
+function emit(hookEventName, output) {
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName,
+        ...output,
+      },
+    })
+  );
+}
+
+function parseArgs(value) {
+  if (value && typeof value === 'object') return value;
+  if (typeof value !== 'string') return {};
+  try {
+    return JSON.parse(value);
+  } catch {
+    return {};
+  }
+}
+
+function isPartialRead(args) {
+  return [
+    'offset',
+    'limit',
+    'lineStart',
+    'lineEnd',
+    'start_line',
+    'end_line',
+  ].some((key) => args[key] !== undefined);
+}
+
+function largeRead(payload) {
+  const args = parseArgs(payload.tool_input);
+  if (isPartialRead(args)) return undefined;
+
+  const requestedPath = args.file_path ?? args.filePath ?? args.path;
+  if (typeof requestedPath !== 'string' || requestedPath.length === 0) {
+    return undefined;
+  }
+
+  const absolutePath = isAbsolute(requestedPath)
+    ? requestedPath
+    : resolve(payload.cwd || process.cwd(), requestedPath);
+
+  try {
+    const stats = statSync(absolutePath);
+    if (!stats.isFile() || stats.size < threshold) return undefined;
+    return { absolutePath, size: stats.size };
+  } catch {
+    return undefined;
+  }
+}
+
+const raw = await readStdin();
+let payload;
+try {
+  payload = JSON.parse(raw);
+} catch {
+  process.exit(0);
+}
+
+const event = payload?.hook_event_name;
+if (event === 'SessionStart') {
+  emit(event, { additionalContext: guidance });
+  process.exit(0);
+}
+
+if (event !== 'PreToolUse') process.exit(0);
+
+const read = largeRead(payload);
+if (!read) process.exit(0);
+
+const kb = Math.round(read.size / 1024);
+const message = `${read.absolutePath} is ${kb} KB. Use token-optimizer smart_read with path="${read.absolutePath}" so repeat reads return cached diffs instead of the full file.`;
+
+if (redirect) {
+  emit(event, {
+    permissionDecision: 'deny',
+    permissionDecisionReason: message,
+  });
+} else {
+  emit(event, { additionalContext: `Token Optimizer suggestion: ${message}` });
+}

--- a/integrations/copilot/.github/hooks/token-optimizer-advisor.mjs
+++ b/integrations/copilot/.github/hooks/token-optimizer-advisor.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+
+import { statSync } from 'node:fs';
+import { isAbsolute, resolve } from 'node:path';
+
+const mode = process.argv[2];
+const threshold =
+  Number(process.env.TOKEN_OPTIMIZER_LARGE_READ_BYTES) || 25_600;
+const redirect = process.env.TOKEN_OPTIMIZER_REDIRECT_LARGE_READS === 'true';
+
+const guidance =
+  'Use the token-optimizer MCP for large or repeated operations: smart_read for large/repeated files, smart_glob or smart_grep for noisy searches, optimize_text for bulky output, optimize_session before context gets tight, and get_optimization_report for savings. Built-in tools remain appropriate for small one-off operations.';
+
+function readStdin() {
+  return new Promise((resolveInput) => {
+    let input = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => (input += chunk));
+    process.stdin.on('end', () => resolveInput(input));
+    process.stdin.on('error', () => resolveInput(input));
+  });
+}
+
+function parseArgs(value) {
+  if (value && typeof value === 'object') return value;
+  if (typeof value !== 'string') return {};
+  try {
+    return JSON.parse(value);
+  } catch {
+    return {};
+  }
+}
+
+function isPartialRead(args) {
+  return [
+    'offset',
+    'limit',
+    'lineStart',
+    'lineEnd',
+    'start_line',
+    'end_line',
+  ].some((key) => args[key] !== undefined);
+}
+
+function largeRead(payload) {
+  const args = parseArgs(payload.toolArgs);
+  if (isPartialRead(args)) return undefined;
+
+  const requestedPath = args.file_path ?? args.filePath ?? args.path;
+  if (typeof requestedPath !== 'string' || requestedPath.length === 0) {
+    return undefined;
+  }
+
+  const absolutePath = isAbsolute(requestedPath)
+    ? requestedPath
+    : resolve(payload.cwd || process.cwd(), requestedPath);
+
+  try {
+    const stats = statSync(absolutePath);
+    if (!stats.isFile() || stats.size < threshold) return undefined;
+    return { absolutePath, size: stats.size };
+  } catch {
+    return undefined;
+  }
+}
+
+const raw = await readStdin();
+let payload;
+try {
+  payload = JSON.parse(raw);
+} catch {
+  process.exit(0);
+}
+
+if (mode === 'session-start') {
+  process.stdout.write(JSON.stringify({ additionalContext: guidance }));
+  process.exit(0);
+}
+
+if (payload?.toolName !== 'view') process.exit(0);
+
+const read = largeRead(payload);
+if (!read) process.exit(0);
+
+const kb = Math.round(read.size / 1024);
+const message = `${read.absolutePath} is ${kb} KB. Use token-optimizer smart_read with path="${read.absolutePath}" for cached, diff-based repeat reads.`;
+
+if (mode === 'before-read' && redirect) {
+  process.stdout.write(
+    JSON.stringify({
+      permissionDecision: 'deny',
+      permissionDecisionReason: message,
+    })
+  );
+} else if (mode === 'after-read') {
+  process.stdout.write(
+    JSON.stringify({
+      additionalContext: `Token Optimizer suggestion: ${message}`,
+    })
+  );
+}

--- a/integrations/copilot/.github/hooks/token-optimizer.json
+++ b/integrations/copilot/.github/hooks/token-optimizer.json
@@ -1,0 +1,31 @@
+{
+  "version": 1,
+  "hooks": {
+    "sessionStart": [
+      {
+        "type": "command",
+        "bash": "node .github/hooks/token-optimizer-advisor.mjs session-start",
+        "powershell": "node .github/hooks/token-optimizer-advisor.mjs session-start",
+        "timeoutSec": 5
+      }
+    ],
+    "preToolUse": [
+      {
+        "type": "command",
+        "matcher": "view",
+        "bash": "node .github/hooks/token-optimizer-advisor.mjs before-read",
+        "powershell": "node .github/hooks/token-optimizer-advisor.mjs before-read",
+        "timeoutSec": 5
+      }
+    ],
+    "postToolUse": [
+      {
+        "type": "command",
+        "matcher": "view",
+        "bash": "node .github/hooks/token-optimizer-advisor.mjs after-read",
+        "powershell": "node .github/hooks/token-optimizer-advisor.mjs after-read",
+        "timeoutSec": 5
+      }
+    ]
+  }
+}

--- a/integrations/gemini/gemini-extension.json
+++ b/integrations/gemini/gemini-extension.json
@@ -8,5 +8,19 @@
       "args": ["-y", "@ooples/token-optimizer-mcp@latest"]
     }
   },
+  "settings": [
+    {
+      "name": "Automatic large-read routing",
+      "description": "Set to true to replace large built-in read results with token-optimizer smart_read results.",
+      "envVar": "TOKEN_OPTIMIZER_REDIRECT_LARGE_READS",
+      "sensitive": false
+    },
+    {
+      "name": "Large-read threshold in bytes",
+      "description": "Optional byte threshold for large-read guidance and routing (default 25600).",
+      "envVar": "TOKEN_OPTIMIZER_LARGE_READ_BYTES",
+      "sensitive": false
+    }
+  ],
   "contextFileName": "GEMINI.md"
 }

--- a/integrations/gemini/hooks/gemini-token-optimizer-advisor.mjs
+++ b/integrations/gemini/hooks/gemini-token-optimizer-advisor.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+
+import { statSync } from 'node:fs';
+import { isAbsolute, resolve } from 'node:path';
+
+const mode = process.argv[2];
+const threshold =
+  Number(process.env.TOKEN_OPTIMIZER_LARGE_READ_BYTES) || 25_600;
+const redirect = process.env.TOKEN_OPTIMIZER_REDIRECT_LARGE_READS === 'true';
+
+const guidance =
+  'Use the token-optimizer MCP for large or repeated operations: smart_read for large/repeated files, smart_glob or smart_grep for noisy searches, optimize_text for bulky output, optimize_session before context gets tight, and get_optimization_report for savings. Built-in tools remain appropriate for small one-off operations.';
+
+function readStdin() {
+  return new Promise((resolveInput) => {
+    let input = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => (input += chunk));
+    process.stdin.on('end', () => resolveInput(input));
+    process.stdin.on('error', () => resolveInput(input));
+  });
+}
+
+function isPartialRead(args) {
+  return ['offset', 'limit', 'start_line', 'end_line'].some(
+    (key) => args[key] !== undefined
+  );
+}
+
+const raw = await readStdin();
+let payload;
+try {
+  payload = JSON.parse(raw);
+} catch {
+  process.exit(0);
+}
+
+if (mode === 'session-start') {
+  process.stdout.write(
+    JSON.stringify({ hookSpecificOutput: { additionalContext: guidance } })
+  );
+  process.exit(0);
+}
+
+if (mode !== 'after-read' || payload?.tool_name !== 'read_file') {
+  process.exit(0);
+}
+
+const args = payload.tool_input ?? {};
+if (isPartialRead(args)) process.exit(0);
+
+const requestedPath = args.file_path;
+if (typeof requestedPath !== 'string' || requestedPath.length === 0) {
+  process.exit(0);
+}
+
+const absolutePath = isAbsolute(requestedPath)
+  ? requestedPath
+  : resolve(payload.cwd || process.cwd(), requestedPath);
+
+let size;
+try {
+  const stats = statSync(absolutePath);
+  if (!stats.isFile() || stats.size < threshold) process.exit(0);
+  size = stats.size;
+} catch {
+  process.exit(0);
+}
+
+const kb = Math.round(size / 1024);
+const message = `${absolutePath} is ${kb} KB. Token Optimizer can cache it and return only diffs on repeat reads.`;
+
+if (redirect) {
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        tailToolCallRequest: {
+          name: 'mcp_token-optimizer_smart_read',
+          args: { path: absolutePath },
+        },
+      },
+    })
+  );
+} else {
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        additionalContext: `Token Optimizer suggestion: ${message} Use smart_read for this file on the next read.`,
+      },
+    })
+  );
+}

--- a/integrations/gemini/hooks/hooks.json
+++ b/integrations/gemini/hooks/hooks.json
@@ -1,0 +1,31 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "name": "token-optimizer-session-guidance",
+            "command": "node \"${extensionPath}${/}hooks${/}gemini-token-optimizer-advisor.mjs\" session-start",
+            "timeout": 5000,
+            "description": "Load token-optimizer guidance into the Gemini session."
+          }
+        ]
+      }
+    ],
+    "AfterTool": [
+      {
+        "matcher": "read_file",
+        "hooks": [
+          {
+            "type": "command",
+            "name": "token-optimizer-large-read",
+            "command": "node \"${extensionPath}${/}hooks${/}gemini-token-optimizer-advisor.mjs\" after-read",
+            "timeout": 5000,
+            "description": "Advise on large reads or replace them with smart_read when automatic routing is enabled."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrations/opencode/.opencode/plugins/token-optimizer.js
+++ b/integrations/opencode/.opencode/plugins/token-optimizer.js
@@ -1,0 +1,52 @@
+import { statSync } from 'node:fs';
+import { isAbsolute, resolve } from 'node:path';
+
+const threshold =
+  Number(process.env.TOKEN_OPTIMIZER_LARGE_READ_BYTES) || 25_600;
+const redirect = process.env.TOKEN_OPTIMIZER_REDIRECT_LARGE_READS === 'true';
+
+const compactionGuidance = `
+## Token Optimizer state
+
+Preserve which large files and bulky outputs have already been processed. After
+compaction, continue using token-optimizer smart_read for large or repeated
+files, smart_glob/smart_grep for noisy searches, optimize_text for bulky output,
+and get_optimization_report when savings are requested.
+`;
+
+function isPartialRead(args) {
+  return ['offset', 'limit', 'lineStart', 'lineEnd'].some(
+    (key) => args[key] !== undefined
+  );
+}
+
+export const TokenOptimizerPlugin = async ({ directory }) => ({
+  'tool.execute.before': async (input, output) => {
+    if (!redirect || input.tool !== 'read' || isPartialRead(output.args))
+      return;
+
+    const requestedPath = output.args.filePath;
+    if (typeof requestedPath !== 'string' || requestedPath.length === 0) return;
+
+    const absolutePath = isAbsolute(requestedPath)
+      ? requestedPath
+      : resolve(directory, requestedPath);
+
+    let stats;
+    try {
+      stats = statSync(absolutePath);
+    } catch {
+      return;
+    }
+
+    if (!stats.isFile() || stats.size < threshold) return;
+
+    const kb = Math.round(stats.size / 1024);
+    throw new Error(
+      `${absolutePath} is ${kb} KB. Use token-optimizer smart_read with path="${absolutePath}" for cached, diff-based repeat reads.`
+    );
+  },
+  'experimental.session.compacting': async (_input, output) => {
+    output.context.push(compactionGuidance);
+  },
+});

--- a/tests/integration/client-hooks.test.ts
+++ b/tests/integration/client-hooks.test.ts
@@ -1,0 +1,236 @@
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const repoRoot = resolve(process.cwd());
+const codexHook = join(
+  repoRoot,
+  'integrations/codex/plugin/hooks/token-optimizer-advisor.mjs'
+);
+const copilotHook = join(
+  repoRoot,
+  'integrations/copilot/.github/hooks/token-optimizer-advisor.mjs'
+);
+const geminiHook = join(repoRoot, 'hooks/gemini-token-optimizer-advisor.mjs');
+
+function runHook(
+  script: string,
+  args: string[],
+  payload: object,
+  env: Record<string, string> = {}
+) {
+  const result = spawnSync(process.execPath, [script, ...args], {
+    cwd: repoRoot,
+    input: JSON.stringify(payload),
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+  });
+
+  expect(result.status).toBe(0);
+  expect(result.stderr).toBe('');
+  return result.stdout ? JSON.parse(result.stdout) : undefined;
+}
+
+describe('native CLI hook integrations', () => {
+  let fixtureDir: string;
+  let largeFile: string;
+  let smallFile: string;
+
+  beforeAll(() => {
+    fixtureDir = mkdtempSync(join(tmpdir(), 'token-optimizer-hooks-'));
+    largeFile = join(fixtureDir, 'large.txt');
+    smallFile = join(fixtureDir, 'small.txt');
+    writeFileSync(largeFile, 'x'.repeat(30_000));
+    writeFileSync(smallFile, 'small');
+  });
+
+  afterAll(() => {
+    rmSync(fixtureDir, { recursive: true, force: true });
+  });
+
+  it('injects session guidance using each client output schema', () => {
+    const codex = runHook(codexHook, [], {
+      hook_event_name: 'SessionStart',
+      cwd: fixtureDir,
+    });
+    const copilot = runHook(copilotHook, ['session-start'], {
+      source: 'startup',
+      cwd: fixtureDir,
+    });
+    const gemini = runHook(geminiHook, ['session-start'], {
+      hook_event_name: 'SessionStart',
+      cwd: fixtureDir,
+    });
+
+    expect(codex.hookSpecificOutput.additionalContext).toContain('smart_read');
+    expect(copilot.additionalContext).toContain('smart_read');
+    expect(gemini.hookSpecificOutput.additionalContext).toContain('smart_read');
+  });
+
+  it('keeps small and partial reads unchanged', () => {
+    const smallCodex = runHook(codexHook, [], {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Read',
+      tool_input: { file_path: smallFile },
+      cwd: fixtureDir,
+    });
+    const partialGemini = runHook(geminiHook, ['after-read'], {
+      hook_event_name: 'AfterTool',
+      tool_name: 'read_file',
+      tool_input: { file_path: largeFile, limit: 20 },
+      cwd: fixtureDir,
+    });
+
+    expect(smallCodex).toBeUndefined();
+    expect(partialGemini).toBeUndefined();
+  });
+
+  it('advises on large reads without blocking by default', () => {
+    const codex = runHook(codexHook, [], {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Read',
+      tool_input: { file_path: largeFile },
+      cwd: fixtureDir,
+    });
+    const copilot = runHook(copilotHook, ['after-read'], {
+      toolName: 'view',
+      toolArgs: JSON.stringify({ path: largeFile }),
+      cwd: fixtureDir,
+    });
+    const gemini = runHook(geminiHook, ['after-read'], {
+      hook_event_name: 'AfterTool',
+      tool_name: 'read_file',
+      tool_input: { file_path: largeFile },
+      cwd: fixtureDir,
+    });
+
+    expect(codex.hookSpecificOutput.additionalContext).toContain('29 KB');
+    expect(copilot.additionalContext).toContain('29 KB');
+    expect(gemini.hookSpecificOutput.additionalContext).toContain('29 KB');
+  });
+
+  it('uses each client native redirect mechanism when explicitly enabled', () => {
+    const env = { TOKEN_OPTIMIZER_REDIRECT_LARGE_READS: 'true' };
+    const codex = runHook(
+      codexHook,
+      [],
+      {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Read',
+        tool_input: { file_path: largeFile },
+        cwd: fixtureDir,
+      },
+      env
+    );
+    const copilot = runHook(
+      copilotHook,
+      ['before-read'],
+      {
+        toolName: 'view',
+        toolArgs: { path: largeFile },
+        cwd: fixtureDir,
+      },
+      env
+    );
+    const gemini = runHook(
+      geminiHook,
+      ['after-read'],
+      {
+        hook_event_name: 'AfterTool',
+        tool_name: 'read_file',
+        tool_input: { file_path: largeFile },
+        cwd: fixtureDir,
+      },
+      env
+    );
+
+    expect(codex.hookSpecificOutput.permissionDecision).toBe('deny');
+    expect(copilot.permissionDecision).toBe('deny');
+    expect(gemini.hookSpecificOutput.tailToolCallRequest).toEqual({
+      name: 'mcp_token-optimizer_smart_read',
+      args: { path: largeFile },
+    });
+  });
+
+  it('ships matching Gemini hooks in the root and standalone extension', () => {
+    const rootHooks = readFileSync(join(repoRoot, 'hooks/hooks.json'), 'utf8');
+    const standaloneHooks = readFileSync(
+      join(repoRoot, 'integrations/gemini/hooks/hooks.json'),
+      'utf8'
+    );
+    const rootScript = readFileSync(geminiHook, 'utf8');
+    const standaloneScript = readFileSync(
+      join(
+        repoRoot,
+        'integrations/gemini/hooks/gemini-token-optimizer-advisor.mjs'
+      ),
+      'utf8'
+    );
+
+    expect(JSON.parse(rootHooks)).toEqual(JSON.parse(standaloneHooks));
+    expect(rootScript).toBe(standaloneScript);
+  });
+
+  it('loads valid hook manifests whose commands resolve to shipped scripts', () => {
+    const manifests = [
+      join(repoRoot, 'integrations/codex/plugin/hooks/hooks.json'),
+      join(repoRoot, 'integrations/copilot/.github/hooks/token-optimizer.json'),
+      join(repoRoot, 'hooks/hooks.json'),
+    ];
+
+    for (const manifest of manifests) {
+      expect(() => JSON.parse(readFileSync(manifest, 'utf8'))).not.toThrow();
+      expect(dirname(manifest)).toBeTruthy();
+    }
+  });
+
+  it('ships matching Codex plugin and standalone hook logic', () => {
+    const standalone = readFileSync(
+      join(repoRoot, 'integrations/codex/hooks/token-optimizer-advisor.mjs'),
+      'utf8'
+    );
+    expect(readFileSync(codexHook, 'utf8')).toBe(standalone);
+  });
+
+  it('preserves guidance through OpenCode compaction and supports strict routing', async () => {
+    const pluginPath = join(
+      repoRoot,
+      'integrations/opencode/.opencode/plugins/token-optimizer.js'
+    );
+    const previous = process.env.TOKEN_OPTIMIZER_REDIRECT_LARGE_READS;
+    process.env.TOKEN_OPTIMIZER_REDIRECT_LARGE_READS = 'true';
+
+    try {
+      const pluginModule = (await import(
+        `${pathToFileURL(pluginPath).href}?test=${Date.now()}`
+      )) as {
+        TokenOptimizerPlugin: (context: {
+          directory: string;
+        }) => Promise<Record<string, (...args: any[]) => Promise<void>>>;
+      };
+      const hooks = await pluginModule.TokenOptimizerPlugin({
+        directory: fixtureDir,
+      });
+      const compactionOutput = { context: [] as string[] };
+
+      await hooks['experimental.session.compacting']({}, compactionOutput);
+      expect(compactionOutput.context.join('\n')).toContain('smart_read');
+
+      await expect(
+        hooks['tool.execute.before'](
+          { tool: 'read' },
+          { args: { filePath: largeFile } }
+        )
+      ).rejects.toThrow('Use token-optimizer smart_read');
+    } finally {
+      if (previous === undefined) {
+        delete process.env.TOKEN_OPTIMIZER_REDIRECT_LARGE_READS;
+      } else {
+        process.env.TOKEN_OPTIMIZER_REDIRECT_LARGE_READS = previous;
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- add native Codex plugin and standalone hooks for session guidance and large-read steering
- add GitHub Copilot CLI repository hooks using `sessionStart`, `preToolUse`, and `postToolUse`
- add Gemini extension hooks with optional `tailToolCallRequest` result replacement
- add an OpenCode local plugin for compaction preservation and optional strict large-read routing
- expand every top-level CLI installation section with equivalent guidance/hook setup while retaining the full Claude seven-phase architecture reference
- add cross-client integration tests for advisory mode, strict mode, small/partial reads, manifests, and duplicated distribution artifacts

## Behavior

The adapters are advisory by default and fail open for malformed payloads, missing files, small files, and partial reads. Set `TOKEN_OPTIMIZER_REDIRECT_LARGE_READS=true` for strict native routing. The default threshold is 25,600 bytes and can be changed with `TOKEN_OPTIMIZER_LARGE_READ_BYTES`.

## Validation

- `npm run build`
- `npm test -- --runInBand` (42 suites; 682 passed, 1 skipped)
- `npm run lint` (0 errors; existing repository warnings only)
- `npm run validate`
- targeted Prettier checks
- `npm pack --dry-run --json` (Gemini hook assets included)
- live ephemeral Codex session with the standalone global hook loaded

## Background

This follows the now-merged README restoration in #194. The branch was rebased onto current `master`, so this PR contains only the cross-client lifecycle integrations and their documentation/tests.