### PR TITLE
fix(doctor): give each run a fresh session, so it stops failing its own second run

### DIFF
--- a/hooks-core/doctor.mjs
+++ b/hooks-core/doctor.mjs
@@ -19,6 +19,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
 import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { readManifest, verifyManifest, residue } from './manifest.mjs';
@@ -118,7 +119,7 @@ export function probeEnforcement({ root, workspace }) {
   // on a machine therefore reported both probes as failures -- the product
   // behaving correctly, scored as broken. A doctor that cries wolf on its own
   // second run is worse than no doctor.
-  const probeId = `doctor-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
+  const probeId = `doctor-${process.pid}-${randomBytes(4).toString('hex')}`;
   const big = join(workspace, `${probeId}-large.ts`);
   const small = join(workspace, `${probeId}-small.ts`);
   writeFileSync(big, 'export const x = 1;\n'.repeat(20_000));

--- a/hooks-core/doctor.mjs
+++ b/hooks-core/doctor.mjs
@@ -111,14 +111,22 @@ export function probeEnforcement({ root, workspace }) {
   }
 
   mkdirSync(workspace, { recursive: true });
-  const big = join(workspace, 'doctor-large.ts');
-  const small = join(workspace, 'doctor-small.ts');
+  // A FRESH SESSION AND FRESH FILENAMES PER RUN. The router remembers what a
+  // session has already seen and degrades a repeat refusal to an advisory
+  // (loop-breaking), and it refuses a file it has seen before (re-read
+  // detection). With a fixed session id and fixed paths, the SECOND doctor run
+  // on a machine therefore reported both probes as failures -- the product
+  // behaving correctly, scored as broken. A doctor that cries wolf on its own
+  // second run is worse than no doctor.
+  const probeId = `doctor-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
+  const big = join(workspace, `${probeId}-large.ts`);
+  const small = join(workspace, `${probeId}-small.ts`);
   writeFileSync(big, 'export const x = 1;\n'.repeat(20_000));
   writeFileSync(small, 'export const y = 2;\n');
 
   try {
     const denied = probe(binary, {
-      tool_name: 'Read', tool_input: { file_path: big }, cwd: workspace, session_id: 'doctor',
+      tool_name: 'Read', tool_input: { file_path: big }, cwd: workspace, session_id: probeId,
     });
     const deniedOk = typeof denied === 'string' && denied.includes('deny');
     checks.push(deniedOk
@@ -127,7 +135,7 @@ export function probeEnforcement({ root, workspace }) {
         'check TOKEN_OPTIMIZER_MODE is not "off" or "advise", then reinstall the hooks'));
 
     const allowed = probe(binary, {
-      tool_name: 'Read', tool_input: { file_path: small }, cwd: workspace, session_id: 'doctor',
+      tool_name: 'Read', tool_input: { file_path: small }, cwd: workspace, session_id: probeId,
     });
     const allowedOk = !allowed || !allowed.includes('deny');
     checks.push(allowedOk

--- a/integrations/codex/hooks/lib/doctor.mjs
+++ b/integrations/codex/hooks/lib/doctor.mjs
@@ -21,6 +21,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
 import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { readManifest, verifyManifest, residue } from './manifest.mjs';
@@ -120,7 +121,7 @@ export function probeEnforcement({ root, workspace }) {
   // on a machine therefore reported both probes as failures -- the product
   // behaving correctly, scored as broken. A doctor that cries wolf on its own
   // second run is worse than no doctor.
-  const probeId = `doctor-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
+  const probeId = `doctor-${process.pid}-${randomBytes(4).toString('hex')}`;
   const big = join(workspace, `${probeId}-large.ts`);
   const small = join(workspace, `${probeId}-small.ts`);
   writeFileSync(big, 'export const x = 1;\n'.repeat(20_000));

--- a/integrations/codex/hooks/lib/doctor.mjs
+++ b/integrations/codex/hooks/lib/doctor.mjs
@@ -113,14 +113,22 @@ export function probeEnforcement({ root, workspace }) {
   }
 
   mkdirSync(workspace, { recursive: true });
-  const big = join(workspace, 'doctor-large.ts');
-  const small = join(workspace, 'doctor-small.ts');
+  // A FRESH SESSION AND FRESH FILENAMES PER RUN. The router remembers what a
+  // session has already seen and degrades a repeat refusal to an advisory
+  // (loop-breaking), and it refuses a file it has seen before (re-read
+  // detection). With a fixed session id and fixed paths, the SECOND doctor run
+  // on a machine therefore reported both probes as failures -- the product
+  // behaving correctly, scored as broken. A doctor that cries wolf on its own
+  // second run is worse than no doctor.
+  const probeId = `doctor-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
+  const big = join(workspace, `${probeId}-large.ts`);
+  const small = join(workspace, `${probeId}-small.ts`);
   writeFileSync(big, 'export const x = 1;\n'.repeat(20_000));
   writeFileSync(small, 'export const y = 2;\n');
 
   try {
     const denied = probe(binary, {
-      tool_name: 'Read', tool_input: { file_path: big }, cwd: workspace, session_id: 'doctor',
+      tool_name: 'Read', tool_input: { file_path: big }, cwd: workspace, session_id: probeId,
     });
     const deniedOk = typeof denied === 'string' && denied.includes('deny');
     checks.push(deniedOk
@@ -129,7 +137,7 @@ export function probeEnforcement({ root, workspace }) {
         'check TOKEN_OPTIMIZER_MODE is not "off" or "advise", then reinstall the hooks'));
 
     const allowed = probe(binary, {
-      tool_name: 'Read', tool_input: { file_path: small }, cwd: workspace, session_id: 'doctor',
+      tool_name: 'Read', tool_input: { file_path: small }, cwd: workspace, session_id: probeId,
     });
     const allowedOk = !allowed || !allowed.includes('deny');
     checks.push(allowedOk

--- a/integrations/codex/plugin/hooks/lib/doctor.mjs
+++ b/integrations/codex/plugin/hooks/lib/doctor.mjs
@@ -21,6 +21,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
 import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { readManifest, verifyManifest, residue } from './manifest.mjs';
@@ -120,7 +121,7 @@ export function probeEnforcement({ root, workspace }) {
   // on a machine therefore reported both probes as failures -- the product
   // behaving correctly, scored as broken. A doctor that cries wolf on its own
   // second run is worse than no doctor.
-  const probeId = `doctor-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
+  const probeId = `doctor-${process.pid}-${randomBytes(4).toString('hex')}`;
   const big = join(workspace, `${probeId}-large.ts`);
   const small = join(workspace, `${probeId}-small.ts`);
   writeFileSync(big, 'export const x = 1;\n'.repeat(20_000));

--- a/integrations/codex/plugin/hooks/lib/doctor.mjs
+++ b/integrations/codex/plugin/hooks/lib/doctor.mjs
@@ -113,14 +113,22 @@ export function probeEnforcement({ root, workspace }) {
   }
 
   mkdirSync(workspace, { recursive: true });
-  const big = join(workspace, 'doctor-large.ts');
-  const small = join(workspace, 'doctor-small.ts');
+  // A FRESH SESSION AND FRESH FILENAMES PER RUN. The router remembers what a
+  // session has already seen and degrades a repeat refusal to an advisory
+  // (loop-breaking), and it refuses a file it has seen before (re-read
+  // detection). With a fixed session id and fixed paths, the SECOND doctor run
+  // on a machine therefore reported both probes as failures -- the product
+  // behaving correctly, scored as broken. A doctor that cries wolf on its own
+  // second run is worse than no doctor.
+  const probeId = `doctor-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
+  const big = join(workspace, `${probeId}-large.ts`);
+  const small = join(workspace, `${probeId}-small.ts`);
   writeFileSync(big, 'export const x = 1;\n'.repeat(20_000));
   writeFileSync(small, 'export const y = 2;\n');
 
   try {
     const denied = probe(binary, {
-      tool_name: 'Read', tool_input: { file_path: big }, cwd: workspace, session_id: 'doctor',
+      tool_name: 'Read', tool_input: { file_path: big }, cwd: workspace, session_id: probeId,
     });
     const deniedOk = typeof denied === 'string' && denied.includes('deny');
     checks.push(deniedOk
@@ -129,7 +137,7 @@ export function probeEnforcement({ root, workspace }) {
         'check TOKEN_OPTIMIZER_MODE is not "off" or "advise", then reinstall the hooks'));
 
     const allowed = probe(binary, {
-      tool_name: 'Read', tool_input: { file_path: small }, cwd: workspace, session_id: 'doctor',
+      tool_name: 'Read', tool_input: { file_path: small }, cwd: workspace, session_id: probeId,
     });
     const allowedOk = !allowed || !allowed.includes('deny');
     checks.push(allowedOk

--- a/integrations/gemini/hooks/lib/doctor.mjs
+++ b/integrations/gemini/hooks/lib/doctor.mjs
@@ -21,6 +21,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
 import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { readManifest, verifyManifest, residue } from './manifest.mjs';
@@ -120,7 +121,7 @@ export function probeEnforcement({ root, workspace }) {
   // on a machine therefore reported both probes as failures -- the product
   // behaving correctly, scored as broken. A doctor that cries wolf on its own
   // second run is worse than no doctor.
-  const probeId = `doctor-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
+  const probeId = `doctor-${process.pid}-${randomBytes(4).toString('hex')}`;
   const big = join(workspace, `${probeId}-large.ts`);
   const small = join(workspace, `${probeId}-small.ts`);
   writeFileSync(big, 'export const x = 1;\n'.repeat(20_000));

--- a/integrations/gemini/hooks/lib/doctor.mjs
+++ b/integrations/gemini/hooks/lib/doctor.mjs
@@ -113,14 +113,22 @@ export function probeEnforcement({ root, workspace }) {
   }
 
   mkdirSync(workspace, { recursive: true });
-  const big = join(workspace, 'doctor-large.ts');
-  const small = join(workspace, 'doctor-small.ts');
+  // A FRESH SESSION AND FRESH FILENAMES PER RUN. The router remembers what a
+  // session has already seen and degrades a repeat refusal to an advisory
+  // (loop-breaking), and it refuses a file it has seen before (re-read
+  // detection). With a fixed session id and fixed paths, the SECOND doctor run
+  // on a machine therefore reported both probes as failures -- the product
+  // behaving correctly, scored as broken. A doctor that cries wolf on its own
+  // second run is worse than no doctor.
+  const probeId = `doctor-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
+  const big = join(workspace, `${probeId}-large.ts`);
+  const small = join(workspace, `${probeId}-small.ts`);
   writeFileSync(big, 'export const x = 1;\n'.repeat(20_000));
   writeFileSync(small, 'export const y = 2;\n');
 
   try {
     const denied = probe(binary, {
-      tool_name: 'Read', tool_input: { file_path: big }, cwd: workspace, session_id: 'doctor',
+      tool_name: 'Read', tool_input: { file_path: big }, cwd: workspace, session_id: probeId,
     });
     const deniedOk = typeof denied === 'string' && denied.includes('deny');
     checks.push(deniedOk
@@ -129,7 +137,7 @@ export function probeEnforcement({ root, workspace }) {
         'check TOKEN_OPTIMIZER_MODE is not "off" or "advise", then reinstall the hooks'));
 
     const allowed = probe(binary, {
-      tool_name: 'Read', tool_input: { file_path: small }, cwd: workspace, session_id: 'doctor',
+      tool_name: 'Read', tool_input: { file_path: small }, cwd: workspace, session_id: probeId,
     });
     const allowedOk = !allowed || !allowed.includes('deny');
     checks.push(allowedOk

--- a/integrations/opencode/hooks/lib/doctor.mjs
+++ b/integrations/opencode/hooks/lib/doctor.mjs
@@ -21,6 +21,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
 import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { readManifest, verifyManifest, residue } from './manifest.mjs';
@@ -120,7 +121,7 @@ export function probeEnforcement({ root, workspace }) {
   // on a machine therefore reported both probes as failures -- the product
   // behaving correctly, scored as broken. A doctor that cries wolf on its own
   // second run is worse than no doctor.
-  const probeId = `doctor-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
+  const probeId = `doctor-${process.pid}-${randomBytes(4).toString('hex')}`;
   const big = join(workspace, `${probeId}-large.ts`);
   const small = join(workspace, `${probeId}-small.ts`);
   writeFileSync(big, 'export const x = 1;\n'.repeat(20_000));

--- a/integrations/opencode/hooks/lib/doctor.mjs
+++ b/integrations/opencode/hooks/lib/doctor.mjs
@@ -113,14 +113,22 @@ export function probeEnforcement({ root, workspace }) {
   }
 
   mkdirSync(workspace, { recursive: true });
-  const big = join(workspace, 'doctor-large.ts');
-  const small = join(workspace, 'doctor-small.ts');
+  // A FRESH SESSION AND FRESH FILENAMES PER RUN. The router remembers what a
+  // session has already seen and degrades a repeat refusal to an advisory
+  // (loop-breaking), and it refuses a file it has seen before (re-read
+  // detection). With a fixed session id and fixed paths, the SECOND doctor run
+  // on a machine therefore reported both probes as failures -- the product
+  // behaving correctly, scored as broken. A doctor that cries wolf on its own
+  // second run is worse than no doctor.
+  const probeId = `doctor-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
+  const big = join(workspace, `${probeId}-large.ts`);
+  const small = join(workspace, `${probeId}-small.ts`);
   writeFileSync(big, 'export const x = 1;\n'.repeat(20_000));
   writeFileSync(small, 'export const y = 2;\n');
 
   try {
     const denied = probe(binary, {
-      tool_name: 'Read', tool_input: { file_path: big }, cwd: workspace, session_id: 'doctor',
+      tool_name: 'Read', tool_input: { file_path: big }, cwd: workspace, session_id: probeId,
     });
     const deniedOk = typeof denied === 'string' && denied.includes('deny');
     checks.push(deniedOk
@@ -129,7 +137,7 @@ export function probeEnforcement({ root, workspace }) {
         'check TOKEN_OPTIMIZER_MODE is not "off" or "advise", then reinstall the hooks'));
 
     const allowed = probe(binary, {
-      tool_name: 'Read', tool_input: { file_path: small }, cwd: workspace, session_id: 'doctor',
+      tool_name: 'Read', tool_input: { file_path: small }, cwd: workspace, session_id: probeId,
     });
     const allowedOk = !allowed || !allowed.includes('deny');
     checks.push(allowedOk

--- a/integrations/qwen/hooks/lib/doctor.mjs
+++ b/integrations/qwen/hooks/lib/doctor.mjs
@@ -21,6 +21,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
 import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { readManifest, verifyManifest, residue } from './manifest.mjs';
@@ -120,7 +121,7 @@ export function probeEnforcement({ root, workspace }) {
   // on a machine therefore reported both probes as failures -- the product
   // behaving correctly, scored as broken. A doctor that cries wolf on its own
   // second run is worse than no doctor.
-  const probeId = `doctor-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
+  const probeId = `doctor-${process.pid}-${randomBytes(4).toString('hex')}`;
   const big = join(workspace, `${probeId}-large.ts`);
   const small = join(workspace, `${probeId}-small.ts`);
   writeFileSync(big, 'export const x = 1;\n'.repeat(20_000));

--- a/integrations/qwen/hooks/lib/doctor.mjs
+++ b/integrations/qwen/hooks/lib/doctor.mjs
@@ -113,14 +113,22 @@ export function probeEnforcement({ root, workspace }) {
   }
 
   mkdirSync(workspace, { recursive: true });
-  const big = join(workspace, 'doctor-large.ts');
-  const small = join(workspace, 'doctor-small.ts');
+  // A FRESH SESSION AND FRESH FILENAMES PER RUN. The router remembers what a
+  // session has already seen and degrades a repeat refusal to an advisory
+  // (loop-breaking), and it refuses a file it has seen before (re-read
+  // detection). With a fixed session id and fixed paths, the SECOND doctor run
+  // on a machine therefore reported both probes as failures -- the product
+  // behaving correctly, scored as broken. A doctor that cries wolf on its own
+  // second run is worse than no doctor.
+  const probeId = `doctor-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
+  const big = join(workspace, `${probeId}-large.ts`);
+  const small = join(workspace, `${probeId}-small.ts`);
   writeFileSync(big, 'export const x = 1;\n'.repeat(20_000));
   writeFileSync(small, 'export const y = 2;\n');
 
   try {
     const denied = probe(binary, {
-      tool_name: 'Read', tool_input: { file_path: big }, cwd: workspace, session_id: 'doctor',
+      tool_name: 'Read', tool_input: { file_path: big }, cwd: workspace, session_id: probeId,
     });
     const deniedOk = typeof denied === 'string' && denied.includes('deny');
     checks.push(deniedOk
@@ -129,7 +137,7 @@ export function probeEnforcement({ root, workspace }) {
         'check TOKEN_OPTIMIZER_MODE is not "off" or "advise", then reinstall the hooks'));
 
     const allowed = probe(binary, {
-      tool_name: 'Read', tool_input: { file_path: small }, cwd: workspace, session_id: 'doctor',
+      tool_name: 'Read', tool_input: { file_path: small }, cwd: workspace, session_id: probeId,
     });
     const allowedOk = !allowed || !allowed.includes('deny');
     checks.push(allowedOk

--- a/plugin/hooks/lib/doctor.mjs
+++ b/plugin/hooks/lib/doctor.mjs
@@ -21,6 +21,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
 import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { readManifest, verifyManifest, residue } from './manifest.mjs';
@@ -120,7 +121,7 @@ export function probeEnforcement({ root, workspace }) {
   // on a machine therefore reported both probes as failures -- the product
   // behaving correctly, scored as broken. A doctor that cries wolf on its own
   // second run is worse than no doctor.
-  const probeId = `doctor-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
+  const probeId = `doctor-${process.pid}-${randomBytes(4).toString('hex')}`;
   const big = join(workspace, `${probeId}-large.ts`);
   const small = join(workspace, `${probeId}-small.ts`);
   writeFileSync(big, 'export const x = 1;\n'.repeat(20_000));

--- a/plugin/hooks/lib/doctor.mjs
+++ b/plugin/hooks/lib/doctor.mjs
@@ -113,14 +113,22 @@ export function probeEnforcement({ root, workspace }) {
   }
 
   mkdirSync(workspace, { recursive: true });
-  const big = join(workspace, 'doctor-large.ts');
-  const small = join(workspace, 'doctor-small.ts');
+  // A FRESH SESSION AND FRESH FILENAMES PER RUN. The router remembers what a
+  // session has already seen and degrades a repeat refusal to an advisory
+  // (loop-breaking), and it refuses a file it has seen before (re-read
+  // detection). With a fixed session id and fixed paths, the SECOND doctor run
+  // on a machine therefore reported both probes as failures -- the product
+  // behaving correctly, scored as broken. A doctor that cries wolf on its own
+  // second run is worse than no doctor.
+  const probeId = `doctor-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
+  const big = join(workspace, `${probeId}-large.ts`);
+  const small = join(workspace, `${probeId}-small.ts`);
   writeFileSync(big, 'export const x = 1;\n'.repeat(20_000));
   writeFileSync(small, 'export const y = 2;\n');
 
   try {
     const denied = probe(binary, {
-      tool_name: 'Read', tool_input: { file_path: big }, cwd: workspace, session_id: 'doctor',
+      tool_name: 'Read', tool_input: { file_path: big }, cwd: workspace, session_id: probeId,
     });
     const deniedOk = typeof denied === 'string' && denied.includes('deny');
     checks.push(deniedOk
@@ -129,7 +137,7 @@ export function probeEnforcement({ root, workspace }) {
         'check TOKEN_OPTIMIZER_MODE is not "off" or "advise", then reinstall the hooks'));
 
     const allowed = probe(binary, {
-      tool_name: 'Read', tool_input: { file_path: small }, cwd: workspace, session_id: 'doctor',
+      tool_name: 'Read', tool_input: { file_path: small }, cwd: workspace, session_id: probeId,
     });
     const allowedOk = !allowed || !allowed.includes('deny');
     checks.push(allowedOk


### PR DESCRIPTION
Found on the first real install of a published build: **8/10**, with both enforcement probes reported as failures on a machine where enforcement was working perfectly.

The probes used a fixed session id (`doctor`) and fixed filenames. The router remembers what a session has seen — so on the **second** run, loop-breaking degraded the large-read refusal to an advisory, and re-read detection refused the small file. Both probes scored the product as broken for behaving exactly as designed.

A doctor that cries wolf on its own second run is worse than no doctor: it teaches people to ignore it, which is the one thing this check cannot afford.

Each run now uses a unique session id and unique filenames. Verified by running twice in a row — **10/10 both times**, where the second previously reported 8/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)