### PR TITLE
fix(pkg): ship the enforcement hooks and installer scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,13 +15,14 @@
     "hooks/**/*",
     "install-hooks.ps1",
     "install-hooks.sh",
-    "scripts/postinstall.cjs",
     "README.md",
     "LICENSE",
     "CHANGELOG.md",
     "CLI_WRAPPER_README.md",
     "hooks-core/**/*",
-    "integrations/**/*"
+    "integrations/**/*",
+    "plugin/**/*",
+    "scripts/**/*"
   ],
   "scripts": {
     "postinstall": "node scripts/postinstall.cjs",


### PR DESCRIPTION
**5.3.0 cannot install working hooks.**

The published `files` array omits `plugin/**` entirely, and all of `scripts/` except `postinstall.cjs`. The npm tarball therefore contains none of:

| missing | consequence |
|---|---|
| `plugin/hooks/pretooluse-router.mjs` | **the enforcement hook itself** |
| `plugin/hooks/session-start.mjs` | standing policy + project briefing |
| `plugin/hooks/precompact-optimize.mjs` | the compaction pass |
| `scripts/wire-hooks.mjs` | what `install-hooks.sh` calls to wire settings |
| `scripts/record-install.mjs` | the manifest uninstall depends on |
| `scripts/doctor.mjs` / `uninstall.mjs` | `npm run doctor` / `uninstall-hooks` |

A fresh `npm i -g` fails at *Could not find the plugin hooks to install* and wires nothing; every trust command errors `MODULE_NOT_FOUND`.

The Claude Code **marketplace** path is unaffected — it installs from the repo, not the tarball — which is why this survived undetected.

Found on the first real install of a published build, by `npm run doctor` failing to load. That is exactly the failure mode the doctor exists for: every config-level check would have passed while the product did nothing.

Verified with `npm pack --dry-run` — all three hook entry points and all four scripts are now included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)