### PR TITLE
fix(hooks): a write is not a read, and compaction ends the claim

### DIFF
--- a/hooks-core/decide.mjs
+++ b/hooks-core/decide.mjs
@@ -620,10 +620,23 @@ export function decide(payload, state) {
   return null;
 }
 
-/** Records a successful (allowed) read so a later repeat is recognised. */
+/**
+ * Records a successful (allowed) READ so a later repeat is recognised.
+ *
+ * READ ONLY, which is what this docstring always claimed. The condition also
+ * admitted `Write`, and a write is not a read: the model holds what it wrote, not
+ * the file, and for a small edit to a large file those are very different things.
+ *
+ * What that cost, observed live: a test file authored earlier in the session via
+ * Write was refused on its FIRST EVER Read with "UNCHANGED since you last read it
+ * this session -- use what you already have", and the harness then refused the
+ * following Write with "File has not been read yet", because from its side no read
+ * had happened. Neither side was wrong about its own bookkeeping; the hook had
+ * simply asserted a read that never occurred. Escapable only by retrying the Read.
+ */
 export function remember(payload, state) {
   const path = payload.tool_input?.file_path;
-  if (path && (payload.tool_name === 'Read' || payload.tool_name === 'Write')) {
+  if (path && payload.tool_name === 'Read') {
     state.seen[path] = true;
   }
 }

--- a/hooks-core/policy.mjs
+++ b/hooks-core/policy.mjs
@@ -301,6 +301,54 @@ export function saveState(sessionId, state) {
   }
 }
 
+/**
+ * Forgets which files the session has read, keeping the rest of its state.
+ *
+ * SEPARATE FROM `saveState` BECAUSE saveState CANNOT SHRINK `seen`. It merges --
+ * `{ ...current.seen, ...state.seen }` -- deliberately, so two concurrent hook
+ * processes cannot erase each other's additions. Passing `seen: {}` through it
+ * therefore does nothing at all: the merge restores every key. That was the first
+ * attempt at this, and the test caught it.
+ *
+ * The one caller is the PreCompact hook. `seen` is what licenses the router to
+ * refuse a Read with "unchanged since you last read it -- use what you already
+ * have", which is a claim about the READER's context, and compaction is exactly the
+ * event that empties it. Uncleared, the hook withholds content the model no longer
+ * holds for the rest of the session.
+ *
+ * Same lock and write-then-rename discipline as saveState: a reader must never see a
+ * half-written file, and a missed lock skips the write rather than racing it.
+ */
+export function clearSeen(sessionId) {
+  let lock = null;
+  try {
+    mkdirSync(stateRoot(), { recursive: true, mode: 0o700 });
+    lock = takeLock(sessionId);
+    if (!lock) return false;
+
+    const current = loadState(sessionId);
+    const cleared = { ...current, seen: {} };
+
+    const target = statePath(sessionId);
+    const temporary = `${target}.${process.pid}.tmp`;
+    writeFileSync(temporary, JSON.stringify(cleared), { mode: 0o600 });
+    renameSync(temporary, target);
+    return true;
+  } catch {
+    // Same rule as saveState: state is an optimization and must never fail a
+    // compaction. Not clearing degrades to the old behaviour.
+    return false;
+  } finally {
+    if (lock) {
+      try {
+        unlinkSync(lock);
+      } catch {
+        // Already gone; nothing to release.
+      }
+    }
+  }
+}
+
 /** Best-effort exclusive lock. Returns the lock path, or null if not acquired. */
 /**
  * Sleeps synchronously.

--- a/integrations/codex/hooks/lib/decide.mjs
+++ b/integrations/codex/hooks/lib/decide.mjs
@@ -622,10 +622,23 @@ export function decide(payload, state) {
   return null;
 }
 
-/** Records a successful (allowed) read so a later repeat is recognised. */
+/**
+ * Records a successful (allowed) READ so a later repeat is recognised.
+ *
+ * READ ONLY, which is what this docstring always claimed. The condition also
+ * admitted `Write`, and a write is not a read: the model holds what it wrote, not
+ * the file, and for a small edit to a large file those are very different things.
+ *
+ * What that cost, observed live: a test file authored earlier in the session via
+ * Write was refused on its FIRST EVER Read with "UNCHANGED since you last read it
+ * this session -- use what you already have", and the harness then refused the
+ * following Write with "File has not been read yet", because from its side no read
+ * had happened. Neither side was wrong about its own bookkeeping; the hook had
+ * simply asserted a read that never occurred. Escapable only by retrying the Read.
+ */
 export function remember(payload, state) {
   const path = payload.tool_input?.file_path;
-  if (path && (payload.tool_name === 'Read' || payload.tool_name === 'Write')) {
+  if (path && payload.tool_name === 'Read') {
     state.seen[path] = true;
   }
 }

--- a/integrations/codex/hooks/lib/policy.mjs
+++ b/integrations/codex/hooks/lib/policy.mjs
@@ -303,6 +303,54 @@ export function saveState(sessionId, state) {
   }
 }
 
