### PR TITLE
fix(mcp): declare the options tools accept, and ratchet the rest

### DIFF
--- a/src/tools/api-database/smart-cache-api.ts
+++ b/src/tools/api-database/smart-cache-api.ts
@@ -1003,7 +1003,8 @@ Token Reduction:
       since: {
         type: 'string',
         format: 'date-time',
-        description: 'Only entries created or updated after this ISO-8601 timestamp',
+        description:
+          'Only entries created or updated after this ISO-8601 timestamp',
       },
       includeDetails: {
         type: 'boolean',

--- a/src/tools/api-database/smart-cache-api.ts
+++ b/src/tools/api-database/smart-cache-api.ts
@@ -998,6 +998,18 @@ Token Reduction:
         items: { type: 'string' },
         description: 'Headers to exclude from cache key',
       },
+      // DECLARED BECAUSE THEY ARE ACCEPTED: the server spreads the caller's whole
+      // argument object into options, so these worked while being undiscoverable.
+      since: {
+        type: 'string',
+        format: 'date-time',
+        description: 'Only entries created or updated after this ISO-8601 timestamp',
+      },
+      includeDetails: {
+        type: 'boolean',
+        description: 'Include per-entry detail rather than totals only',
+        default: false,
+      },
     },
     required: ['action'],
   },

--- a/src/tools/dashboard-monitoring/metric-collector.ts
+++ b/src/tools/dashboard-monitoring/metric-collector.ts
@@ -1377,6 +1377,12 @@ export const METRIC_COLLECTOR_TOOL_DEFINITION = {
         description: 'Enable caching (default: true)',
         default: true,
       },
+      // DECLARED BECAUSE IT IS ACCEPTED: the server spreads the caller's whole
+      // argument object into options, so this worked while being undiscoverable.
+      cacheTTL: {
+        type: 'number',
+        description: 'Cache lifetime in seconds',
+      },
     },
     required: ['operation'],
   },

--- a/src/tools/file-operations/smart-branch.ts
+++ b/src/tools/file-operations/smart-branch.ts
@@ -663,7 +663,8 @@ export const SMART_BRANCH_TOOL_DEFINITION = {
       // argument object into options, so these worked while being undiscoverable.
       local: {
         type: 'boolean',
-        description: 'Restrict to local branches, excluding remote-tracking ones',
+        description:
+          'Restrict to local branches, excluding remote-tracking ones',
         default: false,
       },
       mergedInto: {
@@ -678,7 +679,8 @@ export const SMART_BRANCH_TOOL_DEFINITION = {
       },
       offset: {
         type: 'number',
-        description: 'Skip this many results before returning any; use with limit to page',
+        description:
+          'Skip this many results before returning any; use with limit to page',
         default: 0,
       },
       useCache: {

--- a/src/tools/file-operations/smart-branch.ts
+++ b/src/tools/file-operations/smart-branch.ts
@@ -659,6 +659,38 @@ export const SMART_BRANCH_TOOL_DEFINITION = {
         description: 'Field to sort by',
         default: 'name',
       },
+      // DECLARED BECAUSE THEY ARE ACCEPTED: the server spreads the caller's whole
+      // argument object into options, so these worked while being undiscoverable.
+      local: {
+        type: 'boolean',
+        description: 'Restrict to local branches, excluding remote-tracking ones',
+        default: false,
+      },
+      mergedInto: {
+        type: 'string',
+        description: 'Only branches already merged into this ref',
+      },
+      sortOrder: {
+        type: 'string',
+        enum: ['asc', 'desc'],
+        description: 'Sort direction for sortBy',
+        default: 'asc',
+      },
+      offset: {
+        type: 'number',
+        description: 'Skip this many results before returning any; use with limit to page',
+        default: 0,
+      },
+      useCache: {
+        type: 'boolean',
+        description: 'Serve a previously cached result for the same query',
+        default: false,
+      },
+      ttl: {
+        type: 'number',
+        description: 'Cache lifetime in seconds, when useCache is on',
+        default: 300,
+      },
     },
   },
 };

--- a/src/tools/file-operations/smart-diff.ts
+++ b/src/tools/file-operations/smart-diff.ts
@@ -611,6 +611,43 @@ export const SMART_DIFF_TOOL_DEFINITION = {
         type: 'number',
         description: 'Maximum number of files to diff',
       },
+      // DECLARED BECAUSE THEY ARE ACCEPTED: the server spreads the caller's whole
+      // argument object into options, so these worked while being undiscoverable.
+      unified: {
+        type: 'boolean',
+        description: 'Return a unified diff rather than a structured list of changes',
+        default: true,
+      },
+      includeLineNumbers: {
+        type: 'boolean',
+        description: 'Annotate each changed line with its line number',
+        default: true,
+      },
+      includeBinary: {
+        type: 'boolean',
+        description: 'Report binary files as changed instead of skipping them',
+        default: false,
+      },
+      showRenames: {
+        type: 'boolean',
+        description: 'Detect renames instead of reporting a delete plus an add',
+        default: true,
+      },
+      offset: {
+        type: 'number',
+        description: 'Skip this many files before returning any; use with limit to page',
+        default: 0,
+      },
+      useCache: {
+        type: 'boolean',
+        description: 'Serve a previously cached diff for the same inputs',
+        default: false,
+      },
+      ttl: {
+        type: 'number',
+        description: 'Cache lifetime in seconds, when useCache is on',
+        default: 300,
+      },
     },
   },
 };

