### PR TITLE
fix(mcp): close the two verification holes that let bad schemas and stale manifests through

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,11 +1,14 @@
 {
   "name": "token-optimizer",
-  "version": "5.1.2",
+  "version": "5.4.3",
   "description": "Context-window optimization tools (caching, compression, smart file tooling) for the Gemini CLI.",
   "mcpServers": {
     "token-optimizer": {
       "command": "npx",
-      "args": ["-y", "@ooples/token-optimizer-mcp@latest"]
+      "args": [
+        "-y",
+        "@ooples/token-optimizer-mcp@latest"
+      ]
     }
   },
   "settings": [

--- a/mcp.json
+++ b/mcp.json
@@ -1,6 +1,6 @@
 {
   "name": "io.github.ooples/token-optimizer-mcp",
-  "version": "0.2.0",
+  "version": "5.4.3",
   "description": "Intelligent token optimization for Claude Code - achieving 95%+ token reduction through caching, compression, and smart tool intelligence",
   "author": {
     "name": "ooples",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -14,6 +14,26 @@
           "type": "json",
           "path": "plugin/.claude-plugin/plugin.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "server.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "server.json",
+          "jsonpath": "$.packages[0].version"
+        },
+        {
+          "type": "json",
+          "path": "mcp.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "gemini-extension.json",
+          "jsonpath": "$.version"
         }
       ]
     }

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/ooples/token-optimizer-mcp",
     "source": "github"
   },
-  "version": "5.1.1",
+  "version": "5.4.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@ooples/token-optimizer-mcp",
-      "version": "5.1.1",
+      "version": "5.4.3",
       "transport": {
         "type": "stdio"
       },

--- a/src/tools/advanced-caching/cache-analytics.ts
+++ b/src/tools/advanced-caching/cache-analytics.ts
@@ -2266,6 +2266,9 @@ export const CACHE_ANALYTICS_TOOL_DEFINITION = {
           severity: { type: 'string', enum: ['info', 'warning', 'critical'] },
           enabled: { type: 'boolean' },
         },
+        // AlertConfiguration has no optional fields, so a partial object is not a valid
+        // alert. Pre-existing: the properties were declared without any `required`.
+        required: ['metric', 'condition', 'threshold', 'severity', 'enabled'],
         description: 'Alert configuration',
       },
       heatmapType: {

--- a/src/tools/advanced-caching/cache-benchmark.ts
+++ b/src/tools/advanced-caching/cache-benchmark.ts
@@ -1556,8 +1556,17 @@ Token Reduction:
           },
           maxSize: { type: 'number' },
           maxEntries: { type: 'number' },
-          ttl: { type: 'number' },
+          ttl: { type: 'number', description: 'Seconds' },
+          evictionPolicy: { type: 'string', enum: ['strict', 'lazy'] },
+          compressionEnabled: { type: 'boolean' },
+          params: {
+            type: 'object',
+            additionalProperties: true,
+            description: 'Strategy-specific parameters',
+          },
         },
+        // CacheConfig requires name and strategy; the rest are optional.
+        required: ['name', 'strategy'],
       },
       configs: {
         type: 'array',
@@ -1570,7 +1579,19 @@ Token Reduction:
               type: 'string',
               enum: ['LRU', 'LFU', 'FIFO', 'TTL', 'size', 'hybrid'],
             },
+            maxSize: { type: 'number', description: 'MB' },
+            maxEntries: { type: 'number' },
+            ttl: { type: 'number', description: 'Seconds' },
+            evictionPolicy: { type: 'string', enum: ['strict', 'lazy'] },
+            compressionEnabled: { type: 'boolean' },
+            params: {
+              type: 'object',
+              additionalProperties: true,
+              description: 'Strategy-specific parameters',
+            },
           },
+          // CacheConfig requires name and strategy; the rest are optional.
+          required: ['name', 'strategy'],
         },
       },
       duration: {

--- a/src/tools/advanced-caching/cache-optimizer.ts
+++ b/src/tools/advanced-caching/cache-optimizer.ts
@@ -2286,6 +2286,18 @@ export const CACHE_OPTIMIZER_TOOL_DEFINITION = {
           prefetchEnabled: { type: 'boolean' },
           writeMode: { type: 'string', enum: ['write-through', 'write-back'] },
         },
+        // Every field of CacheConfiguration is non-optional, so a partial object is not
+        // a valid configuration. Declaring the properties without this said otherwise.
+        required: [
+          'strategy',
+          'l1MaxSize',
+          'l2MaxSize',
+          'l3MaxSize',
+          'ttl',
+          'compressionEnabled',
+          'prefetchEnabled',
+          'writeMode',
+        ],
         description: 'Full cache configuration in use now',
       },
       targetStrategy: {
@@ -2308,6 +2320,18 @@ export const CACHE_OPTIMIZER_TOOL_DEFINITION = {
           prefetchEnabled: { type: 'boolean' },
           writeMode: { type: 'string', enum: ['write-through', 'write-back'] },
         },
+        // Every field of CacheConfiguration is non-optional, so a partial object is not
+        // a valid configuration. Declaring the properties without this said otherwise.
+        required: [
+          'strategy',
+          'l1MaxSize',
+          'l2MaxSize',
+          'l3MaxSize',
+          'ttl',
+          'compressionEnabled',
+          'prefetchEnabled',
+          'writeMode',
+        ],
         description:
           'Full cache configuration to evaluate against the current one',
       },

--- a/src/tools/advanced-caching/cache-replication.ts
+++ b/src/tools/advanced-caching/cache-replication.ts
@@ -1557,9 +1557,15 @@ export const CACHE_REPLICATION_TOOL_DEFINITION = {
             localEntry: { type: 'object' },
             remoteEntry: { type: 'object' },
             resolution: { type: 'object' },
+            resolvedBy: {
+              type: 'string',
+              description: 'Which resolution rule settled this conflict',
+            },
             timestamp: { type: 'number' },
           },
-          required: ['key'],
+          // Conflict requires all of these; only `resolution` and `resolvedBy` are
+          // optional, because they are what a resolve operation fills in.
+          required: ['key', 'localEntry', 'remoteEntry', 'timestamp'],
         },
       },
     },

--- a/src/tools/advanced-caching/cache-warmup.ts
+++ b/src/tools/advanced-caching/cache-warmup.ts
@@ -1569,6 +1569,37 @@ export const CACHE_WARMUP_TOOL_DEFINITION = {
       dependencies: {
         type: 'object',
         description: 'Dependency graph for dependency-based warmup',
+        // Declared in full. This was `{ type: 'object' }` with no properties,
+        // so dependency-based warmup -- the entire reason this option exists --
+        // could not be configured from the published contract.
+        properties: {
+          nodes: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                key: { type: 'string' },
+                priority: { type: 'number' },
+                category: { type: 'string' },
+                estimatedSize: { type: 'number' },
+              },
+              required: ['key', 'priority'],
+            },
+          },
+          edges: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                from: { type: 'string', description: 'Dependent key' },
+                to: { type: 'string', description: 'Dependency key' },
+                type: { type: 'string', enum: ['required', 'optional'] },
+              },
+              required: ['from', 'to', 'type'],
+            },
+          },
+        },
+        required: ['nodes', 'edges'],
       },
       accessHistory: {
         type: 'array',

--- a/src/tools/advanced-caching/predictive-cache.ts
+++ b/src/tools/advanced-caching/predictive-cache.ts
@@ -1180,7 +1180,14 @@ export const PREDICTIVE_CACHE_TOOL_DEFINITION = {
             key: { type: 'string' },
             timestamp: { type: 'number' },
             hitCount: { type: 'number' },
+            metadata: {
+              type: 'object',
+              additionalProperties: true,
+              description: 'Arbitrary context recorded with the access',
+            },
           },
+          // AccessPattern requires all but metadata.
+          required: ['key', 'timestamp', 'hitCount'],
         },
         description: 'Training data (for train operation)',
       },

--- a/src/tools/api-database/smart-cache-api.ts
+++ b/src/tools/api-database/smart-cache-api.ts
@@ -941,6 +941,8 @@ Token Reduction:
           body: { type: 'object' },
           params: { type: 'object' },
         },
+        // APIRequest requires a url; everything else is optional.
+        required: ['url'],
       },
       response: {
         description: 'API response data (for set)',

--- a/src/tools/dashboard-monitoring/alert-manager.ts
+++ b/src/tools/dashboard-monitoring/alert-manager.ts
@@ -1273,6 +1273,10 @@ export const ALERT_MANAGER_TOOL_DEFINITION = {
             },
           },
         },
+        // `metric` is the only non-optional field of AlertCondition. Without it
+        // here, a condition naming no metric satisfied the published contract
+        // and failed inside the tool instead.
+        required: ['metric'],
       },
       severity: {
         type: 'string',

--- a/src/tools/dashboard-monitoring/custom-widget.ts
+++ b/src/tools/dashboard-monitoring/custom-widget.ts
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Custom Widget Tool - 88% token reduction through template caching and widget definition compression
  *
  * Features:
@@ -1195,10 +1195,127 @@ export const CUSTOM_WIDGET_TOOL_DEFINITION = {
       config: {
         type: 'object',
         description: 'Widget configuration',
+        // Declared in full. This was `{ type: 'object' }` with no properties,
+        // so the published contract described none of the 21 fields a widget
+        // actually accepts -- a caller had no way to learn them, and any
+        // misspelling passed validation and vanished.
+        //
+        // Every field is optional in WidgetConfig because which ones apply
+        // depends on the widget type, so there is no `required` list here.
+        properties: {
+          chartType: {
+            type: 'string',
+            enum: ['line', 'bar', 'pie', 'scatter', 'area', 'radar'],
+          },
+          // Inlined rather than $ref'd: this schema declares no $defs, and a
+          // reference into a section that does not exist resolves to nothing --
+          // a validator either errors or silently accepts anything.
+          xAxis: {
+            type: 'object',
+            properties: {
+              field: { type: 'string' },
+              label: { type: 'string' },
+              format: { type: 'string' },
+            },
+            required: ['field'],
+          },
+          yAxis: {
+            type: 'object',
+            properties: {
+              field: { type: 'string' },
+              label: { type: 'string' },
+              format: { type: 'string' },
+            },
+            required: ['field'],
+          },
+          series: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                field: { type: 'string' },
+                label: { type: 'string' },
+                color: { type: 'string' },
+              },
+              required: ['field'],
+            },
+          },
+          metric: { type: 'string' },
+          threshold: {
+            type: 'object',
+            properties: {
+              warning: { type: 'number' },
+              critical: { type: 'number' },
+            },
+          },
+          format: { type: 'string' },
+          sparkline: { type: 'boolean' },
+          columns: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                field: { type: 'string' },
+                label: { type: 'string' },
+                format: { type: 'string' },
+                sortable: { type: 'boolean' },
+              },
+              required: ['field', 'label'],
+            },
+          },
+          pagination: {
+            type: 'object',
+            properties: {
+              pageSize: { type: 'number' },
+              showSizeChanger: { type: 'boolean' },
+            },
+            required: ['pageSize'],
+          },
+          min: { type: 'number' },
+          max: { type: 'number' },
+          ranges: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                min: { type: 'number' },
+                max: { type: 'number' },
+                color: { type: 'string' },
+                label: { type: 'string' },
+              },
+              required: ['min', 'max', 'color'],
+            },
+          },
+          html: { type: 'string' },
+          css: { type: 'string' },
+          javascript: { type: 'string' },
+          title: { type: 'string' },
+          description: { type: 'string' },
+          refreshInterval: { type: 'number' },
+          height: { type: 'number' },
+          width: { type: 'number' },
+        },
       },
       dataSource: {
         type: 'object',
         description: 'Data source configuration',
+        properties: {
+          type: {
+            type: 'string',
+            enum: ['static', 'api', 'query', 'mcp-tool'],
+          },
+          data: {
+            description: 'Inline data, for type "static". Any JSON value.',
+          },
+          url: { type: 'string' },
+          query: { type: 'string' },
+          tool: { type: 'string' },
+          transform: {
+            type: 'string',
+            description: 'JavaScript expression applied to the fetched data',
+          },
+        },
+        required: ['type'],
       },
       templateName: {
         type: 'string',

--- a/src/tools/dashboard-monitoring/log-dashboard.ts
+++ b/src/tools/dashboard-monitoring/log-dashboard.ts
@@ -1407,7 +1407,14 @@ export const LOG_DASHBOARD_TOOL_DEFINITION = {
             description: 'Exclude matches instead of including them',
             default: false,
           },
+          createdAt: {
+            type: 'number',
+            description: 'Epoch milliseconds the filter was created',
+          },
         },