+/**
+ * Forgets which files the session has read, keeping the rest of its state.
+ *
+ * SEPARATE FROM `saveState` BECAUSE saveState CANNOT SHRINK `seen`. It merges --
+ * `{ ...current.seen, ...state.seen }` -- deliberately, so two concurrent hook
+ * processes cannot erase each other's additions. Passing `seen: {}` through it
+ * therefore does nothing at all: the merge restores every key. That was the first
+ * attempt at this, and the test caught it.
+ *
+ * The one caller is the PreCompact hook. `seen` is what licenses the router to
+ * refuse a Read with "unchanged since you last read it -- use what you already
+ * have", which is a claim about the READER's context, and compaction is exactly the
+ * event that empties it. Uncleared, the hook withholds content the model no longer
+ * holds for the rest of the session.
+ *
+ * Same lock and write-then-rename discipline as saveState: a reader must never see a
+ * half-written file, and a missed lock skips the write rather than racing it.
+ */
+export function clearSeen(sessionId) {
+  let lock = null;
+  try {
+    mkdirSync(stateRoot(), { recursive: true, mode: 0o700 });
+    lock = takeLock(sessionId);
+    if (!lock) return false;
+
+    const current = loadState(sessionId);
+    const cleared = { ...current, seen: {} };
+
+    const target = statePath(sessionId);
+    const temporary = `${target}.${process.pid}.tmp`;
+    writeFileSync(temporary, JSON.stringify(cleared), { mode: 0o600 });
+    renameSync(temporary, target);
+    return true;
+  } catch {
+    // Same rule as saveState: state is an optimization and must never fail a
+    // compaction. Not clearing degrades to the old behaviour.
+    return false;
+  } finally {
+    if (lock) {
+      try {
+        unlinkSync(lock);
+      } catch {
+        // Already gone; nothing to release.
+      }
+    }
+  }
+}
+
 /** Best-effort exclusive lock. Returns the lock path, or null if not acquired. */
 /**
  * Sleeps synchronously.

--- a/integrations/codex/plugin/hooks/lib/decide.mjs
+++ b/integrations/codex/plugin/hooks/lib/decide.mjs
@@ -622,10 +622,23 @@ export function decide(payload, state) {
   return null;
 }
 
-/** Records a successful (allowed) read so a later repeat is recognised. */
+/**
+ * Records a successful (allowed) READ so a later repeat is recognised.
+ *
+ * READ ONLY, which is what this docstring always claimed. The condition also
+ * admitted `Write`, and a write is not a read: the model holds what it wrote, not
+ * the file, and for a small edit to a large file those are very different things.
+ *
+ * What that cost, observed live: a test file authored earlier in the session via
+ * Write was refused on its FIRST EVER Read with "UNCHANGED since you last read it
+ * this session -- use what you already have", and the harness then refused the
+ * following Write with "File has not been read yet", because from its side no read
+ * had happened. Neither side was wrong about its own bookkeeping; the hook had
+ * simply asserted a read that never occurred. Escapable only by retrying the Read.
+ */
 export function remember(payload, state) {
   const path = payload.tool_input?.file_path;
-  if (path && (payload.tool_name === 'Read' || payload.tool_name === 'Write')) {
+  if (path && payload.tool_name === 'Read') {
     state.seen[path] = true;
   }
 }

--- a/integrations/codex/plugin/hooks/lib/policy.mjs
+++ b/integrations/codex/plugin/hooks/lib/policy.mjs
@@ -303,6 +303,54 @@ export function saveState(sessionId, state) {
   }
 }
 
