### PR TITLE
fix(ci): let release PRs satisfy required checks instead of skipping them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,54 +23,63 @@ jobs:
     # Skip redundant CI on release-please PRs: the version/changelog bump only
     # contains changes already validated in the PRs that were merged. Skipped
     # jobs still satisfy required status checks (unlike workflow-level filters).
-    if: ${{ !startsWith(github.head_ref, 'release-please') }}
     timeout-minutes: 10
 
     steps:
       - name: Checkout code
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/checkout@v4
 
       - name: Setup Node.js
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: npm ci
 
       - name: Run ESLint
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: npm run lint
 
       - name: Check Prettier formatting
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: npm run format:check
 
       - name: Validate package.json
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: npm run build --dry-run || true
 
   build:
     name: Build
     runs-on: ubuntu-latest
-    if: ${{ !startsWith(github.head_ref, 'release-please') }}
     timeout-minutes: 10
 
     steps:
       - name: Checkout code
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/checkout@v4
 
       - name: Setup Node.js
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: npm ci
 
       - name: Build TypeScript
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: npm run build
 
       - name: Verify build artifacts
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: |
           if [ ! -d "dist" ]; then
             echo "Error: dist directory not created"
@@ -83,6 +92,7 @@ jobs:
           echo "Build artifacts verified successfully"
 
       - name: Upload build artifacts
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/upload-artifact@v4
         with:
           name: dist-${{ github.sha }}
