### PR TITLE
feat(hooks): wire co-occurrence to restoration, so the graph can predict

### DIFF
--- a/plugin/hooks/precompact-optimize.mjs
+++ b/plugin/hooks/precompact-optimize.mjs
@@ -22,16 +22,21 @@ import { spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { mode, MODE_OFF, loadState } from './lib/policy.mjs';
+import { linkCoOccurrence } from './lib/inject.mjs';
+import { wikiDir, projectRootFor } from './lib/wiki.mjs';
 
 /** Longest compaction may be delayed. Past this the work is abandoned. */
-const TIMEOUT_MS = Number(process.env.TOKEN_OPTIMIZER_PRECOMPACT_TIMEOUT_MS) || 8000;
+const TIMEOUT_MS =
+  Number(process.env.TOKEN_OPTIMIZER_PRECOMPACT_TIMEOUT_MS) || 8000;
 
 function findWrapper() {
   // Plugin installs place the plugin under .../plugin; the wrapper, when
   // present, sits at the package root above it. Global installs resolve it
   // through the package directory directly.
   const roots = [
-    process.env.CLAUDE_PLUGIN_ROOT ? join(process.env.CLAUDE_PLUGIN_ROOT, '..') : null,
+    process.env.CLAUDE_PLUGIN_ROOT
+      ? join(process.env.CLAUDE_PLUGIN_ROOT, '..')
+      : null,
     process.env.TOKEN_OPTIMIZER_HOME || null,
   ].filter(Boolean);
 
@@ -56,32 +61,87 @@ async function main() {
     return;
   }
 
+  // STATE AND CO-OCCURRENCE BEFORE THE WRAPPER CHECK, deliberately.
+  //
+  // The wrapper is only needed to spawn optimize_session, and plugin-only
+  // installs do not ship one -- the hook returns early for them by design. But
+  // recording which files were worked on together needs nothing but the graph,
+  // so gating it on the wrapper would mean every plugin-only user silently got
+  // no `related` edges and therefore no restoration, forever. That is the same
+  // shape as the defect this whole change is fixing: a feature present, correct,
+  // and unreachable for a reason nobody would think to look for.
+  const state = loadState(payload.session_id);
+  const seen = Object.keys(state.seen || {});
+  const seenCount = seen.length;
+  if (seenCount === 0) return;
+
+  // CO-OCCURRENCE, RECORDED AT THE ONE MOMENT IT IS COMPLETE.
+  //
+  // `linkCoOccurrence` is the only producer of `related` edges, and it was
+  // called by nothing -- so the edge kind was declared, the consumer was
+  // written, and the graph never contained a single one. This is the natural
+  // site: `state.seen` is exactly "the files this session worked on together",
+  // which is the signal, and it is whole only once the session is long enough
+  // to be compacted.
+  //
+  // GROUPED BY PROJECT, because the graph is per project. A session that
+  // touches two checkouts must write each repository's edges into its own
+  // graph, or it invents relationships between files that have never met.
+  try {
+    const byProject = new Map();
+    for (const path of seen) {
+      const root = projectRootFor(path, payload.cwd);
+      if (!root) continue;
+      if (!byProject.has(root)) byProject.set(root, []);
+      byProject.get(root).push(path);
+    }
+    for (const [root, paths] of byProject) {
+      // Two files are the minimum that can co-occur; one writes no edge and
+      // only costs a graph load.
+      if (paths.length < 2) continue;
+      linkCoOccurrence(wikiDir(root), payload.session_id, paths);
+    }
+  } catch {
+    // Bookkeeping must never delay or fail a compaction.
+  }
+
+  // NOW the wrapper, which only the optimize_session spawn needs. Plugin-only
+  // installs stop here having still recorded their co-occurrence above.
   const wrapper = findWrapper();
   if (!wrapper) return;
-
-  // Only worth spawning if this session actually accumulated file operations.
-  const state = loadState(payload.session_id);
-  const seenCount = Object.keys(state.seen || {}).length;
-  if (seenCount === 0) return;
 
   await new Promise((resolve) => {
     const child = spawn(
       process.execPath,
-      [wrapper, 'optimize_session', JSON.stringify({ sessionId: payload.session_id })],
+      [
+        wrapper,
+        'optimize_session',
+        JSON.stringify({ sessionId: payload.session_id }),
+      ],
       { stdio: 'ignore', windowsHide: true }
     );
     const timer = setTimeout(() => {
       child.kill();
       resolve();
     }, TIMEOUT_MS);
-    child.on('exit', () => { clearTimeout(timer); resolve(); });
-    child.on('error', () => { clearTimeout(timer); resolve(); });
+    child.on('exit', () => {
+      clearTimeout(timer);
+      resolve();
+    });
+    child.on('error', () => {
+      clearTimeout(timer);
+      resolve();
+    });
   });
 
-  process.stdout.write(JSON.stringify({
-    systemMessage: `token-optimizer: compressed ${seenCount} tracked file operation(s) before compaction.`,
-  }));
+  process.stdout.write(
+    JSON.stringify({
+      systemMessage: `token-optimizer: compressed ${seenCount} tracked file operation(s) before compaction.`,
+    })
+  );
 }
 
 // Compaction must proceed whatever happens here.
-main().catch(() => {}).finally(() => process.exit(0));
+main()
+  .catch(() => {})
+  .finally(() => process.exit(0));

--- a/plugin/hooks/session-start.mjs
+++ b/plugin/hooks/session-start.mjs
@@ -18,10 +18,69 @@
  * refused, which wastes a turn per tool family.
  */
 
-import { mode, MODE_OFF } from './lib/policy.mjs';
+import { mode, MODE_OFF, readPayload, loadState } from './lib/policy.mjs';
 import { policyText } from './lib/adapter.mjs';
+import { restorationPlan } from './lib/restore.mjs';
+import { wikiDir, load, projectRootFor } from './lib/wiki.mjs';
 
 if (mode() === MODE_OFF) process.exit(0);
+
+/**
+ * The restoration block, when this session is resuming from a compaction.
+ *
+ * `restorationPlan` was written, tested, and called by nothing -- the other half
+ * of a feature whose only producer of `related` edges was equally unreachable,
+ * so the graph never held one and the plan had nothing to predict from.
+ * PreCompact now writes those edges; this is where they are spent.
+ *
+ * SessionStart is the right site because the plan is explicitly about resuming:
+ * a PreCompact hook emits into the context that is ABOUT to be discarded, which
+ * is the one place restoration text cannot survive. The `compact` source is the
+ * harness telling us exactly this case.
+ */
+async function restoration() {
+  // `readPayload` returns the PARSED object, not the raw text. Parsing it again
+  // throws on `[object Object]`, and the throw is swallowed by the catch below,
+  // so the restoration block simply never appeared -- the failure mode a
+  // fail-open hook is most likely to hide.
+  const parsed = await readPayload();
+  if (!parsed) return null;
+
+  // Only after a compaction. A cold start has nothing to restore, and paying
+  // for this text on every session is the always-on bloat the project measures
+  // against elsewhere.
+  if (parsed.source !== 'compact') return null;
+
+  const state = loadState(parsed.session_id);
+  const seen = Object.keys(state.seen || {});
+  if (!seen.length) return null;
+
+  // The graph belongs to the project the FILES are in, not to wherever the
+  // client happens to be running. Restoring from the busiest project is the
+  // honest choice when a session spans two.
+  const counts = new Map();
+  for (const path of seen) {
+    const root = projectRootFor(path, parsed.cwd);
+    if (root) counts.set(root, (counts.get(root) || 0) + 1);
+  }
+  const root = [...counts.entries()].sort((a, b) => b[1] - a[1])[0]?.[0];
+  if (!root) return null;
+
+  const dir = wikiDir(root);
+  const plan = restorationPlan(dir, load(dir), {
+    recentAnchors: seen.slice(-12),
+  });
+  return plan?.text ?? null;
+}
+
+const parts = [policyText(true)];
+
+try {
+  const restored = await restoration();
+  if (restored) parts.push(restored);
+} catch {
+  // The policy notice must still arrive if anything above fails.
+}
 
 // THE TEXT ITSELF LIVES IN THE SHARED CORE. It used to be duplicated here,
 // which is exactly the drift the adapter was built to end: an addition to the
@@ -29,9 +88,11 @@ if (mode() === MODE_OFF) process.exit(0);
 // clients and silently skipped Claude Code, the one client most users are on.
 // Claude Code keeps its own entry point because its PreToolUse router does more
 // than the shared one; the standing notice is not a place it needs to differ.
-process.stdout.write(JSON.stringify({
-  hookSpecificOutput: {
-    hookEventName: 'SessionStart',
-    additionalContext: policyText(true),
-  },
-}));
+process.stdout.write(
+  JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: 'SessionStart',
+      additionalContext: parts.join('\n\n'),
+    },
+  })
+);

