### PR TITLE
fix(curate): a correction claimed to be a person's assertion

### DIFF
--- a/hooks-core/curate.mjs
+++ b/hooks-core/curate.mjs
@@ -57,7 +57,12 @@ export function pin(dir, key, pinned = true) {
  * changed, and what it changed from -- which is the same reason `contradicts`
  * is an edge rather than an overwrite.
  */
-export function correct(dir, key, claim, { confidence = 0.95 } = {}) {
+export function correct(
+  dir,
+  key,
+  claim,
+  { confidence = 0.95, origin = ORIGIN_HUMAN } = {}
+) {
   const graph = load(dir);
   const existing = findingByKey(graph, key);
   if (!existing) return false;
@@ -75,7 +80,22 @@ export function correct(dir, key, claim, { confidence = 0.95 } = {}) {
     claim,
     confidence,
     type: existing.type || 'finding',
-    origin: ORIGIN_HUMAN,
+    // THE CALLER'S ORIGIN, not an assumption. This stamped ORIGIN_HUMAN
+    // unconditionally, so a correction written by an agent -- or carried over
+    // from a harvested claim -- was recorded as a person's assertion. That is
+    // the exact confusion the origin field exists to prevent, and the one
+    // harvest-write.mjs refuses to create when it writes a finding: "a
+    // hand-written assertion and a machine guess look identical three months
+    // later, which quietly destroys the reader's ability to calibrate trust".
+    // It also outranks its own source, since human findings carry the highest
+    // ranking weight.
+    //
+    // Defaults to ORIGIN_HUMAN because curate is the hand-curation path, so
+    // every existing caller keeps its current behaviour. Deliberately NOT
+    // validated against a fixed list: the set of origins differs across
+    // branches, and an unrecognised value already degrades to the neutral
+    // ranking weight rather than doing damage.
+    origin: typeof origin === 'string' && origin ? origin : ORIGIN_HUMAN,
   });
 
   const replacementId = nodeId('finding', replacementKey);

--- a/integrations/codex/hooks/lib/curate.mjs
+++ b/integrations/codex/hooks/lib/curate.mjs
@@ -59,7 +59,12 @@ export function pin(dir, key, pinned = true) {
  * changed, and what it changed from -- which is the same reason `contradicts`
  * is an edge rather than an overwrite.
  */
-export function correct(dir, key, claim, { confidence = 0.95 } = {}) {
+export function correct(
+  dir,
+  key,
+  claim,
+  { confidence = 0.95, origin = ORIGIN_HUMAN } = {}
+) {
   const graph = load(dir);
   const existing = findingByKey(graph, key);
   if (!existing) return false;
@@ -77,7 +82,22 @@ export function correct(dir, key, claim, { confidence = 0.95 } = {}) {
     claim,
     confidence,
     type: existing.type || 'finding',
-    origin: ORIGIN_HUMAN,
+    // THE CALLER'S ORIGIN, not an assumption. This stamped ORIGIN_HUMAN
+    // unconditionally, so a correction written by an agent -- or carried over
+    // from a harvested claim -- was recorded as a person's assertion. That is
+    // the exact confusion the origin field exists to prevent, and the one
+    // harvest-write.mjs refuses to create when it writes a finding: "a
+    // hand-written assertion and a machine guess look identical three months
+    // later, which quietly destroys the reader's ability to calibrate trust".
+    // It also outranks its own source, since human findings carry the highest
+    // ranking weight.
+    //
+    // Defaults to ORIGIN_HUMAN because curate is the hand-curation path, so
+    // every existing caller keeps its current behaviour. Deliberately NOT
+    // validated against a fixed list: the set of origins differs across
+    // branches, and an unrecognised value already degrades to the neutral
+    // ranking weight rather than doing damage.
+    origin: typeof origin === 'string' && origin ? origin : ORIGIN_HUMAN,
   });
 
   const replacementId = nodeId('finding', replacementKey);

--- a/integrations/codex/plugin/hooks/lib/curate.mjs
+++ b/integrations/codex/plugin/hooks/lib/curate.mjs
@@ -59,7 +59,12 @@ export function pin(dir, key, pinned = true) {
  * changed, and what it changed from -- which is the same reason `contradicts`
  * is an edge rather than an overwrite.
  */
-export function correct(dir, key, claim, { confidence = 0.95 } = {}) {
+export function correct(
+  dir,
+  key,
+  claim,
+  { confidence = 0.95, origin = ORIGIN_HUMAN } = {}
+) {
   const graph = load(dir);
   const existing = findingByKey(graph, key);
   if (!existing) return false;
@@ -77,7 +82,22 @@ export function correct(dir, key, claim, { confidence = 0.95 } = {}) {
     claim,
     confidence,
     type: existing.type || 'finding',
-    origin: ORIGIN_HUMAN,
+    // THE CALLER'S ORIGIN, not an assumption. This stamped ORIGIN_HUMAN
+    // unconditionally, so a correction written by an agent -- or carried over
+    // from a harvested claim -- was recorded as a person's assertion. That is
+    // the exact confusion the origin field exists to prevent, and the one
+    // harvest-write.mjs refuses to create when it writes a finding: "a
+    // hand-written assertion and a machine guess look identical three months
+    // later, which quietly destroys the reader's ability to calibrate trust".
+    // It also outranks its own source, since human findings carry the highest
+    // ranking weight.
+    //
+    // Defaults to ORIGIN_HUMAN because curate is the hand-curation path, so
+    // every existing caller keeps its current behaviour. Deliberately NOT
+    // validated against a fixed list: the set of origins differs across
+    // branches, and an unrecognised value already degrades to the neutral
+    // ranking weight rather than doing damage.
+    origin: typeof origin === 'string' && origin ? origin : ORIGIN_HUMAN,
   });
 
   const replacementId = nodeId('finding', replacementKey);

--- a/integrations/gemini/hooks/lib/curate.mjs
+++ b/integrations/gemini/hooks/lib/curate.mjs
@@ -59,7 +59,12 @@ export function pin(dir, key, pinned = true) {
  * changed, and what it changed from -- which is the same reason `contradicts`
  * is an edge rather than an overwrite.
  */
-export function correct(dir, key, claim, { confidence = 0.95 } = {}) {
+export function correct(
+  dir,
+  key,
+  claim,
+  { confidence = 0.95, origin = ORIGIN_HUMAN } = {}
+) {
   const graph = load(dir);
   const existing = findingByKey(graph, key);
   if (!existing) return false;
@@ -77,7 +82,22 @@ export function correct(dir, key, claim, { confidence = 0.95 } = {}) {
     claim,
     confidence,
     type: existing.type || 'finding',
-    origin: ORIGIN_HUMAN,
+    // THE CALLER'S ORIGIN, not an assumption. This stamped ORIGIN_HUMAN
+    // unconditionally, so a correction written by an agent -- or carried over
+    // from a harvested claim -- was recorded as a person's assertion. That is
+    // the exact confusion the origin field exists to prevent, and the one
+    // harvest-write.mjs refuses to create when it writes a finding: "a
+    // hand-written assertion and a machine guess look identical three months
+    // later, which quietly destroys the reader's ability to calibrate trust".
+    // It also outranks its own source, since human findings carry the highest
+    // ranking weight.
+    //
+    // Defaults to ORIGIN_HUMAN because curate is the hand-curation path, so
+    // every existing caller keeps its current behaviour. Deliberately NOT
+    // validated against a fixed list: the set of origins differs across
+    // branches, and an unrecognised value already degrades to the neutral
+    // ranking weight rather than doing damage.
+    origin: typeof origin === 'string' && origin ? origin : ORIGIN_HUMAN,
   });
 
   const replacementId = nodeId('finding', replacementKey);

--- a/integrations/opencode/hooks/lib/curate.mjs
+++ b/integrations/opencode/hooks/lib/curate.mjs
@@ -59,7 +59,12 @@ export function pin(dir, key, pinned = true) {
  * changed, and what it changed from -- which is the same reason `contradicts`
  * is an edge rather than an overwrite.
  */
-export function correct(dir, key, claim, { confidence = 0.95 } = {}) {
+export function correct(
+  dir,
+  key,
+  claim,
+  { confidence = 0.95, origin = ORIGIN_HUMAN } = {}
+) {
   const graph = load(dir);
   const existing = findingByKey(graph, key);
   if (!existing) return false;
@@ -77,7 +82,22 @@ export function correct(dir, key, claim, { confidence = 0.95 } = {}) {
     claim,
     confidence,
     type: existing.type || 'finding',
-    origin: ORIGIN_HUMAN,
+    // THE CALLER'S ORIGIN, not an assumption. This stamped ORIGIN_HUMAN
+    // unconditionally, so a correction written by an agent -- or carried over
+    // from a harvested claim -- was recorded as a person's assertion. That is
+    // the exact confusion the origin field exists to prevent, and the one
+    // harvest-write.mjs refuses to create when it writes a finding: "a
+    // hand-written assertion and a machine guess look identical three months
+    // later, which quietly destroys the reader's ability to calibrate trust".
+    // It also outranks its own source, since human findings carry the highest
+    // ranking weight.
+    //
+    // Defaults to ORIGIN_HUMAN because curate is the hand-curation path, so
+    // every existing caller keeps its current behaviour. Deliberately NOT
+    // validated against a fixed list: the set of origins differs across
+    // branches, and an unrecognised value already degrades to the neutral
+    // ranking weight rather than doing damage.
+    origin: typeof origin === 'string' && origin ? origin : ORIGIN_HUMAN,
   });
 
   const replacementId = nodeId('finding', replacementKey);

--- a/integrations/qwen/hooks/lib/curate.mjs
+++ b/integrations/qwen/hooks/lib/curate.mjs
@@ -59,7 +59,12 @@ export function pin(dir, key, pinned = true) {
  * changed, and what it changed from -- which is the same reason `contradicts`
  * is an edge rather than an overwrite.
  */
-export function correct(dir, key, claim, { confidence = 0.95 } = {}) {
+export function correct(
+  dir,
+  key,
+  claim,
+  { confidence = 0.95, origin = ORIGIN_HUMAN } = {}
+) {
   const graph = load(dir);
   const existing = findingByKey(graph, key);
   if (!existing) return false;
@@ -77,7 +82,22 @@ export function correct(dir, key, claim, { confidence = 0.95 } = {}) {
     claim,
     confidence,
     type: existing.type || 'finding',
-    origin: ORIGIN_HUMAN,
+    // THE CALLER'S ORIGIN, not an assumption. This stamped ORIGIN_HUMAN
+    // unconditionally, so a correction written by an agent -- or carried over
+    // from a harvested claim -- was recorded as a person's assertion. That is
+    // the exact confusion the origin field exists to prevent, and the one
+    // harvest-write.mjs refuses to create when it writes a finding: "a
+    // hand-written assertion and a machine guess look identical three months
+    // later, which quietly destroys the reader's ability to calibrate trust".
+    // It also outranks its own source, since human findings carry the highest
+    // ranking weight.
+    //
+    // Defaults to ORIGIN_HUMAN because curate is the hand-curation path, so
+    // every existing caller keeps its current behaviour. Deliberately NOT
+    // validated against a fixed list: the set of origins differs across
+    // branches, and an unrecognised value already degrades to the neutral
+    // ranking weight rather than doing damage.
+    origin: typeof origin === 'string' && origin ? origin : ORIGIN_HUMAN,
   });
 
   const replacementId = nodeId('finding', replacementKey);

--- a/plugin/hooks/lib/curate.mjs
+++ b/plugin/hooks/lib/curate.mjs
@@ -59,7 +59,12 @@ export function pin(dir, key, pinned = true) {
  * changed, and what it changed from -- which is the same reason `contradicts`
  * is an edge rather than an overwrite.
  */
-export function correct(dir, key, claim, { confidence = 0.95 } = {}) {
+export function correct(
+  dir,
+  key,
+  claim,
+  { confidence = 0.95, origin = ORIGIN_HUMAN } = {}
+) {
   const graph = load(dir);
   const existing = findingByKey(graph, key);
   if (!existing) return false;
@@ -77,7 +82,22 @@ export function correct(dir, key, claim, { confidence = 0.95 } = {}) {
     claim,
     confidence,
     type: existing.type || 'finding',
-    origin: ORIGIN_HUMAN,
+    // THE CALLER'S ORIGIN, not an assumption. This stamped ORIGIN_HUMAN
+    // unconditionally, so a correction written by an agent -- or carried over
+    // from a harvested claim -- was recorded as a person's assertion. That is
+    // the exact confusion the origin field exists to prevent, and the one
+    // harvest-write.mjs refuses to create when it writes a finding: "a
+    // hand-written assertion and a machine guess look identical three months
+    // later, which quietly destroys the reader's ability to calibrate trust".
+    // It also outranks its own source, since human findings carry the highest
+    // ranking weight.
+    //
+    // Defaults to ORIGIN_HUMAN because curate is the hand-curation path, so
+    // every existing caller keeps its current behaviour. Deliberately NOT
+    // validated against a fixed list: the set of origins differs across
+    // branches, and an unrecognised value already degrades to the neutral
+    // ranking weight rather than doing damage.
+    origin: typeof origin === 'string' && origin ? origin : ORIGIN_HUMAN,
   });
 
   const replacementId = nodeId('finding', replacementKey);

--- a/tests/unit/curate-correct-origin.test.ts
+++ b/tests/unit/curate-correct-origin.test.ts
@@ -1,0 +1,123 @@
+/**
+ * A correction must not claim to be a person's assertion.
+ *
+ * `correct()` stamped `origin: ORIGIN_HUMAN` unconditionally, so a correction
+ * written programmatically was recorded as hand-curated. curate.mjs itself
+ * warns about exactly this: "a hand-written assertion and a machine guess look
+ * identical three months later, which quietly destroys the reader's ability to
+ * calibrate trust". It also has a ranking consequence -- human findings carry
+ * the highest weight, so a machine correction outranked the human claim it
+ * replaced.
+ *
+ * Observed live: correcting a machine-written finding produced a replacement
+ * labelled `human`.
+ */
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { pathToFileURL } from 'url';
+import { join } from 'path';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+
+const CURATE = pathToFileURL(join(process.cwd(), 'hooks-core', 'curate.mjs'))
+  .href;
+const WIKI = pathToFileURL(join(process.cwd(), 'hooks-core', 'wiki.mjs')).href;
+
+let dir: string;
+let anchor: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'curate-origin-'));
+  anchor = join(dir, 'subject.ts');
+  writeFileSync(anchor, 'export function subject() {\n  return 1;\n}\n');
+});
+
+afterEach(() => {
+  try {
+    rmSync(dir, { recursive: true, force: true });
+  } catch {
+    /* windows can hold a handle briefly */
+  }
+});
+
+/** The replacement finding produced by correct(). */
+async function findingFor(store: string, key: string) {
+  const { load, nodeId } = await import(WIKI);
+  return load(store).nodes.get(nodeId('finding', key));
+}
+
+describe('curate.correct origin', () => {
+  it('records the caller-supplied origin rather than assuming human', async () => {
+    const { create, correct, ORIGIN_HARVESTED } = await import(CURATE);
+
+    const key = create(dir, {
+      claim: 'subject() returns one',
+      anchors: [anchor],
+    });
+    expect(key).toBeTruthy();
+
+    const replacementKey = correct(dir, key, 'subject() actually returns two', {
+      origin: ORIGIN_HARVESTED,
+    });
+    expect(replacementKey).toBeTruthy();
+
+    const replacement = await findingFor(dir, replacementKey);
+    expect(replacement.origin).toBe(ORIGIN_HARVESTED);
+  });
+
+  it('still defaults to human, because curate is the hand-curation path', async () => {
+    const { create, correct, ORIGIN_HUMAN } = await import(CURATE);
+
+    const key = create(dir, {
+      claim: 'subject() returns one',
+      anchors: [anchor],
+    });
+    const replacementKey = correct(dir, key, 'subject() returns two');
+
+    const replacement = await findingFor(dir, replacementKey);
+    expect(replacement.origin).toBe(ORIGIN_HUMAN);
+  });
+
+  it('falls back to human for a nonsense origin rather than storing it', async () => {
+    const { create, correct, ORIGIN_HUMAN } = await import(CURATE);
+
+    const key = create(dir, {
+      claim: 'subject() returns one',
+      anchors: [anchor],
+    });
+    const replacementKey = correct(dir, key, 'subject() returns two', {
+      origin: 42 as unknown as string,
+    });
+
+    const replacement = await findingFor(dir, replacementKey);
+    expect(replacement.origin).toBe(ORIGIN_HUMAN);
+  });
+
+  it('keeps the correction anchored and supersedes the original', async () => {
+    // The origin change must not disturb the rest of the contract.
+    const { create, correct } = await import(CURATE);
+    const { load, nodeId } = await import(WIKI);
+
+    const key = create(dir, {
+      claim: 'subject() returns one',
+      anchors: [anchor],
+    });
+    const replacementKey = correct(dir, key, 'subject() returns two');
+
+    const graph = load(dir);
+    const replacementId = nodeId('finding', replacementKey);
+
+    const anchored = graph.edges.some(
+      (e: any) => e.edge === 'derived_from' && e.from === replacementId
+    );
+    const supersedes = graph.edges.some(
+      (e: any) =>
+        e.edge === 'supersedes' &&
+        e.from === replacementId &&
+        e.to === nodeId('finding', key)
+    );
+
+    expect(anchored).toBe(true);
+    expect(supersedes).toBe(true);
+    expect(graph.nodes.get(nodeId('finding', key)).retired).toBe(true);
+  });
+});

--- a/tests/unit/curate-correct-origin.test.ts
+++ b/tests/unit/curate-correct-origin.test.ts
@@ -92,6 +92,26 @@ describe('curate.correct origin', () => {
     expect(replacement.origin).toBe(ORIGIN_HUMAN);
   });
 
+  it('falls back to human for an empty-string origin', async () => {
+    // A separate branch of the guard from the type check above: '' is a string,
+    // so it passes `typeof origin === 'string'` and is caught only by the
+    // truthiness test. Storing it would leave a finding whose origin is neither
+    // absent nor meaningful, which ranks at the neutral weight while looking
+    // deliberate to a reader.
+    const { create, correct, ORIGIN_HUMAN } = await import(CURATE);
+
+    const key = create(dir, {
+      claim: 'subject() returns one',
+      anchors: [anchor],
+    });
+    const replacementKey = correct(dir, key, 'subject() returns two', {
+      origin: '',
+    });
+
+    const replacement = await findingFor(dir, replacementKey);
+    expect(replacement.origin).toBe(ORIGIN_HUMAN);
+  });
+
   it('keeps the correction anchored and supersedes the original', async () => {
     // The origin change must not disturb the rest of the contract.
     const { create, correct } = await import(CURATE);


### PR DESCRIPTION
## The bug

`correct()` stamped `origin: ORIGIN_HUMAN` unconditionally, so a correction written programmatically was recorded as hand-curated.

`curate.mjs` warns about exactly this in its own header:

> a hand-written assertion and a machine guess look identical three months later, which quietly destroys the reader's ability to calibrate trust

`harvest-write.mjs` refuses to route machine output through `create()` for that reason — and `correct()` reintroduced it by the back door.

It's also a **ranking** bug, not just labelling: human findings carry the highest origin weight, so a machine-written correction outranked the claim it replaced purely because of how it was stored.

Observed live — correcting a machine-written finding produced a replacement labelled `human`.

## Change

`correct()` now takes an `origin`, defaulting to `ORIGIN_HUMAN` so every existing caller keeps its behaviour (curate is the hand-curation path; that default is right for it). A non-string or empty value falls back to human.

**Deliberately not validated against an allowlist.** The set of defined origins differs between branches — `ORIGIN_AGENT` doesn't exist on master — so an allowlist here would conflict on merge and reject a legitimate origin the moment one is added. An unrecognised value already degrades to the neutral ranking weight.

## Verification

4 tests: caller's origin is recorded, human default preserved, nonsense origin falls back, and the correction still inherits its anchors and supersedes the original. Generated hook copies re-synced via `npm run sync:hooks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)