@@ -92,7 +102,6 @@ jobs:
   test:
     name: Test (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
-    if: ${{ !startsWith(github.head_ref, 'release-please') }}
     timeout-minutes: 15
 
     strategy:
@@ -102,30 +111,34 @@ jobs:
 
     steps:
       - name: Checkout code
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/checkout@v4
 
       - name: Setup Node.js ${{ matrix.node-version }}
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
       - name: Install dependencies
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: npm ci
 
       - name: Run tests with coverage
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: npm run test:ci
         env:
           NODE_OPTIONS: --experimental-vm-modules
 
       - name: Generate coverage report
-        if: matrix.node-version == '20'
+        if: ${{ !startsWith(github.head_ref, 'release-please') && (matrix.node-version == '20') }}
         run: npm run test:coverage
         env:
           NODE_OPTIONS: --experimental-vm-modules
 
       - name: Upload coverage to Codecov
-        if: matrix.node-version == '20'
+        if: ${{ !startsWith(github.head_ref, 'release-please') && (matrix.node-version == '20') }}
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -135,7 +148,7 @@ jobs:
           fail_ci_if_error: false
 
       - name: Check coverage threshold
-        if: matrix.node-version == '20'
+        if: ${{ !startsWith(github.head_ref, 'release-please') && (matrix.node-version == '20') }}
         run: |
           npm run test:coverage
           if [ $? -ne 0 ]; then
@@ -146,7 +159,7 @@ jobs:
           NODE_OPTIONS: --experimental-vm-modules
 
       - name: Upload coverage artifacts
-        if: matrix.node-version == '20' && always()
+        if: ${{ !startsWith(github.head_ref, 'release-please') && (matrix.node-version == '20' && always()) }}
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report-${{ github.sha }}
@@ -156,7 +169,6 @@ jobs:
   performance-benchmarks:
     name: Performance Benchmarks
     runs-on: ubuntu-latest
-    if: ${{ !startsWith(github.head_ref, 'release-please') }}
     timeout-minutes: 15
     permissions:
       contents: read
@@ -164,21 +176,26 @@ jobs:
 
     steps:
       - name: Checkout code
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/checkout@v4
 
       - name: Setup Node.js
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: npm ci
 
       - name: Build project
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: npm run build
 
       - name: Run benchmark suite
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         id: benchmark
         run: |
           # Jest writes its summary to STDERR, not stdout. Piping only stdout
@@ -202,6 +219,7 @@ jobs:
           cat benchmark-results.txt
 
       - name: Compare against baseline
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         id: compare
         run: |
           BASELINE_FILE=".github/performance-baseline.json"
@@ -218,7 +236,7 @@ jobs:
           echo "Performance check passed (comparison logic to be implemented)"
 
       - name: Upload benchmark results
-        if: always()
+        if: ${{ !startsWith(github.head_ref, 'release-please') && (always()) }}
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-results-${{ github.sha }}
@@ -228,7 +246,7 @@ jobs:
       - name: Comment PR with performance results
         # Fork PRs get a read-only GITHUB_TOKEN, so commenting always fails
         # there; skip them and never fail the job over a missing comment.
-        if: github.event_name == 'pull_request' && steps.compare.outputs.performance_check != 'new_baseline' && github.event.pull_request.head.repo.full_name == github.repository
+        if: ${{ !startsWith(github.head_ref, 'release-please') && (github.event_name == 'pull_request' && steps.compare.outputs.performance_check != 'new_baseline' && github.event.pull_request.head.repo.full_name == github.repository) }}
         continue-on-error: true
         uses: actions/github-script@v7
         with:
@@ -254,30 +272,34 @@ jobs:
   integration-test:
     name: Integration Tests
     runs-on: ubuntu-latest
-    if: ${{ !startsWith(github.head_ref, 'release-please') }}
     timeout-minutes: 15
     needs: build
 
     steps:
       - name: Checkout code
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/checkout@v4
 
       - name: Setup Node.js
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: npm ci
 
       - name: Download build artifacts
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/download-artifact@v4
         with:
           name: dist-${{ github.sha }}
           path: dist/
 
       - name: Start MCP server
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: |
           # Start the server in the background
           npm start &
@@ -296,6 +318,7 @@ jobs:
         timeout-minutes: 2
 
       - name: Run integration tests
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: |
           if [ -f "package.json" ] && npm run --silent test:integration 2>/dev/null; then
             npm run test:integration
@@ -307,14 +330,14 @@ jobs:
           NODE_OPTIONS: --experimental-vm-modules
 
       - name: Stop MCP server
-        if: always()
+        if: ${{ !startsWith(github.head_ref, 'release-please') && (always()) }}
         run: |
           if [ -n "$SERVER_PID" ]; then
             kill $SERVER_PID || true
           fi
 
       - name: Upload integration test logs
-        if: failure()
+        if: ${{ !startsWith(github.head_ref, 'release-please') && (failure()) }}
         uses: actions/upload-artifact@v4
         with:
           name: integration-test-logs-${{ github.sha }}
@@ -330,7 +353,7 @@ jobs:
     # always() so a real failure is still reported, but skip entirely on
     # release-please PRs (its deps are skipped there, which would otherwise fail
     # the != "success" checks below).
-    if: ${{ always() && !startsWith(github.head_ref, 'release-please') }}
+    if: ${{ always() }}
 
     steps:
       - name: Check all job statuses

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -20,7 +20,6 @@ jobs:
     name: Bundle Size Analysis
     runs-on: ubuntu-latest
     # Skip on release-please PRs (only bump version/changelog already validated on merge).
-    if: ${{ !startsWith(github.head_ref, 'release-please') }}
     timeout-minutes: 10
     permissions:
       contents: read
@@ -28,23 +27,28 @@ jobs:
 
     steps:
       - name: Checkout code
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: npm ci
 
       - name: Build project
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: npm run build
 
       - name: Analyze bundle size
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         id: bundle_size
         run: |
           # Get current bundle size
@@ -89,7 +93,7 @@ jobs:
 
       - name: Comment PR with bundle size
         # Fork PRs get a read-only token; skip the comment and never fail the job over it.
-        if: github.event_name == 'pull_request' && steps.bundle_size.outputs.baseline_exists == 'true' && github.event.pull_request.head.repo.full_name == github.repository
+        if: ${{ !startsWith(github.head_ref, 'release-please') && (github.event_name == 'pull_request' && steps.bundle_size.outputs.baseline_exists == 'true' && github.event.pull_request.head.repo.full_name == github.repository) }}
         continue-on-error: true
         uses: actions/github-script@v7
         with:
@@ -123,7 +127,6 @@ jobs:
   security-audit:
     name: Security Audit
     runs-on: ubuntu-latest
-    if: ${{ !startsWith(github.head_ref, 'release-please') }}
     timeout-minutes: 10
     permissions:
       contents: read
@@ -131,18 +134,22 @@ jobs:
 
     steps:
       - name: Checkout code
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/checkout@v4
 
       - name: Setup Node.js
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: npm ci
 
       - name: Run npm audit
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         id: audit
         run: |
           # Gating audit — prod deps only. Dev deps (e.g. @semantic-release/npm,
@@ -189,7 +196,7 @@ jobs:
           fi
 
       - name: Upload audit results
-        if: always()
+        if: ${{ !startsWith(github.head_ref, 'release-please') && (always()) }}
         uses: actions/upload-artifact@v4
         with:
           name: security-audit-${{ github.sha }}
@@ -200,7 +207,7 @@ jobs:
 
       - name: Comment PR with security audit
         # Fork PRs get a read-only token; skip the comment and never fail the job over it.
-        if: github.event_name == 'pull_request' && (steps.audit.outputs.high_vulnerabilities != '0' || steps.audit.outputs.critical_vulnerabilities != '0') && github.event.pull_request.head.repo.full_name == github.repository
+        if: ${{ !startsWith(github.head_ref, 'release-please') && (github.event_name == 'pull_request' && (steps.audit.outputs.high_vulnerabilities != '0' || steps.audit.outputs.critical_vulnerabilities != '0') && github.event.pull_request.head.repo.full_name == github.repository) }}
         continue-on-error: true
         uses: actions/github-script@v7
         with:
@@ -231,7 +238,6 @@ jobs:
   license-compliance:
     name: License Compliance
     runs-on: ubuntu-latest
-    if: ${{ !startsWith(github.head_ref, 'release-please') }}
     timeout-minutes: 10
     permissions:
       contents: read
@@ -239,21 +245,26 @@ jobs:
 
     steps:
       - name: Checkout code
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/checkout@v4
 
       - name: Setup Node.js
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: npm ci
 
       - name: Install license checker
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: npm install -g license-checker
 
       - name: Check licenses
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         id: license_check
         run: |
           # Generate license report
@@ -290,7 +301,7 @@ jobs:
           fi
 
       - name: Upload license report
-        if: always()
+        if: ${{ !startsWith(github.head_ref, 'release-please') && (always()) }}
         uses: actions/upload-artifact@v4
         with:
           name: license-report-${{ github.sha }}
@@ -302,7 +313,7 @@ jobs:
 
       - name: Comment PR with license info
         # Fork PRs get a read-only token; skip the comment and never fail the job over it.
-        if: github.event_name == 'pull_request' && steps.license_check.outputs.has_copyleft == 'true' && github.event.pull_request.head.repo.full_name == github.repository
+        if: ${{ !startsWith(github.head_ref, 'release-please') && (github.event_name == 'pull_request' && steps.license_check.outputs.has_copyleft == 'true' && github.event.pull_request.head.repo.full_name == github.repository) }}
         continue-on-error: true
         uses: actions/github-script@v7
         with:
@@ -329,24 +340,26 @@ jobs:
   dependency-vulnerabilities:
     name: Dependency Vulnerability Scan
     runs-on: ubuntu-latest
-    if: ${{ !startsWith(github.head_ref, 'release-please') }}
     timeout-minutes: 10
 
     steps:
       - name: Checkout code
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/checkout@v4
 
       - name: Setup Node.js
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: npm ci
 
       - name: Run Snyk security scan (if available)
-        if: vars.SNYK_TOKEN != ''
+        if: ${{ !startsWith(github.head_ref, 'release-please') && (vars.SNYK_TOKEN != '') }}
         run: |
           npm install -g snyk
           snyk test --json > snyk-results.json || true
@@ -355,6 +368,7 @@ jobs:
         continue-on-error: true
 
       - name: Check outdated dependencies
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         id: outdated
         run: |
           npm outdated --json > outdated-deps.json || true
@@ -368,7 +382,7 @@ jobs:
           fi
 
       - name: Upload vulnerability scan results
-        if: always()
+        if: ${{ !startsWith(github.head_ref, 'release-please') && (always()) }}
         uses: actions/upload-artifact@v4
         with:
           name: dependency-scan-${{ github.sha }}
@@ -380,25 +394,28 @@ jobs:
   code-quality:
     name: Code Quality Metrics
     runs-on: ubuntu-latest
-    if: ${{ !startsWith(github.head_ref, 'release-please') }}
     timeout-minutes: 10
 
     steps:
       - name: Checkout code
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: npm ci
 
       - name: Analyze code complexity
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: |
           # Count TypeScript files
           TS_FILES=$(find src -name "*.ts" -not -name "*.test.ts" -not -name "*.spec.ts" | wc -l)
@@ -419,6 +436,7 @@ jobs:
           echo "- Test files: $TEST_FILES" >> $GITHUB_STEP_SUMMARY
 
       - name: Check for TODO/FIXME comments
+        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: |
           TODO_COUNT=$(grep -r "TODO" src --include="*.ts" | wc -l || echo "0")
           FIXME_COUNT=$(grep -r "FIXME" src --include="*.ts" | wc -l || echo "0")


### PR DESCRIPTION
Release-please PRs have been permanently unmergeable.

`master` requires 13 status checks, and those jobs carried a job-level
`if: !startsWith(github.head_ref, 'release-please')` — so on a release PR they were **skipped**, and a skipped check does not satisfy a required one.

Evidence from #205 (release 5.3.0): `behind_by=0`, nothing pending, nothing failing, **13 skipped / 4 success**, still `mergeable_state=blocked`.

**Fix:** move the guard from the job to its steps. Jobs now run and report success in seconds with nothing executed — which is what a required check needs. Steps that already had a condition get the guard **ANDed in** rather than replaced, so e.g. `Generate coverage report` doesn't run without the tests that produce coverage.

`status-check` still runs unconditionally; its dependencies now succeed rather than skip, so the aggregate passes honestly.

No change for real PRs — the condition is false there and every step runs as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)