### PR TITLE
fix(hooks): say what was observed about an unreadable anchor

### DIFF
--- a/hooks-core/staleness.mjs
+++ b/hooks-core/staleness.mjs
@@ -249,7 +249,13 @@ export function checkAnchor(anchor) {
   try {
     source = readAnySpelling(path);
   } catch {
-    return { fresh: false, before: anchor.snapshot || '', hasBefore: Boolean(anchor.snapshot), after: '', reason: 'file no longer readable' };
+    // REASON-NEUTRAL, for the reason spelled out beside the fallback text below:
+    // report what was determined, not a cause that was not. "no longer readable"
+    // asserts a change of state, and the commonest way to reach this branch
+    // involves none -- a branch, worktree, uninitialised submodule or fresh clone
+    // where the file simply is not present. Observed here: a finding anchored to
+    // a file added on another branch reported it gone.
+    return { fresh: false, before: anchor.snapshot || '', hasBefore: Boolean(anchor.snapshot), after: '', reason: 'anchor not readable from this checkout' };
   }
 
   if (anchor.kind === 'file') {

--- a/integrations/codex/hooks/lib/staleness.mjs
+++ b/integrations/codex/hooks/lib/staleness.mjs
@@ -251,7 +251,13 @@ export function checkAnchor(anchor) {
   try {
     source = readAnySpelling(path);
   } catch {
-    return { fresh: false, before: anchor.snapshot || '', hasBefore: Boolean(anchor.snapshot), after: '', reason: 'file no longer readable' };
+    // REASON-NEUTRAL, for the reason spelled out beside the fallback text below:
+    // report what was determined, not a cause that was not. "no longer readable"
+    // asserts a change of state, and the commonest way to reach this branch
+    // involves none -- a branch, worktree, uninitialised submodule or fresh clone
+    // where the file simply is not present. Observed here: a finding anchored to
+    // a file added on another branch reported it gone.
+    return { fresh: false, before: anchor.snapshot || '', hasBefore: Boolean(anchor.snapshot), after: '', reason: 'anchor not readable from this checkout' };
   }
 
   if (anchor.kind === 'file') {

--- a/integrations/codex/plugin/hooks/lib/staleness.mjs
+++ b/integrations/codex/plugin/hooks/lib/staleness.mjs
@@ -251,7 +251,13 @@ export function checkAnchor(anchor) {
   try {
     source = readAnySpelling(path);
   } catch {
-    return { fresh: false, before: anchor.snapshot || '', hasBefore: Boolean(anchor.snapshot), after: '', reason: 'file no longer readable' };
+    // REASON-NEUTRAL, for the reason spelled out beside the fallback text below:
+    // report what was determined, not a cause that was not. "no longer readable"
+    // asserts a change of state, and the commonest way to reach this branch
+    // involves none -- a branch, worktree, uninitialised submodule or fresh clone
+    // where the file simply is not present. Observed here: a finding anchored to
+    // a file added on another branch reported it gone.
+    return { fresh: false, before: anchor.snapshot || '', hasBefore: Boolean(anchor.snapshot), after: '', reason: 'anchor not readable from this checkout' };
   }
 
   if (anchor.kind === 'file') {

--- a/integrations/gemini/hooks/lib/staleness.mjs
+++ b/integrations/gemini/hooks/lib/staleness.mjs
@@ -251,7 +251,13 @@ export function checkAnchor(anchor) {
   try {
     source = readAnySpelling(path);
   } catch {
-    return { fresh: false, before: anchor.snapshot || '', hasBefore: Boolean(anchor.snapshot), after: '', reason: 'file no longer readable' };
+    // REASON-NEUTRAL, for the reason spelled out beside the fallback text below:
+    // report what was determined, not a cause that was not. "no longer readable"
+    // asserts a change of state, and the commonest way to reach this branch
+    // involves none -- a branch, worktree, uninitialised submodule or fresh clone
+    // where the file simply is not present. Observed here: a finding anchored to
+    // a file added on another branch reported it gone.
+    return { fresh: false, before: anchor.snapshot || '', hasBefore: Boolean(anchor.snapshot), after: '', reason: 'anchor not readable from this checkout' };
   }
 
   if (anchor.kind === 'file') {

--- a/integrations/opencode/hooks/lib/staleness.mjs
+++ b/integrations/opencode/hooks/lib/staleness.mjs
@@ -251,7 +251,13 @@ export function checkAnchor(anchor) {
   try {
     source = readAnySpelling(path);
   } catch {
-    return { fresh: false, before: anchor.snapshot || '', hasBefore: Boolean(anchor.snapshot), after: '', reason: 'file no longer readable' };
+    // REASON-NEUTRAL, for the reason spelled out beside the fallback text below:
+    // report what was determined, not a cause that was not. "no longer readable"
+    // asserts a change of state, and the commonest way to reach this branch
+    // involves none -- a branch, worktree, uninitialised submodule or fresh clone
+    // where the file simply is not present. Observed here: a finding anchored to
+    // a file added on another branch reported it gone.
+    return { fresh: false, before: anchor.snapshot || '', hasBefore: Boolean(anchor.snapshot), after: '', reason: 'anchor not readable from this checkout' };
   }
 
   if (anchor.kind === 'file') {

--- a/integrations/qwen/hooks/lib/staleness.mjs
+++ b/integrations/qwen/hooks/lib/staleness.mjs
@@ -251,7 +251,13 @@ export function checkAnchor(anchor) {
   try {
     source = readAnySpelling(path);
   } catch {
-    return { fresh: false, before: anchor.snapshot || '', hasBefore: Boolean(anchor.snapshot), after: '', reason: 'file no longer readable' };
+    // REASON-NEUTRAL, for the reason spelled out beside the fallback text below:
+    // report what was determined, not a cause that was not. "no longer readable"
+    // asserts a change of state, and the commonest way to reach this branch
+    // involves none -- a branch, worktree, uninitialised submodule or fresh clone
+    // where the file simply is not present. Observed here: a finding anchored to
+    // a file added on another branch reported it gone.
+    return { fresh: false, before: anchor.snapshot || '', hasBefore: Boolean(anchor.snapshot), after: '', reason: 'anchor not readable from this checkout' };
   }
 
   if (anchor.kind === 'file') {

--- a/plugin/hooks/lib/staleness.mjs
+++ b/plugin/hooks/lib/staleness.mjs
@@ -251,7 +251,13 @@ export function checkAnchor(anchor) {
   try {
     source = readAnySpelling(path);
   } catch {
-    return { fresh: false, before: anchor.snapshot || '', hasBefore: Boolean(anchor.snapshot), after: '', reason: 'file no longer readable' };
+    // REASON-NEUTRAL, for the reason spelled out beside the fallback text below:
+    // report what was determined, not a cause that was not. "no longer readable"
+    // asserts a change of state, and the commonest way to reach this branch
+    // involves none -- a branch, worktree, uninitialised submodule or fresh clone
+    // where the file simply is not present. Observed here: a finding anchored to
+    // a file added on another branch reported it gone.
+    return { fresh: false, before: anchor.snapshot || '', hasBefore: Boolean(anchor.snapshot), after: '', reason: 'anchor not readable from this checkout' };
   }
 
   if (anchor.kind === 'file') {

--- a/tests/hooks/stale-reason-states-what-was-observed.test.mjs
+++ b/tests/hooks/stale-reason-states-what-was-observed.test.mjs
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+/**
+ * The stale reason must state what was OBSERVED, not infer a cause.
+ *
+ * "file no longer readable" asserts a change of state -- it was readable, now it
+ * is not -- and the most common way to reach this branch does not involve any
+ * such change. Checking out a branch where the anchored file does not exist yet
+ * produces it, and so does a worktree, a submodule that is not initialised, and
+ * a clone that never had the file. Observed live in this repository: a finding
+ * anchored to `src/utils/search-scope.ts` reported the file gone purely because
+ * the current branch predated it.
+ *
+ * The file already holds itself to this standard elsewhere, in the note beside
+ * the fallback text: "REASON-NEUTRAL. The earlier text asserted 'the anchor
+ * changed', which is only one of the ways a finding reaches this branch ... In
+ * those cases the sentence stated a cause that had not been established." The
+ * same objection applies here, and this wording was simply missed.
+ *
+ * What is actually known is narrow and worth saying precisely: the anchor could
+ * not be read from THIS checkout. That is honest whether the file was deleted,
+ * never existed here, or lives on another branch -- and it points at the thing
+ * the reader can check.
+ */
+
+const CORE = (name) =>
+  pathToFileURL(join(process.cwd(), 'hooks-core', name)).href;
+
+let checkAnchor;
+let dir;
+
+beforeAll(async () => {
+  ({ checkAnchor } = await import(CORE('staleness.mjs')));
+  dir = mkdtempSync(join(tmpdir(), 'stale-reason-'));
+  mkdirSync(join(dir, 'src'), { recursive: true });
+});
+
+afterAll(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('the reason given for an unreadable anchor', () => {
+  const missing = () => ({
+    kind: 'file',
+    key: join(dir, 'src', 'not-on-this-branch.ts'),
+    hash: 'deadbeefdeadbeef',
+    snapshot: 'export const gone = 1;\n',
+  });
+
+  it('does not claim the file was deleted or stopped being readable', () => {
+    const { reason } = checkAnchor(missing());
+
+    expect(reason).not.toMatch(/no longer/i);
+    expect(reason).not.toMatch(/deleted/i);
+  });
+
+  it('says the anchor could not be read from this checkout', () => {
+    const { reason } = checkAnchor(missing());
+
+    expect(reason).toMatch(/checkout/i);
+  });
+
+  it('still reports the anchor as stale, carrying its snapshot as evidence', () => {
+    // The wording is the only thing changing. A finding whose anchor cannot be
+    // read must still be served stale WITH the stored snapshot, because a claim
+    // about a file that is not here is exactly the kind that must not be handed
+    // over as though it were verified.
+    const check = checkAnchor(missing());
+
+    expect(check.fresh).toBe(false);
+    expect(check.hasBefore).toBe(true);
+    expect(check.before).toContain('export const gone');
+  });
+
+  it('leaves a genuinely changed file reporting a change', () => {
+    // The neighbouring reason must not be collateral damage.
+    const path = join(dir, 'src', 'present.ts');
+    writeFileSync(path, 'export const value = 2;\n');
+
+    const { reason } = checkAnchor({
+      kind: 'file',
+      key: path,
+      hash: 'notthehashofthatfile',
+      snapshot: 'export const value = 1;\n',
+    });
+
+    expect(reason).toMatch(/changed/i);
+  });
+});

--- a/tests/hooks/stale-reason-states-what-was-observed.test.mjs
+++ b/tests/hooks/stale-reason-states-what-was-observed.test.mjs
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+﻿import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
 import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -61,7 +61,10 @@ describe('the reason given for an unreadable anchor', () => {
   it('says the anchor could not be read from this checkout', () => {
     const { reason } = checkAnchor(missing());
 
-    expect(reason).toMatch(/checkout/i);
+    // Exact, not a /checkout/ match: this string IS the contract the renderer
+    // prints, and a loose pattern would accept any replacement that happened to
+    // contain the word -- including one that went back to asserting a cause.
+    expect(reason).toBe('anchor not readable from this checkout');
   });
 
   it('still reports the anchor as stale, carrying its snapshot as evidence', () => {


### PR DESCRIPTION
`"file no longer readable"` asserts a change of state — it *was* readable, now it is not — and the commonest way to reach that branch involves no such change. A branch that predates the file, a worktree, an uninitialised submodule, or a fresh clone all produce it.

Observed live in this repository: a finding anchored to `src/utils/search-scope.ts` reported the file gone, purely because the checked-out branch predated it.

## The file already holds itself to this standard

A few lines further down, beside the fallback text:

> **REASON-NEUTRAL.** The earlier text asserted "the anchor changed", which is only one of the ways a finding reaches this branch […] In those cases the sentence stated a cause that had not been established.

The same objection applies to this string. It was simply missed when that lesson was applied.

## The change

`anchor not readable from this checkout` — true whether the file was deleted, never existed here, or lives on another branch, and it points the reader at something they can actually check.

Wording only. The anchor is still reported stale and still carries its stored snapshot as evidence; two of the four tests assert exactly that, so this cannot quietly turn into a suppression. A genuinely changed file still reports a change.

## Correction to an earlier report

I had also described this path as dumping ~90 lines of removed content into the context. **That was wrong.** `diffLines` caps at 40 lines (20 removed, 20 added) and appends a count of the remainder — the "87 more removed" I read as content was that count. There is no unbounded output here, and nothing in this PR changes the volume.

## Gates

124 suites, 1,530 passed, 4 skipped. `tsc --noEmit` clean. eslint 0 errors. `prettier --check` clean. `sync:hooks:check` clean.

Branched off `master`, independent of #262–#265.