### PR TITLE
fix: install verification, plugin-aware doctor, and release pin drift

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -16,6 +16,36 @@ permissions:
   contents: read
 
 jobs:
+  # Generated and pinned artifacts must match their sources.
+  #
+  # `sync:hooks:check` already existed and already detected this drift. It was
+  # simply never invoked by any workflow, so it never ran -- and seven client
+  # configs shipped pinned to 5.3.2 while the hooks beside them were 5.3.6.
+  #
+  # This job carries NO release-please skip on purpose. The version bump is
+  # precisely what knocks the pinned specs out of step, so a gate that skips
+  # release commits cannot see the only event that causes the failure.
+  generated-artifacts:
+    name: Generated Artifacts In Sync
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify hook core, client entries, configs and pins are in sync
+        run: npm run sync:hooks:check
+
   bundle-size:
     name: Bundle Size Analysis
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,18 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # A release is the ONLY event that can introduce pin drift, because
+      # release-please bumps package.json without touching the specs pinned
+      # inside the hand-maintained client configs. Publishing that tree ships
+      # hooks at the new version calling an MCP server at the old one.
+      #
+      # This fails the publish rather than repairing the tree: the tag is
+      # already cut, so silently publishing something different from the tag
+      # would be worse than stopping. The sync-release-pins job below is what
+      # keeps it from getting this far.
+      - name: Verify pinned specs match the released version
+        run: npm run sync:hooks:check
+
       - name: Build project
         run: npm run build
 

