### PR TITLE
feat(inject): deliver findings to the model, and measure whether it helps

### DIFF
--- a/docs/INJECTION_PROOF_PROTOCOL.md
+++ b/docs/INJECTION_PROOF_PROTOCOL.md
@@ -1,0 +1,79 @@
+# Injection proof protocol
+
+Pre-registered before the fix was written. The point of writing it first is that
+the pass bar cannot be moved after seeing the numbers.
+
+## The claim under test
+
+That the knowledge graph makes an agent **measurably better at the work**, not
+merely that it stores and can retrieve facts. Storage and retrieval were already
+demonstrated; behaviour change was not.
+
+## Baseline, measured 2026-08-04 (before any fix)
+
+Taken from `metrics.jsonl` across three real project graphs after a long working
+session.
+
+| measurement | value |
+|---|---|
+| capture events (token-optimizer) | 4,053 |
+| read events (token-optimizer) | 2,063 |
+| **inject events that served a finding, all projects** | **2** |
+| findings served for a `command`-type finding | 0 |
+
+Two compounding causes, both verified by reading the shipped build:
+
+1. **`forTouch()` is wired to nothing.** It is imported only by
+   `tests/hooks/injection.test.mjs`. The production hook
+   (`pretooluse-router.mjs`) imports `refusalPayload` and `substitutionFor` from
+   the same module and never `forTouch`. So touching a file has never injected a
+   finding; the only findings that reached a model arrived through the refusal
+   path.
+
+2. **There is no action trigger.** Injection is keyed on *file touch*, but the
+   highest-value findings are about *actions*. The concrete case: a finding of
+   type `command` — "run the suite with `npm test`, not `npx jest`" — is anchored
+   to `plugin/hooks/lib/harvest.mjs`. An agent about to run `npx jest` is not
+   touching that file, so the finding could never fire at the moment it mattered.
+   It did not, and the agent lost a test cycle to exactly that mistake.
+
+## Primary metric (the gate)
+
+**Avoided dead-ends.** Seed the graph with N findings, each recording a real
+dead-end already hit in this repository. A **fresh subagent** — no session
+history, so it cannot know the answers — attempts tasks that walk into them.
+
+- **Treatment**: graph enabled.
+- **Control**: identical prompt, identical model, `TOKEN_OPTIMIZER_MODE=off`.
+
+Pass requires **both**:
+
+- **≥ 80%** of seeded dead-ends avoided in treatment that the control walks into.
+- **0 regressions** — no case where an injected finding pushes the subagent into
+  a *new* wrong path. A misleading finding is worse than no finding, so this is a
+  hard zero, not a percentage.
+
+## Secondary metric
+
+**Tokens to the same correct outcome**, treatment vs control. Reported as a raw
+number. Not a gate: token counts swing on unrelated choices, and a single run
+cannot separate signal from that noise.
+
+## Diagnostic
+
+The **injection log** (`metrics.jsonl`, `kind: 'inject'`): what was served, for
+which anchor or command, how many tokens, and whether the touch fell in the
+stratified holdout. This explains *why* the primary metric moved, and is the
+only thing that can distinguish "the graph had nothing" from "the graph had it
+and never delivered it" — which is precisely the failure the baseline above
+records.
+
+## Honesty conditions
+
+- The subagent is the subject because the author of this document has already
+  seen the answers and is a contaminated subject.
+- Seeded findings must describe dead-ends that are **not** discoverable from the
+  code, comments, or git history in the time budget given. Otherwise the control
+  can reach them by ordinary reading and the comparison measures nothing.
+- Raw counts are reported alongside the verdict, so the numbers can be checked
+  against the bar independently.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -5,7 +5,7 @@
   "mcpServers": {
     "token-optimizer": {
       "command": "npx",
-      "args": ["-y", "@ooples/token-optimizer-mcp@5.3.2"]
+      "args": ["-y", "@ooples/token-optimizer-mcp@5.3.6"]
     }
   },
   "settings": [

--- a/hooks-core/harvest-write.mjs
+++ b/hooks-core/harvest-write.mjs
@@ -116,6 +116,14 @@ export function writeHarvested(
         claim: finding.claim,
         confidence: finding.confidence,
         type: finding.type,
+        // WHEN this finding is relevant, not just what it is about. Anchors
+        // answer "which file", which is the wrong question for a claim about
+        // running something: the agent that needs "use npm test, not npx jest"
+        // is executing a command, not reading the file the claim is anchored
+        // to. Optional, so nothing that omits it changes behaviour.
+        trigger: typeof finding.trigger === 'string' && finding.trigger
+          ? finding.trigger
+          : undefined,
         origin: provenance,
         sessionId,
       },

--- a/hooks-core/inject.mjs
+++ b/hooks-core/inject.mjs
@@ -91,6 +91,139 @@ export function forTouch(dir, graph, rawPath, { budget = touchBudget(), sessionI
 }
 
 /**
+ * Does this finding apply to the command about to run?
+ *
+ * A finding carries an optional `trigger`: a string or regex source matched
+ * against the command text. Explicit beats inferred -- the alternative was
+ * scraping command-looking tokens out of the claim, which both misses (a claim
+ * that describes the command in prose) and misfires (a claim that merely
+ * mentions a command it is not about).
+ *
+ * With no trigger, a `command` or `failure` finding still qualifies on a weaker
+ * test: the command mentions a distinctive token from the claim. That keeps the
+ * findings already in existing graphs useful without a migration, while new
+ * ones can be precise.
+ */
+function appliesToCommand(finding, command) {
+  const text = String(command || '');
+  if (!text) return false;
+
+  if (finding.trigger) {
+    try {
+      return new RegExp(finding.trigger, 'i').test(text);
+    } catch {
+      // A malformed trigger must not throw on the hook path; fall back to a
+      // literal search so a bad regex degrades to a substring match.
+      return text.toLowerCase().includes(String(finding.trigger).toLowerCase());
+    }
+  }
+
+  // Untriggered findings only qualify if they are about doing something.
+  if (finding.type !== 'command' && finding.type !== 'failure') return false;
+
+  // Distinctive tokens, matched as WHOLE WORDS.
+  //
+  // The floor is three characters because the tokens that carry the meaning are
+  // short: jest, npm, git, ssh, tsc. A five-character floor -- the first
+  // attempt -- excluded "jest" from the very finding this feature exists to
+  // deliver, which the tests caught. Whole-word matching is what makes the low
+  // floor safe: without it "npm" would fire on any path containing "npm", and
+  // every claim mentioning a common word would match every command.
+  const claim = String(finding.claim || '');
+  const tokens = [
+    ...new Set(
+      (claim.match(/[a-z][a-z0-9._-]{2,}/gi) || [])
+        .map((t) => t.toLowerCase().replace(/[._-]+$/, ''))
+        .filter((t) => t.length >= 3 && !STOPWORDS.has(t))
+    ),
+  ];
+
+  return tokens.some((t) => {
+    const escaped = t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    try {
+      return new RegExp(`(^|[^a-z0-9])${escaped}([^a-z0-9]|$)`, 'i').test(text);
+    } catch {
+      return false;
+    }
+  });
+}
+
+/**
+ * Words common enough that matching on them would fire on every command.
+ * Deliberately small: this is a noise floor, not a language model.
+ */
+const STOPWORDS = new Set([
+  // Long enough to pass the length floor, common enough to match anything.
+  'about', 'after', 'again', 'against', 'because', 'before', 'being', 'between',
+  'could', 'every', 'first', 'instead', 'other', 'rather', 'should', 'since',
+  'their', 'there', 'these', 'thing', 'those', 'through', 'where', 'which',
+  'while', 'would', 'without', 'project', 'always', 'never',
+  // Short words that only became candidates once the floor dropped to three,
+  // which it had to so that the tool names that matter -- jest, npm, git, ssh
+  // -- are matchable at all.
+  'and', 'are', 'but', 'for', 'from', 'has', 'have', 'into', 'its', 'not',
+  'one', 'only', 'our', 'out', 'same', 'some', 'such', 'than', 'that', 'the',
+  'them', 'then', 'they', 'this', 'too', 'use', 'used', 'very', 'was', 'were',
+  'what', 'when', 'will', 'with', 'you', 'your', 'run', 'runs', 'way', 'why',
+]);
+
+/**
+ * What the model sees when it is about to RUN something.
+ *
+ * The gap this closes: injection was keyed entirely on touching a FILE, but the
+ * findings worth the most are about ACTIONS. The case that proved it -- a
+ * finding of type `command`, "run the suite with npm test, not npx jest",
+ * anchored to a source file. An agent about to run `npx jest` is not touching
+ * that file, so the finding could not fire at the only moment it mattered, and
+ * the agent made exactly the mistake the graph had already recorded.
+ *
+ * `alreadyInjected` is the once-per-session gate. Repeating the same advice on
+ * every command is how a real signal becomes wallpaper, and an ignored
+ * injection still costs its tokens on every call.
+ */
+export function forCommand(
+  dir,
+  graph,
+  command,
+  { budget = touchBudget(), sessionId, alreadyInjected = new Set() } = {}
+) {
+  if (!command) return null;
+
+  const candidates = [];
+  for (const node of graph.nodes.values()) {
+    if (node.kind !== 'finding' || node.retired) continue;
+    if (alreadyInjected.has(node.key)) continue;
+    if (!appliesToCommand(node, command)) continue;
+    candidates.push(node);
+  }
+  if (!candidates.length) return null;
+
+  // Highest confidence first, so a tight budget keeps the most trustworthy.
+  candidates.sort((a, b) => (b.confidence ?? 0.5) - (a.confidence ?? 0.5));
+
+  const served = serve(graph, candidates);
+  const { kept, spent } = fit(served, budget);
+  if (!kept.length) return null;
+
+  record(dir, {
+    kind: 'inject',
+    trigger: 'command',
+    anchor: String(command).slice(0, 120),
+    holdout: false,
+    tokens: spent,
+    count: kept.length,
+    stale: kept.some((f) => f.stale),
+    sessionId,
+  });
+
+  for (const f of kept) alreadyInjected.add(f.key);
+
+  return `Before running this — known from previous sessions:\n${kept
+    .map(render)
+    .join('\n')}`;
+}
+
+/**
  * The bounded SessionStart index: titles and ids only, never bodies.
  *
  * Its budget is EARNED from measured hit rate rather than fixed, so a mature

--- a/hooks-core/inject.mjs
+++ b/hooks-core/inject.mjs
@@ -28,6 +28,42 @@ import { substitutionBudget } from './metrics.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
+
+/** Most findings considered for one command before the budget decides. */
+const MAX_COMMAND_CANDIDATES = 20;
+
+/**
+ * Compiles a finding's trigger, or returns null if it is not safe to run.
+ *
+ * TRIGGERS ARE MODEL-SUPPLIED. The harvest writes them, and a model asked for a
+ * regex can produce `(a+)+b` as readily as `\bnpx\b` -- a pattern whose
+ * backtracking is exponential in the input length. That would execute on the
+ * PreToolUse path against a command the user is waiting on, so a single bad
+ * trigger would hang every subsequent tool call in the session. Neither a
+ * try/catch nor a timeout helps: catastrophic backtracking does not throw, it
+ * simply does not return.
+ *
+ * So the pattern is rejected before it is ever run. The test is deliberately
+ * conservative -- nested quantifiers are the shape that causes this, and no
+ * legitimate trigger for a command needs one.
+ */
+export function safeTrigger(source) {
+  const raw = String(source || '');
+  if (!raw || raw.length > 200) return null;
+
+  // A quantifier applied to a group that itself contains a quantifier: (a+)+,
+  // (a*)*, (\d+)*, (?:ab+)+ and so on. This is the classic ReDoS shape.
+  if (/\([^)]*[+*}][^)]*\)\s*[+*{]/.test(raw)) return null;
+
+  // Stacked quantifiers outside a group, e.g. `a+*` or `.*+`.
+  if (/[+*}]\s*[+*]/.test(raw)) return null;
+
+  try {
+    return new RegExp(raw, 'i');
+  } catch {
+    return null;
+  }
+}
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
 
 /**
@@ -64,11 +100,21 @@ function render(finding) {
  * measurement holdout -- in which case the caller must behave exactly as if the
  * graph were empty, or the experiment measures nothing.
  */
