### PR TITLE
fix: cache recorded original and compressed sizes backwards

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1061,12 +1061,21 @@ async function handleToolCall(request: {
           };
         }
 
-        // Compression helps! Cache the compressed version
+        // Compression helps! Cache the compressed version.
+        //
+        // ARGUMENT ORDER: set(key, value, originalSize, compressedSize). These
+        // two were transposed, so every cached entry recorded its sizes
+        // backwards. Measured: writing 5,000 characters reported
+        // `totalOriginalSize: 13, totalCompressedSize: 5000` -- and
+        // compressionRatio, computed as compressed/original, came out at 384.6.
+        // A compression ratio above 1 is expansion, so the statistic said the
+        // cache was making data 384x LARGER while it was in fact compressing it
+        // ~384x smaller.
         cache.set(
           key,
           compressionResult.compressed,
-          compressionResult.compressedSize,
-          compressionResult.originalSize
+          compressionResult.originalSize,
+          compressionResult.compressedSize
         );
 
         return {
@@ -1662,11 +1671,13 @@ async function handleToolCall(request: {
 
             // Only cache if compression actually reduces tokens
             if (compressedCount.tokens < originalCount.tokens) {
+              // set(key, value, originalSize, compressedSize) -- see the
+              // matching fix above; these were transposed here too.
               cache.set(
                 filePath,
                 compressionResult.compressed,
-                compressionResult.compressedSize,
-                compressionResult.originalSize
+                compressionResult.originalSize,
+                compressionResult.compressedSize
               );
               compressedTokens += compressedCount.tokens;
               operationsCompressed++;

--- a/tests/unit/cache-set-argument-order.test.ts
+++ b/tests/unit/cache-set-argument-order.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from '@jest/globals';
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * `CacheEngine.set(key, value, originalSize, compressedSize)`.
+ *
+ * Two call sites in server/index.ts passed those last two the wrong way round.
+ * Nothing errors -- both are numbers, both look plausible alone -- and only the
+ * ORIENTATION is wrong, so the engine's own unit tests all passed while every
+ * cached entry recorded its sizes backwards.
+ *
+ * Measured live before the fix: writing 5,000 highly compressible characters
+ * reported `totalOriginalSize: 13, totalCompressedSize: 5000` and a
+ * compressionRatio of 384.6 -- a statistic claiming the cache made data 384x
+ * LARGER while it was storing it ~384x smaller.
+ *
+ * A behavioural test of the engine cannot catch this, because the engine was
+ * never wrong. The defect lives at the call sites, so that is what this checks.
+ */
+
+const SRC = join(process.cwd(), 'src');
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...sourceFiles(full));
+    else if (entry.endsWith('.ts')) out.push(full);
+  }
+  return out;
+}
+
+/** Every `cache.set(...)` call with four arguments, as written. */
+function fourArgSetCalls(): Array<{ file: string; line: number; third: string; fourth: string }> {
+  const calls: Array<{ file: string; line: number; third: string; fourth: string }> = [];
+
+  for (const file of sourceFiles(SRC)) {
+    const src = readFileSync(file, 'utf8');
+    const re = /(?:^|[^\w.])(?:this\.)?cache\.set\(([\s\S]{0,300}?)\);/g;
+    let m: RegExpExecArray | null;
+
+    while ((m = re.exec(src)) !== null) {
+      const args = m[1]
+        .split(',')
+        .map((a) => a.trim().replace(/\s+/g, ' '))
+        .filter(Boolean);
+      if (args.length !== 4) continue;
+
+      calls.push({
+        file: file.replace(SRC, 'src').replace(/\\/g, '/'),
+        line: src.slice(0, m.index).split('\n').length,
+        third: args[2],
+        fourth: args[3],
+      });
+    }
+  }
+
+  return calls;
+}
+
+const COMPRESSED = /compress/i;
+const ORIGINAL = /original|\braw\b|uncompressed/i;
+
+describe('cache.set arguments are in the declared order', () => {
+  const calls = fourArgSetCalls();
+
+  it('finds the call sites at all, so an empty pass cannot look like success', () => {
+    expect(calls.length).toBeGreaterThan(0);
+  });
+
+  it('never passes a compressed size where the original belongs', () => {
+    // The third parameter is originalSize.
+    const wrong = calls.filter(
+      (c) => COMPRESSED.test(c.third) && !ORIGINAL.test(c.third)
+    );
+
+    expect(
+      wrong.map((c) => `${c.file}:${c.line} third arg is "${c.third}"`)
+    ).toEqual([]);
+  });
+
+  it('never passes an original size where the compressed belongs', () => {
+    // The fourth parameter is compressedSize. Passing the same value twice is
+    // allowed -- that is how an uncompressed entry is honestly recorded -- so
+    // this only fires when the fourth names ORIGINAL and the third does not.
+    const wrong = calls.filter(
+      (c) => ORIGINAL.test(c.fourth) && !COMPRESSED.test(c.fourth) && c.third !== c.fourth
+    );
+
+    expect(
+      wrong.map((c) => `${c.file}:${c.line} fourth arg is "${c.fourth}"`)
+    ).toEqual([]);
+  });
+});

--- a/tests/unit/cache-size-orientation.test.ts
+++ b/tests/unit/cache-size-orientation.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { CacheEngine } from '../../src/core/cache-engine.js';
+
+/**
+ * The cache records an original size and a compressed size, and every
+ * compression statistic is derived from the two.
+ *
+ * Two call sites passed them the wrong way round -- the signature is
+ * `set(key, value, originalSize, compressedSize)` and they passed
+ * `compressedSize, originalSize`. Measured live: writing 5,000 highly
+ * compressible characters reported `totalOriginalSize: 13,
+ * totalCompressedSize: 5000`, and a compressionRatio of 384.6.
+ *
+ * A compression ratio ABOVE 1 means expansion, so the statistic claimed the
+ * cache was making data 384x larger while it was in fact storing it ~384x
+ * smaller. Nothing errors, both numbers look plausible in isolation, and only
+ * their ORIENTATION is wrong -- which is why a test has to assert the
+ * relationship rather than the presence of the fields.
+ */
+
+describe('cache size statistics are the right way round', () => {
+  let dir: string;
+  let cache: CacheEngine;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'cache-orientation-'));
+    cache = new CacheEngine(join(dir, 'cache.db'), 100);
+  });
+
+  afterEach(() => {
+    cache.close();
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* temp dir, reclaimed by the OS */
+    }
+  });
+
+  /** Deliberately lopsided, so a swap cannot hide behind similar numbers. */
+  const ORIGINAL = 5000;
+  const COMPRESSED = 13;
+
+  it('reports the original size that was written', () => {
+    cache.set('k', 'stored value', ORIGINAL, COMPRESSED);
+
+    expect(cache.getStats().totalOriginalSize).toBe(ORIGINAL);
+  });
+
+  it('reports the compressed size that was written', () => {
+    cache.set('k', 'stored value', ORIGINAL, COMPRESSED);
+
+    expect(cache.getStats().totalCompressedSize).toBe(COMPRESSED);
+  });
+
+  it('never reports a compressed size larger than the original', () => {
+    cache.set('k', 'stored value', ORIGINAL, COMPRESSED);
+
+    const { totalCompressedSize, totalOriginalSize } = cache.getStats();
+    expect(totalCompressedSize).toBeLessThanOrEqual(totalOriginalSize);
+  });
+
+  it('yields a compression ratio below 1, because compression shrinks', () => {
+    cache.set('k', 'stored value', ORIGINAL, COMPRESSED);
+
+    // The swap produced 384.6 here. Any value above 1 describes expansion.
+    const { compressionRatio } = cache.getStats();
+    expect(compressionRatio).toBeGreaterThan(0);
+    expect(compressionRatio).toBeLessThan(1);
+  });
+
+  it('derives the ratio from the two sizes it reports', () => {
+    cache.set('k', 'stored value', ORIGINAL, COMPRESSED);
+
+    const { compressionRatio, totalCompressedSize, totalOriginalSize } = cache.getStats();
+    expect(compressionRatio).toBeCloseTo(totalCompressedSize / totalOriginalSize, 6);
+  });
+
+  it('keeps the orientation across several entries', () => {
+    for (let i = 0; i < 5; i++) {
+      cache.set(`k${i}`, `value ${i}`, ORIGINAL, COMPRESSED);
+    }
+
+    const { totalOriginalSize, totalCompressedSize } = cache.getStats();
+    expect(totalOriginalSize).toBe(ORIGINAL * 5);
+    expect(totalCompressedSize).toBe(COMPRESSED * 5);
+  });
+});


