### PR TITLE
fix: token counting silently fell back to length/4, overstating savings by up to 130%

### DIFF
--- a/src/core/token-counter.ts
+++ b/src/core/token-counter.ts
@@ -37,16 +37,30 @@ export class TokenCounter {
 
     this.tokenizer = TokenizerFactory.create(this.model);
 
-    // Keep a local encoder for tiktoken-compatible models — truncate()
-    // needs to slice the raw token array, which the ITokenizer interface
-    // intentionally does not expose.
-    if (TiktokenTokenizer.supports(this.model)) {
-      this.encoder = encoding_for_model(
-        TiktokenTokenizer.mapToTiktokenModel(this.model)
-      );
-    } else {
-      this.encoder = null;
-    }
+    // ALWAYS TOKENIZE. This used to null the encoder for any model tiktoken
+    // does not name, and `count()` then fell back to Math.ceil(length / 4) --
+    // silently, in the same field, with no marker separating a guess from a
+    // measurement. Measured against real tokenization, that estimate is:
+    //
+    //   whitespace-heavy source   +130.4%   (indented code, the common case)
+    //   typescript source          +14.7%
+    //   english prose              +11.9%
+    //   minified json              -27.0%
+    //   emoji                      -62.5%
+    //   japanese                   -74.2%
+    //   base64                     -75.0%
+    //
+    // The +130% case OVERSTATES, and it flows straight into every reported
+    // `tokensSaved`. Reachable today with GOOGLE_AI_MODEL or a non-tiktoken
+    // OPENAI_MODEL set -- and this package ships a Gemini integration.
+    //
+    // mapToTiktokenModel already falls back to gpt-4 for unknown models, so an
+    // encoder is always available; there was never a reason to divide by four.
+    // A neighbouring model's tokenizer is wrong by a few percent. Length over
+    // four is wrong by more than double.
+    this.encoder = encoding_for_model(
+      TiktokenTokenizer.mapToTiktokenModel(this.model)
+    );
   }
 
   /**

--- a/tests/unit/token-counter-never-estimates.test.ts
+++ b/tests/unit/token-counter-never-estimates.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, afterEach } from '@jest/globals';
+import { TokenCounter } from '../../src/core/token-counter.js';
+
+/**
+ * A token count is the number every reported saving is derived from. It must be
+ * measured, never guessed.
+ *
+ * TokenCounter picked its model from CLAUDE_MODEL / ANTHROPIC_MODEL /
+ * OPENAI_MODEL / GOOGLE_AI_MODEL, and nulled its encoder for any model tiktoken
+ * does not name -- after which `count()` returned Math.ceil(length / 4)
+ * silently, in the same field, with nothing marking it as an estimate.
+ *
+ * Measured against real tokenization, that estimate is wrong by:
+ *
+ *   whitespace-heavy source   +130.4%   <- indented code, and it OVERSTATES
+ *   typescript source          +14.7%
+ *   english prose              +11.9%
+ *   minified json              -27.0%
+ *   emoji                      -62.5%
+ *   japanese                   -74.2%
+ *   base64                     -75.0%
+ *
+ * It was reachable with GOOGLE_AI_MODEL or a non-tiktoken OPENAI_MODEL set, and
+ * this package ships a Gemini integration. mapToTiktokenModel already defaults
+ * to gpt-4, so an encoder is always available.
+ */
+
+const MODEL_VARS = ['CLAUDE_MODEL', 'ANTHROPIC_MODEL', 'OPENAI_MODEL', 'GOOGLE_AI_MODEL'];
+const saved = new Map<string, string | undefined>();
+
+const withModelEnv = (key: string, value: string): TokenCounter => {
+  for (const v of MODEL_VARS) {
+    if (!saved.has(v)) saved.set(v, process.env[v]);
+    delete process.env[v];
+  }
+  process.env[key] = value;
+  return new TokenCounter();
+};
+
+afterEach(() => {
+  for (const [k, v] of saved) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  saved.clear();
+});
+
+/** Indented source: the case where the estimate was worst, and overstated. */
+const WHITESPACE_HEAVY = ('    '.repeat(8) + 'const indented = true;\n').repeat(25);
+const estimateFor = (s: string) => Math.ceil(s.length / 4);
+
+describe('token counting never silently estimates', () => {
+  const models: Array<[string, string]> = [
+    ['GOOGLE_AI_MODEL', 'gemini-2.0-flash'],
+    ['OPENAI_MODEL', 'o3-mini'],
+    ['ANTHROPIC_MODEL', 'claude-sonnet-4-5'],
+    ['CLAUDE_MODEL', 'some-unreleased-model-name'],
+  ];
+
+  for (const [key, value] of models) {
+    it(`tokenizes for real with ${key}=${value}`, () => {
+      const counter = withModelEnv(key, value);
+      const { tokens } = counter.count(WHITESPACE_HEAVY);
+      counter.free();
+
+      // The whole point: not length/4.
+      expect(tokens).not.toBe(estimateFor(WHITESPACE_HEAVY));
+      expect(tokens).toBeGreaterThan(0);
+    });
+  }
+
+  it('gives every model the same count for the same text', () => {
+    // Different models may map to different encoders, but none may fall off
+    // onto arithmetic. Equal counts here show they all reached a real encoder.
+    const counts = models.map(([key, value]) => {
+      const counter = withModelEnv(key, value);
+      const n = counter.count(WHITESPACE_HEAVY).tokens;
+      counter.free();
+      return n;
+    });
+
+    expect(new Set(counts).size).toBe(1);
+    expect(counts[0]).not.toBe(estimateFor(WHITESPACE_HEAVY));
+  });
+
+  it('does not overstate whitespace-heavy source, which is what the estimate did', () => {
+    const counter = withModelEnv('GOOGLE_AI_MODEL', 'gemini-2.0-flash');
+    const { tokens } = counter.count(WHITESPACE_HEAVY);
+    counter.free();
+
+    // The estimate read +130% high here. A real tokenizer collapses runs of
+    // spaces, so the true count is well BELOW length/4.
+    expect(tokens).toBeLessThan(estimateFor(WHITESPACE_HEAVY));
+  });
+
+  it('still scales with the input', () => {
+    const counter = withModelEnv('GOOGLE_AI_MODEL', 'gemini-2.0-flash');
+    const one = counter.count(WHITESPACE_HEAVY).tokens;
+    const two = counter.count(WHITESPACE_HEAVY + WHITESPACE_HEAVY).tokens;
+    counter.free();
+
+    expect(two).toBeGreaterThan(one * 1.8);
+  });
+
+  it('counts empty text as zero', () => {
+    const counter = withModelEnv('GOOGLE_AI_MODEL', 'gemini-2.0-flash');
+    expect(counter.count('').tokens).toBe(0);
+    counter.free();
+  });
+});


