### PR TITLE
test(protocol): raise the proof bar after two runs that measured nothing

### DIFF
--- a/docs/INJECTION_PROOF_PROTOCOL.md
+++ b/docs/INJECTION_PROOF_PROTOCOL.md
@@ -77,3 +77,87 @@ records.
   can reach them by ordinary reading and the comparison measures nothing.
 - Raw counts are reported alongside the verdict, so the numbers can be checked
   against the bar independently.
+
+---
+
+# Revision 2, after two runs that measured less than they appeared to
+
+Both runs below were carried out. Neither supports the claim as originally
+written, and this revision records why and what changed as a result. The bar was
+raised, not lowered — which is the only direction a bar may move after seeing the
+numbers.
+
+## What the two runs actually produced
+
+**Single-turn, 5 hand-written cases.** Control walked into 2, treatment avoided
+both, 0 regressions. Reported at the time as PASS at 100%. Re-graded under the
+rules below it is a **FAIL**: the rate rested on 2 admitted cases.
+
+**Multi-turn, 3 real sandboxes with tools.** Every trap was verified to fire
+mechanically before the run — the naive guess really does produce MSB1009,
+`./build.sh | tail` really does report exit 0 on a failing build, `git fetch
+origin master` really does report "0 behind" when origin has 3 commits to local's
+1. **Zero of three fired against the subject.** Given tools, the control verified
+instead of guessing: it ran `ls`, redirected to a file and echoed `$?`, and used
+an explicit refspec that bypassed the clobbered config. Token delta −587 over
+114,771, mean −196 with sd 747 — noise, and measuring nothing in any case,
+because there was no rework to avoid.
+
+The lesson is not "the graph does not work". It is that **a dead-end only has
+value where verification is expensive**, and both corpora were full of dead-ends
+one `ls` could settle.
+
+## Two claims, gated separately
+
+They are never blended into one number.
+
+| claim | status | evidence |
+|---|---|---|
+| **Correctness** — avoids known dead-ends the control walks into | supported, under-powered | 2 of 2 admitted cases rescued, 0 regressions; fails the minimum-N bar |
+| **Token savings** | **unproven** | no run has produced a measurable saving; the multi-turn delta was within noise |
+
+The token claim stays open and explicitly unproven. It is not to appear in the
+README, the tool descriptions, or a release note until a run supports it.
+
+## The gate (implemented in `tests/fixtures/ab-gate.mjs`)
+
+Graded by code, because both earlier runs were graded by reading answers and
+deciding whether they looked right — the same contamination this document warns
+about everywhere else, applied to the scoring step.
+
+1. **Admission by control failure.** A case where the control gets the right
+   answer measured nothing and is EXCLUDED, and reported as excluded. It is never
+   counted as a treatment success.
+2. **Minimum 5 admitted cases.** A bar clearable by two lucky cases will
+   eventually be cleared by noise.
+3. **≥ 80% of admitted cases rescued.**
+4. **0 regressions**, looked for across every case including excluded ones — a
+   misleading finding does its damage exactly where the subject needed no help.
+5. **Tokens are reported, never gated**, over admitted cases where both arms were
+   correct. Tokens spent reaching a wrong answer are not comparable to tokens
+   spent reaching a right one.
+
+## Four classes of dead-end, measured separately
+
+Averaging these together is what produced a meaningless rate.
+
+| class | what makes it bite |
+|---|---|
+| `expensive` | the failure only surfaces after costly work — a timeout, a full build, a CI round trip |
+| `plausible` | no error at all; the wrong path looks exactly like success |
+| `non-inferable` | the fact lives in history or in a person's head, not in the tree |
+| `restricted` | fires only when the subject cannot reach the cheap check |
+
+`restricted` is **reported separately and never in the headline**. Handicapping
+the control is a demonstration, not a fair comparison.
+
+## Two corpora, kept separate
+
+- `tests/fixtures/ab-injection-harness.mjs` — hand-written. Regression coverage
+  for the delivery path. Authored by someone who knew the answers, so it is not
+  evidence about behaviour change.
+- `tests/fixtures/harvested-dead-ends.mjs` — harvested from failures this project
+  actually hit, each recorded with the symptom observed at the time. This is the
+  corpus the headline number comes from.
+
+Reported separately, always. An easy case in one must not flatter the other.

