### PR TITLE
fix(hooks): a path must not be able to abort the hook process

### DIFF
--- a/hooks-core/decide.mjs
+++ b/hooks-core/decide.mjs
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * The routing decision, as a pure function.
  *
  * Deliberately free of process, stdin, and exit codes so it can be unit tested
@@ -13,7 +13,7 @@
 
 import { fileSize, isBinaryPath, isMachineOwned, largeFileBytes, refusalFloorBytes } from './policy.mjs';
 import { statSync } from 'node:fs';
-import { canonicalPath, resolvableCandidates } from './paths.mjs';
+import { canonicalPath, resolvableCandidates, isFsSafePath } from './paths.mjs';
 import { activeRules } from './remedy.mjs';
 import { wikiDir } from './wiki.mjs';
 
@@ -267,6 +267,11 @@ export function touchedFiles(payload) {
   const add = (candidate) => {
     if (!candidate || typeof candidate !== 'string') return;
     for (const spelling of resolvableCandidates(candidate, cwd)) {
+      // Sizing a candidate stats it, and a path carrying U+10FFFF aborts libuv
+      // outright rather than throwing. This is where externally supplied paths
+      // first enter the hook, so refusing here keeps the character away from
+      // every downstream consumer instead of asking each one to defend itself.
+      if (!isFsSafePath(spelling)) continue;
       const size = fileSize(spelling);
       if (size >= 0) {
         // Nothing under .git/, node_modules/ or a build directory belongs in a

--- a/hooks-core/decide.mjs
+++ b/hooks-core/decide.mjs
@@ -21,6 +21,9 @@ const KB = (bytes) => Math.round(bytes / 1024);
 
 /** Whether a path names an existing directory. Never throws. */
 function isDirectory(path) {
+  // See fileSize: a native abort is not catchable, so the check precedes the
+  // stat rather than relying on the try below.
+  if (!isFsSafePath(path)) return false;
   try {
     return statSync(path).isDirectory();
   } catch {
@@ -262,6 +265,11 @@ export function touchedFiles(payload) {
   // every relative operand onto a path resolving to nothing, so the call records
   // no touch at all. Falling back to the session cwd is strictly better than
   // losing the observation.
+  // `isDirectory` is a statSync, and it runs ahead of the per-candidate check
+  // below -- so guarding only the candidates left the abort reachable through
+  // any command beginning `cd <bad path> && ...`. The guard lives INSIDE
+  // isDirectory rather than here: a second check at this call site would mask
+  // the removal of the real one, and a mutation proved exactly that.
   const cwd = cdTarget && isDirectory(cdTarget) ? cdTarget : payload?.cwd;
 
   const add = (candidate) => {

--- a/hooks-core/paths.mjs
+++ b/hooks-core/paths.mjs
@@ -154,6 +154,37 @@ function normaliseOnce(input, cwd) {
  * form depends on how many times it has been canonicalised gives one file two
  * graph nodes, with findings anchored under one invisible from the other.
  */
+/**
+ * True unless handing this path to the filesystem would ABORT the process.
+ *
+ * U+10FFFF is the largest legal Unicode code point, and libuv asserts
+ * `code_point < 0x10FFFF` -- strictly less than -- while converting a UTF-8 path
+ * to UTF-16 on Windows:
+ *
+ *     Assertion failed: code_point < 0x10FFFF, file deps\uv\src\idna.c, line 397
+ *
+ * The assert is off by one, so `existsSync`, `statSync` and `readFileSync` all
+ * kill the process rather than throwing. That is categorically worse than an
+ * exception here: the hook is wrapped whole in a try/catch on the promise that
+ * "any defect in this hook must cost the user nothing", and a native abort walks
+ * straight through it, so the hook's one guarantee about its own failures does
+ * not hold. A path is checked BEFORE it reaches the filesystem because there is
+ * nothing to catch afterwards.
+ *
+ * Deliberately narrow. U+10FFFD and U+10FFFE were measured and are handled
+ * correctly, so only the character that actually aborts is refused -- a broader
+ * filter would silently drop paths that work.
+ */
+export function isFsSafePath(input) {
+  if (typeof input !== 'string') return false;
+  // Iterates code POINTS, so the surrogate pair for U+10FFFF is seen as one
+  // character rather than two unremarkable halves.
+  for (const character of input) {
+    if (character.codePointAt(0) === 0x10ffff) return false;
+  }
+  return true;
+}
+
 export function canonicalPath(input, cwd) {
   let path = normaliseOnce(input, cwd);
   for (let i = 0; i < 8; i++) {

--- a/hooks-core/policy.mjs
+++ b/hooks-core/policy.mjs
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Shared policy for the token-optimizer Claude Code hooks.
  *
  * WHY THIS EXISTS: before this module, installing the plugin registered exactly
@@ -35,6 +35,7 @@
 import { statSync, mkdirSync, readFileSync, writeFileSync, renameSync, openSync, closeSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { isFsSafePath } from './paths.mjs';
 
 /** Enforcement modes, least to most permissive. */
 export const MODE_ENFORCE = 'enforce';
@@ -159,6 +160,11 @@ export function isMachineOwned(path) {
 
 /** Size in bytes, or -1 when the path is missing or is not a regular file. */
 export function fileSize(path) {
+  // A path carrying U+10FFFF aborts libuv instead of throwing, so the catch
+  // below cannot help. Checked here rather than at each call site: this is
+  // exported and widely used, and review already found one caller that stat-ed
+  // an unguarded path ahead of a call-site check.
+  if (!isFsSafePath(path)) return -1;
   try {
     const st = statSync(path);
     return st.isFile() ? st.size : -1;

--- a/hooks-core/staleness.mjs
+++ b/hooks-core/staleness.mjs
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * P2: staleness, snapshots, and the invalidating diff.
  *
  * THE LOAD-BEARING RULE, from docs/WIKI_GRAPH.md: a stale finding is SERVED,
@@ -30,10 +30,13 @@ import { createHash } from 'node:crypto';
 import { dirname, join } from 'node:path';
 import { putNode, putEdge, contentHash, nodeId } from './wiki.mjs';
 import { extractSymbols, spanText, symbolKey, extractImports } from './symbols.mjs';
-import { canonicalPath, resolvableCandidates } from './paths.mjs';
+import { canonicalPath, resolvableCandidates, isFsSafePath } from './paths.mjs';
 
 /** Reads a path in whichever spelling resolves, or throws if none do. */
 function readAnySpelling(path) {
+  // Unreadable is already this function's failure mode; an unsafe path takes
+  // the same route instead of killing the process.
+  if (!isFsSafePath(path)) throw new Error('unreadable');
   let last;
   for (const candidate of resolvableCandidates(path)) {
     try {
@@ -92,6 +95,10 @@ function symbolSnapshotLimit() {
  * function is orders of magnitude smaller than the file containing it.
  */
 export function indexFile(dir, rawPath, text) {
+  // This reads rawPath through its own loop rather than readAnySpelling, so it
+  // needs the same guard: an unsafe path aborts libuv instead of throwing, and
+  // the per-candidate try/catch below cannot catch that.
+  if (!isFsSafePath(rawPath)) return null;
   // The graph KEY is canonical, so one file is one node however it was spelled.
   // Reading still tries the spellings that actually resolve on this host.
   const path = canonicalPath(rawPath);
@@ -180,6 +187,9 @@ const IMPORT_SUFFIXES = [
  * that question without taking on a module-resolution dependency.
  */
 function resolveImport(base, specifier) {
+  // Import specifiers come from file contents, so they are external input
+  // reaching statSync below.
+  if (!isFsSafePath(base) || !isFsSafePath(specifier)) return null;
   // TypeScript sources routinely import `./x.js` and mean `./x.ts`; trying the
   // stripped stem covers it without special-casing the whole ESM/TS story.
   const stems = [specifier, specifier.replace(/\.(js|mjs|cjs)$/, '')];

--- a/hooks-core/wiki.mjs
+++ b/hooks-core/wiki.mjs
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * The wiki graph store. Phase 1: skeleton, structural only.
  *
  * See docs/WIKI_GRAPH.md for the design. This file is the persistence layer and
@@ -20,7 +20,7 @@ import {
 } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { createHash } from 'node:crypto';
-import { canonicalPath } from './paths.mjs';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
 
 /**
  * Schema version stamped on every record.
@@ -71,6 +71,10 @@ export function wikiDir(cwd) {
  * file is not inside one, which is the honest answer for a scratch file.
  */
 export function projectRootFor(filePath, fallback) {
+  // This walks UP the path calling existsSync at every level, so one character
+  // that aborts libuv would do it up to forty times over. Refused before the
+  // first stat rather than defended at each one.
+  if (!isFsSafePath(filePath)) return fallback ? canonicalPath(fallback) : null;
   // VCS markers ONLY, and the whole tree is walked before falling back.
   //
   // `package.json` was in this list and it is the wrong marker: in a monorepo
@@ -141,6 +145,10 @@ export function canonicalKey(kind, key) {
  * an allowed tool call, so one avoidable read per file is one too many.
  */
 export function contentHash(path, text) {
+  // Checked BEFORE the read, because an unsafe path aborts the process instead
+  // of throwing and there would be nothing for the catch below to handle.
+  // `text` supplied means no read happens, so the path is only a key then.
+  if (text === undefined && !isFsSafePath(path)) return null;
   try {
     return createHash('sha256')
       .update(text === undefined ? readFileSync(path) : text)

--- a/integrations/codex/hooks/lib/decide.mjs
+++ b/integrations/codex/hooks/lib/decide.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/decide.mjs. Regenerate with `npm run sync:hooks`.
-/**
+﻿/**
  * The routing decision, as a pure function.
  *
  * Deliberately free of process, stdin, and exit codes so it can be unit tested
@@ -15,7 +15,7 @@
 
 import { fileSize, isBinaryPath, isMachineOwned, largeFileBytes, refusalFloorBytes } from './policy.mjs';
 import { statSync } from 'node:fs';
-import { canonicalPath, resolvableCandidates } from './paths.mjs';
+import { canonicalPath, resolvableCandidates, isFsSafePath } from './paths.mjs';
 import { activeRules } from './remedy.mjs';
 import { wikiDir } from './wiki.mjs';
 
@@ -269,6 +269,11 @@ export function touchedFiles(payload) {
   const add = (candidate) => {
     if (!candidate || typeof candidate !== 'string') return;
     for (const spelling of resolvableCandidates(candidate, cwd)) {
+      // Sizing a candidate stats it, and a path carrying U+10FFFF aborts libuv
+      // outright rather than throwing. This is where externally supplied paths
+      // first enter the hook, so refusing here keeps the character away from
+      // every downstream consumer instead of asking each one to defend itself.
+      if (!isFsSafePath(spelling)) continue;
       const size = fileSize(spelling);
       if (size >= 0) {
         // Nothing under .git/, node_modules/ or a build directory belongs in a

--- a/integrations/codex/hooks/lib/decide.mjs
+++ b/integrations/codex/hooks/lib/decide.mjs
@@ -23,6 +23,9 @@ const KB = (bytes) => Math.round(bytes / 1024);
 
 /** Whether a path names an existing directory. Never throws. */
 function isDirectory(path) {
+  // See fileSize: a native abort is not catchable, so the check precedes the
+  // stat rather than relying on the try below.
+  if (!isFsSafePath(path)) return false;
   try {
     return statSync(path).isDirectory();
   } catch {
@@ -264,6 +267,11 @@ export function touchedFiles(payload) {
   // every relative operand onto a path resolving to nothing, so the call records
   // no touch at all. Falling back to the session cwd is strictly better than
   // losing the observation.
+  // `isDirectory` is a statSync, and it runs ahead of the per-candidate check
+  // below -- so guarding only the candidates left the abort reachable through
+  // any command beginning `cd <bad path> && ...`. The guard lives INSIDE
+  // isDirectory rather than here: a second check at this call site would mask
+  // the removal of the real one, and a mutation proved exactly that.
   const cwd = cdTarget && isDirectory(cdTarget) ? cdTarget : payload?.cwd;
 
   const add = (candidate) => {

--- a/integrations/codex/hooks/lib/paths.mjs
+++ b/integrations/codex/hooks/lib/paths.mjs
@@ -156,6 +156,37 @@ function normaliseOnce(input, cwd) {
  * form depends on how many times it has been canonicalised gives one file two
  * graph nodes, with findings anchored under one invisible from the other.
  */
+/**
+ * True unless handing this path to the filesystem would ABORT the process.
+ *
+ * U+10FFFF is the largest legal Unicode code point, and libuv asserts
+ * `code_point < 0x10FFFF` -- strictly less than -- while converting a UTF-8 path
+ * to UTF-16 on Windows:
+ *
+ *     Assertion failed: code_point < 0x10FFFF, file deps\uv\src\idna.c, line 397
+ *
+ * The assert is off by one, so `existsSync`, `statSync` and `readFileSync` all
+ * kill the process rather than throwing. That is categorically worse than an
+ * exception here: the hook is wrapped whole in a try/catch on the promise that
+ * "any defect in this hook must cost the user nothing", and a native abort walks
+ * straight through it, so the hook's one guarantee about its own failures does
+ * not hold. A path is checked BEFORE it reaches the filesystem because there is
+ * nothing to catch afterwards.
+ *
+ * Deliberately narrow. U+10FFFD and U+10FFFE were measured and are handled
+ * correctly, so only the character that actually aborts is refused -- a broader
+ * filter would silently drop paths that work.
+ */
+export function isFsSafePath(input) {
+  if (typeof input !== 'string') return false;
+  // Iterates code POINTS, so the surrogate pair for U+10FFFF is seen as one
+  // character rather than two unremarkable halves.
+  for (const character of input) {
+    if (character.codePointAt(0) === 0x10ffff) return false;
+  }
+  return true;
+}
+
 export function canonicalPath(input, cwd) {
   let path = normaliseOnce(input, cwd);
   for (let i = 0; i < 8; i++) {

--- a/integrations/codex/hooks/lib/policy.mjs
+++ b/integrations/codex/hooks/lib/policy.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/policy.mjs. Regenerate with `npm run sync:hooks`.
-/**
+﻿/**
  * Shared policy for the token-optimizer Claude Code hooks.
  *
  * WHY THIS EXISTS: before this module, installing the plugin registered exactly
@@ -37,6 +37,7 @@
 import { statSync, mkdirSync, readFileSync, writeFileSync, renameSync, openSync, closeSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { isFsSafePath } from './paths.mjs';
 
 /** Enforcement modes, least to most permissive. */
 export const MODE_ENFORCE = 'enforce';
@@ -161,6 +162,11 @@ export function isMachineOwned(path) {
 
 /** Size in bytes, or -1 when the path is missing or is not a regular file. */
 export function fileSize(path) {
+  // A path carrying U+10FFFF aborts libuv instead of throwing, so the catch
+  // below cannot help. Checked here rather than at each call site: this is
+  // exported and widely used, and review already found one caller that stat-ed
+  // an unguarded path ahead of a call-site check.
+  if (!isFsSafePath(path)) return -1;
   try {
     const st = statSync(path);
     return st.isFile() ? st.size : -1;

--- a/integrations/codex/hooks/lib/staleness.mjs
+++ b/integrations/codex/hooks/lib/staleness.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/staleness.mjs. Regenerate with `npm run sync:hooks`.
-/**
+﻿/**
  * P2: staleness, snapshots, and the invalidating diff.
  *
  * THE LOAD-BEARING RULE, from docs/WIKI_GRAPH.md: a stale finding is SERVED,
@@ -32,10 +32,13 @@ import { createHash } from 'node:crypto';
 import { dirname, join } from 'node:path';
 import { putNode, putEdge, contentHash, nodeId } from './wiki.mjs';
 import { extractSymbols, spanText, symbolKey, extractImports } from './symbols.mjs';
-import { canonicalPath, resolvableCandidates } from './paths.mjs';
+import { canonicalPath, resolvableCandidates, isFsSafePath } from './paths.mjs';
 
 /** Reads a path in whichever spelling resolves, or throws if none do. */
 function readAnySpelling(path) {
+  // Unreadable is already this function's failure mode; an unsafe path takes
+  // the same route instead of killing the process.
+  if (!isFsSafePath(path)) throw new Error('unreadable');
   let last;
   for (const candidate of resolvableCandidates(path)) {
     try {
@@ -94,6 +97,10 @@ function symbolSnapshotLimit() {
  * function is orders of magnitude smaller than the file containing it.
  */
 export function indexFile(dir, rawPath, text) {
+  // This reads rawPath through its own loop rather than readAnySpelling, so it
+  // needs the same guard: an unsafe path aborts libuv instead of throwing, and
+  // the per-candidate try/catch below cannot catch that.
+  if (!isFsSafePath(rawPath)) return null;
   // The graph KEY is canonical, so one file is one node however it was spelled.
   // Reading still tries the spellings that actually resolve on this host.
   const path = canonicalPath(rawPath);
@@ -182,6 +189,9 @@ const IMPORT_SUFFIXES = [
  * that question without taking on a module-resolution dependency.
  */
 function resolveImport(base, specifier) {
+  // Import specifiers come from file contents, so they are external input
+  // reaching statSync below.
+  if (!isFsSafePath(base) || !isFsSafePath(specifier)) return null;
   // TypeScript sources routinely import `./x.js` and mean `./x.ts`; trying the
   // stripped stem covers it without special-casing the whole ESM/TS story.
   const stems = [specifier, specifier.replace(/\.(js|mjs|cjs)$/, '')];

--- a/integrations/codex/hooks/lib/wiki.mjs
+++ b/integrations/codex/hooks/lib/wiki.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/wiki.mjs. Regenerate with `npm run sync:hooks`.
-/**
+﻿/**
  * The wiki graph store. Phase 1: skeleton, structural only.
  *
  * See docs/WIKI_GRAPH.md for the design. This file is the persistence layer and
@@ -22,7 +22,7 @@ import {
 } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { createHash } from 'node:crypto';
-import { canonicalPath } from './paths.mjs';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
 
 /**
  * Schema version stamped on every record.
@@ -73,6 +73,10 @@ export function wikiDir(cwd) {
  * file is not inside one, which is the honest answer for a scratch file.
  */
 export function projectRootFor(filePath, fallback) {
+  // This walks UP the path calling existsSync at every level, so one character
+  // that aborts libuv would do it up to forty times over. Refused before the
+  // first stat rather than defended at each one.
+  if (!isFsSafePath(filePath)) return fallback ? canonicalPath(fallback) : null;
   // VCS markers ONLY, and the whole tree is walked before falling back.
   //
   // `package.json` was in this list and it is the wrong marker: in a monorepo
@@ -143,6 +147,10 @@ export function canonicalKey(kind, key) {
  * an allowed tool call, so one avoidable read per file is one too many.
  */
 export function contentHash(path, text) {
+  // Checked BEFORE the read, because an unsafe path aborts the process instead
+  // of throwing and there would be nothing for the catch below to handle.
+  // `text` supplied means no read happens, so the path is only a key then.
+  if (text === undefined && !isFsSafePath(path)) return null;
   try {
     return createHash('sha256')
       .update(text === undefined ? readFileSync(path) : text)

--- a/integrations/codex/plugin/hooks/lib/decide.mjs
+++ b/integrations/codex/plugin/hooks/lib/decide.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/decide.mjs. Regenerate with `npm run sync:hooks`.
-/**
+﻿/**
  * The routing decision, as a pure function.
  *
  * Deliberately free of process, stdin, and exit codes so it can be unit tested
@@ -15,7 +15,7 @@
 
 import { fileSize, isBinaryPath, isMachineOwned, largeFileBytes, refusalFloorBytes } from './policy.mjs';
 import { statSync } from 'node:fs';
-import { canonicalPath, resolvableCandidates } from './paths.mjs';
+import { canonicalPath, resolvableCandidates, isFsSafePath } from './paths.mjs';
 import { activeRules } from './remedy.mjs';
 import { wikiDir } from './wiki.mjs';
 
@@ -269,6 +269,11 @@ export function touchedFiles(payload) {
   const add = (candidate) => {
     if (!candidate || typeof candidate !== 'string') return;
     for (const spelling of resolvableCandidates(candidate, cwd)) {
+      // Sizing a candidate stats it, and a path carrying U+10FFFF aborts libuv
+      // outright rather than throwing. This is where externally supplied paths
+      // first enter the hook, so refusing here keeps the character away from
+      // every downstream consumer instead of asking each one to defend itself.
+      if (!isFsSafePath(spelling)) continue;
       const size = fileSize(spelling);
       if (size >= 0) {
         // Nothing under .git/, node_modules/ or a build directory belongs in a

--- a/integrations/codex/plugin/hooks/lib/decide.mjs
+++ b/integrations/codex/plugin/hooks/lib/decide.mjs
@@ -23,6 +23,9 @@ const KB = (bytes) => Math.round(bytes / 1024);
 
 /** Whether a path names an existing directory. Never throws. */
 function isDirectory(path) {
+  // See fileSize: a native abort is not catchable, so the check precedes the
+  // stat rather than relying on the try below.
+  if (!isFsSafePath(path)) return false;
   try {
     return statSync(path).isDirectory();
   } catch {
@@ -264,6 +267,11 @@ export function touchedFiles(payload) {
   // every relative operand onto a path resolving to nothing, so the call records
   // no touch at all. Falling back to the session cwd is strictly better than
   // losing the observation.
+  // `isDirectory` is a statSync, and it runs ahead of the per-candidate check
+  // below -- so guarding only the candidates left the abort reachable through
+  // any command beginning `cd <bad path> && ...`. The guard lives INSIDE
+  // isDirectory rather than here: a second check at this call site would mask
+  // the removal of the real one, and a mutation proved exactly that.
   const cwd = cdTarget && isDirectory(cdTarget) ? cdTarget : payload?.cwd;
 
   const add = (candidate) => {

--- a/integrations/codex/plugin/hooks/lib/paths.mjs
+++ b/integrations/codex/plugin/hooks/lib/paths.mjs
@@ -156,6 +156,37 @@ function normaliseOnce(input, cwd) {
  * form depends on how many times it has been canonicalised gives one file two
  * graph nodes, with findings anchored under one invisible from the other.
  */
+/**
+ * True unless handing this path to the filesystem would ABORT the process.
+ *
+ * U+10FFFF is the largest legal Unicode code point, and libuv asserts
+ * `code_point < 0x10FFFF` -- strictly less than -- while converting a UTF-8 path
+ * to UTF-16 on Windows:
+ *
+ *     Assertion failed: code_point < 0x10FFFF, file deps\uv\src\idna.c, line 397
+ *
+ * The assert is off by one, so `existsSync`, `statSync` and `readFileSync` all
+ * kill the process rather than throwing. That is categorically worse than an
+ * exception here: the hook is wrapped whole in a try/catch on the promise that
+ * "any defect in this hook must cost the user nothing", and a native abort walks
+ * straight through it, so the hook's one guarantee about its own failures does
+ * not hold. A path is checked BEFORE it reaches the filesystem because there is
+ * nothing to catch afterwards.
+ *
+ * Deliberately narrow. U+10FFFD and U+10FFFE were measured and are handled
+ * correctly, so only the character that actually aborts is refused -- a broader
+ * filter would silently drop paths that work.
+ */
+export function isFsSafePath(input) {
+  if (typeof input !== 'string') return false;
+  // Iterates code POINTS, so the surrogate pair for U+10FFFF is seen as one
+  // character rather than two unremarkable halves.
+  for (const character of input) {
+    if (character.codePointAt(0) === 0x10ffff) return false;
+  }
+  return true;
+}
+
 export function canonicalPath(input, cwd) {
   let path = normaliseOnce(input, cwd);
   for (let i = 0; i < 8; i++) {

--- a/integrations/codex/plugin/hooks/lib/policy.mjs
+++ b/integrations/codex/plugin/hooks/lib/policy.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/policy.mjs. Regenerate with `npm run sync:hooks`.
-/**
+﻿/**
  * Shared policy for the token-optimizer Claude Code hooks.
  *
  * WHY THIS EXISTS: before this module, installing the plugin registered exactly
@@ -37,6 +37,7 @@
 import { statSync, mkdirSync, readFileSync, writeFileSync, renameSync, openSync, closeSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { isFsSafePath } from './paths.mjs';
 
 /** Enforcement modes, least to most permissive. */
 export const MODE_ENFORCE = 'enforce';
@@ -161,6 +162,11 @@ export function isMachineOwned(path) {
 
 /** Size in bytes, or -1 when the path is missing or is not a regular file. */
 export function fileSize(path) {
+  // A path carrying U+10FFFF aborts libuv instead of throwing, so the catch
+  // below cannot help. Checked here rather than at each call site: this is
+  // exported and widely used, and review already found one caller that stat-ed
+  // an unguarded path ahead of a call-site check.
+  if (!isFsSafePath(path)) return -1;
   try {
     const st = statSync(path);
     return st.isFile() ? st.size : -1;

--- a/integrations/codex/plugin/hooks/lib/staleness.mjs
+++ b/integrations/codex/plugin/hooks/lib/staleness.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/staleness.mjs. Regenerate with `npm run sync:hooks`.
-/**
+﻿/**
  * P2: staleness, snapshots, and the invalidating diff.
  *
  * THE LOAD-BEARING RULE, from docs/WIKI_GRAPH.md: a stale finding is SERVED,
@@ -32,10 +32,13 @@ import { createHash } from 'node:crypto';
 import { dirname, join } from 'node:path';
 import { putNode, putEdge, contentHash, nodeId } from './wiki.mjs';
 import { extractSymbols, spanText, symbolKey, extractImports } from './symbols.mjs';
-import { canonicalPath, resolvableCandidates } from './paths.mjs';
+import { canonicalPath, resolvableCandidates, isFsSafePath } from './paths.mjs';
 
 /** Reads a path in whichever spelling resolves, or throws if none do. */
 function readAnySpelling(path) {
+  // Unreadable is already this function's failure mode; an unsafe path takes
+  // the same route instead of killing the process.
+  if (!isFsSafePath(path)) throw new Error('unreadable');
   let last;
   for (const candidate of resolvableCandidates(path)) {
     try {
@@ -94,6 +97,10 @@ function symbolSnapshotLimit() {
  * function is orders of magnitude smaller than the file containing it.
  */
 export function indexFile(dir, rawPath, text) {
+  // This reads rawPath through its own loop rather than readAnySpelling, so it
+  // needs the same guard: an unsafe path aborts libuv instead of throwing, and
+  // the per-candidate try/catch below cannot catch that.
+  if (!isFsSafePath(rawPath)) return null;
   // The graph KEY is canonical, so one file is one node however it was spelled.
   // Reading still tries the spellings that actually resolve on this host.
   const path = canonicalPath(rawPath);
@@ -182,6 +189,9 @@ const IMPORT_SUFFIXES = [
  * that question without taking on a module-resolution dependency.
  */
 function resolveImport(base, specifier) {
+  // Import specifiers come from file contents, so they are external input
+  // reaching statSync below.
+  if (!isFsSafePath(base) || !isFsSafePath(specifier)) return null;
   // TypeScript sources routinely import `./x.js` and mean `./x.ts`; trying the
   // stripped stem covers it without special-casing the whole ESM/TS story.
   const stems = [specifier, specifier.replace(/\.(js|mjs|cjs)$/, '')];

--- a/integrations/codex/plugin/hooks/lib/wiki.mjs
+++ b/integrations/codex/plugin/hooks/lib/wiki.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/wiki.mjs. Regenerate with `npm run sync:hooks`.
-/**
+﻿/**
  * The wiki graph store. Phase 1: skeleton, structural only.
  *
  * See docs/WIKI_GRAPH.md for the design. This file is the persistence layer and
@@ -22,7 +22,7 @@ import {
 } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { createHash } from 'node:crypto';
-import { canonicalPath } from './paths.mjs';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
 
 /**
  * Schema version stamped on every record.
@@ -73,6 +73,10 @@ export function wikiDir(cwd) {
  * file is not inside one, which is the honest answer for a scratch file.
  */
 export function projectRootFor(filePath, fallback) {
+  // This walks UP the path calling existsSync at every level, so one character
+  // that aborts libuv would do it up to forty times over. Refused before the
+  // first stat rather than defended at each one.
+  if (!isFsSafePath(filePath)) return fallback ? canonicalPath(fallback) : null;
   // VCS markers ONLY, and the whole tree is walked before falling back.
   //
   // `package.json` was in this list and it is the wrong marker: in a monorepo
@@ -143,6 +147,10 @@ export function canonicalKey(kind, key) {
  * an allowed tool call, so one avoidable read per file is one too many.
  */
 export function contentHash(path, text) {
+  // Checked BEFORE the read, because an unsafe path aborts the process instead
+  // of throwing and there would be nothing for the catch below to handle.
+  // `text` supplied means no read happens, so the path is only a key then.
+  if (text === undefined && !isFsSafePath(path)) return null;
   try {
     return createHash('sha256')
       .update(text === undefined ? readFileSync(path) : text)

--- a/integrations/gemini/hooks/lib/decide.mjs
+++ b/integrations/gemini/hooks/lib/decide.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/decide.mjs. Regenerate with `npm run sync:hooks`.
-/**
+﻿/**
  * The routing decision, as a pure function.
  *
  * Deliberately free of process, stdin, and exit codes so it can be unit tested
@@ -15,7 +15,7 @@
 
 import { fileSize, isBinaryPath, isMachineOwned, largeFileBytes, refusalFloorBytes } from './policy.mjs';
 import { statSync } from 'node:fs';
-import { canonicalPath, resolvableCandidates } from './paths.mjs';
+import { canonicalPath, resolvableCandidates, isFsSafePath } from './paths.mjs';
 import { activeRules } from './remedy.mjs';
 import { wikiDir } from './wiki.mjs';
 
@@ -269,6 +269,11 @@ export function touchedFiles(payload) {
   const add = (candidate) => {
     if (!candidate || typeof candidate !== 'string') return;
     for (const spelling of resolvableCandidates(candidate, cwd)) {
+      // Sizing a candidate stats it, and a path carrying U+10FFFF aborts libuv
+      // outright rather than throwing. This is where externally supplied paths
+      // first enter the hook, so refusing here keeps the character away from
+      // every downstream consumer instead of asking each one to defend itself.
+      if (!isFsSafePath(spelling)) continue;
       const size = fileSize(spelling);
       if (size >= 0) {
         // Nothing under .git/, node_modules/ or a build directory belongs in a

--- a/integrations/gemini/hooks/lib/decide.mjs
+++ b/integrations/gemini/hooks/lib/decide.mjs
@@ -23,6 +23,9 @@ const KB = (bytes) => Math.round(bytes / 1024);
 
 /** Whether a path names an existing directory. Never throws. */
 function isDirectory(path) {
+  // See fileSize: a native abort is not catchable, so the check precedes the
+  // stat rather than relying on the try below.
+  if (!isFsSafePath(path)) return false;
   try {
     return statSync(path).isDirectory();
   } catch {
@@ -264,6 +267,11 @@ export function touchedFiles(payload) {
   // every relative operand onto a path resolving to nothing, so the call records
   // no touch at all. Falling back to the session cwd is strictly better than
   // losing the observation.
+  // `isDirectory` is a statSync, and it runs ahead of the per-candidate check
+  // below -- so guarding only the candidates left the abort reachable through
+  // any command beginning `cd <bad path> && ...`. The guard lives INSIDE
+  // isDirectory rather than here: a second check at this call site would mask
+  // the removal of the real one, and a mutation proved exactly that.
   const cwd = cdTarget && isDirectory(cdTarget) ? cdTarget : payload?.cwd;
 
   const add = (candidate) => {

--- a/integrations/gemini/hooks/lib/paths.mjs
+++ b/integrations/gemini/hooks/lib/paths.mjs
@@ -156,6 +156,37 @@ function normaliseOnce(input, cwd) {
  * form depends on how many times it has been canonicalised gives one file two
  * graph nodes, with findings anchored under one invisible from the other.
  */
+/**
+ * True unless handing this path to the filesystem would ABORT the process.
+ *
+ * U+10FFFF is the largest legal Unicode code point, and libuv asserts
+ * `code_point < 0x10FFFF` -- strictly less than -- while converting a UTF-8 path
+ * to UTF-16 on Windows:
+ *
+ *     Assertion failed: code_point < 0x10FFFF, file deps\uv\src\idna.c, line 397
+ *
+ * The assert is off by one, so `existsSync`, `statSync` and `readFileSync` all
+ * kill the process rather than throwing. That is categorically worse than an
+ * exception here: the hook is wrapped whole in a try/catch on the promise that
+ * "any defect in this hook must cost the user nothing", and a native abort walks
+ * straight through it, so the hook's one guarantee about its own failures does
+ * not hold. A path is checked BEFORE it reaches the filesystem because there is
+ * nothing to catch afterwards.
+ *
+ * Deliberately narrow. U+10FFFD and U+10FFFE were measured and are handled
+ * correctly, so only the character that actually aborts is refused -- a broader
+ * filter would silently drop paths that work.
+ */
+export function isFsSafePath(input) {
+  if (typeof input !== 'string') return false;
+  // Iterates code POINTS, so the surrogate pair for U+10FFFF is seen as one
+  // character rather than two unremarkable halves.
+  for (const character of input) {
+    if (character.codePointAt(0) === 0x10ffff) return false;
+  }
+  return true;
+}
+
 export function canonicalPath(input, cwd) {
   let path = normaliseOnce(input, cwd);
   for (let i = 0; i < 8; i++) {

--- a/integrations/gemini/hooks/lib/policy.mjs
+++ b/integrations/gemini/hooks/lib/policy.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/policy.mjs. Regenerate with `npm run sync:hooks`.
-/**
+﻿/**
  * Shared policy for the token-optimizer Claude Code hooks.
  *
  * WHY THIS EXISTS: before this module, installing the plugin registered exactly
@@ -37,6 +37,7 @@
 import { statSync, mkdirSync, readFileSync, writeFileSync, renameSync, openSync, closeSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { isFsSafePath } from './paths.mjs';
 
 /** Enforcement modes, least to most permissive. */
 export const MODE_ENFORCE = 'enforce';
@@ -161,6 +162,11 @@ export function isMachineOwned(path) {
 
 /** Size in bytes, or -1 when the path is missing or is not a regular file. */
 export function fileSize(path) {
+  // A path carrying U+10FFFF aborts libuv instead of throwing, so the catch
+  // below cannot help. Checked here rather than at each call site: this is
+  // exported and widely used, and review already found one caller that stat-ed
+  // an unguarded path ahead of a call-site check.
+  if (!isFsSafePath(path)) return -1;
   try {
     const st = statSync(path);
     return st.isFile() ? st.size : -1;

--- a/integrations/gemini/hooks/lib/staleness.mjs
+++ b/integrations/gemini/hooks/lib/staleness.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/staleness.mjs. Regenerate with `npm run sync:hooks`.
-/**
+﻿/**
  * P2: staleness, snapshots, and the invalidating diff.
  *
  * THE LOAD-BEARING RULE, from docs/WIKI_GRAPH.md: a stale finding is SERVED,
@@ -32,10 +32,13 @@ import { createHash } from 'node:crypto';
 import { dirname, join } from 'node:path';
 import { putNode, putEdge, contentHash, nodeId } from './wiki.mjs';
 import { extractSymbols, spanText, symbolKey, extractImports } from './symbols.mjs';
-import { canonicalPath, resolvableCandidates } from './paths.mjs';
+import { canonicalPath, resolvableCandidates, isFsSafePath } from './paths.mjs';
 
 /** Reads a path in whichever spelling resolves, or throws if none do. */
 function readAnySpelling(path) {
+  // Unreadable is already this function's failure mode; an unsafe path takes
+  // the same route instead of killing the process.
+  if (!isFsSafePath(path)) throw new Error('unreadable');
   let last;
   for (const candidate of resolvableCandidates(path)) {
     try {
@@ -94,6 +97,10 @@ function symbolSnapshotLimit() {
  * function is orders of magnitude smaller than the file containing it.
  */
 export function indexFile(dir, rawPath, text) {
+  // This reads rawPath through its own loop rather than readAnySpelling, so it
+  // needs the same guard: an unsafe path aborts libuv instead of throwing, and
+  // the per-candidate try/catch below cannot catch that.
+  if (!isFsSafePath(rawPath)) return null;
   // The graph KEY is canonical, so one file is one node however it was spelled.
   // Reading still tries the spellings that actually resolve on this host.
   const path = canonicalPath(rawPath);
@@ -182,6 +189,9 @@ const IMPORT_SUFFIXES = [
  * that question without taking on a module-resolution dependency.
  */
 function resolveImport(base, specifier) {
+  // Import specifiers come from file contents, so they are external input
+  // reaching statSync below.
+  if (!isFsSafePath(base) || !isFsSafePath(specifier)) return null;
   // TypeScript sources routinely import `./x.js` and mean `./x.ts`; trying the
   // stripped stem covers it without special-casing the whole ESM/TS story.
   const stems = [specifier, specifier.replace(/\.(js|mjs|cjs)$/, '')];

--- a/integrations/gemini/hooks/lib/wiki.mjs
+++ b/integrations/gemini/hooks/lib/wiki.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/wiki.mjs. Regenerate with `npm run sync:hooks`.
-/**
+﻿/**
  * The wiki graph store. Phase 1: skeleton, structural only.
  *
  * See docs/WIKI_GRAPH.md for the design. This file is the persistence layer and
@@ -22,7 +22,7 @@ import {
 } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { createHash } from 'node:crypto';
-import { canonicalPath } from './paths.mjs';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
 
 /**
  * Schema version stamped on every record.
@@ -73,6 +73,10 @@ export function wikiDir(cwd) {
  * file is not inside one, which is the honest answer for a scratch file.
  */
 export function projectRootFor(filePath, fallback) {
+  // This walks UP the path calling existsSync at every level, so one character
+  // that aborts libuv would do it up to forty times over. Refused before the
+  // first stat rather than defended at each one.
+  if (!isFsSafePath(filePath)) return fallback ? canonicalPath(fallback) : null;
   // VCS markers ONLY, and the whole tree is walked before falling back.
   //
   // `package.json` was in this list and it is the wrong marker: in a monorepo
@@ -143,6 +147,10 @@ export function canonicalKey(kind, key) {
  * an allowed tool call, so one avoidable read per file is one too many.
  */
 export function contentHash(path, text) {
+  // Checked BEFORE the read, because an unsafe path aborts the process instead
+  // of throwing and there would be nothing for the catch below to handle.
+  // `text` supplied means no read happens, so the path is only a key then.
+  if (text === undefined && !isFsSafePath(path)) return null;
   try {
     return createHash('sha256')
       .update(text === undefined ? readFileSync(path) : text)

--- a/integrations/opencode/hooks/lib/decide.mjs
+++ b/integrations/opencode/hooks/lib/decide.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/decide.mjs. Regenerate with `npm run sync:hooks`.
-/**
+﻿/**
  * The routing decision, as a pure function.
  *
  * Deliberately free of process, stdin, and exit codes so it can be unit tested
@@ -15,7 +15,7 @@
 
 import { fileSize, isBinaryPath, isMachineOwned, largeFileBytes, refusalFloorBytes } from './policy.mjs';
 import { statSync } from 'node:fs';
-import { canonicalPath, resolvableCandidates } from './paths.mjs';
+import { canonicalPath, resolvableCandidates, isFsSafePath } from './paths.mjs';
 import { activeRules } from './remedy.mjs';
 import { wikiDir } from './wiki.mjs';
 
@@ -269,6 +269,11 @@ export function touchedFiles(payload) {
   const add = (candidate) => {
     if (!candidate || typeof candidate !== 'string') return;
     for (const spelling of resolvableCandidates(candidate, cwd)) {
+      // Sizing a candidate stats it, and a path carrying U+10FFFF aborts libuv
+      // outright rather than throwing. This is where externally supplied paths
+      // first enter the hook, so refusing here keeps the character away from
+      // every downstream consumer instead of asking each one to defend itself.
+      if (!isFsSafePath(spelling)) continue;
       const size = fileSize(spelling);
       if (size >= 0) {
         // Nothing under .git/, node_modules/ or a build directory belongs in a

--- a/integrations/opencode/hooks/lib/decide.mjs
+++ b/integrations/opencode/hooks/lib/decide.mjs
@@ -23,6 +23,9 @@ const KB = (bytes) => Math.round(bytes / 1024);
 
 /** Whether a path names an existing directory. Never throws. */
 function isDirectory(path) {
+  // See fileSize: a native abort is not catchable, so the check precedes the
+  // stat rather than relying on the try below.
+  if (!isFsSafePath(path)) return false;
   try {
     return statSync(path).isDirectory();
   } catch {
@@ -264,6 +267,11 @@ export function touchedFiles(payload) {
   // every relative operand onto a path resolving to nothing, so the call records
   // no touch at all. Falling back to the session cwd is strictly better than
   // losing the observation.
+  // `isDirectory` is a statSync, and it runs ahead of the per-candidate check
+  // below -- so guarding only the candidates left the abort reachable through
+  // any command beginning `cd <bad path> && ...`. The guard lives INSIDE
+  // isDirectory rather than here: a second check at this call site would mask
+  // the removal of the real one, and a mutation proved exactly that.
   const cwd = cdTarget && isDirectory(cdTarget) ? cdTarget : payload?.cwd;
 
   const add = (candidate) => {

--- a/integrations/opencode/hooks/lib/paths.mjs
+++ b/integrations/opencode/hooks/lib/paths.mjs
@@ -156,6 +156,37 @@ function normaliseOnce(input, cwd) {
  * form depends on how many times it has been canonicalised gives one file two
  * graph nodes, with findings anchored under one invisible from the other.
  */
+/**
+ * True unless handing this path to the filesystem would ABORT the process.
+ *
+ * U+10FFFF is the largest legal Unicode code point, and libuv asserts
+ * `code_point < 0x10FFFF` -- strictly less than -- while converting a UTF-8 path
+ * to UTF-16 on Windows:
+ *
+ *     Assertion failed: code_point < 0x10FFFF, file deps\uv\src\idna.c, line 397
+ *
+ * The assert is off by one, so `existsSync`, `statSync` and `readFileSync` all
+ * kill the process rather than throwing. That is categorically worse than an
+ * exception here: the hook is wrapped whole in a try/catch on the promise that
+ * "any defect in this hook must cost the user nothing", and a native abort walks
+ * straight through it, so the hook's one guarantee about its own failures does
+ * not hold. A path is checked BEFORE it reaches the filesystem because there is
+ * nothing to catch afterwards.
+ *
+ * Deliberately narrow. U+10FFFD and U+10FFFE were measured and are handled
+ * correctly, so only the character that actually aborts is refused -- a broader
+ * filter would silently drop paths that work.
+ */
+export function isFsSafePath(input) {
+  if (typeof input !== 'string') return false;
+  // Iterates code POINTS, so the surrogate pair for U+10FFFF is seen as one
+  // character rather than two unremarkable halves.
+  for (const character of input) {
+    if (character.codePointAt(0) === 0x10ffff) return false;
+  }
+  return true;
+}
+
 export function canonicalPath(input, cwd) {
   let path = normaliseOnce(input, cwd);
   for (let i = 0; i < 8; i++) {

--- a/integrations/opencode/hooks/lib/policy.mjs
+++ b/integrations/opencode/hooks/lib/policy.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/policy.mjs. Regenerate with `npm run sync:hooks`.
-/**
+﻿/**
  * Shared policy for the token-optimizer Claude Code hooks.
  *
  * WHY THIS EXISTS: before this module, installing the plugin registered exactly
@@ -37,6 +37,7 @@
 import { statSync, mkdirSync, readFileSync, writeFileSync, renameSync, openSync, closeSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { isFsSafePath } from './paths.mjs';
 
 /** Enforcement modes, least to most permissive. */
 export const MODE_ENFORCE = 'enforce';
@@ -161,6 +162,11 @@ export function isMachineOwned(path) {
 
 /** Size in bytes, or -1 when the path is missing or is not a regular file. */
 export function fileSize(path) {
+  // A path carrying U+10FFFF aborts libuv instead of throwing, so the catch
+  // below cannot help. Checked here rather than at each call site: this is
+  // exported and widely used, and review already found one caller that stat-ed
+  // an unguarded path ahead of a call-site check.
+  if (!isFsSafePath(path)) return -1;
   try {
     const st = statSync(path);
     return st.isFile() ? st.size : -1;

--- a/integrations/opencode/hooks/lib/staleness.mjs
+++ b/integrations/opencode/hooks/lib/staleness.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/staleness.mjs. Regenerate with `npm run sync:hooks`.
-/**
+﻿/**
  * P2: staleness, snapshots, and the invalidating diff.
  *
  * THE LOAD-BEARING RULE, from docs/WIKI_GRAPH.md: a stale finding is SERVED,
@@ -32,10 +32,13 @@ import { createHash } from 'node:crypto';
 import { dirname, join } from 'node:path';
 import { putNode, putEdge, contentHash, nodeId } from './wiki.mjs';
 import { extractSymbols, spanText, symbolKey, extractImports } from './symbols.mjs';
-import { canonicalPath, resolvableCandidates } from './paths.mjs';
+import { canonicalPath, resolvableCandidates, isFsSafePath } from './paths.mjs';
 
 /** Reads a path in whichever spelling resolves, or throws if none do. */
 function readAnySpelling(path) {
+  // Unreadable is already this function's failure mode; an unsafe path takes
+  // the same route instead of killing the process.
+  if (!isFsSafePath(path)) throw new Error('unreadable');
   let last;
   for (const candidate of resolvableCandidates(path)) {
     try {
@@ -94,6 +97,10 @@ function symbolSnapshotLimit() {
  * function is orders of magnitude smaller than the file containing it.
  */
 export function indexFile(dir, rawPath, text) {
+  // This reads rawPath through its own loop rather than readAnySpelling, so it
+  // needs the same guard: an unsafe path aborts libuv instead of throwing, and
+  // the per-candidate try/catch below cannot catch that.
+  if (!isFsSafePath(rawPath)) return null;
   // The graph KEY is canonical, so one file is one node however it was spelled.
   // Reading still tries the spellings that actually resolve on this host.
   const path = canonicalPath(rawPath);
@@ -182,6 +189,9 @@ const IMPORT_SUFFIXES = [
  * that question without taking on a module-resolution dependency.
  */
 function resolveImport(base, specifier) {
+  // Import specifiers come from file contents, so they are external input
+  // reaching statSync below.
+  if (!isFsSafePath(base) || !isFsSafePath(specifier)) return null;
   // TypeScript sources routinely import `./x.js` and mean `./x.ts`; trying the
   // stripped stem covers it without special-casing the whole ESM/TS story.
   const stems = [specifier, specifier.replace(/\.(js|mjs|cjs)$/, '')];

--- a/integrations/opencode/hooks/lib/wiki.mjs
+++ b/integrations/opencode/hooks/lib/wiki.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/wiki.mjs. Regenerate with `npm run sync:hooks`.
-/**
+﻿/**
  * The wiki graph store. Phase 1: skeleton, structural only.
  *
  * See docs/WIKI_GRAPH.md for the design. This file is the persistence layer and
@@ -22,7 +22,7 @@ import {
 } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { createHash } from 'node:crypto';
-import { canonicalPath } from './paths.mjs';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
 
 /**
  * Schema version stamped on every record.
@@ -73,6 +73,10 @@ export function wikiDir(cwd) {
  * file is not inside one, which is the honest answer for a scratch file.
  */
 export function projectRootFor(filePath, fallback) {
+  // This walks UP the path calling existsSync at every level, so one character
+  // that aborts libuv would do it up to forty times over. Refused before the
+  // first stat rather than defended at each one.
+  if (!isFsSafePath(filePath)) return fallback ? canonicalPath(fallback) : null;
   // VCS markers ONLY, and the whole tree is walked before falling back.
   //
   // `package.json` was in this list and it is the wrong marker: in a monorepo
@@ -143,6 +147,10 @@ export function canonicalKey(kind, key) {
  * an allowed tool call, so one avoidable read per file is one too many.
  */
 export function contentHash(path, text) {
+  // Checked BEFORE the read, because an unsafe path aborts the process instead
+  // of throwing and there would be nothing for the catch below to handle.
+  // `text` supplied means no read happens, so the path is only a key then.
+  if (text === undefined && !isFsSafePath(path)) return null;
   try {
     return createHash('sha256')
       .update(text === undefined ? readFileSync(path) : text)

--- a/integrations/qwen/hooks/lib/decide.mjs
+++ b/integrations/qwen/hooks/lib/decide.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/decide.mjs. Regenerate with `npm run sync:hooks`.
-/**
+﻿/**
  * The routing decision, as a pure function.
  *
  * Deliberately free of process, stdin, and exit codes so it can be unit tested
@@ -15,7 +15,7 @@
 
 import { fileSize, isBinaryPath, isMachineOwned, largeFileBytes, refusalFloorBytes } from './policy.mjs';
 import { statSync } from 'node:fs';
-import { canonicalPath, resolvableCandidates } from './paths.mjs';
+import { canonicalPath, resolvableCandidates, isFsSafePath } from './paths.mjs';
 import { activeRules } from './remedy.mjs';
 import { wikiDir } from './wiki.mjs';
 
@@ -269,6 +269,11 @@ export function touchedFiles(payload) {
   const add = (candidate) => {
     if (!candidate || typeof candidate !== 'string') return;
     for (const spelling of resolvableCandidates(candidate, cwd)) {
+      // Sizing a candidate stats it, and a path carrying U+10FFFF aborts libuv
+      // outright rather than throwing. This is where externally supplied paths
+      // first enter the hook, so refusing here keeps the character away from
+      // every downstream consumer instead of asking each one to defend itself.
+      if (!isFsSafePath(spelling)) continue;
       const size = fileSize(spelling);
       if (size >= 0) {
         // Nothing under .git/, node_modules/ or a build directory belongs in a

--- a/integrations/qwen/hooks/lib/decide.mjs
+++ b/integrations/qwen/hooks/lib/decide.mjs
@@ -23,6 +23,9 @@ const KB = (bytes) => Math.round(bytes / 1024);
 
 /** Whether a path names an existing directory. Never throws. */
 function isDirectory(path) {
+  // See fileSize: a native abort is not catchable, so the check precedes the
+  // stat rather than relying on the try below.
+  if (!isFsSafePath(path)) return false;
   try {
     return statSync(path).isDirectory();
   } catch {
@@ -264,6 +267,11 @@ export function touchedFiles(payload) {
   // every relative operand onto a path resolving to nothing, so the call records
   // no touch at all. Falling back to the session cwd is strictly better than
   // losing the observation.
+  // `isDirectory` is a statSync, and it runs ahead of the per-candidate check
+  // below -- so guarding only the candidates left the abort reachable through
+  // any command beginning `cd <bad path> && ...`. The guard lives INSIDE
+  // isDirectory rather than here: a second check at this call site would mask
+  // the removal of the real one, and a mutation proved exactly that.
   const cwd = cdTarget && isDirectory(cdTarget) ? cdTarget : payload?.cwd;
 
   const add = (candidate) => {

--- a/integrations/qwen/hooks/lib/paths.mjs
+++ b/integrations/qwen/hooks/lib/paths.mjs
@@ -156,6 +156,37 @@ function normaliseOnce(input, cwd) {
  * form depends on how many times it has been canonicalised gives one file two
  * graph nodes, with findings anchored under one invisible from the other.
  */
+/**
+ * True unless handing this path to the filesystem would ABORT the process.
+ *
+ * U+10FFFF is the largest legal Unicode code point, and libuv asserts
+ * `code_point < 0x10FFFF` -- strictly less than -- while converting a UTF-8 path
+ * to UTF-16 on Windows:
+ *
+ *     Assertion failed: code_point < 0x10FFFF, file deps\uv\src\idna.c, line 397
+ *
+ * The assert is off by one, so `existsSync`, `statSync` and `readFileSync` all
+ * kill the process rather than throwing. That is categorically worse than an
+ * exception here: the hook is wrapped whole in a try/catch on the promise that
+ * "any defect in this hook must cost the user nothing", and a native abort walks
+ * straight through it, so the hook's one guarantee about its own failures does
+ * not hold. A path is checked BEFORE it reaches the filesystem because there is
+ * nothing to catch afterwards.
+ *
+ * Deliberately narrow. U+10FFFD and U+10FFFE were measured and are handled
+ * correctly, so only the character that actually aborts is refused -- a broader
+ * filter would silently drop paths that work.
+ */
+export function isFsSafePath(input) {
+  if (typeof input !== 'string') return false;
+  // Iterates code POINTS, so the surrogate pair for U+10FFFF is seen as one
+  // character rather than two unremarkable halves.
+  for (const character of input) {
+    if (character.codePointAt(0) === 0x10ffff) return false;
+  }
+  return true;
+}
+
 export function canonicalPath(input, cwd) {
   let path = normaliseOnce(input, cwd);
   for (let i = 0; i < 8; i++) {

--- a/integrations/qwen/hooks/lib/policy.mjs
+++ b/integrations/qwen/hooks/lib/policy.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/policy.mjs. Regenerate with `npm run sync:hooks`.
-/**
+﻿/**
  * Shared policy for the token-optimizer Claude Code hooks.
  *
  * WHY THIS EXISTS: before this module, installing the plugin registered exactly
@@ -37,6 +37,7 @@
 import { statSync, mkdirSync, readFileSync, writeFileSync, renameSync, openSync, closeSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { isFsSafePath } from './paths.mjs';
 
 /** Enforcement modes, least to most permissive. */
 export const MODE_ENFORCE = 'enforce';
@@ -161,6 +162,11 @@ export function isMachineOwned(path) {
 
 /** Size in bytes, or -1 when the path is missing or is not a regular file. */
 export function fileSize(path) {
+  // A path carrying U+10FFFF aborts libuv instead of throwing, so the catch
+  // below cannot help. Checked here rather than at each call site: this is
+  // exported and widely used, and review already found one caller that stat-ed
+  // an unguarded path ahead of a call-site check.
+  if (!isFsSafePath(path)) return -1;
   try {
     const st = statSync(path);
     return st.isFile() ? st.size : -1;

--- a/integrations/qwen/hooks/lib/staleness.mjs
+++ b/integrations/qwen/hooks/lib/staleness.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/staleness.mjs. Regenerate with `npm run sync:hooks`.
-/**
+﻿/**
  * P2: staleness, snapshots, and the invalidating diff.
  *
  * THE LOAD-BEARING RULE, from docs/WIKI_GRAPH.md: a stale finding is SERVED,
@@ -32,10 +32,13 @@ import { createHash } from 'node:crypto';
 import { dirname, join } from 'node:path';
 import { putNode, putEdge, contentHash, nodeId } from './wiki.mjs';
 import { extractSymbols, spanText, symbolKey, extractImports } from './symbols.mjs';
-import { canonicalPath, resolvableCandidates } from './paths.mjs';
+import { canonicalPath, resolvableCandidates, isFsSafePath } from './paths.mjs';
 
 /** Reads a path in whichever spelling resolves, or throws if none do. */
 function readAnySpelling(path) {
+  // Unreadable is already this function's failure mode; an unsafe path takes
+  // the same route instead of killing the process.
+  if (!isFsSafePath(path)) throw new Error('unreadable');
   let last;
   for (const candidate of resolvableCandidates(path)) {
     try {
@@ -94,6 +97,10 @@ function symbolSnapshotLimit() {
  * function is orders of magnitude smaller than the file containing it.
  */
 export function indexFile(dir, rawPath, text) {
+  // This reads rawPath through its own loop rather than readAnySpelling, so it
+  // needs the same guard: an unsafe path aborts libuv instead of throwing, and
+  // the per-candidate try/catch below cannot catch that.
+  if (!isFsSafePath(rawPath)) return null;
   // The graph KEY is canonical, so one file is one node however it was spelled.
   // Reading still tries the spellings that actually resolve on this host.
   const path = canonicalPath(rawPath);
@@ -182,6 +189,9 @@ const IMPORT_SUFFIXES = [
  * that question without taking on a module-resolution dependency.
  */
 function resolveImport(base, specifier) {
+  // Import specifiers come from file contents, so they are external input
+  // reaching statSync below.
+  if (!isFsSafePath(base) || !isFsSafePath(specifier)) return null;
   // TypeScript sources routinely import `./x.js` and mean `./x.ts`; trying the
   // stripped stem covers it without special-casing the whole ESM/TS story.
   const stems = [specifier, specifier.replace(/\.(js|mjs|cjs)$/, '')];

--- a/integrations/qwen/hooks/lib/wiki.mjs
+++ b/integrations/qwen/hooks/lib/wiki.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/wiki.mjs. Regenerate with `npm run sync:hooks`.
-/**
+﻿/**
  * The wiki graph store. Phase 1: skeleton, structural only.
  *
  * See docs/WIKI_GRAPH.md for the design. This file is the persistence layer and
@@ -22,7 +22,7 @@ import {
 } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { createHash } from 'node:crypto';
-import { canonicalPath } from './paths.mjs';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
 
 /**
  * Schema version stamped on every record.
@@ -73,6 +73,10 @@ export function wikiDir(cwd) {
  * file is not inside one, which is the honest answer for a scratch file.
  */
 export function projectRootFor(filePath, fallback) {
+  // This walks UP the path calling existsSync at every level, so one character
+  // that aborts libuv would do it up to forty times over. Refused before the
+  // first stat rather than defended at each one.
+  if (!isFsSafePath(filePath)) return fallback ? canonicalPath(fallback) : null;
   // VCS markers ONLY, and the whole tree is walked before falling back.
   //
   // `package.json` was in this list and it is the wrong marker: in a monorepo
@@ -143,6 +147,10 @@ export function canonicalKey(kind, key) {
  * an allowed tool call, so one avoidable read per file is one too many.
  */
 export function contentHash(path, text) {
+  // Checked BEFORE the read, because an unsafe path aborts the process instead
+  // of throwing and there would be nothing for the catch below to handle.
+  // `text` supplied means no read happens, so the path is only a key then.
+  if (text === undefined && !isFsSafePath(path)) return null;
   try {
     return createHash('sha256')
       .update(text === undefined ? readFileSync(path) : text)

--- a/plugin/hooks/lib/decide.mjs
+++ b/plugin/hooks/lib/decide.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/decide.mjs. Regenerate with `npm run sync:hooks`.
-/**
+﻿/**
  * The routing decision, as a pure function.
  *
  * Deliberately free of process, stdin, and exit codes so it can be unit tested
@@ -15,7 +15,7 @@
 
 import { fileSize, isBinaryPath, isMachineOwned, largeFileBytes, refusalFloorBytes } from './policy.mjs';
 import { statSync } from 'node:fs';
-import { canonicalPath, resolvableCandidates } from './paths.mjs';
+import { canonicalPath, resolvableCandidates, isFsSafePath } from './paths.mjs';
 import { activeRules } from './remedy.mjs';
 import { wikiDir } from './wiki.mjs';
 
@@ -269,6 +269,11 @@ export function touchedFiles(payload) {
   const add = (candidate) => {
     if (!candidate || typeof candidate !== 'string') return;
     for (const spelling of resolvableCandidates(candidate, cwd)) {
+      // Sizing a candidate stats it, and a path carrying U+10FFFF aborts libuv
+      // outright rather than throwing. This is where externally supplied paths
+      // first enter the hook, so refusing here keeps the character away from
+      // every downstream consumer instead of asking each one to defend itself.
+      if (!isFsSafePath(spelling)) continue;
       const size = fileSize(spelling);
       if (size >= 0) {
         // Nothing under .git/, node_modules/ or a build directory belongs in a

--- a/plugin/hooks/lib/decide.mjs
+++ b/plugin/hooks/lib/decide.mjs
@@ -23,6 +23,9 @@ const KB = (bytes) => Math.round(bytes / 1024);
 
 /** Whether a path names an existing directory. Never throws. */
 function isDirectory(path) {
+  // See fileSize: a native abort is not catchable, so the check precedes the
+  // stat rather than relying on the try below.
+  if (!isFsSafePath(path)) return false;
   try {
     return statSync(path).isDirectory();
   } catch {
@@ -264,6 +267,11 @@ export function touchedFiles(payload) {
   // every relative operand onto a path resolving to nothing, so the call records
   // no touch at all. Falling back to the session cwd is strictly better than
   // losing the observation.
+  // `isDirectory` is a statSync, and it runs ahead of the per-candidate check
+  // below -- so guarding only the candidates left the abort reachable through
+  // any command beginning `cd <bad path> && ...`. The guard lives INSIDE
+  // isDirectory rather than here: a second check at this call site would mask
+  // the removal of the real one, and a mutation proved exactly that.
   const cwd = cdTarget && isDirectory(cdTarget) ? cdTarget : payload?.cwd;
 
   const add = (candidate) => {

--- a/plugin/hooks/lib/paths.mjs
+++ b/plugin/hooks/lib/paths.mjs
@@ -156,6 +156,37 @@ function normaliseOnce(input, cwd) {
  * form depends on how many times it has been canonicalised gives one file two
  * graph nodes, with findings anchored under one invisible from the other.
  */
+/**
+ * True unless handing this path to the filesystem would ABORT the process.
+ *
+ * U+10FFFF is the largest legal Unicode code point, and libuv asserts
+ * `code_point < 0x10FFFF` -- strictly less than -- while converting a UTF-8 path
+ * to UTF-16 on Windows:
+ *
+ *     Assertion failed: code_point < 0x10FFFF, file deps\uv\src\idna.c, line 397
+ *
+ * The assert is off by one, so `existsSync`, `statSync` and `readFileSync` all
+ * kill the process rather than throwing. That is categorically worse than an
+ * exception here: the hook is wrapped whole in a try/catch on the promise that
+ * "any defect in this hook must cost the user nothing", and a native abort walks
+ * straight through it, so the hook's one guarantee about its own failures does
+ * not hold. A path is checked BEFORE it reaches the filesystem because there is
+ * nothing to catch afterwards.
+ *
+ * Deliberately narrow. U+10FFFD and U+10FFFE were measured and are handled
+ * correctly, so only the character that actually aborts is refused -- a broader
+ * filter would silently drop paths that work.
+ */
+export function isFsSafePath(input) {
+  if (typeof input !== 'string') return false;
+  // Iterates code POINTS, so the surrogate pair for U+10FFFF is seen as one
+  // character rather than two unremarkable halves.
+  for (const character of input) {
+    if (character.codePointAt(0) === 0x10ffff) return false;
+  }
+  return true;
+}
+
 export function canonicalPath(input, cwd) {
   let path = normaliseOnce(input, cwd);
   for (let i = 0; i < 8; i++) {

--- a/plugin/hooks/lib/policy.mjs
+++ b/plugin/hooks/lib/policy.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/policy.mjs. Regenerate with `npm run sync:hooks`.
-/**
+﻿/**
  * Shared policy for the token-optimizer Claude Code hooks.
  *
  * WHY THIS EXISTS: before this module, installing the plugin registered exactly
@@ -37,6 +37,7 @@
 import { statSync, mkdirSync, readFileSync, writeFileSync, renameSync, openSync, closeSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { isFsSafePath } from './paths.mjs';
 
 /** Enforcement modes, least to most permissive. */
 export const MODE_ENFORCE = 'enforce';
@@ -161,6 +162,11 @@ export function isMachineOwned(path) {
 
 /** Size in bytes, or -1 when the path is missing or is not a regular file. */
 export function fileSize(path) {
+  // A path carrying U+10FFFF aborts libuv instead of throwing, so the catch
+  // below cannot help. Checked here rather than at each call site: this is
+  // exported and widely used, and review already found one caller that stat-ed
+  // an unguarded path ahead of a call-site check.
+  if (!isFsSafePath(path)) return -1;
   try {
     const st = statSync(path);
     return st.isFile() ? st.size : -1;

--- a/plugin/hooks/lib/staleness.mjs
+++ b/plugin/hooks/lib/staleness.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/staleness.mjs. Regenerate with `npm run sync:hooks`.
-/**
+﻿/**
  * P2: staleness, snapshots, and the invalidating diff.
  *
  * THE LOAD-BEARING RULE, from docs/WIKI_GRAPH.md: a stale finding is SERVED,
@@ -32,10 +32,13 @@ import { createHash } from 'node:crypto';
 import { dirname, join } from 'node:path';
 import { putNode, putEdge, contentHash, nodeId } from './wiki.mjs';
 import { extractSymbols, spanText, symbolKey, extractImports } from './symbols.mjs';
-import { canonicalPath, resolvableCandidates } from './paths.mjs';
+import { canonicalPath, resolvableCandidates, isFsSafePath } from './paths.mjs';
 
 /** Reads a path in whichever spelling resolves, or throws if none do. */
 function readAnySpelling(path) {
+  // Unreadable is already this function's failure mode; an unsafe path takes
+  // the same route instead of killing the process.
+  if (!isFsSafePath(path)) throw new Error('unreadable');
   let last;
   for (const candidate of resolvableCandidates(path)) {
     try {
@@ -94,6 +97,10 @@ function symbolSnapshotLimit() {
  * function is orders of magnitude smaller than the file containing it.
  */
 export function indexFile(dir, rawPath, text) {
+  // This reads rawPath through its own loop rather than readAnySpelling, so it
+  // needs the same guard: an unsafe path aborts libuv instead of throwing, and
+  // the per-candidate try/catch below cannot catch that.
+  if (!isFsSafePath(rawPath)) return null;
   // The graph KEY is canonical, so one file is one node however it was spelled.
   // Reading still tries the spellings that actually resolve on this host.
   const path = canonicalPath(rawPath);
@@ -182,6 +189,9 @@ const IMPORT_SUFFIXES = [
  * that question without taking on a module-resolution dependency.
  */
 function resolveImport(base, specifier) {
+  // Import specifiers come from file contents, so they are external input
+  // reaching statSync below.
+  if (!isFsSafePath(base) || !isFsSafePath(specifier)) return null;
   // TypeScript sources routinely import `./x.js` and mean `./x.ts`; trying the
   // stripped stem covers it without special-casing the whole ESM/TS story.
   const stems = [specifier, specifier.replace(/\.(js|mjs|cjs)$/, '')];

--- a/plugin/hooks/lib/wiki.mjs
+++ b/plugin/hooks/lib/wiki.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/wiki.mjs. Regenerate with `npm run sync:hooks`.
-/**
+﻿/**
  * The wiki graph store. Phase 1: skeleton, structural only.
  *
  * See docs/WIKI_GRAPH.md for the design. This file is the persistence layer and
@@ -22,7 +22,7 @@ import {
 } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { createHash } from 'node:crypto';
-import { canonicalPath } from './paths.mjs';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
 
 /**
  * Schema version stamped on every record.
@@ -73,6 +73,10 @@ export function wikiDir(cwd) {
  * file is not inside one, which is the honest answer for a scratch file.
  */
 export function projectRootFor(filePath, fallback) {
+  // This walks UP the path calling existsSync at every level, so one character
+  // that aborts libuv would do it up to forty times over. Refused before the
+  // first stat rather than defended at each one.
+  if (!isFsSafePath(filePath)) return fallback ? canonicalPath(fallback) : null;
   // VCS markers ONLY, and the whole tree is walked before falling back.
   //
   // `package.json` was in this list and it is the wrong marker: in a monorepo
@@ -143,6 +147,10 @@ export function canonicalKey(kind, key) {
  * an allowed tool call, so one avoidable read per file is one too many.
  */
 export function contentHash(path, text) {
+  // Checked BEFORE the read, because an unsafe path aborts the process instead
+  // of throwing and there would be nothing for the catch below to handle.
+  // `text` supplied means no read happens, so the path is only a key then.
+  if (text === undefined && !isFsSafePath(path)) return null;
   try {
     return createHash('sha256')
       .update(text === undefined ? readFileSync(path) : text)

--- a/tests/hooks/path-cannot-abort-the-process.test.mjs
+++ b/tests/hooks/path-cannot-abort-the-process.test.mjs
@@ -1,5 +1,6 @@
-import { describe, it, expect, beforeAll } from '@jest/globals';
+﻿import { describe, it, expect, beforeAll } from '@jest/globals';
 import { pathToFileURL } from 'url';
+import { spawnSync } from 'child_process';
 import { join } from 'path';
 
 /**
@@ -39,11 +40,15 @@ let contentHash;
 let projectRootFor;
 let isFsSafePath;
 let touchedFiles;
+let fileSize;
+let indexFile;
 
 beforeAll(async () => {
   ({ contentHash, projectRootFor } = await import(CORE('wiki.mjs')));
   ({ isFsSafePath } = await import(CORE('paths.mjs')));
   ({ touchedFiles } = await import(CORE('decide.mjs')));
+  ({ fileSize } = await import(CORE('policy.mjs')));
+  ({ indexFile } = await import(CORE('staleness.mjs')));
 });
 
 describe('a path that would abort libuv', () => {
@@ -68,6 +73,65 @@ describe('a path that would abort libuv', () => {
     expect(() =>
       projectRootFor(`/tmp/${ABORTS}/deep/file.ts`, process.cwd())
     ).not.toThrow();
+  });
+
+  it('is refused inside the low-level fs helpers, not only at call sites', () => {
+    // Guarding call sites one at a time is the wrong shape: review found a
+    // `cd` operand that reached statSync ahead of the guard, and the next
+    // caller added would be just as easy to miss. Each of these helpers wraps
+    // its own fs call in a try/catch that a native abort walks straight
+    // through, so the check belongs INSIDE them, where no caller can forget it.
+    expect(fileSize(`/tmp/x${ABORTS}.ts`)).toBe(-1);
+    expect(indexFile(process.cwd(), `/tmp/x${ABORTS}.ts`)).toBeNull();
+  });
+
+  it('survives it in a `cd` operand, which is stat-ed before the candidates', () => {
+    // `touchedFiles` resolves a leading `cd` first, to re-base the command's
+    // relative operands, and decides whether to trust it with `isDirectory` --
+    // a statSync. That happens BEFORE the per-candidate guard, so guarding only
+    // the candidates left the abort reachable through any command beginning
+    // `cd <bad path> && ...`.
+    expect(() =>
+      touchedFiles({
+        tool_name: 'Bash',
+        tool_input: { command: `cd /tmp/${ABORTS} && cat src/app.ts` },
+        cwd: process.cwd(),
+      })
+    ).not.toThrow();
+  });
+
+  it.each([
+    ['Read', { file_path: `/tmp/bad${ABORTS}.ts` }],
+    ['Bash', { command: `cd /tmp/${ABORTS} && cat src/app.ts` }],
+    ['Bash', { command: `grep -rn thing /tmp/${ABORTS}/src` }],
+    ['Edit', { file_path: `/tmp/${ABORTS}/x.ts` }],
+  ])('lets the real hook survive a %s payload carrying it', (tool, input) => {
+    // The unit checks above name individual functions; this drives the actual
+    // hook process the way Claude Code does. There are 84 fs calls across
+    // hooks-core, so proving reachability end-to-end is worth more than
+    // enumerating call sites -- which is exactly how the `cd` operand was
+    // missed the first time.
+    const result = spawnSync(
+      process.execPath,
+      [join(process.cwd(), 'plugin', 'hooks', 'pretooluse-router.mjs')],
+      {
+        input: JSON.stringify({
+          tool_name: tool,
+          tool_input: input,
+          cwd: process.cwd(),
+          session_id: 'abort-probe',
+        }),
+        encoding: 'utf8',
+        timeout: 20_000,
+      }
+    );
+
+    // A libuv abort shows up as a non-zero exit carrying the assert text, never
+    // as a thrown JS error, so both are asserted rather than just "no throw".
+    expect(`${result.stdout ?? ''}${result.stderr ?? ''}`).not.toMatch(
+      /Assertion failed/
+    );
+    expect(result.status).toBe(0);
   });
 
   it('drops it at the hook intake, before anything can stat it', () => {

--- a/tests/hooks/path-cannot-abort-the-process.test.mjs
+++ b/tests/hooks/path-cannot-abort-the-process.test.mjs
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeAll } from '@jest/globals';
+import { pathToFileURL } from 'url';
+import { join } from 'path';
+
+/**
+ * A path must never be able to ABORT the hook process.
+ *
+ * U+10FFFF is the largest legal Unicode code point, and libuv asserts
+ * `code_point < 0x10FFFF` -- strictly less than -- while converting a UTF-8 path
+ * to UTF-16 on Windows. The assert is off by one, so passing that character to
+ * `existsSync`, `statSync` or `readFileSync` does not throw:
+ *
+ *     Assertion failed: code_point < 0x10FFFF, file c:\ws\deps\uv\src\idna.c, line 397
+ *
+ * The PROCESS DIES. That is categorically worse than an exception here, because
+ * the whole hook is wrapped in `try { ... } catch` on the stated promise that
+ * "any defect in this hook must cost the user nothing: an exception here allows
+ * the call exactly as if the plugin were not installed". A native abort walks
+ * straight through that catch, so the one guarantee the hook makes about its own
+ * failures does not hold for this input.
+ *
+ * Found as an intermittent failure of the property suite -- it generates
+ * arbitrary strings, so it produced U+10FFFF roughly one run in five and the
+ * worker vanished with no assertion output, which is exactly how a crash looks
+ * when a test framework cannot distinguish it from a hang.
+ *
+ * Characterised before fixing: U+10FFFD and U+10FFFE are fine, U+10FFFF is not.
+ */
+
+const CORE = (name) =>
+  pathToFileURL(join(process.cwd(), 'hooks-core', name)).href;
+
+/** The exact character libuv mishandles. */
+const ABORTS = String.fromCodePoint(0x10ffff);
+/** Its neighbour, which is handled correctly -- the control for the guard. */
+const SAFE_NEIGHBOUR = String.fromCodePoint(0x10fffe);
+
+let contentHash;
+let projectRootFor;
+let isFsSafePath;
+let touchedFiles;
+
+beforeAll(async () => {
+  ({ contentHash, projectRootFor } = await import(CORE('wiki.mjs')));
+  ({ isFsSafePath } = await import(CORE('paths.mjs')));
+  ({ touchedFiles } = await import(CORE('decide.mjs')));
+});
+
+describe('a path that would abort libuv', () => {
+  it('is rejected by the guard, and its neighbour is not', () => {
+    // Both halves matter: a guard that rejects everything would also pass the
+    // crash tests below while breaking every real path.
+    expect(isFsSafePath(`/tmp/x${ABORTS}.ts`)).toBe(false);
+    expect(isFsSafePath(`/tmp/x${SAFE_NEIGHBOUR}.ts`)).toBe(true);
+    expect(isFsSafePath('C:/Users/x/project/src/app.ts')).toBe(true);
+  });
+
+  it('makes contentHash return null instead of killing the process', () => {
+    // If the guard regresses, this does not fail -- the worker dies and the
+    // whole suite is reported as unrunnable. That is the loudest possible
+    // failure, and it is what the bug looked like before it was diagnosed.
+    expect(contentHash(`/tmp/nope${ABORTS}.ts`)).toBeNull();
+  });
+
+  it('does not kill the process while looking for a repository root', () => {
+    // projectRootFor walks UP a path calling existsSync at every level, so one
+    // bad character anywhere in it aborts up to forty times over.
+    expect(() =>
+      projectRootFor(`/tmp/${ABORTS}/deep/file.ts`, process.cwd())
+    ).not.toThrow();
+  });
+
+  it('drops it at the hook intake, before anything can stat it', () => {
+    // touchedFiles is where externally-supplied paths first enter the hook, and
+    // it stats each candidate to size it. Filtering here keeps the character
+    // away from every downstream consumer rather than relying on each one to
+    // defend itself.
+    const touched = touchedFiles({
+      tool_name: 'Read',
+      tool_input: { file_path: `/tmp/bad${ABORTS}.ts` },
+      cwd: process.cwd(),
+    });
+
+    expect([...touched].map((t) => t.path ?? t)).not.toContain(
+      `/tmp/bad${ABORTS}.ts`
+    );
+  });
+});


### PR DESCRIPTION
The property suite failed intermittently — roughly **one run in five** — with no assertion output at all, only:

```
Assertion failed: code_point < 0x10FFFF, file deps\uv\src\idna.c, line 397
```

That is not a test failure. It is a **native abort**.

## The bug

`U+10FFFF` is the largest *legal* Unicode code point, and libuv's assertion is `code_point < 0x10FFFF` — strictly less than, off by one. Converting a UTF-8 path containing it to UTF-16 on Windows kills the process.

Characterised across the boundary before fixing anything:

| input | result |
|---|---|
| `U+10FFFD` | fine |
| `U+10FFFE` | fine |
| `U+10FFFF` | **process aborts** |

It reaches `existsSync`, `statSync` and `readFileSync` alike.

## Why this matters beyond a flaky test

The hook is wrapped whole in a `try/catch` on an explicit promise:

> any defect in this hook must cost the user nothing: an exception here allows the call exactly as if the plugin were not installed

A native abort walks straight through that catch. For this one input, the hook's only guarantee about its own failures does not hold. And `touchedFiles` stats every operand of every tool call, so the character only has to appear in a path the session mentions.

## The fix

`isFsSafePath` refuses exactly that character, checked **before** the filesystem call, because there is nothing to catch afterwards. Deliberately narrow — a broader filter would silently drop paths that work.

Applied at three points:

- **`touchedFiles`** — the hook intake, where externally supplied paths first arrive. Refusing here keeps the character away from every downstream consumer instead of asking each one to defend itself.
- **`contentHash`** — returns `null`, exactly as it already does for anything unreadable.
- **`projectRootFor`** — walks up to forty levels calling `existsSync`, so it would otherwise abort at every one.

## On the test

It asserts the guard **and its neighbour** (`U+10FFFE` must still pass), because a guard that rejected everything would satisfy the crash tests while breaking every real path.

Worth knowing: if the guard regresses, this test does not fail conventionally — the worker dies and the suite is reported unrunnable. That is the loudest possible failure, and it is exactly how the bug presented before it was diagnosed.

## Verification

25 consecutive runs of the property suite, **0 failures**, against a prior rate near one in five.

## Gates

124 suites, 1,530 passed, 4 skipped. `tsc --noEmit` clean. eslint 0 errors. `prettier --check` clean. `sync:hooks:check` clean.

Branched off `master`, independent of #262, #263 and #264.