### PR TITLE
fix: smart_ast_grep was entirely non-functional on windows, and said nothing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "token-optimizer-mcp": "dist/server/index.js"
       },
       "devDependencies": {
+        "@ast-grep/cli": "0.45.0",
         "@commitlint/cli": "^19.6.0",
         "@commitlint/config-conventional": "^19.6.0",
         "@semantic-release/changelog": "^6.0.3",
@@ -118,6 +119,158 @@
       "integrity": "sha512-Jv33IN09XLO+0HS79aaODsvIRyduiF7NY/F6LYeK5oeUmrsz7aFdRphQjFoESF4jS7lMauDOttKALcpapVDIAg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@ast-grep/cli": {
+      "version": "0.45.0",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli/-/cli-0.45.0.tgz",
+      "integrity": "sha512-OQ4pcktMtg1hcQat/iCpX9r8HJ7mU/2SZVoGHA9id2gEfosvDw5m5RINQXsSRZXQW8bl45FW6FhdK0O2FiKjsw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "2.1.2"
+      },
+      "bin": {
+        "ast-grep": "ast-grep",
+        "sg": "sg"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "optionalDependencies": {
+        "@ast-grep/cli-darwin-arm64": "0.45.0",
+        "@ast-grep/cli-darwin-x64": "0.45.0",
+        "@ast-grep/cli-linux-arm64-gnu": "0.45.0",
+        "@ast-grep/cli-linux-x64-gnu": "0.45.0",
+        "@ast-grep/cli-win32-arm64-msvc": "0.45.0",
+        "@ast-grep/cli-win32-ia32-msvc": "0.45.0",
+        "@ast-grep/cli-win32-x64-msvc": "0.45.0"
+      }
+    },
+    "node_modules/@ast-grep/cli-darwin-arm64": {
+      "version": "0.45.0",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-darwin-arm64/-/cli-darwin-arm64-0.45.0.tgz",
+      "integrity": "sha512-/GqKTawC6/g9k+NDr0u3PvJ0LJkmY5NH4GfvwrgmB8HjRVOoUXWQx5vVzZoEVrAcTogfNWEMs4I5Gdh+glQvPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-darwin-x64": {
+      "version": "0.45.0",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-darwin-x64/-/cli-darwin-x64-0.45.0.tgz",
+      "integrity": "sha512-SvcLPpOX2HaPepwuuSzTRdnrlcaVprQGdwuoW00+KWRjGZJj5z0WGIY84wjfTYhzUxaN5+z4GlCwLGgn0ojMzw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-linux-arm64-gnu": {
+      "version": "0.45.0",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-0.45.0.tgz",
+      "integrity": "sha512-N0vVTmASn/YR76BoY1zrIltLJ+PJ/zOv2aszX51Wym1ZA6P75tUPctofXh6KzEpESMdx2DcIDyDWVRi672SaQQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-linux-x64-gnu": {
+      "version": "0.45.0",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-linux-x64-gnu/-/cli-linux-x64-gnu-0.45.0.tgz",
+      "integrity": "sha512-rAMZJzAiBuXMViuJgdPeMZXI9HnqwMCh3ybIoj8dfWBPsAywKgU8vyH4kd/R5fFr/oB4lKVhTJ2/mEBsOQTHaQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-win32-arm64-msvc": {
+      "version": "0.45.0",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-0.45.0.tgz",
+      "integrity": "sha512-9RMvGHSE7uMGzlrQ296caPUkF5jX3KcWewyUJLqpxtEQVwZUkJ7R2/rSxBhjZeg7dp1+keIgt/vH/7FyIO5Wwg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-win32-ia32-msvc": {
+      "version": "0.45.0",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-0.45.0.tgz",
+      "integrity": "sha512-jkQtIpWYJcorhfoRh99cMyeK+edAaysF2z2MR3bRdCDE8EcNfWfqGuWDcLInXwFWFX739dQ6rq9ev3e9o+owXA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-win32-x64-msvc": {
+      "version": "0.45.0",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-win32-x64-msvc/-/cli-win32-x64-msvc-0.45.0.tgz",
+      "integrity": "sha512-2okmFrV/NP1qBATV21+pFIFiUlh5QbKNzTjCTyuaOhCzt0TwYao/RF5b2VUfsvBMtLqYj4rz69GvcPikznskfg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
   },
   "homepage": "https://github.com/ooples/token-optimizer-mcp#readme",
   "devDependencies": {
+    "@ast-grep/cli": "0.45.0",
     "@commitlint/cli": "^19.6.0",
     "@commitlint/config-conventional": "^19.6.0",
     "@semantic-release/changelog": "^6.0.3",

--- a/src/tools/code-analysis/smart-ast-grep.ts
+++ b/src/tools/code-analysis/smart-ast-grep.ts
@@ -12,12 +12,26 @@
  */
 
 import { execFileSafeSync } from '../../utils/safe-exec.js';
+import {
+  resolveBinScript,
+  resolveNpmScript,
+} from '../build-systems/run-node-bin.js';
 import { existsSync, statSync, readdirSync } from 'fs';
 import { join, relative } from 'path';
 import { CacheEngine } from '../../core/cache-engine.js';
 import { TokenCounter } from '../../core/token-counter.js';
 import { MetricsCollector } from '../../core/metrics.js';
 import { hashFile } from '../shared/hash-utils.js';
+
+/**
+ * The ast-grep CLI package, pinned by name.
+ *
+ * NOT `ast-grep` -- that npm name belongs to an unrelated stub at 0.1.0. The
+ * tool this file drives is `@ast-grep/cli`, which ships the `ast-grep` and `sg`
+ * binaries. Pinning the minor keeps a future breaking release from silently
+ * changing what a search returns.
+ */
+const AST_GREP_PACKAGE = '@ast-grep/cli';
 
 export interface SmartAstGrepOptions {
   // Pattern options
@@ -458,12 +472,62 @@ export class SmartAstGrepTool {
     // cannot be interpreted by a shell (previously they were concatenated into
     // a command string and run through execSync — a command-injection sink).
     try {
-      const npx = process.platform === 'win32' ? 'npx.cmd' : 'npx';
-      const output = execFileSafeSync(npx, ['ast-grep', ...args], {
-        cwd: index.projectPath,
-        maxBuffer: 10 * 1024 * 1024, // 10MB buffer
-        timeout: 120000, // 2 minutes timeout
-      });
+      // NEVER SPAWN A .cmd. Node 20.12 refuses to spawn `.cmd`/`.bat` without a
+      // shell -- the fix for CVE-2024-27980 -- so `spawnSync npx.cmd` fails with
+      // EINVAL on every Windows machine. The error went to console.warn, which
+      // on a stdio MCP server is stderr the client never sees, so the tool
+      // returned "0 matches" instead of "I could not run".
+      //
+      // Six sibling tools already route through run-node-bin.ts for exactly
+      // this; this one was missed. Measured: with the fix, `function $NAME`
+      // finds all three fixture functions where it previously found none.
+      //
+      // The package is `@ast-grep/cli`. Plain `ast-grep` on npm is an unrelated
+      // stub at 0.1.0 that errors on any real input, so `npx ast-grep` -- even
+      // where it could spawn -- ran the wrong program.
+      const script = resolveBinScript(
+        AST_GREP_PACKAGE,
+        'ast-grep',
+        index.projectPath
+      );
+
+      let output: string;
+      if (script) {
+        // Installed locally: run its JS entry directly. No shim, no shell.
+        output = execFileSafeSync(process.execPath, [script, ...args], {
+          cwd: index.projectPath,
+          maxBuffer: 10 * 1024 * 1024,
+          timeout: 120000,
+        });
+      } else {
+        // Not installed. npx can fetch it, but must be reached through npm's own
+        // JS entry rather than npx.cmd.
+        const npmScript = resolveNpmScript();
+        if (!npmScript) {
+          throw new Error(
+            `${AST_GREP_PACKAGE} is not installed in ${index.projectPath}, and npm ` +
+              `could not be located to fetch it. Install it with: npm i -D ${AST_GREP_PACKAGE}`
+          );
+        }
+        output = execFileSafeSync(
+          process.execPath,
+          [
+            npmScript,
+            'exec',
+            '--yes',
+            '--package',
+            AST_GREP_PACKAGE,
+            '--',
+            'ast-grep',
+            ...args,
+          ],
+          {
+            cwd: index.projectPath,
+            maxBuffer: 10 * 1024 * 1024,
+            timeout: 120000,
+          }
+        );
+      }
 
       // Parse JSON stream output
       const lines = output

--- a/src/tools/code-analysis/smart-ast-grep.ts
+++ b/src/tools/code-analysis/smart-ast-grep.ts
@@ -563,14 +563,22 @@ export class SmartAstGrepTool {
         }
       }
     } catch (error) {
-      // ast-grep returns non-zero exit code when no matches found
+      // Exit code 1 means "ran fine, matched nothing" -- a real, empty answer.
       if (error instanceof Error && 'status' in error && error.status === 1) {
-        // No matches found, return empty array
         return matches;
       }
 
-      // Other errors, log and continue
-      console.warn('ast-grep execution error:', error);
+      // ANYTHING ELSE MUST SURFACE. This logged to console.warn and returned an
+      // empty array, which on a stdio MCP server means stderr the client never
+      // sees -- so "I could not run" was delivered as "0 matches", the exact
+      // confusion this file's other fix exists to end. Worse, the informative
+      // error thrown above for a missing CLI was itself caught here and
+      // swallowed: a plain Error has no `.status`, so it fell straight to the
+      // warn. The message was written and then thrown away.
+      throw new Error(
+        `ast-grep could not be run: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error }
+      );
     }
 
     return matches;

--- a/tests/unit/code-analysis/ast-grep-failure-surfaces.test.ts
+++ b/tests/unit/code-analysis/ast-grep-failure-surfaces.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { SmartAstGrepTool } from '../../../src/tools/code-analysis/smart-ast-grep.js';
+import { CacheEngine } from '../../../src/core/cache-engine.js';
+import { TokenCounter } from '../../../src/core/token-counter.js';
+import { MetricsCollector } from '../../../src/core/metrics.js';
+
+/**
+ * "Could not run" and "ran fine, found nothing" must be distinguishable.
+ *
+ * The tool spawned `npx.cmd`, which Node has refused since 20.12 (the fix for
+ * CVE-2024-27980), so on Windows it failed with EINVAL on every call. The catch
+ * logged to console.warn -- stderr, which an MCP client never sees -- and
+ * returned an empty match array. A tool that could not run reported "0
+ * matches".
+ *
+ * The first attempt at fixing that added an informative throw INSIDE the same
+ * try, where the same catch swallowed it: a plain Error has no `.status`, so it
+ * failed the exit-code-1 check and fell straight to the warn. The message was
+ * written and then discarded. Review caught it; this pins the behaviour.
+ */
+
+describe('ast-grep distinguishes "no matches" from "could not run"', () => {
+  let root: string;
+  let cache: CacheEngine;
+  let counter: TokenCounter;
+  let tool: SmartAstGrepTool;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'ast-grep-surfaces-'));
+    mkdirSync(join(root, 'src'), { recursive: true });
+    writeFileSync(join(root, 'src', 'a.ts'), 'export function alpha() {\n  return 1;\n}\n');
+
+    cache = new CacheEngine(join(root, 'cache.db'), 100);
+    counter = new TokenCounter();
+    tool = new SmartAstGrepTool(cache, counter, new MetricsCollector());
+  });
+
+  afterEach(() => {
+    cache.close();
+    counter.free();
+    try {
+      rmSync(root, { recursive: true, force: true });
+    } catch {
+      /* temp dir, reclaimed by the OS */
+    }
+  });
+
+  const grep = (pattern: string) =>
+    tool.grep(pattern, { pattern, projectPath: root, language: 'ts', enableCache: false });
+
+  it('finds a function that is there', async () => {
+    const result = await grep('function $NAME');
+
+    // Before the spawn fix this was 0 on every Windows machine.
+    expect(result.metadata.matchCount).toBeGreaterThan(0);
+  }, 120_000);
+
+  it('returns zero for a pattern that matches nothing, without throwing', async () => {
+    // The empty answer must stay an ANSWER. Turning every empty result into an
+    // error would be the opposite failure.
+    const result = await grep('class $NOT_PRESENT_ANYWHERE');
+
+    expect(result.metadata.matchCount).toBe(0);
+  }, 120_000);
+
+  it('throws when the CLI cannot be run at all', async () => {
+    // Point the runtime at something unrunnable, which is what a missing or
+    // unspawnable ast-grep looks like from inside.
+    const notNode = join(root, 'not-a-runtime');
+    writeFileSync(notNode, 'this is not an executable');
+
+    const real = process.execPath;
+    Object.defineProperty(process, 'execPath', { value: notNode, configurable: true });
+
+    try {
+      await expect(grep('function $NAME')).rejects.toThrow(/ast-grep could not be run/);
+    } finally {
+      Object.defineProperty(process, 'execPath', { value: real, configurable: true });
+    }
+  }, 120_000);
+
+  it('names the package in the failure, so the message is actionable', async () => {
+    const notNode = join(root, 'not-a-runtime-2');
+    writeFileSync(notNode, 'this is not an executable');
+
+    const real = process.execPath;
+    Object.defineProperty(process, 'execPath', { value: notNode, configurable: true });
+
+    try {
+      await expect(grep('function $NAME')).rejects.toThrow(/@ast-grep\/cli/);
+    } finally {
+      Object.defineProperty(process, 'execPath', { value: real, configurable: true });
+    }
+  }, 120_000);
+});


### PR DESCRIPTION
Found by live-testing: `smart_ast_grep` returned **0 matches for every documented pattern form** against a fixture with three exported functions. Two independent causes — and the second is why the first was never noticed.

## 1. It spawned a `.cmd`, which Node refuses

`execFileSafeSync('npx.cmd', ...)` fails with **EINVAL on every Windows machine**. Node 20.12 stopped spawning `.cmd`/`.bat` without a shell, as the fix for CVE-2024-27980. Captured from the server's stderr:

```
ast-grep execution error: Error: spawnSync npx.cmd EINVAL
```

**Six sibling tools already route through `run-node-bin.ts` for exactly this reason** — this one was missed. It now resolves `@ast-grep/cli`'s JS entry and runs it via `process.execPath` (argv mode, no shell, no shim), falling back to npm's own JS entry to fetch the package when it isn't installed locally.

## 2. The failure was invisible

The `catch` logged to `console.warn` and returned an empty array. On a stdio MCP server that's **stderr, which the client never sees** — so a tool that couldn't run at all reported "0 matches", indistinguishable from a pattern that genuinely matched nothing. Not-running now throws, naming the package and how to install it.

## 3. And it named the wrong package

`npx ast-grep` fetches the npm package literally called `ast-grep`: an unrelated stub at **0.1.0** that errors on any real input. The tool this file is written against is **`@ast-grep/cli`**, currently 0.45.0. So even where spawning could succeed, the wrong program ran.

## Verified against the rebuilt install over MCP

| | before | after |
|---|---|---|
| `function $NAME` | 0 of 3 functions, matchCount 0 | **3 of 3** (alpha, beta, gamma), matchCount 4 |

## Checked, not a defect

`export function $NAME($ARGS) { $BODY }` still returns 0. The `@ast-grep/cli` binary behaves identically standalone, so that's the matcher's own pattern semantics rather than anything this code does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)