### PR TITLE
test(edge-cases): generated inputs and real concurrent processes

### DIFF
--- a/hooks-core/paths.mjs
+++ b/hooks-core/paths.mjs
@@ -51,9 +51,6 @@ export function canonicalPath(input, cwd) {
     path = path.slice(1, -1);
   }
 
-  const msys = MSYS.exec(path);
-  if (msys) path = `${msys[1].toUpperCase()}:/${msys[2]}`;
-
   path = path.replace(/\\/g, '/');
 
   // Resolve relatives against the session's cwd so `src/a.ts` and the absolute
@@ -91,6 +88,19 @@ export function canonicalPath(input, cwd) {
     segments.push(segment);
   }
   path = (unc ? '//' : '') + segments.join('/');
+
+  // MSYS TRANSLATION AFTER THE COLLAPSE, NOT BEFORE.
+  //
+  // Running it first made canonicalPath non-idempotent, which a generated-
+  // input property caught: `/./c/Users/me/x` is not MSYS-shaped, so the first
+  // pass only dropped the `.` and returned `/c/Users/me/x` -- which IS
+  // MSYS-shaped, so a second pass returned `C:/Users/me/x`. The same file then
+  // held two identities depending on how many times its path had been round-
+  // tripped, which is precisely the fragmentation this module exists to end.
+  //
+  // Translating after normalisation means one pass reaches the fixed point.
+  const msys = MSYS.exec(path);
+  if (msys) path = `${msys[1].toUpperCase()}:/${msys[2]}`;
 
   // Upper-case a drive letter however it arrived, so `c:/x` and `C:/x` agree.
   path = path.replace(/^([A-Za-z]):/, (_, drive) => `${drive.toUpperCase()}:`);

--- a/integrations/codex/hooks/lib/paths.mjs
+++ b/integrations/codex/hooks/lib/paths.mjs
@@ -53,9 +53,6 @@ export function canonicalPath(input, cwd) {
     path = path.slice(1, -1);
   }
 
-  const msys = MSYS.exec(path);
-  if (msys) path = `${msys[1].toUpperCase()}:/${msys[2]}`;
-
   path = path.replace(/\\/g, '/');
 
   // Resolve relatives against the session's cwd so `src/a.ts` and the absolute
@@ -93,6 +90,19 @@ export function canonicalPath(input, cwd) {
     segments.push(segment);
   }
   path = (unc ? '//' : '') + segments.join('/');
+
+  // MSYS TRANSLATION AFTER THE COLLAPSE, NOT BEFORE.
+  //
+  // Running it first made canonicalPath non-idempotent, which a generated-
+  // input property caught: `/./c/Users/me/x` is not MSYS-shaped, so the first
+  // pass only dropped the `.` and returned `/c/Users/me/x` -- which IS
+  // MSYS-shaped, so a second pass returned `C:/Users/me/x`. The same file then
+  // held two identities depending on how many times its path had been round-
+  // tripped, which is precisely the fragmentation this module exists to end.
+  //
+  // Translating after normalisation means one pass reaches the fixed point.
+  const msys = MSYS.exec(path);
+  if (msys) path = `${msys[1].toUpperCase()}:/${msys[2]}`;
 
   // Upper-case a drive letter however it arrived, so `c:/x` and `C:/x` agree.
   path = path.replace(/^([A-Za-z]):/, (_, drive) => `${drive.toUpperCase()}:`);

--- a/integrations/codex/plugin/hooks/lib/paths.mjs
+++ b/integrations/codex/plugin/hooks/lib/paths.mjs
@@ -53,9 +53,6 @@ export function canonicalPath(input, cwd) {
     path = path.slice(1, -1);
   }
 
-  const msys = MSYS.exec(path);
-  if (msys) path = `${msys[1].toUpperCase()}:/${msys[2]}`;
-
   path = path.replace(/\\/g, '/');
 
   // Resolve relatives against the session's cwd so `src/a.ts` and the absolute
@@ -93,6 +90,19 @@ export function canonicalPath(input, cwd) {
     segments.push(segment);
   }
   path = (unc ? '//' : '') + segments.join('/');
+
+  // MSYS TRANSLATION AFTER THE COLLAPSE, NOT BEFORE.
+  //
+  // Running it first made canonicalPath non-idempotent, which a generated-
+  // input property caught: `/./c/Users/me/x` is not MSYS-shaped, so the first
+  // pass only dropped the `.` and returned `/c/Users/me/x` -- which IS
+  // MSYS-shaped, so a second pass returned `C:/Users/me/x`. The same file then
+  // held two identities depending on how many times its path had been round-
+  // tripped, which is precisely the fragmentation this module exists to end.
+  //
+  // Translating after normalisation means one pass reaches the fixed point.
+  const msys = MSYS.exec(path);
+  if (msys) path = `${msys[1].toUpperCase()}:/${msys[2]}`;
 
   // Upper-case a drive letter however it arrived, so `c:/x` and `C:/x` agree.
   path = path.replace(/^([A-Za-z]):/, (_, drive) => `${drive.toUpperCase()}:`);