--- a/src/tools/file-operations/smart-diff.ts
+++ b/src/tools/file-operations/smart-diff.ts
@@ -615,7 +615,8 @@ export const SMART_DIFF_TOOL_DEFINITION = {
       // argument object into options, so these worked while being undiscoverable.
       unified: {
         type: 'boolean',
-        description: 'Return a unified diff rather than a structured list of changes',
+        description:
+          'Return a unified diff rather than a structured list of changes',
         default: true,
       },
       includeLineNumbers: {
@@ -635,7 +636,8 @@ export const SMART_DIFF_TOOL_DEFINITION = {
       },
       offset: {
         type: 'number',
-        description: 'Skip this many files before returning any; use with limit to page',
+        description:
+          'Skip this many files before returning any; use with limit to page',
         default: 0,
       },
       useCache: {

--- a/src/tools/file-operations/smart-edit.ts
+++ b/src/tools/file-operations/smart-edit.ts
@@ -762,12 +762,14 @@ export const SMART_EDIT_TOOL_DEFINITION = {
       // argument object into options, so these worked while being undiscoverable.
       verifyBeforeApply: {
         type: 'boolean',
-        description: 'Re-read and verify the target lines still match before writing',
+        description:
+          'Re-read and verify the target lines still match before writing',
         default: true,
       },
       batchEdits: {
         type: 'boolean',
-        description: 'Apply all operations in one pass rather than one at a time',
+        description:
+          'Apply all operations in one pass rather than one at a time',
         default: true,
       },
       contextLines: {

--- a/src/tools/file-operations/smart-edit.ts
+++ b/src/tools/file-operations/smart-edit.ts
@@ -758,6 +758,38 @@ export const SMART_EDIT_TOOL_DEFINITION = {
         description: 'Create backup before editing',
         default: true,
       },
+      // DECLARED BECAUSE THEY ARE ACCEPTED: the server spreads the caller's whole
+      // argument object into options, so these worked while being undiscoverable.
+      verifyBeforeApply: {
+        type: 'boolean',
+        description: 'Re-read and verify the target lines still match before writing',
+        default: true,
+      },
+      batchEdits: {
+        type: 'boolean',
+        description: 'Apply all operations in one pass rather than one at a time',
+        default: true,
+      },
+      contextLines: {
+        type: 'number',
+        description: 'Lines of context around each change in the returned diff',
+        default: 3,
+      },
+      updateCache: {
+        type: 'boolean',
+        description: 'Refresh this file in the read cache after editing',
+        default: true,
+      },
+      ttl: {
+        type: 'number',
+        description: 'Cache lifetime in seconds for the refreshed entry',
+        default: 300,
+      },
+      encoding: {
+        type: 'string',
+        description: 'File encoding used to read and write the file',
+        default: 'utf-8',
+      },
     },
     required: ['path', 'operations'],
   },

--- a/src/tools/file-operations/smart-glob.ts
+++ b/src/tools/file-operations/smart-glob.ts
@@ -616,6 +616,82 @@ export const SMART_GLOB_TOOL_DEFINITION = {
         description: 'Field to sort results by',
         default: 'path',
       },
+      // DECLARED BECAUSE THEY ARE ACCEPTED. The server spreads the caller's whole
+      // argument object into options, so these already worked and were simply
+      // undiscoverable -- the same gap that let `path` be dropped silently and every
+      // "scoped" search run from the wrong directory.
+      absolute: {
+        type: 'boolean',
+        description: 'Return absolute paths instead of paths relative to the search root',
+        default: false,
+      },
+      ignore: {
+        type: 'array',
+        items: { type: 'string' },
+        description:
+          'Glob patterns to skip. Defaults exclude node_modules, .git, dist and build -- the last two hold real source in some projects, so metadata.ignoredMatches reports what they withheld. Pass [] to search everything.',
+        default: ['**/node_modules/**', '**/.git/**', '**/dist/**', '**/build/**'],
+      },
+      onlyFiles: {
+        type: 'boolean',
+        description: 'Return files only, excluding directories',
+        default: true,
+      },
+      onlyDirectories: {
+        type: 'boolean',
+        description: 'Return directories only',
+        default: false,
+      },
+      excludeExtensions: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Skip files with these extensions',
+      },
+      minSize: {
+        type: 'number',
+        description: 'Skip files smaller than this many bytes',
+      },
+      maxSize: {
+        type: 'number',
+        description: 'Skip files larger than this many bytes',
+      },
+      modifiedAfter: {
+        type: 'string',
+        format: 'date-time',
+        description: 'Only files modified after this ISO-8601 timestamp',
+      },
+      modifiedBefore: {
+        type: 'string',
+        format: 'date-time',
+        description: 'Only files modified before this ISO-8601 timestamp',
+      },
+      maxContentSize: {
+        type: 'number',
+        description: 'Largest file, in bytes, for which includeContent returns content',
+        default: 10240,
+      },
+      offset: {
+        type: 'number',
+        description: 'Skip this many results before returning any; use with limit to page',
+        default: 0,
+      },
+      sortOrder: {
+        type: 'string',
+        enum: ['asc', 'desc'],
+        description: 'Sort direction for sortBy',
+        default: 'asc',
+      },
+      useCache: {
+        type: 'boolean',
+        description:
+          'Serve a previously cached result for the same query. Off by default: the key describes the query, not the tree, so a file created between two identical searches will not appear.',
+        default: false,
+      },
+      ttl: {
+        type: 'number',
+        description: 'Cache lifetime in seconds, when useCache is on',
+        default: 300,
+      },
     },
     required: ['pattern'],
   },

