### PR TITLE
fix(mcp): finish declaring every option every tool accepts

### DIFF
--- a/src/tools/advanced-caching/cache-benchmark.ts
+++ b/src/tools/advanced-caching/cache-benchmark.ts
@@ -1644,6 +1644,41 @@ Token Reduction:
         type: 'number',
         description: 'Cache TTL in seconds (default: 604800 - 7 days)',
       },
+      // DECLARED BECAUSE THEY ARE ACCEPTED: the server spreads the caller's whole
+      // argument object into options, so these worked while being undiscoverable.
+      workload: {
+        type: 'object',
+        description:
+          'Shape of the synthetic load to run. Every field is optional.',
+        properties: {
+          type: {
+            type: 'string',
+            enum: ['read-heavy', 'write-heavy', 'mixed', 'custom', 'realistic'],
+          },
+          ratio: {
+            type: 'object',
+            description: 'Read/write split, used when type is mixed or custom',
+            properties: { read: { type: 'number' }, write: { type: 'number' } },
+          },
+          duration: { type: 'number', description: 'Seconds' },
+          concurrency: { type: 'number' },
+          keyCount: { type: 'number' },
+          valueSize: { type: 'number', description: 'Bytes per value' },
+          keyDistribution: {
+            type: 'string',
+            enum: ['uniform', 'zipf', 'gaussian'],
+          },
+          accessPattern: {
+            type: 'string',
+            enum: ['sequential', 'random', 'temporal'],
+          },
+        },
+      },
+      resultsPath: {
+        type: 'string',
+        description:
+          'File to write the benchmark results to, in addition to returning them',
+      },
     },
     required: ['operation'],
   },

--- a/src/tools/advanced-caching/cache-compression.ts
+++ b/src/tools/advanced-caching/cache-compression.ts
@@ -1461,6 +1461,25 @@ export const CACHE_COMPRESSION_TOOL_DEFINITION = {
         description: 'Cache TTL in seconds',
         default: 3600,
       },
+      // DECLARED BECAUSE THEY ARE ACCEPTED: the server spreads the caller's whole
+      // argument object into options, so these worked while being undiscoverable.
+      // `dictionary` is deliberately absent -- it is a Buffer handed straight to zlib,
+      // so it cannot arrive as JSON and is programmatic-only.
+      sampleSize: {
+        type: 'number',
+        description:
+          'Bytes of the input to sample when choosing an algorithm, instead of measuring all of it',
+      },
+      includeMetrics: {
+        type: 'boolean',
+        description:
+          'Include per-algorithm ratio and timing metrics in the result',
+        default: false,
+      },
+      testData: {
+        description:
+          'Data to compress for a benchmark or analysis operation. Any JSON value; a string is used as-is and anything else is serialised first.',
+      },
     },
     required: ['operation'],
   },

--- a/src/tools/advanced-caching/cache-optimizer.ts
+++ b/src/tools/advanced-caching/cache-optimizer.ts
@@ -2230,6 +2230,113 @@ export const CACHE_OPTIMIZER_TOOL_DEFINITION = {
         description: 'Cache TTL in seconds (default: 300)',
         default: 300,
       },
+      // DECLARED BECAUSE THEY ARE ACCEPTED: the server spreads the caller's whole
+      // argument object into options, so these worked while being undiscoverable.
+      includePredictions: {
+        type: 'boolean',
+        description:
+          'Include forecast figures alongside the current measurements',
+        default: false,
+      },
+      includeBottlenecks: {
+        type: 'boolean',
+        description:
+          'Include the identified bottlenecks rather than the summary alone',
+        default: false,
+      },
+      workloadSize: {
+        type: 'number',
+        description:
+          'Number of synthetic operations to model when simulating a workload',
+      },
+      iterations: {
+        type: 'number',
+        description: 'How many times to repeat a simulation or tuning pass',
+      },
+      constraints: {
+        type: 'object',
+        description: 'Hard limits the recommendation must respect',
+        properties: {
+          maxMemory: { type: 'number', description: 'Cap in bytes' },
+          maxLatency: { type: 'number', description: 'Cap in milliseconds' },
+          minHitRate: {
+            type: 'number',
+            description: 'Floor as a fraction from 0 to 1',
+          },
+        },
+      },
+      currentStrategy: {
+        type: 'string',
+        enum: ['LRU', 'LFU', 'FIFO', 'TTL', 'SIZE', 'HYBRID'],
+        description:
+          'Eviction strategy in use now, used as the comparison baseline',
+      },
+      currentConfig: {
+        type: 'object',
+        properties: {
+          strategy: {
+            type: 'string',
+            enum: ['LRU', 'LFU', 'FIFO', 'TTL', 'SIZE', 'HYBRID'],
+          },
+          l1MaxSize: { type: 'number' },
+          l2MaxSize: { type: 'number' },
+          l3MaxSize: { type: 'number' },
+          ttl: { type: 'number' },
+          compressionEnabled: { type: 'boolean' },
+          prefetchEnabled: { type: 'boolean' },
+          writeMode: { type: 'string', enum: ['write-through', 'write-back'] },
+        },
+        description: 'Full cache configuration in use now',
+      },
+      targetStrategy: {
+        type: 'string',
+        enum: ['LRU', 'LFU', 'FIFO', 'TTL', 'SIZE', 'HYBRID'],
+        description: 'Eviction strategy to evaluate against the current one',
+      },
+      targetConfig: {
+        type: 'object',
+        properties: {
+          strategy: {
+            type: 'string',
+            enum: ['LRU', 'LFU', 'FIFO', 'TTL', 'SIZE', 'HYBRID'],
+          },
+          l1MaxSize: { type: 'number' },
+          l2MaxSize: { type: 'number' },
+          l3MaxSize: { type: 'number' },
+          ttl: { type: 'number' },
+          compressionEnabled: { type: 'boolean' },
+          prefetchEnabled: { type: 'boolean' },
+          writeMode: { type: 'string', enum: ['write-through', 'write-back'] },
+        },
+        description:
+          'Full cache configuration to evaluate against the current one',
+      },
+      simulationDuration: {
+        type: 'number',
+        description: 'Simulated time span in seconds',
+      },
+      learningRate: {
+        type: 'number',
+        description:
+          'Step size for the adaptive tuner; larger converges faster and overshoots',
+      },
+      reportFormat: {
+        type: 'string',
+        enum: ['json', 'markdown', 'html'],
+        description: 'Format for a report operation',
+        default: 'json',
+      },
+      includeCharts: {
+        type: 'boolean',
+        description: 'Embed charts in a markdown or html report',
+        default: false,
+      },
+      includeRecommendations: {
+        type: 'boolean',
+        description:
+          'Include the recommended changes, not just the measurements',
+        default: true,
+      },
     },
     required: ['operation'],
   },

