### PR TITLE
revert(ci): skip jobs on release PRs again, now that nothing requires them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,63 +23,54 @@ jobs:
     # Skip redundant CI on release-please PRs: the version/changelog bump only
     # contains changes already validated in the PRs that were merged. Skipped
     # jobs still satisfy required status checks (unlike workflow-level filters).
+    if: ${{ !startsWith(github.head_ref, 'release-please') }}
     timeout-minutes: 10
 
     steps:
       - name: Checkout code
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/checkout@v4
 
       - name: Setup Node.js
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: npm ci
 
       - name: Run ESLint
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: npm run lint
 
       - name: Check Prettier formatting
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: npm run format:check
 
       - name: Validate package.json
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: npm run build --dry-run || true
 
   build:
     name: Build
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.head_ref, 'release-please') }}
     timeout-minutes: 10
 
     steps:
       - name: Checkout code
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/checkout@v4
 
       - name: Setup Node.js
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: npm ci
 
       - name: Build TypeScript
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: npm run build
 
       - name: Verify build artifacts
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: |
           if [ ! -d "dist" ]; then
             echo "Error: dist directory not created"
@@ -92,7 +83,6 @@ jobs:
           echo "Build artifacts verified successfully"
 
       - name: Upload build artifacts
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/upload-artifact@v4
         with:
           name: dist-${{ github.sha }}
@@ -102,6 +92,7 @@ jobs:
   test:
     name: Test (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.head_ref, 'release-please') }}
     timeout-minutes: 15
 
     strategy:
@@ -111,34 +102,30 @@ jobs:
 
     steps:
       - name: Checkout code
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/checkout@v4
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
       - name: Install dependencies
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: npm ci
 
       - name: Run tests with coverage
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: npm run test:ci
         env:
           NODE_OPTIONS: --experimental-vm-modules
 
       - name: Generate coverage report
-        if: ${{ !startsWith(github.head_ref, 'release-please') && (matrix.node-version == '20') }}
+        if: matrix.node-version == '20'
         run: npm run test:coverage
         env:
           NODE_OPTIONS: --experimental-vm-modules
 
       - name: Upload coverage to Codecov
-        if: ${{ !startsWith(github.head_ref, 'release-please') && (matrix.node-version == '20') }}
+        if: matrix.node-version == '20'
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -148,7 +135,7 @@ jobs:
           fail_ci_if_error: false
 
       - name: Check coverage threshold
-        if: ${{ !startsWith(github.head_ref, 'release-please') && (matrix.node-version == '20') }}
+        if: matrix.node-version == '20'
         run: |
           npm run test:coverage
           if [ $? -ne 0 ]; then
@@ -159,7 +146,7 @@ jobs:
           NODE_OPTIONS: --experimental-vm-modules
 
       - name: Upload coverage artifacts
-        if: ${{ !startsWith(github.head_ref, 'release-please') && (matrix.node-version == '20' && always()) }}
+        if: matrix.node-version == '20' && always()
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report-${{ github.sha }}
@@ -169,6 +156,7 @@ jobs:
   performance-benchmarks:
     name: Performance Benchmarks
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.head_ref, 'release-please') }}
     timeout-minutes: 15
     permissions:
       contents: read
@@ -176,26 +164,21 @@ jobs:
 
     steps:
       - name: Checkout code
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/checkout@v4
 
       - name: Setup Node.js
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: npm ci
 
       - name: Build project
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: npm run build
 
       - name: Run benchmark suite
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         id: benchmark
         run: |
           # Jest writes its summary to STDERR, not stdout. Piping only stdout
@@ -219,7 +202,6 @@ jobs:
           cat benchmark-results.txt
 
       - name: Compare against baseline
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         id: compare
         run: |
           BASELINE_FILE=".github/performance-baseline.json"
@@ -236,7 +218,7 @@ jobs:
           echo "Performance check passed (comparison logic to be implemented)"
 
       - name: Upload benchmark results
-        if: ${{ !startsWith(github.head_ref, 'release-please') && (always()) }}
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-results-${{ github.sha }}
@@ -246,7 +228,7 @@ jobs:
       - name: Comment PR with performance results
         # Fork PRs get a read-only GITHUB_TOKEN, so commenting always fails
         # there; skip them and never fail the job over a missing comment.
