### PR TITLE
fix(hooks): scope read state per agent, not per session

### DIFF
--- a/hooks-core/decide.mjs
+++ b/hooks-core/decide.mjs
@@ -432,6 +432,14 @@ export function normalizePayload(raw) {
 
   return {
     session_id: raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? 'default',
+    // WHICH AGENT, not just which session. Subagents inherit the parent's session
+    // id, so state keyed on the session alone is shared by every agent under it
+    // -- which made one agent's reads silence another's. The transcript path is
+    // per agent, and it has to survive normalisation to be usable: this function
+    // returns a NEW object rather than spreading `raw`, so a field that is not
+    // named here is silently dropped. That is exactly how it was lost the first
+    // time this fix was attempted.
+    transcript_path: raw.transcript_path ?? raw.transcriptPath ?? null,
     cwd,
     tool_name: normalizeTool(raw.tool_name ?? raw.toolName ?? raw.tool),
     tool_input: {

--- a/hooks-core/policy.mjs
+++ b/hooks-core/policy.mjs
@@ -32,9 +32,19 @@
  *      would trade real tokens for hook overhead and user irritation.
  */
 
-import { statSync, mkdirSync, readFileSync, writeFileSync, renameSync, openSync, closeSync, unlinkSync } from 'node:fs';
+import {
+  statSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+  openSync,
+  closeSync,
+  unlinkSync,
+} from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { createHash } from 'node:crypto';
 import { isFsSafePath } from './paths.mjs';
 
 /** Enforcement modes, least to most permissive. */
@@ -66,7 +76,8 @@ function intEnv(name, fallback) {
  * single file. Below it the hook's own overhead is a meaningful fraction of the
  * savings, so the call is left alone.
  */
-export const largeFileBytes = () => intEnv('TOKEN_OPTIMIZER_LARGE_READ_BYTES', 25_600);
+export const largeFileBytes = () =>
+  intEnv('TOKEN_OPTIMIZER_LARGE_READ_BYTES', 25_600);
 
 /**
  * Size below which NO refusal can pay for itself.
@@ -84,14 +95,39 @@ export const largeFileBytes = () => intEnv('TOKEN_OPTIMIZER_LARGE_READ_BYTES', 2
  * 1 KB is about 256 tokens, comfortably above the largest refusal this hook
  * emits, so a refusal above the floor always pays.
  */
-export const refusalFloorBytes = () => intEnv('TOKEN_OPTIMIZER_REFUSAL_FLOOR_BYTES', 1_024);
+export const refusalFloorBytes = () =>
+  intEnv('TOKEN_OPTIMIZER_REFUSAL_FLOOR_BYTES', 1_024);
 
 /** Extensions whose bytes are not tokens, so byte thresholds do not apply. */
 const BINARY_EXTENSIONS = new Set([
-  '.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.ico', '.svg',
-  '.pdf', '.zip', '.gz', '.tar', '.7z', '.rar',
-  '.exe', '.dll', '.so', '.dylib', '.bin', '.wasm',
-  '.mp3', '.mp4', '.wav', '.mov', '.woff', '.woff2', '.ttf', '.eot',
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+  '.bmp',
+  '.ico',
+  '.svg',
+  '.pdf',
+  '.zip',
+  '.gz',
+  '.tar',
+  '.7z',
+  '.rar',
+  '.exe',
+  '.dll',
+  '.so',
+  '.dylib',
+  '.bin',
+  '.wasm',
+  '.mp3',
+  '.mp4',
+  '.wav',
+  '.mov',
+  '.woff',
+  '.woff2',
+  '.ttf',
+  '.eot',
 ]);
 
 export function isBinaryPath(path) {
@@ -113,7 +149,8 @@ export function isBinaryPath(path) {
  * knowledge, all of it churns constantly (so it would thrash staleness), and
  * none of it is something a person reads.
  */
-const MACHINE_OWNED = /(?:^|[/\\])(?:\.git|\.hg|\.svn|node_modules|\.venv|__pycache__|\.next|\.turbo|dist|obj|bin)(?:[/\\]|$)/i;
+const MACHINE_OWNED =
+  /(?:^|[/\\])(?:\.git|\.hg|\.svn|node_modules|\.venv|__pycache__|\.next|\.turbo|dist|obj|bin)(?:[/\\]|$)/i;
 
 /**
  * Collapses `.` and `..` textually, without touching the filesystem.
@@ -155,7 +192,13 @@ export function isMachineOwned(path) {
   // stores `.git` as a FILE, so `/repo/.git` has no trailing separator and
   // was classified as authored content -- putting git metadata through Read
   // refusal and into the knowledge graph.
-  return MACHINE_OWNED.test(normalizeSegments(String(path || '').split('\\').join('/')));
+  return MACHINE_OWNED.test(
+    normalizeSegments(
+      String(path || '')
+        .split('\\')
+        .join('/')
+    )
+  );
 }
 
 /** Size in bytes, or -1 when the path is missing or is not a regular file. */
@@ -193,13 +236,36 @@ export function fileSize(path) {
  * read-modify-write survived here unnoticed.
  */
 const stateRoot = () =>
-  process.env.TOKEN_OPTIMIZER_STATE_DIR || join(tmpdir(), 'token-optimizer-hooks');
+  process.env.TOKEN_OPTIMIZER_STATE_DIR ||
+  join(tmpdir(), 'token-optimizer-hooks');
 
-function statePath(sessionId) {
+/**
+ * Per SESSION and per AGENT, not per session alone.
+ *
+ * Every subagent inherits its parent's session id, so keying on the session
+ * alone gave all of them ONE `seen` set. An agent was then refused a file it had
+ * never opened -- observed verbatim: "release.yml is UNCHANGED since you last
+ * read it this session" -- because a different agent had read it. That agent
+ * fell back to Bash to get the contents, which defeats the optimizer and costs
+ * more than the read it replaced.
+ *
+ * `agent` is the caller's transcript path, which is distinct per subagent. It is
+ * HASHED rather than sanitised into the filename: it is an absolute path, so
+ * stripping separators would collide across directories, and the digest keeps
+ * the name bounded.
+ *
+ * Absent, the scope falls back to the session -- the main session's own calls
+ * must keep sharing one state, or the once-per-session gates would reset on
+ * every tool call.
+ */
+function statePath(sessionId, agent) {
   // Session ids come from the harness and are uuid-shaped, but they land in a
   // file path, so anything that could traverse is stripped rather than trusted.
   const safe = String(sessionId || 'default').replace(/[^A-Za-z0-9_-]/g, '');
-  return join(stateRoot(), `${safe || 'default'}.json`);
+  const scope = agent
+    ? `-${createHash('sha256').update(String(agent)).digest('hex').slice(0, 12)}`
+    : '';
+  return join(stateRoot(), `${safe || 'default'}${scope}.json`);
 }
 
 /** A usable state object, whatever was on disk. */
@@ -217,13 +283,16 @@ function emptyState() {
  * have been "enforcement silently stops working for this session", which is
  * exactly the kind of quiet failure that never gets reported.
  */
-export function loadState(sessionId) {
+export function loadState(sessionId, agent) {
   try {
-    const parsed = JSON.parse(readFileSync(statePath(sessionId), 'utf8'));
+    const parsed = JSON.parse(
+      readFileSync(statePath(sessionId, agent), 'utf8')
+    );
     if (!parsed || typeof parsed !== 'object') return emptyState();
     return {
       seen: parsed.seen && typeof parsed.seen === 'object' ? parsed.seen : {},
-      denied: parsed.denied && typeof parsed.denied === 'object' ? parsed.denied : {},
+      denied:
+        parsed.denied && typeof parsed.denied === 'object' ? parsed.denied : {},
       // WITHOUT THIS THE ONCE-PER-SESSION GATE DOES NOT EXIST. Every tool call
       // is a separate hook PROCESS, so a set held only in memory dies with the
       // process that built it: the router recorded which findings it had
@@ -253,7 +322,7 @@ export function loadState(sessionId) {
  * but it turns "last writer wins" into "union of writers", which is the
  * behaviour the two maps actually want, since both are append-only sets.
  */
-export function saveState(sessionId, state) {
+export function saveState(sessionId, state, agent) {
   let lock = null;
   try {
     mkdirSync(stateRoot(), { recursive: true, mode: 0o700 });
@@ -274,10 +343,10 @@ export function saveState(sessionId, state) {
     // bounded by design -- a repeated denial is allowed through by rule, and a
     // repeated injection costs its tokens once more. A stale lock is still
     // broken and taken below, so a killed process cannot wedge enforcement.
-    lock = takeLock(sessionId);
+    lock = takeLock(sessionId, agent);
     if (!lock) return false;
 
-    const current = loadState(sessionId);
+    const current = loadState(sessionId, agent);
     const merged = {
       seen: { ...current.seen, ...state.seen },
       denied: { ...current.denied, ...state.denied },
@@ -285,11 +354,13 @@ export function saveState(sessionId, state) {
       // their own view of what has been injected; taking the last writer's copy
       // would resurrect a finding the other had already delivered, which is the
       // repetition the once-per-session gate exists to stop.
-      injected: [...new Set([...(current.injected || []), ...(state.injected || [])])],
+      injected: [
+        ...new Set([...(current.injected || []), ...(state.injected || [])]),
+      ],
     };
 
     // Write-then-rename so a reader never observes a half-written file.
-    const target = statePath(sessionId);
+    const target = statePath(sessionId, agent);
     const temporary = `${target}.${process.pid}.tmp`;
     writeFileSync(temporary, JSON.stringify(merged), { mode: 0o600 });
     renameSync(temporary, target);
@@ -325,17 +396,17 @@ export function saveState(sessionId, state) {
  * Same lock and write-then-rename discipline as saveState: a reader must never see a
  * half-written file, and a missed lock skips the write rather than racing it.
  */
-export function clearSeen(sessionId) {
+export function clearSeen(sessionId, agent) {
   let lock = null;
   try {
     mkdirSync(stateRoot(), { recursive: true, mode: 0o700 });
-    lock = takeLock(sessionId);
+    lock = takeLock(sessionId, agent);
     if (!lock) return false;
 
-    const current = loadState(sessionId);
+    const current = loadState(sessionId, agent);
     const cleared = { ...current, seen: {} };
 
-    const target = statePath(sessionId);
+    const target = statePath(sessionId, agent);
     const temporary = `${target}.${process.pid}.tmp`;
     writeFileSync(temporary, JSON.stringify(cleared), { mode: 0o600 });
     renameSync(temporary, target);
@@ -374,8 +445,16 @@ function sleepSync(ms) {
 }
 
 /** Best-effort exclusive lock. Returns the lock path, or null if not acquired. */
-function takeLock(sessionId, { attempts = 20, staleMs = 5000, waitMs = 15 } = {}) {
-  const path = `${statePath(sessionId)}.lock`;
+function takeLock(
+  sessionId,
+  agent,
+  { attempts = 20, staleMs = 5000, waitMs = 15 } = {}
+) {
+  // Locks the file it actually guards. Scoping the state per agent while leaving
+  // the lock on the session path would serialise every agent on one lock AND
+  // protect the wrong file -- two agents could then interleave a
+  // read-modify-write on their own states while holding a lock on neither.
+  const path = `${statePath(sessionId, agent)}.lock`;
   for (let i = 0; i < attempts; i++) {
     try {
       const fd = openSync(path, 'wx', 0o600);
@@ -466,13 +545,15 @@ export function allowWithContext(context) {
  * says "use the optimized tool" gets met with a retry of the same call.
  */
 export function deny(reason) {
-  process.stdout.write(JSON.stringify({
-    hookSpecificOutput: {
-      hookEventName: 'PreToolUse',
-      permissionDecision: 'deny',
-      permissionDecisionReason: withEscape(reason),
-    },
-  }));
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: withEscape(reason),
+      },
+    })
+  );
   process.exit(0);
 }
 
@@ -497,12 +578,14 @@ export function withEscape(reason) {
 
 /** Lets the call through, attaching a note the model sees. */
 export function advise(context) {
-  process.stdout.write(JSON.stringify({
-    hookSpecificOutput: {
-      hookEventName: 'PreToolUse',
-      additionalContext: context,
-    },
-  }));
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        additionalContext: context,
+      },
+    })
+  );
   process.exit(0);
 }
 
@@ -530,7 +613,10 @@ export function enforce(reason, deniedBefore) {
  * than an absent one, so the wait has a ceiling and expiring it is treated
  * exactly like unusable input.
  */
-export async function readPayload({ timeoutMs = 5000, maxBytes = 8_000_000 } = {}) {
+export async function readPayload({
+  timeoutMs = 5000,
+  maxBytes = 8_000_000,
+} = {}) {
   const chunks = [];
   let size = 0;
 
@@ -539,7 +625,10 @@ export async function readPayload({ timeoutMs = 5000, maxBytes = 8_000_000 } = {
       size += chunk.length;
       // A payload this large is not a tool call; refusing to buffer it
       // unboundedly keeps a hook from becoming a memory problem.
-      if (size > maxBytes) { finish(null); return; }
+      if (size > maxBytes) {
+        finish(null);
+        return;
+      }
       chunks.push(chunk);
     };
     const onEnd = () => finish(chunks.join(''));

--- a/integrations/codex/hooks/lib/decide.mjs
+++ b/integrations/codex/hooks/lib/decide.mjs
@@ -434,6 +434,14 @@ export function normalizePayload(raw) {
 
   return {
     session_id: raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? 'default',
+    // WHICH AGENT, not just which session. Subagents inherit the parent's session
+    // id, so state keyed on the session alone is shared by every agent under it
+    // -- which made one agent's reads silence another's. The transcript path is
+    // per agent, and it has to survive normalisation to be usable: this function
+    // returns a NEW object rather than spreading `raw`, so a field that is not
+    // named here is silently dropped. That is exactly how it was lost the first
+    // time this fix was attempted.
+    transcript_path: raw.transcript_path ?? raw.transcriptPath ?? null,
     cwd,
     tool_name: normalizeTool(raw.tool_name ?? raw.toolName ?? raw.tool),
     tool_input: {

--- a/integrations/codex/hooks/lib/policy.mjs
+++ b/integrations/codex/hooks/lib/policy.mjs
@@ -34,9 +34,19 @@
  *      would trade real tokens for hook overhead and user irritation.
  */
 
-import { statSync, mkdirSync, readFileSync, writeFileSync, renameSync, openSync, closeSync, unlinkSync } from 'node:fs';
+import {
+  statSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+  openSync,
+  closeSync,
+  unlinkSync,
+} from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { createHash } from 'node:crypto';
 import { isFsSafePath } from './paths.mjs';
 
 /** Enforcement modes, least to most permissive. */
@@ -68,7 +78,8 @@ function intEnv(name, fallback) {
  * single file. Below it the hook's own overhead is a meaningful fraction of the
  * savings, so the call is left alone.
  */
-export const largeFileBytes = () => intEnv('TOKEN_OPTIMIZER_LARGE_READ_BYTES', 25_600);
+export const largeFileBytes = () =>
+  intEnv('TOKEN_OPTIMIZER_LARGE_READ_BYTES', 25_600);
 
 /**
  * Size below which NO refusal can pay for itself.
@@ -86,14 +97,39 @@ export const largeFileBytes = () => intEnv('TOKEN_OPTIMIZER_LARGE_READ_BYTES', 2
  * 1 KB is about 256 tokens, comfortably above the largest refusal this hook
  * emits, so a refusal above the floor always pays.
  */
-export const refusalFloorBytes = () => intEnv('TOKEN_OPTIMIZER_REFUSAL_FLOOR_BYTES', 1_024);
+export const refusalFloorBytes = () =>
+  intEnv('TOKEN_OPTIMIZER_REFUSAL_FLOOR_BYTES', 1_024);
 
 /** Extensions whose bytes are not tokens, so byte thresholds do not apply. */
 const BINARY_EXTENSIONS = new Set([
-  '.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.ico', '.svg',
-  '.pdf', '.zip', '.gz', '.tar', '.7z', '.rar',
-  '.exe', '.dll', '.so', '.dylib', '.bin', '.wasm',
-  '.mp3', '.mp4', '.wav', '.mov', '.woff', '.woff2', '.ttf', '.eot',
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+  '.bmp',
+  '.ico',
+  '.svg',
+  '.pdf',
+  '.zip',
+  '.gz',
+  '.tar',
+  '.7z',
+  '.rar',
+  '.exe',
+  '.dll',
+  '.so',
+  '.dylib',
+  '.bin',
+  '.wasm',
+  '.mp3',
+  '.mp4',
+  '.wav',
+  '.mov',
+  '.woff',
+  '.woff2',
+  '.ttf',
+  '.eot',
 ]);
 
 export function isBinaryPath(path) {
@@ -115,7 +151,8 @@ export function isBinaryPath(path) {
  * knowledge, all of it churns constantly (so it would thrash staleness), and
  * none of it is something a person reads.
  */
-const MACHINE_OWNED = /(?:^|[/\\])(?:\.git|\.hg|\.svn|node_modules|\.venv|__pycache__|\.next|\.turbo|dist|obj|bin)(?:[/\\]|$)/i;
+const MACHINE_OWNED =
+  /(?:^|[/\\])(?:\.git|\.hg|\.svn|node_modules|\.venv|__pycache__|\.next|\.turbo|dist|obj|bin)(?:[/\\]|$)/i;
 
 /**
  * Collapses `.` and `..` textually, without touching the filesystem.
@@ -157,7 +194,13 @@ export function isMachineOwned(path) {
   // stores `.git` as a FILE, so `/repo/.git` has no trailing separator and
   // was classified as authored content -- putting git metadata through Read
   // refusal and into the knowledge graph.
-  return MACHINE_OWNED.test(normalizeSegments(String(path || '').split('\\').join('/')));
+  return MACHINE_OWNED.test(
+    normalizeSegments(
+      String(path || '')
+        .split('\\')
+        .join('/')
+    )
+  );
 }
 
 /** Size in bytes, or -1 when the path is missing or is not a regular file. */
@@ -195,13 +238,36 @@ export function fileSize(path) {
  * read-modify-write survived here unnoticed.
  */
 const stateRoot = () =>
-  process.env.TOKEN_OPTIMIZER_STATE_DIR || join(tmpdir(), 'token-optimizer-hooks');
+  process.env.TOKEN_OPTIMIZER_STATE_DIR ||
+  join(tmpdir(), 'token-optimizer-hooks');
 
-function statePath(sessionId) {
+/**
+ * Per SESSION and per AGENT, not per session alone.
+ *
+ * Every subagent inherits its parent's session id, so keying on the session
+ * alone gave all of them ONE `seen` set. An agent was then refused a file it had
+ * never opened -- observed verbatim: "release.yml is UNCHANGED since you last
+ * read it this session" -- because a different agent had read it. That agent
+ * fell back to Bash to get the contents, which defeats the optimizer and costs
+ * more than the read it replaced.
+ *
+ * `agent` is the caller's transcript path, which is distinct per subagent. It is
+ * HASHED rather than sanitised into the filename: it is an absolute path, so
+ * stripping separators would collide across directories, and the digest keeps
+ * the name bounded.
+ *
+ * Absent, the scope falls back to the session -- the main session's own calls
+ * must keep sharing one state, or the once-per-session gates would reset on
+ * every tool call.
+ */
+function statePath(sessionId, agent) {
   // Session ids come from the harness and are uuid-shaped, but they land in a
   // file path, so anything that could traverse is stripped rather than trusted.
   const safe = String(sessionId || 'default').replace(/[^A-Za-z0-9_-]/g, '');
-  return join(stateRoot(), `${safe || 'default'}.json`);
+  const scope = agent
+    ? `-${createHash('sha256').update(String(agent)).digest('hex').slice(0, 12)}`
+    : '';
+  return join(stateRoot(), `${safe || 'default'}${scope}.json`);
 }
 
 /** A usable state object, whatever was on disk. */
@@ -219,13 +285,16 @@ function emptyState() {
  * have been "enforcement silently stops working for this session", which is
  * exactly the kind of quiet failure that never gets reported.
  */
-export function loadState(sessionId) {
+export function loadState(sessionId, agent) {
   try {
-    const parsed = JSON.parse(readFileSync(statePath(sessionId), 'utf8'));
+    const parsed = JSON.parse(
+      readFileSync(statePath(sessionId, agent), 'utf8')
+    );
     if (!parsed || typeof parsed !== 'object') return emptyState();
     return {
       seen: parsed.seen && typeof parsed.seen === 'object' ? parsed.seen : {},
-      denied: parsed.denied && typeof parsed.denied === 'object' ? parsed.denied : {},
+      denied:
+        parsed.denied && typeof parsed.denied === 'object' ? parsed.denied : {},
       // WITHOUT THIS THE ONCE-PER-SESSION GATE DOES NOT EXIST. Every tool call
       // is a separate hook PROCESS, so a set held only in memory dies with the
       // process that built it: the router recorded which findings it had
@@ -255,7 +324,7 @@ export function loadState(sessionId) {
  * but it turns "last writer wins" into "union of writers", which is the
  * behaviour the two maps actually want, since both are append-only sets.
  */
-export function saveState(sessionId, state) {
+export function saveState(sessionId, state, agent) {
   let lock = null;
   try {
     mkdirSync(stateRoot(), { recursive: true, mode: 0o700 });
@@ -276,10 +345,10 @@ export function saveState(sessionId, state) {
     // bounded by design -- a repeated denial is allowed through by rule, and a
     // repeated injection costs its tokens once more. A stale lock is still
     // broken and taken below, so a killed process cannot wedge enforcement.
-    lock = takeLock(sessionId);
+    lock = takeLock(sessionId, agent);
     if (!lock) return false;
 
-    const current = loadState(sessionId);
+    const current = loadState(sessionId, agent);
     const merged = {
       seen: { ...current.seen, ...state.seen },
       denied: { ...current.denied, ...state.denied },
@@ -287,11 +356,13 @@ export function saveState(sessionId, state) {
       // their own view of what has been injected; taking the last writer's copy
       // would resurrect a finding the other had already delivered, which is the
       // repetition the once-per-session gate exists to stop.
-      injected: [...new Set([...(current.injected || []), ...(state.injected || [])])],
+      injected: [
+        ...new Set([...(current.injected || []), ...(state.injected || [])]),
+      ],
     };
 
     // Write-then-rename so a reader never observes a half-written file.
-    const target = statePath(sessionId);
+    const target = statePath(sessionId, agent);
     const temporary = `${target}.${process.pid}.tmp`;
     writeFileSync(temporary, JSON.stringify(merged), { mode: 0o600 });
     renameSync(temporary, target);
@@ -327,17 +398,17 @@ export function saveState(sessionId, state) {
  * Same lock and write-then-rename discipline as saveState: a reader must never see a
  * half-written file, and a missed lock skips the write rather than racing it.
  */
-export function clearSeen(sessionId) {
+export function clearSeen(sessionId, agent) {
   let lock = null;
   try {
     mkdirSync(stateRoot(), { recursive: true, mode: 0o700 });
-    lock = takeLock(sessionId);
+    lock = takeLock(sessionId, agent);
     if (!lock) return false;
 
-    const current = loadState(sessionId);
+    const current = loadState(sessionId, agent);
     const cleared = { ...current, seen: {} };
 
-    const target = statePath(sessionId);
+    const target = statePath(sessionId, agent);
     const temporary = `${target}.${process.pid}.tmp`;
     writeFileSync(temporary, JSON.stringify(cleared), { mode: 0o600 });
     renameSync(temporary, target);
@@ -376,8 +447,16 @@ function sleepSync(ms) {
 }
 
 /** Best-effort exclusive lock. Returns the lock path, or null if not acquired. */
-function takeLock(sessionId, { attempts = 20, staleMs = 5000, waitMs = 15 } = {}) {
-  const path = `${statePath(sessionId)}.lock`;
+function takeLock(
+  sessionId,
+  agent,
+  { attempts = 20, staleMs = 5000, waitMs = 15 } = {}
+) {
+  // Locks the file it actually guards. Scoping the state per agent while leaving
+  // the lock on the session path would serialise every agent on one lock AND
+  // protect the wrong file -- two agents could then interleave a
+  // read-modify-write on their own states while holding a lock on neither.
+  const path = `${statePath(sessionId, agent)}.lock`;
   for (let i = 0; i < attempts; i++) {
     try {
       const fd = openSync(path, 'wx', 0o600);
@@ -468,13 +547,15 @@ export function allowWithContext(context) {
  * says "use the optimized tool" gets met with a retry of the same call.
  */
 export function deny(reason) {
-  process.stdout.write(JSON.stringify({
-    hookSpecificOutput: {
-      hookEventName: 'PreToolUse',
-      permissionDecision: 'deny',
-      permissionDecisionReason: withEscape(reason),
-    },
-  }));
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: withEscape(reason),
+      },
+    })
+  );
   process.exit(0);
 }
 
@@ -499,12 +580,14 @@ export function withEscape(reason) {
 
 /** Lets the call through, attaching a note the model sees. */
 export function advise(context) {
-  process.stdout.write(JSON.stringify({
-    hookSpecificOutput: {
-      hookEventName: 'PreToolUse',
-      additionalContext: context,
-    },
-  }));
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        additionalContext: context,
+      },
+    })
+  );
   process.exit(0);
 }
 
@@ -532,7 +615,10 @@ export function enforce(reason, deniedBefore) {
  * than an absent one, so the wait has a ceiling and expiring it is treated
  * exactly like unusable input.
  */
-export async function readPayload({ timeoutMs = 5000, maxBytes = 8_000_000 } = {}) {
+export async function readPayload({
+  timeoutMs = 5000,
+  maxBytes = 8_000_000,
+} = {}) {
   const chunks = [];
   let size = 0;
 
@@ -541,7 +627,10 @@ export async function readPayload({ timeoutMs = 5000, maxBytes = 8_000_000 } = {
       size += chunk.length;
       // A payload this large is not a tool call; refusing to buffer it
       // unboundedly keeps a hook from becoming a memory problem.
-      if (size > maxBytes) { finish(null); return; }
+      if (size > maxBytes) {
+        finish(null);
+        return;
+      }
       chunks.push(chunk);
     };
     const onEnd = () => finish(chunks.join(''));

--- a/integrations/codex/plugin/hooks/lib/decide.mjs
+++ b/integrations/codex/plugin/hooks/lib/decide.mjs
@@ -434,6 +434,14 @@ export function normalizePayload(raw) {
 
   return {
     session_id: raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? 'default',
+    // WHICH AGENT, not just which session. Subagents inherit the parent's session
+    // id, so state keyed on the session alone is shared by every agent under it
+    // -- which made one agent's reads silence another's. The transcript path is
+    // per agent, and it has to survive normalisation to be usable: this function
+    // returns a NEW object rather than spreading `raw`, so a field that is not
+    // named here is silently dropped. That is exactly how it was lost the first
+    // time this fix was attempted.
+    transcript_path: raw.transcript_path ?? raw.transcriptPath ?? null,
     cwd,
     tool_name: normalizeTool(raw.tool_name ?? raw.toolName ?? raw.tool),
     tool_input: {

--- a/integrations/codex/plugin/hooks/lib/policy.mjs
+++ b/integrations/codex/plugin/hooks/lib/policy.mjs
@@ -34,9 +34,19 @@
  *      would trade real tokens for hook overhead and user irritation.
  */
 
-import { statSync, mkdirSync, readFileSync, writeFileSync, renameSync, openSync, closeSync, unlinkSync } from 'node:fs';
+import {
+  statSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+  openSync,
+  closeSync,
+  unlinkSync,
+} from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { createHash } from 'node:crypto';
 import { isFsSafePath } from './paths.mjs';
 
 /** Enforcement modes, least to most permissive. */
@@ -68,7 +78,8 @@ function intEnv(name, fallback) {
  * single file. Below it the hook's own overhead is a meaningful fraction of the
  * savings, so the call is left alone.
  */
-export const largeFileBytes = () => intEnv('TOKEN_OPTIMIZER_LARGE_READ_BYTES', 25_600);
+export const largeFileBytes = () =>
+  intEnv('TOKEN_OPTIMIZER_LARGE_READ_BYTES', 25_600);
 
 /**
  * Size below which NO refusal can pay for itself.
@@ -86,14 +97,39 @@ export const largeFileBytes = () => intEnv('TOKEN_OPTIMIZER_LARGE_READ_BYTES', 2
  * 1 KB is about 256 tokens, comfortably above the largest refusal this hook
  * emits, so a refusal above the floor always pays.
  */
-export const refusalFloorBytes = () => intEnv('TOKEN_OPTIMIZER_REFUSAL_FLOOR_BYTES', 1_024);
+export const refusalFloorBytes = () =>
+  intEnv('TOKEN_OPTIMIZER_REFUSAL_FLOOR_BYTES', 1_024);
 
 /** Extensions whose bytes are not tokens, so byte thresholds do not apply. */
 const BINARY_EXTENSIONS = new Set([
-  '.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.ico', '.svg',
-  '.pdf', '.zip', '.gz', '.tar', '.7z', '.rar',
-  '.exe', '.dll', '.so', '.dylib', '.bin', '.wasm',
-  '.mp3', '.mp4', '.wav', '.mov', '.woff', '.woff2', '.ttf', '.eot',
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+  '.bmp',
+  '.ico',
+  '.svg',
+  '.pdf',
+  '.zip',
+  '.gz',
+  '.tar',
+  '.7z',
+  '.rar',
+  '.exe',
+  '.dll',
+  '.so',
+  '.dylib',
+  '.bin',
+  '.wasm',
+  '.mp3',
+  '.mp4',
+  '.wav',
+  '.mov',
+  '.woff',
+  '.woff2',
+  '.ttf',
+  '.eot',
 ]);
 
 export function isBinaryPath(path) {
@@ -115,7 +151,8 @@ export function isBinaryPath(path) {
  * knowledge, all of it churns constantly (so it would thrash staleness), and
  * none of it is something a person reads.
  */
-const MACHINE_OWNED = /(?:^|[/\\])(?:\.git|\.hg|\.svn|node_modules|\.venv|__pycache__|\.next|\.turbo|dist|obj|bin)(?:[/\\]|$)/i;
+const MACHINE_OWNED =
+  /(?:^|[/\\])(?:\.git|\.hg|\.svn|node_modules|\.venv|__pycache__|\.next|\.turbo|dist|obj|bin)(?:[/\\]|$)/i;
 
 /**
  * Collapses `.` and `..` textually, without touching the filesystem.
@@ -157,7 +194,13 @@ export function isMachineOwned(path) {
   // stores `.git` as a FILE, so `/repo/.git` has no trailing separator and
   // was classified as authored content -- putting git metadata through Read
   // refusal and into the knowledge graph.
-  return MACHINE_OWNED.test(normalizeSegments(String(path || '').split('\\').join('/')));
+  return MACHINE_OWNED.test(
+    normalizeSegments(
+      String(path || '')
+        .split('\\')
+        .join('/')
+    )
+  );
 }
 
 /** Size in bytes, or -1 when the path is missing or is not a regular file. */
@@ -195,13 +238,36 @@ export function fileSize(path) {
  * read-modify-write survived here unnoticed.
  */
 const stateRoot = () =>
-  process.env.TOKEN_OPTIMIZER_STATE_DIR || join(tmpdir(), 'token-optimizer-hooks');
+  process.env.TOKEN_OPTIMIZER_STATE_DIR ||
+  join(tmpdir(), 'token-optimizer-hooks');
 
-function statePath(sessionId) {
+/**
+ * Per SESSION and per AGENT, not per session alone.
+ *
+ * Every subagent inherits its parent's session id, so keying on the session
+ * alone gave all of them ONE `seen` set. An agent was then refused a file it had
+ * never opened -- observed verbatim: "release.yml is UNCHANGED since you last
+ * read it this session" -- because a different agent had read it. That agent
+ * fell back to Bash to get the contents, which defeats the optimizer and costs
+ * more than the read it replaced.
+ *
+ * `agent` is the caller's transcript path, which is distinct per subagent. It is
+ * HASHED rather than sanitised into the filename: it is an absolute path, so
+ * stripping separators would collide across directories, and the digest keeps
+ * the name bounded.
+ *
+ * Absent, the scope falls back to the session -- the main session's own calls
+ * must keep sharing one state, or the once-per-session gates would reset on
+ * every tool call.
+ */
+function statePath(sessionId, agent) {
   // Session ids come from the harness and are uuid-shaped, but they land in a
   // file path, so anything that could traverse is stripped rather than trusted.
   const safe = String(sessionId || 'default').replace(/[^A-Za-z0-9_-]/g, '');
-  return join(stateRoot(), `${safe || 'default'}.json`);
+  const scope = agent
+    ? `-${createHash('sha256').update(String(agent)).digest('hex').slice(0, 12)}`
+    : '';
+  return join(stateRoot(), `${safe || 'default'}${scope}.json`);
 }
 
 /** A usable state object, whatever was on disk. */
@@ -219,13 +285,16 @@ function emptyState() {
  * have been "enforcement silently stops working for this session", which is
  * exactly the kind of quiet failure that never gets reported.
  */
-export function loadState(sessionId) {
+export function loadState(sessionId, agent) {
   try {
-    const parsed = JSON.parse(readFileSync(statePath(sessionId), 'utf8'));
+    const parsed = JSON.parse(
+      readFileSync(statePath(sessionId, agent), 'utf8')
+    );
     if (!parsed || typeof parsed !== 'object') return emptyState();
     return {
       seen: parsed.seen && typeof parsed.seen === 'object' ? parsed.seen : {},
-      denied: parsed.denied && typeof parsed.denied === 'object' ? parsed.denied : {},
+      denied:
+        parsed.denied && typeof parsed.denied === 'object' ? parsed.denied : {},
       // WITHOUT THIS THE ONCE-PER-SESSION GATE DOES NOT EXIST. Every tool call
       // is a separate hook PROCESS, so a set held only in memory dies with the
       // process that built it: the router recorded which findings it had
@@ -255,7 +324,7 @@ export function loadState(sessionId) {
  * but it turns "last writer wins" into "union of writers", which is the
  * behaviour the two maps actually want, since both are append-only sets.
  */
-export function saveState(sessionId, state) {
+export function saveState(sessionId, state, agent) {
   let lock = null;
   try {
     mkdirSync(stateRoot(), { recursive: true, mode: 0o700 });
@@ -276,10 +345,10 @@ export function saveState(sessionId, state) {
     // bounded by design -- a repeated denial is allowed through by rule, and a
     // repeated injection costs its tokens once more. A stale lock is still
     // broken and taken below, so a killed process cannot wedge enforcement.
-    lock = takeLock(sessionId);
+    lock = takeLock(sessionId, agent);
     if (!lock) return false;
 
-    const current = loadState(sessionId);
+    const current = loadState(sessionId, agent);
     const merged = {
       seen: { ...current.seen, ...state.seen },
       denied: { ...current.denied, ...state.denied },
@@ -287,11 +356,13 @@ export function saveState(sessionId, state) {
       // their own view of what has been injected; taking the last writer's copy
       // would resurrect a finding the other had already delivered, which is the
       // repetition the once-per-session gate exists to stop.
-      injected: [...new Set([...(current.injected || []), ...(state.injected || [])])],
+      injected: [
+        ...new Set([...(current.injected || []), ...(state.injected || [])]),
+      ],
     };
 
     // Write-then-rename so a reader never observes a half-written file.
-    const target = statePath(sessionId);
+    const target = statePath(sessionId, agent);
     const temporary = `${target}.${process.pid}.tmp`;
     writeFileSync(temporary, JSON.stringify(merged), { mode: 0o600 });
     renameSync(temporary, target);
@@ -327,17 +398,17 @@ export function saveState(sessionId, state) {
  * Same lock and write-then-rename discipline as saveState: a reader must never see a
  * half-written file, and a missed lock skips the write rather than racing it.
  */
-export function clearSeen(sessionId) {
+export function clearSeen(sessionId, agent) {
   let lock = null;
   try {
     mkdirSync(stateRoot(), { recursive: true, mode: 0o700 });
-    lock = takeLock(sessionId);
+    lock = takeLock(sessionId, agent);
     if (!lock) return false;
 
-    const current = loadState(sessionId);
+    const current = loadState(sessionId, agent);
     const cleared = { ...current, seen: {} };
 
-    const target = statePath(sessionId);
+    const target = statePath(sessionId, agent);
     const temporary = `${target}.${process.pid}.tmp`;
     writeFileSync(temporary, JSON.stringify(cleared), { mode: 0o600 });
     renameSync(temporary, target);
@@ -376,8 +447,16 @@ function sleepSync(ms) {
 }
 
 /** Best-effort exclusive lock. Returns the lock path, or null if not acquired. */
-function takeLock(sessionId, { attempts = 20, staleMs = 5000, waitMs = 15 } = {}) {
-  const path = `${statePath(sessionId)}.lock`;
+function takeLock(
+  sessionId,
+  agent,
+  { attempts = 20, staleMs = 5000, waitMs = 15 } = {}
+) {
+  // Locks the file it actually guards. Scoping the state per agent while leaving
+  // the lock on the session path would serialise every agent on one lock AND
+  // protect the wrong file -- two agents could then interleave a
+  // read-modify-write on their own states while holding a lock on neither.
+  const path = `${statePath(sessionId, agent)}.lock`;
   for (let i = 0; i < attempts; i++) {
     try {
       const fd = openSync(path, 'wx', 0o600);
@@ -468,13 +547,15 @@ export function allowWithContext(context) {
  * says "use the optimized tool" gets met with a retry of the same call.
  */
 export function deny(reason) {
-  process.stdout.write(JSON.stringify({
-    hookSpecificOutput: {
-      hookEventName: 'PreToolUse',
-      permissionDecision: 'deny',
-      permissionDecisionReason: withEscape(reason),
-    },
-  }));
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: withEscape(reason),
+      },
+    })
+  );
   process.exit(0);
 }
 
@@ -499,12 +580,14 @@ export function withEscape(reason) {
 
 /** Lets the call through, attaching a note the model sees. */
 export function advise(context) {
-  process.stdout.write(JSON.stringify({
-    hookSpecificOutput: {
-      hookEventName: 'PreToolUse',
-      additionalContext: context,
-    },
-  }));
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        additionalContext: context,
+      },
+    })
+  );
   process.exit(0);
 }
 
@@ -532,7 +615,10 @@ export function enforce(reason, deniedBefore) {
  * than an absent one, so the wait has a ceiling and expiring it is treated
  * exactly like unusable input.
  */
-export async function readPayload({ timeoutMs = 5000, maxBytes = 8_000_000 } = {}) {
+export async function readPayload({
+  timeoutMs = 5000,
+  maxBytes = 8_000_000,
+} = {}) {
   const chunks = [];
   let size = 0;
 
@@ -541,7 +627,10 @@ export async function readPayload({ timeoutMs = 5000, maxBytes = 8_000_000 } = {
       size += chunk.length;
       // A payload this large is not a tool call; refusing to buffer it
       // unboundedly keeps a hook from becoming a memory problem.
-      if (size > maxBytes) { finish(null); return; }
+      if (size > maxBytes) {
+        finish(null);
+        return;
+      }
       chunks.push(chunk);
     };
     const onEnd = () => finish(chunks.join(''));

--- a/integrations/gemini/hooks/lib/decide.mjs
+++ b/integrations/gemini/hooks/lib/decide.mjs
@@ -434,6 +434,14 @@ export function normalizePayload(raw) {
 
   return {
     session_id: raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? 'default',
+    // WHICH AGENT, not just which session. Subagents inherit the parent's session
+    // id, so state keyed on the session alone is shared by every agent under it
+    // -- which made one agent's reads silence another's. The transcript path is
+    // per agent, and it has to survive normalisation to be usable: this function
+    // returns a NEW object rather than spreading `raw`, so a field that is not
+    // named here is silently dropped. That is exactly how it was lost the first
+    // time this fix was attempted.
+    transcript_path: raw.transcript_path ?? raw.transcriptPath ?? null,
     cwd,
     tool_name: normalizeTool(raw.tool_name ?? raw.toolName ?? raw.tool),
     tool_input: {

--- a/integrations/gemini/hooks/lib/policy.mjs
+++ b/integrations/gemini/hooks/lib/policy.mjs
@@ -34,9 +34,19 @@
  *      would trade real tokens for hook overhead and user irritation.
  */
 
-import { statSync, mkdirSync, readFileSync, writeFileSync, renameSync, openSync, closeSync, unlinkSync } from 'node:fs';
+import {
+  statSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+  openSync,
+  closeSync,
+  unlinkSync,
+} from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { createHash } from 'node:crypto';
 import { isFsSafePath } from './paths.mjs';
 
 /** Enforcement modes, least to most permissive. */
@@ -68,7 +78,8 @@ function intEnv(name, fallback) {
  * single file. Below it the hook's own overhead is a meaningful fraction of the
  * savings, so the call is left alone.
  */
-export const largeFileBytes = () => intEnv('TOKEN_OPTIMIZER_LARGE_READ_BYTES', 25_600);
+export const largeFileBytes = () =>
+  intEnv('TOKEN_OPTIMIZER_LARGE_READ_BYTES', 25_600);
 
 /**
  * Size below which NO refusal can pay for itself.
@@ -86,14 +97,39 @@ export const largeFileBytes = () => intEnv('TOKEN_OPTIMIZER_LARGE_READ_BYTES', 2
  * 1 KB is about 256 tokens, comfortably above the largest refusal this hook
  * emits, so a refusal above the floor always pays.
  */
-export const refusalFloorBytes = () => intEnv('TOKEN_OPTIMIZER_REFUSAL_FLOOR_BYTES', 1_024);
+export const refusalFloorBytes = () =>
+  intEnv('TOKEN_OPTIMIZER_REFUSAL_FLOOR_BYTES', 1_024);
 
 /** Extensions whose bytes are not tokens, so byte thresholds do not apply. */
 const BINARY_EXTENSIONS = new Set([
-  '.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.ico', '.svg',
-  '.pdf', '.zip', '.gz', '.tar', '.7z', '.rar',
-  '.exe', '.dll', '.so', '.dylib', '.bin', '.wasm',
-  '.mp3', '.mp4', '.wav', '.mov', '.woff', '.woff2', '.ttf', '.eot',
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+  '.bmp',
+  '.ico',
+  '.svg',
+  '.pdf',
+  '.zip',
+  '.gz',
+  '.tar',
+  '.7z',
+  '.rar',
+  '.exe',
+  '.dll',
+  '.so',
+  '.dylib',
+  '.bin',
+  '.wasm',
+  '.mp3',
+  '.mp4',
+  '.wav',
+  '.mov',
+  '.woff',
+  '.woff2',
+  '.ttf',
+  '.eot',
 ]);
 
 export function isBinaryPath(path) {
@@ -115,7 +151,8 @@ export function isBinaryPath(path) {
  * knowledge, all of it churns constantly (so it would thrash staleness), and
  * none of it is something a person reads.
  */
-const MACHINE_OWNED = /(?:^|[/\\])(?:\.git|\.hg|\.svn|node_modules|\.venv|__pycache__|\.next|\.turbo|dist|obj|bin)(?:[/\\]|$)/i;
+const MACHINE_OWNED =
+  /(?:^|[/\\])(?:\.git|\.hg|\.svn|node_modules|\.venv|__pycache__|\.next|\.turbo|dist|obj|bin)(?:[/\\]|$)/i;
 
 /**
  * Collapses `.` and `..` textually, without touching the filesystem.
@@ -157,7 +194,13 @@ export function isMachineOwned(path) {
   // stores `.git` as a FILE, so `/repo/.git` has no trailing separator and
   // was classified as authored content -- putting git metadata through Read
   // refusal and into the knowledge graph.
-  return MACHINE_OWNED.test(normalizeSegments(String(path || '').split('\\').join('/')));
+  return MACHINE_OWNED.test(
+    normalizeSegments(
+      String(path || '')
+        .split('\\')
+        .join('/')
+    )
+  );
 }
 
 /** Size in bytes, or -1 when the path is missing or is not a regular file. */
@@ -195,13 +238,36 @@ export function fileSize(path) {
  * read-modify-write survived here unnoticed.
  */
 const stateRoot = () =>
-  process.env.TOKEN_OPTIMIZER_STATE_DIR || join(tmpdir(), 'token-optimizer-hooks');
+  process.env.TOKEN_OPTIMIZER_STATE_DIR ||
+  join(tmpdir(), 'token-optimizer-hooks');
 
-function statePath(sessionId) {
+/**
+ * Per SESSION and per AGENT, not per session alone.
+ *
+ * Every subagent inherits its parent's session id, so keying on the session
+ * alone gave all of them ONE `seen` set. An agent was then refused a file it had
+ * never opened -- observed verbatim: "release.yml is UNCHANGED since you last
+ * read it this session" -- because a different agent had read it. That agent
+ * fell back to Bash to get the contents, which defeats the optimizer and costs
+ * more than the read it replaced.
+ *
+ * `agent` is the caller's transcript path, which is distinct per subagent. It is
+ * HASHED rather than sanitised into the filename: it is an absolute path, so
+ * stripping separators would collide across directories, and the digest keeps
+ * the name bounded.
+ *
+ * Absent, the scope falls back to the session -- the main session's own calls
+ * must keep sharing one state, or the once-per-session gates would reset on
+ * every tool call.
+ */
+function statePath(sessionId, agent) {
   // Session ids come from the harness and are uuid-shaped, but they land in a
   // file path, so anything that could traverse is stripped rather than trusted.
   const safe = String(sessionId || 'default').replace(/[^A-Za-z0-9_-]/g, '');
-  return join(stateRoot(), `${safe || 'default'}.json`);
+  const scope = agent
+    ? `-${createHash('sha256').update(String(agent)).digest('hex').slice(0, 12)}`
+    : '';
+  return join(stateRoot(), `${safe || 'default'}${scope}.json`);
 }
 
 /** A usable state object, whatever was on disk. */
@@ -219,13 +285,16 @@ function emptyState() {
  * have been "enforcement silently stops working for this session", which is
  * exactly the kind of quiet failure that never gets reported.
  */
-export function loadState(sessionId) {
+export function loadState(sessionId, agent) {
   try {
-    const parsed = JSON.parse(readFileSync(statePath(sessionId), 'utf8'));
+    const parsed = JSON.parse(
+      readFileSync(statePath(sessionId, agent), 'utf8')
+    );
     if (!parsed || typeof parsed !== 'object') return emptyState();
     return {
       seen: parsed.seen && typeof parsed.seen === 'object' ? parsed.seen : {},
-      denied: parsed.denied && typeof parsed.denied === 'object' ? parsed.denied : {},
+      denied:
+        parsed.denied && typeof parsed.denied === 'object' ? parsed.denied : {},
       // WITHOUT THIS THE ONCE-PER-SESSION GATE DOES NOT EXIST. Every tool call
       // is a separate hook PROCESS, so a set held only in memory dies with the
       // process that built it: the router recorded which findings it had
@@ -255,7 +324,7 @@ export function loadState(sessionId) {
  * but it turns "last writer wins" into "union of writers", which is the
  * behaviour the two maps actually want, since both are append-only sets.
  */
-export function saveState(sessionId, state) {
+export function saveState(sessionId, state, agent) {
   let lock = null;
   try {
     mkdirSync(stateRoot(), { recursive: true, mode: 0o700 });
@@ -276,10 +345,10 @@ export function saveState(sessionId, state) {
     // bounded by design -- a repeated denial is allowed through by rule, and a
     // repeated injection costs its tokens once more. A stale lock is still
     // broken and taken below, so a killed process cannot wedge enforcement.
-    lock = takeLock(sessionId);
+    lock = takeLock(sessionId, agent);
     if (!lock) return false;
 
-    const current = loadState(sessionId);
+    const current = loadState(sessionId, agent);
     const merged = {
       seen: { ...current.seen, ...state.seen },
       denied: { ...current.denied, ...state.denied },
@@ -287,11 +356,13 @@ export function saveState(sessionId, state) {
       // their own view of what has been injected; taking the last writer's copy
       // would resurrect a finding the other had already delivered, which is the
       // repetition the once-per-session gate exists to stop.
-      injected: [...new Set([...(current.injected || []), ...(state.injected || [])])],
+      injected: [
+        ...new Set([...(current.injected || []), ...(state.injected || [])]),
+      ],
     };
 
     // Write-then-rename so a reader never observes a half-written file.
-    const target = statePath(sessionId);
+    const target = statePath(sessionId, agent);
     const temporary = `${target}.${process.pid}.tmp`;
     writeFileSync(temporary, JSON.stringify(merged), { mode: 0o600 });
     renameSync(temporary, target);
@@ -327,17 +398,17 @@ export function saveState(sessionId, state) {
  * Same lock and write-then-rename discipline as saveState: a reader must never see a
  * half-written file, and a missed lock skips the write rather than racing it.
  */
-export function clearSeen(sessionId) {
+export function clearSeen(sessionId, agent) {
   let lock = null;
   try {
     mkdirSync(stateRoot(), { recursive: true, mode: 0o700 });
-    lock = takeLock(sessionId);
+    lock = takeLock(sessionId, agent);
     if (!lock) return false;
 
-    const current = loadState(sessionId);
+    const current = loadState(sessionId, agent);
     const cleared = { ...current, seen: {} };
 
-    const target = statePath(sessionId);
+    const target = statePath(sessionId, agent);
     const temporary = `${target}.${process.pid}.tmp`;
     writeFileSync(temporary, JSON.stringify(cleared), { mode: 0o600 });
     renameSync(temporary, target);
@@ -376,8 +447,16 @@ function sleepSync(ms) {
 }
 
 /** Best-effort exclusive lock. Returns the lock path, or null if not acquired. */
-function takeLock(sessionId, { attempts = 20, staleMs = 5000, waitMs = 15 } = {}) {
-  const path = `${statePath(sessionId)}.lock`;
+function takeLock(
+  sessionId,
+  agent,
+  { attempts = 20, staleMs = 5000, waitMs = 15 } = {}
+) {
+  // Locks the file it actually guards. Scoping the state per agent while leaving
+  // the lock on the session path would serialise every agent on one lock AND
+  // protect the wrong file -- two agents could then interleave a
+  // read-modify-write on their own states while holding a lock on neither.
+  const path = `${statePath(sessionId, agent)}.lock`;
   for (let i = 0; i < attempts; i++) {
     try {
       const fd = openSync(path, 'wx', 0o600);
@@ -468,13 +547,15 @@ export function allowWithContext(context) {
  * says "use the optimized tool" gets met with a retry of the same call.
  */
 export function deny(reason) {
-  process.stdout.write(JSON.stringify({
-    hookSpecificOutput: {
-      hookEventName: 'PreToolUse',
-      permissionDecision: 'deny',
-      permissionDecisionReason: withEscape(reason),
-    },
-  }));
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: withEscape(reason),
+      },
+    })
+  );
   process.exit(0);
 }
 
@@ -499,12 +580,14 @@ export function withEscape(reason) {
 
 /** Lets the call through, attaching a note the model sees. */
 export function advise(context) {
-  process.stdout.write(JSON.stringify({
-    hookSpecificOutput: {
-      hookEventName: 'PreToolUse',
-      additionalContext: context,
-    },
-  }));
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        additionalContext: context,
+      },
+    })
+  );
   process.exit(0);
 }
 
@@ -532,7 +615,10 @@ export function enforce(reason, deniedBefore) {
  * than an absent one, so the wait has a ceiling and expiring it is treated
  * exactly like unusable input.
  */
-export async function readPayload({ timeoutMs = 5000, maxBytes = 8_000_000 } = {}) {
+export async function readPayload({
+  timeoutMs = 5000,
+  maxBytes = 8_000_000,
+} = {}) {
   const chunks = [];
   let size = 0;
 
@@ -541,7 +627,10 @@ export async function readPayload({ timeoutMs = 5000, maxBytes = 8_000_000 } = {
       size += chunk.length;
       // A payload this large is not a tool call; refusing to buffer it
       // unboundedly keeps a hook from becoming a memory problem.
-      if (size > maxBytes) { finish(null); return; }
+      if (size > maxBytes) {
+        finish(null);
+        return;
+      }
       chunks.push(chunk);
     };
     const onEnd = () => finish(chunks.join(''));

--- a/integrations/opencode/hooks/lib/decide.mjs
+++ b/integrations/opencode/hooks/lib/decide.mjs
@@ -434,6 +434,14 @@ export function normalizePayload(raw) {
 
   return {
     session_id: raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? 'default',
+    // WHICH AGENT, not just which session. Subagents inherit the parent's session
+    // id, so state keyed on the session alone is shared by every agent under it
+    // -- which made one agent's reads silence another's. The transcript path is
+    // per agent, and it has to survive normalisation to be usable: this function
+    // returns a NEW object rather than spreading `raw`, so a field that is not
+    // named here is silently dropped. That is exactly how it was lost the first
+    // time this fix was attempted.
+    transcript_path: raw.transcript_path ?? raw.transcriptPath ?? null,
     cwd,
     tool_name: normalizeTool(raw.tool_name ?? raw.toolName ?? raw.tool),
     tool_input: {

--- a/integrations/opencode/hooks/lib/policy.mjs
+++ b/integrations/opencode/hooks/lib/policy.mjs
@@ -34,9 +34,19 @@
  *      would trade real tokens for hook overhead and user irritation.
  */
 
-import { statSync, mkdirSync, readFileSync, writeFileSync, renameSync, openSync, closeSync, unlinkSync } from 'node:fs';
+import {
+  statSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+  openSync,
+  closeSync,
+  unlinkSync,
+} from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { createHash } from 'node:crypto';
 import { isFsSafePath } from './paths.mjs';
 
 /** Enforcement modes, least to most permissive. */
@@ -68,7 +78,8 @@ function intEnv(name, fallback) {
  * single file. Below it the hook's own overhead is a meaningful fraction of the
  * savings, so the call is left alone.
  */
-export const largeFileBytes = () => intEnv('TOKEN_OPTIMIZER_LARGE_READ_BYTES', 25_600);
+export const largeFileBytes = () =>
+  intEnv('TOKEN_OPTIMIZER_LARGE_READ_BYTES', 25_600);
 
 /**
  * Size below which NO refusal can pay for itself.
@@ -86,14 +97,39 @@ export const largeFileBytes = () => intEnv('TOKEN_OPTIMIZER_LARGE_READ_BYTES', 2
  * 1 KB is about 256 tokens, comfortably above the largest refusal this hook
  * emits, so a refusal above the floor always pays.
  */
-export const refusalFloorBytes = () => intEnv('TOKEN_OPTIMIZER_REFUSAL_FLOOR_BYTES', 1_024);
+export const refusalFloorBytes = () =>
+  intEnv('TOKEN_OPTIMIZER_REFUSAL_FLOOR_BYTES', 1_024);
 
 /** Extensions whose bytes are not tokens, so byte thresholds do not apply. */
 const BINARY_EXTENSIONS = new Set([
-  '.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.ico', '.svg',
-  '.pdf', '.zip', '.gz', '.tar', '.7z', '.rar',
-  '.exe', '.dll', '.so', '.dylib', '.bin', '.wasm',
-  '.mp3', '.mp4', '.wav', '.mov', '.woff', '.woff2', '.ttf', '.eot',
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+  '.bmp',
+  '.ico',
+  '.svg',
+  '.pdf',
+  '.zip',
+  '.gz',
+  '.tar',
+  '.7z',
+  '.rar',
+  '.exe',
+  '.dll',
+  '.so',
+  '.dylib',
+  '.bin',
+  '.wasm',
+  '.mp3',
+  '.mp4',
+  '.wav',
+  '.mov',
+  '.woff',
+  '.woff2',
+  '.ttf',
+  '.eot',
 ]);
 
 export function isBinaryPath(path) {
@@ -115,7 +151,8 @@ export function isBinaryPath(path) {
  * knowledge, all of it churns constantly (so it would thrash staleness), and
  * none of it is something a person reads.
  */
-const MACHINE_OWNED = /(?:^|[/\\])(?:\.git|\.hg|\.svn|node_modules|\.venv|__pycache__|\.next|\.turbo|dist|obj|bin)(?:[/\\]|$)/i;
+const MACHINE_OWNED =
+  /(?:^|[/\\])(?:\.git|\.hg|\.svn|node_modules|\.venv|__pycache__|\.next|\.turbo|dist|obj|bin)(?:[/\\]|$)/i;
 
 /**
  * Collapses `.` and `..` textually, without touching the filesystem.
@@ -157,7 +194,13 @@ export function isMachineOwned(path) {
   // stores `.git` as a FILE, so `/repo/.git` has no trailing separator and
   // was classified as authored content -- putting git metadata through Read
   // refusal and into the knowledge graph.
-  return MACHINE_OWNED.test(normalizeSegments(String(path || '').split('\\').join('/')));
+  return MACHINE_OWNED.test(
+    normalizeSegments(
+      String(path || '')
+        .split('\\')
+        .join('/')
+    )
+  );
 }
 
 /** Size in bytes, or -1 when the path is missing or is not a regular file. */
@@ -195,13 +238,36 @@ export function fileSize(path) {
  * read-modify-write survived here unnoticed.
  */
 const stateRoot = () =>
-  process.env.TOKEN_OPTIMIZER_STATE_DIR || join(tmpdir(), 'token-optimizer-hooks');
+  process.env.TOKEN_OPTIMIZER_STATE_DIR ||
+  join(tmpdir(), 'token-optimizer-hooks');
 
-function statePath(sessionId) {
+/**
+ * Per SESSION and per AGENT, not per session alone.
+ *
+ * Every subagent inherits its parent's session id, so keying on the session
+ * alone gave all of them ONE `seen` set. An agent was then refused a file it had
+ * never opened -- observed verbatim: "release.yml is UNCHANGED since you last
+ * read it this session" -- because a different agent had read it. That agent
+ * fell back to Bash to get the contents, which defeats the optimizer and costs
+ * more than the read it replaced.
+ *
+ * `agent` is the caller's transcript path, which is distinct per subagent. It is
+ * HASHED rather than sanitised into the filename: it is an absolute path, so
+ * stripping separators would collide across directories, and the digest keeps
+ * the name bounded.
+ *
+ * Absent, the scope falls back to the session -- the main session's own calls
+ * must keep sharing one state, or the once-per-session gates would reset on
+ * every tool call.
+ */
+function statePath(sessionId, agent) {
   // Session ids come from the harness and are uuid-shaped, but they land in a
   // file path, so anything that could traverse is stripped rather than trusted.
   const safe = String(sessionId || 'default').replace(/[^A-Za-z0-9_-]/g, '');
-  return join(stateRoot(), `${safe || 'default'}.json`);
+  const scope = agent
+    ? `-${createHash('sha256').update(String(agent)).digest('hex').slice(0, 12)}`
+    : '';
+  return join(stateRoot(), `${safe || 'default'}${scope}.json`);
 }
 
 /** A usable state object, whatever was on disk. */
@@ -219,13 +285,16 @@ function emptyState() {
  * have been "enforcement silently stops working for this session", which is
  * exactly the kind of quiet failure that never gets reported.
  */
-export function loadState(sessionId) {
+export function loadState(sessionId, agent) {
   try {
-    const parsed = JSON.parse(readFileSync(statePath(sessionId), 'utf8'));
+    const parsed = JSON.parse(
+      readFileSync(statePath(sessionId, agent), 'utf8')
+    );
     if (!parsed || typeof parsed !== 'object') return emptyState();
     return {
       seen: parsed.seen && typeof parsed.seen === 'object' ? parsed.seen : {},
-      denied: parsed.denied && typeof parsed.denied === 'object' ? parsed.denied : {},
+      denied:
+        parsed.denied && typeof parsed.denied === 'object' ? parsed.denied : {},
       // WITHOUT THIS THE ONCE-PER-SESSION GATE DOES NOT EXIST. Every tool call
       // is a separate hook PROCESS, so a set held only in memory dies with the
       // process that built it: the router recorded which findings it had
@@ -255,7 +324,7 @@ export function loadState(sessionId) {
  * but it turns "last writer wins" into "union of writers", which is the
  * behaviour the two maps actually want, since both are append-only sets.
  */
-export function saveState(sessionId, state) {
+export function saveState(sessionId, state, agent) {
   let lock = null;
   try {
     mkdirSync(stateRoot(), { recursive: true, mode: 0o700 });
@@ -276,10 +345,10 @@ export function saveState(sessionId, state) {
     // bounded by design -- a repeated denial is allowed through by rule, and a
     // repeated injection costs its tokens once more. A stale lock is still
     // broken and taken below, so a killed process cannot wedge enforcement.
-    lock = takeLock(sessionId);
+    lock = takeLock(sessionId, agent);
     if (!lock) return false;
 
-    const current = loadState(sessionId);
+    const current = loadState(sessionId, agent);
     const merged = {
       seen: { ...current.seen, ...state.seen },
       denied: { ...current.denied, ...state.denied },
@@ -287,11 +356,13 @@ export function saveState(sessionId, state) {
       // their own view of what has been injected; taking the last writer's copy
       // would resurrect a finding the other had already delivered, which is the
       // repetition the once-per-session gate exists to stop.
-      injected: [...new Set([...(current.injected || []), ...(state.injected || [])])],
+      injected: [
+        ...new Set([...(current.injected || []), ...(state.injected || [])]),
+      ],
     };
 
     // Write-then-rename so a reader never observes a half-written file.
-    const target = statePath(sessionId);
+    const target = statePath(sessionId, agent);
     const temporary = `${target}.${process.pid}.tmp`;
     writeFileSync(temporary, JSON.stringify(merged), { mode: 0o600 });
     renameSync(temporary, target);
@@ -327,17 +398,17 @@ export function saveState(sessionId, state) {
  * Same lock and write-then-rename discipline as saveState: a reader must never see a
  * half-written file, and a missed lock skips the write rather than racing it.
  */
-export function clearSeen(sessionId) {
+export function clearSeen(sessionId, agent) {
   let lock = null;
   try {
     mkdirSync(stateRoot(), { recursive: true, mode: 0o700 });
-    lock = takeLock(sessionId);
+    lock = takeLock(sessionId, agent);
     if (!lock) return false;
 
-    const current = loadState(sessionId);
+    const current = loadState(sessionId, agent);
     const cleared = { ...current, seen: {} };
 
-    const target = statePath(sessionId);
+    const target = statePath(sessionId, agent);
     const temporary = `${target}.${process.pid}.tmp`;
     writeFileSync(temporary, JSON.stringify(cleared), { mode: 0o600 });
     renameSync(temporary, target);
@@ -376,8 +447,16 @@ function sleepSync(ms) {
 }
 
 /** Best-effort exclusive lock. Returns the lock path, or null if not acquired. */
-function takeLock(sessionId, { attempts = 20, staleMs = 5000, waitMs = 15 } = {}) {
-  const path = `${statePath(sessionId)}.lock`;
+function takeLock(
+  sessionId,
+  agent,
+  { attempts = 20, staleMs = 5000, waitMs = 15 } = {}
+) {
+  // Locks the file it actually guards. Scoping the state per agent while leaving
+  // the lock on the session path would serialise every agent on one lock AND
+  // protect the wrong file -- two agents could then interleave a
+  // read-modify-write on their own states while holding a lock on neither.
+  const path = `${statePath(sessionId, agent)}.lock`;
   for (let i = 0; i < attempts; i++) {
     try {
       const fd = openSync(path, 'wx', 0o600);
@@ -468,13 +547,15 @@ export function allowWithContext(context) {
  * says "use the optimized tool" gets met with a retry of the same call.
  */
 export function deny(reason) {
-  process.stdout.write(JSON.stringify({
-    hookSpecificOutput: {
-      hookEventName: 'PreToolUse',
-      permissionDecision: 'deny',
-      permissionDecisionReason: withEscape(reason),
-    },
-  }));
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: withEscape(reason),
+      },
+    })
+  );
   process.exit(0);
 }
 
@@ -499,12 +580,14 @@ export function withEscape(reason) {
 
 /** Lets the call through, attaching a note the model sees. */
 export function advise(context) {
-  process.stdout.write(JSON.stringify({
-    hookSpecificOutput: {
-      hookEventName: 'PreToolUse',
-      additionalContext: context,
-    },
-  }));
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        additionalContext: context,
+      },
+    })
+  );
   process.exit(0);
 }
 
@@ -532,7 +615,10 @@ export function enforce(reason, deniedBefore) {
  * than an absent one, so the wait has a ceiling and expiring it is treated
  * exactly like unusable input.
  */
-export async function readPayload({ timeoutMs = 5000, maxBytes = 8_000_000 } = {}) {
+export async function readPayload({
+  timeoutMs = 5000,
+  maxBytes = 8_000_000,
+} = {}) {
   const chunks = [];
   let size = 0;
 
@@ -541,7 +627,10 @@ export async function readPayload({ timeoutMs = 5000, maxBytes = 8_000_000 } = {
       size += chunk.length;
       // A payload this large is not a tool call; refusing to buffer it
       // unboundedly keeps a hook from becoming a memory problem.
-      if (size > maxBytes) { finish(null); return; }
+      if (size > maxBytes) {
+        finish(null);
+        return;
+      }
       chunks.push(chunk);
     };
     const onEnd = () => finish(chunks.join(''));

--- a/integrations/qwen/hooks/lib/decide.mjs
+++ b/integrations/qwen/hooks/lib/decide.mjs
@@ -434,6 +434,14 @@ export function normalizePayload(raw) {
 
   return {
     session_id: raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? 'default',
+    // WHICH AGENT, not just which session. Subagents inherit the parent's session
+    // id, so state keyed on the session alone is shared by every agent under it
+    // -- which made one agent's reads silence another's. The transcript path is
+    // per agent, and it has to survive normalisation to be usable: this function
+    // returns a NEW object rather than spreading `raw`, so a field that is not
+    // named here is silently dropped. That is exactly how it was lost the first
+    // time this fix was attempted.
+    transcript_path: raw.transcript_path ?? raw.transcriptPath ?? null,
     cwd,
     tool_name: normalizeTool(raw.tool_name ?? raw.toolName ?? raw.tool),
     tool_input: {

--- a/integrations/qwen/hooks/lib/policy.mjs
+++ b/integrations/qwen/hooks/lib/policy.mjs
@@ -34,9 +34,19 @@
  *      would trade real tokens for hook overhead and user irritation.
  */
 
-import { statSync, mkdirSync, readFileSync, writeFileSync, renameSync, openSync, closeSync, unlinkSync } from 'node:fs';
+import {
+  statSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+  openSync,
+  closeSync,
+  unlinkSync,
+} from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { createHash } from 'node:crypto';
 import { isFsSafePath } from './paths.mjs';
 
 /** Enforcement modes, least to most permissive. */
@@ -68,7 +78,8 @@ function intEnv(name, fallback) {
  * single file. Below it the hook's own overhead is a meaningful fraction of the
  * savings, so the call is left alone.
  */
-export const largeFileBytes = () => intEnv('TOKEN_OPTIMIZER_LARGE_READ_BYTES', 25_600);
+export const largeFileBytes = () =>
+  intEnv('TOKEN_OPTIMIZER_LARGE_READ_BYTES', 25_600);
 
 /**
  * Size below which NO refusal can pay for itself.
@@ -86,14 +97,39 @@ export const largeFileBytes = () => intEnv('TOKEN_OPTIMIZER_LARGE_READ_BYTES', 2
  * 1 KB is about 256 tokens, comfortably above the largest refusal this hook
  * emits, so a refusal above the floor always pays.
  */
-export const refusalFloorBytes = () => intEnv('TOKEN_OPTIMIZER_REFUSAL_FLOOR_BYTES', 1_024);
+export const refusalFloorBytes = () =>
+  intEnv('TOKEN_OPTIMIZER_REFUSAL_FLOOR_BYTES', 1_024);
 
 /** Extensions whose bytes are not tokens, so byte thresholds do not apply. */
 const BINARY_EXTENSIONS = new Set([
-  '.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.ico', '.svg',
-  '.pdf', '.zip', '.gz', '.tar', '.7z', '.rar',
-  '.exe', '.dll', '.so', '.dylib', '.bin', '.wasm',
-  '.mp3', '.mp4', '.wav', '.mov', '.woff', '.woff2', '.ttf', '.eot',
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+  '.bmp',
+  '.ico',
+  '.svg',
+  '.pdf',
+  '.zip',
+  '.gz',
+  '.tar',
+  '.7z',
+  '.rar',
+  '.exe',
+  '.dll',
+  '.so',
+  '.dylib',
+  '.bin',
+  '.wasm',
+  '.mp3',
+  '.mp4',
+  '.wav',
+  '.mov',
+  '.woff',
+  '.woff2',
+  '.ttf',
+  '.eot',
 ]);
 
 export function isBinaryPath(path) {
@@ -115,7 +151,8 @@ export function isBinaryPath(path) {
  * knowledge, all of it churns constantly (so it would thrash staleness), and
  * none of it is something a person reads.
  */
-const MACHINE_OWNED = /(?:^|[/\\])(?:\.git|\.hg|\.svn|node_modules|\.venv|__pycache__|\.next|\.turbo|dist|obj|bin)(?:[/\\]|$)/i;
+const MACHINE_OWNED =
+  /(?:^|[/\\])(?:\.git|\.hg|\.svn|node_modules|\.venv|__pycache__|\.next|\.turbo|dist|obj|bin)(?:[/\\]|$)/i;
 
 /**
  * Collapses `.` and `..` textually, without touching the filesystem.
@@ -157,7 +194,13 @@ export function isMachineOwned(path) {
   // stores `.git` as a FILE, so `/repo/.git` has no trailing separator and
   // was classified as authored content -- putting git metadata through Read
   // refusal and into the knowledge graph.
-  return MACHINE_OWNED.test(normalizeSegments(String(path || '').split('\\').join('/')));
+  return MACHINE_OWNED.test(
+    normalizeSegments(
+      String(path || '')
+        .split('\\')
+        .join('/')
+    )
+  );
 }
 
 /** Size in bytes, or -1 when the path is missing or is not a regular file. */
@@ -195,13 +238,36 @@ export function fileSize(path) {
  * read-modify-write survived here unnoticed.
  */
 const stateRoot = () =>
-  process.env.TOKEN_OPTIMIZER_STATE_DIR || join(tmpdir(), 'token-optimizer-hooks');
+  process.env.TOKEN_OPTIMIZER_STATE_DIR ||
+  join(tmpdir(), 'token-optimizer-hooks');
 
-function statePath(sessionId) {
+/**
+ * Per SESSION and per AGENT, not per session alone.
+ *
+ * Every subagent inherits its parent's session id, so keying on the session
+ * alone gave all of them ONE `seen` set. An agent was then refused a file it had
+ * never opened -- observed verbatim: "release.yml is UNCHANGED since you last
+ * read it this session" -- because a different agent had read it. That agent
+ * fell back to Bash to get the contents, which defeats the optimizer and costs
+ * more than the read it replaced.
+ *
+ * `agent` is the caller's transcript path, which is distinct per subagent. It is
+ * HASHED rather than sanitised into the filename: it is an absolute path, so
+ * stripping separators would collide across directories, and the digest keeps
+ * the name bounded.
+ *
+ * Absent, the scope falls back to the session -- the main session's own calls
+ * must keep sharing one state, or the once-per-session gates would reset on
+ * every tool call.
+ */
+function statePath(sessionId, agent) {
   // Session ids come from the harness and are uuid-shaped, but they land in a
   // file path, so anything that could traverse is stripped rather than trusted.
   const safe = String(sessionId || 'default').replace(/[^A-Za-z0-9_-]/g, '');
-  return join(stateRoot(), `${safe || 'default'}.json`);
+  const scope = agent
+    ? `-${createHash('sha256').update(String(agent)).digest('hex').slice(0, 12)}`
+    : '';
+  return join(stateRoot(), `${safe || 'default'}${scope}.json`);
 }
 
 /** A usable state object, whatever was on disk. */
@@ -219,13 +285,16 @@ function emptyState() {
  * have been "enforcement silently stops working for this session", which is
  * exactly the kind of quiet failure that never gets reported.
  */
-export function loadState(sessionId) {
+export function loadState(sessionId, agent) {
   try {
-    const parsed = JSON.parse(readFileSync(statePath(sessionId), 'utf8'));
+    const parsed = JSON.parse(
+      readFileSync(statePath(sessionId, agent), 'utf8')
+    );
     if (!parsed || typeof parsed !== 'object') return emptyState();
     return {
       seen: parsed.seen && typeof parsed.seen === 'object' ? parsed.seen : {},
-      denied: parsed.denied && typeof parsed.denied === 'object' ? parsed.denied : {},
+      denied:
+        parsed.denied && typeof parsed.denied === 'object' ? parsed.denied : {},
       // WITHOUT THIS THE ONCE-PER-SESSION GATE DOES NOT EXIST. Every tool call
       // is a separate hook PROCESS, so a set held only in memory dies with the
       // process that built it: the router recorded which findings it had
@@ -255,7 +324,7 @@ export function loadState(sessionId) {
  * but it turns "last writer wins" into "union of writers", which is the
  * behaviour the two maps actually want, since both are append-only sets.
  */
-export function saveState(sessionId, state) {
+export function saveState(sessionId, state, agent) {
   let lock = null;
   try {
     mkdirSync(stateRoot(), { recursive: true, mode: 0o700 });
@@ -276,10 +345,10 @@ export function saveState(sessionId, state) {
     // bounded by design -- a repeated denial is allowed through by rule, and a
     // repeated injection costs its tokens once more. A stale lock is still
     // broken and taken below, so a killed process cannot wedge enforcement.
-    lock = takeLock(sessionId);
+    lock = takeLock(sessionId, agent);
     if (!lock) return false;
 
-    const current = loadState(sessionId);
+    const current = loadState(sessionId, agent);
     const merged = {
       seen: { ...current.seen, ...state.seen },
       denied: { ...current.denied, ...state.denied },
@@ -287,11 +356,13 @@ export function saveState(sessionId, state) {
       // their own view of what has been injected; taking the last writer's copy
       // would resurrect a finding the other had already delivered, which is the
       // repetition the once-per-session gate exists to stop.
-      injected: [...new Set([...(current.injected || []), ...(state.injected || [])])],
+      injected: [
+        ...new Set([...(current.injected || []), ...(state.injected || [])]),
+      ],
     };
 
     // Write-then-rename so a reader never observes a half-written file.
-    const target = statePath(sessionId);
+    const target = statePath(sessionId, agent);
     const temporary = `${target}.${process.pid}.tmp`;
     writeFileSync(temporary, JSON.stringify(merged), { mode: 0o600 });
     renameSync(temporary, target);
@@ -327,17 +398,17 @@ export function saveState(sessionId, state) {
  * Same lock and write-then-rename discipline as saveState: a reader must never see a
  * half-written file, and a missed lock skips the write rather than racing it.
  */
-export function clearSeen(sessionId) {
+export function clearSeen(sessionId, agent) {
   let lock = null;
   try {
     mkdirSync(stateRoot(), { recursive: true, mode: 0o700 });
-    lock = takeLock(sessionId);
+    lock = takeLock(sessionId, agent);
     if (!lock) return false;
 
-    const current = loadState(sessionId);
+    const current = loadState(sessionId, agent);
     const cleared = { ...current, seen: {} };
 
-    const target = statePath(sessionId);
+    const target = statePath(sessionId, agent);
     const temporary = `${target}.${process.pid}.tmp`;
     writeFileSync(temporary, JSON.stringify(cleared), { mode: 0o600 });
     renameSync(temporary, target);
@@ -376,8 +447,16 @@ function sleepSync(ms) {
 }
 
 /** Best-effort exclusive lock. Returns the lock path, or null if not acquired. */
-function takeLock(sessionId, { attempts = 20, staleMs = 5000, waitMs = 15 } = {}) {
-  const path = `${statePath(sessionId)}.lock`;
+function takeLock(
+  sessionId,
+  agent,
+  { attempts = 20, staleMs = 5000, waitMs = 15 } = {}
+) {
+  // Locks the file it actually guards. Scoping the state per agent while leaving
+  // the lock on the session path would serialise every agent on one lock AND
+  // protect the wrong file -- two agents could then interleave a
+  // read-modify-write on their own states while holding a lock on neither.
+  const path = `${statePath(sessionId, agent)}.lock`;
   for (let i = 0; i < attempts; i++) {
     try {
       const fd = openSync(path, 'wx', 0o600);
@@ -468,13 +547,15 @@ export function allowWithContext(context) {
  * says "use the optimized tool" gets met with a retry of the same call.
  */
 export function deny(reason) {
-  process.stdout.write(JSON.stringify({
-    hookSpecificOutput: {
-      hookEventName: 'PreToolUse',
-      permissionDecision: 'deny',
-      permissionDecisionReason: withEscape(reason),
-    },
-  }));
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: withEscape(reason),
+      },
+    })
+  );
   process.exit(0);
 }
 
@@ -499,12 +580,14 @@ export function withEscape(reason) {
 
 /** Lets the call through, attaching a note the model sees. */
 export function advise(context) {
-  process.stdout.write(JSON.stringify({
-    hookSpecificOutput: {
-      hookEventName: 'PreToolUse',
-      additionalContext: context,
-    },
-  }));
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        additionalContext: context,
+      },
+    })
+  );
   process.exit(0);
 }
 
@@ -532,7 +615,10 @@ export function enforce(reason, deniedBefore) {
  * than an absent one, so the wait has a ceiling and expiring it is treated
  * exactly like unusable input.
  */
-export async function readPayload({ timeoutMs = 5000, maxBytes = 8_000_000 } = {}) {
+export async function readPayload({
+  timeoutMs = 5000,
+  maxBytes = 8_000_000,
+} = {}) {
   const chunks = [];
   let size = 0;
 
@@ -541,7 +627,10 @@ export async function readPayload({ timeoutMs = 5000, maxBytes = 8_000_000 } = {
       size += chunk.length;
       // A payload this large is not a tool call; refusing to buffer it
       // unboundedly keeps a hook from becoming a memory problem.
-      if (size > maxBytes) { finish(null); return; }
+      if (size > maxBytes) {
+        finish(null);
+        return;
+      }
       chunks.push(chunk);
     };
     const onEnd = () => finish(chunks.join(''));

--- a/plugin/hooks/lib/decide.mjs
+++ b/plugin/hooks/lib/decide.mjs
@@ -434,6 +434,14 @@ export function normalizePayload(raw) {
 
   return {
     session_id: raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? 'default',
+    // WHICH AGENT, not just which session. Subagents inherit the parent's session
+    // id, so state keyed on the session alone is shared by every agent under it
+    // -- which made one agent's reads silence another's. The transcript path is
+    // per agent, and it has to survive normalisation to be usable: this function
+    // returns a NEW object rather than spreading `raw`, so a field that is not
+    // named here is silently dropped. That is exactly how it was lost the first
+    // time this fix was attempted.
+    transcript_path: raw.transcript_path ?? raw.transcriptPath ?? null,
     cwd,
     tool_name: normalizeTool(raw.tool_name ?? raw.toolName ?? raw.tool),
     tool_input: {

--- a/plugin/hooks/lib/policy.mjs
+++ b/plugin/hooks/lib/policy.mjs
@@ -34,9 +34,19 @@
  *      would trade real tokens for hook overhead and user irritation.
  */
 
-import { statSync, mkdirSync, readFileSync, writeFileSync, renameSync, openSync, closeSync, unlinkSync } from 'node:fs';
+import {
+  statSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+  openSync,
+  closeSync,
+  unlinkSync,
+} from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { createHash } from 'node:crypto';
 import { isFsSafePath } from './paths.mjs';
 
 /** Enforcement modes, least to most permissive. */
@@ -68,7 +78,8 @@ function intEnv(name, fallback) {
  * single file. Below it the hook's own overhead is a meaningful fraction of the
  * savings, so the call is left alone.
  */
-export const largeFileBytes = () => intEnv('TOKEN_OPTIMIZER_LARGE_READ_BYTES', 25_600);
+export const largeFileBytes = () =>
+  intEnv('TOKEN_OPTIMIZER_LARGE_READ_BYTES', 25_600);
 
 /**
  * Size below which NO refusal can pay for itself.
@@ -86,14 +97,39 @@ export const largeFileBytes = () => intEnv('TOKEN_OPTIMIZER_LARGE_READ_BYTES', 2
  * 1 KB is about 256 tokens, comfortably above the largest refusal this hook
  * emits, so a refusal above the floor always pays.
  */
-export const refusalFloorBytes = () => intEnv('TOKEN_OPTIMIZER_REFUSAL_FLOOR_BYTES', 1_024);
+export const refusalFloorBytes = () =>
+  intEnv('TOKEN_OPTIMIZER_REFUSAL_FLOOR_BYTES', 1_024);
 
 /** Extensions whose bytes are not tokens, so byte thresholds do not apply. */
 const BINARY_EXTENSIONS = new Set([
-  '.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.ico', '.svg',
-  '.pdf', '.zip', '.gz', '.tar', '.7z', '.rar',
-  '.exe', '.dll', '.so', '.dylib', '.bin', '.wasm',
-  '.mp3', '.mp4', '.wav', '.mov', '.woff', '.woff2', '.ttf', '.eot',
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+  '.bmp',
+  '.ico',
+  '.svg',
+  '.pdf',
+  '.zip',
+  '.gz',
+  '.tar',
+  '.7z',
+  '.rar',
+  '.exe',
+  '.dll',
+  '.so',
+  '.dylib',
+  '.bin',
+  '.wasm',
+  '.mp3',
+  '.mp4',
+  '.wav',
+  '.mov',
+  '.woff',
+  '.woff2',
+  '.ttf',
+  '.eot',
 ]);
 
 export function isBinaryPath(path) {
@@ -115,7 +151,8 @@ export function isBinaryPath(path) {
  * knowledge, all of it churns constantly (so it would thrash staleness), and
  * none of it is something a person reads.
  */
-const MACHINE_OWNED = /(?:^|[/\\])(?:\.git|\.hg|\.svn|node_modules|\.venv|__pycache__|\.next|\.turbo|dist|obj|bin)(?:[/\\]|$)/i;
+const MACHINE_OWNED =
+  /(?:^|[/\\])(?:\.git|\.hg|\.svn|node_modules|\.venv|__pycache__|\.next|\.turbo|dist|obj|bin)(?:[/\\]|$)/i;
 
 /**
  * Collapses `.` and `..` textually, without touching the filesystem.
@@ -157,7 +194,13 @@ export function isMachineOwned(path) {
   // stores `.git` as a FILE, so `/repo/.git` has no trailing separator and
   // was classified as authored content -- putting git metadata through Read
   // refusal and into the knowledge graph.
-  return MACHINE_OWNED.test(normalizeSegments(String(path || '').split('\\').join('/')));
+  return MACHINE_OWNED.test(
+    normalizeSegments(
+      String(path || '')
+        .split('\\')
+        .join('/')
+    )
+  );
 }
 
 /** Size in bytes, or -1 when the path is missing or is not a regular file. */
@@ -195,13 +238,36 @@ export function fileSize(path) {
  * read-modify-write survived here unnoticed.
  */
 const stateRoot = () =>
-  process.env.TOKEN_OPTIMIZER_STATE_DIR || join(tmpdir(), 'token-optimizer-hooks');
+  process.env.TOKEN_OPTIMIZER_STATE_DIR ||
+  join(tmpdir(), 'token-optimizer-hooks');
 
-function statePath(sessionId) {
+/**
+ * Per SESSION and per AGENT, not per session alone.
+ *
+ * Every subagent inherits its parent's session id, so keying on the session
+ * alone gave all of them ONE `seen` set. An agent was then refused a file it had
+ * never opened -- observed verbatim: "release.yml is UNCHANGED since you last
+ * read it this session" -- because a different agent had read it. That agent
+ * fell back to Bash to get the contents, which defeats the optimizer and costs
+ * more than the read it replaced.
+ *
+ * `agent` is the caller's transcript path, which is distinct per subagent. It is
+ * HASHED rather than sanitised into the filename: it is an absolute path, so
+ * stripping separators would collide across directories, and the digest keeps
+ * the name bounded.
+ *
+ * Absent, the scope falls back to the session -- the main session's own calls
+ * must keep sharing one state, or the once-per-session gates would reset on
+ * every tool call.
+ */
+function statePath(sessionId, agent) {
   // Session ids come from the harness and are uuid-shaped, but they land in a
   // file path, so anything that could traverse is stripped rather than trusted.
   const safe = String(sessionId || 'default').replace(/[^A-Za-z0-9_-]/g, '');
-  return join(stateRoot(), `${safe || 'default'}.json`);
+  const scope = agent
+    ? `-${createHash('sha256').update(String(agent)).digest('hex').slice(0, 12)}`
+    : '';
+  return join(stateRoot(), `${safe || 'default'}${scope}.json`);
 }
 
 /** A usable state object, whatever was on disk. */
@@ -219,13 +285,16 @@ function emptyState() {
  * have been "enforcement silently stops working for this session", which is
  * exactly the kind of quiet failure that never gets reported.
  */
-export function loadState(sessionId) {
+export function loadState(sessionId, agent) {
   try {
-    const parsed = JSON.parse(readFileSync(statePath(sessionId), 'utf8'));
+    const parsed = JSON.parse(
+      readFileSync(statePath(sessionId, agent), 'utf8')
+    );
     if (!parsed || typeof parsed !== 'object') return emptyState();
     return {
       seen: parsed.seen && typeof parsed.seen === 'object' ? parsed.seen : {},
-      denied: parsed.denied && typeof parsed.denied === 'object' ? parsed.denied : {},
+      denied:
+        parsed.denied && typeof parsed.denied === 'object' ? parsed.denied : {},
       // WITHOUT THIS THE ONCE-PER-SESSION GATE DOES NOT EXIST. Every tool call
       // is a separate hook PROCESS, so a set held only in memory dies with the
       // process that built it: the router recorded which findings it had
@@ -255,7 +324,7 @@ export function loadState(sessionId) {
  * but it turns "last writer wins" into "union of writers", which is the
  * behaviour the two maps actually want, since both are append-only sets.
  */
-export function saveState(sessionId, state) {
+export function saveState(sessionId, state, agent) {
   let lock = null;
   try {
     mkdirSync(stateRoot(), { recursive: true, mode: 0o700 });
@@ -276,10 +345,10 @@ export function saveState(sessionId, state) {
     // bounded by design -- a repeated denial is allowed through by rule, and a
     // repeated injection costs its tokens once more. A stale lock is still
     // broken and taken below, so a killed process cannot wedge enforcement.
-    lock = takeLock(sessionId);
+    lock = takeLock(sessionId, agent);
     if (!lock) return false;
 
-    const current = loadState(sessionId);
+    const current = loadState(sessionId, agent);
     const merged = {
       seen: { ...current.seen, ...state.seen },
       denied: { ...current.denied, ...state.denied },
@@ -287,11 +356,13 @@ export function saveState(sessionId, state) {
       // their own view of what has been injected; taking the last writer's copy
       // would resurrect a finding the other had already delivered, which is the
       // repetition the once-per-session gate exists to stop.
-      injected: [...new Set([...(current.injected || []), ...(state.injected || [])])],
+      injected: [
+        ...new Set([...(current.injected || []), ...(state.injected || [])]),
+      ],
     };
 
     // Write-then-rename so a reader never observes a half-written file.
-    const target = statePath(sessionId);
+    const target = statePath(sessionId, agent);
     const temporary = `${target}.${process.pid}.tmp`;
     writeFileSync(temporary, JSON.stringify(merged), { mode: 0o600 });
     renameSync(temporary, target);
@@ -327,17 +398,17 @@ export function saveState(sessionId, state) {
  * Same lock and write-then-rename discipline as saveState: a reader must never see a
  * half-written file, and a missed lock skips the write rather than racing it.
  */
-export function clearSeen(sessionId) {
+export function clearSeen(sessionId, agent) {
   let lock = null;
   try {
     mkdirSync(stateRoot(), { recursive: true, mode: 0o700 });
-    lock = takeLock(sessionId);
+    lock = takeLock(sessionId, agent);
     if (!lock) return false;
 
-    const current = loadState(sessionId);
+    const current = loadState(sessionId, agent);
     const cleared = { ...current, seen: {} };
 
-    const target = statePath(sessionId);
+    const target = statePath(sessionId, agent);
     const temporary = `${target}.${process.pid}.tmp`;
     writeFileSync(temporary, JSON.stringify(cleared), { mode: 0o600 });
     renameSync(temporary, target);
@@ -376,8 +447,16 @@ function sleepSync(ms) {
 }
 
 /** Best-effort exclusive lock. Returns the lock path, or null if not acquired. */
-function takeLock(sessionId, { attempts = 20, staleMs = 5000, waitMs = 15 } = {}) {
-  const path = `${statePath(sessionId)}.lock`;
+function takeLock(
+  sessionId,
+  agent,
+  { attempts = 20, staleMs = 5000, waitMs = 15 } = {}
+) {
+  // Locks the file it actually guards. Scoping the state per agent while leaving
+  // the lock on the session path would serialise every agent on one lock AND
+  // protect the wrong file -- two agents could then interleave a
+  // read-modify-write on their own states while holding a lock on neither.
+  const path = `${statePath(sessionId, agent)}.lock`;
   for (let i = 0; i < attempts; i++) {
     try {
       const fd = openSync(path, 'wx', 0o600);
@@ -468,13 +547,15 @@ export function allowWithContext(context) {
  * says "use the optimized tool" gets met with a retry of the same call.
  */
 export function deny(reason) {
-  process.stdout.write(JSON.stringify({
-    hookSpecificOutput: {
-      hookEventName: 'PreToolUse',
-      permissionDecision: 'deny',
-      permissionDecisionReason: withEscape(reason),
-    },
-  }));
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: withEscape(reason),
+      },
+    })
+  );
   process.exit(0);
 }
 
@@ -499,12 +580,14 @@ export function withEscape(reason) {
 
 /** Lets the call through, attaching a note the model sees. */
 export function advise(context) {
-  process.stdout.write(JSON.stringify({
-    hookSpecificOutput: {
-      hookEventName: 'PreToolUse',
-      additionalContext: context,
-    },
-  }));
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        additionalContext: context,
+      },
+    })
+  );
   process.exit(0);
 }
 
@@ -532,7 +615,10 @@ export function enforce(reason, deniedBefore) {
  * than an absent one, so the wait has a ceiling and expiring it is treated
  * exactly like unusable input.
  */
-export async function readPayload({ timeoutMs = 5000, maxBytes = 8_000_000 } = {}) {
+export async function readPayload({
+  timeoutMs = 5000,
+  maxBytes = 8_000_000,
+} = {}) {
   const chunks = [];
   let size = 0;
 
@@ -541,7 +627,10 @@ export async function readPayload({ timeoutMs = 5000, maxBytes = 8_000_000 } = {
       size += chunk.length;
       // A payload this large is not a tool call; refusing to buffer it
       // unboundedly keeps a hook from becoming a memory problem.
-      if (size > maxBytes) { finish(null); return; }
+      if (size > maxBytes) {
+        finish(null);
+        return;
+      }
       chunks.push(chunk);
     };
     const onEnd = () => finish(chunks.join(''));

--- a/plugin/hooks/precompact-optimize.mjs
+++ b/plugin/hooks/precompact-optimize.mjs
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+﻿#!/usr/bin/env node
 /**
  * Claude Code PreCompact adapter -- optimize at the moment it matters most.
  *
@@ -123,7 +123,7 @@ async function main() {
   // concurrent hook processes cannot erase each other's additions, which means it
   // cannot shrink the map at all. The first version of this used saveState and was a
   // silent no-op until a test caught it.
-  clearSeen(payload.session_id);
+  clearSeen(payload.session_id, payload.transcript_path || null);
 
   // NOW the wrapper, which only the optimize_session spawn needs. Plugin-only
   // installs stop here having still recorded their co-occurrence above.

--- a/plugin/hooks/pretooluse-router.mjs
+++ b/plugin/hooks/pretooluse-router.mjs
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+﻿#!/usr/bin/env node
 /**
  * Claude Code PreToolUse adapter.
  *
@@ -11,12 +11,39 @@
  * free to -- and routinely did -- ignore.
  */
 
-import { readPayload, loadState, saveState, alreadyDenied, allow, allowWithContext, enforce, mode, MODE_OFF }
-  from './lib/policy.mjs';
-import { decide, remember, normalizePayload, readCostBytes, touchedFiles, isContentDump } from './lib/decide.mjs';
+import {
+  readPayload,
+  loadState,
+  saveState,
+  alreadyDenied,
+  allow,
+  allowWithContext,
+  enforce,
+  mode,
+  MODE_OFF,
+} from './lib/policy.mjs';
+import {
+  decide,
+  remember,
+  normalizePayload,
+  readCostBytes,
+  touchedFiles,
+  isContentDump,
+} from './lib/decide.mjs';
 import { recordRead, fingerprint } from './lib/metrics.mjs';
-import { wikiDir, load, harvest, projectRootFor, contentHash } from './lib/wiki.mjs';
-import { refusalPayload, substitutionFor, forTouch, forCommand } from './lib/inject.mjs';
+import {
+  wikiDir,
+  load,
+  harvest,
+  projectRootFor,
+  contentHash,
+} from './lib/wiki.mjs';
+import {
+  refusalPayload,
+  substitutionFor,
+  forTouch,
+  forCommand,
+} from './lib/inject.mjs';
 import { indexFile } from './lib/staleness.mjs';
 import { isArchived } from './lib/transcript.mjs';
 import { readFileSync } from 'node:fs';
@@ -26,7 +53,8 @@ import { readFileSync } from 'node:fs';
  * observed, but nothing is hashed or snapshotted -- a build log must never
  * become hook latency the user waits on.
  */
-const HARVEST_MAX_BYTES = Number(process.env.TOKEN_OPTIMIZER_HARVEST_MAX_BYTES) || 4_000_000;
+const HARVEST_MAX_BYTES =
+  Number(process.env.TOKEN_OPTIMIZER_HARVEST_MAX_BYTES) || 4_000_000;
 
 // Wrapped whole. Any defect in this hook must cost the user nothing: an
 // exception here allows the call exactly as if the plugin were not installed.
@@ -41,14 +69,20 @@ try {
   const payload = normalizePayload(raw);
   if (!payload.tool_name) allow();
 
-  const state = loadState(payload.session_id);
+  // The AGENT, not just the session. Subagents inherit the parent's session id,
+  // so keying state on the session alone made one agent's reads silence another's
+  // -- observed: an agent refused a file it had never opened because a sibling had
+  // read it. `transcript_path` is per agent; absent, this falls back to session
+  // scope, which is right for the main session's own calls.
+  const agentScope = payload.transcript_path || null;
+  const state = loadState(payload.session_id, agentScope);
   const verdict = decide(payload, state);
 
   if (!verdict) {
     // Allowed calls are what BUILD the re-read index -- this is the only place
     // a first read gets recorded, so the second one can be recognised.
     remember(payload, state);
-    saveState(payload.session_id, state);
+    saveState(payload.session_id, state, agentScope);
 
     // And what the read COST, which is the signal the holdout comparison
     // consumes. Without a producer here the measurement subtracts two zeroes.
@@ -144,7 +178,9 @@ try {
         // Index on the way past, so the NEXT touch can be answered with
         // structure instead of the file. Bounded by the snapshot limit.
         indexFile(dir, path, source);
-      } catch { /* never let bookkeeping break an allowed call */ }
+      } catch {
+        /* never let bookkeeping break an allowed call */
+      }
     }
 
     // DELIVER WHAT THE GRAPH ALREADY KNOWS. Everything above this line WRITES
@@ -189,7 +225,7 @@ try {
 
       if (alreadyInjected.size !== before) {
         state.injected = [...alreadyInjected];
-        saveState(payload.session_id, state);
+        saveState(payload.session_id, state, agentScope);
       }
       if (parts.length) context = parts.join('\n\n');
     } catch {
@@ -206,7 +242,7 @@ try {
   // IN, not what this call adds.
   const seenThisSession = Boolean(state.seen?.[payload.tool_input?.file_path]);
   remember(payload, state);
-  saveState(payload.session_id, state);
+  saveState(payload.session_id, state, agentScope);
 
   // CARRY THE ANSWER IN THE REFUSAL where we can. A refusal that only redirects
   // costs the model a whole turn to get what we already have; one that carries
@@ -217,12 +253,16 @@ try {
     try {
       // Same per-project rule as the allowed path: a refusal must consult the
       // graph belonging to the FILE, or it answers from the wrong project.
-      const dir = wikiDir(projectRootFor(payload.tool_input.file_path, payload.cwd));
+      const dir = wikiDir(
+        projectRootFor(payload.tool_input.file_path, payload.cwd)
+      );
       const graph = load(dir);
       // Only THIS session's own read history can license "unchanged since you
       // read it" or a diff -- the graph is durable and per project, so its
       // snapshot may predate this session entirely.
-      const carried = refusalPayload(graph, payload.tool_input.file_path, { seenThisSession });
+      const carried = refusalPayload(graph, payload.tool_input.file_path, {
+        seenThisSession,
+      });
       if (carried) {
         reason = carried;
       } else {

--- a/tests/hooks/read-state-is-per-agent.test.mjs
+++ b/tests/hooks/read-state-is-per-agent.test.mjs
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+/**
+ * One agent's reads must not silence another agent's.
+ *
+ * `statePath(sessionId)` keyed the `seen` set by SESSION ONLY, and every subagent
+ * inherits its parent's session id. So the set is shared by every agent running
+ * under one session, and the refusal that says "you already read this" fires for
+ * an agent that has never seen the file.
+ *
+ * OBSERVED, verbatim, from a subagent that had never opened the file:
+ *
+ *     .../\.github/workflows/release.yml is UNCHANGED since you last read it this
+ *     session. Nothing to re-read -- use what you already have.
+ *
+ * It was denied the contents because a DIFFERENT agent had read that file, and
+ * worked around the refusal with Bash -- which defeats the optimizer entirely and
+ * costs more than the read it replaced.
+ *
+ * This is the same defect class as "a write is not a read" one level up: a read
+ * that never happened. It matters more than it looks, because parallel subagents
+ * are exactly the workload where token optimization is worth the most, and this
+ * turns the tool from a saving into an obstacle precisely there.
+ */
+
+const CORE = pathToFileURL(
+  join(process.cwd(), 'hooks-core', 'policy.mjs')
+).href;
+
+let dir;
+let original;
+let policy;
+
+beforeEach(async () => {
+  dir = mkdtempSync(join(tmpdir(), 'per-agent-state-'));
+  original = process.env.TOKEN_OPTIMIZER_STATE_DIR;
+  process.env.TOKEN_OPTIMIZER_STATE_DIR = dir;
+  policy = await import(`${CORE}?t=${dir}`);
+});
+
+afterEach(() => {
+  if (original === undefined) delete process.env.TOKEN_OPTIMIZER_STATE_DIR;
+  else process.env.TOKEN_OPTIMIZER_STATE_DIR = original;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+const SESSION = 'shared-session-id';
+const AGENT_A = '/tmp/transcripts/agent-a.jsonl';
+const AGENT_B = '/tmp/transcripts/agent-b.jsonl';
+
+describe('read state under one session with several agents', () => {
+  it('does not report another agent\u2019s read as this agent\u2019s', () => {
+    const { loadState, saveState } = policy;
+
+    const a = loadState(SESSION, AGENT_A);
+    a.seen['C:/repo/.github/workflows/release.yml'] = { hash: 'abc' };
+    saveState(SESSION, a, AGENT_A);
+
+    const b = loadState(SESSION, AGENT_B);
+
+    expect(b.seen['C:/repo/.github/workflows/release.yml']).toBeUndefined();
+  });
+
+  it('still remembers an agent\u2019s own read', () => {
+    // The optimization has to keep working within one agent, or the fix is just
+    // a way of switching the feature off.
+    const { loadState, saveState } = policy;
+
+    const first = loadState(SESSION, AGENT_A);
+    first.seen['C:/repo/src/app.ts'] = { hash: 'abc' };
+    saveState(SESSION, first, AGENT_A);
+
+    const second = loadState(SESSION, AGENT_A);
+
+    expect(second.seen['C:/repo/src/app.ts']).toEqual({ hash: 'abc' });
+  });
+
+  it('keeps separate sessions separate, as before', () => {
+    const { loadState, saveState } = policy;
+
+    const a = loadState('session-one', AGENT_A);
+    a.seen['C:/repo/x.ts'] = { hash: 'abc' };
+    saveState('session-one', a, AGENT_A);
+
+    expect(
+      loadState('session-two', AGENT_A).seen['C:/repo/x.ts']
+    ).toBeUndefined();
+  });
+
+  it('falls back to session scope when no agent is identified', () => {
+    // The main session's own tool calls may carry no discriminator. Those must
+    // still share one state rather than getting a fresh one per call, which
+    // would disable the once-per-session gates entirely.
+    const { loadState, saveState } = policy;
+
+    const a = loadState(SESSION);
+    a.seen['C:/repo/y.ts'] = { hash: 'abc' };
+    saveState(SESSION, a);
+
+    expect(loadState(SESSION).seen['C:/repo/y.ts']).toEqual({ hash: 'abc' });
+  });
+});


### PR DESCRIPTION
An agent was refused a file it had **never opened**. Observed verbatim from a subagent during an unrelated experiment:

> `.../.github/workflows/release.yml is UNCHANGED since you last read it this session. Nothing to re-read -- use what you already have.`

It had never read that file. A sibling agent had.

## Cause

`statePath(sessionId)` keyed the `seen` set by session alone, and **every subagent inherits its parent's session id**. So all agents under one session share a single `seen` map, and the "you already read this" refusal fires for an agent that has not.

The agent worked around it with Bash — which defeats the optimizer entirely and costs more than the read it replaced. Parallel subagents are precisely the workload where the saving is worth the most, so this turns the tool into an obstacle exactly where it should pay off.

Same defect class as #257 ("a write is not a read"), one level up: **a read that never happened.**

## Fix

State, its lock, and `clearSeen` are scoped by session **and** agent, keyed on the transcript path, which is per agent. Absent one, it falls back to session scope — correct for the main session's own calls, which must keep sharing state or the once-per-session gates would reset on every tool call.

The lock moved with it deliberately: leaving it on the session path would serialise every agent on one lock *and* protect a file none of them were writing.

## The first attempt silently did nothing, and that is worth recording

`normalizePayload` builds a **new** object naming each field it keeps, so `transcript_path` was dropped before the router ever saw it. Every state file still landed on the session path, and the end-to-end check showed two agents sharing one file.

That is this project's signature bug — an undeclared field discarded silently, the exact failure the schema ratchet exists to prevent — committed here by me, in the fix for another silent-omission bug. It survives normalisation now, at the layer every client adapter shares.

## Proven against the real hook binary, not only in unit tests

```
agent A 1st read -> allowed
agent A 2nd read -> REFUSED    (the optimization still works within an agent)
agent B 1st read -> allowed    (the cross-agent refusal is gone)
```

And the bug reproduced by reverting one line — with `transcript_path` dropped from normalisation:

```
agent A 1st read -> allowed
agent B 1st read -> REFUSED    <-- refused a file it never read
```

Four unit tests cover the scoping, including that a session with no agent identifier still shares one state.

## Gates

130 suites, 1,570 passed, 4 skipped. `tsc --noEmit` clean. eslint 0 errors. `prettier --check` clean. `sync:hooks:check` clean.