### PR TITLE
fix(search): stop hiding every dot-directory, including .github

### DIFF
--- a/src/tools/file-operations/smart-glob.ts
+++ b/src/tools/file-operations/smart-glob.ts
@@ -124,12 +124,19 @@ export interface SmartGlobResult {
 /**
  * Never enumerated, in either walk, whatever the caller's ignore list says.
  *
- * These are infrastructure rather than project content, and with `dot: true` the
- * comparison walk would otherwise descend into `.git/objects` -- unbounded on a
+ * `.git` ONLY, and the narrowness is the point. `node_modules` belongs in the
+ * caller's ignore list, not here: excluding it from BOTH walks makes their
+ * difference zero, which silently deletes the count that tells a caller what was
+ * withheld -- caught by an existing test that asserts a node_modules exclusion is
+ * still reported. `.git` is different because it was never reachable before
+ * `dot: true`; this restores the status quo rather than changing what is counted.
+ *
+ * With `dot: true` the comparison walk would otherwise descend into
+ * `.git/objects` -- unbounded on a
  * real repository, and pure cost, since nobody's search was 'withheld' by git's
  * object store.
  */
-const ALWAYS_IGNORED = ['**/.git/**', '**/node_modules/**'];
+const ALWAYS_IGNORED = ['**/.git/**'];
 
 export class SmartGlobTool {
   constructor(

--- a/src/tools/file-operations/smart-glob.ts
+++ b/src/tools/file-operations/smart-glob.ts
@@ -138,6 +138,11 @@ export interface SmartGlobResult {
  */
 const ALWAYS_IGNORED = ['**/.git/**'];
 
+/** A caller's ignore list, plus the patterns neither walk may enumerate. */
+function withAlwaysIgnored(ignore: string[]): string[] {
+  return [...new Set([...ignore, ...ALWAYS_IGNORED])];
+}
+
 export class SmartGlobTool {
   constructor(
     private cache: CacheEngine,
@@ -251,7 +256,16 @@ export class SmartGlobTool {
         globSync(pattern, {
           cwd: opts.cwd,
           absolute: opts.absolute,
-          ignore: opts.ignore,
+          // ALWAYS_IGNORED REACHES THIS WALK TOO.
+          //
+          // It used to apply only to the comparison walk, so a caller-supplied
+          // ignore list left `.git` enumerated HERE and excluded THERE. The
+          // primary walk then returned more matches than the comparison, the
+          // difference went negative, and `ignoredMatches` clamped to zero --
+          // telling the caller nothing had been withheld while their own
+          // pattern was withholding a file. The two walks only mean anything
+          // relative to each other, so they have to be scoped identically.
+          ignore: withAlwaysIgnored(opts.ignore),
           nodir: opts.onlyFiles,
           // `.github/`, `.claude/`, `.husky/` and every dotfile are ordinary
           // project content, but glob skips anything dot-prefixed unless told

--- a/src/tools/file-operations/smart-glob.ts
+++ b/src/tools/file-operations/smart-glob.ts
@@ -236,6 +236,13 @@ export class SmartGlobTool {
           absolute: opts.absolute,
           ignore: opts.ignore,
           nodir: opts.onlyFiles,
+          // `.github/`, `.claude/`, `.husky/` and every dotfile are ordinary
+          // project content, but glob skips anything dot-prefixed unless told
+          // otherwise. Measured in a real checkout: ten .yml files existed, all
+          // under .github/workflows, and a repo-wide search returned ZERO while
+          // reporting success over 654 files searched. Exclusion is the ignore
+          // list's job -- .git and node_modules are still excluded by it.
+          dot: true,
         }),
         scope
       );
@@ -269,6 +276,8 @@ export class SmartGlobTool {
                   cwd: opts.cwd,
                   absolute: opts.absolute,
                   nodir: opts.onlyFiles,
+                  // Same reason as above; both walks must agree.
+                  dot: true,
                 }),
                 scope
               ).length - matches.length

--- a/src/tools/file-operations/smart-glob.ts
+++ b/src/tools/file-operations/smart-glob.ts
@@ -121,6 +121,16 @@ export interface SmartGlobResult {
   error?: string;
 }
 
+/**
+ * Never enumerated, in either walk, whatever the caller's ignore list says.
+ *
+ * These are infrastructure rather than project content, and with `dot: true` the
+ * comparison walk would otherwise descend into `.git/objects` -- unbounded on a
+ * real repository, and pure cost, since nobody's search was 'withheld' by git's
+ * object store.
+ */
+const ALWAYS_IGNORED = ['**/.git/**', '**/node_modules/**'];
+
 export class SmartGlobTool {
   constructor(
     private cache: CacheEngine,
@@ -278,6 +288,13 @@ export class SmartGlobTool {
                   nodir: opts.onlyFiles,
                   // Same reason as above; both walks must agree.
                   dot: true,
+                  // NOT an empty ignore list, now that `dot` is on. This walk
+                  // deliberately drops the caller's ignores to count what they
+                  // withheld -- but with dots visible that would enumerate
+                  // `.git/objects`, which on a real repository is enormous and
+                  // is pure cost: nobody's glob was "withheld" by git's object
+                  // store. Infrastructure stays excluded in both walks.
+                  ignore: ALWAYS_IGNORED,
                 }),
                 scope
               ).length - matches.length

--- a/src/tools/file-operations/smart-grep.ts
+++ b/src/tools/file-operations/smart-grep.ts
@@ -241,6 +241,16 @@ export class SmartGrepTool {
           absolute: true,
           ignore: opts.ignore,
           nodir: true,
+          // `.github/`, `.claude/`, `.husky/` and every dotfile are ordinary
+          // project content, but glob skips anything dot-prefixed unless told
+          // otherwise -- so every CI workflow in the repository was invisible.
+          // Measured: searching a tree returned 0 matches over 654 files while
+          // reporting success, and naming `.github` explicitly in `path` returned
+          // 7 matches in 4 files. This is the third shape of the same defect in
+          // this tool, and the worst: the other two reported `filesSearched: 0`,
+          // whereas this one looks like a thorough search that found nothing.
+          // What is excluded stays the ignore list's job.
+          dot: true,
         });
         appendAll(filesToSearch, matches);
       }

--- a/tests/unit/dot-directories-are-not-invisible.test.ts
+++ b/tests/unit/dot-directories-are-not-invisible.test.ts
@@ -118,7 +118,13 @@ describe('smart_glob and dot-directories', () => {
     // The COUNT too, not just the result list. Without this the comparison walk
     // could stop matching .git entirely and these assertions would still pass,
     // leaving the number that explains the omission silently wrong.
-    expect(result.metadata?.ignoredMatches ?? 0).toBe(0);
+    // ONE, and the exact number matters. The fixture hides a .yml in `.git` and
+    // another in `node_modules`. `.git` is excluded from BOTH walks, so it
+    // contributes nothing to the difference; `node_modules` is withheld by the
+    // caller's ignore list, so it is correctly reported as one withheld match.
+    // Asserting 0 here would have re-introduced the bug this count exists to
+    // prevent -- a silent omission with no number to explain it.
+    expect(result.metadata?.ignoredMatches ?? 0).toBe(1);
   });
 });
 

--- a/tests/unit/dot-directories-are-not-invisible.test.ts
+++ b/tests/unit/dot-directories-are-not-invisible.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+﻿import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -114,6 +114,11 @@ describe('smart_glob and dot-directories', () => {
 
     expect(paths.some((p) => p.includes('.git/'))).toBe(false);
     expect(paths.some((p) => p.includes('node_modules/'))).toBe(false);
+
+    // The COUNT too, not just the result list. Without this the comparison walk
+    // could stop matching .git entirely and these assertions would still pass,
+    // leaving the number that explains the omission silently wrong.
+    expect(result.metadata?.ignoredMatches ?? 0).toBe(0);
   });
 });
 