+/**
+ * Forgets which files the session has read, keeping the rest of its state.
+ *
+ * SEPARATE FROM `saveState` BECAUSE saveState CANNOT SHRINK `seen`. It merges --
+ * `{ ...current.seen, ...state.seen }` -- deliberately, so two concurrent hook
+ * processes cannot erase each other's additions. Passing `seen: {}` through it
+ * therefore does nothing at all: the merge restores every key. That was the first
+ * attempt at this, and the test caught it.
+ *
+ * The one caller is the PreCompact hook. `seen` is what licenses the router to
+ * refuse a Read with "unchanged since you last read it -- use what you already
+ * have", which is a claim about the READER's context, and compaction is exactly the
+ * event that empties it. Uncleared, the hook withholds content the model no longer
+ * holds for the rest of the session.
+ *
+ * Same lock and write-then-rename discipline as saveState: a reader must never see a
+ * half-written file, and a missed lock skips the write rather than racing it.
+ */
+export function clearSeen(sessionId) {
+  let lock = null;
+  try {
+    mkdirSync(stateRoot(), { recursive: true, mode: 0o700 });
+    lock = takeLock(sessionId);
+    if (!lock) return false;
+
+    const current = loadState(sessionId);
+    const cleared = { ...current, seen: {} };
+
+    const target = statePath(sessionId);
+    const temporary = `${target}.${process.pid}.tmp`;
+    writeFileSync(temporary, JSON.stringify(cleared), { mode: 0o600 });
+    renameSync(temporary, target);
+    return true;
+  } catch {
+    // Same rule as saveState: state is an optimization and must never fail a
+    // compaction. Not clearing degrades to the old behaviour.
+    return false;
+  } finally {
+    if (lock) {
+      try {
+        unlinkSync(lock);
+      } catch {
+        // Already gone; nothing to release.
+      }
+    }
+  }
+}
+
 /** Best-effort exclusive lock. Returns the lock path, or null if not acquired. */
 /**
  * Sleeps synchronously.

--- a/integrations/gemini/hooks/lib/decide.mjs
+++ b/integrations/gemini/hooks/lib/decide.mjs
@@ -622,10 +622,23 @@ export function decide(payload, state) {
   return null;
 }
 
-/** Records a successful (allowed) read so a later repeat is recognised. */
+/**
+ * Records a successful (allowed) READ so a later repeat is recognised.
+ *
+ * READ ONLY, which is what this docstring always claimed. The condition also
+ * admitted `Write`, and a write is not a read: the model holds what it wrote, not
+ * the file, and for a small edit to a large file those are very different things.
+ *
+ * What that cost, observed live: a test file authored earlier in the session via
+ * Write was refused on its FIRST EVER Read with "UNCHANGED since you last read it
+ * this session -- use what you already have", and the harness then refused the
+ * following Write with "File has not been read yet", because from its side no read
+ * had happened. Neither side was wrong about its own bookkeeping; the hook had
+ * simply asserted a read that never occurred. Escapable only by retrying the Read.
+ */
 export function remember(payload, state) {
   const path = payload.tool_input?.file_path;
-  if (path && (payload.tool_name === 'Read' || payload.tool_name === 'Write')) {
+  if (path && payload.tool_name === 'Read') {
     state.seen[path] = true;
   }
 }

--- a/integrations/gemini/hooks/lib/policy.mjs
+++ b/integrations/gemini/hooks/lib/policy.mjs
@@ -303,6 +303,54 @@ export function saveState(sessionId, state) {
   }
 }
 
