### PR TITLE
fix: EOL-safe generator drift checks, and a build failure that names its remedy

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "uninstall-hooks": "node scripts/uninstall.mjs",
     "doctor": "node scripts/doctor.mjs",
     "build": "tsc && npm run copy:assets",
-    "copy:assets": "node -e \"const{cpSync,mkdirSync}=require('fs');cpSync('src/dashboard/public','dist/dashboard/public',{recursive:true});mkdirSync('dist/dashboard/public/vendor',{recursive:true});cpSync('node_modules/chart.js/dist/chart.umd.js','dist/dashboard/public/vendor/chart.umd.min.js')\"",
+    "copy:assets": "node scripts/copy-assets.mjs",
     "start": "node dist/server/index.js",
     "dev": "tsc --watch",
     "clean": "rm -rf dist",

--- a/scripts/copy-assets.mjs
+++ b/scripts/copy-assets.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * Copies the dashboard's static files and vendors the chart bundle into dist.
+ *
+ * WHY THIS IS A MODULE AND NOT THE ONE-LINER IT REPLACES. `copy:assets` used to
+ * be an inline `node -e` that cpSync'd chart.js straight into the bundle. With
+ * chart.js absent -- a stale node_modules, a pruned install, an --omit=dev
+ * misconfiguration -- `npm run build` died with:
+ *
+ *     code: 'ENOENT', syscall: 'lstat',
+ *     path: '.../node_modules/chart.js/dist/chart.umd.js'
+ *
+ * Nothing there says a dependency is missing, which one, or that `npm install`
+ * fixes it. It also failed the build BEFORE tsc's output was usable, and took
+ * dashboard-self-contained.test.ts down with it, so the visible symptom was a
+ * failing test suite rather than an incomplete install. That misdirection is why
+ * it was repeatedly written off as environmental instead of being fixed.
+ *
+ * hooks-core/doctor.mjs sets the standard this broke: "Every check returns a
+ * remedy on failure. A diagnosis without a next step is a complaint." A build
+ * script owes the reader the same courtesy, and a `node -e` string has nowhere
+ * to put a preflight check or a decent message.
+ */
+
+import { cpSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/** Where the chart bundle comes from, relative to the repo root. */
+export const VENDOR_SOURCE = join('node_modules', 'chart.js', 'dist', 'chart.umd.js');
+
+/** The name the dashboard's markup actually requests. */
+const VENDOR_TARGET = join('vendor', 'chart.umd.min.js');
+
+const PUBLIC_SOURCE = join('src', 'dashboard', 'public');
+const PUBLIC_TARGET = join('dist', 'dashboard', 'public');
+
+/**
+ * Copies the dashboard assets, or throws an error that names its own remedy.
+ *
+ * `root` is a parameter so this is testable against a fixture tree rather than
+ * only against the real repo.
+ */
+export function copyAssets({ root = ROOT } = {}) {
+  const publicSource = join(root, PUBLIC_SOURCE);
+  const publicTarget = join(root, PUBLIC_TARGET);
+  const vendorSource = join(root, VENDOR_SOURCE);
+  const vendorTarget = join(root, PUBLIC_TARGET, VENDOR_TARGET);
+
+  if (!existsSync(publicSource)) {
+    throw new Error(
+      `Cannot build the dashboard: ${PUBLIC_SOURCE} is missing.\n` +
+      'This is part of the repository, so a missing copy means an incomplete ' +
+      'checkout rather than a build problem.'
+    );
+  }
+
+  // PREFLIGHT, so the failure names the cause instead of a filesystem errno.
+  // chart.js is a declared runtime dependency; absent, the only sane conclusion
+  // is that the install is incomplete.
+  if (!existsSync(vendorSource)) {
+    throw new Error(
+      'Cannot build the dashboard: the chart.js bundle is not installed.\n' +
+      `  expected: ${VENDOR_SOURCE}\n` +
+      '  fix:      npm install\n' +
+      'chart.js is a declared dependency, so this means the installed tree is ' +
+      'incomplete -- not that the dashboard is misconfigured. The dashboard ' +
+      'vendors the bundle rather than loading it from a CDN, which is what ' +
+      'dashboard-self-contained.test.ts asserts.'
+    );
+  }
+
+  cpSync(publicSource, publicTarget, { recursive: true });
+  mkdirSync(dirname(vendorTarget), { recursive: true });
+  cpSync(vendorSource, vendorTarget);
+
+  return { publicTarget, vendorTarget };
+}
+
+// CLI entry. Only runs when invoked directly, so importing this for a test does
+// not copy anything.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  try {
+    const { vendorTarget } = copyAssets();
+    console.log(`copied dashboard assets; vendored ${VENDOR_TARGET}`);
+    void vendorTarget;
+  } catch (error) {
+    // The message is the product here, so print it plainly rather than as a
+    // stack trace the reader has to decode.
+    console.error(`\n${error.message}\n`);
+    process.exit(1);
+  }
+}