--- a/src/tools/advanced-caching/cache-replication.ts
+++ b/src/tools/advanced-caching/cache-replication.ts
@@ -1538,6 +1538,30 @@ export const CACHE_REPLICATION_TOOL_DEFINITION = {
         description: 'Cache TTL in seconds (default: 300)',
         default: 300,
       },
+      // DECLARED BECAUSE THEY ARE ACCEPTED: the server spreads the caller's whole
+      // argument object into options, so these worked while being undiscoverable.
+      enableCompression: {
+        type: 'boolean',
+        description:
+          'Compress replicated payloads before sending them to peers',
+        default: false,
+      },
+      conflicts: {
+        type: 'array',
+        description:
+          'Conflicts to resolve, for a resolve operation. Each entry names the key and the competing local and remote entries.',
+        items: {
+          type: 'object',
+          properties: {
+            key: { type: 'string' },
+            localEntry: { type: 'object' },
+            remoteEntry: { type: 'object' },
+            resolution: { type: 'object' },
+            timestamp: { type: 'number' },
+          },
+          required: ['key'],
+        },
+      },
     },
     required: ['operation'],
   },

--- a/src/tools/advanced-caching/cache-warmup.ts
+++ b/src/tools/advanced-caching/cache-warmup.ts
@@ -1652,6 +1652,49 @@ export const CACHE_WARMUP_TOOL_DEFINITION = {
         description: 'Cache TTL in seconds (default: 300)',
         default: 300,
       },
+      // DECLARED BECAUSE THEY ARE ACCEPTED: the server spreads the caller's whole
+      // argument object into options, so these worked while being undiscoverable.
+      // `dataFetcher` is deliberately absent -- it is a callback, so it cannot arrive
+      // as JSON. `dataSource.customFetcher` is omitted below for the same reason.
+      dataSource: {
+        type: 'object',
+        description:
+          'Where to fetch values from when warming keys that are not cached',
+        properties: {
+          type: {
+            type: 'string',
+            enum: ['database', 'api', 'file', 'cache', 'custom'],
+          },
+          connectionString: {
+            type: 'string',
+            description: 'For type database',
+          },
+          endpoint: { type: 'string', description: 'For type api' },
+          filePath: { type: 'string', description: 'For type file' },
+        },
+        required: ['type'],
+      },
+      startTime: {
+        type: 'number',
+        description:
+          'Epoch milliseconds at which a scheduled warmup becomes active',
+      },
+      endTime: {
+        type: 'number',
+        description: 'Epoch milliseconds after which a scheduled warmup stops',
+      },
+      resolveDependencies: {
+        type: 'boolean',
+        description:
+          'Warm each key’s dependencies first, in graph order, rather than the listed keys alone',
+        default: false,
+      },
+      validateBeforeCommit: {
+        type: 'boolean',
+        description:
+          'Check each fetched value before writing it into the cache',
+        default: false,
+      },
     },
     required: ['operation'],
   },

--- a/src/tools/advanced-caching/predictive-cache.ts
+++ b/src/tools/advanced-caching/predictive-cache.ts
@@ -1249,6 +1249,14 @@ export const PREDICTIVE_CACHE_TOOL_DEFINITION = {
         description: 'Cache TTL in seconds (default: 300)',
         default: 300,
       },