--- a/integrations/gemini/hooks/lib/paths.mjs
+++ b/integrations/gemini/hooks/lib/paths.mjs
@@ -53,9 +53,6 @@ export function canonicalPath(input, cwd) {
     path = path.slice(1, -1);
   }
 
-  const msys = MSYS.exec(path);
-  if (msys) path = `${msys[1].toUpperCase()}:/${msys[2]}`;
-
   path = path.replace(/\\/g, '/');
 
   // Resolve relatives against the session's cwd so `src/a.ts` and the absolute
@@ -93,6 +90,19 @@ export function canonicalPath(input, cwd) {
     segments.push(segment);
   }
   path = (unc ? '//' : '') + segments.join('/');
+
+  // MSYS TRANSLATION AFTER THE COLLAPSE, NOT BEFORE.
+  //
+  // Running it first made canonicalPath non-idempotent, which a generated-
+  // input property caught: `/./c/Users/me/x` is not MSYS-shaped, so the first
+  // pass only dropped the `.` and returned `/c/Users/me/x` -- which IS
+  // MSYS-shaped, so a second pass returned `C:/Users/me/x`. The same file then
+  // held two identities depending on how many times its path had been round-
+  // tripped, which is precisely the fragmentation this module exists to end.
+  //
+  // Translating after normalisation means one pass reaches the fixed point.
+  const msys = MSYS.exec(path);
+  if (msys) path = `${msys[1].toUpperCase()}:/${msys[2]}`;
 
   // Upper-case a drive letter however it arrived, so `c:/x` and `C:/x` agree.
   path = path.replace(/^([A-Za-z]):/, (_, drive) => `${drive.toUpperCase()}:`);

--- a/integrations/opencode/hooks/lib/paths.mjs
+++ b/integrations/opencode/hooks/lib/paths.mjs
@@ -53,9 +53,6 @@ export function canonicalPath(input, cwd) {
     path = path.slice(1, -1);
   }
 
-  const msys = MSYS.exec(path);
-  if (msys) path = `${msys[1].toUpperCase()}:/${msys[2]}`;
-
   path = path.replace(/\\/g, '/');
 
   // Resolve relatives against the session's cwd so `src/a.ts` and the absolute
@@ -93,6 +90,19 @@ export function canonicalPath(input, cwd) {
     segments.push(segment);
   }
   path = (unc ? '//' : '') + segments.join('/');
+
+  // MSYS TRANSLATION AFTER THE COLLAPSE, NOT BEFORE.
+  //
+  // Running it first made canonicalPath non-idempotent, which a generated-
+  // input property caught: `/./c/Users/me/x` is not MSYS-shaped, so the first
+  // pass only dropped the `.` and returned `/c/Users/me/x` -- which IS
+  // MSYS-shaped, so a second pass returned `C:/Users/me/x`. The same file then
+  // held two identities depending on how many times its path had been round-
+  // tripped, which is precisely the fragmentation this module exists to end.
+  //
+  // Translating after normalisation means one pass reaches the fixed point.
+  const msys = MSYS.exec(path);
+  if (msys) path = `${msys[1].toUpperCase()}:/${msys[2]}`;
 
   // Upper-case a drive letter however it arrived, so `c:/x` and `C:/x` agree.
   path = path.replace(/^([A-Za-z]):/, (_, drive) => `${drive.toUpperCase()}:`);

--- a/integrations/qwen/hooks/lib/paths.mjs
+++ b/integrations/qwen/hooks/lib/paths.mjs
@@ -53,9 +53,6 @@ export function canonicalPath(input, cwd) {
     path = path.slice(1, -1);
   }
 
-  const msys = MSYS.exec(path);
-  if (msys) path = `${msys[1].toUpperCase()}:/${msys[2]}`;
-
   path = path.replace(/\\/g, '/');
 
   // Resolve relatives against the session's cwd so `src/a.ts` and the absolute
@@ -93,6 +90,19 @@ export function canonicalPath(input, cwd) {
     segments.push(segment);
   }
   path = (unc ? '//' : '') + segments.join('/');
+
+  // MSYS TRANSLATION AFTER THE COLLAPSE, NOT BEFORE.
+  //
+  // Running it first made canonicalPath non-idempotent, which a generated-
+  // input property caught: `/./c/Users/me/x` is not MSYS-shaped, so the first
+  // pass only dropped the `.` and returned `/c/Users/me/x` -- which IS
+  // MSYS-shaped, so a second pass returned `C:/Users/me/x`. The same file then
+  // held two identities depending on how many times its path had been round-
+  // tripped, which is precisely the fragmentation this module exists to end.
+  //
+  // Translating after normalisation means one pass reaches the fixed point.
+  const msys = MSYS.exec(path);
+  if (msys) path = `${msys[1].toUpperCase()}:/${msys[2]}`;
 
   // Upper-case a drive letter however it arrived, so `c:/x` and `C:/x` agree.
   path = path.replace(/^([A-Za-z]):/, (_, drive) => `${drive.toUpperCase()}:`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "conventional-changelog-conventionalcommits": "^8.0.0",
         "eslint": "^9.38.0",
         "eslint-config-prettier": "^10.1.8",
+        "fast-check": "^4.9.0",
         "jest": "^30.2.0",
         "npm": "^11.19.0",
         "playwright": "^1.62.1",
@@ -6376,6 +6377,46 @@
       "peerDependencies": {
         "express": ">= 4.11"
       }
+    },
+    "node_modules/fast-check": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
+    "node_modules/fast-check/node_modules/pure-rand": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
+      "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/fast-content-type-parse": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "conventional-changelog-conventionalcommits": "^8.0.0",
     "eslint": "^9.38.0",
     "eslint-config-prettier": "^10.1.8",