-export function forTouch(dir, graph, rawPath, { budget = touchBudget(), sessionId } = {}) {
+export function forTouch(
+  dir,
+  graph,
+  rawPath,
+  { budget = touchBudget(), sessionId, alreadyInjected = new Set() } = {}
+) {
   // Canonical, so a touch finds findings anchored under any other spelling.
   const filePath = canonicalPath(rawPath);
   const anchorId = nodeId('file', filePath);
-  const candidates = findingsFor(graph, anchorId, { limit: 30 });
+  // The same once-per-session gate the command path uses. A file touched
+  // repeatedly -- which is the normal shape of working on it -- would otherwise
+  // re-serve the same findings on every single touch, which is both a token
+  // cost per call and the fastest way to train a model to skim past them.
+  const candidates = findingsFor(graph, anchorId, { limit: 30 })
+    .filter((f) => !alreadyInjected.has(f.key));
   if (!candidates.length) return null;
 
   const holdout = inHoldout(filePath);
@@ -86,6 +132,8 @@ export function forTouch(dir, graph, rawPath, { budget = touchBudget(), sessionI
   });
 
   if (holdout || !kept.length) return null;
+
+  for (const f of kept) alreadyInjected.add(f.key);
 
   return `Known about ${filePath} (from previous sessions):\n${kept.map(render).join('\n')}`;
 }
@@ -109,13 +157,18 @@ function appliesToCommand(finding, command) {
   if (!text) return false;
 
   if (finding.trigger) {
-    try {
-      return new RegExp(finding.trigger, 'i').test(text);
-    } catch {
-      // A malformed trigger must not throw on the hook path; fall back to a
-      // literal search so a bad regex degrades to a substring match.
-      return text.toLowerCase().includes(String(finding.trigger).toLowerCase());
+    const pattern = safeTrigger(finding.trigger);
+    if (pattern) {
+      try {
+        return pattern.test(text);
+      } catch {
+        return false;
+      }
     }
+    // Rejected as unsafe or malformed: fall back to a literal search, which
+    // cannot backtrack. A bad trigger degrades to a substring match rather
+    // than taking the hook down or hanging it.
+    return text.toLowerCase().includes(String(finding.trigger).toLowerCase());
   }
 
   // Untriggered findings only qualify if they are about doing something.
@@ -201,7 +254,14 @@ export function forCommand(
   // Highest confidence first, so a tight budget keeps the most trustworthy.
   candidates.sort((a, b) => (b.confidence ?? 0.5) - (a.confidence ?? 0.5));
 
-  const served = serve(graph, candidates);
+  // CAPPED BEFORE serve(). serve() re-reads and diffs the anchor of every
+  // finding it is handed, so an unbounded candidate list turns one command into
+  // one file read per matching finding -- on the hook path, with the user
+  // waiting. The budget would discard the surplus a moment later anyway, so the
+  // only thing an uncapped list buys is the I/O.
+  const considered = candidates.slice(0, MAX_COMMAND_CANDIDATES);
+
+  const served = serve(graph, considered);
   const { kept, spent } = fit(served, budget);
   if (!kept.length) return null;
 

--- a/hooks-core/inject.mjs
+++ b/hooks-core/inject.mjs
@@ -252,7 +252,21 @@ export function forCommand(
   if (!candidates.length) return null;
 
   // Highest confidence first, so a tight budget keeps the most trustworthy.
-  candidates.sort((a, b) => (b.confidence ?? 0.5) - (a.confidence ?? 0.5));
+  // AN EXPLICIT TRIGGER BEATS AN INCIDENTAL WORD, before confidence is even
+  // consulted. A finding whose author wrote a pattern that matched this command
+  // is about this command; one that matched because its prose happened to
+  // contain "build" is not, however confident it was about something else.
+  //
+  // Observed live: `dotnet build App.csproj | tail -20` surfaced a finding about
+  // stale MCP server processes instead of the one about pipes hiding exit
+  // codes, and `gh run list` surfaced a git-refspec finding instead of the one
+  // about mergeStateStatus. Both had the same confidence as the right answer,
+  // so confidence alone could not separate them -- and a tight budget then kept
+  // the wrong one.
+  const explicit = (n) => (n.trigger && safeTrigger(n.trigger)?.test(command) ? 1 : 0);
+  candidates.sort(
+    (a, b) => explicit(b) - explicit(a) || (b.confidence ?? 0.5) - (a.confidence ?? 0.5)
+  );
 
   // CAPPED BEFORE serve(). serve() re-reads and diffs the anchor of every
   // finding it is handed, so an unbounded candidate list turns one command into

--- a/hooks-core/policy.mjs
+++ b/hooks-core/policy.mjs
@@ -177,13 +177,23 @@ export function fileSize(path) {
  * means state on disk, keyed by the session id the hook payload carries.
  * ------------------------------------------------------------------ */
 
-const STATE_ROOT = join(tmpdir(), 'token-optimizer-hooks');
+/**
+ * Where per-session hook state lives.
+ *
+ * Read per call rather than captured at import, so a test can point it at a
+ * temp directory. Contention on this file is the normal case -- parallel tool
+ * calls each spawn their own hook process -- and it was untestable while the
+ * path was a module constant, which is part of why an unlocked
+ * read-modify-write survived here unnoticed.
+ */
+const stateRoot = () =>
+  process.env.TOKEN_OPTIMIZER_STATE_DIR || join(tmpdir(), 'token-optimizer-hooks');
 
 function statePath(sessionId) {
   // Session ids come from the harness and are uuid-shaped, but they land in a
   // file path, so anything that could traverse is stripped rather than trusted.
   const safe = String(sessionId || 'default').replace(/[^A-Za-z0-9_-]/g, '');
-  return join(STATE_ROOT, `${safe || 'default'}.json`);
+  return join(stateRoot(), `${safe || 'default'}.json`);
 }
 
 /** A usable state object, whatever was on disk. */
@@ -240,18 +250,26 @@ export function loadState(sessionId) {
 export function saveState(sessionId, state) {
   let lock = null;
   try {
-    mkdirSync(STATE_ROOT, { recursive: true, mode: 0o700 });
+    mkdirSync(stateRoot(), { recursive: true, mode: 0o700 });
 
     // A LOCK, because merging alone still loses updates: two processes can both
     // read, both merge, and the second write still discards the first's
     // additions. `wx` fails if the file exists, which makes creation an atomic
     // test-and-set on every platform we target.
     //
-    // Bounded and best-effort: if the lock cannot be taken quickly the write
-    // proceeds anyway. A stale lock from a killed process must never wedge
-    // enforcement, and the worst case without the lock is the merge behaviour
-    // that was already acceptable.
+    // NO UNLOCKED READ-MODIFY-WRITE. This used to fall through and write anyway
+    // when the lock could not be taken, which reintroduces exactly the lost
+    // update the lock exists to prevent: a process that misses the lock reads
+    // the pre-merge state and can erase an `injected` id another process just
+    // recorded, letting the same finding be injected twice in one session.
+    //
+    // Skipping the write is the safe direction. The cost is that THIS process's
+    // additions are not persisted, and every consequence of that is already
+    // bounded by design -- a repeated denial is allowed through by rule, and a
+    // repeated injection costs its tokens once more. A stale lock is still
+    // broken and taken below, so a killed process cannot wedge enforcement.
     lock = takeLock(sessionId);
+    if (!lock) return false;
 
     const current = loadState(sessionId);
     const merged = {
@@ -284,7 +302,25 @@ export function saveState(sessionId, state) {
 }
 
 /** Best-effort exclusive lock. Returns the lock path, or null if not acquired. */
-function takeLock(sessionId, { attempts = 20, staleMs = 5000 } = {}) {
+/**
+ * Sleeps synchronously.
+ *
+ * These hooks are single-shot processes that must reach a decision before they
+ * return, so there is no event loop to yield to and nothing to await. Atomics
+ * on a throwaway SharedArrayBuffer is the standard way to block a worker for a
+ * bounded time without burning the CPU.
+ */
+function sleepSync(ms) {
+  try {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+  } catch {
+    // SharedArrayBuffer unavailable under some policies. The caller still makes
+    // progress; it simply retries sooner.
+  }
+}
+
+/** Best-effort exclusive lock. Returns the lock path, or null if not acquired. */
+function takeLock(sessionId, { attempts = 20, staleMs = 5000, waitMs = 15 } = {}) {
   const path = `${statePath(sessionId)}.lock`;
   for (let i = 0; i < attempts; i++) {
     try {
@@ -295,10 +331,21 @@ function takeLock(sessionId, { attempts = 20, staleMs = 5000 } = {}) {
       // A lock left behind by a killed process would otherwise block every
       // future write for the life of the session.
       try {
-        if (Date.now() - statSync(path).mtimeMs > staleMs) unlinkSync(path);
+        if (Date.now() - statSync(path).mtimeMs > staleMs) {
+          unlinkSync(path);
+          continue; // Retry immediately; the holder is gone.
+        }
       } catch {
-        // Raced with the holder releasing it; just retry.
+        // Raced with the holder releasing it; retry immediately.
+        continue;
       }
+
+      // A LIVE holder. Waiting is the whole point: the previous loop retried
+      // 20 times with no delay, so it exhausted in microseconds and the caller
+      // fell through to an unlocked write. Backing off actually lets the holder
+      // finish -- a state write is a few milliseconds -- which is the
+      // difference between contending and merely pretending to.
+      if (i < attempts - 1) sleepSync(waitMs);
     }
   }
   return null;

--- a/hooks-core/policy.mjs
+++ b/hooks-core/policy.mjs
@@ -188,7 +188,7 @@ function statePath(sessionId) {
 
 /** A usable state object, whatever was on disk. */
 function emptyState() {
-  return { seen: {}, denied: {} };
+  return { seen: {}, denied: {}, injected: [] };
 }
 
 /**
@@ -208,6 +208,13 @@ export function loadState(sessionId) {
     return {
       seen: parsed.seen && typeof parsed.seen === 'object' ? parsed.seen : {},
       denied: parsed.denied && typeof parsed.denied === 'object' ? parsed.denied : {},
+      // WITHOUT THIS THE ONCE-PER-SESSION GATE DOES NOT EXIST. Every tool call
+      // is a separate hook PROCESS, so a set held only in memory dies with the
+      // process that built it: the router recorded which findings it had
+      // injected, saveState dropped the field, and the next call re-injected
+      // the same advice. The gate looked correct in unit tests, which share one
+      // process, and did nothing at all in production.
+      injected: Array.isArray(parsed.injected) ? parsed.injected : [],
     };
   } catch {
     return emptyState();
@@ -250,6 +257,11 @@ export function saveState(sessionId, state) {
     const merged = {
       seen: { ...current.seen, ...state.seen },
       denied: { ...current.denied, ...state.denied },
+      // UNION, not overwrite. Two hook processes running in parallel each hold
+      // their own view of what has been injected; taking the last writer's copy
+      // would resurrect a finding the other had already delivered, which is the
+      // repetition the once-per-session gate exists to stop.
+      injected: [...new Set([...(current.injected || []), ...(state.injected || [])])],
     };
 
     // Write-then-rename so a reader never observes a half-written file.

--- a/hooks-core/policy.mjs
+++ b/hooks-core/policy.mjs
@@ -316,6 +316,36 @@ export function allow() {
 }
 
 /**
+ * Allows the call AND hands the model something it did not ask for.
+ *
+ * This is the delivery half of the knowledge graph, and it had no
+ * implementation. `forTouch` -- the just-in-time injection the design calls
+ * "where the win lands" -- was imported by nothing outside its own test, so a
+ * finding could only ever reach a model through a REFUSAL. Measured across a
+ * full working session on three real projects: 4,053 capture events, 2,063
+ * reads, and findings served exactly twice. The graph was writing knowledge it
+ * had no way to deliver.
+ *
+ * `additionalContext` rather than a `permissionDecisionReason`, because the call
+ * is not being judged -- it is proceeding, and this rides along with it. Nothing
+ * is emitted when there is nothing to say, so the common path stays a bare
+ * exit(0).
+ */
+export function allowWithContext(context) {
+  if (context) {
+    process.stdout.write(
+      JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          additionalContext: withEscape(context),
+        },
+      })
+    );
+  }
+  process.exit(0);
+}
+
+/**
  * Blocks the call and tells the model exactly what to call instead.
  *
  * The reason string is the whole user interface of this product for an agent.

--- a/hooks-core/staleness.mjs
+++ b/hooks-core/staleness.mjs
@@ -357,10 +357,22 @@ export function serve(graph, findings) {
     }
 
     if (stale && !diff) {
-      // The invariant. Rather than serve a bare stale finding -- which the
-      // design calls worse than no graph -- say plainly that the evidence is
-      // gone, so the model treats the claim as unverified rather than current.
-      diff = '(the change could not be reconstructed; treat this finding as unverified)';
+      // The invariant holds: never serve a bare stale finding as though it were
+      // current. But the WORDING was doing more than that, and it was measured.
+      //
+      // "treat this finding as unverified" is an instruction to discount, and
+      // models follow it. In an A/B on a fresh subagent, identical findings
+      // scored 1/3 dead-ends avoided when rendered with that sentence and 2/3
+      // when rendered clean -- no code change, only the wording. The claim being
+      // discounted was correct every time; all that had changed was the anchor
+      // file, which says nothing about whether the claim still holds.
+      //
+      // So: report what is actually known -- the anchor moved and the evidence
+      // cannot be rebuilt -- and let the claim stand or fall on its own. That is
+      // honest about staleness without arguing against the content.
+      diff = '(the anchor changed since this was recorded and the diff can no longer be '
+        + 'reconstructed; the claim itself may well still hold, so weigh it rather than '
+        + 'discard it)';
     }
 
     served.push({ ...finding, stale, ...(stale ? { diff, staleReason: reason } : {}) });

--- a/hooks-core/staleness.mjs
+++ b/hooks-core/staleness.mjs
@@ -377,9 +377,14 @@ export function serve(graph, findings) {
       // those cases the sentence stated a cause that had not been established.
       // `reason` already carries whatever was actually determined, so the
       // fallback now describes only the evidence gap.
+      // NO DISMISSAL VOCABULARY AT ALL, not even in a sentence arguing against
+      // dismissal. "weigh it rather than discard it" still puts the word in
+      // front of the model, and this text exists precisely because the previous
+      // phrasing was measured suppressing correct findings. State the evidence
+      // gap and stop.
       diff = `(marked stale: ${reason}. The supporting diff can no longer be `
-        + 'reconstructed; the claim itself may well still hold, so weigh it rather '
-        + 'than discard it)';
+        + 'reconstructed; the claim itself may well still hold, so weigh it on '
+        + 'its own merits.)';
     }
 
     served.push({ ...finding, stale, ...(stale ? { diff, staleReason: reason } : {}) });

--- a/hooks-core/staleness.mjs
+++ b/hooks-core/staleness.mjs
@@ -367,12 +367,19 @@ export function serve(graph, findings) {
       // discounted was correct every time; all that had changed was the anchor
       // file, which says nothing about whether the claim still holds.
       //
-      // So: report what is actually known -- the anchor moved and the evidence
-      // cannot be rebuilt -- and let the claim stand or fall on its own. That is
-      // honest about staleness without arguing against the content.
-      diff = '(the anchor changed since this was recorded and the diff can no longer be '
-        + 'reconstructed; the claim itself may well still hold, so weigh it rather than '
-        + 'discard it)';
+      // So: report what is actually known and let the claim stand or fall on its
+      // own. That is honest about staleness without arguing against the content.
+      //
+      // REASON-NEUTRAL. The earlier text asserted "the anchor changed", which is
+      // only one of the ways a finding reaches this branch -- it is also reached
+      // when the eager path marked the finding at write time, or when the anchor
+      // was never snapshotted at all because it exceeded the snapshot limit. In
+      // those cases the sentence stated a cause that had not been established.
+      // `reason` already carries whatever was actually determined, so the
+      // fallback now describes only the evidence gap.
+      diff = `(marked stale: ${reason}. The supporting diff can no longer be `
+        + 'reconstructed; the claim itself may well still hold, so weigh it rather '
+        + 'than discard it)';
     }
 
     served.push({ ...finding, stale, ...(stale ? { diff, staleReason: reason } : {}) });

--- a/integrations/amp/settings.json
+++ b/integrations/amp/settings.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@ooples/token-optimizer-mcp@5.3.2"
+        "@ooples/token-optimizer-mcp@5.3.6"
       ],
       "env": {}
     }

--- a/integrations/cline/mcp.json
+++ b/integrations/cline/mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@ooples/token-optimizer-mcp@5.3.2"
+        "@ooples/token-optimizer-mcp@5.3.6"
       ],
       "env": {}
     }

--- a/integrations/codex/config.toml
+++ b/integrations/codex/config.toml
@@ -5,6 +5,6 @@
 
 [mcp_servers.token-optimizer]
 command = "npx"
-args = ["-y", "@ooples/token-optimizer-mcp@5.3.2"]
+args = ["-y", "@ooples/token-optimizer-mcp@5.3.6"]
 # Optional: point the cache somewhere stable.
 # env = { TOKEN_OPTIMIZER_CACHE_DIR = "~/.token-optimizer-cache" }

--- a/integrations/codex/hooks/lib/harvest-write.mjs
+++ b/integrations/codex/hooks/lib/harvest-write.mjs
@@ -118,6 +118,14 @@ export function writeHarvested(
         claim: finding.claim,
         confidence: finding.confidence,
         type: finding.type,
+        // WHEN this finding is relevant, not just what it is about. Anchors
+        // answer "which file", which is the wrong question for a claim about
+        // running something: the agent that needs "use npm test, not npx jest"
+        // is executing a command, not reading the file the claim is anchored
+        // to. Optional, so nothing that omits it changes behaviour.
+        trigger: typeof finding.trigger === 'string' && finding.trigger
+          ? finding.trigger
+          : undefined,
         origin: provenance,
         sessionId,
       },

--- a/integrations/codex/hooks/lib/inject.mjs
+++ b/integrations/codex/hooks/lib/inject.mjs
@@ -30,6 +30,42 @@ import { substitutionBudget } from './metrics.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
+
+/** Most findings considered for one command before the budget decides. */
+const MAX_COMMAND_CANDIDATES = 20;
+
+/**
+ * Compiles a finding's trigger, or returns null if it is not safe to run.
+ *
+ * TRIGGERS ARE MODEL-SUPPLIED. The harvest writes them, and a model asked for a
+ * regex can produce `(a+)+b` as readily as `\bnpx\b` -- a pattern whose
+ * backtracking is exponential in the input length. That would execute on the
+ * PreToolUse path against a command the user is waiting on, so a single bad
+ * trigger would hang every subsequent tool call in the session. Neither a
+ * try/catch nor a timeout helps: catastrophic backtracking does not throw, it
+ * simply does not return.
+ *
+ * So the pattern is rejected before it is ever run. The test is deliberately
+ * conservative -- nested quantifiers are the shape that causes this, and no
+ * legitimate trigger for a command needs one.
+ */
+export function safeTrigger(source) {
+  const raw = String(source || '');
+  if (!raw || raw.length > 200) return null;
+
+  // A quantifier applied to a group that itself contains a quantifier: (a+)+,
+  // (a*)*, (\d+)*, (?:ab+)+ and so on. This is the classic ReDoS shape.
+  if (/\([^)]*[+*}][^)]*\)\s*[+*{]/.test(raw)) return null;
+
+  // Stacked quantifiers outside a group, e.g. `a+*` or `.*+`.
+  if (/[+*}]\s*[+*]/.test(raw)) return null;
+
+  try {
+    return new RegExp(raw, 'i');
+  } catch {
+    return null;
+  }
+}
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
 
 /**
@@ -66,11 +102,21 @@ function render(finding) {
  * measurement holdout -- in which case the caller must behave exactly as if the
  * graph were empty, or the experiment measures nothing.
  */
-export function forTouch(dir, graph, rawPath, { budget = touchBudget(), sessionId } = {}) {
+export function forTouch(
+  dir,
+  graph,
+  rawPath,
+  { budget = touchBudget(), sessionId, alreadyInjected = new Set() } = {}
+) {
   // Canonical, so a touch finds findings anchored under any other spelling.
   const filePath = canonicalPath(rawPath);
   const anchorId = nodeId('file', filePath);
-  const candidates = findingsFor(graph, anchorId, { limit: 30 });
+  // The same once-per-session gate the command path uses. A file touched
+  // repeatedly -- which is the normal shape of working on it -- would otherwise
+  // re-serve the same findings on every single touch, which is both a token
+  // cost per call and the fastest way to train a model to skim past them.
+  const candidates = findingsFor(graph, anchorId, { limit: 30 })
+    .filter((f) => !alreadyInjected.has(f.key));
   if (!candidates.length) return null;
 
   const holdout = inHoldout(filePath);
@@ -88,6 +134,8 @@ export function forTouch(dir, graph, rawPath, { budget = touchBudget(), sessionI
   });
 
   if (holdout || !kept.length) return null;
+
+  for (const f of kept) alreadyInjected.add(f.key);
 
   return `Known about ${filePath} (from previous sessions):\n${kept.map(render).join('\n')}`;
 }
@@ -111,13 +159,18 @@ function appliesToCommand(finding, command) {
   if (!text) return false;
 
   if (finding.trigger) {
-    try {
-      return new RegExp(finding.trigger, 'i').test(text);
-    } catch {
-      // A malformed trigger must not throw on the hook path; fall back to a
-      // literal search so a bad regex degrades to a substring match.
-      return text.toLowerCase().includes(String(finding.trigger).toLowerCase());
+    const pattern = safeTrigger(finding.trigger);
+    if (pattern) {
+      try {
+        return pattern.test(text);
+      } catch {
+        return false;
+      }
     }
+    // Rejected as unsafe or malformed: fall back to a literal search, which
+    // cannot backtrack. A bad trigger degrades to a substring match rather
+    // than taking the hook down or hanging it.
+    return text.toLowerCase().includes(String(finding.trigger).toLowerCase());
   }
 
   // Untriggered findings only qualify if they are about doing something.
@@ -203,7 +256,14 @@ export function forCommand(
   // Highest confidence first, so a tight budget keeps the most trustworthy.
   candidates.sort((a, b) => (b.confidence ?? 0.5) - (a.confidence ?? 0.5));
 
-  const served = serve(graph, candidates);
+  // CAPPED BEFORE serve(). serve() re-reads and diffs the anchor of every
+  // finding it is handed, so an unbounded candidate list turns one command into
+  // one file read per matching finding -- on the hook path, with the user
+  // waiting. The budget would discard the surplus a moment later anyway, so the
+  // only thing an uncapped list buys is the I/O.
+  const considered = candidates.slice(0, MAX_COMMAND_CANDIDATES);
+
+  const served = serve(graph, considered);
   const { kept, spent } = fit(served, budget);
   if (!kept.length) return null;
 

--- a/integrations/codex/hooks/lib/inject.mjs
+++ b/integrations/codex/hooks/lib/inject.mjs
@@ -93,6 +93,139 @@ export function forTouch(dir, graph, rawPath, { budget = touchBudget(), sessionI
 }
 
 /**
+ * Does this finding apply to the command about to run?
+ *
+ * A finding carries an optional `trigger`: a string or regex source matched
+ * against the command text. Explicit beats inferred -- the alternative was
+ * scraping command-looking tokens out of the claim, which both misses (a claim
+ * that describes the command in prose) and misfires (a claim that merely
+ * mentions a command it is not about).
+ *
+ * With no trigger, a `command` or `failure` finding still qualifies on a weaker
+ * test: the command mentions a distinctive token from the claim. That keeps the
+ * findings already in existing graphs useful without a migration, while new
+ * ones can be precise.
+ */
+function appliesToCommand(finding, command) {
+  const text = String(command || '');
+  if (!text) return false;
+
+  if (finding.trigger) {
+    try {
+      return new RegExp(finding.trigger, 'i').test(text);
+    } catch {
+      // A malformed trigger must not throw on the hook path; fall back to a
+      // literal search so a bad regex degrades to a substring match.
+      return text.toLowerCase().includes(String(finding.trigger).toLowerCase());
+    }
+  }
+
+  // Untriggered findings only qualify if they are about doing something.
+  if (finding.type !== 'command' && finding.type !== 'failure') return false;
+
+  // Distinctive tokens, matched as WHOLE WORDS.
+  //
+  // The floor is three characters because the tokens that carry the meaning are
+  // short: jest, npm, git, ssh, tsc. A five-character floor -- the first
+  // attempt -- excluded "jest" from the very finding this feature exists to
+  // deliver, which the tests caught. Whole-word matching is what makes the low
+  // floor safe: without it "npm" would fire on any path containing "npm", and
+  // every claim mentioning a common word would match every command.
+  const claim = String(finding.claim || '');
+  const tokens = [
+    ...new Set(
+      (claim.match(/[a-z][a-z0-9._-]{2,}/gi) || [])
+        .map((t) => t.toLowerCase().replace(/[._-]+$/, ''))
+        .filter((t) => t.length >= 3 && !STOPWORDS.has(t))
+    ),
+  ];
+
+  return tokens.some((t) => {
+    const escaped = t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    try {
+      return new RegExp(`(^|[^a-z0-9])${escaped}([^a-z0-9]|$)`, 'i').test(text);
+    } catch {
+      return false;
+    }
+  });
+}
+
+/**
+ * Words common enough that matching on them would fire on every command.
+ * Deliberately small: this is a noise floor, not a language model.
+ */
+const STOPWORDS = new Set([
+  // Long enough to pass the length floor, common enough to match anything.
+  'about', 'after', 'again', 'against', 'because', 'before', 'being', 'between',
+  'could', 'every', 'first', 'instead', 'other', 'rather', 'should', 'since',
+  'their', 'there', 'these', 'thing', 'those', 'through', 'where', 'which',
+  'while', 'would', 'without', 'project', 'always', 'never',
+  // Short words that only became candidates once the floor dropped to three,
+  // which it had to so that the tool names that matter -- jest, npm, git, ssh
+  // -- are matchable at all.
+  'and', 'are', 'but', 'for', 'from', 'has', 'have', 'into', 'its', 'not',
+  'one', 'only', 'our', 'out', 'same', 'some', 'such', 'than', 'that', 'the',
+  'them', 'then', 'they', 'this', 'too', 'use', 'used', 'very', 'was', 'were',
+  'what', 'when', 'will', 'with', 'you', 'your', 'run', 'runs', 'way', 'why',
+]);
+
+/**
+ * What the model sees when it is about to RUN something.
+ *
+ * The gap this closes: injection was keyed entirely on touching a FILE, but the
+ * findings worth the most are about ACTIONS. The case that proved it -- a
+ * finding of type `command`, "run the suite with npm test, not npx jest",
+ * anchored to a source file. An agent about to run `npx jest` is not touching
+ * that file, so the finding could not fire at the only moment it mattered, and
+ * the agent made exactly the mistake the graph had already recorded.
+ *
+ * `alreadyInjected` is the once-per-session gate. Repeating the same advice on
+ * every command is how a real signal becomes wallpaper, and an ignored
+ * injection still costs its tokens on every call.
+ */
+export function forCommand(
+  dir,
+  graph,
+  command,
+  { budget = touchBudget(), sessionId, alreadyInjected = new Set() } = {}
+) {
+  if (!command) return null;
+
+  const candidates = [];
+  for (const node of graph.nodes.values()) {
+    if (node.kind !== 'finding' || node.retired) continue;
+    if (alreadyInjected.has(node.key)) continue;
+    if (!appliesToCommand(node, command)) continue;
+    candidates.push(node);
+  }
+  if (!candidates.length) return null;
+
+  // Highest confidence first, so a tight budget keeps the most trustworthy.
+  candidates.sort((a, b) => (b.confidence ?? 0.5) - (a.confidence ?? 0.5));
+
+  const served = serve(graph, candidates);
+  const { kept, spent } = fit(served, budget);
+  if (!kept.length) return null;
+
+  record(dir, {
+    kind: 'inject',
+    trigger: 'command',
+    anchor: String(command).slice(0, 120),
+    holdout: false,
+    tokens: spent,
+    count: kept.length,
+    stale: kept.some((f) => f.stale),
+    sessionId,
+  });
+
+  for (const f of kept) alreadyInjected.add(f.key);
+
+  return `Before running this — known from previous sessions:\n${kept
+    .map(render)
+    .join('\n')}`;
+}
+
+/**
  * The bounded SessionStart index: titles and ids only, never bodies.
  *
  * Its budget is EARNED from measured hit rate rather than fixed, so a mature

--- a/integrations/codex/hooks/lib/inject.mjs
+++ b/integrations/codex/hooks/lib/inject.mjs
@@ -254,7 +254,21 @@ export function forCommand(
   if (!candidates.length) return null;
 
   // Highest confidence first, so a tight budget keeps the most trustworthy.
-  candidates.sort((a, b) => (b.confidence ?? 0.5) - (a.confidence ?? 0.5));
+  // AN EXPLICIT TRIGGER BEATS AN INCIDENTAL WORD, before confidence is even
+  // consulted. A finding whose author wrote a pattern that matched this command
+  // is about this command; one that matched because its prose happened to
+  // contain "build" is not, however confident it was about something else.
+  //
+  // Observed live: `dotnet build App.csproj | tail -20` surfaced a finding about
+  // stale MCP server processes instead of the one about pipes hiding exit
+  // codes, and `gh run list` surfaced a git-refspec finding instead of the one
+  // about mergeStateStatus. Both had the same confidence as the right answer,
+  // so confidence alone could not separate them -- and a tight budget then kept
+  // the wrong one.
+  const explicit = (n) => (n.trigger && safeTrigger(n.trigger)?.test(command) ? 1 : 0);
+  candidates.sort(
+    (a, b) => explicit(b) - explicit(a) || (b.confidence ?? 0.5) - (a.confidence ?? 0.5)
+  );
 
   // CAPPED BEFORE serve(). serve() re-reads and diffs the anchor of every
   // finding it is handed, so an unbounded candidate list turns one command into

--- a/integrations/codex/hooks/lib/policy.mjs
+++ b/integrations/codex/hooks/lib/policy.mjs
@@ -318,6 +318,36 @@ export function allow() {
 }
 
 /**
+ * Allows the call AND hands the model something it did not ask for.
+ *
+ * This is the delivery half of the knowledge graph, and it had no
+ * implementation. `forTouch` -- the just-in-time injection the design calls
+ * "where the win lands" -- was imported by nothing outside its own test, so a
+ * finding could only ever reach a model through a REFUSAL. Measured across a
+ * full working session on three real projects: 4,053 capture events, 2,063
+ * reads, and findings served exactly twice. The graph was writing knowledge it
+ * had no way to deliver.
+ *
+ * `additionalContext` rather than a `permissionDecisionReason`, because the call
+ * is not being judged -- it is proceeding, and this rides along with it. Nothing
+ * is emitted when there is nothing to say, so the common path stays a bare
+ * exit(0).
+ */
+export function allowWithContext(context) {
+  if (context) {
+    process.stdout.write(
+      JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          additionalContext: withEscape(context),
+        },
+      })
+    );
+  }
+  process.exit(0);
+}
+
+/**
  * Blocks the call and tells the model exactly what to call instead.
  *
  * The reason string is the whole user interface of this product for an agent.

--- a/integrations/codex/hooks/lib/policy.mjs
+++ b/integrations/codex/hooks/lib/policy.mjs
@@ -190,7 +190,7 @@ function statePath(sessionId) {
 
 /** A usable state object, whatever was on disk. */
 function emptyState() {
-  return { seen: {}, denied: {} };
+  return { seen: {}, denied: {}, injected: [] };
 }
 
 /**
@@ -210,6 +210,13 @@ export function loadState(sessionId) {
     return {
       seen: parsed.seen && typeof parsed.seen === 'object' ? parsed.seen : {},
       denied: parsed.denied && typeof parsed.denied === 'object' ? parsed.denied : {},
+      // WITHOUT THIS THE ONCE-PER-SESSION GATE DOES NOT EXIST. Every tool call
+      // is a separate hook PROCESS, so a set held only in memory dies with the
+      // process that built it: the router recorded which findings it had
+      // injected, saveState dropped the field, and the next call re-injected
+      // the same advice. The gate looked correct in unit tests, which share one
+      // process, and did nothing at all in production.
+      injected: Array.isArray(parsed.injected) ? parsed.injected : [],
     };
   } catch {
     return emptyState();
@@ -252,6 +259,11 @@ export function saveState(sessionId, state) {
     const merged = {
       seen: { ...current.seen, ...state.seen },
       denied: { ...current.denied, ...state.denied },
+      // UNION, not overwrite. Two hook processes running in parallel each hold
+      // their own view of what has been injected; taking the last writer's copy
+      // would resurrect a finding the other had already delivered, which is the
+      // repetition the once-per-session gate exists to stop.
+      injected: [...new Set([...(current.injected || []), ...(state.injected || [])])],
     };
 
     // Write-then-rename so a reader never observes a half-written file.

--- a/integrations/codex/hooks/lib/policy.mjs
+++ b/integrations/codex/hooks/lib/policy.mjs
@@ -179,13 +179,23 @@ export function fileSize(path) {
  * means state on disk, keyed by the session id the hook payload carries.
  * ------------------------------------------------------------------ */
 
-const STATE_ROOT = join(tmpdir(), 'token-optimizer-hooks');
+/**
+ * Where per-session hook state lives.
+ *
+ * Read per call rather than captured at import, so a test can point it at a
+ * temp directory. Contention on this file is the normal case -- parallel tool
+ * calls each spawn their own hook process -- and it was untestable while the
+ * path was a module constant, which is part of why an unlocked
+ * read-modify-write survived here unnoticed.
+ */
+const stateRoot = () =>
+  process.env.TOKEN_OPTIMIZER_STATE_DIR || join(tmpdir(), 'token-optimizer-hooks');
 
 function statePath(sessionId) {
   // Session ids come from the harness and are uuid-shaped, but they land in a
   // file path, so anything that could traverse is stripped rather than trusted.
   const safe = String(sessionId || 'default').replace(/[^A-Za-z0-9_-]/g, '');
-  return join(STATE_ROOT, `${safe || 'default'}.json`);
+  return join(stateRoot(), `${safe || 'default'}.json`);
 }
 
 /** A usable state object, whatever was on disk. */
@@ -242,18 +252,26 @@ export function loadState(sessionId) {
 export function saveState(sessionId, state) {
   let lock = null;
   try {
-    mkdirSync(STATE_ROOT, { recursive: true, mode: 0o700 });
+    mkdirSync(stateRoot(), { recursive: true, mode: 0o700 });
 
     // A LOCK, because merging alone still loses updates: two processes can both
     // read, both merge, and the second write still discards the first's
     // additions. `wx` fails if the file exists, which makes creation an atomic
     // test-and-set on every platform we target.
     //
-    // Bounded and best-effort: if the lock cannot be taken quickly the write
-    // proceeds anyway. A stale lock from a killed process must never wedge
-    // enforcement, and the worst case without the lock is the merge behaviour
-    // that was already acceptable.
+    // NO UNLOCKED READ-MODIFY-WRITE. This used to fall through and write anyway
+    // when the lock could not be taken, which reintroduces exactly the lost
+    // update the lock exists to prevent: a process that misses the lock reads
+    // the pre-merge state and can erase an `injected` id another process just
+    // recorded, letting the same finding be injected twice in one session.
+    //
+    // Skipping the write is the safe direction. The cost is that THIS process's
+    // additions are not persisted, and every consequence of that is already
+    // bounded by design -- a repeated denial is allowed through by rule, and a
+    // repeated injection costs its tokens once more. A stale lock is still
+    // broken and taken below, so a killed process cannot wedge enforcement.
     lock = takeLock(sessionId);
+    if (!lock) return false;
 
     const current = loadState(sessionId);
     const merged = {
@@ -286,7 +304,25 @@ export function saveState(sessionId, state) {
 }
 
 /** Best-effort exclusive lock. Returns the lock path, or null if not acquired. */
-function takeLock(sessionId, { attempts = 20, staleMs = 5000 } = {}) {
+/**
+ * Sleeps synchronously.
+ *
+ * These hooks are single-shot processes that must reach a decision before they
+ * return, so there is no event loop to yield to and nothing to await. Atomics
+ * on a throwaway SharedArrayBuffer is the standard way to block a worker for a
+ * bounded time without burning the CPU.
+ */
+function sleepSync(ms) {
+  try {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+  } catch {
+    // SharedArrayBuffer unavailable under some policies. The caller still makes
+    // progress; it simply retries sooner.
+  }
+}
+
+/** Best-effort exclusive lock. Returns the lock path, or null if not acquired. */
+function takeLock(sessionId, { attempts = 20, staleMs = 5000, waitMs = 15 } = {}) {
   const path = `${statePath(sessionId)}.lock`;
   for (let i = 0; i < attempts; i++) {
     try {
@@ -297,10 +333,21 @@ function takeLock(sessionId, { attempts = 20, staleMs = 5000 } = {}) {
       // A lock left behind by a killed process would otherwise block every
       // future write for the life of the session.
       try {
-        if (Date.now() - statSync(path).mtimeMs > staleMs) unlinkSync(path);
+        if (Date.now() - statSync(path).mtimeMs > staleMs) {
+          unlinkSync(path);
+          continue; // Retry immediately; the holder is gone.
+        }
       } catch {
-        // Raced with the holder releasing it; just retry.
+        // Raced with the holder releasing it; retry immediately.
+        continue;
       }
+
+      // A LIVE holder. Waiting is the whole point: the previous loop retried
+      // 20 times with no delay, so it exhausted in microseconds and the caller
+      // fell through to an unlocked write. Backing off actually lets the holder
+      // finish -- a state write is a few milliseconds -- which is the
+      // difference between contending and merely pretending to.
+      if (i < attempts - 1) sleepSync(waitMs);
     }
   }
   return null;

--- a/integrations/codex/hooks/lib/staleness.mjs
+++ b/integrations/codex/hooks/lib/staleness.mjs
@@ -359,10 +359,22 @@ export function serve(graph, findings) {
     }
 
     if (stale && !diff) {
-      // The invariant. Rather than serve a bare stale finding -- which the
-      // design calls worse than no graph -- say plainly that the evidence is
-      // gone, so the model treats the claim as unverified rather than current.
-      diff = '(the change could not be reconstructed; treat this finding as unverified)';
+      // The invariant holds: never serve a bare stale finding as though it were
+      // current. But the WORDING was doing more than that, and it was measured.
+      //
+      // "treat this finding as unverified" is an instruction to discount, and
+      // models follow it. In an A/B on a fresh subagent, identical findings
+      // scored 1/3 dead-ends avoided when rendered with that sentence and 2/3
+      // when rendered clean -- no code change, only the wording. The claim being
+      // discounted was correct every time; all that had changed was the anchor
+      // file, which says nothing about whether the claim still holds.
+      //
+      // So: report what is actually known -- the anchor moved and the evidence
+      // cannot be rebuilt -- and let the claim stand or fall on its own. That is
+      // honest about staleness without arguing against the content.
+      diff = '(the anchor changed since this was recorded and the diff can no longer be '
+        + 'reconstructed; the claim itself may well still hold, so weigh it rather than '
+        + 'discard it)';
     }
 
     served.push({ ...finding, stale, ...(stale ? { diff, staleReason: reason } : {}) });

--- a/integrations/codex/hooks/lib/staleness.mjs
+++ b/integrations/codex/hooks/lib/staleness.mjs
@@ -369,12 +369,19 @@ export function serve(graph, findings) {
       // discounted was correct every time; all that had changed was the anchor
       // file, which says nothing about whether the claim still holds.
       //
-      // So: report what is actually known -- the anchor moved and the evidence
-      // cannot be rebuilt -- and let the claim stand or fall on its own. That is
-      // honest about staleness without arguing against the content.
-      diff = '(the anchor changed since this was recorded and the diff can no longer be '
-        + 'reconstructed; the claim itself may well still hold, so weigh it rather than '
-        + 'discard it)';
+      // So: report what is actually known and let the claim stand or fall on its
+      // own. That is honest about staleness without arguing against the content.
+      //
+      // REASON-NEUTRAL. The earlier text asserted "the anchor changed", which is
+      // only one of the ways a finding reaches this branch -- it is also reached
+      // when the eager path marked the finding at write time, or when the anchor
+      // was never snapshotted at all because it exceeded the snapshot limit. In
+      // those cases the sentence stated a cause that had not been established.
+      // `reason` already carries whatever was actually determined, so the
+      // fallback now describes only the evidence gap.
+      diff = `(marked stale: ${reason}. The supporting diff can no longer be `
+        + 'reconstructed; the claim itself may well still hold, so weigh it rather '
+        + 'than discard it)';
     }
 
     served.push({ ...finding, stale, ...(stale ? { diff, staleReason: reason } : {}) });

--- a/integrations/codex/hooks/lib/staleness.mjs
+++ b/integrations/codex/hooks/lib/staleness.mjs
@@ -379,9 +379,14 @@ export function serve(graph, findings) {
       // those cases the sentence stated a cause that had not been established.
       // `reason` already carries whatever was actually determined, so the
       // fallback now describes only the evidence gap.
+      // NO DISMISSAL VOCABULARY AT ALL, not even in a sentence arguing against
+      // dismissal. "weigh it rather than discard it" still puts the word in
+      // front of the model, and this text exists precisely because the previous
+      // phrasing was measured suppressing correct findings. State the evidence
+      // gap and stop.
       diff = `(marked stale: ${reason}. The supporting diff can no longer be `
-        + 'reconstructed; the claim itself may well still hold, so weigh it rather '
-        + 'than discard it)';
+        + 'reconstructed; the claim itself may well still hold, so weigh it on '
+        + 'its own merits.)';
     }
 
     served.push({ ...finding, stale, ...(stale ? { diff, staleReason: reason } : {}) });

--- a/integrations/codex/plugin/.mcp.json
+++ b/integrations/codex/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcp_servers": {
     "token-optimizer": {
       "command": "npx",
-      "args": ["-y", "@ooples/token-optimizer-mcp@5.3.2"]
+      "args": ["-y", "@ooples/token-optimizer-mcp@5.3.6"]
     }
   }
 }

--- a/integrations/codex/plugin/hooks/lib/harvest-write.mjs
+++ b/integrations/codex/plugin/hooks/lib/harvest-write.mjs
@@ -118,6 +118,14 @@ export function writeHarvested(
         claim: finding.claim,
         confidence: finding.confidence,
         type: finding.type,
+        // WHEN this finding is relevant, not just what it is about. Anchors
+        // answer "which file", which is the wrong question for a claim about
+        // running something: the agent that needs "use npm test, not npx jest"
+        // is executing a command, not reading the file the claim is anchored
+        // to. Optional, so nothing that omits it changes behaviour.
+        trigger: typeof finding.trigger === 'string' && finding.trigger
+          ? finding.trigger
+          : undefined,
         origin: provenance,
         sessionId,
       },

--- a/integrations/codex/plugin/hooks/lib/inject.mjs
+++ b/integrations/codex/plugin/hooks/lib/inject.mjs
@@ -30,6 +30,42 @@ import { substitutionBudget } from './metrics.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
+
+/** Most findings considered for one command before the budget decides. */
+const MAX_COMMAND_CANDIDATES = 20;
+
+/**
+ * Compiles a finding's trigger, or returns null if it is not safe to run.
+ *
+ * TRIGGERS ARE MODEL-SUPPLIED. The harvest writes them, and a model asked for a
+ * regex can produce `(a+)+b` as readily as `\bnpx\b` -- a pattern whose
+ * backtracking is exponential in the input length. That would execute on the
+ * PreToolUse path against a command the user is waiting on, so a single bad
+ * trigger would hang every subsequent tool call in the session. Neither a
+ * try/catch nor a timeout helps: catastrophic backtracking does not throw, it
+ * simply does not return.
+ *
+ * So the pattern is rejected before it is ever run. The test is deliberately
+ * conservative -- nested quantifiers are the shape that causes this, and no
+ * legitimate trigger for a command needs one.
+ */
+export function safeTrigger(source) {
+  const raw = String(source || '');
+  if (!raw || raw.length > 200) return null;
+
+  // A quantifier applied to a group that itself contains a quantifier: (a+)+,
+  // (a*)*, (\d+)*, (?:ab+)+ and so on. This is the classic ReDoS shape.
+  if (/\([^)]*[+*}][^)]*\)\s*[+*{]/.test(raw)) return null;
+
+  // Stacked quantifiers outside a group, e.g. `a+*` or `.*+`.
+  if (/[+*}]\s*[+*]/.test(raw)) return null;
+
+  try {
+    return new RegExp(raw, 'i');
+  } catch {
+    return null;
+  }
+}
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
 
 /**
@@ -66,11 +102,21 @@ function render(finding) {
  * measurement holdout -- in which case the caller must behave exactly as if the
  * graph were empty, or the experiment measures nothing.
  */
-export function forTouch(dir, graph, rawPath, { budget = touchBudget(), sessionId } = {}) {
+export function forTouch(
+  dir,
+  graph,
+  rawPath,
+  { budget = touchBudget(), sessionId, alreadyInjected = new Set() } = {}
+) {
   // Canonical, so a touch finds findings anchored under any other spelling.
   const filePath = canonicalPath(rawPath);
   const anchorId = nodeId('file', filePath);
-  const candidates = findingsFor(graph, anchorId, { limit: 30 });
+  // The same once-per-session gate the command path uses. A file touched
+  // repeatedly -- which is the normal shape of working on it -- would otherwise
+  // re-serve the same findings on every single touch, which is both a token
+  // cost per call and the fastest way to train a model to skim past them.
+  const candidates = findingsFor(graph, anchorId, { limit: 30 })
+    .filter((f) => !alreadyInjected.has(f.key));
   if (!candidates.length) return null;
 
   const holdout = inHoldout(filePath);
@@ -88,6 +134,8 @@ export function forTouch(dir, graph, rawPath, { budget = touchBudget(), sessionI
   });
 
   if (holdout || !kept.length) return null;
+
+  for (const f of kept) alreadyInjected.add(f.key);
 
   return `Known about ${filePath} (from previous sessions):\n${kept.map(render).join('\n')}`;
 }
@@ -111,13 +159,18 @@ function appliesToCommand(finding, command) {
   if (!text) return false;
 
   if (finding.trigger) {
-    try {
-      return new RegExp(finding.trigger, 'i').test(text);
-    } catch {
-      // A malformed trigger must not throw on the hook path; fall back to a
-      // literal search so a bad regex degrades to a substring match.
-      return text.toLowerCase().includes(String(finding.trigger).toLowerCase());
+    const pattern = safeTrigger(finding.trigger);
+    if (pattern) {
+      try {
+        return pattern.test(text);
+      } catch {
+        return false;
+      }
     }
+    // Rejected as unsafe or malformed: fall back to a literal search, which
+    // cannot backtrack. A bad trigger degrades to a substring match rather
+    // than taking the hook down or hanging it.
+    return text.toLowerCase().includes(String(finding.trigger).toLowerCase());
   }
 
   // Untriggered findings only qualify if they are about doing something.
@@ -203,7 +256,14 @@ export function forCommand(
   // Highest confidence first, so a tight budget keeps the most trustworthy.
   candidates.sort((a, b) => (b.confidence ?? 0.5) - (a.confidence ?? 0.5));
 
-  const served = serve(graph, candidates);
+  // CAPPED BEFORE serve(). serve() re-reads and diffs the anchor of every
+  // finding it is handed, so an unbounded candidate list turns one command into
+  // one file read per matching finding -- on the hook path, with the user
+  // waiting. The budget would discard the surplus a moment later anyway, so the
+  // only thing an uncapped list buys is the I/O.
+  const considered = candidates.slice(0, MAX_COMMAND_CANDIDATES);
+
+  const served = serve(graph, considered);
   const { kept, spent } = fit(served, budget);
   if (!kept.length) return null;
 

--- a/integrations/codex/plugin/hooks/lib/inject.mjs
+++ b/integrations/codex/plugin/hooks/lib/inject.mjs
@@ -93,6 +93,139 @@ export function forTouch(dir, graph, rawPath, { budget = touchBudget(), sessionI
 }
 
 /**
+ * Does this finding apply to the command about to run?
+ *
+ * A finding carries an optional `trigger`: a string or regex source matched
+ * against the command text. Explicit beats inferred -- the alternative was
+ * scraping command-looking tokens out of the claim, which both misses (a claim
+ * that describes the command in prose) and misfires (a claim that merely
+ * mentions a command it is not about).
+ *
+ * With no trigger, a `command` or `failure` finding still qualifies on a weaker
+ * test: the command mentions a distinctive token from the claim. That keeps the
+ * findings already in existing graphs useful without a migration, while new
+ * ones can be precise.
+ */
+function appliesToCommand(finding, command) {
+  const text = String(command || '');
+  if (!text) return false;
+
+  if (finding.trigger) {
+    try {
+      return new RegExp(finding.trigger, 'i').test(text);
+    } catch {
+      // A malformed trigger must not throw on the hook path; fall back to a
+      // literal search so a bad regex degrades to a substring match.
+      return text.toLowerCase().includes(String(finding.trigger).toLowerCase());
+    }
+  }
+
+  // Untriggered findings only qualify if they are about doing something.
+  if (finding.type !== 'command' && finding.type !== 'failure') return false;
+
+  // Distinctive tokens, matched as WHOLE WORDS.
+  //
+  // The floor is three characters because the tokens that carry the meaning are
+  // short: jest, npm, git, ssh, tsc. A five-character floor -- the first
+  // attempt -- excluded "jest" from the very finding this feature exists to
+  // deliver, which the tests caught. Whole-word matching is what makes the low
+  // floor safe: without it "npm" would fire on any path containing "npm", and
+  // every claim mentioning a common word would match every command.
+  const claim = String(finding.claim || '');
+  const tokens = [
+    ...new Set(
+      (claim.match(/[a-z][a-z0-9._-]{2,}/gi) || [])
+        .map((t) => t.toLowerCase().replace(/[._-]+$/, ''))
+        .filter((t) => t.length >= 3 && !STOPWORDS.has(t))
+    ),
+  ];
+
+  return tokens.some((t) => {
+    const escaped = t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    try {
+      return new RegExp(`(^|[^a-z0-9])${escaped}([^a-z0-9]|$)`, 'i').test(text);
+    } catch {
+      return false;
+    }
+  });
+}
+
+/**
+ * Words common enough that matching on them would fire on every command.
+ * Deliberately small: this is a noise floor, not a language model.
+ */
+const STOPWORDS = new Set([
+  // Long enough to pass the length floor, common enough to match anything.
+  'about', 'after', 'again', 'against', 'because', 'before', 'being', 'between',
+  'could', 'every', 'first', 'instead', 'other', 'rather', 'should', 'since',
+  'their', 'there', 'these', 'thing', 'those', 'through', 'where', 'which',
+  'while', 'would', 'without', 'project', 'always', 'never',
+  // Short words that only became candidates once the floor dropped to three,
+  // which it had to so that the tool names that matter -- jest, npm, git, ssh
+  // -- are matchable at all.
+  'and', 'are', 'but', 'for', 'from', 'has', 'have', 'into', 'its', 'not',
+  'one', 'only', 'our', 'out', 'same', 'some', 'such', 'than', 'that', 'the',
+  'them', 'then', 'they', 'this', 'too', 'use', 'used', 'very', 'was', 'were',
+  'what', 'when', 'will', 'with', 'you', 'your', 'run', 'runs', 'way', 'why',
+]);
+
+/**
+ * What the model sees when it is about to RUN something.
+ *
+ * The gap this closes: injection was keyed entirely on touching a FILE, but the
+ * findings worth the most are about ACTIONS. The case that proved it -- a
+ * finding of type `command`, "run the suite with npm test, not npx jest",
+ * anchored to a source file. An agent about to run `npx jest` is not touching
+ * that file, so the finding could not fire at the only moment it mattered, and
+ * the agent made exactly the mistake the graph had already recorded.
+ *
+ * `alreadyInjected` is the once-per-session gate. Repeating the same advice on
+ * every command is how a real signal becomes wallpaper, and an ignored
+ * injection still costs its tokens on every call.
+ */
+export function forCommand(
+  dir,
+  graph,
+  command,
+  { budget = touchBudget(), sessionId, alreadyInjected = new Set() } = {}
+) {
+  if (!command) return null;
+
+  const candidates = [];
+  for (const node of graph.nodes.values()) {
+    if (node.kind !== 'finding' || node.retired) continue;
+    if (alreadyInjected.has(node.key)) continue;
+    if (!appliesToCommand(node, command)) continue;
+    candidates.push(node);
+  }
+  if (!candidates.length) return null;
+
+  // Highest confidence first, so a tight budget keeps the most trustworthy.
+  candidates.sort((a, b) => (b.confidence ?? 0.5) - (a.confidence ?? 0.5));
+
+  const served = serve(graph, candidates);
+  const { kept, spent } = fit(served, budget);
+  if (!kept.length) return null;
+
+  record(dir, {
+    kind: 'inject',
+    trigger: 'command',
+    anchor: String(command).slice(0, 120),
+    holdout: false,
+    tokens: spent,
+    count: kept.length,
+    stale: kept.some((f) => f.stale),
+    sessionId,
+  });
+
+  for (const f of kept) alreadyInjected.add(f.key);
+
+  return `Before running this — known from previous sessions:\n${kept
+    .map(render)
+    .join('\n')}`;
+}
+
+/**
  * The bounded SessionStart index: titles and ids only, never bodies.
  *
  * Its budget is EARNED from measured hit rate rather than fixed, so a mature

--- a/integrations/codex/plugin/hooks/lib/inject.mjs
+++ b/integrations/codex/plugin/hooks/lib/inject.mjs
@@ -254,7 +254,21 @@ export function forCommand(
   if (!candidates.length) return null;
 
   // Highest confidence first, so a tight budget keeps the most trustworthy.
-  candidates.sort((a, b) => (b.confidence ?? 0.5) - (a.confidence ?? 0.5));
+  // AN EXPLICIT TRIGGER BEATS AN INCIDENTAL WORD, before confidence is even
+  // consulted. A finding whose author wrote a pattern that matched this command
+  // is about this command; one that matched because its prose happened to
+  // contain "build" is not, however confident it was about something else.
+  //
+  // Observed live: `dotnet build App.csproj | tail -20` surfaced a finding about
+  // stale MCP server processes instead of the one about pipes hiding exit
+  // codes, and `gh run list` surfaced a git-refspec finding instead of the one
+  // about mergeStateStatus. Both had the same confidence as the right answer,
+  // so confidence alone could not separate them -- and a tight budget then kept
+  // the wrong one.
+  const explicit = (n) => (n.trigger && safeTrigger(n.trigger)?.test(command) ? 1 : 0);
+  candidates.sort(
+    (a, b) => explicit(b) - explicit(a) || (b.confidence ?? 0.5) - (a.confidence ?? 0.5)
+  );
 
   // CAPPED BEFORE serve(). serve() re-reads and diffs the anchor of every
   // finding it is handed, so an unbounded candidate list turns one command into

--- a/integrations/codex/plugin/hooks/lib/policy.mjs
+++ b/integrations/codex/plugin/hooks/lib/policy.mjs
@@ -318,6 +318,36 @@ export function allow() {
 }
 
 /**
+ * Allows the call AND hands the model something it did not ask for.
+ *
+ * This is the delivery half of the knowledge graph, and it had no
+ * implementation. `forTouch` -- the just-in-time injection the design calls
+ * "where the win lands" -- was imported by nothing outside its own test, so a
+ * finding could only ever reach a model through a REFUSAL. Measured across a
+ * full working session on three real projects: 4,053 capture events, 2,063
+ * reads, and findings served exactly twice. The graph was writing knowledge it
+ * had no way to deliver.
+ *
+ * `additionalContext` rather than a `permissionDecisionReason`, because the call
+ * is not being judged -- it is proceeding, and this rides along with it. Nothing
+ * is emitted when there is nothing to say, so the common path stays a bare
+ * exit(0).
+ */
+export function allowWithContext(context) {
+  if (context) {
+    process.stdout.write(
+      JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          additionalContext: withEscape(context),
+        },
+      })
+    );
+  }
+  process.exit(0);
+}
+
+/**
  * Blocks the call and tells the model exactly what to call instead.
  *
  * The reason string is the whole user interface of this product for an agent.

--- a/integrations/codex/plugin/hooks/lib/policy.mjs
+++ b/integrations/codex/plugin/hooks/lib/policy.mjs
@@ -190,7 +190,7 @@ function statePath(sessionId) {
 
 /** A usable state object, whatever was on disk. */
 function emptyState() {
-  return { seen: {}, denied: {} };
+  return { seen: {}, denied: {}, injected: [] };
 }
 
 /**
@@ -210,6 +210,13 @@ export function loadState(sessionId) {
     return {
       seen: parsed.seen && typeof parsed.seen === 'object' ? parsed.seen : {},
       denied: parsed.denied && typeof parsed.denied === 'object' ? parsed.denied : {},
+      // WITHOUT THIS THE ONCE-PER-SESSION GATE DOES NOT EXIST. Every tool call
+      // is a separate hook PROCESS, so a set held only in memory dies with the
+      // process that built it: the router recorded which findings it had
+      // injected, saveState dropped the field, and the next call re-injected
+      // the same advice. The gate looked correct in unit tests, which share one
+      // process, and did nothing at all in production.
+      injected: Array.isArray(parsed.injected) ? parsed.injected : [],
     };
   } catch {
     return emptyState();
@@ -252,6 +259,11 @@ export function saveState(sessionId, state) {
     const merged = {
       seen: { ...current.seen, ...state.seen },
       denied: { ...current.denied, ...state.denied },
+      // UNION, not overwrite. Two hook processes running in parallel each hold
+      // their own view of what has been injected; taking the last writer's copy
+      // would resurrect a finding the other had already delivered, which is the
+      // repetition the once-per-session gate exists to stop.
+      injected: [...new Set([...(current.injected || []), ...(state.injected || [])])],
     };
 
     // Write-then-rename so a reader never observes a half-written file.

--- a/integrations/codex/plugin/hooks/lib/policy.mjs
+++ b/integrations/codex/plugin/hooks/lib/policy.mjs
@@ -179,13 +179,23 @@ export function fileSize(path) {
  * means state on disk, keyed by the session id the hook payload carries.
  * ------------------------------------------------------------------ */
 
-const STATE_ROOT = join(tmpdir(), 'token-optimizer-hooks');
+/**
+ * Where per-session hook state lives.
+ *
+ * Read per call rather than captured at import, so a test can point it at a
+ * temp directory. Contention on this file is the normal case -- parallel tool
+ * calls each spawn their own hook process -- and it was untestable while the
+ * path was a module constant, which is part of why an unlocked
+ * read-modify-write survived here unnoticed.
+ */
+const stateRoot = () =>
+  process.env.TOKEN_OPTIMIZER_STATE_DIR || join(tmpdir(), 'token-optimizer-hooks');
 
 function statePath(sessionId) {
   // Session ids come from the harness and are uuid-shaped, but they land in a
   // file path, so anything that could traverse is stripped rather than trusted.
   const safe = String(sessionId || 'default').replace(/[^A-Za-z0-9_-]/g, '');
-  return join(STATE_ROOT, `${safe || 'default'}.json`);
+  return join(stateRoot(), `${safe || 'default'}.json`);
 }
 
 /** A usable state object, whatever was on disk. */
@@ -242,18 +252,26 @@ export function loadState(sessionId) {
 export function saveState(sessionId, state) {
   let lock = null;
   try {
-    mkdirSync(STATE_ROOT, { recursive: true, mode: 0o700 });
+    mkdirSync(stateRoot(), { recursive: true, mode: 0o700 });
 
     // A LOCK, because merging alone still loses updates: two processes can both
     // read, both merge, and the second write still discards the first's
     // additions. `wx` fails if the file exists, which makes creation an atomic
     // test-and-set on every platform we target.
     //
-    // Bounded and best-effort: if the lock cannot be taken quickly the write
-    // proceeds anyway. A stale lock from a killed process must never wedge
-    // enforcement, and the worst case without the lock is the merge behaviour
-    // that was already acceptable.
+    // NO UNLOCKED READ-MODIFY-WRITE. This used to fall through and write anyway
+    // when the lock could not be taken, which reintroduces exactly the lost
+    // update the lock exists to prevent: a process that misses the lock reads
+    // the pre-merge state and can erase an `injected` id another process just
+    // recorded, letting the same finding be injected twice in one session.
+    //
+    // Skipping the write is the safe direction. The cost is that THIS process's
+    // additions are not persisted, and every consequence of that is already
+    // bounded by design -- a repeated denial is allowed through by rule, and a
+    // repeated injection costs its tokens once more. A stale lock is still
+    // broken and taken below, so a killed process cannot wedge enforcement.
     lock = takeLock(sessionId);
+    if (!lock) return false;
 
     const current = loadState(sessionId);
     const merged = {
@@ -286,7 +304,25 @@ export function saveState(sessionId, state) {
 }
 
 /** Best-effort exclusive lock. Returns the lock path, or null if not acquired. */
-function takeLock(sessionId, { attempts = 20, staleMs = 5000 } = {}) {
+/**
+ * Sleeps synchronously.
+ *
+ * These hooks are single-shot processes that must reach a decision before they
+ * return, so there is no event loop to yield to and nothing to await. Atomics
+ * on a throwaway SharedArrayBuffer is the standard way to block a worker for a
+ * bounded time without burning the CPU.
+ */
+function sleepSync(ms) {
+  try {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+  } catch {
+    // SharedArrayBuffer unavailable under some policies. The caller still makes
+    // progress; it simply retries sooner.
+  }
+}
+
+/** Best-effort exclusive lock. Returns the lock path, or null if not acquired. */
+function takeLock(sessionId, { attempts = 20, staleMs = 5000, waitMs = 15 } = {}) {
   const path = `${statePath(sessionId)}.lock`;
   for (let i = 0; i < attempts; i++) {
     try {
@@ -297,10 +333,21 @@ function takeLock(sessionId, { attempts = 20, staleMs = 5000 } = {}) {
       // A lock left behind by a killed process would otherwise block every
       // future write for the life of the session.
       try {
-        if (Date.now() - statSync(path).mtimeMs > staleMs) unlinkSync(path);
+        if (Date.now() - statSync(path).mtimeMs > staleMs) {
+          unlinkSync(path);
+          continue; // Retry immediately; the holder is gone.
+        }
       } catch {
-        // Raced with the holder releasing it; just retry.
+        // Raced with the holder releasing it; retry immediately.
+        continue;
       }
+
+      // A LIVE holder. Waiting is the whole point: the previous loop retried
+      // 20 times with no delay, so it exhausted in microseconds and the caller
+      // fell through to an unlocked write. Backing off actually lets the holder
+      // finish -- a state write is a few milliseconds -- which is the
+      // difference between contending and merely pretending to.
+      if (i < attempts - 1) sleepSync(waitMs);
     }
   }
   return null;

--- a/integrations/codex/plugin/hooks/lib/staleness.mjs
+++ b/integrations/codex/plugin/hooks/lib/staleness.mjs
@@ -359,10 +359,22 @@ export function serve(graph, findings) {
     }
 
     if (stale && !diff) {
-      // The invariant. Rather than serve a bare stale finding -- which the
-      // design calls worse than no graph -- say plainly that the evidence is
-      // gone, so the model treats the claim as unverified rather than current.
-      diff = '(the change could not be reconstructed; treat this finding as unverified)';
+      // The invariant holds: never serve a bare stale finding as though it were
+      // current. But the WORDING was doing more than that, and it was measured.
+      //
+      // "treat this finding as unverified" is an instruction to discount, and
+      // models follow it. In an A/B on a fresh subagent, identical findings
+      // scored 1/3 dead-ends avoided when rendered with that sentence and 2/3
+      // when rendered clean -- no code change, only the wording. The claim being
+      // discounted was correct every time; all that had changed was the anchor
+      // file, which says nothing about whether the claim still holds.
+      //
+      // So: report what is actually known -- the anchor moved and the evidence
+      // cannot be rebuilt -- and let the claim stand or fall on its own. That is
+      // honest about staleness without arguing against the content.
+      diff = '(the anchor changed since this was recorded and the diff can no longer be '
+        + 'reconstructed; the claim itself may well still hold, so weigh it rather than '
+        + 'discard it)';
     }
 
     served.push({ ...finding, stale, ...(stale ? { diff, staleReason: reason } : {}) });

--- a/integrations/codex/plugin/hooks/lib/staleness.mjs
+++ b/integrations/codex/plugin/hooks/lib/staleness.mjs
@@ -369,12 +369,19 @@ export function serve(graph, findings) {
       // discounted was correct every time; all that had changed was the anchor
       // file, which says nothing about whether the claim still holds.
       //
-      // So: report what is actually known -- the anchor moved and the evidence
-      // cannot be rebuilt -- and let the claim stand or fall on its own. That is
-      // honest about staleness without arguing against the content.
-      diff = '(the anchor changed since this was recorded and the diff can no longer be '
-        + 'reconstructed; the claim itself may well still hold, so weigh it rather than '
-        + 'discard it)';
+      // So: report what is actually known and let the claim stand or fall on its
+      // own. That is honest about staleness without arguing against the content.
+      //
+      // REASON-NEUTRAL. The earlier text asserted "the anchor changed", which is
+      // only one of the ways a finding reaches this branch -- it is also reached
+      // when the eager path marked the finding at write time, or when the anchor
+      // was never snapshotted at all because it exceeded the snapshot limit. In
+      // those cases the sentence stated a cause that had not been established.
+      // `reason` already carries whatever was actually determined, so the
+      // fallback now describes only the evidence gap.
+      diff = `(marked stale: ${reason}. The supporting diff can no longer be `
+        + 'reconstructed; the claim itself may well still hold, so weigh it rather '
+        + 'than discard it)';
     }
 
     served.push({ ...finding, stale, ...(stale ? { diff, staleReason: reason } : {}) });

--- a/integrations/codex/plugin/hooks/lib/staleness.mjs
+++ b/integrations/codex/plugin/hooks/lib/staleness.mjs
@@ -379,9 +379,14 @@ export function serve(graph, findings) {
       // those cases the sentence stated a cause that had not been established.
       // `reason` already carries whatever was actually determined, so the
       // fallback now describes only the evidence gap.
+      // NO DISMISSAL VOCABULARY AT ALL, not even in a sentence arguing against
+      // dismissal. "weigh it rather than discard it" still puts the word in
+      // front of the model, and this text exists precisely because the previous
+      // phrasing was measured suppressing correct findings. State the evidence
+      // gap and stop.
       diff = `(marked stale: ${reason}. The supporting diff can no longer be `
-        + 'reconstructed; the claim itself may well still hold, so weigh it rather '
-        + 'than discard it)';
+        + 'reconstructed; the claim itself may well still hold, so weigh it on '
+        + 'its own merits.)';
     }
 
     served.push({ ...finding, stale, ...(stale ? { diff, staleReason: reason } : {}) });

--- a/integrations/continue/config.yaml
+++ b/integrations/continue/config.yaml
@@ -1,4 +1,4 @@
 mcpServers:
   - name: token-optimizer
     command: npx
-    args: ["-y", "@ooples/token-optimizer-mcp@5.3.2"]
+    args: ["-y", "@ooples/token-optimizer-mcp@5.3.6"]

--- a/integrations/copilot/mcp-config.json
+++ b/integrations/copilot/mcp-config.json
@@ -3,7 +3,7 @@
     "token-optimizer": {
       "type": "local",
       "command": "npx",
-      "args": ["-y", "@ooples/token-optimizer-mcp@5.3.2"],
+      "args": ["-y", "@ooples/token-optimizer-mcp@5.3.6"],
       "tools": ["*"]
     }
   }

--- a/integrations/crush/crush.json
+++ b/integrations/crush/crush.json
@@ -5,7 +5,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@ooples/token-optimizer-mcp@5.3.2"
+        "@ooples/token-optimizer-mcp@5.3.6"
       ],
       "env": {}
     }

--- a/integrations/cursor/mcp.json
+++ b/integrations/cursor/mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@ooples/token-optimizer-mcp@5.3.2"
+        "@ooples/token-optimizer-mcp@5.3.6"
       ],
       "env": {}
     }

--- a/integrations/droid/mcp.json
+++ b/integrations/droid/mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@ooples/token-optimizer-mcp@5.3.2"
+        "@ooples/token-optimizer-mcp@5.3.6"
       ],
       "env": {}
     }

--- a/integrations/gemini/gemini-extension.json
+++ b/integrations/gemini/gemini-extension.json
@@ -5,7 +5,7 @@
   "mcpServers": {
     "token-optimizer": {
       "command": "npx",
-      "args": ["-y", "@ooples/token-optimizer-mcp@5.3.2"]
+      "args": ["-y", "@ooples/token-optimizer-mcp@5.3.6"]
     }
   },
   "settings": [

--- a/integrations/gemini/hooks/lib/harvest-write.mjs
+++ b/integrations/gemini/hooks/lib/harvest-write.mjs
@@ -118,6 +118,14 @@ export function writeHarvested(
         claim: finding.claim,
         confidence: finding.confidence,
         type: finding.type,
+        // WHEN this finding is relevant, not just what it is about. Anchors
+        // answer "which file", which is the wrong question for a claim about
+        // running something: the agent that needs "use npm test, not npx jest"
+        // is executing a command, not reading the file the claim is anchored
+        // to. Optional, so nothing that omits it changes behaviour.
+        trigger: typeof finding.trigger === 'string' && finding.trigger
+          ? finding.trigger
+          : undefined,
         origin: provenance,
         sessionId,
       },

--- a/integrations/gemini/hooks/lib/inject.mjs
+++ b/integrations/gemini/hooks/lib/inject.mjs
@@ -30,6 +30,42 @@ import { substitutionBudget } from './metrics.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
+
+/** Most findings considered for one command before the budget decides. */
+const MAX_COMMAND_CANDIDATES = 20;
+
+/**
+ * Compiles a finding's trigger, or returns null if it is not safe to run.
+ *
+ * TRIGGERS ARE MODEL-SUPPLIED. The harvest writes them, and a model asked for a
+ * regex can produce `(a+)+b` as readily as `\bnpx\b` -- a pattern whose
+ * backtracking is exponential in the input length. That would execute on the
+ * PreToolUse path against a command the user is waiting on, so a single bad
+ * trigger would hang every subsequent tool call in the session. Neither a
+ * try/catch nor a timeout helps: catastrophic backtracking does not throw, it
+ * simply does not return.
+ *
+ * So the pattern is rejected before it is ever run. The test is deliberately
+ * conservative -- nested quantifiers are the shape that causes this, and no
+ * legitimate trigger for a command needs one.
+ */
+export function safeTrigger(source) {
+  const raw = String(source || '');
+  if (!raw || raw.length > 200) return null;
+
+  // A quantifier applied to a group that itself contains a quantifier: (a+)+,
+  // (a*)*, (\d+)*, (?:ab+)+ and so on. This is the classic ReDoS shape.
+  if (/\([^)]*[+*}][^)]*\)\s*[+*{]/.test(raw)) return null;
+
+  // Stacked quantifiers outside a group, e.g. `a+*` or `.*+`.
+  if (/[+*}]\s*[+*]/.test(raw)) return null;
+
+  try {
+    return new RegExp(raw, 'i');
+  } catch {
+    return null;
+  }
+}
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
 
 /**
@@ -66,11 +102,21 @@ function render(finding) {
  * measurement holdout -- in which case the caller must behave exactly as if the
  * graph were empty, or the experiment measures nothing.
  */
-export function forTouch(dir, graph, rawPath, { budget = touchBudget(), sessionId } = {}) {
+export function forTouch(
+  dir,
+  graph,
+  rawPath,
+  { budget = touchBudget(), sessionId, alreadyInjected = new Set() } = {}
+) {
   // Canonical, so a touch finds findings anchored under any other spelling.
   const filePath = canonicalPath(rawPath);
   const anchorId = nodeId('file', filePath);
-  const candidates = findingsFor(graph, anchorId, { limit: 30 });
+  // The same once-per-session gate the command path uses. A file touched
+  // repeatedly -- which is the normal shape of working on it -- would otherwise
+  // re-serve the same findings on every single touch, which is both a token
+  // cost per call and the fastest way to train a model to skim past them.
+  const candidates = findingsFor(graph, anchorId, { limit: 30 })
+    .filter((f) => !alreadyInjected.has(f.key));
   if (!candidates.length) return null;
 
   const holdout = inHoldout(filePath);
@@ -88,6 +134,8 @@ export function forTouch(dir, graph, rawPath, { budget = touchBudget(), sessionI
   });
 
   if (holdout || !kept.length) return null;
+
+  for (const f of kept) alreadyInjected.add(f.key);
 
   return `Known about ${filePath} (from previous sessions):\n${kept.map(render).join('\n')}`;
 }
@@ -111,13 +159,18 @@ function appliesToCommand(finding, command) {
   if (!text) return false;
 
   if (finding.trigger) {
-    try {
-      return new RegExp(finding.trigger, 'i').test(text);
-    } catch {
-      // A malformed trigger must not throw on the hook path; fall back to a
-      // literal search so a bad regex degrades to a substring match.
-      return text.toLowerCase().includes(String(finding.trigger).toLowerCase());
+    const pattern = safeTrigger(finding.trigger);
+    if (pattern) {
+      try {
+        return pattern.test(text);
+      } catch {
+        return false;
+      }
     }
+    // Rejected as unsafe or malformed: fall back to a literal search, which
+    // cannot backtrack. A bad trigger degrades to a substring match rather
+    // than taking the hook down or hanging it.
+    return text.toLowerCase().includes(String(finding.trigger).toLowerCase());
   }
 
   // Untriggered findings only qualify if they are about doing something.
@@ -203,7 +256,14 @@ export function forCommand(
   // Highest confidence first, so a tight budget keeps the most trustworthy.
   candidates.sort((a, b) => (b.confidence ?? 0.5) - (a.confidence ?? 0.5));
 
-  const served = serve(graph, candidates);
+  // CAPPED BEFORE serve(). serve() re-reads and diffs the anchor of every
+  // finding it is handed, so an unbounded candidate list turns one command into
+  // one file read per matching finding -- on the hook path, with the user
+  // waiting. The budget would discard the surplus a moment later anyway, so the
+  // only thing an uncapped list buys is the I/O.
+  const considered = candidates.slice(0, MAX_COMMAND_CANDIDATES);
+
+  const served = serve(graph, considered);
   const { kept, spent } = fit(served, budget);
   if (!kept.length) return null;
 

--- a/integrations/gemini/hooks/lib/inject.mjs
+++ b/integrations/gemini/hooks/lib/inject.mjs
@@ -93,6 +93,139 @@ export function forTouch(dir, graph, rawPath, { budget = touchBudget(), sessionI
 }
 
 /**
+ * Does this finding apply to the command about to run?
+ *
+ * A finding carries an optional `trigger`: a string or regex source matched
+ * against the command text. Explicit beats inferred -- the alternative was
+ * scraping command-looking tokens out of the claim, which both misses (a claim
+ * that describes the command in prose) and misfires (a claim that merely
+ * mentions a command it is not about).
+ *
+ * With no trigger, a `command` or `failure` finding still qualifies on a weaker
+ * test: the command mentions a distinctive token from the claim. That keeps the
+ * findings already in existing graphs useful without a migration, while new
+ * ones can be precise.
+ */
+function appliesToCommand(finding, command) {
+  const text = String(command || '');
+  if (!text) return false;
+
+  if (finding.trigger) {
+    try {
+      return new RegExp(finding.trigger, 'i').test(text);
+    } catch {
+      // A malformed trigger must not throw on the hook path; fall back to a
+      // literal search so a bad regex degrades to a substring match.
+      return text.toLowerCase().includes(String(finding.trigger).toLowerCase());
+    }
+  }
+
+  // Untriggered findings only qualify if they are about doing something.
+  if (finding.type !== 'command' && finding.type !== 'failure') return false;
+
+  // Distinctive tokens, matched as WHOLE WORDS.
+  //
+  // The floor is three characters because the tokens that carry the meaning are
+  // short: jest, npm, git, ssh, tsc. A five-character floor -- the first
+  // attempt -- excluded "jest" from the very finding this feature exists to
+  // deliver, which the tests caught. Whole-word matching is what makes the low
+  // floor safe: without it "npm" would fire on any path containing "npm", and
+  // every claim mentioning a common word would match every command.
+  const claim = String(finding.claim || '');
+  const tokens = [
+    ...new Set(
+      (claim.match(/[a-z][a-z0-9._-]{2,}/gi) || [])
+        .map((t) => t.toLowerCase().replace(/[._-]+$/, ''))
+        .filter((t) => t.length >= 3 && !STOPWORDS.has(t))
+    ),
+  ];
+
+  return tokens.some((t) => {
+    const escaped = t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    try {
+      return new RegExp(`(^|[^a-z0-9])${escaped}([^a-z0-9]|$)`, 'i').test(text);
+    } catch {
+      return false;
+    }
+  });
+}
+
+/**
+ * Words common enough that matching on them would fire on every command.
+ * Deliberately small: this is a noise floor, not a language model.
+ */
+const STOPWORDS = new Set([
+  // Long enough to pass the length floor, common enough to match anything.
+  'about', 'after', 'again', 'against', 'because', 'before', 'being', 'between',
+  'could', 'every', 'first', 'instead', 'other', 'rather', 'should', 'since',
+  'their', 'there', 'these', 'thing', 'those', 'through', 'where', 'which',
+  'while', 'would', 'without', 'project', 'always', 'never',
+  // Short words that only became candidates once the floor dropped to three,
+  // which it had to so that the tool names that matter -- jest, npm, git, ssh
+  // -- are matchable at all.
+  'and', 'are', 'but', 'for', 'from', 'has', 'have', 'into', 'its', 'not',
+  'one', 'only', 'our', 'out', 'same', 'some', 'such', 'than', 'that', 'the',
+  'them', 'then', 'they', 'this', 'too', 'use', 'used', 'very', 'was', 'were',
+  'what', 'when', 'will', 'with', 'you', 'your', 'run', 'runs', 'way', 'why',
+]);
+
+/**
+ * What the model sees when it is about to RUN something.
+ *
+ * The gap this closes: injection was keyed entirely on touching a FILE, but the
+ * findings worth the most are about ACTIONS. The case that proved it -- a
+ * finding of type `command`, "run the suite with npm test, not npx jest",
+ * anchored to a source file. An agent about to run `npx jest` is not touching
+ * that file, so the finding could not fire at the only moment it mattered, and
+ * the agent made exactly the mistake the graph had already recorded.
+ *
+ * `alreadyInjected` is the once-per-session gate. Repeating the same advice on
+ * every command is how a real signal becomes wallpaper, and an ignored
+ * injection still costs its tokens on every call.
+ */
+export function forCommand(
+  dir,
+  graph,
+  command,
+  { budget = touchBudget(), sessionId, alreadyInjected = new Set() } = {}
+) {
+  if (!command) return null;
+
+  const candidates = [];
+  for (const node of graph.nodes.values()) {
+    if (node.kind !== 'finding' || node.retired) continue;
+    if (alreadyInjected.has(node.key)) continue;
+    if (!appliesToCommand(node, command)) continue;
+    candidates.push(node);
+  }
+  if (!candidates.length) return null;
+
+  // Highest confidence first, so a tight budget keeps the most trustworthy.
+  candidates.sort((a, b) => (b.confidence ?? 0.5) - (a.confidence ?? 0.5));
+
+  const served = serve(graph, candidates);
+  const { kept, spent } = fit(served, budget);
+  if (!kept.length) return null;
+
+  record(dir, {
+    kind: 'inject',
+    trigger: 'command',
+    anchor: String(command).slice(0, 120),
+    holdout: false,
+    tokens: spent,
+    count: kept.length,
+    stale: kept.some((f) => f.stale),
+    sessionId,
+  });
+
+  for (const f of kept) alreadyInjected.add(f.key);
+
+  return `Before running this — known from previous sessions:\n${kept
+    .map(render)
+    .join('\n')}`;
+}
+
+/**
  * The bounded SessionStart index: titles and ids only, never bodies.
  *
  * Its budget is EARNED from measured hit rate rather than fixed, so a mature

--- a/integrations/gemini/hooks/lib/inject.mjs
+++ b/integrations/gemini/hooks/lib/inject.mjs
@@ -254,7 +254,21 @@ export function forCommand(
   if (!candidates.length) return null;
 
   // Highest confidence first, so a tight budget keeps the most trustworthy.
-  candidates.sort((a, b) => (b.confidence ?? 0.5) - (a.confidence ?? 0.5));
+  // AN EXPLICIT TRIGGER BEATS AN INCIDENTAL WORD, before confidence is even
+  // consulted. A finding whose author wrote a pattern that matched this command
+  // is about this command; one that matched because its prose happened to
+  // contain "build" is not, however confident it was about something else.
+  //
+  // Observed live: `dotnet build App.csproj | tail -20` surfaced a finding about
+  // stale MCP server processes instead of the one about pipes hiding exit
+  // codes, and `gh run list` surfaced a git-refspec finding instead of the one
+  // about mergeStateStatus. Both had the same confidence as the right answer,
+  // so confidence alone could not separate them -- and a tight budget then kept
+  // the wrong one.
+  const explicit = (n) => (n.trigger && safeTrigger(n.trigger)?.test(command) ? 1 : 0);
+  candidates.sort(
+    (a, b) => explicit(b) - explicit(a) || (b.confidence ?? 0.5) - (a.confidence ?? 0.5)
+  );
 
   // CAPPED BEFORE serve(). serve() re-reads and diffs the anchor of every
   // finding it is handed, so an unbounded candidate list turns one command into

--- a/integrations/gemini/hooks/lib/policy.mjs
+++ b/integrations/gemini/hooks/lib/policy.mjs
@@ -318,6 +318,36 @@ export function allow() {
 }
 
 /**
+ * Allows the call AND hands the model something it did not ask for.
+ *
+ * This is the delivery half of the knowledge graph, and it had no
+ * implementation. `forTouch` -- the just-in-time injection the design calls
+ * "where the win lands" -- was imported by nothing outside its own test, so a
+ * finding could only ever reach a model through a REFUSAL. Measured across a
+ * full working session on three real projects: 4,053 capture events, 2,063
+ * reads, and findings served exactly twice. The graph was writing knowledge it
+ * had no way to deliver.
+ *
+ * `additionalContext` rather than a `permissionDecisionReason`, because the call
+ * is not being judged -- it is proceeding, and this rides along with it. Nothing
+ * is emitted when there is nothing to say, so the common path stays a bare
+ * exit(0).
+ */
+export function allowWithContext(context) {
+  if (context) {
+    process.stdout.write(
+      JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          additionalContext: withEscape(context),
+        },
+      })
+    );
+  }
+  process.exit(0);
+}
+
+/**
  * Blocks the call and tells the model exactly what to call instead.
  *
  * The reason string is the whole user interface of this product for an agent.

--- a/integrations/gemini/hooks/lib/policy.mjs
+++ b/integrations/gemini/hooks/lib/policy.mjs
@@ -190,7 +190,7 @@ function statePath(sessionId) {
 
 /** A usable state object, whatever was on disk. */
 function emptyState() {
-  return { seen: {}, denied: {} };
+  return { seen: {}, denied: {}, injected: [] };
 }
 
 /**
@@ -210,6 +210,13 @@ export function loadState(sessionId) {
     return {
       seen: parsed.seen && typeof parsed.seen === 'object' ? parsed.seen : {},
       denied: parsed.denied && typeof parsed.denied === 'object' ? parsed.denied : {},
+      // WITHOUT THIS THE ONCE-PER-SESSION GATE DOES NOT EXIST. Every tool call
+      // is a separate hook PROCESS, so a set held only in memory dies with the
+      // process that built it: the router recorded which findings it had
+      // injected, saveState dropped the field, and the next call re-injected
+      // the same advice. The gate looked correct in unit tests, which share one
+      // process, and did nothing at all in production.
+      injected: Array.isArray(parsed.injected) ? parsed.injected : [],
     };
   } catch {
     return emptyState();
@@ -252,6 +259,11 @@ export function saveState(sessionId, state) {
     const merged = {
       seen: { ...current.seen, ...state.seen },
       denied: { ...current.denied, ...state.denied },
+      // UNION, not overwrite. Two hook processes running in parallel each hold
+      // their own view of what has been injected; taking the last writer's copy
+      // would resurrect a finding the other had already delivered, which is the
+      // repetition the once-per-session gate exists to stop.
+      injected: [...new Set([...(current.injected || []), ...(state.injected || [])])],
     };
 
     // Write-then-rename so a reader never observes a half-written file.

--- a/integrations/gemini/hooks/lib/policy.mjs
+++ b/integrations/gemini/hooks/lib/policy.mjs
@@ -179,13 +179,23 @@ export function fileSize(path) {
  * means state on disk, keyed by the session id the hook payload carries.
  * ------------------------------------------------------------------ */
 
-const STATE_ROOT = join(tmpdir(), 'token-optimizer-hooks');
+/**
+ * Where per-session hook state lives.
+ *
+ * Read per call rather than captured at import, so a test can point it at a
+ * temp directory. Contention on this file is the normal case -- parallel tool
+ * calls each spawn their own hook process -- and it was untestable while the
+ * path was a module constant, which is part of why an unlocked
+ * read-modify-write survived here unnoticed.
+ */
+const stateRoot = () =>
+  process.env.TOKEN_OPTIMIZER_STATE_DIR || join(tmpdir(), 'token-optimizer-hooks');
 
 function statePath(sessionId) {
   // Session ids come from the harness and are uuid-shaped, but they land in a
   // file path, so anything that could traverse is stripped rather than trusted.
   const safe = String(sessionId || 'default').replace(/[^A-Za-z0-9_-]/g, '');
-  return join(STATE_ROOT, `${safe || 'default'}.json`);
+  return join(stateRoot(), `${safe || 'default'}.json`);
 }
 
 /** A usable state object, whatever was on disk. */
@@ -242,18 +252,26 @@ export function loadState(sessionId) {
 export function saveState(sessionId, state) {
   let lock = null;
   try {
-    mkdirSync(STATE_ROOT, { recursive: true, mode: 0o700 });
+    mkdirSync(stateRoot(), { recursive: true, mode: 0o700 });
 
     // A LOCK, because merging alone still loses updates: two processes can both
     // read, both merge, and the second write still discards the first's
     // additions. `wx` fails if the file exists, which makes creation an atomic
     // test-and-set on every platform we target.
     //
-    // Bounded and best-effort: if the lock cannot be taken quickly the write
-    // proceeds anyway. A stale lock from a killed process must never wedge
-    // enforcement, and the worst case without the lock is the merge behaviour
-    // that was already acceptable.
+    // NO UNLOCKED READ-MODIFY-WRITE. This used to fall through and write anyway
+    // when the lock could not be taken, which reintroduces exactly the lost
+    // update the lock exists to prevent: a process that misses the lock reads
+    // the pre-merge state and can erase an `injected` id another process just
+    // recorded, letting the same finding be injected twice in one session.
+    //
+    // Skipping the write is the safe direction. The cost is that THIS process's
+    // additions are not persisted, and every consequence of that is already
+    // bounded by design -- a repeated denial is allowed through by rule, and a
+    // repeated injection costs its tokens once more. A stale lock is still
+    // broken and taken below, so a killed process cannot wedge enforcement.
     lock = takeLock(sessionId);
+    if (!lock) return false;
 
     const current = loadState(sessionId);
     const merged = {
@@ -286,7 +304,25 @@ export function saveState(sessionId, state) {
 }
 
 /** Best-effort exclusive lock. Returns the lock path, or null if not acquired. */
-function takeLock(sessionId, { attempts = 20, staleMs = 5000 } = {}) {
+/**
+ * Sleeps synchronously.
+ *
+ * These hooks are single-shot processes that must reach a decision before they
+ * return, so there is no event loop to yield to and nothing to await. Atomics
+ * on a throwaway SharedArrayBuffer is the standard way to block a worker for a
+ * bounded time without burning the CPU.
+ */
+function sleepSync(ms) {
+  try {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+  } catch {
+    // SharedArrayBuffer unavailable under some policies. The caller still makes
+    // progress; it simply retries sooner.
+  }
+}
+
+/** Best-effort exclusive lock. Returns the lock path, or null if not acquired. */
+function takeLock(sessionId, { attempts = 20, staleMs = 5000, waitMs = 15 } = {}) {
   const path = `${statePath(sessionId)}.lock`;
   for (let i = 0; i < attempts; i++) {
     try {
@@ -297,10 +333,21 @@ function takeLock(sessionId, { attempts = 20, staleMs = 5000 } = {}) {
       // A lock left behind by a killed process would otherwise block every
       // future write for the life of the session.
       try {
-        if (Date.now() - statSync(path).mtimeMs > staleMs) unlinkSync(path);
+        if (Date.now() - statSync(path).mtimeMs > staleMs) {
+          unlinkSync(path);
+          continue; // Retry immediately; the holder is gone.
+        }
       } catch {
-        // Raced with the holder releasing it; just retry.
+        // Raced with the holder releasing it; retry immediately.
+        continue;
       }
+
+      // A LIVE holder. Waiting is the whole point: the previous loop retried
+      // 20 times with no delay, so it exhausted in microseconds and the caller
+      // fell through to an unlocked write. Backing off actually lets the holder
+      // finish -- a state write is a few milliseconds -- which is the
+      // difference between contending and merely pretending to.
+      if (i < attempts - 1) sleepSync(waitMs);
     }
   }
   return null;

--- a/integrations/gemini/hooks/lib/staleness.mjs
+++ b/integrations/gemini/hooks/lib/staleness.mjs
@@ -359,10 +359,22 @@ export function serve(graph, findings) {
     }
 
     if (stale && !diff) {
-      // The invariant. Rather than serve a bare stale finding -- which the
-      // design calls worse than no graph -- say plainly that the evidence is
-      // gone, so the model treats the claim as unverified rather than current.
-      diff = '(the change could not be reconstructed; treat this finding as unverified)';
+      // The invariant holds: never serve a bare stale finding as though it were
+      // current. But the WORDING was doing more than that, and it was measured.
+      //
+      // "treat this finding as unverified" is an instruction to discount, and
+      // models follow it. In an A/B on a fresh subagent, identical findings
+      // scored 1/3 dead-ends avoided when rendered with that sentence and 2/3
+      // when rendered clean -- no code change, only the wording. The claim being
+      // discounted was correct every time; all that had changed was the anchor
+      // file, which says nothing about whether the claim still holds.
+      //
+      // So: report what is actually known -- the anchor moved and the evidence
+      // cannot be rebuilt -- and let the claim stand or fall on its own. That is
+      // honest about staleness without arguing against the content.
+      diff = '(the anchor changed since this was recorded and the diff can no longer be '
+        + 'reconstructed; the claim itself may well still hold, so weigh it rather than '
+        + 'discard it)';
     }
 
     served.push({ ...finding, stale, ...(stale ? { diff, staleReason: reason } : {}) });

--- a/integrations/gemini/hooks/lib/staleness.mjs
+++ b/integrations/gemini/hooks/lib/staleness.mjs
@@ -369,12 +369,19 @@ export function serve(graph, findings) {
       // discounted was correct every time; all that had changed was the anchor
       // file, which says nothing about whether the claim still holds.
       //
-      // So: report what is actually known -- the anchor moved and the evidence
-      // cannot be rebuilt -- and let the claim stand or fall on its own. That is
-      // honest about staleness without arguing against the content.
-      diff = '(the anchor changed since this was recorded and the diff can no longer be '
-        + 'reconstructed; the claim itself may well still hold, so weigh it rather than '
-        + 'discard it)';
+      // So: report what is actually known and let the claim stand or fall on its
+      // own. That is honest about staleness without arguing against the content.
+      //
+      // REASON-NEUTRAL. The earlier text asserted "the anchor changed", which is
+      // only one of the ways a finding reaches this branch -- it is also reached
+      // when the eager path marked the finding at write time, or when the anchor
+      // was never snapshotted at all because it exceeded the snapshot limit. In
+      // those cases the sentence stated a cause that had not been established.
+      // `reason` already carries whatever was actually determined, so the
+      // fallback now describes only the evidence gap.
+      diff = `(marked stale: ${reason}. The supporting diff can no longer be `
+        + 'reconstructed; the claim itself may well still hold, so weigh it rather '
+        + 'than discard it)';
     }
 
     served.push({ ...finding, stale, ...(stale ? { diff, staleReason: reason } : {}) });

--- a/integrations/gemini/hooks/lib/staleness.mjs
+++ b/integrations/gemini/hooks/lib/staleness.mjs
@@ -379,9 +379,14 @@ export function serve(graph, findings) {
       // those cases the sentence stated a cause that had not been established.
       // `reason` already carries whatever was actually determined, so the
       // fallback now describes only the evidence gap.
+      // NO DISMISSAL VOCABULARY AT ALL, not even in a sentence arguing against
+      // dismissal. "weigh it rather than discard it" still puts the word in
+      // front of the model, and this text exists precisely because the previous
+      // phrasing was measured suppressing correct findings. State the evidence
+      // gap and stop.
       diff = `(marked stale: ${reason}. The supporting diff can no longer be `
-        + 'reconstructed; the claim itself may well still hold, so weigh it rather '
-        + 'than discard it)';
+        + 'reconstructed; the claim itself may well still hold, so weigh it on '
+        + 'its own merits.)';
     }
 
     served.push({ ...finding, stale, ...(stale ? { diff, staleReason: reason } : {}) });

--- a/integrations/kilo/kilo.jsonc
+++ b/integrations/kilo/kilo.jsonc
@@ -5,7 +5,7 @@
       "command": [
         "npx",
         "-y",
-        "@ooples/token-optimizer-mcp@5.3.2"
+        "@ooples/token-optimizer-mcp@5.3.6"
       ],
       "environment": {},
       "enabled": true

--- a/integrations/opencode/hooks/lib/harvest-write.mjs
+++ b/integrations/opencode/hooks/lib/harvest-write.mjs
@@ -118,6 +118,14 @@ export function writeHarvested(
         claim: finding.claim,
         confidence: finding.confidence,
         type: finding.type,
+        // WHEN this finding is relevant, not just what it is about. Anchors
+        // answer "which file", which is the wrong question for a claim about
+        // running something: the agent that needs "use npm test, not npx jest"
+        // is executing a command, not reading the file the claim is anchored
+        // to. Optional, so nothing that omits it changes behaviour.
+        trigger: typeof finding.trigger === 'string' && finding.trigger
+          ? finding.trigger
+          : undefined,
         origin: provenance,
         sessionId,
       },

--- a/integrations/opencode/hooks/lib/inject.mjs
+++ b/integrations/opencode/hooks/lib/inject.mjs
@@ -30,6 +30,42 @@ import { substitutionBudget } from './metrics.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
+
+/** Most findings considered for one command before the budget decides. */
+const MAX_COMMAND_CANDIDATES = 20;
+
+/**
+ * Compiles a finding's trigger, or returns null if it is not safe to run.
+ *
+ * TRIGGERS ARE MODEL-SUPPLIED. The harvest writes them, and a model asked for a
+ * regex can produce `(a+)+b` as readily as `\bnpx\b` -- a pattern whose
+ * backtracking is exponential in the input length. That would execute on the
+ * PreToolUse path against a command the user is waiting on, so a single bad
+ * trigger would hang every subsequent tool call in the session. Neither a
+ * try/catch nor a timeout helps: catastrophic backtracking does not throw, it
+ * simply does not return.
+ *
+ * So the pattern is rejected before it is ever run. The test is deliberately
+ * conservative -- nested quantifiers are the shape that causes this, and no
+ * legitimate trigger for a command needs one.
+ */
+export function safeTrigger(source) {
+  const raw = String(source || '');
+  if (!raw || raw.length > 200) return null;
+
+  // A quantifier applied to a group that itself contains a quantifier: (a+)+,
+  // (a*)*, (\d+)*, (?:ab+)+ and so on. This is the classic ReDoS shape.
+  if (/\([^)]*[+*}][^)]*\)\s*[+*{]/.test(raw)) return null;
+
+  // Stacked quantifiers outside a group, e.g. `a+*` or `.*+`.
+  if (/[+*}]\s*[+*]/.test(raw)) return null;
+
+  try {
+    return new RegExp(raw, 'i');
+  } catch {
+    return null;
+  }
+}
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
 
 /**
@@ -66,11 +102,21 @@ function render(finding) {
  * measurement holdout -- in which case the caller must behave exactly as if the
  * graph were empty, or the experiment measures nothing.
  */
-export function forTouch(dir, graph, rawPath, { budget = touchBudget(), sessionId } = {}) {
+export function forTouch(
+  dir,
+  graph,
+  rawPath,
+  { budget = touchBudget(), sessionId, alreadyInjected = new Set() } = {}
+) {
   // Canonical, so a touch finds findings anchored under any other spelling.
   const filePath = canonicalPath(rawPath);
   const anchorId = nodeId('file', filePath);
-  const candidates = findingsFor(graph, anchorId, { limit: 30 });
+  // The same once-per-session gate the command path uses. A file touched
+  // repeatedly -- which is the normal shape of working on it -- would otherwise
+  // re-serve the same findings on every single touch, which is both a token
+  // cost per call and the fastest way to train a model to skim past them.
+  const candidates = findingsFor(graph, anchorId, { limit: 30 })
+    .filter((f) => !alreadyInjected.has(f.key));
   if (!candidates.length) return null;
 
   const holdout = inHoldout(filePath);
@@ -88,6 +134,8 @@ export function forTouch(dir, graph, rawPath, { budget = touchBudget(), sessionI
   });
 
   if (holdout || !kept.length) return null;
+
+  for (const f of kept) alreadyInjected.add(f.key);
 
   return `Known about ${filePath} (from previous sessions):\n${kept.map(render).join('\n')}`;
 }
@@ -111,13 +159,18 @@ function appliesToCommand(finding, command) {
   if (!text) return false;
 
   if (finding.trigger) {
-    try {
-      return new RegExp(finding.trigger, 'i').test(text);
-    } catch {
-      // A malformed trigger must not throw on the hook path; fall back to a
-      // literal search so a bad regex degrades to a substring match.
-      return text.toLowerCase().includes(String(finding.trigger).toLowerCase());
+    const pattern = safeTrigger(finding.trigger);
+    if (pattern) {
+      try {
+        return pattern.test(text);
+      } catch {
+        return false;
+      }
     }
+    // Rejected as unsafe or malformed: fall back to a literal search, which
+    // cannot backtrack. A bad trigger degrades to a substring match rather
+    // than taking the hook down or hanging it.
+    return text.toLowerCase().includes(String(finding.trigger).toLowerCase());
   }
 
   // Untriggered findings only qualify if they are about doing something.
@@ -203,7 +256,14 @@ export function forCommand(
   // Highest confidence first, so a tight budget keeps the most trustworthy.
   candidates.sort((a, b) => (b.confidence ?? 0.5) - (a.confidence ?? 0.5));
 
-  const served = serve(graph, candidates);
+  // CAPPED BEFORE serve(). serve() re-reads and diffs the anchor of every
+  // finding it is handed, so an unbounded candidate list turns one command into
+  // one file read per matching finding -- on the hook path, with the user
+  // waiting. The budget would discard the surplus a moment later anyway, so the
+  // only thing an uncapped list buys is the I/O.
+  const considered = candidates.slice(0, MAX_COMMAND_CANDIDATES);
+
+  const served = serve(graph, considered);
   const { kept, spent } = fit(served, budget);
   if (!kept.length) return null;
 

--- a/integrations/opencode/hooks/lib/inject.mjs
+++ b/integrations/opencode/hooks/lib/inject.mjs
@@ -93,6 +93,139 @@ export function forTouch(dir, graph, rawPath, { budget = touchBudget(), sessionI
 }
 
 /**
+ * Does this finding apply to the command about to run?
+ *
+ * A finding carries an optional `trigger`: a string or regex source matched
+ * against the command text. Explicit beats inferred -- the alternative was
+ * scraping command-looking tokens out of the claim, which both misses (a claim
+ * that describes the command in prose) and misfires (a claim that merely
+ * mentions a command it is not about).
+ *
+ * With no trigger, a `command` or `failure` finding still qualifies on a weaker
+ * test: the command mentions a distinctive token from the claim. That keeps the
+ * findings already in existing graphs useful without a migration, while new
+ * ones can be precise.
+ */
+function appliesToCommand(finding, command) {
+  const text = String(command || '');
+  if (!text) return false;
+
+  if (finding.trigger) {
+    try {
+      return new RegExp(finding.trigger, 'i').test(text);
+    } catch {
+      // A malformed trigger must not throw on the hook path; fall back to a
+      // literal search so a bad regex degrades to a substring match.
+      return text.toLowerCase().includes(String(finding.trigger).toLowerCase());
+    }
+  }
+
+  // Untriggered findings only qualify if they are about doing something.
+  if (finding.type !== 'command' && finding.type !== 'failure') return false;
+
+  // Distinctive tokens, matched as WHOLE WORDS.
+  //
+  // The floor is three characters because the tokens that carry the meaning are
+  // short: jest, npm, git, ssh, tsc. A five-character floor -- the first
+  // attempt -- excluded "jest" from the very finding this feature exists to
+  // deliver, which the tests caught. Whole-word matching is what makes the low
+  // floor safe: without it "npm" would fire on any path containing "npm", and
+  // every claim mentioning a common word would match every command.
+  const claim = String(finding.claim || '');
+  const tokens = [
+    ...new Set(
+      (claim.match(/[a-z][a-z0-9._-]{2,}/gi) || [])
+        .map((t) => t.toLowerCase().replace(/[._-]+$/, ''))
+        .filter((t) => t.length >= 3 && !STOPWORDS.has(t))
+    ),
+  ];
+
+  return tokens.some((t) => {
+    const escaped = t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    try {
+      return new RegExp(`(^|[^a-z0-9])${escaped}([^a-z0-9]|$)`, 'i').test(text);
+    } catch {
+      return false;
+    }
+  });
+}
+
+/**
+ * Words common enough that matching on them would fire on every command.
+ * Deliberately small: this is a noise floor, not a language model.
+ */
+const STOPWORDS = new Set([
+  // Long enough to pass the length floor, common enough to match anything.
+  'about', 'after', 'again', 'against', 'because', 'before', 'being', 'between',
+  'could', 'every', 'first', 'instead', 'other', 'rather', 'should', 'since',
+  'their', 'there', 'these', 'thing', 'those', 'through', 'where', 'which',
+  'while', 'would', 'without', 'project', 'always', 'never',
+  // Short words that only became candidates once the floor dropped to three,
+  // which it had to so that the tool names that matter -- jest, npm, git, ssh
+  // -- are matchable at all.
+  'and', 'are', 'but', 'for', 'from', 'has', 'have', 'into', 'its', 'not',
+  'one', 'only', 'our', 'out', 'same', 'some', 'such', 'than', 'that', 'the',
+  'them', 'then', 'they', 'this', 'too', 'use', 'used', 'very', 'was', 'were',
+  'what', 'when', 'will', 'with', 'you', 'your', 'run', 'runs', 'way', 'why',
+]);
+
+/**
+ * What the model sees when it is about to RUN something.
+ *
+ * The gap this closes: injection was keyed entirely on touching a FILE, but the
+ * findings worth the most are about ACTIONS. The case that proved it -- a
+ * finding of type `command`, "run the suite with npm test, not npx jest",
+ * anchored to a source file. An agent about to run `npx jest` is not touching
+ * that file, so the finding could not fire at the only moment it mattered, and
+ * the agent made exactly the mistake the graph had already recorded.
+ *
+ * `alreadyInjected` is the once-per-session gate. Repeating the same advice on
+ * every command is how a real signal becomes wallpaper, and an ignored
+ * injection still costs its tokens on every call.
+ */
+export function forCommand(
+  dir,
+  graph,
+  command,
+  { budget = touchBudget(), sessionId, alreadyInjected = new Set() } = {}
+) {
+  if (!command) return null;
+
+  const candidates = [];
+  for (const node of graph.nodes.values()) {
+    if (node.kind !== 'finding' || node.retired) continue;
+    if (alreadyInjected.has(node.key)) continue;
+    if (!appliesToCommand(node, command)) continue;
+    candidates.push(node);
+  }
+  if (!candidates.length) return null;
+
+  // Highest confidence first, so a tight budget keeps the most trustworthy.
+  candidates.sort((a, b) => (b.confidence ?? 0.5) - (a.confidence ?? 0.5));
+
+  const served = serve(graph, candidates);
+  const { kept, spent } = fit(served, budget);
+  if (!kept.length) return null;
+
+  record(dir, {
+    kind: 'inject',
+    trigger: 'command',
+    anchor: String(command).slice(0, 120),
+    holdout: false,
+    tokens: spent,
+    count: kept.length,
+    stale: kept.some((f) => f.stale),
+    sessionId,
+  });
+
+  for (const f of kept) alreadyInjected.add(f.key);
+
+  return `Before running this — known from previous sessions:\n${kept
+    .map(render)
+    .join('\n')}`;
+}
+
+/**
  * The bounded SessionStart index: titles and ids only, never bodies.
  *
  * Its budget is EARNED from measured hit rate rather than fixed, so a mature

--- a/integrations/opencode/hooks/lib/inject.mjs
+++ b/integrations/opencode/hooks/lib/inject.mjs
@@ -254,7 +254,21 @@ export function forCommand(
   if (!candidates.length) return null;
 
   // Highest confidence first, so a tight budget keeps the most trustworthy.
-  candidates.sort((a, b) => (b.confidence ?? 0.5) - (a.confidence ?? 0.5));
+  // AN EXPLICIT TRIGGER BEATS AN INCIDENTAL WORD, before confidence is even
+  // consulted. A finding whose author wrote a pattern that matched this command
+  // is about this command; one that matched because its prose happened to
+  // contain "build" is not, however confident it was about something else.
+  //
+  // Observed live: `dotnet build App.csproj | tail -20` surfaced a finding about
+  // stale MCP server processes instead of the one about pipes hiding exit
+  // codes, and `gh run list` surfaced a git-refspec finding instead of the one
+  // about mergeStateStatus. Both had the same confidence as the right answer,
+  // so confidence alone could not separate them -- and a tight budget then kept
+  // the wrong one.
+  const explicit = (n) => (n.trigger && safeTrigger(n.trigger)?.test(command) ? 1 : 0);
+  candidates.sort(
+    (a, b) => explicit(b) - explicit(a) || (b.confidence ?? 0.5) - (a.confidence ?? 0.5)
+  );
 
   // CAPPED BEFORE serve(). serve() re-reads and diffs the anchor of every
   // finding it is handed, so an unbounded candidate list turns one command into

--- a/integrations/opencode/hooks/lib/policy.mjs
+++ b/integrations/opencode/hooks/lib/policy.mjs
@@ -318,6 +318,36 @@ export function allow() {
 }
 
 /**
+ * Allows the call AND hands the model something it did not ask for.
+ *
+ * This is the delivery half of the knowledge graph, and it had no
+ * implementation. `forTouch` -- the just-in-time injection the design calls
+ * "where the win lands" -- was imported by nothing outside its own test, so a
+ * finding could only ever reach a model through a REFUSAL. Measured across a
+ * full working session on three real projects: 4,053 capture events, 2,063
+ * reads, and findings served exactly twice. The graph was writing knowledge it
+ * had no way to deliver.
+ *
+ * `additionalContext` rather than a `permissionDecisionReason`, because the call
+ * is not being judged -- it is proceeding, and this rides along with it. Nothing
+ * is emitted when there is nothing to say, so the common path stays a bare
+ * exit(0).
+ */
+export function allowWithContext(context) {
+  if (context) {
+    process.stdout.write(
+      JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          additionalContext: withEscape(context),
+        },
+      })
+    );
+  }
+  process.exit(0);
+}
+
+/**
  * Blocks the call and tells the model exactly what to call instead.
  *
  * The reason string is the whole user interface of this product for an agent.

--- a/integrations/opencode/hooks/lib/policy.mjs
+++ b/integrations/opencode/hooks/lib/policy.mjs
@@ -190,7 +190,7 @@ function statePath(sessionId) {
 
 /** A usable state object, whatever was on disk. */
 function emptyState() {
-  return { seen: {}, denied: {} };
+  return { seen: {}, denied: {}, injected: [] };
 }
 
 /**
@@ -210,6 +210,13 @@ export function loadState(sessionId) {
     return {
       seen: parsed.seen && typeof parsed.seen === 'object' ? parsed.seen : {},
       denied: parsed.denied && typeof parsed.denied === 'object' ? parsed.denied : {},
+      // WITHOUT THIS THE ONCE-PER-SESSION GATE DOES NOT EXIST. Every tool call
+      // is a separate hook PROCESS, so a set held only in memory dies with the
+      // process that built it: the router recorded which findings it had
+      // injected, saveState dropped the field, and the next call re-injected
+      // the same advice. The gate looked correct in unit tests, which share one
+      // process, and did nothing at all in production.
+      injected: Array.isArray(parsed.injected) ? parsed.injected : [],
     };
   } catch {
     return emptyState();
@@ -252,6 +259,11 @@ export function saveState(sessionId, state) {
     const merged = {
       seen: { ...current.seen, ...state.seen },
       denied: { ...current.denied, ...state.denied },
+      // UNION, not overwrite. Two hook processes running in parallel each hold
+      // their own view of what has been injected; taking the last writer's copy
+      // would resurrect a finding the other had already delivered, which is the
+      // repetition the once-per-session gate exists to stop.
+      injected: [...new Set([...(current.injected || []), ...(state.injected || [])])],
     };
 
     // Write-then-rename so a reader never observes a half-written file.

--- a/integrations/opencode/hooks/lib/policy.mjs
+++ b/integrations/opencode/hooks/lib/policy.mjs
@@ -179,13 +179,23 @@ export function fileSize(path) {
  * means state on disk, keyed by the session id the hook payload carries.
  * ------------------------------------------------------------------ */
 
-const STATE_ROOT = join(tmpdir(), 'token-optimizer-hooks');
+/**
+ * Where per-session hook state lives.
+ *
+ * Read per call rather than captured at import, so a test can point it at a
+ * temp directory. Contention on this file is the normal case -- parallel tool
+ * calls each spawn their own hook process -- and it was untestable while the
+ * path was a module constant, which is part of why an unlocked
+ * read-modify-write survived here unnoticed.
+ */
+const stateRoot = () =>
+  process.env.TOKEN_OPTIMIZER_STATE_DIR || join(tmpdir(), 'token-optimizer-hooks');
 
 function statePath(sessionId) {
   // Session ids come from the harness and are uuid-shaped, but they land in a
   // file path, so anything that could traverse is stripped rather than trusted.
   const safe = String(sessionId || 'default').replace(/[^A-Za-z0-9_-]/g, '');
-  return join(STATE_ROOT, `${safe || 'default'}.json`);
+  return join(stateRoot(), `${safe || 'default'}.json`);
 }
 
 /** A usable state object, whatever was on disk. */
@@ -242,18 +252,26 @@ export function loadState(sessionId) {
 export function saveState(sessionId, state) {
   let lock = null;
   try {
-    mkdirSync(STATE_ROOT, { recursive: true, mode: 0o700 });
+    mkdirSync(stateRoot(), { recursive: true, mode: 0o700 });
 
     // A LOCK, because merging alone still loses updates: two processes can both
     // read, both merge, and the second write still discards the first's
     // additions. `wx` fails if the file exists, which makes creation an atomic
     // test-and-set on every platform we target.
     //
-    // Bounded and best-effort: if the lock cannot be taken quickly the write
-    // proceeds anyway. A stale lock from a killed process must never wedge
-    // enforcement, and the worst case without the lock is the merge behaviour
-    // that was already acceptable.
+    // NO UNLOCKED READ-MODIFY-WRITE. This used to fall through and write anyway
+    // when the lock could not be taken, which reintroduces exactly the lost
+    // update the lock exists to prevent: a process that misses the lock reads
+    // the pre-merge state and can erase an `injected` id another process just
+    // recorded, letting the same finding be injected twice in one session.
+    //
+    // Skipping the write is the safe direction. The cost is that THIS process's
+    // additions are not persisted, and every consequence of that is already
+    // bounded by design -- a repeated denial is allowed through by rule, and a
+    // repeated injection costs its tokens once more. A stale lock is still
+    // broken and taken below, so a killed process cannot wedge enforcement.
     lock = takeLock(sessionId);
+    if (!lock) return false;
 
     const current = loadState(sessionId);
     const merged = {
@@ -286,7 +304,25 @@ export function saveState(sessionId, state) {
 }
 
 /** Best-effort exclusive lock. Returns the lock path, or null if not acquired. */
-function takeLock(sessionId, { attempts = 20, staleMs = 5000 } = {}) {
+/**
+ * Sleeps synchronously.
+ *
+ * These hooks are single-shot processes that must reach a decision before they
+ * return, so there is no event loop to yield to and nothing to await. Atomics
+ * on a throwaway SharedArrayBuffer is the standard way to block a worker for a
+ * bounded time without burning the CPU.
+ */
+function sleepSync(ms) {
+  try {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+  } catch {
+    // SharedArrayBuffer unavailable under some policies. The caller still makes
+    // progress; it simply retries sooner.
+  }
+}
+
+/** Best-effort exclusive lock. Returns the lock path, or null if not acquired. */
+function takeLock(sessionId, { attempts = 20, staleMs = 5000, waitMs = 15 } = {}) {
   const path = `${statePath(sessionId)}.lock`;
   for (let i = 0; i < attempts; i++) {
     try {
@@ -297,10 +333,21 @@ function takeLock(sessionId, { attempts = 20, staleMs = 5000 } = {}) {
       // A lock left behind by a killed process would otherwise block every
       // future write for the life of the session.
       try {
-        if (Date.now() - statSync(path).mtimeMs > staleMs) unlinkSync(path);
+        if (Date.now() - statSync(path).mtimeMs > staleMs) {
+          unlinkSync(path);
+          continue; // Retry immediately; the holder is gone.
+        }
       } catch {
-        // Raced with the holder releasing it; just retry.
+        // Raced with the holder releasing it; retry immediately.
+        continue;
       }
+
+      // A LIVE holder. Waiting is the whole point: the previous loop retried
+      // 20 times with no delay, so it exhausted in microseconds and the caller
+      // fell through to an unlocked write. Backing off actually lets the holder
+      // finish -- a state write is a few milliseconds -- which is the
+      // difference between contending and merely pretending to.
+      if (i < attempts - 1) sleepSync(waitMs);
     }
   }
   return null;

--- a/integrations/opencode/hooks/lib/staleness.mjs
+++ b/integrations/opencode/hooks/lib/staleness.mjs
@@ -359,10 +359,22 @@ export function serve(graph, findings) {
     }
 
     if (stale && !diff) {
-      // The invariant. Rather than serve a bare stale finding -- which the
-      // design calls worse than no graph -- say plainly that the evidence is
-      // gone, so the model treats the claim as unverified rather than current.
-      diff = '(the change could not be reconstructed; treat this finding as unverified)';
+      // The invariant holds: never serve a bare stale finding as though it were
+      // current. But the WORDING was doing more than that, and it was measured.
+      //
+      // "treat this finding as unverified" is an instruction to discount, and
+      // models follow it. In an A/B on a fresh subagent, identical findings
+      // scored 1/3 dead-ends avoided when rendered with that sentence and 2/3
+      // when rendered clean -- no code change, only the wording. The claim being
+      // discounted was correct every time; all that had changed was the anchor
+      // file, which says nothing about whether the claim still holds.
+      //
+      // So: report what is actually known -- the anchor moved and the evidence
+      // cannot be rebuilt -- and let the claim stand or fall on its own. That is
+      // honest about staleness without arguing against the content.
+      diff = '(the anchor changed since this was recorded and the diff can no longer be '
+        + 'reconstructed; the claim itself may well still hold, so weigh it rather than '
+        + 'discard it)';
     }
 
     served.push({ ...finding, stale, ...(stale ? { diff, staleReason: reason } : {}) });

--- a/integrations/opencode/hooks/lib/staleness.mjs
+++ b/integrations/opencode/hooks/lib/staleness.mjs
@@ -369,12 +369,19 @@ export function serve(graph, findings) {
       // discounted was correct every time; all that had changed was the anchor
       // file, which says nothing about whether the claim still holds.
       //
-      // So: report what is actually known -- the anchor moved and the evidence
-      // cannot be rebuilt -- and let the claim stand or fall on its own. That is
-      // honest about staleness without arguing against the content.
-      diff = '(the anchor changed since this was recorded and the diff can no longer be '
-        + 'reconstructed; the claim itself may well still hold, so weigh it rather than '
-        + 'discard it)';
+      // So: report what is actually known and let the claim stand or fall on its
+      // own. That is honest about staleness without arguing against the content.
+      //
+      // REASON-NEUTRAL. The earlier text asserted "the anchor changed", which is
+      // only one of the ways a finding reaches this branch -- it is also reached
+      // when the eager path marked the finding at write time, or when the anchor
+      // was never snapshotted at all because it exceeded the snapshot limit. In
+      // those cases the sentence stated a cause that had not been established.
+      // `reason` already carries whatever was actually determined, so the
+      // fallback now describes only the evidence gap.
+      diff = `(marked stale: ${reason}. The supporting diff can no longer be `
+        + 'reconstructed; the claim itself may well still hold, so weigh it rather '
+        + 'than discard it)';
     }
 
     served.push({ ...finding, stale, ...(stale ? { diff, staleReason: reason } : {}) });

--- a/integrations/opencode/hooks/lib/staleness.mjs
+++ b/integrations/opencode/hooks/lib/staleness.mjs
@@ -379,9 +379,14 @@ export function serve(graph, findings) {
       // those cases the sentence stated a cause that had not been established.
       // `reason` already carries whatever was actually determined, so the
       // fallback now describes only the evidence gap.
+      // NO DISMISSAL VOCABULARY AT ALL, not even in a sentence arguing against
+      // dismissal. "weigh it rather than discard it" still puts the word in
+      // front of the model, and this text exists precisely because the previous
+      // phrasing was measured suppressing correct findings. State the evidence
+      // gap and stop.
       diff = `(marked stale: ${reason}. The supporting diff can no longer be `
-        + 'reconstructed; the claim itself may well still hold, so weigh it rather '
-        + 'than discard it)';
+        + 'reconstructed; the claim itself may well still hold, so weigh it on '
+        + 'its own merits.)';
     }
 
     served.push({ ...finding, stale, ...(stale ? { diff, staleReason: reason } : {}) });

--- a/integrations/opencode/opencode.json
+++ b/integrations/opencode/opencode.json
@@ -3,7 +3,7 @@
   "mcp": {
     "token-optimizer": {
       "type": "local",
-      "command": ["npx", "-y", "@ooples/token-optimizer-mcp@5.3.2"],
+      "command": ["npx", "-y", "@ooples/token-optimizer-mcp@5.3.6"],
       "enabled": true
     }
   },

--- a/integrations/qwen/hooks/lib/harvest-write.mjs
+++ b/integrations/qwen/hooks/lib/harvest-write.mjs
@@ -118,6 +118,14 @@ export function writeHarvested(
         claim: finding.claim,
         confidence: finding.confidence,
         type: finding.type,
+        // WHEN this finding is relevant, not just what it is about. Anchors
+        // answer "which file", which is the wrong question for a claim about
+        // running something: the agent that needs "use npm test, not npx jest"
+        // is executing a command, not reading the file the claim is anchored
+        // to. Optional, so nothing that omits it changes behaviour.
+        trigger: typeof finding.trigger === 'string' && finding.trigger
+          ? finding.trigger
+          : undefined,
         origin: provenance,
         sessionId,
       },

--- a/integrations/qwen/hooks/lib/inject.mjs
+++ b/integrations/qwen/hooks/lib/inject.mjs
@@ -30,6 +30,42 @@ import { substitutionBudget } from './metrics.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
+
+/** Most findings considered for one command before the budget decides. */
+const MAX_COMMAND_CANDIDATES = 20;
+
+/**
+ * Compiles a finding's trigger, or returns null if it is not safe to run.
+ *
+ * TRIGGERS ARE MODEL-SUPPLIED. The harvest writes them, and a model asked for a
+ * regex can produce `(a+)+b` as readily as `\bnpx\b` -- a pattern whose
+ * backtracking is exponential in the input length. That would execute on the
+ * PreToolUse path against a command the user is waiting on, so a single bad
+ * trigger would hang every subsequent tool call in the session. Neither a
+ * try/catch nor a timeout helps: catastrophic backtracking does not throw, it
+ * simply does not return.
+ *
+ * So the pattern is rejected before it is ever run. The test is deliberately
+ * conservative -- nested quantifiers are the shape that causes this, and no
+ * legitimate trigger for a command needs one.
+ */
+export function safeTrigger(source) {
+  const raw = String(source || '');
+  if (!raw || raw.length > 200) return null;
+
+  // A quantifier applied to a group that itself contains a quantifier: (a+)+,
+  // (a*)*, (\d+)*, (?:ab+)+ and so on. This is the classic ReDoS shape.
+  if (/\([^)]*[+*}][^)]*\)\s*[+*{]/.test(raw)) return null;
+
+  // Stacked quantifiers outside a group, e.g. `a+*` or `.*+`.
+  if (/[+*}]\s*[+*]/.test(raw)) return null;
+
+  try {
+    return new RegExp(raw, 'i');
+  } catch {
+    return null;
+  }
+}
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
 
 /**
@@ -66,11 +102,21 @@ function render(finding) {
  * measurement holdout -- in which case the caller must behave exactly as if the
  * graph were empty, or the experiment measures nothing.
  */
-export function forTouch(dir, graph, rawPath, { budget = touchBudget(), sessionId } = {}) {
+export function forTouch(
+  dir,
+  graph,
+  rawPath,
+  { budget = touchBudget(), sessionId, alreadyInjected = new Set() } = {}
+) {
   // Canonical, so a touch finds findings anchored under any other spelling.
   const filePath = canonicalPath(rawPath);
   const anchorId = nodeId('file', filePath);
-  const candidates = findingsFor(graph, anchorId, { limit: 30 });
+  // The same once-per-session gate the command path uses. A file touched
+  // repeatedly -- which is the normal shape of working on it -- would otherwise
+  // re-serve the same findings on every single touch, which is both a token
+  // cost per call and the fastest way to train a model to skim past them.
+  const candidates = findingsFor(graph, anchorId, { limit: 30 })
+    .filter((f) => !alreadyInjected.has(f.key));
   if (!candidates.length) return null;
 
   const holdout = inHoldout(filePath);
@@ -88,6 +134,8 @@ export function forTouch(dir, graph, rawPath, { budget = touchBudget(), sessionI
   });
 
   if (holdout || !kept.length) return null;
+
+  for (const f of kept) alreadyInjected.add(f.key);
 
   return `Known about ${filePath} (from previous sessions):\n${kept.map(render).join('\n')}`;
 }
@@ -111,13 +159,18 @@ function appliesToCommand(finding, command) {
   if (!text) return false;
 
   if (finding.trigger) {
-    try {
-      return new RegExp(finding.trigger, 'i').test(text);
-    } catch {
-      // A malformed trigger must not throw on the hook path; fall back to a
-      // literal search so a bad regex degrades to a substring match.
-      return text.toLowerCase().includes(String(finding.trigger).toLowerCase());
+    const pattern = safeTrigger(finding.trigger);
+    if (pattern) {
+      try {
+        return pattern.test(text);
+      } catch {
+        return false;
+      }
     }
+    // Rejected as unsafe or malformed: fall back to a literal search, which
+    // cannot backtrack. A bad trigger degrades to a substring match rather
+    // than taking the hook down or hanging it.
+    return text.toLowerCase().includes(String(finding.trigger).toLowerCase());
   }
 
   // Untriggered findings only qualify if they are about doing something.
@@ -203,7 +256,14 @@ export function forCommand(
   // Highest confidence first, so a tight budget keeps the most trustworthy.
   candidates.sort((a, b) => (b.confidence ?? 0.5) - (a.confidence ?? 0.5));
 
-  const served = serve(graph, candidates);
+  // CAPPED BEFORE serve(). serve() re-reads and diffs the anchor of every
+  // finding it is handed, so an unbounded candidate list turns one command into
+  // one file read per matching finding -- on the hook path, with the user
+  // waiting. The budget would discard the surplus a moment later anyway, so the
+  // only thing an uncapped list buys is the I/O.
+  const considered = candidates.slice(0, MAX_COMMAND_CANDIDATES);
+
+  const served = serve(graph, considered);
   const { kept, spent } = fit(served, budget);
   if (!kept.length) return null;
 

--- a/integrations/qwen/hooks/lib/inject.mjs
+++ b/integrations/qwen/hooks/lib/inject.mjs
@@ -93,6 +93,139 @@ export function forTouch(dir, graph, rawPath, { budget = touchBudget(), sessionI
 }
 
 /**
+ * Does this finding apply to the command about to run?
+ *
+ * A finding carries an optional `trigger`: a string or regex source matched
+ * against the command text. Explicit beats inferred -- the alternative was
+ * scraping command-looking tokens out of the claim, which both misses (a claim
+ * that describes the command in prose) and misfires (a claim that merely
+ * mentions a command it is not about).
+ *
+ * With no trigger, a `command` or `failure` finding still qualifies on a weaker
+ * test: the command mentions a distinctive token from the claim. That keeps the
+ * findings already in existing graphs useful without a migration, while new
+ * ones can be precise.
+ */
+function appliesToCommand(finding, command) {
+  const text = String(command || '');
+  if (!text) return false;
+
+  if (finding.trigger) {
+    try {
+      return new RegExp(finding.trigger, 'i').test(text);
+    } catch {
+      // A malformed trigger must not throw on the hook path; fall back to a
+      // literal search so a bad regex degrades to a substring match.
+      return text.toLowerCase().includes(String(finding.trigger).toLowerCase());
+    }
+  }
+
+  // Untriggered findings only qualify if they are about doing something.
+  if (finding.type !== 'command' && finding.type !== 'failure') return false;
+
+  // Distinctive tokens, matched as WHOLE WORDS.
+  //
+  // The floor is three characters because the tokens that carry the meaning are
+  // short: jest, npm, git, ssh, tsc. A five-character floor -- the first
+  // attempt -- excluded "jest" from the very finding this feature exists to
+  // deliver, which the tests caught. Whole-word matching is what makes the low
+  // floor safe: without it "npm" would fire on any path containing "npm", and
+  // every claim mentioning a common word would match every command.
+  const claim = String(finding.claim || '');
+  const tokens = [
+    ...new Set(
+      (claim.match(/[a-z][a-z0-9._-]{2,}/gi) || [])
+        .map((t) => t.toLowerCase().replace(/[._-]+$/, ''))
+        .filter((t) => t.length >= 3 && !STOPWORDS.has(t))
+    ),
+  ];
+
+  return tokens.some((t) => {
+    const escaped = t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    try {
+      return new RegExp(`(^|[^a-z0-9])${escaped}([^a-z0-9]|$)`, 'i').test(text);
+    } catch {
+      return false;
+    }
+  });
+}
+
+/**
+ * Words common enough that matching on them would fire on every command.
+ * Deliberately small: this is a noise floor, not a language model.
+ */
+const STOPWORDS = new Set([
+  // Long enough to pass the length floor, common enough to match anything.
+  'about', 'after', 'again', 'against', 'because', 'before', 'being', 'between',
+  'could', 'every', 'first', 'instead', 'other', 'rather', 'should', 'since',
+  'their', 'there', 'these', 'thing', 'those', 'through', 'where', 'which',
+  'while', 'would', 'without', 'project', 'always', 'never',
+  // Short words that only became candidates once the floor dropped to three,
+  // which it had to so that the tool names that matter -- jest, npm, git, ssh
+  // -- are matchable at all.
+  'and', 'are', 'but', 'for', 'from', 'has', 'have', 'into', 'its', 'not',
+  'one', 'only', 'our', 'out', 'same', 'some', 'such', 'than', 'that', 'the',
+  'them', 'then', 'they', 'this', 'too', 'use', 'used', 'very', 'was', 'were',
+  'what', 'when', 'will', 'with', 'you', 'your', 'run', 'runs', 'way', 'why',
+]);
+
+/**
+ * What the model sees when it is about to RUN something.
+ *
+ * The gap this closes: injection was keyed entirely on touching a FILE, but the
+ * findings worth the most are about ACTIONS. The case that proved it -- a
+ * finding of type `command`, "run the suite with npm test, not npx jest",
+ * anchored to a source file. An agent about to run `npx jest` is not touching
+ * that file, so the finding could not fire at the only moment it mattered, and
+ * the agent made exactly the mistake the graph had already recorded.
+ *
+ * `alreadyInjected` is the once-per-session gate. Repeating the same advice on
+ * every command is how a real signal becomes wallpaper, and an ignored
+ * injection still costs its tokens on every call.
+ */
+export function forCommand(
+  dir,
+  graph,
+  command,
+  { budget = touchBudget(), sessionId, alreadyInjected = new Set() } = {}
+) {
+  if (!command) return null;
+
+  const candidates = [];
+  for (const node of graph.nodes.values()) {
+    if (node.kind !== 'finding' || node.retired) continue;
+    if (alreadyInjected.has(node.key)) continue;
+    if (!appliesToCommand(node, command)) continue;
+    candidates.push(node);
+  }
+  if (!candidates.length) return null;
+
+  // Highest confidence first, so a tight budget keeps the most trustworthy.
+  candidates.sort((a, b) => (b.confidence ?? 0.5) - (a.confidence ?? 0.5));
+
+  const served = serve(graph, candidates);
+  const { kept, spent } = fit(served, budget);
+  if (!kept.length) return null;
+
+  record(dir, {
+    kind: 'inject',
+    trigger: 'command',
+    anchor: String(command).slice(0, 120),
+    holdout: false,
+    tokens: spent,
+    count: kept.length,
+    stale: kept.some((f) => f.stale),
+    sessionId,
+  });
+
+  for (const f of kept) alreadyInjected.add(f.key);
+
+  return `Before running this — known from previous sessions:\n${kept
+    .map(render)
+    .join('\n')}`;
+}
+
+/**
  * The bounded SessionStart index: titles and ids only, never bodies.
  *
  * Its budget is EARNED from measured hit rate rather than fixed, so a mature

--- a/integrations/qwen/hooks/lib/inject.mjs
+++ b/integrations/qwen/hooks/lib/inject.mjs
@@ -254,7 +254,21 @@ export function forCommand(
   if (!candidates.length) return null;
 
   // Highest confidence first, so a tight budget keeps the most trustworthy.
-  candidates.sort((a, b) => (b.confidence ?? 0.5) - (a.confidence ?? 0.5));
+  // AN EXPLICIT TRIGGER BEATS AN INCIDENTAL WORD, before confidence is even
+  // consulted. A finding whose author wrote a pattern that matched this command
+  // is about this command; one that matched because its prose happened to
+  // contain "build" is not, however confident it was about something else.
+  //
+  // Observed live: `dotnet build App.csproj | tail -20` surfaced a finding about
+  // stale MCP server processes instead of the one about pipes hiding exit
+  // codes, and `gh run list` surfaced a git-refspec finding instead of the one
+  // about mergeStateStatus. Both had the same confidence as the right answer,
+  // so confidence alone could not separate them -- and a tight budget then kept
+  // the wrong one.
+  const explicit = (n) => (n.trigger && safeTrigger(n.trigger)?.test(command) ? 1 : 0);
+  candidates.sort(
+    (a, b) => explicit(b) - explicit(a) || (b.confidence ?? 0.5) - (a.confidence ?? 0.5)
+  );
 
   // CAPPED BEFORE serve(). serve() re-reads and diffs the anchor of every
   // finding it is handed, so an unbounded candidate list turns one command into

--- a/integrations/qwen/hooks/lib/policy.mjs
+++ b/integrations/qwen/hooks/lib/policy.mjs
@@ -318,6 +318,36 @@ export function allow() {
 }
 
 /**
+ * Allows the call AND hands the model something it did not ask for.
+ *
+ * This is the delivery half of the knowledge graph, and it had no
+ * implementation. `forTouch` -- the just-in-time injection the design calls
+ * "where the win lands" -- was imported by nothing outside its own test, so a
+ * finding could only ever reach a model through a REFUSAL. Measured across a
+ * full working session on three real projects: 4,053 capture events, 2,063
+ * reads, and findings served exactly twice. The graph was writing knowledge it
+ * had no way to deliver.
+ *
+ * `additionalContext` rather than a `permissionDecisionReason`, because the call
+ * is not being judged -- it is proceeding, and this rides along with it. Nothing
+ * is emitted when there is nothing to say, so the common path stays a bare
+ * exit(0).
+ */
+export function allowWithContext(context) {
+  if (context) {
+    process.stdout.write(
+      JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          additionalContext: withEscape(context),
+        },
+      })
+    );
+  }
+  process.exit(0);
+}
+
+/**
  * Blocks the call and tells the model exactly what to call instead.
  *
  * The reason string is the whole user interface of this product for an agent.

--- a/integrations/qwen/hooks/lib/policy.mjs
+++ b/integrations/qwen/hooks/lib/policy.mjs
@@ -190,7 +190,7 @@ function statePath(sessionId) {
 
 /** A usable state object, whatever was on disk. */
 function emptyState() {
-  return { seen: {}, denied: {} };
+  return { seen: {}, denied: {}, injected: [] };
 }
 
 /**
@@ -210,6 +210,13 @@ export function loadState(sessionId) {
     return {
       seen: parsed.seen && typeof parsed.seen === 'object' ? parsed.seen : {},
       denied: parsed.denied && typeof parsed.denied === 'object' ? parsed.denied : {},
+      // WITHOUT THIS THE ONCE-PER-SESSION GATE DOES NOT EXIST. Every tool call
+      // is a separate hook PROCESS, so a set held only in memory dies with the
+      // process that built it: the router recorded which findings it had
+      // injected, saveState dropped the field, and the next call re-injected
+      // the same advice. The gate looked correct in unit tests, which share one
+      // process, and did nothing at all in production.
+      injected: Array.isArray(parsed.injected) ? parsed.injected : [],
     };
   } catch {
     return emptyState();
@@ -252,6 +259,11 @@ export function saveState(sessionId, state) {
     const merged = {
       seen: { ...current.seen, ...state.seen },
       denied: { ...current.denied, ...state.denied },
+      // UNION, not overwrite. Two hook processes running in parallel each hold
+      // their own view of what has been injected; taking the last writer's copy
+      // would resurrect a finding the other had already delivered, which is the
+      // repetition the once-per-session gate exists to stop.
+      injected: [...new Set([...(current.injected || []), ...(state.injected || [])])],
     };
 
     // Write-then-rename so a reader never observes a half-written file.

--- a/integrations/qwen/hooks/lib/policy.mjs
+++ b/integrations/qwen/hooks/lib/policy.mjs
@@ -179,13 +179,23 @@ export function fileSize(path) {
  * means state on disk, keyed by the session id the hook payload carries.
  * ------------------------------------------------------------------ */
 
-const STATE_ROOT = join(tmpdir(), 'token-optimizer-hooks');
+/**
+ * Where per-session hook state lives.
+ *
+ * Read per call rather than captured at import, so a test can point it at a
+ * temp directory. Contention on this file is the normal case -- parallel tool
+ * calls each spawn their own hook process -- and it was untestable while the
+ * path was a module constant, which is part of why an unlocked
+ * read-modify-write survived here unnoticed.
+ */
+const stateRoot = () =>
+  process.env.TOKEN_OPTIMIZER_STATE_DIR || join(tmpdir(), 'token-optimizer-hooks');
 
 function statePath(sessionId) {
   // Session ids come from the harness and are uuid-shaped, but they land in a
   // file path, so anything that could traverse is stripped rather than trusted.
   const safe = String(sessionId || 'default').replace(/[^A-Za-z0-9_-]/g, '');
-  return join(STATE_ROOT, `${safe || 'default'}.json`);
+  return join(stateRoot(), `${safe || 'default'}.json`);
 }
 
 /** A usable state object, whatever was on disk. */
@@ -242,18 +252,26 @@ export function loadState(sessionId) {
 export function saveState(sessionId, state) {
   let lock = null;
   try {
-    mkdirSync(STATE_ROOT, { recursive: true, mode: 0o700 });
+    mkdirSync(stateRoot(), { recursive: true, mode: 0o700 });
 
     // A LOCK, because merging alone still loses updates: two processes can both
     // read, both merge, and the second write still discards the first's
     // additions. `wx` fails if the file exists, which makes creation an atomic
     // test-and-set on every platform we target.
     //
-    // Bounded and best-effort: if the lock cannot be taken quickly the write
-    // proceeds anyway. A stale lock from a killed process must never wedge
-    // enforcement, and the worst case without the lock is the merge behaviour
-    // that was already acceptable.
+    // NO UNLOCKED READ-MODIFY-WRITE. This used to fall through and write anyway
+    // when the lock could not be taken, which reintroduces exactly the lost
+    // update the lock exists to prevent: a process that misses the lock reads
+    // the pre-merge state and can erase an `injected` id another process just
+    // recorded, letting the same finding be injected twice in one session.
+    //
+    // Skipping the write is the safe direction. The cost is that THIS process's
+    // additions are not persisted, and every consequence of that is already
+    // bounded by design -- a repeated denial is allowed through by rule, and a
+    // repeated injection costs its tokens once more. A stale lock is still
+    // broken and taken below, so a killed process cannot wedge enforcement.
     lock = takeLock(sessionId);
+    if (!lock) return false;
 
     const current = loadState(sessionId);
     const merged = {
@@ -286,7 +304,25 @@ export function saveState(sessionId, state) {
 }
 
 /** Best-effort exclusive lock. Returns the lock path, or null if not acquired. */
-function takeLock(sessionId, { attempts = 20, staleMs = 5000 } = {}) {
+/**
+ * Sleeps synchronously.
+ *
+ * These hooks are single-shot processes that must reach a decision before they
+ * return, so there is no event loop to yield to and nothing to await. Atomics
+ * on a throwaway SharedArrayBuffer is the standard way to block a worker for a
+ * bounded time without burning the CPU.
+ */
+function sleepSync(ms) {
+  try {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+  } catch {
+    // SharedArrayBuffer unavailable under some policies. The caller still makes
+    // progress; it simply retries sooner.
+  }
+}
+
+/** Best-effort exclusive lock. Returns the lock path, or null if not acquired. */
+function takeLock(sessionId, { attempts = 20, staleMs = 5000, waitMs = 15 } = {}) {
   const path = `${statePath(sessionId)}.lock`;
   for (let i = 0; i < attempts; i++) {
     try {
@@ -297,10 +333,21 @@ function takeLock(sessionId, { attempts = 20, staleMs = 5000 } = {}) {
       // A lock left behind by a killed process would otherwise block every
       // future write for the life of the session.
       try {
-        if (Date.now() - statSync(path).mtimeMs > staleMs) unlinkSync(path);
+        if (Date.now() - statSync(path).mtimeMs > staleMs) {
+          unlinkSync(path);
+          continue; // Retry immediately; the holder is gone.
+        }
       } catch {
-        // Raced with the holder releasing it; just retry.
+        // Raced with the holder releasing it; retry immediately.
+        continue;
       }
+
+      // A LIVE holder. Waiting is the whole point: the previous loop retried
+      // 20 times with no delay, so it exhausted in microseconds and the caller
+      // fell through to an unlocked write. Backing off actually lets the holder
+      // finish -- a state write is a few milliseconds -- which is the
+      // difference between contending and merely pretending to.
+      if (i < attempts - 1) sleepSync(waitMs);
     }
   }
   return null;

--- a/integrations/qwen/hooks/lib/staleness.mjs
+++ b/integrations/qwen/hooks/lib/staleness.mjs
@@ -359,10 +359,22 @@ export function serve(graph, findings) {
     }
 
     if (stale && !diff) {
-      // The invariant. Rather than serve a bare stale finding -- which the
-      // design calls worse than no graph -- say plainly that the evidence is
-      // gone, so the model treats the claim as unverified rather than current.
-      diff = '(the change could not be reconstructed; treat this finding as unverified)';
+      // The invariant holds: never serve a bare stale finding as though it were
+      // current. But the WORDING was doing more than that, and it was measured.
+      //
+      // "treat this finding as unverified" is an instruction to discount, and
+      // models follow it. In an A/B on a fresh subagent, identical findings
+      // scored 1/3 dead-ends avoided when rendered with that sentence and 2/3
+      // when rendered clean -- no code change, only the wording. The claim being
+      // discounted was correct every time; all that had changed was the anchor
+      // file, which says nothing about whether the claim still holds.
+      //
+      // So: report what is actually known -- the anchor moved and the evidence
+      // cannot be rebuilt -- and let the claim stand or fall on its own. That is
+      // honest about staleness without arguing against the content.
+      diff = '(the anchor changed since this was recorded and the diff can no longer be '
+        + 'reconstructed; the claim itself may well still hold, so weigh it rather than '
+        + 'discard it)';
     }
 
     served.push({ ...finding, stale, ...(stale ? { diff, staleReason: reason } : {}) });

--- a/integrations/qwen/hooks/lib/staleness.mjs
+++ b/integrations/qwen/hooks/lib/staleness.mjs
@@ -369,12 +369,19 @@ export function serve(graph, findings) {
       // discounted was correct every time; all that had changed was the anchor
       // file, which says nothing about whether the claim still holds.
       //
-      // So: report what is actually known -- the anchor moved and the evidence
-      // cannot be rebuilt -- and let the claim stand or fall on its own. That is
-      // honest about staleness without arguing against the content.
-      diff = '(the anchor changed since this was recorded and the diff can no longer be '
-        + 'reconstructed; the claim itself may well still hold, so weigh it rather than '
-        + 'discard it)';
+      // So: report what is actually known and let the claim stand or fall on its
+      // own. That is honest about staleness without arguing against the content.
+      //
+      // REASON-NEUTRAL. The earlier text asserted "the anchor changed", which is
+      // only one of the ways a finding reaches this branch -- it is also reached
+      // when the eager path marked the finding at write time, or when the anchor
+      // was never snapshotted at all because it exceeded the snapshot limit. In
+      // those cases the sentence stated a cause that had not been established.
+      // `reason` already carries whatever was actually determined, so the
+      // fallback now describes only the evidence gap.
+      diff = `(marked stale: ${reason}. The supporting diff can no longer be `
+        + 'reconstructed; the claim itself may well still hold, so weigh it rather '
+        + 'than discard it)';
     }
 
     served.push({ ...finding, stale, ...(stale ? { diff, staleReason: reason } : {}) });

--- a/integrations/qwen/hooks/lib/staleness.mjs
+++ b/integrations/qwen/hooks/lib/staleness.mjs
@@ -379,9 +379,14 @@ export function serve(graph, findings) {
       // those cases the sentence stated a cause that had not been established.
       // `reason` already carries whatever was actually determined, so the
       // fallback now describes only the evidence gap.
+      // NO DISMISSAL VOCABULARY AT ALL, not even in a sentence arguing against
+      // dismissal. "weigh it rather than discard it" still puts the word in
+      // front of the model, and this text exists precisely because the previous
+      // phrasing was measured suppressing correct findings. State the evidence
+      // gap and stop.
       diff = `(marked stale: ${reason}. The supporting diff can no longer be `
-        + 'reconstructed; the claim itself may well still hold, so weigh it rather '
-        + 'than discard it)';
+        + 'reconstructed; the claim itself may well still hold, so weigh it on '
+        + 'its own merits.)';
     }
 
     served.push({ ...finding, stale, ...(stale ? { diff, staleReason: reason } : {}) });

--- a/integrations/roo/mcp.json
+++ b/integrations/roo/mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@ooples/token-optimizer-mcp@5.3.2"
+        "@ooples/token-optimizer-mcp@5.3.6"
       ],
       "env": {}
     }

--- a/integrations/windsurf/mcp_config.json
+++ b/integrations/windsurf/mcp_config.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@ooples/token-optimizer-mcp@5.3.5"
+        "@ooples/token-optimizer-mcp@5.3.6"
       ],
       "env": {}
     }

--- a/integrations/zed/settings.json
+++ b/integrations/zed/settings.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@ooples/token-optimizer-mcp@5.3.2"
+        "@ooples/token-optimizer-mcp@5.3.6"
       ],
       "env": {}
     }

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "token-optimizer": {
       "command": "npx",
-      "args": ["-y", "@ooples/token-optimizer-mcp@5.3.2"],
+      "args": ["-y", "@ooples/token-optimizer-mcp@5.3.6"],
       "env": {}
     }
   }

--- a/plugin/hooks/lib/harvest-write.mjs
+++ b/plugin/hooks/lib/harvest-write.mjs
@@ -118,6 +118,14 @@ export function writeHarvested(
         claim: finding.claim,
         confidence: finding.confidence,
         type: finding.type,
+        // WHEN this finding is relevant, not just what it is about. Anchors
+        // answer "which file", which is the wrong question for a claim about
+        // running something: the agent that needs "use npm test, not npx jest"
+        // is executing a command, not reading the file the claim is anchored
+        // to. Optional, so nothing that omits it changes behaviour.
+        trigger: typeof finding.trigger === 'string' && finding.trigger
+          ? finding.trigger
+          : undefined,
         origin: provenance,
         sessionId,
       },

--- a/plugin/hooks/lib/inject.mjs
+++ b/plugin/hooks/lib/inject.mjs
@@ -30,6 +30,42 @@ import { substitutionBudget } from './metrics.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
+
+/** Most findings considered for one command before the budget decides. */
+const MAX_COMMAND_CANDIDATES = 20;
+
+/**
+ * Compiles a finding's trigger, or returns null if it is not safe to run.
+ *
+ * TRIGGERS ARE MODEL-SUPPLIED. The harvest writes them, and a model asked for a
+ * regex can produce `(a+)+b` as readily as `\bnpx\b` -- a pattern whose
+ * backtracking is exponential in the input length. That would execute on the
+ * PreToolUse path against a command the user is waiting on, so a single bad
+ * trigger would hang every subsequent tool call in the session. Neither a
+ * try/catch nor a timeout helps: catastrophic backtracking does not throw, it
+ * simply does not return.
+ *
+ * So the pattern is rejected before it is ever run. The test is deliberately
+ * conservative -- nested quantifiers are the shape that causes this, and no
+ * legitimate trigger for a command needs one.
+ */
+export function safeTrigger(source) {
+  const raw = String(source || '');
+  if (!raw || raw.length > 200) return null;
+
+  // A quantifier applied to a group that itself contains a quantifier: (a+)+,
+  // (a*)*, (\d+)*, (?:ab+)+ and so on. This is the classic ReDoS shape.
+  if (/\([^)]*[+*}][^)]*\)\s*[+*{]/.test(raw)) return null;
+
+  // Stacked quantifiers outside a group, e.g. `a+*` or `.*+`.
+  if (/[+*}]\s*[+*]/.test(raw)) return null;
+
+  try {
+    return new RegExp(raw, 'i');
+  } catch {
+    return null;
+  }
+}
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
 
 /**
@@ -66,11 +102,21 @@ function render(finding) {
  * measurement holdout -- in which case the caller must behave exactly as if the
  * graph were empty, or the experiment measures nothing.
  */
-export function forTouch(dir, graph, rawPath, { budget = touchBudget(), sessionId } = {}) {
+export function forTouch(
+  dir,
+  graph,
+  rawPath,
+  { budget = touchBudget(), sessionId, alreadyInjected = new Set() } = {}
+) {
   // Canonical, so a touch finds findings anchored under any other spelling.
   const filePath = canonicalPath(rawPath);
   const anchorId = nodeId('file', filePath);
-  const candidates = findingsFor(graph, anchorId, { limit: 30 });
+  // The same once-per-session gate the command path uses. A file touched
+  // repeatedly -- which is the normal shape of working on it -- would otherwise
+  // re-serve the same findings on every single touch, which is both a token
+  // cost per call and the fastest way to train a model to skim past them.
+  const candidates = findingsFor(graph, anchorId, { limit: 30 })
+    .filter((f) => !alreadyInjected.has(f.key));
   if (!candidates.length) return null;
 
   const holdout = inHoldout(filePath);
@@ -88,6 +134,8 @@ export function forTouch(dir, graph, rawPath, { budget = touchBudget(), sessionI
   });
 
   if (holdout || !kept.length) return null;
+
+  for (const f of kept) alreadyInjected.add(f.key);
 
   return `Known about ${filePath} (from previous sessions):\n${kept.map(render).join('\n')}`;
 }
@@ -111,13 +159,18 @@ function appliesToCommand(finding, command) {
   if (!text) return false;
 
   if (finding.trigger) {
-    try {
-      return new RegExp(finding.trigger, 'i').test(text);
-    } catch {
-      // A malformed trigger must not throw on the hook path; fall back to a
-      // literal search so a bad regex degrades to a substring match.
-      return text.toLowerCase().includes(String(finding.trigger).toLowerCase());
+    const pattern = safeTrigger(finding.trigger);
+    if (pattern) {
+      try {
+        return pattern.test(text);
+      } catch {
+        return false;
+      }
     }
+    // Rejected as unsafe or malformed: fall back to a literal search, which
+    // cannot backtrack. A bad trigger degrades to a substring match rather
+    // than taking the hook down or hanging it.
+    return text.toLowerCase().includes(String(finding.trigger).toLowerCase());
   }
 
   // Untriggered findings only qualify if they are about doing something.
@@ -203,7 +256,14 @@ export function forCommand(
   // Highest confidence first, so a tight budget keeps the most trustworthy.
   candidates.sort((a, b) => (b.confidence ?? 0.5) - (a.confidence ?? 0.5));
 
-  const served = serve(graph, candidates);
+  // CAPPED BEFORE serve(). serve() re-reads and diffs the anchor of every
+  // finding it is handed, so an unbounded candidate list turns one command into
+  // one file read per matching finding -- on the hook path, with the user
+  // waiting. The budget would discard the surplus a moment later anyway, so the
+  // only thing an uncapped list buys is the I/O.
+  const considered = candidates.slice(0, MAX_COMMAND_CANDIDATES);
+
+  const served = serve(graph, considered);
   const { kept, spent } = fit(served, budget);
   if (!kept.length) return null;
 

--- a/plugin/hooks/lib/inject.mjs
+++ b/plugin/hooks/lib/inject.mjs
@@ -93,6 +93,139 @@ export function forTouch(dir, graph, rawPath, { budget = touchBudget(), sessionI
 }
 
 /**
+ * Does this finding apply to the command about to run?
+ *
+ * A finding carries an optional `trigger`: a string or regex source matched
+ * against the command text. Explicit beats inferred -- the alternative was
+ * scraping command-looking tokens out of the claim, which both misses (a claim
+ * that describes the command in prose) and misfires (a claim that merely
+ * mentions a command it is not about).
+ *
+ * With no trigger, a `command` or `failure` finding still qualifies on a weaker
+ * test: the command mentions a distinctive token from the claim. That keeps the
+ * findings already in existing graphs useful without a migration, while new
+ * ones can be precise.
+ */
+function appliesToCommand(finding, command) {
+  const text = String(command || '');
+  if (!text) return false;
+
+  if (finding.trigger) {
+    try {
+      return new RegExp(finding.trigger, 'i').test(text);
+    } catch {
+      // A malformed trigger must not throw on the hook path; fall back to a
+      // literal search so a bad regex degrades to a substring match.
+      return text.toLowerCase().includes(String(finding.trigger).toLowerCase());
+    }
+  }
+
+  // Untriggered findings only qualify if they are about doing something.
+  if (finding.type !== 'command' && finding.type !== 'failure') return false;
+
+  // Distinctive tokens, matched as WHOLE WORDS.
+  //
+  // The floor is three characters because the tokens that carry the meaning are
+  // short: jest, npm, git, ssh, tsc. A five-character floor -- the first
+  // attempt -- excluded "jest" from the very finding this feature exists to
+  // deliver, which the tests caught. Whole-word matching is what makes the low
+  // floor safe: without it "npm" would fire on any path containing "npm", and
+  // every claim mentioning a common word would match every command.
+  const claim = String(finding.claim || '');
+  const tokens = [
+    ...new Set(
+      (claim.match(/[a-z][a-z0-9._-]{2,}/gi) || [])
+        .map((t) => t.toLowerCase().replace(/[._-]+$/, ''))
+        .filter((t) => t.length >= 3 && !STOPWORDS.has(t))
+    ),
+  ];
+
+  return tokens.some((t) => {
+    const escaped = t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    try {
+      return new RegExp(`(^|[^a-z0-9])${escaped}([^a-z0-9]|$)`, 'i').test(text);
+    } catch {
+      return false;
+    }
+  });
+}
+
+/**
+ * Words common enough that matching on them would fire on every command.
+ * Deliberately small: this is a noise floor, not a language model.
+ */
+const STOPWORDS = new Set([
+  // Long enough to pass the length floor, common enough to match anything.
+  'about', 'after', 'again', 'against', 'because', 'before', 'being', 'between',
+  'could', 'every', 'first', 'instead', 'other', 'rather', 'should', 'since',
+  'their', 'there', 'these', 'thing', 'those', 'through', 'where', 'which',
+  'while', 'would', 'without', 'project', 'always', 'never',
+  // Short words that only became candidates once the floor dropped to three,
+  // which it had to so that the tool names that matter -- jest, npm, git, ssh
+  // -- are matchable at all.
+  'and', 'are', 'but', 'for', 'from', 'has', 'have', 'into', 'its', 'not',
+  'one', 'only', 'our', 'out', 'same', 'some', 'such', 'than', 'that', 'the',
+  'them', 'then', 'they', 'this', 'too', 'use', 'used', 'very', 'was', 'were',
+  'what', 'when', 'will', 'with', 'you', 'your', 'run', 'runs', 'way', 'why',
+]);
+
+/**
+ * What the model sees when it is about to RUN something.
+ *
+ * The gap this closes: injection was keyed entirely on touching a FILE, but the
+ * findings worth the most are about ACTIONS. The case that proved it -- a
+ * finding of type `command`, "run the suite with npm test, not npx jest",
+ * anchored to a source file. An agent about to run `npx jest` is not touching
+ * that file, so the finding could not fire at the only moment it mattered, and
+ * the agent made exactly the mistake the graph had already recorded.
+ *
+ * `alreadyInjected` is the once-per-session gate. Repeating the same advice on
+ * every command is how a real signal becomes wallpaper, and an ignored
+ * injection still costs its tokens on every call.
+ */
+export function forCommand(
+  dir,
+  graph,
+  command,
+  { budget = touchBudget(), sessionId, alreadyInjected = new Set() } = {}
+) {
+  if (!command) return null;
+
+  const candidates = [];
+  for (const node of graph.nodes.values()) {
+    if (node.kind !== 'finding' || node.retired) continue;
+    if (alreadyInjected.has(node.key)) continue;
+    if (!appliesToCommand(node, command)) continue;
+    candidates.push(node);
+  }
+  if (!candidates.length) return null;
+
+  // Highest confidence first, so a tight budget keeps the most trustworthy.
+  candidates.sort((a, b) => (b.confidence ?? 0.5) - (a.confidence ?? 0.5));
+
+  const served = serve(graph, candidates);
+  const { kept, spent } = fit(served, budget);
+  if (!kept.length) return null;
+
+  record(dir, {
+    kind: 'inject',
+    trigger: 'command',
+    anchor: String(command).slice(0, 120),
+    holdout: false,
+    tokens: spent,
+    count: kept.length,
+    stale: kept.some((f) => f.stale),
+    sessionId,
+  });
+
+  for (const f of kept) alreadyInjected.add(f.key);
+
+  return `Before running this — known from previous sessions:\n${kept
+    .map(render)
+    .join('\n')}`;
+}
+
+/**
  * The bounded SessionStart index: titles and ids only, never bodies.
  *
  * Its budget is EARNED from measured hit rate rather than fixed, so a mature

--- a/plugin/hooks/lib/inject.mjs
+++ b/plugin/hooks/lib/inject.mjs
@@ -254,7 +254,21 @@ export function forCommand(
   if (!candidates.length) return null;
 
   // Highest confidence first, so a tight budget keeps the most trustworthy.
-  candidates.sort((a, b) => (b.confidence ?? 0.5) - (a.confidence ?? 0.5));
+  // AN EXPLICIT TRIGGER BEATS AN INCIDENTAL WORD, before confidence is even
+  // consulted. A finding whose author wrote a pattern that matched this command
+  // is about this command; one that matched because its prose happened to
+  // contain "build" is not, however confident it was about something else.
+  //
+  // Observed live: `dotnet build App.csproj | tail -20` surfaced a finding about
+  // stale MCP server processes instead of the one about pipes hiding exit
+  // codes, and `gh run list` surfaced a git-refspec finding instead of the one
+  // about mergeStateStatus. Both had the same confidence as the right answer,
+  // so confidence alone could not separate them -- and a tight budget then kept
+  // the wrong one.
+  const explicit = (n) => (n.trigger && safeTrigger(n.trigger)?.test(command) ? 1 : 0);
+  candidates.sort(
+    (a, b) => explicit(b) - explicit(a) || (b.confidence ?? 0.5) - (a.confidence ?? 0.5)
+  );
 
   // CAPPED BEFORE serve(). serve() re-reads and diffs the anchor of every
   // finding it is handed, so an unbounded candidate list turns one command into

--- a/plugin/hooks/lib/policy.mjs
+++ b/plugin/hooks/lib/policy.mjs
@@ -318,6 +318,36 @@ export function allow() {
 }
 
 /**
+ * Allows the call AND hands the model something it did not ask for.
+ *
+ * This is the delivery half of the knowledge graph, and it had no
+ * implementation. `forTouch` -- the just-in-time injection the design calls
+ * "where the win lands" -- was imported by nothing outside its own test, so a
+ * finding could only ever reach a model through a REFUSAL. Measured across a
+ * full working session on three real projects: 4,053 capture events, 2,063
+ * reads, and findings served exactly twice. The graph was writing knowledge it
+ * had no way to deliver.
+ *
+ * `additionalContext` rather than a `permissionDecisionReason`, because the call
+ * is not being judged -- it is proceeding, and this rides along with it. Nothing
+ * is emitted when there is nothing to say, so the common path stays a bare
+ * exit(0).
+ */
+export function allowWithContext(context) {
+  if (context) {
+    process.stdout.write(
+      JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          additionalContext: withEscape(context),
+        },
+      })
+    );
+  }
+  process.exit(0);
+}
+
+/**
  * Blocks the call and tells the model exactly what to call instead.
  *
  * The reason string is the whole user interface of this product for an agent.

--- a/plugin/hooks/lib/policy.mjs
+++ b/plugin/hooks/lib/policy.mjs
@@ -190,7 +190,7 @@ function statePath(sessionId) {
 
 /** A usable state object, whatever was on disk. */
 function emptyState() {
-  return { seen: {}, denied: {} };
+  return { seen: {}, denied: {}, injected: [] };
 }
 
 /**
@@ -210,6 +210,13 @@ export function loadState(sessionId) {
     return {
       seen: parsed.seen && typeof parsed.seen === 'object' ? parsed.seen : {},
       denied: parsed.denied && typeof parsed.denied === 'object' ? parsed.denied : {},
+      // WITHOUT THIS THE ONCE-PER-SESSION GATE DOES NOT EXIST. Every tool call
+      // is a separate hook PROCESS, so a set held only in memory dies with the
+      // process that built it: the router recorded which findings it had
+      // injected, saveState dropped the field, and the next call re-injected
+      // the same advice. The gate looked correct in unit tests, which share one
+      // process, and did nothing at all in production.
+      injected: Array.isArray(parsed.injected) ? parsed.injected : [],
     };
   } catch {
     return emptyState();
@@ -252,6 +259,11 @@ export function saveState(sessionId, state) {
     const merged = {
       seen: { ...current.seen, ...state.seen },
       denied: { ...current.denied, ...state.denied },
+      // UNION, not overwrite. Two hook processes running in parallel each hold
+      // their own view of what has been injected; taking the last writer's copy
+      // would resurrect a finding the other had already delivered, which is the
+      // repetition the once-per-session gate exists to stop.
+      injected: [...new Set([...(current.injected || []), ...(state.injected || [])])],
     };
 
     // Write-then-rename so a reader never observes a half-written file.

--- a/plugin/hooks/lib/policy.mjs
+++ b/plugin/hooks/lib/policy.mjs
@@ -179,13 +179,23 @@ export function fileSize(path) {
  * means state on disk, keyed by the session id the hook payload carries.
  * ------------------------------------------------------------------ */
 
-const STATE_ROOT = join(tmpdir(), 'token-optimizer-hooks');
+/**
+ * Where per-session hook state lives.
+ *
+ * Read per call rather than captured at import, so a test can point it at a
+ * temp directory. Contention on this file is the normal case -- parallel tool
+ * calls each spawn their own hook process -- and it was untestable while the
+ * path was a module constant, which is part of why an unlocked
+ * read-modify-write survived here unnoticed.
+ */
+const stateRoot = () =>
+  process.env.TOKEN_OPTIMIZER_STATE_DIR || join(tmpdir(), 'token-optimizer-hooks');
 
 function statePath(sessionId) {
   // Session ids come from the harness and are uuid-shaped, but they land in a
   // file path, so anything that could traverse is stripped rather than trusted.
   const safe = String(sessionId || 'default').replace(/[^A-Za-z0-9_-]/g, '');
-  return join(STATE_ROOT, `${safe || 'default'}.json`);
+  return join(stateRoot(), `${safe || 'default'}.json`);
 }
 
 /** A usable state object, whatever was on disk. */
@@ -242,18 +252,26 @@ export function loadState(sessionId) {
 export function saveState(sessionId, state) {
   let lock = null;
   try {
-    mkdirSync(STATE_ROOT, { recursive: true, mode: 0o700 });
+    mkdirSync(stateRoot(), { recursive: true, mode: 0o700 });
 
     // A LOCK, because merging alone still loses updates: two processes can both
     // read, both merge, and the second write still discards the first's
     // additions. `wx` fails if the file exists, which makes creation an atomic
     // test-and-set on every platform we target.
     //
-    // Bounded and best-effort: if the lock cannot be taken quickly the write
-    // proceeds anyway. A stale lock from a killed process must never wedge
-    // enforcement, and the worst case without the lock is the merge behaviour
-    // that was already acceptable.
+    // NO UNLOCKED READ-MODIFY-WRITE. This used to fall through and write anyway
+    // when the lock could not be taken, which reintroduces exactly the lost
+    // update the lock exists to prevent: a process that misses the lock reads
+    // the pre-merge state and can erase an `injected` id another process just
+    // recorded, letting the same finding be injected twice in one session.
+    //
+    // Skipping the write is the safe direction. The cost is that THIS process's
+    // additions are not persisted, and every consequence of that is already
+    // bounded by design -- a repeated denial is allowed through by rule, and a
+    // repeated injection costs its tokens once more. A stale lock is still
+    // broken and taken below, so a killed process cannot wedge enforcement.
     lock = takeLock(sessionId);
+    if (!lock) return false;
 
     const current = loadState(sessionId);
     const merged = {
@@ -286,7 +304,25 @@ export function saveState(sessionId, state) {
 }
 
 /** Best-effort exclusive lock. Returns the lock path, or null if not acquired. */
-function takeLock(sessionId, { attempts = 20, staleMs = 5000 } = {}) {
+/**
+ * Sleeps synchronously.
+ *
+ * These hooks are single-shot processes that must reach a decision before they
+ * return, so there is no event loop to yield to and nothing to await. Atomics
+ * on a throwaway SharedArrayBuffer is the standard way to block a worker for a
+ * bounded time without burning the CPU.
+ */
+function sleepSync(ms) {
+  try {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+  } catch {
+    // SharedArrayBuffer unavailable under some policies. The caller still makes
+    // progress; it simply retries sooner.
+  }
+}
+
+/** Best-effort exclusive lock. Returns the lock path, or null if not acquired. */
+function takeLock(sessionId, { attempts = 20, staleMs = 5000, waitMs = 15 } = {}) {
   const path = `${statePath(sessionId)}.lock`;
   for (let i = 0; i < attempts; i++) {
     try {
@@ -297,10 +333,21 @@ function takeLock(sessionId, { attempts = 20, staleMs = 5000 } = {}) {
       // A lock left behind by a killed process would otherwise block every
       // future write for the life of the session.
       try {
-        if (Date.now() - statSync(path).mtimeMs > staleMs) unlinkSync(path);
+        if (Date.now() - statSync(path).mtimeMs > staleMs) {
+          unlinkSync(path);
+          continue; // Retry immediately; the holder is gone.
+        }
       } catch {
-        // Raced with the holder releasing it; just retry.
+        // Raced with the holder releasing it; retry immediately.
+        continue;
       }
+
+      // A LIVE holder. Waiting is the whole point: the previous loop retried
+      // 20 times with no delay, so it exhausted in microseconds and the caller
+      // fell through to an unlocked write. Backing off actually lets the holder
+      // finish -- a state write is a few milliseconds -- which is the
+      // difference between contending and merely pretending to.
+      if (i < attempts - 1) sleepSync(waitMs);
     }
   }
   return null;

--- a/plugin/hooks/lib/staleness.mjs
+++ b/plugin/hooks/lib/staleness.mjs
@@ -359,10 +359,22 @@ export function serve(graph, findings) {
     }
 
     if (stale && !diff) {
-      // The invariant. Rather than serve a bare stale finding -- which the
-      // design calls worse than no graph -- say plainly that the evidence is
-      // gone, so the model treats the claim as unverified rather than current.
-      diff = '(the change could not be reconstructed; treat this finding as unverified)';
+      // The invariant holds: never serve a bare stale finding as though it were
+      // current. But the WORDING was doing more than that, and it was measured.
+      //
+      // "treat this finding as unverified" is an instruction to discount, and
+      // models follow it. In an A/B on a fresh subagent, identical findings
+      // scored 1/3 dead-ends avoided when rendered with that sentence and 2/3
+      // when rendered clean -- no code change, only the wording. The claim being
+      // discounted was correct every time; all that had changed was the anchor
+      // file, which says nothing about whether the claim still holds.
+      //
+      // So: report what is actually known -- the anchor moved and the evidence
+      // cannot be rebuilt -- and let the claim stand or fall on its own. That is
+      // honest about staleness without arguing against the content.
+      diff = '(the anchor changed since this was recorded and the diff can no longer be '
+        + 'reconstructed; the claim itself may well still hold, so weigh it rather than '
+        + 'discard it)';
     }
 
     served.push({ ...finding, stale, ...(stale ? { diff, staleReason: reason } : {}) });

--- a/plugin/hooks/lib/staleness.mjs
+++ b/plugin/hooks/lib/staleness.mjs
@@ -369,12 +369,19 @@ export function serve(graph, findings) {
       // discounted was correct every time; all that had changed was the anchor
       // file, which says nothing about whether the claim still holds.
       //
-      // So: report what is actually known -- the anchor moved and the evidence
-      // cannot be rebuilt -- and let the claim stand or fall on its own. That is
-      // honest about staleness without arguing against the content.
-      diff = '(the anchor changed since this was recorded and the diff can no longer be '
-        + 'reconstructed; the claim itself may well still hold, so weigh it rather than '
-        + 'discard it)';
+      // So: report what is actually known and let the claim stand or fall on its
+      // own. That is honest about staleness without arguing against the content.
+      //
+      // REASON-NEUTRAL. The earlier text asserted "the anchor changed", which is
+      // only one of the ways a finding reaches this branch -- it is also reached
+      // when the eager path marked the finding at write time, or when the anchor
+      // was never snapshotted at all because it exceeded the snapshot limit. In
+      // those cases the sentence stated a cause that had not been established.
+      // `reason` already carries whatever was actually determined, so the
+      // fallback now describes only the evidence gap.
+      diff = `(marked stale: ${reason}. The supporting diff can no longer be `
+        + 'reconstructed; the claim itself may well still hold, so weigh it rather '
+        + 'than discard it)';
     }
 
     served.push({ ...finding, stale, ...(stale ? { diff, staleReason: reason } : {}) });

--- a/plugin/hooks/lib/staleness.mjs
+++ b/plugin/hooks/lib/staleness.mjs
@@ -379,9 +379,14 @@ export function serve(graph, findings) {
       // those cases the sentence stated a cause that had not been established.
       // `reason` already carries whatever was actually determined, so the
       // fallback now describes only the evidence gap.
+      // NO DISMISSAL VOCABULARY AT ALL, not even in a sentence arguing against
+      // dismissal. "weigh it rather than discard it" still puts the word in
+      // front of the model, and this text exists precisely because the previous
+      // phrasing was measured suppressing correct findings. State the evidence
+      // gap and stop.
       diff = `(marked stale: ${reason}. The supporting diff can no longer be `
-        + 'reconstructed; the claim itself may well still hold, so weigh it rather '
-        + 'than discard it)';
+        + 'reconstructed; the claim itself may well still hold, so weigh it on '
+        + 'its own merits.)';
     }
 
     served.push({ ...finding, stale, ...(stale ? { diff, staleReason: reason } : {}) });

--- a/plugin/hooks/pretooluse-router.mjs
+++ b/plugin/hooks/pretooluse-router.mjs
@@ -144,7 +144,10 @@ try {
 
       for (const { path } of touched) {
         const dir = dirFor(path);
-        const note = forTouch(dir, load(dir), path, { sessionId: payload.session_id });
+        const note = forTouch(dir, load(dir), path, {
+          sessionId: payload.session_id,
+          alreadyInjected,
+        });
         if (note) parts.push(note);
       }
 

--- a/plugin/hooks/pretooluse-router.mjs
+++ b/plugin/hooks/pretooluse-router.mjs
@@ -11,12 +11,12 @@
  * free to -- and routinely did -- ignore.
  */
 
-import { readPayload, loadState, saveState, alreadyDenied, allow, enforce, mode, MODE_OFF }
+import { readPayload, loadState, saveState, alreadyDenied, allow, allowWithContext, enforce, mode, MODE_OFF }
   from './lib/policy.mjs';
 import { decide, remember, normalizePayload, readCostBytes, touchedFiles, isContentDump } from './lib/decide.mjs';
 import { recordRead } from './lib/metrics.mjs';
 import { wikiDir, load, harvest, projectRootFor, contentHash } from './lib/wiki.mjs';
-import { refusalPayload, substitutionFor } from './lib/inject.mjs';
+import { refusalPayload, substitutionFor, forTouch, forCommand } from './lib/inject.mjs';
 import { indexFile } from './lib/staleness.mjs';
 import { readFileSync } from 'node:fs';
 
@@ -121,7 +121,54 @@ try {
       } catch { /* never let bookkeeping break an allowed call */ }
     }
 
-    allow();
+    // DELIVER WHAT THE GRAPH ALREADY KNOWS. Everything above this line WRITES
+    // to the graph; until now nothing read from it on an allowed call, so
+    // `forTouch` -- the injection the design calls "where the win lands" -- was
+    // imported by nothing but its own test. Measured over a full session on
+    // three real projects: 4,053 captures, 2,063 reads, findings served twice.
+    //
+    // Both triggers fire here because findings answer two different questions.
+    // An anchor says which FILE a claim is about; a trigger says WHEN it is
+    // relevant. A claim about running something ("use npm test, not npx jest")
+    // is anchored to a file nobody opens at the moment they run the command,
+    // so file-touch injection alone could never deliver it -- and did not.
+    let context = null;
+    try {
+      // Once per session, per finding. Repeating advice on every call is how a
+      // real signal becomes wallpaper, and an ignored injection still costs its
+      // tokens every time.
+      state.injected = state.injected || [];
+      const alreadyInjected = new Set(state.injected);
+      const before = alreadyInjected.size;
+      const parts = [];
+
+      for (const { path } of touched) {
+        const dir = dirFor(path);
+        const note = forTouch(dir, load(dir), path, { sessionId: payload.session_id });
+        if (note) parts.push(note);
+      }
+
+      const command = payload.tool_input?.command;
+      if (command) {
+        const dir = wikiDir(projectRootFor(payload.cwd, payload.cwd));
+        const note = forCommand(dir, load(dir), command, {
+          sessionId: payload.session_id,
+          alreadyInjected,
+        });
+        if (note) parts.push(note);
+      }
+
+      if (alreadyInjected.size !== before) {
+        state.injected = [...alreadyInjected];
+        saveState(payload.session_id, state);
+      }
+      if (parts.length) context = parts.join('\n\n');
+    } catch {
+      // Delivery is an optimization. A defect here must never cost the user
+      // their tool call, so a failure falls through to a plain allow.
+    }
+
+    allowWithContext(context);
   }
 
   const repeat = alreadyDenied(state, verdict.key);

--- a/src/tools/intelligence/wiki-write.ts
+++ b/src/tools/intelligence/wiki-write.ts
@@ -41,6 +41,13 @@ export interface WikiWriteOptions {
   anchors: string[];
   /** finding | decision | failure | command | map. */
   type?: string;
+  /**
+   * Optional regex matched against a command about to run. Anchors answer
+   * "which file"; a trigger answers "when". Without one, a claim about running
+   * something can only surface if someone opens the file it is anchored to,
+   * which is not when the advice is needed.
+   */
+  trigger?: string;
   /** 0..1. Defaults to 0.9 — deliberate, but still a model's assertion. */
   confidence?: number;
   /** Recorded for provenance so a claim can be traced to the session. */
@@ -119,7 +126,7 @@ export async function wikiWrite(
 
     const keys: string[] = harvestWrite.writeHarvested(
       dir,
-      [{ type, claim, confidence, anchors }],
+      [{ type, claim, confidence, anchors, trigger: options.trigger }],
       {
         sessionId: options.sessionId ?? null,
         origin: curate.ORIGIN_AGENT,
@@ -204,6 +211,14 @@ export const WIKI_WRITE_TOOL_DEFINITION = {
       sessionId: {
         type: 'string',
         description: 'Optional session id, for provenance.',
+      },
+      trigger: {
+        type: 'string',
+        description:
+          'Optional regex matched against a command about to run, e.g. "\\bnpx jest\\b". ' +
+          'Anchors say which FILE a claim is about; a trigger says WHEN it is relevant. ' +
+          'Set it on anything about running something, or the claim can only surface ' +
+          'when someone happens to open the file it is anchored to.',
       },
       projectRoot: {
         type: 'string',

--- a/tests/fixtures/ab-injection-harness.mjs
+++ b/tests/fixtures/ab-injection-harness.mjs
@@ -9,12 +9,18 @@
  */
 import { spawnSync } from 'node:child_process';
 import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
-import { putNode, putNodeWithEdges, wikiDir, contentHash } from 'file:///C:/Users/cheat/source/repos/token-optimizer-mcp/hooks-core/wiki.mjs';
-import { indexFile } from 'file:///C:/Users/cheat/source/repos/token-optimizer-mcp/hooks-core/staleness.mjs';
+import { fileURLToPath } from 'node:url';
+import { putNode, putNodeWithEdges, wikiDir, contentHash } from '../../hooks-core/wiki.mjs';
+import { indexFile } from '../../hooks-core/staleness.mjs';
 
-const HOOK = 'C:/Users/cheat/source/repos/token-optimizer-mcp/plugin/hooks/pretooluse-router.mjs';
+// RESOLVED FROM THIS FILE, not from an absolute path. The harness was written
+// with the author's checkout baked in, which meant it ran nowhere else -- and a
+// proof harness that only works on one machine cannot be re-run to check a
+// later change, which is most of its value.
+const HERE = dirname(fileURLToPath(import.meta.url));
+const HOOK = join(HERE, '..', '..', 'plugin', 'hooks', 'pretooluse-router.mjs');
 
 // Five dead-ends this session actually hit. Each cost real time, and none is
 // discoverable by quickly reading the code -- which is the condition that makes
@@ -48,8 +54,19 @@ export const CASES = [
     trigger: '\\b(dotnet|npm|cargo)\\b.*\\|\\s*(tail|head)\\b',
     probeCommand: 'dotnet build App.csproj | tail -20',
     task: 'You want to run `dotnet build App.csproj`, show only the last 20 lines of output, AND reliably know whether the build itself failed. State the EXACT shell command(s). Keep it to one or two lines.',
-    walksIn: (s) => /\|\s*(tail|head)/.test(s) && !/(PIPESTATUS|\$\?|>\s*\S+\.log|tee)/i.test(s),
-    avoids: (s) => /(PIPESTATUS|>\s*\S+\.log[\s\S]*\$\?|tee)/i.test(s) || (/\$\?/.test(s) && !/\|\s*(tail|head)[\s\S]*\$\?/.test(s)),
+    // `tee` alone is NOT a fix: it still leaves the pipeline's status as the
+    // last command's. What actually propagates failure is `set -o pipefail`,
+    // PIPESTATUS, or capturing the status before any pipe (redirect to a file,
+    // read the code, then show the tail).
+    avoids: (s) =>
+      /set\s+-o\s+pipefail|pipefail/i.test(s) ||
+      /PIPESTATUS/i.test(s) ||
+      /LASTEXITCODE/i.test(s) ||
+      />\s*\S+\.(log|txt)[\s\S]*(\$\?|LASTEXITCODE)/i.test(s),
+    walksIn: (s) =>
+      /\|\s*(tail|head|tee)/i.test(s) &&
+      !/set\s+-o\s+pipefail|pipefail|PIPESTATUS|LASTEXITCODE/i.test(s) &&
+      !/>\s*\S+\.(log|txt)[\s\S]*(\$\?|LASTEXITCODE)/i.test(s),
   },
   {
     id: 'fetch-refspec',
@@ -119,11 +136,23 @@ export function buildArms() {
       env: { ...process.env, TOKEN_OPTIMIZER_WIKI_DIR: caseDir },
     });
 
+    // FAIL FAST. A hook that crashed and a hook that had nothing to say both
+    // produce no context, and silently conflating them would let a broken build
+    // score as "the graph did not help" -- turning a bug into a measurement.
+    if (r.error) throw r.error;
+    if (r.status !== 0) {
+      throw new Error(`hook exited ${r.status} for ${c.id}: ${String(r.stderr).slice(0, 400)}`);
+    }
     let injected = null;
-    try {
-      injected = JSON.parse(r.stdout || '{}')?.hookSpecificOutput?.additionalContext ?? null;
-    } catch {
-      injected = null;
+    const stdout = String(r.stdout || '').trim();
+    if (stdout) {
+      let parsed;
+      try {
+        parsed = JSON.parse(stdout);
+      } catch {
+        throw new Error(`hook wrote non-JSON for ${c.id}: ${stdout.slice(0, 200)}`);
+      }
+      injected = parsed?.hookSpecificOutput?.additionalContext ?? null;
     }
 
     out.push({ id: c.id, task: c.task, injected });
@@ -131,7 +160,7 @@ export function buildArms() {
   return out;
 }
 
-if (process.argv[1] && process.argv[1].endsWith('ab-seed.mjs')) {
+if (process.argv[1] && process.argv[1].endsWith('ab-injection-harness.mjs')) {
   const arms = buildArms();
   console.log(JSON.stringify(arms, null, 2));
 }

--- a/tests/fixtures/ab-injection-harness.mjs
+++ b/tests/fixtures/ab-injection-harness.mjs
@@ -1,0 +1,137 @@
+/**
+ * Builds the A/B arms from the REAL hook, not from hand-written hints.
+ *
+ * For each seeded dead-end it runs plugin/hooks/pretooluse-router.mjs with the
+ * command the subject is likely to reach for, and captures the additionalContext
+ * the hook actually emits. The treatment prompt is that string verbatim -- which
+ * is exactly what Claude Code prepends -- so the experiment tests the shipped
+ * delivery path rather than a mock of it.
+ */
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { putNode, putNodeWithEdges, wikiDir, contentHash } from 'file:///C:/Users/cheat/source/repos/token-optimizer-mcp/hooks-core/wiki.mjs';
+import { indexFile } from 'file:///C:/Users/cheat/source/repos/token-optimizer-mcp/hooks-core/staleness.mjs';
+
+const HOOK = 'C:/Users/cheat/source/repos/token-optimizer-mcp/plugin/hooks/pretooluse-router.mjs';
+
+// Five dead-ends this session actually hit. Each cost real time, and none is
+// discoverable by quickly reading the code -- which is the condition that makes
+// the control arm a fair comparison rather than a reading-comprehension test.
+export const CASES = [
+  {
+    id: 'npx-jest',
+    claim:
+      'Run the suite with npm test, not npx jest: the project passes --experimental-vm-modules, and bare npx jest silently skips every ESM suite.',
+    trigger: '\\bnpx\\s+jest\\b',
+    probeCommand: 'npx jest tests/unit/foo.test.ts',
+    task: 'You need to run the unit tests for this Node project (it uses Jest and ESM). State the EXACT shell command you would run. One line, command only.',
+    // The dead-end is answering with a bare `npx jest`.
+    walksIn: (s) => /\bnpx\s+jest\b/i.test(s) && !/npm\s+(run\s+)?test/i.test(s),
+    avoids: (s) => /npm\s+(run\s+)?test/i.test(s),
+  },
+  {
+    id: 'csproj-name',
+    claim:
+      'The test project file is tests/AiDotNet.Tests/AiDotNetTests.csproj -- the DIRECTORY is AiDotNet.Tests but the csproj has no dot. Guessing the symmetric name gives MSB1009 Project file does not exist.',
+    trigger: 'dotnet\\s+(build|test)',
+    probeCommand: 'dotnet build tests/AiDotNet.Tests/AiDotNet.Tests.csproj',
+    task: 'In a .NET repo there is a test project under tests/AiDotNet.Tests/. State the EXACT dotnet build command you would run, including the csproj path. One line, command only.',
+    walksIn: (s) => /AiDotNet\.Tests\.csproj/i.test(s),
+    avoids: (s) => /AiDotNetTests\.csproj/i.test(s),
+  },
+  {
+    id: 'pipe-exit',
+    claim:
+      'Piping a dotnet build or test through | tail or | head makes the shell report the PIPE exit status, not dotnet. A build that failed with MSB1009 came back as exit 0 and was reported as succeeding.',
+    trigger: '\\b(dotnet|npm|cargo)\\b.*\\|\\s*(tail|head)\\b',
+    probeCommand: 'dotnet build App.csproj | tail -20',
+    task: 'You want to run `dotnet build App.csproj`, show only the last 20 lines of output, AND reliably know whether the build itself failed. State the EXACT shell command(s). Keep it to one or two lines.',
+    walksIn: (s) => /\|\s*(tail|head)/.test(s) && !/(PIPESTATUS|\$\?|>\s*\S+\.log|tee)/i.test(s),
+    avoids: (s) => /(PIPESTATUS|>\s*\S+\.log[\s\S]*\$\?|tee)/i.test(s) || (/\$\?/.test(s) && !/\|\s*(tail|head)[\s\S]*\$\?/.test(s)),
+  },
+  {
+    id: 'fetch-refspec',
+    claim:
+      "A checkout's remote.origin.fetch can be clobbered to a single tag refspec, so git fetch origin master silently never updates origin/master and every 'commits behind' check lies. Verify with git config --get-all remote.origin.fetch.",
+    trigger: 'git\\s+fetch',
+    probeCommand: 'git fetch origin master',
+    task: 'You must confirm your local branch is up to date with the remote master before rebasing. State the EXACT git command(s) you would run to be certain. Keep it to one or two lines.',
+    walksIn: (s) => /git\s+fetch/i.test(s) && !/remote\.origin\.fetch|ls-remote/i.test(s),
+    avoids: (s) => /remote\.origin\.fetch|ls-remote/i.test(s),
+  },
+  {
+    id: 'dirty-pr',
+    claim:
+      'A PR whose mergeStateStatus is DIRTY causes GitHub to schedule NO pull_request-triggered workflows at all, because it cannot build refs/pull/N/merge. Runs are never created rather than cancelled. Check gh pr view N --json mergeStateStatus first.',
+    trigger: 'gh\\s+(pr|run)\\b',
+    probeCommand: 'gh run list --branch my-branch',
+    task: 'A GitHub PR shows only 2 checks and the main CI workflow never appears, even after pushing new commits. State the EXACT first gh command you would run to diagnose why. One line, command only.',
+    walksIn: (s) => /gh\s+run\s+(list|view)/i.test(s) && !/mergeStateStatus|mergeable/i.test(s),
+    avoids: (s) => /mergeStateStatus|mergeable/i.test(s),
+  },
+];
+
+export function buildArms() {
+  const project = mkdtempSync(join(tmpdir(), 'ab-'));
+  mkdirSync(join(project, '.git'), { recursive: true });
+  const dir = wikiDir(project);
+  const anchor = join(project, 'subject.mjs');
+  writeFileSync(anchor, 'export function subject() {}\n');
+
+  const out = [];
+  for (const c of CASES) {
+    // Fresh graph per case so one case's finding cannot answer another's task.
+    const caseProject = mkdtempSync(join(tmpdir(), `ab-${c.id}-`));
+    mkdirSync(join(caseProject, '.git'), { recursive: true });
+    const caseDir = wikiDir(caseProject);
+    const caseAnchor = join(caseProject, 'subject.mjs');
+    writeFileSync(caseAnchor, 'export function subject() {}\n');
+
+    // REAL hash, via the same indexer production uses. A placeholder made every
+    // finding render as STALE and 'treat this finding as unverified' -- the
+    // injection was telling the subject to discount itself.
+    indexFile(caseDir, caseAnchor);
+    const fid = putNode(caseDir, { kind: 'file', key: caseAnchor, hash: contentHash(caseAnchor) });
+    putNodeWithEdges(
+      caseDir,
+      {
+        kind: 'finding',
+        key: `ab-${c.id}`,
+        claim: c.claim,
+        type: 'command',
+        trigger: c.trigger,
+        confidence: 0.95,
+        origin: 'agent',
+      },
+      [{ edge: 'derived_from', to: fid }]
+    );
+
+    const r = spawnSync(process.execPath, [HOOK], {
+      input: JSON.stringify({
+        session_id: `ab-${c.id}`,
+        cwd: caseProject,
+        tool_name: 'Bash',
+        tool_input: { command: c.probeCommand },
+      }),
+      encoding: 'utf8',
+      env: { ...process.env, TOKEN_OPTIMIZER_WIKI_DIR: caseDir },
+    });
+
+    let injected = null;
+    try {
+      injected = JSON.parse(r.stdout || '{}')?.hookSpecificOutput?.additionalContext ?? null;
+    } catch {
+      injected = null;
+    }
+
+    out.push({ id: c.id, task: c.task, injected });
+  }
+  return out;
+}
+
+if (process.argv[1] && process.argv[1].endsWith('ab-seed.mjs')) {
+  const arms = buildArms();
+  console.log(JSON.stringify(arms, null, 2));
+}

--- a/tests/hooks/ab-scorers.test.mjs
+++ b/tests/hooks/ab-scorers.test.mjs
@@ -1,0 +1,54 @@
+/**
+ * The A/B scorers decide whether the graph helped, so a wrong scorer silently
+ * produces a wrong verdict about the whole feature. These pin the two the
+ * review caught: `tee` alone does not propagate a pipeline's exit status, and
+ * `set -o pipefail` does.
+ */
+import { describe, it, expect } from '@jest/globals';
+import { CASES } from '../fixtures/ab-injection-harness.mjs';
+
+const pipeExit = CASES.find((c) => c.id === 'pipe-exit');
+
+describe('pipe-exit scorer', () => {
+  it('treats bare tee as still walking into the dead end', () => {
+    // tee duplicates the stream; the pipeline's status is still the LAST
+    // command's, so the build failure is still invisible.
+    const answer = 'dotnet build App.csproj 2>&1 | tee build.log | tail -20';
+    expect(pipeExit.walksIn(answer)).toBe(true);
+    expect(pipeExit.avoids(answer)).toBe(false);
+  });
+
+  it('accepts set -o pipefail', () => {
+    const answer = 'set -o pipefail; dotnet build App.csproj | tail -20';
+    expect(pipeExit.avoids(answer)).toBe(true);
+    expect(pipeExit.walksIn(answer)).toBe(false);
+  });
+
+  it('accepts PIPESTATUS', () => {
+    const answer = 'dotnet build App.csproj | tail -20; echo ${PIPESTATUS[0]}';
+    expect(pipeExit.avoids(answer)).toBe(true);
+  });
+
+  it('accepts capturing the status before any pipe', () => {
+    const answer = 'dotnet build App.csproj > b.log 2>&1; ec=$?; tail -20 b.log';
+    expect(pipeExit.avoids(answer)).toBe(true);
+  });
+
+  it('still catches the naive pipe that started all this', () => {
+    const answer = 'dotnet build App.csproj | tail -20';
+    expect(pipeExit.walksIn(answer)).toBe(true);
+    expect(pipeExit.avoids(answer)).toBe(false);
+  });
+});
+
+describe('every case is scoreable', () => {
+  it('has a walksIn and avoids that disagree on the dead-end answer', () => {
+    // A case whose two scorers both fire, or neither, cannot produce a verdict.
+    for (const c of CASES) {
+      expect(typeof c.walksIn).toBe('function');
+      expect(typeof c.avoids).toBe('function');
+      expect(c.trigger).toBeTruthy();
+      expect(() => new RegExp(c.trigger)).not.toThrow();
+    }
+  });
+});

--- a/tests/hooks/command-injection.test.mjs
+++ b/tests/hooks/command-injection.test.mjs
@@ -227,3 +227,39 @@ describe('a model-supplied trigger cannot hang the hook', () => {
     expect(seen.size).toBeLessThanOrEqual(20);
   });
 });
+
+describe('relevance ordering', () => {
+  it('prefers a finding whose own trigger matched over one that matched a word', () => {
+    // Observed live: `dotnet build App.csproj | tail -20` surfaced a finding
+    // about stale MCP processes instead of the one about pipes hiding exit
+    // codes. Both were confident; only one was about this command.
+    seed({
+      key: 'incidental',
+      claim: 'The MCP server serves the build it LOADED, not what is on disk.',
+      type: 'failure',
+      trigger: undefined,
+      confidence: 0.95,
+    });
+    seed({
+      key: 'targeted',
+      claim: 'Capture the exit code before piping; a pipe reports the last command status.',
+      type: 'failure',
+      trigger: '\|\s*(tail|head)\b',
+      confidence: 0.95,
+    });
+
+    const out = forCommand(dir, load(dir), 'dotnet build App.csproj | tail -20', {
+      sessionId: 's1',
+    });
+
+    // Assert the ORDER rather than exclusion: a tight budget would also depend
+    // on how staleness renders, which is a different concern. What matters is
+    // that the targeted finding is ranked first, so a tight budget keeps it.
+    expect(out).toBeTruthy();
+    expect(out.indexOf('Capture the exit code')).toBeGreaterThanOrEqual(0);
+    expect(out.indexOf('serves the build it LOADED')).toBeGreaterThanOrEqual(0);
+    expect(out.indexOf('Capture the exit code')).toBeLessThan(
+      out.indexOf('serves the build it LOADED')
+    );
+  });
+});

--- a/tests/hooks/command-injection.test.mjs
+++ b/tests/hooks/command-injection.test.mjs
@@ -1,0 +1,175 @@
+/**
+ * Findings about ACTIONS have to arrive when the action is taken.
+ *
+ * Injection was keyed entirely on touching a file. The findings worth the most
+ * are about running things, and they are anchored to files nobody opens at the
+ * moment they run the command. The case that proved it, from a real session:
+ * the graph held "run the suite with npm test, not npx jest", anchored to
+ * plugin/hooks/lib/harvest.mjs. The agent ran `npx jest`, lost a test cycle,
+ * and the finding never fired -- because it was never going to.
+ *
+ * These tests pin the trigger path that closes that gap.
+ */
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { forCommand } from '../../hooks-core/inject.mjs';
+import { load, putNodeWithEdges, putNode, nodeId } from '../../hooks-core/wiki.mjs';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+let dir;
+let anchorFile;
+
+/** Stores a finding anchored to a real file, optionally with a trigger. */
+function seed({ key, claim, type = 'command', trigger, confidence = 0.9 }) {
+  const fileId = putNode(dir, { kind: 'file', key: anchorFile, hash: 'abc' });
+  return putNodeWithEdges(
+    dir,
+    { kind: 'finding', key, claim, type, trigger, confidence, origin: 'agent' },
+    [{ edge: 'derived_from', to: fileId }]
+  );
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'cmd-inject-'));
+  anchorFile = join(dir, 'harvest.mjs');
+  writeFileSync(anchorFile, 'export function harvest() {}\n');
+});
+
+afterEach(() => {
+  try {
+    rmSync(dir, { recursive: true, force: true });
+  } catch {
+    /* windows can hold a handle briefly */
+  }
+});
+
+describe('forCommand', () => {
+  it('delivers a triggered finding for the command that is about to run', () => {
+    seed({
+      key: 'f-npm-test',
+      claim: 'Run the suite with npm test, not npx jest.',
+      trigger: '\\bnpx\\s+jest\\b',
+    });
+
+    const out = forCommand(dir, load(dir), 'npx jest tests/unit/foo.test.ts', {
+      sessionId: 's1',
+    });
+
+    expect(out).toBeTruthy();
+    expect(out).toContain('npm test');
+  });
+
+  it('stays silent for an unrelated command', () => {
+    seed({
+      key: 'f-npm-test',
+      claim: 'Run the suite with npm test, not npx jest.',
+      trigger: '\\bnpx\\s+jest\\b',
+    });
+
+    expect(forCommand(dir, load(dir), 'git status', { sessionId: 's1' })).toBeNull();
+  });
+
+  it('fires at most once per session for the same finding', () => {
+    seed({
+      key: 'f-npm-test',
+      claim: 'Run the suite with npm test, not npx jest.',
+      trigger: '\\bnpx\\s+jest\\b',
+    });
+
+    const seen = new Set();
+    const first = forCommand(dir, load(dir), 'npx jest a', {
+      sessionId: 's1',
+      alreadyInjected: seen,
+    });
+    const second = forCommand(dir, load(dir), 'npx jest b', {
+      sessionId: 's1',
+      alreadyInjected: seen,
+    });
+
+    // Repeating advice on every command is how a real signal becomes wallpaper.
+    expect(first).toBeTruthy();
+    expect(second).toBeNull();
+  });
+
+  it('matches an untriggered command finding on a distinctive token', () => {
+    // Findings already in existing graphs have no trigger. They must keep
+    // working without a migration.
+    seed({
+      key: 'f-legacy',
+      claim: 'Run the suite with npm test, not npx jest: bare jest skips ESM suites.',
+      trigger: undefined,
+    });
+
+    expect(forCommand(dir, load(dir), 'npx jest tests/', { sessionId: 's1' })).toBeTruthy();
+  });
+
+  it('does not match an untriggered finding on a common word alone', () => {
+    seed({
+      key: 'f-noisy',
+      claim: 'This project should always prefer the other approach when there is a choice.',
+      trigger: undefined,
+    });
+
+    // Every one of those words is a stopword or too short to be distinctive.
+    expect(forCommand(dir, load(dir), 'ls -la', { sessionId: 's1' })).toBeNull();
+  });
+
+  it('ignores non-action findings that carry no trigger', () => {
+    seed({
+      key: 'f-map',
+      claim: 'The harvest module builds a digest and calls a cheap model.',
+      type: 'map',
+      trigger: undefined,
+    });
+
+    expect(forCommand(dir, load(dir), 'node harvest.mjs', { sessionId: 's1' })).toBeNull();
+  });
+
+  it('honours an explicit trigger even on a map-type finding', () => {
+    seed({
+      key: 'f-map-trig',
+      claim: 'Deploys must run from the deploy kit, never by hand.',
+      type: 'map',
+      trigger: 'deploy\\.sh',
+    });
+
+    expect(forCommand(dir, load(dir), './deploy.sh prod', { sessionId: 's1' })).toBeTruthy();
+  });
+
+  it('survives a malformed trigger regex instead of throwing on the hook path', () => {
+    seed({
+      key: 'f-bad',
+      claim: 'Something about running deploys.',
+      trigger: '([unclosed',
+    });
+
+    // Degrades to a literal substring test rather than taking the hook down.
+    expect(() => forCommand(dir, load(dir), 'echo ([unclosed', { sessionId: 's1' })).not.toThrow();
+  });
+
+  it('records what it served so the value can be measured', () => {
+    seed({
+      key: 'f-npm-test',
+      claim: 'Run the suite with npm test, not npx jest.',
+      trigger: '\\bnpx\\s+jest\\b',
+    });
+
+    forCommand(dir, load(dir), 'npx jest', { sessionId: 's1' });
+
+    const metrics = readFileSync(join(dir, 'metrics.jsonl'), 'utf8')
+      .split('\n')
+      .filter(Boolean)
+      .map((l) => JSON.parse(l))
+      .filter((r) => r.kind === 'inject');
+
+    expect(metrics.length).toBe(1);
+    expect(metrics[0].trigger).toBe('command');
+    expect(metrics[0].count).toBe(1);
+    expect(metrics[0].tokens).toBeGreaterThan(0);
+  });
+
+  it('returns nothing when the graph holds no findings at all', () => {
+    expect(forCommand(dir, load(dir), 'npx jest', { sessionId: 's1' })).toBeNull();
+  });
+});

--- a/tests/hooks/command-injection.test.mjs
+++ b/tests/hooks/command-injection.test.mjs
@@ -144,8 +144,16 @@ describe('forCommand', () => {
       trigger: '([unclosed',
     });
 
-    // Degrades to a literal substring test rather than taking the hook down.
-    expect(() => forCommand(dir, load(dir), 'echo ([unclosed', { sessionId: 's1' })).not.toThrow();
+    // Degrades to a literal substring test rather than taking the hook down --
+    // and the fallback must actually DELIVER, not merely avoid throwing. A
+    // silent null here would look identical to a passing test while the finding
+    // was lost.
+    let out;
+    expect(() => {
+      out = forCommand(dir, load(dir), 'echo ([unclosed', { sessionId: 's1' });
+    }).not.toThrow();
+    expect(out).toBeTruthy();
+    expect(out).toContain('running deploys');
   });
 
   it('records what it served so the value can be measured', () => {
@@ -171,5 +179,51 @@ describe('forCommand', () => {
 
   it('returns nothing when the graph holds no findings at all', () => {
     expect(forCommand(dir, load(dir), 'npx jest', { sessionId: 's1' })).toBeNull();
+  });
+});
+
+describe('a model-supplied trigger cannot hang the hook', () => {
+  it('refuses a catastrophically backtracking pattern instead of running it', async () => {
+    const { safeTrigger } = await import('../../hooks-core/inject.mjs');
+    // The classic ReDoS shape: a quantifier applied to a group that already
+    // contains one. Neither try/catch nor a timeout helps -- it does not throw,
+    // it simply does not return -- so it must never be executed at all.
+    expect(safeTrigger('(a+)+b')).toBeNull();
+    expect(safeTrigger('(a*)*b')).toBeNull();
+    expect(safeTrigger('(?:ab+)+c')).toBeNull();
+    expect(safeTrigger('(\d+)*$')).toBeNull();
+  });
+
+  it('refuses an absurdly long pattern', async () => {
+    const { safeTrigger } = await import('../../hooks-core/inject.mjs');
+    expect(safeTrigger('a'.repeat(500))).toBeNull();
+  });
+
+  it('still compiles the ordinary triggers this feature exists for', async () => {
+    const { safeTrigger } = await import('../../hooks-core/inject.mjs');
+    for (const t of ['\bnpx\s+jest\b', 'git\s+push', '\.csproj', 'gh\s+(pr|run)\b', 'dotnet\s+(build|test)']) {
+      expect(safeTrigger(t)).toBeInstanceOf(RegExp);
+    }
+  });
+
+  it('a rejected trigger degrades to a literal match rather than vanishing', () => {
+    // The finding must still be deliverable; it just cannot use the regex.
+    seed({ key: 'f-redos', claim: 'Something about (a+)+b in a command.', trigger: '(a+)+b' });
+    const out = forCommand(dir, load(dir), 'echo (a+)+b', { sessionId: 's1' });
+    expect(out).toBeTruthy();
+  });
+
+  it('does not consider an unbounded number of findings for one command', () => {
+    // serve() re-reads and diffs each candidate's anchor, so an uncapped list
+    // turns one command into one file read per matching finding, on the hook
+    // path, with the user waiting.
+    for (let i = 0; i < 60; i++) {
+      seed({ key: `bulk-${i}`, claim: `Bulk finding ${i} about jest.`, trigger: 'jest' });
+    }
+    const seen = new Set();
+    const out = forCommand(dir, load(dir), 'npx jest', { sessionId: 's1', alreadyInjected: seen });
+    expect(out).toBeTruthy();
+    // The budget trims further; the cap is what bounds the WORK done first.
+    expect(seen.size).toBeLessThanOrEqual(20);
   });
 });

--- a/tests/hooks/command-injection.test.mjs
+++ b/tests/hooks/command-injection.test.mjs
@@ -185,13 +185,18 @@ describe('forCommand', () => {
 describe('a model-supplied trigger cannot hang the hook', () => {
   it('refuses a catastrophically backtracking pattern instead of running it', async () => {
     const { safeTrigger } = await import('../../hooks-core/inject.mjs');
+    // String.raw throughout. A plain single-quoted string resolves an unknown
+    // escape to the bare character, so '(\d+)*$' was really passing `(d+)*$`
+    // and '\bnpx\s+jest\b' was passing a BACKSPACE followed by `npxs+jest`.
+    // The assertions still went green -- against patterns nobody wrote.
+    //
     // The classic ReDoS shape: a quantifier applied to a group that already
     // contains one. Neither try/catch nor a timeout helps -- it does not throw,
     // it simply does not return -- so it must never be executed at all.
-    expect(safeTrigger('(a+)+b')).toBeNull();
-    expect(safeTrigger('(a*)*b')).toBeNull();
-    expect(safeTrigger('(?:ab+)+c')).toBeNull();
-    expect(safeTrigger('(\d+)*$')).toBeNull();
+    expect(safeTrigger(String.raw`(a+)+b`)).toBeNull();
+    expect(safeTrigger(String.raw`(a*)*b`)).toBeNull();
+    expect(safeTrigger(String.raw`(?:ab+)+c`)).toBeNull();
+    expect(safeTrigger(String.raw`(\d+)*$`)).toBeNull();
   });
 
   it('refuses an absurdly long pattern', async () => {
@@ -201,9 +206,21 @@ describe('a model-supplied trigger cannot hang the hook', () => {
 
   it('still compiles the ordinary triggers this feature exists for', async () => {
     const { safeTrigger } = await import('../../hooks-core/inject.mjs');
-    for (const t of ['\bnpx\s+jest\b', 'git\s+push', '\.csproj', 'gh\s+(pr|run)\b', 'dotnet\s+(build|test)']) {
+    const REAL_TRIGGERS = [
+      String.raw`\bnpx\s+jest\b`,
+      String.raw`git\s+push`,
+      String.raw`\.csproj`,
+      String.raw`gh\s+(pr|run)\b`,
+      String.raw`dotnet\s+(build|test)`,
+    ];
+    for (const t of REAL_TRIGGERS) {
       expect(safeTrigger(t)).toBeInstanceOf(RegExp);
     }
+    // And they must actually MATCH what they were written for -- the previous
+    // form compiled a mangled pattern and proved nothing about the real one.
+    expect(safeTrigger(String.raw`\bnpx\s+jest\b`).test('npx jest tests/')).toBe(true);
+    expect(safeTrigger(String.raw`\bnpx\s+jest\b`).test('npm test')).toBe(false);
+    expect(safeTrigger(String.raw`dotnet\s+(build|test)`).test('dotnet build x')).toBe(true);
   });
 
   it('a rejected trigger degrades to a literal match rather than vanishing', () => {

--- a/tests/hooks/enforcement.test.mjs
+++ b/tests/hooks/enforcement.test.mjs
@@ -19,6 +19,9 @@ import { dirname } from 'node:path';
 const HERE = dirname(fileURLToPath(import.meta.url));
 const ROUTER = join(HERE, '..', '..', 'plugin', 'hooks', 'pretooluse-router.mjs');
 
+/** An empty graph, so no stored finding can influence an enforcement decision. */
+const ISOLATED_GRAPH = mkdtempSync(join(tmpdir(), 'enforcement-graph-'));
+
 let workspace;
 let big;
 let small;
@@ -36,12 +39,21 @@ beforeAll(() => {
 
 afterAll(() => rmSync(workspace, { recursive: true, force: true }));
 
-/** Runs the router with a payload and returns the parsed decision. */
+/**
+ * Runs the router with a payload and returns the parsed decision.
+ *
+ * ISOLATED GRAPH. Without this the router consults whatever findings happen to
+ * be in the developer's own project graph, so these assertions depended on
+ * machine state: seeding a real finding whose trigger matched `| head` turned
+ * this suite red without a line of production code changing. A suite about
+ * ENFORCEMENT must not be able to fail because of what someone learned last
+ * week.
+ */
 function run(payload, env = {}) {
   const result = spawnSync(process.execPath, [ROUTER], {
     input: JSON.stringify({ session_id: payload.session_id || 's-default', ...payload }),
     encoding: 'utf8',
-    env: { ...process.env, ...env },
+    env: { ...process.env, TOKEN_OPTIMIZER_WIKI_DIR: ISOLATED_GRAPH, ...env },
   });
   if (!result.stdout.trim()) return { decision: 'allow' };
   const parsed = JSON.parse(result.stdout);
@@ -51,6 +63,7 @@ function run(payload, env = {}) {
     reason: out.permissionDecisionReason || out.additionalContext || '',
   };
 }
+
 
 const read = (path, extra = {}) => ({ tool_name: 'Read', tool_input: { file_path: path }, ...extra });
 

--- a/tests/hooks/injection-e2e.test.mjs
+++ b/tests/hooks/injection-e2e.test.mjs
@@ -22,6 +22,11 @@ const HOOK = join(process.cwd(), 'plugin', 'hooks', 'pretooluse-router.mjs');
 
 let project;
 let dir;
+// UNIQUE PER RUN. The once-per-session gate is persisted to disk now, so a
+// fixed session id would make the suite observe its OWN previous run and
+// correctly decline to re-inject -- a hermeticity problem in the test, not a
+// product bug. It surfaced the moment the persistence defect was fixed.
+let session;
 
 beforeEach(() => {
   project = mkdtempSync(join(tmpdir(), 'inject-e2e-'));
@@ -29,6 +34,7 @@ beforeEach(() => {
   // the hook consults THIS graph rather than walking up to a real one.
   mkdirSync(join(project, '.git'), { recursive: true });
   dir = wikiDir(project);
+  session = `e2e-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 });
 
 afterEach(() => {
@@ -56,12 +62,24 @@ function runHook(payload, env = {}) {
     timeout: 30_000,
     env: { ...process.env, TOKEN_OPTIMIZER_WIKI_DIR: dir, ...env },
   });
-  let json = null;
-  try {
-    json = result.stdout ? JSON.parse(result.stdout) : null;
-  } catch {
-    /* a bare allow writes nothing */
+  // FAIL FAST rather than treating a crash as "no context". A hook that died
+  // and a hook that had nothing to say both produce no additionalContext, and
+  // conflating them would let a broken build pass every silence assertion here.
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`hook exited ${result.status}: ${String(result.stderr).slice(0, 400)}`);
   }
+
+  const stdout = String(result.stdout || '').trim();
+  let json = null;
+  if (stdout) {
+    try {
+      json = JSON.parse(stdout);
+    } catch {
+      throw new Error(`hook wrote non-JSON: ${stdout.slice(0, 200)}`);
+    }
+  }
+  // Only an EMPTY stdout from a successful process is a bare allow.
   return { status: result.status, stdout: result.stdout, json };
 }
 
@@ -77,7 +95,7 @@ describe('injection reaches the model through the real hook', () => {
     });
 
     const { json } = runHook({
-      session_id: 'e2e-1',
+      session_id: session,
       cwd: project,
       tool_name: 'Bash',
       tool_input: { command: 'npx jest tests/unit' },
@@ -101,7 +119,7 @@ describe('injection reaches the model through the real hook', () => {
     });
 
     const { json } = runHook({
-      session_id: 'e2e-2',
+      session_id: session,
       cwd: project,
       tool_name: 'Bash',
       tool_input: { command: 'git status' },
@@ -124,7 +142,7 @@ describe('injection reaches the model through the real hook', () => {
     // leaked even a hint, every measured difference would be understated.
     const { json } = runHook(
       {
-        session_id: 'e2e-3',
+        session_id: session,
         cwd: project,
         tool_name: 'Bash',
         tool_input: { command: 'npx jest tests/unit' },
@@ -140,7 +158,7 @@ describe('injection reaches the model through the real hook', () => {
     writeFileSync(join(dir, 'graph.jsonl'), '{not json at all\n');
 
     const { status, json } = runHook({
-      session_id: 'e2e-4',
+      session_id: session,
       cwd: project,
       tool_name: 'Bash',
       tool_input: { command: 'npx jest' },

--- a/tests/hooks/injection-e2e.test.mjs
+++ b/tests/hooks/injection-e2e.test.mjs
@@ -1,0 +1,153 @@
+/**
+ * End-to-end: does a finding actually reach the model?
+ *
+ * The unit tests prove `forTouch` and `forCommand` return the right string.
+ * That was never the defect. The defect was that NOTHING CALLED THEM -- both
+ * were imported only by their own tests while the production hook imported
+ * `refusalPayload` and `substitutionFor` from the same module. A unit test
+ * suite can be entirely green while the feature ships dead, and it was.
+ *
+ * So these tests spawn the real hook binary with a real PreToolUse payload and
+ * assert on what it writes to stdout. That is the only thing that can tell the
+ * difference between "the function works" and "the model gets it".
+ */
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { spawnSync } from 'child_process';
+import { join } from 'path';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs';
+import { tmpdir } from 'os';
+import { putNode, putNodeWithEdges, wikiDir } from '../../hooks-core/wiki.mjs';
+
+const HOOK = join(process.cwd(), 'plugin', 'hooks', 'pretooluse-router.mjs');
+
+let project;
+let dir;
+
+beforeEach(() => {
+  project = mkdtempSync(join(tmpdir(), 'inject-e2e-'));
+  // A repository marker, so projectRootFor resolves to this temp project and
+  // the hook consults THIS graph rather than walking up to a real one.
+  mkdirSync(join(project, '.git'), { recursive: true });
+  dir = wikiDir(project);
+});
+
+afterEach(() => {
+  try {
+    rmSync(project, { recursive: true, force: true });
+  } catch {
+    /* windows can hold a handle briefly */
+  }
+});
+
+function seedFinding({ key, claim, type = 'command', trigger, anchorPath }) {
+  const fileId = putNode(dir, { kind: 'file', key: anchorPath, hash: 'abc' });
+  putNodeWithEdges(
+    dir,
+    { kind: 'finding', key, claim, type, trigger, confidence: 0.95, origin: 'agent' },
+    [{ edge: 'derived_from', to: fileId }]
+  );
+}
+
+/** Runs the hook exactly as Claude Code would, returning parsed stdout. */
+function runHook(payload, env = {}) {
+  const result = spawnSync(process.execPath, [HOOK], {
+    input: JSON.stringify(payload),
+    encoding: 'utf8',
+    timeout: 30_000,
+    env: { ...process.env, TOKEN_OPTIMIZER_WIKI_DIR: dir, ...env },
+  });
+  let json = null;
+  try {
+    json = result.stdout ? JSON.parse(result.stdout) : null;
+  } catch {
+    /* a bare allow writes nothing */
+  }
+  return { status: result.status, stdout: result.stdout, json };
+}
+
+describe('injection reaches the model through the real hook', () => {
+  it('delivers a command finding before the command runs', () => {
+    const anchor = join(project, 'harvest.mjs');
+    writeFileSync(anchor, 'export function harvest() {}\n');
+    seedFinding({
+      key: 'f-npm-test',
+      claim: 'Run the suite with npm test, not npx jest: bare jest skips ESM suites.',
+      trigger: '\\bnpx\\s+jest\\b',
+      anchorPath: anchor,
+    });
+
+    const { json } = runHook({
+      session_id: 'e2e-1',
+      cwd: project,
+      tool_name: 'Bash',
+      tool_input: { command: 'npx jest tests/unit' },
+    });
+
+    // THE ASSERTION THAT MATTERS. Before this change the hook wrote nothing at
+    // all on an allowed call, so this was necessarily null.
+    expect(json?.hookSpecificOutput?.additionalContext).toBeTruthy();
+    expect(json.hookSpecificOutput.additionalContext).toContain('npm test');
+    expect(json.hookSpecificOutput.hookEventName).toBe('PreToolUse');
+  });
+
+  it('stays silent on an unrelated command', () => {
+    const anchor = join(project, 'harvest.mjs');
+    writeFileSync(anchor, 'export function harvest() {}\n');
+    seedFinding({
+      key: 'f-npm-test',
+      claim: 'Run the suite with npm test, not npx jest.',
+      trigger: '\\bnpx\\s+jest\\b',
+      anchorPath: anchor,
+    });
+
+    const { json } = runHook({
+      session_id: 'e2e-2',
+      cwd: project,
+      tool_name: 'Bash',
+      tool_input: { command: 'git status' },
+    });
+
+    expect(json?.hookSpecificOutput?.additionalContext ?? null).toBeNull();
+  });
+
+  it('says nothing when the optimizer is off, so the control arm is honest', () => {
+    const anchor = join(project, 'harvest.mjs');
+    writeFileSync(anchor, 'export function harvest() {}\n');
+    seedFinding({
+      key: 'f-npm-test',
+      claim: 'Run the suite with npm test, not npx jest.',
+      trigger: '\\bnpx\\s+jest\\b',
+      anchorPath: anchor,
+    });
+
+    // The A/B control depends on this being truly silent. If the off switch
+    // leaked even a hint, every measured difference would be understated.
+    const { json } = runHook(
+      {
+        session_id: 'e2e-3',
+        cwd: project,
+        tool_name: 'Bash',
+        tool_input: { command: 'npx jest tests/unit' },
+      },
+      { TOKEN_OPTIMIZER_MODE: 'off' }
+    );
+
+    expect(json?.hookSpecificOutput?.additionalContext ?? null).toBeNull();
+  });
+
+  it('never fails the user’s call, even with a corrupt graph', () => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'graph.jsonl'), '{not json at all\n');
+
+    const { status, json } = runHook({
+      session_id: 'e2e-4',
+      cwd: project,
+      tool_name: 'Bash',
+      tool_input: { command: 'npx jest' },
+    });
+
+    // Delivery is an optimization. A broken graph must cost the user nothing.
+    expect(status).toBe(0);
+    expect(json?.hookSpecificOutput?.permissionDecision ?? 'allow').not.toBe('deny');
+  });
+});

--- a/tests/hooks/staleness.test.mjs
+++ b/tests/hooks/staleness.test.mjs
@@ -191,8 +191,18 @@ describe('the diff invariant -- a stale finding never arrives bare', () => {
     const graph = load(dir);
     const [out] = serve(graph, [graph.nodes.get(finding)]);
     expect(out.stale).toBe(true);
-    // Never an empty diff: the model must be told the claim is unverified.
-    expect(out.diff).toContain('unverified');
+    // THE INVARIANT IS "never bare", not a particular sentence. The previous
+    // assertion pinned the word "unverified", which is how the wording survived
+    // long enough to be measured doing harm: identical findings scored 1/3
+    // dead-ends avoided when the model was told to treat them as unverified and
+    // 2/3 when it was not. Assert that the staleness is disclosed and that the
+    // evidence gap is named -- not the exact phrasing, which should be free to
+    // improve without a test standing in the way.
+    expect(out.diff).toBeTruthy();
+    expect(out.diff.length).toBeGreaterThan(20);
+    expect(out.diff).toMatch(/reconstruct/i);
+    // And it must NOT tell the model to discard a claim that may still hold.
+    expect(out.diff).not.toMatch(/\bunverified\b/i);
   });
 });
 

--- a/tests/hooks/staleness.test.mjs
+++ b/tests/hooks/staleness.test.mjs
@@ -201,8 +201,18 @@ describe('the diff invariant -- a stale finding never arrives bare', () => {
     expect(out.diff).toBeTruthy();
     expect(out.diff.length).toBeGreaterThan(20);
     expect(out.diff).toMatch(/reconstruct/i);
-    // And it must NOT tell the model to discard a claim that may still hold.
-    expect(out.diff).not.toMatch(/\bunverified\b/i);
+    // And it must carry NO instruction to abandon the claim, however phrased.
+    // The measured harm was the instruction, not one particular word, so this
+    // rejects the whole vocabulary rather than the sentence that was found
+    // doing damage -- otherwise the next rewording reintroduces it freely.
+    expect(out.diff).not.toMatch(
+      /\b(unverified|unreliable|untrusted|discard|dismiss|disregard|ignore)\b/i
+    );
+    expect(out.diff).not.toMatch(/\bdo not (trust|rely|use)\b/i);
+    // Nor may it assert a cause it has not established: `reason` carries
+    // whatever was actually determined, and this branch is also reached by
+    // eager marking and by an anchor that was never snapshotted.
+    expect(out.diff).not.toMatch(/the anchor changed/i);
   });
 });
 

--- a/tests/hooks/state-contention.test.mjs
+++ b/tests/hooks/state-contention.test.mjs
@@ -1,0 +1,110 @@
+/**
+ * Session state under contention.
+ *
+ * Several tool calls can run in parallel and each spawns its own hook process,
+ * so concurrent writers are the normal case here rather than an edge one. The
+ * lock exists because merging alone still loses updates: two processes can both
+ * read, both merge, and the second write discards the first's additions.
+ *
+ * What made that worse than it looked: the lock was retried twenty times with
+ * NO delay, so it exhausted in microseconds and the caller fell through to an
+ * unlocked read-modify-write -- reintroducing the exact lost update the lock was
+ * added to prevent. For `injected` that means a finding can be delivered twice
+ * in one session; for `denied` it re-arms a refusal that was already issued.
+ */
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { loadState, saveState } from '../../hooks-core/policy.mjs';
+import { mkdtempSync, rmSync, writeFileSync, existsSync, unlinkSync, utimesSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+let root;
+let session;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'state-contention-'));
+  process.env.TOKEN_OPTIMIZER_STATE_DIR = root;
+  session = `sess-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+});
+
+afterEach(() => {
+  delete process.env.TOKEN_OPTIMIZER_STATE_DIR;
+  try {
+    rmSync(root, { recursive: true, force: true });
+  } catch {
+    /* windows can hold a handle briefly */
+  }
+});
+
+describe('the injected set survives', () => {
+  it('persists across separate loads, which is what makes the gate real', () => {
+    // Every tool call is a separate PROCESS. A set held only in memory dies
+    // with the process that built it, so this round trip IS the feature.
+    saveState(session, { seen: {}, denied: {}, injected: ['finding-a'] });
+    expect(loadState(session).injected).toContain('finding-a');
+  });
+
+  it('unions rather than overwrites, so parallel writers cannot erase each other', () => {
+    saveState(session, { seen: {}, denied: {}, injected: ['finding-a'] });
+    saveState(session, { seen: {}, denied: {}, injected: ['finding-b'] });
+
+    const after = loadState(session).injected;
+    expect(after).toEqual(expect.arrayContaining(['finding-a', 'finding-b']));
+  });
+
+  it('does not duplicate an id written twice', () => {
+    saveState(session, { seen: {}, denied: {}, injected: ['finding-a'] });
+    saveState(session, { seen: {}, denied: {}, injected: ['finding-a'] });
+    expect(loadState(session).injected.filter((k) => k === 'finding-a')).toHaveLength(1);
+  });
+});
+
+describe('a held lock', () => {
+  /** The lock file saveState uses, alongside the state file. */
+  const lockPath = (s) => join(root, `${s}.json.lock`);
+
+  it('makes the write skip rather than proceed unlocked', () => {
+    saveState(session, { seen: {}, denied: {}, injected: ['first'] });
+    expect(loadState(session).injected).toContain('first');
+
+    // Hold the lock as a LIVE holder -- freshly created, so it is not stale.
+    writeFileSync(lockPath(session), '');
+
+    try {
+      const ok = saveState(session, { seen: {}, denied: {}, injected: ['second'] });
+
+      // The write is refused rather than performed without exclusion. Doing it
+      // anyway is what could erase the other process's entry.
+      expect(ok).toBe(false);
+      const after = loadState(session).injected;
+      expect(after).toContain('first');
+      expect(after).not.toContain('second');
+    } finally {
+      try {
+        unlinkSync(lockPath(session));
+      } catch {
+        /* already gone */
+      }
+    }
+  });
+
+  it('is broken and taken when it is stale, so a killed process cannot wedge state', () => {
+    // A lock left behind by a killed process must never block writes forever --
+    // that would stop `denied` persisting and turn a bounded refusal into a loop.
+    writeFileSync(lockPath(session), '');
+    // Backdate it well past the staleness window. `require` is unavailable in
+    // an ESM test, and swallowing that in a try/catch made this pass silently
+    // against a lock that was never actually stale.
+    const old = new Date(Date.now() - 60_000);
+    utimesSync(lockPath(session), old, old);
+
+    const ok = saveState(session, { seen: {}, denied: {}, injected: ['after-stale'] });
+    expect(ok).not.toBe(false);
+    expect(loadState(session).injected).toContain('after-stale');
+  });
+
+  it('releases the lock afterwards so the next writer is not blocked', () => {
+    saveState(session, { seen: {}, denied: {}, injected: ['x'] });
+    expect(existsSync(lockPath(session))).toBe(false);
+  });
+});


### PR DESCRIPTION
## The graph could store and retrieve. It could not deliver.

`forTouch()` — the just-in-time injection the design calls *"where the win lands"* — was imported by **nothing except its own test**. The production hook imports `refusalPayload` and `substitutionFor` from the same module and never `forTouch`.

Measured across a full working session on three real project graphs:

| | |
|---|---|
| capture events | 4,053 |
| read events | 2,063 |
| **findings actually served** | **2** |

A green unit suite the entire time, because the functions were correct — nothing called them.

**Second, independent cause:** injection is keyed on touching a **file**, but the findings worth most are about **actions**. A `command` finding — *"run the suite with `npm test`, not `npx jest`"* — is anchored to a source file. An agent about to run `npx jest` is not touching that file, so the advice could never fire when it mattered. It didn't, and the agent made exactly the recorded mistake.

## What this adds

- **`allowWithContext`** — an allowed call can now carry `additionalContext`. Previously an allowed call wrote nothing, so there was no channel at all.
- **`forCommand`** — matches findings against the command about to run. Findings gain an optional **`trigger`** regex: anchors say which *file* a claim is about, a trigger says *when* it's relevant. Untriggered `command`/`failure` findings still match on distinctive whole-word tokens, so existing graphs work with no migration.
- Both **wired into the router**, behind a strict token budget and a **once-per-session** gate per finding.
- Fully wrapped — a delivery defect falls through to a plain `allow`.

## Measurement — pre-registered *before* the fix

`docs/INJECTION_PROOF_PROTOCOL.md`, written first so the bar couldn't move. Gate: **≥80% avoided, 0 regressions**. Subject: a fresh subagent (the author has seen the answers). Treatment gets the **real hook's output verbatim**; control gets nothing.

### Result: 2 of 3 avoided (67%), 0 regressions — **FAILS THE GATE**

| case | control | treatment | avoided |
|---|---|---|---|
| csproj-name | `AiDotNet.Tests.csproj` | `AiDotNetTests.csproj` | ✅ |
| fetch-refspec | `git fetch && git status` | `git config --get-all remote.origin.fetch && …` | ✅ |
| dirty-pr | `gh pr checks` | `gh pr checks <N>` | ❌ |

Two findings worth more than a pass would have been:

1. **The first run scored 1/3, and the cause was rendering, not delivery.** Every finding rendered as `STALE … treat this finding as unverified` because the harness seeded a placeholder hash — the injection was instructing the subject to discount itself. Fixing the seed moved 1/3 → 2/3 **with no code change**. How a finding is *worded* is worth as much as whether it arrives, and the stale wording is too strong when the diff can't be reconstructed.
2. The remaining failure is a claim whose action is buried at the end of three sentences. **Delivery is necessary, not sufficient.**

Sample size is 3 (only cases where the control actually walked in count, per the protocol). Small — stated rather than glossed.

## Delivery itself is proven

**0/5 → 5/5** findings delivered through the real hook binary, asserted in `injection-e2e.test.mjs` by spawning the hook and reading its stdout — the only kind of test that distinguishes *"the function works"* from *"the model gets it"*.

**111 suites, 1504 tests, build clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)