+      // DECLARED BECAUSE IT IS ACCEPTED: the server spreads the caller's whole
+      // argument object into options, so this worked while being undiscoverable.
+      metadata: {
+        type: 'object',
+        description:
+          'Arbitrary key/value context stored alongside the entry and available to the predictor',
+        additionalProperties: true,
+      },
     },
     required: ['operation'],
   },

--- a/src/tools/advanced-caching/smart-cache.ts
+++ b/src/tools/advanced-caching/smart-cache.ts
@@ -1403,6 +1403,18 @@ export const SMART_CACHE_TOOL_DEFINITION = {
         description: 'Cache TTL in seconds (default: 300)',
         default: 300,
       },
+      // DECLARED BECAUSE THEY ARE ACCEPTED: the server spreads the caller's whole
+      // argument object into options, so these worked while being undiscoverable.
+      compressionEnabled: {
+        type: 'boolean',
+        description: 'Compress entries before storing them',
+        default: false,
+      },
+      metadata: {
+        type: 'object',
+        description: 'Arbitrary key/value context stored alongside the entry',
+        additionalProperties: true,
+      },
     },
     required: ['operation'],
   },

--- a/src/tools/api-database/smart-database.ts
+++ b/src/tools/api-database/smart-database.ts
@@ -1907,6 +1907,75 @@ export const SMART_DATABASE_TOOL_DEFINITION = {
         description: 'Number of parallel batch operations (default: 4)',
         default: 4,
       },
+      // DECLARED BECAUSE THEY ARE ACCEPTED: the server spreads the caller's whole
+      // argument object into options, so these worked while being undiscoverable.
+      //
+      // CONNECTION CREDENTIALS ARE PART OF THAT SURFACE. They were reachable while
+      // undocumented, which is the worst combination: a caller could send a password
+      // and have no way to know the field existed, or misspell it and have it silently
+      // dropped while the tool fell back to another connection.
+      connectionString: {
+        type: 'string',
+        description:
+          'Full connection string. Takes precedence over the individual host/port/database fields.',
+      },
+      host: { type: 'string', description: 'Database host' },
+      port: { type: 'number', description: 'Database port' },
+      database: { type: 'string', description: 'Database name' },
+      user: { type: 'string', description: 'Username' },
+      password: {
+        type: 'string',
+        description:
+          'Password. Prefer a connection string sourced from the environment over passing this in a tool call, which puts the secret in the transcript.',
+      },
+      includeMetadata: {
+        type: 'boolean',
+        description: 'Include column types and row counts alongside the rows',
+        default: false,
+      },
+      explain: {
+        type: 'boolean',
+        description: 'Attach the query plan for a SELECT',
+        default: false,
+      },
+      minPoolSize: {
+        type: 'number',
+        description: 'Connections kept open even when idle',
+        default: 2,
+      },
+      connectionTimeout: {
+        type: 'number',
+        description: 'Milliseconds to wait for a connection before failing',
+        default: 5000,
+      },
+      idleTimeout: {
+        type: 'number',
+        description:
+          'Milliseconds an idle connection is kept before being closed',
+        default: 30000,
+      },
+      analyzeIndexUsage: {
+        type: 'boolean',
+        description:
+          'Report which indexes the query used, and which were available but unused',
+        default: false,
+      },
+      detectN1: {
+        type: 'boolean',
+        description:
+          'Flag repeated similar queries that look like an N+1 pattern',
+        default: false,
+      },
+      circuitBreakerThreshold: {
+        type: 'number',
+        description: 'Consecutive failures before the breaker opens',
+        default: 5,
+      },
+      circuitBreakerTimeout: {
+        type: 'number',
+        description: 'Milliseconds the breaker stays open before retrying',
+        default: 30000,
+      },
     },
   },
 } as const;

--- a/src/tools/code-analysis/smart-ast-grep.ts
+++ b/src/tools/code-analysis/smart-ast-grep.ts
@@ -1008,6 +1008,29 @@ export const SMART_AST_GREP_TOOL_DEFINITION = {
         default: true,
         description: 'Enable AST index and pattern caching',
       },
+      // DECLARED BECAUSE THEY ARE ACCEPTED: the server spreads the caller's whole
+      // argument object into options, so these worked while being undiscoverable.
+      ttl: {
+        type: 'number',
+        description: 'Lifetime of the AST index cache in seconds',
+        default: 604800,
+      },
+      includeContext: {
+        type: 'boolean',
+        description: 'Include surrounding source lines with each match',
+        default: false,
+      },
+      respectGitignore: {
+        type: 'boolean',
+        description: 'Skip files git ignores when walking the project',
+        default: true,
+      },
+      incrementalIndexing: {
+        type: 'boolean',
+        description:
+          'Reindex only files changed since the last run instead of the whole project',
+        default: true,
+      },
     },
     required: ['pattern', 'projectPath'],
   },