+    "fast-check": "^4.9.0",
     "jest": "^30.2.0",
     "npm": "^11.19.0",
     "playwright": "^1.62.1",

--- a/plugin/hooks/lib/paths.mjs
+++ b/plugin/hooks/lib/paths.mjs
@@ -53,9 +53,6 @@ export function canonicalPath(input, cwd) {
     path = path.slice(1, -1);
   }
 
-  const msys = MSYS.exec(path);
-  if (msys) path = `${msys[1].toUpperCase()}:/${msys[2]}`;
-
   path = path.replace(/\\/g, '/');
 
   // Resolve relatives against the session's cwd so `src/a.ts` and the absolute
@@ -93,6 +90,19 @@ export function canonicalPath(input, cwd) {
     segments.push(segment);
   }
   path = (unc ? '//' : '') + segments.join('/');
+
+  // MSYS TRANSLATION AFTER THE COLLAPSE, NOT BEFORE.
+  //
+  // Running it first made canonicalPath non-idempotent, which a generated-
+  // input property caught: `/./c/Users/me/x` is not MSYS-shaped, so the first
+  // pass only dropped the `.` and returned `/c/Users/me/x` -- which IS
+  // MSYS-shaped, so a second pass returned `C:/Users/me/x`. The same file then
+  // held two identities depending on how many times its path had been round-
+  // tripped, which is precisely the fragmentation this module exists to end.
+  //
+  // Translating after normalisation means one pass reaches the fixed point.
+  const msys = MSYS.exec(path);
+  if (msys) path = `${msys[1].toUpperCase()}:/${msys[2]}`;
 
   // Upper-case a drive letter however it arrived, so `c:/x` and `C:/x` agree.
   path = path.replace(/^([A-Za-z]):/, (_, drive) => `${drive.toUpperCase()}:`);

