### PR TITLE
fix(release): unblock the 5.4.0 publish, and stop the harvest worker crashing on exit

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -5,7 +5,7 @@
   "mcpServers": {
     "token-optimizer": {
       "command": "npx",
-      "args": ["-y", "@ooples/token-optimizer-mcp@5.3.6"]
+      "args": ["-y", "@ooples/token-optimizer-mcp@5.4.0"]
     }
   },
   "settings": [

--- a/integrations/amp/settings.json
+++ b/integrations/amp/settings.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@ooples/token-optimizer-mcp@5.3.6"
+        "@ooples/token-optimizer-mcp@5.4.0"
       ],
       "env": {}
     }

--- a/integrations/cline/mcp.json
+++ b/integrations/cline/mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@ooples/token-optimizer-mcp@5.3.6"
+        "@ooples/token-optimizer-mcp@5.4.0"
       ],
       "env": {}
     }

--- a/integrations/codex/config.toml
+++ b/integrations/codex/config.toml
@@ -5,6 +5,6 @@
 
 [mcp_servers.token-optimizer]
 command = "npx"
-args = ["-y", "@ooples/token-optimizer-mcp@5.3.6"]
+args = ["-y", "@ooples/token-optimizer-mcp@5.4.0"]
 # Optional: point the cache somewhere stable.
 # env = { TOKEN_OPTIMIZER_CACHE_DIR = "~/.token-optimizer-cache" }

--- a/integrations/codex/plugin/.mcp.json
+++ b/integrations/codex/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcp_servers": {
     "token-optimizer": {
       "command": "npx",
-      "args": ["-y", "@ooples/token-optimizer-mcp@5.3.6"]
+      "args": ["-y", "@ooples/token-optimizer-mcp@5.4.0"]
     }
   }
 }

--- a/integrations/continue/config.yaml
+++ b/integrations/continue/config.yaml
@@ -1,4 +1,4 @@
 mcpServers:
   - name: token-optimizer
     command: npx
-    args: ["-y", "@ooples/token-optimizer-mcp@5.3.6"]
+    args: ["-y", "@ooples/token-optimizer-mcp@5.4.0"]

--- a/integrations/copilot/mcp-config.json
+++ b/integrations/copilot/mcp-config.json
@@ -3,7 +3,7 @@
     "token-optimizer": {
       "type": "local",
       "command": "npx",
-      "args": ["-y", "@ooples/token-optimizer-mcp@5.3.6"],
+      "args": ["-y", "@ooples/token-optimizer-mcp@5.4.0"],
       "tools": ["*"]
     }
   }

--- a/integrations/crush/crush.json
+++ b/integrations/crush/crush.json
@@ -5,7 +5,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@ooples/token-optimizer-mcp@5.3.6"
+        "@ooples/token-optimizer-mcp@5.4.0"
       ],
       "env": {}
     }

--- a/integrations/cursor/mcp.json
+++ b/integrations/cursor/mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@ooples/token-optimizer-mcp@5.3.6"
+        "@ooples/token-optimizer-mcp@5.4.0"
       ],
       "env": {}
     }

--- a/integrations/droid/mcp.json
+++ b/integrations/droid/mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@ooples/token-optimizer-mcp@5.3.6"
+        "@ooples/token-optimizer-mcp@5.4.0"
       ],
       "env": {}
     }

--- a/integrations/gemini/gemini-extension.json
+++ b/integrations/gemini/gemini-extension.json
@@ -5,7 +5,7 @@
   "mcpServers": {
     "token-optimizer": {
       "command": "npx",
-      "args": ["-y", "@ooples/token-optimizer-mcp@5.3.6"]
+      "args": ["-y", "@ooples/token-optimizer-mcp@5.4.0"]
     }
   },
   "settings": [

--- a/integrations/kilo/kilo.jsonc
+++ b/integrations/kilo/kilo.jsonc
@@ -5,7 +5,7 @@
       "command": [
         "npx",
         "-y",
-        "@ooples/token-optimizer-mcp@5.3.6"
+        "@ooples/token-optimizer-mcp@5.4.0"
       ],
       "environment": {},
       "enabled": true

--- a/integrations/opencode/opencode.json
+++ b/integrations/opencode/opencode.json
@@ -3,7 +3,7 @@
   "mcp": {
     "token-optimizer": {
       "type": "local",
-      "command": ["npx", "-y", "@ooples/token-optimizer-mcp@5.3.6"],
+      "command": ["npx", "-y", "@ooples/token-optimizer-mcp@5.4.0"],
       "enabled": true
     }
   },

--- a/integrations/roo/mcp.json
+++ b/integrations/roo/mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@ooples/token-optimizer-mcp@5.3.6"
+        "@ooples/token-optimizer-mcp@5.4.0"
       ],
       "env": {}
     }