--- a/src/tools/code-analysis/smart-dependencies.ts
+++ b/src/tools/code-analysis/smart-dependencies.ts
@@ -1449,7 +1449,11 @@ export const SMART_DEPENDENCIES_TOOL_DEFINITION = {
       },
       ttl: {
         type: 'number',
-        description: 'Cache lifetime in seconds',
+        // DAYS, not seconds. `cacheGraph` multiplies by 24*60*60 before storing, so a
+        // caller who read "seconds" here and passed 300 would get a 300-DAY entry. A
+        // unit that is confidently wrong is worse than one that is absent.
+        description: 'Cache lifetime in DAYS (converted to seconds internally)',
+        default: 7,
       },
       includeMetadata: {
         type: 'boolean',

--- a/src/tools/code-analysis/smart-dependencies.ts
+++ b/src/tools/code-analysis/smart-dependencies.ts
@@ -1439,6 +1439,24 @@ export const SMART_DEPENDENCIES_TOOL_DEFINITION = {
         description: 'Output format',
         default: 'compact',
       },
+      // DECLARED BECAUSE THEY ARE ACCEPTED: the server spreads the caller's whole
+      // argument object into options, so these worked while being undiscoverable.
+      exclude: {
+        type: 'array',
+        items: { type: 'string' },
+        description:
+          'Glob patterns for files to skip while resolving the graph',
+      },
+      ttl: {
+        type: 'number',
+        description: 'Cache lifetime in seconds',
+      },
+      includeMetadata: {
+        type: 'boolean',
+        description:
+          'Include per-package version and resolution detail, not just the edges',
+        default: false,
+      },
     },
   },
 };

--- a/src/tools/configuration/smart-config-read.ts
+++ b/src/tools/configuration/smart-config-read.ts
@@ -40,7 +40,13 @@ export interface SmartConfigReadOptions {
 
   // Output options
   diffMode?: boolean; // Return only diff if config changed
-  includeMetadata?: boolean;
+  // `includeMetadata` REMOVED. It was never read -- `metadata` is built unconditionally
+  // on every return path -- so the option could not change anything. Declaring it in the
+  // schema would have promised control that does not exist, which is the same class of
+  // untruth as an undeclared option, pointing the other way; and honouring it would mean
+  // making `metadata` optional on the result type, a breaking change for every consumer
+  // in service of an option nobody could have been using. Nothing in the repository
+  // passed it.
   includeSuggestions?: boolean;
   validateOnly?: boolean; // Only validate, don't return full config
 
@@ -853,12 +859,6 @@ export const SMART_CONFIG_READ_TOOL_DEFINITION = {
         description:
           'Reuse a cached parse of this config when it has not changed',
         default: true,
-      },
-      includeMetadata: {
-        type: 'boolean',
-        description:
-          'Include format, size and parse details alongside the parsed value',
-        default: false,
       },
     },
     required: ['path'],

--- a/src/tools/configuration/smart-config-read.ts
+++ b/src/tools/configuration/smart-config-read.ts
@@ -846,6 +846,20 @@ export const SMART_CONFIG_READ_TOOL_DEFINITION = {
         description: 'Cache time-to-live in seconds (default: 604800 = 7 days)',
         default: 604800,
       },
+      // DECLARED BECAUSE THEY ARE ACCEPTED: the server spreads the caller's whole
+      // argument object into options, so these worked while being undiscoverable.
+      enableCache: {
+        type: 'boolean',
+        description:
+          'Reuse a cached parse of this config when it has not changed',
+        default: true,
+      },
+      includeMetadata: {
+        type: 'boolean',
+        description:
+          'Include format, size and parse details alongside the parsed value',
+        default: false,
+      },
     },
     required: ['path'],
   },

--- a/src/tools/dashboard-monitoring/alert-manager.ts
+++ b/src/tools/dashboard-monitoring/alert-manager.ts
@@ -1397,10 +1397,30 @@ export const ALERT_MANAGER_TOOL_DEFINITION = {
                 additionalProperties: { type: 'string' },
               },
               query: { type: 'string' },
+              tool: {
+                type: 'string',
+                description: 'MCP tool to call, for type mcp-tool',
+              },
             },
           },
+          transform: {
+            type: 'string',
+            description: 'JavaScript expression applied to the fetched value',
+          },
+          cache: {
+            type: 'object',
+            description: 'Whether and how long to cache this source',
+            properties: {
+              enabled: { type: 'boolean' },
+              ttl: { type: 'number', description: 'Seconds' },
+            },
+            required: ['enabled', 'ttl'],
+          },
         },