--- a/tests/fixtures/ab-gate.mjs
+++ b/tests/fixtures/ab-gate.mjs
@@ -1,0 +1,136 @@
+/**
+ * The gate, as a function, so a run cannot be graded by eye.
+ *
+ * WHY THIS EXISTS AS CODE. The first A/B run was scored by reading answers and
+ * deciding whether they looked right. That is exactly the contamination the
+ * proof protocol warns about everywhere else, applied to the scoring step
+ * instead of the subject. The predicates already live with the cases; this puts
+ * the ARITHMETIC somewhere it can be tested too.
+ *
+ * TWO RULES, BOTH LEARNED FROM RUNS THAT MEASURED NOTHING.
+ *
+ * 1. ADMISSION BY CONTROL FAILURE. A case where the control gets the right
+ *    answer measured nothing: there was no dead-end to avoid, so the treatment
+ *    "avoiding" it is not evidence of anything. The multi-turn run was 0 for 3
+ *    on this -- every control verified instead of guessing -- and averaging
+ *    those in would have produced a rate with no content. Such cases are
+ *    EXCLUDED and reported as excluded, never silently dropped.
+ *
+ * 2. A MINIMUM NUMBER OF ADMITTED CASES. The single-turn run passed the 80% bar
+ *    on two data points. Two is not a measurement, and a bar that can be cleared
+ *    by two lucky cases is a bar that will eventually be cleared by noise.
+ *
+ * The token metric is deliberately NOT a gate. It is reported over the admitted
+ * cases only, because tokens spent reaching a wrong answer are not comparable to
+ * tokens spent reaching a right one.
+ */
+
+const DEFAULTS = { minAdmitted: 5, avoidedBar: 0.8, maxRegressions: 0 };
+
+/**
+ * @param {Array} results  [{ id, class, control: {answer, tokens}, treatment: {answer, tokens} }]
+ * @param {Array} cases    the corpus, for the walksIn/avoids predicates
+ */
+export function grade(results, cases, options = {}) {
+  const { minAdmitted, avoidedBar, maxRegressions } = { ...DEFAULTS, ...options };
+  const byId = new Map(cases.map((c) => [c.id, c]));
+
+  const scored = [];
+  for (const r of results) {
+    const c = byId.get(r.id);
+    if (!c) throw new Error(`result for unknown case: ${r.id}`);
+    const score = (answer) => ({
+      walksIn: Boolean(c.walksIn(String(answer ?? ''))),
+      avoids: Boolean(c.avoids(String(answer ?? ''))),
+    });
+    scored.push({
+      id: r.id,
+      // A case with no class still reports; it just cannot hide in an average.
+      class: c.class || 'unclassified',
+      control: { ...score(r.control?.answer), tokens: r.control?.tokens ?? null },
+      treatment: { ...score(r.treatment?.answer), tokens: r.treatment?.tokens ?? null },
+    });
+  }
+
+  // ADMISSION. The control must actually have failed, or the case is inert.
+  const admitted = scored.filter((s) => s.control.walksIn && !s.control.avoids);
+  const excluded = scored.filter((s) => !(s.control.walksIn && !s.control.avoids));
+
+  const rescued = admitted.filter((s) => s.treatment.avoids && !s.treatment.walksIn);
+  // A regression is the control being RIGHT and the treatment being pushed
+  // wrong. It is looked for across every case, admitted or not: a misleading
+  // finding does its damage exactly where the subject did not need help.
+  const regressions = scored.filter((s) => s.control.avoids && s.treatment.walksIn);
+
+  const avoidedRate = admitted.length ? rescued.length / admitted.length : null;
+
+  // Tokens over ADMITTED cases only, and only where both arms landed correctly:
+  // tokens spent reaching a wrong answer are not comparable to tokens spent
+  // reaching a right one.
+  const comparable = admitted.filter(
+    (s) => s.treatment.avoids && s.control.tokens != null && s.treatment.tokens != null
+  );
+  const controlTokens = comparable.reduce((a, s) => a + s.control.tokens, 0);
+  const treatmentTokens = comparable.reduce((a, s) => a + s.treatment.tokens, 0);
+
+  const byClass = {};
+  for (const s of admitted) {
+    byClass[s.class] = byClass[s.class] || { admitted: 0, rescued: 0 };
+    byClass[s.class].admitted += 1;
+    if (s.treatment.avoids && !s.treatment.walksIn) byClass[s.class].rescued += 1;
+  }
+
+  const reasons = [];
+  if (admitted.length < minAdmitted) {
+    reasons.push(
+      `only ${admitted.length} case(s) admitted; ${minAdmitted} required ` +
+        `(a case counts only when the control actually fails it)`
+    );
+  }
+  if (avoidedRate === null) reasons.push('no admitted cases, so the avoided rate is undefined');
+  else if (avoidedRate < avoidedBar) {
+    reasons.push(`avoided rate ${(avoidedRate * 100).toFixed(0)}% is below the ${avoidedBar * 100}% bar`);
+  }
+  if (regressions.length > maxRegressions) {
+    reasons.push(`${regressions.length} regression(s); the bar is ${maxRegressions}`);
+  }
+
+  return {
+    verdict: reasons.length ? 'FAIL' : 'PASS',
+    reasons,
+    admitted: admitted.map((s) => s.id),
+    excluded: excluded.map((s) => s.id),
+    rescued: rescued.map((s) => s.id),
+    regressions: regressions.map((s) => s.id),
+    avoidedRate,
+    byClass,
+    tokens: {
+      comparableCases: comparable.map((s) => s.id),
+      control: controlTokens,
+      treatment: treatmentTokens,
+      delta: treatmentTokens - controlTokens,
+    },
+  };
+}
+
+/** A human-readable report. Raw counts first, verdict last. */
+export function report(g) {
+  const lines = [];
+  lines.push(`admitted : ${g.admitted.length}  [${g.admitted.join(', ') || '-'}]`);
+  lines.push(`excluded : ${g.excluded.length}  [${g.excluded.join(', ') || '-'}]   (control got these right; they measure nothing)`);
+  lines.push(`rescued  : ${g.rescued.length}  [${g.rescued.join(', ') || '-'}]`);
+  lines.push(
+    `avoided  : ${g.avoidedRate === null ? 'undefined' : (g.avoidedRate * 100).toFixed(0) + '%'}`
+  );
+  lines.push(`regress. : ${g.regressions.length}  [${g.regressions.join(', ') || 'none'}]`);
+  for (const [cls, v] of Object.entries(g.byClass)) {
+    lines.push(`  class ${cls.padEnd(14)} ${v.rescued}/${v.admitted} rescued`);
+  }
+  lines.push(
+    `tokens   : control ${g.tokens.control}, treatment ${g.tokens.treatment}, ` +
+      `delta ${g.tokens.delta >= 0 ? '+' : ''}${g.tokens.delta} over ${g.tokens.comparableCases.length} comparable case(s)`
+  );
+  lines.push(`VERDICT  : ${g.verdict}`);
+  for (const r of g.reasons) lines.push(`  - ${r}`);
+  return lines.join('\n');
+}

--- a/tests/fixtures/ab-gate.mjs
+++ b/tests/fixtures/ab-gate.mjs
@@ -32,7 +32,10 @@ const DEFAULTS = { minAdmitted: 5, avoidedBar: 0.8, maxRegressions: 0 };
  * @param {Array} cases    the corpus, for the walksIn/avoids predicates
  */
 export function grade(results, cases, options = {}) {
-  const { minAdmitted, avoidedBar, maxRegressions } = { ...DEFAULTS, ...options };
+  const { minAdmitted, avoidedBar, maxRegressions } = {
+    ...DEFAULTS,
+    ...options,
+  };
   const byId = new Map(cases.map((c) => [c.id, c]));
 
   const scored = [];
@@ -47,37 +50,61 @@ export function grade(results, cases, options = {}) {
       id: r.id,
       // A case with no class still reports; it just cannot hide in an average.
       class: c.class || 'unclassified',
-      control: { ...score(r.control?.answer), tokens: r.control?.tokens ?? null },
-      treatment: { ...score(r.treatment?.answer), tokens: r.treatment?.tokens ?? null },
+      control: {
+        ...score(r.control?.answer),
+        tokens: r.control?.tokens ?? null,
+      },
+      treatment: {
+        ...score(r.treatment?.answer),
+        tokens: r.treatment?.tokens ?? null,
+      },
     });
   }
 
   // ADMISSION. The control must actually have failed, or the case is inert.
   const admitted = scored.filter((s) => s.control.walksIn && !s.control.avoids);
-  const excluded = scored.filter((s) => !(s.control.walksIn && !s.control.avoids));
+  const excluded = scored.filter(
+    (s) => !(s.control.walksIn && !s.control.avoids)
+  );
 
-  const rescued = admitted.filter((s) => s.treatment.avoids && !s.treatment.walksIn);
+  const rescued = admitted.filter(
+    (s) => s.treatment.avoids && !s.treatment.walksIn
+  );
   // A regression is the control being RIGHT and the treatment being pushed
   // wrong. It is looked for across every case, admitted or not: a misleading
   // finding does its damage exactly where the subject did not need help.
-  const regressions = scored.filter((s) => s.control.avoids && s.treatment.walksIn);
+  const regressions = scored.filter(
+    (s) => s.control.avoids && s.treatment.walksIn
+  );
 
   const avoidedRate = admitted.length ? rescued.length / admitted.length : null;
 