+        // LogFilter requires all three; the schema demanded none of them, so a
+        // filter object missing its identity passed validation.
+        required: ['id', 'name', 'createdAt'],
       },
       cacheTTL: {
         type: 'number',

--- a/src/tools/dashboard-monitoring/metric-collector.ts
+++ b/src/tools/dashboard-monitoring/metric-collector.ts
@@ -1312,6 +1312,56 @@ export const METRIC_COLLECTOR_TOOL_DEFINITION = {
       source: {
         type: 'object',
         description: 'Source configuration for configure-source operation',
+        // Declared in full. This was `{ type: 'object' }` with no properties,
+        // which accepts anything at all -- including a source object missing
+        // every field the tool then requires.
+        properties: {
+          id: { type: 'string' },
+          name: { type: 'string' },
+          type: {
+            type: 'string',
+            enum: [
+              'prometheus',
+              'graphite',
+              'influxdb',
+              'cloudwatch',
+              'datadog',
+              'custom',
+            ],
+          },
+          enabled: { type: 'boolean' },
+          config: {
+            type: 'object',
+            properties: {
+              url: { type: 'string' },
+              apiKey: { type: 'string' },
+              region: { type: 'string', description: 'CloudWatch only' },
+              database: { type: 'string', description: 'InfluxDB only' },
+              username: { type: 'string' },
+              password: { type: 'string' },
+              interval: {
+                type: 'number',
+                description: 'Collection interval in seconds',
+              },
+              metrics: { type: 'array', items: { type: 'string' } },
+              tags: {
+                type: 'object',
+                additionalProperties: { type: 'string' },
+                description: 'Default tags applied to every collected metric',
+              },
+            },
+          },
+          lastCollected: {
+            type: 'number',
+            description: 'Epoch milliseconds of the last successful collection',
+          },
+          status: {
+            type: 'string',
+            enum: ['active', 'error', 'disabled'],
+          },
+          errorMessage: { type: 'string' },
+        },
+        required: ['id', 'name', 'type', 'enabled', 'config', 'status'],
       },
       metrics: {
         type: 'array',

--- a/src/tools/output-formatting/smart-pretty.ts
+++ b/src/tools/output-formatting/smart-pretty.ts
@@ -1530,8 +1530,20 @@ export const SMART_PRETTY_TOOL_DEFINITION = {
         description: 'Custom theme definition (use with theme: "custom")',
         properties: {
           name: { type: 'string' as const },
-          colors: { type: 'object' as const },
+          colors: {
+            type: 'object' as const,
+            additionalProperties: { type: 'string' as const },
+            description:
+              'Token colours, for example background, keyword, string, comment, number',
+          },
+          styles: {
+            type: 'object' as const,
+            additionalProperties: true,
+            description: 'Per-token style flags such as bold or italic',
+          },
         },
+        // ThemeDefinition requires a name and colors; styles is optional.
+        required: ['name', 'colors'],
       },
       showLineNumbers: {
         type: 'boolean' as const,

--- a/src/tools/output-formatting/smart-pretty.ts
+++ b/src/tools/output-formatting/smart-pretty.ts
@@ -1538,8 +1538,28 @@ export const SMART_PRETTY_TOOL_DEFINITION = {
           },
           styles: {
             type: 'object' as const,
-            additionalProperties: true,
-            description: 'Per-token style flags such as bold or italic',
+            // The three keys are named, and each is a LIST OF TOKEN NAMES rather
+            // than a flag. `additionalProperties: true` with no properties made
+            // `{ styles: { bold: false } }` valid input for a field the tool
+            // iterates as an array, so the schema accepted a shape that fails
+            // inside the tool.
+            properties: {
+              bold: {
+                type: 'array' as const,
+                items: { type: 'string' as const },
+              },
+              italic: {
+                type: 'array' as const,
+                items: { type: 'string' as const },
+              },
+              underline: {
+                type: 'array' as const,
+                items: { type: 'string' as const },
+              },
+            },
+            additionalProperties: false,
+            description:
+              'Token names to render bold, italic or underlined, e.g. { bold: ["keyword"] }',
           },
         },
         // ThemeDefinition requires a name and colors; styles is optional.

--- a/tests/unit/analytics/analytics-manager.test.ts
+++ b/tests/unit/analytics/analytics-manager.test.ts
@@ -24,15 +24,15 @@ describe('AnalyticsManager', () => {
   afterEach(async () => {
     // Clean up test database
     await manager.clear();
-    
+
     // Close the database connection
     if (manager && (manager as any).storage && (manager as any).storage.close) {
       (manager as any).storage.close();
     }
-    
+
     // Wait a bit for the file handle to be released
-    await new Promise(resolve => setTimeout(resolve, 100));
-    
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
     if (fs.existsSync(testDbPath)) {
       try {
         fs.unlinkSync(testDbPath);

--- a/tests/unit/analytics/record-tool-analytics.test.ts
+++ b/tests/unit/analytics/record-tool-analytics.test.ts
@@ -75,7 +75,11 @@ describe('extractSavings', () => {
     ).toBeNull();
     // real measurement that happened to save nothing
     expect(
-      extractSavings({ originalTokens: 50, optimizedTokens: 50, tokensSaved: 0 })
+      extractSavings({
+        originalTokens: 50,
+        optimizedTokens: 50,
+        tokensSaved: 0,
+      })
     ).toEqual({ originalTokens: 50, optimizedTokens: 50, tokensSaved: 0 });
   });
 });
@@ -96,7 +100,10 @@ describe('recordToolAnalytics', () => {
   let manager: AnalyticsManager;
 
   beforeEach(() => {
-    const dbPath = path.join(os.tmpdir(), `rec-analytics-${Date.now()}-${Math.round(performance.now())}.db`);
+    const dbPath = path.join(
+      os.tmpdir(),
+      `rec-analytics-${Date.now()}-${Math.round(performance.now())}.db`
+    );
     manager = new AnalyticsManager(new SqliteAnalyticsStorage(dbPath));
   });
 
@@ -104,7 +111,11 @@ describe('recordToolAnalytics', () => {
     await recordToolAnalytics(
       manager,
       'smart_read',
-      mcpResult({ originalTokens: 1000, optimizedTokens: 100, tokensSaved: 900 })
+      mcpResult({
+        originalTokens: 1000,
+        optimizedTokens: 100,
+        tokensSaved: 900,
+      })
     );
     const action = await manager.getActionAnalytics();
     expect(action.summary.totalOperations).toBe(1);
@@ -126,7 +137,11 @@ describe('recordToolAnalytics', () => {
     await recordToolAnalytics(manager, 'x', {
       content: [{ type: 'text', text: 'not json' }],
     });
-    await recordToolAnalytics(manager, 'count_tokens', mcpResult({ tokens: 2001 }));
+    await recordToolAnalytics(
+      manager,
+      'count_tokens',
+      mcpResult({ tokens: 2001 })
+    );
     expect(await manager.count()).toBe(0);
   });
 });

--- a/tests/unit/build-systems/wmic-process-parser.test.ts
+++ b/tests/unit/build-systems/wmic-process-parser.test.ts
@@ -58,7 +58,11 @@ describe('wmic CSV parsing', () => {
   it('reads the process NAME, not the command line', () => {
     // The old mapping produced 'C:\WINDOWS\Explorer.EXE' here.
     expect(parsed[0].name).toBe('explorer.exe');
-    expect(parsed.map((p) => p.name)).toEqual(['explorer.exe', 'app.exe', 'builder.exe']);
+    expect(parsed.map((p) => p.name)).toEqual([
+      'explorer.exe',
+      'app.exe',
+      'builder.exe',
+    ]);
   });
 
   it('reads memory from WorkingSetSize, not UserModeTime', () => {
@@ -119,11 +123,15 @@ describe('output that yields no processes', () => {
   // and falls through to the CIM path rather than returning it as an answer.
 
   it('returns an empty array for an error message', () => {
-    expect(parseWmicProcessCsv('ERROR: Description = Invalid query\n', NOW)).toEqual([]);
+    expect(
+      parseWmicProcessCsv('ERROR: Description = Invalid query\n', NOW)
+    ).toEqual([]);
   });
 
   it('returns an empty array for an unrecognised format', () => {
-    expect(parseWmicProcessCsv('Name  ProcessId\nexplorer.exe  15748\n', NOW)).toEqual([]);
+    expect(
+      parseWmicProcessCsv('Name  ProcessId\nexplorer.exe  15748\n', NOW)
+    ).toEqual([]);
   });
 
   it('does not invent a process from a header alone', () => {
@@ -133,7 +141,9 @@ describe('output that yields no processes', () => {
 
 describe('WMI datetime parsing', () => {
   it('reads the fixed-width fields', () => {
-    expect(parseWmiDate('20260720023604.916473+000')).toBe(Date.UTC(2026, 6, 20, 2, 36, 4, 916));
+    expect(parseWmiDate('20260720023604.916473+000')).toBe(
+      Date.UTC(2026, 6, 20, 2, 36, 4, 916)
+    );
   });
 
   it('treats the suffix as MINUTES from UTC, not hours', () => {
@@ -157,6 +167,8 @@ describe('lifetime CPU percentage', () => {
 
   it('is zero for a process that has not yet aged, rather than Infinity', () => {
     expect(lifetimeCpuPercent(1e9, CREATED, CREATED_MS)).toBe(0);
-    expect(Number.isFinite(lifetimeCpuPercent(1e9, CREATED, CREATED_MS))).toBe(true);
+    expect(Number.isFinite(lifetimeCpuPercent(1e9, CREATED, CREATED_MS))).toBe(
+      true
+    );
   });
 });

--- a/tests/unit/cache-engine.test.ts
+++ b/tests/unit/cache-engine.test.ts
@@ -10,7 +10,14 @@
  * - Configurable cache path via environment variable
  */
 
-import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  jest,
+} from '@jest/globals';
 import { CacheEngine, CacheStats } from '../../src/core/cache-engine.js';
 import fs from 'fs';
 import path from 'path';
@@ -58,7 +65,7 @@ describe('CacheEngine', () => {
 
     // Clean up
     cache.close();
-    await new Promise(resolve => setTimeout(resolve, 100)); // Add a small delay
+    await new Promise((resolve) => setTimeout(resolve, 100)); // Add a small delay
     if (fs.existsSync(testDbPath)) {
       fs.unlinkSync(testDbPath);
     }
@@ -117,7 +124,12 @@ describe('CacheEngine', () => {
       const key = 'unicode-key';
       const value = 'Hello 世界 🚀 café';
 
-      cache.set(key, value, Buffer.from(value).length, Buffer.from(value).length);
+      cache.set(
+        key,
+        value,
+        Buffer.from(value).length,
+        Buffer.from(value).length
+      );
       const retrieved = cache.get(key);
 
       expect(retrieved).toBe(value);
@@ -173,7 +185,12 @@ describe('CacheEngine', () => {
       const originalSize = 1000;
       const compressedSize = 200;
 
-      cache.set('compressed-key', 'compressed-data', originalSize, compressedSize);
+      cache.set(
+        'compressed-key',
+        'compressed-data',
+        originalSize,
+        compressedSize
+      );
 
       const stats = cache.getStats();
       expect(stats.totalOriginalSize).toBe(originalSize);
@@ -302,13 +319,14 @@ describe('CacheEngine', () => {
       cache.set(key, 'value', 5, 5);
 
       // Small delay
-      const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+      const delay = (ms: number) =>
+        new Promise((resolve) => setTimeout(resolve, ms));
 
       return delay(10).then(() => {
         cache.get(key);
 
         const entries = cache.getAllEntries();
-        const entry = entries.find(e => e.key === key);
+        const entry = entries.find((e) => e.key === key);
 
         expect(entry).toBeDefined();
         expect(entry!.lastAccessedAt).toBeGreaterThanOrEqual(beforeSet);
@@ -322,16 +340,17 @@ describe('CacheEngine', () => {
 
       cache.set(key, 'original', 8, 8);
       const entries1 = cache.getAllEntries();
-      const originalCreatedAt = entries1.find(e => e.key === key)!.createdAt;
+      const originalCreatedAt = entries1.find((e) => e.key === key)!.createdAt;
 
       // Small delay
-      const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+      const delay = (ms: number) =>
+        new Promise((resolve) => setTimeout(resolve, ms));
 
       return delay(10).then(() => {
         cache.set(key, 'updated', 7, 7);
 
         const entries2 = cache.getAllEntries();
-        const updatedEntry = entries2.find(e => e.key === key);
+        const updatedEntry = entries2.find((e) => e.key === key);
 
         expect(updatedEntry!.createdAt).toBe(originalCreatedAt);
       });
@@ -366,7 +385,7 @@ describe('CacheEngine', () => {
       cache.set('key1', 'value1', 10, 10);
 
       // Wait 100ms to make them both slightly old
-      await new Promise(resolve => setTimeout(resolve, 100));
+      await new Promise((resolve) => setTimeout(resolve, 100));
 
       // Access key1 just before eviction (updates last_accessed)
       cache.get('key1');
@@ -389,7 +408,7 @@ describe('CacheEngine', () => {
       cache.set('old-key', 'old-value', 10, 5);
 
       // Wait longer than the 1-second safety margin
-      await new Promise(resolve => setTimeout(resolve, 1100));
+      await new Promise((resolve) => setTimeout(resolve, 1100));
 
       // Add another entry (will be recent)
       cache.set('new-key', 'new-value', 10, 5);
@@ -428,15 +447,11 @@ describe('CacheEngine', () => {
       const operations = [];
 
       for (let i = 0; i < 100; i++) {
-        operations.push(
-          cache.set(`key${i}`, `value${i}`, 10, 10)
-        );
+        operations.push(cache.set(`key${i}`, `value${i}`, 10, 10));
       }
 
       for (let i = 0; i < 100; i++) {
-        operations.push(
-          cache.get(`key${i}`)
-        );
+        operations.push(cache.get(`key${i}`));
       }
 
       // Should not throw
@@ -495,7 +510,10 @@ describe('CacheEngine', () => {
 
   describe('Configurable Cache Path', () => {
     it('should use environment variable for cache directory when no dbPath provided', () => {
-      const customCacheDir = path.join(os.tmpdir(), `custom-cache-${Date.now()}`);
+      const customCacheDir = path.join(
+        os.tmpdir(),
+        `custom-cache-${Date.now()}`
+      );
       process.env.TOKEN_OPTIMIZER_CACHE_DIR = customCacheDir;
 
       const cacheWithEnv = new CacheEngine(undefined, 100);
@@ -555,10 +573,17 @@ describe('CacheEngine', () => {
     });
 
     it('should prioritize explicit dbPath parameter over environment variable', () => {
-      const customCacheDir = path.join(os.tmpdir(), `custom-cache-${Date.now()}`);
+      const customCacheDir = path.join(
+        os.tmpdir(),
+        `custom-cache-${Date.now()}`
+      );
       process.env.TOKEN_OPTIMIZER_CACHE_DIR = customCacheDir;
 
-      const explicitPath = path.join(os.tmpdir(), `explicit-cache-${Date.now()}`, 'cache.db');
+      const explicitPath = path.join(
+        os.tmpdir(),
+        `explicit-cache-${Date.now()}`,
+        'cache.db'
+      );
       const cacheWithExplicit = new CacheEngine(explicitPath, 100);
       const dbPath = cacheWithExplicit.getDatabasePath();
 
@@ -572,7 +597,10 @@ describe('CacheEngine', () => {
     });
 
     it('should create cache directory from environment variable if it does not exist', () => {
-      const customCacheDir = path.join(os.tmpdir(), `nonexistent-${Date.now()}`);
+      const customCacheDir = path.join(
+        os.tmpdir(),
+        `nonexistent-${Date.now()}`
+      );
       process.env.TOKEN_OPTIMIZER_CACHE_DIR = customCacheDir;
 
       expect(fs.existsSync(customCacheDir)).toBe(false);

--- a/tests/unit/cache-round-trip.test.ts
+++ b/tests/unit/cache-round-trip.test.ts
@@ -2,7 +2,10 @@ import { describe, it, expect, afterEach } from '@jest/globals';
 import { mkdtempSync, rmSync, readdirSync, readFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { compress, decompress } from '../../src/tools/shared/compression-utils.js';
+import {
+  compress,
+  decompress,
+} from '../../src/tools/shared/compression-utils.js';
 
 /**
  * A cache entry must be readable by the code that wrote it.
@@ -24,12 +27,21 @@ describe('compressed cache entries survive a round trip', () => {
   afterEach(() => {
     while (dirs.length) {
       const d = dirs.pop();
-      if (d) { try { rmSync(d, { recursive: true, force: true }); } catch { /* windows */ } }
+      if (d) {
+        try {
+          rmSync(d, { recursive: true, force: true });
+        } catch {
+          /* windows */
+        }
+      }
     }
   });
 
   it('utf8 destroys gzip bytes, which is why the encoding must be explicit', () => {
-    const payload = JSON.stringify({ code: 'const x = 1;', language: 'typescript' });
+    const payload = JSON.stringify({
+      code: 'const x = 1;',
+      language: 'typescript',
+    });
     const { compressed } = compress(payload, 'gzip');
 
     // What the old write path did.
@@ -50,9 +62,14 @@ describe('compressed cache entries survive a round trip', () => {
       for (const entry of readdirSync(dir, { withFileTypes: true })) {
         const full = join(dir, entry.name);
         if (entry.isDirectory()) walk(full);
-        else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) {
+        else if (
+          entry.name.endsWith('.ts') &&
+          !entry.name.endsWith('.test.ts')
+        ) {
           const src = readFileSync(full, 'utf8');
-          for (const m of src.matchAll(/\w*[Cc]ompress\w*\.compressed\.toString\(\)/g)) {
+          for (const m of src.matchAll(
+            /\w*[Cc]ompress\w*\.compressed\.toString\(\)/g
+          )) {
             offenders.push(`${entry.name}: ${m[0]}`);
           }
         }
@@ -76,17 +93,31 @@ describe('compressed cache entries survive a round trip', () => {
     const cache = new CacheEngine(join(dir, 'c.db'));
     try {
       const ToolClass = (mod.SmartPretty ?? mod.SmartPrettyTool) as new (
-        c: unknown, t: unknown, m: unknown
+        c: unknown,
+        t: unknown,
+        m: unknown
       ) => { run(args: unknown): Promise<unknown> };
 
-      const tool = new ToolClass(cache, new TokenCounter(), new MetricsCollector());
-      const args = { operation: 'format-code', code: 'const   x=1', language: 'typescript' };
+      const tool = new ToolClass(
+        cache,
+        new TokenCounter(),
+        new MetricsCollector()
+      );
+      const args = {
+        operation: 'format-code',
+        code: 'const   x=1',
+        language: 'typescript',
+      };
 
       await expect(tool.run(args)).resolves.toBeDefined();
       // The second call is the one that reads what the first wrote.
       await expect(tool.run(args)).resolves.toBeDefined();
     } finally {
-      try { cache.close(); } catch { /* already closed */ }
+      try {
+        cache.close();
+      } catch {
+        /* already closed */
+      }
     }
   });
 });

--- a/tests/unit/cache-set-argument-order.test.ts
+++ b/tests/unit/cache-set-argument-order.test.ts
@@ -32,8 +32,18 @@ function sourceFiles(dir: string): string[] {
 }
 
 /** Every `cache.set(...)` call with four arguments, as written. */
-function fourArgSetCalls(): Array<{ file: string; line: number; third: string; fourth: string }> {
-  const calls: Array<{ file: string; line: number; third: string; fourth: string }> = [];
+function fourArgSetCalls(): Array<{
+  file: string;
+  line: number;
+  third: string;
+  fourth: string;
+}> {
+  const calls: Array<{
+    file: string;
+    line: number;
+    third: string;
+    fourth: string;
+  }> = [];
 
   for (const file of sourceFiles(SRC)) {
     const src = readFileSync(file, 'utf8');
@@ -85,7 +95,10 @@ describe('cache.set arguments are in the declared order', () => {
     // allowed -- that is how an uncompressed entry is honestly recorded -- so
     // this only fires when the fourth names ORIGINAL and the third does not.
     const wrong = calls.filter(
-      (c) => ORIGINAL.test(c.fourth) && !COMPRESSED.test(c.fourth) && c.third !== c.fourth
+      (c) =>
+        ORIGINAL.test(c.fourth) &&
+        !COMPRESSED.test(c.fourth) &&
+        c.third !== c.fourth
     );
 
     expect(

--- a/tests/unit/cache-size-orientation.test.ts
+++ b/tests/unit/cache-size-orientation.test.ts
@@ -74,8 +74,12 @@ describe('cache size statistics are the right way round', () => {
   it('derives the ratio from the two sizes it reports', () => {
     cache.set('k', 'stored value', ORIGINAL, COMPRESSED);
 
-    const { compressionRatio, totalCompressedSize, totalOriginalSize } = cache.getStats();
-    expect(compressionRatio).toBeCloseTo(totalCompressedSize / totalOriginalSize, 6);
+    const { compressionRatio, totalCompressedSize, totalOriginalSize } =
+      cache.getStats();
+    expect(compressionRatio).toBeCloseTo(
+      totalCompressedSize / totalOriginalSize,
+      6
+    );
   });
 
   it('keeps the orientation across several entries', () => {

--- a/tests/unit/code-analysis/ast-grep-failure-surfaces.test.ts
+++ b/tests/unit/code-analysis/ast-grep-failure-surfaces.test.ts
@@ -31,7 +31,10 @@ describe('ast-grep distinguishes "no matches" from "could not run"', () => {
   beforeEach(() => {
     root = mkdtempSync(join(tmpdir(), 'ast-grep-surfaces-'));
     mkdirSync(join(root, 'src'), { recursive: true });
-    writeFileSync(join(root, 'src', 'a.ts'), 'export function alpha() {\n  return 1;\n}\n');
+    writeFileSync(
+      join(root, 'src', 'a.ts'),
+      'export function alpha() {\n  return 1;\n}\n'
+    );
 
     cache = new CacheEngine(join(root, 'cache.db'), 100);
     counter = new TokenCounter();
@@ -49,7 +52,12 @@ describe('ast-grep distinguishes "no matches" from "could not run"', () => {
   });
 
   const grep = (pattern: string) =>
-    tool.grep(pattern, { pattern, projectPath: root, language: 'ts', enableCache: false });
+    tool.grep(pattern, {
+      pattern,
+      projectPath: root,
+      language: 'ts',
+      enableCache: false,
+    });
 
   it('finds a function that is there', async () => {
     const result = await grep('function $NAME');
@@ -73,12 +81,20 @@ describe('ast-grep distinguishes "no matches" from "could not run"', () => {
     writeFileSync(notNode, 'this is not an executable');
 
     const real = process.execPath;
-    Object.defineProperty(process, 'execPath', { value: notNode, configurable: true });
+    Object.defineProperty(process, 'execPath', {
+      value: notNode,
+      configurable: true,
+    });
 
     try {
-      await expect(grep('function $NAME')).rejects.toThrow(/ast-grep could not be run/);
+      await expect(grep('function $NAME')).rejects.toThrow(
+        /ast-grep could not be run/
+      );
     } finally {
-      Object.defineProperty(process, 'execPath', { value: real, configurable: true });
+      Object.defineProperty(process, 'execPath', {
+        value: real,
+        configurable: true,
+      });
     }
   }, 120_000);
 
@@ -87,12 +103,18 @@ describe('ast-grep distinguishes "no matches" from "could not run"', () => {
     writeFileSync(notNode, 'this is not an executable');
 
     const real = process.execPath;
-    Object.defineProperty(process, 'execPath', { value: notNode, configurable: true });
+    Object.defineProperty(process, 'execPath', {
+      value: notNode,
+      configurable: true,
+    });
 
     try {
       await expect(grep('function $NAME')).rejects.toThrow(/@ast-grep\/cli/);
     } finally {
-      Object.defineProperty(process, 'execPath', { value: real, configurable: true });
+      Object.defineProperty(process, 'execPath', {
+        value: real,
+        configurable: true,
+      });
     }
   }, 120_000);
 });

--- a/tests/unit/code-analysis/security-finds-real-secrets.test.ts
+++ b/tests/unit/code-analysis/security-finds-real-secrets.test.ts
@@ -33,16 +33,31 @@ import { MetricsCollector } from '../../../src/core/metrics.js';
 const j = (...parts: string[]): string => parts.join('');
 
 const CREDENTIALS: Array<[string, string]> = [
-  ['stripe live', j('sk', '_', 'live', '_', '51H8xQ2eZvKYlo2Cabcdefghijklmnop')],
-  ['stripe test', j('sk', '_', 'test', '_', '51H8xQ2eZvKYlo2Cabcdefghijklmnop')],
+  [
+    'stripe live',
+    j('sk', '_', 'live', '_', '51H8xQ2eZvKYlo2Cabcdefghijklmnop'),
+  ],
+  [
+    'stripe test',
+    j('sk', '_', 'test', '_', '51H8xQ2eZvKYlo2Cabcdefghijklmnop'),
+  ],
   ['github pat', j('ghp', '_', '16CharactersOrMoreAbcdefghijklmnop')],
-  ['github fine-grained', j('github', '_', 'pat', '_', '11ABCDEFG0abcdefghijklmnop')],
-  ['slack bot', j('xoxb', '-', '1234567890', '-', '1234567890', '-', 'AbCdEfGhIjKlMnOp')],
+  [
+    'github fine-grained',
+    j('github', '_', 'pat', '_', '11ABCDEFG0abcdefghijklmnop'),
+  ],
+  [
+    'slack bot',
+    j('xoxb', '-', '1234567890', '-', '1234567890', '-', 'AbCdEfGhIjKlMnOp'),
+  ],
   ['aws access key', j('AKIA', 'IOSFODNN7EXAMPLE')],
   ['google api', j('AIza', 'SyD', '-', '1234567890abcdefghijklmnopqrst')],
   ['sendgrid', j('SG', '.', 'abcdefghijklmnop', '.', 'qrstuvwxyz1234567890')],
   ['openai', j('sk', '-', 'proj', '-', 'abcdefghijklmnopqrstuvwxyz1234')],
-  ['anthropic', j('sk', '-', 'ant', '-', 'api03', '-', 'abcdefghijklmnopqrstuvwxyz')],
+  [
+    'anthropic',
+    j('sk', '-', 'ant', '-', 'api03', '-', 'abcdefghijklmnopqrstuvwxyz'),
+  ],
 ];
 
 /** Code that must NOT be flagged -- a scanner that cries wolf gets muted. */
@@ -51,7 +66,10 @@ const INNOCENT: Array<[string, string]> = [
   ['url', "const apiKey = 'https://api.example.com/v1/endpoint';"],
   ['config reference', 'const apiKey = config.apiKey;'],
   ['short value', "const apiKey = 'short';"],
-  ['unrelated variable', "const username = 'abcdefghijklmnopqrstuvwxyz123456';"],
+  [
+    'unrelated variable',
+    "const username = 'abcdefghijklmnopqrstuvwxyz123456';",
+  ],
 ];
 
 describe('security scanner finds real credential formats', () => {
@@ -77,17 +95,27 @@ describe('security scanner finds real credential formats', () => {
   });
 
   const scan = async () => {
-    const tool = new SmartSecurity(cache, counter, new MetricsCollector(), root);
+    const tool = new SmartSecurity(
+      cache,
+      counter,
+      new MetricsCollector(),
+      root
+    );
     // force: true, or a cached "Secure" from a previous scan answers instead.
     return tool.run({ projectRoot: root, force: true });
   };
 
   for (const [label, value] of CREDENTIALS) {
     it(`flags a ${label} key`, async () => {
-      writeFileSync(join(root, 'src', 'leak.ts'), `const apiKey = '${value}';\n`);
+      writeFileSync(
+        join(root, 'src', 'leak.ts'),
+        `const apiKey = '${value}';\n`
+      );
 
       const result = await scan();
-      const secrets = result.findingsByCategory.find((c) => c.category === 'secrets');
+      const secrets = result.findingsByCategory.find(
+        (c) => c.category === 'secrets'
+      );
 
       expect(secrets?.count ?? 0).toBeGreaterThan(0);
       expect(result.summary.criticalCount).toBeGreaterThan(0);
@@ -99,7 +127,9 @@ describe('security scanner finds real credential formats', () => {
       writeFileSync(join(root, 'src', 'fine.ts'), `${code}\n`);
 
       const result = await scan();
-      const secrets = result.findingsByCategory.find((c) => c.category === 'secrets');
+      const secrets = result.findingsByCategory.find(
+        (c) => c.category === 'secrets'
+      );
 
       expect(secrets?.count ?? 0).toBe(0);
     });
@@ -115,17 +145,22 @@ describe('security scanner finds real credential formats', () => {
     );
 
     const result = await scan();
-    const { originalTokens, compactedTokens, reductionPercentage } = result.metrics;
+    const { originalTokens, compactedTokens, reductionPercentage } =
+      result.metrics;
 
     expect(originalTokens).toBeGreaterThan(0);
     expect(compactedTokens).toBeGreaterThan(0);
 
     // The published percentage must be derivable from the two published numbers.
-    const derived = Math.round(((originalTokens - compactedTokens) / originalTokens) * 100);
+    const derived = Math.round(
+      ((originalTokens - compactedTokens) / originalTokens) * 100
+    );
     expect(reductionPercentage).toBe(derived);
 
     // A guess of 300 chars per finding gives 1 finding -> (300 + 50*n + 1000)/4.
     // Whatever the real measurement is, it must not be that arithmetic.
-    expect(originalTokens).not.toBe(Math.ceil((300 + 50 * result.summary.filesScanned + 1000) / 4));
+    expect(originalTokens).not.toBe(
+      Math.ceil((300 + 50 * result.summary.filesScanned + 1000) / 4)
+    );
   });
 });

--- a/tests/unit/compression-module.test.ts
+++ b/tests/unit/compression-module.test.ts
@@ -12,7 +12,10 @@
 import { describe, it, expect, beforeEach } from '@jest/globals';
 import { CompressionModule } from '../../src/modules/CompressionModule.js';
 import { CompressionEngine } from '../../src/core/compression-engine.js';
-import { ITokenCounter, TokenCountResult } from '../../src/interfaces/ITokenCounter.js';
+import {
+  ITokenCounter,
+  TokenCountResult,
+} from '../../src/interfaces/ITokenCounter.js';
 
 // Mock token counter
 class MockTokenCounter implements ITokenCounter {
@@ -168,7 +171,11 @@ describe('CompressionModule', () => {
     it('should handle different compression modes', async () => {
       const text = 'Test text for mode testing. '.repeat(50);
 
-      const modes: Array<'text' | 'font' | 'generic'> = ['text', 'font', 'generic'];
+      const modes: Array<'text' | 'font' | 'generic'> = [
+        'text',
+        'font',
+        'generic',
+      ];
 
       for (const mode of modes) {
         const moduleWithMode = new CompressionModule(

--- a/tests/unit/copy-assets-names-its-remedy.test.ts
+++ b/tests/unit/copy-assets-names-its-remedy.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'fs';
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  rmSync,
+} from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
@@ -39,11 +46,16 @@ let root: string;
 /** A source tree shaped like the repo's, minus whatever the test omits. */
 function givenTree({ withVendor }: { withVendor: boolean }) {
   mkdirSync(join(root, 'src', 'dashboard', 'public'), { recursive: true });
-  writeFileSync(join(root, 'src', 'dashboard', 'public', 'index.html'), '<html></html>');
+  writeFileSync(
+    join(root, 'src', 'dashboard', 'public', 'index.html'),
+    '<html></html>'
+  );
 
   if (withVendor) {
     const dir = join(root, VENDOR_SOURCE, '..');
-    mkdirSync(join(root, VENDOR_SOURCE).replace(/[\\/][^\\/]+$/, ''), { recursive: true });
+    mkdirSync(join(root, VENDOR_SOURCE).replace(/[\\/][^\\/]+$/, ''), {
+      recursive: true,
+    });
     writeFileSync(join(root, VENDOR_SOURCE), '/* chart.js umd */');
     void dir;
   }
@@ -92,7 +104,9 @@ describe('copyAssets on a complete tree', () => {
 
     copyAssets({ root });
 
-    expect(existsSync(join(root, 'dist', 'dashboard', 'public', 'index.html'))).toBe(true);
+    expect(
+      existsSync(join(root, 'dist', 'dashboard', 'public', 'index.html'))
+    ).toBe(true);
   });
 
   it('vendors the chart bundle under the name the dashboard loads', () => {
@@ -100,7 +114,14 @@ describe('copyAssets on a complete tree', () => {
 
     copyAssets({ root });
 
-    const vendored = join(root, 'dist', 'dashboard', 'public', 'vendor', 'chart.umd.min.js');
+    const vendored = join(
+      root,
+      'dist',
+      'dashboard',
+      'public',
+      'vendor',
+      'chart.umd.min.js'
+    );
     expect(readFileSync(vendored, 'utf8')).toBe('/* chart.js umd */');
   });
 });
@@ -109,7 +130,9 @@ describe('the build wiring', () => {
   it('uses the script rather than an inline one-liner', () => {
     // An inline `node -e` has nowhere to put a preflight check or a remedy, so
     // reverting to one would silently reintroduce the bare ENOENT.
-    const pkg = JSON.parse(readFileSync(join(process.cwd(), 'package.json'), 'utf8'));
+    const pkg = JSON.parse(
+      readFileSync(join(process.cwd(), 'package.json'), 'utf8')
+    );
 
     expect(pkg.scripts['copy:assets']).toContain('scripts/copy-assets.mjs');
     expect(pkg.scripts['copy:assets']).not.toContain('node -e');

--- a/tests/unit/csv-with-header.test.ts
+++ b/tests/unit/csv-with-header.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from '@jest/globals';
-import { parseCsvWithHeader, splitCsvLine } from '../../src/utils/csv-with-header.js';
+import {
+  parseCsvWithHeader,
+  splitCsvLine,
+} from '../../src/utils/csv-with-header.js';
 
 /**
  * `schtasks /query /fo CSV /v` starts with HostName, not TaskName, and the

--- a/tests/unit/curate-correct-origin.test.ts
+++ b/tests/unit/curate-correct-origin.test.ts
@@ -18,8 +18,9 @@ import { join } from 'path';
 import { mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 
-const CURATE = pathToFileURL(join(process.cwd(), 'hooks-core', 'curate.mjs'))
-  .href;
+const CURATE = pathToFileURL(
+  join(process.cwd(), 'hooks-core', 'curate.mjs')
+).href;
 const WIKI = pathToFileURL(join(process.cwd(), 'hooks-core', 'wiki.mjs')).href;
 
 let dir: string;

--- a/tests/unit/dashboard-self-contained.test.ts
+++ b/tests/unit/dashboard-self-contained.test.ts
@@ -54,8 +54,12 @@ describe('the dashboard is self-contained', () => {
       const source = readFileSync(file, 'utf8');
       const calls = [
         ...source.matchAll(/fetch\(\s*[`'"](https?:)?\/\//gi),
-        ...source.matchAll(/new\s+(?:WebSocket|EventSource)\(\s*[`'"][a-z]+:\/\//gi),
-        ...source.matchAll(/XMLHttpRequest[\s\S]{0,80}?open\([^)]*[`'"]https?:\/\//gi),
+        ...source.matchAll(
+          /new\s+(?:WebSocket|EventSource)\(\s*[`'"][a-z]+:\/\//gi
+        ),
+        ...source.matchAll(
+          /XMLHttpRequest[\s\S]{0,80}?open\([^)]*[`'"]https?:\/\//gi
+        ),
       ].map((m) => m[0]);
 
       expect(calls).toEqual([]);
@@ -63,7 +67,9 @@ describe('the dashboard is self-contained', () => {
   );
 
   it('vendors chart.js locally instead of pulling it from a CDN', () => {
-    const pkg = JSON.parse(readFileSync(join(process.cwd(), 'package.json'), 'utf8'));
+    const pkg = JSON.parse(
+      readFileSync(join(process.cwd(), 'package.json'), 'utf8')
+    );
 
     // Pinned exactly: a caret range would let the dependency change under us,
     // which is the supply-chain half of what was wrong with the CDN.
@@ -74,7 +80,10 @@ describe('the dashboard is self-contained', () => {
     // remedy instead of a bare ENOENT. Assert it where it now lives -- deleting
     // the vendoring from that module must still fail this test.
     expect(pkg.scripts['copy:assets']).toContain('scripts/copy-assets.mjs');
-    const copyAssets = readFileSync(join(process.cwd(), 'scripts', 'copy-assets.mjs'), 'utf8');
+    const copyAssets = readFileSync(
+      join(process.cwd(), 'scripts', 'copy-assets.mjs'),
+      'utf8'
+    );
     expect(copyAssets).toContain('chart.umd.min.js'); // the vendored target
     expect(copyAssets).toContain('chart.umd.js'); // sourced from the local package
     expect(copyAssets).not.toMatch(/https?:\/\/[^\s'"]*chart/i); // never a CDN
@@ -85,7 +94,14 @@ describe('the dashboard is self-contained', () => {
   });
 
   it('ships the vendored file when the assets have been built', () => {
-    const built = join(process.cwd(), 'dist', 'dashboard', 'public', 'vendor', 'chart.umd.min.js');
+    const built = join(
+      process.cwd(),
+      'dist',
+      'dashboard',
+      'public',
+      'vendor',
+      'chart.umd.min.js'
+    );
     if (!existsSync(join(process.cwd(), 'dist', 'dashboard', 'public'))) return;
     expect(existsSync(built)).toBe(true);
   });

--- a/tests/unit/deduplication-module.test.ts
+++ b/tests/unit/deduplication-module.test.ts
@@ -11,7 +11,10 @@
 
 import { describe, it, expect, beforeEach } from '@jest/globals';
 import { DeduplicationModule } from '../../src/modules/DeduplicationModule.js';
-import { ITokenCounter, TokenCountResult } from '../../src/interfaces/ITokenCounter.js';
+import {
+  ITokenCounter,
+  TokenCountResult,
+} from '../../src/interfaces/ITokenCounter.js';
 
 // Mock token counter
 class MockTokenCounter implements ITokenCounter {
@@ -77,7 +80,8 @@ describe('DeduplicationModule', () => {
         minSentenceLength: 20,
       });
 
-      const text = 'Short. Short. This is a longer sentence. This is a longer sentence.';
+      const text =
+        'Short. Short. This is a longer sentence. This is a longer sentence.';
       const result = await moduleMinLength.apply(text);
 
       // Short duplicates should be kept, long ones removed
@@ -235,7 +239,8 @@ Same paragraph.
     });
 
     it('should handle text without duplicates', async () => {
-      const text = 'Every sentence is unique. No repetition here. All different.';
+      const text =
+        'Every sentence is unique. No repetition here. All different.';
       const result = await module.apply(text);
 
       expect(result.text).toBe(text);

--- a/tests/unit/disk-output.test.ts
+++ b/tests/unit/disk-output.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from '@jest/globals';
-import { parseWindowsDiskOutput, parseUnixDiskOutput } from '../../src/utils/disk-output.js';
+import {
+  parseWindowsDiskOutput,
+  parseUnixDiskOutput,
+} from '../../src/utils/disk-output.js';
 
 /**
  * smart_system_metrics takes a LIST of disk paths and answers one per path.
@@ -59,7 +62,10 @@ describe('windows disk output', () => {
   it('returns null for a drive with no media rather than NaN', () => {
     // An empty card reader or optical drive reports blank Size and FreeSpace.
     // parseInt('') is NaN, which used to flow straight into usagePercent.
-    const output = ['Caption  FreeSpace  Size', 'D:                        '].join('\n');
+    const output = [
+      'Caption  FreeSpace  Size',
+      'D:                        ',
+    ].join('\n');
     expect(parseWindowsDiskOutput(output, 'D:\\')).toBeNull();
   });
 
@@ -105,7 +111,12 @@ describe('unix disk output', () => {
   });
 
   it('returns null when there is no data row', () => {
-    expect(parseUnixDiskOutput('Filesystem 1K-blocks Used Available Use% Mounted on', '/')).toBeNull();
+    expect(
+      parseUnixDiskOutput(
+        'Filesystem 1K-blocks Used Available Use% Mounted on',
+        '/'
+      )
+    ).toBeNull();
     expect(parseUnixDiskOutput('', '/')).toBeNull();
   });
 });

--- a/tests/unit/doctor-knows-plugin-installs.test.ts
+++ b/tests/unit/doctor-knows-plugin-installs.test.ts
@@ -4,7 +4,11 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 
 // @ts-expect-error -- hooks-core ships as plain ESM with no type declarations.
-import { detectInstall, checklist, probeVersion } from '../../hooks-core/doctor.mjs';
+import {
+  detectInstall,
+  checklist,
+  probeVersion,
+} from '../../hooks-core/doctor.mjs';
 
 /**
  * The doctor was written for the script-install path and is blind to plugin
@@ -35,23 +39,52 @@ const PLUGIN_ID = 'token-optimizer@token-optimizer';
 let fixture: string;
 
 /** A plugins dir shaped like Claude Code's, with the given installed version. */
-function givenPluginInstall(installedVersion: string, availableVersion: string) {
+function givenPluginInstall(
+  installedVersion: string,
+  availableVersion: string
+) {
   const pluginsDir = join(fixture, '.claude', 'plugins');
-  const installPath = join(pluginsDir, 'cache', 'token-optimizer', 'token-optimizer', installedVersion);
+  const installPath = join(
+    pluginsDir,
+    'cache',
+    'token-optimizer',
+    'token-optimizer',
+    installedVersion
+  );
   mkdirSync(join(installPath, 'hooks', 'lib'), { recursive: true });
-  for (const f of ['pretooluse-router.mjs', 'session-start.mjs', 'precompact-optimize.mjs']) {
+  for (const f of [
+    'pretooluse-router.mjs',
+    'session-start.mjs',
+    'precompact-optimize.mjs',
+  ]) {
     writeFileSync(join(installPath, 'hooks', f), '// hook\n');
   }
   writeFileSync(join(installPath, 'hooks', 'hooks.json'), '{}\n');
 
   writeFileSync(
     join(pluginsDir, 'installed_plugins.json'),
-    JSON.stringify({ version: 1, plugins: { [PLUGIN_ID]: [{ scope: 'user', installPath, version: installedVersion }] } })
+    JSON.stringify({
+      version: 1,
+      plugins: {
+        [PLUGIN_ID]: [
+          { scope: 'user', installPath, version: installedVersion },
+        ],
+      },
+    })
   );
 
-  const marketplace = join(pluginsDir, 'marketplaces', 'token-optimizer', 'plugin', '.claude-plugin');
+  const marketplace = join(
+    pluginsDir,
+    'marketplaces',
+    'token-optimizer',
+    'plugin',
+    '.claude-plugin'
+  );
   mkdirSync(marketplace, { recursive: true });
-  writeFileSync(join(marketplace, 'plugin.json'), JSON.stringify({ name: 'token-optimizer', version: availableVersion }));
+  writeFileSync(
+    join(marketplace, 'plugin.json'),
+    JSON.stringify({ name: 'token-optimizer', version: availableVersion })
+  );
 
   return { pluginsDir, installPath };
 }
@@ -100,7 +133,9 @@ describe('detectInstall', () => {
 describe('probeVersion', () => {
   it('fails when the installed plugin is behind what is available', () => {
     const { pluginsDir } = givenPluginInstall('5.0.2', '5.3.6');
-    const [check] = probeVersion({ install: detectInstall({ pluginsDir, root: fixture }) });
+    const [check] = probeVersion({
+      install: detectInstall({ pluginsDir, root: fixture }),
+    });
 
     expect(check.pass).toBe(false);
     expect(check.detail).toContain('5.0.2');
@@ -109,7 +144,9 @@ describe('probeVersion', () => {
 
   it('passes when installed matches available', () => {
     const { pluginsDir } = givenPluginInstall('5.3.6', '5.3.6');
-    const [check] = probeVersion({ install: detectInstall({ pluginsDir, root: fixture }) });
+    const [check] = probeVersion({
+      install: detectInstall({ pluginsDir, root: fixture }),
+    });
 
     expect(check.pass).toBe(true);
   });
@@ -124,7 +161,11 @@ describe('checklist on a plugin install', () => {
     const { pluginsDir } = givenPluginInstall('5.3.6', '5.3.6');
     const install = detectInstall({ pluginsDir, root: fixture });
     // No settings file at all: a plugin install does not need one.
-    const checks = checklist({ root: fixture, settingsPath: join(fixture, 'settings.json'), install });
+    const checks = checklist({
+      root: fixture,
+      settingsPath: join(fixture, 'settings.json'),
+      install,
+    });
 
     expect(failedNames(checks)).not.toContain('hooks wired into settings');
     expect(failedNames(checks)).not.toContain('settings file present');
@@ -133,7 +174,11 @@ describe('checklist on a plugin install', () => {
   it('does not demand an install manifest', () => {
     const { pluginsDir } = givenPluginInstall('5.3.6', '5.3.6');
     const install = detectInstall({ pluginsDir, root: fixture });
-    const checks = checklist({ root: fixture, settingsPath: undefined, install });
+    const checks = checklist({
+      root: fixture,
+      settingsPath: undefined,
+      install,
+    });
 
     expect(failedNames(checks)).not.toContain('install manifest present');
   });
@@ -143,7 +188,11 @@ describe('checklist on a plugin install', () => {
     // they were skipped or passed. The report has to say which path it took.
     const { pluginsDir } = givenPluginInstall('5.3.6', '5.3.6');
     const install = detectInstall({ pluginsDir, root: fixture });
-    const checks = checklist({ root: fixture, settingsPath: undefined, install });
+    const checks = checklist({
+      root: fixture,
+      settingsPath: undefined,
+      install,
+    });
 
     expect(names(checks)).toContain('install method');
   });

--- a/tests/unit/doctor-reports-harvest-state.test.ts
+++ b/tests/unit/doctor-reports-harvest-state.test.ts
@@ -78,7 +78,10 @@ describe('probeHarvest', () => {
   });
 
   it('passes on a local endpoint, which is free and private', () => {
-    envOnly({ TOKEN_OPTIMIZER_HARVEST_ENDPOINT: 'http://127.0.0.1:11434/v1/chat/completions' });
+    envOnly({
+      TOKEN_OPTIMIZER_HARVEST_ENDPOINT:
+        'http://127.0.0.1:11434/v1/chat/completions',
+    });
     const [check] = probeHarvest();
 
     expect(check.pass).toBe(true);
@@ -86,7 +89,10 @@ describe('probeHarvest', () => {
   });
 
   it('passes when opted in with a credential', () => {
-    envOnly({ TOKEN_OPTIMIZER_HARVEST: 'true', TOKEN_OPTIMIZER_API_KEY: 'sk-test' });
+    envOnly({
+      TOKEN_OPTIMIZER_HARVEST: 'true',
+      TOKEN_OPTIMIZER_API_KEY: 'sk-test',
+    });
     const [check] = probeHarvest();
 
     expect(check.pass).toBe(true);

--- a/tests/unit/embedding-generator.test.ts
+++ b/tests/unit/embedding-generator.test.ts
@@ -58,7 +58,7 @@ describe('FoundationModelEmbeddingGenerator', () => {
 
     expect(embedding).toHaveLength(128);
     // All values should be finite numbers
-    expect(embedding.every(v => Number.isFinite(v))).toBe(true);
+    expect(embedding.every((v) => Number.isFinite(v))).toBe(true);
   });
 
   it('should handle long texts', async () => {
@@ -67,7 +67,7 @@ describe('FoundationModelEmbeddingGenerator', () => {
     const embedding = await generator.generateEmbedding(longText);
 
     expect(embedding).toHaveLength(128);
-    expect(embedding.every(v => Number.isFinite(v))).toBe(true);
+    expect(embedding.every((v) => Number.isFinite(v))).toBe(true);
   });
 
   it('should produce consistent embeddings for the same text', async () => {

--- a/tests/unit/file-backup.test.ts
+++ b/tests/unit/file-backup.test.ts
@@ -101,13 +101,27 @@ describe('backup filenames', () => {
     }
   });
 
-  it('does not lose a version when calls are concurrent', async () => {
-    // Five at once. With a millisecond timestamp alone this produced four
-    // files; the fifth silently overwrote one of the others.
+  it('does not lose a version when two writes share a timestamp', () => {
+    // THE CLOCK IS PINNED, and that is the whole point of the test.
+    //
+    // This used to wrap the writes in `Promise.all`, which proves nothing:
+    // `writeBackup` is synchronous, so each callback runs to completion before
+    // the next begins. There was no concurrency, and whether the writes
+    // collided depended on whether all five happened to land inside the same
+    // millisecond -- true on a fast machine, not guaranteed. On a slow or
+    // heavily loaded one they straddle a millisecond boundary, timestamp-only
+    // names come out distinct, and the test passes while testing nothing.
+    //
+    // Freezing `toISOString` forces the exact collision the naming scheme
+    // exists to survive, so the test fails for the real reason or not at all.
     const versions = ['a', 'b', 'c', 'd', 'e'];
-    await Promise.all(
-      versions.map((v) => Promise.resolve().then(() => writeBackup(file, v)))
-    );
+    const realToISOString = Date.prototype.toISOString;
+    Date.prototype.toISOString = () => '2026-01-01T00:00:00.000Z';
+    try {
+      for (const v of versions) writeBackup(file, v);
+    } finally {
+      Date.prototype.toISOString = realToISOString;
+    }
 
     const written = readdirSync(backupDirFor(file));
     expect(written).toHaveLength(versions.length);

--- a/tests/unit/file-backup.test.ts
+++ b/tests/unit/file-backup.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+﻿import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import { mkdtempSync, readdirSync, readFileSync, existsSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir, homedir } from 'os';
@@ -101,7 +101,7 @@ describe('backup filenames', () => {
     }
   });
 
-  it('does not lose a version when two writes share a timestamp', () => {
+  it('does not lose a version when five writes share a timestamp', () => {
     // THE CLOCK IS PINNED, and that is the whole point of the test.
     //
     // This used to wrap the writes in `Promise.all`, which proves nothing:

--- a/tests/unit/file-backup.test.ts
+++ b/tests/unit/file-backup.test.ts
@@ -105,12 +105,16 @@ describe('backup filenames', () => {
     // Five at once. With a millisecond timestamp alone this produced four
     // files; the fifth silently overwrote one of the others.
     const versions = ['a', 'b', 'c', 'd', 'e'];
-    await Promise.all(versions.map((v) => Promise.resolve().then(() => writeBackup(file, v))));
+    await Promise.all(
+      versions.map((v) => Promise.resolve().then(() => writeBackup(file, v)))
+    );
 
     const written = readdirSync(backupDirFor(file));
     expect(written).toHaveLength(versions.length);
 
-    const contents = written.map((f) => readFileSync(join(backupDirFor(file), f), 'utf8')).sort();
+    const contents = written
+      .map((f) => readFileSync(join(backupDirFor(file), f), 'utf8'))
+      .sort();
     expect(contents).toEqual(versions);
   });
 
@@ -151,7 +155,9 @@ describe('backup filenames', () => {
     const kept = readdirSync(backupDirFor(file));
     expect(kept).toHaveLength(5);
 
-    const contents = kept.map((f) => readFileSync(join(backupDirFor(file), f), 'utf8'));
+    const contents = kept.map((f) =>
+      readFileSync(join(backupDirFor(file), f), 'utf8')
+    );
     expect(contents).toContain('version 8');
     expect(contents).not.toContain('version 0');
   });

--- a/tests/unit/file-operations/backup-location.test.ts
+++ b/tests/unit/file-operations/backup-location.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { mkdtempSync, writeFileSync, existsSync, rmSync, readdirSync } from 'fs';
+import {
+  mkdtempSync,
+  writeFileSync,
+  existsSync,
+  rmSync,
+  readdirSync,
+} from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { SmartWriteTool } from '../../../src/tools/file-operations/smart-write.js';
@@ -55,7 +61,8 @@ describe('backups never land next to the file', () => {
     cache.close();
     counter.free();
 
-    if (originalBackupDir === undefined) delete process.env.TOKEN_OPTIMIZER_BACKUP_DIR;
+    if (originalBackupDir === undefined)
+      delete process.env.TOKEN_OPTIMIZER_BACKUP_DIR;
     else process.env.TOKEN_OPTIMIZER_BACKUP_DIR = originalBackupDir;
 
     for (const dir of [home, backups]) {
@@ -114,7 +121,14 @@ describe('backups never land next to the file', () => {
 
       await tool.edit(
         file,
-        [{ type: 'replace', startLine: 1, endLine: 1, content: 'const edited = 3;' }],
+        [
+          {
+            type: 'replace',
+            startLine: 1,
+            endLine: 1,
+            content: 'const edited = 3;',
+          },
+        ],
         { createBackup: true }
       );
 
@@ -126,7 +140,14 @@ describe('backups never land next to the file', () => {
 
       await tool.edit(
         file,
-        [{ type: 'replace', startLine: 1, endLine: 1, content: 'const edited = 3;' }],
+        [
+          {
+            type: 'replace',
+            startLine: 1,
+            endLine: 1,
+            content: 'const edited = 3;',
+          },
+        ],
         { createBackup: true }
       );
 

--- a/tests/unit/file-operations/search-honesty.test.ts
+++ b/tests/unit/file-operations/search-honesty.test.ts
@@ -31,16 +31,30 @@ describe('search tools bound their output', () => {
 
   afterEach(() => {
     while (caches.length) {
-      try { caches.pop()?.close(); } catch { /* already closed */ }
+      try {
+        caches.pop()?.close();
+      } catch {
+        /* already closed */
+      }
     }
     while (dirs.length) {
       const d = dirs.pop();
-      if (d) { try { rmSync(d, { recursive: true, force: true }); } catch { /* windows */ } }
+      if (d) {
+        try {
+          rmSync(d, { recursive: true, force: true });
+        } catch {
+          /* windows */
+        }
+      }
     }
   });
 
   /** A tree big enough that an unbounded search is genuinely dangerous. */
-  function bigRepo(): { dir: string; counter: TokenCounter; cache: CacheEngine } {
+  function bigRepo(): {
+    dir: string;
+    counter: TokenCounter;
+    cache: CacheEngine;
+  } {
     const dir = mkdtempSync(join(tmpdir(), 'token-optimizer-search-'));
     dirs.push(dir);
     const cache = new CacheEngine(join(dir, 'c.db'));
@@ -49,7 +63,9 @@ describe('search tools bound their output', () => {
     for (let f = 0; f < 40; f++) {
       const lines = [];
       for (let i = 0; i < 120; i++) {
-        lines.push(`export function target${f}_${i}() { return ${i}; } // padding padding padding`);
+        lines.push(
+          `export function target${f}_${i}() { return ${i}; } // padding padding padding`
+        );
       }
       writeFileSync(join(dir, 'src', `mod${f}.ts`), lines.join('\n'));
     }
@@ -95,7 +111,9 @@ describe('search tools bound their output', () => {
     }
     // And the baseline must be at least as large as the result it replaced.
     expect(md.originalTokenCount).toBeGreaterThanOrEqual(md.tokenCount);
-    expect(md.tokensSaved).toBe(Math.max(0, md.originalTokenCount - md.tokenCount));
+    expect(md.tokensSaved).toBe(
+      Math.max(0, md.originalTokenCount - md.tokenCount)
+    );
   });
 
   it('a glob claims only what pagination actually withheld', async () => {
@@ -109,11 +127,19 @@ describe('search tools bound their output', () => {
     expect(all.metadata.originalTokenCount).toBe(all.metadata.tokenCount);
 
     // With a limit, the saving is the paths held back -- countable, so counted.
-    const paged = await glob.glob('src/**/*.ts', { cwd: dir, limit: 5, useCache: false });
+    const paged = await glob.glob('src/**/*.ts', {
+      cwd: dir,
+      limit: 5,
+      useCache: false,
+    });
     expect(paged.metadata.tokensSaved).toBeGreaterThan(0);
-    expect(paged.metadata.originalTokenCount).toBeGreaterThan(paged.metadata.tokenCount);
+    expect(paged.metadata.originalTokenCount).toBeGreaterThan(
+      paged.metadata.tokenCount
+    );
     for (const factor of [10, 50]) {
-      expect(paged.metadata.originalTokenCount).not.toBe(paged.metadata.tokenCount * factor);
+      expect(paged.metadata.originalTokenCount).not.toBe(
+        paged.metadata.tokenCount * factor
+      );
     }
   });
 });

--- a/tests/unit/file-operations/smart-edit-patterns.test.ts
+++ b/tests/unit/file-operations/smart-edit-patterns.test.ts
@@ -54,7 +54,8 @@ describe('smart_edit pattern operations', () => {
     cache.close();
     counter.free();
 
-    if (originalBackupDir === undefined) delete process.env.TOKEN_OPTIMIZER_BACKUP_DIR;
+    if (originalBackupDir === undefined)
+      delete process.env.TOKEN_OPTIMIZER_BACKUP_DIR;
     else process.env.TOKEN_OPTIMIZER_BACKUP_DIR = originalBackupDir;
 
     for (const dir of [home, backups]) {
@@ -70,7 +71,14 @@ describe('smart_edit pattern operations', () => {
     it('fails rather than reporting success', async () => {
       const result = await tool.edit(
         file,
-        [{ type: 'replace', startLine: 1, pattern: 'NOT_PRESENT_ANYWHERE', replacement: 'x' }],
+        [
+          {
+            type: 'replace',
+            startLine: 1,
+            pattern: 'NOT_PRESENT_ANYWHERE',
+            replacement: 'x',
+          },
+        ],
         { createBackup: false }
       );
 
@@ -82,7 +90,14 @@ describe('smart_edit pattern operations', () => {
     it('names the pattern that missed, so the caller can fix it', async () => {
       const result = await tool.edit(
         file,
-        [{ type: 'replace', startLine: 1, pattern: 'NOT_PRESENT_ANYWHERE', replacement: 'x' }],
+        [
+          {
+            type: 'replace',
+            startLine: 1,
+            pattern: 'NOT_PRESENT_ANYWHERE',
+            replacement: 'x',
+          },
+        ],
         { createBackup: false }
       );
 
@@ -92,7 +107,14 @@ describe('smart_edit pattern operations', () => {
     it('leaves the file untouched', async () => {
       await tool.edit(
         file,
-        [{ type: 'replace', startLine: 1, pattern: 'NOT_PRESENT_ANYWHERE', replacement: 'x' }],
+        [
+          {
+            type: 'replace',
+            startLine: 1,
+            pattern: 'NOT_PRESENT_ANYWHERE',
+            replacement: 'x',
+          },
+        ],
         { createBackup: false }
       );
 
@@ -105,8 +127,18 @@ describe('smart_edit pattern operations', () => {
       const result = await tool.edit(
         file,
         [
-          { type: 'replace', startLine: 1, pattern: 'const a = 1;', replacement: 'const a = 11;' },
-          { type: 'replace', startLine: 3, pattern: 'NOT_PRESENT', replacement: 'x' },
+          {
+            type: 'replace',
+            startLine: 1,
+            pattern: 'const a = 1;',
+            replacement: 'const a = 11;',
+          },
+          {
+            type: 'replace',
+            startLine: 3,
+            pattern: 'NOT_PRESENT',
+            replacement: 'x',
+          },
         ],
         { createBackup: false }
       );
@@ -133,7 +165,9 @@ describe('smart_edit pattern operations', () => {
       );
 
       expect(result.success).toBe(true);
-      expect(readFileSync(file, 'utf8')).toBe(['const ab = 12;', 'const c = 3;'].join('\n'));
+      expect(readFileSync(file, 'utf8')).toBe(
+        ['const ab = 12;', 'const c = 3;'].join('\n')
+      );
     });
 
     it('is reported as applied, not as unchanged', async () => {
@@ -165,7 +199,14 @@ describe('smart_edit pattern operations', () => {
     it('is a no-op, not a failure', async () => {
       const result = await tool.edit(
         file,
-        [{ type: 'replace', startLine: 1, pattern: 'const a = 1;', replacement: 'const a = 1;' }],
+        [
+          {
+            type: 'replace',
+            startLine: 1,
+            pattern: 'const a = 1;',
+            replacement: 'const a = 1;',
+          },
+        ],
         { createBackup: false }
       );
 
@@ -176,7 +217,14 @@ describe('smart_edit pattern operations', () => {
     it('handles a capture-group substitution that rebuilds the original', async () => {
       const result = await tool.edit(
         file,
-        [{ type: 'replace', startLine: 1, pattern: '(const) (a)', replacement: '$1 $2' }],
+        [
+          {
+            type: 'replace',
+            startLine: 1,
+            pattern: '(const) (a)',
+            replacement: '$1 $2',
+          },
+        ],
         { createBackup: false }
       );
 
@@ -188,7 +236,14 @@ describe('smart_edit pattern operations', () => {
       // The distinction has to cut both ways, or the fix just disables the guard.
       const result = await tool.edit(
         file,
-        [{ type: 'replace', startLine: 1, pattern: 'NOT_HERE', replacement: 'NOT_HERE' }],
+        [
+          {
+            type: 'replace',
+            startLine: 1,
+            pattern: 'NOT_HERE',
+            replacement: 'NOT_HERE',
+          },
+        ],
         { createBackup: false }
       );
 
@@ -199,9 +254,24 @@ describe('smart_edit pattern operations', () => {
       // A global regex is stateful. Probing with the same object would make the
       // outcome depend on what was tested before it.
       const ops = [
-        { type: 'replace' as const, startLine: 1, pattern: 'const', replacement: 'const' },
-        { type: 'replace' as const, startLine: 2, pattern: 'const', replacement: 'const' },
-        { type: 'replace' as const, startLine: 3, pattern: 'const', replacement: 'const' },
+        {
+          type: 'replace' as const,
+          startLine: 1,
+          pattern: 'const',
+          replacement: 'const',
+        },
+        {
+          type: 'replace' as const,
+          startLine: 2,
+          pattern: 'const',
+          replacement: 'const',
+        },
+        {
+          type: 'replace' as const,
+          startLine: 3,
+          pattern: 'const',
+          replacement: 'const',
+        },
       ];
       const result = await tool.edit(file, ops, { createBackup: false });
 
@@ -213,7 +283,14 @@ describe('smart_edit pattern operations', () => {
     it('still applies a matching single-line pattern', async () => {
       const result = await tool.edit(
         file,
-        [{ type: 'replace', startLine: 2, pattern: 'const b = 2;', replacement: 'const b = 22;' }],
+        [
+          {
+            type: 'replace',
+            startLine: 2,
+            pattern: 'const b = 2;',
+            replacement: 'const b = 22;',
+          },
+        ],
         { createBackup: false }
       );
 
@@ -229,7 +306,14 @@ describe('smart_edit pattern operations', () => {
       // or every idempotent edit becomes a failure.
       const result = await tool.edit(
         file,
-        [{ type: 'replace', startLine: 1, endLine: 1, content: 'const a = 1;' }],
+        [
+          {
+            type: 'replace',
+            startLine: 1,
+            endLine: 1,
+            content: 'const a = 1;',
+          },
+        ],
         { createBackup: false }
       );
 
@@ -242,7 +326,14 @@ describe('smart_edit pattern operations', () => {
       // the original dirtied the repository it was meant to protect.
       await tool.edit(
         file,
-        [{ type: 'replace', startLine: 2, pattern: 'const b = 2;', replacement: 'const b = 22;' }],
+        [
+          {
+            type: 'replace',
+            startLine: 2,
+            pattern: 'const b = 2;',
+            replacement: 'const b = 22;',
+          },
+        ],
         { createBackup: true }
       );
 

--- a/tests/unit/generators-are-eol-insensitive.test.ts
+++ b/tests/unit/generators-are-eol-insensitive.test.ts
@@ -1,14 +1,25 @@
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import {
-  mkdtempSync, writeFileSync, readFileSync, rmSync, statSync,
-  mkdirSync, copyFileSync, readdirSync, existsSync,
+  mkdtempSync,
+  writeFileSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  mkdirSync,
+  copyFileSync,
+  readdirSync,
+  existsSync,
 } from 'fs';
 import { spawnSync } from 'child_process';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
 // @ts-expect-error -- scripts ship as plain ESM with no type declarations.
-import { normalizeEol, contentMatches, writeIfChanged } from '../../scripts/lib/text.mjs';
+import {
+  normalizeEol,
+  contentMatches,
+  writeIfChanged,
+} from '../../scripts/lib/text.mjs';
 
 /**
  * The generators compared generated content to on-disk content byte-for-byte,
@@ -63,11 +74,15 @@ describe('normalizeEol', () => {
 
 describe('contentMatches', () => {
   it('treats a CRLF file as matching LF generated output', () => {
-    expect(contentMatches('export const x = 1;\r\n', 'export const x = 1;\n')).toBe(true);
+    expect(
+      contentMatches('export const x = 1;\r\n', 'export const x = 1;\n')
+    ).toBe(true);
   });
 
   it('still detects a real content change', () => {
-    expect(contentMatches('export const x = 1;\r\n', 'export const x = 2;\n')).toBe(false);
+    expect(
+      contentMatches('export const x = 1;\r\n', 'export const x = 2;\n')
+    ).toBe(false);
   });
 
   it('reports a missing file as not matching', () => {
@@ -125,10 +140,13 @@ describe('every generator', () => {
   // generate-client-entries.mjs to a raw byte comparison AND an unconditional
   // write while keeping the import: all fourteen tests stayed green. A guard
   // that cannot fail is decoration.
-  it.each(GENERATORS)('%s routes its comparison through the helpers', (file) => {
-    const source = readFileSync(join(ROOT, file), 'utf8');
-    expect(source).toMatch(/contentMatches\s*\(\s*readIfExists\s*\(/);
-  });
+  it.each(GENERATORS)(
+    '%s routes its comparison through the helpers',
+    (file) => {
+      const source = readFileSync(join(ROOT, file), 'utf8');
+      expect(source).toMatch(/contentMatches\s*\(\s*readIfExists\s*\(/);
+    }
+  );
 
   it.each(GENERATORS)('%s routes its writes through writeIfChanged', (file) => {
     const source = readFileSync(join(ROOT, file), 'utf8');
@@ -140,10 +158,13 @@ describe('every generator', () => {
   // straight past. No generator imports writeFileSync today, and requiring that
   // to stay true means a direct write cannot be reintroduced under any name,
   // because it has nowhere to come from.
-  it.each(GENERATORS)('%s cannot write bytes except through the helper', (file) => {
-    const source = readFileSync(join(ROOT, file), 'utf8');
-    expect(source).not.toMatch(/\bwriteFileSync\b/);
-  });
+  it.each(GENERATORS)(
+    '%s cannot write bytes except through the helper',
+    (file) => {
+      const source = readFileSync(join(ROOT, file), 'utf8');
+      expect(source).not.toMatch(/\bwriteFileSync\b/);
+    }
+  );
 
   it.each(GENERATORS)('%s does not compare raw file contents', (file) => {
     const source = readFileSync(join(ROOT, file), 'utf8');
@@ -167,7 +188,10 @@ describe('a generator run against a CRLF working tree', () => {
   function sandbox() {
     const root = mkdtempSync(join(tmpdir(), 'gen-eol-'));
     mkdirSync(join(root, 'scripts', 'lib'), { recursive: true });
-    copyFileSync(join(process.cwd(), 'scripts', GEN), join(root, 'scripts', GEN));
+    copyFileSync(
+      join(process.cwd(), 'scripts', GEN),
+      join(root, 'scripts', GEN)
+    );
     copyFileSync(
       join(process.cwd(), 'scripts', 'lib', 'text.mjs'),
       join(root, 'scripts', 'lib', 'text.mjs')
@@ -191,7 +215,8 @@ describe('a generator run against a CRLF working tree', () => {
         else if (full.endsWith('.mjs')) out.push(full);
       }
     };
-    if (existsSync(join(root, 'integrations'))) walk(join(root, 'integrations'));
+    if (existsSync(join(root, 'integrations')))
+      walk(join(root, 'integrations'));
     return out;
   }
 

--- a/tests/unit/graph-atomicity.test.ts
+++ b/tests/unit/graph-atomicity.test.ts
@@ -36,10 +36,7 @@ afterEach(() => {
 });
 
 const logPath = () => join(dir, 'graph.jsonl');
-const lines = () =>
-  readFileSync(logPath(), 'utf8')
-    .split('\n')
-    .filter(Boolean);
+const lines = () => readFileSync(logPath(), 'utf8').split('\n').filter(Boolean);
 
 describe('putNodeWithEdges', () => {
   it('writes the node and every edge in ONE append', async () => {
@@ -72,8 +69,12 @@ describe('putNodeWithEdges', () => {
     ]);
 
     const written = lines().map((l) => JSON.parse(l));
-    const nodeIndex = written.findIndex((r) => r.t === 'n' && r.kind === 'finding');
-    const edgeIndex = written.findIndex((r) => r.t === 'e' && r.edge === 'derived_from');
+    const nodeIndex = written.findIndex(
+      (r) => r.t === 'n' && r.kind === 'finding'
+    );
+    const edgeIndex = written.findIndex(
+      (r) => r.t === 'e' && r.edge === 'derived_from'
+    );
 
     expect(edgeIndex).toBeGreaterThanOrEqual(0);
     expect(nodeIndex).toBeGreaterThan(edgeIndex);
@@ -103,13 +104,18 @@ describe('putNodeWithEdges', () => {
 
       const graph = load(dir);
       const anchored = new Set(
-        graph.edges.filter((e: any) => e.edge === 'derived_from').map((e: any) => e.from)
+        graph.edges
+          .filter((e: any) => e.edge === 'derived_from')
+          .map((e: any) => e.from)
       );
       const orphans = [...graph.nodes.values()].filter(
         (n: any) => n.kind === 'finding' && !anchored.has(n.id)
       );
 
-      expect({ cut, orphans: orphans.map((o: any) => o.key) }).toEqual({ cut, orphans: [] });
+      expect({ cut, orphans: orphans.map((o: any) => o.key) }).toEqual({
+        cut,
+        orphans: [],
+      });
     }
   });
 
@@ -144,16 +150,27 @@ describe('writeHarvested', () => {
 
     const keys = writeHarvested(
       dir,
-      [{ type: 'finding', claim: 'subject() returns one', confidence: 0.9, anchors: [file] }],
+      [
+        {
+          type: 'finding',
+          claim: 'subject() returns one',
+          confidence: 0.9,
+          anchors: [file],
+        },
+      ],
       { projectRoot: dir }
     );
 
     expect(keys).toHaveLength(1);
 
     const graph = load(dir);
-    const findings = [...graph.nodes.values()].filter((n: any) => n.kind === 'finding');
+    const findings = [...graph.nodes.values()].filter(
+      (n: any) => n.kind === 'finding'
+    );
     const anchored = new Set(
-      graph.edges.filter((e: any) => e.edge === 'derived_from').map((e: any) => e.from)
+      graph.edges
+        .filter((e: any) => e.edge === 'derived_from')
+        .map((e: any) => e.from)
     );
 
     expect(findings).toHaveLength(1);

--- a/tests/unit/gzip.test.ts
+++ b/tests/unit/gzip.test.ts
@@ -3,71 +3,71 @@ import { mkdtempSync, existsSync, writeFileSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import {
-    gzipString,
-    gunzipBuffer,
-    saveGzippedFile,
-    loadMaybeGzippedFile,
+  gzipString,
+  gunzipBuffer,
+  saveGzippedFile,
+  loadMaybeGzippedFile,
 } from '../../src/utils/gzip.js';
 
 describe('gzip utils', () => {
-    const tempDirs: string[] = [];
-    afterEach(() => {
-        while (tempDirs.length) {
-            const dir = tempDirs.pop();
-            if (dir) {
-                rmSync(dir, { recursive: true, force: true });
-            }
-        }
-    });
-
-    function tempDir(): string {
-        const dir = mkdtempSync(join(tmpdir(), 'token-optimizer-gzip-'));
-        tempDirs.push(dir);
-        return dir;
+  const tempDirs: string[] = [];
+  afterEach(() => {
+    while (tempDirs.length) {
+      const dir = tempDirs.pop();
+      if (dir) {
+        rmSync(dir, { recursive: true, force: true });
+      }
     }
+  });
 
-    it('gzipString round-trips via gunzipBuffer', () => {
-        const text = 'Hello, world. '.repeat(1000);
-        const buffer = gzipString(text);
-        expect(buffer.length).toBeLessThan(text.length);
-        expect(gunzipBuffer(buffer)).toBe(text);
-    });
+  function tempDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'token-optimizer-gzip-'));
+    tempDirs.push(dir);
+    return dir;
+  }
 
-    it('saveGzippedFile writes .gz and removes plaintext', () => {
-        const dir = tempDir();
-        const file = join(dir, 'sessions.json');
-        writeFileSync(file, 'stale plaintext');
-        const stats = saveGzippedFile(file, JSON.stringify({ hello: 'world' }));
-        expect(existsSync(`${file}.gz`)).toBe(true);
-        expect(existsSync(file)).toBe(false);
-        expect(stats.originalBytes).toBeGreaterThan(0);
-        expect(stats.compressedBytes).toBeGreaterThan(0);
-    });
+  it('gzipString round-trips via gunzipBuffer', () => {
+    const text = 'Hello, world. '.repeat(1000);
+    const buffer = gzipString(text);
+    expect(buffer.length).toBeLessThan(text.length);
+    expect(gunzipBuffer(buffer)).toBe(text);
+  });
 
-    it('loadMaybeGzippedFile prefers the .gz sibling', () => {
-        const dir = tempDir();
-        const file = join(dir, 'state.json');
-        saveGzippedFile(file, '{"compressed":true}');
-        expect(loadMaybeGzippedFile(file)).toBe('{"compressed":true}');
-    });
+  it('saveGzippedFile writes .gz and removes plaintext', () => {
+    const dir = tempDir();
+    const file = join(dir, 'sessions.json');
+    writeFileSync(file, 'stale plaintext');
+    const stats = saveGzippedFile(file, JSON.stringify({ hello: 'world' }));
+    expect(existsSync(`${file}.gz`)).toBe(true);
+    expect(existsSync(file)).toBe(false);
+    expect(stats.originalBytes).toBeGreaterThan(0);
+    expect(stats.compressedBytes).toBeGreaterThan(0);
+  });
 
-    it('loadMaybeGzippedFile falls back to plaintext when no .gz exists', () => {
-        const dir = tempDir();
-        const file = join(dir, 'legacy.json');
-        writeFileSync(file, '{"legacy":true}');
-        expect(loadMaybeGzippedFile(file)).toBe('{"legacy":true}');
-    });
+  it('loadMaybeGzippedFile prefers the .gz sibling', () => {
+    const dir = tempDir();
+    const file = join(dir, 'state.json');
+    saveGzippedFile(file, '{"compressed":true}');
+    expect(loadMaybeGzippedFile(file)).toBe('{"compressed":true}');
+  });
 
-    it('loadMaybeGzippedFile returns null when neither exists', () => {
-        const dir = tempDir();
-        const file = join(dir, 'missing.json');
-        expect(loadMaybeGzippedFile(file)).toBeNull();
-    });
+  it('loadMaybeGzippedFile falls back to plaintext when no .gz exists', () => {
+    const dir = tempDir();
+    const file = join(dir, 'legacy.json');
+    writeFileSync(file, '{"legacy":true}');
+    expect(loadMaybeGzippedFile(file)).toBe('{"legacy":true}');
+  });
 
-    it('saves with high compression ratio on repetitive content', () => {
-        const dir = tempDir();
-        const file = join(dir, 'repeated.txt');
-        const stats = saveGzippedFile(file, 'aa'.repeat(10_000));
-        expect(stats.percentSaved).toBeGreaterThan(95);
-    });
+  it('loadMaybeGzippedFile returns null when neither exists', () => {
+    const dir = tempDir();
+    const file = join(dir, 'missing.json');
+    expect(loadMaybeGzippedFile(file)).toBeNull();
+  });
+
+  it('saves with high compression ratio on repetitive content', () => {
+    const dir = tempDir();
+    const file = join(dir, 'repeated.txt');
+    const stats = saveGzippedFile(file, 'aa'.repeat(10_000));
+    expect(stats.percentSaved).toBeGreaterThan(95);
+  });
 });

--- a/tests/unit/harvest-gating.test.ts
+++ b/tests/unit/harvest-gating.test.ts
@@ -81,7 +81,8 @@ describe('harvest enablement', () => {
   it('runs against a LOCAL endpoint with no key and no opt-in', async () => {
     // Nothing is spent and nothing leaves the machine, so there is nothing to
     // consent to.
-    process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT = 'http://localhost:11434/v1/messages';
+    process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT =
+      'http://localhost:11434/v1/messages';
     const { harvestMode, harvestEnabled, localEndpoint } = await harvest();
     expect(localEndpoint()).toBeTruthy();
     expect(harvestMode()).toBe('local');
@@ -89,7 +90,8 @@ describe('harvest enablement', () => {
   });
 
   it('treats a REMOTE endpoint as remote even with a key present', async () => {
-    process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT = 'https://api.anthropic.com/v1/messages';
+    process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT =
+      'https://api.anthropic.com/v1/messages';
     process.env.ANTHROPIC_API_KEY = 'sk-ant-xxx';
     const { harvestMode, localEndpoint } = await harvest();
     expect(localEndpoint()).toBeNull();
@@ -98,14 +100,16 @@ describe('harvest enablement', () => {
 
   it('does not mistake a hostname that merely contains "localhost" for local', async () => {
     // localhost.attacker.example resolves wherever its owner wants it to.
-    process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT = 'https://localhost.attacker.example/v1/messages';
+    process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT =
+      'https://localhost.attacker.example/v1/messages';
     const { localEndpoint } = await harvest();
     expect(localEndpoint()).toBeNull();
   });
 
   it('stays off entirely when the optimizer is off', async () => {
     process.env.TOKEN_OPTIMIZER_MODE = 'off';
-    process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT = 'http://localhost:11434/v1/messages';
+    process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT =
+      'http://localhost:11434/v1/messages';
     const { harvestMode, harvestEnabled } = await harvest();
     expect(harvestMode()).toBe('off:mode');
     expect(harvestEnabled()).toBe(false);
@@ -143,7 +147,8 @@ describe('harvest enablement', () => {
     // The negative test above is only meaningful next to a positive one: if
     // extract() never called fetch under ANY configuration, zero calls would
     // prove nothing about the gate.
-    process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT = 'http://127.0.0.1:11434/v1/messages';
+    process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT =
+      'http://127.0.0.1:11434/v1/messages';
 
     const realFetch = globalThis.fetch;
     const calls: unknown[] = [];

--- a/tests/unit/helpers/schema-source.ts
+++ b/tests/unit/helpers/schema-source.ts
@@ -1,0 +1,324 @@
+/**
+ * Shared parser for reading tool schemas and Options interfaces out of source.
+ *
+ * ONE COPY, DELIBERATELY. Two tests need this and an earlier attempt kept a second
+ * copy in a scratch script; the copies drifted, the stale one reported 11 freshly
+ * declared properties as still missing, and the numbers looked plausible enough to
+ * believe. A scanner that silently under-reports is worse than no scanner.
+ */
+
+export interface InterfaceField {
+  name: string;
+  optional: boolean;
+  type: string;
+}
+
+export interface NestedShape {
+  /** Keys under the property's `properties:` block. */
+  properties: string[];
+  /** Names listed in the property's own `required: [...]`. */
+  required: string[];
+  /** True when the property declares an array whose `items` carry the shape. */
+  isArray: boolean;
+}
+
+/**
+ * Top-level keys of the object literal whose `{` is at `open`.
+ *
+ * COMMENT-AWARE, and that is not a nicety. Without it an apostrophe inside a `//`
+ * comment -- "the caller's argument object" -- opens a string that never closes and
+ * every later key is swallowed.
+ */
+export function topLevelKeys(text: string, open: number): string[] {
+  const keys: string[] = [];
+  let depth = 0;
+  let inString: string | null = null;
+
+  for (let i = open; i < text.length; i++) {
+    const c = text[i];
+
+    if (inString) {
+      if (c === '\\') i++;
+      else if (c === inString) inString = null;
+      continue;
+    }
+    if (c === '/' && text[i + 1] === '/') {
+      const end = text.indexOf('\n', i);
+      if (end === -1) break;
+      i = end;
+      continue;
+    }
+    if (c === '/' && text[i + 1] === '*') {
+      const end = text.indexOf('*/', i + 2);
+      if (end === -1) break;
+      i = end + 1;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === '`') {
+      inString = c;
+      continue;
+    }
+    if (c === '{' || c === '[') {
+      depth++;
+      continue;
+    }
+    if (c === '}' || c === ']') {
+      depth--;
+      if (depth === 0) break;
+      continue;
+    }
+    if (depth === 1 && /[A-Za-z_$]/.test(c)) {
+      const m = /^([A-Za-z_$][\w$]*)\s*:/.exec(text.slice(i));
+      if (m) {
+        keys.push(m[1]);
+        i += m[1].length;
+      }
+    }
+  }
+  return keys;
+}
+
+/** Index just past the matching close brace for the `{` at `open`, or -1. */
+function matchingClose(text: string, open: number): number {
+  let depth = 0;
+  let inString: string | null = null;
+
+  for (let i = open; i < text.length; i++) {
+    const c = text[i];
+    if (inString) {
+      if (c === '\\') i++;
+      else if (c === inString) inString = null;
+      continue;
+    }
+    if (c === '/' && text[i + 1] === '/') {
+      const end = text.indexOf('\n', i);
+      if (end === -1) return -1;
+      i = end;
+      continue;
+    }
+    if (c === '/' && text[i + 1] === '*') {
+      const end = text.indexOf('*/', i + 2);
+      if (end === -1) return -1;
+      i = end + 1;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === '`') {
+      inString = c;
+      continue;
+    }
+    if (c === '{' || c === '[') depth++;
+    else if (c === '}' || c === ']') {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+/** The source text of the `inputSchema.properties` object, or null. */
+function schemaPropertiesSlice(text: string): string | null {
+  const schema = text.indexOf('inputSchema');
+  if (schema === -1) return null;
+  const props = text.indexOf('properties:', schema);
+  if (props === -1) return null;
+  const open = text.indexOf('{', props);
+  if (open === -1) return null;
+  const close = matchingClose(text, open);
+  return close === -1 ? null : text.slice(open, close + 1);
+}
+
+/** Names declared directly under `inputSchema.properties`. */
+export function declaredProperties(text: string): string[] | null {
+  const slice = schemaPropertiesSlice(text);
+  if (!slice) return null;
+
+  const top = topLevelKeys(slice, 0);
+  if (!top.includes('options')) return top;
+
+  // A few tools take options as a separate argument and nest them under `options`,
+  // which is correct for that call shape.
+  const optionsKey = slice.indexOf('options:');
+  const nested =
+    optionsKey === -1 ? -1 : slice.indexOf('properties:', optionsKey);
+  if (nested === -1) return top;
+  const open = slice.indexOf('{', nested);
+  return open === -1 ? top : [...top, ...topLevelKeys(slice, open)];
+}
+
+/** Fields of every `export interface *Options` in the file, function/Buffer types dropped. */
+export function acceptedOptions(text: string): string[] {
+  return acceptedOptionFields(text).map((f) => f.name);
+}
+
+/**
+ * The same fields WITH their declared types and optionality.
+ *
+ * Callers must take the type from here rather than re-searching the file for
+ * `<name>:`. That search matches the first field of that name ANYWHERE, so a field
+ * sharing a name with one in a different interface resolves to the wrong type --
+ * observed: `workload?: Partial<WorkloadConfig>` was read as plain `WorkloadConfig`
+ * from an unrelated declaration, which made a Partial look like it required all eight
+ * of its fields.
+ */
+export function acceptedOptionFields(text: string): InterfaceField[] {
+  return interfaceFieldsMatching(text, /Options$/).filter(
+    (f) => !isUnsendable(f.type)
+  );
+}
+
+/** A type that cannot cross a JSON boundary, so cannot be declared or sent. */
+export function isUnsendable(type: string): boolean {
+  return (
+    type.includes('=>') || /\bFunction\b/.test(type) || /\bBuffer\b/.test(type)
+  );
+}
+
+/** Fields of one named interface, or [] when it is not declared in this file. */
+export function interfaceFields(text: string, name: string): InterfaceField[] {
+  const match = new RegExp(`export interface\\s+${name}\\s*\\{`).exec(text);
+  return match ? fieldsFrom(text, text.indexOf('{', match.index)) : [];
+}
+
+function interfaceFieldsMatching(
+  text: string,
+  pattern: RegExp
+): InterfaceField[] {
+  const out: InterfaceField[] = [];
+  for (const m of text.matchAll(/export interface\s+(\w+)\s*\{/g)) {
+    if (!pattern.test(m[1])) continue;
+    out.push(...fieldsFrom(text, text.indexOf('{', m.index)));
+  }
+
+  const seen = new Set<string>();
+  return out.filter((f) =>
+    seen.has(f.name) ? false : (seen.add(f.name), true)
+  );
+}
+
+/** Direct fields of the interface body whose `{` is at `open`. */
+function fieldsFrom(text: string, open: number): InterfaceField[] {
+  const fields: InterfaceField[] = [];
+  let depth = 0;
+
+  for (let i = open; i < text.length; i++) {
+    const c = text[i];
+    if (c === '{') {
+      depth++;
+      continue;
+    }
+    if (c === '}') {
+      depth--;
+      if (depth === 0) break;
+      continue;
+    }
+    if (depth !== 1 || text[i - 1] !== '\n') continue;
+
+    const line = /^\s*([A-Za-z_$][\w$]*)(\?)?\s*:\s*([^;\n]*)/.exec(
+      text.slice(i)
+    );
+    if (line) {
+      fields.push({
+        name: line[1],
+        optional: Boolean(line[2]),
+        type: line[3].trim(),
+      });
+    }
+  }
+  return fields;
+}
+
+/**
+ * The nested shape a schema property declares, or null when it declares none.
+ *
+ * Reaches through `items` for an array, because that is where an array's element shape
+ * lives -- and where two incomplete declarations hid: `logSources` items omitted three
+ * fields while the top-level name was present and correct, so a name-only check passed.
+ */
+export function nestedShape(
+  text: string,
+  property: string
+): NestedShape | null {
+  const slice = schemaPropertiesSlice(text);
+  if (!slice) return null;
+
+  const key = new RegExp(`(^|\\n)\\s{2,}${property}:\\s*\\{`).exec(slice);
+  if (!key) return null;
+  const open = slice.indexOf('{', key.index + key[0].length - 1);
+  const close = matchingClose(slice, open);
+  if (close === -1) return null;
+
+  let block = slice.slice(open, close + 1);
+  const isArray = /type:\s*'array'/.test(block);
+
+  if (isArray) {
+    const items = block.indexOf('items:');
+    if (items === -1) return null;
+    const itemsOpen = block.indexOf('{', items);
+    const itemsClose = matchingClose(block, itemsOpen);
+    if (itemsOpen === -1 || itemsClose === -1) return null;
+    block = block.slice(itemsOpen, itemsClose + 1);
+  }
+
+  const props = block.indexOf('properties:');
+  if (props === -1) return null;
+  const propsOpen = block.indexOf('{', props);
+  if (propsOpen === -1) return null;
+
+  return {
+    properties: topLevelKeys(block, propsOpen),
+    required: requiredAtTopLevel(block),
+    isArray,
+  };
+}
+
+/**
+ * The `required: [...]` belonging to THIS object, not to one nested inside it.
+ *
+ * A plain search for the first `required:` reads the wrong list: alert_manager's
+ * `dataSource` contains `cache: { ..., required: ['enabled','ttl'] }`, so a naive regex
+ * reported dataSource as requiring `enabled` and `ttl` and its real requirements as
+ * missing. That produced a confident, wrong finding about a property I had just fixed
+ * correctly -- which is how it was noticed.
+ */
+function requiredAtTopLevel(block: string): string[] {
+  let depth = 0;
+  let inString: string | null = null;
+
+  for (let i = 0; i < block.length; i++) {
+    const c = block[i];
+
+    if (inString) {
+      if (c === '\\') i++;
+      else if (c === inString) inString = null;
+      continue;
+    }
+    if (c === '/' && block[i + 1] === '/') {
+      const end = block.indexOf('\n', i);
+      if (end === -1) break;
+      i = end;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === '`') {
+      inString = c;
+      continue;
+    }
+    if (c === '{' || c === '[') {
+      depth++;
+      continue;
+    }
+    if (c === '}' || c === ']') {
+      depth--;
+      continue;
+    }
+    if (depth === 1 && c === 'r' && block.startsWith('required:', i)) {
+      const open = block.indexOf('[', i);
+      if (open === -1) return [];
+      const close = matchingClose(block, open);
+      if (close === -1) return [];
+      return [...block.slice(open, close).matchAll(/'([^']+)'/g)].map(
+        (m) => m[1]
+      );
+    }
+  }
+  return [];
+}

--- a/tests/unit/helpers/schema-source.ts
+++ b/tests/unit/helpers/schema-source.ts
@@ -248,7 +248,15 @@ export function nestedShape(
   if (close === -1) return null;
 
   let block = slice.slice(open, close + 1);
-  const isArray = /type:\s*'array'/.test(block);
+  // The option's OWN type, not any type appearing inside it. A plain regex over
+  // the whole block matched a nested array property -- `condition` is an object
+  // whose fields include `groupBy` and `filters`, both arrays -- so the parser
+  // treated the object as an array, reached into `groupBy.items` (`{ type:
+  // 'string' }`, no `properties`), and reported the option as declaring no shape
+  // whatsoever. Five correct schemas were condemned that way, which is how it was
+  // noticed: a scanner that indicts working code is as useless as one that misses
+  // broken code. Same depth-awareness the `required` lookup already needed.
+  const isArray = valueAtTopLevel(block, 'type') === 'array';
 
   if (isArray) {
     const items = block.indexOf('items:');
@@ -269,6 +277,90 @@ export function nestedShape(
     required: requiredAtTopLevel(block),
     isArray,
   };
+}
+
+/**
+ * Fields of an interface that the schema's declaration of `option` fails to
+ * declare, or null when the schema does not mention `option` at all.
+ *
+ * THE NULL CASE IS A DELIBERATE HAND-OFF, not a gap. An option missing from the
+ * schema entirely is the name-check's finding, reported there with the right
+ * message; repeating it here would make one defect fail two tests and read as
+ * two defects.
+ *
+ * A DECLARED BUT SHAPELESS OPTION IS THIS FUNCTION'S FINDING, and it used to be
+ * nobody's. The audit skipped any property with no nested `properties` block on
+ * the reasoning that the name-check covered it -- but that check only confirms
+ * the NAME exists, so `request: { type: 'object' }` satisfied both while
+ * declaring none of its fields and none of its requirements. Every sendable
+ * field is reported missing, because none of them is declared.
+ */
+export function shapeGaps(
+  text: string,
+  option: string,
+  fields: InterfaceField[]
+): { missingProperties: string[]; missingRequired: string[] } | null {
+  if (!(declaredProperties(text) ?? []).includes(option)) return null;
+
+  const sendable = fields.filter((f) => !isUnsendable(f.type));
+  const declared = nestedShape(text, option);
+
+  const properties = declared ? declared.properties : [];
+  const required = declared ? declared.required : [];
+
+  return {
+    missingProperties: sendable
+      .filter((f) => !properties.includes(f.name))
+      .map((f) => f.name),
+    missingRequired: sendable
+      .filter((f) => !f.optional && !required.includes(f.name))
+      .map((f) => f.name),
+  };
+}
+
+/**
+ * The quoted value of a key belonging to THIS object, not to one nested in it.
+ *
+ * Depth-aware for the same reason `requiredAtTopLevel` is: keys like `type`
+ * recur at every level of a JSON Schema, so the first textual match is almost
+ * never the one being asked about.
+ */
+function valueAtTopLevel(block: string, key: string): string | null {
+  let depth = 0;
+  let inString: string | null = null;
+
+  for (let i = 0; i < block.length; i++) {
+    const c = block[i];
+
+    if (inString) {
+      if (c === '\\') i++;
+      else if (c === inString) inString = null;
+      continue;
+    }
+    if (c === '/' && block[i + 1] === '/') {
+      const end = block.indexOf('\n', i);
+      if (end === -1) break;
+      i = end;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === '`') {
+      inString = c;
+      continue;
+    }
+    if (c === '{' || c === '[') {
+      depth++;
+      continue;
+    }
+    if (c === '}' || c === ']') {
+      depth--;
+      continue;
+    }
+    if (depth === 1 && block.startsWith(`${key}:`, i)) {
+      const m = /^[A-Za-z_$][\w$]*:\s*'([^']*)'/.exec(block.slice(i));
+      if (m) return m[1];
+    }
+  }
+  return null;
 }
 
 /**

--- a/tests/unit/helpers/schema-source.ts
+++ b/tests/unit/helpers/schema-source.ts
@@ -343,6 +343,16 @@ function valueAtTopLevel(block: string, key: string): string | null {
       i = end;
       continue;
     }
+    // Block comments too. Skipping only `//` left a comment containing
+    // `type: 'array'` or a `required:` list being read as declaration -- the
+    // same class of defect as the apostrophe that once swallowed eleven
+    // properties, and half-applying the lesson does not close it.
+    if (c === '/' && block[i + 1] === '*') {
+      const end = block.indexOf('*/', i + 2);
+      if (end === -1) break;
+      i = end + 1;
+      continue;
+    }
     if (c === '"' || c === "'" || c === '`') {
       inString = c;
       continue;
@@ -388,6 +398,16 @@ function requiredAtTopLevel(block: string): string[] {
       const end = block.indexOf('\n', i);
       if (end === -1) break;
       i = end;
+      continue;
+    }
+    // Block comments too. Skipping only `//` left a comment containing
+    // `type: 'array'` or a `required:` list being read as declaration -- the
+    // same class of defect as the apostrophe that once swallowed eleven
+    // properties, and half-applying the lesson does not close it.
+    if (c === '/' && block[i + 1] === '*') {
+      const end = block.indexOf('*/', i + 2);
+      if (end === -1) break;
+      i = end + 1;
       continue;
     }
     if (c === '"' || c === "'" || c === '`') {

--- a/tests/unit/installer-verifies-what-it-installs.test.ts
+++ b/tests/unit/installer-verifies-what-it-installs.test.ts
@@ -56,11 +56,19 @@ function requiredByInstaller(source: string): string[] {
   // `@(` in PowerShell, `(` in bash.
   const block = source.match(/required_?[Ff]iles\s*=\s*@?\(([\s\S]*?)\)/);
   if (!block) return [];
-  const matches = block[1].matchAll(/["']\$(?:\{)?HOOKS_DIR(?:\})?[\\/]([^"']+)["']/g);
-  return [...matches].map((m) => m[1].replace(/\\/g, '/').split('/').pop() as string);
+  const matches = block[1].matchAll(
+    /["']\$(?:\{)?HOOKS_DIR(?:\})?[\\/]([^"']+)["']/g
+  );
+  return [...matches].map(
+    (m) => m[1].replace(/\\/g, '/').split('/').pop() as string
+  );
 }
 
-const ENTRYPOINTS = ['session-start.mjs', 'pretooluse-router.mjs', 'precompact-optimize.mjs'];
+const ENTRYPOINTS = [
+  'session-start.mjs',
+  'pretooluse-router.mjs',
+  'precompact-optimize.mjs',
+];
 
 describe.each([
   ['install-hooks.ps1', 'install-hooks.ps1'],
@@ -102,7 +110,8 @@ describe('the install manifest', () => {
     expect(recordIndex).toBeGreaterThan(-1);
 
     // The recording must not be gated on the verification verdict.
-    const gatedOnVerified = /if\s*\(\s*\$verified\s*\)[\s\S]{0,400}record-install\.mjs/.test(ps1);
+    const gatedOnVerified =
+      /if\s*\(\s*\$verified\s*\)[\s\S]{0,400}record-install\.mjs/.test(ps1);
     expect(gatedOnVerified).toBe(false);
   });
 });

--- a/tests/unit/json-carryable-responses.test.ts
+++ b/tests/unit/json-carryable-responses.test.ts
@@ -57,10 +57,12 @@ describe('responses survive JSON', () => {
     });
 
     const analyze = () =>
-      new SmartDependenciesTool(cache, counter, new MetricsCollector()).analyze({
-        cwd: root,
-        useCache: false,
-      });
+      new SmartDependenciesTool(cache, counter, new MetricsCollector()).analyze(
+        {
+          cwd: root,
+          useCache: false,
+        }
+      );
 
     it('survives a JSON round-trip with its content intact', async () => {
       const result = await analyze();
@@ -78,7 +80,11 @@ describe('responses survive JSON', () => {
 
       // index.ts imports a and b. Two edges, from index.
       expect(result.graph.edges.length).toBe(2);
-      expect(result.graph.edges.every((e: { from: string }) => e.from.includes('index'))).toBe(true);
+      expect(
+        result.graph.edges.every((e: { from: string }) =>
+          e.from.includes('index')
+        )
+      ).toBe(true);
     });
 
     it('agrees with its own metadata', async () => {
@@ -86,7 +92,9 @@ describe('responses survive JSON', () => {
 
       // The metadata was right all along; the payload is what went missing.
       expect(result.graph.nodes.length).toBe(result.metadata.totalFiles);
-      expect(result.graph.edges.length).toBe(result.metadata.internalDependencies);
+      expect(result.graph.edges.length).toBe(
+        result.metadata.internalDependencies
+      );
     });
 
     it('reports a token count describing the data it actually sent', async () => {
@@ -95,7 +103,9 @@ describe('responses survive JSON', () => {
       // The count was computed on the compact form, which was then discarded in
       // favour of the Map -- so it described something the caller never got.
       const actual = counter.count(JSON.stringify(result.graph)).tokens;
-      expect(Math.abs(actual - result.metadata.tokenCount)).toBeLessThan(actual * 0.5 + 5);
+      expect(Math.abs(actual - result.metadata.tokenCount)).toBeLessThan(
+        actual * 0.5 + 5
+      );
     });
   });
 
@@ -112,7 +122,9 @@ describe('responses survive JSON', () => {
       envPath = join(root, '.env');
       writeFileSync(
         envPath,
-        Object.entries(SECRETS).map(([k, v]) => `${k}=${v}`).join('\n') + '\n'
+        Object.entries(SECRETS)
+          .map(([k, v]) => `${k}=${v}`)
+          .join('\n') + '\n'
       );
     });
 

--- a/tests/unit/manifest-versions-track-package.test.ts
+++ b/tests/unit/manifest-versions-track-package.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from '@jest/globals';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * Every manifest that names a version must name the SAME version as package.json.
+ *
+ * `plugin-version-tracks-package.test.ts` covers the Claude plugin manifest. Three more
+ * carried their own version and nothing checked any of them, so they rotted for many
+ * releases while every build stayed green:
+ *
+ *     server.json            5.1.1   against a package at 5.4.3
+ *     server.json packages[0]  5.1.1
+ *     mcp.json               0.2.0
+ *     gemini-extension.json  5.1.2
+ *
+ * server.json is the one with teeth. docs/PUBLISHING.md states the rule outright --
+ * "registry returns 422; keep server.json version in lockstep with npm" -- because the
+ * MCP Registry validates that the declared version exists on npm carrying the matching
+ * mcpName. At 5.1.1 the registry entry described a version three minors behind whatever
+ * users install, and a publish attempt would be rejected.
+ *
+ * The cause was the same one that let the plugin manifest rot: release-please only bumps
+ * what it is told about. All four are now in `extra-files`, and this asserts the result,
+ * because the failure mode is invisible from inside the repo -- nothing builds
+ * differently, no test fails, and the npm release publishes perfectly well.
+ */
+
+const ROOT = process.cwd();
+const read = (p: string) => JSON.parse(readFileSync(join(ROOT, p), 'utf8'));
+
+const packageVersion = read('package.json').version as string;
+
+/** Manifest path -> the version fields inside it that mean "the released version". */
+const MANIFESTS: Array<
+  [string, (m: Record<string, unknown>) => Array<[string, unknown]>]
+> = [
+  ['server.json', (m) => [['$.version', m.version]]],
+  [
+    'server.json',
+    (m) => {
+      const packages = (m.packages ?? []) as Array<{ version?: unknown }>;
+      return packages.map(
+        (p, i) => [`$.packages[${i}].version`, p.version] as [string, unknown]
+      );
+    },
+  ],
+  ['mcp.json', (m) => [['$.version', m.version]]],
+  ['gemini-extension.json', (m) => [['$.version', m.version]]],
+];
+
+describe('manifest versions track package.json', () => {
+  it.each(MANIFESTS)('%s declares the package version', (path, extract) => {
+    const fields = extract(read(path));
+
+    // A manifest that stopped declaring a version at all would otherwise pass by
+    // yielding nothing to compare.
+    expect(fields.length).toBeGreaterThan(0);
+
+    for (const [jsonpath, value] of fields) {
+      expect({ jsonpath, value }).toEqual({ jsonpath, value: packageVersion });
+    }
+  });
+
+  it('every manifest with a version is wired into release-please', () => {
+    // The check above only catches drift AFTER it happens. This catches the cause: a
+    // manifest release-please does not know about will drift on the very next release,
+    // and nobody will notice until a registry publish returns 422.
+    const config = read('release-please-config.json');
+    const extras = (config.packages['.']['extra-files'] ?? []) as Array<{
+      path: string;
+    }>;
+    const wired = new Set(extras.map((e) => e.path));
+
+    for (const path of new Set(MANIFESTS.map(([p]) => p))) {
+      expect(wired.has(path)).toBe(true);
+    }
+    expect(wired.has('plugin/.claude-plugin/plugin.json')).toBe(true);
+  });
+
+  it('covers the nested packages[0].version, not only the top-level one', () => {
+    // server.json carries the version twice: once for the server entry and once for the
+    // npm package. Bumping only the outer one leaves the registry pointing at a version
+    // that may not exist, which is exactly the 422 PUBLISHING.md warns about.
+    const server = read('server.json');
+
+    expect(server.packages?.[0]?.version).toBe(packageVersion);
+    expect(server.version).toBe(packageVersion);
+  });
+});

--- a/tests/unit/manifest-versions-track-package.test.ts
+++ b/tests/unit/manifest-versions-track-package.test.ts
@@ -3,7 +3,8 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 
 /**
- * Every manifest that names a version must name the SAME version as package.json.
+ * Every manifest that names a version must name the SAME version as package.json,
+ * and release-please must be told about every one of those fields BY JSONPATH.
  *
  * `plugin-version-tracks-package.test.ts` covers the Claude plugin manifest. Three more
  * carried their own version and nothing checked any of them, so they rotted for many
@@ -20,10 +21,11 @@ import { join } from 'path';
  * mcpName. At 5.1.1 the registry entry described a version three minors behind whatever
  * users install, and a publish attempt would be rejected.
  *
- * The cause was the same one that let the plugin manifest rot: release-please only bumps
- * what it is told about. All four are now in `extra-files`, and this asserts the result,
- * because the failure mode is invisible from inside the repo -- nothing builds
- * differently, no test fails, and the npm release publishes perfectly well.
+ * WIRING IS CHECKED PER JSONPATH, NOT PER FILE. An earlier version of this test
+ * collected `extra-files` into a set of PATHS, so both server.json entries collapsed
+ * into one member and deleting `$.packages[0].version` from the config still passed --
+ * the exact drift it exists to prevent, left uncovered by the test that claimed to
+ * cover it. Verified by deleting that entry: all six assertions passed.
  */
 
 const ROOT = process.cwd();
@@ -31,60 +33,80 @@ const read = (p: string) => JSON.parse(readFileSync(join(ROOT, p), 'utf8'));
 
 const packageVersion = read('package.json').version as string;
 
-/** Manifest path -> the version fields inside it that mean "the released version". */
-const MANIFESTS: Array<
-  [string, (m: Record<string, unknown>) => Array<[string, unknown]>]
-> = [
-  ['server.json', (m) => [['$.version', m.version]]],
-  [
-    'server.json',
-    (m) => {
-      const packages = (m.packages ?? []) as Array<{ version?: unknown }>;
-      return packages.map(
-        (p, i) => [`$.packages[${i}].version`, p.version] as [string, unknown]
-      );
+interface Target {
+  path: string;
+  jsonpath: string;
+  value: unknown;
+}
+
+/**
+ * Every version field release-please has to bump, addressed exactly as the config
+ * addresses it.
+ *
+ * server.json's packages are enumerated rather than hard-coded at index 0, so adding a
+ * second package entry produces a target that must be wired instead of a silent gap.
+ */
+function targets(): Target[] {
+  const server = read('server.json');
+  const packages = (server.packages ?? []) as Array<{ version?: unknown }>;
+
+  return [
+    { path: 'server.json', jsonpath: '$.version', value: server.version },
+    ...packages.map((p, i) => ({
+      path: 'server.json',
+      jsonpath: `$.packages[${i}].version`,
+      value: p.version,
+    })),
+    {
+      path: 'mcp.json',
+      jsonpath: '$.version',
+      value: read('mcp.json').version,
     },
-  ],
-  ['mcp.json', (m) => [['$.version', m.version]]],
-  ['gemini-extension.json', (m) => [['$.version', m.version]]],
-];
+    {
+      path: 'gemini-extension.json',
+      jsonpath: '$.version',
+      value: read('gemini-extension.json').version,
+    },
+  ];
+}
 
 describe('manifest versions track package.json', () => {
-  it.each(MANIFESTS)('%s declares the package version', (path, extract) => {
-    const fields = extract(read(path));
+  const required = targets();
 
-    // A manifest that stopped declaring a version at all would otherwise pass by
-    // yielding nothing to compare.
-    expect(fields.length).toBeGreaterThan(0);
-
-    for (const [jsonpath, value] of fields) {
-      expect({ jsonpath, value }).toEqual({ jsonpath, value: packageVersion });
-    }
+  it('finds every version field it is meant to check', () => {
+    // Without this, a manifest that stopped declaring a version would empty the
+    // list and turn every assertion below into a vacuous pass.
+    expect(required.length).toBeGreaterThanOrEqual(4);
   });
 
-  it('every manifest with a version is wired into release-please', () => {
-    // The check above only catches drift AFTER it happens. This catches the cause: a
-    // manifest release-please does not know about will drift on the very next release,
-    // and nobody will notice until a registry publish returns 422.
+  it.each(required.map((t) => [`${t.path} ${t.jsonpath}`, t] as const))(
+    '%s declares the package version',
+    (_label, target) => {
+      expect({ at: _label, value: target.value }).toEqual({
+        at: _label,
+        value: packageVersion,
+      });
+    }
+  );
+
+  it('wires every one of those fields into release-please, by jsonpath', () => {
+    // The value check above only catches drift AFTER it happens. This catches the
+    // cause: a field release-please does not know about will drift on the very next
+    // release, and nobody will notice until a registry publish returns 422.
     const config = read('release-please-config.json');
     const extras = (config.packages['.']['extra-files'] ?? []) as Array<{
       path: string;
+      jsonpath: string;
     }>;
-    const wired = new Set(extras.map((e) => e.path));
+    const wired = new Set(extras.map((e) => `${e.path} ${e.jsonpath}`));
 
-    for (const path of new Set(MANIFESTS.map(([p]) => p))) {
-      expect(wired.has(path)).toBe(true);
-    }
-    expect(wired.has('plugin/.claude-plugin/plugin.json')).toBe(true);
-  });
+    const missing = required
+      .map((t) => `${t.path} ${t.jsonpath}`)
+      .filter((key) => !wired.has(key));
 
-  it('covers the nested packages[0].version, not only the top-level one', () => {
-    // server.json carries the version twice: once for the server entry and once for the
-    // npm package. Bumping only the outer one leaves the registry pointing at a version
-    // that may not exist, which is exactly the 422 PUBLISHING.md warns about.
-    const server = read('server.json');
-
-    expect(server.packages?.[0]?.version).toBe(packageVersion);
-    expect(server.version).toBe(packageVersion);
+    expect(missing).toEqual([]);
+    // The plugin manifest has its own value test but the same wiring requirement,
+    // and it is the one that already rotted through four releases.
+    expect(wired.has('plugin/.claude-plugin/plugin.json $.version')).toBe(true);
   });
 });

--- a/tests/unit/marker-based-optimizer.test.ts
+++ b/tests/unit/marker-based-optimizer.test.ts
@@ -12,7 +12,10 @@ import { describe, it, expect, beforeEach } from '@jest/globals';
 import { MarkerBasedOptimizer } from '../../src/services/MarkerBasedOptimizer.js';
 import { SummarizationModule } from '../../src/modules/SummarizationModule.js';
 import { MockFoundationModel } from '../../src/modules/MockFoundationModel.js';
-import { ITokenCounter, TokenCountResult } from '../../src/interfaces/ITokenCounter.js';
+import {
+  ITokenCounter,
+  TokenCountResult,
+} from '../../src/interfaces/ITokenCounter.js';
 
 // Mock token counter
 class MockTokenCounter implements ITokenCounter {
@@ -40,7 +43,8 @@ describe('MarkerBasedOptimizer', () => {
 
   describe('Basic Marker Processing', () => {
     it('should detect and process single marker', async () => {
-      const prompt = 'Before <summarize>This is a long text that needs to be summarized. It has multiple sentences. More content here.</summarize> After';
+      const prompt =
+        'Before <summarize>This is a long text that needs to be summarized. It has multiple sentences. More content here.</summarize> After';
 
       const result = await optimizer.processMarkers(prompt);
 
@@ -53,7 +57,8 @@ describe('MarkerBasedOptimizer', () => {
     });
 
     it('should process multiple markers', async () => {
-      const prompt = '<summarize>First section to summarize.</summarize> Middle content. <summarize>Second section to summarize.</summarize>';
+      const prompt =
+        '<summarize>First section to summarize.</summarize> Middle content. <summarize>Second section to summarize.</summarize>';
 
       const result = await optimizer.processMarkers(prompt);
 
@@ -64,7 +69,8 @@ describe('MarkerBasedOptimizer', () => {
     });
 
     it('should preserve content outside markers', async () => {
-      const prompt = 'Keep this. <summarize>Summarize this part.</summarize> Keep this too.';
+      const prompt =
+        'Keep this. <summarize>Summarize this part.</summarize> Keep this too.';
 
       const result = await optimizer.processMarkers(prompt);
 
@@ -129,7 +135,8 @@ describe('MarkerBasedOptimizer', () => {
     });
 
     it('should handle marker with whitespace', async () => {
-      const prompt = '<summarize>  \n\n  Content with whitespace.  \n\n  </summarize>';
+      const prompt =
+        '<summarize>  \n\n  Content with whitespace.  \n\n  </summarize>';
 
       const result = await optimizer.processMarkers(prompt);
 
@@ -138,7 +145,8 @@ describe('MarkerBasedOptimizer', () => {
     });
 
     it('should handle marker with special characters', async () => {
-      const prompt = '<summarize>Content with @#$%^&*() special chars.</summarize>';
+      const prompt =
+        '<summarize>Content with @#$%^&*() special chars.</summarize>';
 
       const result = await optimizer.processMarkers(prompt);
 
@@ -147,7 +155,8 @@ describe('MarkerBasedOptimizer', () => {
     });
 
     it('should handle marker with unicode', async () => {
-      const prompt = '<summarize>Unicode: 你好世界 こんにちは 안녕하세요</summarize>';
+      const prompt =
+        '<summarize>Unicode: 你好世界 こんにちは 안녕하세요</summarize>';
 
       const result = await optimizer.processMarkers(prompt);
 
@@ -156,7 +165,8 @@ describe('MarkerBasedOptimizer', () => {
     });
 
     it('should handle consecutive markers', async () => {
-      const prompt = '<summarize>First.</summarize><summarize>Second.</summarize>';
+      const prompt =
+        '<summarize>First.</summarize><summarize>Second.</summarize>';
 
       const result = await optimizer.processMarkers(prompt);
 
@@ -185,7 +195,8 @@ describe('MarkerBasedOptimizer', () => {
 
     it('should not process nested markers', async () => {
       // The regex doesn't handle nesting, so outer marker will consume inner one
-      const prompt = '<summarize>Outer <summarize>Inner</summarize> still outer</summarize>';
+      const prompt =
+        '<summarize>Outer <summarize>Inner</summarize> still outer</summarize>';
 
       const result = await optimizer.processMarkers(prompt);
 
@@ -227,7 +238,8 @@ This is important.
     });
 
     it('should handle mixed content with newlines', async () => {
-      const prompt = 'Before\n<summarize>\nContent\nwith\nnewlines\n</summarize>\nAfter';
+      const prompt =
+        'Before\n<summarize>\nContent\nwith\nnewlines\n</summarize>\nAfter';
 
       const result = await optimizer.processMarkers(prompt);
 

--- a/tests/unit/metrics.test.ts
+++ b/tests/unit/metrics.test.ts
@@ -39,9 +39,24 @@ describe('MetricsCollector', () => {
     });
 
     it('should record multiple metrics', () => {
-      metrics.record({ operation: 'op1', duration: 10, success: true, cacheHit: false });
-      metrics.record({ operation: 'op2', duration: 20, success: true, cacheHit: true });
-      metrics.record({ operation: 'op3', duration: 30, success: false, cacheHit: false });
+      metrics.record({
+        operation: 'op1',
+        duration: 10,
+        success: true,
+        cacheHit: false,
+      });
+      metrics.record({
+        operation: 'op2',
+        duration: 20,
+        success: true,
+        cacheHit: true,
+      });
+      metrics.record({
+        operation: 'op3',
+        duration: 30,
+        success: false,
+        cacheHit: false,
+      });
 
       const operations = metrics.getOperations();
       expect(operations.length).toBe(3);
@@ -110,14 +125,25 @@ describe('MetricsCollector', () => {
       const oneHourAgo = now - 3600000;
 
       // Manually create operations with specific timestamps
-      metrics.record({ operation: 'old-op', duration: 10, success: true, cacheHit: false });
+      metrics.record({
+        operation: 'old-op',
+        duration: 10,
+        success: true,
+        cacheHit: false,
+      });
 
       // Wait a tiny bit to ensure different timestamp
-      const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+      const delay = (ms: number) =>
+        new Promise((resolve) => setTimeout(resolve, ms));
 
       return delay(5).then(() => {
         const recentTime = Date.now();
-        metrics.record({ operation: 'new-op', duration: 20, success: true, cacheHit: false });
+        metrics.record({
+          operation: 'new-op',
+          duration: 20,
+          success: true,
+          cacheHit: false,
+        });
 
         const allOps = metrics.getOperations();
         const recentOps = metrics.getOperations(recentTime);
@@ -129,18 +155,48 @@ describe('MetricsCollector', () => {
     });
 
     it('should return all operations when no timestamp filter provided', () => {
-      metrics.record({ operation: 'op1', duration: 10, success: true, cacheHit: false });
-      metrics.record({ operation: 'op2', duration: 20, success: true, cacheHit: false });
-      metrics.record({ operation: 'op3', duration: 30, success: true, cacheHit: false });
+      metrics.record({
+        operation: 'op1',
+        duration: 10,
+        success: true,
+        cacheHit: false,
+      });
+      metrics.record({
+        operation: 'op2',
+        duration: 20,
+        success: true,
+        cacheHit: false,
+      });
+      metrics.record({
+        operation: 'op3',
+        duration: 30,
+        success: true,
+        cacheHit: false,
+      });
 
       const operations = metrics.getOperations();
       expect(operations.length).toBe(3);
     });
 
     it('should filter by operation name', () => {
-      metrics.record({ operation: 'op-A', duration: 10, success: true, cacheHit: false });
-      metrics.record({ operation: 'op-B', duration: 20, success: true, cacheHit: false });
-      metrics.record({ operation: 'op-A', duration: 30, success: true, cacheHit: false });
+      metrics.record({
+        operation: 'op-A',
+        duration: 10,
+        success: true,
+        cacheHit: false,
+      });
+      metrics.record({
+        operation: 'op-B',
+        duration: 20,
+        success: true,
+        cacheHit: false,
+      });
+      metrics.record({
+        operation: 'op-A',
+        duration: 30,
+        success: true,
+        cacheHit: false,
+      });
 
       const opsA = metrics.getOperations(undefined, 'op-A');
       const opsB = metrics.getOperations(undefined, 'op-B');
@@ -150,15 +206,36 @@ describe('MetricsCollector', () => {
     });
 
     it('should filter by both timestamp and operation', () => {
-      metrics.record({ operation: 'op-A', duration: 10, success: true, cacheHit: false });
-      metrics.record({ operation: 'op-B', duration: 20, success: true, cacheHit: false });
+      metrics.record({
+        operation: 'op-A',
+        duration: 10,
+        success: true,
+        cacheHit: false,
+      });
+      metrics.record({
+        operation: 'op-B',
+        duration: 20,
+        success: true,
+        cacheHit: false,
+      });
 
-      const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+      const delay = (ms: number) =>
+        new Promise((resolve) => setTimeout(resolve, ms));
 
       return delay(5).then(() => {
         const recentTime = Date.now();
-        metrics.record({ operation: 'op-A', duration: 30, success: true, cacheHit: false });
-        metrics.record({ operation: 'op-B', duration: 40, success: true, cacheHit: false });
+        metrics.record({
+          operation: 'op-A',
+          duration: 30,
+          success: true,
+          cacheHit: false,
+        });
+        metrics.record({
+          operation: 'op-B',
+          duration: 40,
+          success: true,
+          cacheHit: false,
+        });
 
         const filtered = metrics.getOperations(recentTime, 'op-A');
         expect(filtered.length).toBe(1);
@@ -169,10 +246,30 @@ describe('MetricsCollector', () => {
 
   describe('Cache Statistics', () => {
     it('should calculate cache hit rate', () => {
-      metrics.record({ operation: 'op1', duration: 10, success: true, cacheHit: true });
-      metrics.record({ operation: 'op2', duration: 20, success: true, cacheHit: true });
-      metrics.record({ operation: 'op3', duration: 30, success: true, cacheHit: false });
-      metrics.record({ operation: 'op4', duration: 40, success: true, cacheHit: false });
+      metrics.record({
+        operation: 'op1',
+        duration: 10,
+        success: true,
+        cacheHit: true,
+      });
+      metrics.record({
+        operation: 'op2',
+        duration: 20,
+        success: true,
+        cacheHit: true,
+      });
+      metrics.record({
+        operation: 'op3',
+        duration: 30,
+        success: true,
+        cacheHit: false,
+      });
+      metrics.record({
+        operation: 'op4',
+        duration: 40,
+        success: true,
+        cacheHit: false,
+      });
 
       const stats = metrics.getCacheStats();
 
@@ -183,19 +280,54 @@ describe('MetricsCollector', () => {
     });
 
     it('should calculate average duration', () => {
-      metrics.record({ operation: 'op1', duration: 10, success: true, cacheHit: false });
-      metrics.record({ operation: 'op2', duration: 20, success: true, cacheHit: false });
-      metrics.record({ operation: 'op3', duration: 30, success: true, cacheHit: false });
+      metrics.record({
+        operation: 'op1',
+        duration: 10,
+        success: true,
+        cacheHit: false,
+      });
+      metrics.record({
+        operation: 'op2',
+        duration: 20,
+        success: true,
+        cacheHit: false,
+      });
+      metrics.record({
+        operation: 'op3',
+        duration: 30,
+        success: true,
+        cacheHit: false,
+      });
 
       const stats = metrics.getCacheStats();
       expect(stats.averageDuration).toBeCloseTo(20, 2);
     });
 
     it('should calculate success rate', () => {
-      metrics.record({ operation: 'op1', duration: 10, success: true, cacheHit: false });
-      metrics.record({ operation: 'op2', duration: 20, success: true, cacheHit: false });
-      metrics.record({ operation: 'op3', duration: 30, success: false, cacheHit: false });
-      metrics.record({ operation: 'op4', duration: 40, success: false, cacheHit: false });
+      metrics.record({
+        operation: 'op1',
+        duration: 10,
+        success: true,
+        cacheHit: false,
+      });
+      metrics.record({
+        operation: 'op2',
+        duration: 20,
+        success: true,
+        cacheHit: false,
+      });
+      metrics.record({
+        operation: 'op3',
+        duration: 30,
+        success: false,
+        cacheHit: false,
+      });
+      metrics.record({
+        operation: 'op4',
+        duration: 40,
+        success: false,
+        cacheHit: false,
+      });
 
       const stats = metrics.getCacheStats();
       expect(stats.successRate).toBeCloseTo(50, 2);
@@ -213,13 +345,24 @@ describe('MetricsCollector', () => {
     });
 
     it('should filter stats by time', () => {
-      metrics.record({ operation: 'old', duration: 10, success: true, cacheHit: true });
+      metrics.record({
+        operation: 'old',
+        duration: 10,
+        success: true,
+        cacheHit: true,
+      });
 
-      const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+      const delay = (ms: number) =>
+        new Promise((resolve) => setTimeout(resolve, ms));
 
       return delay(5).then(() => {
         const recentTime = Date.now();
-        metrics.record({ operation: 'new', duration: 20, success: true, cacheHit: false });
+        metrics.record({
+          operation: 'new',
+          duration: 20,
+          success: true,
+          cacheHit: false,
+        });
 
         const allStats = metrics.getCacheStats();
         const recentStats = metrics.getCacheStats(recentTime);
@@ -231,8 +374,18 @@ describe('MetricsCollector', () => {
     });
 
     it('should handle 100% cache hit rate', () => {
-      metrics.record({ operation: 'op1', duration: 10, success: true, cacheHit: true });
-      metrics.record({ operation: 'op2', duration: 20, success: true, cacheHit: true });
+      metrics.record({
+        operation: 'op1',
+        duration: 10,
+        success: true,
+        cacheHit: true,
+      });
+      metrics.record({
+        operation: 'op2',
+        duration: 20,
+        success: true,
+        cacheHit: true,
+      });
 
       const stats = metrics.getCacheStats();
       expect(stats.cacheHitRate).toBe(100);
@@ -240,8 +393,18 @@ describe('MetricsCollector', () => {
     });
 
     it('should handle 0% cache hit rate', () => {
-      metrics.record({ operation: 'op1', duration: 10, success: true, cacheHit: false });
-      metrics.record({ operation: 'op2', duration: 20, success: true, cacheHit: false });
+      metrics.record({
+        operation: 'op1',
+        duration: 10,
+        success: true,
+        cacheHit: false,
+      });
+      metrics.record({
+        operation: 'op2',
+        duration: 20,
+        success: true,
+        cacheHit: false,
+      });
 
       const stats = metrics.getCacheStats();
       expect(stats.cacheHitRate).toBe(0);
@@ -251,9 +414,24 @@ describe('MetricsCollector', () => {
 
   describe('Operation Breakdown', () => {
     it('should break down metrics by operation type', () => {
-      metrics.record({ operation: 'read', duration: 10, success: true, cacheHit: true });
-      metrics.record({ operation: 'read', duration: 15, success: true, cacheHit: false });
-      metrics.record({ operation: 'write', duration: 30, success: true, cacheHit: false });
+      metrics.record({
+        operation: 'read',
+        duration: 10,
+        success: true,
+        cacheHit: true,
+      });
+      metrics.record({
+        operation: 'read',
+        duration: 15,
+        success: true,
+        cacheHit: false,
+      });
+      metrics.record({
+        operation: 'write',
+        duration: 30,
+        success: true,
+        cacheHit: false,
+      });
 
       const breakdown = metrics.getOperationBreakdown();
 
@@ -264,10 +442,30 @@ describe('MetricsCollector', () => {
     });
 
     it('should calculate per-operation average duration', () => {
-      metrics.record({ operation: 'fast', duration: 10, success: true, cacheHit: false });
-      metrics.record({ operation: 'fast', duration: 20, success: true, cacheHit: false });
-      metrics.record({ operation: 'slow', duration: 100, success: true, cacheHit: false });
-      metrics.record({ operation: 'slow', duration: 200, success: true, cacheHit: false });
+      metrics.record({
+        operation: 'fast',
+        duration: 10,
+        success: true,
+        cacheHit: false,
+      });
+      metrics.record({
+        operation: 'fast',
+        duration: 20,
+        success: true,
+        cacheHit: false,
+      });
+      metrics.record({
+        operation: 'slow',
+        duration: 100,
+        success: true,
+        cacheHit: false,
+      });
+      metrics.record({
+        operation: 'slow',
+        duration: 200,
+        success: true,
+        cacheHit: false,
+      });
 
       const breakdown = metrics.getOperationBreakdown();
 
@@ -276,10 +474,30 @@ describe('MetricsCollector', () => {
     });
 
     it('should calculate per-operation success rate', () => {
-      metrics.record({ operation: 'reliable', duration: 10, success: true, cacheHit: false });
-      metrics.record({ operation: 'reliable', duration: 10, success: true, cacheHit: false });
-      metrics.record({ operation: 'flaky', duration: 10, success: true, cacheHit: false });
-      metrics.record({ operation: 'flaky', duration: 10, success: false, cacheHit: false });
+      metrics.record({
+        operation: 'reliable',
+        duration: 10,
+        success: true,
+        cacheHit: false,
+      });
+      metrics.record({
+        operation: 'reliable',
+        duration: 10,
+        success: true,
+        cacheHit: false,
+      });
+      metrics.record({
+        operation: 'flaky',
+        duration: 10,
+        success: true,
+        cacheHit: false,
+      });
+      metrics.record({
+        operation: 'flaky',
+        duration: 10,
+        success: false,
+        cacheHit: false,
+      });
 
       const breakdown = metrics.getOperationBreakdown();
 
@@ -293,13 +511,24 @@ describe('MetricsCollector', () => {
     });
 
     it('should filter breakdown by time', () => {
-      metrics.record({ operation: 'old', duration: 10, success: true, cacheHit: false });
+      metrics.record({
+        operation: 'old',
+        duration: 10,
+        success: true,
+        cacheHit: false,
+      });
 
-      const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+      const delay = (ms: number) =>
+        new Promise((resolve) => setTimeout(resolve, ms));
 
       return delay(5).then(() => {
         const recentTime = Date.now();
-        metrics.record({ operation: 'new', duration: 20, success: true, cacheHit: false });
+        metrics.record({
+          operation: 'new',
+          duration: 20,
+          success: true,
+          cacheHit: false,
+        });
 
         const allBreakdown = metrics.getOperationBreakdown();
         const recentBreakdown = metrics.getOperationBreakdown(recentTime);
@@ -342,7 +571,12 @@ describe('MetricsCollector', () => {
     });
 
     it('should handle single operation', () => {
-      metrics.record({ operation: 'single', duration: 42, success: true, cacheHit: false });
+      metrics.record({
+        operation: 'single',
+        duration: 42,
+        success: true,
+        cacheHit: false,
+      });
 
       const percentiles = metrics.getPerformancePercentiles();
 
@@ -353,13 +587,24 @@ describe('MetricsCollector', () => {
     });
 
     it('should filter percentiles by time', () => {
-      metrics.record({ operation: 'slow', duration: 1000, success: true, cacheHit: false });
+      metrics.record({
+        operation: 'slow',
+        duration: 1000,
+        success: true,
+        cacheHit: false,
+      });
 
-      const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+      const delay = (ms: number) =>
+        new Promise((resolve) => setTimeout(resolve, ms));
 
       return delay(5).then(() => {
         const recentTime = Date.now();
-        metrics.record({ operation: 'fast', duration: 10, success: true, cacheHit: false });
+        metrics.record({
+          operation: 'fast',
+          duration: 10,
+          success: true,
+          cacheHit: false,
+        });
 
         const allPercentiles = metrics.getPerformancePercentiles();
         const recentPercentiles = metrics.getPerformancePercentiles(recentTime);
@@ -390,8 +635,18 @@ describe('MetricsCollector', () => {
 
   describe('Clear and Export', () => {
     it('should clear all metrics', () => {
-      metrics.record({ operation: 'op1', duration: 10, success: true, cacheHit: false });
-      metrics.record({ operation: 'op2', duration: 20, success: true, cacheHit: false });
+      metrics.record({
+        operation: 'op1',
+        duration: 10,
+        success: true,
+        cacheHit: false,
+      });
+      metrics.record({
+        operation: 'op2',
+        duration: 20,
+        success: true,
+        cacheHit: false,
+      });
 
       expect(metrics.getOperations().length).toBe(2);
 
@@ -411,8 +666,18 @@ describe('MetricsCollector', () => {
     });
 
     it('should export metrics as JSON', () => {
-      metrics.record({ operation: 'op1', duration: 10, success: true, cacheHit: false });
-      metrics.record({ operation: 'op2', duration: 20, success: true, cacheHit: true });
+      metrics.record({
+        operation: 'op1',
+        duration: 10,
+        success: true,
+        cacheHit: false,
+      });
+      metrics.record({
+        operation: 'op2',
+        duration: 20,
+        success: true,
+        cacheHit: true,
+      });
 
       const exported = metrics.export();
       const parsed = JSON.parse(exported);
@@ -424,13 +689,24 @@ describe('MetricsCollector', () => {
     });
 
     it('should export with time filter', () => {
-      metrics.record({ operation: 'old', duration: 10, success: true, cacheHit: false });
+      metrics.record({
+        operation: 'old',
+        duration: 10,
+        success: true,
+        cacheHit: false,
+      });
 
-      const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+      const delay = (ms: number) =>
+        new Promise((resolve) => setTimeout(resolve, ms));
 
       return delay(5).then(() => {
         const recentTime = Date.now();
-        metrics.record({ operation: 'new', duration: 20, success: true, cacheHit: false });
+        metrics.record({
+          operation: 'new',
+          duration: 20,
+          success: true,
+          cacheHit: false,
+        });
 
         const allExport = JSON.parse(metrics.export());
         const recentExport = JSON.parse(metrics.export(recentTime));
@@ -452,7 +728,12 @@ describe('MetricsCollector', () => {
 
   describe('Edge Cases', () => {
     it('should handle operations with zero duration', () => {
-      metrics.record({ operation: 'instant', duration: 0, success: true, cacheHit: true });
+      metrics.record({
+        operation: 'instant',
+        duration: 0,
+        success: true,
+        cacheHit: true,
+      });
 
       const stats = metrics.getCacheStats();
       expect(stats.averageDuration).toBe(0);
@@ -507,7 +788,12 @@ describe('MetricsCollector', () => {
 
       // Record multiple operations that might have the same timestamp
       for (let i = 0; i < 10; i++) {
-        metrics.record({ operation: `op${i}`, duration: 10, success: true, cacheHit: false });
+        metrics.record({
+          operation: `op${i}`,
+          duration: 10,
+          success: true,
+          cacheHit: false,
+        });
       }
 
       const operations = metrics.getOperations();

--- a/tests/unit/net-command-output.test.ts
+++ b/tests/unit/net-command-output.test.ts
@@ -101,7 +101,9 @@ describe('net user', () => {
   });
 
   it('excludes the trailing status line', () => {
-    expect(parseNetUserList(NET_USER).some((u) => /command completed/i.test(u))).toBe(false);
+    expect(
+      parseNetUserList(NET_USER).some((u) => /command completed/i.test(u))
+    ).toBe(false);
   });
 });
 

--- a/tests/unit/no-fabricated-savings.test.ts
+++ b/tests/unit/no-fabricated-savings.test.ts
@@ -22,7 +22,8 @@ function sourceFiles(dir: string, out: string[] = []): string[] {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const full = join(dir, entry.name);
     if (entry.isDirectory()) sourceFiles(full, out);
-    else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) out.push(full);
+    else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts'))
+      out.push(full);
   }
   return out;
 }
@@ -32,7 +33,8 @@ const FABRICATED_BASELINE =
   /(original\w*Tokens?|baseline\w*Tokens?)\s*=\s*[\w.]+\s*\*\s*\d/;
 
 /** `tokensSaved = something * 1000` -- a saving conjured from a count. */
-const FABRICATED_SAVING = /(tokensSaved|savedTokens)\s*=\s*[\w.()]+\s*\*\s*[\d.]/;
+const FABRICATED_SAVING =
+  /(tokensSaved|savedTokens)\s*=\s*[\w.()]+\s*\*\s*[\d.]/;
 
 describe('savings are measured, never assumed', () => {
   const files = sourceFiles(ROOT);
@@ -48,7 +50,9 @@ describe('savings are measured, never assumed', () => {
       const lines = readFileSync(file, 'utf8').split('\n');
       lines.forEach((line, i) => {
         if (FABRICATED_BASELINE.test(line) || FABRICATED_SAVING.test(line)) {
-          offenders.push(`${relative(ROOT, file).split('\\').join('/')}:${i + 1}  ${line.trim()}`);
+          offenders.push(
+            `${relative(ROOT, file).split('\\').join('/')}:${i + 1}  ${line.trim()}`
+          );
         }
       });
     }

--- a/tests/unit/no-stray-control-characters.test.ts
+++ b/tests/unit/no-stray-control-characters.test.ts
@@ -53,9 +53,15 @@ const CONTROL_NAMES: Record<number, string> = {
   27: 'escape',
 };
 
-const FORBIDDEN: Array<[number, string]> = Array.from({ length: 32 }, (_, code) => code)
+const FORBIDDEN: Array<[number, string]> = Array.from(
+  { length: 32 },
+  (_, code) => code
+)
   .filter((code) => !ALLOWED_CONTROLS.has(code))
-  .map((code) => [code, CONTROL_NAMES[code] ?? `control 0x${code.toString(16)}`]);
+  .map((code) => [
+    code,
+    CONTROL_NAMES[code] ?? `control 0x${code.toString(16)}`,
+  ]);
 
 function sourceFiles(dir: string): string[] {
   const out: string[] = [];

--- a/tests/unit/pinned-spec-tracks-package.test.ts
+++ b/tests/unit/pinned-spec-tracks-package.test.ts
@@ -78,9 +78,10 @@ describe('the MCP spec in client configs', () => {
       // mcp.json and server.json are excluded because they are MCP REGISTRY manifests:
       // they name the package and its version in separate fields rather than as an
       // `@version` suffix, which is why pin-mcp-version reports seven configs and not
-      // nine. Their `version` fields are separately stale (0.2.0 and 5.1.1 against a
-      // package at 5.4.2) and nothing checks them -- recorded here because it is the
-      // same class of drift, not fixed here.
+      // nine. Their `version` fields were separately stale and unchecked; that is now
+      // `manifest-versions-track-package.test.ts`, which also asserts release-please is
+      // wired to bump them. Nothing about those fields is verified HERE, because an
+      // inline-spec test is the wrong place to assert a registry manifest's contents.
       if (INLINE_SPEC_CONFIGS.includes(relative)) {
         expect(specs.length).toBeGreaterThan(0);
       }

--- a/tests/unit/pinned-spec-tracks-package.test.ts
+++ b/tests/unit/pinned-spec-tracks-package.test.ts
@@ -62,31 +62,34 @@ const INLINE_SPEC_CONFIGS = PINNED_CONFIGS.filter(
 const present = () => PINNED_CONFIGS.filter((r) => existsSync(join(ROOT, r)));
 
 describe('the MCP spec in client configs', () => {
-  it.each(PINNED_CONFIGS)('in %s resolves to latest, not a frozen version', (relative) => {
-    if (!existsSync(join(ROOT, relative))) return; // not every target ships in every layout
+  it.each(PINNED_CONFIGS)(
+    'in %s resolves to latest, not a frozen version',
+    (relative) => {
+      if (!existsSync(join(ROOT, relative))) return; // not every target ships in every layout
 
-    const specs = [...read(relative).matchAll(SPEC)].map((m) => m[1]);
+      const specs = [...read(relative).matchAll(SPEC)].map((m) => m[1]);
 
-    // AT LEAST ONE, asserted before the values are -- but only for the configs that
-    // carry an inline `package@version` spec. A file that exists and carries no spec
-    // made this loop body never execute, so the test passed while the config said
-    // nothing about which server to launch, and the coverage test below only ever
-    // required ONE spec across the whole set.
-    //
-    // mcp.json and server.json are excluded because they are MCP REGISTRY manifests:
-    // they name the package and its version in separate fields rather than as an
-    // `@version` suffix, which is why pin-mcp-version reports seven configs and not
-    // nine. Their `version` fields are separately stale (0.2.0 and 5.1.1 against a
-    // package at 5.4.2) and nothing checks them -- recorded here because it is the
-    // same class of drift, not fixed here.
-    if (INLINE_SPEC_CONFIGS.includes(relative)) {
-      expect(specs.length).toBeGreaterThan(0);
+      // AT LEAST ONE, asserted before the values are -- but only for the configs that
+      // carry an inline `package@version` spec. A file that exists and carries no spec
+      // made this loop body never execute, so the test passed while the config said
+      // nothing about which server to launch, and the coverage test below only ever
+      // required ONE spec across the whole set.
+      //
+      // mcp.json and server.json are excluded because they are MCP REGISTRY manifests:
+      // they name the package and its version in separate fields rather than as an
+      // `@version` suffix, which is why pin-mcp-version reports seven configs and not
+      // nine. Their `version` fields are separately stale (0.2.0 and 5.1.1 against a
+      // package at 5.4.2) and nothing checks them -- recorded here because it is the
+      // same class of drift, not fixed here.
+      if (INLINE_SPEC_CONFIGS.includes(relative)) {
+        expect(specs.length).toBeGreaterThan(0);
+      }
+
+      for (const spec of specs) {
+        expect(spec).toBe('latest');
+      }
     }
-
-    for (const spec of specs) {
-      expect(spec).toBe('latest');
-    }
-  });
+  );
 
   it('never carries a numeric version, which is what went stale every release', () => {
     const frozen = present().filter((r) =>
@@ -99,7 +102,9 @@ describe('the MCP spec in client configs', () => {
   it('covers at least one real config, so this file cannot pass vacuously', () => {
     // Every assertion above short-circuits on a missing file. Without this, deleting
     // the configs would turn the suite green.
-    const withSpec = present().filter((r) => [...read(r).matchAll(SPEC)].length > 0);
+    const withSpec = present().filter(
+      (r) => [...read(r).matchAll(SPEC)].length > 0
+    );
 
     expect(withSpec.length).toBeGreaterThan(0);
   });
@@ -107,8 +112,12 @@ describe('the MCP spec in client configs', () => {
 
 describe('the generated-config gate', () => {
   const workflowDir = '.github/workflows';
-  const workflows = readdirSync(join(ROOT, workflowDir)).filter((f) => /\.ya?ml$/.test(f));
-  const allWorkflowText = workflows.map((f) => read(join(workflowDir, f))).join('\n');
+  const workflows = readdirSync(join(ROOT, workflowDir)).filter((f) =>
+    /\.ya?ml$/.test(f)
+  );
+  const allWorkflowText = workflows
+    .map((f) => read(join(workflowDir, f)))
+    .join('\n');
 
   it('runs sync:hooks:check somewhere in CI', () => {
     // The spec can no longer drift, but these files are still GENERATED, so a

--- a/tests/unit/plugin-version-tracks-package.test.ts
+++ b/tests/unit/plugin-version-tracks-package.test.ts
@@ -38,7 +38,8 @@ describe('plugin manifest version', () => {
     expect(
       extras.some(
         (e: { path?: string; jsonpath?: string }) =>
-          e.path === 'plugin/.claude-plugin/plugin.json' && e.jsonpath === '$.version'
+          e.path === 'plugin/.claude-plugin/plugin.json' &&
+          e.jsonpath === '$.version'
       )
     ).toBe(true);
   });

--- a/tests/unit/security/injection-validation.test.ts
+++ b/tests/unit/security/injection-validation.test.ts
@@ -16,7 +16,9 @@ describe('tool-schema injection rejection', () => {
 
   it('smart_install: rejects option-flag package specs', () => {
     expect(() =>
-      validateToolArgs('smart_install', { packages: ['--registry=http://evil'] })
+      validateToolArgs('smart_install', {
+        packages: ['--registry=http://evil'],
+      })
     ).toThrow(/Validation failed/);
   });
 
@@ -37,9 +39,9 @@ describe('tool-schema injection rejection', () => {
   });
 
   it('smart_log: rejects a command-substitution filePath', () => {
-    expect(() =>
-      validateToolArgs('smart_log', { filePath: 'a\nb' })
-    ).toThrow(/Validation failed/);
+    expect(() => validateToolArgs('smart_log', { filePath: 'a\nb' })).toThrow(
+      /Validation failed/
+    );
   });
 
   it('smart_diff: accepts legitimate refs and files', () => {

--- a/tests/unit/security/safe-exec.test.ts
+++ b/tests/unit/security/safe-exec.test.ts
@@ -90,7 +90,9 @@ describe('safe-exec validators', () => {
     it('accepts allowed values and rejects others', () => {
       const allowed = ['npm', 'yarn', 'pnpm'] as const;
       expect(assertAllowed('npm', allowed, 'packageManager')).toBe('npm');
-      expect(() => assertAllowed('npm; id', allowed, 'packageManager')).toThrow();
+      expect(() =>
+        assertAllowed('npm; id', allowed, 'packageManager')
+      ).toThrow();
       expect(() => assertAllowed('bun', allowed, 'packageManager')).toThrow();
     });
   });
@@ -127,11 +129,7 @@ describe('argv-mode execution neutralizes shell metacharacters', () => {
     const marker = join(dir, 'PWNED');
     // If a shell were interpreting this, the marker file would be created.
     const injection = `x"; require('fs').writeFileSync(${JSON.stringify(marker)}, 'x'); "`;
-    execFileSafeSync('node', [
-      '-e',
-      'process.stdout.write("ok")',
-      injection,
-    ]);
+    execFileSafeSync('node', ['-e', 'process.stdout.write("ok")', injection]);
     expect(existsSync(marker)).toBe(false);
   });
 

--- a/tests/unit/server/lifecycle.test.ts
+++ b/tests/unit/server/lifecycle.test.ts
@@ -7,7 +7,14 @@
  * which is the race the idempotency guard exists to prevent.
  */
 
-import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from '@jest/globals';
 import { EventEmitter } from 'events';
 import { installShutdownHandlers } from '../../../src/server/lifecycle.js';
 

--- a/tests/unit/shipped-imports.test.ts
+++ b/tests/unit/shipped-imports.test.ts
@@ -24,7 +24,9 @@ import { builtinModules } from 'module';
  *      and smart_cache_api were all broken this way.
  */
 const ROOT = join(process.cwd(), 'src');
-const PKG = JSON.parse(readFileSync(join(process.cwd(), 'package.json'), 'utf8'));
+const PKG = JSON.parse(
+  readFileSync(join(process.cwd(), 'package.json'), 'utf8')
+);
 const DECLARED = new Set(Object.keys(PKG.dependencies || {}));
 const BUILTIN = new Set(builtinModules);
 
@@ -74,11 +76,20 @@ function importBlock(source: string): string[] {
   const out: string[] = [];
   for (const line of source.split('\n')) {
     const t = line.trim();
-    if (t === '' || t.startsWith('//') || t.startsWith('*') || t.startsWith('/*')) {
+    if (
+      t === '' ||
+      t.startsWith('//') ||
+      t.startsWith('*') ||
+      t.startsWith('/*')
+    ) {
       out.push(line);
       continue;
     }
-    if (/^import[\s{*]/.test(t) || /^\}\s*from\s/.test(t) || /^['"][^'"]+['"];?$/.test(t)) {
+    if (
+      /^import[\s{*]/.test(t) ||
+      /^\}\s*from\s/.test(t) ||
+      /^['"][^'"]+['"];?$/.test(t)
+    ) {
       out.push(line);
       continue;
     }
@@ -105,12 +116,17 @@ describe('the shipped build only imports what it ships', () => {
       importBlock(readFileSync(file, 'utf8')).forEach((line, i) => {
         // Top-level static imports only; a `type` import is erased at compile
         // time and needs nothing at runtime.
-        const m = line.match(/^import\s+(?!type\s)[^'"]*from\s+['"]([^'"]+)['"]/);
+        const m = line.match(
+          /^import\s+(?!type\s)[^'"]*from\s+['"]([^'"]+)['"]/
+        );
         if (!m) return;
         const spec = m[1];
         if (spec.startsWith('.') || spec.startsWith('node:')) return;
-        const name = spec.startsWith('@') ? spec.split('/').slice(0, 2).join('/') : spec.split('/')[0];
-        if (BUILTIN.has(name) || DECLARED.has(name) || OPTIONAL.has(name)) return;
+        const name = spec.startsWith('@')
+          ? spec.split('/').slice(0, 2).join('/')
+          : spec.split('/')[0];
+        if (BUILTIN.has(name) || DECLARED.has(name) || OPTIONAL.has(name))
+          return;
         undeclared.push(`${rel(file)}:${i + 1}  imports "${name}"`);
       });
     }
@@ -122,14 +138,18 @@ describe('the shipped build only imports what it ships', () => {
     const bad: string[] = [];
 
     for (const file of files) {
-      readFileSync(file, 'utf8').split('\n').forEach((line, i) => {
-        if (isComment(line)) return;
-        for (const m of line.matchAll(/import\(\s*['"](\.[^'"]*)['"]\s*\)/g)) {
-          if (!/\.(js|json|mjs|cjs)$/.test(m[1])) {
-            bad.push(`${rel(file)}:${i + 1}  import('${m[1]}')`);
+      readFileSync(file, 'utf8')
+        .split('\n')
+        .forEach((line, i) => {
+          if (isComment(line)) return;
+          for (const m of line.matchAll(
+            /import\(\s*['"](\.[^'"]*)['"]\s*\)/g
+          )) {
+            if (!/\.(js|json|mjs|cjs)$/.test(m[1])) {
+              bad.push(`${rel(file)}:${i + 1}  import('${m[1]}')`);
+            }
           }
-        }
-      });
+        });
     }
 
     expect(bad).toEqual([]);
@@ -143,15 +163,20 @@ describe('the shipped build only imports what it ships', () => {
     const shims: string[] = [];
 
     for (const file of files) {
-      readFileSync(file, 'utf8').split('\n').forEach((line, i) => {
-        if (isComment(line)) return;
-        if (/['"`][^'"`]*\.(cmd|bat)['"`]/.test(line) && /spawn|exec/.test(line)) {
-          shims.push(`${rel(file)}:${i + 1}  ${line.trim().slice(0, 80)}`);
-        }
-        if (/\$\{[^}]*\}\.cmd/.test(line)) {
-          shims.push(`${rel(file)}:${i + 1}  ${line.trim().slice(0, 80)}`);
-        }
-      });
+      readFileSync(file, 'utf8')
+        .split('\n')
+        .forEach((line, i) => {
+          if (isComment(line)) return;
+          if (
+            /['"`][^'"`]*\.(cmd|bat)['"`]/.test(line) &&
+            /spawn|exec/.test(line)
+          ) {
+            shims.push(`${rel(file)}:${i + 1}  ${line.trim().slice(0, 80)}`);
+          }
+          if (/\$\{[^}]*\}\.cmd/.test(line)) {
+            shims.push(`${rel(file)}:${i + 1}  ${line.trim().slice(0, 80)}`);
+          }
+        });
     }
 
     expect(shims).toEqual([]);

--- a/tests/unit/stop-harvest-markers.test.ts
+++ b/tests/unit/stop-harvest-markers.test.ts
@@ -15,13 +15,20 @@
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import { spawnSync } from 'child_process';
 import { join, dirname, resolve } from 'path';
-import { mkdtempSync, rmSync, writeFileSync, existsSync, readdirSync } from 'fs';
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  existsSync,
+  readdirSync,
+} from 'fs';
 import { tmpdir } from 'os';
 
 const HOOK = join(process.cwd(), 'plugin', 'hooks', 'stop-harvest.mjs');
 
 /** The env var this platform actually reads for per-user state. */
-const STATE_VAR = process.platform === 'win32' ? 'LOCALAPPDATA' : 'XDG_STATE_HOME';
+const STATE_VAR =
+  process.platform === 'win32' ? 'LOCALAPPDATA' : 'XDG_STATE_HOME';
 
 let work: string;
 let state: string;
@@ -50,20 +57,16 @@ function runHook(sessionId: string) {
   delete env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT;
   delete env.TOKEN_OPTIMIZER_MODE;
 
-  return spawnSync(
-    process.execPath,
-    [HOOK],
-    {
-      input: JSON.stringify({
-        transcript_path: transcript,
-        session_id: sessionId,
-        cwd: work,
-      }),
-      env,
-      encoding: 'utf8',
-      timeout: 30_000,
-    }
-  );
+  return spawnSync(process.execPath, [HOOK], {
+    input: JSON.stringify({
+      transcript_path: transcript,
+      session_id: sessionId,
+      cwd: work,
+    }),
+    env,
+    encoding: 'utf8',
+    timeout: 30_000,
+  });
 }
 
 describe('stop-harvest marker location', () => {

--- a/tests/unit/summarization-module.test.ts
+++ b/tests/unit/summarization-module.test.ts
@@ -12,8 +12,14 @@
 import { describe, it, expect, beforeEach } from '@jest/globals';
 import { SummarizationModule } from '../../src/modules/SummarizationModule.js';
 import { MockFoundationModel } from '../../src/modules/MockFoundationModel.js';
-import { ITokenCounter, TokenCountResult } from '../../src/interfaces/ITokenCounter.js';
-import { IMetrics, SummarizationMetrics } from '../../src/interfaces/IMetrics.js';
+import {
+  ITokenCounter,
+  TokenCountResult,
+} from '../../src/interfaces/ITokenCounter.js';
+import {
+  IMetrics,
+  SummarizationMetrics,
+} from '../../src/interfaces/IMetrics.js';
 
 // Mock token counter
 class MockTokenCounter implements ITokenCounter {
@@ -83,7 +89,8 @@ describe('SummarizationModule', () => {
 
   describe('Basic Summarization', () => {
     it('should summarize text and return result with metrics', async () => {
-      const text = 'This is a long piece of text that needs to be summarized. It contains multiple sentences. Each sentence adds more context. The summarization should reduce the token count.';
+      const text =
+        'This is a long piece of text that needs to be summarized. It contains multiple sentences. Each sentence adds more context. The summarization should reduce the token count.';
 
       const result = await module.summarize(text);
 
@@ -110,10 +117,7 @@ describe('SummarizationModule', () => {
     });
 
     it('should work without metrics', async () => {
-      const moduleWithoutMetrics = new SummarizationModule(
-        model,
-        tokenCounter
-      );
+      const moduleWithoutMetrics = new SummarizationModule(model, tokenCounter);
       const text = 'Test text for summarization.';
 
       const result = await moduleWithoutMetrics.summarize(text);
@@ -125,7 +129,8 @@ describe('SummarizationModule', () => {
 
   describe('Summarization Options', () => {
     it('should respect maxOutputTokens option', async () => {
-      const text = 'This is a long text that needs summarization. It has many words.';
+      const text =
+        'This is a long text that needs summarization. It has many words.';
       const maxTokens = 5;
 
       const result = await module.summarize(text, {
@@ -170,7 +175,8 @@ describe('SummarizationModule', () => {
     });
 
     it('should handle preserveCodeBlocks option', async () => {
-      const text = 'Here is some code:\n```js\nconst x = 42;\n```\nThis is important.';
+      const text =
+        'Here is some code:\n```js\nconst x = 42;\n```\nThis is important.';
 
       const result = await module.summarize(text, {
         preserveCodeBlocks: true,
@@ -182,7 +188,8 @@ describe('SummarizationModule', () => {
     });
 
     it('should handle compressionRatio option', async () => {
-      const text = 'This is a long text with multiple sentences. Each sentence adds context.';
+      const text =
+        'This is a long text with multiple sentences. Each sentence adds context.';
 
       const result = await module.summarize(text, {
         compressionRatio: 0.5,

--- a/tests/unit/summarization.test.ts
+++ b/tests/unit/summarization.test.ts
@@ -1,102 +1,105 @@
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import {
-    TruncatingSummarizer,
-    AnthropicSummarizer,
-    GoogleAISummarizer,
-    createSummarizerFromEnv,
+  TruncatingSummarizer,
+  AnthropicSummarizer,
+  GoogleAISummarizer,
+  createSummarizerFromEnv,
 } from '../../src/core/summarization.js';
 import { Message } from '../../src/core/session.js';
 
 function makeMessages(n: number): Message[] {
-    return Array.from({ length: n }, (_, i) => ({
-        role: (i % 2 === 0 ? 'user' : 'assistant') as Message['role'],
-        content: `Turn ${i}: ${'x'.repeat(50)}`,
-        timestamp: Date.now() + i,
-    }));
+  return Array.from({ length: n }, (_, i) => ({
+    role: (i % 2 === 0 ? 'user' : 'assistant') as Message['role'],
+    content: `Turn ${i}: ${'x'.repeat(50)}`,
+    timestamp: Date.now() + i,
+  }));
 }
 
 describe('TruncatingSummarizer', () => {
-    it('returns empty string for empty input', async () => {
-        const s = new TruncatingSummarizer();
-        expect(await s.summarize([])).toBe('');
-    });
+  it('returns empty string for empty input', async () => {
+    const s = new TruncatingSummarizer();
+    expect(await s.summarize([])).toBe('');
+  });
 
-    it('returns untruncated text when under maxChars', async () => {
-        const s = new TruncatingSummarizer({ maxChars: 10_000 });
-        const out = await s.summarize(makeMessages(3));
-        expect(out).toContain('Turn 0');
-        expect(out).toContain('Turn 2');
-        expect(out).not.toContain('[truncated]');
-    });
+  it('returns untruncated text when under maxChars', async () => {
+    const s = new TruncatingSummarizer({ maxChars: 10_000 });
+    const out = await s.summarize(makeMessages(3));
+    expect(out).toContain('Turn 0');
+    expect(out).toContain('Turn 2');
+    expect(out).not.toContain('[truncated]');
+  });
 
-    it('truncates with a marker when over maxChars', async () => {
-        const s = new TruncatingSummarizer({ maxChars: 500 });
-        const out = await s.summarize(makeMessages(50));
-        expect(out).toContain('[truncated]');
-        expect(out.length).toBeLessThan(600);
-    });
+  it('truncates with a marker when over maxChars', async () => {
+    const s = new TruncatingSummarizer({ maxChars: 500 });
+    const out = await s.summarize(makeMessages(50));
+    expect(out).toContain('[truncated]');
+    expect(out.length).toBeLessThan(600);
+  });
 });
 
 describe('AnthropicSummarizer / GoogleAISummarizer constructors', () => {
-    const savedAnthropic = process.env.ANTHROPIC_API_KEY;
-    const savedGoogle = process.env.GOOGLE_AI_API_KEY;
+  const savedAnthropic = process.env.ANTHROPIC_API_KEY;
+  const savedGoogle = process.env.GOOGLE_AI_API_KEY;
 
-    beforeEach(() => {
-        delete process.env.ANTHROPIC_API_KEY;
-        delete process.env.GOOGLE_AI_API_KEY;
-    });
-    afterEach(() => {
-        if (savedAnthropic !== undefined) process.env.ANTHROPIC_API_KEY = savedAnthropic;
-        else delete process.env.ANTHROPIC_API_KEY;
-        if (savedGoogle !== undefined) process.env.GOOGLE_AI_API_KEY = savedGoogle;
-        else delete process.env.GOOGLE_AI_API_KEY;
-    });
+  beforeEach(() => {
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.GOOGLE_AI_API_KEY;
+  });
+  afterEach(() => {
+    if (savedAnthropic !== undefined)
+      process.env.ANTHROPIC_API_KEY = savedAnthropic;
+    else delete process.env.ANTHROPIC_API_KEY;
+    if (savedGoogle !== undefined) process.env.GOOGLE_AI_API_KEY = savedGoogle;
+    else delete process.env.GOOGLE_AI_API_KEY;
+  });
 
-    it('AnthropicSummarizer throws without a key', () => {
-        expect(() => new AnthropicSummarizer()).toThrow(/ANTHROPIC_API_KEY/);
-    });
+  it('AnthropicSummarizer throws without a key', () => {
+    expect(() => new AnthropicSummarizer()).toThrow(/ANTHROPIC_API_KEY/);
+  });
 
-    it('GoogleAISummarizer throws without a key', () => {
-        expect(() => new GoogleAISummarizer()).toThrow(/GOOGLE_AI_API_KEY/);
-    });
+  it('GoogleAISummarizer throws without a key', () => {
+    expect(() => new GoogleAISummarizer()).toThrow(/GOOGLE_AI_API_KEY/);
+  });
 
-    it('AnthropicSummarizer constructs with explicit apiKey', () => {
-        expect(() => new AnthropicSummarizer({ apiKey: 'sk-test' })).not.toThrow();
-    });
+  it('AnthropicSummarizer constructs with explicit apiKey', () => {
+    expect(() => new AnthropicSummarizer({ apiKey: 'sk-test' })).not.toThrow();
+  });
 
-    it('GoogleAISummarizer constructs with explicit apiKey', () => {
-        expect(() => new GoogleAISummarizer({ apiKey: 'gapi-test' })).not.toThrow();
-    });
+  it('GoogleAISummarizer constructs with explicit apiKey', () => {
+    expect(() => new GoogleAISummarizer({ apiKey: 'gapi-test' })).not.toThrow();
+  });
 });
 
 describe('createSummarizerFromEnv', () => {
-    const saved = {
-        anthropic: process.env.ANTHROPIC_API_KEY,
-        google: process.env.GOOGLE_AI_API_KEY,
-    };
+  const saved = {
+    anthropic: process.env.ANTHROPIC_API_KEY,
+    google: process.env.GOOGLE_AI_API_KEY,
+  };
 
-    afterEach(() => {
-        if (saved.anthropic !== undefined) process.env.ANTHROPIC_API_KEY = saved.anthropic;
-        else delete process.env.ANTHROPIC_API_KEY;
-        if (saved.google !== undefined) process.env.GOOGLE_AI_API_KEY = saved.google;
-        else delete process.env.GOOGLE_AI_API_KEY;
-    });
+  afterEach(() => {
+    if (saved.anthropic !== undefined)
+      process.env.ANTHROPIC_API_KEY = saved.anthropic;
+    else delete process.env.ANTHROPIC_API_KEY;
+    if (saved.google !== undefined)
+      process.env.GOOGLE_AI_API_KEY = saved.google;
+    else delete process.env.GOOGLE_AI_API_KEY;
+  });
 
-    it('falls back to TruncatingSummarizer when no keys are set', () => {
-        delete process.env.ANTHROPIC_API_KEY;
-        delete process.env.GOOGLE_AI_API_KEY;
-        expect(createSummarizerFromEnv()).toBeInstanceOf(TruncatingSummarizer);
-    });
+  it('falls back to TruncatingSummarizer when no keys are set', () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.GOOGLE_AI_API_KEY;
+    expect(createSummarizerFromEnv()).toBeInstanceOf(TruncatingSummarizer);
+  });
 
-    it('prefers Anthropic when its key is set', () => {
-        process.env.ANTHROPIC_API_KEY = 'sk-test';
-        delete process.env.GOOGLE_AI_API_KEY;
-        expect(createSummarizerFromEnv()).toBeInstanceOf(AnthropicSummarizer);
-    });
+  it('prefers Anthropic when its key is set', () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-test';
+    delete process.env.GOOGLE_AI_API_KEY;
+    expect(createSummarizerFromEnv()).toBeInstanceOf(AnthropicSummarizer);
+  });
 
-    it('uses Google AI when only its key is set', () => {
-        delete process.env.ANTHROPIC_API_KEY;
-        process.env.GOOGLE_AI_API_KEY = 'gapi-test';
-        expect(createSummarizerFromEnv()).toBeInstanceOf(GoogleAISummarizer);
-    });
+  it('uses Google AI when only its key is set', () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    process.env.GOOGLE_AI_API_KEY = 'gapi-test';
+    expect(createSummarizerFromEnv()).toBeInstanceOf(GoogleAISummarizer);
+  });
 });

--- a/tests/unit/token-counter-never-estimates.test.ts
+++ b/tests/unit/token-counter-never-estimates.test.ts
@@ -25,7 +25,12 @@ import { TokenCounter } from '../../src/core/token-counter.js';
  * to gpt-4, so an encoder is always available.
  */
 
-const MODEL_VARS = ['CLAUDE_MODEL', 'ANTHROPIC_MODEL', 'OPENAI_MODEL', 'GOOGLE_AI_MODEL'];
+const MODEL_VARS = [
+  'CLAUDE_MODEL',
+  'ANTHROPIC_MODEL',
+  'OPENAI_MODEL',
+  'GOOGLE_AI_MODEL',
+];
 const saved = new Map<string, string | undefined>();
 
 const withModelEnv = (key: string, value: string): TokenCounter => {
@@ -46,7 +51,9 @@ afterEach(() => {
 });
 
 /** Indented source: the case where the estimate was worst, and overstated. */
-const WHITESPACE_HEAVY = ('    '.repeat(8) + 'const indented = true;\n').repeat(25);
+const WHITESPACE_HEAVY = ('    '.repeat(8) + 'const indented = true;\n').repeat(
+  25
+);
 const estimateFor = (s: string) => Math.ceil(s.length / 4);
 
 describe('token counting never silently estimates', () => {

--- a/tests/unit/token-counter.test.ts
+++ b/tests/unit/token-counter.test.ts
@@ -11,7 +11,10 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { TokenCounter, TokenCountResult } from '../../src/core/token-counter.js';
+import {
+  TokenCounter,
+  TokenCountResult,
+} from '../../src/core/token-counter.js';
 
 describe('TokenCounter', () => {
   let tokenCounter: TokenCounter;
@@ -136,7 +139,9 @@ describe('TokenCounter', () => {
       const batch = tokenCounter.countBatch([text1, text2]);
 
       expect(batch.tokens).toBe(individual1.tokens + individual2.tokens);
-      expect(batch.characters).toBe(individual1.characters + individual2.characters);
+      expect(batch.characters).toBe(
+        individual1.characters + individual2.characters
+      );
     });
 
     it('should handle large batch', () => {
@@ -270,7 +275,9 @@ describe('TokenCounter', () => {
 
       expect(tokenCounter.exceedsLimit(longText, result.tokens - 1)).toBe(true);
       expect(tokenCounter.exceedsLimit(longText, result.tokens)).toBe(false);
-      expect(tokenCounter.exceedsLimit(longText, result.tokens + 1)).toBe(false);
+      expect(tokenCounter.exceedsLimit(longText, result.tokens + 1)).toBe(
+        false
+      );
     });
 
     it('should handle empty text with any limit', () => {

--- a/tests/unit/token-optimizer.test.ts
+++ b/tests/unit/token-optimizer.test.ts
@@ -14,7 +14,10 @@ import {
   IOptimizationModule,
   OptimizationResult as ModuleResult,
 } from '../../src/modules/IOptimizationModule.js';
-import { ITokenCounter, TokenCountResult } from '../../src/interfaces/ITokenCounter.js';
+import {
+  ITokenCounter,
+  TokenCountResult,
+} from '../../src/interfaces/ITokenCounter.js';
 
 // Mock token counter
 class MockTokenCounter implements ITokenCounter {
@@ -91,9 +94,8 @@ describe('TokenOptimizer', () => {
     });
 
     it('should calculate token counts correctly', async () => {
-      const module = new MockOptimizationModule(
-        'remove-spaces',
-        (text) => text.replace(/\s+/g, '')
+      const module = new MockOptimizationModule('remove-spaces', (text) =>
+        text.replace(/\s+/g, '')
       );
       const optimizer = new TokenOptimizer([module], tokenCounter);
       const prompt = 'This is a test';
@@ -105,9 +107,7 @@ describe('TokenOptimizer', () => {
 
       expect(result.originalTokens).toBe(originalCount.tokens);
       expect(result.optimizedTokens).toBe(optimizedCount.tokens);
-      expect(result.savings).toBe(
-        originalCount.tokens - optimizedCount.tokens
-      );
+      expect(result.savings).toBe(originalCount.tokens - optimizedCount.tokens);
     });
   });
 

--- a/tests/unit/tokenizers.test.ts
+++ b/tests/unit/tokenizers.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from '@jest/globals';
-import { HeuristicTokenizer, ContentType } from '../../src/core/tokenizers/heuristic-tokenizer.js';
+import {
+  HeuristicTokenizer,
+  ContentType,
+} from '../../src/core/tokenizers/heuristic-tokenizer.js';
 import { TokenizerFactory } from '../../src/core/tokenizers/tokenizer-factory.js';
 import { TiktokenTokenizer } from '../../src/core/tokenizers/tiktoken-tokenizer.js';
 

--- a/tests/unit/tool-arguments.test.ts
+++ b/tests/unit/tool-arguments.test.ts
@@ -66,10 +66,16 @@ describe('assertKnownFields', () => {
     // the caller still has to pick `files`, but the message names a real field
     // and lists the full set rather than sending them to the schema.
     expect(() =>
-      checker.assertKnownFields('smart_grep', { pattern: 'x', filePattern: 'y' })
+      checker.assertKnownFields('smart_grep', {
+        pattern: 'x',
+        filePattern: 'y',
+      })
     ).toThrow(/did you mean pattern\?/);
     expect(() =>
-      checker.assertKnownFields('smart_grep', { pattern: 'x', filePattern: 'y' })
+      checker.assertKnownFields('smart_grep', {
+        pattern: 'x',
+        filePattern: 'y',
+      })
     ).toThrow(/Accepted: caseSensitive, contextAfter/);
   });
 
@@ -130,7 +136,9 @@ describe('assertKnownFields', () => {
   });
 
   it('tolerates absent and empty arguments', () => {
-    expect(() => checker.assertKnownFields('smart_grep', undefined)).not.toThrow();
+    expect(() =>
+      checker.assertKnownFields('smart_grep', undefined)
+    ).not.toThrow();
     expect(() => checker.assertKnownFields('smart_grep', {})).not.toThrow();
   });
 
@@ -146,7 +154,9 @@ describe('nearestKnownField', () => {
 
   it('prefers a contained name over edit distance', () => {
     expect(nearestKnownField('filePattern', known)).toBe('pattern');
-    expect(nearestKnownField('contextBeforeLines', known)).toBe('contextBefore');
+    expect(nearestKnownField('contextBeforeLines', known)).toBe(
+      'contextBefore'
+    );
   });
 
   it('catches a single-character slip', () => {

--- a/tests/unit/tool-schemas-declare-what-they-accept.test.ts
+++ b/tests/unit/tool-schemas-declare-what-they-accept.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from '@jest/globals';
 import { readFileSync, readdirSync, statSync } from 'fs';
 import { join } from 'path';
+import {
+  acceptedOptions,
+  declaredProperties,
+} from './helpers/schema-source.js';
 
 /**
  * A tool's published inputSchema must declare every option it accepts.
@@ -46,147 +50,6 @@ function walk(dir: string): string[] {
       out.push(full);
   }
   return out;
-}
-
-/**
- * Top-level keys of the object literal whose `{` is at `open`.
- *
- * COMMENT-AWARE, and that is not a nicety. Without it an apostrophe inside a `//`
- * comment -- "the caller's argument object" -- opens a string that never closes, and
- * every key after it is swallowed. That happened while writing this file: the audit
- * reported 11 newly declared properties as still missing, and the numbers looked
- * plausible enough to believe. A scanner that silently under-reports is worse than
- * no scanner, because it makes a real gap look fixed.
- */
-function topLevelKeys(text: string, open: number): string[] {
-  const keys: string[] = [];
-  let depth = 0;
-  let inString: string | null = null;
-
-  for (let i = open; i < text.length; i++) {
-    const c = text[i];
-
-    if (inString) {
-      if (c === '\\') i++;
-      else if (c === inString) inString = null;
-      continue;
-    }
-
-    // Comments first: their contents are prose, not syntax.
-    if (c === '/' && text[i + 1] === '/') {
-      const end = text.indexOf('\n', i);
-      if (end === -1) break;
-      i = end;
-      continue;
-    }
-    if (c === '/' && text[i + 1] === '*') {
-      const end = text.indexOf('*/', i + 2);
-      if (end === -1) break;
-      i = end + 1;
-      continue;
-    }
-
-    if (c === '"' || c === "'" || c === '`') {
-      inString = c;
-      continue;
-    }
-    if (c === '{' || c === '[') {
-      depth++;
-      continue;
-    }
-    if (c === '}' || c === ']') {
-      depth--;
-      if (depth === 0) break;
-      continue;
-    }
-    if (depth === 1 && /[A-Za-z_$]/.test(c)) {
-      const m = /^([A-Za-z_$][\w$]*)\s*:/.exec(text.slice(i));
-      if (m) {
-        keys.push(m[1]);
-        i += m[1].length;
-      }
-    }
-  }
-  return keys;
-}
-
-/**
- * Property names a schema declares, counting an `options` sub-object as declared.
- *
- * MOST tools are flattened by the server -- `const { pattern, ...options } = args` --
- * so their options belong at the top level. A few instead take options as a SEPARATE
- * argument (`run(target, options)`) and nest them under an `options` property, which is
- * correct for that call shape. Counting only top-level keys reported those as
- * undeclared, which was the checker being wrong rather than the tool: smart_workflow
- * declares all six of its options inside `options`, exactly as its signature expects.
- */
-function declaredProperties(text: string): string[] | null {
-  const schema = text.indexOf('inputSchema');
-  if (schema === -1) return null;
-  const props = text.indexOf('properties:', schema);
-  if (props === -1) return null;
-  const open = text.indexOf('{', props);
-  if (open === -1) return null;
-
-  const top = topLevelKeys(text, open);
-  if (!top.includes('options')) return top;
-
-  // Descend into the `options` object and treat its keys as declared too.
-  const optionsKey = text.indexOf('options:', open);
-  const nestedProps =
-    optionsKey === -1 ? -1 : text.indexOf('properties:', optionsKey);
-  if (nestedProps === -1) return top;
-  const nestedOpen = text.indexOf('{', nestedProps);
-  return nestedOpen === -1 ? top : [...top, ...topLevelKeys(text, nestedOpen)];
-}
-
-/**
- * Option names an interface accepts, with function-typed fields dropped.
- *
- * A `(x) => y` field cannot be expressed in JSON Schema and cannot arrive over MCP,
- * so it is programmatic-only rather than undeclared.
- */
-function acceptedOptions(text: string): string[] {
-  const fields: string[] = [];
-
-  for (const match of text.matchAll(/export interface\s+\w*Options\s*\{/g)) {
-    const open = text.indexOf('{', match.index);
-    let depth = 0;
-
-    for (let i = open; i < text.length; i++) {
-      const c = text[i];
-      if (c === '{') {
-        depth++;
-        continue;
-      }
-      if (c === '}') {
-        depth--;
-        if (depth === 0) break;
-        continue;
-      }
-      if (depth !== 1 || text[i - 1] !== '\n') continue;
-
-      const line = /^\s*([A-Za-z_$][\w$]*)\??\s*:\s*([^;\n]*)/.exec(
-        text.slice(i)
-      );
-      if (!line) continue;
-
-      const [, name, type] = line;
-
-      // NOT EXPRESSIBLE AS JSON, so not declarable and not reachable over MCP.
-      //
-      // Functions are obvious. `Buffer` is here for the same reason and was checked
-      // rather than assumed: cache_compression's `dictionary` is handed straight to
-      // zlib as a Buffer, so declaring it as a base64 string would promise a shape the
-      // implementation cannot consume -- a different lie from the one this test exists
-      // to catch, not a fix for it.
-      const isFunction = type.includes('=>') || /\bFunction\b/.test(type);
-      const isBinary = /\bBuffer\b/.test(type);
-      if (!isFunction && !isBinary) fields.push(name);
-    }
-  }
-
-  return [...new Set(fields)];
 }
 
 function toolName(text: string): string {

--- a/tests/unit/tool-schemas-match-nested-shapes.test.ts
+++ b/tests/unit/tool-schemas-match-nested-shapes.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from '@jest/globals';
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join } from 'path';
+import {
+  acceptedOptionFields,
+  interfaceFields,
+  isUnsendable,
+  nestedShape,
+} from './helpers/schema-source.js';
+
+/**
+ * A declared option must also declare the SHAPE it accepts.
+ *
+ * THIS CLOSES THE HOLE THAT LET BAD WORK THROUGH TWICE. The sibling test compares
+ * option NAMES: every field of an Options interface must appear in inputSchema. That
+ * check passed while four nested declarations were wrong, because the names were all
+ * present and only the structure inside them was incomplete:
+ *
+ *   - alert_manager `dataSource` omitted `connection.tool`, `transform` and `cache`,
+ *     and did not require `connection`. An mcp-tool source therefore could not be
+ *     configured through the published contract at all.
+ *   - log_dashboard `logSources` omitted `name`, `enabled` and `config.parser`, and
+ *     required only id and type -- so it accepted source objects the tool itself
+ *     rejects. A schema loose enough to produce invalid input.
+ *
+ * tsc cannot catch either: a JSON-Schema literal is just an object, so a missing
+ * nested key is not a type error. Review caught them, which is not a system.
+ *
+ * What this asserts, for every option whose type is an interface declared in the same
+ * file: every field of that interface appears in the schema's nested `properties`, and
+ * every NON-OPTIONAL field appears in its `required`. Types from other modules are
+ * skipped because they cannot be resolved from source text -- a real limit, stated
+ * rather than hidden.
+ */
+
+const ROOT = process.cwd();
+const SRC = join(ROOT, 'src', 'tools');
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...walk(full));
+    else if (entry.endsWith('.ts') && !entry.endsWith('.test.ts'))
+      out.push(full);
+  }
+  return out;
+}
+
+/** `Foo` and `Foo[]` and `Array<Foo>` all name the element interface `Foo`. */
+function namedType(type: string): string | null {
+  const cleaned = type.replace(/\s*\|\s*undefined/g, '').trim();
+  const m =
+    /^([A-Z]\w*)\[\]$/.exec(cleaned) ??
+    /^Array<([A-Z]\w*)>$/.exec(cleaned) ??
+    /^([A-Z]\w*)$/.exec(cleaned);
+  return m ? m[1] : null;
+}
+
+interface Mismatch {
+  file: string;
+  option: string;
+  shape: string;
+  missingProperties: string[];
+  missingRequired: string[];
+}
+
+function audit(): { mismatches: Mismatch[]; checked: number } {
+  const mismatches: Mismatch[] = [];
+  let checked = 0;
+
+  for (const file of walk(SRC)) {
+    const text = readFileSync(file, 'utf8');
+    if (!text.includes('_TOOL_DEFINITION')) continue;
+
+    const relative = file
+      .replace(ROOT, '')
+      .replace(/\\/g, '/')
+      .replace(/^\//, '');
+    for (const { name: option, type } of acceptedOptionFields(text)) {
+      const shapeName = namedType(type);
+      if (!shapeName) continue;
+
+      const fields = interfaceFields(text, shapeName);
+      if (!fields.length) continue; // defined elsewhere; cannot resolve from source
+
+      const declared = nestedShape(text, option);
+      if (!declared) continue; // declares no nested shape at all; the name check covers it
+
+      checked++;
+      const sendable = fields.filter((f) => !isUnsendable(f.type));
+      const missingProperties = sendable
+        .filter((f) => !declared.properties.includes(f.name))
+        .map((f) => f.name);
+      const missingRequired = sendable
+        .filter((f) => !f.optional && !declared.required.includes(f.name))
+        .map((f) => f.name);
+
+      if (missingProperties.length || missingRequired.length) {
+        mismatches.push({
+          file: relative,
+          option,
+          shape: shapeName,
+          missingProperties,
+          missingRequired,
+        });
+      }
+    }
+  }
+
+  return { mismatches, checked };
+}
+
+describe('a declared option declares its shape too', () => {
+  const { mismatches, checked } = audit();
+
+  it('has no nested shape that omits a field of its interface', () => {
+    const report = mismatches
+      .map(
+        (m) =>
+          `${m.file} ${m.option} (${m.shape}): missing properties [${m.missingProperties.join(', ')}] missing required [${m.missingRequired.join(', ')}]`
+      )
+      .join('\n');
+
+    expect(report).toBe('');
+  });
+
+  it('actually resolved some shapes, so it cannot pass by checking nothing', () => {
+    // Every branch above bails out on something it cannot resolve. Without this, a
+    // parser regression would empty the audit and turn the file green.
+    expect(checked).toBeGreaterThan(0);
+  });
+
+  it('reaches through an array to the element shape', () => {
+    // `logSources` is an array; its fields live under `items.properties`, which is
+    // exactly where a name-only check cannot see and where two omissions hid.
+    const text = readFileSync(
+      join(SRC, 'dashboard-monitoring', 'log-dashboard.ts'),
+      'utf8'
+    );
+    const shape = nestedShape(text, 'logSources');
+
+    expect(shape?.isArray).toBe(true);
+    expect(shape?.properties).toContain('config');
+    expect(shape?.required).toContain('enabled');
+  });
+
+  it('reads a plain object shape and its required list', () => {
+    const text = readFileSync(
+      join(SRC, 'dashboard-monitoring', 'alert-manager.ts'),
+      'utf8'
+    );
+    const shape = nestedShape(text, 'dataSource');
+
+    expect(shape?.isArray).toBe(false);
+    expect(shape?.properties).toEqual(
+      expect.arrayContaining(['id', 'type', 'connection', 'transform', 'cache'])
+    );
+    expect(shape?.required).toContain('connection');
+  });
+});

--- a/tests/unit/tool-schemas-match-nested-shapes.test.ts
+++ b/tests/unit/tool-schemas-match-nested-shapes.test.ts
@@ -6,6 +6,7 @@ import {
   interfaceFields,
   isUnsendable,
   nestedShape,
+  shapeGaps,
 } from './helpers/schema-source.js';
 
 /**
@@ -84,17 +85,14 @@ function audit(): { mismatches: Mismatch[]; checked: number } {
       const fields = interfaceFields(text, shapeName);
       if (!fields.length) continue; // defined elsewhere; cannot resolve from source
 
-      const declared = nestedShape(text, option);
-      if (!declared) continue; // declares no nested shape at all; the name check covers it
+      // Null means the schema does not declare the option at all, which is the
+      // name-check's finding. A DECLARED option with no nested shape is not
+      // skipped -- that was the hole, and it now reports every field.
+      const gaps = shapeGaps(text, option, fields);
+      if (!gaps) continue;
 
       checked++;
-      const sendable = fields.filter((f) => !isUnsendable(f.type));
-      const missingProperties = sendable
-        .filter((f) => !declared.properties.includes(f.name))
-        .map((f) => f.name);
-      const missingRequired = sendable
-        .filter((f) => !f.optional && !declared.required.includes(f.name))
-        .map((f) => f.name);
+      const { missingProperties, missingRequired } = gaps;
 
       if (missingProperties.length || missingRequired.length) {
         mismatches.push({
@@ -143,6 +141,83 @@ describe('a declared option declares its shape too', () => {
     expect(shape?.isArray).toBe(true);
     expect(shape?.properties).toContain('config');
     expect(shape?.required).toContain('enabled');
+  });
+
+  it('does not mistake a nested array property for an array-typed option', () => {
+    // `condition` is an OBJECT whose fields include two arrays (`groupBy`,
+    // `filters`). Deciding array-ness by searching the whole block for
+    // `type: 'array'` matched those nested properties, so the parser reached
+    // into `groupBy.items` -- `{ type: 'string' }`, which has no `properties` --
+    // and reported the option as declaring no shape at all. Combined with the
+    // stricter rule above, that would have condemned five CORRECT schemas and
+    // invited "fixing" them. Array-ness must come from the option's own `type`.
+    const text = readFileSync(
+      join(SRC, 'dashboard-monitoring', 'alert-manager.ts'),
+      'utf8'
+    );
+    const shape = nestedShape(text, 'condition');
+
+    expect(shape?.isArray).toBe(false);
+    expect(shape?.properties).toEqual(
+      expect.arrayContaining([
+        'metric',
+        'aggregation',
+        'percentile',
+        'groupBy',
+        'filters',
+      ])
+    );
+  });
+
+  it('flags an object option that declares NO nested properties at all', () => {
+    // THE HOLE THIS CLOSES. The audit used to `continue` whenever a property
+    // declared no nested shape, on the reasoning that the sibling name-check
+    // covered it. It does not: the name-check only confirms the NAME exists, so
+    // `request: { type: 'object' }` satisfied both tests while declaring none of
+    // its fields and none of its requirements. A schema that accepts anything is
+    // not a contract, and this file's whole purpose is to notice that.
+    const text = `
+export interface Req {
+  url: string;
+  method?: string;
+}
+export interface ThingOptions {
+  request: Req;
+}
+const X_TOOL_DEFINITION = {
+  inputSchema: {
+    properties: {
+      request: { type: 'object', description: 'shapeless' },
+    },
+  },
+};`;
+
+    expect(shapeGaps(text, 'request', interfaceFields(text, 'Req'))).toEqual({
+      missingProperties: ['url', 'method'],
+      missingRequired: ['url'],
+    });
+  });
+
+  it('stays silent about an option the schema never declares', () => {
+    // That case belongs to the name-check, which reports it with the right
+    // message. Reporting it here too would make one defect fail two tests and
+    // read as two defects.
+    const text = `
+export interface Req {
+  url: string;
+}
+export interface ThingOptions {
+  request: Req;
+}
+const X_TOOL_DEFINITION = {
+  inputSchema: {
+    properties: {
+      somethingElse: { type: 'string' },
+    },
+  },
+};`;
+
+    expect(shapeGaps(text, 'request', interfaceFields(text, 'Req'))).toBeNull();
   });
 
   it('reads a plain object shape and its required list', () => {

--- a/tests/unit/tool-schemas-match-nested-shapes.test.ts
+++ b/tests/unit/tool-schemas-match-nested-shapes.test.ts
@@ -169,6 +169,47 @@ describe('a declared option declares its shape too', () => {
     );
   });
 
+  it('reads through a block comment rather than treating it as source', () => {
+    // `//` comments were skipped and `/* */` were not, so a block comment that
+    // happens to contain `type: 'array'` or a `required:` list was read as
+    // declaration. The scanners already learned this lesson once -- an
+    // apostrophe in a `//` comment opened a string that swallowed eleven
+    // properties -- and half-applying it leaves the same class of defect.
+    const text = `
+export interface Cfg {
+  host: string;
+  ports?: number[];
+}
+export interface ThingOptions {
+  cfg: Cfg;
+}
+const X_TOOL_DEFINITION = {
+  inputSchema: {
+    properties: {
+      cfg: {
+        /* Historically this was type: 'array' with required: ['legacy'].
+           It is an object now. */
+        type: 'object',
+        properties: {
+          host: { type: 'string' },
+          ports: { type: 'array', items: { type: 'number' } },
+        },
+        required: ['host'],
+      },
+    },
+  },
+};`;
+
+    const shape = nestedShape(text, 'cfg');
+
+    expect(shape?.isArray).toBe(false);
+    expect(shape?.required).toEqual(['host']);
+    expect(shapeGaps(text, 'cfg', interfaceFields(text, 'Cfg'))).toEqual({
+      missingProperties: [],
+      missingRequired: [],
+    });
+  });
+
   it('flags an object option that declares NO nested properties at all', () => {
     // THE HOLE THIS CLOSES. The audit used to `continue` whenever a property
     // declared no nested shape, on the reasoning that the sibling name-check

--- a/tests/unit/uninstall-reversibility.test.ts
+++ b/tests/unit/uninstall-reversibility.test.ts
@@ -21,7 +21,12 @@ describe('the settings round trip', () => {
     env: { SOME_USER_VAR: 'keep-me' },
     hooks: {
       PreToolUse: [
-        { matcher: 'Bash', hooks: [{ type: 'command', command: 'node /somebody/elses/hook.mjs' }] },
+        {
+          matcher: 'Bash',
+          hooks: [
+            { type: 'command', command: 'node /somebody/elses/hook.mjs' },
+          ],
+        },
       ],
     },
   };
@@ -35,8 +40,9 @@ describe('the settings round trip', () => {
     expect(wired.env.SOME_USER_VAR).toBe('keep-me');
     expect(wiredEntries(wired).length).toBeGreaterThan(0);
 
-    const foreign = wired.hooks.PreToolUse.flatMap((e: { hooks?: Array<{ command?: string }> }) =>
-      (e.hooks || []).map((h) => h.command)
+    const foreign = wired.hooks.PreToolUse.flatMap(
+      (e: { hooks?: Array<{ command?: string }> }) =>
+        (e.hooks || []).map((h) => h.command)
     );
     expect(foreign).toContain('node /somebody/elses/hook.mjs');
   });
@@ -60,7 +66,9 @@ describe('the settings round trip', () => {
   it('leaves no empty event keys behind', () => {
     // A settings file with `"PreCompact": []` in it still says we were here.
     const bare = {};
-    const restored = unwire(wire(bare, HOOKS_DIR)) as { hooks?: Record<string, unknown> };
+    const restored = unwire(wire(bare, HOOKS_DIR)) as {
+      hooks?: Record<string, unknown>;
+    };
     for (const [event, entries] of Object.entries(restored.hooks || {})) {
       expect(Array.isArray(entries) && entries.length === 0).toBe(false);
       expect(event).toBeTruthy();
@@ -71,7 +79,10 @@ describe('the settings round trip', () => {
     const shared = {
       hooks: {
         PreToolUse: [
-          { matcher: 'Read', hooks: [{ type: 'command', command: 'node /their/reader.mjs' }] },
+          {
+            matcher: 'Read',
+            hooks: [{ type: 'command', command: 'node /their/reader.mjs' }],
+          },
         ],
       },
     };

--- a/tests/unit/validation/validator.test.ts
+++ b/tests/unit/validation/validator.test.ts
@@ -34,6 +34,8 @@ describe('validateToolArgs zod-v4 compatibility', () => {
   });
 
   it('throws a clear error for an unknown tool', () => {
-    expect(() => validateToolArgs('does_not_exist', {})).toThrow(/Unknown tool/);
+    expect(() => validateToolArgs('does_not_exist', {})).toThrow(
+      /Unknown tool/
+    );
   });
 });

--- a/tests/unit/vector-store.test.ts
+++ b/tests/unit/vector-store.test.ts
@@ -30,7 +30,7 @@ describe('InMemoryVectorStore', () => {
     expect(results[0].similarity).toBeCloseTo(1.0, 5);
 
     // Second result should be key3 (similar)
-    const key3Result = results.find(r => r.id === 'key3');
+    const key3Result = results.find((r) => r.id === 'key3');
     expect(key3Result).toBeDefined();
     expect(key3Result!.similarity).toBeGreaterThan(0.7);
   });
@@ -71,7 +71,9 @@ describe('InMemoryVectorStore', () => {
 
     // Results should be sorted by similarity (descending)
     for (let i = 0; i < results.length - 1; i++) {
-      expect(results[i].similarity).toBeGreaterThanOrEqual(results[i + 1].similarity);
+      expect(results[i].similarity).toBeGreaterThanOrEqual(
+        results[i + 1].similarity
+      );
     }
   });
 
@@ -89,7 +91,7 @@ describe('InMemoryVectorStore', () => {
 
     // Deleted vector should not appear in search
     const results = await store.search([1, 0, 0, 0], 5, 0.0);
-    expect(results.find(r => r.id === 'key1')).toBeUndefined();
+    expect(results.find((r) => r.id === 'key1')).toBeUndefined();
   });
 
   it('should clear all vectors', async () => {
@@ -141,9 +143,9 @@ describe('InMemoryVectorStore', () => {
 
     const results = await store.search([1, 0, 0], 3, -1.0); // Include all
 
-    const same = results.find(r => r.id === 'same');
-    const opposite = results.find(r => r.id === 'opposite');
-    const orthogonal = results.find(r => r.id === 'orthogonal');
+    const same = results.find((r) => r.id === 'same');
+    const opposite = results.find((r) => r.id === 'opposite');
+    const orthogonal = results.find((r) => r.id === 'orthogonal');
 
     expect(same!.similarity).toBeCloseTo(1.0, 5);
     expect(opposite!.similarity).toBeCloseTo(-1.0, 5);
@@ -158,6 +160,6 @@ describe('InMemoryVectorStore', () => {
     const results = await store.search([0, 0, 0, 0], 5, -1.0);
 
     // Should not crash, but zero vector has 0 similarity with everything
-    expect(results.every(r => r.similarity === 0)).toBe(true);
+    expect(results.every((r) => r.similarity === 0)).toBe(true);
   });
 });

--- a/tests/unit/whitespace-optimization-module.test.ts
+++ b/tests/unit/whitespace-optimization-module.test.ts
@@ -11,7 +11,10 @@
 
 import { describe, it, expect, beforeEach } from '@jest/globals';
 import { WhitespaceOptimizationModule } from '../../src/modules/WhitespaceOptimizationModule.js';
-import { ITokenCounter, TokenCountResult } from '../../src/interfaces/ITokenCounter.js';
+import {
+  ITokenCounter,
+  TokenCountResult,
+} from '../../src/interfaces/ITokenCounter.js';
 
 // Mock token counter
 class MockTokenCounter implements ITokenCounter {

--- a/tests/unit/wmic-csv.test.ts
+++ b/tests/unit/wmic-csv.test.ts
@@ -46,7 +46,9 @@ describe('wmic CSV rows are keyed by the header, not by request order', () => {
 
     const [row] = parseWmicCsvRows(csv);
 
-    expect(row.CommandLine).toBe(String.raw`"C:\app.exe" --enable=a,b,c,d --also=e,f`);
+    expect(row.CommandLine).toBe(
+      String.raw`"C:\app.exe" --enable=a,b,c,d --also=e,f`
+    );
     // Everything after the command line is still read correctly.
     expect(row.Name).toBe('app.exe');
     expect(row.ProcessId).toBe('777');
@@ -86,9 +88,12 @@ describe('wmic CSV rows are keyed by the header, not by request order', () => {
   });
 
   it('skips the blank lines wmic prints before the header', () => {
-    const csv = ['', '  ', PROCESS_HEADER, 'HOST,c,20260720000000.000000+000,1,2,n.exe,9,3,4,5'].join(
-      '\n'
-    );
+    const csv = [
+      '',
+      '  ',
+      PROCESS_HEADER,
+      'HOST,c,20260720000000.000000+000,1,2,n.exe,9,3,4,5',
+    ].join('\n');
     const rows = parseWmicCsvRows(csv);
     expect(rows).toHaveLength(1);
     expect(rows[0].ProcessId).toBe('9');


### PR DESCRIPTION
Two gaps in the checks themselves, each of which had already let real defects reach master.

## 1. The schema ratchet compared names, not shapes

`tool-schemas-declare-what-they-accept.test.ts` asserts every field of an `*Options` interface appears in `inputSchema`. That check was green while four nested declarations were wrong, because the *names* were all present and only the structure inside them was incomplete:

- `alert_manager` `dataSource` omitted `connection.tool`, `transform` and `cache`, and did not require `connection` — so an mcp-tool source could not be configured through the published contract at all.
- `log_dashboard` `logSources` omitted `name`, `enabled` and `config.parser` and required only `id`/`type` — a schema loose enough to accept source objects the tool itself rejects.

tsc cannot catch either: a JSON-Schema literal is just an object, so a missing nested key is not a type error. Review caught them, which is not a system. Both were my own defects, found in review on #261.

`tool-schemas-match-nested-shapes.test.ts` now asserts, for every option whose type is an interface declared in the same file, that every field appears in the nested `properties` and every non-optional field appears in `required`, reaching through `items` for arrays. Types imported from other modules are skipped — a real limit, stated in the test rather than hidden.

Nine schema files were incomplete once the check existed: `cache-optimizer`, `cache-replication`, `cache-analytics`, `cache-benchmark`, `predictive-cache`, `smart-cache-api`, `smart-pretty`, plus the two above.

**The parser is now one shared copy** (`tests/unit/helpers/schema-source.ts`). An earlier scratch copy drifted and under-reported 11 freshly-declared properties as still missing, and the numbers looked plausible enough to believe. Two bugs in it are fixed and documented at the point of the fix:

- an apostrophe in a `//` comment opened a string that never closed, swallowing every later key — the scanner is now comment-aware;
- `required:` was read from the first match anywhere in the block, so `dataSource`'s nested `cache: { required: [...] }` was reported as `dataSource`'s own requirements. Now depth-aware. This produced a confident, wrong finding about a property I had just fixed correctly, which is the only reason it was noticed.

## 2. Three manifests carried a version nothing checked

    server.json               5.1.1   against a package at 5.4.3
    server.json packages[0]   5.1.1
    mcp.json                  0.2.0
    gemini-extension.json     5.1.2

`server.json` is the one with teeth. `docs/PUBLISHING.md:38` already states the rule — *"registry returns 422; keep `server.json` `version` in lockstep with npm"* — because the MCP Registry validates that the declared version exists on npm carrying the matching `mcpName`. At 5.1.1 the registry entry described a version three minors behind what users install.

Same cause as the plugin manifest rotting through four releases: release-please only bumps what it is told about, and only `plugin.json` was listed. All four are now in `extra-files`, including `server.json`'s **nested** `$.packages[0].version` — bumping only the outer field leaves the registry pointing at a version that need not exist, which is precisely the 422.

`mcp.json`'s `0.2.0` was checked rather than assumed to be a package version: it sits beside `name`, `license` and `installation.npm.package` with no `$schema` anywhere, so it is the server version.

Every jsonpath was resolved against its file to confirm it addresses a real string, so release-please cannot silently no-op on a path that does not exist.

## Both new tests were mutation-verified

Not "the suite is green" — each assertion was made to fail on purpose:

| mutation | result |
|---|---|
| revert one nested `properties` entry | nested-shape test fails |
| empty a nested `required` | nested-shape test fails |
| break the parser so it resolves nothing | `checked > 0` guard fails |
| revert only `server.json` `packages[0].version` | 2 of 6 manifest tests fail |
| unwire `server.json` from release-please, versions still correct | 1 of 6 fails — the **cause**, not the symptom |

The manifest test deliberately fails on an unwired manifest even while the versions agree, because that one drifts on the very next release and nobody notices until a publish is rejected.

## Gates

125 suites, 1,536 passed, 4 skipped. `tsc --noEmit` clean. eslint 0 errors. `prettier --check` clean. `npm run validate` clean.