--- a/integrations/windsurf/mcp_config.json
+++ b/integrations/windsurf/mcp_config.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@ooples/token-optimizer-mcp@5.3.6"
+        "@ooples/token-optimizer-mcp@5.4.0"
       ],
       "env": {}
     }

--- a/integrations/zed/settings.json
+++ b/integrations/zed/settings.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@ooples/token-optimizer-mcp@5.3.6"
+        "@ooples/token-optimizer-mcp@5.4.0"
       ],
       "env": {}
     }

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "token-optimizer": {
       "command": "npx",
-      "args": ["-y", "@ooples/token-optimizer-mcp@5.3.6"],
+      "args": ["-y", "@ooples/token-optimizer-mcp@5.4.0"],
       "env": {}
     }
   }

--- a/plugin/hooks/harvest-worker.mjs
+++ b/plugin/hooks/harvest-worker.mjs
@@ -126,4 +126,23 @@ async function main() {
 
 main()
   .catch(() => {})
-  .finally(() => process.exit(0));
+  .finally(() => {
+    // NEVER process.exit() SYNCHRONOUSLY HERE.
+    //
+    // It crashed this worker on Windows every single time the feedback pass
+    // ran -- libuv asserts `!(handle->flags & UV_HANDLE_CLOSING)` when the
+    // process exits while the sockets from the model call are still closing,
+    // giving exit code 0xC0000409. Reproduced 5 runs out of 5, and silently,
+    // because this worker is spawned detached and nothing reads its status.
+    // Deferring by one tick is NOT enough; the handles are still closing then.
+    //
+    // So the normal path just lets the loop drain, which it does promptly.
+    process.exitCode = 0;
+
+    // The watchdog keeps the original guarantee: a detached worker must never
+    // linger holding a keep-alive socket open. It is UNREF'D, so it cannot
+    // itself keep the process alive -- it only fires if something else already
+    // has, which is exactly the case worth killing.
+    const watchdog = setTimeout(() => process.exit(0), 5000);
+    watchdog.unref();
+  });

--- a/plugin/hooks/harvest-worker.mjs
+++ b/plugin/hooks/harvest-worker.mjs
@@ -137,12 +137,18 @@ main()
     // Deferring by one tick is NOT enough; the handles are still closing then.
     //
     // So the normal path just lets the loop drain, which it does promptly.
-    process.exitCode = 0;
+    //
+    // THE RECORDED CODE IS PRESERVED, not overwritten with 0. Assigning 0
+    // unconditionally would turn a harvest that had already recorded a failure
+    // into one that reports success -- and this worker is detached, so that
+    // status is the only signal a supervisor could ever act on.
+    const code = process.exitCode ?? 0;
+    process.exitCode = code;
 
     // The watchdog keeps the original guarantee: a detached worker must never
     // linger holding a keep-alive socket open. It is UNREF'D, so it cannot
     // itself keep the process alive -- it only fires if something else already
     // has, which is exactly the case worth killing.
-    const watchdog = setTimeout(() => process.exit(0), 5000);
+    const watchdog = setTimeout(() => process.exit(code), 5000);
     watchdog.unref();
   });

