### PR TITLE
fix: smart_env returned every .env value; smart_dependencies never delivered its graph

### DIFF
--- a/src/tools/code-analysis/smart-dependencies.ts
+++ b/src/tools/code-analysis/smart-dependencies.ts
@@ -304,10 +304,14 @@ export class SmartDependenciesTool {
     opts: Required<SmartDependenciesOptions>,
     _startTime: number
   ): Promise<
-    // `graph` is the JSON payload; `rawGraph` is the Map later stages need.
-    // They used to be the same field, which is how a Map ended up being
-    // JSON.stringify'd into `{}`.
-    SmartDependenciesResult & { rawGraph?: Map<string, DependencyNode> }
+    // ONLY `rawGraph`. This used to return the Map as `graph`, which
+    // JSON.stringify turns into `{}` -- the defect this change fixes. The first
+    // fix built the JSON payload here as well, but analyze() reads only
+    // `rawGraph`, and every mode handler builds its own result from it, so that
+    // payload was computed and thrown away on all four paths -- including the
+    // cached fast path, turning an O(1) reference return into an O(n) traversal
+    // for a value nobody read.
+    SmartDependenciesResult & { rawGraph: Map<string, DependencyNode> }
   > {
     const cacheKey = generateCacheKey('dependency_graph', { cwd: opts.cwd });
 
@@ -326,7 +330,6 @@ export class SmartDependenciesTool {
             return {
               success: true,
               mode: 'graph',
-              graph: this.compactGraphRepresentation(cachedGraph),
               rawGraph: cachedGraph,
               metadata: {
                 totalFiles: cachedGraph.size,
@@ -368,7 +371,6 @@ export class SmartDependenciesTool {
             return {
               success: true,
               mode: 'graph',
-              graph: this.compactGraphRepresentation(updatedGraph),
               rawGraph: updatedGraph,
               metadata: {
                 totalFiles: updatedGraph.size,
@@ -390,7 +392,6 @@ export class SmartDependenciesTool {
           return {
             success: true,
             mode: 'graph',
-            graph: this.compactGraphRepresentation(cachedGraph),
             rawGraph: cachedGraph,
             metadata: {
               totalFiles: cachedGraph.size,
@@ -426,7 +427,6 @@ export class SmartDependenciesTool {
     return {
       success: true,
       mode: 'graph',
-      graph: this.compactGraphRepresentation(graph),
       rawGraph: graph,
       metadata: {
         totalFiles: graph.size,

--- a/src/tools/code-analysis/smart-dependencies.ts
+++ b/src/tools/code-analysis/smart-dependencies.ts
@@ -119,6 +119,13 @@ export interface SmartDependenciesOptions {
   includeMetadata?: boolean; // Include file metadata
 }
 
+/** JSON-safe shape of the dependency graph. */
+export interface DependencyGraphPayload {
+  nodes: string[];
+  edges: Array<{ from: string; to: string; type: string }>;
+  externalDependencies: string[];
+}
+
 export interface SmartDependenciesResult {
   success: boolean;
   mode: string;
@@ -135,7 +142,21 @@ export interface SmartDependenciesResult {
     cacheHit: boolean;
     incrementalUpdate: boolean;
   };
-  graph?: Map<string, DependencyNode>; // Full graph (graph mode)
+  /**
+   * The dependency graph, as data JSON can carry.
+   *
+   * THIS WAS A `Map`, and `JSON.stringify(new Map([...]))` is `{}` -- so every
+   * response delivered `"graph": {}` no matter what was found. Measured on a
+   * four-file fixture: metadata correctly reported analyzedFiles 4,
+   * externalDependencies 2, internalDependencies 3, while the graph itself
+   * arrived empty. The analysis was right and only the payload was lost, which
+   * is why nothing ever looked broken from inside.
+   *
+   * The compact form was already being built to count tokens against, then
+   * thrown away -- so the reported token count described data the caller never
+   * received.
+   */
+  graph?: DependencyGraphPayload; // Full graph (graph mode)
   circular?: CircularDependency[]; // Circular dependencies (circular mode)
   unused?: UnusedDependency[]; // Unused imports/exports (unused mode)
   impact?: DependencyImpact; // Impact analysis (impact mode)
@@ -199,7 +220,10 @@ export class SmartDependenciesTool {
         return graphResult;
       }
 
-      const graph = graphResult.graph!;
+      // The MAP, for the analysis modes below. `graphResult.graph` is the
+      // JSON payload the caller receives; the two were one field, which is how
+      // a Map came to be JSON.stringify'd into `{}`.
+      const graph = graphResult.rawGraph!;
 
       // Run analysis based on mode
       let result: SmartDependenciesResult;
@@ -280,7 +304,10 @@ export class SmartDependenciesTool {
     opts: Required<SmartDependenciesOptions>,
     _startTime: number
   ): Promise<
-    SmartDependenciesResult & { graph?: Map<string, DependencyNode> }
+    // `graph` is the JSON payload; `rawGraph` is the Map later stages need.
+    // They used to be the same field, which is how a Map ended up being
+    // JSON.stringify'd into `{}`.
+    SmartDependenciesResult & { rawGraph?: Map<string, DependencyNode> }
   > {
     const cacheKey = generateCacheKey('dependency_graph', { cwd: opts.cwd });
 
@@ -299,7 +326,8 @@ export class SmartDependenciesTool {
             return {
               success: true,
               mode: 'graph',
-              graph: cachedGraph,
+              graph: this.compactGraphRepresentation(cachedGraph),
+              rawGraph: cachedGraph,
               metadata: {
                 totalFiles: cachedGraph.size,
                 analyzedFiles: 0,
@@ -340,7 +368,8 @@ export class SmartDependenciesTool {
             return {
               success: true,
               mode: 'graph',
-              graph: updatedGraph,
+              graph: this.compactGraphRepresentation(updatedGraph),
+              rawGraph: updatedGraph,
               metadata: {
                 totalFiles: updatedGraph.size,
                 analyzedFiles: changedFiles.length,
@@ -361,7 +390,8 @@ export class SmartDependenciesTool {
           return {
             success: true,
             mode: 'graph',
-            graph: cachedGraph,
+            graph: this.compactGraphRepresentation(cachedGraph),
+            rawGraph: cachedGraph,
             metadata: {
               totalFiles: cachedGraph.size,
               analyzedFiles: 0,
@@ -396,7 +426,8 @@ export class SmartDependenciesTool {
     return {
       success: true,
       mode: 'graph',
-      graph,
+      graph: this.compactGraphRepresentation(graph),
+      rawGraph: graph,
       metadata: {
         totalFiles: graph.size,
         analyzedFiles: graph.size,
@@ -1063,10 +1094,11 @@ export class SmartDependenciesTool {
     }
 
     // Calculate tokens
-    const graphData =
-      opts.format === 'compact'
-        ? this.compactGraphRepresentation(filteredGraph)
-        : Array.from(filteredGraph.entries());
+    // Both branches must be JSON-carryable. `detailed` used
+    // Array.from(map.entries()), which survives JSON but was never the value
+    // actually returned -- the raw Map was.
+    const graphData: DependencyGraphPayload =
+      this.compactGraphRepresentation(filteredGraph);
 
     const resultTokens = this.tokenCounter.count(
       JSON.stringify(graphData)
@@ -1080,7 +1112,9 @@ export class SmartDependenciesTool {
     return {
       success: true,
       mode: 'graph',
-      graph: filteredGraph,
+      // The SAME data the token count above describes. This returned the raw
+      // Map, so the count measured one thing and the caller received another.
+      graph: graphData,
       metadata: {
         totalFiles: filteredGraph.size,
         analyzedFiles: filteredGraph.size,
@@ -1100,7 +1134,9 @@ export class SmartDependenciesTool {
   /**
    * Create compact graph representation (edges only)
    */
-  private compactGraphRepresentation(graph: Map<string, DependencyNode>): any {
+  private compactGraphRepresentation(
+    graph: Map<string, DependencyNode>
+  ): DependencyGraphPayload {
     const edges: Array<{ from: string; to: string; type: string }> = [];
     const externalDeps = new Set<string>();
 

--- a/src/tools/configuration/smart-env.ts
+++ b/src/tools/configuration/smart-env.ts
@@ -34,10 +34,41 @@ export interface SmartEnvOptions {
 
 export interface EnvVariable {
   key: string;
+  /**
+   * REDACTED IN RESPONSES. Present while parsing, because the security checks
+   * genuinely need it -- weak-password detection, localhost URLs, unquoted
+   * whitespace -- but replaced with a placeholder before the result leaves this
+   * module. See {@link redactValues}.
+   */
   value: string;
   line: number;
   hasQuotes: boolean;
   isEmpty: boolean;
+  /** Characters the value had, so "is it set and plausible" is still answerable. */
+  length?: number;
+}
+
+/**
+ * A .env is where credentials live, so its VALUES must never be returned.
+ *
+ * Measured live: the tool echoed `"value": "CANARY_password_hunter2_correct"`
+ * for every variable, including DB_PASSWORD, JWT_SECRET and STRIPE_KEY, and
+ * `checkSecurity: true` made no difference. Every secret in a project therefore
+ * landed in the model's context on a single call -- and off the machine
+ * entirely for anyone using a hosted model.
+ *
+ * The key, line, quoting, emptiness and length are all preserved, which is what
+ * every legitimate use of this tool actually needs: knowing WHICH variables are
+ * defined, not what they are set to.
+ */
+const REDACTED = '[redacted]';
+
+function redactValues(vars: EnvVariable[]): EnvVariable[] {
+  return vars.map((v) => ({
+    ...v,
+    length: v.value.length,
+    value: v.isEmpty ? '' : REDACTED,
+  }));
 }
 
 export interface SecurityIssue {
@@ -341,7 +372,9 @@ export class SmartEnv {
       success: true,
       environment,
       variables: { total, loaded, empty, commented },
-      parsed,
+      // REDACTED HERE, after the security analysis above has used the real
+      // values and before anything leaves this module.
+      parsed: redactValues(parsed),
       missing,
       security,
       suggestions,
@@ -530,7 +563,9 @@ export class SmartEnv {
               issues.push({
                 severity: 'critical',
                 variable: variable.key,
-                issue: `Weak or common ${weakPattern.name}: "${variable.value}"`,
+                // The VALUE is exactly what must not be repeated back. Naming the
+                // variable and the pattern it matched is enough to act on.
+                issue: `Weak or common ${weakPattern.name} in ${variable.key}`,
                 recommendation:
                   'Use a strong, unique value. Never use default or test values in production',
                 line: variable.line,

--- a/tests/unit/json-carryable-responses.test.ts
+++ b/tests/unit/json-carryable-responses.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { SmartDependenciesTool } from '../../src/tools/code-analysis/smart-dependencies.js';
+import { SmartEnv } from '../../src/tools/configuration/smart-env.js';
+import { CacheEngine } from '../../src/core/cache-engine.js';
+import { TokenCounter } from '../../src/core/token-counter.js';
+import { MetricsCollector } from '../../src/core/metrics.js';
+
+/**
+ * Two defects an in-process test would never have seen, because both only
+ * appear once the answer crosses the JSON boundary an MCP client sits behind.
+ *
+ * 1. smart_dependencies returned its graph as a `Map`, and
+ *    `JSON.stringify(new Map([...]))` is `{}`. Every response carried
+ *    `"graph": {}` no matter what was found -- while the metadata beside it
+ *    correctly reported analyzedFiles 4, externalDependencies 2 and
+ *    internalDependencies 3. The analysis was right and only the payload was
+ *    lost, which is exactly why nothing looked broken from inside.
+ *
+ * 2. smart_env returned the VALUE of every variable, so DB_PASSWORD,
+ *    JWT_SECRET and STRIPE_KEY all left the machine on a single call, and
+ *    `checkSecurity: true` made no difference.
+ */
+
+describe('responses survive JSON', () => {
+  let root: string;
+  let cache: CacheEngine;
+  let counter: TokenCounter;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'json-carry-'));
+    mkdirSync(join(root, 'src'), { recursive: true });
+    cache = new CacheEngine(join(root, 'cache.db'), 100);
+    counter = new TokenCounter();
+  });
+
+  afterEach(() => {
+    cache.close();
+    counter.free();
+    try {
+      rmSync(root, { recursive: true, force: true });
+    } catch {
+      /* temp dir, reclaimed by the OS */
+    }
+  });
+
+  describe('smart_dependencies graph', () => {
+    beforeEach(() => {
+      writeFileSync(join(root, 'src', 'a.ts'), `export const a = 1;\n`);
+      writeFileSync(join(root, 'src', 'b.ts'), `export const b = 2;\n`);
+      writeFileSync(
+        join(root, 'src', 'index.ts'),
+        `import { a } from './a.js';\nimport { b } from './b.js';\nexport const total = a + b;\n`
+      );
+    });
+
+    const analyze = () =>
+      new SmartDependenciesTool(cache, counter, new MetricsCollector()).analyze({
+        cwd: root,
+        useCache: false,
+      });
+
+    it('survives a JSON round-trip with its content intact', async () => {
+      const result = await analyze();
+
+      // The defect in one line: this used to be `{}`.
+      const roundTripped = JSON.parse(JSON.stringify(result));
+
+      expect(roundTripped.graph).toBeDefined();
+      expect(Array.isArray(roundTripped.graph.nodes)).toBe(true);
+      expect(roundTripped.graph.nodes.length).toBe(3);
+    });
+
+    it('carries the edges that actually exist', async () => {
+      const result = JSON.parse(JSON.stringify(await analyze()));
+
+      // index.ts imports a and b. Two edges, from index.
+      expect(result.graph.edges.length).toBe(2);
+      expect(result.graph.edges.every((e: { from: string }) => e.from.includes('index'))).toBe(true);
+    });
+
+    it('agrees with its own metadata', async () => {
+      const result = JSON.parse(JSON.stringify(await analyze()));
+
+      // The metadata was right all along; the payload is what went missing.
+      expect(result.graph.nodes.length).toBe(result.metadata.totalFiles);
+      expect(result.graph.edges.length).toBe(result.metadata.internalDependencies);
+    });
+
+    it('reports a token count describing the data it actually sent', async () => {
+      const result = JSON.parse(JSON.stringify(await analyze()));
+
+      // The count was computed on the compact form, which was then discarded in
+      // favour of the Map -- so it described something the caller never got.
+      const actual = counter.count(JSON.stringify(result.graph)).tokens;
+      expect(Math.abs(actual - result.metadata.tokenCount)).toBeLessThan(actual * 0.5 + 5);
+    });
+  });
+
+  describe('smart_env values', () => {
+    const SECRETS = {
+      DB_PASSWORD: 'CANARY_password_hunter2_correct',
+      JWT_SECRET: 'CANARY_jwt_aaaabbbbccccddddeeee',
+      PUBLIC_URL: 'https://example.com',
+    };
+
+    let envPath: string;
+
+    beforeEach(() => {
+      envPath = join(root, '.env');
+      writeFileSync(
+        envPath,
+        Object.entries(SECRETS).map(([k, v]) => `${k}=${v}`).join('\n') + '\n'
+      );
+    });
+
+    const analyze = (checkSecurity = false) =>
+      new SmartEnv(cache, counter, new MetricsCollector()).run({
+        envFile: envPath,
+        force: true,
+        checkSecurity,
+      });
+
+    it('never returns a variable value', async () => {
+      const text = JSON.stringify(await analyze());
+
+      for (const value of Object.values(SECRETS)) {
+        if (value.startsWith('CANARY')) expect(text).not.toContain(value);
+      }
+    });
+
+    it('still returns every variable NAME, which is the useful part', async () => {
+      const text = JSON.stringify(await analyze());
+
+      for (const key of Object.keys(SECRETS)) expect(text).toContain(key);
+    });
+
+    it('redacts under checkSecurity too, where the risk is highest', async () => {
+      // The security path is the one that reads values most closely, and it
+      // used to echo them into its own issue messages as well.
+      const text = JSON.stringify(await analyze(true));
+
+      expect(text).not.toContain('CANARY_password_hunter2_correct');
+      expect(text).not.toContain('CANARY_jwt_aaaabbbbccccddddeeee');
+    });
+
+    it('keeps the length, so "is it set" is still answerable', async () => {
+      const result = await analyze();
+      const dbPassword = result.parsed?.find((v) => v.key === 'DB_PASSWORD');
+
+      expect(dbPassword?.value).toBe('[redacted]');
+      expect(dbPassword?.length).toBe(SECRETS.DB_PASSWORD.length);
+    });
+  });
+});


### PR DESCRIPTION
Two findings from live-testing the installed build. Both are invisible in-process and only appear once an answer crosses the JSON boundary an MCP client sits behind.

## 1. `smart_env` returned every secret in the project

A `.env` is where credentials live. The tool echoed the **value** of every variable. Measured with canary values:

```
"key": "STRIPE_KEY",  "value": "CANARY_stripe_9f3a2b1c8d7e6f5a"
"key": "DB_PASSWORD", "value": "CANARY_password_hunter2_correct"
"key": "JWT_SECRET",  "value": "CANARY_jwt_aaaabbbbccccddddeeee"
```

**3 of 3 secrets echoed**, and `checkSecurity: true` made no difference — that path also embedded the value in its own issue message (`Weak or common password: <value>`). Every credential in a project landed in the model's context on one call, and off the machine entirely for anyone on a hosted model.

Values are redacted at the boundary, **after** the security analysis has used them. Names, line numbers, quoting, emptiness and value **length** are preserved — which is what every legitimate use actually needs.

## 2. `smart_dependencies` never delivered its graph

The graph was returned as a `Map`, and `JSON.stringify(new Map([...]))` is `{}`. Every response carried `"graph": {}` regardless of what was found.

On a four-file fixture the metadata beside it was **entirely correct** — `analyzedFiles: 4, externalDependencies: 2, internalDependencies: 3` — so the analysis worked and only the payload was lost. That's exactly why it never looked broken.

The compact form was **already** being built to count tokens against, then discarded — so the reported `tokenCount` described data the caller never received.

All four return paths now send that compact form; the internal `Map` moved to a separate `rawGraph` field the analysis modes consume. After: **4 nodes and the 3 real edges**, matching the fixture.

## Tests

8 tests that check values **after a JSON round-trip** rather than in-process — the property both defects violated. **7 fail against the previous behaviour.**

Both verified against the rebuilt install over MCP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)