### PR TITLE
feat(lessons): capture user corrections and deliver them back as instructions

### DIFF
--- a/hooks-core/harvest-write.mjs
+++ b/hooks-core/harvest-write.mjs
@@ -26,7 +26,7 @@ import { indexFile } from './staleness.mjs';
 import { symbolKey } from './symbols.mjs';
 import { canonicalPath } from './paths.mjs';
 import { randomBytes } from 'node:crypto';
-import { ORIGIN_HARVESTED, ORIGIN_AGENT } from './curate.mjs';
+import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
 
 /**
  * Resolves an `path` or `path#symbol` anchor to an existing node id.
@@ -79,11 +79,33 @@ export function writeHarvested(
 ) {
   if (!Array.isArray(findings) || !findings.length) return [];
 
-  // Only the two origins this path can honestly claim. A caller asking for
-  // anything else -- notably ORIGIN_HUMAN -- would be labelling machine output
-  // as a person's assertion, which is the confusion the field exists to prevent.
-  const provenance = origin === ORIGIN_AGENT ? ORIGIN_AGENT : ORIGIN_HARVESTED;
-  const prefix = provenance === ORIGIN_AGENT ? 'agent' : 'harvested';
+  // The batch default. A caller asking for anything else -- notably
+  // ORIGIN_HUMAN -- would be labelling machine output as a person's assertion,
+  // which is the confusion the field exists to prevent.
+  const batch = origin === ORIGIN_AGENT ? ORIGIN_AGENT : ORIGIN_HARVESTED;
+
+  /**
+   * ORIGIN_HUMAN IS EARNED PER FINDING, BY EVIDENCE.
+   *
+   * A batch-wide origin was the whole story here, and it silently discarded
+   * the per-lesson provenance `validateLessons` had just computed: a
+   * correction whose quote was verified word-for-word in the user's own turn
+   * was stored as ORIGIN_HARVESTED like any model paraphrase. The standing-
+   * rules layer selects on human origin, so it matched nothing this pipeline
+   * wrote, and the verbatim check had no observable effect at all.
+   *
+   * The original rule still holds -- a caller cannot simply DECLARE machine
+   * output human. It is the verified quote that promotes it, and the quote is
+   * stored alongside so the claim carries its own evidence.
+   */
+  const provenanceFor = (finding) =>
+    finding.origin === ORIGIN_HUMAN &&
+    typeof finding.quote === 'string' &&
+    finding.quote.trim()
+      ? ORIGIN_HUMAN
+      : batch;
+  const prefixFor = (p) =>
+    p === ORIGIN_AGENT ? 'agent' : p === ORIGIN_HUMAN ? 'human' : 'harvested';
 
   const written = [];
   for (const finding of findings) {
@@ -101,7 +123,8 @@ export function writeHarvested(
     // same key, and putNode keeps the last write for an id -- so one session's
     // finding silently replaces another's. A random suffix makes that
     // collision vanishingly unlikely while keeping the timestamp readable.
-    const key = `${prefix}-${Date.now().toString(36)}-${written.length}-${randomBytes(4).toString("hex")}`;
+    const provenance = provenanceFor(finding);
+    const key = `${prefixFor(provenance)}-${Date.now().toString(36)}-${written.length}-${randomBytes(4).toString("hex")}`;
     // ONE APPEND for the finding and every anchor it resolved. This runs in a
     // detached worker, so "the process survives to finish the loop" is not a
     // safe assumption: a node written without its edges is an active finding
@@ -125,6 +148,11 @@ export function writeHarvested(
           ? finding.trigger
           : undefined,
         origin: provenance,
+        // THE EVIDENCE TRAVELS WITH THE CLAIM. Without it a human-origin
+        // finding asserts its own provenance and nothing can check it.
+        quote: typeof finding.quote === 'string' && finding.quote.trim()
+          ? finding.quote
+          : undefined,
         sessionId,
       },
       resolved.map((target) => ({ edge: 'derived_from', to: target }))

--- a/hooks-core/harvest.mjs
+++ b/hooks-core/harvest.mjs
@@ -34,7 +34,10 @@ const ENDPOINT = () => process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT
   || 'https://api.anthropic.com/v1/messages';
 
 /** Findings must be one of these. Free-form claims are rejected. */
-export const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map'];
+// 'feedback' is a lesson extracted from a USER CORRECTION rather than from the
+// code -- the only finding type whose source is a person telling the agent it
+// was wrong, which is why it is kept distinguishable from an ordinary finding.
+export const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map', 'feedback'];
 
 export function apiKey() {
   return process.env.TOKEN_OPTIMIZER_API_KEY || process.env.ANTHROPIC_API_KEY || null;
@@ -220,7 +223,7 @@ export function validate(raw, { knownFiles = null } = {}) {
  * indistinguishable, from the caller's side, from a session with nothing to
  * learn.
  */
-export async function extract(digest, { timeoutMs = 30_000 } = {}) {
+export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}) {
   if (!digest || !harvestEnabled()) return [];
 
   // A local endpoint usually has no auth at all, so requiring a key there would
@@ -246,7 +249,7 @@ export async function extract(digest, { timeoutMs = 30_000 } = {}) {
       body: JSON.stringify({
         model: MODEL(),
         max_tokens: 2048,
-        system: PROMPT,
+        system: prompt || PROMPT,
         messages: [{ role: 'user', content: digest }],
       }),
     });

--- a/hooks-core/inject.mjs
+++ b/hooks-core/inject.mjs
@@ -29,6 +29,20 @@ import { substitutionBudget } from './metrics.mjs';
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
 
+/**
+ * Tokens allowed for the always-on standing rules.
+ *
+ * FIXED AND SMALL, unlike the session index whose budget is earned from measured
+ * hit rate. An earned budget is right for a catalogue that grows with the graph;
+ * it is wrong here, because this text is paid for on EVERY session whether or
+ * not it is relevant, and a set that grows with the project is exactly how an
+ * always-on block becomes wallpaper. 400 tokens is roughly a dozen rules -- if a
+ * project needs more standing rules than that, the honest answer is that some of
+ * them are situational and belong behind a trigger.
+ */
+const standingBudget = () =>
+  Number(process.env.TOKEN_OPTIMIZER_STANDING_BUDGET) || 400;
+
 /** Most findings considered for one command before the budget decides. */
 const MAX_COMMAND_CANDIDATES = 20;
 
@@ -337,6 +351,77 @@ Established in previous sessions. Call wiki_query with a key for detail, or just
 work -- findings anchored to a file are surfaced automatically when you touch it.
 
 ${lines.join('\n')}`;
+}
+
+/**
+ * The always-on set: rules that must hold before the first tool call.
+ *
+ * WHY THESE CANNOT BE TRIGGER-FIRED. A trigger answers "this situation is
+ * happening now". Some rules are not about a situation -- "report the number you
+ * measured, not the one you expected" governs how every turn is conducted, and
+ * by the time any command matched a trigger the turn would already be going
+ * wrong. Those have to be present before anything happens or they are useless.
+ *
+ * WHY THIS IS NOT THE SESSION INDEX. `sessionIndex` lists keys and truncated
+ * titles and tells the model to call wiki_query for detail; that is right for a
+ * catalogue of things it MIGHT want. A standing rule that needs a lookup before
+ * it can be obeyed is not a standing rule -- so these are rendered in full, and
+ * are budgeted separately and much more tightly because of it.
+ *
+ * WHAT QUALIFIES, deliberately narrow:
+ *   - anything a human PINNED, which curate.mjs already defines as a fact that
+ *     stays true and should not decay, or
+ *   - a `feedback` lesson whose quote was verified against the transcript, so a
+ *     person demonstrably said it.
+ *
+ * Everything else waits for its trigger. The failure mode this guards against
+ * is the one that already happened here: an always-on block that grows until it
+ * is wallpaper, and the model stops reading the thing it always sees.
+ */
+export function standingRules(dir, graph, { budget = standingBudget() } = {}) {
+  const rules = [...graph.nodes.values()].filter(
+    (n) =>
+      n.kind === 'finding' &&
+      !n.retired &&
+      typeof n.claim === 'string' &&
+      (n.pinned === true || (n.type === 'feedback' && n.origin === 'human'))
+  );
+  if (!rules.length) return null;
+
+  // A person's own correction outranks anything inferred, then confidence.
+  rules.sort((a, b) => {
+    const weight = (n) => (n.origin === 'human' ? 2 : n.pinned ? 1.5 : 1);
+    return weight(b) * (b.confidence ?? 0.5) - weight(a) * (a.confidence ?? 0.5);
+  });
+
+  const lines = [];
+  let spent = 0;
+  let dropped = 0;
+  for (const rule of rules) {
+    const line = `- ${rule.claim}`;
+    const cost = estimate(line);
+    if (spent + cost > budget) {
+      dropped += 1;
+      continue;
+    }
+    lines.push(line);
+    spent += cost;
+  }
+  if (!lines.length) return null;
+
+  record(dir, { kind: 'standing', count: lines.length, dropped, tokens: spent });
+
+  // SAY WHAT WAS DROPPED. A silent cap reads as "these are all the rules",
+  // which is worse than saying there are more: a model that knows the list is
+  // truncated can ask, one that does not will assume it is complete.
+  const truncated = dropped
+    ? `\n(${dropped} further standing rule${dropped === 1 ? '' : 's'} did not fit this budget; ` +
+      `raise TOKEN_OPTIMIZER_STANDING_BUDGET or retire some.)`
+    : '';
+
+  return `# Standing rules for this project\n\nEstablished in previous sessions and expected to hold. These are not suggestions.\n\n${lines.join(
+    '\n'
+  )}${truncated}`;
 }
 
 /**

--- a/hooks-core/inject.mjs
+++ b/hooks-core/inject.mjs
@@ -394,8 +394,30 @@ export function standingRules(dir, graph, { budget = standingBudget() } = {}) {
     return weight(b) * (b.confidence ?? 0.5) - weight(a) * (a.confidence ?? 0.5);
   });
 
+  // THE BUDGET COVERS THE WHOLE MESSAGE, not just the claim lines.
+  //
+  // `spent` used to count selected claims only, while the returned text also
+  // carries a heading, two lines of fixed instruction and an optional
+  // truncation notice. A selection that exactly filled the budget therefore
+  // injected more than the budget allowed and recorded fewer tokens than it
+  // spent -- in a block whose entire justification is that it is tightly
+  // bounded and measured against the control arm.
+  const HEADING =
+    '# Standing rules for this project' +
+    '\n\nEstablished in previous sessions and expected to hold. ' +
+    'These are not suggestions.\n\n';
+  const noticeFor = (n) =>
+    n
+      ? `\n(${n} further standing rule${n === 1 ? '' : 's'} did not fit this budget; ` +
+        'raise TOKEN_OPTIMIZER_STANDING_BUDGET or retire some.)'
+      : '';
+
+  // The wrapper is charged up front, and the worst-case notice is reserved, so
+  // admitting the last line can never push the total over by adding one.
+  const overhead = estimate(HEADING) + estimate(noticeFor(rules.length));
+
   const lines = [];
-  let spent = 0;
+  let spent = overhead;
   let dropped = 0;
   for (const rule of rules) {
     const line = `- ${rule.claim}`;
@@ -407,21 +429,24 @@ export function standingRules(dir, graph, { budget = standingBudget() } = {}) {
     lines.push(line);
     spent += cost;
   }
-  if (!lines.length) return null;
 
-  record(dir, { kind: 'standing', count: lines.length, dropped, tokens: spent });
+  // RECORDED EVEN WHEN NOTHING FITS. Returning early without a metric hid the
+  // one case most worth knowing about: rules exist and every one is too large
+  // for the budget, so the block silently does nothing all session and the
+  // measurement shows no sign of it.
+  const truncated = noticeFor(dropped);
+  record(dir, {
+    kind: 'standing',
+    count: lines.length,
+    dropped,
+    tokens: lines.length ? spent : 0,
+  });
+  if (!lines.length) return null;
 
   // SAY WHAT WAS DROPPED. A silent cap reads as "these are all the rules",
   // which is worse than saying there are more: a model that knows the list is
   // truncated can ask, one that does not will assume it is complete.
-  const truncated = dropped
-    ? `\n(${dropped} further standing rule${dropped === 1 ? '' : 's'} did not fit this budget; ` +
-      `raise TOKEN_OPTIMIZER_STANDING_BUDGET or retire some.)`
-    : '';
-
-  return `# Standing rules for this project\n\nEstablished in previous sessions and expected to hold. These are not suggestions.\n\n${lines.join(
-    '\n'
-  )}${truncated}`;
+  return `${HEADING}${lines.join('\n')}${truncated}`;
 }
 
 /**

--- a/hooks-core/lessons.mjs
+++ b/hooks-core/lessons.mjs
@@ -96,24 +96,64 @@ export function buildFeedbackDigest(turns, { maxChars = 40_000 } = {}) {
   return out.length ? out.join('\n\n') : null;
 }
 
-/** True when the quote really appears in the archive, allowing for whitespace. */
+/**
+ * True when the quote really appears in the archive, allowing for whitespace.
+ *
+ * CASE IS PART OF VERBATIM. Lower-casing both sides accepted a quote whose
+ * capitalisation never occurred -- `NO, USE NPM TEST` matched a transcript
+ * saying `no, use npm test` -- and that quote then earned ORIGIN_HUMAN and 0.95
+ * confidence on the strength of a check it had not actually passed. The prompt
+ * asks for an exact copy, so this asks for one.
+ *
+ * Whitespace IS still normalised: line wrapping is an artefact of how the turn
+ * was stored, not something the user chose.
+ */
 export function quoteIsVerbatim(quote, turns) {
-  const needle = String(quote || '').trim().toLowerCase().replace(/\s+/g, ' ');
+  // A missing archive is not a match. `buildFeedbackDigest` guards its input in
+  // this same module; without the same guard here a null archive threw a
+  // TypeError out of a validator whose entire job is to reject bad input.
+  if (!Array.isArray(turns)) return false;
+  const needle = String(quote || '').trim().replace(/\s+/g, ' ');
   if (needle.length < 8) return false;
   return turns
-    .filter((t) => t.role === 'user')
-    .some((t) => String(t.text).toLowerCase().replace(/\s+/g, ' ').includes(needle));
+    .filter((t) => t && t.role === 'user')
+    .some((t) => String(t.text).replace(/\s+/g, ' ').includes(needle));
 }
 
-/** A claim that leads with a verb, which is what makes it act like an instruction. */
+/**
+ * A claim that leads with a bare verb, which is what makes it an instruction.
+ *
+ * A POSITIVE RULE, NOT A DENYLIST. The denylist rejected the openings a
+ * paraphrase usually starts with -- `the user prefers`, `you should` -- and
+ * accepted everything else, so `npm test is preferred over npx jest.` passed
+ * and was stored as a standing rule despite being a description rather than an
+ * instruction. Any noun-led sentence walked straight through.
+ *
+ * The test is now positive: the first word must be a bare verb form. That is
+ * still not a parts-of-speech tagger, but it fails CLOSED -- an unrecognised
+ * opening is rejected rather than admitted, which is the right direction for a
+ * gate on text that becomes an always-on instruction.
+ */
+const IMPERATIVE_VERBS = new Set([
+  'use', 'run', 'call', 'prefer', 'avoid', 'never', 'always', 'do', "don't", 'dont',
+  'stop', 'start', 'check', 'verify', 'confirm', 'read', 'write', 'edit', 'add',
+  'remove', 'delete', 'fix', 'keep', 'make', 'set', 'pass', 'build', 'test',
+  'install', 'update', 'rebase', 'merge', 'commit', 'push', 'pull', 'fetch',
+  'branch', 'open', 'close', 'ask', 'report', 'measure', 'record', 'skip',
+  'ignore', 'include', 'exclude', 'treat', 'assume', 'ensure', 'require',
+  'apply', 'revert', 'restore', 'replace', 'rename', 'move', 'copy', 'create',
+  'wait', 'retry', 'log', 'print', 'return', 'throw', 'catch', 'handle',
+  'quote', 'escape', 'sanitise', 'sanitize', 'validate', 'reject', 'accept',
+]);
+
 export function isImperative(claim) {
-  const first = String(claim || '').trim().split(/\s+/)[0] || '';
-  // Not a parts-of-speech tagger, and does not need to be: what it rejects is
-  // the shape corrections actually arrive in when a model paraphrases them --
-  // "the user prefers", "it is better to", "you should".
-  return !/^(the|a|an|it|this|that|there|you|we|i|user|users|when|because|since|although)$/i.test(
-    first
-  );
+  const first = String(claim || '')
+    .trim()
+    .split(/\s+/)[0]
+    .replace(/[^A-Za-z']/g, '')
+    .toLowerCase();
+  if (!first) return false;
+  return IMPERATIVE_VERBS.has(first);
 }
 
 /**

--- a/hooks-core/lessons.mjs
+++ b/hooks-core/lessons.mjs
@@ -1,0 +1,190 @@
+/**
+ * Turning corrections into lessons the next session actually receives.
+ *
+ * The signal this exists to capture is sparse and specific: the moments where
+ * the user pushed back. Everything else in a session is ordinary work. Measured
+ * on one real session, the graph recorded 4,053 file touches and none of the
+ * three corrections the user actually gave -- which are the only turns that
+ * carried information the code could not.
+ *
+ * TWO THINGS THIS MODULE REFUSES TO GUESS.
+ *
+ * 1. WHO SAID IT. A lesson is stored as a human assertion only when the
+ *    extractor supplies the user's words verbatim AND those words are found in
+ *    the archive. curate.mjs warns that "a hand-written assertion and a machine
+ *    guess look identical three months later", and human origin carries the
+ *    highest ranking weight -- so claiming it on a model's paraphrase would let
+ *    an inference outrank the correction it was inferred from. Unverifiable
+ *    quotes still store, as ORIGIN_HARVESTED.
+ *
+ * 2. WHEN IT APPLIES. Every lesson must carry a trigger. A lesson with no
+ *    trigger can only surface if someone happens to open the file it is anchored
+ *    to, which is not when advice about doing something is needed.
+ *
+ * AND ONE THING IT INSISTS ON: the action first. Measured in the injection A/B,
+ * a correctly stored and correctly delivered finding was still ignored because
+ * its instruction sat at the end of three sentences of context. Delivery is
+ * necessary and not sufficient; phrasing is the other half.
+ */
+
+import { ORIGIN_HARVESTED, ORIGIN_HUMAN } from './curate.mjs';
+
+/** Lessons longer than this are prose, not instructions. */
+const MAX_CLAIM = 400;
+
+/**
+ * The extraction prompt.
+ *
+ * Deliberately narrow. Asked for "lessons" a model will summarise the session;
+ * asked for corrections it returns the handful of turns that actually taught
+ * something, which is the whole point of keeping the store sparse.
+ */
+export const LESSON_PROMPT = `You are reading a transcript between a user and a coding agent.
+
+Extract ONLY the moments where the USER corrected, rejected, or redirected the agent —
+where the agent did something the user did not want, and the user said so. Ignore
+ordinary instructions, questions, and approvals. Most transcripts contain between zero
+and five of these. Returning an empty list is a correct and common answer.
+
+For each correction return an object with:
+  "claim"   - the lesson, as an IMPERATIVE with the action FIRST. Start with a verb.
+              Not "the user prefers X because Y" but "Do X. Y is why."
+              Under ${MAX_CLAIM} characters. This is the sentence a future agent reads
+              at the moment it is about to make the same mistake, so it must lead with
+              what to do, not with background.
+  "quote"   - the user's own words that constitute the correction, copied EXACTLY from
+              the transcript. Do not paraphrase, do not fix typos, do not add quotes.
+  "trigger" - a JavaScript regex source matching the situation where this applies, e.g.
+              "\\\\bnpx\\\\s+jest\\\\b" or "git\\\\s+push" or "\\\\.csproj". If the lesson is about a
+              tool or command, match that. Required.
+  "anchors" - array of absolute file paths the lesson concerns. May be empty.
+
+Return ONLY a JSON array. No prose, no markdown fence.`;
+
+/**
+ * Builds the extractor input from archived turns.
+ *
+ * Assistant tool RESULTS never entered the archive, so they cannot enter here.
+ * What is sent is the conversation: what was asked, what was answered, and which
+ * commands were run.
+ */
+export function buildFeedbackDigest(turns, { maxChars = 40_000 } = {}) {
+  if (!Array.isArray(turns) || !turns.length) return null;
+
+  const rendered = turns.map((t) => {
+    if (t.role === 'user') return `USER: ${t.text}`;
+    const tools = (t.tools || [])
+      .map((x) => (x.command ? `${x.name}(${x.command})` : x.name))
+      .filter(Boolean)
+      .slice(0, 8)
+      .join(', ');
+    const head = t.text ? `AGENT: ${t.text}` : 'AGENT:';
+    return tools ? `${head}\n  [tools: ${tools}]` : head;
+  });
+
+  // KEEP THE END, not the beginning. Corrections cluster where the work went
+  // wrong, and a transcript that needed correcting tends to have gone wrong
+  // later rather than sooner.
+  let out = [];
+  let total = 0;
+  for (let i = rendered.length - 1; i >= 0; i--) {
+    const piece = rendered[i];
+    if (total + piece.length > maxChars) break;
+    out.unshift(piece);
+    total += piece.length;
+  }
+  return out.length ? out.join('\n\n') : null;
+}
+
+/** True when the quote really appears in the archive, allowing for whitespace. */
+export function quoteIsVerbatim(quote, turns) {
+  const needle = String(quote || '').trim().toLowerCase().replace(/\s+/g, ' ');
+  if (needle.length < 8) return false;
+  return turns
+    .filter((t) => t.role === 'user')
+    .some((t) => String(t.text).toLowerCase().replace(/\s+/g, ' ').includes(needle));
+}
+
+/** A claim that leads with a verb, which is what makes it act like an instruction. */
+export function isImperative(claim) {
+  const first = String(claim || '').trim().split(/\s+/)[0] || '';
+  // Not a parts-of-speech tagger, and does not need to be: what it rejects is
+  // the shape corrections actually arrive in when a model paraphrases them --
+  // "the user prefers", "it is better to", "you should".
+  return !/^(the|a|an|it|this|that|there|you|we|i|user|users|when|because|since|although)$/i.test(
+    first
+  );
+}
+
+/**
+ * Validates extractor output and decides each lesson's origin.
+ *
+ * Returns { lessons, rejected } so a caller can report what was dropped rather
+ * than silently storing less than it was given.
+ */
+export function validateLessons(raw, turns) {
+  let parsed = raw;
+  if (typeof raw === 'string') {
+    try {
+      parsed = JSON.parse(raw.replace(/^```(?:json)?\s*|\s*```$/g, ''));
+    } catch {
+      return { lessons: [], rejected: [{ reason: 'unparseable', raw: String(raw).slice(0, 200) }] };
+    }
+  }
+  if (!Array.isArray(parsed)) {
+    return { lessons: [], rejected: [{ reason: 'not-an-array' }] };
+  }
+
+  const lessons = [];
+  const rejected = [];
+
+  for (const item of parsed) {
+    const claim = String(item?.claim || '').trim();
+    const trigger = String(item?.trigger || '').trim();
+    const quote = String(item?.quote || '').trim();
+
+    if (claim.length < 12) {
+      rejected.push({ reason: 'claim-too-short', claim });
+      continue;
+    }
+    if (claim.length > MAX_CLAIM) {
+      rejected.push({ reason: 'claim-too-long', claim: claim.slice(0, 80) });
+      continue;
+    }
+    if (!trigger) {
+      // Without one it can only surface by file touch, which is not when advice
+      // about an action is needed.
+      rejected.push({ reason: 'no-trigger', claim: claim.slice(0, 80) });
+      continue;
+    }
+    try {
+      new RegExp(trigger);
+    } catch {
+      rejected.push({ reason: 'bad-trigger-regex', trigger });
+      continue;
+    }
+    if (!isImperative(claim)) {
+      rejected.push({ reason: 'not-imperative', claim: claim.slice(0, 80) });
+      continue;
+    }
+
+    // THE PROVENANCE TEST. Verbatim and present means the user really said it.
+    const verified = quoteIsVerbatim(quote, turns);
+
+    lessons.push({
+      type: 'feedback',
+      claim,
+      trigger,
+      quote: verified ? quote : undefined,
+      origin: verified ? ORIGIN_HUMAN : ORIGIN_HARVESTED,
+      // A verified human correction is as close to ground truth as this system
+      // gets. An unverified paraphrase is a model's reading of one.
+      confidence: verified ? 0.95 : 0.6,
+      anchors: Array.isArray(item?.anchors)
+        ? item.anchors.filter((a) => typeof a === 'string' && a.trim())
+        : [],
+    });
+  }
+
+  return { lessons, rejected };
+}

--- a/hooks-core/transcript.mjs
+++ b/hooks-core/transcript.mjs
@@ -1,0 +1,211 @@
+/**
+ * The raw local archive of what was asked and what was answered.
+ *
+ * THE ARCHIVE AND THE LESSONS ARE DIFFERENT THINGS, and keeping them separate
+ * is the whole design. The archive is complete and never retrieved; the lessons
+ * extracted from it are sparse and are the only thing ever injected. Storing
+ * everything AND retrieving everything would drown the graph -- a session is
+ * thousands of turns of ordinary work and a handful of moments that taught
+ * something. Storing everything and retrieving only the lessons keeps the record
+ * complete without diluting what gets served.
+ *
+ * NOTHING HERE LEAVES THE MACHINE. The archive is written inside the wiki
+ * directory, which already carries a `.gitignore` of `*`, and it is explicitly
+ * excluded from the harvest digest -- the one code path that sends anything to a
+ * model endpoint. A feedback loop must never become the reason a user's prompts
+ * are transmitted.
+ */
+
+import {
+  readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, readdirSync, statSync, unlinkSync,
+} from 'node:fs';
+import { join } from 'node:path';
+
+/** Where a project's transcripts live, under the graph it belongs to. */
+export const transcriptDir = (dir) => join(dir, 'transcripts');
+
+/**
+ * Total bytes of archive kept per project before the oldest are dropped.
+ *
+ * An unbounded archive of every session is a disk leak that grows fastest for
+ * the users who use the tool most, which is exactly backwards.
+ */
+const archiveBudget = () =>
+  Number(process.env.TOKEN_OPTIMIZER_TRANSCRIPT_BUDGET_BYTES) || 50 * 1024 * 1024;
+
+/** A session id reduced to something that cannot escape the archive directory. */
+export function safeName(sessionId) {
+  const safe = String(sessionId || 'unknown').replace(/[^A-Za-z0-9._-]/g, '_');
+  return (/^[.]+$/.test(safe) ? 'unknown' : safe).slice(0, 64);
+}
+
+/**
+ * Turns a Claude transcript into the prompt/response pairs worth keeping.
+ *
+ * TOOL RESULTS ARE DROPPED, for the same reason `buildDigest` drops them: that
+ * is where whole file contents would enter the record. The archive is meant to
+ * hold the conversation, not a second copy of the repository.
+ */
+export function readTurns(transcriptPath) {
+  let lines;
+  try {
+    lines = readFileSync(transcriptPath, 'utf8').split('\n');
+  } catch {
+    return [];
+  }
+
+  const turns = [];
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    let entry;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+
+    const message = entry.message || entry;
+    const role = message.role || entry.type;
+    const content = message.content;
+
+    if (role === 'user') {
+      const text =
+        typeof content === 'string'
+          ? content
+          : Array.isArray(content)
+            ? content
+                .filter((b) => b && b.type === 'text')
+                .map((b) => String(b.text))
+                .join('\n')
+            : '';
+      if (text.trim()) turns.push({ role: 'user', text: text.trim(), at: entry.timestamp ?? null });
+      continue;
+    }
+
+    if (role === 'assistant' && Array.isArray(content)) {
+      const text = content
+        .filter((b) => b && b.type === 'text')
+        .map((b) => String(b.text))
+        .join('\n');
+      const tools = content
+        .filter((b) => b && b.type === 'tool_use')
+        .map((b) => ({
+          name: b.name,
+          // Arguments only, never results, and truncated: a command is the
+          // useful part, its output is not.
+          command: b.input?.command ? String(b.input.command).slice(0, 300) : undefined,
+          path: b.input?.file_path || b.input?.path || undefined,
+        }));
+      if (text.trim() || tools.length) {
+        turns.push({ role: 'assistant', text: text.trim(), tools, at: entry.timestamp ?? null });
+      }
+    }
+  }
+  return turns;
+}
+
+/**
+ * Appends this session's turns to the project archive.
+ *
+ * Idempotent per session by rewriting that session's file, so a Stop hook firing
+ * repeatedly does not multiply the record.
+ */
+export function archive(dir, transcriptPath, { sessionId } = {}) {
+  const turns = readTurns(transcriptPath);
+  if (!turns.length) return 0;
+
+  const root = transcriptDir(dir);
+  try {
+    mkdirSync(root, { recursive: true, mode: 0o700 });
+    try {
+      chmodSync(root, 0o700);
+    } catch {
+      /* not POSIX, or not ours */
+    }
+  } catch {
+    return 0;
+  }
+
+  const file = join(root, `${safeName(sessionId)}.jsonl`);
+  try {
+    // Truncate-and-write rather than append: Stop fires many times per session
+    // and the transcript is cumulative, so appending would store the early turns
+    // once per firing.
+    const payload = turns.map((t) => JSON.stringify(t)).join('\n') + '\n';
+    writeFileSync(file, payload, { mode: 0o600 });
+  } catch {
+    return 0;
+  }
+
+  prune(root);
+  return turns.length;
+}
+
+/**
+ * Drops the oldest sessions once the archive exceeds its budget.
+ *
+ * Oldest-first, because the value of a transcript is highest while the work it
+ * describes is still live.
+ */
+export function prune(root, budget = archiveBudget()) {
+  let entries;
+  try {
+    entries = readdirSync(root)
+      .filter((f) => f.endsWith('.jsonl'))
+      .map((f) => {
+        const full = join(root, f);
+        try {
+          const s = statSync(full);
+          return { full, size: s.size, mtime: s.mtimeMs };
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch {
+    return 0;
+  }
+
+  let total = entries.reduce((a, e) => a + e.size, 0);
+  if (total <= budget) return 0;
+
+  entries.sort((a, b) => a.mtime - b.mtime);
+  let dropped = 0;
+  for (const e of entries) {
+    if (total <= budget) break;
+    try {
+      unlinkSync(e.full);
+      total -= e.size;
+      dropped += 1;
+    } catch {
+      /* leave it; a locked file must not stop the rest */
+    }
+  }
+  return dropped;
+}
+
+/** True when a path is inside a transcript archive -- the never-transmit test. */
+export function isArchived(path) {
+  return /[\\/]\.token-optimizer[\\/]wiki[\\/]transcripts[\\/]/.test(String(path));
+}
+
+/** Reads a session's archived turns back, for the lesson extractor. */
+export function readArchive(dir, sessionId) {
+  const file = join(transcriptDir(dir), `${safeName(sessionId)}.jsonl`);
+  if (!existsSync(file)) return [];
+  try {
+    return readFileSync(file, 'utf8')
+      .split('\n')
+      .filter(Boolean)
+      .map((l) => {
+        try {
+          return JSON.parse(l);
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}

--- a/integrations/codex/hooks/lib/harvest-write.mjs
+++ b/integrations/codex/hooks/lib/harvest-write.mjs
@@ -28,7 +28,7 @@ import { indexFile } from './staleness.mjs';
 import { symbolKey } from './symbols.mjs';
 import { canonicalPath } from './paths.mjs';
 import { randomBytes } from 'node:crypto';
-import { ORIGIN_HARVESTED, ORIGIN_AGENT } from './curate.mjs';
+import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
 
 /**
  * Resolves an `path` or `path#symbol` anchor to an existing node id.