--- a/tests/hooks/concurrency.test.mjs
+++ b/tests/hooks/concurrency.test.mjs
@@ -37,7 +37,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import { spawnSync, spawn } from 'child_process';
-import { mkdtempSync, rmSync, readFileSync, existsSync, writeFileSync } from 'fs';
+import { mkdtempSync, rmSync, readFileSync, existsSync, writeFileSync, utimesSync, statSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { load } from '../../hooks-core/wiki.mjs';
@@ -164,17 +164,40 @@ describe('parallel processes appending to one graph', () => {
 });
 
 describe('a lock left behind by a killed process', () => {
-  it('does not wedge the graph forever', () => {
-    // A crashed writer must not stop every future write for the life of the
-    // session. The lock is broken once it is provably stale.
-    writeFileSync(join(dir, '.graph.lock'), '');
+  it('is broken and reclaimed, not merely stepped around', () => {
+    // WHAT THIS CAN AND CANNOT PROVE, stated plainly.
+    //
+    // `withLock` calls `write()` whether or not the lock was taken -- that is
+    // deliberate, because a stale lock from a killed process must never stop
+    // the graph being written. The consequence is that "the write still lands"
+    // is true with the stale-lock branch REMOVED, so asserting only that proves
+    // nothing. Verified by deleting the branch: the first version of this test
+    // stayed green.
+    //
+    // The observable difference is reclamation. When the stale lock is broken
+    // the writer holds it and releases it on the way out, so the file is gone
+    // afterwards; when it is not broken the writer never held it and the stale
+    // file survives, leaving every subsequent write unsynchronised for the life
+    // of the session. That is the property worth guarding, and it is what is
+    // asserted below.
+    // BACKDATED WITHOUT A try/catch, and asserted.
+    //
+    // This used to call `require('fs')` inside a catch-all. Jest runs .mjs as
+    // native ESM, where `require` is not defined, so it threw a ReferenceError
+    // straight into the catch on every run -- the lock was never backdated and
+    // the test proved only that a writer succeeds against a FRESH lock, which
+    // is a different code path from the one it names. Reported by CodeRabbit on
+    // this PR.
+    //
+    // `utimesSync` is imported at the top and called directly, and the mtime is
+    // asserted afterwards, so a backdate that silently fails can no longer be
+    // mistaken for recovery.
+    const lockPath = join(dir, '.graph.lock');
+    writeFileSync(lockPath, '');
+    // Comfortably past the 5s threshold in wiki.mjs.
     const old = new Date(Date.now() - 60_000);
-    try {
-      const { utimesSync } = require('fs');
-      utimesSync(join(dir, '.graph.lock'), old, old);
-    } catch {
-      /* handled below by the assertion itself */
-    }
+    utimesSync(lockPath, old, old);
+    expect(Date.now() - statSync(lockPath).mtimeMs).toBeGreaterThan(30_000);
 
     const script = join(dir, 'after-stale.mjs');
     writeFileSync(
@@ -191,5 +214,10 @@ describe('a lock left behind by a killed process', () => {
     const graph = load(dir);
     const keys = [...graph.nodes.values()].map((n) => n.key);
     expect(keys.some((k) => String(k).includes('after-stale.ts'))).toBe(true);
+
+    // THE ASSERTION THAT DISTINGUISHES THE TWO. The stale lock was reclaimed
+    // and released, so it is gone. Leave it in place and every later write in
+    // the session runs unsynchronised.
+    expect(existsSync(lockPath)).toBe(false);
   }, 90_000);
 });

--- a/tests/hooks/concurrency.test.mjs
+++ b/tests/hooks/concurrency.test.mjs
@@ -1,0 +1,195 @@
+/**
+ * Concurrent WRITERS, in real processes.
+ *
+ * Several tool calls can run at once and each spawns its own hook process, so
+ * concurrency here is the ordinary case rather than an edge one. Every test in
+ * this repository until now ran in a single process, which is a category of
+ * behaviour they structurally cannot reach: a lock that is never contended
+ * always looks correct, and an in-memory set always survives.
+ *
+ * That blind spot has already cost twice. A session-state field was dropped on
+ * write and absent on read, so a gate that passed every unit test did nothing in
+ * production because each tool call is a separate process. And the lock guarding
+ * that state retried twenty times with no delay, so it exhausted in microseconds
+ * and the caller fell through to an unlocked read-modify-write.
+ *
+ * So these spawn actual `node` processes and let them race.
+ *
+ * WHAT THIS SUITE DOES AND DOES NOT ESTABLISH -- stated because the difference
+ * was measured rather than assumed.
+ *
+ * It DOES verify the invariants under genuine multi-process load: no write is
+ * lost, no line is left unparseable, and no finding survives without its
+ * anchors while several processes append at once.
+ *
+ * It does NOT prove the append lock in wiki.mjs is load-bearing on Windows.
+ * That was checked directly: with the lock removed entirely, eight processes
+ * writing forty records of 256 KB each -- far past the PIPE_BUF threshold the
+ * lock's own comment cites -- produced 320 of 320 lines, none torn. Append-mode
+ * writes are atomic on this platform, so the failure the lock guards against
+ * does not reproduce here and no test run here can demonstrate its value.
+ *
+ * The suite is kept because CI runs Linux, where the PIPE_BUF limit is real and
+ * these same assertions may have teeth, and because the invariants matter
+ * regardless of which mechanism upholds them. What is avoided is the worse
+ * outcome: a green concurrency test that would stay green with the lock deleted
+ * and would therefore be evidence of nothing.
+ */
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { spawnSync, spawn } from 'child_process';
+import { mkdtempSync, rmSync, readFileSync, existsSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { load } from '../../hooks-core/wiki.mjs';
+
+const WIKI = join(process.cwd(), 'hooks-core', 'wiki.mjs').replace(/\\/g, '/');
+
+let dir;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'concurrency-'));
+});
+
+afterEach(() => {
+  try {
+    rmSync(dir, { recursive: true, force: true });
+  } catch {
+    /* windows can hold a handle briefly */
+  }
+});
+
+/**
+ * A child that appends `count` findings, each with its own anchors.
+ *
+ * THE RECORDS MUST BE BIG. The first version of this suite wrote small findings
+ * and passed even with the lock REMOVED -- a single small append is atomic
+ * enough on its own, so the test proved nothing. wiki.mjs says why in its own
+ * docstring: POSIX guarantees atomicity only up to PIPE_BUF (often 4 KB) and
+ * Windows guarantees none, while a real record can carry a 256 KB file
+ * snapshot. The padding below puts every record over that line, which is where
+ * interleaving actually happens.
+ */
+function writerScript(tag, count) {
+  return `
+    import { putNodeWithEdges, putNode } from 'file:///${WIKI}';
+    const dir = ${JSON.stringify(dir)};
+    const PAD = 'x'.repeat(96 * 1024);
+    for (let i = 0; i < ${count}; i++) {
+      const fileId = putNode(dir, { kind: 'file', key: dir + '/f-${tag}-' + i + '.ts', hash: 'h' });
+      putNodeWithEdges(
+        dir,
+        { kind: 'finding', key: '${tag}-' + i, claim: 'claim ${tag} ' + i, confidence: 0.9, snapshot: PAD },
+        [{ edge: 'derived_from', to: fileId }]
+      );
+    }
+  `;
+}
+
+/** Runs N writers truly in parallel and waits for all of them. */
+async function raceWriters(tags, perWriter) {
+  const children = tags.map((tag) => {
+    const file = join(dir, `writer-${tag}.mjs`);
+    writeFileSync(file, writerScript(tag, perWriter));
+    return spawn(process.execPath, [file], { stdio: 'ignore' });
+  });
+
+  await Promise.all(
+    children.map(
+      (c) =>
+        new Promise((resolve, reject) => {
+          c.on('exit', (code) => (code === 0 ? resolve() : reject(new Error(`writer exited ${code}`))));
+          c.on('error', reject);
+        })
+    )
+  );
+}
+
+describe('parallel processes appending to one graph', () => {
+  it('loses no writes and corrupts no records', async () => {
+    const tags = ['a', 'b', 'c', 'd'];
+    const each = 15;
+    await raceWriters(tags, each);
+
+    const graph = load(dir);
+    const findings = [...graph.nodes.values()].filter((n) => n.kind === 'finding');
+
+    // EVERY write must survive. Interleaved appends that corrupt a line would
+    // show up as a missing finding, because load() skips unparseable records --
+    // which is exactly how this failure would hide without a test like this.
+    expect(findings).toHaveLength(tags.length * each);
+    for (const tag of tags) {
+      expect(findings.filter((f) => String(f.key).startsWith(`${tag}-`))).toHaveLength(each);
+    }
+  }, 120_000);
+
+  it('leaves every line individually parseable', async () => {
+    await raceWriters(['x', 'y', 'z'], 12);
+
+    const raw = readFileSync(join(dir, 'graph.jsonl'), 'utf8').split('\n').filter(Boolean);
+    const bad = [];
+    for (const line of raw) {
+      try {
+        JSON.parse(line);
+      } catch {
+        bad.push(line.slice(0, 80));
+      }
+    }
+
+    // A torn line is the visible symptom of two processes writing at once. The
+    // fold tolerates it by design, so only a raw check can prove it is absent.
+    expect(bad).toEqual([]);
+  }, 120_000);
+
+  it('never leaves a finding without its anchors, whoever was writing', async () => {
+    await raceWriters(['p', 'q', 'r'], 12);
+
+    const graph = load(dir);
+    const anchored = new Set(
+      graph.edges.filter((e) => e.edge === 'derived_from').map((e) => e.from)
+    );
+    const orphans = [...graph.nodes.values()]
+      .filter((n) => n.kind === 'finding' && !anchored.has(n.id))
+      .map((n) => n.key);
+
+    // The invariant putNodeWithEdges exists to hold, now under contention: an
+    // unanchored finding can never be invalidated, so it would be served as
+    // current forever.
+    expect(orphans).toEqual([]);
+  }, 120_000);
+
+  it('releases its lock, so a later writer is never blocked by a finished one', async () => {
+    await raceWriters(['s'], 5);
+    expect(existsSync(join(dir, '.graph.lock'))).toBe(false);
+  }, 60_000);
+});
+
+describe('a lock left behind by a killed process', () => {
+  it('does not wedge the graph forever', () => {
+    // A crashed writer must not stop every future write for the life of the
+    // session. The lock is broken once it is provably stale.
+    writeFileSync(join(dir, '.graph.lock'), '');
+    const old = new Date(Date.now() - 60_000);
+    try {
+      const { utimesSync } = require('fs');
+      utimesSync(join(dir, '.graph.lock'), old, old);
+    } catch {
+      /* handled below by the assertion itself */
+    }
+
+    const script = join(dir, 'after-stale.mjs');
+    writeFileSync(
+      script,
+      `
+      import { putNode } from 'file:///${WIKI}';
+      putNode(${JSON.stringify(dir)}, { kind: 'file', key: 'after-stale.ts', hash: 'h' });
+      `
+    );
+
+    const r = spawnSync(process.execPath, [script], { encoding: 'utf8', timeout: 60_000 });
+    expect(r.status).toBe(0);
+
+    const graph = load(dir);
+    const keys = [...graph.nodes.values()].map((n) => n.key);
+    expect(keys.some((k) => String(k).includes('after-stale.ts'))).toBe(true);
+  }, 90_000);
+});

--- a/tests/hooks/property-inputs.test.mjs
+++ b/tests/hooks/property-inputs.test.mjs
@@ -1,0 +1,345 @@
+/**
+ * Generated inputs, because hand-picked ones come from the same assumptions
+ * that produced the bug.
+ *
+ * Two defects in recent work were exactly this shape. A test passed
+ * `'\bnpx\s+jest\b'` in single quotes, which JavaScript resolves to a BACKSPACE
+ * followed by `npxs+jest` -- so the assertion went green against a pattern
+ * nobody wrote. Another asserted a filename did not contain `..`, when the real
+ * invariant was containment and `a.._..b` satisfies one while failing the other.
+ * In both cases the author chose the input, and the input agreed with him.
+ *
+ * So these state INVARIANTS and let fast-check hunt for counterexamples: what
+ * must be true for every input, including the ones nobody would think to write.
+ * When it finds one it shrinks it to the smallest failing case and prints it,
+ * which is the part that makes the failure actionable rather than mysterious.
+ */
+import { describe, it, expect } from '@jest/globals';
+import fc from 'fast-check';
+import { canonicalPath } from '../../hooks-core/paths.mjs';
+import { canonicalKey, nodeId, contentHash, load, findingsFor } from '../../hooks-core/wiki.mjs';
+import { extractSymbols, extractImports, symbolKey, languageOf } from '../../hooks-core/symbols.mjs';
+import { normalizePayload, touchedFiles } from '../../hooks-core/decide.mjs';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+/**
+ * Strings chosen to break parsers, mixed in with generated ones.
+ *
+ * Every entry is a real failure mode from this codebase or its neighbours, not
+ * a generic fuzz list: control characters (the backspace that mangled a regex),
+ * traversal, UNC and drive-relative paths, mixed separators, and the empty and
+ * whitespace cases that so often take a different branch.
+ */
+const NASTY = [
+  '',
+  ' ',
+  '\t\n',
+  '..',
+  '../..',
+  '..\\..\\',
+  './/.//..',
+  'a\u0008b', // backspace, the character that silently mangled a trigger
+  'a\u0000b', // NUL
+  '\uFEFFleading-bom',
+  'C:',
+  'C:\\',
+  'C:/',
+  '\\\\server\\share\\file.ts',
+  '//server/share/file.ts',
+  '/',
+  '//',
+  'a'.repeat(2000),
+  '\u{1F600}emoji.ts',
+  'file with spaces.ts',
+  "quote'and\"quote.ts",
+  'semi;colon|pipe&amp.ts',
+  '.hidden',
+  'trailing/',
+  'trailing\\',
+];
+
+// fast-check v4 folded the unicode generators into string({ unit }); the v3
+// name fc.fullUnicodeString no longer exists.
+const anyString = () =>
+  fc.oneof(fc.string(), fc.constantFrom(...NASTY), fc.string({ unit: 'binary' }));
+
+describe('canonicalPath', () => {
+  it('never throws, whatever it is handed', () => {
+    fc.assert(
+      fc.property(anyString(), (s) => {
+        canonicalPath(s);
+      }),
+      { numRuns: 500 }
+    );
+  });
+
+  it('is idempotent -- canonicalising twice equals canonicalising once', () => {
+    // The property that matters for identity: if it were not idempotent, the
+    // same file could occupy two nodes depending on how many times a path had
+    // been round-tripped.
+    fc.assert(
+      fc.property(anyString(), (s) => {
+        const once = canonicalPath(s);
+        expect(canonicalPath(once)).toBe(once);
+      }),
+      { numRuns: 500 }
+    );
+  });
+
+  it('is deterministic', () => {
+    fc.assert(
+      fc.property(anyString(), (s) => {
+        expect(canonicalPath(s)).toBe(canonicalPath(s));
+      }),
+      { numRuns: 300 }
+    );
+  });
+});
+
+describe('node identity', () => {
+  it('canonicalKey is idempotent for file keys, so one file is never two nodes', () => {
+    fc.assert(
+      fc.property(anyString(), (s) => {
+        const once = canonicalKey('file', s);
+        expect(canonicalKey('file', once)).toBe(once);
+      }),
+      { numRuns: 400 }
+    );
+  });
+
+  it('nodeId is stable and shaped, whatever the key', () => {
+    fc.assert(
+      fc.property(fc.constantFrom('file', 'symbol', 'task', 'finding'), anyString(), (kind, key) => {
+        const id = nodeId(kind, key);
+        expect(id).toBe(nodeId(kind, key));
+        // `kind:16hex` -- anything else means a key escaped into the id.
+        expect(id).toMatch(/^(file|symbol|task|finding):[0-9a-f]{16}$/);
+      }),
+      { numRuns: 400 }
+    );
+  });
+
+  it('paths that differ only in spelling collapse to one id', () => {
+    fc.assert(
+      fc.property(fc.stringMatching(/^[a-z]{1,8}$/), (name) => {
+        const a = nodeId('file', `C:\\repo\\${name}.ts`);
+        const b = nodeId('file', `C:/repo/${name}.ts`);
+        expect(a).toBe(b);
+      }),
+      { numRuns: 100 }
+    );
+  });
+});
+
+describe('symbol extraction', () => {
+  it('never throws on arbitrary text in any recognised language', () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom('a.ts', 'a.py', 'a.go', 'a.rs', 'a.cs', 'a.rb', 'a.php', 'a.sh', 'a.unknown'),
+        fc.string({ maxLength: 4000 }),
+        (path, text) => {
+          extractSymbols(path, text);
+          extractImports(path, text);
+        }
+      ),
+      { numRuns: 400 }
+    );
+  });
+
+  it('produces spans that are ordered and inside the file', () => {
+    // A span that runs past the end, or backwards, would make staleness compare
+    // the wrong region -- reporting a function stale because of an edit
+    // somewhere else entirely.
+    fc.assert(
+      fc.property(fc.array(fc.string({ maxLength: 40 }), { maxLength: 60 }), (lines) => {
+        const text = lines.join('\n');
+        const total = text.split('\n').length;
+        for (const s of extractSymbols('a.ts', text)) {
+          expect(s.line).toBeGreaterThanOrEqual(1);
+          expect(s.endLine).toBeGreaterThanOrEqual(s.line);
+          expect(s.endLine).toBeLessThanOrEqual(total);
+        }
+      }),
+      { numRuns: 300 }
+    );
+  });
+
+  it('never emits a symbol name containing a path separator', () => {
+    // symbolKey joins path and name with '#', so a separator in the name would
+    // make the key ambiguous with a path.
+    fc.assert(
+      fc.property(fc.string({ maxLength: 2000 }), (text) => {
+        for (const s of extractSymbols('a.ts', text)) {
+          expect(s.name).not.toMatch(/[\\/]/);
+          expect(symbolKey('a.ts', s.name)).toContain('#');
+        }
+      }),
+      { numRuns: 300 }
+    );
+  });
+
+  it('only ever returns RELATIVE import specifiers', () => {
+    // A bare specifier names a package, not a file in this project, so an edge
+    // pointing at it would be a lie.
+    fc.assert(
+      fc.property(fc.string({ maxLength: 3000 }), (text) => {
+        for (const spec of extractImports('a.ts', text)) {
+          expect(spec).toMatch(/^\.\.?[\\/]/);
+        }
+      }),
+      { numRuns: 300 }
+    );
+  });
+
+  it('languageOf never throws and returns null or a known family', () => {
+    fc.assert(
+      fc.property(anyString(), (s) => {
+        const fam = languageOf(s);
+        expect(fam === null || typeof fam === 'string').toBe(true);
+      }),
+      { numRuns: 300 }
+    );
+  });
+});
+
+describe('hook payloads', () => {
+  /** Arbitrary JSON-ish objects, because payloads come from another process. */
+  const anyPayload = () =>
+    fc.record(
+      {
+        tool_name: fc.oneof(fc.string(), fc.constantFrom('Read', 'Bash', 'Edit', 'Write')),
+        session_id: anyString(),
+        cwd: anyString(),
+        tool_input: fc.oneof(
+          fc.constant(undefined),
+          fc.constant(null),
+          fc.record(
+            {
+              file_path: anyString(),
+              command: anyString(),
+              path: anyString(),
+            },
+            { requiredKeys: [] }
+          )
+        ),
+      },
+      { requiredKeys: [] }
+    );
+
+  it('normalizePayload never throws on a malformed payload', () => {
+    // The hook is fed by another process. A payload that crashes the router
+    // costs the user their tool call.
+    fc.assert(
+      fc.property(anyPayload(), (p) => {
+        normalizePayload(p);
+      }),
+      { numRuns: 500 }
+    );
+  });
+
+  it('touchedFiles never throws and always returns an array of entries with paths', () => {
+    fc.assert(
+      fc.property(anyPayload(), (p) => {
+        const out = touchedFiles(normalizePayload(p));
+        expect(Array.isArray(out)).toBe(true);
+        for (const t of out) expect(typeof t.path).toBe('string');
+      }),
+      { numRuns: 400 }
+    );
+  });
+});
+
+describe('the graph parser', () => {
+  let dir;
+
+  it('survives arbitrary bytes in the log rather than losing the whole graph', () => {
+    // A partially written final line is the normal consequence of a process
+    // being killed mid-append, so one bad line must never make the accumulated
+    // graph unreadable.
+    fc.assert(
+      fc.property(fc.array(anyString(), { maxLength: 40 }), (lines) => {
+        dir = mkdtempSync(join(tmpdir(), 'prop-graph-'));
+        try {
+          writeFileSync(join(dir, 'graph.jsonl'), lines.join('\n'));
+          const graph = load(dir);
+          expect(graph.nodes instanceof Map).toBe(true);
+          expect(Array.isArray(graph.edges)).toBe(true);
+          // And retrieval over whatever survived must not throw either.
+          findingsFor(graph, nodeId('file', 'x.ts'));
+        } finally {
+          try {
+            rmSync(dir, { recursive: true, force: true });
+          } catch {
+            /* windows */
+          }
+        }
+      }),
+      { numRuns: 120 }
+    );
+  });
+
+  it('contentHash returns null for anything unreadable instead of throwing', () => {
+    fc.assert(
+      fc.property(anyString(), (s) => {
+        const h = contentHash(s);
+        expect(h === null || /^[0-9a-f]{16}$/.test(h)).toBe(true);
+      }),
+      { numRuns: 200 }
+    );
+  });
+});
+
+describe('the containment invariant', () => {
+  /**
+   * The sanitiser the product applies to any untrusted name before it becomes
+   * part of a path -- session ids in policy.statePath, and the marker and
+   * archive names in the Stop hook. Mirrored here so the PROPERTY is tested
+   * rather than a particular caller.
+   */
+  const sanitise = (raw) => {
+    const safe = String(raw || 'default').replace(/[^A-Za-z0-9._-]/g, '');
+    return (/^[.]*$/.test(safe) ? 'default' : safe).slice(0, 64);
+  };
+
+  it('no sanitised name can escape its directory, whatever it started as', () => {
+    // THE FIRST VERSION OF THIS PROPERTY WAS WRONG, and fast-check said so in
+    // 58 runs with the counterexample "..". Containment is not a property of
+    // join -- join(root, '..') resolves to the parent and is supposed to. It is
+    // a property of the SANITISER, which is the thing that actually defends the
+    // boundary. Asserting it of join would have pinned a guarantee the code was
+    // never making.
+    const root = canonicalPath(mkdtempSync(join(tmpdir(), 'contain-')));
+    const prefix = root.endsWith('/') ? root : `${root}/`;
+
+    fc.assert(
+      fc.property(anyString(), (raw) => {
+        const full = canonicalPath(join(root, sanitise(raw)));
+        expect(full === root || full.startsWith(prefix)).toBe(true);
+      }),
+      { numRuns: 500 }
+    );
+
+    try {
+      rmSync(root, { recursive: true, force: true });
+    } catch {
+      /* windows can hold a handle briefly */
+    }
+  });
+
+  it('and raw join genuinely does escape, which is why sanitising is required', () => {
+    // Stated explicitly so nobody later "simplifies" the sanitiser away on the
+    // assumption that join was safe all along.
+    const root = canonicalPath(mkdtempSync(join(tmpdir(), 'escape-')));
+    const prefix = root.endsWith('/') ? root : `${root}/`;
+    const escaped = canonicalPath(join(root, '..'));
+    expect(escaped === root || escaped.startsWith(prefix)).toBe(false);
+
+    try {
+      rmSync(root, { recursive: true, force: true });
+    } catch {
+      /* windows */
+    }
+  });
+});

