### PR TITLE
fix(ci): let the release-pin sync be triggered manually

### DIFF
--- a/.github/workflows/sync-release-pins.yml
+++ b/.github/workflows/sync-release-pins.yml
@@ -21,6 +21,23 @@ name: Sync Release Pins
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  # MANUAL TRIGGER, for a release PR that is already open and has nothing pending.
+  #
+  # pull_request only fires on opened/synchronize/reopened, so a release PR that
+  # existed BEFORE this workflow landed never gets one. That happened on the
+  # first release after the workflow was added: #239 sat with package.json at
+  # 5.4.0 and every pin at 5.3.6, with no event to repair it. Merging it would
+  # have tripped the guard in release.yml and failed the publish -- caught, but
+  # only after the tag was cut.
+  #
+  # A dispatch with the branch name unsticks it without waiting for
+  # release-please to amend the PR.
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Release PR branch to sync (defaults to the current ref)'
+        required: false
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -35,17 +52,45 @@ jobs:
     # Scoped to release-please PRs on purpose. Auto-committing to a
     # contributor's branch would be a surprising thing for a lint-adjacent job
     # to do; the release PR is machine-authored, so amending it is not.
-    if: startsWith(github.head_ref, 'release-please')
+    #
+    # head_ref is empty on workflow_dispatch, so that case is admitted here and
+    # the branch is re-checked below -- the scoping is enforced either way.
+    if: >-
+      startsWith(github.head_ref, 'release-please')
+      || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       contents: write
 
     steps:
+      - name: Resolve the branch to sync
+        id: target
+        env:
+          # Via env rather than inline, so a branch name cannot be interpreted
+          # as shell.
+          INPUT_REF: ${{ inputs.ref }}
+          HEAD_REF: ${{ github.head_ref }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          BRANCH="${INPUT_REF:-${HEAD_REF:-$REF_NAME}}"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "Resolved target branch: $BRANCH"
+
+          # The same scoping the pull_request path gets from its `if`. Without
+          # this, a dispatch could auto-commit to any branch in the repo.
+          case "$BRANCH" in
+            release-please*) ;;
+            *)
+              echo "::error::Refusing to sync '$BRANCH': only release-please branches are amended automatically."
+              exit 1
+              ;;
+          esac
+
       - name: Checkout the release PR branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ steps.target.outputs.branch }}
           # Default GITHUB_TOKEN is enough to push to a same-repo PR branch.
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Found while installing latest master locally. **PR #239 is currently broken in exactly the way #241 was meant to prevent**, and there is no event that will repair it.

## The gap

`sync-release-pins.yml` (added in #241) triggers only on `pull_request` `opened`/`synchronize`/`reopened`. #239 was opened at 17:50, before that workflow existed, so it has received none of those events and the sync has never run.

Verified against `release-please--branches--master--components--token-optimizer-mcp`:

```
package.json:        5.4.0
plugin/.mcp.json:    @5.3.6
copilot config:      @5.3.6

pin-mcp-version --check  -> 7 configs not pinned to 5.4.0, exit 1
sync:hooks:check         -> 10 generated config files differ, exit 1
```

The protection is not absent, only **late**. Merging #239 as-is trips the guard added to `release.yml` and fails the publish — correct, but only after the tag is cut, leaving a released version with no npm artifact.

## The fix

`workflow_dispatch` with an optional branch input, so an already-open release PR can be unstuck without waiting for release-please to amend it.

Two things the dispatch path needs that the `pull_request` path got for free:

- **`github.head_ref` is empty on `workflow_dispatch`**, so the job-level `if` would have skipped every manual run. It now admits dispatch explicitly.
- **That `if` was the only thing scoping this to machine-authored branches.** Admitting dispatch would let a manual run auto-commit to any branch in the repo. The resolved branch is re-checked in a first step that fails loudly on anything not `release-please*`, and reaches the shell via `env` rather than inline interpolation so a branch name cannot be read as shell.

Guard verified:

| branch | result |
|---|---|
| `release-please--branches--master` | sync |
| `main` | refuse |
| `feature/x` | refuse |
| *(empty)* | refuse |

## Action needed on #239, separately from this PR

Once this merges, run the workflow against #239's branch — or let release-please amend the PR, which fires `synchronize` and self-heals it. **Do not merge #239 before one of those happens**, or the publish will fail after tagging.

Future release PRs are unaffected: they will get an `opened` event with the workflow already on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
