### PR TITLE
ci: skip redundant jobs on the release merge commit, not just the release PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     # Skip redundant CI on release-please PRs: the version/changelog bump only
     # contains changes already validated in the PRs that were merged. Skipped
     # jobs still satisfy required status checks (unlike workflow-level filters).
-    if: ${{ !startsWith(github.head_ref, 'release-please') }}
+    if: "${{ !startsWith(github.head_ref, 'release-please') && !startsWith(github.event.head_commit.message, 'chore(master): release') }}"
     timeout-minutes: 10
 
     steps:
@@ -51,7 +51,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    if: ${{ !startsWith(github.head_ref, 'release-please') }}
+    if: "${{ !startsWith(github.head_ref, 'release-please') && !startsWith(github.event.head_commit.message, 'chore(master): release') }}"
     timeout-minutes: 10
 
     steps:
@@ -92,7 +92,7 @@ jobs:
   test:
     name: Test (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
-    if: ${{ !startsWith(github.head_ref, 'release-please') }}
+    if: "${{ !startsWith(github.head_ref, 'release-please') && !startsWith(github.event.head_commit.message, 'chore(master): release') }}"
     timeout-minutes: 15
 
     strategy:
@@ -156,7 +156,7 @@ jobs:
   performance-benchmarks:
     name: Performance Benchmarks
     runs-on: ubuntu-latest
-    if: ${{ !startsWith(github.head_ref, 'release-please') }}
+    if: "${{ !startsWith(github.head_ref, 'release-please') && !startsWith(github.event.head_commit.message, 'chore(master): release') }}"
     timeout-minutes: 15
     permissions:
       contents: read
@@ -254,7 +254,7 @@ jobs:
   integration-test:
     name: Integration Tests
     runs-on: ubuntu-latest
-    if: ${{ !startsWith(github.head_ref, 'release-please') }}
+    if: "${{ !startsWith(github.head_ref, 'release-please') && !startsWith(github.event.head_commit.message, 'chore(master): release') }}"
     timeout-minutes: 15
     needs: build
 

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -20,7 +20,7 @@ jobs:
     name: Bundle Size Analysis
     runs-on: ubuntu-latest
     # Skip on release-please PRs (only bump version/changelog already validated on merge).
-    if: ${{ !startsWith(github.head_ref, 'release-please') }}
+    if: "${{ !startsWith(github.head_ref, 'release-please') && !startsWith(github.event.head_commit.message, 'chore(master): release') }}"
     timeout-minutes: 10
     permissions:
       contents: read
@@ -123,7 +123,7 @@ jobs:
   security-audit:
     name: Security Audit
     runs-on: ubuntu-latest
-    if: ${{ !startsWith(github.head_ref, 'release-please') }}
+    if: "${{ !startsWith(github.head_ref, 'release-please') && !startsWith(github.event.head_commit.message, 'chore(master): release') }}"
     timeout-minutes: 10
     permissions:
       contents: read
@@ -231,7 +231,7 @@ jobs:
   license-compliance:
     name: License Compliance
     runs-on: ubuntu-latest
-    if: ${{ !startsWith(github.head_ref, 'release-please') }}
+    if: "${{ !startsWith(github.head_ref, 'release-please') && !startsWith(github.event.head_commit.message, 'chore(master): release') }}"
     timeout-minutes: 10
     permissions:
       contents: read
@@ -329,7 +329,7 @@ jobs:
   dependency-vulnerabilities:
     name: Dependency Vulnerability Scan
     runs-on: ubuntu-latest
-    if: ${{ !startsWith(github.head_ref, 'release-please') }}
+    if: "${{ !startsWith(github.head_ref, 'release-please') && !startsWith(github.event.head_commit.message, 'chore(master): release') }}"
     timeout-minutes: 10
 
     steps:
@@ -380,7 +380,7 @@ jobs:
   code-quality:
     name: Code Quality Metrics
     runs-on: ubuntu-latest
-    if: ${{ !startsWith(github.head_ref, 'release-please') }}
+    if: "${{ !startsWith(github.head_ref, 'release-please') && !startsWith(github.event.head_commit.message, 'chore(master): release') }}"
     timeout-minutes: 10
 
     steps:


### PR DESCRIPTION
The guard only tested `github.head_ref`, which is **empty on push events** — so merging the release PR re-ran the full matrix on master against a version bump and CHANGELOG entry already validated in the PRs being released. Nine checks queued on the 5.3.0 merge commit for nothing.

Now also skips when the head commit subject starts with `chore(master): release`.

The expression is quoted because the `: ` inside `'chore(master): release'` otherwise parses as a YAML mapping — that's why two earlier attempts failed to load.

Real work on master is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)