### PR TITLE
fix(search): honour `path` and survive result sets V8 cannot spread

### DIFF
--- a/src/tools/file-operations/smart-glob.ts
+++ b/src/tools/file-operations/smart-glob.ts
@@ -35,6 +35,11 @@ export interface FileMetadata {
 
 export interface SmartGlobOptions {
   // Pattern options
+  /**
+   * Directory to search. The natural name for it, and the one the hook's
+   * refusal message leads callers to pass; takes precedence over `cwd`.
+   */
+  path?: string;
   cwd?: string; // Working directory (default: process.cwd())
   absolute?: boolean; // Return absolute paths (default: false)
 
@@ -130,7 +135,12 @@ export class SmartGlobTool {
 
     // Default options
     const opts: Required<SmartGlobOptions> = {
-      cwd: options.cwd ?? process.cwd(),
+      // See smart-grep.ts: `path` was silently discarded, so a scoped search
+      // actually ran from the server's own launch directory. This tool did not
+      // crash on it -- it returned confident results from the wrong tree, which
+      // is the worse of the two failures.
+      cwd: options.path ?? options.cwd ?? process.cwd(),
+      path: options.path ?? '',
       absolute: options.absolute ?? false,
       // `dist` and `build` are conventions, not guarantees. Real projects keep
       // real source in both -- AiDotNet.Tensors has two .csproj files under
@@ -571,6 +581,11 @@ export const SMART_GLOB_TOOL_DEFINITION = {
         type: 'string',
         description:
           'Glob pattern to match files (e.g., "src/**/*.ts", "*.json")',
+      },
+      path: {
+        type: 'string',
+        description:
+          'Directory to search. Preferred over cwd; without it the search falls back to the server process directory rather than your project.',
       },
       cwd: {
         type: 'string',

--- a/src/tools/file-operations/smart-grep.ts
+++ b/src/tools/file-operations/smart-grep.ts
@@ -21,6 +21,7 @@ import { MetricsCollector } from '../../core/metrics.js';
 import { generateCacheKey } from '../shared/hash-utils.js';
 import { fsGeneration } from '../../utils/fs-generation.js';
 import { detectFileType } from '../shared/syntax-utils.js';
+import { appendAll } from '../shared/append-all.js';
 
 /**
  * The most this tool will ever return in one response.
@@ -44,6 +45,11 @@ export interface GrepMatch {
 
 export interface SmartGrepOptions {
   // Search scope
+  /**
+   * Directory to search. The natural name for it, and the one the hook's
+   * refusal message leads callers to pass; takes precedence over `cwd`.
+   */
+  path?: string;
   cwd?: string; // Working directory (default: process.cwd())
   files?: string[]; // Specific files to search (glob patterns)
 
@@ -134,7 +140,18 @@ export class SmartGrepTool {
 
     // Default options
     const opts: Required<SmartGrepOptions> = {
-      cwd: options.cwd ?? process.cwd(),
+      // `path` FIRST, and it is not a cosmetic alias.
+      //
+      // The hook refuses the built-in Grep and names this tool as the
+      // replacement, so callers pass the one argument that describes a search:
+      // where to look. `path` was undeclared, and an undeclared field that is
+      // not a near miss of a declared one is discarded silently -- so `cwd` fell
+      // back to process.cwd(), which for an MCP server is its own launch
+      // directory. Measured: every "scoped" search actually walked 676,875 files
+      // across the whole home directory, for 65 seconds, and answered about the
+      // wrong tree.
+      cwd: options.path ?? options.cwd ?? process.cwd(),
+      path: options.path ?? '',
       files: options.files ?? ['**/*'],
       caseSensitive: options.caseSensitive ?? false,
       wholeWord: options.wholeWord ?? false,
@@ -210,7 +227,7 @@ export class SmartGrepTool {
           ignore: opts.ignore,
           nodir: true,
         });
-        filesToSearch.push(...matches);
+        appendAll(filesToSearch, matches);
       }
 
       // Filter files by extension and size
@@ -293,7 +310,7 @@ export class SmartGrepTool {
           if (fileMatches.length > 0) {
             filesWithMatches.add(relative(opts.cwd, file));
             matchCounts.set(relative(opts.cwd, file), fileMatches.length);
-            allMatches.push(...fileMatches);
+            appendAll(allMatches, fileMatches);
           }
         } catch {
           // Skip files we can't read
@@ -612,6 +629,11 @@ export const SMART_GREP_TOOL_DEFINITION = {
       pattern: {
         type: 'string',
         description: 'Search pattern (string or regex)',
+      },
+      path: {
+        type: 'string',
+        description:
+          'Directory to search. Preferred over cwd; without it the search falls back to the server process directory rather than your project.',
       },
       cwd: {
         type: 'string',

--- a/src/tools/shared/append-all.ts
+++ b/src/tools/shared/append-all.ts
@@ -1,0 +1,17 @@
+/**
+ * Append every item to `destination` without spreading them as arguments.
+ *
+ * `destination.push(...items)` passes one argument per item, and V8 accepts a
+ * measured 125,262 of them before throwing
+ * `RangeError: Maximum call stack size exceeded`. That is not a theoretical
+ * ceiling: smart_grep globbed 676,875 files on an ordinary home directory and
+ * threw on the very first push, so the tool failed identically for every caller
+ * in every project.
+ *
+ * A loop has no argument list and therefore no limit.
+ */
+export function appendAll<T>(destination: T[], items: readonly T[]): void {
+  for (const item of items) {
+    destination.push(item);
+  }
+}

--- a/tests/unit/file-operations/search-scope-and-scale.test.ts
+++ b/tests/unit/file-operations/search-scope-and-scale.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  SmartGrepTool,
+  type SmartGrepOptions,
+} from '../../../src/tools/file-operations/smart-grep.js';
+import {
+  SmartGlobTool,
+  type SmartGlobOptions,
+} from '../../../src/tools/file-operations/smart-glob.js';
+import { appendAll } from '../../../src/tools/shared/append-all.js';
+import { CacheEngine } from '../../../src/core/cache-engine.js';
+import { TokenCounter } from '../../../src/core/token-counter.js';
+import { MetricsCollector } from '../../../src/core/metrics.js';
+
+/**
+ * A search must search where it was told, and must survive what it finds.
+ *
+ * Both halves were measured live and both were broken. The hook REFUSES the
+ * built-in Grep and names smart_grep as the replacement, so a caller passes the
+ * one argument that describes a search -- where to look. Neither smart_grep nor
+ * smart_glob declared `path`, and an undeclared field that is not a near miss of
+ * a declared one is dropped without a word: `cwd` then fell back to
+ * process.cwd(), which for an MCP server is its own launch directory, not the
+ * caller's target.
+ *
+ * On this machine that was the whole home directory: 676,875 files, 65 seconds
+ * per call. smart_glob returned confident results from the wrong tree.
+ * smart_grep never returned at all -- `filesToSearch.push(...matches)` spread
+ * 676,875 arguments past V8's limit of 125,262 and threw
+ * "Maximum call stack size exceeded", the same error for every caller in every
+ * project. The tool the hook forces you to use could not succeed.
+ */
+
+describe('a search searches where it was told', () => {
+  let root: string;
+  let wanted: string;
+  let other: string;
+  let cache: CacheEngine;
+  let counter: TokenCounter;
+  let tool: SmartGrepTool;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'search-scope-'));
+
+    // Two sibling trees holding the SAME token. Scope is the only thing that can
+    // tell them apart, so an ignored `path` cannot accidentally pass.
+    wanted = join(root, 'wanted');
+    other = join(root, 'other');
+    mkdirSync(wanted);
+    mkdirSync(other);
+    writeFileSync(join(wanted, 'a.ts'), 'const x = UNIQUE_SCOPE_TOKEN;\n');
+    writeFileSync(join(other, 'b.ts'), 'const y = UNIQUE_SCOPE_TOKEN;\n');
+
+    cache = new CacheEngine(join(root, 'cache.db'), 100);
+    counter = new TokenCounter();
+    tool = new SmartGrepTool(cache, counter, new MetricsCollector());
+  });
+
+  afterEach(() => {
+    cache.close();
+    counter.free();
+    try {
+      rmSync(root, { recursive: true, force: true });
+    } catch {
+      // A locked cache file on Windows must not fail the run.
+    }
+  });
+
+  it('treats `path` as the search root, not as an unknown field to discard', async () => {
+    const result = await tool.grep('UNIQUE_SCOPE_TOKEN', {
+      path: wanted,
+    } as unknown as SmartGrepOptions);
+
+    expect(result.success).toBe(true);
+    expect(result.metadata.totalMatches).toBe(1);
+    // Asserting on the file, not just the count: a count of 1 could also come
+    // from the wrong tree.
+    expect(result.matches?.[0]?.file).toContain('a.ts');
+  });
+
+  it('still honours `cwd`, which is what the schema has always declared', async () => {
+    const result = await tool.grep('UNIQUE_SCOPE_TOKEN', { cwd: other });
+
+    expect(result.success).toBe(true);
+    expect(result.metadata.totalMatches).toBe(1);
+    expect(result.matches?.[0]?.file).toContain('b.ts');
+  });
+
+  it('prefers `path` when both are given, because it is the more specific ask', async () => {
+    const result = await tool.grep('UNIQUE_SCOPE_TOKEN', {
+      cwd: other,
+      path: wanted,
+    } as unknown as SmartGrepOptions);
+
+    expect(result.metadata.totalMatches).toBe(1);
+    expect(result.matches?.[0]?.file).toContain('a.ts');
+  });
+});
+
+describe('a search survives a result set larger than V8 can spread', () => {
+  let root: string;
+  let cache: CacheEngine;
+  let counter: TokenCounter;
+  let tool: SmartGrepTool;
+
+  // Comfortably past the measured ceiling of 125,262 spread arguments.
+  const MATCH_COUNT = 130_000;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'search-scale-'));
+    // One file, many matching lines: this reaches the per-file accumulation
+    // without needing 130,000 files on disk.
+    writeFileSync(join(root, 'many.txt'), 'needle\n'.repeat(MATCH_COUNT));
+
+    cache = new CacheEngine(join(root, 'cache.db'), 100);
+    counter = new TokenCounter();
+    tool = new SmartGrepTool(cache, counter, new MetricsCollector());
+  });
+
+  afterEach(() => {
+    cache.close();
+    counter.free();
+    try {
+      rmSync(root, { recursive: true, force: true });
+    } catch {
+      // See above.
+    }
+  });
+
+  it('does not throw when one file holds more matches than the spread limit', async () => {
+    const result = await tool.grep('needle', { cwd: root });
+
+    // The failure this pins down is not a wrong number, it is no number at all:
+    // success false and error "Maximum call stack size exceeded".
+    expect(result.error).toBeUndefined();
+    expect(result.success).toBe(true);
+    expect(result.metadata.totalMatches).toBe(MATCH_COUNT);
+  });
+
+  it('still caps what it returns, so surviving does not mean flooding the caller', async () => {
+    const result = await tool.grep('needle', { cwd: root });
+
+    expect(result.metadata.truncated).toBe(true);
+    expect(result.metadata.tokenCount).toBeLessThanOrEqual(8_000);
+  });
+});
+
+/**
+ * smart_glob has the same defect and must be fixed with it.
+ *
+ * Not speculation: a live call passing `path` for one repository returned a hit
+ * from a DIFFERENT repository, because the search actually ran from the home
+ * directory. It does not crash only because a narrow pattern matches few files
+ * -- it still walks the whole tree and still answers about the wrong one, which
+ * is worse than failing. This repository has already been bitten by fixing one
+ * tool and not its twin (see backup-location.test.ts).
+ */
+describe('smart_glob searches where it was told, exactly as smart_grep does', () => {
+  let root: string;
+  let wanted: string;
+  let other: string;
+  let cache: CacheEngine;
+  let counter: TokenCounter;
+  let tool: SmartGlobTool;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'glob-scope-'));
+    wanted = join(root, 'wanted');
+    other = join(root, 'other');
+    mkdirSync(wanted);
+    mkdirSync(other);
+    writeFileSync(join(wanted, 'inside.ts'), 'export const a = 1;\n');
+    writeFileSync(join(other, 'outside.ts'), 'export const b = 2;\n');
+
+    cache = new CacheEngine(join(root, 'cache.db'), 100);
+    counter = new TokenCounter();
+    tool = new SmartGlobTool(cache, counter, new MetricsCollector());
+  });
+
+  afterEach(() => {
+    cache.close();
+    counter.free();
+    try {
+      rmSync(root, { recursive: true, force: true });
+    } catch {
+      // See above.
+    }
+  });
+
+  it('treats `path` as the search root', async () => {
+    const result = await tool.glob('**/*.ts', {
+      path: wanted,
+    } as unknown as SmartGlobOptions);
+
+    const names = (result.files ?? []).map((f) =>
+      typeof f === 'string' ? f : f.relativePath
+    );
+    expect(names).toHaveLength(1);
+    expect(names[0]).toContain('inside.ts');
+  });
+
+  it('still honours `cwd`', async () => {
+    const result = await tool.glob('**/*.ts', { cwd: other });
+
+    const names = (result.files ?? []).map((f) =>
+      typeof f === 'string' ? f : f.relativePath
+    );
+    expect(names).toHaveLength(1);
+    expect(names[0]).toContain('outside.ts');
+  });
+});
+
+/**
+ * The file-list site cannot be reached from a test -- it needs more than 125,262
+ * files on disk -- so the fix is a helper that is tested directly at that scale.
+ */
+describe('appendAll moves any number of items without spreading them', () => {
+  it('appends more elements than V8 accepts as spread arguments', () => {
+    const source = new Array(200_000).fill('x');
+    const dest: string[] = [];
+
+    appendAll(dest, source);
+
+    expect(dest.length).toBe(200_000);
+  });
+
+  it('is the operation push(...items) would have been, for a small input', () => {
+    const dest = [1, 2];
+
+    appendAll(dest, [3, 4, 5]);
+
+    expect(dest).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('leaves the destination alone when there is nothing to add', () => {
+    const dest = [1];
+
+    appendAll(dest, []);
+
+    expect(dest).toEqual([1]);
+  });
+
+  it('proves the bug it exists to prevent: push(...) throws at this size', () => {
+    const source = new Array(200_000).fill('x');
+
+    // Guarding the guard. If a future V8 raises the limit this assertion is the
+    // thing that tells us, rather than the helper quietly becoming pointless.
+    expect(() => [].push(...(source as never[]))).toThrow(RangeError);
+  });
+});


### PR DESCRIPTION
## What was broken

`smart_grep` **could not succeed for any caller in any project**, and `smart_glob` answered about the wrong directory. Both found by using them, not by reading them.

The hook refuses the built-in `Grep`/`Glob` and names these tools as the replacement, so a caller passes the one argument that describes a search: where to look. **Neither tool declared `path`.** An undeclared field that is not a near miss of a declared one is dropped silently (the deliberate behaviour documented in `src/server/tool-arguments.ts`), so `cwd` fell back to `process.cwd()` — for an MCP server, its own launch directory rather than the caller's target.

On this machine that meant every "scoped" search walked the entire home directory.

| Measurement | Value |
|---|---|
| Files globbed from `process.cwd()` (`C:\Users\yolan`) | **676,875** |
| Time per call | **65.5 s** |
| V8 ceiling on `push(...spread)` arguments | **125,262** |
| Result | `RangeError: Maximum call stack size exceeded` |

`smart_glob` survived that and returned confident results from the wrong tree — a call scoped to one repository came back with a file from a *different* repository. That is the worse of the two failures, because nothing looks wrong.

`smart_grep` never returned at all: `filesToSearch.push(...matches)` spreads one argument per file, so with 676,875 files it threw on the first push, every time.

## The fix

Both tools together, because fixing one and not its twin is exactly what happened last time (see the note in `tests/unit/file-operations/backup-location.test.ts`).

- `path` is declared in the options interface **and the published input schema**, and takes precedence over `cwd`.
- The two spread pushes become `appendAll()` — a loop, which has no argument list and therefore no limit.

The file-list site needs 125,262+ files on disk to reach from a test, so `appendAll` is tested directly at 200,000 elements. That suite also asserts `push(...)` still throws at that size: if a future V8 raises the limit, that test is what tells us, rather than the helper quietly becoming pointless.

## Verification

Written test-first; each test was watched failing for the right reason before any fix. The reds were specific rather than incidental — the `path` test initially reported `Expected 1, Received 5`, having searched the repository and matched the token **in the test file itself**, and the `smart_glob` test returned **281 files from this repo's own `src/`** instead of the one file it asked for.

Against the **compiled `dist`**, not just the source:

| Case | Before | After |
|---|---|---|
| `smart_grep` with `path` | walked 676,875 files, threw | 1 match, correct file |
| 200,000 matches in one file | `RangeError` | `success=true`, 200,000 counted, 421 returned, 7,582 tokens, capped |
| `smart_glob` with `path` | 281 files from the wrong tree | correctly scoped |

- `npm run test:unit`: **81 of 82 suites pass, 863 tests pass**
- `npx tsc --noEmit`: clean
- `npm run lint`: 0 errors

The one failing suite, `pinned-spec-tracks-package.test.ts`, is unrelated and pre-existing: `package.json` is `5.4.0` while every integration spec is still pinned to `5.3.6`, because the 5.4.0 release aborted at the pin-verification step. `integrations/` is byte-identical to `master`, so neither that failure nor the `sync:hooks:check` drift comes from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)