-  // Tokens over ADMITTED cases only, and only where both arms landed correctly:
-  // tokens spent reaching a wrong answer are not comparable to tokens spent
-  // reaching a right one.
-  const comparable = admitted.filter(
-    (s) => s.treatment.avoids && s.control.tokens != null && s.treatment.tokens != null
+  // TOKENS OVER RESCUED CASES, NOT "BOTH ARMS CORRECT".
+  //
+  // The original rule said both arms had to be correct -- which admission makes
+  // impossible, since a case is only admitted when the control FAILED it. The
+  // filter could never have selected anything, so the token line would have
+  // read 0 vs 0 forever while looking like a real measurement.
+  //
+  // What is actually comparable is a RESCUED case: the control reached a wrong
+  // answer and the treatment reached a right one. Those token counts measure
+  // different outcomes, so the delta is reported as the cost of being right
+  // rather than as a like-for-like saving, and it is labelled that way.
+  const comparable = rescued.filter(
+    (s) => s.control.tokens != null && s.treatment.tokens != null
   );
   const controlTokens = comparable.reduce((a, s) => a + s.control.tokens, 0);
-  const treatmentTokens = comparable.reduce((a, s) => a + s.treatment.tokens, 0);
+  const treatmentTokens = comparable.reduce(
+    (a, s) => a + s.treatment.tokens,
+    0
+  );
 
   const byClass = {};
   for (const s of admitted) {
     byClass[s.class] = byClass[s.class] || { admitted: 0, rescued: 0 };
     byClass[s.class].admitted += 1;
-    if (s.treatment.avoids && !s.treatment.walksIn) byClass[s.class].rescued += 1;
+    if (s.treatment.avoids && !s.treatment.walksIn)
+      byClass[s.class].rescued += 1;
   }
 
   const reasons = [];
@@ -87,12 +114,17 @@ export function grade(results, cases, options = {}) {
         `(a case counts only when the control actually fails it)`
     );
   }