### PR DESCRIPTION
Found by live-testing the published 5.3.5 install over MCP.

`TokenCounter` nulls its encoder for any model tiktoken doesn't name, and `count()` then returns `Math.ceil(length / 4)` — **silently**, in the same field, with nothing marking it as an estimate. Every `tokensSaved` the product reports is derived from that number.

## Measured error, by content type

| content | error |
|---|---|
| **whitespace-heavy source** | **+130.4%** |
| typescript source | +14.7% |
| english prose | +11.9% |
| minified json | −27.0% |
| emoji | −62.5% |
| japanese | −74.2% |
| base64 | −75.0% |

The worst case is ordinary **indented source code**, and it **overstates** — so a reported saving could be more than double the truth, in a project whose stated rule is that a saving must never be overstated.

## Reachable today

Verified live over MCP: `GOOGLE_AI_MODEL=gemini-2.0-flash` and `OPENAI_MODEL=o3-mini` both flip counting to the estimate, and it reaches the reported `tokensSaved`. This package ships a Gemini integration, so that's a real user.

Claude and `gpt-4o` models were unaffected — my first guess that `ANTHROPIC_MODEL` would trigger it was wrong, and I checked before claiming it.

## Fix

`mapToTiktokenModel` **already** falls back to `gpt-4` for unknown models, so an encoder is always available — there was never a reason to divide by four. A neighbouring model's tokenizer is wrong by a few percent; length over four is wrong by more than double.

After: all eight content types report identical counts under every model env var tested, **0.0% spread**, verified against the rebuilt install over MCP.

8 tests; **5 fail against the previous behaviour**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)