-        if: ${{ !startsWith(github.head_ref, 'release-please') && (github.event_name == 'pull_request' && steps.compare.outputs.performance_check != 'new_baseline' && github.event.pull_request.head.repo.full_name == github.repository) }}
+        if: github.event_name == 'pull_request' && steps.compare.outputs.performance_check != 'new_baseline' && github.event.pull_request.head.repo.full_name == github.repository
         continue-on-error: true
         uses: actions/github-script@v7
         with:
@@ -272,34 +254,30 @@ jobs:
   integration-test:
     name: Integration Tests
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.head_ref, 'release-please') }}
     timeout-minutes: 15
     needs: build
 
     steps:
       - name: Checkout code
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/checkout@v4
 
       - name: Setup Node.js
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: npm ci
 
       - name: Download build artifacts
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/download-artifact@v4
         with:
           name: dist-${{ github.sha }}
           path: dist/
 
       - name: Start MCP server
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: |
           # Start the server in the background
           npm start &
@@ -318,7 +296,6 @@ jobs:
         timeout-minutes: 2
 
       - name: Run integration tests
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: |
           if [ -f "package.json" ] && npm run --silent test:integration 2>/dev/null; then
             npm run test:integration
@@ -330,14 +307,14 @@ jobs:
           NODE_OPTIONS: --experimental-vm-modules
 
       - name: Stop MCP server
-        if: ${{ !startsWith(github.head_ref, 'release-please') && (always()) }}
+        if: always()
         run: |
           if [ -n "$SERVER_PID" ]; then
             kill $SERVER_PID || true
           fi
 
       - name: Upload integration test logs
-        if: ${{ !startsWith(github.head_ref, 'release-please') && (failure()) }}
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: integration-test-logs-${{ github.sha }}
@@ -353,7 +330,7 @@ jobs:
     # always() so a real failure is still reported, but skip entirely on
     # release-please PRs (its deps are skipped there, which would otherwise fail
     # the != "success" checks below).
-    if: ${{ always() }}
+    if: ${{ always() && !startsWith(github.head_ref, 'release-please') }}
 
     steps:
       - name: Check all job statuses

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -20,6 +20,7 @@ jobs:
     name: Bundle Size Analysis
     runs-on: ubuntu-latest
     # Skip on release-please PRs (only bump version/changelog already validated on merge).
+    if: ${{ !startsWith(github.head_ref, 'release-please') }}
     timeout-minutes: 10
     permissions:
       contents: read
@@ -27,28 +28,23 @@ jobs:
 
     steps:
       - name: Checkout code
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: npm ci
 
       - name: Build project
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: npm run build
 
       - name: Analyze bundle size
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         id: bundle_size
         run: |
           # Get current bundle size
@@ -93,7 +89,7 @@ jobs:
 
       - name: Comment PR with bundle size
         # Fork PRs get a read-only token; skip the comment and never fail the job over it.
-        if: ${{ !startsWith(github.head_ref, 'release-please') && (github.event_name == 'pull_request' && steps.bundle_size.outputs.baseline_exists == 'true' && github.event.pull_request.head.repo.full_name == github.repository) }}
+        if: github.event_name == 'pull_request' && steps.bundle_size.outputs.baseline_exists == 'true' && github.event.pull_request.head.repo.full_name == github.repository
         continue-on-error: true
         uses: actions/github-script@v7
         with:
@@ -127,6 +123,7 @@ jobs:
   security-audit:
     name: Security Audit
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.head_ref, 'release-please') }}
     timeout-minutes: 10
     permissions:
       contents: read
@@ -134,22 +131,18 @@ jobs:
 
     steps:
       - name: Checkout code
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/checkout@v4
 
       - name: Setup Node.js
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: npm ci
 
       - name: Run npm audit
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         id: audit
         run: |
           # Gating audit — prod deps only. Dev deps (e.g. @semantic-release/npm,
@@ -196,7 +189,7 @@ jobs:
           fi
 
       - name: Upload audit results
-        if: ${{ !startsWith(github.head_ref, 'release-please') && (always()) }}
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: security-audit-${{ github.sha }}
@@ -207,7 +200,7 @@ jobs:
 
       - name: Comment PR with security audit
         # Fork PRs get a read-only token; skip the comment and never fail the job over it.
-        if: ${{ !startsWith(github.head_ref, 'release-please') && (github.event_name == 'pull_request' && (steps.audit.outputs.high_vulnerabilities != '0' || steps.audit.outputs.critical_vulnerabilities != '0') && github.event.pull_request.head.repo.full_name == github.repository) }}
+        if: github.event_name == 'pull_request' && (steps.audit.outputs.high_vulnerabilities != '0' || steps.audit.outputs.critical_vulnerabilities != '0') && github.event.pull_request.head.repo.full_name == github.repository
         continue-on-error: true
         uses: actions/github-script@v7
         with:
@@ -238,6 +231,7 @@ jobs:
   license-compliance:
     name: License Compliance
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.head_ref, 'release-please') }}
     timeout-minutes: 10
     permissions:
       contents: read
@@ -245,26 +239,21 @@ jobs:
 
     steps:
       - name: Checkout code
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/checkout@v4
 
       - name: Setup Node.js
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: npm ci
 
       - name: Install license checker
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: npm install -g license-checker
 
       - name: Check licenses
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         id: license_check
         run: |
           # Generate license report
@@ -301,7 +290,7 @@ jobs:
           fi
 
       - name: Upload license report
-        if: ${{ !startsWith(github.head_ref, 'release-please') && (always()) }}
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: license-report-${{ github.sha }}
@@ -313,7 +302,7 @@ jobs:
 
       - name: Comment PR with license info
         # Fork PRs get a read-only token; skip the comment and never fail the job over it.
-        if: ${{ !startsWith(github.head_ref, 'release-please') && (github.event_name == 'pull_request' && steps.license_check.outputs.has_copyleft == 'true' && github.event.pull_request.head.repo.full_name == github.repository) }}
+        if: github.event_name == 'pull_request' && steps.license_check.outputs.has_copyleft == 'true' && github.event.pull_request.head.repo.full_name == github.repository
         continue-on-error: true
         uses: actions/github-script@v7
         with:
@@ -340,26 +329,24 @@ jobs:
   dependency-vulnerabilities:
     name: Dependency Vulnerability Scan
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.head_ref, 'release-please') }}
     timeout-minutes: 10
 
     steps:
       - name: Checkout code
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/checkout@v4
 
       - name: Setup Node.js
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: npm ci
 
       - name: Run Snyk security scan (if available)
-        if: ${{ !startsWith(github.head_ref, 'release-please') && (vars.SNYK_TOKEN != '') }}
+        if: vars.SNYK_TOKEN != ''
         run: |
           npm install -g snyk
           snyk test --json > snyk-results.json || true
@@ -368,7 +355,6 @@ jobs:
         continue-on-error: true
 
       - name: Check outdated dependencies
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         id: outdated
         run: |
           npm outdated --json > outdated-deps.json || true
@@ -382,7 +368,7 @@ jobs:
           fi
 
       - name: Upload vulnerability scan results
-        if: ${{ !startsWith(github.head_ref, 'release-please') && (always()) }}
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: dependency-scan-${{ github.sha }}
@@ -394,28 +380,25 @@ jobs:
   code-quality:
     name: Code Quality Metrics
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.head_ref, 'release-please') }}
     timeout-minutes: 10
 
     steps:
       - name: Checkout code
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: npm ci
 
       - name: Analyze code complexity
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: |
           # Count TypeScript files
           TS_FILES=$(find src -name "*.ts" -not -name "*.test.ts" -not -name "*.spec.ts" | wc -l)
@@ -436,7 +419,6 @@ jobs:
           echo "- Test files: $TEST_FILES" >> $GITHUB_STEP_SUMMARY
 
       - name: Check for TODO/FIXME comments
-        if: ${{ !startsWith(github.head_ref, 'release-please') }}
         run: |
           TODO_COUNT=$(grep -r "TODO" src --include="*.ts" | wc -l || echo "0")
           FIXME_COUNT=$(grep -r "FIXME" src --include="*.ts" | wc -l || echo "0")


### PR DESCRIPTION
Reverts #206 — which fixed the right problem at the wrong layer.

#206 made guarded jobs **run and succeed** on release PRs because 13 contexts were required by branch protection and a skipped check doesn't satisfy a required one. That unblocked the release PR at the cost of spinning up eleven runners to do nothing, every release.

The requirement was the actual problem, and it's now removed at the source — **matching AiDotNet**:

| | AiDotNet | here (now) |
|---|---|---|
| Legacy branch protection | none | required-status-checks rule **removed** |
| Ruleset bypass actors | RepositoryRole ×2 + **Integration ×2** | **same** (apps 347564, 1236702) |

With nothing requiring those contexts, the jobs go back to skipping outright: cheaper, and honest — a version bump plus a CHANGELOG entry can't break a test, and `publish-npm` independently installs, builds and verifies before publishing.

Real PRs are unaffected — the condition is false there and every job runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)