--- a/tests/hooks/feedback-e2e.test.mjs
+++ b/tests/hooks/feedback-e2e.test.mjs
@@ -1,0 +1,181 @@
+/**
+ * The feedback loop, from a real transcript to a served standing rule.
+ *
+ * THE PRODUCER HAD NEVER BEEN RUN BY ANYTHING. harvest-worker.mjs is spawned
+ * detached by the Stop adapter, and nothing else referenced it -- so when an
+ * edit severed a `record(dir, {...})` call and left the file a SYNTAX ERROR,
+ * the suite stayed green and the worker had simply been dead. A second defect
+ * in the same file, a missing `wikiDir` import, was equally invisible.
+ *
+ * Loadability is guarded separately now. This is the other half: that the
+ * pipeline actually produces something, end to end, through the real worker.
+ *
+ * THE MODEL CALL IS A LOOPBACK STUB, not a mock of the module. `localEndpoint`
+ * exists because organisations route model traffic through their own gateway,
+ * so pointing it at 127.0.0.1 exercises the real fetch, the real response
+ * parsing, the real validation and the real write path -- everything except who
+ * answers. Mocking `extract` would have proved none of that.
+ */
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { spawn } from 'child_process';
+import { createServer } from 'http';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { load } from '../../hooks-core/wiki.mjs';
+import { standingRules } from '../../hooks-core/inject.mjs';
+import { ORIGIN_HUMAN } from '../../hooks-core/curate.mjs';
+import { transcriptDir, safeName } from '../../hooks-core/transcript.mjs';
+
+const WORKER = join(process.cwd(), 'plugin', 'hooks', 'harvest-worker.mjs');
+const SESSION = 's-feedback-e2e';
+
+let project;
+let dir;
+let server;
+let endpoint;
+let bodies;
+
+/** The exact correction the user typed, which the lesson must quote verbatim. */
+const USER_TURN = "no, use npm test not npx jest";
+
+function startStub() {
+  bodies = [];
+  return new Promise((resolve) => {
+    server = createServer((req, res) => {
+      let raw = '';
+      req.on('data', (c) => (raw += c));
+      req.on('end', () => {
+        bodies.push(raw);
+        // The worker calls twice: once for the code harvest, once for the
+        // feedback pass. Both must be answered or the first await never
+        // settles; only the second is asserted on.
+        const isFeedback = /correct|wrong|instruction/i.test(raw);
+        const payload = isFeedback
+          ? [
+              {
+                type: 'feedback',
+                claim: 'Use npm test, not npx jest.',
+                trigger: 'jest',
+                quote: USER_TURN,
+                anchors: [join(project, 'a.ts')],
+                confidence: 0.9,
+              },
+            ]
+          : [];
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ content: [{ type: 'text', text: JSON.stringify(payload) }] }));
+      });
+    });
+    server.listen(0, '127.0.0.1', () =>
+      resolve(`http://127.0.0.1:${server.address().port}/v1/messages`)
+    );
+  });
+}
+
+beforeEach(async () => {
+  project = mkdtempSync(join(tmpdir(), 'feedback-e2e-'));
+  mkdirSync(join(project, '.git'), { recursive: true });
+  dir = join(project, '.token-optimizer', 'wiki');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(project, 'a.ts'), 'export const a = 1;' + '\n');
+  endpoint = await startStub();
+});
+
+afterEach(async () => {
+  await new Promise((r) => server.close(r));
+  try {
+    rmSync(project, { recursive: true, force: true });
+  } catch {
+    /* windows */
+  }
+});
+
+describe('the feedback loop end to end', () => {
+  // ASYNC SPAWN, NOT spawnSync. The stub server runs in THIS process, and
+  // `spawnSync` blocks the event loop until the child exits -- so the child's
+  // request could never be answered and both sides waited for each other until
+  // the timeout. An in-process stub and a synchronous child cannot coexist.
+  function runWorker(args, env) {
+    return new Promise((resolve) => {
+      const child = spawn(process.execPath, [WORKER, ...args], {
+        encoding: 'utf8',
+        env: { ...process.env, ...env },
+      });
+      let stderr = '';
+      child.stderr.on('data', (c) => (stderr += c));
+      child.on('close', (code) => resolve({ status: code, stderr }));
+      child.on('error', () => resolve({ status: -1, stderr }));
+    });
+  }
+
+  it('turns a user correction into a served standing rule', async () => {
+    // The archive the Stop adapter would have written.
+    mkdirSync(transcriptDir(dir), { recursive: true });
+    writeFileSync(
+      join(transcriptDir(dir), `${safeName(SESSION)}.jsonl`),
+      [
+        JSON.stringify({ role: 'user', text: 'run the tests' }),
+        JSON.stringify({ role: 'assistant', text: 'Running npx jest.' }),
+        JSON.stringify({ role: 'user', text: USER_TURN }),
+      ].join('\n') + '\n'
+    );
+
+    // And the raw transcript the worker reads for the code harvest.
+    const transcript = join(project, 'transcript.jsonl');
+    writeFileSync(
+      transcript,
+      [
+        JSON.stringify({ type: 'user', message: { role: 'user', content: 'run the tests' } }),
+        JSON.stringify({
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            content: [
+              { type: 'tool_use', name: 'Edit', input: { file_path: join(project, 'a.ts') } },
+            ],
+          },
+        }),
+        JSON.stringify({ type: 'user', message: { role: 'user', content: USER_TURN } }),
+      ].join('\n') + '\n'
+    );
+
+    const r = await runWorker([transcript, SESSION, project], {
+      TOKEN_OPTIMIZER_MODE: 'on',
+      TOKEN_OPTIMIZER_WIKI_DIR: dir,
+      TOKEN_OPTIMIZER_HARVEST_ENDPOINT: endpoint,
+    });
+
+    // EXIT STATUS IS PART OF THE CONTRACT. This caught a crash no assertion
+    // about the graph would have: process.exit() in the worker's `finally` ran
+    // while the model call's sockets were still closing, so libuv aborted the
+    // process with 0xC0000409 on every Windows run -- silently, because the
+    // worker is detached and nothing reads its status.
+    expect(r.status).toBe(0);
+    expect(String(r.stderr || '')).not.toMatch(
+      /SyntaxError|ReferenceError|is not defined|Assertion failed/
+    );
+
+    // The worker actually reached the model. Without this, a worker that
+    // returned early would look identical to one that found nothing to learn.
+    expect(bodies.length).toBeGreaterThanOrEqual(2);
+
+    const graph = load(dir);
+    const lesson = [...graph.nodes.values()].find(
+      (n) => n.kind === 'finding' && n.type === 'feedback'
+    );
+    expect(lesson).toBeDefined();
+
+    // Promoted BY EVIDENCE: the quote was found word-for-word in the user's own
+    // turn, and travels with the claim so the provenance can be checked.
+    expect(lesson.origin).toBe(ORIGIN_HUMAN);
+    expect(lesson.quote).toBe(USER_TURN);
+    expect(lesson.claim).toContain('npm test');
+
+    // AND IT IS ACTUALLY SERVED. Everything above only proves it was stored;
+    // delivery is the half that was disconnected, and the reason the feature
+    // could pass its own unit tests while doing nothing at all.
+    const rules = standingRules(dir, load(dir));
+    expect(rules).toContain('Use npm test, not npx jest.');
+  }, 120_000);
+});

