### PR TITLE
feat(hooks): ask the running session to record what it worked out

### DIFF
--- a/hooks-core/adapter.mjs
+++ b/hooks-core/adapter.mjs
@@ -100,7 +100,20 @@ output:
 ${enforcement}
 
 When the context window gets tight, call optimize_session. To report savings,
-call get_optimization_report. Small one-off reads are fine with the built-ins.${projectBriefing()}`;
+call get_optimization_report. Small one-off reads are fine with the built-ins.
+
+## Record what you work out
+
+Call wiki_write when you establish something durable about this project, while
+you still hold the context. Every claim needs at least one anchor -- a real file
+path, or path#symbol -- because an unanchored claim can never be checked against
+the code again and would be served as current forever; unanchored writes are
+refused.
+
+Worth recording: a decision and why the alternative was rejected, a failure and
+what actually caused it, a command that turned out to be the one that works.
+Not worth recording: what the code plainly says. Prefer the thing someone had to
+work out, because that exists nowhere in the source tree.${projectBriefing()}`;
 }
 
 /**

--- a/integrations/codex/hooks/lib/adapter.mjs
+++ b/integrations/codex/hooks/lib/adapter.mjs
@@ -102,7 +102,20 @@ output:
 ${enforcement}
 
 When the context window gets tight, call optimize_session. To report savings,
-call get_optimization_report. Small one-off reads are fine with the built-ins.${projectBriefing()}`;
+call get_optimization_report. Small one-off reads are fine with the built-ins.
+
+## Record what you work out
+
+Call wiki_write when you establish something durable about this project, while
+you still hold the context. Every claim needs at least one anchor -- a real file
+path, or path#symbol -- because an unanchored claim can never be checked against
+the code again and would be served as current forever; unanchored writes are
+refused.
+
+Worth recording: a decision and why the alternative was rejected, a failure and
+what actually caused it, a command that turned out to be the one that works.
+Not worth recording: what the code plainly says. Prefer the thing someone had to
+work out, because that exists nowhere in the source tree.${projectBriefing()}`;
 }
 
 /**

--- a/integrations/codex/plugin/hooks/lib/adapter.mjs
+++ b/integrations/codex/plugin/hooks/lib/adapter.mjs
@@ -102,7 +102,20 @@ output:
 ${enforcement}
 
 When the context window gets tight, call optimize_session. To report savings,
-call get_optimization_report. Small one-off reads are fine with the built-ins.${projectBriefing()}`;
+call get_optimization_report. Small one-off reads are fine with the built-ins.
+
+## Record what you work out
+
+Call wiki_write when you establish something durable about this project, while
+you still hold the context. Every claim needs at least one anchor -- a real file
+path, or path#symbol -- because an unanchored claim can never be checked against
+the code again and would be served as current forever; unanchored writes are
+refused.
+
+Worth recording: a decision and why the alternative was rejected, a failure and
+what actually caused it, a command that turned out to be the one that works.
+Not worth recording: what the code plainly says. Prefer the thing someone had to
+work out, because that exists nowhere in the source tree.${projectBriefing()}`;
 }
 
 /**

--- a/integrations/gemini/hooks/lib/adapter.mjs
+++ b/integrations/gemini/hooks/lib/adapter.mjs
@@ -102,7 +102,20 @@ output:
 ${enforcement}
 
 When the context window gets tight, call optimize_session. To report savings,
-call get_optimization_report. Small one-off reads are fine with the built-ins.${projectBriefing()}`;
+call get_optimization_report. Small one-off reads are fine with the built-ins.
+
+## Record what you work out
+
+Call wiki_write when you establish something durable about this project, while
+you still hold the context. Every claim needs at least one anchor -- a real file
+path, or path#symbol -- because an unanchored claim can never be checked against
+the code again and would be served as current forever; unanchored writes are
+refused.
+
+Worth recording: a decision and why the alternative was rejected, a failure and
+what actually caused it, a command that turned out to be the one that works.
+Not worth recording: what the code plainly says. Prefer the thing someone had to
+work out, because that exists nowhere in the source tree.${projectBriefing()}`;
 }
 
 /**

--- a/integrations/opencode/hooks/lib/adapter.mjs
+++ b/integrations/opencode/hooks/lib/adapter.mjs
@@ -102,7 +102,20 @@ output:
 ${enforcement}
 
 When the context window gets tight, call optimize_session. To report savings,
-call get_optimization_report. Small one-off reads are fine with the built-ins.${projectBriefing()}`;
+call get_optimization_report. Small one-off reads are fine with the built-ins.
+
+## Record what you work out
+
+Call wiki_write when you establish something durable about this project, while
+you still hold the context. Every claim needs at least one anchor -- a real file
+path, or path#symbol -- because an unanchored claim can never be checked against
+the code again and would be served as current forever; unanchored writes are
+refused.
+
+Worth recording: a decision and why the alternative was rejected, a failure and
+what actually caused it, a command that turned out to be the one that works.
+Not worth recording: what the code plainly says. Prefer the thing someone had to
+work out, because that exists nowhere in the source tree.${projectBriefing()}`;
 }
 
 /**

--- a/integrations/qwen/hooks/lib/adapter.mjs
+++ b/integrations/qwen/hooks/lib/adapter.mjs
@@ -102,7 +102,20 @@ output:
 ${enforcement}
 
 When the context window gets tight, call optimize_session. To report savings,
-call get_optimization_report. Small one-off reads are fine with the built-ins.${projectBriefing()}`;
+call get_optimization_report. Small one-off reads are fine with the built-ins.
+
+## Record what you work out
+
+Call wiki_write when you establish something durable about this project, while
+you still hold the context. Every claim needs at least one anchor -- a real file
+path, or path#symbol -- because an unanchored claim can never be checked against
+the code again and would be served as current forever; unanchored writes are
+refused.
+
+Worth recording: a decision and why the alternative was rejected, a failure and
+what actually caused it, a command that turned out to be the one that works.
+Not worth recording: what the code plainly says. Prefer the thing someone had to
+work out, because that exists nowhere in the source tree.${projectBriefing()}`;
 }
 
 /**

--- a/plugin/hooks/lib/adapter.mjs
+++ b/plugin/hooks/lib/adapter.mjs
@@ -102,7 +102,20 @@ output:
 ${enforcement}
 
 When the context window gets tight, call optimize_session. To report savings,
-call get_optimization_report. Small one-off reads are fine with the built-ins.${projectBriefing()}`;
+call get_optimization_report. Small one-off reads are fine with the built-ins.
+
+## Record what you work out
+
+Call wiki_write when you establish something durable about this project, while
+you still hold the context. Every claim needs at least one anchor -- a real file
+path, or path#symbol -- because an unanchored claim can never be checked against
+the code again and would be served as current forever; unanchored writes are
+refused.
+
+Worth recording: a decision and why the alternative was rejected, a failure and
+what actually caused it, a command that turned out to be the one that works.
+Not worth recording: what the code plainly says. Prefer the thing someone had to
+work out, because that exists nowhere in the source tree.${projectBriefing()}`;
 }
 
 /**

--- a/tests/hooks/policy-asks-for-findings.test.mjs
+++ b/tests/hooks/policy-asks-for-findings.test.mjs
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeAll } from '@jest/globals';
+import { pathToFileURL } from 'url';
+import { join } from 'path';
+
+/**
+ * The standing policy must ask the agent to RECORD what it concluded.
+ *
+ * The graph had 851 structural nodes and zero findings on a real project after
+ * days of work. Not because extraction was broken -- `wiki_write` works, and
+ * writes a finding anchored to real file nodes -- but because nothing ever asked
+ * for it. The only other route was `harvest.mjs`, which calls a SEPARATE model
+ * and is therefore opt-in for cost and disclosure reasons, so on a default
+ * install the semantic layer could never fill.
+ *
+ * The session already running is the right extractor: it knows what it
+ * concluded, at no marginal cost, with nothing leaving the machine. The lever
+ * that reaches it is the SessionStart briefing -- the same standing context that
+ * already redirects reads and searches to the smart tools, and demonstrably
+ * changes behaviour for a whole session.
+ *
+ * ANCHORS ARE ASSERTED HERE because an unanchored finding can never go stale, so
+ * it is served as current forever; `wiki_write` refuses one, and a briefing that
+ * omitted the requirement would produce refusals the agent cannot diagnose.
+ */
+
+const ADAPTER = pathToFileURL(
+  join(process.cwd(), 'hooks-core', 'adapter.mjs')
+).href;
+
+let policyText;
+
+beforeAll(async () => {
+  ({ policyText } = await import(ADAPTER));
+});
+
+describe('the standing policy asks for findings', () => {
+  it('names the tool that records them', () => {
+    expect(policyText(true)).toMatch(/wiki_write/);
+  });
+
+  it('states the anchor requirement, which the tool enforces', () => {
+    // Without this the agent learns the rule by having writes refused.
+    expect(policyText(true)).toMatch(/anchor/i);
+  });
+
+  it('says what is worth recording, not merely that recording exists', () => {
+    // "Record findings" is an exhortation. The graph's own extraction prompt is
+    // specific -- what was TRIED AND REJECTED, and why, because that exists
+    // nowhere in the source tree -- and the briefing has to carry that same
+    // specificity or it produces restatements of what the code already says.
+    expect(policyText(true)).toMatch(/rejected|failure|decision/i);
+  });
+
+  it('keeps the briefing in both enforcement modes', () => {
+    // policyText(false) is the advise-only wording used by clients that cannot
+    // deny a tool call. Recording findings is not an enforcement feature, so it
+    // must not disappear along with the denial language.
+    expect(policyText(false)).toMatch(/wiki_write/);
+  });
+});