--- a/src/tools/file-operations/smart-glob.ts
+++ b/src/tools/file-operations/smart-glob.ts
@@ -622,7 +622,8 @@ export const SMART_GLOB_TOOL_DEFINITION = {
       // "scoped" search run from the wrong directory.
       absolute: {
         type: 'boolean',
-        description: 'Return absolute paths instead of paths relative to the search root',
+        description:
+          'Return absolute paths instead of paths relative to the search root',
         default: false,
       },
       ignore: {
@@ -630,7 +631,12 @@ export const SMART_GLOB_TOOL_DEFINITION = {
         items: { type: 'string' },
         description:
           'Glob patterns to skip. Defaults exclude node_modules, .git, dist and build -- the last two hold real source in some projects, so metadata.ignoredMatches reports what they withheld. Pass [] to search everything.',
-        default: ['**/node_modules/**', '**/.git/**', '**/dist/**', '**/build/**'],
+        default: [
+          '**/node_modules/**',
+          '**/.git/**',
+          '**/dist/**',
+          '**/build/**',
+        ],
       },
       onlyFiles: {
         type: 'boolean',
@@ -667,12 +673,14 @@ export const SMART_GLOB_TOOL_DEFINITION = {
       },
       maxContentSize: {
         type: 'number',
-        description: 'Largest file, in bytes, for which includeContent returns content',
+        description:
+          'Largest file, in bytes, for which includeContent returns content',
         default: 10240,
       },
       offset: {
         type: 'number',
-        description: 'Skip this many results before returning any; use with limit to page',
+        description:
+          'Skip this many results before returning any; use with limit to page',
         default: 0,
       },
       sortOrder: {

--- a/src/tools/file-operations/smart-grep.ts
+++ b/src/tools/file-operations/smart-grep.ts
@@ -688,6 +688,68 @@ export const SMART_GREP_TOOL_DEFINITION = {
         description: 'Only return match counts per file',
         default: false,
       },
+      // DECLARED BECAUSE THEY ARE ACCEPTED. The server spreads the caller's whole
+      // argument object into options, so each of these already worked -- it simply
+      // could not be discovered, and a caller guessing a neighbouring name got
+      // silence rather than an error.
+      wholeWord: {
+        type: 'boolean',
+        description: 'Match whole words only',
+        default: false,
+      },
+      excludeExtensions: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Skip files with these extensions',
+        default: ['.min.js', '.map', '.lock'],
+      },
+      skipBinary: {
+        type: 'boolean',
+        description: 'Skip files that look binary',
+        default: true,
+      },
+      ignore: {
+        type: 'array',
+        items: { type: 'string' },
+        description:
+          'Glob patterns to skip. Defaults exclude node_modules, .git, dist and build; pass [] to search everything.',
+        default: ['**/node_modules/**', '**/.git/**', '**/dist/**', '**/build/**'],
+      },
+      includeColumn: {
+        type: 'boolean',
+        description: 'Include the 0-based column of each match',
+        default: false,
+      },
+      maxMatchesPerFile: {
+        type: 'number',
+        description: 'Stop after this many matches in any one file',
+      },
+      offset: {
+        type: 'number',
+        description: 'Skip this many matches before returning any; use with limit to page',
+        default: 0,
+      },
+      useCache: {
+        type: 'boolean',
+        description:
+          'Serve a previously cached result for the same query. Off by default: a cached search is keyed on the query, not on the tree it ran against, so a file created between two identical searches will not appear.',
+        default: false,
+      },
+      ttl: {
+        type: 'number',
+        description: 'Cache lifetime in seconds, when useCache is on',
+        default: 300,
+      },
+      maxFileSize: {
+        type: 'number',
+        description: 'Skip files larger than this many bytes',
+        default: 10485760,
+      },
+      encoding: {
+        type: 'string',
+        description: 'File encoding used to read candidates',
+        default: 'utf-8',
+      },
     },
     required: ['pattern'],
   },

--- a/src/tools/file-operations/smart-grep.ts
+++ b/src/tools/file-operations/smart-grep.ts
@@ -713,7 +713,12 @@ export const SMART_GREP_TOOL_DEFINITION = {
         items: { type: 'string' },
         description:
           'Glob patterns to skip. Defaults exclude node_modules, .git, dist and build; pass [] to search everything.',
-        default: ['**/node_modules/**', '**/.git/**', '**/dist/**', '**/build/**'],
+        default: [
+          '**/node_modules/**',
+          '**/.git/**',
+          '**/dist/**',
+          '**/build/**',
+        ],
       },
       includeColumn: {
         type: 'boolean',
@@ -726,7 +731,8 @@ export const SMART_GREP_TOOL_DEFINITION = {
       },
       offset: {
         type: 'number',
-        description: 'Skip this many matches before returning any; use with limit to page',
+        description:
+          'Skip this many matches before returning any; use with limit to page',
         default: 0,
       },
       useCache: {

--- a/src/tools/file-operations/smart-log.ts
+++ b/src/tools/file-operations/smart-log.ts
@@ -686,6 +686,34 @@ export const SMART_LOG_TOOL_DEFINITION = {
         description: 'Skip first N commits',
         default: 0,
       },
+      // DECLARED BECAUSE THEY ARE ACCEPTED: the server spreads the caller's whole
+      // argument object into options, so these worked while being undiscoverable.
+      includeRefs: {
+        type: 'boolean',
+        description: 'Include the branch and tag names pointing at each commit',
+        default: false,
+      },
+      fields: {
+        type: 'array',
+        items: { type: 'string' },
+        description:
+          'Return only these commit fields, for example ["hash", "subject", "author"]. Fewer fields means fewer tokens.',
+      },
+      reverse: {
+        type: 'boolean',
+        description: 'Oldest commit first instead of newest',
+        default: false,
+      },
+      useCache: {
+        type: 'boolean',
+        description: 'Serve a previously cached result for the same query',
+        default: false,
+      },
+      ttl: {
+        type: 'number',
+        description: 'Cache lifetime in seconds, when useCache is on',
+        default: 300,
+      },
     },
   },
 };

--- a/src/tools/file-operations/smart-merge.ts
+++ b/src/tools/file-operations/smart-merge.ts
@@ -842,6 +842,30 @@ export const SMART_MERGE_TOOL_DEFINITION = {
         type: 'number',
         description: 'Maximum conflicts to return',
       },
+      // DECLARED BECAUSE THEY ARE ACCEPTED: the server spreads the caller's whole
+      // argument object into options, so these worked while being undiscoverable.
+      strategyOption: {
+        type: 'array',
+        items: { type: 'string' },
+        description:
+          'Strategy options passed through to git, for example ["ignore-space-change"]',
+      },
+      resolveUsing: {
+        type: 'string',
+        enum: ['ours', 'theirs'],
+        description:
+          'Resolve every conflict from one side. Destructive: the other side is discarded without review.',
+      },
+      useCache: {
+        type: 'boolean',
+        description: 'Serve a previously cached result for the same query',
+        default: false,
+      },
+      ttl: {
+        type: 'number',
+        description: 'Cache lifetime in seconds, when useCache is on',
+        default: 300,
+      },
     },
   },
 };

--- a/src/tools/file-operations/smart-read.ts
+++ b/src/tools/file-operations/smart-read.ts
@@ -470,7 +470,8 @@ export const SMART_READ_TOOL_DEFINITION = {
       },
       preserveStructure: {
         type: 'boolean',
-        description: 'Keep structural lines (signatures, exports) when compressing output',
+        description:
+          'Keep structural lines (signatures, exports) when compressing output',
         default: true,
       },
       includeMetadata: {

--- a/src/tools/file-operations/smart-read.ts
+++ b/src/tools/file-operations/smart-read.ts
@@ -456,6 +456,33 @@ export const SMART_READ_TOOL_DEFINITION = {
         type: 'number',
         description: 'For chunked files, the chunk index to retrieve',
       },
+      // DECLARED BECAUSE THEY ARE ACCEPTED: the server spreads the caller's whole
+      // argument object into options, so these worked while being undiscoverable.
+      enableCache: {
+        type: 'boolean',
+        description: 'Reuse a cached read of this file when it has not changed',
+        default: true,
+      },
+      ttl: {
+        type: 'number',
+        description: 'Cache lifetime in seconds',
+        default: 300,
+      },
+      preserveStructure: {
+        type: 'boolean',
+        description: 'Keep structural lines (signatures, exports) when compressing output',
+        default: true,
+      },
+      includeMetadata: {
+        type: 'boolean',
+        description: 'Include size, hash and encoding alongside the content',
+        default: true,
+      },
+      encoding: {
+        type: 'string',
+        description: 'File encoding used to read the file',
+        default: 'utf-8',
+      },
     },
     required: ['path'],
   },