@@ -81,11 +81,33 @@ export function writeHarvested(
 ) {
   if (!Array.isArray(findings) || !findings.length) return [];
 
-  // Only the two origins this path can honestly claim. A caller asking for
-  // anything else -- notably ORIGIN_HUMAN -- would be labelling machine output
-  // as a person's assertion, which is the confusion the field exists to prevent.
-  const provenance = origin === ORIGIN_AGENT ? ORIGIN_AGENT : ORIGIN_HARVESTED;
-  const prefix = provenance === ORIGIN_AGENT ? 'agent' : 'harvested';
+  // The batch default. A caller asking for anything else -- notably
+  // ORIGIN_HUMAN -- would be labelling machine output as a person's assertion,
+  // which is the confusion the field exists to prevent.
+  const batch = origin === ORIGIN_AGENT ? ORIGIN_AGENT : ORIGIN_HARVESTED;
+
+  /**
+   * ORIGIN_HUMAN IS EARNED PER FINDING, BY EVIDENCE.
+   *
+   * A batch-wide origin was the whole story here, and it silently discarded
+   * the per-lesson provenance `validateLessons` had just computed: a
+   * correction whose quote was verified word-for-word in the user's own turn
+   * was stored as ORIGIN_HARVESTED like any model paraphrase. The standing-
+   * rules layer selects on human origin, so it matched nothing this pipeline
+   * wrote, and the verbatim check had no observable effect at all.
+   *
+   * The original rule still holds -- a caller cannot simply DECLARE machine
+   * output human. It is the verified quote that promotes it, and the quote is
+   * stored alongside so the claim carries its own evidence.
+   */
+  const provenanceFor = (finding) =>
+    finding.origin === ORIGIN_HUMAN &&
+    typeof finding.quote === 'string' &&
+    finding.quote.trim()
+      ? ORIGIN_HUMAN
+      : batch;
+  const prefixFor = (p) =>
+    p === ORIGIN_AGENT ? 'agent' : p === ORIGIN_HUMAN ? 'human' : 'harvested';
 
   const written = [];
   for (const finding of findings) {
@@ -103,7 +125,8 @@ export function writeHarvested(
     // same key, and putNode keeps the last write for an id -- so one session's
     // finding silently replaces another's. A random suffix makes that
     // collision vanishingly unlikely while keeping the timestamp readable.
-    const key = `${prefix}-${Date.now().toString(36)}-${written.length}-${randomBytes(4).toString("hex")}`;
+    const provenance = provenanceFor(finding);
+    const key = `${prefixFor(provenance)}-${Date.now().toString(36)}-${written.length}-${randomBytes(4).toString("hex")}`;
     // ONE APPEND for the finding and every anchor it resolved. This runs in a
     // detached worker, so "the process survives to finish the loop" is not a
     // safe assumption: a node written without its edges is an active finding
@@ -127,6 +150,11 @@ export function writeHarvested(
           ? finding.trigger
           : undefined,
         origin: provenance,
+        // THE EVIDENCE TRAVELS WITH THE CLAIM. Without it a human-origin
+        // finding asserts its own provenance and nothing can check it.
+        quote: typeof finding.quote === 'string' && finding.quote.trim()
+          ? finding.quote
+          : undefined,
         sessionId,
       },
       resolved.map((target) => ({ edge: 'derived_from', to: target }))

--- a/integrations/codex/hooks/lib/harvest.mjs
+++ b/integrations/codex/hooks/lib/harvest.mjs
@@ -36,7 +36,10 @@ const ENDPOINT = () => process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT
   || 'https://api.anthropic.com/v1/messages';
 
 /** Findings must be one of these. Free-form claims are rejected. */
-export const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map'];
+// 'feedback' is a lesson extracted from a USER CORRECTION rather than from the
+// code -- the only finding type whose source is a person telling the agent it
+// was wrong, which is why it is kept distinguishable from an ordinary finding.
+export const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map', 'feedback'];
 
 export function apiKey() {
   return process.env.TOKEN_OPTIMIZER_API_KEY || process.env.ANTHROPIC_API_KEY || null;
@@ -222,7 +225,7 @@ export function validate(raw, { knownFiles = null } = {}) {
  * indistinguishable, from the caller's side, from a session with nothing to
  * learn.
  */
-export async function extract(digest, { timeoutMs = 30_000 } = {}) {
+export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}) {
   if (!digest || !harvestEnabled()) return [];
 
   // A local endpoint usually has no auth at all, so requiring a key there would
@@ -248,7 +251,7 @@ export async function extract(digest, { timeoutMs = 30_000 } = {}) {
       body: JSON.stringify({
         model: MODEL(),
         max_tokens: 2048,
-        system: PROMPT,
+        system: prompt || PROMPT,
         messages: [{ role: 'user', content: digest }],
       }),
     });

--- a/integrations/codex/hooks/lib/inject.mjs
+++ b/integrations/codex/hooks/lib/inject.mjs
@@ -31,6 +31,20 @@ import { substitutionBudget } from './metrics.mjs';
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
 
+/**
+ * Tokens allowed for the always-on standing rules.
+ *
+ * FIXED AND SMALL, unlike the session index whose budget is earned from measured
+ * hit rate. An earned budget is right for a catalogue that grows with the graph;
+ * it is wrong here, because this text is paid for on EVERY session whether or
+ * not it is relevant, and a set that grows with the project is exactly how an
+ * always-on block becomes wallpaper. 400 tokens is roughly a dozen rules -- if a
+ * project needs more standing rules than that, the honest answer is that some of
+ * them are situational and belong behind a trigger.
+ */
+const standingBudget = () =>
+  Number(process.env.TOKEN_OPTIMIZER_STANDING_BUDGET) || 400;
+
 /** Most findings considered for one command before the budget decides. */
 const MAX_COMMAND_CANDIDATES = 20;
 
@@ -339,6 +353,77 @@ Established in previous sessions. Call wiki_query with a key for detail, or just
 work -- findings anchored to a file are surfaced automatically when you touch it.
 
 ${lines.join('\n')}`;
+}
+
+/**
+ * The always-on set: rules that must hold before the first tool call.
+ *
+ * WHY THESE CANNOT BE TRIGGER-FIRED. A trigger answers "this situation is
+ * happening now". Some rules are not about a situation -- "report the number you
+ * measured, not the one you expected" governs how every turn is conducted, and
+ * by the time any command matched a trigger the turn would already be going
+ * wrong. Those have to be present before anything happens or they are useless.
+ *
+ * WHY THIS IS NOT THE SESSION INDEX. `sessionIndex` lists keys and truncated
+ * titles and tells the model to call wiki_query for detail; that is right for a
+ * catalogue of things it MIGHT want. A standing rule that needs a lookup before
+ * it can be obeyed is not a standing rule -- so these are rendered in full, and
+ * are budgeted separately and much more tightly because of it.
+ *
+ * WHAT QUALIFIES, deliberately narrow:
+ *   - anything a human PINNED, which curate.mjs already defines as a fact that
+ *     stays true and should not decay, or
+ *   - a `feedback` lesson whose quote was verified against the transcript, so a
+ *     person demonstrably said it.
+ *
+ * Everything else waits for its trigger. The failure mode this guards against
+ * is the one that already happened here: an always-on block that grows until it
+ * is wallpaper, and the model stops reading the thing it always sees.
+ */
+export function standingRules(dir, graph, { budget = standingBudget() } = {}) {
+  const rules = [...graph.nodes.values()].filter(
+    (n) =>
+      n.kind === 'finding' &&
+      !n.retired &&
+      typeof n.claim === 'string' &&
+      (n.pinned === true || (n.type === 'feedback' && n.origin === 'human'))
+  );
+  if (!rules.length) return null;
+
+  // A person's own correction outranks anything inferred, then confidence.
+  rules.sort((a, b) => {
+    const weight = (n) => (n.origin === 'human' ? 2 : n.pinned ? 1.5 : 1);
+    return weight(b) * (b.confidence ?? 0.5) - weight(a) * (a.confidence ?? 0.5);
+  });
+
+  const lines = [];
+  let spent = 0;
+  let dropped = 0;
+  for (const rule of rules) {
+    const line = `- ${rule.claim}`;
+    const cost = estimate(line);
+    if (spent + cost > budget) {
+      dropped += 1;
+      continue;
+    }
+    lines.push(line);
+    spent += cost;
+  }
+  if (!lines.length) return null;
+
+  record(dir, { kind: 'standing', count: lines.length, dropped, tokens: spent });
+
+  // SAY WHAT WAS DROPPED. A silent cap reads as "these are all the rules",
+  // which is worse than saying there are more: a model that knows the list is
+  // truncated can ask, one that does not will assume it is complete.
+  const truncated = dropped
+    ? `\n(${dropped} further standing rule${dropped === 1 ? '' : 's'} did not fit this budget; ` +
+      `raise TOKEN_OPTIMIZER_STANDING_BUDGET or retire some.)`
+    : '';
+
+  return `# Standing rules for this project\n\nEstablished in previous sessions and expected to hold. These are not suggestions.\n\n${lines.join(
+    '\n'
+  )}${truncated}`;
 }
 
 /**

--- a/integrations/codex/hooks/lib/inject.mjs
+++ b/integrations/codex/hooks/lib/inject.mjs
@@ -396,8 +396,30 @@ export function standingRules(dir, graph, { budget = standingBudget() } = {}) {
     return weight(b) * (b.confidence ?? 0.5) - weight(a) * (a.confidence ?? 0.5);
   });
 
+  // THE BUDGET COVERS THE WHOLE MESSAGE, not just the claim lines.
+  //
+  // `spent` used to count selected claims only, while the returned text also
+  // carries a heading, two lines of fixed instruction and an optional
+  // truncation notice. A selection that exactly filled the budget therefore
+  // injected more than the budget allowed and recorded fewer tokens than it
+  // spent -- in a block whose entire justification is that it is tightly
+  // bounded and measured against the control arm.
+  const HEADING =
+    '# Standing rules for this project' +
+    '\n\nEstablished in previous sessions and expected to hold. ' +
+    'These are not suggestions.\n\n';
+  const noticeFor = (n) =>
+    n
+      ? `\n(${n} further standing rule${n === 1 ? '' : 's'} did not fit this budget; ` +
+        'raise TOKEN_OPTIMIZER_STANDING_BUDGET or retire some.)'
+      : '';
+
+  // The wrapper is charged up front, and the worst-case notice is reserved, so
+  // admitting the last line can never push the total over by adding one.
+  const overhead = estimate(HEADING) + estimate(noticeFor(rules.length));
+
   const lines = [];
-  let spent = 0;
+  let spent = overhead;
   let dropped = 0;
   for (const rule of rules) {
     const line = `- ${rule.claim}`;
@@ -409,21 +431,24 @@ export function standingRules(dir, graph, { budget = standingBudget() } = {}) {
     lines.push(line);
     spent += cost;
   }
-  if (!lines.length) return null;
 
-  record(dir, { kind: 'standing', count: lines.length, dropped, tokens: spent });
+  // RECORDED EVEN WHEN NOTHING FITS. Returning early without a metric hid the
+  // one case most worth knowing about: rules exist and every one is too large
+  // for the budget, so the block silently does nothing all session and the
+  // measurement shows no sign of it.
+  const truncated = noticeFor(dropped);
+  record(dir, {
+    kind: 'standing',
+    count: lines.length,
+    dropped,
+    tokens: lines.length ? spent : 0,
+  });
+  if (!lines.length) return null;
 
   // SAY WHAT WAS DROPPED. A silent cap reads as "these are all the rules",
   // which is worse than saying there are more: a model that knows the list is
   // truncated can ask, one that does not will assume it is complete.
-  const truncated = dropped
-    ? `\n(${dropped} further standing rule${dropped === 1 ? '' : 's'} did not fit this budget; ` +
-      `raise TOKEN_OPTIMIZER_STANDING_BUDGET or retire some.)`
-    : '';
-
-  return `# Standing rules for this project\n\nEstablished in previous sessions and expected to hold. These are not suggestions.\n\n${lines.join(
-    '\n'
-  )}${truncated}`;
+  return `${HEADING}${lines.join('\n')}${truncated}`;
 }
 
 /**

--- a/integrations/codex/hooks/lib/lessons.mjs
+++ b/integrations/codex/hooks/lib/lessons.mjs
@@ -98,24 +98,64 @@ export function buildFeedbackDigest(turns, { maxChars = 40_000 } = {}) {
   return out.length ? out.join('\n\n') : null;
 }
 
-/** True when the quote really appears in the archive, allowing for whitespace. */
+/**
+ * True when the quote really appears in the archive, allowing for whitespace.
+ *
+ * CASE IS PART OF VERBATIM. Lower-casing both sides accepted a quote whose
+ * capitalisation never occurred -- `NO, USE NPM TEST` matched a transcript
+ * saying `no, use npm test` -- and that quote then earned ORIGIN_HUMAN and 0.95
+ * confidence on the strength of a check it had not actually passed. The prompt
+ * asks for an exact copy, so this asks for one.
+ *
+ * Whitespace IS still normalised: line wrapping is an artefact of how the turn
+ * was stored, not something the user chose.
+ */
 export function quoteIsVerbatim(quote, turns) {
-  const needle = String(quote || '').trim().toLowerCase().replace(/\s+/g, ' ');
+  // A missing archive is not a match. `buildFeedbackDigest` guards its input in
+  // this same module; without the same guard here a null archive threw a
+  // TypeError out of a validator whose entire job is to reject bad input.
+  if (!Array.isArray(turns)) return false;
+  const needle = String(quote || '').trim().replace(/\s+/g, ' ');
   if (needle.length < 8) return false;
   return turns
-    .filter((t) => t.role === 'user')
-    .some((t) => String(t.text).toLowerCase().replace(/\s+/g, ' ').includes(needle));
+    .filter((t) => t && t.role === 'user')
+    .some((t) => String(t.text).replace(/\s+/g, ' ').includes(needle));
 }
 
-/** A claim that leads with a verb, which is what makes it act like an instruction. */
+/**
+ * A claim that leads with a bare verb, which is what makes it an instruction.
+ *
+ * A POSITIVE RULE, NOT A DENYLIST. The denylist rejected the openings a
+ * paraphrase usually starts with -- `the user prefers`, `you should` -- and
+ * accepted everything else, so `npm test is preferred over npx jest.` passed
+ * and was stored as a standing rule despite being a description rather than an
+ * instruction. Any noun-led sentence walked straight through.
+ *
+ * The test is now positive: the first word must be a bare verb form. That is
+ * still not a parts-of-speech tagger, but it fails CLOSED -- an unrecognised
+ * opening is rejected rather than admitted, which is the right direction for a
+ * gate on text that becomes an always-on instruction.
+ */
+const IMPERATIVE_VERBS = new Set([
+  'use', 'run', 'call', 'prefer', 'avoid', 'never', 'always', 'do', "don't", 'dont',
+  'stop', 'start', 'check', 'verify', 'confirm', 'read', 'write', 'edit', 'add',
+  'remove', 'delete', 'fix', 'keep', 'make', 'set', 'pass', 'build', 'test',
+  'install', 'update', 'rebase', 'merge', 'commit', 'push', 'pull', 'fetch',
+  'branch', 'open', 'close', 'ask', 'report', 'measure', 'record', 'skip',
+  'ignore', 'include', 'exclude', 'treat', 'assume', 'ensure', 'require',
+  'apply', 'revert', 'restore', 'replace', 'rename', 'move', 'copy', 'create',
+  'wait', 'retry', 'log', 'print', 'return', 'throw', 'catch', 'handle',
+  'quote', 'escape', 'sanitise', 'sanitize', 'validate', 'reject', 'accept',
+]);
+
 export function isImperative(claim) {
-  const first = String(claim || '').trim().split(/\s+/)[0] || '';
-  // Not a parts-of-speech tagger, and does not need to be: what it rejects is
-  // the shape corrections actually arrive in when a model paraphrases them --
-  // "the user prefers", "it is better to", "you should".
-  return !/^(the|a|an|it|this|that|there|you|we|i|user|users|when|because|since|although)$/i.test(
-    first
-  );
+  const first = String(claim || '')
+    .trim()
+    .split(/\s+/)[0]
+    .replace(/[^A-Za-z']/g, '')
+    .toLowerCase();
+  if (!first) return false;
+  return IMPERATIVE_VERBS.has(first);
 }
 
 /**

--- a/integrations/codex/hooks/lib/lessons.mjs
+++ b/integrations/codex/hooks/lib/lessons.mjs
@@ -1,0 +1,192 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/lessons.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Turning corrections into lessons the next session actually receives.
+ *
+ * The signal this exists to capture is sparse and specific: the moments where
+ * the user pushed back. Everything else in a session is ordinary work. Measured
+ * on one real session, the graph recorded 4,053 file touches and none of the
+ * three corrections the user actually gave -- which are the only turns that
+ * carried information the code could not.
+ *
+ * TWO THINGS THIS MODULE REFUSES TO GUESS.
+ *
+ * 1. WHO SAID IT. A lesson is stored as a human assertion only when the
+ *    extractor supplies the user's words verbatim AND those words are found in
+ *    the archive. curate.mjs warns that "a hand-written assertion and a machine
+ *    guess look identical three months later", and human origin carries the
+ *    highest ranking weight -- so claiming it on a model's paraphrase would let
+ *    an inference outrank the correction it was inferred from. Unverifiable
+ *    quotes still store, as ORIGIN_HARVESTED.
+ *
+ * 2. WHEN IT APPLIES. Every lesson must carry a trigger. A lesson with no
+ *    trigger can only surface if someone happens to open the file it is anchored
+ *    to, which is not when advice about doing something is needed.
+ *
+ * AND ONE THING IT INSISTS ON: the action first. Measured in the injection A/B,
+ * a correctly stored and correctly delivered finding was still ignored because
+ * its instruction sat at the end of three sentences of context. Delivery is
+ * necessary and not sufficient; phrasing is the other half.
+ */
+
+import { ORIGIN_HARVESTED, ORIGIN_HUMAN } from './curate.mjs';
+
+/** Lessons longer than this are prose, not instructions. */
+const MAX_CLAIM = 400;
+
+/**
+ * The extraction prompt.
+ *
+ * Deliberately narrow. Asked for "lessons" a model will summarise the session;
+ * asked for corrections it returns the handful of turns that actually taught
+ * something, which is the whole point of keeping the store sparse.
+ */
+export const LESSON_PROMPT = `You are reading a transcript between a user and a coding agent.
+
+Extract ONLY the moments where the USER corrected, rejected, or redirected the agent —
+where the agent did something the user did not want, and the user said so. Ignore
+ordinary instructions, questions, and approvals. Most transcripts contain between zero
+and five of these. Returning an empty list is a correct and common answer.
+
+For each correction return an object with:
+  "claim"   - the lesson, as an IMPERATIVE with the action FIRST. Start with a verb.
+              Not "the user prefers X because Y" but "Do X. Y is why."
+              Under ${MAX_CLAIM} characters. This is the sentence a future agent reads
+              at the moment it is about to make the same mistake, so it must lead with
+              what to do, not with background.
+  "quote"   - the user's own words that constitute the correction, copied EXACTLY from
+              the transcript. Do not paraphrase, do not fix typos, do not add quotes.
+  "trigger" - a JavaScript regex source matching the situation where this applies, e.g.
+              "\\\\bnpx\\\\s+jest\\\\b" or "git\\\\s+push" or "\\\\.csproj". If the lesson is about a
+              tool or command, match that. Required.
+  "anchors" - array of absolute file paths the lesson concerns. May be empty.
+
+Return ONLY a JSON array. No prose, no markdown fence.`;
+
+/**
+ * Builds the extractor input from archived turns.
+ *
+ * Assistant tool RESULTS never entered the archive, so they cannot enter here.
+ * What is sent is the conversation: what was asked, what was answered, and which
+ * commands were run.
+ */
+export function buildFeedbackDigest(turns, { maxChars = 40_000 } = {}) {
+  if (!Array.isArray(turns) || !turns.length) return null;
+
+  const rendered = turns.map((t) => {
+    if (t.role === 'user') return `USER: ${t.text}`;
+    const tools = (t.tools || [])
+      .map((x) => (x.command ? `${x.name}(${x.command})` : x.name))
+      .filter(Boolean)
+      .slice(0, 8)
+      .join(', ');
+    const head = t.text ? `AGENT: ${t.text}` : 'AGENT:';
+    return tools ? `${head}\n  [tools: ${tools}]` : head;
+  });
+
+  // KEEP THE END, not the beginning. Corrections cluster where the work went
+  // wrong, and a transcript that needed correcting tends to have gone wrong
+  // later rather than sooner.
+  let out = [];
+  let total = 0;
+  for (let i = rendered.length - 1; i >= 0; i--) {
+    const piece = rendered[i];
+    if (total + piece.length > maxChars) break;
+    out.unshift(piece);
+    total += piece.length;
+  }
+  return out.length ? out.join('\n\n') : null;
+}
+
+/** True when the quote really appears in the archive, allowing for whitespace. */
+export function quoteIsVerbatim(quote, turns) {
+  const needle = String(quote || '').trim().toLowerCase().replace(/\s+/g, ' ');
+  if (needle.length < 8) return false;
+  return turns
+    .filter((t) => t.role === 'user')
+    .some((t) => String(t.text).toLowerCase().replace(/\s+/g, ' ').includes(needle));
+}
+
+/** A claim that leads with a verb, which is what makes it act like an instruction. */
+export function isImperative(claim) {
+  const first = String(claim || '').trim().split(/\s+/)[0] || '';
+  // Not a parts-of-speech tagger, and does not need to be: what it rejects is
+  // the shape corrections actually arrive in when a model paraphrases them --
+  // "the user prefers", "it is better to", "you should".
+  return !/^(the|a|an|it|this|that|there|you|we|i|user|users|when|because|since|although)$/i.test(
+    first
+  );
+}
+
+/**
+ * Validates extractor output and decides each lesson's origin.
+ *
+ * Returns { lessons, rejected } so a caller can report what was dropped rather
+ * than silently storing less than it was given.
+ */
+export function validateLessons(raw, turns) {
+  let parsed = raw;
+  if (typeof raw === 'string') {
+    try {
+      parsed = JSON.parse(raw.replace(/^```(?:json)?\s*|\s*```$/g, ''));
+    } catch {
+      return { lessons: [], rejected: [{ reason: 'unparseable', raw: String(raw).slice(0, 200) }] };
+    }
+  }
+  if (!Array.isArray(parsed)) {
+    return { lessons: [], rejected: [{ reason: 'not-an-array' }] };
+  }
+
+  const lessons = [];
+  const rejected = [];
+
+  for (const item of parsed) {
+    const claim = String(item?.claim || '').trim();
+    const trigger = String(item?.trigger || '').trim();
+    const quote = String(item?.quote || '').trim();
+
+    if (claim.length < 12) {
+      rejected.push({ reason: 'claim-too-short', claim });
+      continue;
+    }
+    if (claim.length > MAX_CLAIM) {
+      rejected.push({ reason: 'claim-too-long', claim: claim.slice(0, 80) });
+      continue;
+    }
+    if (!trigger) {
+      // Without one it can only surface by file touch, which is not when advice
+      // about an action is needed.
+      rejected.push({ reason: 'no-trigger', claim: claim.slice(0, 80) });
+      continue;
+    }
+    try {
+      new RegExp(trigger);
+    } catch {
+      rejected.push({ reason: 'bad-trigger-regex', trigger });
+      continue;
+    }
+    if (!isImperative(claim)) {
+      rejected.push({ reason: 'not-imperative', claim: claim.slice(0, 80) });
+      continue;
+    }
+
+    // THE PROVENANCE TEST. Verbatim and present means the user really said it.
+    const verified = quoteIsVerbatim(quote, turns);
+
+    lessons.push({
+      type: 'feedback',
+      claim,
+      trigger,
+      quote: verified ? quote : undefined,
+      origin: verified ? ORIGIN_HUMAN : ORIGIN_HARVESTED,
+      // A verified human correction is as close to ground truth as this system
+      // gets. An unverified paraphrase is a model's reading of one.
+      confidence: verified ? 0.95 : 0.6,
+      anchors: Array.isArray(item?.anchors)
+        ? item.anchors.filter((a) => typeof a === 'string' && a.trim())
+        : [],
+    });
+  }
+
+  return { lessons, rejected };
+}

--- a/integrations/codex/hooks/lib/transcript.mjs
+++ b/integrations/codex/hooks/lib/transcript.mjs
@@ -1,0 +1,213 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/transcript.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * The raw local archive of what was asked and what was answered.
+ *
+ * THE ARCHIVE AND THE LESSONS ARE DIFFERENT THINGS, and keeping them separate
+ * is the whole design. The archive is complete and never retrieved; the lessons
+ * extracted from it are sparse and are the only thing ever injected. Storing
+ * everything AND retrieving everything would drown the graph -- a session is
+ * thousands of turns of ordinary work and a handful of moments that taught
+ * something. Storing everything and retrieving only the lessons keeps the record
+ * complete without diluting what gets served.
+ *
+ * NOTHING HERE LEAVES THE MACHINE. The archive is written inside the wiki
+ * directory, which already carries a `.gitignore` of `*`, and it is explicitly
+ * excluded from the harvest digest -- the one code path that sends anything to a
+ * model endpoint. A feedback loop must never become the reason a user's prompts
+ * are transmitted.
+ */
+
+import {
+  readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, readdirSync, statSync, unlinkSync,
+} from 'node:fs';
+import { join } from 'node:path';
+
+/** Where a project's transcripts live, under the graph it belongs to. */
+export const transcriptDir = (dir) => join(dir, 'transcripts');
+
+/**
+ * Total bytes of archive kept per project before the oldest are dropped.
+ *
+ * An unbounded archive of every session is a disk leak that grows fastest for
+ * the users who use the tool most, which is exactly backwards.
+ */
+const archiveBudget = () =>
+  Number(process.env.TOKEN_OPTIMIZER_TRANSCRIPT_BUDGET_BYTES) || 50 * 1024 * 1024;
+
+/** A session id reduced to something that cannot escape the archive directory. */
+export function safeName(sessionId) {
+  const safe = String(sessionId || 'unknown').replace(/[^A-Za-z0-9._-]/g, '_');
+  return (/^[.]+$/.test(safe) ? 'unknown' : safe).slice(0, 64);
+}
+
+/**
+ * Turns a Claude transcript into the prompt/response pairs worth keeping.
+ *
+ * TOOL RESULTS ARE DROPPED, for the same reason `buildDigest` drops them: that
+ * is where whole file contents would enter the record. The archive is meant to
+ * hold the conversation, not a second copy of the repository.
+ */
+export function readTurns(transcriptPath) {
+  let lines;
+  try {
+    lines = readFileSync(transcriptPath, 'utf8').split('\n');
+  } catch {
+    return [];
+  }
+
+  const turns = [];
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    let entry;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+
+    const message = entry.message || entry;
+    const role = message.role || entry.type;
+    const content = message.content;
+
+    if (role === 'user') {
+      const text =
+        typeof content === 'string'
+          ? content
+          : Array.isArray(content)
+            ? content
+                .filter((b) => b && b.type === 'text')
+                .map((b) => String(b.text))
+                .join('\n')
+            : '';
+      if (text.trim()) turns.push({ role: 'user', text: text.trim(), at: entry.timestamp ?? null });
+      continue;
+    }
+
+    if (role === 'assistant' && Array.isArray(content)) {
+      const text = content
+        .filter((b) => b && b.type === 'text')
+        .map((b) => String(b.text))
+        .join('\n');
+      const tools = content
+        .filter((b) => b && b.type === 'tool_use')
+        .map((b) => ({
+          name: b.name,
+          // Arguments only, never results, and truncated: a command is the
+          // useful part, its output is not.
+          command: b.input?.command ? String(b.input.command).slice(0, 300) : undefined,
+          path: b.input?.file_path || b.input?.path || undefined,
+        }));
+      if (text.trim() || tools.length) {
+        turns.push({ role: 'assistant', text: text.trim(), tools, at: entry.timestamp ?? null });
+      }
+    }
+  }
+  return turns;
+}
+
+/**
+ * Appends this session's turns to the project archive.
+ *
+ * Idempotent per session by rewriting that session's file, so a Stop hook firing
+ * repeatedly does not multiply the record.
+ */
+export function archive(dir, transcriptPath, { sessionId } = {}) {
+  const turns = readTurns(transcriptPath);
+  if (!turns.length) return 0;
+
+  const root = transcriptDir(dir);
+  try {
+    mkdirSync(root, { recursive: true, mode: 0o700 });
+    try {
+      chmodSync(root, 0o700);
+    } catch {
+      /* not POSIX, or not ours */
+    }
+  } catch {
+    return 0;
+  }
+
+  const file = join(root, `${safeName(sessionId)}.jsonl`);
+  try {
+    // Truncate-and-write rather than append: Stop fires many times per session
+    // and the transcript is cumulative, so appending would store the early turns
+    // once per firing.
+    const payload = turns.map((t) => JSON.stringify(t)).join('\n') + '\n';
+    writeFileSync(file, payload, { mode: 0o600 });
+  } catch {
+    return 0;
+  }
+
+  prune(root);
+  return turns.length;
+}
+
+/**
+ * Drops the oldest sessions once the archive exceeds its budget.
+ *
+ * Oldest-first, because the value of a transcript is highest while the work it
+ * describes is still live.
+ */
+export function prune(root, budget = archiveBudget()) {
+  let entries;
+  try {
+    entries = readdirSync(root)
+      .filter((f) => f.endsWith('.jsonl'))
+      .map((f) => {
+        const full = join(root, f);
+        try {
+          const s = statSync(full);
+          return { full, size: s.size, mtime: s.mtimeMs };
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch {
+    return 0;
+  }
+
+  let total = entries.reduce((a, e) => a + e.size, 0);
+  if (total <= budget) return 0;
+
+  entries.sort((a, b) => a.mtime - b.mtime);
+  let dropped = 0;
+  for (const e of entries) {
+    if (total <= budget) break;
+    try {
+      unlinkSync(e.full);
+      total -= e.size;
+      dropped += 1;
+    } catch {
+      /* leave it; a locked file must not stop the rest */
+    }
+  }
+  return dropped;
+}
+
+/** True when a path is inside a transcript archive -- the never-transmit test. */
+export function isArchived(path) {
+  return /[\\/]\.token-optimizer[\\/]wiki[\\/]transcripts[\\/]/.test(String(path));
+}
+
+/** Reads a session's archived turns back, for the lesson extractor. */
+export function readArchive(dir, sessionId) {
+  const file = join(transcriptDir(dir), `${safeName(sessionId)}.jsonl`);
+  if (!existsSync(file)) return [];
+  try {
+    return readFileSync(file, 'utf8')
+      .split('\n')
+      .filter(Boolean)
+      .map((l) => {
+        try {
+          return JSON.parse(l);
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}

--- a/integrations/codex/plugin/hooks/lib/harvest-write.mjs
+++ b/integrations/codex/plugin/hooks/lib/harvest-write.mjs
@@ -28,7 +28,7 @@ import { indexFile } from './staleness.mjs';
 import { symbolKey } from './symbols.mjs';
 import { canonicalPath } from './paths.mjs';
 import { randomBytes } from 'node:crypto';
-import { ORIGIN_HARVESTED, ORIGIN_AGENT } from './curate.mjs';
+import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
 
 /**
  * Resolves an `path` or `path#symbol` anchor to an existing node id.
@@ -81,11 +81,33 @@ export function writeHarvested(
 ) {
   if (!Array.isArray(findings) || !findings.length) return [];
 
-  // Only the two origins this path can honestly claim. A caller asking for
-  // anything else -- notably ORIGIN_HUMAN -- would be labelling machine output
-  // as a person's assertion, which is the confusion the field exists to prevent.
-  const provenance = origin === ORIGIN_AGENT ? ORIGIN_AGENT : ORIGIN_HARVESTED;
-  const prefix = provenance === ORIGIN_AGENT ? 'agent' : 'harvested';
+  // The batch default. A caller asking for anything else -- notably
+  // ORIGIN_HUMAN -- would be labelling machine output as a person's assertion,
+  // which is the confusion the field exists to prevent.
+  const batch = origin === ORIGIN_AGENT ? ORIGIN_AGENT : ORIGIN_HARVESTED;
+
+  /**
+   * ORIGIN_HUMAN IS EARNED PER FINDING, BY EVIDENCE.
+   *
+   * A batch-wide origin was the whole story here, and it silently discarded
+   * the per-lesson provenance `validateLessons` had just computed: a
+   * correction whose quote was verified word-for-word in the user's own turn
+   * was stored as ORIGIN_HARVESTED like any model paraphrase. The standing-
+   * rules layer selects on human origin, so it matched nothing this pipeline
+   * wrote, and the verbatim check had no observable effect at all.
+   *
+   * The original rule still holds -- a caller cannot simply DECLARE machine
+   * output human. It is the verified quote that promotes it, and the quote is
+   * stored alongside so the claim carries its own evidence.
+   */
+  const provenanceFor = (finding) =>
+    finding.origin === ORIGIN_HUMAN &&
+    typeof finding.quote === 'string' &&
+    finding.quote.trim()
+      ? ORIGIN_HUMAN
+      : batch;
+  const prefixFor = (p) =>
+    p === ORIGIN_AGENT ? 'agent' : p === ORIGIN_HUMAN ? 'human' : 'harvested';
 
   const written = [];
   for (const finding of findings) {
@@ -103,7 +125,8 @@ export function writeHarvested(
     // same key, and putNode keeps the last write for an id -- so one session's
     // finding silently replaces another's. A random suffix makes that
     // collision vanishingly unlikely while keeping the timestamp readable.
-    const key = `${prefix}-${Date.now().toString(36)}-${written.length}-${randomBytes(4).toString("hex")}`;
+    const provenance = provenanceFor(finding);
+    const key = `${prefixFor(provenance)}-${Date.now().toString(36)}-${written.length}-${randomBytes(4).toString("hex")}`;
     // ONE APPEND for the finding and every anchor it resolved. This runs in a
     // detached worker, so "the process survives to finish the loop" is not a
     // safe assumption: a node written without its edges is an active finding
@@ -127,6 +150,11 @@ export function writeHarvested(
           ? finding.trigger
           : undefined,
         origin: provenance,
+        // THE EVIDENCE TRAVELS WITH THE CLAIM. Without it a human-origin
+        // finding asserts its own provenance and nothing can check it.
+        quote: typeof finding.quote === 'string' && finding.quote.trim()
+          ? finding.quote
+          : undefined,
         sessionId,
       },
       resolved.map((target) => ({ edge: 'derived_from', to: target }))

--- a/integrations/codex/plugin/hooks/lib/harvest.mjs
+++ b/integrations/codex/plugin/hooks/lib/harvest.mjs
@@ -36,7 +36,10 @@ const ENDPOINT = () => process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT
   || 'https://api.anthropic.com/v1/messages';
 
 /** Findings must be one of these. Free-form claims are rejected. */
-export const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map'];
+// 'feedback' is a lesson extracted from a USER CORRECTION rather than from the
+// code -- the only finding type whose source is a person telling the agent it
+// was wrong, which is why it is kept distinguishable from an ordinary finding.
+export const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map', 'feedback'];
 
 export function apiKey() {
   return process.env.TOKEN_OPTIMIZER_API_KEY || process.env.ANTHROPIC_API_KEY || null;
@@ -222,7 +225,7 @@ export function validate(raw, { knownFiles = null } = {}) {
  * indistinguishable, from the caller's side, from a session with nothing to
  * learn.
  */
-export async function extract(digest, { timeoutMs = 30_000 } = {}) {
+export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}) {
   if (!digest || !harvestEnabled()) return [];
 
   // A local endpoint usually has no auth at all, so requiring a key there would
@@ -248,7 +251,7 @@ export async function extract(digest, { timeoutMs = 30_000 } = {}) {
       body: JSON.stringify({
         model: MODEL(),
         max_tokens: 2048,
-        system: PROMPT,
+        system: prompt || PROMPT,
         messages: [{ role: 'user', content: digest }],
       }),
     });

--- a/integrations/codex/plugin/hooks/lib/inject.mjs
+++ b/integrations/codex/plugin/hooks/lib/inject.mjs
@@ -31,6 +31,20 @@ import { substitutionBudget } from './metrics.mjs';
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
 
+/**
+ * Tokens allowed for the always-on standing rules.
+ *
+ * FIXED AND SMALL, unlike the session index whose budget is earned from measured
+ * hit rate. An earned budget is right for a catalogue that grows with the graph;
+ * it is wrong here, because this text is paid for on EVERY session whether or
+ * not it is relevant, and a set that grows with the project is exactly how an
+ * always-on block becomes wallpaper. 400 tokens is roughly a dozen rules -- if a
+ * project needs more standing rules than that, the honest answer is that some of
+ * them are situational and belong behind a trigger.
+ */
+const standingBudget = () =>
+  Number(process.env.TOKEN_OPTIMIZER_STANDING_BUDGET) || 400;
+
 /** Most findings considered for one command before the budget decides. */
 const MAX_COMMAND_CANDIDATES = 20;
 
@@ -339,6 +353,77 @@ Established in previous sessions. Call wiki_query with a key for detail, or just
 work -- findings anchored to a file are surfaced automatically when you touch it.
 
 ${lines.join('\n')}`;
+}
+
+/**
+ * The always-on set: rules that must hold before the first tool call.
+ *
+ * WHY THESE CANNOT BE TRIGGER-FIRED. A trigger answers "this situation is
+ * happening now". Some rules are not about a situation -- "report the number you
+ * measured, not the one you expected" governs how every turn is conducted, and
+ * by the time any command matched a trigger the turn would already be going
+ * wrong. Those have to be present before anything happens or they are useless.
+ *
+ * WHY THIS IS NOT THE SESSION INDEX. `sessionIndex` lists keys and truncated
+ * titles and tells the model to call wiki_query for detail; that is right for a
+ * catalogue of things it MIGHT want. A standing rule that needs a lookup before
+ * it can be obeyed is not a standing rule -- so these are rendered in full, and
+ * are budgeted separately and much more tightly because of it.
+ *
+ * WHAT QUALIFIES, deliberately narrow:
+ *   - anything a human PINNED, which curate.mjs already defines as a fact that
+ *     stays true and should not decay, or
+ *   - a `feedback` lesson whose quote was verified against the transcript, so a
+ *     person demonstrably said it.
+ *
+ * Everything else waits for its trigger. The failure mode this guards against
+ * is the one that already happened here: an always-on block that grows until it
+ * is wallpaper, and the model stops reading the thing it always sees.
+ */
+export function standingRules(dir, graph, { budget = standingBudget() } = {}) {
+  const rules = [...graph.nodes.values()].filter(
+    (n) =>
+      n.kind === 'finding' &&
+      !n.retired &&
+      typeof n.claim === 'string' &&
+      (n.pinned === true || (n.type === 'feedback' && n.origin === 'human'))
+  );
+  if (!rules.length) return null;
+
+  // A person's own correction outranks anything inferred, then confidence.
+  rules.sort((a, b) => {
+    const weight = (n) => (n.origin === 'human' ? 2 : n.pinned ? 1.5 : 1);
+    return weight(b) * (b.confidence ?? 0.5) - weight(a) * (a.confidence ?? 0.5);
+  });
+
+  const lines = [];
+  let spent = 0;
+  let dropped = 0;
+  for (const rule of rules) {
+    const line = `- ${rule.claim}`;
+    const cost = estimate(line);
+    if (spent + cost > budget) {
+      dropped += 1;
+      continue;
+    }
+    lines.push(line);
+    spent += cost;
+  }
+  if (!lines.length) return null;
+
+  record(dir, { kind: 'standing', count: lines.length, dropped, tokens: spent });
+
+  // SAY WHAT WAS DROPPED. A silent cap reads as "these are all the rules",
+  // which is worse than saying there are more: a model that knows the list is
+  // truncated can ask, one that does not will assume it is complete.
+  const truncated = dropped
+    ? `\n(${dropped} further standing rule${dropped === 1 ? '' : 's'} did not fit this budget; ` +
+      `raise TOKEN_OPTIMIZER_STANDING_BUDGET or retire some.)`
+    : '';
+
+  return `# Standing rules for this project\n\nEstablished in previous sessions and expected to hold. These are not suggestions.\n\n${lines.join(
+    '\n'
+  )}${truncated}`;
 }
 
 /**

--- a/integrations/codex/plugin/hooks/lib/inject.mjs
+++ b/integrations/codex/plugin/hooks/lib/inject.mjs
@@ -396,8 +396,30 @@ export function standingRules(dir, graph, { budget = standingBudget() } = {}) {
     return weight(b) * (b.confidence ?? 0.5) - weight(a) * (a.confidence ?? 0.5);
   });
 
+  // THE BUDGET COVERS THE WHOLE MESSAGE, not just the claim lines.
+  //
+  // `spent` used to count selected claims only, while the returned text also
+  // carries a heading, two lines of fixed instruction and an optional
+  // truncation notice. A selection that exactly filled the budget therefore
+  // injected more than the budget allowed and recorded fewer tokens than it
+  // spent -- in a block whose entire justification is that it is tightly
+  // bounded and measured against the control arm.
+  const HEADING =
+    '# Standing rules for this project' +
+    '\n\nEstablished in previous sessions and expected to hold. ' +
+    'These are not suggestions.\n\n';
+  const noticeFor = (n) =>
+    n
+      ? `\n(${n} further standing rule${n === 1 ? '' : 's'} did not fit this budget; ` +
+        'raise TOKEN_OPTIMIZER_STANDING_BUDGET or retire some.)'
+      : '';
+
+  // The wrapper is charged up front, and the worst-case notice is reserved, so
+  // admitting the last line can never push the total over by adding one.
+  const overhead = estimate(HEADING) + estimate(noticeFor(rules.length));
+
   const lines = [];
-  let spent = 0;
+  let spent = overhead;
   let dropped = 0;
   for (const rule of rules) {
     const line = `- ${rule.claim}`;
@@ -409,21 +431,24 @@ export function standingRules(dir, graph, { budget = standingBudget() } = {}) {
     lines.push(line);
     spent += cost;
   }
-  if (!lines.length) return null;
 
-  record(dir, { kind: 'standing', count: lines.length, dropped, tokens: spent });
+  // RECORDED EVEN WHEN NOTHING FITS. Returning early without a metric hid the
+  // one case most worth knowing about: rules exist and every one is too large
+  // for the budget, so the block silently does nothing all session and the
+  // measurement shows no sign of it.
+  const truncated = noticeFor(dropped);
+  record(dir, {
+    kind: 'standing',
+    count: lines.length,
+    dropped,
+    tokens: lines.length ? spent : 0,
+  });
+  if (!lines.length) return null;
 
   // SAY WHAT WAS DROPPED. A silent cap reads as "these are all the rules",
   // which is worse than saying there are more: a model that knows the list is
   // truncated can ask, one that does not will assume it is complete.
-  const truncated = dropped
-    ? `\n(${dropped} further standing rule${dropped === 1 ? '' : 's'} did not fit this budget; ` +
-      `raise TOKEN_OPTIMIZER_STANDING_BUDGET or retire some.)`
-    : '';
-
-  return `# Standing rules for this project\n\nEstablished in previous sessions and expected to hold. These are not suggestions.\n\n${lines.join(
-    '\n'
-  )}${truncated}`;
+  return `${HEADING}${lines.join('\n')}${truncated}`;
 }
 
 /**

--- a/integrations/codex/plugin/hooks/lib/lessons.mjs
+++ b/integrations/codex/plugin/hooks/lib/lessons.mjs
@@ -98,24 +98,64 @@ export function buildFeedbackDigest(turns, { maxChars = 40_000 } = {}) {
   return out.length ? out.join('\n\n') : null;
 }
 
-/** True when the quote really appears in the archive, allowing for whitespace. */
+/**
+ * True when the quote really appears in the archive, allowing for whitespace.
+ *
+ * CASE IS PART OF VERBATIM. Lower-casing both sides accepted a quote whose
+ * capitalisation never occurred -- `NO, USE NPM TEST` matched a transcript
+ * saying `no, use npm test` -- and that quote then earned ORIGIN_HUMAN and 0.95
+ * confidence on the strength of a check it had not actually passed. The prompt
+ * asks for an exact copy, so this asks for one.
+ *
+ * Whitespace IS still normalised: line wrapping is an artefact of how the turn
+ * was stored, not something the user chose.
+ */
 export function quoteIsVerbatim(quote, turns) {
-  const needle = String(quote || '').trim().toLowerCase().replace(/\s+/g, ' ');
+  // A missing archive is not a match. `buildFeedbackDigest` guards its input in
+  // this same module; without the same guard here a null archive threw a
+  // TypeError out of a validator whose entire job is to reject bad input.
+  if (!Array.isArray(turns)) return false;
+  const needle = String(quote || '').trim().replace(/\s+/g, ' ');
   if (needle.length < 8) return false;
   return turns
-    .filter((t) => t.role === 'user')
-    .some((t) => String(t.text).toLowerCase().replace(/\s+/g, ' ').includes(needle));
+    .filter((t) => t && t.role === 'user')
+    .some((t) => String(t.text).replace(/\s+/g, ' ').includes(needle));
 }
 
-/** A claim that leads with a verb, which is what makes it act like an instruction. */
+/**
+ * A claim that leads with a bare verb, which is what makes it an instruction.
+ *
+ * A POSITIVE RULE, NOT A DENYLIST. The denylist rejected the openings a
+ * paraphrase usually starts with -- `the user prefers`, `you should` -- and
+ * accepted everything else, so `npm test is preferred over npx jest.` passed
+ * and was stored as a standing rule despite being a description rather than an
+ * instruction. Any noun-led sentence walked straight through.
+ *
+ * The test is now positive: the first word must be a bare verb form. That is
+ * still not a parts-of-speech tagger, but it fails CLOSED -- an unrecognised
+ * opening is rejected rather than admitted, which is the right direction for a
+ * gate on text that becomes an always-on instruction.
+ */
+const IMPERATIVE_VERBS = new Set([
+  'use', 'run', 'call', 'prefer', 'avoid', 'never', 'always', 'do', "don't", 'dont',
+  'stop', 'start', 'check', 'verify', 'confirm', 'read', 'write', 'edit', 'add',
+  'remove', 'delete', 'fix', 'keep', 'make', 'set', 'pass', 'build', 'test',
+  'install', 'update', 'rebase', 'merge', 'commit', 'push', 'pull', 'fetch',
+  'branch', 'open', 'close', 'ask', 'report', 'measure', 'record', 'skip',
+  'ignore', 'include', 'exclude', 'treat', 'assume', 'ensure', 'require',
+  'apply', 'revert', 'restore', 'replace', 'rename', 'move', 'copy', 'create',
+  'wait', 'retry', 'log', 'print', 'return', 'throw', 'catch', 'handle',
+  'quote', 'escape', 'sanitise', 'sanitize', 'validate', 'reject', 'accept',
+]);
+
 export function isImperative(claim) {
-  const first = String(claim || '').trim().split(/\s+/)[0] || '';
-  // Not a parts-of-speech tagger, and does not need to be: what it rejects is
-  // the shape corrections actually arrive in when a model paraphrases them --
-  // "the user prefers", "it is better to", "you should".
-  return !/^(the|a|an|it|this|that|there|you|we|i|user|users|when|because|since|although)$/i.test(
-    first
-  );
+  const first = String(claim || '')
+    .trim()
+    .split(/\s+/)[0]
+    .replace(/[^A-Za-z']/g, '')
+    .toLowerCase();
+  if (!first) return false;
+  return IMPERATIVE_VERBS.has(first);
 }
 
 /**

--- a/integrations/codex/plugin/hooks/lib/lessons.mjs
+++ b/integrations/codex/plugin/hooks/lib/lessons.mjs
@@ -1,0 +1,192 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/lessons.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Turning corrections into lessons the next session actually receives.
+ *
+ * The signal this exists to capture is sparse and specific: the moments where
+ * the user pushed back. Everything else in a session is ordinary work. Measured
+ * on one real session, the graph recorded 4,053 file touches and none of the
+ * three corrections the user actually gave -- which are the only turns that
+ * carried information the code could not.
+ *
+ * TWO THINGS THIS MODULE REFUSES TO GUESS.
+ *
+ * 1. WHO SAID IT. A lesson is stored as a human assertion only when the
+ *    extractor supplies the user's words verbatim AND those words are found in
+ *    the archive. curate.mjs warns that "a hand-written assertion and a machine
+ *    guess look identical three months later", and human origin carries the
+ *    highest ranking weight -- so claiming it on a model's paraphrase would let
+ *    an inference outrank the correction it was inferred from. Unverifiable
+ *    quotes still store, as ORIGIN_HARVESTED.
+ *
+ * 2. WHEN IT APPLIES. Every lesson must carry a trigger. A lesson with no
+ *    trigger can only surface if someone happens to open the file it is anchored
+ *    to, which is not when advice about doing something is needed.
+ *
+ * AND ONE THING IT INSISTS ON: the action first. Measured in the injection A/B,
+ * a correctly stored and correctly delivered finding was still ignored because
+ * its instruction sat at the end of three sentences of context. Delivery is
+ * necessary and not sufficient; phrasing is the other half.
+ */
+
+import { ORIGIN_HARVESTED, ORIGIN_HUMAN } from './curate.mjs';
+
+/** Lessons longer than this are prose, not instructions. */
+const MAX_CLAIM = 400;
+
+/**
+ * The extraction prompt.
+ *
+ * Deliberately narrow. Asked for "lessons" a model will summarise the session;
+ * asked for corrections it returns the handful of turns that actually taught
+ * something, which is the whole point of keeping the store sparse.
+ */
+export const LESSON_PROMPT = `You are reading a transcript between a user and a coding agent.
+
+Extract ONLY the moments where the USER corrected, rejected, or redirected the agent —
+where the agent did something the user did not want, and the user said so. Ignore
+ordinary instructions, questions, and approvals. Most transcripts contain between zero
+and five of these. Returning an empty list is a correct and common answer.
+
+For each correction return an object with:
+  "claim"   - the lesson, as an IMPERATIVE with the action FIRST. Start with a verb.
+              Not "the user prefers X because Y" but "Do X. Y is why."
+              Under ${MAX_CLAIM} characters. This is the sentence a future agent reads
+              at the moment it is about to make the same mistake, so it must lead with
+              what to do, not with background.
+  "quote"   - the user's own words that constitute the correction, copied EXACTLY from
+              the transcript. Do not paraphrase, do not fix typos, do not add quotes.
+  "trigger" - a JavaScript regex source matching the situation where this applies, e.g.
+              "\\\\bnpx\\\\s+jest\\\\b" or "git\\\\s+push" or "\\\\.csproj". If the lesson is about a
+              tool or command, match that. Required.
+  "anchors" - array of absolute file paths the lesson concerns. May be empty.
+
+Return ONLY a JSON array. No prose, no markdown fence.`;
+
+/**
+ * Builds the extractor input from archived turns.
+ *
+ * Assistant tool RESULTS never entered the archive, so they cannot enter here.
+ * What is sent is the conversation: what was asked, what was answered, and which
+ * commands were run.
+ */
+export function buildFeedbackDigest(turns, { maxChars = 40_000 } = {}) {
+  if (!Array.isArray(turns) || !turns.length) return null;
+
+  const rendered = turns.map((t) => {
+    if (t.role === 'user') return `USER: ${t.text}`;
+    const tools = (t.tools || [])
+      .map((x) => (x.command ? `${x.name}(${x.command})` : x.name))
+      .filter(Boolean)
+      .slice(0, 8)
+      .join(', ');
+    const head = t.text ? `AGENT: ${t.text}` : 'AGENT:';
+    return tools ? `${head}\n  [tools: ${tools}]` : head;
+  });
+
+  // KEEP THE END, not the beginning. Corrections cluster where the work went
+  // wrong, and a transcript that needed correcting tends to have gone wrong
+  // later rather than sooner.
+  let out = [];
+  let total = 0;
+  for (let i = rendered.length - 1; i >= 0; i--) {
+    const piece = rendered[i];
+    if (total + piece.length > maxChars) break;
+    out.unshift(piece);
+    total += piece.length;
+  }
+  return out.length ? out.join('\n\n') : null;
+}
+
+/** True when the quote really appears in the archive, allowing for whitespace. */
+export function quoteIsVerbatim(quote, turns) {
+  const needle = String(quote || '').trim().toLowerCase().replace(/\s+/g, ' ');
+  if (needle.length < 8) return false;
+  return turns
+    .filter((t) => t.role === 'user')
+    .some((t) => String(t.text).toLowerCase().replace(/\s+/g, ' ').includes(needle));
+}
+
+/** A claim that leads with a verb, which is what makes it act like an instruction. */
+export function isImperative(claim) {
+  const first = String(claim || '').trim().split(/\s+/)[0] || '';
+  // Not a parts-of-speech tagger, and does not need to be: what it rejects is
+  // the shape corrections actually arrive in when a model paraphrases them --
+  // "the user prefers", "it is better to", "you should".
+  return !/^(the|a|an|it|this|that|there|you|we|i|user|users|when|because|since|although)$/i.test(
+    first
+  );
+}
+
+/**
+ * Validates extractor output and decides each lesson's origin.
+ *
+ * Returns { lessons, rejected } so a caller can report what was dropped rather
+ * than silently storing less than it was given.
+ */
+export function validateLessons(raw, turns) {
+  let parsed = raw;
+  if (typeof raw === 'string') {
+    try {
+      parsed = JSON.parse(raw.replace(/^```(?:json)?\s*|\s*```$/g, ''));
+    } catch {
+      return { lessons: [], rejected: [{ reason: 'unparseable', raw: String(raw).slice(0, 200) }] };
+    }
+  }
+  if (!Array.isArray(parsed)) {
+    return { lessons: [], rejected: [{ reason: 'not-an-array' }] };
+  }
+
+  const lessons = [];
+  const rejected = [];
+
+  for (const item of parsed) {
+    const claim = String(item?.claim || '').trim();
+    const trigger = String(item?.trigger || '').trim();
+    const quote = String(item?.quote || '').trim();
+
+    if (claim.length < 12) {
+      rejected.push({ reason: 'claim-too-short', claim });
+      continue;
+    }
+    if (claim.length > MAX_CLAIM) {
+      rejected.push({ reason: 'claim-too-long', claim: claim.slice(0, 80) });
+      continue;
+    }
+    if (!trigger) {
+      // Without one it can only surface by file touch, which is not when advice
+      // about an action is needed.
+      rejected.push({ reason: 'no-trigger', claim: claim.slice(0, 80) });
+      continue;
+    }
+    try {
+      new RegExp(trigger);
+    } catch {
+      rejected.push({ reason: 'bad-trigger-regex', trigger });
+      continue;
+    }
+    if (!isImperative(claim)) {
+      rejected.push({ reason: 'not-imperative', claim: claim.slice(0, 80) });
+      continue;
+    }
+
+    // THE PROVENANCE TEST. Verbatim and present means the user really said it.
+    const verified = quoteIsVerbatim(quote, turns);
+
+    lessons.push({
+      type: 'feedback',
+      claim,
+      trigger,
+      quote: verified ? quote : undefined,
+      origin: verified ? ORIGIN_HUMAN : ORIGIN_HARVESTED,
+      // A verified human correction is as close to ground truth as this system
+      // gets. An unverified paraphrase is a model's reading of one.
+      confidence: verified ? 0.95 : 0.6,
+      anchors: Array.isArray(item?.anchors)
+        ? item.anchors.filter((a) => typeof a === 'string' && a.trim())
+        : [],
+    });
+  }
+
+  return { lessons, rejected };
+}

--- a/integrations/codex/plugin/hooks/lib/transcript.mjs
+++ b/integrations/codex/plugin/hooks/lib/transcript.mjs
@@ -1,0 +1,213 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/transcript.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * The raw local archive of what was asked and what was answered.
+ *
+ * THE ARCHIVE AND THE LESSONS ARE DIFFERENT THINGS, and keeping them separate
+ * is the whole design. The archive is complete and never retrieved; the lessons
+ * extracted from it are sparse and are the only thing ever injected. Storing
+ * everything AND retrieving everything would drown the graph -- a session is
+ * thousands of turns of ordinary work and a handful of moments that taught
+ * something. Storing everything and retrieving only the lessons keeps the record
+ * complete without diluting what gets served.
+ *
+ * NOTHING HERE LEAVES THE MACHINE. The archive is written inside the wiki
+ * directory, which already carries a `.gitignore` of `*`, and it is explicitly
+ * excluded from the harvest digest -- the one code path that sends anything to a
+ * model endpoint. A feedback loop must never become the reason a user's prompts
+ * are transmitted.
+ */
+
+import {
+  readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, readdirSync, statSync, unlinkSync,
+} from 'node:fs';
+import { join } from 'node:path';
+
+/** Where a project's transcripts live, under the graph it belongs to. */
+export const transcriptDir = (dir) => join(dir, 'transcripts');
+
+/**
+ * Total bytes of archive kept per project before the oldest are dropped.
+ *
+ * An unbounded archive of every session is a disk leak that grows fastest for
+ * the users who use the tool most, which is exactly backwards.
+ */
+const archiveBudget = () =>
+  Number(process.env.TOKEN_OPTIMIZER_TRANSCRIPT_BUDGET_BYTES) || 50 * 1024 * 1024;
+
+/** A session id reduced to something that cannot escape the archive directory. */
+export function safeName(sessionId) {
+  const safe = String(sessionId || 'unknown').replace(/[^A-Za-z0-9._-]/g, '_');
+  return (/^[.]+$/.test(safe) ? 'unknown' : safe).slice(0, 64);
+}
+
+/**
+ * Turns a Claude transcript into the prompt/response pairs worth keeping.
+ *
+ * TOOL RESULTS ARE DROPPED, for the same reason `buildDigest` drops them: that
+ * is where whole file contents would enter the record. The archive is meant to
+ * hold the conversation, not a second copy of the repository.
+ */
+export function readTurns(transcriptPath) {
+  let lines;
+  try {
+    lines = readFileSync(transcriptPath, 'utf8').split('\n');
+  } catch {
+    return [];
+  }
+
+  const turns = [];
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    let entry;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+
+    const message = entry.message || entry;
+    const role = message.role || entry.type;
+    const content = message.content;
+
+    if (role === 'user') {
+      const text =
+        typeof content === 'string'
+          ? content
+          : Array.isArray(content)
+            ? content
+                .filter((b) => b && b.type === 'text')
+                .map((b) => String(b.text))
+                .join('\n')
+            : '';
+      if (text.trim()) turns.push({ role: 'user', text: text.trim(), at: entry.timestamp ?? null });
+      continue;
+    }
+
+    if (role === 'assistant' && Array.isArray(content)) {
+      const text = content
+        .filter((b) => b && b.type === 'text')
+        .map((b) => String(b.text))
+        .join('\n');
+      const tools = content
+        .filter((b) => b && b.type === 'tool_use')
+        .map((b) => ({
+          name: b.name,
+          // Arguments only, never results, and truncated: a command is the
+          // useful part, its output is not.
+          command: b.input?.command ? String(b.input.command).slice(0, 300) : undefined,
+          path: b.input?.file_path || b.input?.path || undefined,
+        }));
+      if (text.trim() || tools.length) {
+        turns.push({ role: 'assistant', text: text.trim(), tools, at: entry.timestamp ?? null });
+      }
+    }
+  }
+  return turns;
+}
+
+/**
+ * Appends this session's turns to the project archive.
+ *
+ * Idempotent per session by rewriting that session's file, so a Stop hook firing
+ * repeatedly does not multiply the record.
+ */
+export function archive(dir, transcriptPath, { sessionId } = {}) {
+  const turns = readTurns(transcriptPath);
+  if (!turns.length) return 0;
+
+  const root = transcriptDir(dir);
+  try {
+    mkdirSync(root, { recursive: true, mode: 0o700 });
+    try {
+      chmodSync(root, 0o700);
+    } catch {
+      /* not POSIX, or not ours */
+    }
+  } catch {
+    return 0;
+  }
+
+  const file = join(root, `${safeName(sessionId)}.jsonl`);
+  try {
+    // Truncate-and-write rather than append: Stop fires many times per session
+    // and the transcript is cumulative, so appending would store the early turns
+    // once per firing.
+    const payload = turns.map((t) => JSON.stringify(t)).join('\n') + '\n';
+    writeFileSync(file, payload, { mode: 0o600 });
+  } catch {
+    return 0;
+  }
+
+  prune(root);
+  return turns.length;
+}
+
+/**
+ * Drops the oldest sessions once the archive exceeds its budget.
+ *
+ * Oldest-first, because the value of a transcript is highest while the work it
+ * describes is still live.
+ */
+export function prune(root, budget = archiveBudget()) {
+  let entries;
+  try {
+    entries = readdirSync(root)
+      .filter((f) => f.endsWith('.jsonl'))
+      .map((f) => {
+        const full = join(root, f);
+        try {
+          const s = statSync(full);
+          return { full, size: s.size, mtime: s.mtimeMs };
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch {
+    return 0;
+  }
+
+  let total = entries.reduce((a, e) => a + e.size, 0);
+  if (total <= budget) return 0;
+
+  entries.sort((a, b) => a.mtime - b.mtime);
+  let dropped = 0;
+  for (const e of entries) {
+    if (total <= budget) break;
+    try {
+      unlinkSync(e.full);
+      total -= e.size;
+      dropped += 1;
+    } catch {
+      /* leave it; a locked file must not stop the rest */
+    }
+  }
+  return dropped;
+}
+
+/** True when a path is inside a transcript archive -- the never-transmit test. */
+export function isArchived(path) {
+  return /[\\/]\.token-optimizer[\\/]wiki[\\/]transcripts[\\/]/.test(String(path));
+}
+
+/** Reads a session's archived turns back, for the lesson extractor. */
+export function readArchive(dir, sessionId) {
+  const file = join(transcriptDir(dir), `${safeName(sessionId)}.jsonl`);
+  if (!existsSync(file)) return [];
+  try {
+    return readFileSync(file, 'utf8')
+      .split('\n')
+      .filter(Boolean)
+      .map((l) => {
+        try {
+          return JSON.parse(l);
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}

--- a/integrations/gemini/hooks/lib/harvest-write.mjs
+++ b/integrations/gemini/hooks/lib/harvest-write.mjs
@@ -28,7 +28,7 @@ import { indexFile } from './staleness.mjs';
 import { symbolKey } from './symbols.mjs';
 import { canonicalPath } from './paths.mjs';
 import { randomBytes } from 'node:crypto';
-import { ORIGIN_HARVESTED, ORIGIN_AGENT } from './curate.mjs';
+import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
 
 /**
  * Resolves an `path` or `path#symbol` anchor to an existing node id.
@@ -81,11 +81,33 @@ export function writeHarvested(
 ) {
   if (!Array.isArray(findings) || !findings.length) return [];
 
-  // Only the two origins this path can honestly claim. A caller asking for
-  // anything else -- notably ORIGIN_HUMAN -- would be labelling machine output
-  // as a person's assertion, which is the confusion the field exists to prevent.
-  const provenance = origin === ORIGIN_AGENT ? ORIGIN_AGENT : ORIGIN_HARVESTED;
-  const prefix = provenance === ORIGIN_AGENT ? 'agent' : 'harvested';
+  // The batch default. A caller asking for anything else -- notably
+  // ORIGIN_HUMAN -- would be labelling machine output as a person's assertion,
+  // which is the confusion the field exists to prevent.
+  const batch = origin === ORIGIN_AGENT ? ORIGIN_AGENT : ORIGIN_HARVESTED;
+
+  /**
+   * ORIGIN_HUMAN IS EARNED PER FINDING, BY EVIDENCE.
+   *
+   * A batch-wide origin was the whole story here, and it silently discarded
+   * the per-lesson provenance `validateLessons` had just computed: a
+   * correction whose quote was verified word-for-word in the user's own turn
+   * was stored as ORIGIN_HARVESTED like any model paraphrase. The standing-
+   * rules layer selects on human origin, so it matched nothing this pipeline
+   * wrote, and the verbatim check had no observable effect at all.
+   *
+   * The original rule still holds -- a caller cannot simply DECLARE machine
+   * output human. It is the verified quote that promotes it, and the quote is
+   * stored alongside so the claim carries its own evidence.
+   */
+  const provenanceFor = (finding) =>
+    finding.origin === ORIGIN_HUMAN &&
+    typeof finding.quote === 'string' &&
+    finding.quote.trim()
+      ? ORIGIN_HUMAN
+      : batch;
+  const prefixFor = (p) =>
+    p === ORIGIN_AGENT ? 'agent' : p === ORIGIN_HUMAN ? 'human' : 'harvested';
 
   const written = [];
   for (const finding of findings) {
@@ -103,7 +125,8 @@ export function writeHarvested(
     // same key, and putNode keeps the last write for an id -- so one session's
     // finding silently replaces another's. A random suffix makes that
     // collision vanishingly unlikely while keeping the timestamp readable.
-    const key = `${prefix}-${Date.now().toString(36)}-${written.length}-${randomBytes(4).toString("hex")}`;
+    const provenance = provenanceFor(finding);
+    const key = `${prefixFor(provenance)}-${Date.now().toString(36)}-${written.length}-${randomBytes(4).toString("hex")}`;
     // ONE APPEND for the finding and every anchor it resolved. This runs in a
     // detached worker, so "the process survives to finish the loop" is not a
     // safe assumption: a node written without its edges is an active finding
@@ -127,6 +150,11 @@ export function writeHarvested(
           ? finding.trigger
           : undefined,
         origin: provenance,
+        // THE EVIDENCE TRAVELS WITH THE CLAIM. Without it a human-origin
+        // finding asserts its own provenance and nothing can check it.
+        quote: typeof finding.quote === 'string' && finding.quote.trim()
+          ? finding.quote
+          : undefined,
         sessionId,
       },
       resolved.map((target) => ({ edge: 'derived_from', to: target }))

--- a/integrations/gemini/hooks/lib/harvest.mjs
+++ b/integrations/gemini/hooks/lib/harvest.mjs
@@ -36,7 +36,10 @@ const ENDPOINT = () => process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT
   || 'https://api.anthropic.com/v1/messages';
 
 /** Findings must be one of these. Free-form claims are rejected. */
-export const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map'];
+// 'feedback' is a lesson extracted from a USER CORRECTION rather than from the
+// code -- the only finding type whose source is a person telling the agent it
+// was wrong, which is why it is kept distinguishable from an ordinary finding.
+export const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map', 'feedback'];
 
 export function apiKey() {
   return process.env.TOKEN_OPTIMIZER_API_KEY || process.env.ANTHROPIC_API_KEY || null;
@@ -222,7 +225,7 @@ export function validate(raw, { knownFiles = null } = {}) {
  * indistinguishable, from the caller's side, from a session with nothing to
  * learn.
  */
-export async function extract(digest, { timeoutMs = 30_000 } = {}) {
+export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}) {
   if (!digest || !harvestEnabled()) return [];
 
   // A local endpoint usually has no auth at all, so requiring a key there would
@@ -248,7 +251,7 @@ export async function extract(digest, { timeoutMs = 30_000 } = {}) {
       body: JSON.stringify({
         model: MODEL(),
         max_tokens: 2048,
-        system: PROMPT,
+        system: prompt || PROMPT,
         messages: [{ role: 'user', content: digest }],
       }),
     });

--- a/integrations/gemini/hooks/lib/inject.mjs
+++ b/integrations/gemini/hooks/lib/inject.mjs
@@ -31,6 +31,20 @@ import { substitutionBudget } from './metrics.mjs';
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
 
+/**
+ * Tokens allowed for the always-on standing rules.
+ *
+ * FIXED AND SMALL, unlike the session index whose budget is earned from measured
+ * hit rate. An earned budget is right for a catalogue that grows with the graph;
+ * it is wrong here, because this text is paid for on EVERY session whether or
+ * not it is relevant, and a set that grows with the project is exactly how an
+ * always-on block becomes wallpaper. 400 tokens is roughly a dozen rules -- if a
+ * project needs more standing rules than that, the honest answer is that some of
+ * them are situational and belong behind a trigger.
+ */
+const standingBudget = () =>
+  Number(process.env.TOKEN_OPTIMIZER_STANDING_BUDGET) || 400;
+
 /** Most findings considered for one command before the budget decides. */
 const MAX_COMMAND_CANDIDATES = 20;
 
@@ -339,6 +353,77 @@ Established in previous sessions. Call wiki_query with a key for detail, or just
 work -- findings anchored to a file are surfaced automatically when you touch it.
 
 ${lines.join('\n')}`;
+}
+
+/**
+ * The always-on set: rules that must hold before the first tool call.
+ *
+ * WHY THESE CANNOT BE TRIGGER-FIRED. A trigger answers "this situation is
+ * happening now". Some rules are not about a situation -- "report the number you
+ * measured, not the one you expected" governs how every turn is conducted, and
+ * by the time any command matched a trigger the turn would already be going
+ * wrong. Those have to be present before anything happens or they are useless.
+ *
+ * WHY THIS IS NOT THE SESSION INDEX. `sessionIndex` lists keys and truncated
+ * titles and tells the model to call wiki_query for detail; that is right for a
+ * catalogue of things it MIGHT want. A standing rule that needs a lookup before
+ * it can be obeyed is not a standing rule -- so these are rendered in full, and
+ * are budgeted separately and much more tightly because of it.
+ *
+ * WHAT QUALIFIES, deliberately narrow:
+ *   - anything a human PINNED, which curate.mjs already defines as a fact that
+ *     stays true and should not decay, or
+ *   - a `feedback` lesson whose quote was verified against the transcript, so a
+ *     person demonstrably said it.
+ *
+ * Everything else waits for its trigger. The failure mode this guards against
+ * is the one that already happened here: an always-on block that grows until it
+ * is wallpaper, and the model stops reading the thing it always sees.
+ */
+export function standingRules(dir, graph, { budget = standingBudget() } = {}) {
+  const rules = [...graph.nodes.values()].filter(
+    (n) =>
+      n.kind === 'finding' &&
+      !n.retired &&
+      typeof n.claim === 'string' &&
+      (n.pinned === true || (n.type === 'feedback' && n.origin === 'human'))
+  );
+  if (!rules.length) return null;
+
+  // A person's own correction outranks anything inferred, then confidence.
+  rules.sort((a, b) => {
+    const weight = (n) => (n.origin === 'human' ? 2 : n.pinned ? 1.5 : 1);
+    return weight(b) * (b.confidence ?? 0.5) - weight(a) * (a.confidence ?? 0.5);
+  });
+
+  const lines = [];
+  let spent = 0;
+  let dropped = 0;
+  for (const rule of rules) {
+    const line = `- ${rule.claim}`;
+    const cost = estimate(line);
+    if (spent + cost > budget) {
+      dropped += 1;
+      continue;
+    }
+    lines.push(line);
+    spent += cost;
+  }
+  if (!lines.length) return null;
+
+  record(dir, { kind: 'standing', count: lines.length, dropped, tokens: spent });
+
+  // SAY WHAT WAS DROPPED. A silent cap reads as "these are all the rules",
+  // which is worse than saying there are more: a model that knows the list is
+  // truncated can ask, one that does not will assume it is complete.
+  const truncated = dropped
+    ? `\n(${dropped} further standing rule${dropped === 1 ? '' : 's'} did not fit this budget; ` +
+      `raise TOKEN_OPTIMIZER_STANDING_BUDGET or retire some.)`
+    : '';
+
+  return `# Standing rules for this project\n\nEstablished in previous sessions and expected to hold. These are not suggestions.\n\n${lines.join(
+    '\n'
+  )}${truncated}`;
 }
 
 /**

--- a/integrations/gemini/hooks/lib/inject.mjs
+++ b/integrations/gemini/hooks/lib/inject.mjs
@@ -396,8 +396,30 @@ export function standingRules(dir, graph, { budget = standingBudget() } = {}) {
     return weight(b) * (b.confidence ?? 0.5) - weight(a) * (a.confidence ?? 0.5);
   });
 
+  // THE BUDGET COVERS THE WHOLE MESSAGE, not just the claim lines.
+  //
+  // `spent` used to count selected claims only, while the returned text also
+  // carries a heading, two lines of fixed instruction and an optional
+  // truncation notice. A selection that exactly filled the budget therefore
+  // injected more than the budget allowed and recorded fewer tokens than it
+  // spent -- in a block whose entire justification is that it is tightly
+  // bounded and measured against the control arm.
+  const HEADING =
+    '# Standing rules for this project' +
+    '\n\nEstablished in previous sessions and expected to hold. ' +
+    'These are not suggestions.\n\n';
+  const noticeFor = (n) =>
+    n
+      ? `\n(${n} further standing rule${n === 1 ? '' : 's'} did not fit this budget; ` +
+        'raise TOKEN_OPTIMIZER_STANDING_BUDGET or retire some.)'
+      : '';
+
+  // The wrapper is charged up front, and the worst-case notice is reserved, so
+  // admitting the last line can never push the total over by adding one.
+  const overhead = estimate(HEADING) + estimate(noticeFor(rules.length));
+
   const lines = [];
-  let spent = 0;
+  let spent = overhead;
   let dropped = 0;
   for (const rule of rules) {
     const line = `- ${rule.claim}`;
@@ -409,21 +431,24 @@ export function standingRules(dir, graph, { budget = standingBudget() } = {}) {
     lines.push(line);
     spent += cost;
   }
-  if (!lines.length) return null;
 
-  record(dir, { kind: 'standing', count: lines.length, dropped, tokens: spent });
+  // RECORDED EVEN WHEN NOTHING FITS. Returning early without a metric hid the
+  // one case most worth knowing about: rules exist and every one is too large
+  // for the budget, so the block silently does nothing all session and the
+  // measurement shows no sign of it.
+  const truncated = noticeFor(dropped);
+  record(dir, {
+    kind: 'standing',
+    count: lines.length,
+    dropped,
+    tokens: lines.length ? spent : 0,
+  });
+  if (!lines.length) return null;
 
   // SAY WHAT WAS DROPPED. A silent cap reads as "these are all the rules",
   // which is worse than saying there are more: a model that knows the list is
   // truncated can ask, one that does not will assume it is complete.
-  const truncated = dropped
-    ? `\n(${dropped} further standing rule${dropped === 1 ? '' : 's'} did not fit this budget; ` +
-      `raise TOKEN_OPTIMIZER_STANDING_BUDGET or retire some.)`
-    : '';
-
-  return `# Standing rules for this project\n\nEstablished in previous sessions and expected to hold. These are not suggestions.\n\n${lines.join(
-    '\n'
-  )}${truncated}`;
+  return `${HEADING}${lines.join('\n')}${truncated}`;
 }
 
 /**

--- a/integrations/gemini/hooks/lib/lessons.mjs
+++ b/integrations/gemini/hooks/lib/lessons.mjs
@@ -98,24 +98,64 @@ export function buildFeedbackDigest(turns, { maxChars = 40_000 } = {}) {
   return out.length ? out.join('\n\n') : null;
 }
 
-/** True when the quote really appears in the archive, allowing for whitespace. */
+/**
+ * True when the quote really appears in the archive, allowing for whitespace.
+ *
+ * CASE IS PART OF VERBATIM. Lower-casing both sides accepted a quote whose
+ * capitalisation never occurred -- `NO, USE NPM TEST` matched a transcript
+ * saying `no, use npm test` -- and that quote then earned ORIGIN_HUMAN and 0.95
+ * confidence on the strength of a check it had not actually passed. The prompt
+ * asks for an exact copy, so this asks for one.
+ *
+ * Whitespace IS still normalised: line wrapping is an artefact of how the turn
+ * was stored, not something the user chose.
+ */
 export function quoteIsVerbatim(quote, turns) {
-  const needle = String(quote || '').trim().toLowerCase().replace(/\s+/g, ' ');
+  // A missing archive is not a match. `buildFeedbackDigest` guards its input in
+  // this same module; without the same guard here a null archive threw a
+  // TypeError out of a validator whose entire job is to reject bad input.
+  if (!Array.isArray(turns)) return false;
+  const needle = String(quote || '').trim().replace(/\s+/g, ' ');
   if (needle.length < 8) return false;
   return turns
-    .filter((t) => t.role === 'user')
-    .some((t) => String(t.text).toLowerCase().replace(/\s+/g, ' ').includes(needle));
+    .filter((t) => t && t.role === 'user')
+    .some((t) => String(t.text).replace(/\s+/g, ' ').includes(needle));
 }
 
-/** A claim that leads with a verb, which is what makes it act like an instruction. */
+/**
+ * A claim that leads with a bare verb, which is what makes it an instruction.
+ *
+ * A POSITIVE RULE, NOT A DENYLIST. The denylist rejected the openings a
+ * paraphrase usually starts with -- `the user prefers`, `you should` -- and
+ * accepted everything else, so `npm test is preferred over npx jest.` passed
+ * and was stored as a standing rule despite being a description rather than an
+ * instruction. Any noun-led sentence walked straight through.
+ *
+ * The test is now positive: the first word must be a bare verb form. That is
+ * still not a parts-of-speech tagger, but it fails CLOSED -- an unrecognised
+ * opening is rejected rather than admitted, which is the right direction for a
+ * gate on text that becomes an always-on instruction.
+ */
+const IMPERATIVE_VERBS = new Set([
+  'use', 'run', 'call', 'prefer', 'avoid', 'never', 'always', 'do', "don't", 'dont',
+  'stop', 'start', 'check', 'verify', 'confirm', 'read', 'write', 'edit', 'add',
+  'remove', 'delete', 'fix', 'keep', 'make', 'set', 'pass', 'build', 'test',
+  'install', 'update', 'rebase', 'merge', 'commit', 'push', 'pull', 'fetch',
+  'branch', 'open', 'close', 'ask', 'report', 'measure', 'record', 'skip',
+  'ignore', 'include', 'exclude', 'treat', 'assume', 'ensure', 'require',
+  'apply', 'revert', 'restore', 'replace', 'rename', 'move', 'copy', 'create',
+  'wait', 'retry', 'log', 'print', 'return', 'throw', 'catch', 'handle',
+  'quote', 'escape', 'sanitise', 'sanitize', 'validate', 'reject', 'accept',
+]);
+
 export function isImperative(claim) {
-  const first = String(claim || '').trim().split(/\s+/)[0] || '';
-  // Not a parts-of-speech tagger, and does not need to be: what it rejects is
-  // the shape corrections actually arrive in when a model paraphrases them --
-  // "the user prefers", "it is better to", "you should".
-  return !/^(the|a|an|it|this|that|there|you|we|i|user|users|when|because|since|although)$/i.test(
-    first
-  );
+  const first = String(claim || '')
+    .trim()
+    .split(/\s+/)[0]
+    .replace(/[^A-Za-z']/g, '')
+    .toLowerCase();
+  if (!first) return false;
+  return IMPERATIVE_VERBS.has(first);
 }
 
 /**

--- a/integrations/gemini/hooks/lib/lessons.mjs
+++ b/integrations/gemini/hooks/lib/lessons.mjs
@@ -1,0 +1,192 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/lessons.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Turning corrections into lessons the next session actually receives.
+ *
+ * The signal this exists to capture is sparse and specific: the moments where
+ * the user pushed back. Everything else in a session is ordinary work. Measured
+ * on one real session, the graph recorded 4,053 file touches and none of the
+ * three corrections the user actually gave -- which are the only turns that
+ * carried information the code could not.
+ *
+ * TWO THINGS THIS MODULE REFUSES TO GUESS.
+ *
+ * 1. WHO SAID IT. A lesson is stored as a human assertion only when the
+ *    extractor supplies the user's words verbatim AND those words are found in
+ *    the archive. curate.mjs warns that "a hand-written assertion and a machine
+ *    guess look identical three months later", and human origin carries the
+ *    highest ranking weight -- so claiming it on a model's paraphrase would let
+ *    an inference outrank the correction it was inferred from. Unverifiable
+ *    quotes still store, as ORIGIN_HARVESTED.
+ *
+ * 2. WHEN IT APPLIES. Every lesson must carry a trigger. A lesson with no
+ *    trigger can only surface if someone happens to open the file it is anchored
+ *    to, which is not when advice about doing something is needed.
+ *
+ * AND ONE THING IT INSISTS ON: the action first. Measured in the injection A/B,
+ * a correctly stored and correctly delivered finding was still ignored because
+ * its instruction sat at the end of three sentences of context. Delivery is
+ * necessary and not sufficient; phrasing is the other half.
+ */
+
+import { ORIGIN_HARVESTED, ORIGIN_HUMAN } from './curate.mjs';
+
+/** Lessons longer than this are prose, not instructions. */
+const MAX_CLAIM = 400;
+
+/**
+ * The extraction prompt.
+ *
+ * Deliberately narrow. Asked for "lessons" a model will summarise the session;
+ * asked for corrections it returns the handful of turns that actually taught
+ * something, which is the whole point of keeping the store sparse.
+ */
+export const LESSON_PROMPT = `You are reading a transcript between a user and a coding agent.
+
+Extract ONLY the moments where the USER corrected, rejected, or redirected the agent —
+where the agent did something the user did not want, and the user said so. Ignore
+ordinary instructions, questions, and approvals. Most transcripts contain between zero
+and five of these. Returning an empty list is a correct and common answer.
+
+For each correction return an object with:
+  "claim"   - the lesson, as an IMPERATIVE with the action FIRST. Start with a verb.
+              Not "the user prefers X because Y" but "Do X. Y is why."
+              Under ${MAX_CLAIM} characters. This is the sentence a future agent reads
+              at the moment it is about to make the same mistake, so it must lead with
+              what to do, not with background.
+  "quote"   - the user's own words that constitute the correction, copied EXACTLY from
+              the transcript. Do not paraphrase, do not fix typos, do not add quotes.
+  "trigger" - a JavaScript regex source matching the situation where this applies, e.g.
+              "\\\\bnpx\\\\s+jest\\\\b" or "git\\\\s+push" or "\\\\.csproj". If the lesson is about a
+              tool or command, match that. Required.
+  "anchors" - array of absolute file paths the lesson concerns. May be empty.
+
+Return ONLY a JSON array. No prose, no markdown fence.`;
+
+/**
+ * Builds the extractor input from archived turns.
+ *
+ * Assistant tool RESULTS never entered the archive, so they cannot enter here.
+ * What is sent is the conversation: what was asked, what was answered, and which
+ * commands were run.
+ */
+export function buildFeedbackDigest(turns, { maxChars = 40_000 } = {}) {
+  if (!Array.isArray(turns) || !turns.length) return null;
+
+  const rendered = turns.map((t) => {
+    if (t.role === 'user') return `USER: ${t.text}`;
+    const tools = (t.tools || [])
+      .map((x) => (x.command ? `${x.name}(${x.command})` : x.name))
+      .filter(Boolean)
+      .slice(0, 8)
+      .join(', ');
+    const head = t.text ? `AGENT: ${t.text}` : 'AGENT:';
+    return tools ? `${head}\n  [tools: ${tools}]` : head;
+  });
+
+  // KEEP THE END, not the beginning. Corrections cluster where the work went
+  // wrong, and a transcript that needed correcting tends to have gone wrong
+  // later rather than sooner.
+  let out = [];
+  let total = 0;
+  for (let i = rendered.length - 1; i >= 0; i--) {
+    const piece = rendered[i];
+    if (total + piece.length > maxChars) break;
+    out.unshift(piece);
+    total += piece.length;
+  }
+  return out.length ? out.join('\n\n') : null;
+}
+
+/** True when the quote really appears in the archive, allowing for whitespace. */
+export function quoteIsVerbatim(quote, turns) {
+  const needle = String(quote || '').trim().toLowerCase().replace(/\s+/g, ' ');
+  if (needle.length < 8) return false;
+  return turns
+    .filter((t) => t.role === 'user')
+    .some((t) => String(t.text).toLowerCase().replace(/\s+/g, ' ').includes(needle));
+}
+
+/** A claim that leads with a verb, which is what makes it act like an instruction. */
+export function isImperative(claim) {
+  const first = String(claim || '').trim().split(/\s+/)[0] || '';
+  // Not a parts-of-speech tagger, and does not need to be: what it rejects is
+  // the shape corrections actually arrive in when a model paraphrases them --
+  // "the user prefers", "it is better to", "you should".
+  return !/^(the|a|an|it|this|that|there|you|we|i|user|users|when|because|since|although)$/i.test(
+    first
+  );
+}
+
+/**
+ * Validates extractor output and decides each lesson's origin.
+ *
+ * Returns { lessons, rejected } so a caller can report what was dropped rather
+ * than silently storing less than it was given.
+ */
+export function validateLessons(raw, turns) {
+  let parsed = raw;
+  if (typeof raw === 'string') {
+    try {
+      parsed = JSON.parse(raw.replace(/^```(?:json)?\s*|\s*```$/g, ''));
+    } catch {
+      return { lessons: [], rejected: [{ reason: 'unparseable', raw: String(raw).slice(0, 200) }] };
+    }
+  }
+  if (!Array.isArray(parsed)) {
+    return { lessons: [], rejected: [{ reason: 'not-an-array' }] };
+  }
+
+  const lessons = [];
+  const rejected = [];
+
+  for (const item of parsed) {
+    const claim = String(item?.claim || '').trim();
+    const trigger = String(item?.trigger || '').trim();
+    const quote = String(item?.quote || '').trim();
+
+    if (claim.length < 12) {
+      rejected.push({ reason: 'claim-too-short', claim });
+      continue;
+    }
+    if (claim.length > MAX_CLAIM) {
+      rejected.push({ reason: 'claim-too-long', claim: claim.slice(0, 80) });
+      continue;
+    }
+    if (!trigger) {
+      // Without one it can only surface by file touch, which is not when advice
+      // about an action is needed.
+      rejected.push({ reason: 'no-trigger', claim: claim.slice(0, 80) });
+      continue;
+    }
+    try {
+      new RegExp(trigger);
+    } catch {
+      rejected.push({ reason: 'bad-trigger-regex', trigger });
+      continue;
+    }
+    if (!isImperative(claim)) {
+      rejected.push({ reason: 'not-imperative', claim: claim.slice(0, 80) });
+      continue;
+    }
+
+    // THE PROVENANCE TEST. Verbatim and present means the user really said it.
+    const verified = quoteIsVerbatim(quote, turns);
+
+    lessons.push({
+      type: 'feedback',
+      claim,
+      trigger,
+      quote: verified ? quote : undefined,
+      origin: verified ? ORIGIN_HUMAN : ORIGIN_HARVESTED,
+      // A verified human correction is as close to ground truth as this system
+      // gets. An unverified paraphrase is a model's reading of one.
+      confidence: verified ? 0.95 : 0.6,
+      anchors: Array.isArray(item?.anchors)
+        ? item.anchors.filter((a) => typeof a === 'string' && a.trim())
+        : [],
+    });
+  }
+
+  return { lessons, rejected };
+}

--- a/integrations/gemini/hooks/lib/transcript.mjs
+++ b/integrations/gemini/hooks/lib/transcript.mjs
@@ -1,0 +1,213 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/transcript.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * The raw local archive of what was asked and what was answered.
+ *
+ * THE ARCHIVE AND THE LESSONS ARE DIFFERENT THINGS, and keeping them separate
+ * is the whole design. The archive is complete and never retrieved; the lessons
+ * extracted from it are sparse and are the only thing ever injected. Storing
+ * everything AND retrieving everything would drown the graph -- a session is
+ * thousands of turns of ordinary work and a handful of moments that taught
+ * something. Storing everything and retrieving only the lessons keeps the record
+ * complete without diluting what gets served.
+ *
+ * NOTHING HERE LEAVES THE MACHINE. The archive is written inside the wiki
+ * directory, which already carries a `.gitignore` of `*`, and it is explicitly
+ * excluded from the harvest digest -- the one code path that sends anything to a
+ * model endpoint. A feedback loop must never become the reason a user's prompts
+ * are transmitted.
+ */
+
+import {
+  readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, readdirSync, statSync, unlinkSync,
+} from 'node:fs';
+import { join } from 'node:path';
+
+/** Where a project's transcripts live, under the graph it belongs to. */
+export const transcriptDir = (dir) => join(dir, 'transcripts');
+
+/**
+ * Total bytes of archive kept per project before the oldest are dropped.
+ *
+ * An unbounded archive of every session is a disk leak that grows fastest for
+ * the users who use the tool most, which is exactly backwards.
+ */
+const archiveBudget = () =>
+  Number(process.env.TOKEN_OPTIMIZER_TRANSCRIPT_BUDGET_BYTES) || 50 * 1024 * 1024;
+
+/** A session id reduced to something that cannot escape the archive directory. */
+export function safeName(sessionId) {
+  const safe = String(sessionId || 'unknown').replace(/[^A-Za-z0-9._-]/g, '_');
+  return (/^[.]+$/.test(safe) ? 'unknown' : safe).slice(0, 64);
+}
+
+/**
+ * Turns a Claude transcript into the prompt/response pairs worth keeping.
+ *
+ * TOOL RESULTS ARE DROPPED, for the same reason `buildDigest` drops them: that
+ * is where whole file contents would enter the record. The archive is meant to
+ * hold the conversation, not a second copy of the repository.
+ */
+export function readTurns(transcriptPath) {
+  let lines;
+  try {
+    lines = readFileSync(transcriptPath, 'utf8').split('\n');
+  } catch {
+    return [];
+  }
+
+  const turns = [];
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    let entry;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+
+    const message = entry.message || entry;
+    const role = message.role || entry.type;
+    const content = message.content;
+
+    if (role === 'user') {
+      const text =
+        typeof content === 'string'
+          ? content
+          : Array.isArray(content)
+            ? content
+                .filter((b) => b && b.type === 'text')
+                .map((b) => String(b.text))
+                .join('\n')
+            : '';
+      if (text.trim()) turns.push({ role: 'user', text: text.trim(), at: entry.timestamp ?? null });
+      continue;
+    }
+
+    if (role === 'assistant' && Array.isArray(content)) {
+      const text = content
+        .filter((b) => b && b.type === 'text')
+        .map((b) => String(b.text))
+        .join('\n');
+      const tools = content
+        .filter((b) => b && b.type === 'tool_use')
+        .map((b) => ({
+          name: b.name,
+          // Arguments only, never results, and truncated: a command is the
+          // useful part, its output is not.
+          command: b.input?.command ? String(b.input.command).slice(0, 300) : undefined,
+          path: b.input?.file_path || b.input?.path || undefined,
+        }));
+      if (text.trim() || tools.length) {
+        turns.push({ role: 'assistant', text: text.trim(), tools, at: entry.timestamp ?? null });
+      }
+    }
+  }
+  return turns;
+}
+
+/**
+ * Appends this session's turns to the project archive.
+ *
+ * Idempotent per session by rewriting that session's file, so a Stop hook firing
+ * repeatedly does not multiply the record.
+ */
+export function archive(dir, transcriptPath, { sessionId } = {}) {
+  const turns = readTurns(transcriptPath);
+  if (!turns.length) return 0;
+
+  const root = transcriptDir(dir);
+  try {
+    mkdirSync(root, { recursive: true, mode: 0o700 });
+    try {
+      chmodSync(root, 0o700);
+    } catch {
+      /* not POSIX, or not ours */
+    }
+  } catch {
+    return 0;
+  }
+
+  const file = join(root, `${safeName(sessionId)}.jsonl`);
+  try {
+    // Truncate-and-write rather than append: Stop fires many times per session
+    // and the transcript is cumulative, so appending would store the early turns
+    // once per firing.
+    const payload = turns.map((t) => JSON.stringify(t)).join('\n') + '\n';
+    writeFileSync(file, payload, { mode: 0o600 });
+  } catch {
+    return 0;
+  }
+
+  prune(root);
+  return turns.length;
+}
+
+/**
+ * Drops the oldest sessions once the archive exceeds its budget.
+ *
+ * Oldest-first, because the value of a transcript is highest while the work it
+ * describes is still live.
+ */
+export function prune(root, budget = archiveBudget()) {
+  let entries;
+  try {
+    entries = readdirSync(root)
+      .filter((f) => f.endsWith('.jsonl'))
+      .map((f) => {
+        const full = join(root, f);
+        try {
+          const s = statSync(full);
+          return { full, size: s.size, mtime: s.mtimeMs };
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch {
+    return 0;
+  }
+
+  let total = entries.reduce((a, e) => a + e.size, 0);
+  if (total <= budget) return 0;
+
+  entries.sort((a, b) => a.mtime - b.mtime);
+  let dropped = 0;
+  for (const e of entries) {
+    if (total <= budget) break;
+    try {
+      unlinkSync(e.full);
+      total -= e.size;
+      dropped += 1;
+    } catch {
+      /* leave it; a locked file must not stop the rest */
+    }
+  }
+  return dropped;
+}
+
+/** True when a path is inside a transcript archive -- the never-transmit test. */
+export function isArchived(path) {
+  return /[\\/]\.token-optimizer[\\/]wiki[\\/]transcripts[\\/]/.test(String(path));
+}
+
+/** Reads a session's archived turns back, for the lesson extractor. */
+export function readArchive(dir, sessionId) {
+  const file = join(transcriptDir(dir), `${safeName(sessionId)}.jsonl`);
+  if (!existsSync(file)) return [];
+  try {
+    return readFileSync(file, 'utf8')
+      .split('\n')
+      .filter(Boolean)
+      .map((l) => {
+        try {
+          return JSON.parse(l);
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}

--- a/integrations/opencode/hooks/lib/harvest-write.mjs
+++ b/integrations/opencode/hooks/lib/harvest-write.mjs
@@ -28,7 +28,7 @@ import { indexFile } from './staleness.mjs';
 import { symbolKey } from './symbols.mjs';
 import { canonicalPath } from './paths.mjs';
 import { randomBytes } from 'node:crypto';
-import { ORIGIN_HARVESTED, ORIGIN_AGENT } from './curate.mjs';
+import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
 
 /**
  * Resolves an `path` or `path#symbol` anchor to an existing node id.
@@ -81,11 +81,33 @@ export function writeHarvested(
 ) {
   if (!Array.isArray(findings) || !findings.length) return [];
 
-  // Only the two origins this path can honestly claim. A caller asking for
-  // anything else -- notably ORIGIN_HUMAN -- would be labelling machine output
-  // as a person's assertion, which is the confusion the field exists to prevent.
-  const provenance = origin === ORIGIN_AGENT ? ORIGIN_AGENT : ORIGIN_HARVESTED;
-  const prefix = provenance === ORIGIN_AGENT ? 'agent' : 'harvested';
+  // The batch default. A caller asking for anything else -- notably
+  // ORIGIN_HUMAN -- would be labelling machine output as a person's assertion,
+  // which is the confusion the field exists to prevent.
+  const batch = origin === ORIGIN_AGENT ? ORIGIN_AGENT : ORIGIN_HARVESTED;
+
+  /**
+   * ORIGIN_HUMAN IS EARNED PER FINDING, BY EVIDENCE.
+   *
+   * A batch-wide origin was the whole story here, and it silently discarded
+   * the per-lesson provenance `validateLessons` had just computed: a
+   * correction whose quote was verified word-for-word in the user's own turn
+   * was stored as ORIGIN_HARVESTED like any model paraphrase. The standing-
+   * rules layer selects on human origin, so it matched nothing this pipeline
+   * wrote, and the verbatim check had no observable effect at all.
+   *
+   * The original rule still holds -- a caller cannot simply DECLARE machine
+   * output human. It is the verified quote that promotes it, and the quote is
+   * stored alongside so the claim carries its own evidence.
+   */
+  const provenanceFor = (finding) =>
+    finding.origin === ORIGIN_HUMAN &&
+    typeof finding.quote === 'string' &&
+    finding.quote.trim()
+      ? ORIGIN_HUMAN
+      : batch;
+  const prefixFor = (p) =>
+    p === ORIGIN_AGENT ? 'agent' : p === ORIGIN_HUMAN ? 'human' : 'harvested';
 
   const written = [];
   for (const finding of findings) {
@@ -103,7 +125,8 @@ export function writeHarvested(
     // same key, and putNode keeps the last write for an id -- so one session's
     // finding silently replaces another's. A random suffix makes that
     // collision vanishingly unlikely while keeping the timestamp readable.
-    const key = `${prefix}-${Date.now().toString(36)}-${written.length}-${randomBytes(4).toString("hex")}`;
+    const provenance = provenanceFor(finding);
+    const key = `${prefixFor(provenance)}-${Date.now().toString(36)}-${written.length}-${randomBytes(4).toString("hex")}`;
     // ONE APPEND for the finding and every anchor it resolved. This runs in a
     // detached worker, so "the process survives to finish the loop" is not a
     // safe assumption: a node written without its edges is an active finding
@@ -127,6 +150,11 @@ export function writeHarvested(
           ? finding.trigger
           : undefined,
         origin: provenance,
+        // THE EVIDENCE TRAVELS WITH THE CLAIM. Without it a human-origin
+        // finding asserts its own provenance and nothing can check it.
+        quote: typeof finding.quote === 'string' && finding.quote.trim()
+          ? finding.quote
+          : undefined,
         sessionId,
       },
       resolved.map((target) => ({ edge: 'derived_from', to: target }))

--- a/integrations/opencode/hooks/lib/harvest.mjs
+++ b/integrations/opencode/hooks/lib/harvest.mjs
@@ -36,7 +36,10 @@ const ENDPOINT = () => process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT
   || 'https://api.anthropic.com/v1/messages';
 
 /** Findings must be one of these. Free-form claims are rejected. */
-export const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map'];
+// 'feedback' is a lesson extracted from a USER CORRECTION rather than from the
+// code -- the only finding type whose source is a person telling the agent it
+// was wrong, which is why it is kept distinguishable from an ordinary finding.
+export const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map', 'feedback'];
 
 export function apiKey() {
   return process.env.TOKEN_OPTIMIZER_API_KEY || process.env.ANTHROPIC_API_KEY || null;
@@ -222,7 +225,7 @@ export function validate(raw, { knownFiles = null } = {}) {
  * indistinguishable, from the caller's side, from a session with nothing to
  * learn.
  */
-export async function extract(digest, { timeoutMs = 30_000 } = {}) {
+export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}) {
   if (!digest || !harvestEnabled()) return [];
 
   // A local endpoint usually has no auth at all, so requiring a key there would
@@ -248,7 +251,7 @@ export async function extract(digest, { timeoutMs = 30_000 } = {}) {
       body: JSON.stringify({
         model: MODEL(),
         max_tokens: 2048,
-        system: PROMPT,
+        system: prompt || PROMPT,
         messages: [{ role: 'user', content: digest }],
       }),
     });

--- a/integrations/opencode/hooks/lib/inject.mjs
+++ b/integrations/opencode/hooks/lib/inject.mjs
@@ -31,6 +31,20 @@ import { substitutionBudget } from './metrics.mjs';
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
 
+/**
+ * Tokens allowed for the always-on standing rules.
+ *
+ * FIXED AND SMALL, unlike the session index whose budget is earned from measured
+ * hit rate. An earned budget is right for a catalogue that grows with the graph;
+ * it is wrong here, because this text is paid for on EVERY session whether or
+ * not it is relevant, and a set that grows with the project is exactly how an
+ * always-on block becomes wallpaper. 400 tokens is roughly a dozen rules -- if a
+ * project needs more standing rules than that, the honest answer is that some of
+ * them are situational and belong behind a trigger.
+ */
+const standingBudget = () =>
+  Number(process.env.TOKEN_OPTIMIZER_STANDING_BUDGET) || 400;
+
 /** Most findings considered for one command before the budget decides. */
 const MAX_COMMAND_CANDIDATES = 20;
 
@@ -339,6 +353,77 @@ Established in previous sessions. Call wiki_query with a key for detail, or just
 work -- findings anchored to a file are surfaced automatically when you touch it.
 
 ${lines.join('\n')}`;
+}
+
+/**
+ * The always-on set: rules that must hold before the first tool call.
+ *
+ * WHY THESE CANNOT BE TRIGGER-FIRED. A trigger answers "this situation is
+ * happening now". Some rules are not about a situation -- "report the number you
+ * measured, not the one you expected" governs how every turn is conducted, and
+ * by the time any command matched a trigger the turn would already be going
+ * wrong. Those have to be present before anything happens or they are useless.
+ *
+ * WHY THIS IS NOT THE SESSION INDEX. `sessionIndex` lists keys and truncated
+ * titles and tells the model to call wiki_query for detail; that is right for a
+ * catalogue of things it MIGHT want. A standing rule that needs a lookup before
+ * it can be obeyed is not a standing rule -- so these are rendered in full, and
+ * are budgeted separately and much more tightly because of it.
+ *
+ * WHAT QUALIFIES, deliberately narrow:
+ *   - anything a human PINNED, which curate.mjs already defines as a fact that
+ *     stays true and should not decay, or
+ *   - a `feedback` lesson whose quote was verified against the transcript, so a
+ *     person demonstrably said it.
+ *
+ * Everything else waits for its trigger. The failure mode this guards against
+ * is the one that already happened here: an always-on block that grows until it
+ * is wallpaper, and the model stops reading the thing it always sees.
+ */
+export function standingRules(dir, graph, { budget = standingBudget() } = {}) {
+  const rules = [...graph.nodes.values()].filter(
+    (n) =>
+      n.kind === 'finding' &&
+      !n.retired &&
+      typeof n.claim === 'string' &&
+      (n.pinned === true || (n.type === 'feedback' && n.origin === 'human'))
+  );
+  if (!rules.length) return null;
+
+  // A person's own correction outranks anything inferred, then confidence.
+  rules.sort((a, b) => {
+    const weight = (n) => (n.origin === 'human' ? 2 : n.pinned ? 1.5 : 1);
+    return weight(b) * (b.confidence ?? 0.5) - weight(a) * (a.confidence ?? 0.5);
+  });
+
+  const lines = [];
+  let spent = 0;
+  let dropped = 0;
+  for (const rule of rules) {
+    const line = `- ${rule.claim}`;
+    const cost = estimate(line);
+    if (spent + cost > budget) {
+      dropped += 1;
+      continue;
+    }
+    lines.push(line);
+    spent += cost;
+  }
+  if (!lines.length) return null;
+
+  record(dir, { kind: 'standing', count: lines.length, dropped, tokens: spent });
+
+  // SAY WHAT WAS DROPPED. A silent cap reads as "these are all the rules",
+  // which is worse than saying there are more: a model that knows the list is
+  // truncated can ask, one that does not will assume it is complete.
+  const truncated = dropped
+    ? `\n(${dropped} further standing rule${dropped === 1 ? '' : 's'} did not fit this budget; ` +
+      `raise TOKEN_OPTIMIZER_STANDING_BUDGET or retire some.)`
+    : '';
+
+  return `# Standing rules for this project\n\nEstablished in previous sessions and expected to hold. These are not suggestions.\n\n${lines.join(
+    '\n'
+  )}${truncated}`;
 }
 
 /**

--- a/integrations/opencode/hooks/lib/inject.mjs
+++ b/integrations/opencode/hooks/lib/inject.mjs
@@ -396,8 +396,30 @@ export function standingRules(dir, graph, { budget = standingBudget() } = {}) {
     return weight(b) * (b.confidence ?? 0.5) - weight(a) * (a.confidence ?? 0.5);
   });
 
+  // THE BUDGET COVERS THE WHOLE MESSAGE, not just the claim lines.
+  //
+  // `spent` used to count selected claims only, while the returned text also
+  // carries a heading, two lines of fixed instruction and an optional
+  // truncation notice. A selection that exactly filled the budget therefore
+  // injected more than the budget allowed and recorded fewer tokens than it
+  // spent -- in a block whose entire justification is that it is tightly
+  // bounded and measured against the control arm.
+  const HEADING =
+    '# Standing rules for this project' +
+    '\n\nEstablished in previous sessions and expected to hold. ' +
+    'These are not suggestions.\n\n';
+  const noticeFor = (n) =>
+    n
+      ? `\n(${n} further standing rule${n === 1 ? '' : 's'} did not fit this budget; ` +
+        'raise TOKEN_OPTIMIZER_STANDING_BUDGET or retire some.)'
+      : '';
+
+  // The wrapper is charged up front, and the worst-case notice is reserved, so
+  // admitting the last line can never push the total over by adding one.
+  const overhead = estimate(HEADING) + estimate(noticeFor(rules.length));
+
   const lines = [];
-  let spent = 0;
+  let spent = overhead;
   let dropped = 0;
   for (const rule of rules) {
     const line = `- ${rule.claim}`;
@@ -409,21 +431,24 @@ export function standingRules(dir, graph, { budget = standingBudget() } = {}) {
     lines.push(line);
     spent += cost;
   }
-  if (!lines.length) return null;
 
-  record(dir, { kind: 'standing', count: lines.length, dropped, tokens: spent });
+  // RECORDED EVEN WHEN NOTHING FITS. Returning early without a metric hid the
+  // one case most worth knowing about: rules exist and every one is too large
+  // for the budget, so the block silently does nothing all session and the
+  // measurement shows no sign of it.
+  const truncated = noticeFor(dropped);
+  record(dir, {
+    kind: 'standing',
+    count: lines.length,
+    dropped,
+    tokens: lines.length ? spent : 0,
+  });
+  if (!lines.length) return null;
 
   // SAY WHAT WAS DROPPED. A silent cap reads as "these are all the rules",
   // which is worse than saying there are more: a model that knows the list is
   // truncated can ask, one that does not will assume it is complete.
-  const truncated = dropped
-    ? `\n(${dropped} further standing rule${dropped === 1 ? '' : 's'} did not fit this budget; ` +
-      `raise TOKEN_OPTIMIZER_STANDING_BUDGET or retire some.)`
-    : '';
-
-  return `# Standing rules for this project\n\nEstablished in previous sessions and expected to hold. These are not suggestions.\n\n${lines.join(
-    '\n'
-  )}${truncated}`;
+  return `${HEADING}${lines.join('\n')}${truncated}`;
 }
 
 /**

--- a/integrations/opencode/hooks/lib/lessons.mjs
+++ b/integrations/opencode/hooks/lib/lessons.mjs
@@ -98,24 +98,64 @@ export function buildFeedbackDigest(turns, { maxChars = 40_000 } = {}) {
   return out.length ? out.join('\n\n') : null;
 }
 
-/** True when the quote really appears in the archive, allowing for whitespace. */
+/**
+ * True when the quote really appears in the archive, allowing for whitespace.
+ *
+ * CASE IS PART OF VERBATIM. Lower-casing both sides accepted a quote whose
+ * capitalisation never occurred -- `NO, USE NPM TEST` matched a transcript
+ * saying `no, use npm test` -- and that quote then earned ORIGIN_HUMAN and 0.95
+ * confidence on the strength of a check it had not actually passed. The prompt
+ * asks for an exact copy, so this asks for one.
+ *
+ * Whitespace IS still normalised: line wrapping is an artefact of how the turn
+ * was stored, not something the user chose.
+ */
 export function quoteIsVerbatim(quote, turns) {
-  const needle = String(quote || '').trim().toLowerCase().replace(/\s+/g, ' ');
+  // A missing archive is not a match. `buildFeedbackDigest` guards its input in
+  // this same module; without the same guard here a null archive threw a
+  // TypeError out of a validator whose entire job is to reject bad input.
+  if (!Array.isArray(turns)) return false;
+  const needle = String(quote || '').trim().replace(/\s+/g, ' ');
   if (needle.length < 8) return false;
   return turns
-    .filter((t) => t.role === 'user')
-    .some((t) => String(t.text).toLowerCase().replace(/\s+/g, ' ').includes(needle));
+    .filter((t) => t && t.role === 'user')
+    .some((t) => String(t.text).replace(/\s+/g, ' ').includes(needle));
 }
 
-/** A claim that leads with a verb, which is what makes it act like an instruction. */
+/**
+ * A claim that leads with a bare verb, which is what makes it an instruction.
+ *
+ * A POSITIVE RULE, NOT A DENYLIST. The denylist rejected the openings a
+ * paraphrase usually starts with -- `the user prefers`, `you should` -- and
+ * accepted everything else, so `npm test is preferred over npx jest.` passed
+ * and was stored as a standing rule despite being a description rather than an
+ * instruction. Any noun-led sentence walked straight through.
+ *
+ * The test is now positive: the first word must be a bare verb form. That is
+ * still not a parts-of-speech tagger, but it fails CLOSED -- an unrecognised
+ * opening is rejected rather than admitted, which is the right direction for a
+ * gate on text that becomes an always-on instruction.
+ */
+const IMPERATIVE_VERBS = new Set([
+  'use', 'run', 'call', 'prefer', 'avoid', 'never', 'always', 'do', "don't", 'dont',
+  'stop', 'start', 'check', 'verify', 'confirm', 'read', 'write', 'edit', 'add',
+  'remove', 'delete', 'fix', 'keep', 'make', 'set', 'pass', 'build', 'test',
+  'install', 'update', 'rebase', 'merge', 'commit', 'push', 'pull', 'fetch',
+  'branch', 'open', 'close', 'ask', 'report', 'measure', 'record', 'skip',
+  'ignore', 'include', 'exclude', 'treat', 'assume', 'ensure', 'require',
+  'apply', 'revert', 'restore', 'replace', 'rename', 'move', 'copy', 'create',
+  'wait', 'retry', 'log', 'print', 'return', 'throw', 'catch', 'handle',
+  'quote', 'escape', 'sanitise', 'sanitize', 'validate', 'reject', 'accept',
+]);
+
 export function isImperative(claim) {
-  const first = String(claim || '').trim().split(/\s+/)[0] || '';
-  // Not a parts-of-speech tagger, and does not need to be: what it rejects is
-  // the shape corrections actually arrive in when a model paraphrases them --
-  // "the user prefers", "it is better to", "you should".
-  return !/^(the|a|an|it|this|that|there|you|we|i|user|users|when|because|since|although)$/i.test(
-    first
-  );
+  const first = String(claim || '')
+    .trim()
+    .split(/\s+/)[0]
+    .replace(/[^A-Za-z']/g, '')
+    .toLowerCase();
+  if (!first) return false;
+  return IMPERATIVE_VERBS.has(first);
 }
 
 /**

--- a/integrations/opencode/hooks/lib/lessons.mjs
+++ b/integrations/opencode/hooks/lib/lessons.mjs
@@ -1,0 +1,192 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/lessons.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Turning corrections into lessons the next session actually receives.
+ *
+ * The signal this exists to capture is sparse and specific: the moments where
+ * the user pushed back. Everything else in a session is ordinary work. Measured
+ * on one real session, the graph recorded 4,053 file touches and none of the
+ * three corrections the user actually gave -- which are the only turns that
+ * carried information the code could not.
+ *
+ * TWO THINGS THIS MODULE REFUSES TO GUESS.
+ *
+ * 1. WHO SAID IT. A lesson is stored as a human assertion only when the
+ *    extractor supplies the user's words verbatim AND those words are found in
+ *    the archive. curate.mjs warns that "a hand-written assertion and a machine
+ *    guess look identical three months later", and human origin carries the
+ *    highest ranking weight -- so claiming it on a model's paraphrase would let
+ *    an inference outrank the correction it was inferred from. Unverifiable
+ *    quotes still store, as ORIGIN_HARVESTED.
+ *
+ * 2. WHEN IT APPLIES. Every lesson must carry a trigger. A lesson with no
+ *    trigger can only surface if someone happens to open the file it is anchored
+ *    to, which is not when advice about doing something is needed.
+ *
+ * AND ONE THING IT INSISTS ON: the action first. Measured in the injection A/B,
+ * a correctly stored and correctly delivered finding was still ignored because
+ * its instruction sat at the end of three sentences of context. Delivery is
+ * necessary and not sufficient; phrasing is the other half.
+ */
+
+import { ORIGIN_HARVESTED, ORIGIN_HUMAN } from './curate.mjs';
+
+/** Lessons longer than this are prose, not instructions. */
+const MAX_CLAIM = 400;
+
+/**
+ * The extraction prompt.
+ *
+ * Deliberately narrow. Asked for "lessons" a model will summarise the session;
+ * asked for corrections it returns the handful of turns that actually taught
+ * something, which is the whole point of keeping the store sparse.
+ */
+export const LESSON_PROMPT = `You are reading a transcript between a user and a coding agent.
+
+Extract ONLY the moments where the USER corrected, rejected, or redirected the agent —
+where the agent did something the user did not want, and the user said so. Ignore
+ordinary instructions, questions, and approvals. Most transcripts contain between zero
+and five of these. Returning an empty list is a correct and common answer.
+
+For each correction return an object with:
+  "claim"   - the lesson, as an IMPERATIVE with the action FIRST. Start with a verb.
+              Not "the user prefers X because Y" but "Do X. Y is why."
+              Under ${MAX_CLAIM} characters. This is the sentence a future agent reads
+              at the moment it is about to make the same mistake, so it must lead with
+              what to do, not with background.
+  "quote"   - the user's own words that constitute the correction, copied EXACTLY from
+              the transcript. Do not paraphrase, do not fix typos, do not add quotes.
+  "trigger" - a JavaScript regex source matching the situation where this applies, e.g.
+              "\\\\bnpx\\\\s+jest\\\\b" or "git\\\\s+push" or "\\\\.csproj". If the lesson is about a
+              tool or command, match that. Required.
+  "anchors" - array of absolute file paths the lesson concerns. May be empty.
+
+Return ONLY a JSON array. No prose, no markdown fence.`;
+
+/**
+ * Builds the extractor input from archived turns.
+ *
+ * Assistant tool RESULTS never entered the archive, so they cannot enter here.
+ * What is sent is the conversation: what was asked, what was answered, and which
+ * commands were run.
+ */
+export function buildFeedbackDigest(turns, { maxChars = 40_000 } = {}) {
+  if (!Array.isArray(turns) || !turns.length) return null;
+
+  const rendered = turns.map((t) => {
+    if (t.role === 'user') return `USER: ${t.text}`;
+    const tools = (t.tools || [])
+      .map((x) => (x.command ? `${x.name}(${x.command})` : x.name))
+      .filter(Boolean)
+      .slice(0, 8)
+      .join(', ');
+    const head = t.text ? `AGENT: ${t.text}` : 'AGENT:';
+    return tools ? `${head}\n  [tools: ${tools}]` : head;
+  });
+
+  // KEEP THE END, not the beginning. Corrections cluster where the work went
+  // wrong, and a transcript that needed correcting tends to have gone wrong
+  // later rather than sooner.
+  let out = [];
+  let total = 0;
+  for (let i = rendered.length - 1; i >= 0; i--) {
+    const piece = rendered[i];
+    if (total + piece.length > maxChars) break;
+    out.unshift(piece);
+    total += piece.length;
+  }
+  return out.length ? out.join('\n\n') : null;
+}
+
+/** True when the quote really appears in the archive, allowing for whitespace. */
+export function quoteIsVerbatim(quote, turns) {
+  const needle = String(quote || '').trim().toLowerCase().replace(/\s+/g, ' ');
+  if (needle.length < 8) return false;
+  return turns
+    .filter((t) => t.role === 'user')
+    .some((t) => String(t.text).toLowerCase().replace(/\s+/g, ' ').includes(needle));
+}
+
+/** A claim that leads with a verb, which is what makes it act like an instruction. */
+export function isImperative(claim) {
+  const first = String(claim || '').trim().split(/\s+/)[0] || '';
+  // Not a parts-of-speech tagger, and does not need to be: what it rejects is
+  // the shape corrections actually arrive in when a model paraphrases them --
+  // "the user prefers", "it is better to", "you should".
+  return !/^(the|a|an|it|this|that|there|you|we|i|user|users|when|because|since|although)$/i.test(
+    first
+  );
+}
+
+/**
+ * Validates extractor output and decides each lesson's origin.
+ *
+ * Returns { lessons, rejected } so a caller can report what was dropped rather
+ * than silently storing less than it was given.
+ */
+export function validateLessons(raw, turns) {
+  let parsed = raw;
+  if (typeof raw === 'string') {
+    try {
+      parsed = JSON.parse(raw.replace(/^```(?:json)?\s*|\s*```$/g, ''));
+    } catch {
+      return { lessons: [], rejected: [{ reason: 'unparseable', raw: String(raw).slice(0, 200) }] };
+    }
+  }
+  if (!Array.isArray(parsed)) {
+    return { lessons: [], rejected: [{ reason: 'not-an-array' }] };
+  }
+
+  const lessons = [];
+  const rejected = [];
+
+  for (const item of parsed) {
+    const claim = String(item?.claim || '').trim();
+    const trigger = String(item?.trigger || '').trim();
+    const quote = String(item?.quote || '').trim();
+
+    if (claim.length < 12) {
+      rejected.push({ reason: 'claim-too-short', claim });
+      continue;
+    }
+    if (claim.length > MAX_CLAIM) {
+      rejected.push({ reason: 'claim-too-long', claim: claim.slice(0, 80) });
+      continue;
+    }
+    if (!trigger) {
+      // Without one it can only surface by file touch, which is not when advice
+      // about an action is needed.
+      rejected.push({ reason: 'no-trigger', claim: claim.slice(0, 80) });
+      continue;
+    }
+    try {
+      new RegExp(trigger);
+    } catch {
+      rejected.push({ reason: 'bad-trigger-regex', trigger });
+      continue;
+    }
+    if (!isImperative(claim)) {
+      rejected.push({ reason: 'not-imperative', claim: claim.slice(0, 80) });
+      continue;
+    }
+
+    // THE PROVENANCE TEST. Verbatim and present means the user really said it.
+    const verified = quoteIsVerbatim(quote, turns);
+
+    lessons.push({
+      type: 'feedback',
+      claim,
+      trigger,
+      quote: verified ? quote : undefined,
+      origin: verified ? ORIGIN_HUMAN : ORIGIN_HARVESTED,
+      // A verified human correction is as close to ground truth as this system
+      // gets. An unverified paraphrase is a model's reading of one.
+      confidence: verified ? 0.95 : 0.6,
+      anchors: Array.isArray(item?.anchors)
+        ? item.anchors.filter((a) => typeof a === 'string' && a.trim())
+        : [],
+    });
+  }
+
+  return { lessons, rejected };
+}

--- a/integrations/opencode/hooks/lib/transcript.mjs
+++ b/integrations/opencode/hooks/lib/transcript.mjs
@@ -1,0 +1,213 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/transcript.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * The raw local archive of what was asked and what was answered.
+ *
+ * THE ARCHIVE AND THE LESSONS ARE DIFFERENT THINGS, and keeping them separate
+ * is the whole design. The archive is complete and never retrieved; the lessons
+ * extracted from it are sparse and are the only thing ever injected. Storing
+ * everything AND retrieving everything would drown the graph -- a session is
+ * thousands of turns of ordinary work and a handful of moments that taught
+ * something. Storing everything and retrieving only the lessons keeps the record
+ * complete without diluting what gets served.
+ *
+ * NOTHING HERE LEAVES THE MACHINE. The archive is written inside the wiki
+ * directory, which already carries a `.gitignore` of `*`, and it is explicitly
+ * excluded from the harvest digest -- the one code path that sends anything to a
+ * model endpoint. A feedback loop must never become the reason a user's prompts
+ * are transmitted.
+ */
+
+import {
+  readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, readdirSync, statSync, unlinkSync,
+} from 'node:fs';
+import { join } from 'node:path';
+
+/** Where a project's transcripts live, under the graph it belongs to. */
+export const transcriptDir = (dir) => join(dir, 'transcripts');
+
+/**
+ * Total bytes of archive kept per project before the oldest are dropped.
+ *
+ * An unbounded archive of every session is a disk leak that grows fastest for
+ * the users who use the tool most, which is exactly backwards.
+ */
+const archiveBudget = () =>
+  Number(process.env.TOKEN_OPTIMIZER_TRANSCRIPT_BUDGET_BYTES) || 50 * 1024 * 1024;
+
+/** A session id reduced to something that cannot escape the archive directory. */
+export function safeName(sessionId) {
+  const safe = String(sessionId || 'unknown').replace(/[^A-Za-z0-9._-]/g, '_');
+  return (/^[.]+$/.test(safe) ? 'unknown' : safe).slice(0, 64);
+}
+
+/**
+ * Turns a Claude transcript into the prompt/response pairs worth keeping.
+ *
+ * TOOL RESULTS ARE DROPPED, for the same reason `buildDigest` drops them: that
+ * is where whole file contents would enter the record. The archive is meant to
+ * hold the conversation, not a second copy of the repository.
+ */
+export function readTurns(transcriptPath) {
+  let lines;
+  try {
+    lines = readFileSync(transcriptPath, 'utf8').split('\n');
+  } catch {
+    return [];
+  }
+
+  const turns = [];
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    let entry;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+
+    const message = entry.message || entry;
+    const role = message.role || entry.type;
+    const content = message.content;
+
+    if (role === 'user') {
+      const text =
+        typeof content === 'string'
+          ? content
+          : Array.isArray(content)
+            ? content
+                .filter((b) => b && b.type === 'text')
+                .map((b) => String(b.text))
+                .join('\n')
+            : '';
+      if (text.trim()) turns.push({ role: 'user', text: text.trim(), at: entry.timestamp ?? null });
+      continue;
+    }
+
+    if (role === 'assistant' && Array.isArray(content)) {
+      const text = content
+        .filter((b) => b && b.type === 'text')
+        .map((b) => String(b.text))
+        .join('\n');
+      const tools = content
+        .filter((b) => b && b.type === 'tool_use')
+        .map((b) => ({
+          name: b.name,
+          // Arguments only, never results, and truncated: a command is the
+          // useful part, its output is not.
+          command: b.input?.command ? String(b.input.command).slice(0, 300) : undefined,
+          path: b.input?.file_path || b.input?.path || undefined,
+        }));
+      if (text.trim() || tools.length) {
+        turns.push({ role: 'assistant', text: text.trim(), tools, at: entry.timestamp ?? null });
+      }
+    }
+  }
+  return turns;
+}
+
+/**
+ * Appends this session's turns to the project archive.
+ *
+ * Idempotent per session by rewriting that session's file, so a Stop hook firing
+ * repeatedly does not multiply the record.
+ */
+export function archive(dir, transcriptPath, { sessionId } = {}) {
+  const turns = readTurns(transcriptPath);
+  if (!turns.length) return 0;
+
+  const root = transcriptDir(dir);
+  try {
+    mkdirSync(root, { recursive: true, mode: 0o700 });
+    try {
+      chmodSync(root, 0o700);
+    } catch {
+      /* not POSIX, or not ours */
+    }
+  } catch {
+    return 0;
+  }
+
+  const file = join(root, `${safeName(sessionId)}.jsonl`);
+  try {
+    // Truncate-and-write rather than append: Stop fires many times per session
+    // and the transcript is cumulative, so appending would store the early turns
+    // once per firing.
+    const payload = turns.map((t) => JSON.stringify(t)).join('\n') + '\n';
+    writeFileSync(file, payload, { mode: 0o600 });
+  } catch {
+    return 0;
+  }
+
+  prune(root);
+  return turns.length;
+}
+
+/**
+ * Drops the oldest sessions once the archive exceeds its budget.
+ *
+ * Oldest-first, because the value of a transcript is highest while the work it
+ * describes is still live.
+ */
+export function prune(root, budget = archiveBudget()) {
+  let entries;
+  try {
+    entries = readdirSync(root)
+      .filter((f) => f.endsWith('.jsonl'))
+      .map((f) => {
+        const full = join(root, f);
+        try {
+          const s = statSync(full);
+          return { full, size: s.size, mtime: s.mtimeMs };
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch {
+    return 0;
+  }
+
+  let total = entries.reduce((a, e) => a + e.size, 0);
+  if (total <= budget) return 0;
+
+  entries.sort((a, b) => a.mtime - b.mtime);
+  let dropped = 0;
+  for (const e of entries) {
+    if (total <= budget) break;
+    try {
+      unlinkSync(e.full);
+      total -= e.size;
+      dropped += 1;
+    } catch {
+      /* leave it; a locked file must not stop the rest */
+    }
+  }
+  return dropped;
+}
+
+/** True when a path is inside a transcript archive -- the never-transmit test. */
+export function isArchived(path) {
+  return /[\\/]\.token-optimizer[\\/]wiki[\\/]transcripts[\\/]/.test(String(path));
+}
+
+/** Reads a session's archived turns back, for the lesson extractor. */
+export function readArchive(dir, sessionId) {
+  const file = join(transcriptDir(dir), `${safeName(sessionId)}.jsonl`);
+  if (!existsSync(file)) return [];
+  try {
+    return readFileSync(file, 'utf8')
+      .split('\n')
+      .filter(Boolean)
+      .map((l) => {
+        try {
+          return JSON.parse(l);
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}

--- a/integrations/qwen/hooks/lib/harvest-write.mjs
+++ b/integrations/qwen/hooks/lib/harvest-write.mjs
@@ -28,7 +28,7 @@ import { indexFile } from './staleness.mjs';
 import { symbolKey } from './symbols.mjs';
 import { canonicalPath } from './paths.mjs';
 import { randomBytes } from 'node:crypto';
-import { ORIGIN_HARVESTED, ORIGIN_AGENT } from './curate.mjs';
+import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
 
 /**
  * Resolves an `path` or `path#symbol` anchor to an existing node id.
@@ -81,11 +81,33 @@ export function writeHarvested(
 ) {
   if (!Array.isArray(findings) || !findings.length) return [];
 
-  // Only the two origins this path can honestly claim. A caller asking for
-  // anything else -- notably ORIGIN_HUMAN -- would be labelling machine output
-  // as a person's assertion, which is the confusion the field exists to prevent.
-  const provenance = origin === ORIGIN_AGENT ? ORIGIN_AGENT : ORIGIN_HARVESTED;
-  const prefix = provenance === ORIGIN_AGENT ? 'agent' : 'harvested';
+  // The batch default. A caller asking for anything else -- notably
+  // ORIGIN_HUMAN -- would be labelling machine output as a person's assertion,
+  // which is the confusion the field exists to prevent.
+  const batch = origin === ORIGIN_AGENT ? ORIGIN_AGENT : ORIGIN_HARVESTED;
+
+  /**
+   * ORIGIN_HUMAN IS EARNED PER FINDING, BY EVIDENCE.
+   *
+   * A batch-wide origin was the whole story here, and it silently discarded
+   * the per-lesson provenance `validateLessons` had just computed: a
+   * correction whose quote was verified word-for-word in the user's own turn
+   * was stored as ORIGIN_HARVESTED like any model paraphrase. The standing-
+   * rules layer selects on human origin, so it matched nothing this pipeline
+   * wrote, and the verbatim check had no observable effect at all.
+   *
+   * The original rule still holds -- a caller cannot simply DECLARE machine
+   * output human. It is the verified quote that promotes it, and the quote is
+   * stored alongside so the claim carries its own evidence.
+   */
+  const provenanceFor = (finding) =>
+    finding.origin === ORIGIN_HUMAN &&
+    typeof finding.quote === 'string' &&
+    finding.quote.trim()
+      ? ORIGIN_HUMAN
+      : batch;
+  const prefixFor = (p) =>
+    p === ORIGIN_AGENT ? 'agent' : p === ORIGIN_HUMAN ? 'human' : 'harvested';
 
   const written = [];
   for (const finding of findings) {
@@ -103,7 +125,8 @@ export function writeHarvested(
     // same key, and putNode keeps the last write for an id -- so one session's
     // finding silently replaces another's. A random suffix makes that
     // collision vanishingly unlikely while keeping the timestamp readable.
-    const key = `${prefix}-${Date.now().toString(36)}-${written.length}-${randomBytes(4).toString("hex")}`;
+    const provenance = provenanceFor(finding);
+    const key = `${prefixFor(provenance)}-${Date.now().toString(36)}-${written.length}-${randomBytes(4).toString("hex")}`;
     // ONE APPEND for the finding and every anchor it resolved. This runs in a
     // detached worker, so "the process survives to finish the loop" is not a
     // safe assumption: a node written without its edges is an active finding
@@ -127,6 +150,11 @@ export function writeHarvested(
           ? finding.trigger
           : undefined,
         origin: provenance,
+        // THE EVIDENCE TRAVELS WITH THE CLAIM. Without it a human-origin
+        // finding asserts its own provenance and nothing can check it.
+        quote: typeof finding.quote === 'string' && finding.quote.trim()
+          ? finding.quote
+          : undefined,
         sessionId,
       },
       resolved.map((target) => ({ edge: 'derived_from', to: target }))

--- a/integrations/qwen/hooks/lib/harvest.mjs
+++ b/integrations/qwen/hooks/lib/harvest.mjs
@@ -36,7 +36,10 @@ const ENDPOINT = () => process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT
   || 'https://api.anthropic.com/v1/messages';
 
 /** Findings must be one of these. Free-form claims are rejected. */
-export const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map'];
+// 'feedback' is a lesson extracted from a USER CORRECTION rather than from the
+// code -- the only finding type whose source is a person telling the agent it
+// was wrong, which is why it is kept distinguishable from an ordinary finding.
+export const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map', 'feedback'];
 
 export function apiKey() {
   return process.env.TOKEN_OPTIMIZER_API_KEY || process.env.ANTHROPIC_API_KEY || null;
@@ -222,7 +225,7 @@ export function validate(raw, { knownFiles = null } = {}) {
  * indistinguishable, from the caller's side, from a session with nothing to
  * learn.
  */
-export async function extract(digest, { timeoutMs = 30_000 } = {}) {
+export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}) {
   if (!digest || !harvestEnabled()) return [];
 
   // A local endpoint usually has no auth at all, so requiring a key there would
@@ -248,7 +251,7 @@ export async function extract(digest, { timeoutMs = 30_000 } = {}) {
       body: JSON.stringify({
         model: MODEL(),
         max_tokens: 2048,
-        system: PROMPT,
+        system: prompt || PROMPT,
         messages: [{ role: 'user', content: digest }],
       }),
     });

--- a/integrations/qwen/hooks/lib/inject.mjs
+++ b/integrations/qwen/hooks/lib/inject.mjs
@@ -31,6 +31,20 @@ import { substitutionBudget } from './metrics.mjs';
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
 
+/**
+ * Tokens allowed for the always-on standing rules.
+ *
+ * FIXED AND SMALL, unlike the session index whose budget is earned from measured
+ * hit rate. An earned budget is right for a catalogue that grows with the graph;
+ * it is wrong here, because this text is paid for on EVERY session whether or
+ * not it is relevant, and a set that grows with the project is exactly how an
+ * always-on block becomes wallpaper. 400 tokens is roughly a dozen rules -- if a
+ * project needs more standing rules than that, the honest answer is that some of
+ * them are situational and belong behind a trigger.
+ */
+const standingBudget = () =>
+  Number(process.env.TOKEN_OPTIMIZER_STANDING_BUDGET) || 400;
+
 /** Most findings considered for one command before the budget decides. */
 const MAX_COMMAND_CANDIDATES = 20;
 
@@ -339,6 +353,77 @@ Established in previous sessions. Call wiki_query with a key for detail, or just
 work -- findings anchored to a file are surfaced automatically when you touch it.
 
 ${lines.join('\n')}`;
+}
+
+/**
+ * The always-on set: rules that must hold before the first tool call.
+ *
+ * WHY THESE CANNOT BE TRIGGER-FIRED. A trigger answers "this situation is
+ * happening now". Some rules are not about a situation -- "report the number you
+ * measured, not the one you expected" governs how every turn is conducted, and
+ * by the time any command matched a trigger the turn would already be going
+ * wrong. Those have to be present before anything happens or they are useless.
+ *
+ * WHY THIS IS NOT THE SESSION INDEX. `sessionIndex` lists keys and truncated
+ * titles and tells the model to call wiki_query for detail; that is right for a
+ * catalogue of things it MIGHT want. A standing rule that needs a lookup before
+ * it can be obeyed is not a standing rule -- so these are rendered in full, and
+ * are budgeted separately and much more tightly because of it.
+ *
+ * WHAT QUALIFIES, deliberately narrow:
+ *   - anything a human PINNED, which curate.mjs already defines as a fact that
+ *     stays true and should not decay, or
+ *   - a `feedback` lesson whose quote was verified against the transcript, so a
+ *     person demonstrably said it.
+ *
+ * Everything else waits for its trigger. The failure mode this guards against
+ * is the one that already happened here: an always-on block that grows until it
+ * is wallpaper, and the model stops reading the thing it always sees.
+ */
+export function standingRules(dir, graph, { budget = standingBudget() } = {}) {
+  const rules = [...graph.nodes.values()].filter(
+    (n) =>
+      n.kind === 'finding' &&
+      !n.retired &&
+      typeof n.claim === 'string' &&
+      (n.pinned === true || (n.type === 'feedback' && n.origin === 'human'))
+  );
+  if (!rules.length) return null;
+
+  // A person's own correction outranks anything inferred, then confidence.
+  rules.sort((a, b) => {
+    const weight = (n) => (n.origin === 'human' ? 2 : n.pinned ? 1.5 : 1);
+    return weight(b) * (b.confidence ?? 0.5) - weight(a) * (a.confidence ?? 0.5);
+  });
+
+  const lines = [];
+  let spent = 0;
+  let dropped = 0;
+  for (const rule of rules) {
+    const line = `- ${rule.claim}`;
+    const cost = estimate(line);
+    if (spent + cost > budget) {
+      dropped += 1;
+      continue;
+    }
+    lines.push(line);
+    spent += cost;
+  }
+  if (!lines.length) return null;
+
+  record(dir, { kind: 'standing', count: lines.length, dropped, tokens: spent });
+
+  // SAY WHAT WAS DROPPED. A silent cap reads as "these are all the rules",
+  // which is worse than saying there are more: a model that knows the list is
+  // truncated can ask, one that does not will assume it is complete.
+  const truncated = dropped
+    ? `\n(${dropped} further standing rule${dropped === 1 ? '' : 's'} did not fit this budget; ` +
+      `raise TOKEN_OPTIMIZER_STANDING_BUDGET or retire some.)`
+    : '';
+
+  return `# Standing rules for this project\n\nEstablished in previous sessions and expected to hold. These are not suggestions.\n\n${lines.join(
+    '\n'
+  )}${truncated}`;
 }
 
 /**

--- a/integrations/qwen/hooks/lib/inject.mjs
+++ b/integrations/qwen/hooks/lib/inject.mjs
@@ -396,8 +396,30 @@ export function standingRules(dir, graph, { budget = standingBudget() } = {}) {
     return weight(b) * (b.confidence ?? 0.5) - weight(a) * (a.confidence ?? 0.5);
   });
 
+  // THE BUDGET COVERS THE WHOLE MESSAGE, not just the claim lines.
+  //
+  // `spent` used to count selected claims only, while the returned text also
+  // carries a heading, two lines of fixed instruction and an optional
+  // truncation notice. A selection that exactly filled the budget therefore
+  // injected more than the budget allowed and recorded fewer tokens than it
+  // spent -- in a block whose entire justification is that it is tightly
+  // bounded and measured against the control arm.
+  const HEADING =
+    '# Standing rules for this project' +
+    '\n\nEstablished in previous sessions and expected to hold. ' +
+    'These are not suggestions.\n\n';
+  const noticeFor = (n) =>
+    n
+      ? `\n(${n} further standing rule${n === 1 ? '' : 's'} did not fit this budget; ` +
+        'raise TOKEN_OPTIMIZER_STANDING_BUDGET or retire some.)'
+      : '';
+
+  // The wrapper is charged up front, and the worst-case notice is reserved, so
+  // admitting the last line can never push the total over by adding one.
+  const overhead = estimate(HEADING) + estimate(noticeFor(rules.length));
+
   const lines = [];
-  let spent = 0;
+  let spent = overhead;
   let dropped = 0;
   for (const rule of rules) {
     const line = `- ${rule.claim}`;
@@ -409,21 +431,24 @@ export function standingRules(dir, graph, { budget = standingBudget() } = {}) {
     lines.push(line);
     spent += cost;
   }
-  if (!lines.length) return null;
 
-  record(dir, { kind: 'standing', count: lines.length, dropped, tokens: spent });
+  // RECORDED EVEN WHEN NOTHING FITS. Returning early without a metric hid the
+  // one case most worth knowing about: rules exist and every one is too large
+  // for the budget, so the block silently does nothing all session and the
+  // measurement shows no sign of it.
+  const truncated = noticeFor(dropped);
+  record(dir, {
+    kind: 'standing',
+    count: lines.length,
+    dropped,
+    tokens: lines.length ? spent : 0,
+  });
+  if (!lines.length) return null;
 
   // SAY WHAT WAS DROPPED. A silent cap reads as "these are all the rules",
   // which is worse than saying there are more: a model that knows the list is
   // truncated can ask, one that does not will assume it is complete.
-  const truncated = dropped
-    ? `\n(${dropped} further standing rule${dropped === 1 ? '' : 's'} did not fit this budget; ` +
-      `raise TOKEN_OPTIMIZER_STANDING_BUDGET or retire some.)`
-    : '';
-
-  return `# Standing rules for this project\n\nEstablished in previous sessions and expected to hold. These are not suggestions.\n\n${lines.join(
-    '\n'
-  )}${truncated}`;
+  return `${HEADING}${lines.join('\n')}${truncated}`;
 }
 
 /**

--- a/integrations/qwen/hooks/lib/lessons.mjs
+++ b/integrations/qwen/hooks/lib/lessons.mjs
@@ -98,24 +98,64 @@ export function buildFeedbackDigest(turns, { maxChars = 40_000 } = {}) {
   return out.length ? out.join('\n\n') : null;
 }
 
-/** True when the quote really appears in the archive, allowing for whitespace. */
+/**
+ * True when the quote really appears in the archive, allowing for whitespace.
+ *
+ * CASE IS PART OF VERBATIM. Lower-casing both sides accepted a quote whose
+ * capitalisation never occurred -- `NO, USE NPM TEST` matched a transcript
+ * saying `no, use npm test` -- and that quote then earned ORIGIN_HUMAN and 0.95
+ * confidence on the strength of a check it had not actually passed. The prompt
+ * asks for an exact copy, so this asks for one.
+ *
+ * Whitespace IS still normalised: line wrapping is an artefact of how the turn
+ * was stored, not something the user chose.
+ */
 export function quoteIsVerbatim(quote, turns) {
-  const needle = String(quote || '').trim().toLowerCase().replace(/\s+/g, ' ');
+  // A missing archive is not a match. `buildFeedbackDigest` guards its input in
+  // this same module; without the same guard here a null archive threw a
+  // TypeError out of a validator whose entire job is to reject bad input.
+  if (!Array.isArray(turns)) return false;
+  const needle = String(quote || '').trim().replace(/\s+/g, ' ');
   if (needle.length < 8) return false;
   return turns
-    .filter((t) => t.role === 'user')
-    .some((t) => String(t.text).toLowerCase().replace(/\s+/g, ' ').includes(needle));
+    .filter((t) => t && t.role === 'user')
+    .some((t) => String(t.text).replace(/\s+/g, ' ').includes(needle));
 }
 
-/** A claim that leads with a verb, which is what makes it act like an instruction. */
+/**
+ * A claim that leads with a bare verb, which is what makes it an instruction.
+ *
+ * A POSITIVE RULE, NOT A DENYLIST. The denylist rejected the openings a
+ * paraphrase usually starts with -- `the user prefers`, `you should` -- and
+ * accepted everything else, so `npm test is preferred over npx jest.` passed
+ * and was stored as a standing rule despite being a description rather than an
+ * instruction. Any noun-led sentence walked straight through.
+ *
+ * The test is now positive: the first word must be a bare verb form. That is
+ * still not a parts-of-speech tagger, but it fails CLOSED -- an unrecognised
+ * opening is rejected rather than admitted, which is the right direction for a
+ * gate on text that becomes an always-on instruction.
+ */
+const IMPERATIVE_VERBS = new Set([
+  'use', 'run', 'call', 'prefer', 'avoid', 'never', 'always', 'do', "don't", 'dont',
+  'stop', 'start', 'check', 'verify', 'confirm', 'read', 'write', 'edit', 'add',
+  'remove', 'delete', 'fix', 'keep', 'make', 'set', 'pass', 'build', 'test',
+  'install', 'update', 'rebase', 'merge', 'commit', 'push', 'pull', 'fetch',
+  'branch', 'open', 'close', 'ask', 'report', 'measure', 'record', 'skip',
+  'ignore', 'include', 'exclude', 'treat', 'assume', 'ensure', 'require',
+  'apply', 'revert', 'restore', 'replace', 'rename', 'move', 'copy', 'create',
+  'wait', 'retry', 'log', 'print', 'return', 'throw', 'catch', 'handle',
+  'quote', 'escape', 'sanitise', 'sanitize', 'validate', 'reject', 'accept',
+]);
+
 export function isImperative(claim) {
-  const first = String(claim || '').trim().split(/\s+/)[0] || '';
-  // Not a parts-of-speech tagger, and does not need to be: what it rejects is
-  // the shape corrections actually arrive in when a model paraphrases them --
-  // "the user prefers", "it is better to", "you should".
-  return !/^(the|a|an|it|this|that|there|you|we|i|user|users|when|because|since|although)$/i.test(
-    first
-  );
+  const first = String(claim || '')
+    .trim()
+    .split(/\s+/)[0]
+    .replace(/[^A-Za-z']/g, '')
+    .toLowerCase();
+  if (!first) return false;
+  return IMPERATIVE_VERBS.has(first);
 }
 
 /**

--- a/integrations/qwen/hooks/lib/lessons.mjs
+++ b/integrations/qwen/hooks/lib/lessons.mjs
@@ -1,0 +1,192 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/lessons.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Turning corrections into lessons the next session actually receives.
+ *
+ * The signal this exists to capture is sparse and specific: the moments where
+ * the user pushed back. Everything else in a session is ordinary work. Measured
+ * on one real session, the graph recorded 4,053 file touches and none of the
+ * three corrections the user actually gave -- which are the only turns that
+ * carried information the code could not.
+ *
+ * TWO THINGS THIS MODULE REFUSES TO GUESS.
+ *
+ * 1. WHO SAID IT. A lesson is stored as a human assertion only when the
+ *    extractor supplies the user's words verbatim AND those words are found in
+ *    the archive. curate.mjs warns that "a hand-written assertion and a machine
+ *    guess look identical three months later", and human origin carries the
+ *    highest ranking weight -- so claiming it on a model's paraphrase would let
+ *    an inference outrank the correction it was inferred from. Unverifiable
+ *    quotes still store, as ORIGIN_HARVESTED.
+ *
+ * 2. WHEN IT APPLIES. Every lesson must carry a trigger. A lesson with no
+ *    trigger can only surface if someone happens to open the file it is anchored
+ *    to, which is not when advice about doing something is needed.
+ *
+ * AND ONE THING IT INSISTS ON: the action first. Measured in the injection A/B,
+ * a correctly stored and correctly delivered finding was still ignored because
+ * its instruction sat at the end of three sentences of context. Delivery is
+ * necessary and not sufficient; phrasing is the other half.
+ */
+
+import { ORIGIN_HARVESTED, ORIGIN_HUMAN } from './curate.mjs';
+
+/** Lessons longer than this are prose, not instructions. */
+const MAX_CLAIM = 400;
+
+/**
+ * The extraction prompt.
+ *
+ * Deliberately narrow. Asked for "lessons" a model will summarise the session;
+ * asked for corrections it returns the handful of turns that actually taught
+ * something, which is the whole point of keeping the store sparse.
+ */
+export const LESSON_PROMPT = `You are reading a transcript between a user and a coding agent.
+
+Extract ONLY the moments where the USER corrected, rejected, or redirected the agent —
+where the agent did something the user did not want, and the user said so. Ignore
+ordinary instructions, questions, and approvals. Most transcripts contain between zero
+and five of these. Returning an empty list is a correct and common answer.
+
+For each correction return an object with:
+  "claim"   - the lesson, as an IMPERATIVE with the action FIRST. Start with a verb.
+              Not "the user prefers X because Y" but "Do X. Y is why."
+              Under ${MAX_CLAIM} characters. This is the sentence a future agent reads
+              at the moment it is about to make the same mistake, so it must lead with
+              what to do, not with background.
+  "quote"   - the user's own words that constitute the correction, copied EXACTLY from
+              the transcript. Do not paraphrase, do not fix typos, do not add quotes.
+  "trigger" - a JavaScript regex source matching the situation where this applies, e.g.
+              "\\\\bnpx\\\\s+jest\\\\b" or "git\\\\s+push" or "\\\\.csproj". If the lesson is about a
+              tool or command, match that. Required.
+  "anchors" - array of absolute file paths the lesson concerns. May be empty.
+
+Return ONLY a JSON array. No prose, no markdown fence.`;
+
+/**
+ * Builds the extractor input from archived turns.
+ *
+ * Assistant tool RESULTS never entered the archive, so they cannot enter here.
+ * What is sent is the conversation: what was asked, what was answered, and which
+ * commands were run.
+ */
+export function buildFeedbackDigest(turns, { maxChars = 40_000 } = {}) {
+  if (!Array.isArray(turns) || !turns.length) return null;
+
+  const rendered = turns.map((t) => {
+    if (t.role === 'user') return `USER: ${t.text}`;
+    const tools = (t.tools || [])
+      .map((x) => (x.command ? `${x.name}(${x.command})` : x.name))
+      .filter(Boolean)
+      .slice(0, 8)
+      .join(', ');
+    const head = t.text ? `AGENT: ${t.text}` : 'AGENT:';
+    return tools ? `${head}\n  [tools: ${tools}]` : head;
+  });
+
+  // KEEP THE END, not the beginning. Corrections cluster where the work went
+  // wrong, and a transcript that needed correcting tends to have gone wrong
+  // later rather than sooner.
+  let out = [];
+  let total = 0;
+  for (let i = rendered.length - 1; i >= 0; i--) {
+    const piece = rendered[i];
+    if (total + piece.length > maxChars) break;
+    out.unshift(piece);
+    total += piece.length;
+  }
+  return out.length ? out.join('\n\n') : null;
+}
+
+/** True when the quote really appears in the archive, allowing for whitespace. */
+export function quoteIsVerbatim(quote, turns) {
+  const needle = String(quote || '').trim().toLowerCase().replace(/\s+/g, ' ');
+  if (needle.length < 8) return false;
+  return turns
+    .filter((t) => t.role === 'user')
+    .some((t) => String(t.text).toLowerCase().replace(/\s+/g, ' ').includes(needle));
+}
+
+/** A claim that leads with a verb, which is what makes it act like an instruction. */
+export function isImperative(claim) {
+  const first = String(claim || '').trim().split(/\s+/)[0] || '';
+  // Not a parts-of-speech tagger, and does not need to be: what it rejects is
+  // the shape corrections actually arrive in when a model paraphrases them --
+  // "the user prefers", "it is better to", "you should".
+  return !/^(the|a|an|it|this|that|there|you|we|i|user|users|when|because|since|although)$/i.test(
+    first
+  );
+}
+
+/**
+ * Validates extractor output and decides each lesson's origin.
+ *
+ * Returns { lessons, rejected } so a caller can report what was dropped rather
+ * than silently storing less than it was given.
+ */
+export function validateLessons(raw, turns) {
+  let parsed = raw;
+  if (typeof raw === 'string') {
+    try {
+      parsed = JSON.parse(raw.replace(/^```(?:json)?\s*|\s*```$/g, ''));
+    } catch {
+      return { lessons: [], rejected: [{ reason: 'unparseable', raw: String(raw).slice(0, 200) }] };
+    }
+  }
+  if (!Array.isArray(parsed)) {
+    return { lessons: [], rejected: [{ reason: 'not-an-array' }] };
+  }
+
+  const lessons = [];
+  const rejected = [];
+
+  for (const item of parsed) {
+    const claim = String(item?.claim || '').trim();
+    const trigger = String(item?.trigger || '').trim();
+    const quote = String(item?.quote || '').trim();
+
+    if (claim.length < 12) {
+      rejected.push({ reason: 'claim-too-short', claim });
+      continue;
+    }
+    if (claim.length > MAX_CLAIM) {
+      rejected.push({ reason: 'claim-too-long', claim: claim.slice(0, 80) });
+      continue;
+    }
+    if (!trigger) {
+      // Without one it can only surface by file touch, which is not when advice
+      // about an action is needed.
+      rejected.push({ reason: 'no-trigger', claim: claim.slice(0, 80) });
+      continue;
+    }
+    try {
+      new RegExp(trigger);
+    } catch {
+      rejected.push({ reason: 'bad-trigger-regex', trigger });
+      continue;
+    }
+    if (!isImperative(claim)) {
+      rejected.push({ reason: 'not-imperative', claim: claim.slice(0, 80) });
+      continue;
+    }
+
+    // THE PROVENANCE TEST. Verbatim and present means the user really said it.
+    const verified = quoteIsVerbatim(quote, turns);
+
+    lessons.push({
+      type: 'feedback',
+      claim,
+      trigger,
+      quote: verified ? quote : undefined,
+      origin: verified ? ORIGIN_HUMAN : ORIGIN_HARVESTED,
+      // A verified human correction is as close to ground truth as this system
+      // gets. An unverified paraphrase is a model's reading of one.
+      confidence: verified ? 0.95 : 0.6,
+      anchors: Array.isArray(item?.anchors)
+        ? item.anchors.filter((a) => typeof a === 'string' && a.trim())
+        : [],
+    });
+  }
+
+  return { lessons, rejected };
+}

--- a/integrations/qwen/hooks/lib/transcript.mjs
+++ b/integrations/qwen/hooks/lib/transcript.mjs
@@ -1,0 +1,213 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/transcript.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * The raw local archive of what was asked and what was answered.
+ *
+ * THE ARCHIVE AND THE LESSONS ARE DIFFERENT THINGS, and keeping them separate
+ * is the whole design. The archive is complete and never retrieved; the lessons
+ * extracted from it are sparse and are the only thing ever injected. Storing
+ * everything AND retrieving everything would drown the graph -- a session is
+ * thousands of turns of ordinary work and a handful of moments that taught
+ * something. Storing everything and retrieving only the lessons keeps the record
+ * complete without diluting what gets served.
+ *
+ * NOTHING HERE LEAVES THE MACHINE. The archive is written inside the wiki
+ * directory, which already carries a `.gitignore` of `*`, and it is explicitly
+ * excluded from the harvest digest -- the one code path that sends anything to a
+ * model endpoint. A feedback loop must never become the reason a user's prompts
+ * are transmitted.
+ */
+
+import {
+  readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, readdirSync, statSync, unlinkSync,
+} from 'node:fs';
+import { join } from 'node:path';
+
+/** Where a project's transcripts live, under the graph it belongs to. */
+export const transcriptDir = (dir) => join(dir, 'transcripts');
+
+/**
+ * Total bytes of archive kept per project before the oldest are dropped.
+ *
+ * An unbounded archive of every session is a disk leak that grows fastest for
+ * the users who use the tool most, which is exactly backwards.
+ */
+const archiveBudget = () =>
+  Number(process.env.TOKEN_OPTIMIZER_TRANSCRIPT_BUDGET_BYTES) || 50 * 1024 * 1024;
+
+/** A session id reduced to something that cannot escape the archive directory. */
+export function safeName(sessionId) {
+  const safe = String(sessionId || 'unknown').replace(/[^A-Za-z0-9._-]/g, '_');
+  return (/^[.]+$/.test(safe) ? 'unknown' : safe).slice(0, 64);
+}
+
+/**
+ * Turns a Claude transcript into the prompt/response pairs worth keeping.
+ *
+ * TOOL RESULTS ARE DROPPED, for the same reason `buildDigest` drops them: that
+ * is where whole file contents would enter the record. The archive is meant to
+ * hold the conversation, not a second copy of the repository.
+ */
+export function readTurns(transcriptPath) {
+  let lines;
+  try {
+    lines = readFileSync(transcriptPath, 'utf8').split('\n');
+  } catch {
+    return [];
+  }
+
+  const turns = [];
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    let entry;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+
+    const message = entry.message || entry;
+    const role = message.role || entry.type;
+    const content = message.content;
+
+    if (role === 'user') {
+      const text =
+        typeof content === 'string'
+          ? content
+          : Array.isArray(content)
+            ? content
+                .filter((b) => b && b.type === 'text')
+                .map((b) => String(b.text))
+                .join('\n')
+            : '';
+      if (text.trim()) turns.push({ role: 'user', text: text.trim(), at: entry.timestamp ?? null });
+      continue;
+    }
+
+    if (role === 'assistant' && Array.isArray(content)) {
+      const text = content
+        .filter((b) => b && b.type === 'text')
+        .map((b) => String(b.text))
+        .join('\n');
+      const tools = content
+        .filter((b) => b && b.type === 'tool_use')
+        .map((b) => ({
+          name: b.name,
+          // Arguments only, never results, and truncated: a command is the
+          // useful part, its output is not.
+          command: b.input?.command ? String(b.input.command).slice(0, 300) : undefined,
+          path: b.input?.file_path || b.input?.path || undefined,
+        }));
+      if (text.trim() || tools.length) {
+        turns.push({ role: 'assistant', text: text.trim(), tools, at: entry.timestamp ?? null });
+      }
+    }
+  }
+  return turns;
+}
+
+/**
+ * Appends this session's turns to the project archive.
+ *
+ * Idempotent per session by rewriting that session's file, so a Stop hook firing
+ * repeatedly does not multiply the record.
+ */
+export function archive(dir, transcriptPath, { sessionId } = {}) {
+  const turns = readTurns(transcriptPath);
+  if (!turns.length) return 0;
+
+  const root = transcriptDir(dir);
+  try {
+    mkdirSync(root, { recursive: true, mode: 0o700 });
+    try {
+      chmodSync(root, 0o700);
+    } catch {
+      /* not POSIX, or not ours */
+    }
+  } catch {
+    return 0;
+  }
+
+  const file = join(root, `${safeName(sessionId)}.jsonl`);
+  try {
+    // Truncate-and-write rather than append: Stop fires many times per session
+    // and the transcript is cumulative, so appending would store the early turns
+    // once per firing.
+    const payload = turns.map((t) => JSON.stringify(t)).join('\n') + '\n';
+    writeFileSync(file, payload, { mode: 0o600 });
+  } catch {
+    return 0;
+  }
+
+  prune(root);
+  return turns.length;
+}
+
+/**
+ * Drops the oldest sessions once the archive exceeds its budget.
+ *
+ * Oldest-first, because the value of a transcript is highest while the work it
+ * describes is still live.
+ */
+export function prune(root, budget = archiveBudget()) {
+  let entries;
+  try {
+    entries = readdirSync(root)
+      .filter((f) => f.endsWith('.jsonl'))
+      .map((f) => {
+        const full = join(root, f);
+        try {
+          const s = statSync(full);
+          return { full, size: s.size, mtime: s.mtimeMs };
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch {
+    return 0;
+  }
+
+  let total = entries.reduce((a, e) => a + e.size, 0);
+  if (total <= budget) return 0;
+
+  entries.sort((a, b) => a.mtime - b.mtime);
+  let dropped = 0;
+  for (const e of entries) {
+    if (total <= budget) break;
+    try {
+      unlinkSync(e.full);
+      total -= e.size;
+      dropped += 1;
+    } catch {
+      /* leave it; a locked file must not stop the rest */
+    }
+  }
+  return dropped;
+}
+
+/** True when a path is inside a transcript archive -- the never-transmit test. */
+export function isArchived(path) {
+  return /[\\/]\.token-optimizer[\\/]wiki[\\/]transcripts[\\/]/.test(String(path));
+}
+
+/** Reads a session's archived turns back, for the lesson extractor. */
+export function readArchive(dir, sessionId) {
+  const file = join(transcriptDir(dir), `${safeName(sessionId)}.jsonl`);
+  if (!existsSync(file)) return [];
+  try {
+    return readFileSync(file, 'utf8')
+      .split('\n')
+      .filter(Boolean)
+      .map((l) => {
+        try {
+          return JSON.parse(l);
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}

--- a/plugin/hooks/harvest-worker.mjs
+++ b/plugin/hooks/harvest-worker.mjs
@@ -24,6 +24,7 @@ import {
 } from './lib/harvest.mjs';
 import { writeHarvested } from './lib/harvest-write.mjs';
 import { record } from './lib/metrics.mjs';
+import { wikiDir } from './lib/wiki.mjs';
 import { readArchive } from './lib/transcript.mjs';
 import { buildFeedbackDigest, validateLessons, LESSON_PROMPT } from './lib/lessons.mjs';
 import { ORIGIN_HARVESTED } from './lib/curate.mjs';
@@ -76,6 +77,10 @@ async function main() {
 
   record(dir, {
     kind: 'harvest',
+    sessionId: sessionId || null,
+    tokens: estimateTokens(digest),
+    findings: written.length,
+    at: Date.now(),
   });
 
   // THE FEEDBACK LOOP. A separate extraction with a separate prompt, because
@@ -117,10 +122,6 @@ async function main() {
     // A failed feedback pass must be indistinguishable from a session with
     // nothing to correct.
   }
-    tokens: estimateTokens(digest),
-    findings: written.length,
-    at: Date.now(),
-  });
 }
 
 main()

--- a/plugin/hooks/harvest-worker.mjs
+++ b/plugin/hooks/harvest-worker.mjs
@@ -23,8 +23,10 @@ import {
   estimateTokens,
 } from './lib/harvest.mjs';
 import { writeHarvested } from './lib/harvest-write.mjs';
-import { wikiDir } from './lib/wiki.mjs';
 import { record } from './lib/metrics.mjs';
+import { readArchive } from './lib/transcript.mjs';
+import { buildFeedbackDigest, validateLessons, LESSON_PROMPT } from './lib/lessons.mjs';
+import { ORIGIN_HARVESTED } from './lib/curate.mjs';
 
 /**
  * The files the digest says were touched.
@@ -74,7 +76,47 @@ async function main() {
 
   record(dir, {
     kind: 'harvest',
-    sessionId: sessionId || null,
+  });
+
+  // THE FEEDBACK LOOP. A separate extraction with a separate prompt, because
+  // the two are looking for different things: the harvest above wants what was
+  // LEARNED about the code, this wants where the user said the agent was WRONG.
+  // Asked for both at once a model returns a summary and the corrections get
+  // lost in it -- and corrections are the only turns carrying information the
+  // code itself could never supply.
+  try {
+    const turns = readArchive(dir, sessionId || 'unknown');
+    const feedback = buildFeedbackDigest(turns);
+    if (feedback) {
+      const rawLessons = await extract(feedback, { prompt: LESSON_PROMPT });
+      const { lessons, rejected } = validateLessons(rawLessons, turns);
+
+      // Anchors are optional on a lesson -- "always run npm test" is about no
+      // file -- so each is anchored to the project root when it names nothing,
+      // which keeps the store's rule that an unanchored finding is refused.
+      const anchored = lessons.map((l) => ({
+        ...l,
+        anchors: l.anchors.length ? l.anchors : [cwd || process.cwd()],
+      }));
+
+      const writtenLessons = writeHarvested(dir, anchored, {
+        sessionId: sessionId || null,
+        origin: ORIGIN_HARVESTED,
+      });
+
+      record(dir, {
+        kind: 'lessons',
+        sessionId: sessionId || null,
+        tokens: estimateTokens(feedback),
+        lessons: writtenLessons.length,
+        rejected: rejected.length,
+        at: Date.now(),
+      });
+    }
+  } catch {
+    // A failed feedback pass must be indistinguishable from a session with
+    // nothing to correct.
+  }
     tokens: estimateTokens(digest),
     findings: written.length,
     at: Date.now(),

--- a/plugin/hooks/lib/harvest-write.mjs
+++ b/plugin/hooks/lib/harvest-write.mjs
@@ -28,7 +28,7 @@ import { indexFile } from './staleness.mjs';
 import { symbolKey } from './symbols.mjs';
 import { canonicalPath } from './paths.mjs';
 import { randomBytes } from 'node:crypto';
-import { ORIGIN_HARVESTED, ORIGIN_AGENT } from './curate.mjs';
+import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
 
 /**
  * Resolves an `path` or `path#symbol` anchor to an existing node id.
@@ -81,11 +81,33 @@ export function writeHarvested(
 ) {
   if (!Array.isArray(findings) || !findings.length) return [];
 
-  // Only the two origins this path can honestly claim. A caller asking for
-  // anything else -- notably ORIGIN_HUMAN -- would be labelling machine output
-  // as a person's assertion, which is the confusion the field exists to prevent.
-  const provenance = origin === ORIGIN_AGENT ? ORIGIN_AGENT : ORIGIN_HARVESTED;
-  const prefix = provenance === ORIGIN_AGENT ? 'agent' : 'harvested';
+  // The batch default. A caller asking for anything else -- notably
+  // ORIGIN_HUMAN -- would be labelling machine output as a person's assertion,
+  // which is the confusion the field exists to prevent.
+  const batch = origin === ORIGIN_AGENT ? ORIGIN_AGENT : ORIGIN_HARVESTED;
+
+  /**
+   * ORIGIN_HUMAN IS EARNED PER FINDING, BY EVIDENCE.
+   *
+   * A batch-wide origin was the whole story here, and it silently discarded
+   * the per-lesson provenance `validateLessons` had just computed: a
+   * correction whose quote was verified word-for-word in the user's own turn
+   * was stored as ORIGIN_HARVESTED like any model paraphrase. The standing-
+   * rules layer selects on human origin, so it matched nothing this pipeline
+   * wrote, and the verbatim check had no observable effect at all.
+   *
+   * The original rule still holds -- a caller cannot simply DECLARE machine
+   * output human. It is the verified quote that promotes it, and the quote is
+   * stored alongside so the claim carries its own evidence.
+   */
+  const provenanceFor = (finding) =>
+    finding.origin === ORIGIN_HUMAN &&
+    typeof finding.quote === 'string' &&
+    finding.quote.trim()
+      ? ORIGIN_HUMAN
+      : batch;
+  const prefixFor = (p) =>
+    p === ORIGIN_AGENT ? 'agent' : p === ORIGIN_HUMAN ? 'human' : 'harvested';
 
   const written = [];
   for (const finding of findings) {
@@ -103,7 +125,8 @@ export function writeHarvested(
     // same key, and putNode keeps the last write for an id -- so one session's
     // finding silently replaces another's. A random suffix makes that
     // collision vanishingly unlikely while keeping the timestamp readable.
-    const key = `${prefix}-${Date.now().toString(36)}-${written.length}-${randomBytes(4).toString("hex")}`;
+    const provenance = provenanceFor(finding);
+    const key = `${prefixFor(provenance)}-${Date.now().toString(36)}-${written.length}-${randomBytes(4).toString("hex")}`;
     // ONE APPEND for the finding and every anchor it resolved. This runs in a
     // detached worker, so "the process survives to finish the loop" is not a
     // safe assumption: a node written without its edges is an active finding
@@ -127,6 +150,11 @@ export function writeHarvested(
           ? finding.trigger
           : undefined,
         origin: provenance,
+        // THE EVIDENCE TRAVELS WITH THE CLAIM. Without it a human-origin
+        // finding asserts its own provenance and nothing can check it.
+        quote: typeof finding.quote === 'string' && finding.quote.trim()
+          ? finding.quote
+          : undefined,
         sessionId,
       },
       resolved.map((target) => ({ edge: 'derived_from', to: target }))

--- a/plugin/hooks/lib/harvest.mjs
+++ b/plugin/hooks/lib/harvest.mjs
@@ -36,7 +36,10 @@ const ENDPOINT = () => process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT
   || 'https://api.anthropic.com/v1/messages';
 
 /** Findings must be one of these. Free-form claims are rejected. */
-export const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map'];
+// 'feedback' is a lesson extracted from a USER CORRECTION rather than from the
+// code -- the only finding type whose source is a person telling the agent it
+// was wrong, which is why it is kept distinguishable from an ordinary finding.
+export const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map', 'feedback'];
 
 export function apiKey() {
   return process.env.TOKEN_OPTIMIZER_API_KEY || process.env.ANTHROPIC_API_KEY || null;
@@ -222,7 +225,7 @@ export function validate(raw, { knownFiles = null } = {}) {
  * indistinguishable, from the caller's side, from a session with nothing to
  * learn.
  */
-export async function extract(digest, { timeoutMs = 30_000 } = {}) {
+export async function extract(digest, { timeoutMs = 30_000, prompt = null } = {}) {
   if (!digest || !harvestEnabled()) return [];
 
   // A local endpoint usually has no auth at all, so requiring a key there would
@@ -248,7 +251,7 @@ export async function extract(digest, { timeoutMs = 30_000 } = {}) {
       body: JSON.stringify({
         model: MODEL(),
         max_tokens: 2048,
-        system: PROMPT,
+        system: prompt || PROMPT,
         messages: [{ role: 'user', content: digest }],
       }),
     });

--- a/plugin/hooks/lib/inject.mjs
+++ b/plugin/hooks/lib/inject.mjs
@@ -31,6 +31,20 @@ import { substitutionBudget } from './metrics.mjs';
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
 
+/**
+ * Tokens allowed for the always-on standing rules.
+ *
+ * FIXED AND SMALL, unlike the session index whose budget is earned from measured
+ * hit rate. An earned budget is right for a catalogue that grows with the graph;
+ * it is wrong here, because this text is paid for on EVERY session whether or
+ * not it is relevant, and a set that grows with the project is exactly how an
+ * always-on block becomes wallpaper. 400 tokens is roughly a dozen rules -- if a
+ * project needs more standing rules than that, the honest answer is that some of
+ * them are situational and belong behind a trigger.
+ */
+const standingBudget = () =>
+  Number(process.env.TOKEN_OPTIMIZER_STANDING_BUDGET) || 400;
+
 /** Most findings considered for one command before the budget decides. */
 const MAX_COMMAND_CANDIDATES = 20;
 
@@ -339,6 +353,77 @@ Established in previous sessions. Call wiki_query with a key for detail, or just
 work -- findings anchored to a file are surfaced automatically when you touch it.
 
 ${lines.join('\n')}`;
+}
+
+/**
+ * The always-on set: rules that must hold before the first tool call.
+ *
+ * WHY THESE CANNOT BE TRIGGER-FIRED. A trigger answers "this situation is
+ * happening now". Some rules are not about a situation -- "report the number you
+ * measured, not the one you expected" governs how every turn is conducted, and
+ * by the time any command matched a trigger the turn would already be going
+ * wrong. Those have to be present before anything happens or they are useless.
+ *
+ * WHY THIS IS NOT THE SESSION INDEX. `sessionIndex` lists keys and truncated
+ * titles and tells the model to call wiki_query for detail; that is right for a
+ * catalogue of things it MIGHT want. A standing rule that needs a lookup before
+ * it can be obeyed is not a standing rule -- so these are rendered in full, and
+ * are budgeted separately and much more tightly because of it.
+ *
+ * WHAT QUALIFIES, deliberately narrow:
+ *   - anything a human PINNED, which curate.mjs already defines as a fact that
+ *     stays true and should not decay, or
+ *   - a `feedback` lesson whose quote was verified against the transcript, so a
+ *     person demonstrably said it.
+ *
+ * Everything else waits for its trigger. The failure mode this guards against
+ * is the one that already happened here: an always-on block that grows until it
+ * is wallpaper, and the model stops reading the thing it always sees.
+ */
+export function standingRules(dir, graph, { budget = standingBudget() } = {}) {
+  const rules = [...graph.nodes.values()].filter(
+    (n) =>
+      n.kind === 'finding' &&
+      !n.retired &&
+      typeof n.claim === 'string' &&
+      (n.pinned === true || (n.type === 'feedback' && n.origin === 'human'))
+  );
+  if (!rules.length) return null;
+
+  // A person's own correction outranks anything inferred, then confidence.
+  rules.sort((a, b) => {
+    const weight = (n) => (n.origin === 'human' ? 2 : n.pinned ? 1.5 : 1);
+    return weight(b) * (b.confidence ?? 0.5) - weight(a) * (a.confidence ?? 0.5);
+  });
+
+  const lines = [];
+  let spent = 0;
+  let dropped = 0;
+  for (const rule of rules) {
+    const line = `- ${rule.claim}`;
+    const cost = estimate(line);
+    if (spent + cost > budget) {
+      dropped += 1;
+      continue;
+    }
+    lines.push(line);
+    spent += cost;
+  }
+  if (!lines.length) return null;
+
+  record(dir, { kind: 'standing', count: lines.length, dropped, tokens: spent });
+
+  // SAY WHAT WAS DROPPED. A silent cap reads as "these are all the rules",
+  // which is worse than saying there are more: a model that knows the list is
+  // truncated can ask, one that does not will assume it is complete.
+  const truncated = dropped
+    ? `\n(${dropped} further standing rule${dropped === 1 ? '' : 's'} did not fit this budget; ` +
+      `raise TOKEN_OPTIMIZER_STANDING_BUDGET or retire some.)`
+    : '';
+
+  return `# Standing rules for this project\n\nEstablished in previous sessions and expected to hold. These are not suggestions.\n\n${lines.join(
+    '\n'
+  )}${truncated}`;
 }
 
 /**

--- a/plugin/hooks/lib/inject.mjs
+++ b/plugin/hooks/lib/inject.mjs
@@ -396,8 +396,30 @@ export function standingRules(dir, graph, { budget = standingBudget() } = {}) {
     return weight(b) * (b.confidence ?? 0.5) - weight(a) * (a.confidence ?? 0.5);
   });
 
+  // THE BUDGET COVERS THE WHOLE MESSAGE, not just the claim lines.
+  //
+  // `spent` used to count selected claims only, while the returned text also
+  // carries a heading, two lines of fixed instruction and an optional
+  // truncation notice. A selection that exactly filled the budget therefore
+  // injected more than the budget allowed and recorded fewer tokens than it
+  // spent -- in a block whose entire justification is that it is tightly
+  // bounded and measured against the control arm.
+  const HEADING =
+    '# Standing rules for this project' +
+    '\n\nEstablished in previous sessions and expected to hold. ' +
+    'These are not suggestions.\n\n';
+  const noticeFor = (n) =>
+    n
+      ? `\n(${n} further standing rule${n === 1 ? '' : 's'} did not fit this budget; ` +
+        'raise TOKEN_OPTIMIZER_STANDING_BUDGET or retire some.)'
+      : '';
+
+  // The wrapper is charged up front, and the worst-case notice is reserved, so
+  // admitting the last line can never push the total over by adding one.
+  const overhead = estimate(HEADING) + estimate(noticeFor(rules.length));
+
   const lines = [];
-  let spent = 0;
+  let spent = overhead;
   let dropped = 0;
   for (const rule of rules) {
     const line = `- ${rule.claim}`;
@@ -409,21 +431,24 @@ export function standingRules(dir, graph, { budget = standingBudget() } = {}) {
     lines.push(line);
     spent += cost;
   }
-  if (!lines.length) return null;
 
-  record(dir, { kind: 'standing', count: lines.length, dropped, tokens: spent });
+  // RECORDED EVEN WHEN NOTHING FITS. Returning early without a metric hid the
+  // one case most worth knowing about: rules exist and every one is too large
+  // for the budget, so the block silently does nothing all session and the
+  // measurement shows no sign of it.
+  const truncated = noticeFor(dropped);
+  record(dir, {
+    kind: 'standing',
+    count: lines.length,
+    dropped,
+    tokens: lines.length ? spent : 0,
+  });
+  if (!lines.length) return null;
 
   // SAY WHAT WAS DROPPED. A silent cap reads as "these are all the rules",
   // which is worse than saying there are more: a model that knows the list is
   // truncated can ask, one that does not will assume it is complete.
-  const truncated = dropped
-    ? `\n(${dropped} further standing rule${dropped === 1 ? '' : 's'} did not fit this budget; ` +
-      `raise TOKEN_OPTIMIZER_STANDING_BUDGET or retire some.)`
-    : '';
-
-  return `# Standing rules for this project\n\nEstablished in previous sessions and expected to hold. These are not suggestions.\n\n${lines.join(
-    '\n'
-  )}${truncated}`;
+  return `${HEADING}${lines.join('\n')}${truncated}`;
 }
 
 /**

--- a/plugin/hooks/lib/lessons.mjs
+++ b/plugin/hooks/lib/lessons.mjs
@@ -98,24 +98,64 @@ export function buildFeedbackDigest(turns, { maxChars = 40_000 } = {}) {
   return out.length ? out.join('\n\n') : null;
 }
 
-/** True when the quote really appears in the archive, allowing for whitespace. */
+/**
+ * True when the quote really appears in the archive, allowing for whitespace.
+ *
+ * CASE IS PART OF VERBATIM. Lower-casing both sides accepted a quote whose
+ * capitalisation never occurred -- `NO, USE NPM TEST` matched a transcript
+ * saying `no, use npm test` -- and that quote then earned ORIGIN_HUMAN and 0.95
+ * confidence on the strength of a check it had not actually passed. The prompt
+ * asks for an exact copy, so this asks for one.
+ *
+ * Whitespace IS still normalised: line wrapping is an artefact of how the turn
+ * was stored, not something the user chose.
+ */
 export function quoteIsVerbatim(quote, turns) {
-  const needle = String(quote || '').trim().toLowerCase().replace(/\s+/g, ' ');
+  // A missing archive is not a match. `buildFeedbackDigest` guards its input in
+  // this same module; without the same guard here a null archive threw a
+  // TypeError out of a validator whose entire job is to reject bad input.
+  if (!Array.isArray(turns)) return false;
+  const needle = String(quote || '').trim().replace(/\s+/g, ' ');
   if (needle.length < 8) return false;
   return turns
-    .filter((t) => t.role === 'user')
-    .some((t) => String(t.text).toLowerCase().replace(/\s+/g, ' ').includes(needle));
+    .filter((t) => t && t.role === 'user')
+    .some((t) => String(t.text).replace(/\s+/g, ' ').includes(needle));
 }
 
-/** A claim that leads with a verb, which is what makes it act like an instruction. */
+/**
+ * A claim that leads with a bare verb, which is what makes it an instruction.
+ *
+ * A POSITIVE RULE, NOT A DENYLIST. The denylist rejected the openings a
+ * paraphrase usually starts with -- `the user prefers`, `you should` -- and
+ * accepted everything else, so `npm test is preferred over npx jest.` passed
+ * and was stored as a standing rule despite being a description rather than an
+ * instruction. Any noun-led sentence walked straight through.
+ *
+ * The test is now positive: the first word must be a bare verb form. That is
+ * still not a parts-of-speech tagger, but it fails CLOSED -- an unrecognised
+ * opening is rejected rather than admitted, which is the right direction for a
+ * gate on text that becomes an always-on instruction.
+ */
+const IMPERATIVE_VERBS = new Set([
+  'use', 'run', 'call', 'prefer', 'avoid', 'never', 'always', 'do', "don't", 'dont',
+  'stop', 'start', 'check', 'verify', 'confirm', 'read', 'write', 'edit', 'add',
+  'remove', 'delete', 'fix', 'keep', 'make', 'set', 'pass', 'build', 'test',
+  'install', 'update', 'rebase', 'merge', 'commit', 'push', 'pull', 'fetch',
+  'branch', 'open', 'close', 'ask', 'report', 'measure', 'record', 'skip',
+  'ignore', 'include', 'exclude', 'treat', 'assume', 'ensure', 'require',
+  'apply', 'revert', 'restore', 'replace', 'rename', 'move', 'copy', 'create',
+  'wait', 'retry', 'log', 'print', 'return', 'throw', 'catch', 'handle',
+  'quote', 'escape', 'sanitise', 'sanitize', 'validate', 'reject', 'accept',
+]);
+
 export function isImperative(claim) {
-  const first = String(claim || '').trim().split(/\s+/)[0] || '';
-  // Not a parts-of-speech tagger, and does not need to be: what it rejects is
-  // the shape corrections actually arrive in when a model paraphrases them --
-  // "the user prefers", "it is better to", "you should".
-  return !/^(the|a|an|it|this|that|there|you|we|i|user|users|when|because|since|although)$/i.test(
-    first
-  );
+  const first = String(claim || '')
+    .trim()
+    .split(/\s+/)[0]
+    .replace(/[^A-Za-z']/g, '')
+    .toLowerCase();
+  if (!first) return false;
+  return IMPERATIVE_VERBS.has(first);
 }
 
 /**

--- a/plugin/hooks/lib/lessons.mjs
+++ b/plugin/hooks/lib/lessons.mjs
@@ -1,0 +1,192 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/lessons.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Turning corrections into lessons the next session actually receives.
+ *
+ * The signal this exists to capture is sparse and specific: the moments where
+ * the user pushed back. Everything else in a session is ordinary work. Measured
+ * on one real session, the graph recorded 4,053 file touches and none of the
+ * three corrections the user actually gave -- which are the only turns that
+ * carried information the code could not.
+ *
+ * TWO THINGS THIS MODULE REFUSES TO GUESS.
+ *
+ * 1. WHO SAID IT. A lesson is stored as a human assertion only when the
+ *    extractor supplies the user's words verbatim AND those words are found in
+ *    the archive. curate.mjs warns that "a hand-written assertion and a machine
+ *    guess look identical three months later", and human origin carries the
+ *    highest ranking weight -- so claiming it on a model's paraphrase would let
+ *    an inference outrank the correction it was inferred from. Unverifiable
+ *    quotes still store, as ORIGIN_HARVESTED.
+ *
+ * 2. WHEN IT APPLIES. Every lesson must carry a trigger. A lesson with no
+ *    trigger can only surface if someone happens to open the file it is anchored
+ *    to, which is not when advice about doing something is needed.
+ *
+ * AND ONE THING IT INSISTS ON: the action first. Measured in the injection A/B,
+ * a correctly stored and correctly delivered finding was still ignored because
+ * its instruction sat at the end of three sentences of context. Delivery is
+ * necessary and not sufficient; phrasing is the other half.
+ */
+
+import { ORIGIN_HARVESTED, ORIGIN_HUMAN } from './curate.mjs';
+
+/** Lessons longer than this are prose, not instructions. */
+const MAX_CLAIM = 400;
+
+/**
+ * The extraction prompt.
+ *
+ * Deliberately narrow. Asked for "lessons" a model will summarise the session;
+ * asked for corrections it returns the handful of turns that actually taught
+ * something, which is the whole point of keeping the store sparse.
+ */
+export const LESSON_PROMPT = `You are reading a transcript between a user and a coding agent.
+
+Extract ONLY the moments where the USER corrected, rejected, or redirected the agent —
+where the agent did something the user did not want, and the user said so. Ignore
+ordinary instructions, questions, and approvals. Most transcripts contain between zero
+and five of these. Returning an empty list is a correct and common answer.
+
+For each correction return an object with:
+  "claim"   - the lesson, as an IMPERATIVE with the action FIRST. Start with a verb.
+              Not "the user prefers X because Y" but "Do X. Y is why."
+              Under ${MAX_CLAIM} characters. This is the sentence a future agent reads
+              at the moment it is about to make the same mistake, so it must lead with
+              what to do, not with background.
+  "quote"   - the user's own words that constitute the correction, copied EXACTLY from
+              the transcript. Do not paraphrase, do not fix typos, do not add quotes.
+  "trigger" - a JavaScript regex source matching the situation where this applies, e.g.
+              "\\\\bnpx\\\\s+jest\\\\b" or "git\\\\s+push" or "\\\\.csproj". If the lesson is about a
+              tool or command, match that. Required.
+  "anchors" - array of absolute file paths the lesson concerns. May be empty.
+
+Return ONLY a JSON array. No prose, no markdown fence.`;
+
+/**
+ * Builds the extractor input from archived turns.
+ *
+ * Assistant tool RESULTS never entered the archive, so they cannot enter here.
+ * What is sent is the conversation: what was asked, what was answered, and which
+ * commands were run.
+ */
+export function buildFeedbackDigest(turns, { maxChars = 40_000 } = {}) {
+  if (!Array.isArray(turns) || !turns.length) return null;
+
+  const rendered = turns.map((t) => {
+    if (t.role === 'user') return `USER: ${t.text}`;
+    const tools = (t.tools || [])
+      .map((x) => (x.command ? `${x.name}(${x.command})` : x.name))
+      .filter(Boolean)
+      .slice(0, 8)
+      .join(', ');
+    const head = t.text ? `AGENT: ${t.text}` : 'AGENT:';
+    return tools ? `${head}\n  [tools: ${tools}]` : head;
+  });
+
+  // KEEP THE END, not the beginning. Corrections cluster where the work went
+  // wrong, and a transcript that needed correcting tends to have gone wrong
+  // later rather than sooner.
+  let out = [];
+  let total = 0;
+  for (let i = rendered.length - 1; i >= 0; i--) {
+    const piece = rendered[i];
+    if (total + piece.length > maxChars) break;
+    out.unshift(piece);
+    total += piece.length;
+  }
+  return out.length ? out.join('\n\n') : null;
+}
+
+/** True when the quote really appears in the archive, allowing for whitespace. */
+export function quoteIsVerbatim(quote, turns) {
+  const needle = String(quote || '').trim().toLowerCase().replace(/\s+/g, ' ');
+  if (needle.length < 8) return false;
+  return turns
+    .filter((t) => t.role === 'user')
+    .some((t) => String(t.text).toLowerCase().replace(/\s+/g, ' ').includes(needle));
+}
+
+/** A claim that leads with a verb, which is what makes it act like an instruction. */
+export function isImperative(claim) {
+  const first = String(claim || '').trim().split(/\s+/)[0] || '';
+  // Not a parts-of-speech tagger, and does not need to be: what it rejects is
+  // the shape corrections actually arrive in when a model paraphrases them --
+  // "the user prefers", "it is better to", "you should".
+  return !/^(the|a|an|it|this|that|there|you|we|i|user|users|when|because|since|although)$/i.test(
+    first
+  );
+}
+
+/**
+ * Validates extractor output and decides each lesson's origin.
+ *
+ * Returns { lessons, rejected } so a caller can report what was dropped rather
+ * than silently storing less than it was given.
+ */
+export function validateLessons(raw, turns) {
+  let parsed = raw;
+  if (typeof raw === 'string') {
+    try {
+      parsed = JSON.parse(raw.replace(/^```(?:json)?\s*|\s*```$/g, ''));
+    } catch {
+      return { lessons: [], rejected: [{ reason: 'unparseable', raw: String(raw).slice(0, 200) }] };
+    }
+  }
+  if (!Array.isArray(parsed)) {
+    return { lessons: [], rejected: [{ reason: 'not-an-array' }] };
+  }
+
+  const lessons = [];
+  const rejected = [];
+
+  for (const item of parsed) {
+    const claim = String(item?.claim || '').trim();
+    const trigger = String(item?.trigger || '').trim();
+    const quote = String(item?.quote || '').trim();
+
+    if (claim.length < 12) {
+      rejected.push({ reason: 'claim-too-short', claim });
+      continue;
+    }
+    if (claim.length > MAX_CLAIM) {
+      rejected.push({ reason: 'claim-too-long', claim: claim.slice(0, 80) });
+      continue;
+    }
+    if (!trigger) {
+      // Without one it can only surface by file touch, which is not when advice
+      // about an action is needed.
+      rejected.push({ reason: 'no-trigger', claim: claim.slice(0, 80) });
+      continue;
+    }
+    try {
+      new RegExp(trigger);
+    } catch {
+      rejected.push({ reason: 'bad-trigger-regex', trigger });
+      continue;
+    }
+    if (!isImperative(claim)) {
+      rejected.push({ reason: 'not-imperative', claim: claim.slice(0, 80) });
+      continue;
+    }
+
+    // THE PROVENANCE TEST. Verbatim and present means the user really said it.
+    const verified = quoteIsVerbatim(quote, turns);
+
+    lessons.push({
+      type: 'feedback',
+      claim,
+      trigger,
+      quote: verified ? quote : undefined,
+      origin: verified ? ORIGIN_HUMAN : ORIGIN_HARVESTED,
+      // A verified human correction is as close to ground truth as this system
+      // gets. An unverified paraphrase is a model's reading of one.
+      confidence: verified ? 0.95 : 0.6,
+      anchors: Array.isArray(item?.anchors)
+        ? item.anchors.filter((a) => typeof a === 'string' && a.trim())
+        : [],
+    });
+  }
+
+  return { lessons, rejected };
+}

--- a/plugin/hooks/lib/transcript.mjs
+++ b/plugin/hooks/lib/transcript.mjs
@@ -1,0 +1,213 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/transcript.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * The raw local archive of what was asked and what was answered.
+ *
+ * THE ARCHIVE AND THE LESSONS ARE DIFFERENT THINGS, and keeping them separate
+ * is the whole design. The archive is complete and never retrieved; the lessons
+ * extracted from it are sparse and are the only thing ever injected. Storing
+ * everything AND retrieving everything would drown the graph -- a session is
+ * thousands of turns of ordinary work and a handful of moments that taught
+ * something. Storing everything and retrieving only the lessons keeps the record
+ * complete without diluting what gets served.
+ *
+ * NOTHING HERE LEAVES THE MACHINE. The archive is written inside the wiki
+ * directory, which already carries a `.gitignore` of `*`, and it is explicitly
+ * excluded from the harvest digest -- the one code path that sends anything to a
+ * model endpoint. A feedback loop must never become the reason a user's prompts
+ * are transmitted.
+ */
+
+import {
+  readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, readdirSync, statSync, unlinkSync,
+} from 'node:fs';
+import { join } from 'node:path';
+
+/** Where a project's transcripts live, under the graph it belongs to. */
+export const transcriptDir = (dir) => join(dir, 'transcripts');
+
+/**
+ * Total bytes of archive kept per project before the oldest are dropped.
+ *
+ * An unbounded archive of every session is a disk leak that grows fastest for
+ * the users who use the tool most, which is exactly backwards.
+ */
+const archiveBudget = () =>
+  Number(process.env.TOKEN_OPTIMIZER_TRANSCRIPT_BUDGET_BYTES) || 50 * 1024 * 1024;
+
+/** A session id reduced to something that cannot escape the archive directory. */
+export function safeName(sessionId) {
+  const safe = String(sessionId || 'unknown').replace(/[^A-Za-z0-9._-]/g, '_');
+  return (/^[.]+$/.test(safe) ? 'unknown' : safe).slice(0, 64);
+}
+
+/**
+ * Turns a Claude transcript into the prompt/response pairs worth keeping.
+ *
+ * TOOL RESULTS ARE DROPPED, for the same reason `buildDigest` drops them: that
+ * is where whole file contents would enter the record. The archive is meant to
+ * hold the conversation, not a second copy of the repository.
+ */
+export function readTurns(transcriptPath) {
+  let lines;
+  try {
+    lines = readFileSync(transcriptPath, 'utf8').split('\n');
+  } catch {
+    return [];
+  }
+
+  const turns = [];
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    let entry;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+
+    const message = entry.message || entry;
+    const role = message.role || entry.type;
+    const content = message.content;
+
+    if (role === 'user') {
+      const text =
+        typeof content === 'string'
+          ? content
+          : Array.isArray(content)
+            ? content
+                .filter((b) => b && b.type === 'text')
+                .map((b) => String(b.text))
+                .join('\n')
+            : '';
+      if (text.trim()) turns.push({ role: 'user', text: text.trim(), at: entry.timestamp ?? null });
+      continue;
+    }
+
+    if (role === 'assistant' && Array.isArray(content)) {
+      const text = content
+        .filter((b) => b && b.type === 'text')
+        .map((b) => String(b.text))
+        .join('\n');
+      const tools = content
+        .filter((b) => b && b.type === 'tool_use')
+        .map((b) => ({
+          name: b.name,
+          // Arguments only, never results, and truncated: a command is the
+          // useful part, its output is not.
+          command: b.input?.command ? String(b.input.command).slice(0, 300) : undefined,
+          path: b.input?.file_path || b.input?.path || undefined,
+        }));
+      if (text.trim() || tools.length) {
+        turns.push({ role: 'assistant', text: text.trim(), tools, at: entry.timestamp ?? null });
+      }
+    }
+  }
+  return turns;
+}
+
+/**
+ * Appends this session's turns to the project archive.
+ *
+ * Idempotent per session by rewriting that session's file, so a Stop hook firing
+ * repeatedly does not multiply the record.
+ */
+export function archive(dir, transcriptPath, { sessionId } = {}) {
+  const turns = readTurns(transcriptPath);
+  if (!turns.length) return 0;
+
+  const root = transcriptDir(dir);
+  try {
+    mkdirSync(root, { recursive: true, mode: 0o700 });
+    try {
+      chmodSync(root, 0o700);
+    } catch {
+      /* not POSIX, or not ours */
+    }
+  } catch {
+    return 0;
+  }
+
+  const file = join(root, `${safeName(sessionId)}.jsonl`);
+  try {
+    // Truncate-and-write rather than append: Stop fires many times per session
+    // and the transcript is cumulative, so appending would store the early turns
+    // once per firing.
+    const payload = turns.map((t) => JSON.stringify(t)).join('\n') + '\n';
+    writeFileSync(file, payload, { mode: 0o600 });
+  } catch {
+    return 0;
+  }
+
+  prune(root);
+  return turns.length;
+}
+
+/**
+ * Drops the oldest sessions once the archive exceeds its budget.
+ *
+ * Oldest-first, because the value of a transcript is highest while the work it
+ * describes is still live.
+ */
+export function prune(root, budget = archiveBudget()) {
+  let entries;
+  try {
+    entries = readdirSync(root)
+      .filter((f) => f.endsWith('.jsonl'))
+      .map((f) => {
+        const full = join(root, f);
+        try {
+          const s = statSync(full);
+          return { full, size: s.size, mtime: s.mtimeMs };
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch {
+    return 0;
+  }
+
+  let total = entries.reduce((a, e) => a + e.size, 0);
+  if (total <= budget) return 0;
+
+  entries.sort((a, b) => a.mtime - b.mtime);
+  let dropped = 0;
+  for (const e of entries) {
+    if (total <= budget) break;
+    try {
+      unlinkSync(e.full);
+      total -= e.size;
+      dropped += 1;
+    } catch {
+      /* leave it; a locked file must not stop the rest */
+    }
+  }
+  return dropped;
+}
+
+/** True when a path is inside a transcript archive -- the never-transmit test. */
+export function isArchived(path) {
+  return /[\\/]\.token-optimizer[\\/]wiki[\\/]transcripts[\\/]/.test(String(path));
+}
+
+/** Reads a session's archived turns back, for the lesson extractor. */
+export function readArchive(dir, sessionId) {
+  const file = join(transcriptDir(dir), `${safeName(sessionId)}.jsonl`);
+  if (!existsSync(file)) return [];
+  try {
+    return readFileSync(file, 'utf8')
+      .split('\n')
+      .filter(Boolean)
+      .map((l) => {
+        try {
+          return JSON.parse(l);
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}

--- a/plugin/hooks/pretooluse-router.mjs
+++ b/plugin/hooks/pretooluse-router.mjs
@@ -18,6 +18,7 @@ import { recordRead } from './lib/metrics.mjs';
 import { wikiDir, load, harvest, projectRootFor, contentHash } from './lib/wiki.mjs';
 import { refusalPayload, substitutionFor, forTouch, forCommand } from './lib/inject.mjs';
 import { indexFile } from './lib/staleness.mjs';
+import { isArchived } from './lib/transcript.mjs';
 import { readFileSync } from 'node:fs';
 
 /**
@@ -95,6 +96,19 @@ try {
     // makes no claims.
     for (const { path, size } of touched) {
       try {
+        // NEVER THE TRANSCRIPT ARCHIVE.
+        //
+        // Archived transcripts hold the user's own words verbatim. They are
+        // stored locally, gitignored, and deliberately never harvested -- but
+        // they are ordinary files on disk, so an agent that greps or opens one
+        // would land here and have it hashed, snapshotted and indexed into the
+        // graph, from which injection would later serve it back into context.
+        //
+        // `isArchived` is the test for exactly this, and it was enforcing
+        // nothing: written, tested, and called from nowhere. A privacy
+        // guarantee that no code path consults is not a guarantee.
+        if (isArchived(path)) continue;
+
         // CAPPED BEFORE THE READ. indexFile bounds the stored SNAPSHOT, not the
         // read that produces it, so a single huge operand -- a multi-hundred-
         // megabyte build log is the ordinary case -- would be slurped

--- a/plugin/hooks/session-start.mjs
+++ b/plugin/hooks/session-start.mjs
@@ -21,7 +21,9 @@
 import { mode, MODE_OFF, readPayload, loadState } from './lib/policy.mjs';
 import { policyText } from './lib/adapter.mjs';
 import { restorationPlan } from './lib/restore.mjs';
+import { standingRules } from './lib/inject.mjs';
 import { wikiDir, load, projectRootFor } from './lib/wiki.mjs';
+import { join } from 'node:path';
 
 if (mode() === MODE_OFF) process.exit(0);
 
@@ -73,8 +75,35 @@ async function restoration() {
   return plan?.text ?? null;
 }
 
+// THE TEXT ITSELF LIVES IN THE SHARED CORE. It used to be duplicated here,
+// which is exactly the drift the adapter was built to end: an addition to the
+// shared policy -- the project briefing, for instance -- reached the other five
+// clients and silently skipped Claude Code, the one client most users are on.
+// Claude Code keeps its own entry point because its PreToolUse router does more
+// than the shared one; the standing notice is not a place it needs to differ.
 const parts = [policyText(true)];
 
+// THE ALWAYS-ON HALF OF DELIVERY. Trigger-fired injection answers "this
+// situation is happening now", which cannot cover a rule about how the work is
+// conducted -- by the time a command matched a trigger, a turn governed by that
+// rule would already be going wrong. Those have to be present before the first
+// tool call or they do nothing.
+//
+// Deliberately narrow and tightly budgeted: only pinned facts and human-verified
+// corrections qualify. An always-on block that grows with the project is how it
+// becomes wallpaper, and a model stops reading what it always sees.
+try {
+  const cwd = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+  const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+  const rules = standingRules(dir, load(dir));
+  if (rules) parts.push(rules);
+} catch {
+  // The policy notice must still arrive if the graph is unreadable.
+}
+
+// THE SITUATIONAL HALF, LAST. Standing rules govern every turn; restoration
+// speaks only to a session resuming from a compaction, so it reads as the more
+// specific note after the general one.
 try {
   const restored = await restoration();
   if (restored) parts.push(restored);
@@ -82,12 +111,6 @@ try {
   // The policy notice must still arrive if anything above fails.
 }
 
-// THE TEXT ITSELF LIVES IN THE SHARED CORE. It used to be duplicated here,
-// which is exactly the drift the adapter was built to end: an addition to the
-// shared policy -- the project briefing, for instance -- reached the other five
-// clients and silently skipped Claude Code, the one client most users are on.
-// Claude Code keeps its own entry point because its PreToolUse router does more
-// than the shared one; the standing notice is not a place it needs to differ.
 process.stdout.write(
   JSON.stringify({
     hookSpecificOutput: {

--- a/plugin/hooks/stop-harvest.mjs
+++ b/plugin/hooks/stop-harvest.mjs
@@ -33,6 +33,8 @@ import { tmpdir, homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { mode, MODE_OFF } from './lib/policy.mjs';
 import { harvestEnabled, harvestMode } from './lib/harvest.mjs';
+import { archive } from './lib/transcript.mjs';
+import { wikiDir, projectRootFor } from './lib/wiki.mjs';
 
 /** What to tell the user, per reason the harvest is not running. */
 const OFF_REASON = {
@@ -228,6 +230,22 @@ async function main() {
 
   const transcript = payload.transcript_path;
   if (!transcript || !existsSync(transcript)) return;
+
+  // ARCHIVE FIRST, AND UNCONDITIONALLY. This is a local file copy: it costs no
+  // model call, spends no money, and sends nothing anywhere, so it must not sit
+  // behind the opt-in that exists to gate cost and disclosure. Gating it there
+  // would mean the record of what the user actually said is kept only for the
+  // users who opted into a paid feature, which is exactly backwards.
+  //
+  // It also has to happen before the early return below, or a session with
+  // harvesting off would archive nothing at all.
+  try {
+    archive(wikiDir(projectRootFor(join(payload.cwd || process.cwd(), '__session__'), payload.cwd)), transcript, {
+      sessionId: payload.session_id,
+    });
+  } catch {
+    // The archive is a convenience. Failing to write it must not affect Stop.
+  }
 
   if (!harvestEnabled()) {
     // Say it once, name the reason and the variable that changes it, and state

--- a/src/tools/intelligence/wiki-write.ts
+++ b/src/tools/intelligence/wiki-write.ts
@@ -66,7 +66,14 @@ export interface WikiWriteResult {
   error?: string;
 }
 
-const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map', 'feedback'];
+const FINDING_TYPES = [
+  'finding',
+  'decision',
+  'failure',
+  'command',
+  'map',
+  'feedback',
+];
 
 export async function wikiWrite(
   options: WikiWriteOptions

--- a/src/tools/intelligence/wiki-write.ts
+++ b/src/tools/intelligence/wiki-write.ts
@@ -66,7 +66,7 @@ export interface WikiWriteResult {
   error?: string;
 }
 
-const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map'];
+const FINDING_TYPES = ['finding', 'decision', 'failure', 'command', 'map', 'feedback'];
 
 export async function wikiWrite(
   options: WikiWriteOptions

--- a/tests/hooks/hooks-load.test.mjs
+++ b/tests/hooks/hooks-load.test.mjs
@@ -1,0 +1,117 @@
+/**
+ * Every hook entry point must actually load.
+ *
+ * A guard for the cheapest possible failure, added because it happened: an edit
+ * inserted a block into the MIDDLE of a `record(dir, {...})` call in
+ * harvest-worker.mjs, severing it. The file was not merely wrong, it was a
+ * SYNTAX ERROR -- it could not be parsed at all, so the detached harvest worker
+ * had been dead on arrival and the entire feedback pipeline with it.
+ *
+ * The full suite stayed green. Every test exercised the shared core through
+ * `hooks-core/`, and nothing imported the hook scripts themselves, so a file
+ * that could not be parsed was simply never parsed. Reported by CodeRabbit as a
+ * missing `wikiDir` import, which was the second defect in the same file and the
+ * one visible from a diff.
+ *
+ * `node --check` is not enough on its own: it validates syntax but not that the
+ * imports resolve, and a missing import is exactly the other half of what went
+ * wrong here. So each entry point is really imported, in a child process, with
+ * the environment set so it exits without doing any work.
+ */
+import { describe, it, expect } from '@jest/globals';
+import { spawnSync } from 'child_process';
+import { readdirSync, existsSync } from 'fs';
+import { join } from 'path';
+import { ESLint } from 'eslint';
+
+const HOOK_DIRS = [
+  'plugin/hooks',
+  'integrations/codex/hooks',
+  'integrations/codex/plugin/hooks',
+  'integrations/gemini/hooks',
+  'integrations/qwen/hooks',
+  'integrations/opencode/hooks',
+];
+
+function entryPoints() {
+  const out = [];
+  for (const dir of HOOK_DIRS) {
+    const full = join(process.cwd(), dir);
+    if (!existsSync(full)) continue;
+    for (const name of readdirSync(full)) {
+      // `lib/` is the vendored core and is covered by the suites that use it.
+      if (name.endsWith('.mjs')) out.push(join(dir, name));
+    }
+  }
+  return out;
+}
+
+const ENTRIES = entryPoints();
+
+describe('hook entry points', () => {
+  it('finds some to check, so an empty list cannot pass vacuously', () => {
+    expect(ENTRIES.length).toBeGreaterThan(5);
+  });
+
+  it.each(ENTRIES)('%s parses and its imports resolve', (rel) => {
+    // TOKEN_OPTIMIZER_MODE=off makes every entry point exit at its first line,
+    // so this measures loadability and nothing else -- no graph is touched and
+    // no work is done.
+    const r = spawnSync(process.execPath, [join(process.cwd(), rel)], {
+      input: '{}',
+      encoding: 'utf8',
+      timeout: 30_000,
+      env: { ...process.env, TOKEN_OPTIMIZER_MODE: 'off' },
+    });
+
+    const stderr = String(r.stderr || '');
+    expect(stderr).not.toMatch(/SyntaxError/);
+    expect(stderr).not.toMatch(/ERR_MODULE_NOT_FOUND/);
+    expect(stderr).not.toMatch(/ReferenceError/);
+    expect(stderr).not.toMatch(/is not defined/);
+    // Fail open is the contract: a hook must never break the turn it runs in.
+    expect(r.status).toBe(0);
+  }, 60_000);
+});
+
+describe('no hook entry point references an undefined name', () => {
+  // RUNNING THE HOOK IS NOT ENOUGH, which I established by trying it. Removing
+  // the `wikiDir` import from harvest-worker.mjs leaves the loadability test
+  // above completely green: `main()` returns early when it is handed no
+  // transcript, so the line that would throw is never reached. The same shape
+  // hid a missing `join` import in precompact-optimize.mjs, where the only
+  // caller sat behind a CLAUDE_PLUGIN_ROOT check.
+  //
+  // A fail-open hook is precisely the kind of program whose body does not run
+  // in a smoke test, so this is checked statically instead. `npm run lint`
+  // covers `src` only, which is why nothing was watching these files.
+  it('passes no-undef across every hook directory', async () => {
+    const eslint = new ESLint({
+      overrideConfigFile: true,
+      overrideConfig: {
+        languageOptions: {
+          ecmaVersion: 'latest',
+          sourceType: 'module',
+          globals: {
+            process: 'readonly', console: 'readonly', URL: 'readonly',
+            Buffer: 'readonly', setTimeout: 'readonly', clearTimeout: 'readonly',
+            setInterval: 'readonly', clearInterval: 'readonly',
+            TextEncoder: 'readonly', TextDecoder: 'readonly', fetch: 'readonly',
+            AbortController: 'readonly', SharedArrayBuffer: 'readonly',
+            Int32Array: 'readonly', Atomics: 'readonly', structuredClone: 'readonly',
+          },
+        },
+        rules: { 'no-undef': 'error' },
+      },
+    });
+
+    const results = await eslint.lintFiles(HOOK_DIRS.map((d) => `${d}/*.mjs`));
+    const problems = results.flatMap((r) =>
+      r.messages.map((m) => `${r.filePath}:${m.line} ${m.message}`)
+    );
+
+    // A glob that matched nothing would report zero problems and pass.
+    expect(results.length).toBeGreaterThan(5);
+    expect(problems).toEqual([]);
+  }, 120_000);
+});

--- a/tests/hooks/lessons.test.mjs
+++ b/tests/hooks/lessons.test.mjs
@@ -15,6 +15,12 @@ import {
   LESSON_PROMPT,
 } from '../../hooks-core/lessons.mjs';
 import { ORIGIN_HUMAN, ORIGIN_HARVESTED } from '../../hooks-core/curate.mjs';
+import { writeHarvested } from '../../hooks-core/harvest-write.mjs';
+import { standingRules } from '../../hooks-core/inject.mjs';
+import { wikiDir, load, putNode } from '../../hooks-core/wiki.mjs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
 
 const TURNS = [
   { role: 'user', text: 'run the unit tests please' },
@@ -170,3 +176,116 @@ describe('malformed extractor output', () => {
     expect(lessons[0].origin).toBe(ORIGIN_HUMAN);
   });
 });
+
+describe('the checks the review found were passable without passing', () => {
+  const TURNS = [{ role: 'user', text: 'no, use npm test not npx jest' }];
+
+  it('rejects a quote whose capitalisation never occurred', () => {
+    // Both sides were lower-cased before comparing, so a quote the user never
+    // typed satisfied a VERBATIM check -- and then earned ORIGIN_HUMAN and 0.95
+    // confidence on the strength of it. The prompt asks for an exact copy.
+    expect(quoteIsVerbatim('use npm test not npx jest', TURNS)).toBe(true);
+    expect(quoteIsVerbatim('USE NPM TEST NOT NPX JEST', TURNS)).toBe(false);
+    expect(quoteIsVerbatim('Use Npm Test Not Npx Jest', TURNS)).toBe(false);
+  });
+
+  it('still forgives whitespace, which the storage layer chose, not the user', () => {
+    expect(quoteIsVerbatim('use  npm   test' + String.fromCharCode(92) + 'n not npx jest'.trim(), TURNS)).toBe(false);
+    expect(quoteIsVerbatim('use  npm  test  not  npx  jest', TURNS)).toBe(true);
+  });
+
+  it('does not throw when there is no archive to check against', () => {
+    expect(() => quoteIsVerbatim('use npm test', null)).not.toThrow();
+    expect(quoteIsVerbatim('use npm test', null)).toBe(false);
+    expect(quoteIsVerbatim('use npm test', undefined)).toBe(false);
+  });
+
+  it('rejects a noun-led description that merely avoids the denylist', () => {
+    // The old rule listed the openings a paraphrase usually starts with and
+    // accepted everything else, so any noun-led sentence walked through and was
+    // stored as a standing rule despite describing rather than instructing.
+    expect(isImperative('npm test is preferred over npx jest.')).toBe(false);
+    expect(isImperative('jest runs faster than the npm wrapper.')).toBe(false);
+    expect(isImperative('builds should be run from the worktree.')).toBe(false);
+
+    // And still accepts the shape a real instruction has.
+    expect(isImperative('Use npm test, not npx jest.')).toBe(true);
+    expect(isImperative('Never force-push a shared branch.')).toBe(true);
+    expect(isImperative('Verify the refspec before trusting a fetch.')).toBe(true);
+  });
+
+  it('fails closed on an opening it does not recognise', () => {
+    // The direction matters more than the coverage: this text becomes an
+    // always-on instruction, so an unrecognised opening is refused rather than
+    // admitted.
+    expect(isImperative('frobnicate the widget.')).toBe(false);
+    expect(isImperative('')).toBe(false);
+  });
+});
+
+describe('a verified correction survives the write boundary', () => {
+  // THE FINDING THAT MADE THE WHOLE FEATURE INERT. `validateLessons` computed a
+  // per-lesson origin and kept the verified quote; `writeHarvested` took ONE
+  // origin from its options and persisted no quote at all. So every lesson
+  // landed as ORIGIN_HARVESTED, the standing-rules layer selects on human
+  // origin, and it therefore matched nothing this pipeline had ever written.
+  // The verbatim check ran and had no observable effect.
+  //
+  // This drives the real write path and then the real selector, because both
+  // halves passed their own unit tests for the entire time the pair did nothing.
+  it('is stored as human, keeps its evidence, and reaches the standing rules', () => {
+    const project = mkdtempSync(join(tmpdir(), 'lesson-origin-'));
+    mkdirSync(join(project, '.git'), { recursive: true });
+    const dir = join(project, '.token-optimizer', 'wiki');
+    mkdirSync(dir, { recursive: true });
+
+    const anchor = join(project, 'a.ts');
+    writeFileSync(anchor, 'export const a = 1;');
+    putNode(dir, { kind: 'file', key: anchor, hash: 'h' });
+
+    const written = writeHarvested(
+      dir,
+      [
+        {
+          type: 'feedback',
+          claim: 'Use npm test, not npx jest.',
+          confidence: 0.95,
+          origin: ORIGIN_HUMAN,
+          quote: 'no, use npm test not npx jest',
+          anchors: [anchor],
+        },
+        {
+          type: 'feedback',
+          claim: 'Prefer the worktree build.',
+          confidence: 0.6,
+          origin: ORIGIN_HARVESTED,
+          anchors: [anchor],
+        },
+      ],
+      // The batch default is still HARVESTED, exactly as the worker passes it.
+      { sessionId: 's1', origin: ORIGIN_HARVESTED }
+    );
+    expect(written).toHaveLength(2);
+
+    const graph = load(dir);
+    const findings = [...graph.nodes.values()].filter((n) => n.kind === 'finding');
+    const verified = findings.find((n) => n.claim.startsWith('Use npm test'));
+    const paraphrase = findings.find((n) => n.claim.startsWith('Prefer the worktree'));
+
+    // The verified one is promoted, and carries the evidence that promoted it.
+    expect(verified.origin).toBe(ORIGIN_HUMAN);
+    expect(verified.quote).toBe('no, use npm test not npx jest');
+
+    // The unverified one is NOT promoted. A caller cannot simply declare
+    // machine output human; it is the quote that earns it.
+    expect(paraphrase.origin).toBe(ORIGIN_HARVESTED);
+    expect(paraphrase.quote).toBeUndefined();
+
+    // And the selector that exists to consume it now finds it.
+    const rules = standingRules(dir, load(dir));
+    expect(rules).toContain('Use npm test, not npx jest.');
+    expect(rules).not.toContain('Prefer the worktree build.');
+
+    rmSync(project, { recursive: true, force: true });
+  }, 60_000);
+});

--- a/tests/hooks/lessons.test.mjs
+++ b/tests/hooks/lessons.test.mjs
@@ -1,0 +1,172 @@
+/**
+ * The feedback loop's two refusals, and the phrasing rule the A/B forced.
+ *
+ * A correction is the highest-value thing a session produces and the easiest to
+ * mislabel. These pin the guarantees: human origin is claimed only on a quote
+ * that is actually in the transcript, every lesson carries a trigger, and the
+ * claim leads with the action rather than burying it.
+ */
+import { describe, it, expect } from '@jest/globals';
+import {
+  buildFeedbackDigest,
+  quoteIsVerbatim,
+  isImperative,
+  validateLessons,
+  LESSON_PROMPT,
+} from '../../hooks-core/lessons.mjs';
+import { ORIGIN_HUMAN, ORIGIN_HARVESTED } from '../../hooks-core/curate.mjs';
+
+const TURNS = [
+  { role: 'user', text: 'run the unit tests please' },
+  { role: 'assistant', text: 'Running them.', tools: [{ name: 'Bash', command: 'npx jest tests/' }] },
+  {
+    role: 'user',
+    text: 'no, use npm test — bare npx jest silently skips the ESM suites in this repo',
+  },
+  { role: 'assistant', text: 'You are right, re-running.', tools: [{ name: 'Bash', command: 'npm test' }] },
+];
+
+describe('provenance', () => {
+  it('claims human origin only when the quote is really in the transcript', () => {
+    const { lessons } = validateLessons(
+      [
+        {
+          claim: 'Run npm test, not npx jest. Bare jest skips the ESM suites here.',
+          quote: 'no, use npm test',
+          trigger: '\\bnpx\\s+jest\\b',
+          anchors: [],
+        },
+      ],
+      TURNS
+    );
+
+    expect(lessons).toHaveLength(1);
+    expect(lessons[0].origin).toBe(ORIGIN_HUMAN);
+    expect(lessons[0].confidence).toBe(0.95);
+    expect(lessons[0].quote).toBe('no, use npm test');
+  });
+
+  it('demotes a paraphrase to harvested rather than letting it outrank its source', () => {
+    // Human findings carry the highest ranking weight. A model's reading of a
+    // correction must not be stored as the correction itself.
+    const { lessons } = validateLessons(
+      [
+        {
+          claim: 'Run npm test, not npx jest.',
+          quote: 'the user said to prefer npm test over npx jest',
+          trigger: '\\bnpx\\s+jest\\b',
+        },
+      ],
+      TURNS
+    );
+
+    expect(lessons).toHaveLength(1);
+    expect(lessons[0].origin).toBe(ORIGIN_HARVESTED);
+    expect(lessons[0].confidence).toBeLessThan(0.95);
+    expect(lessons[0].quote).toBeUndefined();
+  });
+
+  it('ignores assistant text when verifying a quote', () => {
+    // Otherwise the agent could "verify" its own words as the user's.
+    expect(quoteIsVerbatim('You are right, re-running.', TURNS)).toBe(false);
+  });
+
+  it('tolerates whitespace differences but not rewording', () => {
+    expect(quoteIsVerbatim('no,   use   npm test', TURNS)).toBe(true);
+    expect(quoteIsVerbatim('please use npm test', TURNS)).toBe(false);
+  });
+});
+
+describe('the phrasing rule', () => {
+  it('accepts a claim that leads with the action', () => {
+    expect(isImperative('Run npm test, not npx jest.')).toBe(true);
+    expect(isImperative('Check mergeStateStatus before investigating CI.')).toBe(true);
+  });
+
+  it('rejects claims that bury the action behind context', () => {
+    // The A/B case that failed even when correctly delivered read exactly like
+    // these: the instruction arrived after three sentences of background.
+    expect(isImperative('The user prefers npm test over npx jest.')).toBe(false);
+    expect(isImperative('It is better to run npm test here.')).toBe(false);
+    expect(isImperative('You should check mergeStateStatus.')).toBe(false);
+  });
+
+  it('drops a non-imperative lesson and says why', () => {
+    const { lessons, rejected } = validateLessons(
+      [{ claim: 'The user prefers npm test to npx jest.', quote: 'no, use npm test', trigger: 'jest' }],
+      TURNS
+    );
+    expect(lessons).toHaveLength(0);
+    expect(rejected[0].reason).toBe('not-imperative');
+  });
+});
+
+describe('triggers are mandatory', () => {
+  it('rejects a lesson with no trigger', () => {
+    const { lessons, rejected } = validateLessons(
+      [{ claim: 'Run npm test, not npx jest.', quote: 'no, use npm test' }],
+      TURNS
+    );
+    expect(lessons).toHaveLength(0);
+    expect(rejected[0].reason).toBe('no-trigger');
+  });
+
+  it('rejects a trigger that is not a valid regex', () => {
+    const { lessons, rejected } = validateLessons(
+      [{ claim: 'Run npm test.', quote: 'no, use npm test', trigger: '([unclosed' }],
+      TURNS
+    );
+    expect(lessons).toHaveLength(0);
+    expect(rejected[0].reason).toBe('bad-trigger-regex');
+  });
+});
+
+describe('extractor input', () => {
+  it('renders the conversation with commands but never tool results', () => {
+    const digest = buildFeedbackDigest(TURNS);
+    expect(digest).toContain('USER: run the unit tests please');
+    expect(digest).toContain('npx jest tests/');
+    // Nothing in the archive carries results, so nothing can leak through here.
+    expect(digest).not.toMatch(/PASS|FAIL|Tests:/);
+  });
+
+  it('keeps the END of a long transcript, where corrections cluster', () => {
+    const many = [];
+    for (let i = 0; i < 500; i++) many.push({ role: 'user', text: `filler turn ${i} ${'x'.repeat(200)}` });
+    many.push({ role: 'user', text: 'THE CORRECTION AT THE END' });
+
+    const digest = buildFeedbackDigest(many, { maxChars: 2000 });
+    expect(digest).toContain('THE CORRECTION AT THE END');
+    expect(digest).not.toContain('filler turn 0 ');
+  });
+
+  it('returns null for an empty session rather than prompting on nothing', () => {
+    expect(buildFeedbackDigest([])).toBeNull();
+  });
+});
+
+describe('the prompt itself', () => {
+  it('asks for the action first and for a verbatim quote', () => {
+    // The two properties everything downstream depends on.
+    expect(LESSON_PROMPT).toMatch(/IMPERATIVE with the action FIRST/);
+    expect(LESSON_PROMPT).toMatch(/copied EXACTLY/);
+    // And it must make an empty answer feel correct, or it will invent lessons.
+    expect(LESSON_PROMPT).toMatch(/empty list is a correct and common answer/);
+  });
+});
+
+describe('malformed extractor output', () => {
+  it('survives unparseable JSON', () => {
+    const { lessons, rejected } = validateLessons('not json at all', TURNS);
+    expect(lessons).toHaveLength(0);
+    expect(rejected[0].reason).toBe('unparseable');
+  });
+
+  it('strips a markdown fence the model added anyway', () => {
+    const raw =
+      '```json\n[{"claim":"Run npm test, not npx jest.","quote":"no, use npm test","trigger":"jest"}]\n```';
+    const { lessons } = validateLessons(raw, TURNS);
+    expect(lessons).toHaveLength(1);
+    expect(lessons[0].origin).toBe(ORIGIN_HUMAN);
+  });
+});

--- a/tests/hooks/standing-rules.test.mjs
+++ b/tests/hooks/standing-rules.test.mjs
@@ -140,7 +140,14 @@ describe('through the real SessionStart hook', () => {
     // called by nothing for its entire life.
     const project = mkdtempSync(join(tmpdir(), 'standing-e2e-'));
     mkdirSync(join(project, '.git'), { recursive: true });
-    const graphDir = wikiDir(project);
+    // EXPLICIT, NOT `wikiDir(project)`. `wikiDir` honours an inherited
+    // TOKEN_OPTIMIZER_WIKI_DIR, so on a machine where that is set -- which is
+    // any machine actually using the tool -- this fixture appended three test
+    // findings to the developer's real persistent graph and then handed that
+    // graph to the child hook. Cleanup only removes the temporary project, so
+    // the findings stayed behind and leaked into later sessions.
+    const graphDir = join(project, '.token-optimizer', 'wiki');
+    mkdirSync(graphDir, { recursive: true });
 
     putNode(graphDir, {
       kind: 'finding', key: 'h1', type: 'feedback', origin: 'human', confidence: 0.95,

--- a/tests/hooks/standing-rules.test.mjs
+++ b/tests/hooks/standing-rules.test.mjs
@@ -1,0 +1,175 @@
+/**
+ * The always-on set, and why it has to stay small.
+ *
+ * Trigger-fired injection answers "this situation is happening now". Some rules
+ * are not about a situation at all -- they govern how every turn is conducted --
+ * and by the time a command matched a trigger, a turn governed by such a rule
+ * would already be going wrong. Those must arrive before the first tool call.
+ *
+ * The danger is the opposite one: an always-on block that grows with the project
+ * until the model stops reading the thing it always sees. So the qualifying set
+ * is narrow and the budget is fixed rather than earned.
+ */
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { standingRules } from '../../hooks-core/inject.mjs';
+import { load, putNode, wikiDir } from '../../hooks-core/wiki.mjs';
+import { spawnSync } from 'child_process';
+import { mkdtempSync, rmSync, readFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+let dir;
+
+function seed(props) {
+  return putNode(dir, { kind: 'finding', confidence: 0.9, ...props });
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'standing-'));
+});
+
+afterEach(() => {
+  try {
+    rmSync(dir, { recursive: true, force: true });
+  } catch {
+    /* windows can hold a handle briefly */
+  }
+});
+
+describe('what qualifies', () => {
+  it('includes a pinned finding', () => {
+    seed({ key: 'p1', claim: 'Build against an isolated worktree, never live WIP.', pinned: true });
+    const out = standingRules(dir, load(dir));
+    expect(out).toContain('isolated worktree');
+  });
+
+  it('includes a human-verified feedback lesson', () => {
+    seed({
+      key: 'f1',
+      claim: 'Report the number you measured, not the one you expected.',
+      type: 'feedback',
+      origin: 'human',
+    });
+    expect(standingRules(dir, load(dir))).toContain('Report the number you measured');
+  });
+
+  it('excludes a feedback lesson whose quote was never verified', () => {
+    // Stored as harvested because the quote could not be found in the archive.
+    // A model's paraphrase of a correction is not a standing rule.
+    seed({
+      key: 'f2',
+      claim: 'Prefer the thing the user seemed to want.',
+      type: 'feedback',
+      origin: 'harvested',
+    });
+    expect(standingRules(dir, load(dir))).toBeNull();
+  });
+
+  it('excludes ordinary findings, which wait for their trigger', () => {
+    seed({ key: 'c1', claim: 'Run npm test, not npx jest.', type: 'command', trigger: 'jest' });
+    seed({ key: 'm1', claim: 'The harvest builds a digest and calls a model.', type: 'map' });
+    expect(standingRules(dir, load(dir))).toBeNull();
+  });
+
+  it('excludes a retired rule even if it was pinned', () => {
+    // Retirement is how a person withdraws a claim. The always-on block is the
+    // first thing read, so a withdrawn rule appearing there is the worst place
+    // for it to survive.
+    seed({ key: 'p2', claim: 'An old rule.', pinned: true, retired: true });
+    expect(standingRules(dir, load(dir))).toBeNull();
+  });
+});
+
+describe('ordering', () => {
+  it("puts a person's own correction above an inferred pin", () => {
+    seed({ key: 'pin', claim: 'PINNED RULE', pinned: true, confidence: 0.99 });
+    seed({
+      key: 'human',
+      claim: 'HUMAN RULE',
+      type: 'feedback',
+      origin: 'human',
+      confidence: 0.9,
+    });
+
+    const out = standingRules(dir, load(dir));
+    expect(out.indexOf('HUMAN RULE')).toBeLessThan(out.indexOf('PINNED RULE'));
+  });
+});
+
+describe('the budget', () => {
+  it('never exceeds it, and says how many were dropped', () => {
+    for (let i = 0; i < 40; i++) {
+      seed({ key: `p${i}`, claim: `Rule number ${i}: ${'x'.repeat(120)}`, pinned: true });
+    }
+
+    const out = standingRules(dir, load(dir), { budget: 200 });
+    expect(out).toBeTruthy();
+    // A silent cap reads as "these are all the rules", which is worse than
+    // admitting the list is truncated.
+    expect(out).toMatch(/further standing rule/);
+    expect(out).toMatch(/TOKEN_OPTIMIZER_STANDING_BUDGET/);
+    // Roughly within budget: 4 chars per token, plus the truncation notice.
+    expect(out.length).toBeLessThan(200 * 4 + 400);
+  });
+
+  it('says nothing at all when there are no standing rules', () => {
+    seed({ key: 'x', claim: 'ordinary', type: 'command' });
+    expect(standingRules(dir, load(dir))).toBeNull();
+  });
+
+  it('records what the always-on block cost, so it can be judged later', () => {
+    seed({ key: 'p1', claim: 'A pinned rule that costs tokens every session.', pinned: true });
+    standingRules(dir, load(dir));
+
+    const rows = readFileSync(join(dir, 'metrics.jsonl'), 'utf8')
+      .split('\n')
+      .filter(Boolean)
+      .map((l) => JSON.parse(l))
+      .filter((r) => r.kind === 'standing');
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].count).toBe(1);
+    expect(rows[0].tokens).toBeGreaterThan(0);
+  });
+});
+
+describe('through the real SessionStart hook', () => {
+  it('delivers standing rules alongside the policy notice, and nothing else', () => {
+    // The unit tests prove the selection. This proves the hook actually emits
+    // it -- the distinction that mattered for forTouch, which was correct and
+    // called by nothing for its entire life.
+    const project = mkdtempSync(join(tmpdir(), 'standing-e2e-'));
+    mkdirSync(join(project, '.git'), { recursive: true });
+    const graphDir = wikiDir(project);
+
+    putNode(graphDir, {
+      kind: 'finding', key: 'h1', type: 'feedback', origin: 'human', confidence: 0.95,
+      claim: 'Report the number you measured, not the one you expected.',
+    });
+    putNode(graphDir, {
+      kind: 'finding', key: 'p1', pinned: true, confidence: 0.9,
+      claim: 'Build against an isolated worktree, never live WIP.',
+    });
+    putNode(graphDir, {
+      kind: 'finding', key: 'c1', type: 'command', trigger: 'jest', confidence: 0.95,
+      claim: 'Run npm test, not npx jest.',
+    });
+
+    const r = spawnSync(process.execPath, [join(process.cwd(), 'plugin', 'hooks', 'session-start.mjs')], {
+      input: '{}',
+      encoding: 'utf8',
+      timeout: 30_000,
+      env: { ...process.env, TOKEN_OPTIMIZER_WIKI_DIR: graphDir, CLAUDE_PROJECT_DIR: project },
+    });
+
+    const ctx = JSON.parse(r.stdout || '{}')?.hookSpecificOutput?.additionalContext || '';
+    expect(ctx).toContain('# Standing rules');
+    expect(ctx).toContain('Report the number you measured');
+    expect(ctx).toContain('isolated worktree');
+    // A situational finding must NOT be in the always-on block; it waits for
+    // its trigger, which is the whole reason the always-on set can stay small.
+    expect(ctx).not.toContain('npx jest');
+
+    try { rmSync(project, { recursive: true, force: true }); } catch { /* windows */ }
+  });
+});

--- a/tests/hooks/transcript.test.mjs
+++ b/tests/hooks/transcript.test.mjs
@@ -14,6 +14,7 @@ import { mkdtempSync, rmSync, writeFileSync, readdirSync, existsSync, mkdirSync 
 import { join, dirname, resolve } from 'path';
 import { tmpdir } from 'os';
 import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
 import { load, nodeId } from '../../hooks-core/wiki.mjs';
 
 let dir;
@@ -185,8 +186,19 @@ describe('the never-transmit guarantee is enforced, not merely stated', () => {
     const ordinary = join(project, 'ordinary.ts');
     writeFileSync(ordinary, 'export const ordinary = 1;\n');
 
-    const router = resolve(dirname(new URL(import.meta.url).pathname.slice(1)),
-      '..', '..', 'plugin', 'hooks', 'pretooluse-router.mjs');
+    // `fileURLToPath`, NOT `pathname.slice(1)`. Stripping the leading slash is
+    // right for a Windows file URL (`/C:/...`) and wrong everywhere else, where
+    // it turns `/home/runner/...` into a relative path -- so the router was
+    // never spawned on CI and the CONTROL assertion failed, which is the only
+    // reason this was caught rather than passing vacuously.
+    const router = resolve(
+      dirname(fileURLToPath(import.meta.url)),
+      '..',
+      '..',
+      'plugin',
+      'hooks',
+      'pretooluse-router.mjs'
+    );
 
     for (const target of [archived, ordinary]) {
       spawnSync(process.execPath, [router], {

--- a/tests/hooks/transcript.test.mjs
+++ b/tests/hooks/transcript.test.mjs
@@ -13,6 +13,8 @@ import {
 import { mkdtempSync, rmSync, writeFileSync, readdirSync, existsSync, mkdirSync } from 'fs';
 import { join, dirname, resolve } from 'path';
 import { tmpdir } from 'os';
+import { spawnSync } from 'child_process';
+import { load, nodeId } from '../../hooks-core/wiki.mjs';
 
 let dir;
 let transcript;
@@ -150,4 +152,76 @@ describe('prune', () => {
     expect(prune(root, 1_000_000)).toBe(0);
     expect(readdirSync(root)).toHaveLength(1);
   });
+});
+
+describe('the never-transmit guarantee is enforced, not merely stated', () => {
+  it('does not harvest a transcript the agent happens to open', () => {
+    // `isArchived` is the test for "this path is a stored conversation". It was
+    // written, unit-tested, and called from NOWHERE -- so the guarantee it
+    // describes was enforced by nothing.
+    //
+    // The exposure is ordinary, not exotic: archived transcripts are plain
+    // files on disk. An agent that greps the project or opens one to look at it
+    // sends it through the PreToolUse router, which hashes, snapshots and
+    // indexes every file it lets through. The user's own words would land in
+    // the graph, and injection would later serve them back into context.
+    //
+    // So this drives the REAL router at a real archive path and asserts the
+    // graph never learned it. Unit-testing `isArchived` cannot show this: the
+    // function was always correct, it was simply never asked.
+    const project = mkdtempSync(join(tmpdir(), 'archive-leak-'));
+    mkdirSync(join(project, '.git'), { recursive: true });
+    const graph = mkdtempSync(join(tmpdir(), 'archive-graph-'));
+
+    const archived = join(project, '.token-optimizer', 'wiki', 'transcripts', 's-old.jsonl');
+    mkdirSync(dirname(archived), { recursive: true });
+    writeFileSync(
+      archived,
+      JSON.stringify({ prompt: 'my AWS key is AKIAEXAMPLE', response: 'noted' }) + '\n'
+    );
+
+    // A normal file in the same session, to prove the router was working at all
+    // and the archive was skipped specifically.
+    const ordinary = join(project, 'ordinary.ts');
+    writeFileSync(ordinary, 'export const ordinary = 1;\n');
+
+    const router = resolve(dirname(new URL(import.meta.url).pathname.slice(1)),
+      '..', '..', 'plugin', 'hooks', 'pretooluse-router.mjs');
+
+    for (const target of [archived, ordinary]) {
+      spawnSync(process.execPath, [router], {
+        input: JSON.stringify({
+          session_id: 's-archive-leak',
+          cwd: project,
+          tool_name: 'Read',
+          tool_input: { file_path: target },
+        }),
+        encoding: 'utf8',
+        timeout: 30_000,
+        env: { ...process.env, TOKEN_OPTIMIZER_WIKI_DIR: graph },
+      });
+    }
+
+    const g = load(graph);
+    const keys = [...g.nodes.values()].filter((n) => n.kind === 'file').map((n) => n.key);
+
+    // The control: the router did run and did harvest.
+    expect(keys.some((k) => k.endsWith('ordinary.ts'))).toBe(true);
+
+    // The guarantee: nothing about the archive, under any spelling.
+    expect(g.nodes.has(nodeId('file', archived))).toBe(false);
+    expect(keys.some((k) => k.includes('transcripts'))).toBe(false);
+
+    // And its contents were never stored anywhere in the graph.
+    const dump = JSON.stringify([...g.nodes.values()]);
+    expect(dump).not.toContain('AKIAEXAMPLE');
+
+    for (const d of [project, graph]) {
+      try {
+        rmSync(d, { recursive: true, force: true });
+      } catch {
+        /* windows */
+      }
+    }
+  }, 60_000);
 });

--- a/tests/hooks/transcript.test.mjs
+++ b/tests/hooks/transcript.test.mjs
@@ -1,0 +1,153 @@
+/**
+ * The archive: complete, local, and never transmitted.
+ *
+ * Storing the whole conversation is only defensible if two things hold. It must
+ * never leave the machine, and it must never be what gets retrieved -- the
+ * lessons extracted from it are. A store that is both complete and retrievable
+ * would drown injection in thousands of ordinary turns.
+ */
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import {
+  readTurns, archive, readArchive, prune, isArchived, transcriptDir, safeName,
+} from '../../hooks-core/transcript.mjs';
+import { mkdtempSync, rmSync, writeFileSync, readdirSync, existsSync, mkdirSync } from 'fs';
+import { join, dirname, resolve } from 'path';
+import { tmpdir } from 'os';
+
+let dir;
+let transcript;
+
+/** A Claude transcript: JSONL, one message per line. */
+function writeTranscript(entries) {
+  const p = join(dir, 'transcript.jsonl');
+  writeFileSync(p, entries.map((e) => JSON.stringify(e)).join('\n') + '\n');
+  return p;
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'transcript-'));
+  transcript = writeTranscript([
+    { type: 'user', message: { role: 'user', content: 'run the tests' } },
+    {
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Running them.' },
+          { type: 'tool_use', name: 'Bash', input: { command: 'npx jest tests/' } },
+        ],
+      },
+    },
+    {
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [{ type: 'tool_result', content: 'PASS tests/a.test.ts\nTests: 40 passed' }],
+      },
+    },
+    { type: 'user', message: { role: 'user', content: 'no, use npm test' } },
+  ]);
+});
+
+afterEach(() => {
+  try {
+    rmSync(dir, { recursive: true, force: true });
+  } catch {
+    /* windows can hold a handle briefly */
+  }
+});
+
+describe('readTurns', () => {
+  it('keeps the conversation and the commands', () => {
+    const turns = readTurns(transcript);
+    expect(turns.find((t) => t.role === 'user' && t.text === 'run the tests')).toBeTruthy();
+    expect(turns.find((t) => t.role === 'assistant')?.tools?.[0]?.command).toBe('npx jest tests/');
+    expect(turns.find((t) => t.text === 'no, use npm test')).toBeTruthy();
+  });
+
+  it('drops tool RESULTS, which is where file contents would enter the record', () => {
+    const turns = readTurns(transcript);
+    const all = JSON.stringify(turns);
+    expect(all).not.toContain('PASS tests/a.test.ts');
+    expect(all).not.toContain('Tests: 40 passed');
+  });
+
+  it('returns nothing for an unreadable transcript instead of throwing', () => {
+    expect(readTurns(join(dir, 'does-not-exist.jsonl'))).toEqual([]);
+  });
+});
+
+describe('archive', () => {
+  it('writes the session and reads back the same turns', () => {
+    const n = archive(dir, transcript, { sessionId: 'sess-1' });
+    expect(n).toBeGreaterThan(0);
+
+    const back = readArchive(dir, 'sess-1');
+    expect(back.length).toBe(n);
+    expect(back.some((t) => t.text === 'no, use npm test')).toBe(true);
+  });
+
+  it('does not multiply the record when Stop fires repeatedly', () => {
+    // Stop fires at the end of every assistant turn and the transcript is
+    // cumulative, so appending would store the early turns once per firing.
+    archive(dir, transcript, { sessionId: 'sess-1' });
+    archive(dir, transcript, { sessionId: 'sess-1' });
+    archive(dir, transcript, { sessionId: 'sess-1' });
+
+    expect(readArchive(dir, 'sess-1').length).toBe(readTurns(transcript).length);
+  });
+
+  it('cannot be made to write outside its directory by the session id', () => {
+    archive(dir, transcript, { sessionId: '../../escaped' });
+    // THE INVARIANT IS CONTAINMENT, not the absence of dots. A name like
+    // ".._.._escaped.jsonl" contains ".." and traverses nothing -- it is one
+    // ordinary flat entry. Asserting on the substring fails correct code, which
+    // is a mistake this repository has already made once.
+    const root = transcriptDir(dir);
+    const files = readdirSync(root);
+    expect(files.length).toBeGreaterThan(0);
+    for (const f of files) {
+      expect(dirname(resolve(root, f))).toBe(resolve(root));
+    }
+    expect(existsSync(join(dir, '..', 'escaped.jsonl'))).toBe(false);
+  });
+
+  it('sanitises a session id of nothing but dots', () => {
+    expect(safeName('...')).toBe('unknown');
+    expect(safeName('')).toBe('unknown');
+  });
+});
+
+describe('the never-transmit rule', () => {
+  it('recognises an archived path so the harvest can exclude it', () => {
+    expect(isArchived('C:/repo/.token-optimizer/wiki/transcripts/abc.jsonl')).toBe(true);
+    expect(isArchived('/repo/.token-optimizer/wiki/transcripts/abc.jsonl')).toBe(true);
+    expect(isArchived('C:/repo/src/index.ts')).toBe(false);
+    // The graph itself is fine to reason about; only the raw conversation is not.
+    expect(isArchived('C:/repo/.token-optimizer/wiki/graph.jsonl')).toBe(false);
+  });
+});
+
+describe('prune', () => {
+  it('drops the oldest sessions once the budget is exceeded', () => {
+    const root = transcriptDir(dir);
+    mkdirSync(root, { recursive: true });
+    for (const name of ['old', 'mid', 'new']) {
+      writeFileSync(join(root, `${name}.jsonl`), 'x'.repeat(1000));
+    }
+
+    const dropped = prune(root, 1500);
+    expect(dropped).toBeGreaterThan(0);
+
+    const left = readdirSync(root);
+    expect(left.length).toBeLessThan(3);
+  });
+
+  it('keeps everything when under budget', () => {
+    const root = transcriptDir(dir);
+    mkdirSync(root, { recursive: true });
+    writeFileSync(join(root, 'a.jsonl'), 'x'.repeat(10));
+    expect(prune(root, 1_000_000)).toBe(0);
+    expect(readdirSync(root)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
> **Stacked on #235** (needs its `trigger` field and `forCommand` delivery). Retarget to `master` once #235 merges.

## The signal we were throwing away

The one thing a session produces that the code can never supply is **the moment the user says the agent got it wrong**. Measured on one real session:

| | |
|---|---|
| file touches recorded | 4,053 |
| user corrections recorded | **0** |

## Two layers, deliberately separate

- **Archive** (`transcript.mjs`) — the whole conversation, local, **never retrieved**
- **Lessons** (`lessons.mjs`) — extracted from it, and the **only** thing ever injected

Storing everything *and* retrieving everything would drown injection in thousands of ordinary turns.

## Nothing leaves the machine

Inside the wiki dir (already self-gitignoring), written `0600` under `0700`, with an `isArchived` predicate so the one path that talks to a model endpoint can exclude it. Archived **unconditionally, before the harvest opt-in check** — it costs no model call and sends nothing, so gating it behind a switch that controls *cost and disclosure* would keep the record of what the user said only for people who paid for a different feature.

## Two things the extractor refuses to guess

**Who said it.** Human origin is claimed only when the extractor supplies the user's words **verbatim** *and* they're found in the archive. Human origin carries the highest ranking weight — claiming it on a paraphrase would let an inference outrank the correction it came from. Unverified quotes store as `harvested`, lower confidence.

**When it applies.** Every lesson carries a `trigger` regex, or it can only surface when someone opens the anchored file — not when advice about *doing something* is needed.

## And one thing it insists on: the action first

#235's A/B measured a correctly stored, correctly delivered finding **being ignored** because its instruction sat at the end of three sentences. The prompt demands an imperative; `validateLessons` rejects claims opening with *"the user prefers"*, *"it is better to"*, *"you should"*.

## Standing rules — the always-on half

Triggers answer *"this situation is happening now"*. Some rules aren't situational: *"report the number you measured"* governs how every turn is conducted, and by the time a command matched a trigger the turn would already be going wrong.

**Not the session index.** That lists keys and truncated titles and says *call `wiki_query` for detail* — right for a catalogue of things you *might* want. A rule needing a lookup before it can be obeyed isn't a standing rule, so these render **in full**, and are budgeted far more tightly for it.

**What qualifies, narrowly:** a human-**pinned** finding, or a `feedback` lesson whose quote was **verified**. An unverified paraphrase does not — the always-on block is the last place for a model's reading of a correction.

**Fixed budget, not earned.** The index earns its allowance from hit rate; that suits a catalogue that grows with the graph. Wrong here — this is paid on *every* session regardless of relevance, and a set that grows with the project is exactly how an always-on block becomes wallpaper. 400 tokens is roughly a dozen rules; needing more means situational rules are mislabelled as standing.

**It says what it dropped.** A silent cap reads as *"these are all the rules"*. Cost is recorded as `kind: 'standing'` so the always-on spend can be judged, not assumed harmless.

## Verification

**114 suites / 1539 tests, build clean.**

Includes tests that spawn the **real hooks** — SessionStart emits the standing block while a situational `command` finding correctly does *not* appear. That is the distinction that mattered for `forTouch`, which was correct and called by nothing for its entire life.

Generated with Claude Code