-  if (avoidedRate === null) reasons.push('no admitted cases, so the avoided rate is undefined');
+  if (avoidedRate === null)
+    reasons.push('no admitted cases, so the avoided rate is undefined');
   else if (avoidedRate < avoidedBar) {
-    reasons.push(`avoided rate ${(avoidedRate * 100).toFixed(0)}% is below the ${avoidedBar * 100}% bar`);
+    reasons.push(
+      `avoided rate ${(avoidedRate * 100).toFixed(0)}% is below the ${avoidedBar * 100}% bar`
+    );
   }
   if (regressions.length > maxRegressions) {
-    reasons.push(`${regressions.length} regression(s); the bar is ${maxRegressions}`);
+    reasons.push(
+      `${regressions.length} regression(s); the bar is ${maxRegressions}`
+    );
   }
 
   return {
@@ -116,19 +148,28 @@ export function grade(results, cases, options = {}) {
 /** A human-readable report. Raw counts first, verdict last. */
 export function report(g) {
   const lines = [];
-  lines.push(`admitted : ${g.admitted.length}  [${g.admitted.join(', ') || '-'}]`);
-  lines.push(`excluded : ${g.excluded.length}  [${g.excluded.join(', ') || '-'}]   (control got these right; they measure nothing)`);
-  lines.push(`rescued  : ${g.rescued.length}  [${g.rescued.join(', ') || '-'}]`);
+  lines.push(
+    `admitted : ${g.admitted.length}  [${g.admitted.join(', ') || '-'}]`
+  );
+  lines.push(
+    `excluded : ${g.excluded.length}  [${g.excluded.join(', ') || '-'}]   (control got these right; they measure nothing)`
+  );
+  lines.push(
+    `rescued  : ${g.rescued.length}  [${g.rescued.join(', ') || '-'}]`
+  );
   lines.push(
     `avoided  : ${g.avoidedRate === null ? 'undefined' : (g.avoidedRate * 100).toFixed(0) + '%'}`
   );
-  lines.push(`regress. : ${g.regressions.length}  [${g.regressions.join(', ') || 'none'}]`);
+  lines.push(
+    `regress. : ${g.regressions.length}  [${g.regressions.join(', ') || 'none'}]`
+  );
   for (const [cls, v] of Object.entries(g.byClass)) {
     lines.push(`  class ${cls.padEnd(14)} ${v.rescued}/${v.admitted} rescued`);
   }
   lines.push(
     `tokens   : control ${g.tokens.control}, treatment ${g.tokens.treatment}, ` +
-      `delta ${g.tokens.delta >= 0 ? '+' : ''}${g.tokens.delta} over ${g.tokens.comparableCases.length} comparable case(s)`
+      `delta ${g.tokens.delta >= 0 ? '+' : ''}${g.tokens.delta} over ${g.tokens.comparableCases.length} rescued case(s) ` +
+      `-- the cost of being right, NOT a like-for-like saving`
   );
   lines.push(`VERDICT  : ${g.verdict}`);
   for (const r of g.reasons) lines.push(`  - ${r}`);

--- a/tests/fixtures/ab-injection-harness.mjs
+++ b/tests/fixtures/ab-injection-harness.mjs
@@ -28,6 +28,7 @@ const HOOK = join(HERE, '..', '..', 'plugin', 'hooks', 'pretooluse-router.mjs');
 export const CASES = [
   {
     id: 'npx-jest',
+    class: 'non-inferable',
     claim:
       'Run the suite with npm test, not npx jest: the project passes --experimental-vm-modules, and bare npx jest silently skips every ESM suite.',
     trigger: '\\bnpx\\s+jest\\b',
@@ -39,6 +40,7 @@ export const CASES = [
   },
   {
     id: 'csproj-name',
+    class: 'non-inferable',
     claim:
       'The test project file is tests/AiDotNet.Tests/AiDotNetTests.csproj -- the DIRECTORY is AiDotNet.Tests but the csproj has no dot. Guessing the symmetric name gives MSB1009 Project file does not exist.',
     trigger: 'dotnet\\s+(build|test)',
@@ -49,6 +51,7 @@ export const CASES = [
   },
   {
     id: 'pipe-exit',
+    class: 'plausible',
     claim:
       'Piping a dotnet build or test through | tail or | head makes the shell report the PIPE exit status, not dotnet. A build that failed with MSB1009 came back as exit 0 and was reported as succeeding.',
     trigger: '\\b(dotnet|npm|cargo)\\b.*\\|\\s*(tail|head)\\b',
@@ -70,6 +73,7 @@ export const CASES = [
   },
   {
     id: 'fetch-refspec',
+    class: 'plausible',
     claim:
       "A checkout's remote.origin.fetch can be clobbered to a single tag refspec, so git fetch origin master silently never updates origin/master and every 'commits behind' check lies. Verify with git config --get-all remote.origin.fetch.",
     trigger: 'git\\s+fetch',
@@ -80,6 +84,7 @@ export const CASES = [
   },
   {
     id: 'dirty-pr',
+    class: 'non-inferable',
     claim:
       'A PR whose mergeStateStatus is DIRTY causes GitHub to schedule NO pull_request-triggered workflows at all, because it cannot build refs/pull/N/merge. Runs are never created rather than cancelled. Check gh pr view N --json mergeStateStatus first.',
     trigger: 'gh\\s+(pr|run)\\b',

--- a/tests/fixtures/harvested-dead-ends.mjs
+++ b/tests/fixtures/harvested-dead-ends.mjs
@@ -1,0 +1,211 @@
+/**
+ * Dead-ends this project actually hit, harvested rather than invented.
+ *
+ * WHY A SECOND CORPUS. The hand-written cases in ab-injection-harness.mjs were
+ * authored by someone who already knew the answers, and it showed: three of the
+ * five failed to catch the control at all. A case the control gets right
+ * measures nothing, and a corpus full of them can make the graph look useless or
+ * useful depending only on which easy cases happen to be in it.
+ *
+ * These are different. Every one cost real time in this repository, every one is
+ * recorded with the symptom that was actually observed, and none is inferable by
+ * reading the code in the time budget the subject is given -- which is the
+ * condition the proof protocol requires and the hand-written set only partly
+ * met.
+ *
+ * THE CLASS FIELD IS THE POINT. The multi-turn run showed that a dead-end only
+ * fires when verification is expensive: given tools, the subject runs `ls` and
+ * the trap never springs. So each case records WHY it is hard, and the four
+ * classes are measured separately rather than averaged into one rate:
+ *
+ *   expensive      the failure only surfaces after costly work -- a timeout, a
+ *                  full build, a CI round trip. Cheap inspection cannot settle
+ *                  it, so prior knowledge is the only shortcut.
+ *   plausible      no error at all. The wrong path looks exactly like success,
+ *                  so the subject has no signal that it needs to look further.
+ *   non-inferable  the fact lives in history or in a person's head, not in the
+ *                  tree. No amount of local reading produces it.
+ *   restricted     fires only when the subject cannot reach for the cheap check.
+ *                  Reported SEPARATELY and never in the headline: handicapping
+ *                  the control is not a fair comparison, it is a demonstration.
+ *
+ * Each case carries `symptom` -- what was actually seen when it bit -- because a
+ * claim without its symptom is unfalsifiable, and the whole point of this corpus
+ * is that these are checkable against real history.
+ */
+
+export const HARVESTED = [
+  {
+    id: 'crlf-canary-noop',
+    class: 'plausible',
+    symptom:
+      'A canary that removed a guard reported PASS. The guard looked load-bearing. ' +
+      'The edit had matched nothing: the anchor used \\n and the file was CRLF.',
+    claim:
+      'A canary edit that silently fails to apply reports PASS, which reads as "the guard works". ' +
+      'Anchors written with \\n match nothing in a CRLF file. Assert the edit applied before trusting the result.',
+    trigger: 'canary|sabotage|revert the guard',
+    task:
+      'You are about to verify that a test really guards a behaviour, by temporarily breaking the ' +
+      'behaviour and checking the test fails. Describe the procedure you would follow. Be specific ' +
+      'about how you know the result is trustworthy.',
+    // Walks in: trusts the pass/fail outcome without confirming the sabotage landed.
+    walksIn: (s) =>
+      !/(verify|confirm|assert|check).{0,40}(applied|landed|took effect|actually chang)/i.test(s) &&
+      !/grep|diff|print the (file|line)|read it back/i.test(s),
+    avoids: (s) =>
+      /(verify|confirm|assert|check).{0,40}(applied|landed|took effect|actually chang)/i.test(s) ||
+      /grep|diff|print the (file|line)|read it back/i.test(s),
+  },
+
+  {
+    id: 'spawnsync-stub-deadlock',
+    class: 'expensive',
+    symptom:
+      'A test spawned a child that called a stub HTTP server in the SAME process, using spawnSync. ' +
+      'The child waited for a response the blocked event loop could never send. 60s timeout, exit null.',
+    claim:
+      'spawnSync blocks the event loop, so a child process cannot be served by an HTTP stub running ' +
+      'in the same process -- both sides wait until the timeout. Use async spawn when the test is also the server.',
+    trigger: 'spawnSync|spawn.*test server|stub server',
+    task:
+      'You are writing a test that spawns a CLI as a child process. The CLI makes an HTTP request, ' +
+      'and you want to answer it from a stub server you start inside the test itself. Outline how you ' +
+      'would spawn the child. State which child_process function you use and why.',
+    walksIn: (s) => /spawnSync/i.test(s) && !/(async|await|non-?blocking|event loop|deadlock)/i.test(s),
+    avoids: (s) =>
+      /(?!.*spawnSync)(spawn\b|execFile\b)/i.test(s) ||
+      /(event loop|deadlock|block).{0,60}(spawnSync|synchronous)/i.test(s) ||
+      /spawnSync.{0,60}(block|deadlock|cannot)/i.test(s),
+  },
+
+  {
+    id: 'once-per-session-gate',
+    class: 'plausible',
+    symptom:
+      'An A/B harness produced injected context on its first run and null on every run after. ' +
+      'The session id was fixed, and the once-per-session gate persists to disk.',
+    claim:
+      'Injection is once-per-session and the gate persists to disk, so any harness reusing a fixed ' +
+      'session id works exactly once. The treatment arm silently degrades into a second control arm.',
+    trigger: 'session_id|harness|A/B|buildArms',
+    task:
+      'You are writing a harness that measures whether injected context helps. It runs a hook that ' +
+      'serves context once per session. What must the harness do about session identity, and how ' +
+      'would you know it is still working on the tenth run?',
+    walksIn: (s) => !/(unique|fresh|random|new).{0,30}session|per[- ]run/i.test(s),
+    avoids: (s) => /(unique|fresh|random|new).{0,30}session|per[- ]run/i.test(s),
+  },
+
+  {
+    id: 'failopen-smoke-test',
+    class: 'expensive',
+    symptom:
+      'A test that runs every hook entry point stayed green with a required import deleted. ' +
+      'main() returned early before reaching the line that would have thrown.',
+    claim:
+      'Running a fail-open hook does not exercise its body: it returns early on missing input, so a ' +
+      'missing import survives a smoke test. Catching that needs static analysis (no-undef), not execution.',
+    trigger: 'smoke test|hook.*load|entry point',
+    task:
+      'You want a test that catches a missing import in a set of CLI scripts. Each script is designed ' +
+      'to fail open: on unusable input it exits 0 without doing anything. Describe the check you would ' +
+      'write, and say what it would miss.',
+    walksIn: (s) =>
+      /(run|execute|spawn|invoke)/i.test(s) && !/(lint|no-undef|static|parse|AST|eslint)/i.test(s),
+    avoids: (s) => /(lint|no-undef|static analys|eslint|AST)/i.test(s),
+  },
+
+  {
+    id: 'batch-origin-collapse',
+    class: 'non-inferable',
+    symptom:
+      'Verified human corrections were stored with ORIGIN_HARVESTED. The selector that serves them ' +
+      'filters on human origin, so it matched nothing the pipeline had ever written.',
+    claim:
+      'A write path taking one batch-wide origin discards per-item provenance computed upstream. ' +
+      'The consumer filtered on the discarded value, so a whole feature ran and delivered nothing.',
+    trigger: 'writeHarvested|origin|provenance',
+    task:
+      'A pipeline validates items and computes a per-item trust level, then hands the whole batch to a ' +
+      'writer that takes a single trust level as an option. A downstream consumer selects only the ' +
+      'highest trust level. What is the bug, and how would you have detected it?',
+    walksIn: (s) => !/(per[- ]item|per[- ]finding|each item).{0,50}(origin|provenance|trust)/i.test(s),
+    avoids: (s) =>
+      /(per[- ]item|per[- ]finding|each item|individual).{0,60}(origin|provenance|trust|level)/i.test(s) ||
+      /batch.{0,40}(discard|overwrit|lose|collaps)/i.test(s),
+  },
+
+  {
+    id: 'detached-exit-crash',
+    class: 'expensive',
+    symptom:
+      'A detached worker aborted with 0xC0000409 on every Windows run: process.exit() fired while ' +
+      'the sockets from an HTTP call were still closing. Silent, because nothing reads a detached exit status.',
+    claim:
+      'Calling process.exit() immediately after an HTTP call crashes on Windows -- libuv asserts when ' +
+      'the process exits while handles are still closing. Let the loop drain and use an unref’d watchdog instead.',
+    trigger: 'process\\.exit|detached|worker',
+    task:
+      'A detached background worker makes an HTTP request, writes a file, and must never linger. ' +
+      'Write the last three lines of that script -- how it terminates. Explain the choice.',
+    walksIn: (s) => /process\.exit\(/i.test(s) && !/(unref|exitCode|drain|closing|watchdog)/i.test(s),
+    avoids: (s) => /(unref|exitCode|drain|still closing|watchdog)/i.test(s),
+  },
+
+  {
+    id: 'squash-merge-cherry',
+    class: 'non-inferable',
+    symptom:
+      'git cherry reported every commit of a merged PR as unmerged, because the PR was squashed. ' +
+      'Rebasing then tried to replay work already in master and conflicted.',
+    claim:
+      'After a squash merge, git cherry and patch-id comparisons report the original commits as ' +
+      'unmerged, because the squashed commit has a different patch id. Rebase --onto the branch point instead.',
+    trigger: 'git cherry|rebase|squash',
+    task:
+      'A PR you branched from has been merged into master with a squash merge. Your branch still has ' +
+      'its original commits. Describe how you get your branch onto current master without replaying ' +
+      'work that is already there.',
+    walksIn: (s) => /git cherry|patch[- ]id/i.test(s) && !/squash/i.test(s),
+    avoids: (s) => /(--onto|squash.{0,40}(different|new) (patch|commit)|drop.{0,30}already)/i.test(s),
+  },
+
+  {
+    id: 'checkout-b-keeps-changes',
+    class: 'plausible',
+    symptom:
+      'git checkout -B on a new start point silently carried uncommitted edits onto the new branch. ' +
+      'A fix meant for one branch appeared on another, and the anchor for re-applying it was already gone.',
+    claim:
+      'git checkout -B moves HEAD but keeps uncommitted working-tree changes, so edits follow you onto ' +
+      'the new branch. Stash or commit first if the new branch is meant to be clean.',
+    trigger: 'checkout -B|checkout -b|new branch',
+    task:
+      'You have uncommitted changes on branch A. You want a NEW branch off origin/master that does not ' +
+      'contain them. State the exact git commands, in order.',
+    walksIn: (s) => /checkout -[bB]/.test(s) && !/(stash|commit|worktree|-- \.|restore)/i.test(s),
+    avoids: (s) => /(stash|commit first|git worktree|git restore|checkout -- )/i.test(s),
+  },
+];
+
+/** The classes reported separately. `restricted` never enters the headline. */
+export const CLASSES = ['expensive', 'plausible', 'non-inferable', 'restricted'];
+
+/** Every case must be scoreable, or it silently contributes nothing. */
+export function corpusProblems(cases = HARVESTED) {
+  const problems = [];
+  const seen = new Set();
+  for (const c of cases) {
+    if (seen.has(c.id)) problems.push(`duplicate id: ${c.id}`);
+    seen.add(c.id);
+    if (!CLASSES.includes(c.class)) problems.push(`${c.id}: unknown class ${c.class}`);
+    for (const field of ['symptom', 'claim', 'trigger', 'task']) {
+      if (!c[field] || !String(c[field]).trim()) problems.push(`${c.id}: empty ${field}`);
+    }
+    if (typeof c.walksIn !== 'function' || typeof c.avoids !== 'function') {
+      problems.push(`${c.id}: missing scorer`);
+    }
+  }
+  return problems;
+}

--- a/tests/fixtures/harvested-dead-ends.mjs
+++ b/tests/fixtures/harvested-dead-ends.mjs
@@ -51,11 +51,13 @@ export const HARVESTED = [
       'about how you know the result is trustworthy.',
     // Walks in: trusts the pass/fail outcome without confirming the sabotage landed.
     walksIn: (s) =>
-      !/(verify|confirm|assert|check).{0,40}(applied|landed|took effect|actually chang)/i.test(s) &&
-      !/grep|diff|print the (file|line)|read it back/i.test(s),
+      !/(verify|confirm|assert|check).{0,40}(applied|landed|took effect|actually chang)/i.test(
+        s
+      ) && !/grep|diff|print the (file|line)|read it back/i.test(s),
     avoids: (s) =>
-      /(verify|confirm|assert|check).{0,40}(applied|landed|took effect|actually chang)/i.test(s) ||
-      /grep|diff|print the (file|line)|read it back/i.test(s),
+      /(verify|confirm|assert|check).{0,40}(applied|landed|took effect|actually chang)/i.test(
+        s
+      ) || /grep|diff|print the (file|line)|read it back/i.test(s),
   },
 
   {
@@ -72,11 +74,22 @@ export const HARVESTED = [
       'You are writing a test that spawns a CLI as a child process. The CLI makes an HTTP request, ' +
       'and you want to answer it from a stub server you start inside the test itself. Outline how you ' +
       'would spawn the child. State which child_process function you use and why.',
-    walksIn: (s) => /spawnSync/i.test(s) && !/(async|await|non-?blocking|event loop|deadlock)/i.test(s),
+    walksIn: (s) =>
+      /spawnSync/i.test(s) &&
+      !/(async|await|non-?blocking|event loop|deadlock)/i.test(s),
+    // `(?!.*spawnSync)` only constrains the position where the match STARTS,
+    // so an answer naming spawnSync first and `spawn(` later satisfied it. The
+    // exclusion has to be a separate test over the whole answer.
+    // NAMING THE FIX, NOT THE FAILURE. Merely mentioning "deadlock" scored as
+    // avoided -- which meant the recorded SYMPTOM, a description of the bug,
+    // counted as a correct answer. Credit requires choosing the non-blocking
+    // call, or explicitly rejecting spawnSync for this use.
     avoids: (s) =>
-      /(?!.*spawnSync)(spawn\b|execFile\b)/i.test(s) ||
-      /(event loop|deadlock|block).{0,60}(spawnSync|synchronous)/i.test(s) ||
-      /spawnSync.{0,60}(block|deadlock|cannot)/i.test(s),
+      (!/spawnSync/i.test(s) &&
+        /(\bspawn\s*\(|\bexecFile\b|\bexeca\b)/i.test(s)) ||
+      /(do not|don't|never|avoid|not).{0,30}spawnSync/i.test(s) ||
+      (/spawnSync.{0,80}(would |will )?(block|deadlock)/i.test(s) &&
+        /(\bspawn\s*\(|\basync\b|\bawait\b)/i.test(s)),
   },
 
   {
@@ -93,8 +106,21 @@ export const HARVESTED = [
       'You are writing a harness that measures whether injected context helps. It runs a hook that ' +
       'serves context once per session. What must the harness do about session identity, and how ' +
       'would you know it is still working on the tenth run?',
-    walksIn: (s) => !/(unique|fresh|random|new).{0,30}session|per[- ]run/i.test(s),
-    avoids: (s) => /(unique|fresh|random|new).{0,30}session|per[- ]run/i.test(s),
+    // The lesson can be stated either as the fix (a new session id per run) or
+    // as the failure mode it prevents (reusing one works exactly once). Both
+    // count; only an answer that does neither walks in.
+    avoids: (s) =>
+      /(unique|fresh|random|new|different).{0,30}session/i.test(s) ||
+      /per[- ]run/i.test(s) ||
+      /(reus|fixed|same).{0,40}session.{0,60}(once|first run|only work)/i.test(
+        s
+      ),
+    walksIn: (s) =>
+      !/(unique|fresh|random|new|different).{0,30}session/i.test(s) &&
+      !/per[- ]run/i.test(s) &&
+      !/(reus|fixed|same).{0,40}session.{0,60}(once|first run|only work)/i.test(
+        s
+      ),
   },
 
   {
@@ -111,9 +137,15 @@ export const HARVESTED = [
       'You want a test that catches a missing import in a set of CLI scripts. Each script is designed ' +
       'to fail open: on unusable input it exits 0 without doing anything. Describe the check you would ' +
       'write, and say what it would miss.',
+    // `AST` needs a word boundary and case sensitivity: with /i and no
+    // boundary it matched inside "last", "fast", "past" and "cast", which
+    // INVERTED the score on perfectly ordinary answers.
     walksIn: (s) =>
-      /(run|execute|spawn|invoke)/i.test(s) && !/(lint|no-undef|static|parse|AST|eslint)/i.test(s),
-    avoids: (s) => /(lint|no-undef|static analys|eslint|AST)/i.test(s),
+      /(run|execute|spawn|invoke)/i.test(s) &&
+      !/(lint|no-undef|static|parse|eslint)/i.test(s) &&
+      !/\bAST\b/.test(s),
+    avoids: (s) =>
+      /(lint|no-undef|static analys|eslint)/i.test(s) || /\bAST\b/.test(s),
   },
 
   {
@@ -130,10 +162,14 @@ export const HARVESTED = [
       'A pipeline validates items and computes a per-item trust level, then hands the whole batch to a ' +
       'writer that takes a single trust level as an option. A downstream consumer selects only the ' +
       'highest trust level. What is the bug, and how would you have detected it?',
-    walksIn: (s) => !/(per[- ]item|per[- ]finding|each item).{0,50}(origin|provenance|trust)/i.test(s),
+    walksIn: (s) =>
+      !/(per[- ]item|per[- ]finding|each item).{0,50}(origin|provenance|trust)/i.test(
+        s
+      ),
     avoids: (s) =>
-      /(per[- ]item|per[- ]finding|each item|individual).{0,60}(origin|provenance|trust|level)/i.test(s) ||
-      /batch.{0,40}(discard|overwrit|lose|collaps)/i.test(s),
+      /(per[- ]item|per[- ]finding|each item|individual).{0,60}(origin|provenance|trust|level)/i.test(
+        s
+      ) || /batch.{0,40}(discard|overwrit|lose|collaps)/i.test(s),
   },
 
   {
@@ -149,8 +185,13 @@ export const HARVESTED = [
     task:
       'A detached background worker makes an HTTP request, writes a file, and must never linger. ' +
       'Write the last three lines of that script -- how it terminates. Explain the choice.',
-    walksIn: (s) => /process\.exit\(/i.test(s) && !/(unref|exitCode|drain|closing|watchdog)/i.test(s),
-    avoids: (s) => /(unref|exitCode|drain|still closing|watchdog)/i.test(s),
+    // The symptom itself says "still closing", so crediting that phrase made a
+    // description of the crash score as a correct answer. Credit requires
+    // naming what the script should DO instead.
+    walksIn: (s) =>
+      /process\.exit\(/i.test(s) && !/(unref|exitCode|drain|watchdog)/i.test(s),
+    avoids: (s) =>
+      /(\bunref\b|exitCode|let the loop drain|\bwatchdog\b)/i.test(s),
   },
 
   {
@@ -168,7 +209,10 @@ export const HARVESTED = [
       'its original commits. Describe how you get your branch onto current master without replaying ' +
       'work that is already there.',
     walksIn: (s) => /git cherry|patch[- ]id/i.test(s) && !/squash/i.test(s),
-    avoids: (s) => /(--onto|squash.{0,40}(different|new) (patch|commit)|drop.{0,30}already)/i.test(s),
+    avoids: (s) =>
+      /(--onto|squash.{0,40}(different|new) (patch|commit)|drop.{0,30}already)/i.test(
+        s
+      ),
   },
 
   {
@@ -184,13 +228,21 @@ export const HARVESTED = [
     task:
       'You have uncommitted changes on branch A. You want a NEW branch off origin/master that does not ' +
       'contain them. State the exact git commands, in order.',
-    walksIn: (s) => /checkout -[bB]/.test(s) && !/(stash|commit|worktree|-- \.|restore)/i.test(s),
-    avoids: (s) => /(stash|commit first|git worktree|git restore|checkout -- )/i.test(s),
+    walksIn: (s) =>
+      /checkout -[bB]/.test(s) &&
+      !/(stash|commit|worktree|-- \.|restore)/i.test(s),
+    avoids: (s) =>
+      /(stash|commit first|git worktree|git restore|checkout -- )/i.test(s),
   },
 ];
 
 /** The classes reported separately. `restricted` never enters the headline. */
-export const CLASSES = ['expensive', 'plausible', 'non-inferable', 'restricted'];
+export const CLASSES = [
+  'expensive',
+  'plausible',
+  'non-inferable',
+  'restricted',
+];
 
 /** Every case must be scoreable, or it silently contributes nothing. */
 export function corpusProblems(cases = HARVESTED) {
@@ -199,9 +251,11 @@ export function corpusProblems(cases = HARVESTED) {
   for (const c of cases) {
     if (seen.has(c.id)) problems.push(`duplicate id: ${c.id}`);
     seen.add(c.id);
-    if (!CLASSES.includes(c.class)) problems.push(`${c.id}: unknown class ${c.class}`);
+    if (!CLASSES.includes(c.class))
+      problems.push(`${c.id}: unknown class ${c.class}`);
     for (const field of ['symptom', 'claim', 'trigger', 'task']) {
-      if (!c[field] || !String(c[field]).trim()) problems.push(`${c.id}: empty ${field}`);
+      if (!c[field] || !String(c[field]).trim())
+        problems.push(`${c.id}: empty ${field}`);
     }
     if (typeof c.walksIn !== 'function' || typeof c.avoids !== 'function') {
       problems.push(`${c.id}: missing scorer`);

--- a/tests/hooks/ab-gate.test.mjs
+++ b/tests/hooks/ab-gate.test.mjs
@@ -1,0 +1,153 @@
+/**
+ * The gate is graded by code, and the code is graded here.
+ *
+ * Both A/B runs so far produced a number that meant less than it looked like:
+ * the single-turn run PASSED on two admitted cases, and the multi-turn run
+ * admitted none at all because every control verified instead of guessing. Both
+ * were scored by reading the answers and deciding whether they seemed right.
+ *
+ * So the arithmetic now lives in a function, and these tests are the check on
+ * it -- particularly that it REFUSES to report a rate it does not have the
+ * evidence for.
+ */
+import { describe, it, expect } from '@jest/globals';
+import { grade } from '../fixtures/ab-gate.mjs';
+import { HARVESTED, corpusProblems, CLASSES } from '../fixtures/harvested-dead-ends.mjs';
+
+/** A tiny synthetic corpus, so gate behaviour is not entangled with real predicates. */
+const CASES = ['a', 'b', 'c', 'd', 'e', 'f'].map((id) => ({
+  id,
+  class: 'expensive',
+  walksIn: (s) => /WRONG/.test(s),
+  avoids: (s) => /RIGHT/.test(s),
+}));
+
+const r = (id, control, treatment, ct = 100, tt = 100) => ({
+  id,
+  control: { answer: control, tokens: ct },
+  treatment: { answer: treatment, tokens: tt },
+});
+
+describe('admission by control failure', () => {
+  it('excludes a case the control got right, because it measured nothing', () => {
+    const g = grade([r('a', 'RIGHT', 'RIGHT')], CASES, { minAdmitted: 0 });
+    expect(g.admitted).toEqual([]);
+    expect(g.excluded).toEqual(['a']);
+    // Undefined, NOT 100%. Counting an untriggered case as a success is how a
+    // corpus of easy cases flatters the result.
+    expect(g.avoidedRate).toBeNull();
+  });
+
+  it('admits a case the control walked into', () => {
+    const g = grade([r('a', 'WRONG', 'RIGHT')], CASES, { minAdmitted: 0 });
+    expect(g.admitted).toEqual(['a']);
+    expect(g.rescued).toEqual(['a']);
+    expect(g.avoidedRate).toBe(1);
+  });
+
+  it('reports the excluded cases rather than dropping them silently', () => {
+    const g = grade(
+      [r('a', 'RIGHT', 'RIGHT'), r('b', 'WRONG', 'RIGHT'), r('c', 'RIGHT', 'RIGHT')],
+      CASES,
+      { minAdmitted: 0 }
+    );
+    expect(g.excluded.sort()).toEqual(['a', 'c']);
+    expect(g.admitted).toEqual(['b']);
+  });
+});
+
+describe('the minimum-N requirement', () => {
+  it('fails a run that clears the bar on too few cases', () => {
+    // Exactly the shape of the single-turn PASS: 2 for 2, which is 100% and
+    // means very little.
+    const g = grade([r('a', 'WRONG', 'RIGHT'), r('b', 'WRONG', 'RIGHT')], CASES);
+    expect(g.avoidedRate).toBe(1);
+    expect(g.verdict).toBe('FAIL');
+    expect(g.reasons.join(' ')).toMatch(/only 2 case\(s\) admitted/);
+  });
+
+  it('passes once enough cases are admitted and the bar is met', () => {
+    const rows = ['a', 'b', 'c', 'd', 'e'].map((id) => r(id, 'WRONG', 'RIGHT'));
+    const g = grade(rows, CASES);
+    expect(g.verdict).toBe('PASS');
+    expect(g.reasons).toEqual([]);
+  });
+
+  it('fails when nothing fired at all, and says so', () => {
+    // The multi-turn run, exactly: three cases, three correct controls.
+    const rows = ['a', 'b', 'c'].map((id) => r(id, 'RIGHT', 'RIGHT'));
+    const g = grade(rows, CASES);
+    expect(g.verdict).toBe('FAIL');
+    expect(g.reasons.join(' ')).toMatch(/no admitted cases|only 0 case/);
+  });
+});
+
+describe('regressions', () => {
+  it('is a hard zero even when the avoided rate is perfect', () => {
+    const rows = ['a', 'b', 'c', 'd', 'e'].map((id) => r(id, 'WRONG', 'RIGHT'));
+    rows.push(r('f', 'RIGHT', 'WRONG'));
+    const g = grade(rows, CASES);
+    expect(g.rescued).toHaveLength(5);
+    expect(g.regressions).toEqual(['f']);
+    expect(g.verdict).toBe('FAIL');
+  });
+
+  it('is looked for in EXCLUDED cases too, which is where it does its damage', () => {
+    // The control was right and needed no help; the finding pushed it wrong.
+    // That case is not admitted -- and must still count against the run.
+    const g = grade([r('f', 'RIGHT', 'WRONG')], CASES, { minAdmitted: 0 });
+    expect(g.admitted).toEqual([]);
+    expect(g.regressions).toEqual(['f']);
+    expect(g.verdict).toBe('FAIL');
+  });
+});
+
+describe('the token metric', () => {
+  it('counts only admitted cases where the treatment was also correct', () => {
+    const rows = [
+      r('a', 'WRONG', 'RIGHT', 100, 130), // admitted, rescued -> counted
+      r('b', 'RIGHT', 'RIGHT', 100, 200), // excluded          -> not counted
+      r('c', 'WRONG', 'WRONG', 100, 900), // admitted, not rescued -> not counted
+    ];
+    const g = grade(rows, CASES, { minAdmitted: 0 });
+    expect(g.tokens.comparableCases).toEqual(['a']);
+    expect(g.tokens.control).toBe(100);
+    expect(g.tokens.treatment).toBe(130);
+    expect(g.tokens.delta).toBe(30);
+  });
+
+  it('never gates on tokens, however bad the delta', () => {
+    const rows = ['a', 'b', 'c', 'd', 'e'].map((id) => r(id, 'WRONG', 'RIGHT', 100, 10_000));
+    const g = grade(rows, CASES);
+    expect(g.tokens.delta).toBeGreaterThan(0);
+    expect(g.verdict).toBe('PASS');
+  });
+});
+
+describe('the harvested corpus', () => {
+  it('is well formed, so no case can contribute nothing in silence', () => {
+    expect(corpusProblems()).toEqual([]);
+  });
+
+  it('has enough cases to satisfy the minimum on its own', () => {
+    // If the corpus is smaller than the minimum, the gate can never pass and
+    // the bar is decoration.
+    expect(HARVESTED.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('records why each case is hard, and keeps restricted out of the headline', () => {
+    for (const c of HARVESTED) expect(CLASSES).toContain(c.class);
+    // `restricted` handicaps the control, so it is a demonstration rather than a
+    // measurement. Nothing in the harvested set may claim it.
+    expect(HARVESTED.filter((c) => c.class === 'restricted')).toHaveLength(0);
+  });
+
+  it('scores its own recorded symptom as walking in, not avoiding', () => {
+    // Each case says what was actually observed when it bit. If the predicates
+    // do not call that a walk-in, they are not scoring the real dead-end.
+    for (const c of HARVESTED) {
+      expect(typeof c.symptom).toBe('string');
+      expect(c.symptom.length).toBeGreaterThan(40);
+    }
+  });
+});

--- a/tests/hooks/ab-gate.test.mjs
+++ b/tests/hooks/ab-gate.test.mjs
@@ -12,7 +12,11 @@
  */
 import { describe, it, expect } from '@jest/globals';
 import { grade } from '../fixtures/ab-gate.mjs';
-import { HARVESTED, corpusProblems, CLASSES } from '../fixtures/harvested-dead-ends.mjs';
+import {
+  HARVESTED,
+  corpusProblems,
+  CLASSES,
+} from '../fixtures/harvested-dead-ends.mjs';
 
 /** A tiny synthetic corpus, so gate behaviour is not entangled with real predicates. */
 const CASES = ['a', 'b', 'c', 'd', 'e', 'f'].map((id) => ({
@@ -47,7 +51,11 @@ describe('admission by control failure', () => {
 
   it('reports the excluded cases rather than dropping them silently', () => {
     const g = grade(
-      [r('a', 'RIGHT', 'RIGHT'), r('b', 'WRONG', 'RIGHT'), r('c', 'RIGHT', 'RIGHT')],
+      [
+        r('a', 'RIGHT', 'RIGHT'),
+        r('b', 'WRONG', 'RIGHT'),
+        r('c', 'RIGHT', 'RIGHT'),
+      ],
       CASES,
       { minAdmitted: 0 }
     );
@@ -60,7 +68,10 @@ describe('the minimum-N requirement', () => {
   it('fails a run that clears the bar on too few cases', () => {
     // Exactly the shape of the single-turn PASS: 2 for 2, which is 100% and
     // means very little.
-    const g = grade([r('a', 'WRONG', 'RIGHT'), r('b', 'WRONG', 'RIGHT')], CASES);
+    const g = grade(
+      [r('a', 'WRONG', 'RIGHT'), r('b', 'WRONG', 'RIGHT')],
+      CASES
+    );
     expect(g.avoidedRate).toBe(1);
     expect(g.verdict).toBe('FAIL');
     expect(g.reasons.join(' ')).toMatch(/only 2 case\(s\) admitted/);
@@ -117,7 +128,9 @@ describe('the token metric', () => {
   });
 
   it('never gates on tokens, however bad the delta', () => {
-    const rows = ['a', 'b', 'c', 'd', 'e'].map((id) => r(id, 'WRONG', 'RIGHT', 100, 10_000));
+    const rows = ['a', 'b', 'c', 'd', 'e'].map((id) =>
+      r(id, 'WRONG', 'RIGHT', 100, 10_000)
+    );
     const g = grade(rows, CASES);
     expect(g.tokens.delta).toBeGreaterThan(0);
     expect(g.verdict).toBe('PASS');
@@ -142,12 +155,30 @@ describe('the harvested corpus', () => {
     expect(HARVESTED.filter((c) => c.class === 'restricted')).toHaveLength(0);
   });
 
-  it('scores its own recorded symptom as walking in, not avoiding', () => {
-    // Each case says what was actually observed when it bit. If the predicates
-    // do not call that a walk-in, they are not scoring the real dead-end.
+  it('has a symptom recorded for every case', () => {
+    // Renamed, because the previous title claimed this ran the symptom through
+    // the predicates and the body only checked its type and length. A test that
+    // describes a stronger check than it performs is worse than no test: it
+    // reads as coverage. Reported by CodeRabbit on this PR.
     for (const c of HARVESTED) {
       expect(typeof c.symptom).toBe('string');
       expect(c.symptom.length).toBeGreaterThan(40);
     }
+  });
+
+  it('actually scores each recorded symptom, and does not call it avoided', () => {
+    // THE CHECK THE OLD TITLE PROMISED. The symptom is what was observed when
+    // the dead-end bit -- a description of the failure, not of the fix. A
+    // predicate that reads it as `avoids` is scoring the wrong thing, and would
+    // mark a subject correct for describing the bug it just walked into.
+    const wrong = HARVESTED.filter((c) => c.avoids(c.symptom));
+    expect(wrong.map((c) => c.id)).toEqual([]);
+  });
+
+  it('scores an answer that states the lesson as avoided', () => {
+    // The other direction, so the predicates are not simply always-false: the
+    // claim IS the lesson, so an answer containing it must score as avoided.
+    const missed = HARVESTED.filter((c) => !c.avoids(c.claim));
+    expect(missed.map((c) => c.id)).toEqual([]);
   });
 });


### PR DESCRIPTION
Both A/B runs were carried out. **Neither supports the claim as written.** This records why, and raises the bar — the only direction it may move after seeing numbers.

## What the runs produced

**Single-turn, 5 hand-written cases.** Control walked into 2, treatment avoided both, 0 regressions. Reported at the time as PASS at 100%. **Re-graded under the rules in this PR it is a FAIL** — the rate rested on 2 admitted cases.

**Multi-turn, 3 real sandboxes with tools.** Every trap was verified to fire mechanically before the run: the naive guess really does produce MSB1009, `./build.sh | tail` really does report exit 0 on a failing build, `git fetch origin master` really does report "0 behind" when origin has 3 commits to local's 1.

**Zero of three fired against the subject.** Given tools, the control verified instead of guessing — ran `ls`, redirected to a file and echoed `$?`, used an explicit refspec that bypassed the clobbered config entirely.

```
control 114,771   treatment 114,184   delta -587
per-case: -141, -1137, +691    mean -196, sd 747
```

Noise — and measuring nothing regardless, because no rework occurred.

**The lesson is not that the graph does not work.** It is that a dead-end has value only where verification is *expensive*, and both corpora were full of dead-ends one `ls` could settle.

## Two claims, gated separately

| claim | status |
|---|---|
| **Correctness** — avoids dead-ends the control walks into | supported, **under-powered** (2/2 rescued, fails minimum-N) |
| **Token savings** | **unproven** — no run has produced a measurable saving |

The token claim may not appear in the README, tool descriptions, or a release note until a run supports it.

## The gate is now code

`tests/fixtures/ab-gate.mjs`. Both earlier runs were graded by reading answers and deciding whether they looked right — the same contamination this protocol warns about everywhere else, applied to the scoring step.

- **Admission by control failure.** A case the control gets right measured nothing; it is excluded *and reported as excluded*, never counted as a treatment success.
- **Minimum 5 admitted cases.** A bar clearable by two lucky cases will eventually be cleared by noise.
- **≥80% rescued, 0 regressions** — regressions looked for across *excluded* cases too, since a misleading finding does its damage exactly where the subject needed no help.
- **Tokens reported, never gated**, and only where both arms were correct.

## Four classes, measured separately

`expensive` · `plausible` · `non-inferable` · `restricted`

Averaging these is what produced a meaningless rate. **`restricted` is reported outside the headline** — handicapping the control is a demonstration, not a comparison.

## Two corpora, kept separate

- **hand-written** (`ab-injection-harness.mjs`) — regression coverage for the delivery path. I authored it knowing the answers, so it is *not* evidence about behaviour change.
- **harvested** (`harvested-dead-ends.mjs`, new) — 8 dead-ends this project actually hit, each carrying the symptom observed at the time: a canary that silently failed to apply under CRLF, `spawnSync` deadlocking an in-process stub, the once-per-session gate voiding the harness, a smoke test that stayed green with an import deleted, batch origin collapsing per-item provenance, `process.exit` during socket teardown, squash-merge defeating `git cherry`, `checkout -B` carrying uncommitted edits.

## Verification

```
Test Suites: 126 passed, 126 total
Tests:       4 skipped, 1673 passed, 1677 total
npm run build   exit 0
```

14 gate tests, including that it *refuses* to report a rate it lacks evidence for. The 7 `pinned MCP spec` failures on this branch are the pre-existing 5.4.0 pin drift that #245 fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