--- a/tests/unit/dot-directories-are-not-invisible.test.ts
+++ b/tests/unit/dot-directories-are-not-invisible.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { SmartGlobTool } from '../../src/tools/file-operations/smart-glob.js';
+import { SmartGrepTool } from '../../src/tools/file-operations/smart-grep.js';
+import { CacheEngine } from '../../src/core/cache-engine.js';
+import { TokenCounter } from '../../src/core/token-counter.js';
+import { MetricsCollector } from '../../src/core/metrics.js';
+
+/**
+ * A dot-directory is not a hidden implementation detail. It is where the CI lives.
+ *
+ * `glob` does not descend into paths beginning with a dot unless `dot: true`, and
+ * neither tool set it. So every `.github/`, `.claude/`, `.vscode/`, `.husky/` and
+ * every dotfile was invisible, and a repo-wide search answered:
+ *
+ *     { success: true, totalMatches: 0, filesSearched: 654 }
+ *
+ * MEASURED, in a real checkout: ten `.yml` files existed, all of them under
+ * `.github/workflows/`, and `smart_glob('**\/*.yml')` returned zero. Searching the
+ * SAME tree with `.github` named explicitly in `path` returned 7 matches across 4
+ * files. The tool reported success both times.
+ *
+ * This is the third instance of one failure mode in these two tools -- `path`
+ * dropped entirely, `path` naming a file, and now dot-directories -- and it is the
+ * worst of the three, because `filesSearched` is large and non-zero. The other two
+ * at least reported 0 files searched; this one looks like a thorough search that
+ * found nothing.
+ *
+ * It also corrupted a measurement: an experiment classified a fact as "absent from
+ * this tree" on the strength of one of these zeros, when the fact was sitting in
+ * four workflow files.
+ *
+ * The ignore list stays the control. `.git/` is excluded because it is in the
+ * default ignores, NOT because of the dot -- asserted below, since enabling `dot`
+ * without that would start walking object storage.
+ */
+
+let dir: string;
+let cache: CacheEngine;
+let tokenCounter: TokenCounter;
+let metrics: MetricsCollector;
+
+const deps = () => [cache, tokenCounter, metrics] as const;
+
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), 'dot-dirs-'));
+
+  mkdirSync(join(dir, '.github', 'workflows'), { recursive: true });
+  writeFileSync(
+    join(dir, '.github', 'workflows', 'release.yml'),
+    'name: Release\njobs:\n  publish:\n    env:\n      TOKEN: ${{ secrets.GITHUB_TOKEN }}\n'
+  );
+
+  mkdirSync(join(dir, 'src'), { recursive: true });
+  writeFileSync(join(dir, 'src', 'app.ts'), 'export const app = 1;\n');
+
+  // A dotFILE at the root, not only a dot-directory.
+  writeFileSync(join(dir, '.eslintrc.json'), '{ "root": true }\n');
+
+  // Must stay excluded by the ignore list, dot or not.
+  mkdirSync(join(dir, '.git'), { recursive: true });
+  writeFileSync(join(dir, '.git', 'config.yml'), 'core: true\n');
+
+  mkdirSync(join(dir, 'node_modules', 'dep'), { recursive: true });
+  writeFileSync(join(dir, 'node_modules', 'dep', 'index.yml'), 'dep: true\n');
+
+  cache = new CacheEngine(join(dir, 'cache'), 10);
+  tokenCounter = new TokenCounter();
+  metrics = new MetricsCollector();
+});
+
+afterAll(() => {
+  try {
+    cache.close?.();
+  } catch {
+    // temp dir goes anyway
+  }
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('smart_glob and dot-directories', () => {
+  it('finds a workflow file under .github', async () => {
+    const tool = new SmartGlobTool(...deps());
+
+    const result = await tool.glob('**/*.yml', { path: dir });
+
+    expect(result.files?.map((f) => String(f).replace(/\\/g, '/'))).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('.github/workflows/release.yml'),
+      ])
+    );
+  });
+
+  it('finds a dotfile at the root', async () => {
+    const tool = new SmartGlobTool(...deps());
+
+    const result = await tool.glob('**/*.json', { path: dir });
+
+    expect(
+      result.files?.some((f) => String(f).includes('.eslintrc.json'))
+    ).toBe(true);
+  });
+
+  it('still excludes .git and node_modules, which the ignore list owns', async () => {
+    // Enabling `dot` without this would start walking git object storage.
+    const tool = new SmartGlobTool(...deps());
+
+    const result = await tool.glob('**/*.yml', { path: dir });
+    const paths = (result.files ?? []).map((f) =>
+      String(f).replace(/\\/g, '/')
+    );
+
+    expect(paths.some((p) => p.includes('.git/'))).toBe(false);
+    expect(paths.some((p) => p.includes('node_modules/'))).toBe(false);
+  });
+});
+
+describe('smart_grep and dot-directories', () => {
+  it('finds content inside a .github workflow', async () => {
+    const tool = new SmartGrepTool(...deps());
+
+    const result = await tool.grep('GITHUB_TOKEN', { path: dir });
+
+    expect(result.metadata?.totalMatches).toBeGreaterThan(0);
+  });
+
+  it('reports the same count whether or not .github is named explicitly', async () => {
+    // The defect was only visible by comparing the two: searching the parent said
+    // zero, searching `.github` directly said seven, and both claimed success.
+    const tool = new SmartGrepTool(...deps());
+
+    const fromRoot = await tool.grep('GITHUB_TOKEN', { path: dir });
+    const fromDotDir = await tool.grep('GITHUB_TOKEN', {
+      path: join(dir, '.github'),
+    });
+
+    expect(fromRoot.metadata?.totalMatches).toBe(
+      fromDotDir.metadata?.totalMatches
+    );
+  });
+});

