### PR TITLE
fix(harness): the A/B measurement instrument only worked once

### DIFF
--- a/tests/fixtures/ab-injection-harness.mjs
+++ b/tests/fixtures/ab-injection-harness.mjs
@@ -8,6 +8,7 @@
  * delivery path rather than a mock of it.
  */
 import { spawnSync } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
 import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -97,6 +98,20 @@ export function buildArms() {
   const anchor = join(project, 'subject.mjs');
   writeFileSync(anchor, 'export function subject() {}\n');
 
+  // A SESSION ID THAT IS NEW ON EVERY RUN.
+  //
+  // The id used to be `ab-${c.id}`, fixed. Injection is deliberately
+  // once-per-session and that gate persists to disk under the shared state
+  // root, so the FIRST run of this harness served the findings and recorded
+  // them, and every run after it received nothing at all.
+  //
+  // That is the worst possible failure for a measurement instrument: the
+  // treatment arm silently degrades into a second control arm, both answer the
+  // same way, and the experiment reports that the graph does not help. It
+  // reproduces exactly -- run buildArms() twice and the second call returns
+  // null for all five cases.
+  const run = randomBytes(6).toString('hex');
+
   const out = [];
   for (const c of CASES) {
     // Fresh graph per case so one case's finding cannot answer another's task.
@@ -127,7 +142,7 @@ export function buildArms() {
 
     const r = spawnSync(process.execPath, [HOOK], {
       input: JSON.stringify({
-        session_id: `ab-${c.id}`,
+        session_id: `ab-${c.id}-${run}`,
         cwd: caseProject,
         tool_name: 'Bash',
         tool_input: { command: c.probeCommand },

--- a/tests/hooks/ab-scorers.test.mjs
+++ b/tests/hooks/ab-scorers.test.mjs
@@ -5,7 +5,7 @@
  * `set -o pipefail` does.
  */
 import { describe, it, expect } from '@jest/globals';
-import { CASES } from '../fixtures/ab-injection-harness.mjs';
+import { CASES, buildArms } from '../fixtures/ab-injection-harness.mjs';
 
 const pipeExit = CASES.find((c) => c.id === 'pipe-exit');
 
@@ -52,3 +52,25 @@ describe('every case is scoreable', () => {
     }
   });
 });
+
+describe('the harness is repeatable', () => {
+  // AN INSTRUMENT THAT ONLY WORKS ONCE MEASURES NOTHING THE SECOND TIME.
+  //
+  // The session id was `ab-${c.id}`, fixed. Injection is deliberately
+  // once-per-session and that gate persists to disk under the shared state
+  // root, so the FIRST run served every finding and recorded it, and every run
+  // afterwards received nothing at all.
+  //
+  // That is the worst failure mode available to a measurement harness: the
+  // treatment arm silently degrades into a second control arm, both arms answer
+  // identically, and the experiment concludes that the graph does not help.
+  // Caught while actually running the A/B -- the first dump showed injected
+  // context for all five cases, and the next showed null for all five.
+  it('carries injected context on every run, not just the first', () => {
+    for (let pass = 0; pass < 3; pass++) {
+      const arms = buildArms();
+      const withContext = arms.filter((a) => a.injected);
+      expect(withContext).toHaveLength(arms.length);
+    }
+  }, 180_000);
+});


### PR DESCRIPTION
Found while actually running the experiment. The first dump showed injected context for all five cases; the very next one showed `null` for all five.

## The defect

The session id was `ab-${c.id}` — fixed. Injection is deliberately once-per-session, and that gate **persists to disk** under the shared state root. So the first run of the harness served every seeded finding and recorded it as delivered, and every run afterwards received nothing at all.

This is the worst failure mode available to a measurement instrument. It does not error and it does not look broken:

- the treatment arm silently degrades into a second control arm
- both arms answer identically
- the experiment concludes that the graph does not help

The headline number this project exists to produce would have been a **false negative, reported with a straight face**.

## The fix

A per-run random suffix, so each pass is a genuinely new session — which is what the arms were always supposed to represent: a fresh subject that has not been told the answer yet.

```
run 1: 5/5 arms carry injected context
run 2: 5/5 arms carry injected context
run 3: 5/5 arms carry injected context
```

The guard calls `buildArms()` three times and requires injected context every time. Restoring the fixed id turns it red.

## Verification

```
Test Suites: 125 passed, 125 total     (excluding pinned-spec, see below)
Tests:       4 skipped, 1660 passed, 1664 total
```

The 7 `pinned MCP spec` failures on this branch are **pre-existing on master** — the 5.4.0 release pin drift that #245 fixes. They are unrelated to this change and will clear when #245 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