--- a/src/tools/file-operations/smart-status.ts
+++ b/src/tools/file-operations/smart-status.ts
@@ -728,12 +728,14 @@ export const SMART_STATUS_TOOL_DEFINITION = {
       },
       includeIgnored: {
         type: 'boolean',
-        description: 'Include ignored files, usually a large and low-signal set',
+        description:
+          'Include ignored files, usually a large and low-signal set',
         default: false,
       },
       offset: {
         type: 'number',
-        description: 'Skip this many files before returning any; use with limit to page',
+        description:
+          'Skip this many files before returning any; use with limit to page',
         default: 0,
       },
       useCache: {

--- a/src/tools/file-operations/smart-status.ts
+++ b/src/tools/file-operations/smart-status.ts
@@ -714,6 +714,38 @@ export const SMART_STATUS_TOOL_DEFINITION = {
         type: 'number',
         description: 'Maximum files to return',
       },
+      // DECLARED BECAUSE THEY ARE ACCEPTED: the server spreads the caller's whole
+      // argument object into options, so these worked while being undiscoverable.
+      includeSize: {
+        type: 'boolean',
+        description: 'Include each file size, which costs a stat per file',
+        default: false,
+      },
+      includeUntracked: {
+        type: 'boolean',
+        description: 'Include files git does not track yet',
+        default: true,
+      },
+      includeIgnored: {
+        type: 'boolean',
+        description: 'Include ignored files, usually a large and low-signal set',
+        default: false,
+      },
+      offset: {
+        type: 'number',
+        description: 'Skip this many files before returning any; use with limit to page',
+        default: 0,
+      },
+      useCache: {
+        type: 'boolean',
+        description: 'Serve a previously cached result for the same query',
+        default: false,
+      },
+      ttl: {
+        type: 'number',
+        description: 'Cache lifetime in seconds, when useCache is on',
+        default: 300,
+      },
     },
   },
 };

--- a/src/tools/file-operations/smart-write.ts
+++ b/src/tools/file-operations/smart-write.ts
@@ -613,6 +613,53 @@ export const SMART_WRITE_TOOL_DEFINITION = {
         description: 'Return diff instead of full content',
         default: true,
       },
+      // DECLARED BECAUSE THEY ARE ACCEPTED: the server spreads the caller's whole
+      // argument object into options, so these worked while being undiscoverable.
+      createBackup: {
+        type: 'boolean',
+        description:
+          'Back the file up before overwriting. Backups go to a home-directory root, never beside the file.',
+        default: true,
+      },
+      tempDir: {
+        type: 'string',
+        description: 'Directory for the temporary file used by the write-then-rename',
+      },
+      formatType: {
+        type: 'string',
+        enum: ['prettier', 'eslint', 'none'],
+        description: 'Formatter to run on the written content',
+        default: 'none',
+      },
+      trackChanges: {
+        type: 'boolean',
+        description: 'Record this write in the change log used by the diff tools',
+        default: false,
+      },
+      updateCache: {
+        type: 'boolean',
+        description: 'Refresh this file in the read cache after writing',
+        default: true,
+      },
+      ttl: {
+        type: 'number',
+        description: 'Cache lifetime in seconds for the refreshed entry',
+        default: 300,
+      },
+      createDirectories: {
+        type: 'boolean',
+        description: 'Create missing parent directories instead of failing',
+        default: true,
+      },
+      encoding: {
+        type: 'string',
+        description: 'File encoding used to write the file',
+        default: 'utf-8',
+      },
+      mode: {
+        type: 'number',
+        description: 'POSIX file mode for a newly created file, for example 420 for 0o644',
+      },
     },
     required: ['path', 'content'],
   },

--- a/src/tools/file-operations/smart-write.ts
+++ b/src/tools/file-operations/smart-write.ts
@@ -623,7 +623,8 @@ export const SMART_WRITE_TOOL_DEFINITION = {
       },
       tempDir: {
         type: 'string',
-        description: 'Directory for the temporary file used by the write-then-rename',
+        description:
+          'Directory for the temporary file used by the write-then-rename',
       },
       formatType: {
         type: 'string',
@@ -633,7 +634,8 @@ export const SMART_WRITE_TOOL_DEFINITION = {
       },
       trackChanges: {
         type: 'boolean',
-        description: 'Record this write in the change log used by the diff tools',
+        description:
+          'Record this write in the change log used by the diff tools',
         default: false,
       },
       updateCache: {
@@ -658,7 +660,8 @@ export const SMART_WRITE_TOOL_DEFINITION = {
       },
       mode: {
         type: 'number',
-        description: 'POSIX file mode for a newly created file, for example 420 for 0o644',
+        description:
+          'POSIX file mode for a newly created file, for example 420 for 0o644',
       },
     },
     required: ['path', 'content'],

--- a/tests/unit/tool-schemas-declare-what-they-accept.test.ts
+++ b/tests/unit/tool-schemas-declare-what-they-accept.test.ts
@@ -42,7 +42,8 @@ function walk(dir: string): string[] {
   for (const entry of readdirSync(dir)) {
     const full = join(dir, entry);
     if (statSync(full).isDirectory()) out.push(...walk(full));
-    else if (entry.endsWith('.ts') && !entry.endsWith('.test.ts')) out.push(full);
+    else if (entry.endsWith('.ts') && !entry.endsWith('.test.ts'))
+      out.push(full);
   }
   return out;
 }
@@ -85,12 +86,25 @@ function topLevelKeys(text: string, open: number): string[] {
       continue;
     }
 
-    if (c === '"' || c === "'" || c === '`') { inString = c; continue; }
-    if (c === '{' || c === '[') { depth++; continue; }
-    if (c === '}' || c === ']') { depth--; if (depth === 0) break; continue; }
+    if (c === '"' || c === "'" || c === '`') {
+      inString = c;
+      continue;
+    }
+    if (c === '{' || c === '[') {
+      depth++;
+      continue;
+    }
+    if (c === '}' || c === ']') {
+      depth--;
+      if (depth === 0) break;
+      continue;
+    }
     if (depth === 1 && /[A-Za-z_$]/.test(c)) {
       const m = /^([A-Za-z_$][\w$]*)\s*:/.exec(text.slice(i));
-      if (m) { keys.push(m[1]); i += m[1].length; }
+      if (m) {
+        keys.push(m[1]);
+        i += m[1].length;
+      }
     }
   }
   return keys;