--- a/tests/hooks/property-inputs.test.mjs
+++ b/tests/hooks/property-inputs.test.mjs
@@ -75,6 +75,31 @@ describe('canonicalPath', () => {
     );
   });
 
+  it('reaches its fixed point on a Git Bash path carrying a dot segment', () => {
+    // THE COUNTEREXAMPLE THE GENERATED INPUTS FOUND, pinned so it cannot come
+    // back. MSYS translation used to run BEFORE `.` and `..` were collapsed, so
+    // `/./c/Users/me/x` was not MSYS-shaped on the way in: the first pass only
+    // dropped the dot and returned `/c/Users/me/x`, which IS MSYS-shaped, so a
+    // second pass returned `C:/Users/me/x`.
+    //
+    // The same file therefore held two identities depending on how many times
+    // its path had been round-tripped -- two graph nodes, findings anchored
+    // under one invisible from the other. That is exactly the fragmentation
+    // canonicalPath exists to end, and it survived every hand-written example
+    // because nobody thinks to write this path down.
+    expect(canonicalPath('/./c/Users/me/x')).toBe('C:/Users/me/x');
+    expect(canonicalPath(canonicalPath('/./c/Users/me/x'))).toBe('C:/Users/me/x');
+
+    // The shape the property actually generated, which is the same defect.
+    expect(canonicalPath(canonicalPath('/./A/!'))).toBe(canonicalPath('/./A/!'));
+
+    // Ordinary spellings are unchanged by the reordering.
+    expect(canonicalPath('/c/Users/me/x')).toBe('C:/Users/me/x');
+    expect(canonicalPath('C:/Users/me/x')).toBe('C:/Users/me/x');
+    expect(canonicalPath('/c/./x')).toBe('C:/x');
+    expect(canonicalPath('//server/share/f')).toBe('//server/share/f');
+  });
+
   it('is idempotent -- canonicalising twice equals canonicalising once', () => {
     // The property that matters for identity: if it were not idempotent, the
     // same file could occupy two nodes depending on how many times a path had


### PR DESCRIPTION
The two remaining blind spots behind *"we keep finding defects"*. Both were built by first asking what the tests **could not see**, then checking the new tests can see it.

## 1. Generated inputs (fast-check)

Hand-picked inputs come from the same assumptions that produced the bug. Two recent defects were exactly that shape:

- `'\bnpx\s+jest\b'` in single quotes resolves to a **backspace** followed by `npxs+jest` — the assertion went green against a pattern nobody wrote
- `not.toContain('..')` on a filename, when the real invariant was containment and `a.._..b` satisfies one while failing the other

In both, the author chose the input and the input agreed with him.

**17 properties** over `canonicalPath`, `canonicalKey`, `nodeId`, `contentHash`, symbol/import extraction, payload normalisation and the graph parser — idempotence, determinism, never-throws, spans inside the file, imports always relative, and a graph that survives arbitrary bytes rather than losing everything after one bad line. The nasty-input corpus is drawn from real failures here: the backspace that mangled a trigger, NUL, BOM, UNC and drive-relative paths, mixed separators.

### It immediately found one — in my own test

The containment property failed in 58 runs with the counterexample `".."`. That's **correct behaviour**: `join(root, '..')` resolves to the parent and is supposed to. Containment isn't a property of `join` at all — it's a property of the **sanitiser**, which is what actually defends the boundary. The property now states that, plus a second test pinning that raw `join` really does escape, so nobody later removes the sanitiser believing `join` was safe all along.

## 2. Real concurrent processes

Every test here ran in one process, and **a lock that is never contended always looks correct**. That blind spot cost twice already: a state field dropped on write, and a lock retried 20× with no delay.

### And the honest part

The first version of this suite **passed with the append lock removed** — it proved nothing. Enlarging records to 96 KB didn't change that, so I checked directly:

> Unlocked. 8 processes × 40 records × 256 KB — far past the PIPE_BUF threshold the lock's own comment cites. **320 of 320 lines, none torn.**

Append-mode writes are atomic on Windows, so no run *here* can demonstrate the lock's value.

The suite is kept and its docstring says exactly that. It verifies the invariants under genuine multi-process load; CI runs Linux where PIPE_BUF is real and the same assertions may have teeth. The alternative — a green concurrency test that would stay green with the lock deleted — is evidence of nothing.

**111 suites, 1512 tests.** `fast-check` added as a dev dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)