### PR TITLE
fix(release): verify the released tag instead of repairing it first

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,19 +83,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # A BACKSTOP, not a repair of version drift -- there is no version drift left
-      # to repair. The client configs now carry
-      # `@ooples/token-optimizer-mcp@latest`, a spec that does not change when
-      # package.json does, so a release can no longer knock them out of step.
-      #
-      # That is what allowed the sync-release-pins workflow and the release-PR sync
-      # step to be deleted, and with them the failure mode that cost four releases:
-      # v5.4.0 and v5.4.1 were both tagged with GitHub Releases and neither reached
-      # npm, each refused for pins naming the previous version.
-      #
-      # These two steps stay because the configs are GENERATED: regenerating before
-      # packing and then verifying still catches drift between a generator and its
-      # committed output. On a healthy tree the regeneration is a no-op.
       # VERIFY, AND DO NOT REPAIR FIRST. Regenerating before the check made the check
       # meaningless: `sync:hooks` rewrote the generated files, so `sync:hooks:check`
       # then compared the repaired tree against itself and passed even when the RELEASED

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,9 +96,21 @@ jobs:
       # These two steps stay because the configs are GENERATED: regenerating before
       # packing and then verifying still catches drift between a generator and its
       # committed output. On a healthy tree the regeneration is a no-op.
-      - name: Regenerate client configs before packing
-        run: npm run sync:hooks
-
+      # VERIFY, AND DO NOT REPAIR FIRST. Regenerating before the check made the check
+      # meaningless: `sync:hooks` rewrote the generated files, so `sync:hooks:check`
+      # then compared the repaired tree against itself and passed even when the RELEASED
+      # TAG contained stale generated output. The publish could ship files that did not
+      # match the tag it claims to be built from, which is the one thing the
+      # provenance attestation is supposed to rule out.
+      #
+      # The repair existed because a release used to knock the pinned specs out of step
+      # every time. It no longer can: the specs say `@latest`, which does not change
+      # when package.json does. With nothing left to repair, the regeneration only
+      # masked real generator drift.
+      #
+      # Generated output must therefore be committed before the tag is cut. The
+      # `generated-artifacts` job in quality-gates.yml runs this same check on every
+      # push, so drift is caught long before a release.
       - name: Verify generated configs match their generators
         run: npm run sync:hooks:check
 

--- a/tests/unit/pinned-spec-tracks-package.test.ts
+++ b/tests/unit/pinned-spec-tracks-package.test.ts
@@ -47,13 +47,43 @@ const PINNED_CONFIGS = [
 
 const SPEC = /@ooples\/token-optimizer-mcp@([^"'\s,\]]+)/g;
 
+/**
+ * The configs that launch the server via an inline `package@version` spec.
+ *
+ * Everything in PINNED_CONFIGS is swept for a numeric version; only these are
+ * required to CARRY a spec. mcp.json and server.json are registry manifests that
+ * name the package and version in separate fields, so demanding an inline spec of
+ * them would assert a shape they do not have.
+ */
+const INLINE_SPEC_CONFIGS = PINNED_CONFIGS.filter(
+  (relative) => relative !== 'mcp.json' && relative !== 'server.json'
+);
+
 const present = () => PINNED_CONFIGS.filter((r) => existsSync(join(ROOT, r)));
 
 describe('the MCP spec in client configs', () => {
   it.each(PINNED_CONFIGS)('in %s resolves to latest, not a frozen version', (relative) => {
     if (!existsSync(join(ROOT, relative))) return; // not every target ships in every layout
 
-    for (const spec of [...read(relative).matchAll(SPEC)].map((m) => m[1])) {
+    const specs = [...read(relative).matchAll(SPEC)].map((m) => m[1]);
+
+    // AT LEAST ONE, asserted before the values are -- but only for the configs that
+    // carry an inline `package@version` spec. A file that exists and carries no spec
+    // made this loop body never execute, so the test passed while the config said
+    // nothing about which server to launch, and the coverage test below only ever
+    // required ONE spec across the whole set.
+    //
+    // mcp.json and server.json are excluded because they are MCP REGISTRY manifests:
+    // they name the package and its version in separate fields rather than as an
+    // `@version` suffix, which is why pin-mcp-version reports seven configs and not
+    // nine. Their `version` fields are separately stale (0.2.0 and 5.1.1 against a
+    // package at 5.4.2) and nothing checks them -- recorded here because it is the
+    // same class of drift, not fixed here.
+    if (INLINE_SPEC_CONFIGS.includes(relative)) {
+      expect(specs.length).toBeGreaterThan(0);
+    }
+
+    for (const spec of specs) {
       expect(spec).toBe('latest');
     }
   });


### PR DESCRIPTION
Addresses the two review findings left unresolved when #256 merged. Both are on files #256 changed, so they land here as a follow-up rather than on #257/#258 (which touch unrelated files and are already clean — 0 unresolved threads each).

## 1. The verify step was verifying its own repair

`sync:hooks` ran immediately before `sync:hooks:check`, so the check compared the **repaired tree against itself** and passed even when the released tag contained stale generated output. The publish could ship files that don't match the tag it claims to be built from — the one thing the provenance attestation exists to rule out.

The repair was there because a release used to knock the pinned specs out of step every time. **It no longer can:** #256 made the specs `@latest`, which doesn't change when `package.json` does. With nothing left to repair, the regeneration only masked real generator drift, so it's removed.

Generated output must be committed before the tag is cut — and `quality-gates.yml`'s `generated-artifacts` job already runs this same check on every push, so drift is caught long before a release.

## 2. The per-config spec test passed vacuously

It looped over the specs found in each config, so a config that existed with **no spec at all** executed no assertion and passed — while saying nothing about which server to launch. The coverage test only required *one* spec across the whole set, so it couldn't catch a single file losing its own.

Applying the fix immediately found two real cases: **`mcp.json` and `server.json` contain zero inline specs.** They're MCP *registry* manifests that name the package and version in separate fields rather than as an `@version` suffix — which is why `pin-mcp-version` reports seven configs, not nine. They're excluded from the inline requirement with that reason recorded.

**A finding I'm flagging rather than fixing:** those two manifests carry their own `version` fields, and both are stale — `0.2.0` and `5.1.1` against a package at `5.4.2` — with nothing checking them. Same class of drift as the pins, different shape, so it needs its own change rather than being smuggled in here.

## Verification

- `pinned-spec-tracks-package`: **14/14**
- The new assertion still fails when a real config loses its spec — verified by stripping `plugin/.mcp.json` (1 failed), then restoring (14/14)
- `release.yml` parses; its publish job no longer contains a regenerate step
- `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)