+/**
+ * Forgets which files the session has read, keeping the rest of its state.
+ *
+ * SEPARATE FROM `saveState` BECAUSE saveState CANNOT SHRINK `seen`. It merges --
+ * `{ ...current.seen, ...state.seen }` -- deliberately, so two concurrent hook
+ * processes cannot erase each other's additions. Passing `seen: {}` through it
+ * therefore does nothing at all: the merge restores every key. That was the first
+ * attempt at this, and the test caught it.
+ *
+ * The one caller is the PreCompact hook. `seen` is what licenses the router to
+ * refuse a Read with "unchanged since you last read it -- use what you already
+ * have", which is a claim about the READER's context, and compaction is exactly the
+ * event that empties it. Uncleared, the hook withholds content the model no longer
+ * holds for the rest of the session.
+ *
+ * Same lock and write-then-rename discipline as saveState: a reader must never see a
+ * half-written file, and a missed lock skips the write rather than racing it.
+ */
+export function clearSeen(sessionId) {
+  let lock = null;
+  try {
+    mkdirSync(stateRoot(), { recursive: true, mode: 0o700 });
+    lock = takeLock(sessionId);
+    if (!lock) return false;
+
+    const current = loadState(sessionId);
+    const cleared = { ...current, seen: {} };
+
+    const target = statePath(sessionId);
+    const temporary = `${target}.${process.pid}.tmp`;
+    writeFileSync(temporary, JSON.stringify(cleared), { mode: 0o600 });
+    renameSync(temporary, target);
+    return true;
+  } catch {
+    // Same rule as saveState: state is an optimization and must never fail a
+    // compaction. Not clearing degrades to the old behaviour.
+    return false;
+  } finally {
+    if (lock) {
+      try {
+        unlinkSync(lock);
+      } catch {
+        // Already gone; nothing to release.
+      }
+    }
+  }
+}
+
 /** Best-effort exclusive lock. Returns the lock path, or null if not acquired. */
 /**
  * Sleeps synchronously.

--- a/integrations/opencode/hooks/lib/decide.mjs
+++ b/integrations/opencode/hooks/lib/decide.mjs
@@ -622,10 +622,23 @@ export function decide(payload, state) {
   return null;
 }
 
-/** Records a successful (allowed) read so a later repeat is recognised. */
+/**
+ * Records a successful (allowed) READ so a later repeat is recognised.
+ *
+ * READ ONLY, which is what this docstring always claimed. The condition also
+ * admitted `Write`, and a write is not a read: the model holds what it wrote, not
+ * the file, and for a small edit to a large file those are very different things.
+ *
+ * What that cost, observed live: a test file authored earlier in the session via
+ * Write was refused on its FIRST EVER Read with "UNCHANGED since you last read it
+ * this session -- use what you already have", and the harness then refused the
+ * following Write with "File has not been read yet", because from its side no read
+ * had happened. Neither side was wrong about its own bookkeeping; the hook had
+ * simply asserted a read that never occurred. Escapable only by retrying the Read.
+ */
 export function remember(payload, state) {
   const path = payload.tool_input?.file_path;
-  if (path && (payload.tool_name === 'Read' || payload.tool_name === 'Write')) {
+  if (path && payload.tool_name === 'Read') {
     state.seen[path] = true;
   }
 }

--- a/integrations/opencode/hooks/lib/policy.mjs
+++ b/integrations/opencode/hooks/lib/policy.mjs
@@ -303,6 +303,54 @@ export function saveState(sessionId, state) {
   }
 }
 
+/**
+ * Forgets which files the session has read, keeping the rest of its state.
+ *
+ * SEPARATE FROM `saveState` BECAUSE saveState CANNOT SHRINK `seen`. It merges --
+ * `{ ...current.seen, ...state.seen }` -- deliberately, so two concurrent hook
+ * processes cannot erase each other's additions. Passing `seen: {}` through it
+ * therefore does nothing at all: the merge restores every key. That was the first
+ * attempt at this, and the test caught it.
+ *
+ * The one caller is the PreCompact hook. `seen` is what licenses the router to
+ * refuse a Read with "unchanged since you last read it -- use what you already
+ * have", which is a claim about the READER's context, and compaction is exactly the
+ * event that empties it. Uncleared, the hook withholds content the model no longer
+ * holds for the rest of the session.
+ *
+ * Same lock and write-then-rename discipline as saveState: a reader must never see a
+ * half-written file, and a missed lock skips the write rather than racing it.
+ */
+export function clearSeen(sessionId) {
+  let lock = null;
+  try {
+    mkdirSync(stateRoot(), { recursive: true, mode: 0o700 });
+    lock = takeLock(sessionId);
+    if (!lock) return false;
+
+    const current = loadState(sessionId);
+    const cleared = { ...current, seen: {} };
+
+    const target = statePath(sessionId);
+    const temporary = `${target}.${process.pid}.tmp`;
+    writeFileSync(temporary, JSON.stringify(cleared), { mode: 0o600 });
+    renameSync(temporary, target);
+    return true;
+  } catch {
+    // Same rule as saveState: state is an optimization and must never fail a
+    // compaction. Not clearing degrades to the old behaviour.
+    return false;
+  } finally {
+    if (lock) {
+      try {
+        unlinkSync(lock);
+      } catch {
+        // Already gone; nothing to release.
+      }
+    }
+  }
+}
+
 /** Best-effort exclusive lock. Returns the lock path, or null if not acquired. */
 /**
  * Sleeps synchronously.

--- a/integrations/qwen/hooks/lib/decide.mjs
+++ b/integrations/qwen/hooks/lib/decide.mjs
@@ -622,10 +622,23 @@ export function decide(payload, state) {
   return null;
 }
 
-/** Records a successful (allowed) read so a later repeat is recognised. */
+/**
+ * Records a successful (allowed) READ so a later repeat is recognised.
+ *
+ * READ ONLY, which is what this docstring always claimed. The condition also
+ * admitted `Write`, and a write is not a read: the model holds what it wrote, not
+ * the file, and for a small edit to a large file those are very different things.
+ *
+ * What that cost, observed live: a test file authored earlier in the session via
+ * Write was refused on its FIRST EVER Read with "UNCHANGED since you last read it
+ * this session -- use what you already have", and the harness then refused the
+ * following Write with "File has not been read yet", because from its side no read
+ * had happened. Neither side was wrong about its own bookkeeping; the hook had
+ * simply asserted a read that never occurred. Escapable only by retrying the Read.
+ */
 export function remember(payload, state) {
   const path = payload.tool_input?.file_path;
-  if (path && (payload.tool_name === 'Read' || payload.tool_name === 'Write')) {
+  if (path && payload.tool_name === 'Read') {
     state.seen[path] = true;
   }
 }

--- a/integrations/qwen/hooks/lib/policy.mjs
+++ b/integrations/qwen/hooks/lib/policy.mjs
@@ -303,6 +303,54 @@ export function saveState(sessionId, state) {
   }
 }
 