### PR DESCRIPTION
Found by live-testing the cache family against a cache whose contents I controlled.

`CacheEngine.set(key, value, originalSize, compressedSize)` — two call sites in `server/index.ts` passed those last two the other way round, so **every compressed entry recorded its sizes inverted**.

## Measured

Writing 5,000 highly compressible characters:

| field | before | after |
|---|---|---|
| `totalOriginalSize` | **13** | 5000 |
| `totalCompressedSize` | **5000** | 13 |
| `compressionRatio` | **384.6** | 0.0026 |

A compression ratio above 1 describes **expansion** — so the statistic claimed the cache was making data 384× larger at the moment it was storing it ~384× smaller.

Nothing errored, both figures are plausible numbers in isolation, and only their **orientation** was wrong. That's why the engine's own tests never caught it: the engine was never wrong, the callers were.

## Two tests, and the second is the one that matters

- **`cache-size-orientation`** — asserts the engine's relationships: compressed ≤ original, ratio < 1, and the ratio derivable from the two sizes reported beside it.
- **`cache-set-argument-order`** — scans the **call sites**, because a behavioural test of a correct engine cannot catch a caller passing good values in the wrong order. Verified it fails on master, where the transposition still exists.

## Checked, deliberately unchanged

Two other call sites pass the same value for both arguments. That's the honest record for an entry stored uncompressed, not a transposition.

Suite 100/100 suites, 1418 passing. (One integration stress test failed once mid-session and passed on the two runs either side and in isolation — the wall-clock-under-load flake this repo has hit before, not this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)