-        required: ['id', 'type'],
+        // `connection` is required by the interface, so it is required here too. The
+        // first draft omitted it along with tool/transform/cache, which meant an
+        // mcp-tool source could not be configured through the published contract.
+        required: ['id', 'type', 'connection'],
       },
       silenceId: {
         type: 'string',

--- a/src/tools/dashboard-monitoring/alert-manager.ts
+++ b/src/tools/dashboard-monitoring/alert-manager.ts
@@ -1374,6 +1374,39 @@ export const ALERT_MANAGER_TOOL_DEFINITION = {
         description:
           'Cache TTL in seconds (optional, uses defaults if not specified)',
       },
+      // DECLARED BECAUSE THEY ARE ACCEPTED: the server spreads the caller's whole
+      // argument object into options, so these worked while being undiscoverable.
+      dataSource: {
+        type: 'object',
+        description: 'Where the alert rule reads its metric from',
+        properties: {
+          id: { type: 'string' },
+          type: {
+            type: 'string',
+            enum: ['api', 'database', 'file', 'mcp-tool', 'custom'],
+          },
+          connection: {
+            type: 'object',
+            description:
+              'Connection details; which fields apply depends on type',
+            properties: {
+              url: { type: 'string' },
+              method: { type: 'string' },
+              headers: {
+                type: 'object',
+                additionalProperties: { type: 'string' },
+              },
+              query: { type: 'string' },
+            },
+          },
+        },
+        required: ['id', 'type'],
+      },
+      silenceId: {
+        type: 'string',
+        description:
+          'Identifier of an existing silence, for extending or removing it',
+      },
     },
     required: ['operation'],
   },

--- a/src/tools/dashboard-monitoring/log-dashboard.ts
+++ b/src/tools/dashboard-monitoring/log-dashboard.ts
@@ -1333,6 +1333,68 @@ export const LOG_DASHBOARD_TOOL_DEFINITION = {
         description: 'Enable caching (default: true)',
         default: true,
       },
+      // DECLARED BECAUSE THEY ARE ACCEPTED: the server spreads the caller's whole
+      // argument object into options, so these worked while being undiscoverable.
+      logSources: {
+        type: 'array',
+        description: 'Log sources to read from',
+        items: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+            name: { type: 'string' },
+            type: {
+              type: 'string',
+              enum: ['file', 'stream', 'api', 'database'],
+            },
+            config: {
+              type: 'object',
+              description: 'Which fields apply depends on type',
+              properties: {
+                path: { type: 'string' },
+                url: { type: 'string' },
+                query: { type: 'string' },
+                format: {
+                  type: 'string',
+                  enum: ['json', 'text', 'syslog', 'custom'],
+                },
+              },
+            },
+          },
+          required: ['id', 'type'],
+        },
+      },
+      filterId: {
+        type: 'string',
+        description: 'Identifier of a saved filter to apply or remove',
+      },
+      filter: {
+        type: 'object',
+        description: 'Filter to apply to the matched entries',
+        properties: {
+          id: { type: 'string' },
+          name: { type: 'string' },
+          pattern: {
+            type: 'string',
+            description: 'Regular expression matched against the message',
+          },
+          level: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Log levels to include',
+          },
+          fields: { type: 'object', additionalProperties: true },
+          exclude: {
+            type: 'boolean',
+            description: 'Exclude matches instead of including them',
+            default: false,
+          },
+        },
+      },
+      cacheTTL: {
+        type: 'number',
+        description: 'Cache lifetime in seconds',
+      },
     },
     required: ['operation'],
   },

--- a/src/tools/dashboard-monitoring/log-dashboard.ts
+++ b/src/tools/dashboard-monitoring/log-dashboard.ts
@@ -1358,10 +1358,28 @@ export const LOG_DASHBOARD_TOOL_DEFINITION = {
                   type: 'string',
                   enum: ['json', 'text', 'syslog', 'custom'],
                 },
+                parser: {
+                  type: 'string',
+                  description:
+                    'Custom parser regular expression, for format custom',
+                },
               },
             },
+            enabled: {
+              type: 'boolean',
+              description:
+                'Whether this source is read; required by the interface',
+            },
+            lastRead: {
+              type: 'number',
+              description:
+                'Epoch milliseconds of the last read, maintained by the tool',
+            },
           },
-          required: ['id', 'type'],
+          // MATCHES LogSource. The first draft required only id and type and omitted
+          // name, enabled and config.parser, so it accepted source objects the tool
+          // itself would reject -- a schema loose enough to produce invalid input.
+          required: ['id', 'name', 'type', 'config', 'enabled'],
         },
       },
       filterId: {

--- a/src/tools/dashboard-monitoring/monitoring-integration.ts
+++ b/src/tools/dashboard-monitoring/monitoring-integration.ts
@@ -696,6 +696,56 @@ export const MONITORING_INTEGRATION_TOOL_DEFINITION = {
         },
       },
       useCache: { type: 'boolean', default: true },
+      // DECLARED BECAUSE THEY ARE ACCEPTED: the server spreads the caller's whole
+      // argument object into options, so these worked while being undiscoverable.
+      syncOptions: {
+        type: 'object',
+        description: 'Narrows what a sync pulls from the external platform',
+        properties: {
+          timeRange: {
+            type: 'object',
+            description: 'Epoch-millisecond bounds',
+            properties: { start: { type: 'number' }, end: { type: 'number' } },
+            required: ['start', 'end'],
+          },
+          metrics: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Metric names to sync; all of them when omitted',
+          },
+          limit: { type: 'number', description: 'Maximum records to pull' },
+        },
+      },
+      pushData: {
+        type: 'object',
+        description: 'Payload to push to the external platform',
+        properties: {
+          metrics: { type: 'array', items: {} },
+          logs: { type: 'array', items: {} },
+          traces: { type: 'array', items: {} },
+        },
+      },
+      mapping: {
+        type: 'array',
+        description: 'Field mappings between the external schema and this one',
+        items: {
+          type: 'object',
+          properties: {
+            externalField: { type: 'string' },
+            internalField: { type: 'string' },
+            transform: {
+              type: 'string',
+              description:
+                'JavaScript expression applied to the value during mapping',
+            },
+          },
+          required: ['externalField', 'internalField'],
+        },
+      },
+      cacheTTL: {
+        type: 'number',
+        description: 'Cache lifetime in seconds',
+      },
     },
     required: ['operation'],
   },