--- a/.github/workflows/sync-release-pins.yml
+++ b/.github/workflows/sync-release-pins.yml
@@ -1,0 +1,77 @@
+name: Sync Release Pins
+
+# Repairs the release PR instead of merely failing it.
+#
+# release-please bumps package.json and, via `extra-files`, the plugin manifest.
+# It cannot bump the npm spec pinned inside the hand-maintained client configs:
+# that version lives inside a string in an args array
+# (`@ooples/token-optimizer-mcp@5.3.2`), which no jsonpath can address. So every
+# release left seven client configs pinned to whatever version last had
+# `sync:hooks` run against it by hand.
+#
+# The `generated-artifacts` gate in quality-gates.yml catches the drift, and the
+# guard in release.yml stops it shipping. Both are refusals. This job is the
+# repair: it runs the sync on the release PR and commits the result, so the PR
+# that bumps the version also carries the matching pins.
+#
+# WHY THIS CANNOT LOOP: pushes made with GITHUB_TOKEN do not trigger further
+# workflow runs. Even if they did, the second run would find nothing to commit
+# and exit, because the sync is idempotent.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  sync-release-pins:
+    name: Sync Pinned Specs On Release PR
+    # Scoped to release-please PRs on purpose. Auto-committing to a
+    # contributor's branch would be a surprising thing for a lint-adjacent job
+    # to do; the release PR is machine-authored, so amending it is not.
+    if: startsWith(github.head_ref, 'release-please')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout the release PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          # Default GITHUB_TOKEN is enough to push to a same-repo PR branch.
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Sync generated artifacts and pinned specs
+        run: npm run sync:hooks
+
+      - name: Commit the sync if it changed anything
+        run: |
+          if git diff --quiet; then
+            echo "Pins and generated artifacts already match the bumped version."
+            exit 0
+          fi
+
+          echo "Changed by the sync:"
+          git diff --name-only
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -am "chore: sync pinned specs and generated artifacts to the released version"
+          git push

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -5,7 +5,7 @@
   "mcpServers": {
     "token-optimizer": {
       "command": "npx",
-      "args": ["-y", "@ooples/token-optimizer-mcp@5.3.2"]
+      "args": ["-y", "@ooples/token-optimizer-mcp@5.3.6"]
     }
   },
   "settings": [

--- a/hooks-core/doctor.mjs
+++ b/hooks-core/doctor.mjs
@@ -21,11 +21,122 @@
 import { execFileSync } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
 import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { readManifest, verifyManifest, residue } from './manifest.mjs';
 
 const ok = (name, detail) => ({ name, pass: true, detail });
 const bad = (name, detail, remedy) => ({ name, pass: false, detail, remedy });
+
+const PLUGIN_ID = 'token-optimizer@token-optimizer';
+
+/** Reads JSON, or null. Never throws: this module must diagnose, not crash. */
+function readJson(path) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+/** Numeric semver compare; unparseable versions sort as equal to avoid crying wolf. */
+function compareVersions(a, b) {
+  const parse = (v) => String(v || '').split('.').map((n) => Number.parseInt(n, 10));
+  const left = parse(a);
+  const right = parse(b);
+  if (left.some(Number.isNaN) || right.some(Number.isNaN)) return 0;
+  for (let i = 0; i < Math.max(left.length, right.length); i++) {
+    const diff = (left[i] ?? 0) - (right[i] ?? 0);
+    if (diff !== 0) return diff < 0 ? -1 : 1;
+  }
+  return 0;
+}
+
+/**
+ * WHICH INSTALL IS THIS, AND WHERE ARE THE HOOKS IT ACTUALLY RUNS?
+ *
+ * Everything below used to assume the script-install path: hooks copied into
+ * ~/.claude-global/hooks, entries written into settings.json, a manifest
+ * recording both. The plugin path satisfies none of that. Its hooks are declared
+ * in the plugin's own hooks.json and live in the plugin cache, so a doctor
+ * looking in settings.json reports "not wired" about a plugin that is wired, and
+ * reports "no manifest" about a file that path never writes.
+ *
+ * It also resolved the hook binary from the npm package root, which is a
+ * DIFFERENT BUILD from the plugin's. Measured on a real machine: the package
+ * shipped 5.3.5 and the plugin cache held 5.3.6, with all 37 hook files
+ * differing. The enforcement probe passed -- for a build that was not running.
+ *
+ * Returns the versions separately rather than a boolean, because "installed is
+ * behind available" is the single most useful thing this tool can say: 5.0.2
+ * shipped one advisory hook, so a stale install is present, listed in /mcp, and
+ * saving nothing.
+ */
+export function detectInstall({ pluginsDir, root } = {}) {
+  const dir = pluginsDir || join(homedir(), '.claude', 'plugins');
+  const packageHooks = join(root || '.', 'plugin', 'hooks');
+
+  const record = readJson(join(dir, 'installed_plugins.json'))?.plugins?.[PLUGIN_ID]?.[0];
+  const marketplace = readJson(
+    join(dir, 'marketplaces', 'token-optimizer', 'plugin', '.claude-plugin', 'plugin.json')
+  );
+
+  const installedVersion = record?.version ?? null;
+  const availableVersion = marketplace?.version ?? null;
+  const pluginHooks = record?.installPath ? join(record.installPath, 'hooks') : null;
+
+  // A record whose installPath has gone missing is a broken plugin install, not
+  // a script install -- saying "script" there would send the user to the wrong
+  // remedy entirely.
+  if (record) {
+    return {
+      method: 'plugin',
+      hooksDir: pluginHooks && existsSync(pluginHooks) ? pluginHooks : packageHooks,
+      installPath: record.installPath ?? null,
+      installedVersion,
+      availableVersion,
+    };
+  }
+
+  return {
+    method: verifyManifest(readManifest()) ? 'script' : 'unknown',
+    hooksDir: packageHooks,
+    installPath: null,
+    installedVersion,
+    availableVersion,
+  };
+}
+
+/** Resolves the directory holding the hook entrypoints for a probe. */
+function hooksDirFor({ hooksDir, install, root }) {
+  return hooksDir || install?.hooksDir || join(root || '.', 'plugin', 'hooks');
+}
+
+/**
+ * Is the installed plugin the version that is available?
+ *
+ * The gap this closes: updating the marketplace does NOT update the installed
+ * plugin. `installed_plugins.json` pins installPath and version, so a machine
+ * can sit on 5.0.2 indefinitely while 5.3.6 is checked out beside it, and
+ * nothing anywhere says so. Restarting does not help, because the restart
+ * faithfully reloads the pinned version.
+ */
+export function probeVersion({ install }) {
+  const { method, installedVersion, availableVersion } = install || {};
+
+  if (method !== 'plugin' || !installedVersion || !availableVersion) {
+    return [];
+  }
+
+  if (compareVersions(installedVersion, availableVersion) < 0) {
+    return [bad('plugin is up to date',
+      `installed ${installedVersion}, but ${availableVersion} is available`,
+      'run /plugin and update token-optimizer -- updating the marketplace alone ' +
+      'does not move the installed version, and older builds shipped far weaker hooks')];
+  }
+
+  return [ok('plugin is up to date', `installed ${installedVersion}`)];
+}
 
 /** Runs a hook binary with a payload and returns its stdout, or null. */
 function probe(binary, payload, { timeoutMs = 8000, cwd } = {}) {
@@ -47,11 +158,21 @@ function probe(binary, payload, { timeoutMs = 8000, cwd } = {}) {
 /* ------------------------------------------------------------- THE CHECKLIST */
 
 /** Cheap structural checks. Fast, and each names its own fix. */
-export function checklist({ root, settingsPath }) {
+export function checklist({ root, settingsPath, install }) {
   const checks = [];
+  const resolved = install || detectInstall({ root });
+  const hooksDir = hooksDirFor({ install: resolved, root });
 
-  const router = join(root, 'plugin', 'hooks', 'pretooluse-router.mjs');
-  const sessionStart = join(root, 'plugin', 'hooks', 'session-start.mjs');
+  // SAY WHICH PATH THIS IS. Skipping the script-install checks silently would
+  // leave a user unable to tell whether they passed or were never run, which is
+  // the same opacity that made a 7/9 score untrustworthy in the first place.
+  checks.push(ok('install method', resolved.method === 'plugin'
+    ? `plugin${resolved.installedVersion ? ` ${resolved.installedVersion}` : ''}` +
+      ` -- hooks from ${hooksDir}`
+    : `${resolved.method} -- hooks from ${hooksDir}`));
+
+  const router = join(hooksDir, 'pretooluse-router.mjs');
+  const sessionStart = join(hooksDir, 'session-start.mjs');
 
   checks.push(existsSync(router)
     ? ok('hook binary present', router)
@@ -63,33 +184,43 @@ export function checklist({ root, settingsPath }) {
     : bad('session-start binary present', `not found at ${sessionStart}`,
       'reinstall the package to restore the session-start hook'));
 
-  if (settingsPath && existsSync(settingsPath)) {
-    try {
-      const settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
-      const wired = JSON.stringify(settings?.hooks || {}).includes('token-optimizer');
-      checks.push(wired
-        ? ok('hooks wired into settings', settingsPath)
-        : bad('hooks wired into settings', 'no token-optimizer entries found',
-          'run install-hooks.sh to add the PreToolUse and SessionStart entries'));
-    } catch {
-      checks.push(bad('settings file parses', `${settingsPath} is not valid JSON`,
-        'fix the JSON by hand -- we will not rewrite a file we cannot parse'));
+  // SETTINGS AND MANIFEST ARE SCRIPT-INSTALL CONCERNS ONLY.
+  //
+  // A plugin declares its hooks in the plugin's own hooks.json and writes
+  // nothing to settings.json, so demanding entries there reported "not wired"
+  // about a plugin that was demonstrably wired -- its SessionStart hook was
+  // injecting the policy at that very moment. Likewise the manifest: only
+  // install-hooks.* writes one. Two guaranteed failures on a healthy install
+  // taught the user to ignore the score.
+  if (resolved.method !== 'plugin') {
+    if (settingsPath && existsSync(settingsPath)) {
+      try {
+        const settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
+        const wired = JSON.stringify(settings?.hooks || {}).includes('token-optimizer');
+        checks.push(wired
+          ? ok('hooks wired into settings', settingsPath)
+          : bad('hooks wired into settings', 'no token-optimizer entries found',
+            'run install-hooks.sh to add the PreToolUse and SessionStart entries'));
+      } catch {
+        checks.push(bad('settings file parses', `${settingsPath} is not valid JSON`,
+          'fix the JSON by hand -- we will not rewrite a file we cannot parse'));
+      }
+    } else {
+      checks.push(bad('settings file present', `${settingsPath || 'settings path unknown'} not found`,
+        'run install-hooks.sh, or point TOKEN_OPTIMIZER_SETTINGS at your settings file'));
     }
-  } else {
-    checks.push(bad('settings file present', `${settingsPath || 'settings path unknown'} not found`,
-      'run install-hooks.sh, or point TOKEN_OPTIMIZER_SETTINGS at your settings file'));
-  }
 
-  // What we recorded putting on the machine, and whether it is still that.
-  const verified = verifyManifest(readManifest());
-  if (verified) {
-    checks.push(verified.modified === 0
-      ? ok('installed files intact', `${verified.intact} file(s) match the install manifest`)
-      : ok('installed files intact', `${verified.modified} file(s) edited since install -- ` +
-        'uninstall will leave those alone rather than destroy your changes'));
-  } else {
-    checks.push(bad('install manifest present', 'no record of what was installed',
-      'harmless if you installed manually; reinstall to get a removable, verifiable record'));
+    // What we recorded putting on the machine, and whether it is still that.
+    const verified = verifyManifest(readManifest());
+    if (verified) {
+      checks.push(verified.modified === 0
+        ? ok('installed files intact', `${verified.intact} file(s) match the install manifest`)
+        : ok('installed files intact', `${verified.modified} file(s) edited since install -- ` +
+          'uninstall will leave those alone rather than destroy your changes'));
+    } else {
+      checks.push(bad('install manifest present', 'no record of what was installed',
+        'harmless if you installed manually; reinstall to get a removable, verifiable record'));
+    }
   }
 
   return checks;
@@ -104,9 +235,12 @@ export function checklist({ root, settingsPath }) {
  * a hook that refuses everything is as broken as one that refuses nothing, and
  * only the second is what shipped last time.
  */
-export function probeEnforcement({ root, workspace }) {
+export function probeEnforcement({ root, workspace, hooksDir, install }) {
   const checks = [];
-  const binary = join(root, 'plugin', 'hooks', 'pretooluse-router.mjs');
+  // Probe the build that RUNS, not the one bundled beside this module. On a real
+  // machine those were 5.3.5 and 5.3.6 with all 37 hook files differing, and
+  // this probe passed for the copy nobody was executing.
+  const binary = join(hooksDirFor({ hooksDir, install, root }), 'pretooluse-router.mjs');
   if (!existsSync(binary)) {
     return [bad('enforcement refuses a large read', 'hook binary missing', 'reinstall the package')];
   }
@@ -153,8 +287,8 @@ export function probeEnforcement({ root, workspace }) {
 }
 
 /** The session-start notice has to actually come out. */
-export function probeSessionStart({ root, workspace }) {
-  const binary = join(root, 'plugin', 'hooks', 'session-start.mjs');
+export function probeSessionStart({ root, workspace, hooksDir, install }) {
+  const binary = join(hooksDirFor({ hooksDir, install, root }), 'session-start.mjs');
   if (!existsSync(binary)) {
     return [bad('session-start emits the policy', 'binary missing', 'reinstall the package')];
   }
@@ -251,11 +385,19 @@ export function probeServer({ root, timeoutMs = 20_000 }) {
  * Structural checks first because they are fast and explain most failures;
  * probes after, because they are what actually prove it works.
  */
-export function diagnose({ root, workspace, graphDir, settingsPath, skipServer = false } = {}) {
+export function diagnose({
+  root, workspace, graphDir, settingsPath, pluginsDir, skipServer = false,
+} = {}) {
+  // Resolved ONCE and threaded through, so every check reasons about the same
+  // install. Detecting per-probe is how the checklist and the enforcement probe
+  // ended up describing two different builds in the same report.
+  const install = detectInstall({ pluginsDir, root });
+
   const checks = [
-    ...checklist({ root, settingsPath }),
-    ...probeEnforcement({ root, workspace }),
-    ...probeSessionStart({ root, workspace }),
+    ...checklist({ root, settingsPath, install }),
+    ...probeVersion({ install }),
+    ...probeEnforcement({ root, workspace, install }),
+    ...probeSessionStart({ root, workspace, install }),
     ...probeGraph({ dir: graphDir }),
     ...(skipServer ? [] : probeServer({ root })),
   ];

--- a/install-hooks.ps1
+++ b/install-hooks.ps1
@@ -342,16 +342,27 @@ function Test-Installation {
 
     $issues = @()
 
-    # Check hooks files exist (including every helper the orchestrator
-    # dot-sources — a missing helper breaks every hook invocation).
+    # Verify the files this installer ACTUALLY SHIPS.
+    #
+    # This list used to require a dispatcher.ps1 plus handlers/ and helpers/
+    # shell libraries -- the design Install-HooksFiles replaced with three ES
+    # modules, as the comment above it says. None of those files has been
+    # produced by an install for some time, so verification could not pass, and
+    # a failed verification skipped record-install.mjs. That is why the doctor
+    # reports "no record of what was installed": the installer was prevented
+    # from writing the manifest by a check on files it no longer creates.
+    #
+    # Note the subdirectory: Install-HooksFiles copies into
+    # $HOOKS_DIR\token-optimizer, not $HOOKS_DIR. The old list omitted it, so
+    # every path was wrong twice over.
     $requiredFiles = @(
-        "$HOOKS_DIR\dispatcher.ps1",
-        "$HOOKS_DIR\handlers\token-optimizer-orchestrator.ps1",
-        "$HOOKS_DIR\helpers\invoke-mcp.ps1",
-        "$HOOKS_DIR\helpers\logging.ps1",
-        "$HOOKS_DIR\helpers\config.ps1",
-        "$HOOKS_DIR\helpers\gzip.ps1",
-        "$HOOKS_DIR\helpers\context-delta.ps1"
+        "$HOOKS_DIR\token-optimizer\session-start.mjs",
+        "$HOOKS_DIR\token-optimizer\pretooluse-router.mjs",
+        "$HOOKS_DIR\token-optimizer\precompact-optimize.mjs",
+        "$HOOKS_DIR\token-optimizer\hooks.json",
+        # The shared library every hook imports. Present but empty would break
+        # all three entrypoints, so it is checked explicitly.
+        "$HOOKS_DIR\token-optimizer\lib\policy.mjs"
     )
 
     foreach ($file in $requiredFiles) {
@@ -424,8 +435,14 @@ function Test-Installation {
         }
     }
 
+    # ADVISORY, NOT FATAL. This check looks for the server in
+    # claude_desktop_config.json, Cursor, Cline, Copilot and Windsurf. A Claude
+    # Code CLI user has it in none of them -- that path gets the MCP server from
+    # the plugin's own .mcp.json -- so treating absence as an installation
+    # failure fails the install for the primary supported client.
     if (-not $mcpConfigured) {
-        $issues += "token-optimizer MCP server not configured in any AI tool"
+        Write-Status "MCP server not found in Claude Desktop / Cursor / Cline / Copilot / Windsurf" "WARN"
+        Write-Status "That is expected on Claude Code, which gets the server from the plugin instead" "INFO"
     } else {
         Write-Status " MCP server configured in: $($checkedConfigs -join ', ')" "SUCCESS"
     }
@@ -483,14 +500,22 @@ try {
     } else {
         $verified = Test-Installation
 
+        # RECORD THE MANIFEST REGARDLESS OF THE VERDICT.
+        #
+        # This used to sit inside `if ($verified)`, which inverted the
+        # relationship it needed: the manifest records what was written to this
+        # machine, and files were written before verification ran. Skipping it on
+        # failure leaves those files with no record of where they came from --
+        # exactly the case where an exact uninstall matters most. It is also why
+        # the doctor reported a missing manifest on a machine whose hooks were
+        # installed and working.
+        try {
+            & node (Join-Path $PSScriptRoot 'scripts/record-install.mjs') $HOOKS_DIR $CLAUDE_SETTINGS
+        } catch {
+            Write-Status "Could not record the install manifest (uninstall will be manual)" "WARN"
+        }
+
         if ($verified) {
-            # Record exactly what we put on this machine, so uninstall can be
-            # exact rather than best-effort.
-            try {
-                & node (Join-Path $PSScriptRoot 'scripts/record-install.mjs') $HOOKS_DIR $CLAUDE_SETTINGS
-            } catch {
-                Write-Status "Could not record the install manifest (uninstall will be manual)" "WARN"
-            }
             Write-Host ""
             Write-Host "=============================================================" -ForegroundColor Green
             Write-Host "   Installation Complete!                                    " -ForegroundColor Green

--- a/install-hooks.sh
+++ b/install-hooks.sh
@@ -344,11 +344,22 @@ test_installation() {
 
     local issues=()
 
-    # Check hooks files exist
+    # Verify the files this installer ACTUALLY SHIPS.
+    #
+    # This required a dispatcher.sh plus handlers/ and helpers/ shell libraries
+    # -- the design install_hooks_files replaced with three ES modules. None of
+    # them is produced by an install, so verification could never pass, and a
+    # failed verification skipped the install manifest. Same bug, same cause, as
+    # install-hooks.ps1.
+    #
+    # Note the subdirectory: install_hooks_files copies into
+    # $HOOKS_DIR/token-optimizer, which the old list also omitted.
     local required_files=(
-        "$HOOKS_DIR/dispatcher.sh"
-        "$HOOKS_DIR/handlers/token-optimizer-orchestrator.sh"
-        "$HOOKS_DIR/helpers/invoke-mcp.sh"
+        "$HOOKS_DIR/token-optimizer/session-start.mjs"
+        "$HOOKS_DIR/token-optimizer/pretooluse-router.mjs"
+        "$HOOKS_DIR/token-optimizer/precompact-optimize.mjs"
+        "$HOOKS_DIR/token-optimizer/hooks.json"
+        "$HOOKS_DIR/token-optimizer/lib/policy.mjs"
     )
 
     for file in "${required_files[@]}"; do
@@ -417,8 +428,14 @@ test_installation() {
         checked_configs+=("Windsurf IDE")
     fi
 
+    # ADVISORY, NOT FATAL. This looks for the server in Claude Desktop, Cursor,
+    # Cline, Copilot and Windsurf. A Claude Code user has it in none of them --
+    # that client gets the MCP server from the plugin's own .mcp.json -- so
+    # counting absence as an installation failure fails the install for the
+    # primary supported client.
     if [[ "$mcp_configured" == "false" ]]; then
-        issues+=("token-optimizer MCP server not configured in any AI tool")
+        write_status "MCP server not found in Claude Desktop / Cursor / Cline / Copilot / Windsurf" "WARN"
+        write_status "That is expected on Claude Code, which gets the server from the plugin instead" "INFO"
     else
         write_status "✓ MCP server configured in: ${checked_configs[*]}" "SUCCESS"
     fi
@@ -475,12 +492,19 @@ echo ""
 if [[ "$DRY_RUN" == "true" ]]; then
     write_status "DRY RUN COMPLETE - No changes were made" "SUCCESS"
 else
+    # RECORD THE MANIFEST REGARDLESS OF THE VERDICT.
+    #
+    # Files were written to this machine before verification ran, so the record
+    # of what was written must not be conditional on verification passing --
+    # that is precisely the case where an exact uninstall matters most, and it
+    # is why the doctor reported a missing manifest on a working install.
+    if command -v node >/dev/null 2>&1; then
+        node "$(dirname "${BASH_SOURCE[0]}")/scripts/record-install.mjs" \
+            "$HOOKS_DIR" "$CLAUDE_SETTINGS" 2>/dev/null \
+            || write_status "Could not record the install manifest (uninstall will be manual)" "WARN"
+    fi
+
     if test_installation; then
-        # Record exactly what we put on this machine, so uninstall can be exact
-        # rather than best-effort and "what did this install" has an answer.
-        if command -v node >/dev/null 2>&1; then
-            node "$(dirname "${BASH_SOURCE[0]}")/scripts/record-install.mjs"                 "$HOOKS_DIR" "$CLAUDE_SETTINGS" 2>/dev/null                 || write_status "Could not record the install manifest (uninstall will be manual)" "WARN"
-        fi
         echo ""
         echo "╔═══════════════════════════════════════════════════════════╗"
         echo "║   Installation Complete!                                  ║"

--- a/integrations/codex/config.toml
+++ b/integrations/codex/config.toml
@@ -5,6 +5,6 @@
 
 [mcp_servers.token-optimizer]
 command = "npx"
-args = ["-y", "@ooples/token-optimizer-mcp@5.3.2"]
+args = ["-y", "@ooples/token-optimizer-mcp@5.3.6"]
 # Optional: point the cache somewhere stable.
 # env = { TOKEN_OPTIMIZER_CACHE_DIR = "~/.token-optimizer-cache" }

--- a/integrations/codex/hooks/lib/doctor.mjs
+++ b/integrations/codex/hooks/lib/doctor.mjs
@@ -23,11 +23,122 @@
 import { execFileSync } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
 import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { readManifest, verifyManifest, residue } from './manifest.mjs';
 
 const ok = (name, detail) => ({ name, pass: true, detail });
 const bad = (name, detail, remedy) => ({ name, pass: false, detail, remedy });
+
+const PLUGIN_ID = 'token-optimizer@token-optimizer';
+
+/** Reads JSON, or null. Never throws: this module must diagnose, not crash. */
+function readJson(path) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+/** Numeric semver compare; unparseable versions sort as equal to avoid crying wolf. */
+function compareVersions(a, b) {
+  const parse = (v) => String(v || '').split('.').map((n) => Number.parseInt(n, 10));
+  const left = parse(a);
+  const right = parse(b);
+  if (left.some(Number.isNaN) || right.some(Number.isNaN)) return 0;
+  for (let i = 0; i < Math.max(left.length, right.length); i++) {
+    const diff = (left[i] ?? 0) - (right[i] ?? 0);
+    if (diff !== 0) return diff < 0 ? -1 : 1;
+  }
+  return 0;
+}
+
+/**
+ * WHICH INSTALL IS THIS, AND WHERE ARE THE HOOKS IT ACTUALLY RUNS?
+ *
+ * Everything below used to assume the script-install path: hooks copied into
+ * ~/.claude-global/hooks, entries written into settings.json, a manifest
+ * recording both. The plugin path satisfies none of that. Its hooks are declared
+ * in the plugin's own hooks.json and live in the plugin cache, so a doctor
+ * looking in settings.json reports "not wired" about a plugin that is wired, and
+ * reports "no manifest" about a file that path never writes.
+ *
+ * It also resolved the hook binary from the npm package root, which is a
+ * DIFFERENT BUILD from the plugin's. Measured on a real machine: the package
+ * shipped 5.3.5 and the plugin cache held 5.3.6, with all 37 hook files
+ * differing. The enforcement probe passed -- for a build that was not running.
+ *
+ * Returns the versions separately rather than a boolean, because "installed is
+ * behind available" is the single most useful thing this tool can say: 5.0.2
+ * shipped one advisory hook, so a stale install is present, listed in /mcp, and
+ * saving nothing.
+ */
+export function detectInstall({ pluginsDir, root } = {}) {
+  const dir = pluginsDir || join(homedir(), '.claude', 'plugins');
+  const packageHooks = join(root || '.', 'plugin', 'hooks');
+
+  const record = readJson(join(dir, 'installed_plugins.json'))?.plugins?.[PLUGIN_ID]?.[0];
+  const marketplace = readJson(
+    join(dir, 'marketplaces', 'token-optimizer', 'plugin', '.claude-plugin', 'plugin.json')
+  );
+
+  const installedVersion = record?.version ?? null;
+  const availableVersion = marketplace?.version ?? null;
+  const pluginHooks = record?.installPath ? join(record.installPath, 'hooks') : null;
+
+  // A record whose installPath has gone missing is a broken plugin install, not
+  // a script install -- saying "script" there would send the user to the wrong
+  // remedy entirely.
+  if (record) {
+    return {
+      method: 'plugin',
+      hooksDir: pluginHooks && existsSync(pluginHooks) ? pluginHooks : packageHooks,
+      installPath: record.installPath ?? null,
+      installedVersion,
+      availableVersion,
+    };
+  }
+
+  return {
+    method: verifyManifest(readManifest()) ? 'script' : 'unknown',
+    hooksDir: packageHooks,
+    installPath: null,
+    installedVersion,
+    availableVersion,
+  };
+}
+
+/** Resolves the directory holding the hook entrypoints for a probe. */
+function hooksDirFor({ hooksDir, install, root }) {
+  return hooksDir || install?.hooksDir || join(root || '.', 'plugin', 'hooks');
+}
+
+/**
+ * Is the installed plugin the version that is available?
+ *
+ * The gap this closes: updating the marketplace does NOT update the installed
+ * plugin. `installed_plugins.json` pins installPath and version, so a machine
+ * can sit on 5.0.2 indefinitely while 5.3.6 is checked out beside it, and
+ * nothing anywhere says so. Restarting does not help, because the restart
+ * faithfully reloads the pinned version.
+ */
+export function probeVersion({ install }) {
+  const { method, installedVersion, availableVersion } = install || {};
+
+  if (method !== 'plugin' || !installedVersion || !availableVersion) {
+    return [];
+  }
+
+  if (compareVersions(installedVersion, availableVersion) < 0) {
+    return [bad('plugin is up to date',
+      `installed ${installedVersion}, but ${availableVersion} is available`,
+      'run /plugin and update token-optimizer -- updating the marketplace alone ' +
+      'does not move the installed version, and older builds shipped far weaker hooks')];
+  }
+
+  return [ok('plugin is up to date', `installed ${installedVersion}`)];
+}
 
 /** Runs a hook binary with a payload and returns its stdout, or null. */
 function probe(binary, payload, { timeoutMs = 8000, cwd } = {}) {
@@ -49,11 +160,21 @@ function probe(binary, payload, { timeoutMs = 8000, cwd } = {}) {
 /* ------------------------------------------------------------- THE CHECKLIST */
 
 /** Cheap structural checks. Fast, and each names its own fix. */
-export function checklist({ root, settingsPath }) {
+export function checklist({ root, settingsPath, install }) {
   const checks = [];
+  const resolved = install || detectInstall({ root });
+  const hooksDir = hooksDirFor({ install: resolved, root });
 
-  const router = join(root, 'plugin', 'hooks', 'pretooluse-router.mjs');
-  const sessionStart = join(root, 'plugin', 'hooks', 'session-start.mjs');
+  // SAY WHICH PATH THIS IS. Skipping the script-install checks silently would
+  // leave a user unable to tell whether they passed or were never run, which is
+  // the same opacity that made a 7/9 score untrustworthy in the first place.
+  checks.push(ok('install method', resolved.method === 'plugin'
+    ? `plugin${resolved.installedVersion ? ` ${resolved.installedVersion}` : ''}` +
+      ` -- hooks from ${hooksDir}`
+    : `${resolved.method} -- hooks from ${hooksDir}`));
+
+  const router = join(hooksDir, 'pretooluse-router.mjs');
+  const sessionStart = join(hooksDir, 'session-start.mjs');
 
   checks.push(existsSync(router)
     ? ok('hook binary present', router)
@@ -65,33 +186,43 @@ export function checklist({ root, settingsPath }) {
     : bad('session-start binary present', `not found at ${sessionStart}`,
       'reinstall the package to restore the session-start hook'));
 
-  if (settingsPath && existsSync(settingsPath)) {
-    try {
-      const settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
-      const wired = JSON.stringify(settings?.hooks || {}).includes('token-optimizer');
-      checks.push(wired
-        ? ok('hooks wired into settings', settingsPath)
-        : bad('hooks wired into settings', 'no token-optimizer entries found',
-          'run install-hooks.sh to add the PreToolUse and SessionStart entries'));
-    } catch {
-      checks.push(bad('settings file parses', `${settingsPath} is not valid JSON`,
-        'fix the JSON by hand -- we will not rewrite a file we cannot parse'));
+  // SETTINGS AND MANIFEST ARE SCRIPT-INSTALL CONCERNS ONLY.
+  //
+  // A plugin declares its hooks in the plugin's own hooks.json and writes
+  // nothing to settings.json, so demanding entries there reported "not wired"
+  // about a plugin that was demonstrably wired -- its SessionStart hook was
+  // injecting the policy at that very moment. Likewise the manifest: only
+  // install-hooks.* writes one. Two guaranteed failures on a healthy install
+  // taught the user to ignore the score.
+  if (resolved.method !== 'plugin') {
+    if (settingsPath && existsSync(settingsPath)) {
+      try {
+        const settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
+        const wired = JSON.stringify(settings?.hooks || {}).includes('token-optimizer');
+        checks.push(wired
+          ? ok('hooks wired into settings', settingsPath)
+          : bad('hooks wired into settings', 'no token-optimizer entries found',
+            'run install-hooks.sh to add the PreToolUse and SessionStart entries'));
+      } catch {
+        checks.push(bad('settings file parses', `${settingsPath} is not valid JSON`,
+          'fix the JSON by hand -- we will not rewrite a file we cannot parse'));
+      }
+    } else {
+      checks.push(bad('settings file present', `${settingsPath || 'settings path unknown'} not found`,
+        'run install-hooks.sh, or point TOKEN_OPTIMIZER_SETTINGS at your settings file'));
     }
-  } else {
-    checks.push(bad('settings file present', `${settingsPath || 'settings path unknown'} not found`,
-      'run install-hooks.sh, or point TOKEN_OPTIMIZER_SETTINGS at your settings file'));
-  }
 
-  // What we recorded putting on the machine, and whether it is still that.
-  const verified = verifyManifest(readManifest());
-  if (verified) {
-    checks.push(verified.modified === 0
-      ? ok('installed files intact', `${verified.intact} file(s) match the install manifest`)
-      : ok('installed files intact', `${verified.modified} file(s) edited since install -- ` +
-        'uninstall will leave those alone rather than destroy your changes'));
-  } else {
-    checks.push(bad('install manifest present', 'no record of what was installed',
-      'harmless if you installed manually; reinstall to get a removable, verifiable record'));
+    // What we recorded putting on the machine, and whether it is still that.
+    const verified = verifyManifest(readManifest());
+    if (verified) {
+      checks.push(verified.modified === 0
+        ? ok('installed files intact', `${verified.intact} file(s) match the install manifest`)
+        : ok('installed files intact', `${verified.modified} file(s) edited since install -- ` +
+          'uninstall will leave those alone rather than destroy your changes'));
+    } else {
+      checks.push(bad('install manifest present', 'no record of what was installed',
+        'harmless if you installed manually; reinstall to get a removable, verifiable record'));
+    }
   }
 
   return checks;
@@ -106,9 +237,12 @@ export function checklist({ root, settingsPath }) {
  * a hook that refuses everything is as broken as one that refuses nothing, and
  * only the second is what shipped last time.
  */
-export function probeEnforcement({ root, workspace }) {
+export function probeEnforcement({ root, workspace, hooksDir, install }) {
   const checks = [];
-  const binary = join(root, 'plugin', 'hooks', 'pretooluse-router.mjs');
+  // Probe the build that RUNS, not the one bundled beside this module. On a real
+  // machine those were 5.3.5 and 5.3.6 with all 37 hook files differing, and
+  // this probe passed for the copy nobody was executing.
+  const binary = join(hooksDirFor({ hooksDir, install, root }), 'pretooluse-router.mjs');
   if (!existsSync(binary)) {
     return [bad('enforcement refuses a large read', 'hook binary missing', 'reinstall the package')];
   }
@@ -155,8 +289,8 @@ export function probeEnforcement({ root, workspace }) {
 }
 
 /** The session-start notice has to actually come out. */
-export function probeSessionStart({ root, workspace }) {
-  const binary = join(root, 'plugin', 'hooks', 'session-start.mjs');
+export function probeSessionStart({ root, workspace, hooksDir, install }) {
+  const binary = join(hooksDirFor({ hooksDir, install, root }), 'session-start.mjs');
   if (!existsSync(binary)) {
     return [bad('session-start emits the policy', 'binary missing', 'reinstall the package')];
   }
@@ -253,11 +387,19 @@ export function probeServer({ root, timeoutMs = 20_000 }) {
  * Structural checks first because they are fast and explain most failures;
  * probes after, because they are what actually prove it works.
  */
-export function diagnose({ root, workspace, graphDir, settingsPath, skipServer = false } = {}) {
+export function diagnose({
+  root, workspace, graphDir, settingsPath, pluginsDir, skipServer = false,
+} = {}) {
+  // Resolved ONCE and threaded through, so every check reasons about the same
+  // install. Detecting per-probe is how the checklist and the enforcement probe
+  // ended up describing two different builds in the same report.
+  const install = detectInstall({ pluginsDir, root });
+
   const checks = [
-    ...checklist({ root, settingsPath }),
-    ...probeEnforcement({ root, workspace }),
-    ...probeSessionStart({ root, workspace }),
+    ...checklist({ root, settingsPath, install }),
+    ...probeVersion({ install }),
+    ...probeEnforcement({ root, workspace, install }),
+    ...probeSessionStart({ root, workspace, install }),
     ...probeGraph({ dir: graphDir }),
     ...(skipServer ? [] : probeServer({ root })),
   ];

--- a/integrations/codex/plugin/.mcp.json
+++ b/integrations/codex/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcp_servers": {
     "token-optimizer": {
       "command": "npx",
-      "args": ["-y", "@ooples/token-optimizer-mcp@5.3.2"]
+      "args": ["-y", "@ooples/token-optimizer-mcp@5.3.6"]
     }
   }
 }

--- a/integrations/codex/plugin/hooks/lib/doctor.mjs
+++ b/integrations/codex/plugin/hooks/lib/doctor.mjs
@@ -23,11 +23,122 @@
 import { execFileSync } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
 import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { readManifest, verifyManifest, residue } from './manifest.mjs';
 
 const ok = (name, detail) => ({ name, pass: true, detail });
 const bad = (name, detail, remedy) => ({ name, pass: false, detail, remedy });
+
+const PLUGIN_ID = 'token-optimizer@token-optimizer';
+
+/** Reads JSON, or null. Never throws: this module must diagnose, not crash. */
+function readJson(path) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+/** Numeric semver compare; unparseable versions sort as equal to avoid crying wolf. */
+function compareVersions(a, b) {
+  const parse = (v) => String(v || '').split('.').map((n) => Number.parseInt(n, 10));
+  const left = parse(a);
+  const right = parse(b);
+  if (left.some(Number.isNaN) || right.some(Number.isNaN)) return 0;
+  for (let i = 0; i < Math.max(left.length, right.length); i++) {
+    const diff = (left[i] ?? 0) - (right[i] ?? 0);
+    if (diff !== 0) return diff < 0 ? -1 : 1;
+  }
+  return 0;
+}
+
+/**
+ * WHICH INSTALL IS THIS, AND WHERE ARE THE HOOKS IT ACTUALLY RUNS?
+ *
+ * Everything below used to assume the script-install path: hooks copied into
+ * ~/.claude-global/hooks, entries written into settings.json, a manifest
+ * recording both. The plugin path satisfies none of that. Its hooks are declared
+ * in the plugin's own hooks.json and live in the plugin cache, so a doctor
+ * looking in settings.json reports "not wired" about a plugin that is wired, and
+ * reports "no manifest" about a file that path never writes.
+ *
+ * It also resolved the hook binary from the npm package root, which is a
+ * DIFFERENT BUILD from the plugin's. Measured on a real machine: the package
+ * shipped 5.3.5 and the plugin cache held 5.3.6, with all 37 hook files
+ * differing. The enforcement probe passed -- for a build that was not running.
+ *
+ * Returns the versions separately rather than a boolean, because "installed is
+ * behind available" is the single most useful thing this tool can say: 5.0.2
+ * shipped one advisory hook, so a stale install is present, listed in /mcp, and
+ * saving nothing.
+ */
+export function detectInstall({ pluginsDir, root } = {}) {
+  const dir = pluginsDir || join(homedir(), '.claude', 'plugins');
+  const packageHooks = join(root || '.', 'plugin', 'hooks');
+
+  const record = readJson(join(dir, 'installed_plugins.json'))?.plugins?.[PLUGIN_ID]?.[0];
+  const marketplace = readJson(
+    join(dir, 'marketplaces', 'token-optimizer', 'plugin', '.claude-plugin', 'plugin.json')
+  );
+
+  const installedVersion = record?.version ?? null;
+  const availableVersion = marketplace?.version ?? null;
+  const pluginHooks = record?.installPath ? join(record.installPath, 'hooks') : null;
+
+  // A record whose installPath has gone missing is a broken plugin install, not
+  // a script install -- saying "script" there would send the user to the wrong
+  // remedy entirely.
+  if (record) {
+    return {
+      method: 'plugin',
+      hooksDir: pluginHooks && existsSync(pluginHooks) ? pluginHooks : packageHooks,
+      installPath: record.installPath ?? null,
+      installedVersion,
+      availableVersion,
+    };
+  }
+
+  return {
+    method: verifyManifest(readManifest()) ? 'script' : 'unknown',
+    hooksDir: packageHooks,
+    installPath: null,
+    installedVersion,
+    availableVersion,
+  };
+}
+
+/** Resolves the directory holding the hook entrypoints for a probe. */
+function hooksDirFor({ hooksDir, install, root }) {
+  return hooksDir || install?.hooksDir || join(root || '.', 'plugin', 'hooks');
+}
+
+/**
+ * Is the installed plugin the version that is available?
+ *
+ * The gap this closes: updating the marketplace does NOT update the installed
+ * plugin. `installed_plugins.json` pins installPath and version, so a machine
+ * can sit on 5.0.2 indefinitely while 5.3.6 is checked out beside it, and
+ * nothing anywhere says so. Restarting does not help, because the restart
+ * faithfully reloads the pinned version.
+ */
+export function probeVersion({ install }) {
+  const { method, installedVersion, availableVersion } = install || {};
+
+  if (method !== 'plugin' || !installedVersion || !availableVersion) {
+    return [];
+  }
+
+  if (compareVersions(installedVersion, availableVersion) < 0) {
+    return [bad('plugin is up to date',
+      `installed ${installedVersion}, but ${availableVersion} is available`,
+      'run /plugin and update token-optimizer -- updating the marketplace alone ' +
+      'does not move the installed version, and older builds shipped far weaker hooks')];
+  }
+
+  return [ok('plugin is up to date', `installed ${installedVersion}`)];
+}
 
 /** Runs a hook binary with a payload and returns its stdout, or null. */
 function probe(binary, payload, { timeoutMs = 8000, cwd } = {}) {
@@ -49,11 +160,21 @@ function probe(binary, payload, { timeoutMs = 8000, cwd } = {}) {
 /* ------------------------------------------------------------- THE CHECKLIST */
 
 /** Cheap structural checks. Fast, and each names its own fix. */
-export function checklist({ root, settingsPath }) {
+export function checklist({ root, settingsPath, install }) {
   const checks = [];
+  const resolved = install || detectInstall({ root });
+  const hooksDir = hooksDirFor({ install: resolved, root });
 
-  const router = join(root, 'plugin', 'hooks', 'pretooluse-router.mjs');
-  const sessionStart = join(root, 'plugin', 'hooks', 'session-start.mjs');
+  // SAY WHICH PATH THIS IS. Skipping the script-install checks silently would
+  // leave a user unable to tell whether they passed or were never run, which is
+  // the same opacity that made a 7/9 score untrustworthy in the first place.
+  checks.push(ok('install method', resolved.method === 'plugin'
+    ? `plugin${resolved.installedVersion ? ` ${resolved.installedVersion}` : ''}` +
+      ` -- hooks from ${hooksDir}`
+    : `${resolved.method} -- hooks from ${hooksDir}`));
+
+  const router = join(hooksDir, 'pretooluse-router.mjs');
+  const sessionStart = join(hooksDir, 'session-start.mjs');
 
   checks.push(existsSync(router)
     ? ok('hook binary present', router)
@@ -65,33 +186,43 @@ export function checklist({ root, settingsPath }) {
     : bad('session-start binary present', `not found at ${sessionStart}`,
       'reinstall the package to restore the session-start hook'));
 
-  if (settingsPath && existsSync(settingsPath)) {
-    try {
-      const settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
-      const wired = JSON.stringify(settings?.hooks || {}).includes('token-optimizer');
-      checks.push(wired
-        ? ok('hooks wired into settings', settingsPath)
-        : bad('hooks wired into settings', 'no token-optimizer entries found',
-          'run install-hooks.sh to add the PreToolUse and SessionStart entries'));
-    } catch {
-      checks.push(bad('settings file parses', `${settingsPath} is not valid JSON`,
-        'fix the JSON by hand -- we will not rewrite a file we cannot parse'));
+  // SETTINGS AND MANIFEST ARE SCRIPT-INSTALL CONCERNS ONLY.
+  //
+  // A plugin declares its hooks in the plugin's own hooks.json and writes
+  // nothing to settings.json, so demanding entries there reported "not wired"
+  // about a plugin that was demonstrably wired -- its SessionStart hook was
+  // injecting the policy at that very moment. Likewise the manifest: only
+  // install-hooks.* writes one. Two guaranteed failures on a healthy install
+  // taught the user to ignore the score.
+  if (resolved.method !== 'plugin') {
+    if (settingsPath && existsSync(settingsPath)) {
+      try {
+        const settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
+        const wired = JSON.stringify(settings?.hooks || {}).includes('token-optimizer');
+        checks.push(wired
+          ? ok('hooks wired into settings', settingsPath)
+          : bad('hooks wired into settings', 'no token-optimizer entries found',
+            'run install-hooks.sh to add the PreToolUse and SessionStart entries'));
+      } catch {
+        checks.push(bad('settings file parses', `${settingsPath} is not valid JSON`,
+          'fix the JSON by hand -- we will not rewrite a file we cannot parse'));
+      }
+    } else {
+      checks.push(bad('settings file present', `${settingsPath || 'settings path unknown'} not found`,
+        'run install-hooks.sh, or point TOKEN_OPTIMIZER_SETTINGS at your settings file'));
     }
-  } else {
-    checks.push(bad('settings file present', `${settingsPath || 'settings path unknown'} not found`,
-      'run install-hooks.sh, or point TOKEN_OPTIMIZER_SETTINGS at your settings file'));
-  }
 
-  // What we recorded putting on the machine, and whether it is still that.
-  const verified = verifyManifest(readManifest());
-  if (verified) {
-    checks.push(verified.modified === 0
-      ? ok('installed files intact', `${verified.intact} file(s) match the install manifest`)
-      : ok('installed files intact', `${verified.modified} file(s) edited since install -- ` +
-        'uninstall will leave those alone rather than destroy your changes'));
-  } else {
-    checks.push(bad('install manifest present', 'no record of what was installed',
-      'harmless if you installed manually; reinstall to get a removable, verifiable record'));
+    // What we recorded putting on the machine, and whether it is still that.
+    const verified = verifyManifest(readManifest());
+    if (verified) {
+      checks.push(verified.modified === 0
+        ? ok('installed files intact', `${verified.intact} file(s) match the install manifest`)
+        : ok('installed files intact', `${verified.modified} file(s) edited since install -- ` +
+          'uninstall will leave those alone rather than destroy your changes'));
+    } else {
+      checks.push(bad('install manifest present', 'no record of what was installed',
+        'harmless if you installed manually; reinstall to get a removable, verifiable record'));
+    }
   }
 
   return checks;
@@ -106,9 +237,12 @@ export function checklist({ root, settingsPath }) {
  * a hook that refuses everything is as broken as one that refuses nothing, and
  * only the second is what shipped last time.
  */
-export function probeEnforcement({ root, workspace }) {
+export function probeEnforcement({ root, workspace, hooksDir, install }) {
   const checks = [];
-  const binary = join(root, 'plugin', 'hooks', 'pretooluse-router.mjs');
+  // Probe the build that RUNS, not the one bundled beside this module. On a real
+  // machine those were 5.3.5 and 5.3.6 with all 37 hook files differing, and
+  // this probe passed for the copy nobody was executing.
+  const binary = join(hooksDirFor({ hooksDir, install, root }), 'pretooluse-router.mjs');
   if (!existsSync(binary)) {
     return [bad('enforcement refuses a large read', 'hook binary missing', 'reinstall the package')];
   }
@@ -155,8 +289,8 @@ export function probeEnforcement({ root, workspace }) {
 }
 
 /** The session-start notice has to actually come out. */
-export function probeSessionStart({ root, workspace }) {
-  const binary = join(root, 'plugin', 'hooks', 'session-start.mjs');
+export function probeSessionStart({ root, workspace, hooksDir, install }) {
+  const binary = join(hooksDirFor({ hooksDir, install, root }), 'session-start.mjs');
   if (!existsSync(binary)) {
     return [bad('session-start emits the policy', 'binary missing', 'reinstall the package')];
   }
@@ -253,11 +387,19 @@ export function probeServer({ root, timeoutMs = 20_000 }) {
  * Structural checks first because they are fast and explain most failures;
  * probes after, because they are what actually prove it works.
  */
-export function diagnose({ root, workspace, graphDir, settingsPath, skipServer = false } = {}) {
+export function diagnose({
+  root, workspace, graphDir, settingsPath, pluginsDir, skipServer = false,
+} = {}) {
+  // Resolved ONCE and threaded through, so every check reasons about the same
+  // install. Detecting per-probe is how the checklist and the enforcement probe
+  // ended up describing two different builds in the same report.
+  const install = detectInstall({ pluginsDir, root });
+
   const checks = [
-    ...checklist({ root, settingsPath }),
-    ...probeEnforcement({ root, workspace }),
-    ...probeSessionStart({ root, workspace }),
+    ...checklist({ root, settingsPath, install }),
+    ...probeVersion({ install }),
+    ...probeEnforcement({ root, workspace, install }),
+    ...probeSessionStart({ root, workspace, install }),
     ...probeGraph({ dir: graphDir }),
     ...(skipServer ? [] : probeServer({ root })),
   ];

--- a/integrations/copilot/mcp-config.json
+++ b/integrations/copilot/mcp-config.json
@@ -3,7 +3,7 @@
     "token-optimizer": {
       "type": "local",
       "command": "npx",
-      "args": ["-y", "@ooples/token-optimizer-mcp@5.3.2"],
+      "args": ["-y", "@ooples/token-optimizer-mcp@5.3.6"],
       "tools": ["*"]
     }
   }

--- a/integrations/gemini/gemini-extension.json
+++ b/integrations/gemini/gemini-extension.json
@@ -5,7 +5,7 @@
   "mcpServers": {
     "token-optimizer": {
       "command": "npx",
-      "args": ["-y", "@ooples/token-optimizer-mcp@5.3.2"]
+      "args": ["-y", "@ooples/token-optimizer-mcp@5.3.6"]
     }
   },
   "settings": [

--- a/integrations/gemini/hooks/lib/doctor.mjs
+++ b/integrations/gemini/hooks/lib/doctor.mjs
@@ -23,11 +23,122 @@
 import { execFileSync } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
 import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { readManifest, verifyManifest, residue } from './manifest.mjs';
 
 const ok = (name, detail) => ({ name, pass: true, detail });
 const bad = (name, detail, remedy) => ({ name, pass: false, detail, remedy });
+
+const PLUGIN_ID = 'token-optimizer@token-optimizer';
+
+/** Reads JSON, or null. Never throws: this module must diagnose, not crash. */
+function readJson(path) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+/** Numeric semver compare; unparseable versions sort as equal to avoid crying wolf. */
+function compareVersions(a, b) {
+  const parse = (v) => String(v || '').split('.').map((n) => Number.parseInt(n, 10));
+  const left = parse(a);
+  const right = parse(b);
+  if (left.some(Number.isNaN) || right.some(Number.isNaN)) return 0;
+  for (let i = 0; i < Math.max(left.length, right.length); i++) {
+    const diff = (left[i] ?? 0) - (right[i] ?? 0);
+    if (diff !== 0) return diff < 0 ? -1 : 1;
+  }
+  return 0;
+}
+
+/**
+ * WHICH INSTALL IS THIS, AND WHERE ARE THE HOOKS IT ACTUALLY RUNS?
+ *
+ * Everything below used to assume the script-install path: hooks copied into
+ * ~/.claude-global/hooks, entries written into settings.json, a manifest
+ * recording both. The plugin path satisfies none of that. Its hooks are declared
+ * in the plugin's own hooks.json and live in the plugin cache, so a doctor
+ * looking in settings.json reports "not wired" about a plugin that is wired, and
+ * reports "no manifest" about a file that path never writes.
+ *
+ * It also resolved the hook binary from the npm package root, which is a
+ * DIFFERENT BUILD from the plugin's. Measured on a real machine: the package
+ * shipped 5.3.5 and the plugin cache held 5.3.6, with all 37 hook files
+ * differing. The enforcement probe passed -- for a build that was not running.
+ *
+ * Returns the versions separately rather than a boolean, because "installed is
+ * behind available" is the single most useful thing this tool can say: 5.0.2
+ * shipped one advisory hook, so a stale install is present, listed in /mcp, and
+ * saving nothing.
+ */
+export function detectInstall({ pluginsDir, root } = {}) {
+  const dir = pluginsDir || join(homedir(), '.claude', 'plugins');
+  const packageHooks = join(root || '.', 'plugin', 'hooks');
+
+  const record = readJson(join(dir, 'installed_plugins.json'))?.plugins?.[PLUGIN_ID]?.[0];
+  const marketplace = readJson(
+    join(dir, 'marketplaces', 'token-optimizer', 'plugin', '.claude-plugin', 'plugin.json')
+  );
+
+  const installedVersion = record?.version ?? null;
+  const availableVersion = marketplace?.version ?? null;
+  const pluginHooks = record?.installPath ? join(record.installPath, 'hooks') : null;
+
+  // A record whose installPath has gone missing is a broken plugin install, not
+  // a script install -- saying "script" there would send the user to the wrong
+  // remedy entirely.
+  if (record) {
+    return {
+      method: 'plugin',
+      hooksDir: pluginHooks && existsSync(pluginHooks) ? pluginHooks : packageHooks,
+      installPath: record.installPath ?? null,
+      installedVersion,
+      availableVersion,
+    };
+  }
+
+  return {
+    method: verifyManifest(readManifest()) ? 'script' : 'unknown',
+    hooksDir: packageHooks,
+    installPath: null,
+    installedVersion,
+    availableVersion,
+  };
+}
+
+/** Resolves the directory holding the hook entrypoints for a probe. */
+function hooksDirFor({ hooksDir, install, root }) {
+  return hooksDir || install?.hooksDir || join(root || '.', 'plugin', 'hooks');
+}
+
+/**
+ * Is the installed plugin the version that is available?
+ *
+ * The gap this closes: updating the marketplace does NOT update the installed
+ * plugin. `installed_plugins.json` pins installPath and version, so a machine
+ * can sit on 5.0.2 indefinitely while 5.3.6 is checked out beside it, and
+ * nothing anywhere says so. Restarting does not help, because the restart
+ * faithfully reloads the pinned version.
+ */
+export function probeVersion({ install }) {
+  const { method, installedVersion, availableVersion } = install || {};
+
+  if (method !== 'plugin' || !installedVersion || !availableVersion) {
+    return [];
+  }
+
+  if (compareVersions(installedVersion, availableVersion) < 0) {
+    return [bad('plugin is up to date',
+      `installed ${installedVersion}, but ${availableVersion} is available`,
+      'run /plugin and update token-optimizer -- updating the marketplace alone ' +
+      'does not move the installed version, and older builds shipped far weaker hooks')];
+  }
+
+  return [ok('plugin is up to date', `installed ${installedVersion}`)];
+}
 
 /** Runs a hook binary with a payload and returns its stdout, or null. */
 function probe(binary, payload, { timeoutMs = 8000, cwd } = {}) {
@@ -49,11 +160,21 @@ function probe(binary, payload, { timeoutMs = 8000, cwd } = {}) {
 /* ------------------------------------------------------------- THE CHECKLIST */
 
 /** Cheap structural checks. Fast, and each names its own fix. */
-export function checklist({ root, settingsPath }) {
+export function checklist({ root, settingsPath, install }) {
   const checks = [];
+  const resolved = install || detectInstall({ root });
+  const hooksDir = hooksDirFor({ install: resolved, root });
 
-  const router = join(root, 'plugin', 'hooks', 'pretooluse-router.mjs');
-  const sessionStart = join(root, 'plugin', 'hooks', 'session-start.mjs');
+  // SAY WHICH PATH THIS IS. Skipping the script-install checks silently would
+  // leave a user unable to tell whether they passed or were never run, which is
+  // the same opacity that made a 7/9 score untrustworthy in the first place.
+  checks.push(ok('install method', resolved.method === 'plugin'
+    ? `plugin${resolved.installedVersion ? ` ${resolved.installedVersion}` : ''}` +
+      ` -- hooks from ${hooksDir}`
+    : `${resolved.method} -- hooks from ${hooksDir}`));
+
+  const router = join(hooksDir, 'pretooluse-router.mjs');
+  const sessionStart = join(hooksDir, 'session-start.mjs');
 
   checks.push(existsSync(router)
     ? ok('hook binary present', router)
@@ -65,33 +186,43 @@ export function checklist({ root, settingsPath }) {
     : bad('session-start binary present', `not found at ${sessionStart}`,
       'reinstall the package to restore the session-start hook'));
 
-  if (settingsPath && existsSync(settingsPath)) {
-    try {
-      const settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
-      const wired = JSON.stringify(settings?.hooks || {}).includes('token-optimizer');
-      checks.push(wired
-        ? ok('hooks wired into settings', settingsPath)
-        : bad('hooks wired into settings', 'no token-optimizer entries found',
-          'run install-hooks.sh to add the PreToolUse and SessionStart entries'));
-    } catch {
-      checks.push(bad('settings file parses', `${settingsPath} is not valid JSON`,
-        'fix the JSON by hand -- we will not rewrite a file we cannot parse'));
+  // SETTINGS AND MANIFEST ARE SCRIPT-INSTALL CONCERNS ONLY.
+  //
+  // A plugin declares its hooks in the plugin's own hooks.json and writes
+  // nothing to settings.json, so demanding entries there reported "not wired"
+  // about a plugin that was demonstrably wired -- its SessionStart hook was
+  // injecting the policy at that very moment. Likewise the manifest: only
+  // install-hooks.* writes one. Two guaranteed failures on a healthy install
+  // taught the user to ignore the score.
+  if (resolved.method !== 'plugin') {
+    if (settingsPath && existsSync(settingsPath)) {
+      try {
+        const settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
+        const wired = JSON.stringify(settings?.hooks || {}).includes('token-optimizer');
+        checks.push(wired
+          ? ok('hooks wired into settings', settingsPath)
+          : bad('hooks wired into settings', 'no token-optimizer entries found',
+            'run install-hooks.sh to add the PreToolUse and SessionStart entries'));
+      } catch {
+        checks.push(bad('settings file parses', `${settingsPath} is not valid JSON`,
+          'fix the JSON by hand -- we will not rewrite a file we cannot parse'));
+      }
+    } else {
+      checks.push(bad('settings file present', `${settingsPath || 'settings path unknown'} not found`,
+        'run install-hooks.sh, or point TOKEN_OPTIMIZER_SETTINGS at your settings file'));
     }
-  } else {
-    checks.push(bad('settings file present', `${settingsPath || 'settings path unknown'} not found`,
-      'run install-hooks.sh, or point TOKEN_OPTIMIZER_SETTINGS at your settings file'));
-  }
 
-  // What we recorded putting on the machine, and whether it is still that.
-  const verified = verifyManifest(readManifest());
-  if (verified) {
-    checks.push(verified.modified === 0
-      ? ok('installed files intact', `${verified.intact} file(s) match the install manifest`)
-      : ok('installed files intact', `${verified.modified} file(s) edited since install -- ` +
-        'uninstall will leave those alone rather than destroy your changes'));
-  } else {
-    checks.push(bad('install manifest present', 'no record of what was installed',
-      'harmless if you installed manually; reinstall to get a removable, verifiable record'));
+    // What we recorded putting on the machine, and whether it is still that.
+    const verified = verifyManifest(readManifest());
+    if (verified) {
+      checks.push(verified.modified === 0
+        ? ok('installed files intact', `${verified.intact} file(s) match the install manifest`)
+        : ok('installed files intact', `${verified.modified} file(s) edited since install -- ` +
+          'uninstall will leave those alone rather than destroy your changes'));
+    } else {
+      checks.push(bad('install manifest present', 'no record of what was installed',
+        'harmless if you installed manually; reinstall to get a removable, verifiable record'));
+    }
   }
 
   return checks;
@@ -106,9 +237,12 @@ export function checklist({ root, settingsPath }) {
  * a hook that refuses everything is as broken as one that refuses nothing, and
  * only the second is what shipped last time.
  */
-export function probeEnforcement({ root, workspace }) {
+export function probeEnforcement({ root, workspace, hooksDir, install }) {
   const checks = [];
-  const binary = join(root, 'plugin', 'hooks', 'pretooluse-router.mjs');
+  // Probe the build that RUNS, not the one bundled beside this module. On a real
+  // machine those were 5.3.5 and 5.3.6 with all 37 hook files differing, and
+  // this probe passed for the copy nobody was executing.
+  const binary = join(hooksDirFor({ hooksDir, install, root }), 'pretooluse-router.mjs');
   if (!existsSync(binary)) {
     return [bad('enforcement refuses a large read', 'hook binary missing', 'reinstall the package')];
   }
@@ -155,8 +289,8 @@ export function probeEnforcement({ root, workspace }) {
 }
 
 /** The session-start notice has to actually come out. */
-export function probeSessionStart({ root, workspace }) {
-  const binary = join(root, 'plugin', 'hooks', 'session-start.mjs');
+export function probeSessionStart({ root, workspace, hooksDir, install }) {
+  const binary = join(hooksDirFor({ hooksDir, install, root }), 'session-start.mjs');
   if (!existsSync(binary)) {
     return [bad('session-start emits the policy', 'binary missing', 'reinstall the package')];
   }
@@ -253,11 +387,19 @@ export function probeServer({ root, timeoutMs = 20_000 }) {
  * Structural checks first because they are fast and explain most failures;
  * probes after, because they are what actually prove it works.
  */
-export function diagnose({ root, workspace, graphDir, settingsPath, skipServer = false } = {}) {
+export function diagnose({
+  root, workspace, graphDir, settingsPath, pluginsDir, skipServer = false,
+} = {}) {
+  // Resolved ONCE and threaded through, so every check reasons about the same
+  // install. Detecting per-probe is how the checklist and the enforcement probe
+  // ended up describing two different builds in the same report.
+  const install = detectInstall({ pluginsDir, root });
+
   const checks = [
-    ...checklist({ root, settingsPath }),
-    ...probeEnforcement({ root, workspace }),
-    ...probeSessionStart({ root, workspace }),
+    ...checklist({ root, settingsPath, install }),
+    ...probeVersion({ install }),
+    ...probeEnforcement({ root, workspace, install }),
+    ...probeSessionStart({ root, workspace, install }),
     ...probeGraph({ dir: graphDir }),
     ...(skipServer ? [] : probeServer({ root })),
   ];

--- a/integrations/opencode/hooks/lib/doctor.mjs
+++ b/integrations/opencode/hooks/lib/doctor.mjs
@@ -23,11 +23,122 @@
 import { execFileSync } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
 import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { readManifest, verifyManifest, residue } from './manifest.mjs';
 
 const ok = (name, detail) => ({ name, pass: true, detail });
 const bad = (name, detail, remedy) => ({ name, pass: false, detail, remedy });
+
+const PLUGIN_ID = 'token-optimizer@token-optimizer';
+
+/** Reads JSON, or null. Never throws: this module must diagnose, not crash. */
+function readJson(path) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+/** Numeric semver compare; unparseable versions sort as equal to avoid crying wolf. */
+function compareVersions(a, b) {
+  const parse = (v) => String(v || '').split('.').map((n) => Number.parseInt(n, 10));
+  const left = parse(a);
+  const right = parse(b);
+  if (left.some(Number.isNaN) || right.some(Number.isNaN)) return 0;
+  for (let i = 0; i < Math.max(left.length, right.length); i++) {
+    const diff = (left[i] ?? 0) - (right[i] ?? 0);
+    if (diff !== 0) return diff < 0 ? -1 : 1;
+  }
+  return 0;
+}
+
+/**
+ * WHICH INSTALL IS THIS, AND WHERE ARE THE HOOKS IT ACTUALLY RUNS?
+ *
+ * Everything below used to assume the script-install path: hooks copied into
+ * ~/.claude-global/hooks, entries written into settings.json, a manifest
+ * recording both. The plugin path satisfies none of that. Its hooks are declared
+ * in the plugin's own hooks.json and live in the plugin cache, so a doctor
+ * looking in settings.json reports "not wired" about a plugin that is wired, and
+ * reports "no manifest" about a file that path never writes.
+ *
+ * It also resolved the hook binary from the npm package root, which is a
+ * DIFFERENT BUILD from the plugin's. Measured on a real machine: the package
+ * shipped 5.3.5 and the plugin cache held 5.3.6, with all 37 hook files
+ * differing. The enforcement probe passed -- for a build that was not running.
+ *
+ * Returns the versions separately rather than a boolean, because "installed is
+ * behind available" is the single most useful thing this tool can say: 5.0.2
+ * shipped one advisory hook, so a stale install is present, listed in /mcp, and
+ * saving nothing.
+ */
+export function detectInstall({ pluginsDir, root } = {}) {
+  const dir = pluginsDir || join(homedir(), '.claude', 'plugins');
+  const packageHooks = join(root || '.', 'plugin', 'hooks');
+
+  const record = readJson(join(dir, 'installed_plugins.json'))?.plugins?.[PLUGIN_ID]?.[0];
+  const marketplace = readJson(
+    join(dir, 'marketplaces', 'token-optimizer', 'plugin', '.claude-plugin', 'plugin.json')
+  );
+
+  const installedVersion = record?.version ?? null;
+  const availableVersion = marketplace?.version ?? null;
+  const pluginHooks = record?.installPath ? join(record.installPath, 'hooks') : null;
+
+  // A record whose installPath has gone missing is a broken plugin install, not
+  // a script install -- saying "script" there would send the user to the wrong
+  // remedy entirely.
+  if (record) {
+    return {
+      method: 'plugin',
+      hooksDir: pluginHooks && existsSync(pluginHooks) ? pluginHooks : packageHooks,
+      installPath: record.installPath ?? null,
+      installedVersion,
+      availableVersion,
+    };
+  }
+
+  return {
+    method: verifyManifest(readManifest()) ? 'script' : 'unknown',
+    hooksDir: packageHooks,
+    installPath: null,
+    installedVersion,
+    availableVersion,
+  };
+}
+
+/** Resolves the directory holding the hook entrypoints for a probe. */
+function hooksDirFor({ hooksDir, install, root }) {
+  return hooksDir || install?.hooksDir || join(root || '.', 'plugin', 'hooks');
+}
+
+/**
+ * Is the installed plugin the version that is available?
+ *
+ * The gap this closes: updating the marketplace does NOT update the installed
+ * plugin. `installed_plugins.json` pins installPath and version, so a machine
+ * can sit on 5.0.2 indefinitely while 5.3.6 is checked out beside it, and
+ * nothing anywhere says so. Restarting does not help, because the restart
+ * faithfully reloads the pinned version.
+ */
+export function probeVersion({ install }) {
+  const { method, installedVersion, availableVersion } = install || {};
+
+  if (method !== 'plugin' || !installedVersion || !availableVersion) {
+    return [];
+  }
+
+  if (compareVersions(installedVersion, availableVersion) < 0) {
+    return [bad('plugin is up to date',
+      `installed ${installedVersion}, but ${availableVersion} is available`,
+      'run /plugin and update token-optimizer -- updating the marketplace alone ' +
+      'does not move the installed version, and older builds shipped far weaker hooks')];
+  }
+
+  return [ok('plugin is up to date', `installed ${installedVersion}`)];
+}
 
 /** Runs a hook binary with a payload and returns its stdout, or null. */
 function probe(binary, payload, { timeoutMs = 8000, cwd } = {}) {
@@ -49,11 +160,21 @@ function probe(binary, payload, { timeoutMs = 8000, cwd } = {}) {
 /* ------------------------------------------------------------- THE CHECKLIST */
 
 /** Cheap structural checks. Fast, and each names its own fix. */
-export function checklist({ root, settingsPath }) {
+export function checklist({ root, settingsPath, install }) {
   const checks = [];
+  const resolved = install || detectInstall({ root });
+  const hooksDir = hooksDirFor({ install: resolved, root });
 
-  const router = join(root, 'plugin', 'hooks', 'pretooluse-router.mjs');
-  const sessionStart = join(root, 'plugin', 'hooks', 'session-start.mjs');
+  // SAY WHICH PATH THIS IS. Skipping the script-install checks silently would
+  // leave a user unable to tell whether they passed or were never run, which is
+  // the same opacity that made a 7/9 score untrustworthy in the first place.
+  checks.push(ok('install method', resolved.method === 'plugin'
+    ? `plugin${resolved.installedVersion ? ` ${resolved.installedVersion}` : ''}` +
+      ` -- hooks from ${hooksDir}`
+    : `${resolved.method} -- hooks from ${hooksDir}`));
+
+  const router = join(hooksDir, 'pretooluse-router.mjs');
+  const sessionStart = join(hooksDir, 'session-start.mjs');
 
   checks.push(existsSync(router)
     ? ok('hook binary present', router)
@@ -65,33 +186,43 @@ export function checklist({ root, settingsPath }) {
     : bad('session-start binary present', `not found at ${sessionStart}`,
       'reinstall the package to restore the session-start hook'));
 
-  if (settingsPath && existsSync(settingsPath)) {
-    try {
-      const settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
-      const wired = JSON.stringify(settings?.hooks || {}).includes('token-optimizer');
-      checks.push(wired
-        ? ok('hooks wired into settings', settingsPath)
-        : bad('hooks wired into settings', 'no token-optimizer entries found',
-          'run install-hooks.sh to add the PreToolUse and SessionStart entries'));
-    } catch {
-      checks.push(bad('settings file parses', `${settingsPath} is not valid JSON`,
-        'fix the JSON by hand -- we will not rewrite a file we cannot parse'));
+  // SETTINGS AND MANIFEST ARE SCRIPT-INSTALL CONCERNS ONLY.
+  //
+  // A plugin declares its hooks in the plugin's own hooks.json and writes
+  // nothing to settings.json, so demanding entries there reported "not wired"
+  // about a plugin that was demonstrably wired -- its SessionStart hook was
+  // injecting the policy at that very moment. Likewise the manifest: only
+  // install-hooks.* writes one. Two guaranteed failures on a healthy install
+  // taught the user to ignore the score.
+  if (resolved.method !== 'plugin') {
+    if (settingsPath && existsSync(settingsPath)) {
+      try {
+        const settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
+        const wired = JSON.stringify(settings?.hooks || {}).includes('token-optimizer');
+        checks.push(wired
+          ? ok('hooks wired into settings', settingsPath)
+          : bad('hooks wired into settings', 'no token-optimizer entries found',
+            'run install-hooks.sh to add the PreToolUse and SessionStart entries'));
+      } catch {
+        checks.push(bad('settings file parses', `${settingsPath} is not valid JSON`,
+          'fix the JSON by hand -- we will not rewrite a file we cannot parse'));
+      }
+    } else {
+      checks.push(bad('settings file present', `${settingsPath || 'settings path unknown'} not found`,
+        'run install-hooks.sh, or point TOKEN_OPTIMIZER_SETTINGS at your settings file'));
     }
-  } else {
-    checks.push(bad('settings file present', `${settingsPath || 'settings path unknown'} not found`,
-      'run install-hooks.sh, or point TOKEN_OPTIMIZER_SETTINGS at your settings file'));
-  }
 
-  // What we recorded putting on the machine, and whether it is still that.
-  const verified = verifyManifest(readManifest());
-  if (verified) {
-    checks.push(verified.modified === 0
-      ? ok('installed files intact', `${verified.intact} file(s) match the install manifest`)
-      : ok('installed files intact', `${verified.modified} file(s) edited since install -- ` +
-        'uninstall will leave those alone rather than destroy your changes'));
-  } else {
-    checks.push(bad('install manifest present', 'no record of what was installed',
-      'harmless if you installed manually; reinstall to get a removable, verifiable record'));
+    // What we recorded putting on the machine, and whether it is still that.
+    const verified = verifyManifest(readManifest());
+    if (verified) {
+      checks.push(verified.modified === 0
+        ? ok('installed files intact', `${verified.intact} file(s) match the install manifest`)
+        : ok('installed files intact', `${verified.modified} file(s) edited since install -- ` +
+          'uninstall will leave those alone rather than destroy your changes'));
+    } else {
+      checks.push(bad('install manifest present', 'no record of what was installed',
+        'harmless if you installed manually; reinstall to get a removable, verifiable record'));
+    }
   }
 
   return checks;
@@ -106,9 +237,12 @@ export function checklist({ root, settingsPath }) {
  * a hook that refuses everything is as broken as one that refuses nothing, and
  * only the second is what shipped last time.
  */
-export function probeEnforcement({ root, workspace }) {
+export function probeEnforcement({ root, workspace, hooksDir, install }) {
   const checks = [];
-  const binary = join(root, 'plugin', 'hooks', 'pretooluse-router.mjs');
+  // Probe the build that RUNS, not the one bundled beside this module. On a real
+  // machine those were 5.3.5 and 5.3.6 with all 37 hook files differing, and
+  // this probe passed for the copy nobody was executing.
+  const binary = join(hooksDirFor({ hooksDir, install, root }), 'pretooluse-router.mjs');
   if (!existsSync(binary)) {
     return [bad('enforcement refuses a large read', 'hook binary missing', 'reinstall the package')];
   }
@@ -155,8 +289,8 @@ export function probeEnforcement({ root, workspace }) {
 }
 
 /** The session-start notice has to actually come out. */
-export function probeSessionStart({ root, workspace }) {
-  const binary = join(root, 'plugin', 'hooks', 'session-start.mjs');
+export function probeSessionStart({ root, workspace, hooksDir, install }) {
+  const binary = join(hooksDirFor({ hooksDir, install, root }), 'session-start.mjs');
   if (!existsSync(binary)) {
     return [bad('session-start emits the policy', 'binary missing', 'reinstall the package')];
   }
@@ -253,11 +387,19 @@ export function probeServer({ root, timeoutMs = 20_000 }) {
  * Structural checks first because they are fast and explain most failures;
  * probes after, because they are what actually prove it works.
  */
-export function diagnose({ root, workspace, graphDir, settingsPath, skipServer = false } = {}) {
+export function diagnose({
+  root, workspace, graphDir, settingsPath, pluginsDir, skipServer = false,
+} = {}) {
+  // Resolved ONCE and threaded through, so every check reasons about the same
+  // install. Detecting per-probe is how the checklist and the enforcement probe
+  // ended up describing two different builds in the same report.
+  const install = detectInstall({ pluginsDir, root });
+
   const checks = [
-    ...checklist({ root, settingsPath }),
-    ...probeEnforcement({ root, workspace }),
-    ...probeSessionStart({ root, workspace }),
+    ...checklist({ root, settingsPath, install }),
+    ...probeVersion({ install }),
+    ...probeEnforcement({ root, workspace, install }),
+    ...probeSessionStart({ root, workspace, install }),
     ...probeGraph({ dir: graphDir }),
     ...(skipServer ? [] : probeServer({ root })),
   ];

--- a/integrations/opencode/opencode.json
+++ b/integrations/opencode/opencode.json
@@ -3,7 +3,7 @@
   "mcp": {
     "token-optimizer": {
       "type": "local",
-      "command": ["npx", "-y", "@ooples/token-optimizer-mcp@5.3.2"],
+      "command": ["npx", "-y", "@ooples/token-optimizer-mcp@5.3.6"],
       "enabled": true
     }
   },

--- a/integrations/qwen/hooks/lib/doctor.mjs
+++ b/integrations/qwen/hooks/lib/doctor.mjs
@@ -23,11 +23,122 @@
 import { execFileSync } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
 import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { readManifest, verifyManifest, residue } from './manifest.mjs';
 
 const ok = (name, detail) => ({ name, pass: true, detail });
 const bad = (name, detail, remedy) => ({ name, pass: false, detail, remedy });
+
+const PLUGIN_ID = 'token-optimizer@token-optimizer';
+
+/** Reads JSON, or null. Never throws: this module must diagnose, not crash. */
+function readJson(path) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+/** Numeric semver compare; unparseable versions sort as equal to avoid crying wolf. */
+function compareVersions(a, b) {
+  const parse = (v) => String(v || '').split('.').map((n) => Number.parseInt(n, 10));
+  const left = parse(a);
+  const right = parse(b);
+  if (left.some(Number.isNaN) || right.some(Number.isNaN)) return 0;
+  for (let i = 0; i < Math.max(left.length, right.length); i++) {
+    const diff = (left[i] ?? 0) - (right[i] ?? 0);
+    if (diff !== 0) return diff < 0 ? -1 : 1;
+  }
+  return 0;
+}
+
+/**
+ * WHICH INSTALL IS THIS, AND WHERE ARE THE HOOKS IT ACTUALLY RUNS?
+ *
+ * Everything below used to assume the script-install path: hooks copied into
+ * ~/.claude-global/hooks, entries written into settings.json, a manifest
+ * recording both. The plugin path satisfies none of that. Its hooks are declared
+ * in the plugin's own hooks.json and live in the plugin cache, so a doctor
+ * looking in settings.json reports "not wired" about a plugin that is wired, and
+ * reports "no manifest" about a file that path never writes.
+ *
+ * It also resolved the hook binary from the npm package root, which is a
+ * DIFFERENT BUILD from the plugin's. Measured on a real machine: the package
+ * shipped 5.3.5 and the plugin cache held 5.3.6, with all 37 hook files
+ * differing. The enforcement probe passed -- for a build that was not running.
+ *
+ * Returns the versions separately rather than a boolean, because "installed is
+ * behind available" is the single most useful thing this tool can say: 5.0.2
+ * shipped one advisory hook, so a stale install is present, listed in /mcp, and
+ * saving nothing.
+ */
+export function detectInstall({ pluginsDir, root } = {}) {
+  const dir = pluginsDir || join(homedir(), '.claude', 'plugins');
+  const packageHooks = join(root || '.', 'plugin', 'hooks');
+
+  const record = readJson(join(dir, 'installed_plugins.json'))?.plugins?.[PLUGIN_ID]?.[0];
+  const marketplace = readJson(
+    join(dir, 'marketplaces', 'token-optimizer', 'plugin', '.claude-plugin', 'plugin.json')
+  );
+
+  const installedVersion = record?.version ?? null;
+  const availableVersion = marketplace?.version ?? null;
+  const pluginHooks = record?.installPath ? join(record.installPath, 'hooks') : null;
+
+  // A record whose installPath has gone missing is a broken plugin install, not
+  // a script install -- saying "script" there would send the user to the wrong
+  // remedy entirely.
+  if (record) {
+    return {
+      method: 'plugin',
+      hooksDir: pluginHooks && existsSync(pluginHooks) ? pluginHooks : packageHooks,
+      installPath: record.installPath ?? null,
+      installedVersion,
+      availableVersion,
+    };
+  }
+
+  return {
+    method: verifyManifest(readManifest()) ? 'script' : 'unknown',
+    hooksDir: packageHooks,
+    installPath: null,
+    installedVersion,
+    availableVersion,
+  };
+}
+
+/** Resolves the directory holding the hook entrypoints for a probe. */
+function hooksDirFor({ hooksDir, install, root }) {
+  return hooksDir || install?.hooksDir || join(root || '.', 'plugin', 'hooks');
+}
+
+/**
+ * Is the installed plugin the version that is available?
+ *
+ * The gap this closes: updating the marketplace does NOT update the installed
+ * plugin. `installed_plugins.json` pins installPath and version, so a machine
+ * can sit on 5.0.2 indefinitely while 5.3.6 is checked out beside it, and
+ * nothing anywhere says so. Restarting does not help, because the restart
+ * faithfully reloads the pinned version.
+ */
+export function probeVersion({ install }) {
+  const { method, installedVersion, availableVersion } = install || {};
+
+  if (method !== 'plugin' || !installedVersion || !availableVersion) {
+    return [];
+  }
+
+  if (compareVersions(installedVersion, availableVersion) < 0) {
+    return [bad('plugin is up to date',
+      `installed ${installedVersion}, but ${availableVersion} is available`,
+      'run /plugin and update token-optimizer -- updating the marketplace alone ' +
+      'does not move the installed version, and older builds shipped far weaker hooks')];
+  }
+
+  return [ok('plugin is up to date', `installed ${installedVersion}`)];
+}
 
 /** Runs a hook binary with a payload and returns its stdout, or null. */
 function probe(binary, payload, { timeoutMs = 8000, cwd } = {}) {
@@ -49,11 +160,21 @@ function probe(binary, payload, { timeoutMs = 8000, cwd } = {}) {
 /* ------------------------------------------------------------- THE CHECKLIST */
 
 /** Cheap structural checks. Fast, and each names its own fix. */
-export function checklist({ root, settingsPath }) {
+export function checklist({ root, settingsPath, install }) {
   const checks = [];
+  const resolved = install || detectInstall({ root });
+  const hooksDir = hooksDirFor({ install: resolved, root });
 
-  const router = join(root, 'plugin', 'hooks', 'pretooluse-router.mjs');
-  const sessionStart = join(root, 'plugin', 'hooks', 'session-start.mjs');
+  // SAY WHICH PATH THIS IS. Skipping the script-install checks silently would
+  // leave a user unable to tell whether they passed or were never run, which is
+  // the same opacity that made a 7/9 score untrustworthy in the first place.
+  checks.push(ok('install method', resolved.method === 'plugin'
+    ? `plugin${resolved.installedVersion ? ` ${resolved.installedVersion}` : ''}` +
+      ` -- hooks from ${hooksDir}`
+    : `${resolved.method} -- hooks from ${hooksDir}`));
+
+  const router = join(hooksDir, 'pretooluse-router.mjs');
+  const sessionStart = join(hooksDir, 'session-start.mjs');
 
   checks.push(existsSync(router)
     ? ok('hook binary present', router)
@@ -65,33 +186,43 @@ export function checklist({ root, settingsPath }) {
     : bad('session-start binary present', `not found at ${sessionStart}`,
       'reinstall the package to restore the session-start hook'));
 
-  if (settingsPath && existsSync(settingsPath)) {
-    try {
-      const settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
-      const wired = JSON.stringify(settings?.hooks || {}).includes('token-optimizer');
-      checks.push(wired
-        ? ok('hooks wired into settings', settingsPath)
-        : bad('hooks wired into settings', 'no token-optimizer entries found',
-          'run install-hooks.sh to add the PreToolUse and SessionStart entries'));
-    } catch {
-      checks.push(bad('settings file parses', `${settingsPath} is not valid JSON`,
-        'fix the JSON by hand -- we will not rewrite a file we cannot parse'));
+  // SETTINGS AND MANIFEST ARE SCRIPT-INSTALL CONCERNS ONLY.
+  //
+  // A plugin declares its hooks in the plugin's own hooks.json and writes
+  // nothing to settings.json, so demanding entries there reported "not wired"
+  // about a plugin that was demonstrably wired -- its SessionStart hook was
+  // injecting the policy at that very moment. Likewise the manifest: only
+  // install-hooks.* writes one. Two guaranteed failures on a healthy install
+  // taught the user to ignore the score.
+  if (resolved.method !== 'plugin') {
+    if (settingsPath && existsSync(settingsPath)) {
+      try {
+        const settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
+        const wired = JSON.stringify(settings?.hooks || {}).includes('token-optimizer');
+        checks.push(wired
+          ? ok('hooks wired into settings', settingsPath)
+          : bad('hooks wired into settings', 'no token-optimizer entries found',
+            'run install-hooks.sh to add the PreToolUse and SessionStart entries'));
+      } catch {
+        checks.push(bad('settings file parses', `${settingsPath} is not valid JSON`,
+          'fix the JSON by hand -- we will not rewrite a file we cannot parse'));
+      }
+    } else {
+      checks.push(bad('settings file present', `${settingsPath || 'settings path unknown'} not found`,
+        'run install-hooks.sh, or point TOKEN_OPTIMIZER_SETTINGS at your settings file'));
     }
-  } else {
-    checks.push(bad('settings file present', `${settingsPath || 'settings path unknown'} not found`,
-      'run install-hooks.sh, or point TOKEN_OPTIMIZER_SETTINGS at your settings file'));
-  }
 
-  // What we recorded putting on the machine, and whether it is still that.
-  const verified = verifyManifest(readManifest());
-  if (verified) {
-    checks.push(verified.modified === 0
-      ? ok('installed files intact', `${verified.intact} file(s) match the install manifest`)
-      : ok('installed files intact', `${verified.modified} file(s) edited since install -- ` +
-        'uninstall will leave those alone rather than destroy your changes'));
-  } else {
-    checks.push(bad('install manifest present', 'no record of what was installed',
-      'harmless if you installed manually; reinstall to get a removable, verifiable record'));
+    // What we recorded putting on the machine, and whether it is still that.
+    const verified = verifyManifest(readManifest());
+    if (verified) {
+      checks.push(verified.modified === 0
+        ? ok('installed files intact', `${verified.intact} file(s) match the install manifest`)
+        : ok('installed files intact', `${verified.modified} file(s) edited since install -- ` +
+          'uninstall will leave those alone rather than destroy your changes'));
+    } else {
+      checks.push(bad('install manifest present', 'no record of what was installed',
+        'harmless if you installed manually; reinstall to get a removable, verifiable record'));
+    }
   }
 
   return checks;
@@ -106,9 +237,12 @@ export function checklist({ root, settingsPath }) {
  * a hook that refuses everything is as broken as one that refuses nothing, and
  * only the second is what shipped last time.
  */
-export function probeEnforcement({ root, workspace }) {
+export function probeEnforcement({ root, workspace, hooksDir, install }) {
   const checks = [];
-  const binary = join(root, 'plugin', 'hooks', 'pretooluse-router.mjs');
+  // Probe the build that RUNS, not the one bundled beside this module. On a real
+  // machine those were 5.3.5 and 5.3.6 with all 37 hook files differing, and
+  // this probe passed for the copy nobody was executing.
+  const binary = join(hooksDirFor({ hooksDir, install, root }), 'pretooluse-router.mjs');
   if (!existsSync(binary)) {
     return [bad('enforcement refuses a large read', 'hook binary missing', 'reinstall the package')];
   }
@@ -155,8 +289,8 @@ export function probeEnforcement({ root, workspace }) {
 }
 
 /** The session-start notice has to actually come out. */
-export function probeSessionStart({ root, workspace }) {
-  const binary = join(root, 'plugin', 'hooks', 'session-start.mjs');
+export function probeSessionStart({ root, workspace, hooksDir, install }) {
+  const binary = join(hooksDirFor({ hooksDir, install, root }), 'session-start.mjs');
   if (!existsSync(binary)) {
     return [bad('session-start emits the policy', 'binary missing', 'reinstall the package')];
   }
@@ -253,11 +387,19 @@ export function probeServer({ root, timeoutMs = 20_000 }) {
  * Structural checks first because they are fast and explain most failures;
  * probes after, because they are what actually prove it works.
  */
-export function diagnose({ root, workspace, graphDir, settingsPath, skipServer = false } = {}) {
+export function diagnose({
+  root, workspace, graphDir, settingsPath, pluginsDir, skipServer = false,
+} = {}) {
+  // Resolved ONCE and threaded through, so every check reasons about the same
+  // install. Detecting per-probe is how the checklist and the enforcement probe
+  // ended up describing two different builds in the same report.
+  const install = detectInstall({ pluginsDir, root });
+
   const checks = [
-    ...checklist({ root, settingsPath }),
-    ...probeEnforcement({ root, workspace }),
-    ...probeSessionStart({ root, workspace }),
+    ...checklist({ root, settingsPath, install }),
+    ...probeVersion({ install }),
+    ...probeEnforcement({ root, workspace, install }),
+    ...probeSessionStart({ root, workspace, install }),
     ...probeGraph({ dir: graphDir }),
     ...(skipServer ? [] : probeServer({ root })),
   ];

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "token-optimizer": {
       "command": "npx",
-      "args": ["-y", "@ooples/token-optimizer-mcp@5.3.2"],
+      "args": ["-y", "@ooples/token-optimizer-mcp@5.3.6"],
       "env": {}
     }
   }

--- a/plugin/hooks/lib/doctor.mjs
+++ b/plugin/hooks/lib/doctor.mjs
@@ -23,11 +23,122 @@
 import { execFileSync } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
 import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { readManifest, verifyManifest, residue } from './manifest.mjs';
 
 const ok = (name, detail) => ({ name, pass: true, detail });
 const bad = (name, detail, remedy) => ({ name, pass: false, detail, remedy });
+
+const PLUGIN_ID = 'token-optimizer@token-optimizer';
+
+/** Reads JSON, or null. Never throws: this module must diagnose, not crash. */
+function readJson(path) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+/** Numeric semver compare; unparseable versions sort as equal to avoid crying wolf. */
+function compareVersions(a, b) {
+  const parse = (v) => String(v || '').split('.').map((n) => Number.parseInt(n, 10));
+  const left = parse(a);
+  const right = parse(b);
+  if (left.some(Number.isNaN) || right.some(Number.isNaN)) return 0;
+  for (let i = 0; i < Math.max(left.length, right.length); i++) {
+    const diff = (left[i] ?? 0) - (right[i] ?? 0);
+    if (diff !== 0) return diff < 0 ? -1 : 1;
+  }
+  return 0;
+}
+
+/**
+ * WHICH INSTALL IS THIS, AND WHERE ARE THE HOOKS IT ACTUALLY RUNS?
+ *
+ * Everything below used to assume the script-install path: hooks copied into
+ * ~/.claude-global/hooks, entries written into settings.json, a manifest
+ * recording both. The plugin path satisfies none of that. Its hooks are declared
+ * in the plugin's own hooks.json and live in the plugin cache, so a doctor
+ * looking in settings.json reports "not wired" about a plugin that is wired, and
+ * reports "no manifest" about a file that path never writes.
+ *
+ * It also resolved the hook binary from the npm package root, which is a
+ * DIFFERENT BUILD from the plugin's. Measured on a real machine: the package
+ * shipped 5.3.5 and the plugin cache held 5.3.6, with all 37 hook files
+ * differing. The enforcement probe passed -- for a build that was not running.
+ *
+ * Returns the versions separately rather than a boolean, because "installed is
+ * behind available" is the single most useful thing this tool can say: 5.0.2
+ * shipped one advisory hook, so a stale install is present, listed in /mcp, and
+ * saving nothing.
+ */
+export function detectInstall({ pluginsDir, root } = {}) {
+  const dir = pluginsDir || join(homedir(), '.claude', 'plugins');
+  const packageHooks = join(root || '.', 'plugin', 'hooks');
+
+  const record = readJson(join(dir, 'installed_plugins.json'))?.plugins?.[PLUGIN_ID]?.[0];
+  const marketplace = readJson(
+    join(dir, 'marketplaces', 'token-optimizer', 'plugin', '.claude-plugin', 'plugin.json')
+  );
+
+  const installedVersion = record?.version ?? null;
+  const availableVersion = marketplace?.version ?? null;
+  const pluginHooks = record?.installPath ? join(record.installPath, 'hooks') : null;
+
+  // A record whose installPath has gone missing is a broken plugin install, not
+  // a script install -- saying "script" there would send the user to the wrong
+  // remedy entirely.
+  if (record) {
+    return {
+      method: 'plugin',
+      hooksDir: pluginHooks && existsSync(pluginHooks) ? pluginHooks : packageHooks,
+      installPath: record.installPath ?? null,
+      installedVersion,
+      availableVersion,
+    };
+  }
+
+  return {
+    method: verifyManifest(readManifest()) ? 'script' : 'unknown',
+    hooksDir: packageHooks,
+    installPath: null,
+    installedVersion,
+    availableVersion,
+  };
+}
+
+/** Resolves the directory holding the hook entrypoints for a probe. */
+function hooksDirFor({ hooksDir, install, root }) {
+  return hooksDir || install?.hooksDir || join(root || '.', 'plugin', 'hooks');
+}
+
+/**
+ * Is the installed plugin the version that is available?
+ *
+ * The gap this closes: updating the marketplace does NOT update the installed
+ * plugin. `installed_plugins.json` pins installPath and version, so a machine
+ * can sit on 5.0.2 indefinitely while 5.3.6 is checked out beside it, and
+ * nothing anywhere says so. Restarting does not help, because the restart
+ * faithfully reloads the pinned version.
+ */
+export function probeVersion({ install }) {
+  const { method, installedVersion, availableVersion } = install || {};
+
+  if (method !== 'plugin' || !installedVersion || !availableVersion) {
+    return [];
+  }
+
+  if (compareVersions(installedVersion, availableVersion) < 0) {
+    return [bad('plugin is up to date',
+      `installed ${installedVersion}, but ${availableVersion} is available`,
+      'run /plugin and update token-optimizer -- updating the marketplace alone ' +
+      'does not move the installed version, and older builds shipped far weaker hooks')];
+  }
+
+  return [ok('plugin is up to date', `installed ${installedVersion}`)];
+}
 
 /** Runs a hook binary with a payload and returns its stdout, or null. */
 function probe(binary, payload, { timeoutMs = 8000, cwd } = {}) {
@@ -49,11 +160,21 @@ function probe(binary, payload, { timeoutMs = 8000, cwd } = {}) {
 /* ------------------------------------------------------------- THE CHECKLIST */
 
 /** Cheap structural checks. Fast, and each names its own fix. */
-export function checklist({ root, settingsPath }) {
+export function checklist({ root, settingsPath, install }) {
   const checks = [];
+  const resolved = install || detectInstall({ root });
+  const hooksDir = hooksDirFor({ install: resolved, root });
 
-  const router = join(root, 'plugin', 'hooks', 'pretooluse-router.mjs');
-  const sessionStart = join(root, 'plugin', 'hooks', 'session-start.mjs');
+  // SAY WHICH PATH THIS IS. Skipping the script-install checks silently would
+  // leave a user unable to tell whether they passed or were never run, which is
+  // the same opacity that made a 7/9 score untrustworthy in the first place.
+  checks.push(ok('install method', resolved.method === 'plugin'
+    ? `plugin${resolved.installedVersion ? ` ${resolved.installedVersion}` : ''}` +
+      ` -- hooks from ${hooksDir}`
+    : `${resolved.method} -- hooks from ${hooksDir}`));
+
+  const router = join(hooksDir, 'pretooluse-router.mjs');
+  const sessionStart = join(hooksDir, 'session-start.mjs');
 
   checks.push(existsSync(router)
     ? ok('hook binary present', router)
@@ -65,33 +186,43 @@ export function checklist({ root, settingsPath }) {
     : bad('session-start binary present', `not found at ${sessionStart}`,
       'reinstall the package to restore the session-start hook'));
 
-  if (settingsPath && existsSync(settingsPath)) {
-    try {
-      const settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
-      const wired = JSON.stringify(settings?.hooks || {}).includes('token-optimizer');
-      checks.push(wired
-        ? ok('hooks wired into settings', settingsPath)
-        : bad('hooks wired into settings', 'no token-optimizer entries found',
-          'run install-hooks.sh to add the PreToolUse and SessionStart entries'));
-    } catch {
-      checks.push(bad('settings file parses', `${settingsPath} is not valid JSON`,
-        'fix the JSON by hand -- we will not rewrite a file we cannot parse'));
+  // SETTINGS AND MANIFEST ARE SCRIPT-INSTALL CONCERNS ONLY.
+  //
+  // A plugin declares its hooks in the plugin's own hooks.json and writes
+  // nothing to settings.json, so demanding entries there reported "not wired"
+  // about a plugin that was demonstrably wired -- its SessionStart hook was
+  // injecting the policy at that very moment. Likewise the manifest: only
+  // install-hooks.* writes one. Two guaranteed failures on a healthy install
+  // taught the user to ignore the score.
+  if (resolved.method !== 'plugin') {
+    if (settingsPath && existsSync(settingsPath)) {
+      try {
+        const settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
+        const wired = JSON.stringify(settings?.hooks || {}).includes('token-optimizer');
+        checks.push(wired
+          ? ok('hooks wired into settings', settingsPath)
+          : bad('hooks wired into settings', 'no token-optimizer entries found',
+            'run install-hooks.sh to add the PreToolUse and SessionStart entries'));
+      } catch {
+        checks.push(bad('settings file parses', `${settingsPath} is not valid JSON`,
+          'fix the JSON by hand -- we will not rewrite a file we cannot parse'));
+      }
+    } else {
+      checks.push(bad('settings file present', `${settingsPath || 'settings path unknown'} not found`,
+        'run install-hooks.sh, or point TOKEN_OPTIMIZER_SETTINGS at your settings file'));
     }
-  } else {
-    checks.push(bad('settings file present', `${settingsPath || 'settings path unknown'} not found`,
-      'run install-hooks.sh, or point TOKEN_OPTIMIZER_SETTINGS at your settings file'));
-  }
 
-  // What we recorded putting on the machine, and whether it is still that.
-  const verified = verifyManifest(readManifest());
-  if (verified) {
-    checks.push(verified.modified === 0
-      ? ok('installed files intact', `${verified.intact} file(s) match the install manifest`)
-      : ok('installed files intact', `${verified.modified} file(s) edited since install -- ` +
-        'uninstall will leave those alone rather than destroy your changes'));
-  } else {
-    checks.push(bad('install manifest present', 'no record of what was installed',
-      'harmless if you installed manually; reinstall to get a removable, verifiable record'));
+    // What we recorded putting on the machine, and whether it is still that.
+    const verified = verifyManifest(readManifest());
+    if (verified) {
+      checks.push(verified.modified === 0
+        ? ok('installed files intact', `${verified.intact} file(s) match the install manifest`)
+        : ok('installed files intact', `${verified.modified} file(s) edited since install -- ` +
+          'uninstall will leave those alone rather than destroy your changes'));
+    } else {
+      checks.push(bad('install manifest present', 'no record of what was installed',
+        'harmless if you installed manually; reinstall to get a removable, verifiable record'));
+    }
   }
 
   return checks;
@@ -106,9 +237,12 @@ export function checklist({ root, settingsPath }) {
  * a hook that refuses everything is as broken as one that refuses nothing, and
  * only the second is what shipped last time.
  */
-export function probeEnforcement({ root, workspace }) {
+export function probeEnforcement({ root, workspace, hooksDir, install }) {
   const checks = [];
-  const binary = join(root, 'plugin', 'hooks', 'pretooluse-router.mjs');
+  // Probe the build that RUNS, not the one bundled beside this module. On a real
+  // machine those were 5.3.5 and 5.3.6 with all 37 hook files differing, and
+  // this probe passed for the copy nobody was executing.
+  const binary = join(hooksDirFor({ hooksDir, install, root }), 'pretooluse-router.mjs');
   if (!existsSync(binary)) {
     return [bad('enforcement refuses a large read', 'hook binary missing', 'reinstall the package')];
   }
@@ -155,8 +289,8 @@ export function probeEnforcement({ root, workspace }) {
 }
 
 /** The session-start notice has to actually come out. */
-export function probeSessionStart({ root, workspace }) {
-  const binary = join(root, 'plugin', 'hooks', 'session-start.mjs');
+export function probeSessionStart({ root, workspace, hooksDir, install }) {
+  const binary = join(hooksDirFor({ hooksDir, install, root }), 'session-start.mjs');
   if (!existsSync(binary)) {
     return [bad('session-start emits the policy', 'binary missing', 'reinstall the package')];
   }
@@ -253,11 +387,19 @@ export function probeServer({ root, timeoutMs = 20_000 }) {
  * Structural checks first because they are fast and explain most failures;
  * probes after, because they are what actually prove it works.
  */
-export function diagnose({ root, workspace, graphDir, settingsPath, skipServer = false } = {}) {
+export function diagnose({
+  root, workspace, graphDir, settingsPath, pluginsDir, skipServer = false,
+} = {}) {
+  // Resolved ONCE and threaded through, so every check reasons about the same
+  // install. Detecting per-probe is how the checklist and the enforcement probe
+  // ended up describing two different builds in the same report.
+  const install = detectInstall({ pluginsDir, root });
+
   const checks = [
-    ...checklist({ root, settingsPath }),
-    ...probeEnforcement({ root, workspace }),
-    ...probeSessionStart({ root, workspace }),
+    ...checklist({ root, settingsPath, install }),
+    ...probeVersion({ install }),
+    ...probeEnforcement({ root, workspace, install }),
+    ...probeSessionStart({ root, workspace, install }),
     ...probeGraph({ dir: graphDir }),
     ...(skipServer ? [] : probeServer({ root })),
   ];

--- a/tests/unit/doctor-knows-plugin-installs.test.ts
+++ b/tests/unit/doctor-knows-plugin-installs.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+// @ts-expect-error -- hooks-core ships as plain ESM with no type declarations.
+import { detectInstall, checklist, probeVersion } from '../../hooks-core/doctor.mjs';
+
+/**
+ * The doctor was written for the script-install path and is blind to plugin
+ * installs, which is how the product is actually distributed.
+ *
+ * Three separate consequences, all observed live on a working 5.3.6 install:
+ *
+ *   1. "hooks wired into settings: FAIL / no token-optimizer entries found".
+ *      Plugin hooks are declared in the plugin's own hooks.json; there is
+ *      nothing in settings.json to find, and never will be.
+ *   2. "install manifest present: FAIL / no record of what was installed".
+ *      Only install-hooks.* writes that manifest. A plugin install has none.
+ *   3. `probeEnforcement` resolves the hook binary from the npm package root, so
+ *      it validated the 5.3.5 copy bundled with the MCP server while the hooks
+ *      Claude Code actually ran came from the plugin cache at 5.3.6 -- 37 files
+ *      different. The doctor passed enforcement for a build that was not the one
+ *      in use.
+ *
+ * Two false failures trained the user to distrust a 7/9 score, and the one check
+ * that would have caught the real problem -- the installed plugin sitting at
+ * 5.0.2 while 5.3.6 was available -- did not exist at all. That skew is the
+ * whole "installed it and saved nothing" failure mode: 5.0.2 shipped a single
+ * advisory hook, so the plugin was present, listed, and saving nothing.
+ */
+
+const PLUGIN_ID = 'token-optimizer@token-optimizer';
+
+let fixture: string;
+
+/** A plugins dir shaped like Claude Code's, with the given installed version. */
+function givenPluginInstall(installedVersion: string, availableVersion: string) {
+  const pluginsDir = join(fixture, '.claude', 'plugins');
+  const installPath = join(pluginsDir, 'cache', 'token-optimizer', 'token-optimizer', installedVersion);
+  mkdirSync(join(installPath, 'hooks', 'lib'), { recursive: true });
+  for (const f of ['pretooluse-router.mjs', 'session-start.mjs', 'precompact-optimize.mjs']) {
+    writeFileSync(join(installPath, 'hooks', f), '// hook\n');
+  }
+  writeFileSync(join(installPath, 'hooks', 'hooks.json'), '{}\n');
+
+  writeFileSync(
+    join(pluginsDir, 'installed_plugins.json'),
+    JSON.stringify({ version: 1, plugins: { [PLUGIN_ID]: [{ scope: 'user', installPath, version: installedVersion }] } })
+  );
+
+  const marketplace = join(pluginsDir, 'marketplaces', 'token-optimizer', 'plugin', '.claude-plugin');
+  mkdirSync(marketplace, { recursive: true });
+  writeFileSync(join(marketplace, 'plugin.json'), JSON.stringify({ name: 'token-optimizer', version: availableVersion }));
+
+  return { pluginsDir, installPath };
+}
+
+beforeEach(() => {
+  fixture = mkdtempSync(join(tmpdir(), 'doctor-install-'));
+});
+
+afterEach(() => {
+  rmSync(fixture, { recursive: true, force: true });
+});
+
+describe('detectInstall', () => {
+  it('recognises a plugin install', () => {
+    const { pluginsDir } = givenPluginInstall('5.3.6', '5.3.6');
+    expect(detectInstall({ pluginsDir, root: fixture }).method).toBe('plugin');
+  });
+
+  it('reports the installed and available versions separately', () => {
+    // These diverge whenever the marketplace has been updated but the installed
+    // record has not -- the state that shipped a dead advisory hook.
+    const { pluginsDir } = givenPluginInstall('5.0.2', '5.3.6');
+    const install = detectInstall({ pluginsDir, root: fixture });
+
+    expect(install.installedVersion).toBe('5.0.2');
+    expect(install.availableVersion).toBe('5.3.6');
+  });
+
+  it('points the hooks directory at the plugin, not the npm package', () => {
+    // The bug that made enforcement PASS for a build that was not running.
+    const { pluginsDir, installPath } = givenPluginInstall('5.3.6', '5.3.6');
+    const install = detectInstall({ pluginsDir, root: fixture });
+
+    expect(install.hooksDir).toBe(join(installPath, 'hooks'));
+  });
+
+  it('falls back to the package tree when there is no plugin install', () => {
+    const pluginsDir = join(fixture, 'no-such-plugins-dir');
+    const install = detectInstall({ pluginsDir, root: fixture });
+
+    expect(install.method).not.toBe('plugin');
+    expect(install.hooksDir).toBe(join(fixture, 'plugin', 'hooks'));
+  });
+});
+
+describe('probeVersion', () => {
+  it('fails when the installed plugin is behind what is available', () => {
+    const { pluginsDir } = givenPluginInstall('5.0.2', '5.3.6');
+    const [check] = probeVersion({ install: detectInstall({ pluginsDir, root: fixture }) });
+
+    expect(check.pass).toBe(false);
+    expect(check.detail).toContain('5.0.2');
+    expect(check.detail).toContain('5.3.6');
+  });
+
+  it('passes when installed matches available', () => {
+    const { pluginsDir } = givenPluginInstall('5.3.6', '5.3.6');
+    const [check] = probeVersion({ install: detectInstall({ pluginsDir, root: fixture }) });
+
+    expect(check.pass).toBe(true);
+  });
+});
+
+describe('checklist on a plugin install', () => {
+  const names = (checks: Array<{ name: string }>) => checks.map((c) => c.name);
+  const failedNames = (checks: Array<{ name: string; pass: boolean }>) =>
+    checks.filter((c) => !c.pass).map((c) => c.name);
+
+  it('does not demand settings.json entries', () => {
+    const { pluginsDir } = givenPluginInstall('5.3.6', '5.3.6');
+    const install = detectInstall({ pluginsDir, root: fixture });
+    // No settings file at all: a plugin install does not need one.
+    const checks = checklist({ root: fixture, settingsPath: join(fixture, 'settings.json'), install });
+
+    expect(failedNames(checks)).not.toContain('hooks wired into settings');
+    expect(failedNames(checks)).not.toContain('settings file present');
+  });
+
+  it('does not demand an install manifest', () => {
+    const { pluginsDir } = givenPluginInstall('5.3.6', '5.3.6');
+    const install = detectInstall({ pluginsDir, root: fixture });
+    const checks = checklist({ root: fixture, settingsPath: undefined, install });
+
+    expect(failedNames(checks)).not.toContain('install manifest present');
+  });
+
+  it('still reports how the plugin is installed, so the score is explicable', () => {
+    // Silently dropping the checks would leave a user unable to tell whether
+    // they were skipped or passed. The report has to say which path it took.
+    const { pluginsDir } = givenPluginInstall('5.3.6', '5.3.6');
+    const install = detectInstall({ pluginsDir, root: fixture });
+    const checks = checklist({ root: fixture, settingsPath: undefined, install });
+
+    expect(names(checks)).toContain('install method');
+  });
+});

--- a/tests/unit/installer-verifies-what-it-installs.test.ts
+++ b/tests/unit/installer-verifies-what-it-installs.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from '@jest/globals';
+import { readFileSync, readdirSync, existsSync, statSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * Both installers verified the wrong files, so both always reported failure.
+ *
+ * The hook layer was redesigned from a downloaded `dispatcher` plus `handlers/`
+ * and `helpers/` shell libraries into three ES modules under plugin/hooks.
+ * `Install-HooksFiles` was updated to copy the new modules; `Test-Installation`
+ * was not, and still required dispatcher.ps1, handlers/*.ps1 and five
+ * helpers/*.ps1 that the same file's own comments describe as replaced.
+ *
+ * The consequence is not a cosmetic warning. Verification failing means the
+ * installer throws "Installation verification failed", which skips
+ * scripts/record-install.mjs -- so no install manifest is written, and
+ * `install_doctor` then reports "install manifest present: FAIL / no record of
+ * what was installed". The doctor was telling the truth about a file the
+ * installer had been prevented from writing.
+ *
+ * install-hooks.sh carries the identical stale list (dispatcher.sh,
+ * handlers/token-optimizer-orchestrator.sh, helpers/invoke-mcp.sh), so this is
+ * not a Windows-only bug.
+ *
+ * These assertions are deliberately about the RELATIONSHIP between the two
+ * halves of each installer rather than about a hardcoded list: an installer must
+ * only require files it actually installs.
+ */
+
+const ROOT = process.cwd();
+const read = (p: string) => readFileSync(join(ROOT, p), 'utf8');
+
+/** Every file actually shipped under plugin/hooks, as basenames. */
+function shippedHookFiles(): Set<string> {
+  const out = new Set<string>();
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(join(ROOT, dir))) {
+      const rel = `${dir}/${entry}`;
+      if (statSync(join(ROOT, rel)).isDirectory()) walk(rel);
+      else out.add(entry);
+    }
+  };
+  walk('plugin/hooks');
+  return out;
+}
+
+/**
+ * Paths an installer treats as required for verification, as basenames.
+ *
+ * Scoped to the required-files array rather than every $HOOKS_DIR mention in the
+ * file: install-hooks.sh also prints "$HOOKS_DIR/logs/dispatcher.log" in its
+ * closing help text, which is a log location, not a file installation produces.
+ * Counting it would fail the installer for telling the user where to look.
+ */
+function requiredByInstaller(source: string): string[] {
+  // `@(` in PowerShell, `(` in bash.
+  const block = source.match(/required_?[Ff]iles\s*=\s*@?\(([\s\S]*?)\)/);
+  if (!block) return [];
+  const matches = block[1].matchAll(/["']\$(?:\{)?HOOKS_DIR(?:\})?[\\/]([^"']+)["']/g);
+  return [...matches].map((m) => m[1].replace(/\\/g, '/').split('/').pop() as string);
+}
+
+const ENTRYPOINTS = ['session-start.mjs', 'pretooluse-router.mjs', 'precompact-optimize.mjs'];
+
+describe.each([
+  ['install-hooks.ps1', 'install-hooks.ps1'],
+  ['install-hooks.sh', 'install-hooks.sh'],
+])('%s verification', (_label, file) => {
+  it('only requires files the installer actually ships', () => {
+    if (!existsSync(join(ROOT, file))) return;
+
+    const shipped = shippedHookFiles();
+    const required = requiredByInstaller(read(file));
+    const missing = required.filter((name) => !shipped.has(name));
+
+    // Anything here is a file verification demands and installation never
+    // produces -- a guaranteed failure on every run.
+    expect(missing).toEqual([]);
+  });
+
+  it('requires the three real hook entrypoints', () => {
+    if (!existsSync(join(ROOT, file))) return;
+
+    // The inverse failure: verification that checks nothing meaningful would
+    // also pass the test above. These are the modules hooks.json invokes, so an
+    // install missing any of them is broken and must not verify clean.
+    const required = requiredByInstaller(read(file));
+    for (const entry of ENTRYPOINTS) {
+      expect(required).toContain(entry);
+    }
+  });
+});
+
+describe('the install manifest', () => {
+  it('is recorded even when optional verification steps do not apply', () => {
+    // record-install.mjs sat inside `if ($verified)`, so any verification
+    // failure -- including the MCP-configured check, which cannot pass for a
+    // Claude Code CLI user because that path configures MCP via the plugin
+    // rather than claude_desktop_config.json -- silently skipped it.
+    const ps1 = read('install-hooks.ps1');
+    const recordIndex = ps1.indexOf('record-install.mjs');
+    expect(recordIndex).toBeGreaterThan(-1);
+
+    // The recording must not be gated on the verification verdict.
+    const gatedOnVerified = /if\s*\(\s*\$verified\s*\)[\s\S]{0,400}record-install\.mjs/.test(ps1);
+    expect(gatedOnVerified).toBe(false);
+  });
+});

--- a/tests/unit/pinned-spec-tracks-package.test.ts
+++ b/tests/unit/pinned-spec-tracks-package.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from '@jest/globals';
+import { readFileSync, readdirSync, existsSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * The SPEC pinned inside the hand-maintained client configs is a second,
+ * independent version that must track package.json -- and it did not.
+ *
+ * `plugin-version-tracks-package.test.ts` covers the plugin MANIFEST, which
+ * release-please bumps via `extra-files`. The pinned npm spec is different: it
+ * lives inside a string in an args array, so no jsonpath can reach it, and
+ * `scripts/pin-mcp-version.mjs` is what keeps it in step. Nothing ran that
+ * script during a release, so plugin/.mcp.json shipped `@5.3.2` while the hooks
+ * beside it were 5.3.6.
+ *
+ * Observed live on a user machine: the plugin's four hooks loaded at 5.3.6 and
+ * launched an MCP server three patch versions behind. Nothing failed loudly --
+ * the tool surface happened to be compatible -- which is exactly why this needs
+ * a test rather than vigilance.
+ *
+ * The second test is the one that actually prevents recurrence. `npm run
+ * sync:hooks:check` already existed and already detected this drift; it simply
+ * was not wired into any workflow, so it never ran. A gate that exists and is
+ * never invoked is indistinguishable from no gate.
+ */
+
+const ROOT = process.cwd();
+const read = (p: string) => readFileSync(join(ROOT, p), 'utf8');
+const pkgVersion = JSON.parse(read('package.json')).version as string;
+
+// Mirrors TARGETS in scripts/pin-mcp-version.mjs. Kept as a literal rather than
+// imported so a target silently dropped from the script is still asserted here.
+const PINNED_CONFIGS = [
+  'integrations/copilot/mcp-config.json',
+  'integrations/gemini/gemini-extension.json',
+  'integrations/opencode/opencode.json',
+  'integrations/codex/config.toml',
+  'integrations/codex/plugin/.mcp.json',
+  'plugin/.mcp.json',
+  'mcp.json',
+  'server.json',
+  'gemini-extension.json',
+];
+
+const SPEC = /@ooples\/token-optimizer-mcp@([^"'\s,\]]+)/g;
+
+describe('pinned MCP spec', () => {
+  it.each(PINNED_CONFIGS)('in %s is pinned to the package version', (relative) => {
+    if (!existsSync(join(ROOT, relative))) return; // not every target ships in every layout
+
+    const pinned = [...read(relative).matchAll(SPEC)].map((m) => m[1]);
+    // A config with no pin at all is fine; one that pins the wrong version is not.
+    for (const version of pinned) {
+      expect(version).toBe(pkgVersion);
+    }
+  });
+
+  it('is never left floating on @latest in a shipped config', () => {
+    // `@latest` resolves at npx time, so the version a user runs depends on when
+    // their npx cache was populated -- unreproducible and unpinnable.
+    const floating = PINNED_CONFIGS.filter(
+      (r) => existsSync(join(ROOT, r)) && read(r).includes('token-optimizer-mcp@latest')
+    );
+    expect(floating).toEqual([]);
+  });
+});
+
+describe('the drift gate', () => {
+  const workflowDir = '.github/workflows';
+  const workflows = readdirSync(join(ROOT, workflowDir)).filter((f) => /\.ya?ml$/.test(f));
+  const allWorkflowText = workflows.map((f) => read(join(workflowDir, f))).join('\n');
+
+  it('runs sync:hooks:check somewhere in CI', () => {
+    // Without this, pin drift can only be caught by a human remembering to run
+    // the script -- which is how three patch versions of drift shipped.
+    expect(allWorkflowText).toMatch(/sync:hooks:check|verify:all/);
+  });
+
+  it('guards the release path, which is where the drift is introduced', () => {
+    // ci.yml deliberately skips release-please commits, so a gate that only runs
+    // on ordinary PRs cannot see a bump made by the release PR itself.
+    const release = read(join(workflowDir, 'release.yml'));
+    expect(release).toMatch(/sync:hooks:check|verify:all/);
+  });
+});


### PR DESCRIPTION
Three bugs found while diagnosing a real install that was reporting 7/9 healthy and saving nothing. Each is committed separately.

All three share one shape: **a mechanism that exists, is correct, and is never reached.** The pin script was wired but never invoked by CI; the installers' verification checked files the installers had stopped producing; the doctor validated a copy of the hooks nobody was running.

## 1. `fix(release)` — pinned client specs lag the release

Seven hand-maintained client configs shipped pinned to `@ooples/token-optimizer-mcp@5.3.2` while the hooks beside them were 5.3.6: copilot, gemini (×2), opencode, codex (×2) and the Claude plugin.

release-please bumps `package.json` and, via `extra-files`, the plugin manifest. It cannot reach the pinned npm spec — that version lives inside a string in an args array, so no jsonpath addresses it. `scripts/pin-mcp-version.mjs` exists to keep them in step, and `npm run sync:hooks:check` already detected this drift, but **that check was wired into no workflow at all**. `sync:hooks:check` was in fact red on master.

Three layers, because a refusal alone leaves every release needing manual repair:
- `quality-gates.yml` gains a `generated-artifacts` job. It deliberately carries **no** release-please skip — the version bump is the only event that causes this drift, so skipping release commits blinds the gate to its sole failure mode.
- `release.yml` verifies pins before publishing, failing the publish rather than repairing a tree whose tag is already cut.
- `sync-release-pins.yml` runs the sync on the release PR and commits the result. It cannot loop: pushes made with `GITHUB_TOKEN` do not trigger further workflow runs, and the sync is idempotent regardless.

## 2. `fix(install)` — installers verify files they no longer ship

Both installers always reported failure, and that is what suppressed the install manifest.

`install-hooks.ps1` required `dispatcher.ps1`, `handlers/token-optimizer-orchestrator.ps1` and five `helpers/*.ps1`; `install-hooks.sh` required the `.sh` equivalents — files the comment directly above each list describes as replaced by three ES modules. Both also omitted the `token-optimizer/` subdirectory they copy into, so every path was wrong twice over.

Failing verification threw `Installation verification failed`, which skipped `scripts/record-install.mjs`, so no manifest was written — and `install_doctor` then correctly reported "no record of what was installed". **The doctor was telling the truth about a file the installer had been prevented from writing.**

- Require the three entrypoints `hooks.json` invokes, plus `hooks.json` and `lib/policy.mjs`, under the correct subdirectory.
- "MCP configured in an AI tool" becomes advisory. It searches Claude Desktop, Cursor, Cline, Copilot and Windsurf; a Claude Code user has it in none of them, because that client gets the server from the plugin's own `.mcp.json`. Absence was failing the install for the primary supported client.
- Record the manifest regardless of verdict — files land before verification runs, and a failed install is exactly when an exact uninstall matters most.

## 3. `fix(doctor)` — doctor is blind to plugin installs

On a healthy plugin install at 5.3.6, the doctor reported 7/9 with two failures that could never pass, and stayed silent about the one fault that mattered.

- **"hooks wired into settings: FAIL"** — a plugin declares hooks in its own `hooks.json` and writes nothing to `settings.json`. The report said "not wired" about a plugin whose SessionStart hook was injecting the policy at that moment.
- **"install manifest present: FAIL"** — only `install-hooks.*` writes that manifest; the plugin path never will.
- **`probeEnforcement` resolved the binary from the npm package root** — a different build from the plugin's. Measured: package at 5.3.5, plugin cache at 5.3.6, all 37 hook files differing. Enforcement PASSED for a build that was not running, which is the precise failure this probe exists to rule out.

Two guaranteed failures are worse than none — they teach the reader that a non-perfect score is normal, so the report stops being evidence.

What was missing entirely is now `plugin is up to date`. **Updating the marketplace does not update the installed plugin**: `installed_plugins.json` pins `installPath` and `version`, so a machine can sit on 5.0.2 while 5.3.6 is checked out beside it, and restarting faithfully reloads the pinned version. 5.0.2 shipped a single non-blocking advisory hook — present, listed in `/mcp`, saving nothing. That is the exact scenario this file's own header says defeats a checklist doctor.

`detectInstall` resolves method, hooks directory in use, and both versions once; `diagnose` threads it through every check, because detecting per-probe is how the checklist and the enforcement probe came to describe two different builds in one report.

## Verification

- `tests/unit`: **828 passed**, 3 new suites (26 tests). Every test was watched failing against the unmodified code first; the installer test was corrected mid-way when it matched a log path in help text rather than a required file, and re-verified as still failing pre-fix.
- `tsc --noEmit`: clean. `npm run lint`: 0 errors. `npm run validate`: passes.
- `bash -n install-hooks.sh` and a PowerShell parser check on `install-hooks.ps1`: both clean.
- All three workflow files parse as YAML with the expected jobs.

**Not fixed, and pre-existing on master:** `dashboard-self-contained.test.ts` fails and `npm run build` fails locally because `chart.js` is not resolvable in this checkout, so `copy:assets` cannot run. Confirmed identical on unmodified master; CI's `npm ci` installs it.

**Also noticed, not addressed here:** `sync:hooks:check` is EOL-naive, so `generate-client-entries.mjs --check` reports false drift for any contributor on Windows with `core.autocrlf=true` (`.gitattributes` is `* text=auto`, so CI on Linux is unaffected). Worth its own change.

Adjacent to #237, which guards against features shipping dead — all three bugs here are instances of exactly that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