+/**
+ * Forgets which files the session has read, keeping the rest of its state.
+ *
+ * SEPARATE FROM `saveState` BECAUSE saveState CANNOT SHRINK `seen`. It merges --
+ * `{ ...current.seen, ...state.seen }` -- deliberately, so two concurrent hook
+ * processes cannot erase each other's additions. Passing `seen: {}` through it
+ * therefore does nothing at all: the merge restores every key. That was the first
+ * attempt at this, and the test caught it.
+ *
+ * The one caller is the PreCompact hook. `seen` is what licenses the router to
+ * refuse a Read with "unchanged since you last read it -- use what you already
+ * have", which is a claim about the READER's context, and compaction is exactly the
+ * event that empties it. Uncleared, the hook withholds content the model no longer
+ * holds for the rest of the session.
+ *
+ * Same lock and write-then-rename discipline as saveState: a reader must never see a
+ * half-written file, and a missed lock skips the write rather than racing it.
+ */
+export function clearSeen(sessionId) {
+  let lock = null;
+  try {
+    mkdirSync(stateRoot(), { recursive: true, mode: 0o700 });
+    lock = takeLock(sessionId);
+    if (!lock) return false;
+
+    const current = loadState(sessionId);
+    const cleared = { ...current, seen: {} };
+
+    const target = statePath(sessionId);
+    const temporary = `${target}.${process.pid}.tmp`;
+    writeFileSync(temporary, JSON.stringify(cleared), { mode: 0o600 });
+    renameSync(temporary, target);
+    return true;
+  } catch {
+    // Same rule as saveState: state is an optimization and must never fail a
+    // compaction. Not clearing degrades to the old behaviour.
+    return false;
+  } finally {
+    if (lock) {
+      try {
+        unlinkSync(lock);
+      } catch {
+        // Already gone; nothing to release.
+      }
+    }
+  }
+}
+
 /** Best-effort exclusive lock. Returns the lock path, or null if not acquired. */
 /**
  * Sleeps synchronously.

--- a/plugin/hooks/lib/decide.mjs
+++ b/plugin/hooks/lib/decide.mjs
@@ -622,10 +622,23 @@ export function decide(payload, state) {
   return null;
 }
 
-/** Records a successful (allowed) read so a later repeat is recognised. */
+/**
+ * Records a successful (allowed) READ so a later repeat is recognised.
+ *
+ * READ ONLY, which is what this docstring always claimed. The condition also
+ * admitted `Write`, and a write is not a read: the model holds what it wrote, not
+ * the file, and for a small edit to a large file those are very different things.
+ *
+ * What that cost, observed live: a test file authored earlier in the session via
+ * Write was refused on its FIRST EVER Read with "UNCHANGED since you last read it
+ * this session -- use what you already have", and the harness then refused the
+ * following Write with "File has not been read yet", because from its side no read
+ * had happened. Neither side was wrong about its own bookkeeping; the hook had
+ * simply asserted a read that never occurred. Escapable only by retrying the Read.
+ */
 export function remember(payload, state) {
   const path = payload.tool_input?.file_path;
-  if (path && (payload.tool_name === 'Read' || payload.tool_name === 'Write')) {
+  if (path && payload.tool_name === 'Read') {
     state.seen[path] = true;
   }
 }

--- a/plugin/hooks/lib/policy.mjs
+++ b/plugin/hooks/lib/policy.mjs
@@ -303,6 +303,54 @@ export function saveState(sessionId, state) {
   }
 }
 