--- a/src/tools/intelligence/knowledge-graph.ts
+++ b/src/tools/intelligence/knowledge-graph.ts
@@ -1900,6 +1900,70 @@ export const KNOWLEDGE_GRAPH_TOOL_DEFINITION = {
         type: 'number',
         description: 'Cache TTL in seconds',
       },
+      // DECLARED BECAUSE THEY ARE ACCEPTED: the server spreads the caller's whole
+      // argument object into options, so these worked while being undiscoverable.
+      maxHops: {
+        type: 'number',
+        description: 'How many relationship hops a traversal may follow',
+      },
+      communityAlgorithm: {
+        type: 'string',
+        enum: ['louvain', 'label-propagation', 'modularity'],
+        description: 'Community detection algorithm',
+      },
+      minCommunitySize: {
+        type: 'number',
+        description: 'Discard detected communities smaller than this',
+      },
+      rankingAlgorithm: {
+        type: 'string',
+        enum: ['pagerank', 'betweenness', 'closeness', 'eigenvector'],
+        description: 'Centrality measure used to rank nodes',
+      },
+      confidenceThreshold: {
+        type: 'number',
+        description: 'Discard inferences scoring below this, from 0 to 1',
+      },
+      maxInferences: {
+        type: 'number',
+        description: 'Cap on how many inferred relationships to return',
+      },
+      maxNodes: {
+        type: 'number',
+        description: 'Cap on nodes included when rendering or exporting',
+      },
+      includeLabels: {
+        type: 'boolean',
+        description: 'Draw node labels in a rendered graph',
+        default: true,
+      },
+      imageWidth: {
+        type: 'number',
+        description: 'Rendered image width in pixels',
+      },
+      imageHeight: {
+        type: 'number',
+        description: 'Rendered image height in pixels',
+      },
+      graphs: {
+        type: 'array',
+        description: 'Graphs to combine, for a merge operation',
+        items: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+            nodes: { type: 'array', items: {} },
+            edges: { type: 'array', items: {} },
+          },
+          required: ['id', 'nodes', 'edges'],
+        },
+      },
+      mergeStrategy: {
+        type: 'string',
+        enum: ['union', 'intersection', 'override'],
+        description:
+          'How to reconcile nodes and edges present in more than one graph',
+      },
     },
     required: ['operation'],
   },

--- a/src/tools/intelligence/sentiment-analysis.ts
+++ b/src/tools/intelligence/sentiment-analysis.ts
@@ -1582,6 +1582,52 @@ export const SENTIMENT_ANALYSIS_TOOL_DEFINITION = {
         type: 'number',
         description: 'Cache TTL in seconds (overrides default)',
       },
+      // DECLARED BECAUSE THEY ARE ACCEPTED: the server spreads the caller's whole
+      // argument object into options, so these worked while being undiscoverable.
+      // `progressCallback` is deliberately absent -- a callback cannot arrive as JSON.
+      batchSize: {
+        type: 'number',
+        description: 'How many texts to score per batch',
+      },
+      trainingData: {
+        type: 'array',
+        description: 'Labelled examples for a train or retrain operation',
+        items: {
+          type: 'object',
+          properties: {
+            text: { type: 'string' },
+            sentiment: {
+              type: 'number',
+              description: 'Label from -1 (negative) to 1 (positive)',
+            },
+            emotions: {
+              type: 'object',
+              additionalProperties: { type: 'number' },
+              description: 'Optional per-emotion intensities',
+            },
+          },
+          required: ['text', 'sentiment'],
+        },
+      },
+      outputPath: {
+        type: 'string',
+        description: 'File to write a trained or exported model to',
+      },
+      threshold: {
+        type: 'object',
+        description: 'Cut-offs below which a result is not reported',
+        properties: {
+          sentiment: {
+            type: 'number',
+            description: 'Minimum absolute sentiment, from -1 to 1',
+          },
+          emotion: {
+            type: 'object',
+            additionalProperties: { type: 'number' },
+            description: 'Per-emotion minimum intensities',
+          },
+        },
+      },
     },
     required: ['operation'],
   },

--- a/tests/unit/tool-schemas-declare-what-they-accept.test.ts
+++ b/tests/unit/tool-schemas-declare-what-they-accept.test.ts
@@ -110,13 +110,34 @@ function topLevelKeys(text: string, open: number): string[] {
   return keys;
 }
 
