### PR TITLE
fix(paths): canonicalise to a fixed point by construction, not by patching

### DIFF
--- a/hooks-core/paths.mjs
+++ b/hooks-core/paths.mjs
@@ -39,15 +39,19 @@ const MSYS = /^\/([A-Za-z])\/(.*)$/;
  * are case-preserving, and lower-casing whole paths would make every graph key
  * unreadable for a property nothing here depends on.
  */
-export function canonicalPath(input, cwd) {
+function normaliseOnce(input, cwd) {
   if (typeof input !== 'string' || !input) return input;
 
   let path = input.trim();
   if (!path) return input;
 
   // Strip surrounding quotes a shell command may carry.
-  if ((path.startsWith('"') && path.endsWith('"')) ||
-      (path.startsWith("'") && path.endsWith("'"))) {
+  // LENGTH >= 2, because `startsWith` and `endsWith` both match the SAME
+  // character on a one-character string: a lone `"` looked like a quoted empty
+  // path and `slice(1, -1)` turned it into one.
+  if (path.length >= 2 &&
+      ((path.startsWith('"') && path.endsWith('"')) ||
+       (path.startsWith("'") && path.endsWith("'")))) {
     path = path.slice(1, -1);
   }
 
@@ -89,6 +93,26 @@ export function canonicalPath(input, cwd) {
   }
   path = (unc ? '//' : '') + segments.join('/');
 
+  // ROOT SURVIVES THE COLLAPSE. `/` splits to ['', ''], the loop keeps only the
+  // leading '' that marks absoluteness, and joining a single empty segment
+  // yields '' -- so the root directory canonicalised to the empty string, and a
+  // second pass could not get back.
+  if (path === '' && segments.length === 1 && segments[0] === '') path = '/';
+
+  // TRIMMED ON THE WAY OUT AS WELL AS ON THE WAY IN.
+  //
+  // The input is trimmed at the top because surrounding whitespace is not part
+  // of a path. Collapsing segments can RE-EXPOSE it: `a /` splits to the single
+  // segment `a ` and joins back to `a `, which the next call would then trim to
+  // `a` -- so the same file got two identities depending on how many times its
+  // path had been canonicalised, which is the fragmentation this module exists
+  // to end.
+  //
+  // Applying the rule the function already commits to at both ends reaches the
+  // fixed point in one pass. Whitespace INSIDE a path is untouched: `x /y` and
+  // `C:/ x` canonicalise to themselves.
+  path = path.trim();
+
   // MSYS TRANSLATION AFTER THE COLLAPSE, NOT BEFORE.
   //
   // Running it first made canonicalPath non-idempotent, which a generated-
@@ -108,6 +132,35 @@ export function canonicalPath(input, cwd) {
   // A trailing separator is not part of a file's identity.
   if (path.length > 3 && path.endsWith('/')) path = path.slice(0, -1);
 
+  return path;
+}
+
+/**
+ * Canonicalises to a FIXED POINT, by construction rather than by patching.
+ *
+ * One pass is not idempotent and cannot easily be made so. Its steps interact:
+ * collapsing `a /` re-exposes whitespace the leading trim had already handled;
+ * collapsing `'.'!'/` produces `'.'!'`, which the NEXT call reads as a quoted
+ * path and unquotes. Generated inputs found three such shapes in a row, each
+ * fixed individually and each replaced by another -- which is the signal that
+ * the invariant belongs in the structure, not in another special case.
+ *
+ * So the pass is applied until it stops changing anything. Every step is
+ * non-expanding (trim, unquote and segment-collapse only shorten; the MSYS
+ * rewrite preserves length), so the sequence must reach a fixed point, and the
+ * iteration cap is a backstop rather than a truncation.
+ *
+ * WHY IT MATTERS: this function decides file IDENTITY. A path whose canonical
+ * form depends on how many times it has been canonicalised gives one file two
+ * graph nodes, with findings anchored under one invisible from the other.
+ */
+export function canonicalPath(input, cwd) {
+  let path = normaliseOnce(input, cwd);
+  for (let i = 0; i < 8; i++) {
+    const next = normaliseOnce(path, cwd);
+    if (next === path) return path;
+    path = next;
+  }
   return path;
 }
 

--- a/integrations/codex/hooks/lib/paths.mjs
+++ b/integrations/codex/hooks/lib/paths.mjs
@@ -41,15 +41,19 @@ const MSYS = /^\/([A-Za-z])\/(.*)$/;
  * are case-preserving, and lower-casing whole paths would make every graph key
  * unreadable for a property nothing here depends on.
  */
-export function canonicalPath(input, cwd) {
+function normaliseOnce(input, cwd) {
   if (typeof input !== 'string' || !input) return input;
 
   let path = input.trim();
   if (!path) return input;
 
   // Strip surrounding quotes a shell command may carry.
-  if ((path.startsWith('"') && path.endsWith('"')) ||
-      (path.startsWith("'") && path.endsWith("'"))) {
+  // LENGTH >= 2, because `startsWith` and `endsWith` both match the SAME
+  // character on a one-character string: a lone `"` looked like a quoted empty
+  // path and `slice(1, -1)` turned it into one.
+  if (path.length >= 2 &&
+      ((path.startsWith('"') && path.endsWith('"')) ||
+       (path.startsWith("'") && path.endsWith("'")))) {
     path = path.slice(1, -1);
   }
 
@@ -91,6 +95,26 @@ export function canonicalPath(input, cwd) {
   }
   path = (unc ? '//' : '') + segments.join('/');
 
+  // ROOT SURVIVES THE COLLAPSE. `/` splits to ['', ''], the loop keeps only the
+  // leading '' that marks absoluteness, and joining a single empty segment
+  // yields '' -- so the root directory canonicalised to the empty string, and a
+  // second pass could not get back.
+  if (path === '' && segments.length === 1 && segments[0] === '') path = '/';
+
+  // TRIMMED ON THE WAY OUT AS WELL AS ON THE WAY IN.
+  //
+  // The input is trimmed at the top because surrounding whitespace is not part
+  // of a path. Collapsing segments can RE-EXPOSE it: `a /` splits to the single
+  // segment `a ` and joins back to `a `, which the next call would then trim to
+  // `a` -- so the same file got two identities depending on how many times its
+  // path had been canonicalised, which is the fragmentation this module exists
+  // to end.
+  //
+  // Applying the rule the function already commits to at both ends reaches the
+  // fixed point in one pass. Whitespace INSIDE a path is untouched: `x /y` and
+  // `C:/ x` canonicalise to themselves.
+  path = path.trim();
+
   // MSYS TRANSLATION AFTER THE COLLAPSE, NOT BEFORE.
   //
   // Running it first made canonicalPath non-idempotent, which a generated-
@@ -110,6 +134,35 @@ export function canonicalPath(input, cwd) {
   // A trailing separator is not part of a file's identity.
   if (path.length > 3 && path.endsWith('/')) path = path.slice(0, -1);
 
+  return path;
+}
+
+/**
+ * Canonicalises to a FIXED POINT, by construction rather than by patching.
+ *
+ * One pass is not idempotent and cannot easily be made so. Its steps interact:
+ * collapsing `a /` re-exposes whitespace the leading trim had already handled;
+ * collapsing `'.'!'/` produces `'.'!'`, which the NEXT call reads as a quoted
+ * path and unquotes. Generated inputs found three such shapes in a row, each
+ * fixed individually and each replaced by another -- which is the signal that
+ * the invariant belongs in the structure, not in another special case.
+ *
+ * So the pass is applied until it stops changing anything. Every step is
+ * non-expanding (trim, unquote and segment-collapse only shorten; the MSYS
+ * rewrite preserves length), so the sequence must reach a fixed point, and the
+ * iteration cap is a backstop rather than a truncation.
+ *
+ * WHY IT MATTERS: this function decides file IDENTITY. A path whose canonical
+ * form depends on how many times it has been canonicalised gives one file two
+ * graph nodes, with findings anchored under one invisible from the other.
+ */
+export function canonicalPath(input, cwd) {
+  let path = normaliseOnce(input, cwd);
+  for (let i = 0; i < 8; i++) {
+    const next = normaliseOnce(path, cwd);
+    if (next === path) return path;
+    path = next;
+  }
   return path;
 }
 

--- a/integrations/codex/plugin/hooks/lib/paths.mjs
+++ b/integrations/codex/plugin/hooks/lib/paths.mjs
@@ -41,15 +41,19 @@ const MSYS = /^\/([A-Za-z])\/(.*)$/;
  * are case-preserving, and lower-casing whole paths would make every graph key
  * unreadable for a property nothing here depends on.
  */
-export function canonicalPath(input, cwd) {
+function normaliseOnce(input, cwd) {
   if (typeof input !== 'string' || !input) return input;
 
   let path = input.trim();
   if (!path) return input;
 
   // Strip surrounding quotes a shell command may carry.
-  if ((path.startsWith('"') && path.endsWith('"')) ||
-      (path.startsWith("'") && path.endsWith("'"))) {
+  // LENGTH >= 2, because `startsWith` and `endsWith` both match the SAME
+  // character on a one-character string: a lone `"` looked like a quoted empty
+  // path and `slice(1, -1)` turned it into one.
+  if (path.length >= 2 &&
+      ((path.startsWith('"') && path.endsWith('"')) ||
+       (path.startsWith("'") && path.endsWith("'")))) {
     path = path.slice(1, -1);
   }
 
@@ -91,6 +95,26 @@ export function canonicalPath(input, cwd) {
   }
   path = (unc ? '//' : '') + segments.join('/');
 
+  // ROOT SURVIVES THE COLLAPSE. `/` splits to ['', ''], the loop keeps only the
+  // leading '' that marks absoluteness, and joining a single empty segment
+  // yields '' -- so the root directory canonicalised to the empty string, and a
+  // second pass could not get back.
+  if (path === '' && segments.length === 1 && segments[0] === '') path = '/';
+
+  // TRIMMED ON THE WAY OUT AS WELL AS ON THE WAY IN.
+  //
+  // The input is trimmed at the top because surrounding whitespace is not part
+  // of a path. Collapsing segments can RE-EXPOSE it: `a /` splits to the single
+  // segment `a ` and joins back to `a `, which the next call would then trim to
+  // `a` -- so the same file got two identities depending on how many times its
+  // path had been canonicalised, which is the fragmentation this module exists
+  // to end.
+  //
+  // Applying the rule the function already commits to at both ends reaches the
+  // fixed point in one pass. Whitespace INSIDE a path is untouched: `x /y` and
+  // `C:/ x` canonicalise to themselves.
+  path = path.trim();
+
   // MSYS TRANSLATION AFTER THE COLLAPSE, NOT BEFORE.
   //
   // Running it first made canonicalPath non-idempotent, which a generated-
@@ -110,6 +134,35 @@ export function canonicalPath(input, cwd) {
   // A trailing separator is not part of a file's identity.
   if (path.length > 3 && path.endsWith('/')) path = path.slice(0, -1);
 
+  return path;
+}
+
+/**
+ * Canonicalises to a FIXED POINT, by construction rather than by patching.
+ *
+ * One pass is not idempotent and cannot easily be made so. Its steps interact:
+ * collapsing `a /` re-exposes whitespace the leading trim had already handled;
+ * collapsing `'.'!'/` produces `'.'!'`, which the NEXT call reads as a quoted
+ * path and unquotes. Generated inputs found three such shapes in a row, each
+ * fixed individually and each replaced by another -- which is the signal that
+ * the invariant belongs in the structure, not in another special case.
+ *
+ * So the pass is applied until it stops changing anything. Every step is
+ * non-expanding (trim, unquote and segment-collapse only shorten; the MSYS
+ * rewrite preserves length), so the sequence must reach a fixed point, and the
+ * iteration cap is a backstop rather than a truncation.
+ *
+ * WHY IT MATTERS: this function decides file IDENTITY. A path whose canonical
+ * form depends on how many times it has been canonicalised gives one file two
+ * graph nodes, with findings anchored under one invisible from the other.
+ */
+export function canonicalPath(input, cwd) {
+  let path = normaliseOnce(input, cwd);
+  for (let i = 0; i < 8; i++) {
+    const next = normaliseOnce(path, cwd);
+    if (next === path) return path;
+    path = next;
+  }
   return path;
 }
 

--- a/integrations/gemini/hooks/lib/paths.mjs
+++ b/integrations/gemini/hooks/lib/paths.mjs
@@ -41,15 +41,19 @@ const MSYS = /^\/([A-Za-z])\/(.*)$/;
  * are case-preserving, and lower-casing whole paths would make every graph key
  * unreadable for a property nothing here depends on.
  */
-export function canonicalPath(input, cwd) {
+function normaliseOnce(input, cwd) {
   if (typeof input !== 'string' || !input) return input;
 
   let path = input.trim();
   if (!path) return input;
 
   // Strip surrounding quotes a shell command may carry.
-  if ((path.startsWith('"') && path.endsWith('"')) ||
-      (path.startsWith("'") && path.endsWith("'"))) {
+  // LENGTH >= 2, because `startsWith` and `endsWith` both match the SAME
+  // character on a one-character string: a lone `"` looked like a quoted empty
+  // path and `slice(1, -1)` turned it into one.
+  if (path.length >= 2 &&
+      ((path.startsWith('"') && path.endsWith('"')) ||
+       (path.startsWith("'") && path.endsWith("'")))) {
     path = path.slice(1, -1);
   }
 
@@ -91,6 +95,26 @@ export function canonicalPath(input, cwd) {
   }
   path = (unc ? '//' : '') + segments.join('/');
 
+  // ROOT SURVIVES THE COLLAPSE. `/` splits to ['', ''], the loop keeps only the
+  // leading '' that marks absoluteness, and joining a single empty segment
+  // yields '' -- so the root directory canonicalised to the empty string, and a
+  // second pass could not get back.
+  if (path === '' && segments.length === 1 && segments[0] === '') path = '/';
+
+  // TRIMMED ON THE WAY OUT AS WELL AS ON THE WAY IN.
+  //
+  // The input is trimmed at the top because surrounding whitespace is not part
+  // of a path. Collapsing segments can RE-EXPOSE it: `a /` splits to the single
+  // segment `a ` and joins back to `a `, which the next call would then trim to
+  // `a` -- so the same file got two identities depending on how many times its
+  // path had been canonicalised, which is the fragmentation this module exists
+  // to end.
+  //
+  // Applying the rule the function already commits to at both ends reaches the
+  // fixed point in one pass. Whitespace INSIDE a path is untouched: `x /y` and
+  // `C:/ x` canonicalise to themselves.
+  path = path.trim();
+
   // MSYS TRANSLATION AFTER THE COLLAPSE, NOT BEFORE.
   //
   // Running it first made canonicalPath non-idempotent, which a generated-
@@ -110,6 +134,35 @@ export function canonicalPath(input, cwd) {
   // A trailing separator is not part of a file's identity.
   if (path.length > 3 && path.endsWith('/')) path = path.slice(0, -1);
 
+  return path;
+}
+
+/**
+ * Canonicalises to a FIXED POINT, by construction rather than by patching.
+ *
+ * One pass is not idempotent and cannot easily be made so. Its steps interact:
+ * collapsing `a /` re-exposes whitespace the leading trim had already handled;
+ * collapsing `'.'!'/` produces `'.'!'`, which the NEXT call reads as a quoted
+ * path and unquotes. Generated inputs found three such shapes in a row, each
+ * fixed individually and each replaced by another -- which is the signal that
+ * the invariant belongs in the structure, not in another special case.
+ *
+ * So the pass is applied until it stops changing anything. Every step is
+ * non-expanding (trim, unquote and segment-collapse only shorten; the MSYS
+ * rewrite preserves length), so the sequence must reach a fixed point, and the
+ * iteration cap is a backstop rather than a truncation.
+ *
+ * WHY IT MATTERS: this function decides file IDENTITY. A path whose canonical
+ * form depends on how many times it has been canonicalised gives one file two
+ * graph nodes, with findings anchored under one invisible from the other.
+ */
+export function canonicalPath(input, cwd) {
+  let path = normaliseOnce(input, cwd);
+  for (let i = 0; i < 8; i++) {
+    const next = normaliseOnce(path, cwd);
+    if (next === path) return path;
+    path = next;
+  }
   return path;
 }
 

--- a/integrations/opencode/hooks/lib/paths.mjs
+++ b/integrations/opencode/hooks/lib/paths.mjs
@@ -41,15 +41,19 @@ const MSYS = /^\/([A-Za-z])\/(.*)$/;
  * are case-preserving, and lower-casing whole paths would make every graph key
  * unreadable for a property nothing here depends on.
  */
-export function canonicalPath(input, cwd) {
+function normaliseOnce(input, cwd) {
   if (typeof input !== 'string' || !input) return input;
 
   let path = input.trim();
   if (!path) return input;
 
   // Strip surrounding quotes a shell command may carry.
-  if ((path.startsWith('"') && path.endsWith('"')) ||
-      (path.startsWith("'") && path.endsWith("'"))) {
+  // LENGTH >= 2, because `startsWith` and `endsWith` both match the SAME
+  // character on a one-character string: a lone `"` looked like a quoted empty
+  // path and `slice(1, -1)` turned it into one.
+  if (path.length >= 2 &&
+      ((path.startsWith('"') && path.endsWith('"')) ||
+       (path.startsWith("'") && path.endsWith("'")))) {
     path = path.slice(1, -1);
   }
 
@@ -91,6 +95,26 @@ export function canonicalPath(input, cwd) {
   }
   path = (unc ? '//' : '') + segments.join('/');
 
+  // ROOT SURVIVES THE COLLAPSE. `/` splits to ['', ''], the loop keeps only the
+  // leading '' that marks absoluteness, and joining a single empty segment
+  // yields '' -- so the root directory canonicalised to the empty string, and a
+  // second pass could not get back.
+  if (path === '' && segments.length === 1 && segments[0] === '') path = '/';
+
+  // TRIMMED ON THE WAY OUT AS WELL AS ON THE WAY IN.
+  //
+  // The input is trimmed at the top because surrounding whitespace is not part
+  // of a path. Collapsing segments can RE-EXPOSE it: `a /` splits to the single
+  // segment `a ` and joins back to `a `, which the next call would then trim to
+  // `a` -- so the same file got two identities depending on how many times its
+  // path had been canonicalised, which is the fragmentation this module exists
+  // to end.
+  //
+  // Applying the rule the function already commits to at both ends reaches the
+  // fixed point in one pass. Whitespace INSIDE a path is untouched: `x /y` and
+  // `C:/ x` canonicalise to themselves.
+  path = path.trim();
+
   // MSYS TRANSLATION AFTER THE COLLAPSE, NOT BEFORE.
   //
   // Running it first made canonicalPath non-idempotent, which a generated-
@@ -110,6 +134,35 @@ export function canonicalPath(input, cwd) {
   // A trailing separator is not part of a file's identity.
   if (path.length > 3 && path.endsWith('/')) path = path.slice(0, -1);
 
+  return path;
+}
+
+/**
+ * Canonicalises to a FIXED POINT, by construction rather than by patching.
+ *
+ * One pass is not idempotent and cannot easily be made so. Its steps interact:
+ * collapsing `a /` re-exposes whitespace the leading trim had already handled;
+ * collapsing `'.'!'/` produces `'.'!'`, which the NEXT call reads as a quoted
+ * path and unquotes. Generated inputs found three such shapes in a row, each
+ * fixed individually and each replaced by another -- which is the signal that
+ * the invariant belongs in the structure, not in another special case.
+ *
+ * So the pass is applied until it stops changing anything. Every step is
+ * non-expanding (trim, unquote and segment-collapse only shorten; the MSYS
+ * rewrite preserves length), so the sequence must reach a fixed point, and the
+ * iteration cap is a backstop rather than a truncation.
+ *
+ * WHY IT MATTERS: this function decides file IDENTITY. A path whose canonical
+ * form depends on how many times it has been canonicalised gives one file two
+ * graph nodes, with findings anchored under one invisible from the other.
+ */
+export function canonicalPath(input, cwd) {
+  let path = normaliseOnce(input, cwd);
+  for (let i = 0; i < 8; i++) {
+    const next = normaliseOnce(path, cwd);
+    if (next === path) return path;
+    path = next;
+  }
   return path;
 }
 

--- a/integrations/qwen/hooks/lib/paths.mjs
+++ b/integrations/qwen/hooks/lib/paths.mjs
@@ -41,15 +41,19 @@ const MSYS = /^\/([A-Za-z])\/(.*)$/;
  * are case-preserving, and lower-casing whole paths would make every graph key
  * unreadable for a property nothing here depends on.
  */
-export function canonicalPath(input, cwd) {
+function normaliseOnce(input, cwd) {
   if (typeof input !== 'string' || !input) return input;
 
   let path = input.trim();
   if (!path) return input;
 
   // Strip surrounding quotes a shell command may carry.
-  if ((path.startsWith('"') && path.endsWith('"')) ||
-      (path.startsWith("'") && path.endsWith("'"))) {
+  // LENGTH >= 2, because `startsWith` and `endsWith` both match the SAME
+  // character on a one-character string: a lone `"` looked like a quoted empty
+  // path and `slice(1, -1)` turned it into one.
+  if (path.length >= 2 &&
+      ((path.startsWith('"') && path.endsWith('"')) ||
+       (path.startsWith("'") && path.endsWith("'")))) {
     path = path.slice(1, -1);
   }
 
@@ -91,6 +95,26 @@ export function canonicalPath(input, cwd) {
   }
   path = (unc ? '//' : '') + segments.join('/');
 
+  // ROOT SURVIVES THE COLLAPSE. `/` splits to ['', ''], the loop keeps only the
+  // leading '' that marks absoluteness, and joining a single empty segment
+  // yields '' -- so the root directory canonicalised to the empty string, and a
+  // second pass could not get back.
+  if (path === '' && segments.length === 1 && segments[0] === '') path = '/';
+
+  // TRIMMED ON THE WAY OUT AS WELL AS ON THE WAY IN.
+  //
+  // The input is trimmed at the top because surrounding whitespace is not part
+  // of a path. Collapsing segments can RE-EXPOSE it: `a /` splits to the single
+  // segment `a ` and joins back to `a `, which the next call would then trim to
+  // `a` -- so the same file got two identities depending on how many times its
+  // path had been canonicalised, which is the fragmentation this module exists
+  // to end.
+  //
+  // Applying the rule the function already commits to at both ends reaches the
+  // fixed point in one pass. Whitespace INSIDE a path is untouched: `x /y` and
+  // `C:/ x` canonicalise to themselves.
+  path = path.trim();
+
   // MSYS TRANSLATION AFTER THE COLLAPSE, NOT BEFORE.
   //
   // Running it first made canonicalPath non-idempotent, which a generated-
@@ -110,6 +134,35 @@ export function canonicalPath(input, cwd) {
   // A trailing separator is not part of a file's identity.
   if (path.length > 3 && path.endsWith('/')) path = path.slice(0, -1);
 
+  return path;
+}
+
+/**
+ * Canonicalises to a FIXED POINT, by construction rather than by patching.
+ *
+ * One pass is not idempotent and cannot easily be made so. Its steps interact:
+ * collapsing `a /` re-exposes whitespace the leading trim had already handled;
+ * collapsing `'.'!'/` produces `'.'!'`, which the NEXT call reads as a quoted
+ * path and unquotes. Generated inputs found three such shapes in a row, each
+ * fixed individually and each replaced by another -- which is the signal that
+ * the invariant belongs in the structure, not in another special case.
+ *
+ * So the pass is applied until it stops changing anything. Every step is
+ * non-expanding (trim, unquote and segment-collapse only shorten; the MSYS
+ * rewrite preserves length), so the sequence must reach a fixed point, and the
+ * iteration cap is a backstop rather than a truncation.
+ *
+ * WHY IT MATTERS: this function decides file IDENTITY. A path whose canonical
+ * form depends on how many times it has been canonicalised gives one file two
+ * graph nodes, with findings anchored under one invisible from the other.
+ */
+export function canonicalPath(input, cwd) {
+  let path = normaliseOnce(input, cwd);
+  for (let i = 0; i < 8; i++) {
+    const next = normaliseOnce(path, cwd);
+    if (next === path) return path;
+    path = next;
+  }
   return path;
 }
 

--- a/plugin/hooks/lib/paths.mjs
+++ b/plugin/hooks/lib/paths.mjs
@@ -41,15 +41,19 @@ const MSYS = /^\/([A-Za-z])\/(.*)$/;
  * are case-preserving, and lower-casing whole paths would make every graph key
  * unreadable for a property nothing here depends on.
  */
-export function canonicalPath(input, cwd) {
+function normaliseOnce(input, cwd) {
   if (typeof input !== 'string' || !input) return input;
 
   let path = input.trim();
   if (!path) return input;
 
   // Strip surrounding quotes a shell command may carry.
-  if ((path.startsWith('"') && path.endsWith('"')) ||
-      (path.startsWith("'") && path.endsWith("'"))) {
+  // LENGTH >= 2, because `startsWith` and `endsWith` both match the SAME
+  // character on a one-character string: a lone `"` looked like a quoted empty
+  // path and `slice(1, -1)` turned it into one.
+  if (path.length >= 2 &&
+      ((path.startsWith('"') && path.endsWith('"')) ||
+       (path.startsWith("'") && path.endsWith("'")))) {
     path = path.slice(1, -1);
   }
 
@@ -91,6 +95,26 @@ export function canonicalPath(input, cwd) {
   }
   path = (unc ? '//' : '') + segments.join('/');
 
+  // ROOT SURVIVES THE COLLAPSE. `/` splits to ['', ''], the loop keeps only the
+  // leading '' that marks absoluteness, and joining a single empty segment
+  // yields '' -- so the root directory canonicalised to the empty string, and a
+  // second pass could not get back.
+  if (path === '' && segments.length === 1 && segments[0] === '') path = '/';
+
+  // TRIMMED ON THE WAY OUT AS WELL AS ON THE WAY IN.
+  //
+  // The input is trimmed at the top because surrounding whitespace is not part
+  // of a path. Collapsing segments can RE-EXPOSE it: `a /` splits to the single
+  // segment `a ` and joins back to `a `, which the next call would then trim to
+  // `a` -- so the same file got two identities depending on how many times its
+  // path had been canonicalised, which is the fragmentation this module exists
+  // to end.
+  //
+  // Applying the rule the function already commits to at both ends reaches the
+  // fixed point in one pass. Whitespace INSIDE a path is untouched: `x /y` and
+  // `C:/ x` canonicalise to themselves.
+  path = path.trim();
+
   // MSYS TRANSLATION AFTER THE COLLAPSE, NOT BEFORE.
   //
   // Running it first made canonicalPath non-idempotent, which a generated-
@@ -110,6 +134,35 @@ export function canonicalPath(input, cwd) {
   // A trailing separator is not part of a file's identity.
   if (path.length > 3 && path.endsWith('/')) path = path.slice(0, -1);
 
+  return path;
+}
+
+/**
+ * Canonicalises to a FIXED POINT, by construction rather than by patching.
+ *
+ * One pass is not idempotent and cannot easily be made so. Its steps interact:
+ * collapsing `a /` re-exposes whitespace the leading trim had already handled;
+ * collapsing `'.'!'/` produces `'.'!'`, which the NEXT call reads as a quoted
+ * path and unquotes. Generated inputs found three such shapes in a row, each
+ * fixed individually and each replaced by another -- which is the signal that
+ * the invariant belongs in the structure, not in another special case.
+ *
+ * So the pass is applied until it stops changing anything. Every step is
+ * non-expanding (trim, unquote and segment-collapse only shorten; the MSYS
+ * rewrite preserves length), so the sequence must reach a fixed point, and the
+ * iteration cap is a backstop rather than a truncation.
+ *
+ * WHY IT MATTERS: this function decides file IDENTITY. A path whose canonical
+ * form depends on how many times it has been canonicalised gives one file two
+ * graph nodes, with findings anchored under one invisible from the other.
+ */
+export function canonicalPath(input, cwd) {
+  let path = normaliseOnce(input, cwd);
+  for (let i = 0; i < 8; i++) {
+    const next = normaliseOnce(path, cwd);
+    if (next === path) return path;
+    path = next;
+  }
   return path;
 }
 

--- a/tests/hooks/property-inputs.test.mjs
+++ b/tests/hooks/property-inputs.test.mjs
@@ -75,6 +75,43 @@ describe('canonicalPath', () => {
     );
   });
 
+  it('reaches its fixed point on every shape the generators found', () => {
+    // FOUR COUNTEREXAMPLES, FOUND ONE AFTER ANOTHER. Each was fixed on its own
+    // and the next run produced a new one, which is what moved the invariant
+    // into the structure -- canonicalPath now iterates a single pass to a fixed
+    // point instead of trying to make that pass idempotent by hand. These stay
+    // pinned because they document why the loop exists.
+    const CASES = [
+      // A segment ending in whitespace before a separator re-exposed the
+      // whitespace the leading trim had already handled.
+      "! /",
+      "a /",
+      // A one-character quote: startsWith and endsWith match the SAME character,
+      // so slice(1, -1) turned it into the empty string.
+      "\"",
+      "\"/",
+      // Collapsing produced something that LOOKED quoted, so the next pass
+      // unquoted it.
+      "'.'!'/",
+      // The root directory collapsed to the empty string and could not return.
+      "/",
+      "/ \\",
+      ". / ",
+    ];
+    for (const c of CASES) {
+      const once = canonicalPath(c);
+      expect(canonicalPath(once)).toBe(once);
+    }
+
+    // And the fixed point is the RIGHT value, not merely a stable one: an
+    // idempotent function that maps the root to the empty string would satisfy
+    // the property above and still be wrong.
+    expect(canonicalPath('/')).toBe('/');
+    expect(canonicalPath("\"")).toBe("\"");
+    expect(canonicalPath('x /y')).toBe('x /y');
+    expect(canonicalPath('C:/ x')).toBe('C:/ x');
+  });
+
   it('reaches its fixed point on a Git Bash path carrying a dot segment', () => {
     // THE COUNTEREXAMPLE THE GENERATED INPUTS FOUND, pinned so it cannot come
     // back. MSYS translation used to run BEFORE `.` and `..` were collapsed, so


### PR DESCRIPTION
The idempotence property from #238 failed again — different function, different input. Its seed is random per run, so this is **not flaky and not platform-specific**: it is a real defect that surfaces on some runs and not others.

## Chasing it one input at a time did not converge

Four counterexamples arrived in sequence, each fix producing the next:

| Input | What went wrong |
|---|---|
| `"! /"` | A segment ending in whitespace before a separator re-exposed whitespace the leading trim had already removed. |
| `'"'` | `startsWith` and `endsWith` match the **same character** on a one-character string, so a lone quote looked like a quoted empty path and `slice(1, -1)` made it one. |
| `"/"` | The root collapsed to the empty string and could not return. |
| `"'.'!'/"` | Collapsing produced something that *looked* quoted, so the next pass unquoted it. |

The fourth settles the approach. The steps interact, so no ordering of them is idempotent by itself — trying to make a single pass idempotent by hand is the wrong shape of fix.

## The fix

The pass is now applied until it stops changing anything. Every step is non-expanding — trim, unquote and segment-collapse only shorten, and the MSYS rewrite preserves length — so the sequence **must** reach a fixed point. The iteration cap is a backstop, not a truncation.

The two correctness fixes stay, because **a stable wrong answer satisfies idempotence perfectly**: without them the root and a lone quote both converge on the empty string. The tests assert the fixed point is the *right* value, not merely a stable one.

## Why it matters

This function decides file **identity**. A path whose canonical form depends on how many times it has been canonicalised gives one file two graph nodes, with findings anchored under one invisible from the other — the exact fragmentation the module exists to prevent.

## Verification

80,000 generated inputs across four generators, including the path-shaped generator that previously found a counterexample within a few hundred runs:

```
canonicalPath       OK
canonicalPath-bin   OK
canonicalPath-pathy OK
canonicalKey        OK
```

Each of the three fixes was individually reverted, and each turns the pinned test red:

| Reverted | Result |
|---|---|
| the fixed-point loop | ✗ |
| root survival | ✗ |
| the quote length guard | ✗ |

```
Test Suites: 120 passed, 120 total
Tests:       4 skipped, 1582 passed, 1586 total
npm run build   exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