+/**
+ * Forgets which files the session has read, keeping the rest of its state.
+ *
+ * SEPARATE FROM `saveState` BECAUSE saveState CANNOT SHRINK `seen`. It merges --
+ * `{ ...current.seen, ...state.seen }` -- deliberately, so two concurrent hook
+ * processes cannot erase each other's additions. Passing `seen: {}` through it
+ * therefore does nothing at all: the merge restores every key. That was the first
+ * attempt at this, and the test caught it.
+ *
+ * The one caller is the PreCompact hook. `seen` is what licenses the router to
+ * refuse a Read with "unchanged since you last read it -- use what you already
+ * have", which is a claim about the READER's context, and compaction is exactly the
+ * event that empties it. Uncleared, the hook withholds content the model no longer
+ * holds for the rest of the session.
+ *
+ * Same lock and write-then-rename discipline as saveState: a reader must never see a
+ * half-written file, and a missed lock skips the write rather than racing it.
+ */
+export function clearSeen(sessionId) {
+  let lock = null;
+  try {
+    mkdirSync(stateRoot(), { recursive: true, mode: 0o700 });
+    lock = takeLock(sessionId);
+    if (!lock) return false;
+
+    const current = loadState(sessionId);
+    const cleared = { ...current, seen: {} };
+
+    const target = statePath(sessionId);
+    const temporary = `${target}.${process.pid}.tmp`;
+    writeFileSync(temporary, JSON.stringify(cleared), { mode: 0o600 });
+    renameSync(temporary, target);
+    return true;
+  } catch {
+    // Same rule as saveState: state is an optimization and must never fail a
+    // compaction. Not clearing degrades to the old behaviour.
+    return false;
+  } finally {
+    if (lock) {
+      try {
+        unlinkSync(lock);
+      } catch {
+        // Already gone; nothing to release.
+      }
+    }
+  }
+}
+
 /** Best-effort exclusive lock. Returns the lock path, or null if not acquired. */
 /**
  * Sleeps synchronously.

--- a/plugin/hooks/precompact-optimize.mjs
+++ b/plugin/hooks/precompact-optimize.mjs
@@ -21,7 +21,7 @@
 import { spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
-import { mode, MODE_OFF, loadState } from './lib/policy.mjs';
+import { mode, MODE_OFF, loadState, clearSeen } from './lib/policy.mjs';
 import { linkCoOccurrence } from './lib/inject.mjs';
 import { wikiDir, projectRootFor } from './lib/wiki.mjs';
 
@@ -104,6 +104,26 @@ async function main() {
   } catch {
     // Bookkeeping must never delay or fail a compaction.
   }
+
+  // COMPACTION ENDS THE CLAIM THAT THE CALLER STILL HOLDS THESE FILES.
+  //
+  // `state.seen` is what licenses the router to refuse a Read with "UNCHANGED
+  // since you last read it this session -- use what you already have". That is a
+  // statement about the READER's context, and compaction is precisely the event
+  // that empties it: the summary survives, the file contents do not.
+  //
+  // Left uncleared, the hook went on withholding content the model demonstrably no
+  // longer had, for the rest of a long session. Cleared here, "seen" means "read
+  // since the last compaction", which is the closest honest approximation of
+  // "still in context" available to a hook.
+  //
+  // Deliberately AFTER the co-occurrence write above, which needs the full list.
+  //
+  // `clearSeen` rather than `saveState({ seen: {} })`: saveState MERGES seen so that
+  // concurrent hook processes cannot erase each other's additions, which means it
+  // cannot shrink the map at all. The first version of this used saveState and was a
+  // silent no-op until a test caught it.
+  clearSeen(payload.session_id);
 
   // NOW the wrapper, which only the optimize_session spawn needs. Plugin-only
   // installs stop here having still recorded their co-occurrence above.

--- a/tests/hooks/seen-means-read.test.mjs
+++ b/tests/hooks/seen-means-read.test.mjs
@@ -1,0 +1,146 @@
+/**
+ * "Seen this session" must mean READ this session, and must not outlive the
+ * context it describes.
+ *
+ * `refusalPayload` refuses a Read with "UNCHANGED since you last read it this
+ * session. Nothing to re-read -- use what you already have." That sentence is a
+ * claim about what the CALLER holds, and it was licensed by `state.seen`, which was
+ * wrong in two ways.
+ *
+ * 1. A WRITE MARKED A FILE AS READ. `remember`'s own docstring says it "records a
+ *    successful (allowed) read", but its condition admitted Write. Observed live:
+ *    a test file authored earlier in the session via Write was, on its FIRST EVER
+ *    Read, refused with "you already read it" -- and the harness then refused the
+ *    following Write with "File has not been read yet", because from its side no
+ *    read had happened. A deadlock, escapable only by retrying the Read.
+ *
+ * 2. COMPACTION EMPTIES THE CONTEXT AND `seen` SURVIVED IT. A long session is
+ *    summarized; the file contents go with it. `state.seen` still said seen, so the
+ *    hook kept withholding content the model demonstrably no longer had. The graph
+ *    snapshot is durable, but "you already have it" is not a statement about the
+ *    graph.
+ *
+ * Both are about honesty rather than savings: a refusal that carries a diff is
+ * useful, and a refusal that carries nothing on a false premise is a lie that costs
+ * a turn.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+import { remember } from '../../hooks-core/decide.mjs';
+import { loadState, saveState } from '../../hooks-core/policy.mjs';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+describe('remember records reads, not writes', () => {
+  const state = () => ({ seen: {} });
+
+  it('records a Read', () => {
+    const s = state();
+    remember({ tool_name: 'Read', tool_input: { file_path: '/tmp/a.ts' } }, s);
+
+    expect(s.seen['/tmp/a.ts']).toBe(true);
+  });
+
+  it('does NOT record a Write, because writing a file is not reading it', () => {
+    // The deadlock: this marked the path seen, the next Read was refused as
+    // "unchanged since you last read it", and the harness refused the Write after
+    // it for never having been read.
+    const s = state();
+    remember({ tool_name: 'Write', tool_input: { file_path: '/tmp/a.ts' } }, s);
+
+    expect(s.seen['/tmp/a.ts']).toBeUndefined();
+  });
+
+  it('does NOT record an Edit either', () => {
+    const s = state();
+    remember({ tool_name: 'Edit', tool_input: { file_path: '/tmp/a.ts' } }, s);
+
+    expect(s.seen['/tmp/a.ts']).toBeUndefined();
+  });
+
+  it('ignores a call with no file_path', () => {
+    const s = state();
+    remember({ tool_name: 'Bash', tool_input: { command: 'ls' } }, s);
+
+    expect(Object.keys(s.seen)).toEqual([]);
+  });
+});
+
+describe('compaction ends the claim that the caller still holds a file', () => {
+  let home;
+  let originalHome;
+  let originalUserProfile;
+
+  // UNIQUE PER RUN, because `saveState` merges `seen` rather than replacing it, so a
+  // fixed id accumulates every previous run's paths and the arrange step cannot
+  // establish a known starting point. The first version of this test used a fixed id
+  // and failed with two temp paths from two different runs.
+  let sessionId;
+
+  beforeEach(() => {
+    sessionId = `seen-compaction-${process.pid}-${Date.now()}`;
+
+    // Redirected so the test never touches the developer's real state store.
+    home = mkdtempSync(join(tmpdir(), 'seen-state-'));
+    originalHome = process.env.HOME;
+    originalUserProfile = process.env.USERPROFILE;
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+  });
+
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = originalUserProfile;
+
+    try {
+      rmSync(home, { recursive: true, force: true });
+    } catch {
+      // Windows may hold a handle briefly.
+    }
+  });
+
+  it('clears seen when the PreCompact hook runs', () => {
+    const file = join(home, 'held.ts');
+    writeFileSync(file, 'export const a = 1;\n');
+
+    const before = loadState(sessionId);
+    before.seen = { [file]: true };
+    saveState(sessionId, before);
+    expect(Object.keys(loadState(sessionId).seen)).toHaveLength(1);
+
+    const hook = join(ROOT, 'plugin', 'hooks', 'precompact-optimize.mjs');
+    const result = spawnSync(process.execPath, [hook], {
+      input: JSON.stringify({ session_id: sessionId, cwd: ROOT, hook_event_name: 'PreCompact' }),
+      encoding: 'utf8',
+      env: { ...process.env, HOME: home, USERPROFILE: home },
+    });
+
+    // The hook must not fall over; it runs on every compaction.
+    expect(result.status).toBe(0);
+
+    // Compaction is the moment the caller stops holding those files.
+    expect(Object.keys(loadState(sessionId).seen ?? {})).toEqual([]);
+  });
+
+  it('leaves a session that was never compacted alone', () => {
+    const other = `seen-untouched-${process.pid}-${Date.now()}`;
+    const s = loadState(other);
+    s.seen = { '/tmp/x.ts': true };
+    saveState(other, s);
+
+    expect(Object.keys(loadState(other).seen)).toEqual(['/tmp/x.ts']);
+  });
+
+  it('the precompact hook exists where the test drives it from', () => {
+    // Guards against the hook being renamed and this suite silently testing nothing.
+    expect(existsSync(join(ROOT, 'plugin', 'hooks', 'precompact-optimize.mjs'))).toBe(true);
+  });
+});


### PR DESCRIPTION
Two defects behind one false statement. The router refuses a Read with:

> `<file>` is UNCHANGED since you last read it this session. Nothing to re-read -- use what you already have.

That is a claim about what the **caller holds**, and `state.seen` licensed it wrongly in two ways.

## 1. A write marked a file as read

`hooks-core/decide.mjs`:

```js
/** Records a successful (allowed) read so a later repeat is recognised. */
export function remember(payload, state) {
  const path = payload.tool_input?.file_path;
  if (path && (payload.tool_name === 'Read' || payload.tool_name === 'Write')) {
```

The docstring says *read*; the condition admitted **Write**.

Hit live in this session: a test file I authored earlier via `Write` was refused on its **first ever** `Read` with *"you already read it"* — and the harness then refused the following `Write` with *"File has not been read yet"*, because from its side no read had happened. Neither side was wrong about its own bookkeeping; the hook had asserted a read that never occurred. Escapable only by retrying the Read, which is why it presents as flakiness rather than a bug.

`remember` now records `Read` only, matching the contract it always documented. `Edit` was already excluded.

## 2. `seen` survived compaction

A long session gets summarized and the file contents go with it — but `seen` still said seen, so the hook kept withholding content the model demonstrably no longer had, for the rest of the session. The graph snapshot is durable; *"you already have it"* is not a statement about the graph.

The PreCompact hook now clears it, so `seen` means **"read since the last compaction"** — the closest honest approximation of "still in context" a hook can compute. Cleared *after* the co-occurrence write, which needs the full list.

## Why `clearSeen` is new

`saveState` **cannot shrink** `seen`. It merges `{ ...current.seen, ...state.seen }` on purpose, so concurrent hook processes cannot erase each other's additions.

My first version of fix 2 passed `seen: {}` through `saveState` and was a **silent no-op**. The test caught it. Reverting to that version still fails 1 of 7:

```
=== with the saveState version (the silent no-op) ===
Tests:       1 failed, 6 passed, 7 total
=== restored (clearSeen) ===
Tests:       7 passed, 7 total
```

`clearSeen` takes the same lock and does the same write-then-rename.

## Test notes

`tests/hooks/seen-means-read.test.mjs` drives the **real PreCompact hook as a subprocess** against real state. It uses a unique session id per run — a fixed id accumulates previous runs' paths through that same merge, which is how the first version of the test failed with two temp paths from two different runs.

## Verification

- `tests/unit` + `tests/hooks`: **123 suites, 1,524 passed, 0 failed**
- `eslint` clean on all three changed sources
- `sync:hooks:check` green

Also carries the pin repair `sync:hooks` performs while propagating `hooks-core` to the six vendored client copies: master pinned `@5.4.1`, a version tagged but never published, so those configs returned **404 on npm**. That overlaps #256, which replaces the pin with `@latest` entirely — trivial to rebase whichever lands second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)