+/**
+ * Property names a schema declares, counting an `options` sub-object as declared.
+ *
+ * MOST tools are flattened by the server -- `const { pattern, ...options } = args` --
+ * so their options belong at the top level. A few instead take options as a SEPARATE
+ * argument (`run(target, options)`) and nest them under an `options` property, which is
+ * correct for that call shape. Counting only top-level keys reported those as
+ * undeclared, which was the checker being wrong rather than the tool: smart_workflow
+ * declares all six of its options inside `options`, exactly as its signature expects.
+ */
 function declaredProperties(text: string): string[] | null {
   const schema = text.indexOf('inputSchema');
   if (schema === -1) return null;
   const props = text.indexOf('properties:', schema);
   if (props === -1) return null;
   const open = text.indexOf('{', props);
-  return open === -1 ? null : topLevelKeys(text, open);
+  if (open === -1) return null;
+
+  const top = topLevelKeys(text, open);
+  if (!top.includes('options')) return top;
+
+  // Descend into the `options` object and treat its keys as declared too.
+  const optionsKey = text.indexOf('options:', open);
+  const nestedProps =
+    optionsKey === -1 ? -1 : text.indexOf('properties:', optionsKey);
+  if (nestedProps === -1) return top;
+  const nestedOpen = text.indexOf('{', nestedProps);
+  return nestedOpen === -1 ? top : [...top, ...topLevelKeys(text, nestedOpen)];
 }
 
 /**
@@ -151,8 +172,17 @@ function acceptedOptions(text: string): string[] {
       if (!line) continue;
 
       const [, name, type] = line;
+
+      // NOT EXPRESSIBLE AS JSON, so not declarable and not reachable over MCP.
+      //
+      // Functions are obvious. `Buffer` is here for the same reason and was checked
+      // rather than assumed: cache_compression's `dictionary` is handed straight to
+      // zlib as a Buffer, so declaring it as a base64 string would promise a shape the
+      // implementation cannot consume -- a different lie from the one this test exists
+      // to catch, not a fix for it.
       const isFunction = type.includes('=>') || /\bFunction\b/.test(type);
-      if (!isFunction) fields.push(name);
+      const isBinary = /\bBuffer\b/.test(type);
+      if (!isFunction && !isBinary) fields.push(name);
     }
   }
 
@@ -214,126 +244,6 @@ function audit(): Gap[] {
  */
 const KNOWN_GAPS: Record<string, string[]> = {
   // registered — reachable over MCP
-  'src/tools/advanced-caching/cache-compression.ts': [
-    'dictionary',
-    'includeMetrics',
-    'sampleSize',
-    'testData',
-  ],
-  'src/tools/advanced-caching/cache-optimizer.ts': [
-    'constraints',
-    'currentConfig',
-    'currentStrategy',
-    'includeBottlenecks',
-    'includeCharts',
-    'includePredictions',
-    'includeRecommendations',
-    'iterations',
-    'learningRate',
-    'reportFormat',
-    'simulationDuration',
-    'targetConfig',
-    'targetStrategy',
-    'workloadSize',
-  ],
-  'src/tools/advanced-caching/cache-replication.ts': [
-    'conflicts',
-    'enableCompression',
-  ],
-  'src/tools/advanced-caching/cache-warmup.ts': [
-    'dataSource',
-    'endTime',
-    'resolveDependencies',
-    'startTime',
-    'validateBeforeCommit',
-  ],
-  'src/tools/advanced-caching/predictive-cache.ts': ['metadata'],
-  'src/tools/advanced-caching/smart-cache.ts': [
-    'compressionEnabled',
-    'metadata',
-  ],
-  'src/tools/code-analysis/smart-ast-grep.ts': [
-    'includeContext',
-    'incrementalIndexing',
-    'respectGitignore',
-    'ttl',
-  ],
-  'src/tools/configuration/smart-config-read.ts': [
-    'enableCache',
-    'includeMetadata',
-  ],
-  'src/tools/dashboard-monitoring/alert-manager.ts': [
-    'dataSource',
-    'silenceId',
-  ],
-  'src/tools/dashboard-monitoring/log-dashboard.ts': [
-    'cacheTTL',
-    'filter',
-    'filterId',
-    'logSources',
-  ],
-  'src/tools/dashboard-monitoring/monitoring-integration.ts': [
-    'cacheTTL',
-    'mapping',
-    'pushData',
-    'syncOptions',
-  ],
-
-  // not registered in src/server/index.ts, so not reachable over MCP today. Still a
-  // contract that lies if the tool is ever wired up.
-  'src/tools/advanced-caching/cache-benchmark.ts': ['resultsPath', 'workload'],
-  'src/tools/api-database/smart-database.ts': [
-    'analyzeIndexUsage',
-    'circuitBreakerThreshold',
-    'circuitBreakerTimeout',
-    'connectionString',
-    'connectionTimeout',
-    'database',
-    'detectN1',
-    'explain',
-    'host',
-    'idleTimeout',
-    'includeMetadata',
-    'minPoolSize',
-    'password',
-    'port',
-    'user',
-  ],
-  'src/tools/code-analysis/smart-dependencies.ts': [
-    'exclude',
-    'includeMetadata',
-    'ttl',
-  ],
-  // Declares these NESTED under an `options` object rather than at the top level; the
-  // tool is unregistered, so which level is correct is undecided until it is wired.
-  'src/tools/configuration/smart-workflow.ts': [
-    'enableCache',
-    'format',
-    'includePerformanceRecommendations',
-    'includeSecurityAnalysis',
-    'ttl',
-    'validateSyntax',
-  ],
-  'src/tools/intelligence/knowledge-graph.ts': [
-    'communityAlgorithm',
-    'confidenceThreshold',
-    'graphs',
-    'imageHeight',
-    'imageWidth',
-    'includeLabels',
-    'maxHops',
-    'maxInferences',
-    'maxNodes',
-    'mergeStrategy',
-    'minCommunitySize',
-    'rankingAlgorithm',
-  ],
-  'src/tools/intelligence/sentiment-analysis.ts': [
-    'batchSize',
-    'outputPath',
-    'threshold',
-    'trainingData',
-  ],
 };
 
 describe('every tool declares the options it accepts', () => {
@@ -364,15 +274,18 @@ describe('every tool declares the options it accepts', () => {
     expect(stale).toEqual([]);
   });
 
-  it('has closed the file-operations tools, which is where the real bugs were', () => {
-    // smart_grep, smart_glob, smart_read, smart_edit, smart_write, smart_diff and the
-    // four git tools are the surface that produced the measured failures, so they are
-    // held to zero rather than ratcheted.
-    const remaining = gaps.filter((g) =>
-      g.file.startsWith('src/tools/file-operations/')
-    );
+  it('has no undeclared option anywhere', () => {
+    // THE RATCHET IS NOW AT ZERO. It started at 29 tools and 166 options, was carried
+    // for a while as recorded debt, and is empty: every tool declares everything it
+    // accepts. Stated as its own assertion so the goal cannot quietly become "no
+    // WORSE than the list", which is all the two tests above check once KNOWN_GAPS is
+    // empty.
+    const report = gaps
+      .map((g) => `${g.file}: ${g.undeclared.join(', ')}`)
+      .join('\n');
 
-    expect(remaining).toEqual([]);
+    expect(report).toBe('');
+    expect(Object.keys(KNOWN_GAPS)).toEqual([]);
   });
 
   it('audits a meaningful number of tools, so it cannot pass by finding nothing', () => {


### PR DESCRIPTION
`KNOWN_GAPS` is empty. The ratchet started at **29 tools / 166 undeclared options**, carried **17 tools / 86 options** as recorded debt after the first pass, and is now at **zero**.

## Why this mattered

An undeclared option is a schema that lies. The server does `const { pattern, ...options } = args`, so every Options-interface field is reachable over MCP — a field missing from `inputSchema` **works while being undiscoverable**, and a caller guessing a neighbouring name gets silence, because `tool-arguments.ts` only refuses near-misses of *declared* fields. That's the mechanism that let `smart_grep` crash for every caller in every project.

## Closed here

`cache_compression`, `cache_optimizer`, `cache_replication`, `cache_warmup`, `predictive_cache`, `smart_cache`, `cache_benchmark`, `smart_database`, `smart_ast_grep`, `smart_dependencies`, `smart_config_read`, `alert_manager`, `log_dashboard`, `monitoring_integration`, `knowledge_graph`, `sentiment_analysis` — plus a checker fix that cleared `smart_workflow`.

## Three judgements, each checked rather than assumed

**`dictionary` on `cache_compression` is a `Buffer`** handed straight to zlib. Declaring it as a base64 string would promise a shape the implementation cannot consume — a different lie from the one this test exists to catch. The scanner now excludes `Buffer` for the same reason it excludes callbacks, computed from the declared type rather than a hand-maintained list.

**`smart_workflow` was not missing declarations.** It takes options as a *separate argument* (`run(target, options)`) and nests all six under an `options` property, which is correct for that call shape. My checker only counted top-level keys. **I fixed the checker, not the tool** — it now descends into an `options` sub-object.

**`smart_database`'s connection credentials** — `host`, `user`, `password`, `connectionString` — were reachable while undocumented, the worst combination. Now declared, with a note preferring an environment-sourced connection string over putting a password in a tool call.

## Verification beyond the typechecker

All 19 touched schemas were loaded from the **built `dist`** and checked for well-formedness:

```
19/19 tool schemas well-formed; 339 properties declared total
```

That caught a real defect an earlier draft had: two `$ref: '#/$defs/cacheConfiguration'` pointers into a `$defs` block this schema set does not define. Inlined instead.

The zero state is asserted on its own, because once `KNOWN_GAPS` is empty the two ratchet tests only check "no worse than the list". Verified it still bites by deleting `knowledge_graph`'s `maxHops` declaration — **2 of 6 fail**, restored **6 of 6**.

- `tests/unit` + `tests/hooks`: **123 suites, 1,526 passed**
- `tsc --noEmit` clean
- `lint` **0 errors**
- `format:check` clean — the gate I missed on #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)