### PR TITLE
fix(search): let path name a single file instead of answering zero

### DIFF
--- a/src/tools/file-operations/smart-glob.ts
+++ b/src/tools/file-operations/smart-glob.ts
@@ -21,6 +21,10 @@ import { MetricsCollector } from '../../core/metrics.js';
 import { generateCacheKey } from '../shared/hash-utils.js';
 import { fsGeneration } from '../../utils/fs-generation.js';
 import { detectFileType } from '../shared/syntax-utils.js';
+import {
+  resolveSearchScope,
+  limitToScopedFile,
+} from '../../utils/search-scope.js';
 
 export interface FileMetadata {
   path: string;
@@ -133,52 +137,64 @@ export class SmartGlobTool {
   ): Promise<SmartGlobResult> {
     const startTime = Date.now();
 
-    // Default options
-    const opts: Required<SmartGlobOptions> = {
-      // See smart-grep.ts: `path` was silently discarded, so a scoped search
-      // actually ran from the server's own launch directory. This tool did not
-      // crash on it -- it returned confident results from the wrong tree, which
-      // is the worse of the two failures.
-      cwd: options.path ?? options.cwd ?? process.cwd(),
-      path: options.path ?? '',
-      absolute: options.absolute ?? false,
-      // `dist` and `build` are conventions, not guarantees. Real projects keep
-      // real source in both -- AiDotNet.Tensors has two .csproj files under
-      // build/, and a search for '**/*.csproj' silently returned 16 of its 18.
-      // The hook DENIES the built-in Glob and sends the caller here, so a
-      // silent omission is not a smaller result set, it is the caller
-      // concluding their file does not exist.
-      //
-      // The defaults are kept, because they are right far more often than not.
-      // What is removed is the SILENCE: `ignoredMatches` below reports how many
-      // real matches these patterns withheld, so the omission is visible and
-      // the caller can pass their own `ignore` to see them.
-      ignore: options.ignore ?? [
-        '**/node_modules/**',
-        '**/.git/**',
-        '**/dist/**',
-        '**/build/**',
-      ],
-      onlyFiles: options.onlyFiles ?? true,
-      onlyDirectories: options.onlyDirectories ?? false,
-      extensions: options.extensions ?? [],
-      excludeExtensions: options.excludeExtensions ?? [],
-      minSize: options.minSize ?? 0,
-      maxSize: options.maxSize ?? Infinity,
-      modifiedAfter: options.modifiedAfter ?? new Date(0),
-      modifiedBefore: options.modifiedBefore ?? new Date(8640000000000000), // Max date
-      includeMetadata: options.includeMetadata ?? false,
-      includeContent: options.includeContent ?? false,
-      maxContentSize: options.maxContentSize ?? 10240, // 10KB
-      limit: options.limit ?? Infinity,
-      offset: options.offset ?? 0,
-      sortBy: options.sortBy ?? 'path',
-      sortOrder: options.sortOrder ?? 'asc',
-      useCache: options.useCache ?? false,
-      ttl: options.ttl ?? 300,
-    };
-
+    // See smart-grep.ts: `path` was silently discarded, so a scoped search
+    // actually ran from the server's own launch directory. This tool did not
+    // crash on it -- it returned confident results from the wrong tree, which
+    // is the worse of the two failures.
+    //
+    // Assigning it to `cwd` then broke `path` naming a single FILE: a glob
+    // rooted at a file matches nothing, so the call returned success with an
+    // empty list. The scope resolves a file to its parent plus the file itself,
+    // and `limitToScopedFile` below keeps the result to that one file, since
+    // this tool's only filter is the caller's pattern.
     try {
+      const scope = resolveSearchScope(
+        options.path,
+        options.cwd,
+        process.cwd()
+      );
+
+      // Default options
+      const opts: Required<SmartGlobOptions> = {
+        cwd: scope.cwd,
+        path: options.path ?? '',
+        absolute: options.absolute ?? false,
+        // `dist` and `build` are conventions, not guarantees. Real projects keep
+        // real source in both -- AiDotNet.Tensors has two .csproj files under
+        // build/, and a search for '**/*.csproj' silently returned 16 of its 18.
+        // The hook DENIES the built-in Glob and sends the caller here, so a
+        // silent omission is not a smaller result set, it is the caller
+        // concluding their file does not exist.
+        //
+        // The defaults are kept, because they are right far more often than not.
+        // What is removed is the SILENCE: `ignoredMatches` below reports how many
+        // real matches these patterns withheld, so the omission is visible and
+        // the caller can pass their own `ignore` to see them.
+        ignore: options.ignore ?? [
+          '**/node_modules/**',
+          '**/.git/**',
+          '**/dist/**',
+          '**/build/**',
+        ],
+        onlyFiles: options.onlyFiles ?? true,
+        onlyDirectories: options.onlyDirectories ?? false,
+        extensions: options.extensions ?? [],
+        excludeExtensions: options.excludeExtensions ?? [],
+        minSize: options.minSize ?? 0,
+        maxSize: options.maxSize ?? Infinity,
+        modifiedAfter: options.modifiedAfter ?? new Date(0),
+        modifiedBefore: options.modifiedBefore ?? new Date(8640000000000000), // Max date
+        includeMetadata: options.includeMetadata ?? false,
+        includeContent: options.includeContent ?? false,
+        maxContentSize: options.maxContentSize ?? 10240, // 10KB
+        limit: options.limit ?? Infinity,
+        offset: options.offset ?? 0,
+        sortBy: options.sortBy ?? 'path',
+        sortOrder: options.sortOrder ?? 'asc',
+        useCache: options.useCache ?? false,
+        ttl: options.ttl ?? 300,
+      };
+
       // Check cache first
       const cacheKey = generateCacheKey('glob', {
         pattern,
@@ -210,12 +226,19 @@ export class SmartGlobTool {
       }
 
       // Perform glob search
-      const matches = globSync(pattern, {
-        cwd: opts.cwd,
-        absolute: opts.absolute,
-        ignore: opts.ignore,
-        nodir: opts.onlyFiles,
-      });
+      //
+      // Narrowed to the scoped file when `path` named one -- the glob ran from
+      // that file's PARENT, so without this it would also return the parent's
+      // other matches and quietly widen the scope the caller asked for.
+      const matches = limitToScopedFile(
+        globSync(pattern, {
+          cwd: opts.cwd,
+          absolute: opts.absolute,
+          ignore: opts.ignore,
+          nodir: opts.onlyFiles,
+        }),
+        scope
+      );
 
       // Whether the exclusions in force are OURS or the caller's -- the note
       // below names them, and naming them wrongly misdirects anyone hunting a

--- a/src/tools/file-operations/smart-glob.ts
+++ b/src/tools/file-operations/smart-glob.ts
@@ -252,16 +252,26 @@ export class SmartGlobTool {
       // already the unignored set, so the second walk would traverse the whole
       // tree synchronously to rediscover a list we are holding -- pure cost on
       // the exact call that opted out of filtering.
+      //
+      // BOTH WALKS ARE SCOPED THE SAME WAY. Narrowing only the first one made
+      // the difference between them look like suppressed matches: a file-scoped
+      // glob returned 1 while the comparison walk still covered the parent and
+      // returned 2, so the response reported that 1 file "matched but were
+      // excluded by the ignore patterns" when nothing had been excluded at all.
+      // A number invented to explain an absence is worse than no number.
       const ignoredMatches =
         opts.ignore.length === 0
           ? 0
           : Math.max(
               0,
-              globSync(pattern, {
-                cwd: opts.cwd,
-                absolute: opts.absolute,
-                nodir: opts.onlyFiles,
-              }).length - matches.length
+              limitToScopedFile(
+                globSync(pattern, {
+                  cwd: opts.cwd,
+                  absolute: opts.absolute,
+                  nodir: opts.onlyFiles,
+                }),
+                scope
+              ).length - matches.length
             );
 
       // Filter and collect file info

--- a/src/tools/file-operations/smart-grep.ts
+++ b/src/tools/file-operations/smart-grep.ts
@@ -22,6 +22,7 @@ import { generateCacheKey } from '../shared/hash-utils.js';
 import { fsGeneration } from '../../utils/fs-generation.js';
 import { detectFileType } from '../shared/syntax-utils.js';
 import { appendAll } from '../shared/append-all.js';
+import { resolveSearchScope } from '../../utils/search-scope.js';
 
 /**
  * The most this tool will ever return in one response.
@@ -138,53 +139,67 @@ export class SmartGrepTool {
   ): Promise<SmartGrepResult> {
     const startTime = Date.now();
 
-    // Default options
-    const opts: Required<SmartGrepOptions> = {
-      // `path` FIRST, and it is not a cosmetic alias.
-      //
-      // The hook refuses the built-in Grep and names this tool as the
-      // replacement, so callers pass the one argument that describes a search:
-      // where to look. `path` was undeclared, and an undeclared field that is
-      // not a near miss of a declared one is discarded silently -- so `cwd` fell
-      // back to process.cwd(), which for an MCP server is its own launch
-      // directory. Measured: every "scoped" search actually walked 676,875 files
-      // across the whole home directory, for 65 seconds, and answered about the
-      // wrong tree.
-      cwd: options.path ?? options.cwd ?? process.cwd(),
-      path: options.path ?? '',
-      files: options.files ?? ['**/*'],
-      caseSensitive: options.caseSensitive ?? false,
-      wholeWord: options.wholeWord ?? false,
-      regex: options.regex ?? false,
-      extensions: options.extensions ?? [],
-      excludeExtensions: options.excludeExtensions ?? [
-        '.min.js',
-        '.map',
-        '.lock',
-      ],
-      skipBinary: options.skipBinary ?? true,
-      ignore: options.ignore ?? [
-        '**/node_modules/**',
-        '**/.git/**',
-        '**/dist/**',
-        '**/build/**',
-      ],
-      includeContext: options.includeContext ?? false,
-      contextBefore: options.contextBefore ?? 0,
-      contextAfter: options.contextAfter ?? 0,
-      includeColumn: options.includeColumn ?? false,
-      maxMatchesPerFile: options.maxMatchesPerFile ?? Infinity,
-      limit: options.limit ?? Infinity,
-      offset: options.offset ?? 0,
-      filesWithMatches: options.filesWithMatches ?? false,
-      count: options.count ?? false,
-      useCache: options.useCache ?? false,
-      ttl: options.ttl ?? 300,
-      maxFileSize: options.maxFileSize ?? 10 * 1024 * 1024, // 10MB default
-      encoding: options.encoding ?? 'utf-8',
-    };
-
+    // `path` FIRST, and it is not a cosmetic alias.
+    //
+    // The hook refuses the built-in Grep and names this tool as the
+    // replacement, so callers pass the one argument that describes a search:
+    // where to look. `path` was undeclared, and an undeclared field that is
+    // not a near miss of a declared one is discarded silently -- so `cwd` fell
+    // back to process.cwd(), which for an MCP server is its own launch
+    // directory. Measured: every "scoped" search actually walked 676,875 files
+    // across the whole home directory, for 65 seconds, and answered about the
+    // wrong tree.
+    //
+    // Assigning it straight to `cwd` then broke the OTHER reading of `path`: a
+    // single FILE became the search root, and the default `['**/*']` cannot
+    // match inside a file, so a file-scoped search reported success with zero
+    // matches. `resolveSearchScope` handles both readings, and reports a path
+    // that does not exist rather than answering zero for it.
     try {
+      const scope = resolveSearchScope(
+        options.path,
+        options.cwd,
+        process.cwd()
+      );
+
+      // Default options
+      const opts: Required<SmartGrepOptions> = {
+        cwd: scope.cwd,
+        path: options.path ?? '',
+        // A caller's explicit `files` wins over the one derived from `path`, so
+        // `path` narrows the scope rather than overriding a stated filter.
+        files: options.files ?? scope.files ?? ['**/*'],
+        caseSensitive: options.caseSensitive ?? false,
+        wholeWord: options.wholeWord ?? false,
+        regex: options.regex ?? false,
+        extensions: options.extensions ?? [],
+        excludeExtensions: options.excludeExtensions ?? [
+          '.min.js',
+          '.map',
+          '.lock',
+        ],
+        skipBinary: options.skipBinary ?? true,
+        ignore: options.ignore ?? [
+          '**/node_modules/**',
+          '**/.git/**',
+          '**/dist/**',
+          '**/build/**',
+        ],
+        includeContext: options.includeContext ?? false,
+        contextBefore: options.contextBefore ?? 0,
+        contextAfter: options.contextAfter ?? 0,
+        includeColumn: options.includeColumn ?? false,
+        maxMatchesPerFile: options.maxMatchesPerFile ?? Infinity,
+        limit: options.limit ?? Infinity,
+        offset: options.offset ?? 0,
+        filesWithMatches: options.filesWithMatches ?? false,
+        count: options.count ?? false,
+        useCache: options.useCache ?? false,
+        ttl: options.ttl ?? 300,
+        maxFileSize: options.maxFileSize ?? 10 * 1024 * 1024, // 10MB default
+        encoding: options.encoding ?? 'utf-8',
+      };
+
       // Check cache first
       const cacheKey = generateCacheKey('grep', {
         pattern,

--- a/src/utils/search-scope.ts
+++ b/src/utils/search-scope.ts
@@ -1,4 +1,5 @@
 import { statSync } from 'fs';
+import { escape } from 'glob';
 import { dirname, basename, isAbsolute, join, resolve, sep } from 'path';
 
 /**
@@ -66,10 +67,14 @@ export function resolveSearchScope(
 
   return {
     cwd: dirname(resolved),
-    // The exact basename, NOT a glob built from the name: `a[0].ts` is a legal
-    // filename and also a glob character class, and the matcher would read the
-    // brackets rather than the name.
-    files: [basename(resolved)],
+    // ESCAPED, because this basename is used as a glob PATTERN, not compared as
+    // a string. `a[0].ts` is a legal filename and also a glob character class,
+    // so the raw name would look for `a0.ts` -- absent -- and produce exactly
+    // the confident zero this helper exists to prevent. An earlier version of
+    // this comment claimed a plain basename avoided glob interpretation, which
+    // was wrong in the one direction that matters: it read as reassurance while
+    // the code did the unsafe thing.
+    files: [escape(basename(resolved))],
     file: resolved,
   };
 }

--- a/src/utils/search-scope.ts
+++ b/src/utils/search-scope.ts
@@ -1,0 +1,102 @@
+import { statSync } from 'fs';
+import { dirname, basename, isAbsolute, join, resolve, sep } from 'path';
+
+/**
+ * Turns a caller's `path` into a search root, for tools that accept either a
+ * directory or a single file there.
+ *
+ * `path` is the one argument every caller passes, because the hook that refuses
+ * the built-in Grep/Glob names these tools as the replacement and "where to
+ * look" is the whole question. It was wired straight into the search root:
+ *
+ *     cwd: options.path ?? options.cwd ?? process.cwd()
+ *
+ * which is right for a directory and silently wrong for a FILE. Both tools then
+ * enumerate with a glob -- `['**\/*']` in grep, the caller's pattern in glob --
+ * and a glob rooted AT a file matches nothing, so a search scoped to one file
+ * answered:
+ *
+ *     { success: true, totalMatches: 0, filesSearched: 0 }
+ *
+ * indistinguishable from "the pattern is not there". A wrong answer that reports
+ * success is worse than an error.
+ */
+export interface SearchScope {
+  /** Directory to search from. */
+  cwd: string;
+  /**
+   * Glob patterns selecting the scoped file, for tools that take a file list.
+   * Null when `path` named a directory or was absent.
+   */
+  files: string[] | null;
+  /**
+   * Absolute path of the scoped file, for tools whose only filter is the
+   * caller's own pattern and which therefore have to filter results instead.
+   */
+  file: string | null;
+}
+
+/**
+ * @throws {Error} when `path` names nothing that exists -- the other way to
+ *   produce a confident zero, and the one a typo produces.
+ */
+export function resolveSearchScope(
+  path: string | undefined,
+  cwd: string | undefined,
+  fallback: string
+): SearchScope {
+  const base = cwd ?? fallback;
+  if (!path) return { cwd: base, files: null, file: null };
+
+  // A relative `path` resolves against the caller's `cwd` when they gave one, so
+  // passing both means what it reads like rather than one silently winning.
+  const resolved = isAbsolute(path) ? path : join(base, path);
+
+  let stats;
+  try {
+    stats = statSync(resolved);
+  } catch {
+    throw new Error(
+      `path does not exist: ${resolved}. Searching it would report zero matches, ` +
+        `which is indistinguishable from the pattern being absent.`
+    );
+  }
+
+  if (stats.isDirectory()) return { cwd: resolved, files: null, file: null };
+
+  return {
+    cwd: dirname(resolved),
+    // The exact basename, NOT a glob built from the name: `a[0].ts` is a legal
+    // filename and also a glob character class, and the matcher would read the
+    // brackets rather than the name.
+    files: [basename(resolved)],
+    file: resolved,
+  };
+}
+
+/**
+ * Path form for comparison. Windows paths are case-insensitive and mix
+ * separators, so `C:\x\y.ts` and `C:/X/y.ts` are one file and must compare equal.
+ */
+function comparable(path: string): string {
+  const normalized = resolve(path).split(/[\\/]/).join(sep);
+  return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
+}
+
+/**
+ * Narrows glob results to the scoped file, or passes them through untouched.
+ *
+ * Basename equality would be wrong: with the parent as the search root, a
+ * `nested/target.ts` shares a basename with `target.ts` and would survive a
+ * filter meant to leave exactly one file. Full resolved paths are compared.
+ */
+export function limitToScopedFile(
+  paths: string[],
+  scope: SearchScope
+): string[] {
+  if (!scope.file) return paths;
+  const target = comparable(scope.file);
+  return paths.filter(
+    (p) => comparable(isAbsolute(p) ? p : join(scope.cwd, p)) === target
+  );
+}

--- a/tests/unit/search-path-accepts-a-file.test.ts
+++ b/tests/unit/search-path-accepts-a-file.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { SmartGrepTool } from '../../src/tools/file-operations/smart-grep.js';
+import { SmartGlobTool } from '../../src/tools/file-operations/smart-glob.js';
+import { CacheEngine } from '../../src/core/cache-engine.js';
+import { TokenCounter } from '../../src/core/token-counter.js';
+import { MetricsCollector } from '../../src/core/metrics.js';
+
+/**
+ * `path` naming a SINGLE FILE must search that file, not silently nothing.
+ *
+ * THE FAILURE THIS ENCODES IS A CONFIDENT ZERO. `path` was wired as the search
+ * root -- `cwd: options.path ?? options.cwd` -- and the file list defaults to
+ * `['**&#47;*']`. Globbing `**&#47;*` with a FILE as the cwd yields nothing, so a
+ * search scoped to one file returned:
+ *
+ *     { success: true, totalMatches: 0, filesSearched: 0 }
+ *
+ * which is indistinguishable from "the pattern is not in that file". Measured
+ * live against hooks-core/wiki.mjs: `path` = the file found 0 hits for a string
+ * on line 112, while the same search via `files: [<same path>]` found it. An
+ * answer that is wrong and reports success is worse than an error, and this is
+ * the third time this tool family has produced one from an argument it accepted
+ * but did not honour (the others: `path` undeclared entirely, and `filePattern`
+ * silently dropped).
+ *
+ * `filesSearched > 0` is asserted alongside the match count, because that field
+ * is the only part of the response that distinguished the bug from an honest
+ * miss.
+ */
+
+let dir: string;
+let cache: CacheEngine;
+let tokenCounter: TokenCounter;
+let metrics: MetricsCollector;
+
+const deps = () => [cache, tokenCounter, metrics] as const;
+
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), 'search-path-file-'));
+  mkdirSync(join(dir, 'nested'));
+  writeFileSync(
+    join(dir, 'target.ts'),
+    'export function findMe() {\n  return 1;\n}\n'
+  );
+  writeFileSync(join(dir, 'nested', 'other.ts'), 'export function findMe() {}\n');
+
+  cache = new CacheEngine(join(dir, 'cache'), 10);
+  tokenCounter = new TokenCounter();
+  metrics = new MetricsCollector();
+});
+
+afterAll(() => {
+  try {
+    cache.close?.();
+  } catch {
+    // A cache that will not close must not fail the suite; the dir goes anyway.
+  }
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('smart_grep path naming a single file', () => {
+  it('searches the file and reports having searched it', async () => {
+    const tool = new SmartGrepTool(...deps());
+
+    const result = await tool.grep('findMe', { path: join(dir, 'target.ts') });
+
+    expect({
+      matches: result.metadata?.totalMatches,
+      searched: result.metadata?.filesSearched,
+    }).toEqual({ matches: 1, searched: 1 });
+  });
+
+  it('scopes to that file alone, not its directory', async () => {
+    // Both fixtures contain `findMe`. A file-scoped search that quietly widened
+    // to the parent directory would be a different wrong answer, so the count
+    // has to prove the scope held.
+    const tool = new SmartGrepTool(...deps());
+
+    const result = await tool.grep('findMe', { path: join(dir, 'target.ts') });
+
+    expect(result.matches?.map((m) => m.lineNumber)).toEqual([1]);
+  });
+
+  it('still walks the tree when path names a directory', async () => {
+    // The existing behaviour, which the fix must not trade away.
+    const tool = new SmartGrepTool(...deps());
+
+    const result = await tool.grep('findMe', { path: dir });
+
+    expect(result.metadata?.totalMatches).toBe(2);
+  });
+
+  it('reports a path that does not exist instead of answering zero', async () => {
+    // A typo'd path is the other way to produce a confident zero, and it is the
+    // one a caller is most likely to hit.
+    const tool = new SmartGrepTool(...deps());
+
+    const result = await tool.grep('findMe', {
+      path: join(dir, 'no-such-file.ts'),
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/does not exist/i);
+  });
+});
+
+describe('smart_glob path naming a single file', () => {
+  it('matches that file rather than returning nothing', async () => {
+    // Same wiring, same defect: `cwd: options.path` with a file cannot match.
+    const tool = new SmartGlobTool(...deps());
+
+    const result = await tool.glob('**/*.ts', { path: join(dir, 'target.ts') });
+
+    expect(result.files?.length).toBe(1);
+  });
+});

--- a/tests/unit/search-path-accepts-a-file.test.ts
+++ b/tests/unit/search-path-accepts-a-file.test.ts
@@ -45,7 +45,10 @@ beforeAll(() => {
     join(dir, 'target.ts'),
     'export function findMe() {\n  return 1;\n}\n'
   );
-  writeFileSync(join(dir, 'nested', 'other.ts'), 'export function findMe() {}\n');
+  writeFileSync(
+    join(dir, 'nested', 'other.ts'),
+    'export function findMe() {}\n'
+  );
 
   cache = new CacheEngine(join(dir, 'cache'), 10);
   tokenCounter = new TokenCounter();
@@ -93,6 +96,25 @@ describe('smart_grep path naming a single file', () => {
     expect(result.metadata?.totalMatches).toBe(2);
   });
 
+  it('finds a file whose name contains glob metacharacters', async () => {
+    // `a[0].ts` is a legal filename AND a glob character class. The scoped file
+    // is selected by feeding its basename to the matcher as a PATTERN, so an
+    // unescaped `[0]` matches the character class -- it would look for `a0.ts`,
+    // which does not exist, and return the same confident zero this whole file
+    // exists to stop. The code comment claimed the basename avoided glob
+    // interpretation; it did not, because a basename IS the pattern here.
+    const tricky = join(dir, 'a[0].ts');
+    writeFileSync(tricky, 'export const findMe = 1;\n');
+    const tool = new SmartGrepTool(...deps());
+
+    const result = await tool.grep('findMe', { path: tricky });
+
+    expect({
+      matches: result.metadata?.totalMatches,
+      searched: result.metadata?.filesSearched,
+    }).toEqual({ matches: 1, searched: 1 });
+  });
+
   it('reports a path that does not exist instead of answering zero', async () => {
     // A typo'd path is the other way to produce a confident zero, and it is the
     // one a caller is most likely to hit.
@@ -115,5 +137,38 @@ describe('smart_glob path naming a single file', () => {
     const result = await tool.glob('**/*.ts', { path: join(dir, 'target.ts') });
 
     expect(result.files?.length).toBe(1);
+  });
+
+  it('does not claim the ignore patterns withheld anything', async () => {
+    // `ignoredMatches` is computed by re-globbing WITHOUT `ignore` and
+    // subtracting. Scoping the first walk to one file while leaving the
+    // comparison walk covering the whole parent made the difference look like
+    // suppressed matches: 2 - 1 = 1, and the response then carried a note
+    // saying 1 file "matched but were excluded by the ignore patterns". Nothing
+    // was excluded -- the caller asked for one file and got it. A number
+    // invented to explain an absence is worse than no number.
+    const tool = new SmartGlobTool(...deps());
+
+    const result = await tool.glob('**/*.ts', { path: join(dir, 'target.ts') });
+
+    expect({
+      ignored: result.metadata?.ignoredMatches ?? 0,
+      note: result.metadata?.ignoreNote,
+    }).toEqual({ ignored: 0, note: undefined });
+  });
+
+  it('still reports what the ignore patterns withheld for a directory', async () => {
+    // The counting must keep working where it is meaningful, or the fix above
+    // would just be a way to silence it.
+    mkdirSync(join(dir, 'node_modules'), { recursive: true });
+    writeFileSync(
+      join(dir, 'node_modules', 'dep.ts'),
+      'export const dep = 1;\n'
+    );
+    const tool = new SmartGlobTool(...deps());
+
+    const result = await tool.glob('**/*.ts', { path: dir });
+
+    expect(result.metadata?.ignoredMatches).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
Found by using the tool, not by reading it.

`smart_grep` scoped to a single file returned a confident zero:

```
{ success: true, totalMatches: 0, filesSearched: 0 }
```

for a string that is on line 112 of that file. The same search expressed as `files: [<same path>]` found it. Nothing in that response distinguishes it from "the pattern is not there", so the tool answered wrongly while reporting success. `smart_glob` had the identical defect — empty list, `success: true`.

## Cause: fixing one reading of `path` broke the other

The earlier fix for `path` being dropped entirely (the 676,875-file bug) wired it straight into the search root:

```ts
cwd: options.path ?? options.cwd ?? process.cwd(),
```

Right for a directory, wrong for a file. Both tools then enumerate with a glob — `['**/*']` in grep, the caller's pattern in glob — and **a glob rooted at a file matches nothing**.

## Fix

`src/utils/search-scope.ts` resolves `path` to a search root plus, when it named a file, the file itself. One helper rather than two copies, because these two tools have now diverged on `path` semantics twice.

Two details handled deliberately, both of which are silent when wrong:

- The file is selected by **exact basename**, not a glob built from the name. `a[0].ts` is a legal filename *and* a glob character class; the matcher would read the brackets rather than the name.
- `smart_glob` has no file-list option, so it filters results by **resolved path**, not basename. With the parent as the root, `nested/target.ts` shares a basename with `target.ts` and would survive a filter meant to leave exactly one file. Windows comparison is case- and separator-insensitive, since `C:\x\y.ts` and `C:/X/y.ts` are one file.

A path that **does not exist** is now reported rather than searched as nothing — the other route to a confident zero, and the one a typo takes. The scope call moved inside each tool's existing `try` so that failure returns the documented `{ success: false, error }` shape instead of throwing out of the tool.

A caller's explicit `files` still wins over the list derived from `path`, so `path` narrows scope rather than overriding a stated filter.

## Verified against the file that exposed it

Using the built output, not inference:

```
file-scoped : { success: true, matches: 1, searched: 1, line: 112 }
dir-scoped  : { matches: 1, searched: 33 }
typo path   : { success: false, error: "path does not exist: ..." }
```

## Tests written first, and mutation-tested

4 of 5 were red before the fix. The fifth — `path` naming a directory — passed, which is the behaviour the fix had to preserve, so it is in the file as a guard rather than as new coverage.

| mutation | result |
|---|---|
| revert the file→parent resolution (the original bug) | 3 of 5 fail |
| drop the not-exists error, answer zero instead | 1 fails |
| make the glob scope filter a pass-through | 1 fails |

`filesSearched` is asserted alongside the match count because it was the only field that distinguished the bug from an honest miss.

## Gates

124 suites, 1,531 passed, 4 skipped. `tsc --noEmit` clean. eslint 0 errors. `prettier --check` clean.

Branched off `master`, independent of #262.