@@ -120,11 +134,20 @@ function acceptedOptions(text: string): string[] {
 
     for (let i = open; i < text.length; i++) {
       const c = text[i];
-      if (c === '{') { depth++; continue; }
-      if (c === '}') { depth--; if (depth === 0) break; continue; }
+      if (c === '{') {
+        depth++;
+        continue;
+      }
+      if (c === '}') {
+        depth--;
+        if (depth === 0) break;
+        continue;
+      }
       if (depth !== 1 || text[i - 1] !== '\n') continue;
 
-      const line = /^\s*([A-Za-z_$][\w$]*)\??\s*:\s*([^;\n]*)/.exec(text.slice(i));
+      const line = /^\s*([A-Za-z_$][\w$]*)\??\s*:\s*([^;\n]*)/.exec(
+        text.slice(i)
+      );
       if (!line) continue;
 
       const [, name, type] = line;
@@ -191,47 +214,126 @@ function audit(): Gap[] {
  */
 const KNOWN_GAPS: Record<string, string[]> = {
   // registered — reachable over MCP
-  'src/tools/advanced-caching/cache-compression.ts': ['dictionary', 'includeMetrics', 'sampleSize', 'testData'],
-  'src/tools/advanced-caching/cache-optimizer.ts': [
-    'constraints', 'currentConfig', 'currentStrategy', 'includeBottlenecks', 'includeCharts',
-    'includePredictions', 'includeRecommendations', 'iterations', 'learningRate', 'reportFormat',
-    'simulationDuration', 'targetConfig', 'targetStrategy', 'workloadSize',
+  'src/tools/advanced-caching/cache-compression.ts': [
+    'dictionary',
+    'includeMetrics',
+    'sampleSize',
+    'testData',
   ],
-  'src/tools/advanced-caching/cache-replication.ts': ['conflicts', 'enableCompression'],
+  'src/tools/advanced-caching/cache-optimizer.ts': [
+    'constraints',
+    'currentConfig',
+    'currentStrategy',
+    'includeBottlenecks',
+    'includeCharts',
+    'includePredictions',
+    'includeRecommendations',
+    'iterations',
+    'learningRate',
+    'reportFormat',
+    'simulationDuration',
+    'targetConfig',
+    'targetStrategy',
+    'workloadSize',
+  ],
+  'src/tools/advanced-caching/cache-replication.ts': [
+    'conflicts',
+    'enableCompression',
+  ],
   'src/tools/advanced-caching/cache-warmup.ts': [
-    'dataSource', 'endTime', 'resolveDependencies', 'startTime', 'validateBeforeCommit',
+    'dataSource',
+    'endTime',
+    'resolveDependencies',
+    'startTime',
+    'validateBeforeCommit',
   ],
   'src/tools/advanced-caching/predictive-cache.ts': ['metadata'],
-  'src/tools/advanced-caching/smart-cache.ts': ['compressionEnabled', 'metadata'],
-  'src/tools/code-analysis/smart-ast-grep.ts': [
-    'includeContext', 'incrementalIndexing', 'respectGitignore', 'ttl',
+  'src/tools/advanced-caching/smart-cache.ts': [
+    'compressionEnabled',
+    'metadata',
   ],
-  'src/tools/configuration/smart-config-read.ts': ['enableCache', 'includeMetadata'],
-  'src/tools/dashboard-monitoring/alert-manager.ts': ['dataSource', 'silenceId'],
-  'src/tools/dashboard-monitoring/log-dashboard.ts': ['cacheTTL', 'filter', 'filterId', 'logSources'],
-  'src/tools/dashboard-monitoring/monitoring-integration.ts': ['cacheTTL', 'mapping', 'pushData', 'syncOptions'],
+  'src/tools/code-analysis/smart-ast-grep.ts': [
+    'includeContext',
+    'incrementalIndexing',
+    'respectGitignore',
+    'ttl',
+  ],
+  'src/tools/configuration/smart-config-read.ts': [
+    'enableCache',
+    'includeMetadata',
+  ],
+  'src/tools/dashboard-monitoring/alert-manager.ts': [
+    'dataSource',
+    'silenceId',
+  ],
+  'src/tools/dashboard-monitoring/log-dashboard.ts': [
+    'cacheTTL',
+    'filter',
+    'filterId',
+    'logSources',
+  ],
+  'src/tools/dashboard-monitoring/monitoring-integration.ts': [
+    'cacheTTL',
+    'mapping',
+    'pushData',
+    'syncOptions',
+  ],
 
   // not registered in src/server/index.ts, so not reachable over MCP today. Still a
   // contract that lies if the tool is ever wired up.
   'src/tools/advanced-caching/cache-benchmark.ts': ['resultsPath', 'workload'],
   'src/tools/api-database/smart-database.ts': [
-    'analyzeIndexUsage', 'circuitBreakerThreshold', 'circuitBreakerTimeout', 'connectionString',
-    'connectionTimeout', 'database', 'detectN1', 'explain', 'host', 'idleTimeout',
-    'includeMetadata', 'minPoolSize', 'password', 'port', 'user',
+    'analyzeIndexUsage',
+    'circuitBreakerThreshold',
+    'circuitBreakerTimeout',
+    'connectionString',
+    'connectionTimeout',
+    'database',
+    'detectN1',
+    'explain',
+    'host',
+    'idleTimeout',
+    'includeMetadata',
+    'minPoolSize',
+    'password',
+    'port',
+    'user',
   ],
-  'src/tools/code-analysis/smart-dependencies.ts': ['exclude', 'includeMetadata', 'ttl'],
+  'src/tools/code-analysis/smart-dependencies.ts': [
+    'exclude',
+    'includeMetadata',
+    'ttl',
+  ],
   // Declares these NESTED under an `options` object rather than at the top level; the
   // tool is unregistered, so which level is correct is undecided until it is wired.
   'src/tools/configuration/smart-workflow.ts': [
-    'enableCache', 'format', 'includePerformanceRecommendations', 'includeSecurityAnalysis',
-    'ttl', 'validateSyntax',
+    'enableCache',
+    'format',
+    'includePerformanceRecommendations',
+    'includeSecurityAnalysis',
+    'ttl',
+    'validateSyntax',
   ],
   'src/tools/intelligence/knowledge-graph.ts': [
-    'communityAlgorithm', 'confidenceThreshold', 'graphs', 'imageHeight', 'imageWidth',
-    'includeLabels', 'maxHops', 'maxInferences', 'maxNodes', 'mergeStrategy',
-    'minCommunitySize', 'rankingAlgorithm',
+    'communityAlgorithm',
+    'confidenceThreshold',
+    'graphs',
+    'imageHeight',
+    'imageWidth',
+    'includeLabels',
+    'maxHops',
+    'maxInferences',
+    'maxNodes',
+    'mergeStrategy',
+    'minCommunitySize',
+    'rankingAlgorithm',
   ],
-  'src/tools/intelligence/sentiment-analysis.ts': ['batchSize', 'outputPath', 'threshold', 'trainingData'],
+  'src/tools/intelligence/sentiment-analysis.ts': [
+    'batchSize',
+    'outputPath',
+    'threshold',
+    'trainingData',
+  ],
 };
 
 describe('every tool declares the options it accepts', () => {
@@ -240,7 +342,9 @@ describe('every tool declares the options it accepts', () => {
   it('introduces no undeclared option beyond the recorded debt', () => {
     const unexpected = gaps.flatMap((g) => {
       const known = KNOWN_GAPS[g.file] ?? [];
-      return g.undeclared.filter((o) => !known.includes(o)).map((o) => `${g.file}: ${o}`);
+      return g.undeclared
+        .filter((o) => !known.includes(o))
+        .map((o) => `${g.file}: ${o}`);
     });
 
     expect(unexpected).toEqual([]);
@@ -264,7 +368,9 @@ describe('every tool declares the options it accepts', () => {
     // smart_grep, smart_glob, smart_read, smart_edit, smart_write, smart_diff and the
     // four git tools are the surface that produced the measured failures, so they are
     // held to zero rather than ratcheted.
-    const remaining = gaps.filter((g) => g.file.startsWith('src/tools/file-operations/'));
+    const remaining = gaps.filter((g) =>
+      g.file.startsWith('src/tools/file-operations/')
+    );
 
     expect(remaining).toEqual([]);
   });
@@ -275,7 +381,11 @@ describe('every tool declares the options it accepts', () => {
     let audited = 0;
     for (const file of walk(SRC)) {
       const text = readFileSync(file, 'utf8');
-      if (text.includes('_TOOL_DEFINITION') && declaredProperties(text) && acceptedOptions(text).length) {
+      if (
+        text.includes('_TOOL_DEFINITION') &&
+        declaredProperties(text) &&
+        acceptedOptions(text).length
+      ) {
         audited++;
       }
     }

--- a/tests/unit/tool-schemas-declare-what-they-accept.test.ts
+++ b/tests/unit/tool-schemas-declare-what-they-accept.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect } from '@jest/globals';
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * A tool's published inputSchema must declare every option it accepts.
+ *
+ * THIS IS NOT TIDINESS. The server hands the caller's whole argument object to the
+ * implementation -- `const { pattern, ...options } = args as any` -- so every field
+ * of an Options interface is reachable over MCP. An option missing from inputSchema
+ * is therefore not "undocumented", it is a schema that lies: the caller cannot know
+ * the option exists, and a caller that guesses a NEIGHBOURING name gets silence,
+ * because `tool-arguments.ts` only refuses near-misses of DECLARED fields.
+ *
+ * That silence has cost real bugs, all found by using the tools rather than reading
+ * them:
+ *
+ *   - smart_grep and smart_glob did not declare `path`. Callers passed it, it was
+ *     dropped, `cwd` fell back to process.cwd(), and every "scoped" search silently
+ *     walked 676,875 files from the home directory. smart_grep then died on
+ *     `RangeError: Maximum call stack size exceeded` for every caller in every
+ *     project; smart_glob returned confident results about the wrong repository.
+ *   - `expand` prints "expand <id>" but its parameter is `ref`, so a caller
+ *     following the printed hint got "No stored output for reference undefined".
+ *   - smart_edit takes `operations`, not `edits`; the wrong name is a validation
+ *     error rather than a silent drop only because `operations` is required.
+ *
+ * When this test was written the surface had 29 tools with 166 undeclared options.
+ * Every one of them is a way for a caller to be quietly ignored.
+ *
+ * Function-valued options are excluded automatically -- a callback cannot cross a
+ * JSON boundary, so it is genuinely programmatic-only. That exclusion is computed
+ * from the declared TYPE rather than kept as a hand-maintained list, so it cannot
+ * become a place to hide a real omission.
+ */
+
+const ROOT = process.cwd();
+const SRC = join(ROOT, 'src', 'tools');
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...walk(full));
+    else if (entry.endsWith('.ts') && !entry.endsWith('.test.ts')) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Top-level keys of the object literal whose `{` is at `open`.
+ *
+ * COMMENT-AWARE, and that is not a nicety. Without it an apostrophe inside a `//`
+ * comment -- "the caller's argument object" -- opens a string that never closes, and
+ * every key after it is swallowed. That happened while writing this file: the audit
+ * reported 11 newly declared properties as still missing, and the numbers looked
+ * plausible enough to believe. A scanner that silently under-reports is worse than
+ * no scanner, because it makes a real gap look fixed.
+ */
+function topLevelKeys(text: string, open: number): string[] {
+  const keys: string[] = [];
+  let depth = 0;
+  let inString: string | null = null;
+
+  for (let i = open; i < text.length; i++) {
+    const c = text[i];
+
+    if (inString) {
+      if (c === '\\') i++;
+      else if (c === inString) inString = null;
+      continue;
+    }
+
+    // Comments first: their contents are prose, not syntax.
+    if (c === '/' && text[i + 1] === '/') {
+      const end = text.indexOf('\n', i);
+      if (end === -1) break;
+      i = end;
+      continue;
+    }
+    if (c === '/' && text[i + 1] === '*') {
+      const end = text.indexOf('*/', i + 2);
+      if (end === -1) break;
+      i = end + 1;
+      continue;
+    }
+
+    if (c === '"' || c === "'" || c === '`') { inString = c; continue; }
+    if (c === '{' || c === '[') { depth++; continue; }
+    if (c === '}' || c === ']') { depth--; if (depth === 0) break; continue; }
+    if (depth === 1 && /[A-Za-z_$]/.test(c)) {
+      const m = /^([A-Za-z_$][\w$]*)\s*:/.exec(text.slice(i));
+      if (m) { keys.push(m[1]); i += m[1].length; }
+    }
+  }
+  return keys;
+}
+
+function declaredProperties(text: string): string[] | null {
+  const schema = text.indexOf('inputSchema');
+  if (schema === -1) return null;
+  const props = text.indexOf('properties:', schema);
+  if (props === -1) return null;
+  const open = text.indexOf('{', props);
+  return open === -1 ? null : topLevelKeys(text, open);
+}
+
+/**
+ * Option names an interface accepts, with function-typed fields dropped.
+ *
+ * A `(x) => y` field cannot be expressed in JSON Schema and cannot arrive over MCP,
+ * so it is programmatic-only rather than undeclared.
+ */
+function acceptedOptions(text: string): string[] {
+  const fields: string[] = [];
+
+  for (const match of text.matchAll(/export interface\s+\w*Options\s*\{/g)) {
+    const open = text.indexOf('{', match.index);
+    let depth = 0;
+
+    for (let i = open; i < text.length; i++) {
+      const c = text[i];
+      if (c === '{') { depth++; continue; }
+      if (c === '}') { depth--; if (depth === 0) break; continue; }
+      if (depth !== 1 || text[i - 1] !== '\n') continue;
+
+      const line = /^\s*([A-Za-z_$][\w$]*)\??\s*:\s*([^;\n]*)/.exec(text.slice(i));
+      if (!line) continue;
+
+      const [, name, type] = line;
+      const isFunction = type.includes('=>') || /\bFunction\b/.test(type);
+      if (!isFunction) fields.push(name);
+    }
+  }
+
+  return [...new Set(fields)];
+}
+
+function toolName(text: string): string {
+  return /name:\s*'([a-z0-9_-]+)'/i.exec(text)?.[1] ?? 'unknown';
+}
+
+interface Gap {
+  tool: string;
+  file: string;
+  undeclared: string[];
+}
+
+function audit(): Gap[] {
+  const gaps: Gap[] = [];
+
+  for (const file of walk(SRC)) {
+    const text = readFileSync(file, 'utf8');
+    if (!text.includes('_TOOL_DEFINITION')) continue;
+
+    const declared = declaredProperties(text);
+    if (!declared) continue;
+
+    const accepted = acceptedOptions(text);
+    if (!accepted.length) continue;
+
+    const undeclared = accepted.filter((option) => !declared.includes(option));
+    if (undeclared.length) {
+      gaps.push({
+        tool: toolName(text),
+        // Repo-relative and forward-slashed, with no leading separator, so the keys in
+        // KNOWN_GAPS read the way a path appears in a diff.
+        file: file.replace(ROOT, '').replace(/\\/g, '/').replace(/^\//, ''),
+        undeclared,
+      });
+    }
+  }
+
+  return gaps;
+}
+
+/**
+ * The gaps that still exist, pinned exactly.
+ *
+ * A RATCHET, not an allowlist. The surface had 29 tools with 166 undeclared options;
+ * 12 tools and 80 options were closed, and the rest are recorded here so that:
+ *
+ *   - adding a NEW undeclared option to any tool fails immediately, which is the
+ *     regression this file exists to prevent;
+ *   - closing one of these fails too, until it is struck off -- so the list can only
+ *     shrink, and progress is visible in the diff rather than in a summary.
+ *
+ * This is debt, written down. It is not permission. Every entry is a way for a caller
+ * to pass an option and be silently ignored, and the ones marked (registered) are
+ * reachable over MCP today.
+ */
+const KNOWN_GAPS: Record<string, string[]> = {
+  // registered — reachable over MCP
+  'src/tools/advanced-caching/cache-compression.ts': ['dictionary', 'includeMetrics', 'sampleSize', 'testData'],
+  'src/tools/advanced-caching/cache-optimizer.ts': [
+    'constraints', 'currentConfig', 'currentStrategy', 'includeBottlenecks', 'includeCharts',
+    'includePredictions', 'includeRecommendations', 'iterations', 'learningRate', 'reportFormat',
+    'simulationDuration', 'targetConfig', 'targetStrategy', 'workloadSize',
+  ],
+  'src/tools/advanced-caching/cache-replication.ts': ['conflicts', 'enableCompression'],
+  'src/tools/advanced-caching/cache-warmup.ts': [
+    'dataSource', 'endTime', 'resolveDependencies', 'startTime', 'validateBeforeCommit',
+  ],
+  'src/tools/advanced-caching/predictive-cache.ts': ['metadata'],
+  'src/tools/advanced-caching/smart-cache.ts': ['compressionEnabled', 'metadata'],
+  'src/tools/code-analysis/smart-ast-grep.ts': [
+    'includeContext', 'incrementalIndexing', 'respectGitignore', 'ttl',
+  ],
+  'src/tools/configuration/smart-config-read.ts': ['enableCache', 'includeMetadata'],
+  'src/tools/dashboard-monitoring/alert-manager.ts': ['dataSource', 'silenceId'],
+  'src/tools/dashboard-monitoring/log-dashboard.ts': ['cacheTTL', 'filter', 'filterId', 'logSources'],
+  'src/tools/dashboard-monitoring/monitoring-integration.ts': ['cacheTTL', 'mapping', 'pushData', 'syncOptions'],
+
+  // not registered in src/server/index.ts, so not reachable over MCP today. Still a
+  // contract that lies if the tool is ever wired up.
+  'src/tools/advanced-caching/cache-benchmark.ts': ['resultsPath', 'workload'],
+  'src/tools/api-database/smart-database.ts': [
+    'analyzeIndexUsage', 'circuitBreakerThreshold', 'circuitBreakerTimeout', 'connectionString',
+    'connectionTimeout', 'database', 'detectN1', 'explain', 'host', 'idleTimeout',
+    'includeMetadata', 'minPoolSize', 'password', 'port', 'user',
+  ],
+  'src/tools/code-analysis/smart-dependencies.ts': ['exclude', 'includeMetadata', 'ttl'],
+  // Declares these NESTED under an `options` object rather than at the top level; the
+  // tool is unregistered, so which level is correct is undecided until it is wired.
+  'src/tools/configuration/smart-workflow.ts': [
+    'enableCache', 'format', 'includePerformanceRecommendations', 'includeSecurityAnalysis',
+    'ttl', 'validateSyntax',
+  ],
+  'src/tools/intelligence/knowledge-graph.ts': [
+    'communityAlgorithm', 'confidenceThreshold', 'graphs', 'imageHeight', 'imageWidth',
+    'includeLabels', 'maxHops', 'maxInferences', 'maxNodes', 'mergeStrategy',
+    'minCommunitySize', 'rankingAlgorithm',
+  ],
+  'src/tools/intelligence/sentiment-analysis.ts': ['batchSize', 'outputPath', 'threshold', 'trainingData'],
+};
+
+describe('every tool declares the options it accepts', () => {
+  const gaps = audit();
+
+  it('introduces no undeclared option beyond the recorded debt', () => {
+    const unexpected = gaps.flatMap((g) => {
+      const known = KNOWN_GAPS[g.file] ?? [];
+      return g.undeclared.filter((o) => !known.includes(o)).map((o) => `${g.file}: ${o}`);
+    });
+
+    expect(unexpected).toEqual([]);
+  });
+
+  it('records no debt that has already been paid off', () => {
+    // Forces the list to shrink as tools are fixed, instead of rotting into an
+    // allowlist that outlives the problem.
+    const stale: string[] = [];
+    for (const [file, options] of Object.entries(KNOWN_GAPS)) {
+      const found = gaps.find((g) => g.file === file)?.undeclared ?? [];
+      for (const option of options) {
+        if (!found.includes(option)) stale.push(`${file}: ${option}`);
+      }
+    }
+
+    expect(stale).toEqual([]);
+  });
+
+  it('has closed the file-operations tools, which is where the real bugs were', () => {
+    // smart_grep, smart_glob, smart_read, smart_edit, smart_write, smart_diff and the
+    // four git tools are the surface that produced the measured failures, so they are
+    // held to zero rather than ratcheted.
+    const remaining = gaps.filter((g) => g.file.startsWith('src/tools/file-operations/'));
+
+    expect(remaining).toEqual([]);
+  });
+
+  it('audits a meaningful number of tools, so it cannot pass by finding nothing', () => {
+    // If the extraction breaks, `gaps` empties and this file would go green while
+    // asserting nothing at all.
+    let audited = 0;
+    for (const file of walk(SRC)) {
+      const text = readFileSync(file, 'utf8');
+      if (text.includes('_TOOL_DEFINITION') && declaredProperties(text) && acceptedOptions(text).length) {
+        audited++;
+      }
+    }
+
+    expect(audited).toBeGreaterThan(40);
+  });
+
+  it('drops function-valued options, which cannot arrive over MCP', () => {
+    const sample = `
+      export interface XOptions {
+        onProgress?: (n: number) => void;
+        keyGenerator?: Function;
+        depth?: number;
+      }
+    `;
+
+    expect(acceptedOptions(sample)).toEqual(['depth']);
+  });
+
+  it('does not lose keys to an apostrophe in a comment', () => {
+    // The scanner bug that made this audit under-report while it was being written:
+    // "caller's" opened a string that never closed, hiding every later key.
+    const sample = `
+      export const X_TOOL_DEFINITION = {
+        inputSchema: {
+          properties: {
+            first: { type: 'string' },
+            // spreads the caller's whole argument object
+            second: { type: 'number' },
+            third: { type: 'boolean', description: 'pass [] to search everything' },
+          },
+        },
+      };
+    `;
+
+    expect(declaredProperties(sample)).toEqual(['first', 'second', 'third']);
+  });
+});


### PR DESCRIPTION
You were right that this was the important one, and right that it explains the pattern. An undeclared option isn't "undocumented" — it's **a schema that lies**.

The server hands the caller's whole argument object to the implementation:

```ts
const { pattern, ...options } = args as any;
```

So every field of an Options interface is reachable over MCP. A field missing from `inputSchema` therefore **works while being undiscoverable** — and a caller that guesses a *neighbouring* name gets silence, because `tool-arguments.ts` only refuses near-misses of **declared** fields.

That silence is behind this week's bugs, every one found by *using* the tools rather than reading them:

| Bug | Cause |
|---|---|
| `smart_grep` died with `RangeError: Maximum call stack size exceeded` for every caller in every project; `smart_glob` answered about the wrong repo | neither declared `path`, so it was dropped and `cwd` fell back to `process.cwd()` — 676,875 files from the home directory |
| `expand` → `No stored output for reference undefined` | prints `expand <id>`, parameter is `ref` |
| `smart_edit` rejected my call | takes `operations`, not `edits` |

## Measured, not assumed

**29 tools, 166 undeclared options.** (The existing comment in `tool-arguments.ts` said 22.)

This closes **12 tools and 80 options**, prioritising the surface that produced real failures: all six file-operations tools (`smart_grep`, `smart_glob`, `smart_read`, `smart_edit`, `smart_write`, `smart_diff`), the four git tools (`smart_branch`, `smart_log`, `smart_merge`, `smart_status`), plus `metric_collector` and `smart_cache_api`.

## The remaining 17 tools / 86 options are ratcheted, not excused

`KNOWN_GAPS` pins them exactly, so the list **can only shrink**:

- a **new** undeclared option anywhere fails immediately — verified by deleting `smart_grep`'s `wholeWord` declaration: **2 of 6 fail**
- striking an entry off while the gap is still open also fails — verified by removing `predictive-cache`: **1 of 6 fails**
- **file-operations is held at zero**, not ratcheted, since that's where the measured bugs were

Entries are split by whether the tool is registered in `src/server/index.ts` — six aren't reachable over MCP today. `smart_workflow` is called out separately: it declares its options **nested** under an `options` object, and which level is correct is undecided until the tool is wired up.

**I did not finish all 29.** 17 remain, 11 of them MCP-reachable. That's recorded in code rather than in a summary so it can't be quietly forgotten.

## One thing the scanner taught me

It's comment-aware, and that isn't a nicety. Without it, an apostrophe in a `//` comment — *"the caller's argument object"* — opens a string that never closes and every later key is swallowed. That happened while writing this: the audit reported 11 newly-declared properties as **still missing**, and the numbers looked plausible enough to believe. There's a test for it now.

## Verification

- `tests/unit` + `tests/hooks` pass, except `pinned-spec-tracks-package` — which fails on master's existing `5.4.1`-vs-`5.4.2` pin drift and is exactly what #256 fixes
- `trust.test.mjs` and `ast-grep-failure-surfaces` pass **25/25 in isolation**; they fail only under full-suite parallel load (81 s and 206 s)
- `tsc --noEmit` clean; `lint` **0 errors**

🤖 Generated with [Claude Code](https://claude.com/claude-code)