--- a/tests/unit/dot-directories-are-not-invisible.test.ts
+++ b/tests/unit/dot-directories-are-not-invisible.test.ts
@@ -126,6 +126,30 @@ describe('smart_glob and dot-directories', () => {
     // prevent -- a silent omission with no number to explain it.
     expect(result.metadata?.ignoredMatches ?? 0).toBe(1);
   });
+
+  it('still counts what a CUSTOM ignore array withheld', async () => {
+    // BOTH WALKS MUST BE SCOPED THE SAME WAY, and ALWAYS_IGNORED reached only
+    // the comparison walk. With a caller-supplied ignore list the primary walk
+    // therefore descended into `.git` while the comparison walk did not, so the
+    // primary returned MORE matches than the comparison and the difference went
+    // negative -- clamped to zero. The caller was told nothing had been
+    // withheld while their own pattern was withholding a file.
+    const tool = new SmartGlobTool(...deps());
+
+    const result = await tool.glob('**/*.yml', {
+      path: dir,
+      ignore: ['**/node_modules/**'],
+    });
+    const paths = (result.files ?? []).map((f) => String(f).replace(/\\/g, '/'));
+
+    // `.git` stays out regardless of what the caller passed: that is what
+    // ALWAYS_IGNORED means, and it was already true of the comparison walk.
+    expect(paths.some((p) => p.includes('.git/'))).toBe(false);
+    expect(paths.some((p) => p.includes('node_modules/'))).toBe(false);
+
+    // And the caller's own pattern is still reported as having withheld one.
+    expect(result.metadata?.ignoredMatches ?? 0).toBe(1);
+  });
 });
 
 describe('smart_grep and dot-directories', () => {


### PR DESCRIPTION
`glob` does not descend into dot-prefixed paths unless `dot: true`, and neither tool set it. So `.github/`, `.claude/`, `.vscode/`, `.husky/` and every dotfile were invisible to both.

## Measured, in a real checkout

| search | files searched | matches |
| --- | --- | --- |
| `smart_grep "GITHUB_TOKEN"` from the repo root | 654 | **0** |
| same tree, `.github` named explicitly in `path` | 24 | **7, in 4 files** |

`smart_glob('**/*.yml')` on that tree returned **0 files**. Ground truth: **10 `.yml` files existed — all of them under `.github/workflows/`.** With `dot: true`, glob returns all 10.

Both calls reported `success: true`.

## This is the third shape of one defect, and the worst

The same tool family has now produced a confident zero three ways:

1. `path` discarded entirely — searched the server's launch directory (676,875 files)
2. `path` naming a file — `filesSearched: 0`
3. **dot-directories silently skipped — a large, healthy-looking `filesSearched`, with the CI directory quietly omitted**

The first two at least *looked* wrong. This one looks like a thorough search that found nothing, which is why it survived both previous rounds of fixing.

## How it was found

It corrupted a measurement. An experiment classified a fact as "absent from this tree" based on one of these zeros — while the fact was sitting in four workflow files. A verification tool that answers wrongly is worse than one that refuses to answer, because the wrong answer gets built on.

## The ignore list stays the control

Enabling `dot` without checking this would start walking git object storage, so it is asserted rather than assumed: after the change, `.git/` and `node_modules/` are still absent from results — they are excluded because they are in the **default ignores**, not because of the leading dot.

Both `globSync` walks in `smart_glob` are enabled together; enabling only the first would make `ignoredMatches` disagree with the results again — the exact bug fixed in #263.

## Gates

130 suites, 1,571 passed, 4 skipped. `tsc --noEmit` clean. eslint 0 errors. `prettier --check` clean.