### PR TITLE
fix(install): make wiring recoverable when npm blocks postinstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,10 +277,19 @@ That is a bigger ask than a normal dependency makes, so:
 signatures` ties the artifact to the workflow run and the commit, without
 trusting us. `CHECKSUMS.sha256` ships alongside for offline checking.
 
+**If nothing seems to be happening, the hooks are probably not wired.** npm 11
+gates lifecycle scripts behind `allow-scripts`, so on a default global install
+our postinstall never runs. Recovery is one line:
+
+```bash
+npx token-optimizer-install     # wire the hooks
+npx token-optimizer-doctor      # prove they work
+```
+
 **Check that it works — not that files exist.**
 
 ```bash
-npm run doctor
+npx token-optimizer-doctor      # or npm run doctor, from a clone
 ```
 
 It feeds a synthetic payload to the *real* hook binary and asserts a large read

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "types": "dist/server/index.d.ts",
   "bin": {
     "token-optimizer-mcp": "./dist/server/index.js",
-    "token-optimizer-daemon": "./dist/server/daemon.js"
+    "token-optimizer-daemon": "./dist/server/daemon.js",
+    "token-optimizer-install": "./scripts/install-cli.mjs",
+    "token-optimizer-doctor": "./scripts/doctor.mjs"
   },
   "files": [
     "dist/**/*",

--- a/scripts/install-cli.mjs
+++ b/scripts/install-cli.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+/**
+ * `npx token-optimizer-install` -- wire the hooks when postinstall could not.
+ *
+ * npm 11 gates lifecycle scripts behind `allow-scripts`, so on a default global
+ * install our postinstall NEVER RUNS and no hooks are wired. The package
+ * installs, the server appears in /mcp, and nothing is optimized -- which is
+ * precisely the "connected but saving nothing" failure this project exists to
+ * prevent, arriving through the package manager instead of through the code.
+ *
+ * Relying on a lifecycle script that the ecosystem is actively disabling is not
+ * a plan, so recovery is a first-class command rather than a buried shell
+ * script: one line, no path archaeology, works the same on every platform.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { homedir } from 'node:os';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const settings = process.env.TOKEN_OPTIMIZER_SETTINGS
+  || join(homedir(), '.claude', 'settings.json');
+const hooksDir = join(root, 'plugin', 'hooks');
+
+const run = (script, args) => execFileSync(process.execPath, [join(root, 'scripts', script), ...args], {
+  stdio: 'inherit', cwd: root,
+});
+
+try {
+  run('wire-hooks.mjs', [settings, hooksDir]);
+  run('record-install.mjs', [hooksDir, settings]);
+  console.log('');
+  console.log('Verify it actually works with: npx token-optimizer-doctor');
+} catch (error) {
+  console.error(`[token-optimizer-mcp] installation failed: ${error?.message || error}`);
+  process.exit(1);
+}


### PR DESCRIPTION
npm 11 gates lifecycle scripts behind `allow-scripts`, so on a default `npm i -g` **our postinstall never runs and no hooks are wired**. The package installs, the server appears in `/mcp`, and nothing is optimized — the 'connected but saving nothing' failure this project exists to prevent, arriving through the package manager instead of the code.

Observed on this machine installing 5.3.0, and again on 5.3.2:

```
npm warn allow-scripts   @ooples/token-optimizer-mcp@5.3.2 (postinstall: node scripts/postinstall.cjs)
```

Relying on a lifecycle script the ecosystem is actively disabling isn't a plan, so recovery is now a first-class command:

```bash
npx token-optimizer-install     # wire the hooks
npx token-optimizer-doctor      # prove they work
```

The doctor being reachable without a clone matters most — it's the only check that proves *enforcement* rather than inspecting configuration.

README documents this up front rather than leaving people to discover a silent no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)