--- a/tests/hooks/cooccurrence-restore.test.mjs
+++ b/tests/hooks/cooccurrence-restore.test.mjs
@@ -1,0 +1,268 @@
+/**
+ * Co-occurrence to restoration, end to end.
+ *
+ * This feature was built complete and connected at neither end. `related` is a
+ * declared edge kind; `linkCoOccurrence` is its only producer and was called by
+ * nothing, so no graph has ever contained one; `predictNext` is its only
+ * consumer, reached solely through `restorationPlan`, which was equally
+ * unreachable. Two halves of a working feature, each waiting for the other.
+ *
+ * So the tests that matter here are not unit tests of either half -- those
+ * already passed for the whole time the feature did nothing. They drive the real
+ * hooks: PreCompact writes the edges, SessionStart with source=compact spends
+ * them, and the assertion is that a file the session never opened comes back
+ * recommended because it was worked on alongside one that was.
+ */
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { spawnSync } from 'child_process';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  wikiDir,
+  load,
+  putNode,
+  putNodeWithEdges,
+  nodeId,
+} from '../../hooks-core/wiki.mjs';
+
+const PRECOMPACT = join(
+  process.cwd(),
+  'plugin',
+  'hooks',
+  'precompact-optimize.mjs'
+);
+const SESSION_START = join(
+  process.cwd(),
+  'plugin',
+  'hooks',
+  'session-start.mjs'
+);
+
+let project;
+let dir;
+let stateRoot;
+let session;
+
+/** Seeds the session state the hooks read, as the router would have written it. */
+function seenState(paths) {
+  const seen = {};
+  for (const p of paths) seen[p] = Date.now();
+  mkdirSync(stateRoot, { recursive: true });
+  writeFileSync(
+    join(stateRoot, `${session}.json`),
+    JSON.stringify({ seen, denied: {}, injected: [] })
+  );
+}
+
+function run(hook, payload, env = {}) {
+  return spawnSync(process.execPath, [hook], {
+    input: JSON.stringify(payload),
+    encoding: 'utf8',
+    timeout: 30_000,
+    env: { ...process.env, TOKEN_OPTIMIZER_STATE_DIR: stateRoot, ...env },
+  });
+}
+
+beforeEach(() => {
+  project = mkdtempSync(join(tmpdir(), 'cooccur-'));
+  mkdirSync(join(project, '.git'), { recursive: true });
+  dir = wikiDir(project);
+  // The hooks read session state from a fixed location on this branch, so the
+  // test writes where they will actually look. The session id is unique per
+  // run, which keeps the files from colliding with a real session or with each
+  // other.
+  stateRoot = join(tmpdir(), 'token-optimizer-hooks');
+  session = `s-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+});
+
+afterEach(() => {
+  try {
+    rmSync(project, { recursive: true, force: true });
+  } catch {
+    /* windows can hold a handle briefly */
+  }
+  // Only this run's own state file -- the directory is shared with real
+  // sessions and must not be removed wholesale.
+  try {
+    rmSync(join(stateRoot, `${session}.json`), { force: true });
+  } catch {
+    /* already gone */
+  }
+});
+
+describe('PreCompact writes the related edges', () => {
+  it('links files the session worked on together', () => {
+    const a = join(project, 'a.ts');
+    const b = join(project, 'b.ts');
+    writeFileSync(a, 'export const a = 1;\n');
+    writeFileSync(b, 'export const b = 2;\n');
+    seenState([a, b]);
+
+    // Before: the edge kind is declared and the graph has never held one.
+    expect(load(dir).edges.filter((e) => e.edge === 'related')).toHaveLength(0);
+
+    run(PRECOMPACT, { session_id: session, cwd: project });
+
+    const related = load(dir).edges.filter((e) => e.edge === 'related');
+    expect(related.length).toBeGreaterThan(0);
+
+    const ids = new Set([nodeId('file', a), nodeId('file', b)]);
+    for (const e of related) {
+      expect(ids.has(e.from) || ids.has(e.to)).toBe(true);
+    }
+  }, 60_000);
+
+  it('writes nothing when only one file was touched', () => {
+    const a = join(project, 'a.ts');
+    writeFileSync(a, 'export const a = 1;\n');
+    seenState([a]);
+
+    run(PRECOMPACT, { session_id: session, cwd: project });
+
+    // Two files are the minimum that can co-occur. One would only cost a graph
+    // load and record a relationship that does not exist.
+    expect(load(dir).edges.filter((e) => e.edge === 'related')).toHaveLength(0);
+  }, 60_000);
+
+  it('reaches the wrapper when a plugin root is configured', () => {
+    // REGRESSION, AND A LESSON ABOUT FAIL-OPEN CODE. `findWrapper` calls
+    // `join`, and its import sat on the line an edit overwrote while adding the
+    // co-occurrence imports. That branch runs only when CLAUDE_PLUGIN_ROOT is
+    // set -- the configuration every real plugin install uses and no test did.
+    //
+    // Asserting on exit status or stderr does NOT catch it: `main()` ends in
+    // `.catch(() => {})` so a compaction is never delayed, which means the
+    // ReferenceError is swallowed and the hook still exits 0 in silence. The
+    // only observable difference is that the wrapper is never reached, so that
+    // is what this asserts: a stub wrapper is planted where findWrapper looks,
+    // and the systemMessage only appears if the hook actually got there.
+    const home = mkdtempSync(join(tmpdir(), 'cooccur-home-'));
+    mkdirSync(join(home, 'plugin'), { recursive: true });
+    writeFileSync(join(home, 'cli-wrapper.mjs'), 'process.exit(0);' + '\n');
+
+    const a = join(project, 'a.ts');
+    const b = join(project, 'b.ts');
+    writeFileSync(a, 'export const a = 1;\n');
+    writeFileSync(b, 'export const b = 2;\n');
+    seenState([a, b]);
+
+    const out = run(
+      PRECOMPACT,
+      { session_id: session, cwd: project },
+      { CLAUDE_PLUGIN_ROOT: join(home, 'plugin') }
+    );
+
+    expect(out.stdout || '').toContain('token-optimizer: compressed');
+
+    try {
+      rmSync(home, { recursive: true, force: true });
+    } catch {
+      /* windows */
+    }
+  }, 60_000);
+
+  it('does not invent relationships across two checkouts', () => {
+    // The graph is per project. A session spanning two repositories must not
+    // relate a file in one to a file in the other -- they have never met.
+    const other = mkdtempSync(join(tmpdir(), 'cooccur-other-'));
+    mkdirSync(join(other, '.git'), { recursive: true });
+    const a = join(project, 'a.ts');
+    const z = join(other, 'z.ts');
+    writeFileSync(a, 'export const a = 1;\n');
+    writeFileSync(z, 'export const z = 3;\n');
+    seenState([a, z]);
+
+    run(PRECOMPACT, { session_id: session, cwd: project });
+
+    // One file each side: neither project has a pair, so neither gets an edge.
+    expect(load(dir).edges.filter((e) => e.edge === 'related')).toHaveLength(0);
+    expect(
+      load(wikiDir(other)).edges.filter((e) => e.edge === 'related')
+    ).toHaveLength(0);
+
+    try {
+      rmSync(other, { recursive: true, force: true });
+    } catch {
+      /* windows */
+    }
+  }, 60_000);
+});
+
+describe('SessionStart spends them', () => {
+  it('recommends a file the session never opened, because a peer was worked on', () => {
+    // THE ASSERTION THE WHOLE FEATURE EXISTS FOR. `b.ts` carries a finding and
+    // is never in `seen`; it comes back only because the graph learned it is
+    // worked on alongside `a.ts`.
+    const a = join(project, 'a.ts');
+    const b = join(project, 'b.ts');
+    writeFileSync(a, 'export const a = 1;\n');
+    writeFileSync(b, 'export const b = 2;\n');
+
+    const bNode = putNode(dir, { kind: 'file', key: b, hash: 'h' });
+    putNodeWithEdges(
+      dir,
+      {
+        kind: 'finding',
+        key: 'about-b',
+        claim: 'b.ts owns the retry budget.',
+        confidence: 0.95,
+      },
+      [{ edge: 'derived_from', to: bNode }]
+    );
+
+    // The session worked on both, so PreCompact relates them.
+    seenState([a, b]);
+    run(PRECOMPACT, { session_id: session, cwd: project });
+
+    // Now resume with only `a` in view -- `b` is what must be predicted.
+    seenState([a]);
+    const out = run(SESSION_START, {
+      session_id: session,
+      cwd: project,
+      source: 'compact',
+    });
+
+    const ctx =
+      JSON.parse(out.stdout || '{}')?.hookSpecificOutput?.additionalContext ||
+      '';
+    expect(ctx).toContain('Restored after compaction');
+    expect(ctx).toContain('b.ts owns the retry budget');
+  }, 90_000);
+
+  it('says nothing on a cold start, so the text is not paid for every session', () => {
+    const a = join(project, 'a.ts');
+    writeFileSync(a, 'export const a = 1;\n');
+    seenState([a]);
+
+    const out = run(SESSION_START, {
+      session_id: session,
+      cwd: project,
+      source: 'startup',
+    });
+    const ctx =
+      JSON.parse(out.stdout || '{}')?.hookSpecificOutput?.additionalContext ||
+      '';
+
+    expect(ctx).not.toContain('Restored after compaction');
+    // The policy notice still arrives, which is the hook's original job.
+    expect(ctx.length).toBeGreaterThan(50);
+  }, 60_000);
+
+  it('still emits the policy notice when the graph is unreadable', () => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'graph.jsonl'), '{not json\n');
+    seenState([join(project, 'a.ts')]);
+
+    const out = run(SESSION_START, {
+      session_id: session,
+      cwd: project,
+      source: 'compact',
+    });
+    expect(out.status).toBe(0);
+    const ctx =
+      JSON.parse(out.stdout || '{}')?.hookSpecificOutput?.additionalContext ||
+      '';
+    expect(ctx.length).toBeGreaterThan(50);
+  }, 60_000);
+});

--- a/tests/hooks/reachability.test.mjs
+++ b/tests/hooks/reachability.test.mjs
@@ -91,16 +91,6 @@ const ALLOWED = new Map([
   // WIRED ELSEWHERE -- leaves this list when that PR merges.
   ['forTouch', 'WIRED by the injection PR: just-in-time delivery, imported by nothing before it.'],
 
-  // A COMPLETE FEATURE, DISCONNECTED AT BOTH ENDS. linkCoOccurrence is the only
-  // producer of `related` edges; predictNext in restore.mjs is their only
-  // consumer, and it is reached only through restorationPlan, which is itself
-  // unreachable. So co-occurrence -> restoration is built end to end and wired
-  // at neither. Turning it on is a product decision, not a cleanup: it would
-  // switch on unmeasured behaviour, which is the thing this project has spent
-  // its recent effort correcting.
-  ['linkCoOccurrence', 'UNWIRED FEATURE: sole producer of `related` edges, whose sole consumer (restorationPlan) is also unreachable.'],
-  ['restorationPlan', 'UNWIRED FEATURE: sole consumer of `related` edges, whose sole producer (linkCoOccurrence) is also unreachable.'],
-
   // A COMPLETE LOOP WITH NO ENTRY POINT. calibration.mjs has no importer at
   // all: logForecast and observeOutcome collect the data, reliability scores it
   // and calibrate applies the score. Nothing starts it, so the module cannot


### PR DESCRIPTION
## The gap

`related` was a declared edge kind with a producer, a consumer, and no graph that
ever contained one.

- `linkCoOccurrence` is its **only** writer — called from nowhere.
- `predictNext` is its **only** reader, reachable only through `restorationPlan`,
  which was equally unreachable.

Two halves of a working feature, each waiting for the other. The reachability
guard from #237 listed both as known-unwired; this connects them and removes both
allowlist entries.

## Producer — PreCompact

`state.seen` is exactly "the files this session worked on together", and it is
complete precisely once the session has grown long enough to be compacted.

Edges are **grouped by project root** before writing, because the graph is per
project: a session spanning two checkouts must not relate files that have never
met.

The recording runs **before** the `findWrapper()` early return. The wrapper is
needed only to spawn `optimize_session`, and plugin-only installs ship none — so
gating co-occurrence on it would have left every plugin-only user with no edges
and therefore no restoration, forever. That is the same shape as the defect this
PR exists to fix.

## Consumer — SessionStart, on `source: compact`

PreCompact cannot deliver restoration text: it writes into the context that is
about to be discarded. SessionStart is the first moment after the discard, and
the `compact` source is the harness naming this exact case. Cold starts return
early, so the text is not paid for on every session.

## Two defects the end-to-end tests found

Both were invisible to unit tests, which had passed for the entire time the
feature did nothing.

1. **Double parse.** `readPayload` returns the *parsed* payload. `restoration()`
   parsed it again, which throws on `[object Object]` — and the throw was
   swallowed by the fail-open catch, so the block silently never appeared.
2. **Overwritten import.** The `join` import was clobbered while adding the new
   imports. `findWrapper` still called it, but only when `CLAUDE_PLUGIN_ROOT` is
   set: a `ReferenceError` waiting in the configuration every real plugin install
   uses and no test exercised.

## Every new guard was broken on purpose

| Sabotage | Result |
|---|---|
| restore the double parse | `recommends a file the session never opened` ✗ |
| replace `linkCoOccurrence(...)` with a no-op | 2 tests ✗ |
| delete the `join` import | `reaches the wrapper when a plugin root is configured` ✗ |

The third one matters most. **The first version of that test passed with the
import removed** — asserting on exit status and stderr proves nothing against a
hook that ends in `.catch(() => {})`, since the error is swallowed and the hook
still exits 0 in silence. It was rewritten to plant a stub wrapper and assert the
`systemMessage`, which is the only observable that actually changes.

## Verification

```
Test Suites: 111 passed, 111 total
Tests:       4 skipped, 1500 passed, 1504 total
npm run build   exit 0
```

The headline assertion: a file the session **never opened** comes back
recommended, because the graph learned it is worked on alongside one that was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
