### PR TITLE
fix: a fresh windows clone failed its own test suite and format check

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,6 @@
   "tabWidth": 2,
   "singleQuote": true,
   "semi": true,
-  "trailingComma": "es5"
+  "trailingComma": "es5",
+  "endOfLine": "auto"
 }

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "token-optimizer",
   "description": "Aggressive context-window optimization by DEFAULT: enforcing hooks route expensive built-in file, search and shell calls to cached/diffed MCP tools, cutting token usage 60-90% without the user configuring anything.",
-  "version": "5.2.0",
+  "version": "5.3.4",
   "author": {
     "name": "ooples"
   },

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,14 @@
       "include-component-in-tag": false,
       "bump-minor-pre-major": false,
       "draft": false,
-      "prerelease": false
+      "prerelease": false,
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "plugin/.claude-plugin/plugin.json",
+          "jsonpath": "$.version"
+        }
+      ]
     }
   },
   "changelog-sections": [

--- a/scripts/sync-hook-core.mjs
+++ b/scripts/sync-hook-core.mjs
@@ -40,6 +40,19 @@ const banner = (name) =>
   `// GENERATED FILE -- do not edit.\n` +
   `// Source of truth: hooks-core/${name}. Regenerate with \`npm run sync:hooks\`.\n`;
 
+/**
+ * Compare CONTENT, not the line endings git happened to check the file out with.
+ *
+ * `.gitattributes` sets `* text=auto`, so these files are stored with LF and
+ * written to the working tree with CRLF on Windows. The banner above is built
+ * with '\n' regardless, so a byte comparison declared all 180 vendored files
+ * drifted on any Windows checkout -- `npm test` failed immediately after a
+ * fresh clone, while Linux CI stayed green because its checkout leaves LF
+ * alone. Nothing was actually out of sync; only the two banner lines differed,
+ * and only in how their newline was spelled.
+ */
+const normalize = (text) => text.replace(/\r\n/g, '\n');
+
 let drifted = 0;
 
 for (const target of TARGETS) {
@@ -49,7 +62,7 @@ for (const target of TARGETS) {
 
     if (check) {
       const current = existsSync(destination) ? readFileSync(destination, 'utf8') : null;
-      if (current !== contents) {
+      if (current === null || normalize(current) !== normalize(contents)) {
         console.error(`DRIFT: ${destination.slice(ROOT.length + 1)}`);
         drifted++;
       }

--- a/tests/unit/plugin-version-tracks-package.test.ts
+++ b/tests/unit/plugin-version-tracks-package.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from '@jest/globals';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * The plugin manifest's version is how Claude Code decides whether an update is
+ * available. release-please only ever bumped package.json, so the manifest sat
+ * at 5.2.0 while the package reached 5.3.4 -- across four releases.
+ *
+ * The consequence is not cosmetic. A user already on 5.2.0 is told there is
+ * nothing to update to, so hook fixes shipped in 5.2.1 through 5.3.4 never
+ * reach them, no matter how many times they check. The MCP server half is
+ * unaffected (it is fetched from npm at @latest), which makes the split
+ * especially easy to miss: the tools update and the hooks silently do not.
+ *
+ * release-please now bumps the manifest via `extra-files`. This asserts the two
+ * stay in step, because the failure mode is invisible from inside the repo --
+ * everything builds, every test passes, and the release publishes.
+ */
+
+const ROOT = process.cwd();
+const read = (p: string) => JSON.parse(readFileSync(join(ROOT, p), 'utf8'));
+
+describe('plugin manifest version', () => {
+  it('matches the package version', () => {
+    const pkg = read('package.json').version;
+    const plugin = read('plugin/.claude-plugin/plugin.json').version;
+
+    expect(plugin).toBe(pkg);
+  });
+
+  it('is still configured for release-please to bump', () => {
+    // If this entry is dropped, the versions drift again and the only symptom
+    // is users quietly not receiving hook updates.
+    const config = read('release-please-config.json');
+    const extras = config.packages?.['.']?.['extra-files'] ?? [];
+
+    expect(
+      extras.some(
+        (e: { path?: string; jsonpath?: string }) =>
+          e.path === 'plugin/.claude-plugin/plugin.json' && e.jsonpath === '$.version'
+      )
+    ).toBe(true);
+  });
+
+  it('is a plain semver, which is what the update check compares', () => {
+    const plugin = read('plugin/.claude-plugin/plugin.json').version;
+    expect(plugin).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+});


### PR DESCRIPTION
Found while installing the merged 5.3.4 release for long-term live testing. On a **clean checkout of master**, on Windows:

- `npm test` → 1 suite fails (`tests/hooks/clients.test.mjs`)
- `npm run format:check` → 80 files flagged

Both pass on Linux CI, which is why neither was visible. Same blind spot as the wmic defects in #218 — every job runs `ubuntu-latest`.

## Cause

`.gitattributes` sets `* text=auto`, so files are stored with LF and written to the working tree with **CRLF** on Windows. Two checks compare against LF regardless:

**`sync-hook-core --check`** builds expected content as `banner + source`, with the banner's newlines hardcoded to `\n`. The source half matched (both CRLF); the two banner lines did not — so all **180** vendored hook files were reported as drifted. Nothing was out of sync; only the spelling of a newline differed.

**prettier** has no `endOfLine` set, so it defaults to `"lf"` and rejects every CRLF file.

## Fix

Line-ending-insensitive comparison in the sync check, and `"endOfLine": "auto"` for prettier.

Both were verified to still catch what they exist for:
- appending a line to one vendored file makes the sync check flag exactly that one
- adding `const badly_formatted   =    {a:1,b:2}` makes format:check flag exactly that file
- `endOfLine: auto` rewrites nothing (working tree stays clean)

## Why it matters

A Windows contributor cloning this repo sees a red suite before writing a line of code — and the obvious remedy, running `npm run format` to "fix" the 80 files, churns the entire tree for nothing.

After: **96/96 suites, 1398 tests**, and a clean `format:check`, on a CRLF working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)