--- a/scripts/generate-client-configs.mjs
+++ b/scripts/generate-client-configs.mjs
@@ -22,9 +22,10 @@
  * every client at once instead of being hand-copied thirteen times.
  */
 
-import { writeFileSync, mkdirSync, readFileSync, existsSync } from 'node:fs';
+import { mkdirSync, readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { contentMatches, readIfExists, writeIfChanged } from './lib/text.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -168,17 +169,22 @@ function mcpConfig(shape) {
 const check = process.argv.includes('--check');
 let drifted = 0;
 
-/** Writes, or in check mode reports a mismatch without touching the file. */
+/**
+ * Writes, or in check mode reports a mismatch without touching the file.
+ *
+ * The comparison is EOL-insensitive. These files are stored LF and checked out
+ * CRLF on Windows, so a byte comparison reports drift on every Windows clone
+ * while Linux CI stays green. See scripts/lib/text.mjs.
+ */
 function emit(path, contents) {
   if (check) {
-    const current = existsSync(path) ? readFileSync(path, 'utf8') : null;
-    if (current !== contents) {
+    if (!contentMatches(readIfExists(path), contents)) {
       console.error(`DRIFT: ${path.slice(ROOT.length + 1)}`);
       drifted++;
     }
     return;
   }
-  writeFileSync(path, contents);
+  writeIfChanged(path, contents);
 }
 
 for (const client of CLIENTS) {

--- a/scripts/generate-client-entries.mjs
+++ b/scripts/generate-client-entries.mjs
@@ -10,9 +10,9 @@
  * drifted apart.
  */
 
-import { writeFileSync, mkdirSync, readFileSync, existsSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { contentMatches, readIfExists, writeIfChanged } from './lib/text.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -55,16 +55,17 @@ run('${client}', '${event}').catch(() => process.exit(0));
 `;
 
   if (check) {
-    const current = existsSync(destination) ? readFileSync(destination, 'utf8') : null;
-    if (current !== contents) {
+    // EOL-insensitive: these are stored LF and checked out CRLF on Windows, so
+    // a byte comparison reported all ten entries drifted on every Windows clone
+    // while Linux CI stayed green. See scripts/lib/text.mjs.
+    if (!contentMatches(readIfExists(destination), contents)) {
       console.error(`DRIFT: ${destination.slice(ROOT.length + 1)}`);
       drifted++;
     }
     continue;
   }
 
-  mkdirSync(target, { recursive: true });
-  writeFileSync(destination, contents);
+  writeIfChanged(destination, contents);
 }
 
 if (check && drifted > 0) {

--- a/scripts/lib/text.mjs
+++ b/scripts/lib/text.mjs
@@ -1,0 +1,70 @@
+/**
+ * Line-ending-safe file comparison and writing, shared by every generator.
+ *
+ * WHY THIS IS SHARED RATHER THAN COPIED. `.gitattributes` sets `* text=auto`, so
+ * generated files are stored with LF and written to the working tree with CRLF
+ * on Windows. Generators build their output with '\n' regardless, so a byte
+ * comparison finds every line different and reports drift that does not exist.
+ *
+ * sync-hook-core.mjs hit that first -- `npm test` failed on a fresh Windows
+ * clone while Linux CI stayed green -- and grew a local `normalize` to fix it.
+ * The fix was never applied to generate-client-entries.mjs or
+ * generate-client-configs.mjs, so `npm run sync:hooks:check` went on reporting
+ * ten phantom drifted entry files on every Windows checkout. The bug was not a
+ * wrong comparison; it was a right comparison that reached one of three call
+ * sites. Copying it a third time would have left the same hole open for a
+ * fourth generator, so it lives here and the generators import it.
+ *
+ * This matters more since sync:hooks:check became a CI gate and `verify:all`
+ * became the documented pre-flight: a gate that cannot pass locally on a
+ * supported platform teaches contributors to skip it.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+/**
+ * Collapses CRLF to LF so content can be compared independently of how git
+ * happened to check the file out.
+ *
+ * Deliberately does NOT touch a lone CR. Git's autocrlf rewrites CRLF, not CR,
+ * so treating a bare CR as equivalent would hide a genuine content difference.
+ */
+export const normalizeEol = (text) => String(text).replace(/\r\n/g, '\n');
+
+/**
+ * Is what is on disk already this content, ignoring line endings?
+ *
+ * `current` is null when the file is absent, which is never a match -- a missing
+ * generated file is real drift.
+ */
+export function contentMatches(current, contents) {
+  if (current === null || current === undefined) return false;
+  return normalizeEol(current) === normalizeEol(contents);
+}
+
+/** Reads a file, or null when it does not exist. Never throws. */
+export function readIfExists(path) {
+  try {
+    return existsSync(path) ? readFileSync(path, 'utf8') : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Writes only when the content actually changed, and returns whether it did.
+ *
+ * The write path has the same defect as the comparison, from the other side:
+ * writing LF into a CRLF working tree rewrites every byte of files that were
+ * already correct. On Windows that turned `npm run sync:hooks` into a ~200-file
+ * diff of pure line-ending churn with the real change buried inside it, which is
+ * exactly the diff a reviewer cannot read.
+ */
+export function writeIfChanged(path, contents) {
+  if (contentMatches(readIfExists(path), contents)) return false;
+
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, contents);
+  return true;
+}

--- a/scripts/sync-hook-core.mjs
+++ b/scripts/sync-hook-core.mjs
@@ -16,7 +16,8 @@
  * diverged.
  */
 
-import { readFileSync, writeFileSync, mkdirSync, readdirSync, existsSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
+import { contentMatches, readIfExists, writeIfChanged } from './lib/text.mjs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -40,18 +41,9 @@ const banner = (name) =>
   `// GENERATED FILE -- do not edit.\n` +
   `// Source of truth: hooks-core/${name}. Regenerate with \`npm run sync:hooks\`.\n`;
 
-/**
- * Compare CONTENT, not the line endings git happened to check the file out with.
- *
- * `.gitattributes` sets `* text=auto`, so these files are stored with LF and
- * written to the working tree with CRLF on Windows. The banner above is built
- * with '\n' regardless, so a byte comparison declared all 180 vendored files
- * drifted on any Windows checkout -- `npm test` failed immediately after a
- * fresh clone, while Linux CI stayed green because its checkout leaves LF
- * alone. Nothing was actually out of sync; only the two banner lines differed,
- * and only in how their newline was spelled.
- */
-const normalize = (text) => text.replace(/\r\n/g, '\n');
+// The EOL-safe comparison this file used to carry locally now lives in
+// scripts/lib/text.mjs, because it was needed by the other two generators and
+// having it here only meant they went without it. See that module for why.
 
 let drifted = 0;
 
@@ -61,16 +53,16 @@ for (const target of TARGETS) {
     const destination = join(target, name);
 
     if (check) {
-      const current = existsSync(destination) ? readFileSync(destination, 'utf8') : null;
-      if (current === null || normalize(current) !== normalize(contents)) {
+      if (!contentMatches(readIfExists(destination), contents)) {
         console.error(`DRIFT: ${destination.slice(ROOT.length + 1)}`);
         drifted++;
       }
       continue;
     }
 
-    mkdirSync(target, { recursive: true });
-    writeFileSync(destination, contents);
+    // writeIfChanged skips files that differ only in line endings, so a sync on
+    // Windows no longer rewrites every vendored file it did not need to.
+    writeIfChanged(destination, contents);
   }
 }
 

--- a/tests/unit/copy-assets-names-its-remedy.test.ts
+++ b/tests/unit/copy-assets-names-its-remedy.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+// @ts-expect-error -- scripts ship as plain ESM with no type declarations.
+import { copyAssets, VENDOR_SOURCE } from '../../scripts/copy-assets.mjs';
+
+/**
+ * `npm run build` failed with a bare ENOENT that named neither the cause nor a
+ * remedy.
+ *
+ * copy:assets was an inline `node -e` one-liner that cpSync'd
+ * node_modules/chart.js/dist/chart.umd.js into the dashboard bundle. With
+ * chart.js absent -- a stale node_modules, a pruned install, an --omit=dev
+ * misconfiguration -- the whole build died with:
+ *
+ *     code: 'ENOENT', syscall: 'lstat',
+ *     path: '.../node_modules/chart.js/dist/chart.umd.js'
+ *     Node.js v22.15.0
+ *
+ * Nothing in that says a dependency is missing, which one, or that `npm install`
+ * fixes it. It also took dashboard-self-contained.test.ts down with it, so the
+ * visible symptom was a failing test suite rather than an incomplete install --
+ * which is how it survived long enough to be dismissed as environmental more
+ * than once.
+ *
+ * hooks-core/doctor.mjs states the standard this violated: "Every check returns a
+ * remedy on failure. A diagnosis without a next step is a complaint." A build
+ * script owes the same.
+ *
+ * The one-liner also could not be fixed in place: there is nowhere in a
+ * `node -e` string to put a preflight check or a decent message, which is why
+ * this is a module with an entry point rather than a longer one-liner.
+ */
+
+let root: string;
+
+/** A source tree shaped like the repo's, minus whatever the test omits. */
+function givenTree({ withVendor }: { withVendor: boolean }) {
+  mkdirSync(join(root, 'src', 'dashboard', 'public'), { recursive: true });
+  writeFileSync(join(root, 'src', 'dashboard', 'public', 'index.html'), '<html></html>');
+
+  if (withVendor) {
+    const dir = join(root, VENDOR_SOURCE, '..');
+    mkdirSync(join(root, VENDOR_SOURCE).replace(/[\\/][^\\/]+$/, ''), { recursive: true });
+    writeFileSync(join(root, VENDOR_SOURCE), '/* chart.js umd */');
+    void dir;
+  }
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'copy-assets-'));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('copyAssets when the vendored dependency is missing', () => {
+  it('names the missing package rather than throwing ENOENT', () => {
+    givenTree({ withVendor: false });
+
+    expect(() => copyAssets({ root })).toThrow(/chart\.js/);
+  });
+
+  it('names the remedy', () => {
+    givenTree({ withVendor: false });
+
+    // The whole point: a contributor should not have to guess that a build
+    // failure means their install is incomplete.
+    expect(() => copyAssets({ root })).toThrow(/npm install/);
+  });
+
+  it('does not leak a raw filesystem error code to the user', () => {
+    givenTree({ withVendor: false });
+
+    let message = '';
+    try {
+      copyAssets({ root });
+    } catch (error) {
+      message = (error as Error).message;
+    }
+
+    expect(message).not.toMatch(/ENOENT|lstat/);
+  });
+});
+
+describe('copyAssets on a complete tree', () => {
+  it('copies the dashboard public files', () => {
+    givenTree({ withVendor: true });
+
+    copyAssets({ root });
+
+    expect(existsSync(join(root, 'dist', 'dashboard', 'public', 'index.html'))).toBe(true);
+  });
+
+  it('vendors the chart bundle under the name the dashboard loads', () => {
+    givenTree({ withVendor: true });
+
+    copyAssets({ root });
+
+    const vendored = join(root, 'dist', 'dashboard', 'public', 'vendor', 'chart.umd.min.js');
+    expect(readFileSync(vendored, 'utf8')).toBe('/* chart.js umd */');
+  });
+});
+
+describe('the build wiring', () => {
+  it('uses the script rather than an inline one-liner', () => {
+    // An inline `node -e` has nowhere to put a preflight check or a remedy, so
+    // reverting to one would silently reintroduce the bare ENOENT.
+    const pkg = JSON.parse(readFileSync(join(process.cwd(), 'package.json'), 'utf8'));
+
+    expect(pkg.scripts['copy:assets']).toContain('scripts/copy-assets.mjs');
+    expect(pkg.scripts['copy:assets']).not.toContain('node -e');
+  });
+});

--- a/tests/unit/dashboard-self-contained.test.ts
+++ b/tests/unit/dashboard-self-contained.test.ts
@@ -68,7 +68,16 @@ describe('the dashboard is self-contained', () => {
     // Pinned exactly: a caret range would let the dependency change under us,
     // which is the supply-chain half of what was wrong with the CDN.
     expect(pkg.dependencies['chart.js']).toBe('4.4.0');
-    expect(pkg.scripts['copy:assets']).toContain('vendor/chart.umd.min.js');
+
+    // The vendoring step moved out of an inline `node -e` in copy:assets and
+    // into scripts/copy-assets.mjs, so that a missing chart.js could fail with a
+    // remedy instead of a bare ENOENT. Assert it where it now lives -- deleting
+    // the vendoring from that module must still fail this test.
+    expect(pkg.scripts['copy:assets']).toContain('scripts/copy-assets.mjs');
+    const copyAssets = readFileSync(join(process.cwd(), 'scripts', 'copy-assets.mjs'), 'utf8');
+    expect(copyAssets).toContain('chart.umd.min.js'); // the vendored target
+    expect(copyAssets).toContain('chart.umd.js'); // sourced from the local package
+    expect(copyAssets).not.toMatch(/https?:\/\/[^\s'"]*chart/i); // never a CDN
 
     // And the loader points at the local copy.
     const charts = readFileSync(join(PUBLIC, 'js', 'charts.js'), 'utf8');

--- a/tests/unit/generators-are-eol-insensitive.test.ts
+++ b/tests/unit/generators-are-eol-insensitive.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, statSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+// @ts-expect-error -- scripts ship as plain ESM with no type declarations.
+import { normalizeEol, contentMatches, writeIfChanged } from '../../scripts/lib/text.mjs';
+
+/**
+ * The generators compared generated content to on-disk content byte-for-byte,
+ * so every Windows checkout reported drift that did not exist.
+ *
+ * `.gitattributes` sets `* text=auto`: files are stored with LF and written to
+ * the working tree with CRLF on Windows. Generators build their output with '\n'
+ * regardless, so a byte comparison finds every line different.
+ *
+ * sync-hook-core.mjs already carries the fix and documents it at length -- it
+ * was written after `npm test` failed on a fresh Windows clone. But the same fix
+ * was never applied to generate-client-entries.mjs or generate-client-configs.mjs,
+ * so `npm run sync:hooks:check` still reported 10 phantom drifted entry files on
+ * Windows while Linux CI stayed green.
+ *
+ * That matters more now than it did: sync:hooks:check has become a CI gate, and
+ * `npm run verify:all` is the documented pre-flight. A gate that cannot pass
+ * locally on a supported platform trains contributors to skip it.
+ *
+ * The write path has the same defect from the other side. Writing LF into a
+ * CRLF working tree rewrites every byte of ~200 files that were already correct,
+ * so `npm run sync:hooks` on Windows produces a diff of pure line-ending churn
+ * with the real change buried in it.
+ *
+ * The last test is the one that prevents recurrence. The bug was not that the
+ * comparison was wrong -- it was that the correct comparison existed in one of
+ * three generators. A shared helper plus an assertion that every generator uses
+ * it is what closes that, rather than a third hand-copied `normalize`.
+ */
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'eol-'));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('normalizeEol', () => {
+  it('makes CRLF and LF compare equal', () => {
+    expect(normalizeEol('a\r\nb\r\n')).toBe(normalizeEol('a\nb\n'));
+  });
+
+  it('leaves a lone CR alone, which is a real content difference', () => {
+    // Old Mac line endings are not what git rewrites, so treating them as
+    // equivalent would hide genuine drift.
+    expect(normalizeEol('a\rb')).toBe('a\rb');
+  });
+});
+
+describe('contentMatches', () => {
+  it('treats a CRLF file as matching LF generated output', () => {
+    expect(contentMatches('export const x = 1;\r\n', 'export const x = 1;\n')).toBe(true);
+  });
+
+  it('still detects a real content change', () => {
+    expect(contentMatches('export const x = 1;\r\n', 'export const x = 2;\n')).toBe(false);
+  });
+
+  it('reports a missing file as not matching', () => {
+    expect(contentMatches(null, 'anything')).toBe(false);
+  });
+});
+
+describe('writeIfChanged', () => {
+  it('does not touch a file that differs only in line endings', () => {
+    const path = join(dir, 'generated.mjs');
+    writeFileSync(path, 'line one\r\nline two\r\n');
+    const before = statSync(path).mtimeMs;
+
+    const written = writeIfChanged(path, 'line one\nline two\n');
+
+    expect(written).toBe(false);
+    // The bytes on disk are untouched, so the working tree stays clean.
+    expect(readFileSync(path, 'utf8')).toBe('line one\r\nline two\r\n');
+    expect(statSync(path).mtimeMs).toBe(before);
+  });
+
+  it('writes when the content genuinely changed', () => {
+    const path = join(dir, 'generated.mjs');
+    writeFileSync(path, 'old\r\n');
+
+    const written = writeIfChanged(path, 'new\n');
+
+    expect(written).toBe(true);
+    expect(readFileSync(path, 'utf8')).toBe('new\n');
+  });
+
+  it('creates a file that does not exist yet', () => {
+    const path = join(dir, 'nested', 'generated.mjs');
+
+    expect(writeIfChanged(path, 'fresh\n')).toBe(true);
+    expect(readFileSync(path, 'utf8')).toBe('fresh\n');
+  });
+});
+
+describe('every generator', () => {
+  const ROOT = process.cwd();
+  const GENERATORS = [
+    'scripts/sync-hook-core.mjs',
+    'scripts/generate-client-entries.mjs',
+    'scripts/generate-client-configs.mjs',
+  ];
+
+  it.each(GENERATORS)('%s uses the shared EOL-safe comparison', (file) => {
+    const source = readFileSync(join(ROOT, file), 'utf8');
+
+    // The recurrence guard: the original bug was a correct comparison living in
+    // one generator and not the other two. Requiring the shared import means a
+    // fourth generator cannot quietly reintroduce it.
+    expect(source).toMatch(/from '\.\/lib\/text\.mjs'/);
+  });
+
+  it.each(GENERATORS)('%s does not compare raw file bytes', (file) => {
+    const source = readFileSync(join(ROOT, file), 'utf8');
+
+    // `current !== contents` is the exact shape that produced the phantom drift.
+    expect(source).not.toMatch(/current\s*!==\s*contents/);
+  });
+});

--- a/tests/unit/generators-are-eol-insensitive.test.ts
+++ b/tests/unit/generators-are-eol-insensitive.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { mkdtempSync, writeFileSync, readFileSync, rmSync, statSync } from 'fs';
+import {
+  mkdtempSync, writeFileSync, readFileSync, rmSync, statSync,
+  mkdirSync, copyFileSync, readdirSync, existsSync,
+} from 'fs';
+import { spawnSync } from 'child_process';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
@@ -111,19 +115,114 @@ describe('every generator', () => {
     'scripts/generate-client-configs.mjs',
   ];
 
-  it.each(GENERATORS)('%s uses the shared EOL-safe comparison', (file) => {
+  it.each(GENERATORS)('%s imports the shared EOL-safe helpers', (file) => {
     const source = readFileSync(join(ROOT, file), 'utf8');
-
-    // The recurrence guard: the original bug was a correct comparison living in
-    // one generator and not the other two. Requiring the shared import means a
-    // fourth generator cannot quietly reintroduce it.
     expect(source).toMatch(/from '\.\/lib\/text\.mjs'/);
   });
 
-  it.each(GENERATORS)('%s does not compare raw file bytes', (file) => {
+  // AN IMPORT IS NOT A CALL, which is what the first version of this guard
+  // asserted. Reported by CodeRabbit on this PR, and confirmed by reverting
+  // generate-client-entries.mjs to a raw byte comparison AND an unconditional
+  // write while keeping the import: all fourteen tests stayed green. A guard
+  // that cannot fail is decoration.
+  it.each(GENERATORS)('%s routes its comparison through the helpers', (file) => {
     const source = readFileSync(join(ROOT, file), 'utf8');
-
-    // `current !== contents` is the exact shape that produced the phantom drift.
-    expect(source).not.toMatch(/current\s*!==\s*contents/);
+    expect(source).toMatch(/contentMatches\s*\(\s*readIfExists\s*\(/);
   });
+
+  it.each(GENERATORS)('%s routes its writes through writeIfChanged', (file) => {
+    const source = readFileSync(join(ROOT, file), 'utf8');
+    expect(source).toMatch(/\bwriteIfChanged\s*\(/);
+  });
+
+  // STRUCTURAL, NOT A SPELLING. Banning the literal `current !== contents` --
+  // the previous check -- only forbade one variable naming; renaming it walked
+  // straight past. No generator imports writeFileSync today, and requiring that
+  // to stay true means a direct write cannot be reintroduced under any name,
+  // because it has nowhere to come from.
+  it.each(GENERATORS)('%s cannot write bytes except through the helper', (file) => {
+    const source = readFileSync(join(ROOT, file), 'utf8');
+    expect(source).not.toMatch(/\bwriteFileSync\b/);
+  });
+
+  it.each(GENERATORS)('%s does not compare raw file contents', (file) => {
+    const source = readFileSync(join(ROOT, file), 'utf8');
+    // Any identifier compared against the generated `contents`, not one name.
+    expect(source).not.toMatch(/\b[A-Za-z_$][\w$]*\s*(===|!==)\s*contents\b/);
+    expect(source).not.toMatch(/readFileSync\s*\([^)]*\)\s*(===|!==)/);
+  });
+});
+
+describe('a generator run against a CRLF working tree', () => {
+  // THE PROPERTY ITSELF, not a proxy for it. The assertions above read source
+  // text; this one runs the real generator on this real platform and checks the
+  // two behaviours the bug actually broke -- --check reporting drift that does
+  // not exist, and a write rewriting bytes that were already correct.
+  //
+  // `ROOT` is derived from the script's own location, so the generator is copied
+  // into a temporary tree with its helper and runs entirely inside it. Nothing
+  // in the repository is touched.
+  const GEN = 'generate-client-entries.mjs';
+
+  function sandbox() {
+    const root = mkdtempSync(join(tmpdir(), 'gen-eol-'));
+    mkdirSync(join(root, 'scripts', 'lib'), { recursive: true });
+    copyFileSync(join(process.cwd(), 'scripts', GEN), join(root, 'scripts', GEN));
+    copyFileSync(
+      join(process.cwd(), 'scripts', 'lib', 'text.mjs'),
+      join(root, 'scripts', 'lib', 'text.mjs')
+    );
+    return root;
+  }
+
+  function run(root: string, args: string[] = []) {
+    return spawnSync(process.execPath, [join(root, 'scripts', GEN), ...args], {
+      encoding: 'utf8',
+      timeout: 60_000,
+    });
+  }
+
+  function generated(root: string) {
+    const out: string[] = [];
+    const walk = (d: string) => {
+      for (const e of readdirSync(d, { withFileTypes: true })) {
+        const full = join(d, e.name);
+        if (e.isDirectory()) walk(full);
+        else if (full.endsWith('.mjs')) out.push(full);
+      }
+    };
+    if (existsSync(join(root, 'integrations'))) walk(join(root, 'integrations'));
+    return out;
+  }
+
+  it('reports no drift, and rewrites nothing, when the files are CRLF', () => {
+    const root = sandbox();
+    try {
+      expect(run(root).status).toBe(0);
+
+      const files = generated(root);
+      expect(files.length).toBeGreaterThan(0);
+
+      // Exactly what git does on a Windows checkout of an LF-stored file.
+      for (const f of files) {
+        writeFileSync(f, readFileSync(f, 'utf8').replace(/\n/g, '\r\n'));
+      }
+      const before = files.map((f) => readFileSync(f));
+
+      // 1. --check must not invent drift.
+      const checked = run(root, ['--check']);
+      expect(checked.stderr || '').not.toMatch(/DRIFT/);
+      expect(checked.status).toBe(0);
+
+      // 2. A plain run must leave every already-correct byte alone. This is the
+      //    half that turned `npm run sync:hooks` into a ~200-file diff of pure
+      //    line-ending churn with the real change buried in it.
+      expect(run(root).status).toBe(0);
+      files.forEach((f, i) => {
+        expect(readFileSync(f).equals(before[i])).toBe(true);
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, 120_000);
 });


### PR DESCRIPTION
Bugs 4 and 5 from the same investigation as #241. Both became visible *because* of #241, so they belong close behind it. One commit each.

Both are the same shape as the three in #241: **a mechanism that exists, is correct, and never reaches the person who needs it.**

## 1. `fix(scripts)` — generator drift checks are line-ending naive

`npm run sync:hooks:check` could not pass on Windows, and `npm run sync:hooks` produced a ~200-file diff of pure line-ending churn.

`.gitattributes` sets `* text=auto`, so generated files are stored LF and written CRLF on Windows. Generators build output with `'\n'` regardless, so a byte comparison finds every line different.

`sync-hook-core.mjs` **already carried the fix and documented it at length** — written after `npm test` failed on a fresh Windows clone. It was never applied to `generate-client-entries.mjs` or `generate-client-configs.mjs`, so the check reported **ten phantom drifted entry files** on every Windows checkout while Linux CI stayed green.

#241 made `sync:hooks:check` a CI gate. A gate that cannot pass locally on a supported platform teaches contributors to skip the `verify:all` pre-flight it belongs to.

The write path has the same defect from the other side: writing LF into a CRLF tree rewrites every byte of files that were already correct. Hit directly while fixing #241 — a full sync had to be **discarded and the pin fix applied in isolation** to get a reviewable seven-line diff instead of ~200 files of churn.

The bug was not a wrong comparison; it was a *right comparison that reached one of three call sites*. Copying it a third time leaves the hole open for a fourth generator, so it lives in `scripts/lib/text.mjs` and all three import it. `normalizeEol` deliberately leaves a lone CR alone — git's autocrlf rewrites CRLF, not CR, so treating bare CR as equivalent would hide genuine drift.

| On Windows | Before | After |
|---|---|---|
| `sync:hooks:check` | 10 phantom drifts, exit 1 | **all four steps pass** |
| `sync:hooks` files dirtied | ~200 | **0** |

## 2. `fix(build)` — a missing chart.js gave a bare ENOENT

`npm run build` died with:

```
code: 'ENOENT', syscall: 'lstat',
path: '.../node_modules/chart.js/dist/chart.umd.js'
Node.js v22.15.0
```

Nothing there says a dependency is missing, which one, or that `npm install` fixes it.

**The misdirection is the worst part.** Because `copy:assets` runs inside `build`, the visible symptom was a failing `dashboard-self-contained` test rather than an incomplete install — and the integration suite could not run locally at all. That is how it survived as a supposedly environmental annoyance instead of being fixed: it looked like a test problem, so it was excused as one, repeatedly, including by me in #241.

`hooks-core/doctor.mjs` sets the standard it broke: *"Every check returns a remedy on failure. A diagnosis without a next step is a complaint."* A `node -e` string has nowhere to put a preflight or a decent message, so the step is now `scripts/copy-assets.mjs`:

```
Cannot build the dashboard: the chart.js bundle is not installed.
  expected: node_modules/chart.js/dist/chart.umd.js
  fix:      npm install
```

### One existing test was updated, not relaxed

`dashboard-self-contained.test.ts` asserted the vendored target appeared in the `copy:assets` string. That string moved into the module, so the assertion now reads the module. **Verified still failing when the vendoring is removed from it** — the guarantee is unchanged. The exact-pin and local-loader assertions are untouched, and a CDN URL in the new module is now rejected too.

## Verification

- **849 unit + 91 integration tests pass — zero failures.** First fully green run; previously the dashboard suite failed and integration could not run locally.
- `tsc --noEmit` clean · `lint` 0 errors · `validate` passes · `sync:hooks:check` green on Windows · `build` works from a clean `dist`
- Both failure paths exercised for real: chart.js temporarily hidden to confirm the new message, and the vendoring removed to confirm the updated test still catches it.

## Two false leads, recorded so nobody re-chases them

While verifying I twice thought I had found another bug. Both were my own artifacts:

- **"10 generated client configs are stale at 5.3.2."** They are at 5.3.6 on current master; my tree was based on the pre-merge master.
- **"`cursor/token-optimizer.mdc` has genuine drift."** An artifact of the `sed 's/\r$//'` I used to build a synthetic LF tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
