### PR TITLE
fix(doctor): report whether finding extraction is actually running

### DIFF
--- a/hooks-core/doctor.mjs
+++ b/hooks-core/doctor.mjs
@@ -23,6 +23,7 @@ import { randomBytes } from 'node:crypto';
 import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { harvestMode } from './harvest.mjs';
 import { readManifest, verifyManifest, residue } from './manifest.mjs';
 
 const ok = (name, detail) => ({ name, pass: true, detail });
@@ -121,6 +122,57 @@ function hooksDirFor({ hooksDir, install, root }) {
  * nothing anywhere says so. Restarting does not help, because the restart
  * faithfully reloads the pinned version.
  */
+/**
+ * Is the half that LEARNS actually running?
+ *
+ * Everything else here checks that reads are being optimised. None of it
+ * notices when finding-extraction is off, and the two failure modes look
+ * identical from outside: a graph that fills with structural nodes either way.
+ *
+ * Measured on a real 5.4.0 install: 484 symbol, 286 file and 122 task nodes and
+ * ZERO findings, because harvestMode() was 'off:not-opted-in'. Fifteen checks
+ * passed and none mentioned harvest. stop-harvest.mjs names this exact gap --
+ * "nothing in doctor, audit or waste mentions harvest, so a user sees a graph
+ * filling with structural nodes and no findings and has no way to learn why" --
+ * and then fixed only its own half, the once-per-session Stop notice. A
+ * systemMessage at Stop is easy to miss; the doctor is where someone goes to ask.
+ *
+ * This does NOT judge the default. Opting in costs a model call and sends a
+ * digest off the machine, so requiring consent is right. The defect is that the
+ * state was invisible, which let a user believe findings were accumulating when
+ * they could not.
+ */
+export function probeHarvest() {
+  const mode = harvestMode();
+
+  // The documented escape hatch. A harvest failure stacked on top of "the whole
+  // optimizer is off" is noise, which is why stop-harvest maps it to no notice.
+  if (mode === 'off:mode') return [];
+
+  if (mode === 'local') {
+    return [ok('finding extraction is on', 'local endpoint -- free and private')];
+  }
+  if (mode === 'remote') {
+    return [ok('finding extraction is on', 'opted in, with a credential')];
+  }
+
+  if (mode === 'off:no-key') {
+    return [bad('finding extraction is on',
+      'opted in, but there is no credential to call a model with',
+      'set TOKEN_OPTIMIZER_API_KEY, or point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a ' +
+      'local model to run it without one')];
+  }
+
+  // off:not-opted-in
+  return [bad('finding extraction is on',
+    'off -- the graph will keep collecting files and symbols, but never a finding, ' +
+    'a lesson or a correction',
+    'point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model to run it free and ' +
+    'private, or set TOKEN_OPTIMIZER_HARVEST=1 with a credential to use a remote ' +
+    'one (that spends money and sends a digest of paths, commands and conclusions ' +
+    '-- never file contents -- off this machine)')];
+}
+
 export function probeVersion({ install }) {
   const { method, installedVersion, availableVersion } = install || {};
 
@@ -396,6 +448,7 @@ export function diagnose({
   const checks = [
     ...checklist({ root, settingsPath, install }),
     ...probeVersion({ install }),
+    ...probeHarvest(),
     ...probeEnforcement({ root, workspace, install }),
     ...probeSessionStart({ root, workspace, install }),
     ...probeGraph({ dir: graphDir }),

--- a/integrations/codex/hooks/lib/doctor.mjs
+++ b/integrations/codex/hooks/lib/doctor.mjs
@@ -25,6 +25,7 @@ import { randomBytes } from 'node:crypto';
 import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { harvestMode } from './harvest.mjs';
 import { readManifest, verifyManifest, residue } from './manifest.mjs';
 
 const ok = (name, detail) => ({ name, pass: true, detail });
@@ -123,6 +124,57 @@ function hooksDirFor({ hooksDir, install, root }) {
  * nothing anywhere says so. Restarting does not help, because the restart
  * faithfully reloads the pinned version.
  */
+/**
+ * Is the half that LEARNS actually running?
+ *
+ * Everything else here checks that reads are being optimised. None of it
+ * notices when finding-extraction is off, and the two failure modes look
+ * identical from outside: a graph that fills with structural nodes either way.
+ *
+ * Measured on a real 5.4.0 install: 484 symbol, 286 file and 122 task nodes and
+ * ZERO findings, because harvestMode() was 'off:not-opted-in'. Fifteen checks
+ * passed and none mentioned harvest. stop-harvest.mjs names this exact gap --
+ * "nothing in doctor, audit or waste mentions harvest, so a user sees a graph
+ * filling with structural nodes and no findings and has no way to learn why" --
+ * and then fixed only its own half, the once-per-session Stop notice. A
+ * systemMessage at Stop is easy to miss; the doctor is where someone goes to ask.
+ *
+ * This does NOT judge the default. Opting in costs a model call and sends a
+ * digest off the machine, so requiring consent is right. The defect is that the
+ * state was invisible, which let a user believe findings were accumulating when
+ * they could not.
+ */
+export function probeHarvest() {
+  const mode = harvestMode();
+
+  // The documented escape hatch. A harvest failure stacked on top of "the whole
+  // optimizer is off" is noise, which is why stop-harvest maps it to no notice.
+  if (mode === 'off:mode') return [];
+
+  if (mode === 'local') {
+    return [ok('finding extraction is on', 'local endpoint -- free and private')];
+  }
+  if (mode === 'remote') {
+    return [ok('finding extraction is on', 'opted in, with a credential')];
+  }
+
+  if (mode === 'off:no-key') {
+    return [bad('finding extraction is on',
+      'opted in, but there is no credential to call a model with',
+      'set TOKEN_OPTIMIZER_API_KEY, or point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a ' +
+      'local model to run it without one')];
+  }
+
+  // off:not-opted-in
+  return [bad('finding extraction is on',
+    'off -- the graph will keep collecting files and symbols, but never a finding, ' +
+    'a lesson or a correction',
+    'point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model to run it free and ' +
+    'private, or set TOKEN_OPTIMIZER_HARVEST=1 with a credential to use a remote ' +
+    'one (that spends money and sends a digest of paths, commands and conclusions ' +
+    '-- never file contents -- off this machine)')];
+}
+
 export function probeVersion({ install }) {
   const { method, installedVersion, availableVersion } = install || {};
 
@@ -398,6 +450,7 @@ export function diagnose({
   const checks = [
     ...checklist({ root, settingsPath, install }),
     ...probeVersion({ install }),
+    ...probeHarvest(),
     ...probeEnforcement({ root, workspace, install }),
     ...probeSessionStart({ root, workspace, install }),
     ...probeGraph({ dir: graphDir }),

--- a/integrations/codex/plugin/hooks/lib/doctor.mjs
+++ b/integrations/codex/plugin/hooks/lib/doctor.mjs
@@ -25,6 +25,7 @@ import { randomBytes } from 'node:crypto';
 import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { harvestMode } from './harvest.mjs';
 import { readManifest, verifyManifest, residue } from './manifest.mjs';
 
 const ok = (name, detail) => ({ name, pass: true, detail });
@@ -123,6 +124,57 @@ function hooksDirFor({ hooksDir, install, root }) {
  * nothing anywhere says so. Restarting does not help, because the restart
  * faithfully reloads the pinned version.
  */
+/**
+ * Is the half that LEARNS actually running?
+ *
+ * Everything else here checks that reads are being optimised. None of it
+ * notices when finding-extraction is off, and the two failure modes look
+ * identical from outside: a graph that fills with structural nodes either way.
+ *
+ * Measured on a real 5.4.0 install: 484 symbol, 286 file and 122 task nodes and
+ * ZERO findings, because harvestMode() was 'off:not-opted-in'. Fifteen checks
+ * passed and none mentioned harvest. stop-harvest.mjs names this exact gap --
+ * "nothing in doctor, audit or waste mentions harvest, so a user sees a graph
+ * filling with structural nodes and no findings and has no way to learn why" --
+ * and then fixed only its own half, the once-per-session Stop notice. A
+ * systemMessage at Stop is easy to miss; the doctor is where someone goes to ask.
+ *
+ * This does NOT judge the default. Opting in costs a model call and sends a
+ * digest off the machine, so requiring consent is right. The defect is that the
+ * state was invisible, which let a user believe findings were accumulating when
+ * they could not.
+ */
+export function probeHarvest() {
+  const mode = harvestMode();
+
+  // The documented escape hatch. A harvest failure stacked on top of "the whole
+  // optimizer is off" is noise, which is why stop-harvest maps it to no notice.
+  if (mode === 'off:mode') return [];
+
+  if (mode === 'local') {
+    return [ok('finding extraction is on', 'local endpoint -- free and private')];
+  }
+  if (mode === 'remote') {
+    return [ok('finding extraction is on', 'opted in, with a credential')];
+  }
+
+  if (mode === 'off:no-key') {
+    return [bad('finding extraction is on',
+      'opted in, but there is no credential to call a model with',
+      'set TOKEN_OPTIMIZER_API_KEY, or point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a ' +
+      'local model to run it without one')];
+  }
+
+  // off:not-opted-in
+  return [bad('finding extraction is on',
+    'off -- the graph will keep collecting files and symbols, but never a finding, ' +
+    'a lesson or a correction',
+    'point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model to run it free and ' +
+    'private, or set TOKEN_OPTIMIZER_HARVEST=1 with a credential to use a remote ' +
+    'one (that spends money and sends a digest of paths, commands and conclusions ' +
+    '-- never file contents -- off this machine)')];
+}
+
 export function probeVersion({ install }) {
   const { method, installedVersion, availableVersion } = install || {};
 
@@ -398,6 +450,7 @@ export function diagnose({
   const checks = [
     ...checklist({ root, settingsPath, install }),
     ...probeVersion({ install }),
+    ...probeHarvest(),
     ...probeEnforcement({ root, workspace, install }),
     ...probeSessionStart({ root, workspace, install }),
     ...probeGraph({ dir: graphDir }),

--- a/integrations/gemini/hooks/lib/doctor.mjs
+++ b/integrations/gemini/hooks/lib/doctor.mjs
@@ -25,6 +25,7 @@ import { randomBytes } from 'node:crypto';
 import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { harvestMode } from './harvest.mjs';
 import { readManifest, verifyManifest, residue } from './manifest.mjs';
 
 const ok = (name, detail) => ({ name, pass: true, detail });
@@ -123,6 +124,57 @@ function hooksDirFor({ hooksDir, install, root }) {
  * nothing anywhere says so. Restarting does not help, because the restart
  * faithfully reloads the pinned version.
  */
+/**
+ * Is the half that LEARNS actually running?
+ *
+ * Everything else here checks that reads are being optimised. None of it
+ * notices when finding-extraction is off, and the two failure modes look
+ * identical from outside: a graph that fills with structural nodes either way.
+ *
+ * Measured on a real 5.4.0 install: 484 symbol, 286 file and 122 task nodes and
+ * ZERO findings, because harvestMode() was 'off:not-opted-in'. Fifteen checks
+ * passed and none mentioned harvest. stop-harvest.mjs names this exact gap --
+ * "nothing in doctor, audit or waste mentions harvest, so a user sees a graph
+ * filling with structural nodes and no findings and has no way to learn why" --
+ * and then fixed only its own half, the once-per-session Stop notice. A
+ * systemMessage at Stop is easy to miss; the doctor is where someone goes to ask.
+ *
+ * This does NOT judge the default. Opting in costs a model call and sends a
+ * digest off the machine, so requiring consent is right. The defect is that the
+ * state was invisible, which let a user believe findings were accumulating when
+ * they could not.
+ */
+export function probeHarvest() {
+  const mode = harvestMode();
+
+  // The documented escape hatch. A harvest failure stacked on top of "the whole
+  // optimizer is off" is noise, which is why stop-harvest maps it to no notice.
+  if (mode === 'off:mode') return [];
+
+  if (mode === 'local') {
+    return [ok('finding extraction is on', 'local endpoint -- free and private')];
+  }
+  if (mode === 'remote') {
+    return [ok('finding extraction is on', 'opted in, with a credential')];
+  }
+
+  if (mode === 'off:no-key') {
+    return [bad('finding extraction is on',
+      'opted in, but there is no credential to call a model with',
+      'set TOKEN_OPTIMIZER_API_KEY, or point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a ' +
+      'local model to run it without one')];
+  }
+
+  // off:not-opted-in
+  return [bad('finding extraction is on',
+    'off -- the graph will keep collecting files and symbols, but never a finding, ' +
+    'a lesson or a correction',
+    'point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model to run it free and ' +
+    'private, or set TOKEN_OPTIMIZER_HARVEST=1 with a credential to use a remote ' +
+    'one (that spends money and sends a digest of paths, commands and conclusions ' +
+    '-- never file contents -- off this machine)')];
+}
+
 export function probeVersion({ install }) {
   const { method, installedVersion, availableVersion } = install || {};
 
@@ -398,6 +450,7 @@ export function diagnose({
   const checks = [
     ...checklist({ root, settingsPath, install }),
     ...probeVersion({ install }),
+    ...probeHarvest(),
     ...probeEnforcement({ root, workspace, install }),
     ...probeSessionStart({ root, workspace, install }),
     ...probeGraph({ dir: graphDir }),

--- a/integrations/opencode/hooks/lib/doctor.mjs
+++ b/integrations/opencode/hooks/lib/doctor.mjs
@@ -25,6 +25,7 @@ import { randomBytes } from 'node:crypto';
 import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { harvestMode } from './harvest.mjs';
 import { readManifest, verifyManifest, residue } from './manifest.mjs';
 
 const ok = (name, detail) => ({ name, pass: true, detail });
@@ -123,6 +124,57 @@ function hooksDirFor({ hooksDir, install, root }) {
  * nothing anywhere says so. Restarting does not help, because the restart
  * faithfully reloads the pinned version.
  */
+/**
+ * Is the half that LEARNS actually running?
+ *
+ * Everything else here checks that reads are being optimised. None of it
+ * notices when finding-extraction is off, and the two failure modes look
+ * identical from outside: a graph that fills with structural nodes either way.
+ *
+ * Measured on a real 5.4.0 install: 484 symbol, 286 file and 122 task nodes and
+ * ZERO findings, because harvestMode() was 'off:not-opted-in'. Fifteen checks
+ * passed and none mentioned harvest. stop-harvest.mjs names this exact gap --
+ * "nothing in doctor, audit or waste mentions harvest, so a user sees a graph
+ * filling with structural nodes and no findings and has no way to learn why" --
+ * and then fixed only its own half, the once-per-session Stop notice. A
+ * systemMessage at Stop is easy to miss; the doctor is where someone goes to ask.
+ *
+ * This does NOT judge the default. Opting in costs a model call and sends a
+ * digest off the machine, so requiring consent is right. The defect is that the
+ * state was invisible, which let a user believe findings were accumulating when
+ * they could not.
+ */
+export function probeHarvest() {
+  const mode = harvestMode();
+
+  // The documented escape hatch. A harvest failure stacked on top of "the whole
+  // optimizer is off" is noise, which is why stop-harvest maps it to no notice.
+  if (mode === 'off:mode') return [];
+
+  if (mode === 'local') {
+    return [ok('finding extraction is on', 'local endpoint -- free and private')];
+  }
+  if (mode === 'remote') {
+    return [ok('finding extraction is on', 'opted in, with a credential')];
+  }
+
+  if (mode === 'off:no-key') {
+    return [bad('finding extraction is on',
+      'opted in, but there is no credential to call a model with',
+      'set TOKEN_OPTIMIZER_API_KEY, or point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a ' +
+      'local model to run it without one')];
+  }
+
+  // off:not-opted-in
+  return [bad('finding extraction is on',
+    'off -- the graph will keep collecting files and symbols, but never a finding, ' +
+    'a lesson or a correction',
+    'point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model to run it free and ' +
+    'private, or set TOKEN_OPTIMIZER_HARVEST=1 with a credential to use a remote ' +
+    'one (that spends money and sends a digest of paths, commands and conclusions ' +
+    '-- never file contents -- off this machine)')];
+}
+
 export function probeVersion({ install }) {
   const { method, installedVersion, availableVersion } = install || {};
 
@@ -398,6 +450,7 @@ export function diagnose({
   const checks = [
     ...checklist({ root, settingsPath, install }),
     ...probeVersion({ install }),
+    ...probeHarvest(),
     ...probeEnforcement({ root, workspace, install }),
     ...probeSessionStart({ root, workspace, install }),
     ...probeGraph({ dir: graphDir }),

--- a/integrations/qwen/hooks/lib/doctor.mjs
+++ b/integrations/qwen/hooks/lib/doctor.mjs
@@ -25,6 +25,7 @@ import { randomBytes } from 'node:crypto';
 import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { harvestMode } from './harvest.mjs';
 import { readManifest, verifyManifest, residue } from './manifest.mjs';
 
 const ok = (name, detail) => ({ name, pass: true, detail });
@@ -123,6 +124,57 @@ function hooksDirFor({ hooksDir, install, root }) {
  * nothing anywhere says so. Restarting does not help, because the restart
  * faithfully reloads the pinned version.
  */
+/**
+ * Is the half that LEARNS actually running?
+ *
+ * Everything else here checks that reads are being optimised. None of it
+ * notices when finding-extraction is off, and the two failure modes look
+ * identical from outside: a graph that fills with structural nodes either way.
+ *
+ * Measured on a real 5.4.0 install: 484 symbol, 286 file and 122 task nodes and
+ * ZERO findings, because harvestMode() was 'off:not-opted-in'. Fifteen checks
+ * passed and none mentioned harvest. stop-harvest.mjs names this exact gap --
+ * "nothing in doctor, audit or waste mentions harvest, so a user sees a graph
+ * filling with structural nodes and no findings and has no way to learn why" --
+ * and then fixed only its own half, the once-per-session Stop notice. A
+ * systemMessage at Stop is easy to miss; the doctor is where someone goes to ask.
+ *
+ * This does NOT judge the default. Opting in costs a model call and sends a
+ * digest off the machine, so requiring consent is right. The defect is that the
+ * state was invisible, which let a user believe findings were accumulating when
+ * they could not.
+ */
+export function probeHarvest() {
+  const mode = harvestMode();
+
+  // The documented escape hatch. A harvest failure stacked on top of "the whole
+  // optimizer is off" is noise, which is why stop-harvest maps it to no notice.
+  if (mode === 'off:mode') return [];
+
+  if (mode === 'local') {
+    return [ok('finding extraction is on', 'local endpoint -- free and private')];
+  }
+  if (mode === 'remote') {
+    return [ok('finding extraction is on', 'opted in, with a credential')];
+  }
+
+  if (mode === 'off:no-key') {
+    return [bad('finding extraction is on',
+      'opted in, but there is no credential to call a model with',
+      'set TOKEN_OPTIMIZER_API_KEY, or point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a ' +
+      'local model to run it without one')];
+  }
+
+  // off:not-opted-in
+  return [bad('finding extraction is on',
+    'off -- the graph will keep collecting files and symbols, but never a finding, ' +
+    'a lesson or a correction',
+    'point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model to run it free and ' +
+    'private, or set TOKEN_OPTIMIZER_HARVEST=1 with a credential to use a remote ' +
+    'one (that spends money and sends a digest of paths, commands and conclusions ' +
+    '-- never file contents -- off this machine)')];
+}
+
 export function probeVersion({ install }) {
   const { method, installedVersion, availableVersion } = install || {};
 
@@ -398,6 +450,7 @@ export function diagnose({
   const checks = [
     ...checklist({ root, settingsPath, install }),
     ...probeVersion({ install }),
+    ...probeHarvest(),
     ...probeEnforcement({ root, workspace, install }),
     ...probeSessionStart({ root, workspace, install }),
     ...probeGraph({ dir: graphDir }),

--- a/plugin/hooks/lib/doctor.mjs
+++ b/plugin/hooks/lib/doctor.mjs
@@ -25,6 +25,7 @@ import { randomBytes } from 'node:crypto';
 import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { harvestMode } from './harvest.mjs';
 import { readManifest, verifyManifest, residue } from './manifest.mjs';
 
 const ok = (name, detail) => ({ name, pass: true, detail });
@@ -123,6 +124,57 @@ function hooksDirFor({ hooksDir, install, root }) {
  * nothing anywhere says so. Restarting does not help, because the restart
  * faithfully reloads the pinned version.
  */
+/**
+ * Is the half that LEARNS actually running?
+ *
+ * Everything else here checks that reads are being optimised. None of it
+ * notices when finding-extraction is off, and the two failure modes look
+ * identical from outside: a graph that fills with structural nodes either way.
+ *
+ * Measured on a real 5.4.0 install: 484 symbol, 286 file and 122 task nodes and
+ * ZERO findings, because harvestMode() was 'off:not-opted-in'. Fifteen checks
+ * passed and none mentioned harvest. stop-harvest.mjs names this exact gap --
+ * "nothing in doctor, audit or waste mentions harvest, so a user sees a graph
+ * filling with structural nodes and no findings and has no way to learn why" --
+ * and then fixed only its own half, the once-per-session Stop notice. A
+ * systemMessage at Stop is easy to miss; the doctor is where someone goes to ask.
+ *
+ * This does NOT judge the default. Opting in costs a model call and sends a
+ * digest off the machine, so requiring consent is right. The defect is that the
+ * state was invisible, which let a user believe findings were accumulating when
+ * they could not.
+ */
+export function probeHarvest() {
+  const mode = harvestMode();
+
+  // The documented escape hatch. A harvest failure stacked on top of "the whole
+  // optimizer is off" is noise, which is why stop-harvest maps it to no notice.
+  if (mode === 'off:mode') return [];
+
+  if (mode === 'local') {
+    return [ok('finding extraction is on', 'local endpoint -- free and private')];
+  }
+  if (mode === 'remote') {
+    return [ok('finding extraction is on', 'opted in, with a credential')];
+  }
+
+  if (mode === 'off:no-key') {
+    return [bad('finding extraction is on',
+      'opted in, but there is no credential to call a model with',
+      'set TOKEN_OPTIMIZER_API_KEY, or point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a ' +
+      'local model to run it without one')];
+  }
+
+  // off:not-opted-in
+  return [bad('finding extraction is on',
+    'off -- the graph will keep collecting files and symbols, but never a finding, ' +
+    'a lesson or a correction',
+    'point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model to run it free and ' +
+    'private, or set TOKEN_OPTIMIZER_HARVEST=1 with a credential to use a remote ' +
+    'one (that spends money and sends a digest of paths, commands and conclusions ' +
+    '-- never file contents -- off this machine)')];
+}
+
 export function probeVersion({ install }) {
   const { method, installedVersion, availableVersion } = install || {};
 
@@ -398,6 +450,7 @@ export function diagnose({
   const checks = [
     ...checklist({ root, settingsPath, install }),
     ...probeVersion({ install }),
+    ...probeHarvest(),
     ...probeEnforcement({ root, workspace, install }),
     ...probeSessionStart({ root, workspace, install }),
     ...probeGraph({ dir: graphDir }),

--- a/tests/unit/doctor-reports-harvest-state.test.ts
+++ b/tests/unit/doctor-reports-harvest-state.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, afterEach } from '@jest/globals';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+// @ts-expect-error -- hooks-core ships as plain ESM with no type declarations.
+import { probeHarvest, diagnose } from '../../hooks-core/doctor.mjs';
+
+/**
+ * The doctor reported a clean bill while the half that learns captured nothing.
+ *
+ * Measured on a real machine running 5.4.0: the project graph held 484 symbol,
+ * 286 file and 122 task nodes and ZERO findings, lessons or corrections, because
+ * harvestMode() was 'off:not-opted-in'. Fifteen doctor checks passed and not one
+ * of them mentioned harvest -- `grep -c harvest hooks-core/doctor.mjs` returned 0.
+ *
+ * stop-harvest.mjs names this exact gap in its own header: "nothing in doctor,
+ * audit or waste mentions harvest, so a user sees a graph filling with structural
+ * nodes and no findings and has no way to learn why." It then fixed its own half,
+ * the once-per-session Stop notice, and the doctor half never landed. A Stop-time
+ * systemMessage is easy to miss; the doctor is where someone goes to ask.
+ *
+ * This is deliberately NOT a judgement about whether opting in is correct. The
+ * default is well-reasoned -- extraction costs a model call and sends a digest
+ * off the machine, and "an ambient credential is not consent". The defect is that
+ * the state is invisible, so a user believes findings are accumulating when they
+ * cannot.
+ */
+
+const ENV_KEYS = [
+  'TOKEN_OPTIMIZER_MODE',
+  'TOKEN_OPTIMIZER_HARVEST',
+  'TOKEN_OPTIMIZER_HARVEST_ENDPOINT',
+  'TOKEN_OPTIMIZER_API_KEY',
+  'ANTHROPIC_API_KEY',
+];
+const saved = new Map(ENV_KEYS.map((k) => [k, process.env[k]]));
+
+function envOnly(vars: Record<string, string>) {
+  for (const k of ENV_KEYS) delete process.env[k];
+  for (const [k, v] of Object.entries(vars)) process.env[k] = v;
+}
+
+afterEach(() => {
+  for (const [k, v] of saved) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+});
+
+describe('probeHarvest', () => {
+  it('fails when extraction is off because nobody opted in', () => {
+    envOnly({});
+    const [check] = probeHarvest();
+
+    expect(check.pass).toBe(false);
+    // The graph will never acquire a finding in this state, which is the thing
+    // the user cannot currently discover.
+    expect(check.name).toMatch(/harvest|finding/i);
+  });
+
+  it('names the variable that changes it, because a diagnosis without a next step is a complaint', () => {
+    envOnly({});
+    const [check] = probeHarvest();
+
+    expect(check.remedy).toMatch(/TOKEN_OPTIMIZER_HARVEST/);
+    // The free, private path must be offered too -- opting in remotely costs
+    // money and sends a digest off the machine.
+    expect(check.remedy).toMatch(/TOKEN_OPTIMIZER_HARVEST_ENDPOINT/);
+  });
+
+  it('fails differently when opted in but with no credential', () => {
+    envOnly({ TOKEN_OPTIMIZER_HARVEST: '1' });
+    const [check] = probeHarvest();
+
+    expect(check.pass).toBe(false);
+    expect(check.detail).toMatch(/credential|key/i);
+  });
+
+  it('passes on a local endpoint, which is free and private', () => {
+    envOnly({ TOKEN_OPTIMIZER_HARVEST_ENDPOINT: 'http://127.0.0.1:11434/v1/chat/completions' });
+    const [check] = probeHarvest();
+
+    expect(check.pass).toBe(true);
+    expect(check.detail).toMatch(/local/i);
+  });
+
+  it('passes when opted in with a credential', () => {
+    envOnly({ TOKEN_OPTIMIZER_HARVEST: 'true', TOKEN_OPTIMIZER_API_KEY: 'sk-test' });
+    const [check] = probeHarvest();
+
+    expect(check.pass).toBe(true);
+  });
+
+  it('says nothing when the whole optimizer is off', () => {
+    // TOKEN_OPTIMIZER_MODE=off is the documented escape hatch. Reporting a
+    // harvest failure on top of it would be noise, which is why stop-harvest maps
+    // that mode to a null notice.
+    envOnly({ TOKEN_OPTIMIZER_MODE: 'off' });
+
+    expect(probeHarvest()).toEqual([]);
+  });
+});
+
+describe('the diagnosis as a whole', () => {
+  it('includes the harvest state, so a clean bill cannot hide an inert graph', () => {
+    envOnly({});
+    // workspace and graphDir are required by the enforcement and graph probes;
+    // skipServer because the MCP probe spawns a server, which is not what this
+    // test is about.
+    const scratch = mkdtempSync(join(tmpdir(), 'doctor-harvest-'));
+    try {
+      const result = diagnose({
+        root: process.cwd(),
+        workspace: join(scratch, 'workspace'),
+        graphDir: join(scratch, 'graph'),
+        skipServer: true,
+      });
+      const names = result.checks.map((c: { name: string }) => c.name);
+
+      expect(names.some((n: string) => /harvest|finding/i.test(n))).toBe(true);
+    } finally {
+      rmSync(scratch, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
The doctor gave a clean bill while the half that learns captured nothing.

## Evidence

Measured on a real 5.4.0 install:

```
graph.jsonl: 2176 records
  symbol 484 | file 286 | task 122
  finding 0 | lesson 0 | correction 0
```

`harvestMode()` was `off:not-opted-in`. Every doctor check passed, and `grep -c harvest hooks-core/doctor.mjs` returned **0**.

`stop-harvest.mjs` names this exact gap in its own header:

> *"nothing in doctor, audit or waste mentions harvest, so a user sees a graph filling with structural nodes and no findings and has no way to learn why. Saying so once per session is the difference between a disabled feature and a broken one."*

It then fixed its own half — the once-per-session Stop notice, which does fire (verified: a marker for the live session, written 17:40:53Z). The doctor half never landed. A `systemMessage` at Stop is easy to miss; the doctor is where someone goes to ask why nothing is accumulating.

## This does not change the default

Opting in costs a model call and sends a digest off the machine, and *"an ambient credential is not consent"* — requiring an explicit choice is right. The defect was that the state was **invisible**, which let a user believe findings were accumulating when they could not be.

## Behaviour

| `harvestMode()` | check |
|---|---|
| `local` | pass — *"local endpoint -- free and private"* |
| `remote` | pass — *"opted in, with a credential"* |
| `off:no-key` | fail — names `TOKEN_OPTIMIZER_API_KEY` and the local-endpoint alternative |
| `off:not-opted-in` | fail — offers the free/private path first, then the remote one with its cost stated |
| `off:mode` | **nothing** — a harvest failure stacked on "the optimizer is off" is noise, matching stop-harvest's null notice for that mode |

Live output on a machine with harvest off:

```
FAIL  finding extraction is on
      off -- the graph will keep collecting files and symbols, but never a
      finding, a lesson or a correction
      fix: point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model to run it
      free and private, or set TOKEN_OPTIMIZER_HARVEST=1 with a credential ...
```

## Verification

- 7 new tests, all six modes plus the full `diagnose()` wiring. Watched failing first.
- `tsc --noEmit` clean. Suite goes 852 → **859 passing**.
- **The 7 pinned-spec failures are the 5.4.0 release drift on master, not this change** — unmodified master fails the identical seven. Being fixed separately.

🤖 Generated with [Claude Code](https://claude.ai/code)