--- a/tests/hooks/feedback-e2e.test.mjs
+++ b/tests/hooks/feedback-e2e.test.mjs
@@ -179,3 +179,39 @@ describe('the feedback loop end to end', () => {
     expect(rules).toContain('Use npm test, not npx jest.');
   }, 120_000);
 });
+
+describe('the worker reports its own status honestly', () => {
+  // The `finally` used to assign `process.exitCode = 0` unconditionally, which
+  // would turn a harvest that had already recorded a failure into one that
+  // reports success. Reported by CodeRabbit on the PR. It matters more here
+  // than it looks: the worker is spawned DETACHED, so its exit status is the
+  // only signal a supervisor could ever act on.
+  it('does not overwrite a failure code recorded before the finally', async () => {
+    const { mkdtempSync: mk, writeFileSync: wf } = await import('fs');
+    const probe = join(mkdtempSync(join(tmpdir(), 'exitcode-')), 'probe.mjs');
+    mkdirSync(join(probe, '..'), { recursive: true });
+
+    // The exact shape of the worker's tail, in isolation: a main() that records
+    // a failure, the same catch, and the same finally.
+    wf(
+      probe,
+      [
+        'async function main() { process.exitCode = 3; throw new Error("boom"); }',
+        'main()',
+        '  .catch(() => {})',
+        '  .finally(() => {',
+        '    const code = process.exitCode ?? 0;',
+        '    process.exitCode = code;',
+        '    const w = setTimeout(() => process.exit(code), 5000);',
+        '    w.unref();',
+        '  });',
+      ].join('\n')
+    );
+
+    const r = await new Promise((resolve) => {
+      const c = spawn(process.execPath, [probe]);
+      c.on('close', (code) => resolve(code));
+    });
+    expect(r).toBe(3);
+  }, 60_000);
+});