### PR DESCRIPTION
## The graph fills its skeleton and nothing else

Measured on this project after days of real work:

```
851 nodes -- 1,997 file / 568 task / 2,911 symbol records, 6,516 edges, 0 dangling, 0 unparseable
0 findings.  0 decisions.  0 failures.
```

**Extraction is not broken.** `wiki_write` works — called with two anchors it stored a finding as `origin: agent` and linked it by `derived_from` edges to both real file nodes. Nothing ever asked for it.

The only other route into the semantic layer is `harvest.mjs`, which calls a **separate** model and is therefore gated behind an explicit opt-in for cost and disclosure — correctly, since an ambient `ANTHROPIC_API_KEY` is not consent. So on a default install the semantic layer could not fill by *any* path, and every feature that reads it (injection, staleness, the zero-turn refusal, consolidation) was fed by a producer that never ran.

## The session already running is the right extractor

It knows what it concluded, at no marginal cost, with nothing leaving the machine: no second model, no digest sent anywhere, no key. The lever that reaches it is the SessionStart briefing — the same standing context that already redirects reads and searches to the smart tools, and which demonstrably changes behaviour for an entire session.

The wording is deliberately specific. "Record findings" is an exhortation; the harvest's own prompt asks for *what was tried and rejected, and why*, because that exists nowhere in the source tree. The briefing carries the same bar, including an explicit **not worth recording: what the code plainly says**.

The anchor requirement is stated because `wiki_write` **refuses** an unanchored claim — it could never be checked against the code again, so it would be served as current forever. An agent that has not been told learns this by having writes rejected.

## Verified working, not assumed

Recorded a real finding from this session through the tool, then read the store back:

```
finding:6f87819650135319  origin=agent  confidence=0.95
  derived_from -> file:9fca27dc9428b2a5  src/utils/search-scope.ts      (node exists)
  derived_from -> file:6cf80aa7fa6b7a3f  src/tools/file-operations/smart-grep.ts  (node exists)
```

The loop then closed on its own: that finding was injected back into a later turn of the same session by the PreToolUse hook, unprompted.

## Cost

~202 tokens once per session, on a briefing that was ~243.

## Generated copies

Six vendored `adapter.mjs` copies had to be regenerated — `sync:hooks:check` caught the drift before I ran it, which is the gate doing its job.

## Gates

126 suites, 1,544 passed, 4 skipped. `tsc --noEmit` clean. eslint 0 errors. `prettier --check` clean. `sync:hooks:check` clean.

Branched off `master`, independent of #262 and #263.