### PR DESCRIPTION
## 5.4.0 did not publish

npm `latest` is still **5.3.6**. The release run failed at *"Verify pinned specs match the released version"*, so the tag exists and the package does not. The guard worked exactly as designed; this is the repair.

**Why it happened**, from the `sync-release-pins` workflow's own docstring: it triggers on `pull_request` opened/synchronize/reopened, and #239 was opened *before* that workflow landed. A release PR that already exists and has nothing pending never receives one of those events, so nothing ran the sync on it. `package.json` went to 5.4.0 and every client pin stayed at 5.3.6. The workflow predicted this case in a comment — and it happened on the very first release after it was added.

**Two sets of files drift**, with different owners:

| Count | Owner | Files |
|---|---|---|
| 7 | `pin-mcp-version.mjs` | gemini-extension, codex `config.toml`, codex plugin `.mcp.json`, copilot, gemini, opencode, `plugin/.mcp.json` |
| 10 | `generate-client-configs.mjs` | cursor, windsurf, cline, roo, kilo, zed, amp, continue, crush, droid |

The failing release only listed the second set, because `generate-client-configs` runs first in `sync:hooks:check` and exits before the pin check is reached. **Fixing only what the log named would have left the other seven behind and failed the next run in the same place.**

`npm run sync:hooks:check` now passes all four stages.

## The harvest worker crashed on exit, every Windows run

```
Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), src\win\async.c
exit code 3221226505 (0xC0000409)
```

`process.exit(0)` in the worker's `finally` ran while the sockets from the model call were still closing. Reproduced **5 runs out of 5**, outside the test runner, whenever the feedback pass runs — which is whenever there is an archived transcript, so the normal case once this feature is on. Silent, because the worker is spawned detached and nothing reads its exit status.

Deferring by one tick is **not** enough; the handles are still closing then. I tried it. The normal path now lets the loop drain — five full runs complete in about a second — and an **unref'd** watchdog keeps the guarantee `process.exit` was there for: a detached worker must never linger holding a keep-alive socket. Unref'd means it cannot keep the process alive itself, so it fires only if something else already has.

## The producer had never been run by any test

`harvest-worker.mjs` is spawned by the Stop adapter and referenced nowhere else — which is how it shipped as a **syntax error** earlier in this branch's history. The new end-to-end test drives the real worker from an archived correction all the way to a served standing rule.

The model call is a **loopback stub**, not a mocked module. `localEndpoint` exists because organisations route model traffic through their own gateway, so pointing it at `127.0.0.1` exercises the real fetch, response parsing, validation and write path — everything except who answers. Mocking `extract` would have proved none of it, and would not have caught this crash, because the crash is in the socket teardown.

Two things the test's own construction had to get right:

- **Async spawn, not `spawnSync`.** The stub server runs in the test process, and `spawnSync` blocks the event loop until the child exits — so the child's request could never be answered and both sides waited for each other until the timeout.
- **The exit status is asserted.** No assertion about the graph would have caught this: the findings were written correctly and *then* the process aborted.

## Verification

```
Test Suites: 127 passed, 127 total
Tests:       4 skipped, 1672 passed, 1676 total
npm run build             exit 0
npm run sync:hooks:check  all four stages pass
```

Canaries — each defect restored on purpose:

| Sabotage | Result |
|---|---|
| synchronous `process.exit(0)` | e2e ✗ |
| batch-only origin at the write boundary | e2e ✗ |
| revert the pin sync | pin test ✗ (12 cases) |

**After merge, the release workflow needs re-running to publish 5.4.0.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
