### PR TITLE
fix(inject): match the framing to the evidence, not to the strongest wording available

### DIFF
--- a/hooks-core/inject.mjs
+++ b/hooks-core/inject.mjs
@@ -117,8 +117,20 @@ function fit(findings, budget) {
 function render(finding) {
   const head = `- [${finding.type || 'finding'}] ${finding.claim}`;
   if (!finding.stale) return head;
-  // A stale finding NEVER renders without its evidence. Serving one bare would
-  // be worse than having no graph at all.
+
+  // A stale finding NEVER renders as though it were current. But the strength
+  // of the framing follows the strength of the evidence, because the framing
+  // was measured: in an A/B on a fresh subagent, identical findings scored 1/3
+  // dead-ends avoided when rendered with the discount wording and 2/3 when
+  // rendered clean. The claims being discounted were correct every time.
+  //
+  // With a diff, the reader can judge for themselves and the strong form is
+  // earned. Without one -- 78% of stale findings on real graphs -- announcing
+  // STALE and promising `What changed:` in front of nothing spends the
+  // strongest signal available on the weakest evidence available.
+  if (!finding.staleEvidence || !finding.diff) {
+    return `${head}\n  (recorded earlier; ${finding.staleReason}, and no diff could be rebuilt)`;
+  }
   return `${head}\n  STALE (${finding.staleReason}). What changed:\n${finding.diff}`;
 }
 

--- a/hooks-core/restore.mjs
+++ b/hooks-core/restore.mjs
@@ -132,7 +132,10 @@ export function restorationPlan(dir, graph, context = {}) {
       if (!node) continue;
       const findings = serve(graph, findingsFor(graph, id, { limit: 2 }));
       for (const finding of findings) {
-        lines.push(`${node.key}: ${finding.stale ? '! STALE ' : ''}${finding.claim}`);
+        // `! STALE` only where a diff actually exists to back it; see the
+        // renderer in inject.mjs for the measurement behind this.
+        const mark = finding.stale ? (finding.staleEvidence ? '! STALE ' : '~ ') : '';
+        lines.push(`${node.key}: ${mark}${finding.claim}`);
       }
     }
     section('Likely next', lines, total * split.forward);

--- a/hooks-core/restore.mjs
+++ b/hooks-core/restore.mjs
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Restoration after compaction.
  *
  * A checkpoint restores what you HAD. That is a recap: it spends the scarcest
@@ -35,7 +35,11 @@ const estimate = (text) => Math.ceil(String(text || '').length / 4);
  * genuinely different things, and treating them identically is what makes a
  * fixed-order restore feel wrong half the time.
  */
-export function classifySituation({ openQuestion, recentAnchors = [], idleMs = 0 } = {}) {
+export function classifySituation({
+  openQuestion,
+  recentAnchors = [],
+  idleMs = 0,
+} = {}) {
   // Days later, nothing in the fresh context connects to anything. Orientation
   // is the only thing that helps; continuation has nothing to continue from.
   if (idleMs > 6 * 60 * 60 * 1000) return 'cold-resume';
@@ -59,21 +63,25 @@ export function classifySituation({ openQuestion, recentAnchors = [], idleMs = 0
  */
 const SPLITS = {
   'mid-problem': { frontier: 0.6, forward: 0.25, brief: 0.15 },
-  'cold-resume': { frontier: 0.15, forward: 0.25, brief: 0.60 },
-  'in-flow': { frontier: 0.20, forward: 0.60, brief: 0.20 },
-  general: { frontier: 0.35, forward: 0.35, brief: 0.30 },
+  'cold-resume': { frontier: 0.15, forward: 0.25, brief: 0.6 },
+  'in-flow': { frontier: 0.2, forward: 0.6, brief: 0.2 },
+  general: { frontier: 0.35, forward: 0.35, brief: 0.3 },
 };
 
 /** Findings for files the co-occurrence graph says are likely next. */
 function predictNext(graph, recentAnchors, limit = 6) {
-  const recent = new Set(recentAnchors.map((a) => nodeId('file', canonicalPath(a))));
+  const recent = new Set(
+    recentAnchors.map((a) => nodeId('file', canonicalPath(a)))
+  );
   const weight = new Map();
 
   for (const edge of graph.edges) {
     if (edge.edge !== 'related') continue;
     const [from, to] = [edge.from, edge.to];
-    if (recent.has(from) && !recent.has(to)) weight.set(to, (weight.get(to) || 0) + 1);
-    if (recent.has(to) && !recent.has(from)) weight.set(from, (weight.get(from) || 0) + 1);
+    if (recent.has(from) && !recent.has(to))
+      weight.set(to, (weight.get(to) || 0) + 1);
+    if (recent.has(to) && !recent.has(from))
+      weight.set(from, (weight.get(from) || 0) + 1);
   }
 
   return [...weight.entries()]
@@ -117,8 +125,10 @@ export function restorationPlan(dir, graph, context = {}) {
   // be recovered by looking at the code again.
   if (context.openQuestion) {
     const lines = [`Open: ${context.openQuestion}`];
-    for (const ruled of context.ruledOut || []) lines.push(`  ruled out: ${ruled}`);
-    for (const open of context.untested || []) lines.push(`  untested: ${open}`);
+    for (const ruled of context.ruledOut || [])
+      lines.push(`  ruled out: ${ruled}`);
+    for (const open of context.untested || [])
+      lines.push(`  untested: ${open}`);
     section('Where you were', lines, total * split.frontier);
   }
 
@@ -134,7 +144,18 @@ export function restorationPlan(dir, graph, context = {}) {
       for (const finding of findings) {
         // `! STALE` only where a diff actually exists to back it; see the
         // renderer in inject.mjs for the measurement behind this.
-        const mark = finding.stale ? (finding.staleEvidence ? '! STALE ' : '~ ') : '';
+        //
+        // BOTH HALVES, matching inject.mjs exactly (`!staleEvidence || !diff`).
+        // Checking staleEvidence alone marked a finding `! STALE` here while the
+        // injector softened the same finding elsewhere -- and the strong marker
+        // claims 'this is contradicted, here is the proof' with no proof to
+        // show, which is the bare stale finding the design calls worse than
+        // having no graph.
+        const mark = finding.stale
+          ? finding.staleEvidence && finding.diff
+            ? '! STALE '
+            : '~ '
+          : '';
         lines.push(`${node.key}: ${mark}${finding.claim}`);
       }
     }
@@ -144,7 +165,9 @@ export function restorationPlan(dir, graph, context = {}) {
   // BRIEF -- orientation. Last, because it is the most replaceable: normal
   // just-in-time injection will deliver most of it the moment work resumes.
   const established = [...graph.nodes.values()]
-    .filter((n) => n.kind === 'finding' && !n.retired && typeof n.claim === 'string')
+    .filter(
+      (n) => n.kind === 'finding' && !n.retired && typeof n.claim === 'string'
+    )
     .sort((a, b) => (b.confidence ?? 0) - (a.confidence ?? 0))
     .slice(0, 12)
     .map((n) => `${n.key}: ${n.claim.slice(0, 100)}`);

--- a/hooks-core/staleness.mjs
+++ b/hooks-core/staleness.mjs
@@ -398,12 +398,30 @@ export function serve(graph, findings) {
       // front of the model, and this text exists precisely because the previous
       // phrasing was measured suppressing correct findings. State the evidence
       // gap and stop.
-      diff = `(marked stale: ${reason}. The supporting diff can no longer be `
-        + 'reconstructed; the claim itself may well still hold, so weigh it on '
-        + 'its own merits.)';
+      // THE PROSE MOVES OUT OF `diff`, and the fact moves into a flag.
+      //
+      // Softening this sentence was not enough, because the RENDERER wraps it:
+      // the model saw `STALE (reason). What changed:` followed by a paragraph
+      // explaining that nothing follows. The strong framing was designed for
+      // the case where evidence exists and was being applied to the case where
+      // it does not.
+      //
+      // Measured across every real graph on one machine: 32 of 241 served
+      // findings were stale, and 25 of those 32 -- 78% -- had no diff at all.
+      // So the strongest wording available was carried by the findings with the
+      // least evidence behind them, on 10.4% of everything served.
+      //
+      // A caller cannot phrase this well from a prose blob, so it gets the two
+      // things it needs: that the finding is stale, and whether any evidence
+      // survives. The wording is then the renderer's business.
+      diff = '';
     }
 
-    served.push({ ...finding, stale, ...(stale ? { diff, staleReason: reason } : {}) });
+    served.push({
+      ...finding,
+      stale,
+      ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
+    });
   }
   return served;
 }

--- a/hooks-core/staleness.mjs
+++ b/hooks-core/staleness.mjs
@@ -339,7 +339,37 @@ export function serve(graph, findings) {
   // graph directly cannot accidentally serve a claim a human explicitly
   // withdrew. A withheld claim reappearing is not a bug anyone would notice
   // quickly.
+/**
+ * Types whose truth is a claim ABOUT the anchor's contents.
+ *
+ * Only these can be invalidated by that file changing. An anchor on any other
+ * type is a RETRIEVAL HOOK -- the file that happened to be open when the lesson
+ * was learned -- and its contents changing says nothing about the claim.
+ *
+ * MEASURED, across every real graph on one machine: 32 findings were served
+ * stale, and 24 of them -- 75% -- were types in neither of these sets. The
+ * clearest example is a `failure` reading "Edit hooks-core/, never the generated
+ * copies", marked stale because hooks-core/wiki.mjs changed. That rule is about
+ * process; wiki.mjs's contents cannot make it wrong. It was being discounted for
+ * a reason that did not exist.
+ *
+ * THE TRADE, STATED. A `command` finding CAN be invalidated by its anchor -- a
+ * claim about `npm test` anchored to package.json genuinely dies if the test
+ * script changes. That case is now missed. It is the better error: today every
+ * version bump marks it stale, so the signal fires overwhelmingly when nothing
+ * relevant happened, and a signal that is usually wrong is one a reader learns
+ * to ignore -- taking the rare true positive with it.
+ */
+const CONTENT_DEPENDENT = new Set(['finding', 'map']);
+
   for (const finding of findings.filter((f) => !f.retired)) {
+    // A claim that does not depend on the anchor's contents cannot be
+    // invalidated by them. It is served as-is rather than discounted.
+    if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) {
+      served.push({ ...finding });
+      continue;
+    }
+
     const anchors = graph.edges
       .filter((e) => e.edge === 'derived_from' && e.from === finding.id)
       .map((e) => graph.nodes.get(e.to))

--- a/hooks-core/wiki.mjs
+++ b/hooks-core/wiki.mjs
@@ -16,7 +16,7 @@
 
 import {
   appendFileSync, readFileSync, existsSync, mkdirSync, chmodSync,
-  openSync, closeSync, unlinkSync, statSync,
+  openSync, closeSync, unlinkSync, statSync, writeFileSync, renameSync,
 } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { createHash } from 'node:crypto';
@@ -240,6 +240,99 @@ function ignoreSelf(dir) {
   }
 }
 
+/**
+ * The log is append-only, and nothing was ever reclaiming it.
+ *
+ * MEASURED on this repository's own graph: 206.6 MB, 41,810 records, 6,125
+ * unique ids. 85.4% of every record in the file was superseded by a later one,
+ * and 97.5 MB was reclaimable. `load()` parses the whole thing on EVERY hook
+ * invocation -- so every tool call paid 1.2-1.6 seconds, against a 118 ms
+ * median when the graph is small.
+ *
+ * That is the optimizer becoming its own cost, in latency instead of tokens.
+ * It also surfaced as a flaky test: a 20 s spawn budget that a loaded machine
+ * could exceed, which is the sort of failure that gets re-run rather than read.
+ *
+ * AMORTISED TRIGGER, not a size threshold. A fixed cap would compact on every
+ * append once the live set alone exceeded it -- here the live set is 109 MB, so
+ * any cap below that would rewrite the file continuously. Instead the size
+ * after each compaction is recorded, and the next one waits until the file has
+ * doubled again: each compaction therefore does at least as much good as the
+ * work it costs, and the amortised cost per append stays constant.
+ */
+// READ PER CALL, not once at module load -- the same rule the holdout
+// fraction already follows in metrics.mjs. Reading it once meant a process
+// started before a config change honoured the old value forever, and it also
+// made the setting untestable: a suite that sets the variable in `beforeEach`
+// runs after the import, so the module had already captured the default.
+const compactFloorBytes = () =>
+  Number(process.env.TOKEN_OPTIMIZER_GRAPH_COMPACT_BYTES) || 8_000_000;
+const markerPath = (dir) => join(dir, 'graph.compact.json');
+
+function compactionBaseline(dir) {
+  try {
+    const raw = JSON.parse(readFileSync(markerPath(dir), 'utf8'));
+    const n = Number(raw.sizeAfter);
+    return Number.isFinite(n) && n > 0 ? n : compactFloorBytes();
+  } catch {
+    return compactFloorBytes();
+  }
+}
+
+/**
+ * Rewrites the log keeping only the surviving version of each record.
+ *
+ * CALLED INSIDE THE LOCK, so no writer can append between the read and the
+ * rename. Written to a temporary file and renamed, which is atomic on the same
+ * volume: a crash mid-compaction leaves the original log untouched rather than
+ * a half-written graph.
+ */
+function compactIfWasteful(dir) {
+  const path = logPath(dir);
+  let size = 0;
+  try {
+    size = statSync(path).size;
+  } catch {
+    return;
+  }
+  if (size < compactFloorBytes() || size < compactionBaseline(dir) * 2) return;
+
+  try {
+    const nodes = new Map();
+    const edges = new Map();
+    for (const line of readFileSync(path, 'utf8').split('\n')) {
+      if (!line) continue;
+      let record;
+      try {
+        record = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      // A record from another schema is KEPT VERBATIM rather than reinterpreted.
+      // load() skips it, but discarding it here would make compaction a silent
+      // migration that deletes data a future version might understand.
+      if ((record.v ?? 0) !== GRAPH_VERSION) {
+        edges.set('raw:' + edges.size, line);
+        continue;
+      }
+      if (record.t === 'n') nodes.set(record.id, line);
+      else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
+      else edges.set('raw:' + edges.size, line);
+    }
+
+    // EDGES BEFORE NODES, matching putNodeWithEdges: a torn write can then only
+    // lose a finding, never leave one anchored to nothing.
+    const out = [...edges.values(), ...nodes.values()].join('\n') + '\n';
+    const tmp = path + '.compact';
+    writeFileSync(tmp, out, { mode: 0o600 });
+    renameSync(tmp, path);
+    writeFileSync(markerPath(dir), JSON.stringify({ sizeAfter: out.length, at: Date.now() }), { mode: 0o600 });
+  } catch {
+    // Compaction is an optimization. A failure leaves the log exactly as it
+    // was, which is correct if larger than it needs to be.
+  }
+}
+
 function appendAll(dir, records) {
   if (!records.length) return true;
   try {
@@ -261,7 +354,10 @@ function appendAll(dir, records) {
     // needs several records to be observed together cannot get that by looping,
     // because every iteration is a separate crash point.
     const payload = records.map((record) => JSON.stringify(record) + '\n').join('');
-    withLock(dir, () => appendFileSync(logPath(dir), payload));
+    withLock(dir, () => {
+      appendFileSync(logPath(dir), payload);
+      compactIfWasteful(dir);
+    });
     return true;
   } catch {
     // The graph is an optimization. Failing to write one must never fail the

--- a/hooks-core/wiki.mjs
+++ b/hooks-core/wiki.mjs
@@ -269,6 +269,17 @@ const compactFloorBytes = () =>
   Number(process.env.TOKEN_OPTIMIZER_GRAPH_COMPACT_BYTES) || 8_000_000;
 const markerPath = (dir) => join(dir, 'graph.compact.json');
 
+/** Cheap enough to test on every line, which is the point. */
+/**
+ * Snapshots live in their own file.
+ *
+ * Skipping them during the parse was only half the win: `load()` still READ
+ * all 23 MB to find the lines it was skipping. Measured, 137 ms -> 99 ms from
+ * the skip alone. A separate file means those bytes are never touched unless a
+ * caller asks for them, which two call sites out of many do.
+ */
+const snapshotsPath = (dir) => join(dir, 'snapshots.jsonl');
+
 /** Finding types whose evidence is a diff, and so need the snapshot kept. */
 const SNAPSHOT_DEPENDENT = new Set(['finding', 'map']);
 
@@ -296,17 +307,31 @@ function compactionBaseline(dir) {
  */
 function compactIfWasteful(dir) {
   const path = logPath(dir);
+  // BOTH FILES. Once snapshots moved to their own log the graph itself stopped
+  // growing, so a trigger watching only it would never fire again -- while the
+  // sidecar, which holds the bulk, grew without bound. The waste is the pair.
   let size = 0;
   try {
     size = statSync(path).size;
   } catch {
     return;
   }
+  try {
+    size += statSync(snapshotsPath(dir)).size;
+  } catch {
+    /* no sidecar yet */
+  }
   if (size < compactFloorBytes() || size < compactionBaseline(dir) * 2) return;
 
   try {
     const nodes = new Map();
     const edges = new Map();
+    const snaps = new Map();
+    for (const rec of readSnapshots(dir)) {
+      if (typeof rec.snapshot === 'string' && rec.snapshot) {
+        snaps.set(rec.id, { at: rec.at || 0, snapshot: rec.snapshot });
+      }
+    }
     for (const line of readFileSync(path, 'utf8').split('\n')) {
       if (!line) continue;
       let record;
@@ -322,8 +347,22 @@ function compactIfWasteful(dir) {
         edges.set('raw:' + edges.size, line);
         continue;
       }
-      if (record.t === 'n') nodes.set(record.id, line);
-      else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
+      if (record.t === 'n') {
+        // MIGRATION. Graphs written before snapshots were split still carry
+        // them inline, and those are exactly the graphs that are slow. Moving
+        // them out here means one compaction fixes an existing install.
+        if (typeof record.snapshot === 'string' && record.snapshot) {
+          const { snapshot, ...rest } = record;
+          nodes.set(record.id, JSON.stringify(rest));
+          snaps.set(record.id, { at: record.at || 0, snapshot });
+        } else {
+          nodes.set(record.id, line);
+        }
+      } else if (record.t === 's') {
+        if (typeof record.snapshot === 'string' && record.snapshot) {
+          snaps.set(record.id, { at: record.at || 0, snapshot: record.snapshot });
+        }
+      } else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
       else edges.set('raw:' + edges.size, line);
     }
 
@@ -365,32 +404,17 @@ function compactIfWasteful(dir) {
       if (f.kind === 'finding' && SNAPSHOT_DEPENDENT.has(f.type || 'finding')) needed.add(e.to);
     }
 
-    const carriers = [];
-    for (const [id, line] of nodes) {
-      let n;
-      try {
-        n = JSON.parse(line);
-      } catch {
-        continue;
-      }
-      if (typeof n.snapshot !== 'string' || !n.snapshot) continue;
-      carriers.push({ id, at: n.at || 0, size: n.snapshot.length, node: n });
-    }
-    carriers.sort((a, b) => b.at - a.at);
+    const carriers = [...snaps.entries()]
+      .map(([id, v]) => ({ id, at: v.at, size: v.snapshot.length }))
+      .sort((a, b) => b.at - a.at);
 
     let spent = 0;
     const budget = snapshotBudgetBytes();
+    const keep = new Map();
     for (const c of carriers) {
-      if (needed.has(c.id)) {
-        spent += c.size;
-        continue;
-      }
-      if (spent + c.size <= budget) {
-        spent += c.size;
-        continue;
-      }
-      const { snapshot, ...rest } = c.node;
-      nodes.set(c.id, JSON.stringify(rest));
+      if (!needed.has(c.id) && spent + c.size > budget) continue;
+      spent += c.size;
+      keep.set(c.id, snaps.get(c.id));
     }
 
     // EDGES BEFORE NODES, matching putNodeWithEdges: a torn write can then only
@@ -399,7 +423,21 @@ function compactIfWasteful(dir) {
     const tmp = path + '.compact';
     writeFileSync(tmp, out, { mode: 0o600 });
     renameSync(tmp, path);
-    writeFileSync(markerPath(dir), JSON.stringify({ sizeAfter: out.length, at: Date.now() }), { mode: 0o600 });
+    // The surviving snapshots are rewritten to their own file, which is also
+    // what migrates a graph that still had them inline.
+    const snapOut =
+      [...keep.entries()]
+        .map(([id, v]) => JSON.stringify({ t: 's', v: GRAPH_VERSION, id, snapshot: v.snapshot, at: v.at }))
+        .join('\n') + (keep.size ? '\n' : '');
+    const snapTmp = snapshotsPath(dir) + '.compact';
+    writeFileSync(snapTmp, snapOut, { mode: 0o600 });
+    renameSync(snapTmp, snapshotsPath(dir));
+    writeFileSync(
+      markerPath(dir),
+      // The baseline is the PAIR, matching what the trigger measures.
+      JSON.stringify({ sizeAfter: out.length + snapOut.length, at: Date.now() }),
+      { mode: 0o600 }
+    );
   } catch {
     // Compaction is an optimization. A failure leaves the log exactly as it
     // was, which is correct if larger than it needs to be.
@@ -456,7 +494,20 @@ export function putNode(dir, { kind, key, ...rest }) {
   // Spreading it after `id` let a caller passing a whole existing node back in
   // -- which curate.mjs does on every pin, retire and correct -- carry a stale
   // `id` or `t` through and write a record that no longer matches its own key.
-  append(dir, { ...rest, t: 'n', v: GRAPH_VERSION, id, kind, key: canonicalKey(kind, key), at: Date.now() });
+  const { snapshot, ...fields } = rest;
+  const at = Date.now();
+  const records = [
+    { ...fields, t: 'n', v: GRAPH_VERSION, id, kind, key: canonicalKey(kind, key), at },
+  ];
+  // SEPARATE RECORD, so `load()` can skip the bytes rather than parse and drop
+  // them. Written after the node: a torn write then loses a snapshot, which
+  // degrades to the ordinary redirect, rather than losing the node itself.
+  appendAll(dir, records);
+  // Written AFTER the node and to a different file: a failure here costs a
+  // snapshot, which degrades to the ordinary redirect, never the node.
+  if (typeof snapshot === 'string' && snapshot) {
+    appendSnapshot(dir, { t: 's', v: GRAPH_VERSION, id, snapshot, at });
+  }
   return id;
 }
 
@@ -513,14 +564,70 @@ export function putNodeWithEdges(dir, { kind, key, ...rest }, edges = []) {
  * line is the normal consequence of a process being killed mid-append, and one
  * bad line must not make the entire accumulated graph unreadable.
  */
-export function load(dir) {
+/** Appends one snapshot record. Failure here must never fail a graph write. */
+function appendSnapshot(dir, record) {
+  try {
+    appendFileSync(snapshotsPath(dir), JSON.stringify(record) + '\n');
+  } catch {
+    /* the node is already durable; the snapshot is an optimization */
+  }
+}
+
+/** Every snapshot record, latest wins. Read only when a caller asks. */
+function readSnapshots(dir) {
+  const out = [];
+  try {
+    for (const line of readFileSync(snapshotsPath(dir), 'utf8').split('\n')) {
+      if (!line) continue;
+      try {
+        const rec = JSON.parse(line);
+        if ((rec.v ?? 0) === GRAPH_VERSION && rec.id) out.push(rec);
+      } catch {
+        /* a torn line costs one snapshot */
+      }
+    }
+  } catch {
+    /* no sidecar yet */
+  }
+  return out;
+}
+
+/**
+ * @param {object} [options]
+ * @param {boolean} [options.snapshots] Parse stored file contents as well.
+ *
+ * SNAPSHOTS ARE SKIPPED BY DEFAULT, and skipped WITHOUT PARSING.
+ *
+ * They are ~95% of the bytes and are read by two call sites: the staleness
+ * diff for a content-dependent finding, and the zero-turn refusal. Neither is
+ * on the path that runs before every tool call, and that path was paying 232 ms
+ * a call to parse them -- measured, on a 23.8 MB graph.
+ *
+ * The skip is a string comparison on the record prefix, so the JSON parser
+ * never sees the payload. Parsing and then discarding would have cost the same
+ * as keeping it, which is the whole reason this is a separate record type.
+ */
+export function load(dir, { snapshots = false } = {}) {
   const nodes = new Map();
   const edges = [];
   const path = logPath(dir);
   if (!existsSync(path)) return { nodes, edges };
 
+  const pending = snapshots ? new Map() : null;
   for (const line of readFileSync(path, 'utf8').split('\n')) {
     if (!line) continue;
+    // Older graphs kept these inline. Skipped without parsing, and moved out
+    // by the next compaction.
+    if (line.startsWith('{"t":"s"')) {
+      if (!snapshots) continue;
+      try {
+        const rec = JSON.parse(line);
+        if ((rec.v ?? 0) === GRAPH_VERSION) pending.set(rec.id, rec.snapshot);
+      } catch {
+        /* a torn line costs one snapshot, not the graph */
+      }
+      continue;
+    }
     let record;
     try {
       record = JSON.parse(line);
@@ -533,6 +640,17 @@ export function load(dir) {
     if ((record.v ?? 0) !== GRAPH_VERSION) continue;
     if (record.t === 'n') nodes.set(record.id, record);
     else if (record.t === 'e') edges.push(record);
+  }
+
+
+  // Re-attached after the sweep, so a snapshot record may appear before or
+  // after the node it belongs to.
+  if (pending) {
+    for (const rec of readSnapshots(dir)) pending.set(rec.id, rec.snapshot);
+    for (const [id, snapshot] of pending) {
+      const node = nodes.get(id);
+      if (node) nodes.set(id, { ...node, snapshot });
+    }
   }
 
   return { nodes, edges };

--- a/hooks-core/wiki.mjs
+++ b/hooks-core/wiki.mjs
@@ -269,6 +269,13 @@ const compactFloorBytes = () =>
   Number(process.env.TOKEN_OPTIMIZER_GRAPH_COMPACT_BYTES) || 8_000_000;
 const markerPath = (dir) => join(dir, 'graph.compact.json');
 
+/** Finding types whose evidence is a diff, and so need the snapshot kept. */
+const SNAPSHOT_DEPENDENT = new Set(['finding', 'map']);
+
+/** Read per call, for the reason documented on the compaction floor above. */
+const snapshotBudgetBytes = () =>
+  Number(process.env.TOKEN_OPTIMIZER_GRAPH_SNAPSHOT_BYTES) || 8_000_000;
+
 function compactionBaseline(dir) {
   try {
     const raw = JSON.parse(readFileSync(markerPath(dir), 'utf8'));
@@ -318,6 +325,72 @@ function compactIfWasteful(dir) {
       if (record.t === 'n') nodes.set(record.id, line);
       else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
       else edges.set('raw:' + edges.size, line);
+    }
+
+    // SNAPSHOTS ARE BOUNDED, and they are the whole file.
+    //
+    // MEASURED after compaction on this repository: 109.5 MB, of which `file`
+    // records are 105.3 MB. The raw snapshot text is 34.8 MB; JSON escaping
+    // triples it. Compaction alone cannot touch this, because every one of
+    // those records is live.
+    //
+    // A snapshot earns its place two ways: it lets a content-dependent finding
+    // show what changed, and it lets a re-read be answered with a diff instead
+    // of the file. The first is rare and identifiable -- 1 of 1,020 file nodes
+    // on this graph had such a finding anchored. The second only pays while the
+    // snapshot is recent: against a weeks-old snapshot the diff approaches the
+    // size of the file and the caller rejects it anyway.
+    //
+    // So: keep every snapshot something depends on, then keep the newest until
+    // the budget runs out, and drop the rest. The NODE always survives -- only
+    // the snapshot field goes, so hashes, staleness and traversal are
+    // unaffected and a dropped snapshot degrades to the ordinary redirect.
+    const needed = new Set();
+    for (const line of edges.values()) {
+      let e;
+      try {
+        e = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (e.t !== 'e' || e.edge !== 'derived_from') continue;
+      const from = nodes.get(e.from);
+      if (!from) continue;
+      let f;
+      try {
+        f = JSON.parse(from);
+      } catch {
+        continue;
+      }
+      if (f.kind === 'finding' && SNAPSHOT_DEPENDENT.has(f.type || 'finding')) needed.add(e.to);
+    }
+
+    const carriers = [];
+    for (const [id, line] of nodes) {
+      let n;
+      try {
+        n = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (typeof n.snapshot !== 'string' || !n.snapshot) continue;
+      carriers.push({ id, at: n.at || 0, size: n.snapshot.length, node: n });
+    }
+    carriers.sort((a, b) => b.at - a.at);
+
+    let spent = 0;
+    const budget = snapshotBudgetBytes();
+    for (const c of carriers) {
+      if (needed.has(c.id)) {
+        spent += c.size;
+        continue;
+      }
+      if (spent + c.size <= budget) {
+        spent += c.size;
+        continue;
+      }
+      const { snapshot, ...rest } = c.node;
+      nodes.set(c.id, JSON.stringify(rest));
     }
 
     // EDGES BEFORE NODES, matching putNodeWithEdges: a torn write can then only

--- a/integrations/codex/hooks/lib/inject.mjs
+++ b/integrations/codex/hooks/lib/inject.mjs
@@ -119,8 +119,20 @@ function fit(findings, budget) {
 function render(finding) {
   const head = `- [${finding.type || 'finding'}] ${finding.claim}`;
   if (!finding.stale) return head;
-  // A stale finding NEVER renders without its evidence. Serving one bare would
-  // be worse than having no graph at all.
+
+  // A stale finding NEVER renders as though it were current. But the strength
+  // of the framing follows the strength of the evidence, because the framing
+  // was measured: in an A/B on a fresh subagent, identical findings scored 1/3
+  // dead-ends avoided when rendered with the discount wording and 2/3 when
+  // rendered clean. The claims being discounted were correct every time.
+  //
+  // With a diff, the reader can judge for themselves and the strong form is
+  // earned. Without one -- 78% of stale findings on real graphs -- announcing
+  // STALE and promising `What changed:` in front of nothing spends the
+  // strongest signal available on the weakest evidence available.
+  if (!finding.staleEvidence || !finding.diff) {
+    return `${head}\n  (recorded earlier; ${finding.staleReason}, and no diff could be rebuilt)`;
+  }
   return `${head}\n  STALE (${finding.staleReason}). What changed:\n${finding.diff}`;
 }
 

--- a/integrations/codex/hooks/lib/restore.mjs
+++ b/integrations/codex/hooks/lib/restore.mjs
@@ -134,7 +134,10 @@ export function restorationPlan(dir, graph, context = {}) {
       if (!node) continue;
       const findings = serve(graph, findingsFor(graph, id, { limit: 2 }));
       for (const finding of findings) {
-        lines.push(`${node.key}: ${finding.stale ? '! STALE ' : ''}${finding.claim}`);
+        // `! STALE` only where a diff actually exists to back it; see the
+        // renderer in inject.mjs for the measurement behind this.
+        const mark = finding.stale ? (finding.staleEvidence ? '! STALE ' : '~ ') : '';
+        lines.push(`${node.key}: ${mark}${finding.claim}`);
       }
     }
     section('Likely next', lines, total * split.forward);

--- a/integrations/codex/hooks/lib/restore.mjs
+++ b/integrations/codex/hooks/lib/restore.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/restore.mjs. Regenerate with `npm run sync:hooks`.
-/**
+﻿/**
  * Restoration after compaction.
  *
  * A checkpoint restores what you HAD. That is a recap: it spends the scarcest
@@ -37,7 +37,11 @@ const estimate = (text) => Math.ceil(String(text || '').length / 4);
  * genuinely different things, and treating them identically is what makes a
  * fixed-order restore feel wrong half the time.
  */
-export function classifySituation({ openQuestion, recentAnchors = [], idleMs = 0 } = {}) {
+export function classifySituation({
+  openQuestion,
+  recentAnchors = [],
+  idleMs = 0,
+} = {}) {
   // Days later, nothing in the fresh context connects to anything. Orientation
   // is the only thing that helps; continuation has nothing to continue from.
   if (idleMs > 6 * 60 * 60 * 1000) return 'cold-resume';
@@ -61,21 +65,25 @@ export function classifySituation({ openQuestion, recentAnchors = [], idleMs = 0
  */
 const SPLITS = {
   'mid-problem': { frontier: 0.6, forward: 0.25, brief: 0.15 },
-  'cold-resume': { frontier: 0.15, forward: 0.25, brief: 0.60 },
-  'in-flow': { frontier: 0.20, forward: 0.60, brief: 0.20 },
-  general: { frontier: 0.35, forward: 0.35, brief: 0.30 },
+  'cold-resume': { frontier: 0.15, forward: 0.25, brief: 0.6 },
+  'in-flow': { frontier: 0.2, forward: 0.6, brief: 0.2 },
+  general: { frontier: 0.35, forward: 0.35, brief: 0.3 },
 };
 
 /** Findings for files the co-occurrence graph says are likely next. */
 function predictNext(graph, recentAnchors, limit = 6) {
-  const recent = new Set(recentAnchors.map((a) => nodeId('file', canonicalPath(a))));
+  const recent = new Set(
+    recentAnchors.map((a) => nodeId('file', canonicalPath(a)))
+  );
   const weight = new Map();
 
   for (const edge of graph.edges) {
     if (edge.edge !== 'related') continue;
     const [from, to] = [edge.from, edge.to];
-    if (recent.has(from) && !recent.has(to)) weight.set(to, (weight.get(to) || 0) + 1);
-    if (recent.has(to) && !recent.has(from)) weight.set(from, (weight.get(from) || 0) + 1);
+    if (recent.has(from) && !recent.has(to))
+      weight.set(to, (weight.get(to) || 0) + 1);
+    if (recent.has(to) && !recent.has(from))
+      weight.set(from, (weight.get(from) || 0) + 1);
   }
 
   return [...weight.entries()]
@@ -119,8 +127,10 @@ export function restorationPlan(dir, graph, context = {}) {
   // be recovered by looking at the code again.
   if (context.openQuestion) {
     const lines = [`Open: ${context.openQuestion}`];
-    for (const ruled of context.ruledOut || []) lines.push(`  ruled out: ${ruled}`);
-    for (const open of context.untested || []) lines.push(`  untested: ${open}`);
+    for (const ruled of context.ruledOut || [])
+      lines.push(`  ruled out: ${ruled}`);
+    for (const open of context.untested || [])
+      lines.push(`  untested: ${open}`);
     section('Where you were', lines, total * split.frontier);
   }
 
@@ -136,7 +146,18 @@ export function restorationPlan(dir, graph, context = {}) {
       for (const finding of findings) {
         // `! STALE` only where a diff actually exists to back it; see the
         // renderer in inject.mjs for the measurement behind this.
-        const mark = finding.stale ? (finding.staleEvidence ? '! STALE ' : '~ ') : '';
+        //
+        // BOTH HALVES, matching inject.mjs exactly (`!staleEvidence || !diff`).
+        // Checking staleEvidence alone marked a finding `! STALE` here while the
+        // injector softened the same finding elsewhere -- and the strong marker
+        // claims 'this is contradicted, here is the proof' with no proof to
+        // show, which is the bare stale finding the design calls worse than
+        // having no graph.
+        const mark = finding.stale
+          ? finding.staleEvidence && finding.diff
+            ? '! STALE '
+            : '~ '
+          : '';
         lines.push(`${node.key}: ${mark}${finding.claim}`);
       }
     }
@@ -146,7 +167,9 @@ export function restorationPlan(dir, graph, context = {}) {
   // BRIEF -- orientation. Last, because it is the most replaceable: normal
   // just-in-time injection will deliver most of it the moment work resumes.
   const established = [...graph.nodes.values()]
-    .filter((n) => n.kind === 'finding' && !n.retired && typeof n.claim === 'string')
+    .filter(
+      (n) => n.kind === 'finding' && !n.retired && typeof n.claim === 'string'
+    )
     .sort((a, b) => (b.confidence ?? 0) - (a.confidence ?? 0))
     .slice(0, 12)
     .map((n) => `${n.key}: ${n.claim.slice(0, 100)}`);

--- a/integrations/codex/hooks/lib/staleness.mjs
+++ b/integrations/codex/hooks/lib/staleness.mjs
@@ -400,12 +400,30 @@ export function serve(graph, findings) {
       // front of the model, and this text exists precisely because the previous
       // phrasing was measured suppressing correct findings. State the evidence
       // gap and stop.
-      diff = `(marked stale: ${reason}. The supporting diff can no longer be `
-        + 'reconstructed; the claim itself may well still hold, so weigh it on '
-        + 'its own merits.)';
+      // THE PROSE MOVES OUT OF `diff`, and the fact moves into a flag.
+      //
+      // Softening this sentence was not enough, because the RENDERER wraps it:
+      // the model saw `STALE (reason). What changed:` followed by a paragraph
+      // explaining that nothing follows. The strong framing was designed for
+      // the case where evidence exists and was being applied to the case where
+      // it does not.
+      //
+      // Measured across every real graph on one machine: 32 of 241 served
+      // findings were stale, and 25 of those 32 -- 78% -- had no diff at all.
+      // So the strongest wording available was carried by the findings with the
+      // least evidence behind them, on 10.4% of everything served.
+      //
+      // A caller cannot phrase this well from a prose blob, so it gets the two
+      // things it needs: that the finding is stale, and whether any evidence
+      // survives. The wording is then the renderer's business.
+      diff = '';
     }
 
-    served.push({ ...finding, stale, ...(stale ? { diff, staleReason: reason } : {}) });
+    served.push({
+      ...finding,
+      stale,
+      ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
+    });
   }
   return served;
 }

--- a/integrations/codex/hooks/lib/staleness.mjs
+++ b/integrations/codex/hooks/lib/staleness.mjs
@@ -341,7 +341,37 @@ export function serve(graph, findings) {
   // graph directly cannot accidentally serve a claim a human explicitly
   // withdrew. A withheld claim reappearing is not a bug anyone would notice
   // quickly.
+/**
+ * Types whose truth is a claim ABOUT the anchor's contents.
+ *
+ * Only these can be invalidated by that file changing. An anchor on any other
+ * type is a RETRIEVAL HOOK -- the file that happened to be open when the lesson
+ * was learned -- and its contents changing says nothing about the claim.
+ *
+ * MEASURED, across every real graph on one machine: 32 findings were served
+ * stale, and 24 of them -- 75% -- were types in neither of these sets. The
+ * clearest example is a `failure` reading "Edit hooks-core/, never the generated
+ * copies", marked stale because hooks-core/wiki.mjs changed. That rule is about
+ * process; wiki.mjs's contents cannot make it wrong. It was being discounted for
+ * a reason that did not exist.
+ *
+ * THE TRADE, STATED. A `command` finding CAN be invalidated by its anchor -- a
+ * claim about `npm test` anchored to package.json genuinely dies if the test
+ * script changes. That case is now missed. It is the better error: today every
+ * version bump marks it stale, so the signal fires overwhelmingly when nothing
+ * relevant happened, and a signal that is usually wrong is one a reader learns
+ * to ignore -- taking the rare true positive with it.
+ */
+const CONTENT_DEPENDENT = new Set(['finding', 'map']);
+
   for (const finding of findings.filter((f) => !f.retired)) {
+    // A claim that does not depend on the anchor's contents cannot be
+    // invalidated by them. It is served as-is rather than discounted.
+    if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) {
+      served.push({ ...finding });
+      continue;
+    }
+
     const anchors = graph.edges
       .filter((e) => e.edge === 'derived_from' && e.from === finding.id)
       .map((e) => graph.nodes.get(e.to))

--- a/integrations/codex/hooks/lib/wiki.mjs
+++ b/integrations/codex/hooks/lib/wiki.mjs
@@ -271,6 +271,13 @@ const compactFloorBytes = () =>
   Number(process.env.TOKEN_OPTIMIZER_GRAPH_COMPACT_BYTES) || 8_000_000;
 const markerPath = (dir) => join(dir, 'graph.compact.json');
 
+/** Finding types whose evidence is a diff, and so need the snapshot kept. */
+const SNAPSHOT_DEPENDENT = new Set(['finding', 'map']);
+
+/** Read per call, for the reason documented on the compaction floor above. */
+const snapshotBudgetBytes = () =>
+  Number(process.env.TOKEN_OPTIMIZER_GRAPH_SNAPSHOT_BYTES) || 8_000_000;
+
 function compactionBaseline(dir) {
   try {
     const raw = JSON.parse(readFileSync(markerPath(dir), 'utf8'));
@@ -320,6 +327,72 @@ function compactIfWasteful(dir) {
       if (record.t === 'n') nodes.set(record.id, line);
       else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
       else edges.set('raw:' + edges.size, line);
+    }
+
+    // SNAPSHOTS ARE BOUNDED, and they are the whole file.
+    //
+    // MEASURED after compaction on this repository: 109.5 MB, of which `file`
+    // records are 105.3 MB. The raw snapshot text is 34.8 MB; JSON escaping
+    // triples it. Compaction alone cannot touch this, because every one of
+    // those records is live.
+    //
+    // A snapshot earns its place two ways: it lets a content-dependent finding
+    // show what changed, and it lets a re-read be answered with a diff instead
+    // of the file. The first is rare and identifiable -- 1 of 1,020 file nodes
+    // on this graph had such a finding anchored. The second only pays while the
+    // snapshot is recent: against a weeks-old snapshot the diff approaches the
+    // size of the file and the caller rejects it anyway.
+    //
+    // So: keep every snapshot something depends on, then keep the newest until
+    // the budget runs out, and drop the rest. The NODE always survives -- only
+    // the snapshot field goes, so hashes, staleness and traversal are
+    // unaffected and a dropped snapshot degrades to the ordinary redirect.
+    const needed = new Set();
+    for (const line of edges.values()) {
+      let e;
+      try {
+        e = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (e.t !== 'e' || e.edge !== 'derived_from') continue;
+      const from = nodes.get(e.from);
+      if (!from) continue;
+      let f;
+      try {
+        f = JSON.parse(from);
+      } catch {
+        continue;
+      }
+      if (f.kind === 'finding' && SNAPSHOT_DEPENDENT.has(f.type || 'finding')) needed.add(e.to);
+    }
+
+    const carriers = [];
+    for (const [id, line] of nodes) {
+      let n;
+      try {
+        n = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (typeof n.snapshot !== 'string' || !n.snapshot) continue;
+      carriers.push({ id, at: n.at || 0, size: n.snapshot.length, node: n });
+    }
+    carriers.sort((a, b) => b.at - a.at);
+
+    let spent = 0;
+    const budget = snapshotBudgetBytes();
+    for (const c of carriers) {
+      if (needed.has(c.id)) {
+        spent += c.size;
+        continue;
+      }
+      if (spent + c.size <= budget) {
+        spent += c.size;
+        continue;
+      }
+      const { snapshot, ...rest } = c.node;
+      nodes.set(c.id, JSON.stringify(rest));
     }
 
     // EDGES BEFORE NODES, matching putNodeWithEdges: a torn write can then only

--- a/integrations/codex/hooks/lib/wiki.mjs
+++ b/integrations/codex/hooks/lib/wiki.mjs
@@ -271,6 +271,17 @@ const compactFloorBytes = () =>
   Number(process.env.TOKEN_OPTIMIZER_GRAPH_COMPACT_BYTES) || 8_000_000;
 const markerPath = (dir) => join(dir, 'graph.compact.json');
 
+/** Cheap enough to test on every line, which is the point. */
+/**
+ * Snapshots live in their own file.
+ *
+ * Skipping them during the parse was only half the win: `load()` still READ
+ * all 23 MB to find the lines it was skipping. Measured, 137 ms -> 99 ms from
+ * the skip alone. A separate file means those bytes are never touched unless a
+ * caller asks for them, which two call sites out of many do.
+ */
+const snapshotsPath = (dir) => join(dir, 'snapshots.jsonl');
+
 /** Finding types whose evidence is a diff, and so need the snapshot kept. */
 const SNAPSHOT_DEPENDENT = new Set(['finding', 'map']);
 
@@ -298,17 +309,31 @@ function compactionBaseline(dir) {
  */
 function compactIfWasteful(dir) {
   const path = logPath(dir);
+  // BOTH FILES. Once snapshots moved to their own log the graph itself stopped
+  // growing, so a trigger watching only it would never fire again -- while the
+  // sidecar, which holds the bulk, grew without bound. The waste is the pair.
   let size = 0;
   try {
     size = statSync(path).size;
   } catch {
     return;
   }
+  try {
+    size += statSync(snapshotsPath(dir)).size;
+  } catch {
+    /* no sidecar yet */
+  }
   if (size < compactFloorBytes() || size < compactionBaseline(dir) * 2) return;
 
   try {
     const nodes = new Map();
     const edges = new Map();
+    const snaps = new Map();
+    for (const rec of readSnapshots(dir)) {
+      if (typeof rec.snapshot === 'string' && rec.snapshot) {
+        snaps.set(rec.id, { at: rec.at || 0, snapshot: rec.snapshot });
+      }
+    }
     for (const line of readFileSync(path, 'utf8').split('\n')) {
       if (!line) continue;
       let record;
@@ -324,8 +349,22 @@ function compactIfWasteful(dir) {
         edges.set('raw:' + edges.size, line);
         continue;
       }
-      if (record.t === 'n') nodes.set(record.id, line);
-      else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
+      if (record.t === 'n') {
+        // MIGRATION. Graphs written before snapshots were split still carry
+        // them inline, and those are exactly the graphs that are slow. Moving
+        // them out here means one compaction fixes an existing install.
+        if (typeof record.snapshot === 'string' && record.snapshot) {
+          const { snapshot, ...rest } = record;
+          nodes.set(record.id, JSON.stringify(rest));
+          snaps.set(record.id, { at: record.at || 0, snapshot });
+        } else {
+          nodes.set(record.id, line);
+        }
+      } else if (record.t === 's') {
+        if (typeof record.snapshot === 'string' && record.snapshot) {
+          snaps.set(record.id, { at: record.at || 0, snapshot: record.snapshot });
+        }
+      } else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
       else edges.set('raw:' + edges.size, line);
     }
 
@@ -367,32 +406,17 @@ function compactIfWasteful(dir) {
       if (f.kind === 'finding' && SNAPSHOT_DEPENDENT.has(f.type || 'finding')) needed.add(e.to);
     }
 
-    const carriers = [];
-    for (const [id, line] of nodes) {
-      let n;
-      try {
-        n = JSON.parse(line);
-      } catch {
-        continue;
-      }
-      if (typeof n.snapshot !== 'string' || !n.snapshot) continue;
-      carriers.push({ id, at: n.at || 0, size: n.snapshot.length, node: n });
-    }
-    carriers.sort((a, b) => b.at - a.at);
+    const carriers = [...snaps.entries()]
+      .map(([id, v]) => ({ id, at: v.at, size: v.snapshot.length }))
+      .sort((a, b) => b.at - a.at);
 
     let spent = 0;
     const budget = snapshotBudgetBytes();
+    const keep = new Map();
     for (const c of carriers) {
-      if (needed.has(c.id)) {
-        spent += c.size;
-        continue;
-      }
-      if (spent + c.size <= budget) {
-        spent += c.size;
-        continue;
-      }
-      const { snapshot, ...rest } = c.node;
-      nodes.set(c.id, JSON.stringify(rest));
+      if (!needed.has(c.id) && spent + c.size > budget) continue;
+      spent += c.size;
+      keep.set(c.id, snaps.get(c.id));
     }
 
     // EDGES BEFORE NODES, matching putNodeWithEdges: a torn write can then only
@@ -401,7 +425,21 @@ function compactIfWasteful(dir) {
     const tmp = path + '.compact';
     writeFileSync(tmp, out, { mode: 0o600 });
     renameSync(tmp, path);
-    writeFileSync(markerPath(dir), JSON.stringify({ sizeAfter: out.length, at: Date.now() }), { mode: 0o600 });
+    // The surviving snapshots are rewritten to their own file, which is also
+    // what migrates a graph that still had them inline.
+    const snapOut =
+      [...keep.entries()]
+        .map(([id, v]) => JSON.stringify({ t: 's', v: GRAPH_VERSION, id, snapshot: v.snapshot, at: v.at }))
+        .join('\n') + (keep.size ? '\n' : '');
+    const snapTmp = snapshotsPath(dir) + '.compact';
+    writeFileSync(snapTmp, snapOut, { mode: 0o600 });
+    renameSync(snapTmp, snapshotsPath(dir));
+    writeFileSync(
+      markerPath(dir),
+      // The baseline is the PAIR, matching what the trigger measures.
+      JSON.stringify({ sizeAfter: out.length + snapOut.length, at: Date.now() }),
+      { mode: 0o600 }
+    );
   } catch {
     // Compaction is an optimization. A failure leaves the log exactly as it
     // was, which is correct if larger than it needs to be.
@@ -458,7 +496,20 @@ export function putNode(dir, { kind, key, ...rest }) {
   // Spreading it after `id` let a caller passing a whole existing node back in
   // -- which curate.mjs does on every pin, retire and correct -- carry a stale
   // `id` or `t` through and write a record that no longer matches its own key.
-  append(dir, { ...rest, t: 'n', v: GRAPH_VERSION, id, kind, key: canonicalKey(kind, key), at: Date.now() });
+  const { snapshot, ...fields } = rest;
+  const at = Date.now();
+  const records = [
+    { ...fields, t: 'n', v: GRAPH_VERSION, id, kind, key: canonicalKey(kind, key), at },
+  ];
+  // SEPARATE RECORD, so `load()` can skip the bytes rather than parse and drop
+  // them. Written after the node: a torn write then loses a snapshot, which
+  // degrades to the ordinary redirect, rather than losing the node itself.
+  appendAll(dir, records);
+  // Written AFTER the node and to a different file: a failure here costs a
+  // snapshot, which degrades to the ordinary redirect, never the node.
+  if (typeof snapshot === 'string' && snapshot) {
+    appendSnapshot(dir, { t: 's', v: GRAPH_VERSION, id, snapshot, at });
+  }
   return id;
 }
 
@@ -515,14 +566,70 @@ export function putNodeWithEdges(dir, { kind, key, ...rest }, edges = []) {
  * line is the normal consequence of a process being killed mid-append, and one
  * bad line must not make the entire accumulated graph unreadable.
  */
-export function load(dir) {
+/** Appends one snapshot record. Failure here must never fail a graph write. */
+function appendSnapshot(dir, record) {
+  try {
+    appendFileSync(snapshotsPath(dir), JSON.stringify(record) + '\n');
+  } catch {
+    /* the node is already durable; the snapshot is an optimization */
+  }
+}
+
+/** Every snapshot record, latest wins. Read only when a caller asks. */
+function readSnapshots(dir) {
+  const out = [];
+  try {
+    for (const line of readFileSync(snapshotsPath(dir), 'utf8').split('\n')) {
+      if (!line) continue;
+      try {
+        const rec = JSON.parse(line);
+        if ((rec.v ?? 0) === GRAPH_VERSION && rec.id) out.push(rec);
+      } catch {
+        /* a torn line costs one snapshot */
+      }
+    }
+  } catch {
+    /* no sidecar yet */
+  }
+  return out;
+}
+
+/**
+ * @param {object} [options]
+ * @param {boolean} [options.snapshots] Parse stored file contents as well.
+ *
+ * SNAPSHOTS ARE SKIPPED BY DEFAULT, and skipped WITHOUT PARSING.
+ *
+ * They are ~95% of the bytes and are read by two call sites: the staleness
+ * diff for a content-dependent finding, and the zero-turn refusal. Neither is
+ * on the path that runs before every tool call, and that path was paying 232 ms
+ * a call to parse them -- measured, on a 23.8 MB graph.
+ *
+ * The skip is a string comparison on the record prefix, so the JSON parser
+ * never sees the payload. Parsing and then discarding would have cost the same
+ * as keeping it, which is the whole reason this is a separate record type.
+ */
+export function load(dir, { snapshots = false } = {}) {
   const nodes = new Map();
   const edges = [];
   const path = logPath(dir);
   if (!existsSync(path)) return { nodes, edges };
 
+  const pending = snapshots ? new Map() : null;
   for (const line of readFileSync(path, 'utf8').split('\n')) {
     if (!line) continue;
+    // Older graphs kept these inline. Skipped without parsing, and moved out
+    // by the next compaction.
+    if (line.startsWith('{"t":"s"')) {
+      if (!snapshots) continue;
+      try {
+        const rec = JSON.parse(line);
+        if ((rec.v ?? 0) === GRAPH_VERSION) pending.set(rec.id, rec.snapshot);
+      } catch {
+        /* a torn line costs one snapshot, not the graph */
+      }
+      continue;
+    }
     let record;
     try {
       record = JSON.parse(line);
@@ -535,6 +642,17 @@ export function load(dir) {
     if ((record.v ?? 0) !== GRAPH_VERSION) continue;
     if (record.t === 'n') nodes.set(record.id, record);
     else if (record.t === 'e') edges.push(record);
+  }
+
+
+  // Re-attached after the sweep, so a snapshot record may appear before or
+  // after the node it belongs to.
+  if (pending) {
+    for (const rec of readSnapshots(dir)) pending.set(rec.id, rec.snapshot);
+    for (const [id, snapshot] of pending) {
+      const node = nodes.get(id);
+      if (node) nodes.set(id, { ...node, snapshot });
+    }
   }
 
   return { nodes, edges };

--- a/integrations/codex/hooks/lib/wiki.mjs
+++ b/integrations/codex/hooks/lib/wiki.mjs
@@ -18,7 +18,7 @@
 
 import {
   appendFileSync, readFileSync, existsSync, mkdirSync, chmodSync,
-  openSync, closeSync, unlinkSync, statSync,
+  openSync, closeSync, unlinkSync, statSync, writeFileSync, renameSync,
 } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { createHash } from 'node:crypto';
@@ -242,6 +242,99 @@ function ignoreSelf(dir) {
   }
 }
 
+/**
+ * The log is append-only, and nothing was ever reclaiming it.
+ *
+ * MEASURED on this repository's own graph: 206.6 MB, 41,810 records, 6,125
+ * unique ids. 85.4% of every record in the file was superseded by a later one,
+ * and 97.5 MB was reclaimable. `load()` parses the whole thing on EVERY hook
+ * invocation -- so every tool call paid 1.2-1.6 seconds, against a 118 ms
+ * median when the graph is small.
+ *
+ * That is the optimizer becoming its own cost, in latency instead of tokens.
+ * It also surfaced as a flaky test: a 20 s spawn budget that a loaded machine
+ * could exceed, which is the sort of failure that gets re-run rather than read.
+ *
+ * AMORTISED TRIGGER, not a size threshold. A fixed cap would compact on every
+ * append once the live set alone exceeded it -- here the live set is 109 MB, so
+ * any cap below that would rewrite the file continuously. Instead the size
+ * after each compaction is recorded, and the next one waits until the file has
+ * doubled again: each compaction therefore does at least as much good as the
+ * work it costs, and the amortised cost per append stays constant.
+ */
+// READ PER CALL, not once at module load -- the same rule the holdout
+// fraction already follows in metrics.mjs. Reading it once meant a process
+// started before a config change honoured the old value forever, and it also
+// made the setting untestable: a suite that sets the variable in `beforeEach`
+// runs after the import, so the module had already captured the default.
+const compactFloorBytes = () =>
+  Number(process.env.TOKEN_OPTIMIZER_GRAPH_COMPACT_BYTES) || 8_000_000;
+const markerPath = (dir) => join(dir, 'graph.compact.json');
+
+function compactionBaseline(dir) {
+  try {
+    const raw = JSON.parse(readFileSync(markerPath(dir), 'utf8'));
+    const n = Number(raw.sizeAfter);
+    return Number.isFinite(n) && n > 0 ? n : compactFloorBytes();
+  } catch {
+    return compactFloorBytes();
+  }
+}
+
+/**
+ * Rewrites the log keeping only the surviving version of each record.
+ *
+ * CALLED INSIDE THE LOCK, so no writer can append between the read and the
+ * rename. Written to a temporary file and renamed, which is atomic on the same
+ * volume: a crash mid-compaction leaves the original log untouched rather than
+ * a half-written graph.
+ */
+function compactIfWasteful(dir) {
+  const path = logPath(dir);
+  let size = 0;
+  try {
+    size = statSync(path).size;
+  } catch {
+    return;
+  }
+  if (size < compactFloorBytes() || size < compactionBaseline(dir) * 2) return;
+
+  try {
+    const nodes = new Map();
+    const edges = new Map();
+    for (const line of readFileSync(path, 'utf8').split('\n')) {
+      if (!line) continue;
+      let record;
+      try {
+        record = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      // A record from another schema is KEPT VERBATIM rather than reinterpreted.
+      // load() skips it, but discarding it here would make compaction a silent
+      // migration that deletes data a future version might understand.
+      if ((record.v ?? 0) !== GRAPH_VERSION) {
+        edges.set('raw:' + edges.size, line);
+        continue;
+      }
+      if (record.t === 'n') nodes.set(record.id, line);
+      else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
+      else edges.set('raw:' + edges.size, line);
+    }
+
+    // EDGES BEFORE NODES, matching putNodeWithEdges: a torn write can then only
+    // lose a finding, never leave one anchored to nothing.
+    const out = [...edges.values(), ...nodes.values()].join('\n') + '\n';
+    const tmp = path + '.compact';
+    writeFileSync(tmp, out, { mode: 0o600 });
+    renameSync(tmp, path);
+    writeFileSync(markerPath(dir), JSON.stringify({ sizeAfter: out.length, at: Date.now() }), { mode: 0o600 });
+  } catch {
+    // Compaction is an optimization. A failure leaves the log exactly as it
+    // was, which is correct if larger than it needs to be.
+  }
+}
+
 function appendAll(dir, records) {
   if (!records.length) return true;
   try {
@@ -263,7 +356,10 @@ function appendAll(dir, records) {
     // needs several records to be observed together cannot get that by looping,
     // because every iteration is a separate crash point.
     const payload = records.map((record) => JSON.stringify(record) + '\n').join('');
-    withLock(dir, () => appendFileSync(logPath(dir), payload));
+    withLock(dir, () => {
+      appendFileSync(logPath(dir), payload);
+      compactIfWasteful(dir);
+    });
     return true;
   } catch {
     // The graph is an optimization. Failing to write one must never fail the

--- a/integrations/codex/plugin/hooks/lib/inject.mjs
+++ b/integrations/codex/plugin/hooks/lib/inject.mjs
@@ -119,8 +119,20 @@ function fit(findings, budget) {
 function render(finding) {
   const head = `- [${finding.type || 'finding'}] ${finding.claim}`;
   if (!finding.stale) return head;
-  // A stale finding NEVER renders without its evidence. Serving one bare would
-  // be worse than having no graph at all.
+
+  // A stale finding NEVER renders as though it were current. But the strength
+  // of the framing follows the strength of the evidence, because the framing
+  // was measured: in an A/B on a fresh subagent, identical findings scored 1/3
+  // dead-ends avoided when rendered with the discount wording and 2/3 when
+  // rendered clean. The claims being discounted were correct every time.
+  //
+  // With a diff, the reader can judge for themselves and the strong form is
+  // earned. Without one -- 78% of stale findings on real graphs -- announcing
+  // STALE and promising `What changed:` in front of nothing spends the
+  // strongest signal available on the weakest evidence available.
+  if (!finding.staleEvidence || !finding.diff) {
+    return `${head}\n  (recorded earlier; ${finding.staleReason}, and no diff could be rebuilt)`;
+  }
   return `${head}\n  STALE (${finding.staleReason}). What changed:\n${finding.diff}`;
 }
 

--- a/integrations/codex/plugin/hooks/lib/restore.mjs
+++ b/integrations/codex/plugin/hooks/lib/restore.mjs
@@ -134,7 +134,10 @@ export function restorationPlan(dir, graph, context = {}) {
       if (!node) continue;
       const findings = serve(graph, findingsFor(graph, id, { limit: 2 }));
       for (const finding of findings) {
-        lines.push(`${node.key}: ${finding.stale ? '! STALE ' : ''}${finding.claim}`);
+        // `! STALE` only where a diff actually exists to back it; see the
+        // renderer in inject.mjs for the measurement behind this.
+        const mark = finding.stale ? (finding.staleEvidence ? '! STALE ' : '~ ') : '';
+        lines.push(`${node.key}: ${mark}${finding.claim}`);
       }
     }
     section('Likely next', lines, total * split.forward);

--- a/integrations/codex/plugin/hooks/lib/restore.mjs
+++ b/integrations/codex/plugin/hooks/lib/restore.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/restore.mjs. Regenerate with `npm run sync:hooks`.
-/**
+﻿/**
  * Restoration after compaction.
  *
  * A checkpoint restores what you HAD. That is a recap: it spends the scarcest
@@ -37,7 +37,11 @@ const estimate = (text) => Math.ceil(String(text || '').length / 4);
  * genuinely different things, and treating them identically is what makes a
  * fixed-order restore feel wrong half the time.
  */
-export function classifySituation({ openQuestion, recentAnchors = [], idleMs = 0 } = {}) {
+export function classifySituation({
+  openQuestion,
+  recentAnchors = [],
+  idleMs = 0,
+} = {}) {
   // Days later, nothing in the fresh context connects to anything. Orientation
   // is the only thing that helps; continuation has nothing to continue from.
   if (idleMs > 6 * 60 * 60 * 1000) return 'cold-resume';
@@ -61,21 +65,25 @@ export function classifySituation({ openQuestion, recentAnchors = [], idleMs = 0
  */
 const SPLITS = {
   'mid-problem': { frontier: 0.6, forward: 0.25, brief: 0.15 },
-  'cold-resume': { frontier: 0.15, forward: 0.25, brief: 0.60 },
-  'in-flow': { frontier: 0.20, forward: 0.60, brief: 0.20 },
-  general: { frontier: 0.35, forward: 0.35, brief: 0.30 },
+  'cold-resume': { frontier: 0.15, forward: 0.25, brief: 0.6 },
+  'in-flow': { frontier: 0.2, forward: 0.6, brief: 0.2 },
+  general: { frontier: 0.35, forward: 0.35, brief: 0.3 },
 };
 
 /** Findings for files the co-occurrence graph says are likely next. */
 function predictNext(graph, recentAnchors, limit = 6) {
-  const recent = new Set(recentAnchors.map((a) => nodeId('file', canonicalPath(a))));
+  const recent = new Set(
+    recentAnchors.map((a) => nodeId('file', canonicalPath(a)))
+  );
   const weight = new Map();
 
   for (const edge of graph.edges) {
     if (edge.edge !== 'related') continue;
     const [from, to] = [edge.from, edge.to];
-    if (recent.has(from) && !recent.has(to)) weight.set(to, (weight.get(to) || 0) + 1);
-    if (recent.has(to) && !recent.has(from)) weight.set(from, (weight.get(from) || 0) + 1);
+    if (recent.has(from) && !recent.has(to))
+      weight.set(to, (weight.get(to) || 0) + 1);
+    if (recent.has(to) && !recent.has(from))
+      weight.set(from, (weight.get(from) || 0) + 1);
   }
 
   return [...weight.entries()]
@@ -119,8 +127,10 @@ export function restorationPlan(dir, graph, context = {}) {
   // be recovered by looking at the code again.
   if (context.openQuestion) {
     const lines = [`Open: ${context.openQuestion}`];
-    for (const ruled of context.ruledOut || []) lines.push(`  ruled out: ${ruled}`);
-    for (const open of context.untested || []) lines.push(`  untested: ${open}`);
+    for (const ruled of context.ruledOut || [])
+      lines.push(`  ruled out: ${ruled}`);
+    for (const open of context.untested || [])
+      lines.push(`  untested: ${open}`);
     section('Where you were', lines, total * split.frontier);
   }
 
@@ -136,7 +146,18 @@ export function restorationPlan(dir, graph, context = {}) {
       for (const finding of findings) {
         // `! STALE` only where a diff actually exists to back it; see the
         // renderer in inject.mjs for the measurement behind this.
-        const mark = finding.stale ? (finding.staleEvidence ? '! STALE ' : '~ ') : '';
+        //
+        // BOTH HALVES, matching inject.mjs exactly (`!staleEvidence || !diff`).
+        // Checking staleEvidence alone marked a finding `! STALE` here while the
+        // injector softened the same finding elsewhere -- and the strong marker
+        // claims 'this is contradicted, here is the proof' with no proof to
+        // show, which is the bare stale finding the design calls worse than
+        // having no graph.
+        const mark = finding.stale
+          ? finding.staleEvidence && finding.diff
+            ? '! STALE '
+            : '~ '
+          : '';
         lines.push(`${node.key}: ${mark}${finding.claim}`);
       }
     }
@@ -146,7 +167,9 @@ export function restorationPlan(dir, graph, context = {}) {
   // BRIEF -- orientation. Last, because it is the most replaceable: normal
   // just-in-time injection will deliver most of it the moment work resumes.
   const established = [...graph.nodes.values()]
-    .filter((n) => n.kind === 'finding' && !n.retired && typeof n.claim === 'string')
+    .filter(
+      (n) => n.kind === 'finding' && !n.retired && typeof n.claim === 'string'
+    )
     .sort((a, b) => (b.confidence ?? 0) - (a.confidence ?? 0))
     .slice(0, 12)
     .map((n) => `${n.key}: ${n.claim.slice(0, 100)}`);

--- a/integrations/codex/plugin/hooks/lib/staleness.mjs
+++ b/integrations/codex/plugin/hooks/lib/staleness.mjs
@@ -400,12 +400,30 @@ export function serve(graph, findings) {
       // front of the model, and this text exists precisely because the previous
       // phrasing was measured suppressing correct findings. State the evidence
       // gap and stop.
-      diff = `(marked stale: ${reason}. The supporting diff can no longer be `
-        + 'reconstructed; the claim itself may well still hold, so weigh it on '
-        + 'its own merits.)';
+      // THE PROSE MOVES OUT OF `diff`, and the fact moves into a flag.
+      //
+      // Softening this sentence was not enough, because the RENDERER wraps it:
+      // the model saw `STALE (reason). What changed:` followed by a paragraph
+      // explaining that nothing follows. The strong framing was designed for
+      // the case where evidence exists and was being applied to the case where
+      // it does not.
+      //
+      // Measured across every real graph on one machine: 32 of 241 served
+      // findings were stale, and 25 of those 32 -- 78% -- had no diff at all.
+      // So the strongest wording available was carried by the findings with the
+      // least evidence behind them, on 10.4% of everything served.
+      //
+      // A caller cannot phrase this well from a prose blob, so it gets the two
+      // things it needs: that the finding is stale, and whether any evidence
+      // survives. The wording is then the renderer's business.
+      diff = '';
     }
 
-    served.push({ ...finding, stale, ...(stale ? { diff, staleReason: reason } : {}) });
+    served.push({
+      ...finding,
+      stale,
+      ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
+    });
   }
   return served;
 }

--- a/integrations/codex/plugin/hooks/lib/staleness.mjs
+++ b/integrations/codex/plugin/hooks/lib/staleness.mjs
@@ -341,7 +341,37 @@ export function serve(graph, findings) {
   // graph directly cannot accidentally serve a claim a human explicitly
   // withdrew. A withheld claim reappearing is not a bug anyone would notice
   // quickly.
+/**
+ * Types whose truth is a claim ABOUT the anchor's contents.
+ *
+ * Only these can be invalidated by that file changing. An anchor on any other
+ * type is a RETRIEVAL HOOK -- the file that happened to be open when the lesson
+ * was learned -- and its contents changing says nothing about the claim.
+ *
+ * MEASURED, across every real graph on one machine: 32 findings were served
+ * stale, and 24 of them -- 75% -- were types in neither of these sets. The
+ * clearest example is a `failure` reading "Edit hooks-core/, never the generated
+ * copies", marked stale because hooks-core/wiki.mjs changed. That rule is about
+ * process; wiki.mjs's contents cannot make it wrong. It was being discounted for
+ * a reason that did not exist.
+ *
+ * THE TRADE, STATED. A `command` finding CAN be invalidated by its anchor -- a
+ * claim about `npm test` anchored to package.json genuinely dies if the test
+ * script changes. That case is now missed. It is the better error: today every
+ * version bump marks it stale, so the signal fires overwhelmingly when nothing
+ * relevant happened, and a signal that is usually wrong is one a reader learns
+ * to ignore -- taking the rare true positive with it.
+ */
+const CONTENT_DEPENDENT = new Set(['finding', 'map']);
+
   for (const finding of findings.filter((f) => !f.retired)) {
+    // A claim that does not depend on the anchor's contents cannot be
+    // invalidated by them. It is served as-is rather than discounted.
+    if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) {
+      served.push({ ...finding });
+      continue;
+    }
+
     const anchors = graph.edges
       .filter((e) => e.edge === 'derived_from' && e.from === finding.id)
       .map((e) => graph.nodes.get(e.to))

--- a/integrations/codex/plugin/hooks/lib/wiki.mjs
+++ b/integrations/codex/plugin/hooks/lib/wiki.mjs
@@ -271,6 +271,13 @@ const compactFloorBytes = () =>
   Number(process.env.TOKEN_OPTIMIZER_GRAPH_COMPACT_BYTES) || 8_000_000;
 const markerPath = (dir) => join(dir, 'graph.compact.json');
 
+/** Finding types whose evidence is a diff, and so need the snapshot kept. */
+const SNAPSHOT_DEPENDENT = new Set(['finding', 'map']);
+
+/** Read per call, for the reason documented on the compaction floor above. */
+const snapshotBudgetBytes = () =>
+  Number(process.env.TOKEN_OPTIMIZER_GRAPH_SNAPSHOT_BYTES) || 8_000_000;
+
 function compactionBaseline(dir) {
   try {
     const raw = JSON.parse(readFileSync(markerPath(dir), 'utf8'));
@@ -320,6 +327,72 @@ function compactIfWasteful(dir) {
       if (record.t === 'n') nodes.set(record.id, line);
       else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
       else edges.set('raw:' + edges.size, line);
+    }
+
+    // SNAPSHOTS ARE BOUNDED, and they are the whole file.
+    //
+    // MEASURED after compaction on this repository: 109.5 MB, of which `file`
+    // records are 105.3 MB. The raw snapshot text is 34.8 MB; JSON escaping
+    // triples it. Compaction alone cannot touch this, because every one of
+    // those records is live.
+    //
+    // A snapshot earns its place two ways: it lets a content-dependent finding
+    // show what changed, and it lets a re-read be answered with a diff instead
+    // of the file. The first is rare and identifiable -- 1 of 1,020 file nodes
+    // on this graph had such a finding anchored. The second only pays while the
+    // snapshot is recent: against a weeks-old snapshot the diff approaches the
+    // size of the file and the caller rejects it anyway.
+    //
+    // So: keep every snapshot something depends on, then keep the newest until
+    // the budget runs out, and drop the rest. The NODE always survives -- only
+    // the snapshot field goes, so hashes, staleness and traversal are
+    // unaffected and a dropped snapshot degrades to the ordinary redirect.
+    const needed = new Set();
+    for (const line of edges.values()) {
+      let e;
+      try {
+        e = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (e.t !== 'e' || e.edge !== 'derived_from') continue;
+      const from = nodes.get(e.from);
+      if (!from) continue;
+      let f;
+      try {
+        f = JSON.parse(from);
+      } catch {
+        continue;
+      }
+      if (f.kind === 'finding' && SNAPSHOT_DEPENDENT.has(f.type || 'finding')) needed.add(e.to);
+    }
+
+    const carriers = [];
+    for (const [id, line] of nodes) {
+      let n;
+      try {
+        n = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (typeof n.snapshot !== 'string' || !n.snapshot) continue;
+      carriers.push({ id, at: n.at || 0, size: n.snapshot.length, node: n });
+    }
+    carriers.sort((a, b) => b.at - a.at);
+
+    let spent = 0;
+    const budget = snapshotBudgetBytes();
+    for (const c of carriers) {
+      if (needed.has(c.id)) {
+        spent += c.size;
+        continue;
+      }
+      if (spent + c.size <= budget) {
+        spent += c.size;
+        continue;
+      }
+      const { snapshot, ...rest } = c.node;
+      nodes.set(c.id, JSON.stringify(rest));
     }
 
     // EDGES BEFORE NODES, matching putNodeWithEdges: a torn write can then only

--- a/integrations/codex/plugin/hooks/lib/wiki.mjs
+++ b/integrations/codex/plugin/hooks/lib/wiki.mjs
@@ -271,6 +271,17 @@ const compactFloorBytes = () =>
   Number(process.env.TOKEN_OPTIMIZER_GRAPH_COMPACT_BYTES) || 8_000_000;
 const markerPath = (dir) => join(dir, 'graph.compact.json');
 
+/** Cheap enough to test on every line, which is the point. */
+/**
+ * Snapshots live in their own file.
+ *
+ * Skipping them during the parse was only half the win: `load()` still READ
+ * all 23 MB to find the lines it was skipping. Measured, 137 ms -> 99 ms from
+ * the skip alone. A separate file means those bytes are never touched unless a
+ * caller asks for them, which two call sites out of many do.
+ */
+const snapshotsPath = (dir) => join(dir, 'snapshots.jsonl');
+
 /** Finding types whose evidence is a diff, and so need the snapshot kept. */
 const SNAPSHOT_DEPENDENT = new Set(['finding', 'map']);
 
@@ -298,17 +309,31 @@ function compactionBaseline(dir) {
  */
 function compactIfWasteful(dir) {
   const path = logPath(dir);
+  // BOTH FILES. Once snapshots moved to their own log the graph itself stopped
+  // growing, so a trigger watching only it would never fire again -- while the
+  // sidecar, which holds the bulk, grew without bound. The waste is the pair.
   let size = 0;
   try {
     size = statSync(path).size;
   } catch {
     return;
   }
+  try {
+    size += statSync(snapshotsPath(dir)).size;
+  } catch {
+    /* no sidecar yet */
+  }
   if (size < compactFloorBytes() || size < compactionBaseline(dir) * 2) return;
 
   try {
     const nodes = new Map();
     const edges = new Map();
+    const snaps = new Map();
+    for (const rec of readSnapshots(dir)) {
+      if (typeof rec.snapshot === 'string' && rec.snapshot) {
+        snaps.set(rec.id, { at: rec.at || 0, snapshot: rec.snapshot });
+      }
+    }
     for (const line of readFileSync(path, 'utf8').split('\n')) {
       if (!line) continue;
       let record;
@@ -324,8 +349,22 @@ function compactIfWasteful(dir) {
         edges.set('raw:' + edges.size, line);
         continue;
       }
-      if (record.t === 'n') nodes.set(record.id, line);
-      else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
+      if (record.t === 'n') {
+        // MIGRATION. Graphs written before snapshots were split still carry
+        // them inline, and those are exactly the graphs that are slow. Moving
+        // them out here means one compaction fixes an existing install.
+        if (typeof record.snapshot === 'string' && record.snapshot) {
+          const { snapshot, ...rest } = record;
+          nodes.set(record.id, JSON.stringify(rest));
+          snaps.set(record.id, { at: record.at || 0, snapshot });
+        } else {
+          nodes.set(record.id, line);
+        }
+      } else if (record.t === 's') {
+        if (typeof record.snapshot === 'string' && record.snapshot) {
+          snaps.set(record.id, { at: record.at || 0, snapshot: record.snapshot });
+        }
+      } else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
       else edges.set('raw:' + edges.size, line);
     }
 
@@ -367,32 +406,17 @@ function compactIfWasteful(dir) {
       if (f.kind === 'finding' && SNAPSHOT_DEPENDENT.has(f.type || 'finding')) needed.add(e.to);
     }
 
-    const carriers = [];
-    for (const [id, line] of nodes) {
-      let n;
-      try {
-        n = JSON.parse(line);
-      } catch {
-        continue;
-      }
-      if (typeof n.snapshot !== 'string' || !n.snapshot) continue;
-      carriers.push({ id, at: n.at || 0, size: n.snapshot.length, node: n });
-    }
-    carriers.sort((a, b) => b.at - a.at);
+    const carriers = [...snaps.entries()]
+      .map(([id, v]) => ({ id, at: v.at, size: v.snapshot.length }))
+      .sort((a, b) => b.at - a.at);
 
     let spent = 0;
     const budget = snapshotBudgetBytes();
+    const keep = new Map();
     for (const c of carriers) {
-      if (needed.has(c.id)) {
-        spent += c.size;
-        continue;
-      }
-      if (spent + c.size <= budget) {
-        spent += c.size;
-        continue;
-      }
-      const { snapshot, ...rest } = c.node;
-      nodes.set(c.id, JSON.stringify(rest));
+      if (!needed.has(c.id) && spent + c.size > budget) continue;
+      spent += c.size;
+      keep.set(c.id, snaps.get(c.id));
     }
 
     // EDGES BEFORE NODES, matching putNodeWithEdges: a torn write can then only
@@ -401,7 +425,21 @@ function compactIfWasteful(dir) {
     const tmp = path + '.compact';
     writeFileSync(tmp, out, { mode: 0o600 });
     renameSync(tmp, path);
-    writeFileSync(markerPath(dir), JSON.stringify({ sizeAfter: out.length, at: Date.now() }), { mode: 0o600 });
+    // The surviving snapshots are rewritten to their own file, which is also
+    // what migrates a graph that still had them inline.
+    const snapOut =
+      [...keep.entries()]
+        .map(([id, v]) => JSON.stringify({ t: 's', v: GRAPH_VERSION, id, snapshot: v.snapshot, at: v.at }))
+        .join('\n') + (keep.size ? '\n' : '');
+    const snapTmp = snapshotsPath(dir) + '.compact';
+    writeFileSync(snapTmp, snapOut, { mode: 0o600 });
+    renameSync(snapTmp, snapshotsPath(dir));
+    writeFileSync(
+      markerPath(dir),
+      // The baseline is the PAIR, matching what the trigger measures.
+      JSON.stringify({ sizeAfter: out.length + snapOut.length, at: Date.now() }),
+      { mode: 0o600 }
+    );
   } catch {
     // Compaction is an optimization. A failure leaves the log exactly as it
     // was, which is correct if larger than it needs to be.
@@ -458,7 +496,20 @@ export function putNode(dir, { kind, key, ...rest }) {
   // Spreading it after `id` let a caller passing a whole existing node back in
   // -- which curate.mjs does on every pin, retire and correct -- carry a stale
   // `id` or `t` through and write a record that no longer matches its own key.
-  append(dir, { ...rest, t: 'n', v: GRAPH_VERSION, id, kind, key: canonicalKey(kind, key), at: Date.now() });
+  const { snapshot, ...fields } = rest;
+  const at = Date.now();
+  const records = [
+    { ...fields, t: 'n', v: GRAPH_VERSION, id, kind, key: canonicalKey(kind, key), at },
+  ];
+  // SEPARATE RECORD, so `load()` can skip the bytes rather than parse and drop
+  // them. Written after the node: a torn write then loses a snapshot, which
+  // degrades to the ordinary redirect, rather than losing the node itself.
+  appendAll(dir, records);
+  // Written AFTER the node and to a different file: a failure here costs a
+  // snapshot, which degrades to the ordinary redirect, never the node.
+  if (typeof snapshot === 'string' && snapshot) {
+    appendSnapshot(dir, { t: 's', v: GRAPH_VERSION, id, snapshot, at });
+  }
   return id;
 }
 
@@ -515,14 +566,70 @@ export function putNodeWithEdges(dir, { kind, key, ...rest }, edges = []) {
  * line is the normal consequence of a process being killed mid-append, and one
  * bad line must not make the entire accumulated graph unreadable.
  */
-export function load(dir) {
+/** Appends one snapshot record. Failure here must never fail a graph write. */
+function appendSnapshot(dir, record) {
+  try {
+    appendFileSync(snapshotsPath(dir), JSON.stringify(record) + '\n');
+  } catch {
+    /* the node is already durable; the snapshot is an optimization */
+  }
+}
+
+/** Every snapshot record, latest wins. Read only when a caller asks. */
+function readSnapshots(dir) {
+  const out = [];
+  try {
+    for (const line of readFileSync(snapshotsPath(dir), 'utf8').split('\n')) {
+      if (!line) continue;
+      try {
+        const rec = JSON.parse(line);
+        if ((rec.v ?? 0) === GRAPH_VERSION && rec.id) out.push(rec);
+      } catch {
+        /* a torn line costs one snapshot */
+      }
+    }
+  } catch {
+    /* no sidecar yet */
+  }
+  return out;
+}
+
+/**
+ * @param {object} [options]
+ * @param {boolean} [options.snapshots] Parse stored file contents as well.
+ *
+ * SNAPSHOTS ARE SKIPPED BY DEFAULT, and skipped WITHOUT PARSING.
+ *
+ * They are ~95% of the bytes and are read by two call sites: the staleness
+ * diff for a content-dependent finding, and the zero-turn refusal. Neither is
+ * on the path that runs before every tool call, and that path was paying 232 ms
+ * a call to parse them -- measured, on a 23.8 MB graph.
+ *
+ * The skip is a string comparison on the record prefix, so the JSON parser
+ * never sees the payload. Parsing and then discarding would have cost the same
+ * as keeping it, which is the whole reason this is a separate record type.
+ */
+export function load(dir, { snapshots = false } = {}) {
   const nodes = new Map();
   const edges = [];
   const path = logPath(dir);
   if (!existsSync(path)) return { nodes, edges };
 
+  const pending = snapshots ? new Map() : null;
   for (const line of readFileSync(path, 'utf8').split('\n')) {
     if (!line) continue;
+    // Older graphs kept these inline. Skipped without parsing, and moved out
+    // by the next compaction.
+    if (line.startsWith('{"t":"s"')) {
+      if (!snapshots) continue;
+      try {
+        const rec = JSON.parse(line);
+        if ((rec.v ?? 0) === GRAPH_VERSION) pending.set(rec.id, rec.snapshot);
+      } catch {
+        /* a torn line costs one snapshot, not the graph */
+      }
+      continue;
+    }
     let record;
     try {
       record = JSON.parse(line);
@@ -535,6 +642,17 @@ export function load(dir) {
     if ((record.v ?? 0) !== GRAPH_VERSION) continue;
     if (record.t === 'n') nodes.set(record.id, record);
     else if (record.t === 'e') edges.push(record);
+  }
+
+
+  // Re-attached after the sweep, so a snapshot record may appear before or
+  // after the node it belongs to.
+  if (pending) {
+    for (const rec of readSnapshots(dir)) pending.set(rec.id, rec.snapshot);
+    for (const [id, snapshot] of pending) {
+      const node = nodes.get(id);
+      if (node) nodes.set(id, { ...node, snapshot });
+    }
   }
 
   return { nodes, edges };

--- a/integrations/codex/plugin/hooks/lib/wiki.mjs
+++ b/integrations/codex/plugin/hooks/lib/wiki.mjs
@@ -18,7 +18,7 @@
 
 import {
   appendFileSync, readFileSync, existsSync, mkdirSync, chmodSync,
-  openSync, closeSync, unlinkSync, statSync,
+  openSync, closeSync, unlinkSync, statSync, writeFileSync, renameSync,
 } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { createHash } from 'node:crypto';
@@ -242,6 +242,99 @@ function ignoreSelf(dir) {
   }
 }
 
+/**
+ * The log is append-only, and nothing was ever reclaiming it.
+ *
+ * MEASURED on this repository's own graph: 206.6 MB, 41,810 records, 6,125
+ * unique ids. 85.4% of every record in the file was superseded by a later one,
+ * and 97.5 MB was reclaimable. `load()` parses the whole thing on EVERY hook
+ * invocation -- so every tool call paid 1.2-1.6 seconds, against a 118 ms
+ * median when the graph is small.
+ *
+ * That is the optimizer becoming its own cost, in latency instead of tokens.
+ * It also surfaced as a flaky test: a 20 s spawn budget that a loaded machine
+ * could exceed, which is the sort of failure that gets re-run rather than read.
+ *
+ * AMORTISED TRIGGER, not a size threshold. A fixed cap would compact on every
+ * append once the live set alone exceeded it -- here the live set is 109 MB, so
+ * any cap below that would rewrite the file continuously. Instead the size
+ * after each compaction is recorded, and the next one waits until the file has
+ * doubled again: each compaction therefore does at least as much good as the
+ * work it costs, and the amortised cost per append stays constant.
+ */
+// READ PER CALL, not once at module load -- the same rule the holdout
+// fraction already follows in metrics.mjs. Reading it once meant a process
+// started before a config change honoured the old value forever, and it also
+// made the setting untestable: a suite that sets the variable in `beforeEach`
+// runs after the import, so the module had already captured the default.
+const compactFloorBytes = () =>
+  Number(process.env.TOKEN_OPTIMIZER_GRAPH_COMPACT_BYTES) || 8_000_000;
+const markerPath = (dir) => join(dir, 'graph.compact.json');
+
+function compactionBaseline(dir) {
+  try {
+    const raw = JSON.parse(readFileSync(markerPath(dir), 'utf8'));
+    const n = Number(raw.sizeAfter);
+    return Number.isFinite(n) && n > 0 ? n : compactFloorBytes();
+  } catch {
+    return compactFloorBytes();
+  }
+}
+
+/**
+ * Rewrites the log keeping only the surviving version of each record.
+ *
+ * CALLED INSIDE THE LOCK, so no writer can append between the read and the
+ * rename. Written to a temporary file and renamed, which is atomic on the same
+ * volume: a crash mid-compaction leaves the original log untouched rather than
+ * a half-written graph.
+ */
+function compactIfWasteful(dir) {
+  const path = logPath(dir);
+  let size = 0;
+  try {
+    size = statSync(path).size;
+  } catch {
+    return;
+  }
+  if (size < compactFloorBytes() || size < compactionBaseline(dir) * 2) return;
+
+  try {
+    const nodes = new Map();
+    const edges = new Map();
+    for (const line of readFileSync(path, 'utf8').split('\n')) {
+      if (!line) continue;
+      let record;
+      try {
+        record = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      // A record from another schema is KEPT VERBATIM rather than reinterpreted.
+      // load() skips it, but discarding it here would make compaction a silent
+      // migration that deletes data a future version might understand.
+      if ((record.v ?? 0) !== GRAPH_VERSION) {
+        edges.set('raw:' + edges.size, line);
+        continue;
+      }
+      if (record.t === 'n') nodes.set(record.id, line);
+      else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
+      else edges.set('raw:' + edges.size, line);
+    }
+
+    // EDGES BEFORE NODES, matching putNodeWithEdges: a torn write can then only
+    // lose a finding, never leave one anchored to nothing.
+    const out = [...edges.values(), ...nodes.values()].join('\n') + '\n';
+    const tmp = path + '.compact';
+    writeFileSync(tmp, out, { mode: 0o600 });
+    renameSync(tmp, path);
+    writeFileSync(markerPath(dir), JSON.stringify({ sizeAfter: out.length, at: Date.now() }), { mode: 0o600 });
+  } catch {
+    // Compaction is an optimization. A failure leaves the log exactly as it
+    // was, which is correct if larger than it needs to be.
+  }
+}
+
 function appendAll(dir, records) {
   if (!records.length) return true;
   try {
@@ -263,7 +356,10 @@ function appendAll(dir, records) {
     // needs several records to be observed together cannot get that by looping,
     // because every iteration is a separate crash point.
     const payload = records.map((record) => JSON.stringify(record) + '\n').join('');
-    withLock(dir, () => appendFileSync(logPath(dir), payload));
+    withLock(dir, () => {
+      appendFileSync(logPath(dir), payload);
+      compactIfWasteful(dir);
+    });
     return true;
   } catch {
     // The graph is an optimization. Failing to write one must never fail the

--- a/integrations/gemini/hooks/lib/inject.mjs
+++ b/integrations/gemini/hooks/lib/inject.mjs
@@ -119,8 +119,20 @@ function fit(findings, budget) {
 function render(finding) {
   const head = `- [${finding.type || 'finding'}] ${finding.claim}`;
   if (!finding.stale) return head;
-  // A stale finding NEVER renders without its evidence. Serving one bare would
-  // be worse than having no graph at all.
+
+  // A stale finding NEVER renders as though it were current. But the strength
+  // of the framing follows the strength of the evidence, because the framing
+  // was measured: in an A/B on a fresh subagent, identical findings scored 1/3
+  // dead-ends avoided when rendered with the discount wording and 2/3 when
+  // rendered clean. The claims being discounted were correct every time.
+  //
+  // With a diff, the reader can judge for themselves and the strong form is
+  // earned. Without one -- 78% of stale findings on real graphs -- announcing
+  // STALE and promising `What changed:` in front of nothing spends the
+  // strongest signal available on the weakest evidence available.
+  if (!finding.staleEvidence || !finding.diff) {
+    return `${head}\n  (recorded earlier; ${finding.staleReason}, and no diff could be rebuilt)`;
+  }
   return `${head}\n  STALE (${finding.staleReason}). What changed:\n${finding.diff}`;
 }
 

--- a/integrations/gemini/hooks/lib/restore.mjs
+++ b/integrations/gemini/hooks/lib/restore.mjs
@@ -134,7 +134,10 @@ export function restorationPlan(dir, graph, context = {}) {
       if (!node) continue;
       const findings = serve(graph, findingsFor(graph, id, { limit: 2 }));
       for (const finding of findings) {
-        lines.push(`${node.key}: ${finding.stale ? '! STALE ' : ''}${finding.claim}`);
+        // `! STALE` only where a diff actually exists to back it; see the
+        // renderer in inject.mjs for the measurement behind this.
+        const mark = finding.stale ? (finding.staleEvidence ? '! STALE ' : '~ ') : '';
+        lines.push(`${node.key}: ${mark}${finding.claim}`);
       }
     }
     section('Likely next', lines, total * split.forward);

--- a/integrations/gemini/hooks/lib/restore.mjs
+++ b/integrations/gemini/hooks/lib/restore.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/restore.mjs. Regenerate with `npm run sync:hooks`.
-/**
+﻿/**
  * Restoration after compaction.
  *
  * A checkpoint restores what you HAD. That is a recap: it spends the scarcest
@@ -37,7 +37,11 @@ const estimate = (text) => Math.ceil(String(text || '').length / 4);
  * genuinely different things, and treating them identically is what makes a
  * fixed-order restore feel wrong half the time.
  */
-export function classifySituation({ openQuestion, recentAnchors = [], idleMs = 0 } = {}) {
+export function classifySituation({
+  openQuestion,
+  recentAnchors = [],
+  idleMs = 0,
+} = {}) {
   // Days later, nothing in the fresh context connects to anything. Orientation
   // is the only thing that helps; continuation has nothing to continue from.
   if (idleMs > 6 * 60 * 60 * 1000) return 'cold-resume';
@@ -61,21 +65,25 @@ export function classifySituation({ openQuestion, recentAnchors = [], idleMs = 0
  */
 const SPLITS = {
   'mid-problem': { frontier: 0.6, forward: 0.25, brief: 0.15 },
-  'cold-resume': { frontier: 0.15, forward: 0.25, brief: 0.60 },
-  'in-flow': { frontier: 0.20, forward: 0.60, brief: 0.20 },
-  general: { frontier: 0.35, forward: 0.35, brief: 0.30 },
+  'cold-resume': { frontier: 0.15, forward: 0.25, brief: 0.6 },
+  'in-flow': { frontier: 0.2, forward: 0.6, brief: 0.2 },
+  general: { frontier: 0.35, forward: 0.35, brief: 0.3 },
 };
 
 /** Findings for files the co-occurrence graph says are likely next. */
 function predictNext(graph, recentAnchors, limit = 6) {
-  const recent = new Set(recentAnchors.map((a) => nodeId('file', canonicalPath(a))));
+  const recent = new Set(
+    recentAnchors.map((a) => nodeId('file', canonicalPath(a)))
+  );
   const weight = new Map();
 
   for (const edge of graph.edges) {
     if (edge.edge !== 'related') continue;
     const [from, to] = [edge.from, edge.to];
-    if (recent.has(from) && !recent.has(to)) weight.set(to, (weight.get(to) || 0) + 1);
-    if (recent.has(to) && !recent.has(from)) weight.set(from, (weight.get(from) || 0) + 1);
+    if (recent.has(from) && !recent.has(to))
+      weight.set(to, (weight.get(to) || 0) + 1);
+    if (recent.has(to) && !recent.has(from))
+      weight.set(from, (weight.get(from) || 0) + 1);
   }
 
   return [...weight.entries()]
@@ -119,8 +127,10 @@ export function restorationPlan(dir, graph, context = {}) {
   // be recovered by looking at the code again.
   if (context.openQuestion) {
     const lines = [`Open: ${context.openQuestion}`];
-    for (const ruled of context.ruledOut || []) lines.push(`  ruled out: ${ruled}`);
-    for (const open of context.untested || []) lines.push(`  untested: ${open}`);
+    for (const ruled of context.ruledOut || [])
+      lines.push(`  ruled out: ${ruled}`);
+    for (const open of context.untested || [])
+      lines.push(`  untested: ${open}`);
     section('Where you were', lines, total * split.frontier);
   }
 
@@ -136,7 +146,18 @@ export function restorationPlan(dir, graph, context = {}) {
       for (const finding of findings) {
         // `! STALE` only where a diff actually exists to back it; see the
         // renderer in inject.mjs for the measurement behind this.
-        const mark = finding.stale ? (finding.staleEvidence ? '! STALE ' : '~ ') : '';
+        //
+        // BOTH HALVES, matching inject.mjs exactly (`!staleEvidence || !diff`).
+        // Checking staleEvidence alone marked a finding `! STALE` here while the
+        // injector softened the same finding elsewhere -- and the strong marker
+        // claims 'this is contradicted, here is the proof' with no proof to
+        // show, which is the bare stale finding the design calls worse than
+        // having no graph.
+        const mark = finding.stale
+          ? finding.staleEvidence && finding.diff
+            ? '! STALE '
+            : '~ '
+          : '';
         lines.push(`${node.key}: ${mark}${finding.claim}`);
       }
     }
@@ -146,7 +167,9 @@ export function restorationPlan(dir, graph, context = {}) {
   // BRIEF -- orientation. Last, because it is the most replaceable: normal
   // just-in-time injection will deliver most of it the moment work resumes.
   const established = [...graph.nodes.values()]
-    .filter((n) => n.kind === 'finding' && !n.retired && typeof n.claim === 'string')
+    .filter(
+      (n) => n.kind === 'finding' && !n.retired && typeof n.claim === 'string'
+    )
     .sort((a, b) => (b.confidence ?? 0) - (a.confidence ?? 0))
     .slice(0, 12)
     .map((n) => `${n.key}: ${n.claim.slice(0, 100)}`);

--- a/integrations/gemini/hooks/lib/staleness.mjs
+++ b/integrations/gemini/hooks/lib/staleness.mjs
@@ -400,12 +400,30 @@ export function serve(graph, findings) {
       // front of the model, and this text exists precisely because the previous
       // phrasing was measured suppressing correct findings. State the evidence
       // gap and stop.
-      diff = `(marked stale: ${reason}. The supporting diff can no longer be `
-        + 'reconstructed; the claim itself may well still hold, so weigh it on '
-        + 'its own merits.)';
+      // THE PROSE MOVES OUT OF `diff`, and the fact moves into a flag.
+      //
+      // Softening this sentence was not enough, because the RENDERER wraps it:
+      // the model saw `STALE (reason). What changed:` followed by a paragraph
+      // explaining that nothing follows. The strong framing was designed for
+      // the case where evidence exists and was being applied to the case where
+      // it does not.
+      //
+      // Measured across every real graph on one machine: 32 of 241 served
+      // findings were stale, and 25 of those 32 -- 78% -- had no diff at all.
+      // So the strongest wording available was carried by the findings with the
+      // least evidence behind them, on 10.4% of everything served.
+      //
+      // A caller cannot phrase this well from a prose blob, so it gets the two
+      // things it needs: that the finding is stale, and whether any evidence
+      // survives. The wording is then the renderer's business.
+      diff = '';
     }
 
-    served.push({ ...finding, stale, ...(stale ? { diff, staleReason: reason } : {}) });
+    served.push({
+      ...finding,
+      stale,
+      ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
+    });
   }
   return served;
 }

--- a/integrations/gemini/hooks/lib/staleness.mjs
+++ b/integrations/gemini/hooks/lib/staleness.mjs
@@ -341,7 +341,37 @@ export function serve(graph, findings) {
   // graph directly cannot accidentally serve a claim a human explicitly
   // withdrew. A withheld claim reappearing is not a bug anyone would notice
   // quickly.
+/**
+ * Types whose truth is a claim ABOUT the anchor's contents.
+ *
+ * Only these can be invalidated by that file changing. An anchor on any other
+ * type is a RETRIEVAL HOOK -- the file that happened to be open when the lesson
+ * was learned -- and its contents changing says nothing about the claim.
+ *
+ * MEASURED, across every real graph on one machine: 32 findings were served
+ * stale, and 24 of them -- 75% -- were types in neither of these sets. The
+ * clearest example is a `failure` reading "Edit hooks-core/, never the generated
+ * copies", marked stale because hooks-core/wiki.mjs changed. That rule is about
+ * process; wiki.mjs's contents cannot make it wrong. It was being discounted for
+ * a reason that did not exist.
+ *
+ * THE TRADE, STATED. A `command` finding CAN be invalidated by its anchor -- a
+ * claim about `npm test` anchored to package.json genuinely dies if the test
+ * script changes. That case is now missed. It is the better error: today every
+ * version bump marks it stale, so the signal fires overwhelmingly when nothing
+ * relevant happened, and a signal that is usually wrong is one a reader learns
+ * to ignore -- taking the rare true positive with it.
+ */
+const CONTENT_DEPENDENT = new Set(['finding', 'map']);
+
   for (const finding of findings.filter((f) => !f.retired)) {
+    // A claim that does not depend on the anchor's contents cannot be
+    // invalidated by them. It is served as-is rather than discounted.
+    if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) {
+      served.push({ ...finding });
+      continue;
+    }
+
     const anchors = graph.edges
       .filter((e) => e.edge === 'derived_from' && e.from === finding.id)
       .map((e) => graph.nodes.get(e.to))

--- a/integrations/gemini/hooks/lib/wiki.mjs
+++ b/integrations/gemini/hooks/lib/wiki.mjs
@@ -271,6 +271,13 @@ const compactFloorBytes = () =>
   Number(process.env.TOKEN_OPTIMIZER_GRAPH_COMPACT_BYTES) || 8_000_000;
 const markerPath = (dir) => join(dir, 'graph.compact.json');
 
+/** Finding types whose evidence is a diff, and so need the snapshot kept. */
+const SNAPSHOT_DEPENDENT = new Set(['finding', 'map']);
+
+/** Read per call, for the reason documented on the compaction floor above. */
+const snapshotBudgetBytes = () =>
+  Number(process.env.TOKEN_OPTIMIZER_GRAPH_SNAPSHOT_BYTES) || 8_000_000;
+
 function compactionBaseline(dir) {
   try {
     const raw = JSON.parse(readFileSync(markerPath(dir), 'utf8'));
@@ -320,6 +327,72 @@ function compactIfWasteful(dir) {
       if (record.t === 'n') nodes.set(record.id, line);
       else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
       else edges.set('raw:' + edges.size, line);
+    }
+
+    // SNAPSHOTS ARE BOUNDED, and they are the whole file.
+    //
+    // MEASURED after compaction on this repository: 109.5 MB, of which `file`
+    // records are 105.3 MB. The raw snapshot text is 34.8 MB; JSON escaping
+    // triples it. Compaction alone cannot touch this, because every one of
+    // those records is live.
+    //
+    // A snapshot earns its place two ways: it lets a content-dependent finding
+    // show what changed, and it lets a re-read be answered with a diff instead
+    // of the file. The first is rare and identifiable -- 1 of 1,020 file nodes
+    // on this graph had such a finding anchored. The second only pays while the
+    // snapshot is recent: against a weeks-old snapshot the diff approaches the
+    // size of the file and the caller rejects it anyway.
+    //
+    // So: keep every snapshot something depends on, then keep the newest until
+    // the budget runs out, and drop the rest. The NODE always survives -- only
+    // the snapshot field goes, so hashes, staleness and traversal are
+    // unaffected and a dropped snapshot degrades to the ordinary redirect.
+    const needed = new Set();
+    for (const line of edges.values()) {
+      let e;
+      try {
+        e = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (e.t !== 'e' || e.edge !== 'derived_from') continue;
+      const from = nodes.get(e.from);
+      if (!from) continue;
+      let f;
+      try {
+        f = JSON.parse(from);
+      } catch {
+        continue;
+      }
+      if (f.kind === 'finding' && SNAPSHOT_DEPENDENT.has(f.type || 'finding')) needed.add(e.to);
+    }
+
+    const carriers = [];
+    for (const [id, line] of nodes) {
+      let n;
+      try {
+        n = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (typeof n.snapshot !== 'string' || !n.snapshot) continue;
+      carriers.push({ id, at: n.at || 0, size: n.snapshot.length, node: n });
+    }
+    carriers.sort((a, b) => b.at - a.at);
+
+    let spent = 0;
+    const budget = snapshotBudgetBytes();
+    for (const c of carriers) {
+      if (needed.has(c.id)) {
+        spent += c.size;
+        continue;
+      }
+      if (spent + c.size <= budget) {
+        spent += c.size;
+        continue;
+      }
+      const { snapshot, ...rest } = c.node;
+      nodes.set(c.id, JSON.stringify(rest));
     }
 
     // EDGES BEFORE NODES, matching putNodeWithEdges: a torn write can then only

--- a/integrations/gemini/hooks/lib/wiki.mjs
+++ b/integrations/gemini/hooks/lib/wiki.mjs
@@ -271,6 +271,17 @@ const compactFloorBytes = () =>
   Number(process.env.TOKEN_OPTIMIZER_GRAPH_COMPACT_BYTES) || 8_000_000;
 const markerPath = (dir) => join(dir, 'graph.compact.json');
 
+/** Cheap enough to test on every line, which is the point. */
+/**
+ * Snapshots live in their own file.
+ *
+ * Skipping them during the parse was only half the win: `load()` still READ
+ * all 23 MB to find the lines it was skipping. Measured, 137 ms -> 99 ms from
+ * the skip alone. A separate file means those bytes are never touched unless a
+ * caller asks for them, which two call sites out of many do.
+ */
+const snapshotsPath = (dir) => join(dir, 'snapshots.jsonl');
+
 /** Finding types whose evidence is a diff, and so need the snapshot kept. */
 const SNAPSHOT_DEPENDENT = new Set(['finding', 'map']);
 
@@ -298,17 +309,31 @@ function compactionBaseline(dir) {
  */
 function compactIfWasteful(dir) {
   const path = logPath(dir);
+  // BOTH FILES. Once snapshots moved to their own log the graph itself stopped
+  // growing, so a trigger watching only it would never fire again -- while the
+  // sidecar, which holds the bulk, grew without bound. The waste is the pair.
   let size = 0;
   try {
     size = statSync(path).size;
   } catch {
     return;
   }
+  try {
+    size += statSync(snapshotsPath(dir)).size;
+  } catch {
+    /* no sidecar yet */
+  }
   if (size < compactFloorBytes() || size < compactionBaseline(dir) * 2) return;
 
   try {
     const nodes = new Map();
     const edges = new Map();
+    const snaps = new Map();
+    for (const rec of readSnapshots(dir)) {
+      if (typeof rec.snapshot === 'string' && rec.snapshot) {
+        snaps.set(rec.id, { at: rec.at || 0, snapshot: rec.snapshot });
+      }
+    }
     for (const line of readFileSync(path, 'utf8').split('\n')) {
       if (!line) continue;
       let record;
@@ -324,8 +349,22 @@ function compactIfWasteful(dir) {
         edges.set('raw:' + edges.size, line);
         continue;
       }
-      if (record.t === 'n') nodes.set(record.id, line);
-      else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
+      if (record.t === 'n') {
+        // MIGRATION. Graphs written before snapshots were split still carry
+        // them inline, and those are exactly the graphs that are slow. Moving
+        // them out here means one compaction fixes an existing install.
+        if (typeof record.snapshot === 'string' && record.snapshot) {
+          const { snapshot, ...rest } = record;
+          nodes.set(record.id, JSON.stringify(rest));
+          snaps.set(record.id, { at: record.at || 0, snapshot });
+        } else {
+          nodes.set(record.id, line);
+        }
+      } else if (record.t === 's') {
+        if (typeof record.snapshot === 'string' && record.snapshot) {
+          snaps.set(record.id, { at: record.at || 0, snapshot: record.snapshot });
+        }
+      } else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
       else edges.set('raw:' + edges.size, line);
     }
 
@@ -367,32 +406,17 @@ function compactIfWasteful(dir) {
       if (f.kind === 'finding' && SNAPSHOT_DEPENDENT.has(f.type || 'finding')) needed.add(e.to);
     }
 
-    const carriers = [];
-    for (const [id, line] of nodes) {
-      let n;
-      try {
-        n = JSON.parse(line);
-      } catch {
-        continue;
-      }
-      if (typeof n.snapshot !== 'string' || !n.snapshot) continue;
-      carriers.push({ id, at: n.at || 0, size: n.snapshot.length, node: n });
-    }
-    carriers.sort((a, b) => b.at - a.at);
+    const carriers = [...snaps.entries()]
+      .map(([id, v]) => ({ id, at: v.at, size: v.snapshot.length }))
+      .sort((a, b) => b.at - a.at);
 
     let spent = 0;
     const budget = snapshotBudgetBytes();
+    const keep = new Map();
     for (const c of carriers) {
-      if (needed.has(c.id)) {
-        spent += c.size;
-        continue;
-      }
-      if (spent + c.size <= budget) {
-        spent += c.size;
-        continue;
-      }
-      const { snapshot, ...rest } = c.node;
-      nodes.set(c.id, JSON.stringify(rest));
+      if (!needed.has(c.id) && spent + c.size > budget) continue;
+      spent += c.size;
+      keep.set(c.id, snaps.get(c.id));
     }
 
     // EDGES BEFORE NODES, matching putNodeWithEdges: a torn write can then only
@@ -401,7 +425,21 @@ function compactIfWasteful(dir) {
     const tmp = path + '.compact';
     writeFileSync(tmp, out, { mode: 0o600 });
     renameSync(tmp, path);
-    writeFileSync(markerPath(dir), JSON.stringify({ sizeAfter: out.length, at: Date.now() }), { mode: 0o600 });
+    // The surviving snapshots are rewritten to their own file, which is also
+    // what migrates a graph that still had them inline.
+    const snapOut =
+      [...keep.entries()]
+        .map(([id, v]) => JSON.stringify({ t: 's', v: GRAPH_VERSION, id, snapshot: v.snapshot, at: v.at }))
+        .join('\n') + (keep.size ? '\n' : '');
+    const snapTmp = snapshotsPath(dir) + '.compact';
+    writeFileSync(snapTmp, snapOut, { mode: 0o600 });
+    renameSync(snapTmp, snapshotsPath(dir));
+    writeFileSync(
+      markerPath(dir),
+      // The baseline is the PAIR, matching what the trigger measures.
+      JSON.stringify({ sizeAfter: out.length + snapOut.length, at: Date.now() }),
+      { mode: 0o600 }
+    );
   } catch {
     // Compaction is an optimization. A failure leaves the log exactly as it
     // was, which is correct if larger than it needs to be.
@@ -458,7 +496,20 @@ export function putNode(dir, { kind, key, ...rest }) {
   // Spreading it after `id` let a caller passing a whole existing node back in
   // -- which curate.mjs does on every pin, retire and correct -- carry a stale
   // `id` or `t` through and write a record that no longer matches its own key.
-  append(dir, { ...rest, t: 'n', v: GRAPH_VERSION, id, kind, key: canonicalKey(kind, key), at: Date.now() });
+  const { snapshot, ...fields } = rest;
+  const at = Date.now();
+  const records = [
+    { ...fields, t: 'n', v: GRAPH_VERSION, id, kind, key: canonicalKey(kind, key), at },
+  ];
+  // SEPARATE RECORD, so `load()` can skip the bytes rather than parse and drop
+  // them. Written after the node: a torn write then loses a snapshot, which
+  // degrades to the ordinary redirect, rather than losing the node itself.
+  appendAll(dir, records);
+  // Written AFTER the node and to a different file: a failure here costs a
+  // snapshot, which degrades to the ordinary redirect, never the node.
+  if (typeof snapshot === 'string' && snapshot) {
+    appendSnapshot(dir, { t: 's', v: GRAPH_VERSION, id, snapshot, at });
+  }
   return id;
 }
 
@@ -515,14 +566,70 @@ export function putNodeWithEdges(dir, { kind, key, ...rest }, edges = []) {
  * line is the normal consequence of a process being killed mid-append, and one
  * bad line must not make the entire accumulated graph unreadable.
  */
-export function load(dir) {
+/** Appends one snapshot record. Failure here must never fail a graph write. */
+function appendSnapshot(dir, record) {
+  try {
+    appendFileSync(snapshotsPath(dir), JSON.stringify(record) + '\n');
+  } catch {
+    /* the node is already durable; the snapshot is an optimization */
+  }
+}
+
+/** Every snapshot record, latest wins. Read only when a caller asks. */
+function readSnapshots(dir) {
+  const out = [];
+  try {
+    for (const line of readFileSync(snapshotsPath(dir), 'utf8').split('\n')) {
+      if (!line) continue;
+      try {
+        const rec = JSON.parse(line);
+        if ((rec.v ?? 0) === GRAPH_VERSION && rec.id) out.push(rec);
+      } catch {
+        /* a torn line costs one snapshot */
+      }
+    }
+  } catch {
+    /* no sidecar yet */
+  }
+  return out;
+}
+
+/**
+ * @param {object} [options]
+ * @param {boolean} [options.snapshots] Parse stored file contents as well.
+ *
+ * SNAPSHOTS ARE SKIPPED BY DEFAULT, and skipped WITHOUT PARSING.
+ *
+ * They are ~95% of the bytes and are read by two call sites: the staleness
+ * diff for a content-dependent finding, and the zero-turn refusal. Neither is
+ * on the path that runs before every tool call, and that path was paying 232 ms
+ * a call to parse them -- measured, on a 23.8 MB graph.
+ *
+ * The skip is a string comparison on the record prefix, so the JSON parser
+ * never sees the payload. Parsing and then discarding would have cost the same
+ * as keeping it, which is the whole reason this is a separate record type.
+ */
+export function load(dir, { snapshots = false } = {}) {
   const nodes = new Map();
   const edges = [];
   const path = logPath(dir);
   if (!existsSync(path)) return { nodes, edges };
 
+  const pending = snapshots ? new Map() : null;
   for (const line of readFileSync(path, 'utf8').split('\n')) {
     if (!line) continue;
+    // Older graphs kept these inline. Skipped without parsing, and moved out
+    // by the next compaction.
+    if (line.startsWith('{"t":"s"')) {
+      if (!snapshots) continue;
+      try {
+        const rec = JSON.parse(line);
+        if ((rec.v ?? 0) === GRAPH_VERSION) pending.set(rec.id, rec.snapshot);
+      } catch {
+        /* a torn line costs one snapshot, not the graph */
+      }
+      continue;
+    }
     let record;
     try {
       record = JSON.parse(line);
@@ -535,6 +642,17 @@ export function load(dir) {
     if ((record.v ?? 0) !== GRAPH_VERSION) continue;
     if (record.t === 'n') nodes.set(record.id, record);
     else if (record.t === 'e') edges.push(record);
+  }
+
+
+  // Re-attached after the sweep, so a snapshot record may appear before or
+  // after the node it belongs to.
+  if (pending) {
+    for (const rec of readSnapshots(dir)) pending.set(rec.id, rec.snapshot);
+    for (const [id, snapshot] of pending) {
+      const node = nodes.get(id);
+      if (node) nodes.set(id, { ...node, snapshot });
+    }
   }
 
   return { nodes, edges };

--- a/integrations/gemini/hooks/lib/wiki.mjs
+++ b/integrations/gemini/hooks/lib/wiki.mjs
@@ -18,7 +18,7 @@
 
 import {
   appendFileSync, readFileSync, existsSync, mkdirSync, chmodSync,
-  openSync, closeSync, unlinkSync, statSync,
+  openSync, closeSync, unlinkSync, statSync, writeFileSync, renameSync,
 } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { createHash } from 'node:crypto';
@@ -242,6 +242,99 @@ function ignoreSelf(dir) {
   }
 }
 
+/**
+ * The log is append-only, and nothing was ever reclaiming it.
+ *
+ * MEASURED on this repository's own graph: 206.6 MB, 41,810 records, 6,125
+ * unique ids. 85.4% of every record in the file was superseded by a later one,
+ * and 97.5 MB was reclaimable. `load()` parses the whole thing on EVERY hook
+ * invocation -- so every tool call paid 1.2-1.6 seconds, against a 118 ms
+ * median when the graph is small.
+ *
+ * That is the optimizer becoming its own cost, in latency instead of tokens.
+ * It also surfaced as a flaky test: a 20 s spawn budget that a loaded machine
+ * could exceed, which is the sort of failure that gets re-run rather than read.
+ *
+ * AMORTISED TRIGGER, not a size threshold. A fixed cap would compact on every
+ * append once the live set alone exceeded it -- here the live set is 109 MB, so
+ * any cap below that would rewrite the file continuously. Instead the size
+ * after each compaction is recorded, and the next one waits until the file has
+ * doubled again: each compaction therefore does at least as much good as the
+ * work it costs, and the amortised cost per append stays constant.
+ */
+// READ PER CALL, not once at module load -- the same rule the holdout
+// fraction already follows in metrics.mjs. Reading it once meant a process
+// started before a config change honoured the old value forever, and it also
+// made the setting untestable: a suite that sets the variable in `beforeEach`
+// runs after the import, so the module had already captured the default.
+const compactFloorBytes = () =>
+  Number(process.env.TOKEN_OPTIMIZER_GRAPH_COMPACT_BYTES) || 8_000_000;
+const markerPath = (dir) => join(dir, 'graph.compact.json');
+
+function compactionBaseline(dir) {
+  try {
+    const raw = JSON.parse(readFileSync(markerPath(dir), 'utf8'));
+    const n = Number(raw.sizeAfter);
+    return Number.isFinite(n) && n > 0 ? n : compactFloorBytes();
+  } catch {
+    return compactFloorBytes();
+  }
+}
+
+/**
+ * Rewrites the log keeping only the surviving version of each record.
+ *
+ * CALLED INSIDE THE LOCK, so no writer can append between the read and the
+ * rename. Written to a temporary file and renamed, which is atomic on the same
+ * volume: a crash mid-compaction leaves the original log untouched rather than
+ * a half-written graph.
+ */
+function compactIfWasteful(dir) {
+  const path = logPath(dir);
+  let size = 0;
+  try {
+    size = statSync(path).size;
+  } catch {
+    return;
+  }
+  if (size < compactFloorBytes() || size < compactionBaseline(dir) * 2) return;
+
+  try {
+    const nodes = new Map();
+    const edges = new Map();
+    for (const line of readFileSync(path, 'utf8').split('\n')) {
+      if (!line) continue;
+      let record;
+      try {
+        record = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      // A record from another schema is KEPT VERBATIM rather than reinterpreted.
+      // load() skips it, but discarding it here would make compaction a silent
+      // migration that deletes data a future version might understand.
+      if ((record.v ?? 0) !== GRAPH_VERSION) {
+        edges.set('raw:' + edges.size, line);
+        continue;
+      }
+      if (record.t === 'n') nodes.set(record.id, line);
+      else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
+      else edges.set('raw:' + edges.size, line);
+    }
+
+    // EDGES BEFORE NODES, matching putNodeWithEdges: a torn write can then only
+    // lose a finding, never leave one anchored to nothing.
+    const out = [...edges.values(), ...nodes.values()].join('\n') + '\n';
+    const tmp = path + '.compact';
+    writeFileSync(tmp, out, { mode: 0o600 });
+    renameSync(tmp, path);
+    writeFileSync(markerPath(dir), JSON.stringify({ sizeAfter: out.length, at: Date.now() }), { mode: 0o600 });
+  } catch {
+    // Compaction is an optimization. A failure leaves the log exactly as it
+    // was, which is correct if larger than it needs to be.
+  }
+}
+
 function appendAll(dir, records) {
   if (!records.length) return true;
   try {
@@ -263,7 +356,10 @@ function appendAll(dir, records) {
     // needs several records to be observed together cannot get that by looping,
     // because every iteration is a separate crash point.
     const payload = records.map((record) => JSON.stringify(record) + '\n').join('');
-    withLock(dir, () => appendFileSync(logPath(dir), payload));
+    withLock(dir, () => {
+      appendFileSync(logPath(dir), payload);
+      compactIfWasteful(dir);
+    });
     return true;
   } catch {
     // The graph is an optimization. Failing to write one must never fail the

--- a/integrations/opencode/hooks/lib/inject.mjs
+++ b/integrations/opencode/hooks/lib/inject.mjs
@@ -119,8 +119,20 @@ function fit(findings, budget) {
 function render(finding) {
   const head = `- [${finding.type || 'finding'}] ${finding.claim}`;
   if (!finding.stale) return head;
-  // A stale finding NEVER renders without its evidence. Serving one bare would
-  // be worse than having no graph at all.
+
+  // A stale finding NEVER renders as though it were current. But the strength
+  // of the framing follows the strength of the evidence, because the framing
+  // was measured: in an A/B on a fresh subagent, identical findings scored 1/3
+  // dead-ends avoided when rendered with the discount wording and 2/3 when
+  // rendered clean. The claims being discounted were correct every time.
+  //
+  // With a diff, the reader can judge for themselves and the strong form is
+  // earned. Without one -- 78% of stale findings on real graphs -- announcing
+  // STALE and promising `What changed:` in front of nothing spends the
+  // strongest signal available on the weakest evidence available.
+  if (!finding.staleEvidence || !finding.diff) {
+    return `${head}\n  (recorded earlier; ${finding.staleReason}, and no diff could be rebuilt)`;
+  }
   return `${head}\n  STALE (${finding.staleReason}). What changed:\n${finding.diff}`;
 }
 

--- a/integrations/opencode/hooks/lib/restore.mjs
+++ b/integrations/opencode/hooks/lib/restore.mjs
@@ -134,7 +134,10 @@ export function restorationPlan(dir, graph, context = {}) {
       if (!node) continue;
       const findings = serve(graph, findingsFor(graph, id, { limit: 2 }));
       for (const finding of findings) {
-        lines.push(`${node.key}: ${finding.stale ? '! STALE ' : ''}${finding.claim}`);
+        // `! STALE` only where a diff actually exists to back it; see the
+        // renderer in inject.mjs for the measurement behind this.
+        const mark = finding.stale ? (finding.staleEvidence ? '! STALE ' : '~ ') : '';
+        lines.push(`${node.key}: ${mark}${finding.claim}`);
       }
     }
     section('Likely next', lines, total * split.forward);

--- a/integrations/opencode/hooks/lib/restore.mjs
+++ b/integrations/opencode/hooks/lib/restore.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/restore.mjs. Regenerate with `npm run sync:hooks`.
-/**
+﻿/**
  * Restoration after compaction.
  *
  * A checkpoint restores what you HAD. That is a recap: it spends the scarcest
@@ -37,7 +37,11 @@ const estimate = (text) => Math.ceil(String(text || '').length / 4);
  * genuinely different things, and treating them identically is what makes a
  * fixed-order restore feel wrong half the time.
  */
-export function classifySituation({ openQuestion, recentAnchors = [], idleMs = 0 } = {}) {
+export function classifySituation({
+  openQuestion,
+  recentAnchors = [],
+  idleMs = 0,
+} = {}) {
   // Days later, nothing in the fresh context connects to anything. Orientation
   // is the only thing that helps; continuation has nothing to continue from.
   if (idleMs > 6 * 60 * 60 * 1000) return 'cold-resume';
@@ -61,21 +65,25 @@ export function classifySituation({ openQuestion, recentAnchors = [], idleMs = 0
  */
 const SPLITS = {
   'mid-problem': { frontier: 0.6, forward: 0.25, brief: 0.15 },
-  'cold-resume': { frontier: 0.15, forward: 0.25, brief: 0.60 },
-  'in-flow': { frontier: 0.20, forward: 0.60, brief: 0.20 },
-  general: { frontier: 0.35, forward: 0.35, brief: 0.30 },
+  'cold-resume': { frontier: 0.15, forward: 0.25, brief: 0.6 },
+  'in-flow': { frontier: 0.2, forward: 0.6, brief: 0.2 },
+  general: { frontier: 0.35, forward: 0.35, brief: 0.3 },
 };
 
 /** Findings for files the co-occurrence graph says are likely next. */
 function predictNext(graph, recentAnchors, limit = 6) {
-  const recent = new Set(recentAnchors.map((a) => nodeId('file', canonicalPath(a))));
+  const recent = new Set(
+    recentAnchors.map((a) => nodeId('file', canonicalPath(a)))
+  );
   const weight = new Map();
 
   for (const edge of graph.edges) {
     if (edge.edge !== 'related') continue;
     const [from, to] = [edge.from, edge.to];
-    if (recent.has(from) && !recent.has(to)) weight.set(to, (weight.get(to) || 0) + 1);
-    if (recent.has(to) && !recent.has(from)) weight.set(from, (weight.get(from) || 0) + 1);
+    if (recent.has(from) && !recent.has(to))
+      weight.set(to, (weight.get(to) || 0) + 1);
+    if (recent.has(to) && !recent.has(from))
+      weight.set(from, (weight.get(from) || 0) + 1);
   }
 
   return [...weight.entries()]
@@ -119,8 +127,10 @@ export function restorationPlan(dir, graph, context = {}) {
   // be recovered by looking at the code again.
   if (context.openQuestion) {
     const lines = [`Open: ${context.openQuestion}`];
-    for (const ruled of context.ruledOut || []) lines.push(`  ruled out: ${ruled}`);
-    for (const open of context.untested || []) lines.push(`  untested: ${open}`);
+    for (const ruled of context.ruledOut || [])
+      lines.push(`  ruled out: ${ruled}`);
+    for (const open of context.untested || [])
+      lines.push(`  untested: ${open}`);
     section('Where you were', lines, total * split.frontier);
   }
 
@@ -136,7 +146,18 @@ export function restorationPlan(dir, graph, context = {}) {
       for (const finding of findings) {
         // `! STALE` only where a diff actually exists to back it; see the
         // renderer in inject.mjs for the measurement behind this.
-        const mark = finding.stale ? (finding.staleEvidence ? '! STALE ' : '~ ') : '';
+        //
+        // BOTH HALVES, matching inject.mjs exactly (`!staleEvidence || !diff`).
+        // Checking staleEvidence alone marked a finding `! STALE` here while the
+        // injector softened the same finding elsewhere -- and the strong marker
+        // claims 'this is contradicted, here is the proof' with no proof to
+        // show, which is the bare stale finding the design calls worse than
+        // having no graph.
+        const mark = finding.stale
+          ? finding.staleEvidence && finding.diff
+            ? '! STALE '
+            : '~ '
+          : '';
         lines.push(`${node.key}: ${mark}${finding.claim}`);
       }
     }
@@ -146,7 +167,9 @@ export function restorationPlan(dir, graph, context = {}) {
   // BRIEF -- orientation. Last, because it is the most replaceable: normal
   // just-in-time injection will deliver most of it the moment work resumes.
   const established = [...graph.nodes.values()]
-    .filter((n) => n.kind === 'finding' && !n.retired && typeof n.claim === 'string')
+    .filter(
+      (n) => n.kind === 'finding' && !n.retired && typeof n.claim === 'string'
+    )
     .sort((a, b) => (b.confidence ?? 0) - (a.confidence ?? 0))
     .slice(0, 12)
     .map((n) => `${n.key}: ${n.claim.slice(0, 100)}`);

--- a/integrations/opencode/hooks/lib/staleness.mjs
+++ b/integrations/opencode/hooks/lib/staleness.mjs
@@ -400,12 +400,30 @@ export function serve(graph, findings) {
       // front of the model, and this text exists precisely because the previous
       // phrasing was measured suppressing correct findings. State the evidence
       // gap and stop.
-      diff = `(marked stale: ${reason}. The supporting diff can no longer be `
-        + 'reconstructed; the claim itself may well still hold, so weigh it on '
-        + 'its own merits.)';
+      // THE PROSE MOVES OUT OF `diff`, and the fact moves into a flag.
+      //
+      // Softening this sentence was not enough, because the RENDERER wraps it:
+      // the model saw `STALE (reason). What changed:` followed by a paragraph
+      // explaining that nothing follows. The strong framing was designed for
+      // the case where evidence exists and was being applied to the case where
+      // it does not.
+      //
+      // Measured across every real graph on one machine: 32 of 241 served
+      // findings were stale, and 25 of those 32 -- 78% -- had no diff at all.
+      // So the strongest wording available was carried by the findings with the
+      // least evidence behind them, on 10.4% of everything served.
+      //
+      // A caller cannot phrase this well from a prose blob, so it gets the two
+      // things it needs: that the finding is stale, and whether any evidence
+      // survives. The wording is then the renderer's business.
+      diff = '';
     }
 
-    served.push({ ...finding, stale, ...(stale ? { diff, staleReason: reason } : {}) });
+    served.push({
+      ...finding,
+      stale,
+      ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
+    });
   }
   return served;
 }

--- a/integrations/opencode/hooks/lib/staleness.mjs
+++ b/integrations/opencode/hooks/lib/staleness.mjs
@@ -341,7 +341,37 @@ export function serve(graph, findings) {
   // graph directly cannot accidentally serve a claim a human explicitly
   // withdrew. A withheld claim reappearing is not a bug anyone would notice
   // quickly.
+/**
+ * Types whose truth is a claim ABOUT the anchor's contents.
+ *
+ * Only these can be invalidated by that file changing. An anchor on any other
+ * type is a RETRIEVAL HOOK -- the file that happened to be open when the lesson
+ * was learned -- and its contents changing says nothing about the claim.
+ *
+ * MEASURED, across every real graph on one machine: 32 findings were served
+ * stale, and 24 of them -- 75% -- were types in neither of these sets. The
+ * clearest example is a `failure` reading "Edit hooks-core/, never the generated
+ * copies", marked stale because hooks-core/wiki.mjs changed. That rule is about
+ * process; wiki.mjs's contents cannot make it wrong. It was being discounted for
+ * a reason that did not exist.
+ *
+ * THE TRADE, STATED. A `command` finding CAN be invalidated by its anchor -- a
+ * claim about `npm test` anchored to package.json genuinely dies if the test
+ * script changes. That case is now missed. It is the better error: today every
+ * version bump marks it stale, so the signal fires overwhelmingly when nothing
+ * relevant happened, and a signal that is usually wrong is one a reader learns
+ * to ignore -- taking the rare true positive with it.
+ */
+const CONTENT_DEPENDENT = new Set(['finding', 'map']);
+
   for (const finding of findings.filter((f) => !f.retired)) {
+    // A claim that does not depend on the anchor's contents cannot be
+    // invalidated by them. It is served as-is rather than discounted.
+    if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) {
+      served.push({ ...finding });
+      continue;
+    }
+
     const anchors = graph.edges
       .filter((e) => e.edge === 'derived_from' && e.from === finding.id)
       .map((e) => graph.nodes.get(e.to))

--- a/integrations/opencode/hooks/lib/wiki.mjs
+++ b/integrations/opencode/hooks/lib/wiki.mjs
@@ -271,6 +271,13 @@ const compactFloorBytes = () =>
   Number(process.env.TOKEN_OPTIMIZER_GRAPH_COMPACT_BYTES) || 8_000_000;
 const markerPath = (dir) => join(dir, 'graph.compact.json');
 
+/** Finding types whose evidence is a diff, and so need the snapshot kept. */
+const SNAPSHOT_DEPENDENT = new Set(['finding', 'map']);
+
+/** Read per call, for the reason documented on the compaction floor above. */
+const snapshotBudgetBytes = () =>
+  Number(process.env.TOKEN_OPTIMIZER_GRAPH_SNAPSHOT_BYTES) || 8_000_000;
+
 function compactionBaseline(dir) {
   try {
     const raw = JSON.parse(readFileSync(markerPath(dir), 'utf8'));
@@ -320,6 +327,72 @@ function compactIfWasteful(dir) {
       if (record.t === 'n') nodes.set(record.id, line);
       else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
       else edges.set('raw:' + edges.size, line);
+    }
+
+    // SNAPSHOTS ARE BOUNDED, and they are the whole file.
+    //
+    // MEASURED after compaction on this repository: 109.5 MB, of which `file`
+    // records are 105.3 MB. The raw snapshot text is 34.8 MB; JSON escaping
+    // triples it. Compaction alone cannot touch this, because every one of
+    // those records is live.
+    //
+    // A snapshot earns its place two ways: it lets a content-dependent finding
+    // show what changed, and it lets a re-read be answered with a diff instead
+    // of the file. The first is rare and identifiable -- 1 of 1,020 file nodes
+    // on this graph had such a finding anchored. The second only pays while the
+    // snapshot is recent: against a weeks-old snapshot the diff approaches the
+    // size of the file and the caller rejects it anyway.
+    //
+    // So: keep every snapshot something depends on, then keep the newest until
+    // the budget runs out, and drop the rest. The NODE always survives -- only
+    // the snapshot field goes, so hashes, staleness and traversal are
+    // unaffected and a dropped snapshot degrades to the ordinary redirect.
+    const needed = new Set();
+    for (const line of edges.values()) {
+      let e;
+      try {
+        e = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (e.t !== 'e' || e.edge !== 'derived_from') continue;
+      const from = nodes.get(e.from);
+      if (!from) continue;
+      let f;
+      try {
+        f = JSON.parse(from);
+      } catch {
+        continue;
+      }
+      if (f.kind === 'finding' && SNAPSHOT_DEPENDENT.has(f.type || 'finding')) needed.add(e.to);
+    }
+
+    const carriers = [];
+    for (const [id, line] of nodes) {
+      let n;
+      try {
+        n = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (typeof n.snapshot !== 'string' || !n.snapshot) continue;
+      carriers.push({ id, at: n.at || 0, size: n.snapshot.length, node: n });
+    }
+    carriers.sort((a, b) => b.at - a.at);
+
+    let spent = 0;
+    const budget = snapshotBudgetBytes();
+    for (const c of carriers) {
+      if (needed.has(c.id)) {
+        spent += c.size;
+        continue;
+      }
+      if (spent + c.size <= budget) {
+        spent += c.size;
+        continue;
+      }
+      const { snapshot, ...rest } = c.node;
+      nodes.set(c.id, JSON.stringify(rest));
     }
 
     // EDGES BEFORE NODES, matching putNodeWithEdges: a torn write can then only

--- a/integrations/opencode/hooks/lib/wiki.mjs
+++ b/integrations/opencode/hooks/lib/wiki.mjs
@@ -271,6 +271,17 @@ const compactFloorBytes = () =>
   Number(process.env.TOKEN_OPTIMIZER_GRAPH_COMPACT_BYTES) || 8_000_000;
 const markerPath = (dir) => join(dir, 'graph.compact.json');
 
+/** Cheap enough to test on every line, which is the point. */
+/**
+ * Snapshots live in their own file.
+ *
+ * Skipping them during the parse was only half the win: `load()` still READ
+ * all 23 MB to find the lines it was skipping. Measured, 137 ms -> 99 ms from
+ * the skip alone. A separate file means those bytes are never touched unless a
+ * caller asks for them, which two call sites out of many do.
+ */
+const snapshotsPath = (dir) => join(dir, 'snapshots.jsonl');
+
 /** Finding types whose evidence is a diff, and so need the snapshot kept. */
 const SNAPSHOT_DEPENDENT = new Set(['finding', 'map']);
 
@@ -298,17 +309,31 @@ function compactionBaseline(dir) {
  */
 function compactIfWasteful(dir) {
   const path = logPath(dir);
+  // BOTH FILES. Once snapshots moved to their own log the graph itself stopped
+  // growing, so a trigger watching only it would never fire again -- while the
+  // sidecar, which holds the bulk, grew without bound. The waste is the pair.
   let size = 0;
   try {
     size = statSync(path).size;
   } catch {
     return;
   }
+  try {
+    size += statSync(snapshotsPath(dir)).size;
+  } catch {
+    /* no sidecar yet */
+  }
   if (size < compactFloorBytes() || size < compactionBaseline(dir) * 2) return;
 
   try {
     const nodes = new Map();
     const edges = new Map();
+    const snaps = new Map();
+    for (const rec of readSnapshots(dir)) {
+      if (typeof rec.snapshot === 'string' && rec.snapshot) {
+        snaps.set(rec.id, { at: rec.at || 0, snapshot: rec.snapshot });
+      }
+    }
     for (const line of readFileSync(path, 'utf8').split('\n')) {
       if (!line) continue;
       let record;
@@ -324,8 +349,22 @@ function compactIfWasteful(dir) {
         edges.set('raw:' + edges.size, line);
         continue;
       }
-      if (record.t === 'n') nodes.set(record.id, line);
-      else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
+      if (record.t === 'n') {
+        // MIGRATION. Graphs written before snapshots were split still carry
+        // them inline, and those are exactly the graphs that are slow. Moving
+        // them out here means one compaction fixes an existing install.
+        if (typeof record.snapshot === 'string' && record.snapshot) {
+          const { snapshot, ...rest } = record;
+          nodes.set(record.id, JSON.stringify(rest));
+          snaps.set(record.id, { at: record.at || 0, snapshot });
+        } else {
+          nodes.set(record.id, line);
+        }
+      } else if (record.t === 's') {
+        if (typeof record.snapshot === 'string' && record.snapshot) {
+          snaps.set(record.id, { at: record.at || 0, snapshot: record.snapshot });
+        }
+      } else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
       else edges.set('raw:' + edges.size, line);
     }
 
@@ -367,32 +406,17 @@ function compactIfWasteful(dir) {
       if (f.kind === 'finding' && SNAPSHOT_DEPENDENT.has(f.type || 'finding')) needed.add(e.to);
     }
 
-    const carriers = [];
-    for (const [id, line] of nodes) {
-      let n;
-      try {
-        n = JSON.parse(line);
-      } catch {
-        continue;
-      }
-      if (typeof n.snapshot !== 'string' || !n.snapshot) continue;
-      carriers.push({ id, at: n.at || 0, size: n.snapshot.length, node: n });
-    }
-    carriers.sort((a, b) => b.at - a.at);
+    const carriers = [...snaps.entries()]
+      .map(([id, v]) => ({ id, at: v.at, size: v.snapshot.length }))
+      .sort((a, b) => b.at - a.at);
 
     let spent = 0;
     const budget = snapshotBudgetBytes();
+    const keep = new Map();
     for (const c of carriers) {
-      if (needed.has(c.id)) {
-        spent += c.size;
-        continue;
-      }
-      if (spent + c.size <= budget) {
-        spent += c.size;
-        continue;
-      }
-      const { snapshot, ...rest } = c.node;
-      nodes.set(c.id, JSON.stringify(rest));
+      if (!needed.has(c.id) && spent + c.size > budget) continue;
+      spent += c.size;
+      keep.set(c.id, snaps.get(c.id));
     }
 
     // EDGES BEFORE NODES, matching putNodeWithEdges: a torn write can then only
@@ -401,7 +425,21 @@ function compactIfWasteful(dir) {
     const tmp = path + '.compact';
     writeFileSync(tmp, out, { mode: 0o600 });
     renameSync(tmp, path);
-    writeFileSync(markerPath(dir), JSON.stringify({ sizeAfter: out.length, at: Date.now() }), { mode: 0o600 });
+    // The surviving snapshots are rewritten to their own file, which is also
+    // what migrates a graph that still had them inline.
+    const snapOut =
+      [...keep.entries()]
+        .map(([id, v]) => JSON.stringify({ t: 's', v: GRAPH_VERSION, id, snapshot: v.snapshot, at: v.at }))
+        .join('\n') + (keep.size ? '\n' : '');
+    const snapTmp = snapshotsPath(dir) + '.compact';
+    writeFileSync(snapTmp, snapOut, { mode: 0o600 });
+    renameSync(snapTmp, snapshotsPath(dir));
+    writeFileSync(
+      markerPath(dir),
+      // The baseline is the PAIR, matching what the trigger measures.
+      JSON.stringify({ sizeAfter: out.length + snapOut.length, at: Date.now() }),
+      { mode: 0o600 }
+    );
   } catch {
     // Compaction is an optimization. A failure leaves the log exactly as it
     // was, which is correct if larger than it needs to be.
@@ -458,7 +496,20 @@ export function putNode(dir, { kind, key, ...rest }) {
   // Spreading it after `id` let a caller passing a whole existing node back in
   // -- which curate.mjs does on every pin, retire and correct -- carry a stale
   // `id` or `t` through and write a record that no longer matches its own key.
-  append(dir, { ...rest, t: 'n', v: GRAPH_VERSION, id, kind, key: canonicalKey(kind, key), at: Date.now() });
+  const { snapshot, ...fields } = rest;
+  const at = Date.now();
+  const records = [
+    { ...fields, t: 'n', v: GRAPH_VERSION, id, kind, key: canonicalKey(kind, key), at },
+  ];
+  // SEPARATE RECORD, so `load()` can skip the bytes rather than parse and drop
+  // them. Written after the node: a torn write then loses a snapshot, which
+  // degrades to the ordinary redirect, rather than losing the node itself.
+  appendAll(dir, records);
+  // Written AFTER the node and to a different file: a failure here costs a
+  // snapshot, which degrades to the ordinary redirect, never the node.
+  if (typeof snapshot === 'string' && snapshot) {
+    appendSnapshot(dir, { t: 's', v: GRAPH_VERSION, id, snapshot, at });
+  }
   return id;
 }
 
@@ -515,14 +566,70 @@ export function putNodeWithEdges(dir, { kind, key, ...rest }, edges = []) {
  * line is the normal consequence of a process being killed mid-append, and one
  * bad line must not make the entire accumulated graph unreadable.
  */
-export function load(dir) {
+/** Appends one snapshot record. Failure here must never fail a graph write. */
+function appendSnapshot(dir, record) {
+  try {
+    appendFileSync(snapshotsPath(dir), JSON.stringify(record) + '\n');
+  } catch {
+    /* the node is already durable; the snapshot is an optimization */
+  }
+}
+
+/** Every snapshot record, latest wins. Read only when a caller asks. */
+function readSnapshots(dir) {
+  const out = [];
+  try {
+    for (const line of readFileSync(snapshotsPath(dir), 'utf8').split('\n')) {
+      if (!line) continue;
+      try {
+        const rec = JSON.parse(line);
+        if ((rec.v ?? 0) === GRAPH_VERSION && rec.id) out.push(rec);
+      } catch {
+        /* a torn line costs one snapshot */
+      }
+    }
+  } catch {
+    /* no sidecar yet */
+  }
+  return out;
+}
+
+/**
+ * @param {object} [options]
+ * @param {boolean} [options.snapshots] Parse stored file contents as well.
+ *
+ * SNAPSHOTS ARE SKIPPED BY DEFAULT, and skipped WITHOUT PARSING.
+ *
+ * They are ~95% of the bytes and are read by two call sites: the staleness
+ * diff for a content-dependent finding, and the zero-turn refusal. Neither is
+ * on the path that runs before every tool call, and that path was paying 232 ms
+ * a call to parse them -- measured, on a 23.8 MB graph.
+ *
+ * The skip is a string comparison on the record prefix, so the JSON parser
+ * never sees the payload. Parsing and then discarding would have cost the same
+ * as keeping it, which is the whole reason this is a separate record type.
+ */
+export function load(dir, { snapshots = false } = {}) {
   const nodes = new Map();
   const edges = [];
   const path = logPath(dir);
   if (!existsSync(path)) return { nodes, edges };
 
+  const pending = snapshots ? new Map() : null;
   for (const line of readFileSync(path, 'utf8').split('\n')) {
     if (!line) continue;
+    // Older graphs kept these inline. Skipped without parsing, and moved out
+    // by the next compaction.
+    if (line.startsWith('{"t":"s"')) {
+      if (!snapshots) continue;
+      try {
+        const rec = JSON.parse(line);
+        if ((rec.v ?? 0) === GRAPH_VERSION) pending.set(rec.id, rec.snapshot);
+      } catch {
+        /* a torn line costs one snapshot, not the graph */
+      }
+      continue;
+    }
     let record;
     try {
       record = JSON.parse(line);
@@ -535,6 +642,17 @@ export function load(dir) {
     if ((record.v ?? 0) !== GRAPH_VERSION) continue;
     if (record.t === 'n') nodes.set(record.id, record);
     else if (record.t === 'e') edges.push(record);
+  }
+
+
+  // Re-attached after the sweep, so a snapshot record may appear before or
+  // after the node it belongs to.
+  if (pending) {
+    for (const rec of readSnapshots(dir)) pending.set(rec.id, rec.snapshot);
+    for (const [id, snapshot] of pending) {
+      const node = nodes.get(id);
+      if (node) nodes.set(id, { ...node, snapshot });
+    }
   }
 
   return { nodes, edges };

--- a/integrations/opencode/hooks/lib/wiki.mjs
+++ b/integrations/opencode/hooks/lib/wiki.mjs
@@ -18,7 +18,7 @@
 
 import {
   appendFileSync, readFileSync, existsSync, mkdirSync, chmodSync,
-  openSync, closeSync, unlinkSync, statSync,
+  openSync, closeSync, unlinkSync, statSync, writeFileSync, renameSync,
 } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { createHash } from 'node:crypto';
@@ -242,6 +242,99 @@ function ignoreSelf(dir) {
   }
 }
 
+/**
+ * The log is append-only, and nothing was ever reclaiming it.
+ *
+ * MEASURED on this repository's own graph: 206.6 MB, 41,810 records, 6,125
+ * unique ids. 85.4% of every record in the file was superseded by a later one,
+ * and 97.5 MB was reclaimable. `load()` parses the whole thing on EVERY hook
+ * invocation -- so every tool call paid 1.2-1.6 seconds, against a 118 ms
+ * median when the graph is small.
+ *
+ * That is the optimizer becoming its own cost, in latency instead of tokens.
+ * It also surfaced as a flaky test: a 20 s spawn budget that a loaded machine
+ * could exceed, which is the sort of failure that gets re-run rather than read.
+ *
+ * AMORTISED TRIGGER, not a size threshold. A fixed cap would compact on every
+ * append once the live set alone exceeded it -- here the live set is 109 MB, so
+ * any cap below that would rewrite the file continuously. Instead the size
+ * after each compaction is recorded, and the next one waits until the file has
+ * doubled again: each compaction therefore does at least as much good as the
+ * work it costs, and the amortised cost per append stays constant.
+ */
+// READ PER CALL, not once at module load -- the same rule the holdout
+// fraction already follows in metrics.mjs. Reading it once meant a process
+// started before a config change honoured the old value forever, and it also
+// made the setting untestable: a suite that sets the variable in `beforeEach`
+// runs after the import, so the module had already captured the default.
+const compactFloorBytes = () =>
+  Number(process.env.TOKEN_OPTIMIZER_GRAPH_COMPACT_BYTES) || 8_000_000;
+const markerPath = (dir) => join(dir, 'graph.compact.json');
+
+function compactionBaseline(dir) {
+  try {
+    const raw = JSON.parse(readFileSync(markerPath(dir), 'utf8'));
+    const n = Number(raw.sizeAfter);
+    return Number.isFinite(n) && n > 0 ? n : compactFloorBytes();
+  } catch {
+    return compactFloorBytes();
+  }
+}
+
+/**
+ * Rewrites the log keeping only the surviving version of each record.
+ *
+ * CALLED INSIDE THE LOCK, so no writer can append between the read and the
+ * rename. Written to a temporary file and renamed, which is atomic on the same
+ * volume: a crash mid-compaction leaves the original log untouched rather than
+ * a half-written graph.
+ */
+function compactIfWasteful(dir) {
+  const path = logPath(dir);
+  let size = 0;
+  try {
+    size = statSync(path).size;
+  } catch {
+    return;
+  }
+  if (size < compactFloorBytes() || size < compactionBaseline(dir) * 2) return;
+
+  try {
+    const nodes = new Map();
+    const edges = new Map();
+    for (const line of readFileSync(path, 'utf8').split('\n')) {
+      if (!line) continue;
+      let record;
+      try {
+        record = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      // A record from another schema is KEPT VERBATIM rather than reinterpreted.
+      // load() skips it, but discarding it here would make compaction a silent
+      // migration that deletes data a future version might understand.
+      if ((record.v ?? 0) !== GRAPH_VERSION) {
+        edges.set('raw:' + edges.size, line);
+        continue;
+      }
+      if (record.t === 'n') nodes.set(record.id, line);
+      else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
+      else edges.set('raw:' + edges.size, line);
+    }
+
+    // EDGES BEFORE NODES, matching putNodeWithEdges: a torn write can then only
+    // lose a finding, never leave one anchored to nothing.
+    const out = [...edges.values(), ...nodes.values()].join('\n') + '\n';
+    const tmp = path + '.compact';
+    writeFileSync(tmp, out, { mode: 0o600 });
+    renameSync(tmp, path);
+    writeFileSync(markerPath(dir), JSON.stringify({ sizeAfter: out.length, at: Date.now() }), { mode: 0o600 });
+  } catch {
+    // Compaction is an optimization. A failure leaves the log exactly as it
+    // was, which is correct if larger than it needs to be.
+  }
+}
+
 function appendAll(dir, records) {
   if (!records.length) return true;
   try {
@@ -263,7 +356,10 @@ function appendAll(dir, records) {
     // needs several records to be observed together cannot get that by looping,
     // because every iteration is a separate crash point.
     const payload = records.map((record) => JSON.stringify(record) + '\n').join('');
-    withLock(dir, () => appendFileSync(logPath(dir), payload));
+    withLock(dir, () => {
+      appendFileSync(logPath(dir), payload);
+      compactIfWasteful(dir);
+    });
     return true;
   } catch {
     // The graph is an optimization. Failing to write one must never fail the

--- a/integrations/qwen/hooks/lib/inject.mjs
+++ b/integrations/qwen/hooks/lib/inject.mjs
@@ -119,8 +119,20 @@ function fit(findings, budget) {
 function render(finding) {
   const head = `- [${finding.type || 'finding'}] ${finding.claim}`;
   if (!finding.stale) return head;
-  // A stale finding NEVER renders without its evidence. Serving one bare would
-  // be worse than having no graph at all.
+
+  // A stale finding NEVER renders as though it were current. But the strength
+  // of the framing follows the strength of the evidence, because the framing
+  // was measured: in an A/B on a fresh subagent, identical findings scored 1/3
+  // dead-ends avoided when rendered with the discount wording and 2/3 when
+  // rendered clean. The claims being discounted were correct every time.
+  //
+  // With a diff, the reader can judge for themselves and the strong form is
+  // earned. Without one -- 78% of stale findings on real graphs -- announcing
+  // STALE and promising `What changed:` in front of nothing spends the
+  // strongest signal available on the weakest evidence available.
+  if (!finding.staleEvidence || !finding.diff) {
+    return `${head}\n  (recorded earlier; ${finding.staleReason}, and no diff could be rebuilt)`;
+  }
   return `${head}\n  STALE (${finding.staleReason}). What changed:\n${finding.diff}`;
 }
 

--- a/integrations/qwen/hooks/lib/restore.mjs
+++ b/integrations/qwen/hooks/lib/restore.mjs
@@ -134,7 +134,10 @@ export function restorationPlan(dir, graph, context = {}) {
       if (!node) continue;
       const findings = serve(graph, findingsFor(graph, id, { limit: 2 }));
       for (const finding of findings) {
-        lines.push(`${node.key}: ${finding.stale ? '! STALE ' : ''}${finding.claim}`);
+        // `! STALE` only where a diff actually exists to back it; see the
+        // renderer in inject.mjs for the measurement behind this.
+        const mark = finding.stale ? (finding.staleEvidence ? '! STALE ' : '~ ') : '';
+        lines.push(`${node.key}: ${mark}${finding.claim}`);
       }
     }
     section('Likely next', lines, total * split.forward);

--- a/integrations/qwen/hooks/lib/restore.mjs
+++ b/integrations/qwen/hooks/lib/restore.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/restore.mjs. Regenerate with `npm run sync:hooks`.
-/**
+﻿/**
  * Restoration after compaction.
  *
  * A checkpoint restores what you HAD. That is a recap: it spends the scarcest
@@ -37,7 +37,11 @@ const estimate = (text) => Math.ceil(String(text || '').length / 4);
  * genuinely different things, and treating them identically is what makes a
  * fixed-order restore feel wrong half the time.
  */
-export function classifySituation({ openQuestion, recentAnchors = [], idleMs = 0 } = {}) {
+export function classifySituation({
+  openQuestion,
+  recentAnchors = [],
+  idleMs = 0,
+} = {}) {
   // Days later, nothing in the fresh context connects to anything. Orientation
   // is the only thing that helps; continuation has nothing to continue from.
   if (idleMs > 6 * 60 * 60 * 1000) return 'cold-resume';
@@ -61,21 +65,25 @@ export function classifySituation({ openQuestion, recentAnchors = [], idleMs = 0
  */
 const SPLITS = {
   'mid-problem': { frontier: 0.6, forward: 0.25, brief: 0.15 },
-  'cold-resume': { frontier: 0.15, forward: 0.25, brief: 0.60 },
-  'in-flow': { frontier: 0.20, forward: 0.60, brief: 0.20 },
-  general: { frontier: 0.35, forward: 0.35, brief: 0.30 },
+  'cold-resume': { frontier: 0.15, forward: 0.25, brief: 0.6 },
+  'in-flow': { frontier: 0.2, forward: 0.6, brief: 0.2 },
+  general: { frontier: 0.35, forward: 0.35, brief: 0.3 },
 };
 
 /** Findings for files the co-occurrence graph says are likely next. */
 function predictNext(graph, recentAnchors, limit = 6) {
-  const recent = new Set(recentAnchors.map((a) => nodeId('file', canonicalPath(a))));
+  const recent = new Set(
+    recentAnchors.map((a) => nodeId('file', canonicalPath(a)))
+  );
   const weight = new Map();
 
   for (const edge of graph.edges) {
     if (edge.edge !== 'related') continue;
     const [from, to] = [edge.from, edge.to];
-    if (recent.has(from) && !recent.has(to)) weight.set(to, (weight.get(to) || 0) + 1);
-    if (recent.has(to) && !recent.has(from)) weight.set(from, (weight.get(from) || 0) + 1);
+    if (recent.has(from) && !recent.has(to))
+      weight.set(to, (weight.get(to) || 0) + 1);
+    if (recent.has(to) && !recent.has(from))
+      weight.set(from, (weight.get(from) || 0) + 1);
   }
 
   return [...weight.entries()]
@@ -119,8 +127,10 @@ export function restorationPlan(dir, graph, context = {}) {
   // be recovered by looking at the code again.
   if (context.openQuestion) {
     const lines = [`Open: ${context.openQuestion}`];
-    for (const ruled of context.ruledOut || []) lines.push(`  ruled out: ${ruled}`);
-    for (const open of context.untested || []) lines.push(`  untested: ${open}`);
+    for (const ruled of context.ruledOut || [])
+      lines.push(`  ruled out: ${ruled}`);
+    for (const open of context.untested || [])
+      lines.push(`  untested: ${open}`);
     section('Where you were', lines, total * split.frontier);
   }
 
@@ -136,7 +146,18 @@ export function restorationPlan(dir, graph, context = {}) {
       for (const finding of findings) {
         // `! STALE` only where a diff actually exists to back it; see the
         // renderer in inject.mjs for the measurement behind this.
-        const mark = finding.stale ? (finding.staleEvidence ? '! STALE ' : '~ ') : '';
+        //
+        // BOTH HALVES, matching inject.mjs exactly (`!staleEvidence || !diff`).
+        // Checking staleEvidence alone marked a finding `! STALE` here while the
+        // injector softened the same finding elsewhere -- and the strong marker
+        // claims 'this is contradicted, here is the proof' with no proof to
+        // show, which is the bare stale finding the design calls worse than
+        // having no graph.
+        const mark = finding.stale
+          ? finding.staleEvidence && finding.diff
+            ? '! STALE '
+            : '~ '
+          : '';
         lines.push(`${node.key}: ${mark}${finding.claim}`);
       }
     }
@@ -146,7 +167,9 @@ export function restorationPlan(dir, graph, context = {}) {
   // BRIEF -- orientation. Last, because it is the most replaceable: normal
   // just-in-time injection will deliver most of it the moment work resumes.
   const established = [...graph.nodes.values()]
-    .filter((n) => n.kind === 'finding' && !n.retired && typeof n.claim === 'string')
+    .filter(
+      (n) => n.kind === 'finding' && !n.retired && typeof n.claim === 'string'
+    )
     .sort((a, b) => (b.confidence ?? 0) - (a.confidence ?? 0))
     .slice(0, 12)
     .map((n) => `${n.key}: ${n.claim.slice(0, 100)}`);

--- a/integrations/qwen/hooks/lib/staleness.mjs
+++ b/integrations/qwen/hooks/lib/staleness.mjs
@@ -400,12 +400,30 @@ export function serve(graph, findings) {
       // front of the model, and this text exists precisely because the previous
       // phrasing was measured suppressing correct findings. State the evidence
       // gap and stop.
-      diff = `(marked stale: ${reason}. The supporting diff can no longer be `
-        + 'reconstructed; the claim itself may well still hold, so weigh it on '
-        + 'its own merits.)';
+      // THE PROSE MOVES OUT OF `diff`, and the fact moves into a flag.
+      //
+      // Softening this sentence was not enough, because the RENDERER wraps it:
+      // the model saw `STALE (reason). What changed:` followed by a paragraph
+      // explaining that nothing follows. The strong framing was designed for
+      // the case where evidence exists and was being applied to the case where
+      // it does not.
+      //
+      // Measured across every real graph on one machine: 32 of 241 served
+      // findings were stale, and 25 of those 32 -- 78% -- had no diff at all.
+      // So the strongest wording available was carried by the findings with the
+      // least evidence behind them, on 10.4% of everything served.
+      //
+      // A caller cannot phrase this well from a prose blob, so it gets the two
+      // things it needs: that the finding is stale, and whether any evidence
+      // survives. The wording is then the renderer's business.
+      diff = '';
     }
 
-    served.push({ ...finding, stale, ...(stale ? { diff, staleReason: reason } : {}) });
+    served.push({
+      ...finding,
+      stale,
+      ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
+    });
   }
   return served;
 }

--- a/integrations/qwen/hooks/lib/staleness.mjs
+++ b/integrations/qwen/hooks/lib/staleness.mjs
@@ -341,7 +341,37 @@ export function serve(graph, findings) {
   // graph directly cannot accidentally serve a claim a human explicitly
   // withdrew. A withheld claim reappearing is not a bug anyone would notice
   // quickly.
+/**
+ * Types whose truth is a claim ABOUT the anchor's contents.
+ *
+ * Only these can be invalidated by that file changing. An anchor on any other
+ * type is a RETRIEVAL HOOK -- the file that happened to be open when the lesson
+ * was learned -- and its contents changing says nothing about the claim.
+ *
+ * MEASURED, across every real graph on one machine: 32 findings were served
+ * stale, and 24 of them -- 75% -- were types in neither of these sets. The
+ * clearest example is a `failure` reading "Edit hooks-core/, never the generated
+ * copies", marked stale because hooks-core/wiki.mjs changed. That rule is about
+ * process; wiki.mjs's contents cannot make it wrong. It was being discounted for
+ * a reason that did not exist.
+ *
+ * THE TRADE, STATED. A `command` finding CAN be invalidated by its anchor -- a
+ * claim about `npm test` anchored to package.json genuinely dies if the test
+ * script changes. That case is now missed. It is the better error: today every
+ * version bump marks it stale, so the signal fires overwhelmingly when nothing
+ * relevant happened, and a signal that is usually wrong is one a reader learns
+ * to ignore -- taking the rare true positive with it.
+ */
+const CONTENT_DEPENDENT = new Set(['finding', 'map']);
+
   for (const finding of findings.filter((f) => !f.retired)) {
+    // A claim that does not depend on the anchor's contents cannot be
+    // invalidated by them. It is served as-is rather than discounted.
+    if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) {
+      served.push({ ...finding });
+      continue;
+    }
+
     const anchors = graph.edges
       .filter((e) => e.edge === 'derived_from' && e.from === finding.id)
       .map((e) => graph.nodes.get(e.to))

--- a/integrations/qwen/hooks/lib/wiki.mjs
+++ b/integrations/qwen/hooks/lib/wiki.mjs
@@ -271,6 +271,13 @@ const compactFloorBytes = () =>
   Number(process.env.TOKEN_OPTIMIZER_GRAPH_COMPACT_BYTES) || 8_000_000;
 const markerPath = (dir) => join(dir, 'graph.compact.json');
 
+/** Finding types whose evidence is a diff, and so need the snapshot kept. */
+const SNAPSHOT_DEPENDENT = new Set(['finding', 'map']);
+
+/** Read per call, for the reason documented on the compaction floor above. */
+const snapshotBudgetBytes = () =>
+  Number(process.env.TOKEN_OPTIMIZER_GRAPH_SNAPSHOT_BYTES) || 8_000_000;
+
 function compactionBaseline(dir) {
   try {
     const raw = JSON.parse(readFileSync(markerPath(dir), 'utf8'));
@@ -320,6 +327,72 @@ function compactIfWasteful(dir) {
       if (record.t === 'n') nodes.set(record.id, line);
       else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
       else edges.set('raw:' + edges.size, line);
+    }
+
+    // SNAPSHOTS ARE BOUNDED, and they are the whole file.
+    //
+    // MEASURED after compaction on this repository: 109.5 MB, of which `file`
+    // records are 105.3 MB. The raw snapshot text is 34.8 MB; JSON escaping
+    // triples it. Compaction alone cannot touch this, because every one of
+    // those records is live.
+    //
+    // A snapshot earns its place two ways: it lets a content-dependent finding
+    // show what changed, and it lets a re-read be answered with a diff instead
+    // of the file. The first is rare and identifiable -- 1 of 1,020 file nodes
+    // on this graph had such a finding anchored. The second only pays while the
+    // snapshot is recent: against a weeks-old snapshot the diff approaches the
+    // size of the file and the caller rejects it anyway.
+    //
+    // So: keep every snapshot something depends on, then keep the newest until
+    // the budget runs out, and drop the rest. The NODE always survives -- only
+    // the snapshot field goes, so hashes, staleness and traversal are
+    // unaffected and a dropped snapshot degrades to the ordinary redirect.
+    const needed = new Set();
+    for (const line of edges.values()) {
+      let e;
+      try {
+        e = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (e.t !== 'e' || e.edge !== 'derived_from') continue;
+      const from = nodes.get(e.from);
+      if (!from) continue;
+      let f;
+      try {
+        f = JSON.parse(from);
+      } catch {
+        continue;
+      }
+      if (f.kind === 'finding' && SNAPSHOT_DEPENDENT.has(f.type || 'finding')) needed.add(e.to);
+    }
+
+    const carriers = [];
+    for (const [id, line] of nodes) {
+      let n;
+      try {
+        n = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (typeof n.snapshot !== 'string' || !n.snapshot) continue;
+      carriers.push({ id, at: n.at || 0, size: n.snapshot.length, node: n });
+    }
+    carriers.sort((a, b) => b.at - a.at);
+
+    let spent = 0;
+    const budget = snapshotBudgetBytes();
+    for (const c of carriers) {
+      if (needed.has(c.id)) {
+        spent += c.size;
+        continue;
+      }
+      if (spent + c.size <= budget) {
+        spent += c.size;
+        continue;
+      }
+      const { snapshot, ...rest } = c.node;
+      nodes.set(c.id, JSON.stringify(rest));
     }
 
     // EDGES BEFORE NODES, matching putNodeWithEdges: a torn write can then only

--- a/integrations/qwen/hooks/lib/wiki.mjs
+++ b/integrations/qwen/hooks/lib/wiki.mjs
@@ -271,6 +271,17 @@ const compactFloorBytes = () =>
   Number(process.env.TOKEN_OPTIMIZER_GRAPH_COMPACT_BYTES) || 8_000_000;
 const markerPath = (dir) => join(dir, 'graph.compact.json');
 
+/** Cheap enough to test on every line, which is the point. */
+/**
+ * Snapshots live in their own file.
+ *
+ * Skipping them during the parse was only half the win: `load()` still READ
+ * all 23 MB to find the lines it was skipping. Measured, 137 ms -> 99 ms from
+ * the skip alone. A separate file means those bytes are never touched unless a
+ * caller asks for them, which two call sites out of many do.
+ */
+const snapshotsPath = (dir) => join(dir, 'snapshots.jsonl');
+
 /** Finding types whose evidence is a diff, and so need the snapshot kept. */
 const SNAPSHOT_DEPENDENT = new Set(['finding', 'map']);
 
@@ -298,17 +309,31 @@ function compactionBaseline(dir) {
  */
 function compactIfWasteful(dir) {
   const path = logPath(dir);
+  // BOTH FILES. Once snapshots moved to their own log the graph itself stopped
+  // growing, so a trigger watching only it would never fire again -- while the
+  // sidecar, which holds the bulk, grew without bound. The waste is the pair.
   let size = 0;
   try {
     size = statSync(path).size;
   } catch {
     return;
   }
+  try {
+    size += statSync(snapshotsPath(dir)).size;
+  } catch {
+    /* no sidecar yet */
+  }
   if (size < compactFloorBytes() || size < compactionBaseline(dir) * 2) return;
 
   try {
     const nodes = new Map();
     const edges = new Map();
+    const snaps = new Map();
+    for (const rec of readSnapshots(dir)) {
+      if (typeof rec.snapshot === 'string' && rec.snapshot) {
+        snaps.set(rec.id, { at: rec.at || 0, snapshot: rec.snapshot });
+      }
+    }
     for (const line of readFileSync(path, 'utf8').split('\n')) {
       if (!line) continue;
       let record;
@@ -324,8 +349,22 @@ function compactIfWasteful(dir) {
         edges.set('raw:' + edges.size, line);
         continue;
       }
-      if (record.t === 'n') nodes.set(record.id, line);
-      else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
+      if (record.t === 'n') {
+        // MIGRATION. Graphs written before snapshots were split still carry
+        // them inline, and those are exactly the graphs that are slow. Moving
+        // them out here means one compaction fixes an existing install.
+        if (typeof record.snapshot === 'string' && record.snapshot) {
+          const { snapshot, ...rest } = record;
+          nodes.set(record.id, JSON.stringify(rest));
+          snaps.set(record.id, { at: record.at || 0, snapshot });
+        } else {
+          nodes.set(record.id, line);
+        }
+      } else if (record.t === 's') {
+        if (typeof record.snapshot === 'string' && record.snapshot) {
+          snaps.set(record.id, { at: record.at || 0, snapshot: record.snapshot });
+        }
+      } else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
       else edges.set('raw:' + edges.size, line);
     }
 
@@ -367,32 +406,17 @@ function compactIfWasteful(dir) {
       if (f.kind === 'finding' && SNAPSHOT_DEPENDENT.has(f.type || 'finding')) needed.add(e.to);
     }
 
-    const carriers = [];
-    for (const [id, line] of nodes) {
-      let n;
-      try {
-        n = JSON.parse(line);
-      } catch {
-        continue;
-      }
-      if (typeof n.snapshot !== 'string' || !n.snapshot) continue;
-      carriers.push({ id, at: n.at || 0, size: n.snapshot.length, node: n });
-    }
-    carriers.sort((a, b) => b.at - a.at);
+    const carriers = [...snaps.entries()]
+      .map(([id, v]) => ({ id, at: v.at, size: v.snapshot.length }))
+      .sort((a, b) => b.at - a.at);
 
     let spent = 0;
     const budget = snapshotBudgetBytes();
+    const keep = new Map();
     for (const c of carriers) {
-      if (needed.has(c.id)) {
-        spent += c.size;
-        continue;
-      }
-      if (spent + c.size <= budget) {
-        spent += c.size;
-        continue;
-      }
-      const { snapshot, ...rest } = c.node;
-      nodes.set(c.id, JSON.stringify(rest));
+      if (!needed.has(c.id) && spent + c.size > budget) continue;
+      spent += c.size;
+      keep.set(c.id, snaps.get(c.id));
     }
 
     // EDGES BEFORE NODES, matching putNodeWithEdges: a torn write can then only
@@ -401,7 +425,21 @@ function compactIfWasteful(dir) {
     const tmp = path + '.compact';
     writeFileSync(tmp, out, { mode: 0o600 });
     renameSync(tmp, path);
-    writeFileSync(markerPath(dir), JSON.stringify({ sizeAfter: out.length, at: Date.now() }), { mode: 0o600 });
+    // The surviving snapshots are rewritten to their own file, which is also
+    // what migrates a graph that still had them inline.
+    const snapOut =
+      [...keep.entries()]
+        .map(([id, v]) => JSON.stringify({ t: 's', v: GRAPH_VERSION, id, snapshot: v.snapshot, at: v.at }))
+        .join('\n') + (keep.size ? '\n' : '');
+    const snapTmp = snapshotsPath(dir) + '.compact';
+    writeFileSync(snapTmp, snapOut, { mode: 0o600 });
+    renameSync(snapTmp, snapshotsPath(dir));
+    writeFileSync(
+      markerPath(dir),
+      // The baseline is the PAIR, matching what the trigger measures.
+      JSON.stringify({ sizeAfter: out.length + snapOut.length, at: Date.now() }),
+      { mode: 0o600 }
+    );
   } catch {
     // Compaction is an optimization. A failure leaves the log exactly as it
     // was, which is correct if larger than it needs to be.
@@ -458,7 +496,20 @@ export function putNode(dir, { kind, key, ...rest }) {
   // Spreading it after `id` let a caller passing a whole existing node back in
   // -- which curate.mjs does on every pin, retire and correct -- carry a stale
   // `id` or `t` through and write a record that no longer matches its own key.
-  append(dir, { ...rest, t: 'n', v: GRAPH_VERSION, id, kind, key: canonicalKey(kind, key), at: Date.now() });
+  const { snapshot, ...fields } = rest;
+  const at = Date.now();
+  const records = [
+    { ...fields, t: 'n', v: GRAPH_VERSION, id, kind, key: canonicalKey(kind, key), at },
+  ];
+  // SEPARATE RECORD, so `load()` can skip the bytes rather than parse and drop
+  // them. Written after the node: a torn write then loses a snapshot, which
+  // degrades to the ordinary redirect, rather than losing the node itself.
+  appendAll(dir, records);
+  // Written AFTER the node and to a different file: a failure here costs a
+  // snapshot, which degrades to the ordinary redirect, never the node.
+  if (typeof snapshot === 'string' && snapshot) {
+    appendSnapshot(dir, { t: 's', v: GRAPH_VERSION, id, snapshot, at });
+  }
   return id;
 }
 
@@ -515,14 +566,70 @@ export function putNodeWithEdges(dir, { kind, key, ...rest }, edges = []) {
  * line is the normal consequence of a process being killed mid-append, and one
  * bad line must not make the entire accumulated graph unreadable.
  */
-export function load(dir) {
+/** Appends one snapshot record. Failure here must never fail a graph write. */
+function appendSnapshot(dir, record) {
+  try {
+    appendFileSync(snapshotsPath(dir), JSON.stringify(record) + '\n');
+  } catch {
+    /* the node is already durable; the snapshot is an optimization */
+  }
+}
+
+/** Every snapshot record, latest wins. Read only when a caller asks. */
+function readSnapshots(dir) {
+  const out = [];
+  try {
+    for (const line of readFileSync(snapshotsPath(dir), 'utf8').split('\n')) {
+      if (!line) continue;
+      try {
+        const rec = JSON.parse(line);
+        if ((rec.v ?? 0) === GRAPH_VERSION && rec.id) out.push(rec);
+      } catch {
+        /* a torn line costs one snapshot */
+      }
+    }
+  } catch {
+    /* no sidecar yet */
+  }
+  return out;
+}
+
+/**
+ * @param {object} [options]
+ * @param {boolean} [options.snapshots] Parse stored file contents as well.
+ *
+ * SNAPSHOTS ARE SKIPPED BY DEFAULT, and skipped WITHOUT PARSING.
+ *
+ * They are ~95% of the bytes and are read by two call sites: the staleness
+ * diff for a content-dependent finding, and the zero-turn refusal. Neither is
+ * on the path that runs before every tool call, and that path was paying 232 ms
+ * a call to parse them -- measured, on a 23.8 MB graph.
+ *
+ * The skip is a string comparison on the record prefix, so the JSON parser
+ * never sees the payload. Parsing and then discarding would have cost the same
+ * as keeping it, which is the whole reason this is a separate record type.
+ */
+export function load(dir, { snapshots = false } = {}) {
   const nodes = new Map();
   const edges = [];
   const path = logPath(dir);
   if (!existsSync(path)) return { nodes, edges };
 
+  const pending = snapshots ? new Map() : null;
   for (const line of readFileSync(path, 'utf8').split('\n')) {
     if (!line) continue;
+    // Older graphs kept these inline. Skipped without parsing, and moved out
+    // by the next compaction.
+    if (line.startsWith('{"t":"s"')) {
+      if (!snapshots) continue;
+      try {
+        const rec = JSON.parse(line);
+        if ((rec.v ?? 0) === GRAPH_VERSION) pending.set(rec.id, rec.snapshot);
+      } catch {
+        /* a torn line costs one snapshot, not the graph */
+      }
+      continue;
+    }
     let record;
     try {
       record = JSON.parse(line);
@@ -535,6 +642,17 @@ export function load(dir) {
     if ((record.v ?? 0) !== GRAPH_VERSION) continue;
     if (record.t === 'n') nodes.set(record.id, record);
     else if (record.t === 'e') edges.push(record);
+  }
+
+
+  // Re-attached after the sweep, so a snapshot record may appear before or
+  // after the node it belongs to.
+  if (pending) {
+    for (const rec of readSnapshots(dir)) pending.set(rec.id, rec.snapshot);
+    for (const [id, snapshot] of pending) {
+      const node = nodes.get(id);
+      if (node) nodes.set(id, { ...node, snapshot });
+    }
   }
 
   return { nodes, edges };

--- a/integrations/qwen/hooks/lib/wiki.mjs
+++ b/integrations/qwen/hooks/lib/wiki.mjs
@@ -18,7 +18,7 @@
 
 import {
   appendFileSync, readFileSync, existsSync, mkdirSync, chmodSync,
-  openSync, closeSync, unlinkSync, statSync,
+  openSync, closeSync, unlinkSync, statSync, writeFileSync, renameSync,
 } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { createHash } from 'node:crypto';
@@ -242,6 +242,99 @@ function ignoreSelf(dir) {
   }
 }
 
+/**
+ * The log is append-only, and nothing was ever reclaiming it.
+ *
+ * MEASURED on this repository's own graph: 206.6 MB, 41,810 records, 6,125
+ * unique ids. 85.4% of every record in the file was superseded by a later one,
+ * and 97.5 MB was reclaimable. `load()` parses the whole thing on EVERY hook
+ * invocation -- so every tool call paid 1.2-1.6 seconds, against a 118 ms
+ * median when the graph is small.
+ *
+ * That is the optimizer becoming its own cost, in latency instead of tokens.
+ * It also surfaced as a flaky test: a 20 s spawn budget that a loaded machine
+ * could exceed, which is the sort of failure that gets re-run rather than read.
+ *
+ * AMORTISED TRIGGER, not a size threshold. A fixed cap would compact on every
+ * append once the live set alone exceeded it -- here the live set is 109 MB, so
+ * any cap below that would rewrite the file continuously. Instead the size
+ * after each compaction is recorded, and the next one waits until the file has
+ * doubled again: each compaction therefore does at least as much good as the
+ * work it costs, and the amortised cost per append stays constant.
+ */
+// READ PER CALL, not once at module load -- the same rule the holdout
+// fraction already follows in metrics.mjs. Reading it once meant a process
+// started before a config change honoured the old value forever, and it also
+// made the setting untestable: a suite that sets the variable in `beforeEach`
+// runs after the import, so the module had already captured the default.
+const compactFloorBytes = () =>
+  Number(process.env.TOKEN_OPTIMIZER_GRAPH_COMPACT_BYTES) || 8_000_000;
+const markerPath = (dir) => join(dir, 'graph.compact.json');
+
+function compactionBaseline(dir) {
+  try {
+    const raw = JSON.parse(readFileSync(markerPath(dir), 'utf8'));
+    const n = Number(raw.sizeAfter);
+    return Number.isFinite(n) && n > 0 ? n : compactFloorBytes();
+  } catch {
+    return compactFloorBytes();
+  }
+}
+
+/**
+ * Rewrites the log keeping only the surviving version of each record.
+ *
+ * CALLED INSIDE THE LOCK, so no writer can append between the read and the
+ * rename. Written to a temporary file and renamed, which is atomic on the same
+ * volume: a crash mid-compaction leaves the original log untouched rather than
+ * a half-written graph.
+ */
+function compactIfWasteful(dir) {
+  const path = logPath(dir);
+  let size = 0;
+  try {
+    size = statSync(path).size;
+  } catch {
+    return;
+  }
+  if (size < compactFloorBytes() || size < compactionBaseline(dir) * 2) return;
+
+  try {
+    const nodes = new Map();
+    const edges = new Map();
+    for (const line of readFileSync(path, 'utf8').split('\n')) {
+      if (!line) continue;
+      let record;
+      try {
+        record = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      // A record from another schema is KEPT VERBATIM rather than reinterpreted.
+      // load() skips it, but discarding it here would make compaction a silent
+      // migration that deletes data a future version might understand.
+      if ((record.v ?? 0) !== GRAPH_VERSION) {
+        edges.set('raw:' + edges.size, line);
+        continue;
+      }
+      if (record.t === 'n') nodes.set(record.id, line);
+      else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
+      else edges.set('raw:' + edges.size, line);
+    }
+
+    // EDGES BEFORE NODES, matching putNodeWithEdges: a torn write can then only
+    // lose a finding, never leave one anchored to nothing.
+    const out = [...edges.values(), ...nodes.values()].join('\n') + '\n';
+    const tmp = path + '.compact';
+    writeFileSync(tmp, out, { mode: 0o600 });
+    renameSync(tmp, path);
+    writeFileSync(markerPath(dir), JSON.stringify({ sizeAfter: out.length, at: Date.now() }), { mode: 0o600 });
+  } catch {
+    // Compaction is an optimization. A failure leaves the log exactly as it
+    // was, which is correct if larger than it needs to be.
+  }
+}
+
 function appendAll(dir, records) {
   if (!records.length) return true;
   try {
@@ -263,7 +356,10 @@ function appendAll(dir, records) {
     // needs several records to be observed together cannot get that by looping,
     // because every iteration is a separate crash point.
     const payload = records.map((record) => JSON.stringify(record) + '\n').join('');
-    withLock(dir, () => appendFileSync(logPath(dir), payload));
+    withLock(dir, () => {
+      appendFileSync(logPath(dir), payload);
+      compactIfWasteful(dir);
+    });
     return true;
   } catch {
     // The graph is an optimization. Failing to write one must never fail the

--- a/plugin/hooks/lib/inject.mjs
+++ b/plugin/hooks/lib/inject.mjs
@@ -119,8 +119,20 @@ function fit(findings, budget) {
 function render(finding) {
   const head = `- [${finding.type || 'finding'}] ${finding.claim}`;
   if (!finding.stale) return head;
-  // A stale finding NEVER renders without its evidence. Serving one bare would
-  // be worse than having no graph at all.
+
+  // A stale finding NEVER renders as though it were current. But the strength
+  // of the framing follows the strength of the evidence, because the framing
+  // was measured: in an A/B on a fresh subagent, identical findings scored 1/3
+  // dead-ends avoided when rendered with the discount wording and 2/3 when
+  // rendered clean. The claims being discounted were correct every time.
+  //
+  // With a diff, the reader can judge for themselves and the strong form is
+  // earned. Without one -- 78% of stale findings on real graphs -- announcing
+  // STALE and promising `What changed:` in front of nothing spends the
+  // strongest signal available on the weakest evidence available.
+  if (!finding.staleEvidence || !finding.diff) {
+    return `${head}\n  (recorded earlier; ${finding.staleReason}, and no diff could be rebuilt)`;
+  }
   return `${head}\n  STALE (${finding.staleReason}). What changed:\n${finding.diff}`;
 }
 

--- a/plugin/hooks/lib/restore.mjs
+++ b/plugin/hooks/lib/restore.mjs
@@ -134,7 +134,10 @@ export function restorationPlan(dir, graph, context = {}) {
       if (!node) continue;
       const findings = serve(graph, findingsFor(graph, id, { limit: 2 }));
       for (const finding of findings) {
-        lines.push(`${node.key}: ${finding.stale ? '! STALE ' : ''}${finding.claim}`);
+        // `! STALE` only where a diff actually exists to back it; see the
+        // renderer in inject.mjs for the measurement behind this.
+        const mark = finding.stale ? (finding.staleEvidence ? '! STALE ' : '~ ') : '';
+        lines.push(`${node.key}: ${mark}${finding.claim}`);
       }
     }
     section('Likely next', lines, total * split.forward);

--- a/plugin/hooks/lib/restore.mjs
+++ b/plugin/hooks/lib/restore.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/restore.mjs. Regenerate with `npm run sync:hooks`.
-/**
+﻿/**
  * Restoration after compaction.
  *
  * A checkpoint restores what you HAD. That is a recap: it spends the scarcest
@@ -37,7 +37,11 @@ const estimate = (text) => Math.ceil(String(text || '').length / 4);
  * genuinely different things, and treating them identically is what makes a
  * fixed-order restore feel wrong half the time.
  */
-export function classifySituation({ openQuestion, recentAnchors = [], idleMs = 0 } = {}) {
+export function classifySituation({
+  openQuestion,
+  recentAnchors = [],
+  idleMs = 0,
+} = {}) {
   // Days later, nothing in the fresh context connects to anything. Orientation
   // is the only thing that helps; continuation has nothing to continue from.
   if (idleMs > 6 * 60 * 60 * 1000) return 'cold-resume';
@@ -61,21 +65,25 @@ export function classifySituation({ openQuestion, recentAnchors = [], idleMs = 0
  */
 const SPLITS = {
   'mid-problem': { frontier: 0.6, forward: 0.25, brief: 0.15 },
-  'cold-resume': { frontier: 0.15, forward: 0.25, brief: 0.60 },
-  'in-flow': { frontier: 0.20, forward: 0.60, brief: 0.20 },
-  general: { frontier: 0.35, forward: 0.35, brief: 0.30 },
+  'cold-resume': { frontier: 0.15, forward: 0.25, brief: 0.6 },
+  'in-flow': { frontier: 0.2, forward: 0.6, brief: 0.2 },
+  general: { frontier: 0.35, forward: 0.35, brief: 0.3 },
 };
 
 /** Findings for files the co-occurrence graph says are likely next. */
 function predictNext(graph, recentAnchors, limit = 6) {
-  const recent = new Set(recentAnchors.map((a) => nodeId('file', canonicalPath(a))));
+  const recent = new Set(
+    recentAnchors.map((a) => nodeId('file', canonicalPath(a)))
+  );
   const weight = new Map();
 
   for (const edge of graph.edges) {
     if (edge.edge !== 'related') continue;
     const [from, to] = [edge.from, edge.to];
-    if (recent.has(from) && !recent.has(to)) weight.set(to, (weight.get(to) || 0) + 1);
-    if (recent.has(to) && !recent.has(from)) weight.set(from, (weight.get(from) || 0) + 1);
+    if (recent.has(from) && !recent.has(to))
+      weight.set(to, (weight.get(to) || 0) + 1);
+    if (recent.has(to) && !recent.has(from))
+      weight.set(from, (weight.get(from) || 0) + 1);
   }
 
   return [...weight.entries()]
@@ -119,8 +127,10 @@ export function restorationPlan(dir, graph, context = {}) {
   // be recovered by looking at the code again.
   if (context.openQuestion) {
     const lines = [`Open: ${context.openQuestion}`];
-    for (const ruled of context.ruledOut || []) lines.push(`  ruled out: ${ruled}`);
-    for (const open of context.untested || []) lines.push(`  untested: ${open}`);
+    for (const ruled of context.ruledOut || [])
+      lines.push(`  ruled out: ${ruled}`);
+    for (const open of context.untested || [])
+      lines.push(`  untested: ${open}`);
     section('Where you were', lines, total * split.frontier);
   }
 
@@ -136,7 +146,18 @@ export function restorationPlan(dir, graph, context = {}) {
       for (const finding of findings) {
         // `! STALE` only where a diff actually exists to back it; see the
         // renderer in inject.mjs for the measurement behind this.
-        const mark = finding.stale ? (finding.staleEvidence ? '! STALE ' : '~ ') : '';
+        //
+        // BOTH HALVES, matching inject.mjs exactly (`!staleEvidence || !diff`).
+        // Checking staleEvidence alone marked a finding `! STALE` here while the
+        // injector softened the same finding elsewhere -- and the strong marker
+        // claims 'this is contradicted, here is the proof' with no proof to
+        // show, which is the bare stale finding the design calls worse than
+        // having no graph.
+        const mark = finding.stale
+          ? finding.staleEvidence && finding.diff
+            ? '! STALE '
+            : '~ '
+          : '';
         lines.push(`${node.key}: ${mark}${finding.claim}`);
       }
     }
@@ -146,7 +167,9 @@ export function restorationPlan(dir, graph, context = {}) {
   // BRIEF -- orientation. Last, because it is the most replaceable: normal
   // just-in-time injection will deliver most of it the moment work resumes.
   const established = [...graph.nodes.values()]
-    .filter((n) => n.kind === 'finding' && !n.retired && typeof n.claim === 'string')
+    .filter(
+      (n) => n.kind === 'finding' && !n.retired && typeof n.claim === 'string'
+    )
     .sort((a, b) => (b.confidence ?? 0) - (a.confidence ?? 0))
     .slice(0, 12)
     .map((n) => `${n.key}: ${n.claim.slice(0, 100)}`);

--- a/plugin/hooks/lib/staleness.mjs
+++ b/plugin/hooks/lib/staleness.mjs
@@ -400,12 +400,30 @@ export function serve(graph, findings) {
       // front of the model, and this text exists precisely because the previous
       // phrasing was measured suppressing correct findings. State the evidence
       // gap and stop.
-      diff = `(marked stale: ${reason}. The supporting diff can no longer be `
-        + 'reconstructed; the claim itself may well still hold, so weigh it on '
-        + 'its own merits.)';
+      // THE PROSE MOVES OUT OF `diff`, and the fact moves into a flag.
+      //
+      // Softening this sentence was not enough, because the RENDERER wraps it:
+      // the model saw `STALE (reason). What changed:` followed by a paragraph
+      // explaining that nothing follows. The strong framing was designed for
+      // the case where evidence exists and was being applied to the case where
+      // it does not.
+      //
+      // Measured across every real graph on one machine: 32 of 241 served
+      // findings were stale, and 25 of those 32 -- 78% -- had no diff at all.
+      // So the strongest wording available was carried by the findings with the
+      // least evidence behind them, on 10.4% of everything served.
+      //
+      // A caller cannot phrase this well from a prose blob, so it gets the two
+      // things it needs: that the finding is stale, and whether any evidence
+      // survives. The wording is then the renderer's business.
+      diff = '';
     }
 
-    served.push({ ...finding, stale, ...(stale ? { diff, staleReason: reason } : {}) });
+    served.push({
+      ...finding,
+      stale,
+      ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
+    });
   }
   return served;
 }

--- a/plugin/hooks/lib/staleness.mjs
+++ b/plugin/hooks/lib/staleness.mjs
@@ -341,7 +341,37 @@ export function serve(graph, findings) {
   // graph directly cannot accidentally serve a claim a human explicitly
   // withdrew. A withheld claim reappearing is not a bug anyone would notice
   // quickly.
+/**
+ * Types whose truth is a claim ABOUT the anchor's contents.
+ *
+ * Only these can be invalidated by that file changing. An anchor on any other
+ * type is a RETRIEVAL HOOK -- the file that happened to be open when the lesson
+ * was learned -- and its contents changing says nothing about the claim.
+ *
+ * MEASURED, across every real graph on one machine: 32 findings were served
+ * stale, and 24 of them -- 75% -- were types in neither of these sets. The
+ * clearest example is a `failure` reading "Edit hooks-core/, never the generated
+ * copies", marked stale because hooks-core/wiki.mjs changed. That rule is about
+ * process; wiki.mjs's contents cannot make it wrong. It was being discounted for
+ * a reason that did not exist.
+ *
+ * THE TRADE, STATED. A `command` finding CAN be invalidated by its anchor -- a
+ * claim about `npm test` anchored to package.json genuinely dies if the test
+ * script changes. That case is now missed. It is the better error: today every
+ * version bump marks it stale, so the signal fires overwhelmingly when nothing
+ * relevant happened, and a signal that is usually wrong is one a reader learns
+ * to ignore -- taking the rare true positive with it.
+ */
+const CONTENT_DEPENDENT = new Set(['finding', 'map']);
+
   for (const finding of findings.filter((f) => !f.retired)) {
+    // A claim that does not depend on the anchor's contents cannot be
+    // invalidated by them. It is served as-is rather than discounted.
+    if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) {
+      served.push({ ...finding });
+      continue;
+    }
+
     const anchors = graph.edges
       .filter((e) => e.edge === 'derived_from' && e.from === finding.id)
       .map((e) => graph.nodes.get(e.to))

--- a/plugin/hooks/lib/wiki.mjs
+++ b/plugin/hooks/lib/wiki.mjs
@@ -271,6 +271,13 @@ const compactFloorBytes = () =>
   Number(process.env.TOKEN_OPTIMIZER_GRAPH_COMPACT_BYTES) || 8_000_000;
 const markerPath = (dir) => join(dir, 'graph.compact.json');
 
+/** Finding types whose evidence is a diff, and so need the snapshot kept. */
+const SNAPSHOT_DEPENDENT = new Set(['finding', 'map']);
+
+/** Read per call, for the reason documented on the compaction floor above. */
+const snapshotBudgetBytes = () =>
+  Number(process.env.TOKEN_OPTIMIZER_GRAPH_SNAPSHOT_BYTES) || 8_000_000;
+
 function compactionBaseline(dir) {
   try {
     const raw = JSON.parse(readFileSync(markerPath(dir), 'utf8'));
@@ -320,6 +327,72 @@ function compactIfWasteful(dir) {
       if (record.t === 'n') nodes.set(record.id, line);
       else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
       else edges.set('raw:' + edges.size, line);
+    }
+
+    // SNAPSHOTS ARE BOUNDED, and they are the whole file.
+    //
+    // MEASURED after compaction on this repository: 109.5 MB, of which `file`
+    // records are 105.3 MB. The raw snapshot text is 34.8 MB; JSON escaping
+    // triples it. Compaction alone cannot touch this, because every one of
+    // those records is live.
+    //
+    // A snapshot earns its place two ways: it lets a content-dependent finding
+    // show what changed, and it lets a re-read be answered with a diff instead
+    // of the file. The first is rare and identifiable -- 1 of 1,020 file nodes
+    // on this graph had such a finding anchored. The second only pays while the
+    // snapshot is recent: against a weeks-old snapshot the diff approaches the
+    // size of the file and the caller rejects it anyway.
+    //
+    // So: keep every snapshot something depends on, then keep the newest until
+    // the budget runs out, and drop the rest. The NODE always survives -- only
+    // the snapshot field goes, so hashes, staleness and traversal are
+    // unaffected and a dropped snapshot degrades to the ordinary redirect.
+    const needed = new Set();
+    for (const line of edges.values()) {
+      let e;
+      try {
+        e = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (e.t !== 'e' || e.edge !== 'derived_from') continue;
+      const from = nodes.get(e.from);
+      if (!from) continue;
+      let f;
+      try {
+        f = JSON.parse(from);
+      } catch {
+        continue;
+      }
+      if (f.kind === 'finding' && SNAPSHOT_DEPENDENT.has(f.type || 'finding')) needed.add(e.to);
+    }
+
+    const carriers = [];
+    for (const [id, line] of nodes) {
+      let n;
+      try {
+        n = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (typeof n.snapshot !== 'string' || !n.snapshot) continue;
+      carriers.push({ id, at: n.at || 0, size: n.snapshot.length, node: n });
+    }
+    carriers.sort((a, b) => b.at - a.at);
+
+    let spent = 0;
+    const budget = snapshotBudgetBytes();
+    for (const c of carriers) {
+      if (needed.has(c.id)) {
+        spent += c.size;
+        continue;
+      }
+      if (spent + c.size <= budget) {
+        spent += c.size;
+        continue;
+      }
+      const { snapshot, ...rest } = c.node;
+      nodes.set(c.id, JSON.stringify(rest));
     }
 
     // EDGES BEFORE NODES, matching putNodeWithEdges: a torn write can then only

--- a/plugin/hooks/lib/wiki.mjs
+++ b/plugin/hooks/lib/wiki.mjs
@@ -271,6 +271,17 @@ const compactFloorBytes = () =>
   Number(process.env.TOKEN_OPTIMIZER_GRAPH_COMPACT_BYTES) || 8_000_000;
 const markerPath = (dir) => join(dir, 'graph.compact.json');
 
+/** Cheap enough to test on every line, which is the point. */
+/**
+ * Snapshots live in their own file.
+ *
+ * Skipping them during the parse was only half the win: `load()` still READ
+ * all 23 MB to find the lines it was skipping. Measured, 137 ms -> 99 ms from
+ * the skip alone. A separate file means those bytes are never touched unless a
+ * caller asks for them, which two call sites out of many do.
+ */
+const snapshotsPath = (dir) => join(dir, 'snapshots.jsonl');
+
 /** Finding types whose evidence is a diff, and so need the snapshot kept. */
 const SNAPSHOT_DEPENDENT = new Set(['finding', 'map']);
 
@@ -298,17 +309,31 @@ function compactionBaseline(dir) {
  */
 function compactIfWasteful(dir) {
   const path = logPath(dir);
+  // BOTH FILES. Once snapshots moved to their own log the graph itself stopped
+  // growing, so a trigger watching only it would never fire again -- while the
+  // sidecar, which holds the bulk, grew without bound. The waste is the pair.
   let size = 0;
   try {
     size = statSync(path).size;
   } catch {
     return;
   }
+  try {
+    size += statSync(snapshotsPath(dir)).size;
+  } catch {
+    /* no sidecar yet */
+  }
   if (size < compactFloorBytes() || size < compactionBaseline(dir) * 2) return;
 
   try {
     const nodes = new Map();
     const edges = new Map();
+    const snaps = new Map();
+    for (const rec of readSnapshots(dir)) {
+      if (typeof rec.snapshot === 'string' && rec.snapshot) {
+        snaps.set(rec.id, { at: rec.at || 0, snapshot: rec.snapshot });
+      }
+    }
     for (const line of readFileSync(path, 'utf8').split('\n')) {
       if (!line) continue;
       let record;
@@ -324,8 +349,22 @@ function compactIfWasteful(dir) {
         edges.set('raw:' + edges.size, line);
         continue;
       }
-      if (record.t === 'n') nodes.set(record.id, line);
-      else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
+      if (record.t === 'n') {
+        // MIGRATION. Graphs written before snapshots were split still carry
+        // them inline, and those are exactly the graphs that are slow. Moving
+        // them out here means one compaction fixes an existing install.
+        if (typeof record.snapshot === 'string' && record.snapshot) {
+          const { snapshot, ...rest } = record;
+          nodes.set(record.id, JSON.stringify(rest));
+          snaps.set(record.id, { at: record.at || 0, snapshot });
+        } else {
+          nodes.set(record.id, line);
+        }
+      } else if (record.t === 's') {
+        if (typeof record.snapshot === 'string' && record.snapshot) {
+          snaps.set(record.id, { at: record.at || 0, snapshot: record.snapshot });
+        }
+      } else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
       else edges.set('raw:' + edges.size, line);
     }
 
@@ -367,32 +406,17 @@ function compactIfWasteful(dir) {
       if (f.kind === 'finding' && SNAPSHOT_DEPENDENT.has(f.type || 'finding')) needed.add(e.to);
     }
 
-    const carriers = [];
-    for (const [id, line] of nodes) {
-      let n;
-      try {
-        n = JSON.parse(line);
-      } catch {
-        continue;
-      }
-      if (typeof n.snapshot !== 'string' || !n.snapshot) continue;
-      carriers.push({ id, at: n.at || 0, size: n.snapshot.length, node: n });
-    }
-    carriers.sort((a, b) => b.at - a.at);
+    const carriers = [...snaps.entries()]
+      .map(([id, v]) => ({ id, at: v.at, size: v.snapshot.length }))
+      .sort((a, b) => b.at - a.at);
 
     let spent = 0;
     const budget = snapshotBudgetBytes();
+    const keep = new Map();
     for (const c of carriers) {
-      if (needed.has(c.id)) {
-        spent += c.size;
-        continue;
-      }
-      if (spent + c.size <= budget) {
-        spent += c.size;
-        continue;
-      }
-      const { snapshot, ...rest } = c.node;
-      nodes.set(c.id, JSON.stringify(rest));
+      if (!needed.has(c.id) && spent + c.size > budget) continue;
+      spent += c.size;
+      keep.set(c.id, snaps.get(c.id));
     }
 
     // EDGES BEFORE NODES, matching putNodeWithEdges: a torn write can then only
@@ -401,7 +425,21 @@ function compactIfWasteful(dir) {
     const tmp = path + '.compact';
     writeFileSync(tmp, out, { mode: 0o600 });
     renameSync(tmp, path);
-    writeFileSync(markerPath(dir), JSON.stringify({ sizeAfter: out.length, at: Date.now() }), { mode: 0o600 });
+    // The surviving snapshots are rewritten to their own file, which is also
+    // what migrates a graph that still had them inline.
+    const snapOut =
+      [...keep.entries()]
+        .map(([id, v]) => JSON.stringify({ t: 's', v: GRAPH_VERSION, id, snapshot: v.snapshot, at: v.at }))
+        .join('\n') + (keep.size ? '\n' : '');
+    const snapTmp = snapshotsPath(dir) + '.compact';
+    writeFileSync(snapTmp, snapOut, { mode: 0o600 });
+    renameSync(snapTmp, snapshotsPath(dir));
+    writeFileSync(
+      markerPath(dir),
+      // The baseline is the PAIR, matching what the trigger measures.
+      JSON.stringify({ sizeAfter: out.length + snapOut.length, at: Date.now() }),
+      { mode: 0o600 }
+    );
   } catch {
     // Compaction is an optimization. A failure leaves the log exactly as it
     // was, which is correct if larger than it needs to be.
@@ -458,7 +496,20 @@ export function putNode(dir, { kind, key, ...rest }) {
   // Spreading it after `id` let a caller passing a whole existing node back in
   // -- which curate.mjs does on every pin, retire and correct -- carry a stale
   // `id` or `t` through and write a record that no longer matches its own key.
-  append(dir, { ...rest, t: 'n', v: GRAPH_VERSION, id, kind, key: canonicalKey(kind, key), at: Date.now() });
+  const { snapshot, ...fields } = rest;
+  const at = Date.now();
+  const records = [
+    { ...fields, t: 'n', v: GRAPH_VERSION, id, kind, key: canonicalKey(kind, key), at },
+  ];
+  // SEPARATE RECORD, so `load()` can skip the bytes rather than parse and drop
+  // them. Written after the node: a torn write then loses a snapshot, which
+  // degrades to the ordinary redirect, rather than losing the node itself.
+  appendAll(dir, records);
+  // Written AFTER the node and to a different file: a failure here costs a
+  // snapshot, which degrades to the ordinary redirect, never the node.
+  if (typeof snapshot === 'string' && snapshot) {
+    appendSnapshot(dir, { t: 's', v: GRAPH_VERSION, id, snapshot, at });
+  }
   return id;
 }
 
@@ -515,14 +566,70 @@ export function putNodeWithEdges(dir, { kind, key, ...rest }, edges = []) {
  * line is the normal consequence of a process being killed mid-append, and one
  * bad line must not make the entire accumulated graph unreadable.
  */
-export function load(dir) {
+/** Appends one snapshot record. Failure here must never fail a graph write. */
+function appendSnapshot(dir, record) {
+  try {
+    appendFileSync(snapshotsPath(dir), JSON.stringify(record) + '\n');
+  } catch {
+    /* the node is already durable; the snapshot is an optimization */
+  }
+}
+
+/** Every snapshot record, latest wins. Read only when a caller asks. */
+function readSnapshots(dir) {
+  const out = [];
+  try {
+    for (const line of readFileSync(snapshotsPath(dir), 'utf8').split('\n')) {
+      if (!line) continue;
+      try {
+        const rec = JSON.parse(line);
+        if ((rec.v ?? 0) === GRAPH_VERSION && rec.id) out.push(rec);
+      } catch {
+        /* a torn line costs one snapshot */
+      }
+    }
+  } catch {
+    /* no sidecar yet */
+  }
+  return out;
+}
+
+/**
+ * @param {object} [options]
+ * @param {boolean} [options.snapshots] Parse stored file contents as well.
+ *
+ * SNAPSHOTS ARE SKIPPED BY DEFAULT, and skipped WITHOUT PARSING.
+ *
+ * They are ~95% of the bytes and are read by two call sites: the staleness
+ * diff for a content-dependent finding, and the zero-turn refusal. Neither is
+ * on the path that runs before every tool call, and that path was paying 232 ms
+ * a call to parse them -- measured, on a 23.8 MB graph.
+ *
+ * The skip is a string comparison on the record prefix, so the JSON parser
+ * never sees the payload. Parsing and then discarding would have cost the same
+ * as keeping it, which is the whole reason this is a separate record type.
+ */
+export function load(dir, { snapshots = false } = {}) {
   const nodes = new Map();
   const edges = [];
   const path = logPath(dir);
   if (!existsSync(path)) return { nodes, edges };
 
+  const pending = snapshots ? new Map() : null;
   for (const line of readFileSync(path, 'utf8').split('\n')) {
     if (!line) continue;
+    // Older graphs kept these inline. Skipped without parsing, and moved out
+    // by the next compaction.
+    if (line.startsWith('{"t":"s"')) {
+      if (!snapshots) continue;
+      try {
+        const rec = JSON.parse(line);
+        if ((rec.v ?? 0) === GRAPH_VERSION) pending.set(rec.id, rec.snapshot);
+      } catch {
+        /* a torn line costs one snapshot, not the graph */
+      }
+      continue;
+    }
     let record;
     try {
       record = JSON.parse(line);
@@ -535,6 +642,17 @@ export function load(dir) {
     if ((record.v ?? 0) !== GRAPH_VERSION) continue;
     if (record.t === 'n') nodes.set(record.id, record);
     else if (record.t === 'e') edges.push(record);
+  }
+
+
+  // Re-attached after the sweep, so a snapshot record may appear before or
+  // after the node it belongs to.
+  if (pending) {
+    for (const rec of readSnapshots(dir)) pending.set(rec.id, rec.snapshot);
+    for (const [id, snapshot] of pending) {
+      const node = nodes.get(id);
+      if (node) nodes.set(id, { ...node, snapshot });
+    }
   }
 
   return { nodes, edges };

--- a/plugin/hooks/lib/wiki.mjs
+++ b/plugin/hooks/lib/wiki.mjs
@@ -18,7 +18,7 @@
 
 import {
   appendFileSync, readFileSync, existsSync, mkdirSync, chmodSync,
-  openSync, closeSync, unlinkSync, statSync,
+  openSync, closeSync, unlinkSync, statSync, writeFileSync, renameSync,
 } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { createHash } from 'node:crypto';
@@ -242,6 +242,99 @@ function ignoreSelf(dir) {
   }
 }
 
+/**
+ * The log is append-only, and nothing was ever reclaiming it.
+ *
+ * MEASURED on this repository's own graph: 206.6 MB, 41,810 records, 6,125
+ * unique ids. 85.4% of every record in the file was superseded by a later one,
+ * and 97.5 MB was reclaimable. `load()` parses the whole thing on EVERY hook
+ * invocation -- so every tool call paid 1.2-1.6 seconds, against a 118 ms
+ * median when the graph is small.
+ *
+ * That is the optimizer becoming its own cost, in latency instead of tokens.
+ * It also surfaced as a flaky test: a 20 s spawn budget that a loaded machine
+ * could exceed, which is the sort of failure that gets re-run rather than read.
+ *
+ * AMORTISED TRIGGER, not a size threshold. A fixed cap would compact on every
+ * append once the live set alone exceeded it -- here the live set is 109 MB, so
+ * any cap below that would rewrite the file continuously. Instead the size
+ * after each compaction is recorded, and the next one waits until the file has
+ * doubled again: each compaction therefore does at least as much good as the
+ * work it costs, and the amortised cost per append stays constant.
+ */
+// READ PER CALL, not once at module load -- the same rule the holdout
+// fraction already follows in metrics.mjs. Reading it once meant a process
+// started before a config change honoured the old value forever, and it also
+// made the setting untestable: a suite that sets the variable in `beforeEach`
+// runs after the import, so the module had already captured the default.
+const compactFloorBytes = () =>
+  Number(process.env.TOKEN_OPTIMIZER_GRAPH_COMPACT_BYTES) || 8_000_000;
+const markerPath = (dir) => join(dir, 'graph.compact.json');
+
+function compactionBaseline(dir) {
+  try {
+    const raw = JSON.parse(readFileSync(markerPath(dir), 'utf8'));
+    const n = Number(raw.sizeAfter);
+    return Number.isFinite(n) && n > 0 ? n : compactFloorBytes();
+  } catch {
+    return compactFloorBytes();
+  }
+}
+
+/**
+ * Rewrites the log keeping only the surviving version of each record.
+ *
+ * CALLED INSIDE THE LOCK, so no writer can append between the read and the
+ * rename. Written to a temporary file and renamed, which is atomic on the same
+ * volume: a crash mid-compaction leaves the original log untouched rather than
+ * a half-written graph.
+ */
+function compactIfWasteful(dir) {
+  const path = logPath(dir);
+  let size = 0;
+  try {
+    size = statSync(path).size;
+  } catch {
+    return;
+  }
+  if (size < compactFloorBytes() || size < compactionBaseline(dir) * 2) return;
+
+  try {
+    const nodes = new Map();
+    const edges = new Map();
+    for (const line of readFileSync(path, 'utf8').split('\n')) {
+      if (!line) continue;
+      let record;
+      try {
+        record = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      // A record from another schema is KEPT VERBATIM rather than reinterpreted.
+      // load() skips it, but discarding it here would make compaction a silent
+      // migration that deletes data a future version might understand.
+      if ((record.v ?? 0) !== GRAPH_VERSION) {
+        edges.set('raw:' + edges.size, line);
+        continue;
+      }
+      if (record.t === 'n') nodes.set(record.id, line);
+      else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
+      else edges.set('raw:' + edges.size, line);
+    }
+
+    // EDGES BEFORE NODES, matching putNodeWithEdges: a torn write can then only
+    // lose a finding, never leave one anchored to nothing.
+    const out = [...edges.values(), ...nodes.values()].join('\n') + '\n';
+    const tmp = path + '.compact';
+    writeFileSync(tmp, out, { mode: 0o600 });
+    renameSync(tmp, path);
+    writeFileSync(markerPath(dir), JSON.stringify({ sizeAfter: out.length, at: Date.now() }), { mode: 0o600 });
+  } catch {
+    // Compaction is an optimization. A failure leaves the log exactly as it
+    // was, which is correct if larger than it needs to be.
+  }
+}
+
 function appendAll(dir, records) {
   if (!records.length) return true;
   try {
@@ -263,7 +356,10 @@ function appendAll(dir, records) {
     // needs several records to be observed together cannot get that by looping,
     // because every iteration is a separate crash point.
     const payload = records.map((record) => JSON.stringify(record) + '\n').join('');
-    withLock(dir, () => appendFileSync(logPath(dir), payload));
+    withLock(dir, () => {
+      appendFileSync(logPath(dir), payload);
+      compactIfWasteful(dir);
+    });
     return true;
   } catch {
     // The graph is an optimization. Failing to write one must never fail the

--- a/plugin/hooks/pretooluse-router.mjs
+++ b/plugin/hooks/pretooluse-router.mjs
@@ -261,7 +261,13 @@ try {
       const dir = wikiDir(
         projectRootFor(payload.tool_input.file_path, payload.cwd)
       );
-      const graph = load(dir);
+      // SNAPSHOTS ONLY HERE. This is the refusal path -- a re-read of a file
+      // large enough to be denied -- and it is the one place the stored
+      // contents actually pay, by answering with a diff instead of the file.
+      // The injection path above deliberately loads without them: it runs
+      // before EVERY tool call and was paying 232 ms to parse bytes it does
+      // not read.
+      const graph = load(dir, { snapshots: true });
       // Only THIS session's own read history can license "unchanged since you
       // read it" or a diff -- the graph is durable and per project, so its
       // snapshot may predate this session entirely.

--- a/src/core/token-counter.ts
+++ b/src/core/token-counter.ts
@@ -82,12 +82,18 @@ export class TokenCounter {
    * separator or a repetitive blob would stall the server for twenty seconds.
    * It surfaced as a 38-second test suite, of which one case was 23 seconds.
    *
-   * SLICING MAKES THE COST LINEAR. A merge cannot span a slice boundary, so
-   * the count can differ slightly from an unsliced encode -- always upward, by
-   * at most one token per boundary. Measured against exact encoding at this
-   * size: prose +0.064%, minified javascript +0.013%, and the repetitive cases
-   * agree exactly. Text shorter than one slice is encoded in a single call and
-   * is bit-identical to before.
+   * SLICING MAKES THE COST LINEAR, and slicing at a LINE START makes it very
+   * nearly free of accuracy cost. Measured across all 342 files in this
+   * repository over 8 KB, against an exact unsliced encode:
+   *
+   *   cut at the byte limit        aggregate +0.06437%
+   *   cut at the last space        aggregate +0.00952%,  64.3% of files exact
+   *   cut after the last newline   aggregate +0.00097%,  98.0% of files exact
+   *
+   * A cl100k token can carry its leading whitespace, which is why cutting at a
+   * space still splits one and cutting after a newline does not. 19 tokens
+   * differ across 1,963,504. Text shorter than one slice is encoded in a single
+   * call and is bit-identical to before.
    */
   private static readonly ENCODE_SLICE = 8192;
 
@@ -100,8 +106,26 @@ export class TokenCounter {
     if (text.length <= slice) return this.encoder.encode(text).length;
 
     let total = 0;
-    for (let i = 0; i < text.length; i += slice) {
-      total += this.encoder.encode(text.slice(i, i + slice)).length;
+    let from = 0;
+    while (from < text.length) {
+      let end = Math.min(from + slice, text.length);
+      if (end < text.length) {
+        // BACK UP TO A LINE START. A cl100k token can carry its leading
+        // whitespace, so cutting AT a space still splits one -- measured across
+        // 342 real files over 8 KB, cutting at spaces matched an exact encode on
+        // 64.3% of them. Cutting immediately after a newline matched on 98.0%,
+        // because a line start is a boundary the pre-tokenizer already respects.
+        //
+        // The search stops halfway back so a file with very long lines cannot
+        // degenerate into tiny slices; when no newline is found in range the cut
+        // is taken as-is, which is the minified-single-line case.
+        const floor = from + (slice >> 1);
+        let cut = end;
+        while (cut > floor && text[cut - 1] !== '\n') cut--;
+        if (cut > floor) end = cut;
+      }
+      total += this.encoder.encode(text.slice(from, end)).length;
+      from = end;
     }
     return total;
   }

--- a/src/core/token-counter.ts
+++ b/src/core/token-counter.ts
@@ -64,6 +64,49 @@ export class TokenCounter {
   }
 
   /**
+   * Longest slice handed to the tokenizer in one call.
+   *
+   * BPE COST IS SUPERLINEAR IN THE LENGTH OF A SINGLE RUN, and pathologically
+   * so on highly repetitive text, because every merge pass has more to merge.
+   * Measured on 100,000 characters:
+   *
+   *   repeated single character   23,004 ms
+   *   a 26-character cycle         6,856 ms
+   *   minified json                   28 ms
+   *   base64                          28 ms
+   *   minified javascript             18 ms
+   *
+   * Ordinary content is fine; repetitive content is not. This is not a
+   * hypothetical input either -- `count_tokens` is the most-called tool in the
+   * product (2,738 of 4,735 recorded captures), and a padding run, an ASCII
+   * separator or a repetitive blob would stall the server for twenty seconds.
+   * It surfaced as a 38-second test suite, of which one case was 23 seconds.
+   *
+   * SLICING MAKES THE COST LINEAR. A merge cannot span a slice boundary, so
+   * the count can differ slightly from an unsliced encode -- always upward, by
+   * at most one token per boundary. Measured against exact encoding at this
+   * size: prose +0.064%, minified javascript +0.013%, and the repetitive cases
+   * agree exactly. Text shorter than one slice is encoded in a single call and
+   * is bit-identical to before.
+   */
+  private static readonly ENCODE_SLICE = 8192;
+
+  /**
+   * Encodes in bounded slices, so one pathological input cannot stall a call.
+   */
+  private encodeBounded(text: string): number {
+    if (!this.encoder) return 0;
+    const slice = TokenCounter.ENCODE_SLICE;
+    if (text.length <= slice) return this.encoder.encode(text).length;
+
+    let total = 0;
+    for (let i = 0; i < text.length; i += slice) {
+      total += this.encoder.encode(text.slice(i, i + slice)).length;
+    }
+    return total;
+  }
+
+  /**
    * Count tokens in text (synchronous).
    *
    * Synchronous on tiktoken-backed tokenizers, which is all we expose
@@ -73,7 +116,7 @@ export class TokenCounter {
   count(text: string): TokenCountResult {
     if (this.encoder) {
       return {
-        tokens: this.encoder.encode(text).length,
+        tokens: this.encodeBounded(text),
         characters: text.length,
       };
     }

--- a/tests/hooks/graph-compaction.test.mjs
+++ b/tests/hooks/graph-compaction.test.mjs
@@ -170,3 +170,82 @@ describe('compaction reclaims superseded records', () => {
     expect(raw).toContain('future:1');
   });
 });
+
+describe('snapshots are bounded, because they are the whole file', () => {
+  beforeEach(() => {
+    // Small budgets, so the test does not have to write megabytes.
+    process.env.TOKEN_OPTIMIZER_GRAPH_COMPACT_BYTES = '20000';
+    process.env.TOKEN_OPTIMIZER_GRAPH_SNAPSHOT_BYTES = '3000';
+  });
+
+  afterEach(() => {
+    delete process.env.TOKEN_OPTIMIZER_GRAPH_SNAPSHOT_BYTES;
+  });
+
+  const SNAP = 'x'.repeat(1000);
+
+  it('drops the oldest snapshots and keeps the node itself', () => {
+    // Ten files, one KB of snapshot each, against a three KB budget.
+    for (let i = 0; i < 10; i++) {
+      putNode(dir, { kind: 'file', key: `/src/f${i}.ts`, hash: 'h' + i, snapshot: SNAP, at: 1000 + i });
+    }
+    // Churn to push the file past the compaction floor.
+    churn(60);
+
+    const g = load(dir);
+    const files = [...g.nodes.values()].filter((n) => n.kind === 'file' && /\/src\/f\d/.test(n.key));
+
+    // EVERY node survives. Only the snapshot field is dropped.
+    expect(files.length).toBe(10);
+    for (const f of files) expect(f.hash).toBeTruthy();
+
+    const withSnap = files.filter((f) => typeof f.snapshot === 'string');
+    expect(withSnap.length).toBeLessThan(10);
+    expect(withSnap.length).toBeGreaterThan(0);
+
+    // The NEWEST are the ones kept -- an old snapshot produces a diff the
+    // caller rejects anyway.
+    const keptKeys = withSnap.map((f) => f.key).sort();
+    expect(keptKeys).toContain('/src/f9.ts');
+    expect(keptKeys).not.toContain('/src/f0.ts');
+  });
+
+  it('never drops a snapshot a content-dependent finding relies on', () => {
+    // An OLD file, which the budget would otherwise evict first.
+    const old = putNode(dir, { kind: 'file', key: '/src/anchored.ts', hash: 'h', snapshot: SNAP, at: 1 });
+    const f = putNode(dir, {
+      kind: 'finding',
+      key: 'about-anchored',
+      type: 'finding',
+      claim: 'anchored.ts exports one thing.',
+      confidence: 0.9,
+    });
+    putEdge(dir, f, 'derived_from', old);
+
+    for (let i = 0; i < 10; i++) {
+      putNode(dir, { kind: 'file', key: `/src/n${i}.ts`, hash: 'h', snapshot: SNAP, at: 9000 + i });
+    }
+    churn(60);
+
+    const g = load(dir);
+    const anchored = g.nodes.get(old);
+    // Its evidence is what makes the staleness diff possible; losing it would
+    // silently turn a checkable claim into an unbacked one.
+    expect(typeof anchored.snapshot).toBe('string');
+    expect(anchored.snapshot.length).toBe(SNAP.length);
+  });
+
+  it('does not strip snapshots that fit inside the budget', () => {
+    process.env.TOKEN_OPTIMIZER_GRAPH_SNAPSHOT_BYTES = '10000000';
+    for (let i = 0; i < 6; i++) {
+      putNode(dir, { kind: 'file', key: `/src/keep${i}.ts`, hash: 'h', snapshot: SNAP, at: 2000 + i });
+    }
+    churn(60);
+
+    const g = load(dir);
+    const kept = [...g.nodes.values()].filter(
+      (n) => n.kind === 'file' && /keep/.test(n.key) && typeof n.snapshot === 'string'
+    );
+    expect(kept.length).toBe(6);
+  });
+});

--- a/tests/hooks/graph-compaction.test.mjs
+++ b/tests/hooks/graph-compaction.test.mjs
@@ -1,0 +1,172 @@
+/**
+ * The graph log is append-only, and nothing was reclaiming it.
+ *
+ * MEASURED on this repository's own graph before this existed: 206.6 MB across
+ * 41,810 records, of which only 6,125 ids were live -- 85.4% of the file was
+ * superseded, 97.5 MB reclaimable. `load()` parses all of it on EVERY hook
+ * invocation, so every tool call paid 1.2-1.6 seconds against a 118 ms median
+ * on a small graph.
+ *
+ * It reached us as a flaky test: a 20 s spawn budget that a loaded machine
+ * sometimes exceeded. That is the kind of failure that gets re-run rather than
+ * read, which is why "flaky" is worth treating as a defect report.
+ *
+ * The risk in compaction is silent data loss, so that is what these assert:
+ * the graph after compaction must be indistinguishable from the graph before.
+ */
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtempSync, rmSync, statSync, readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { load, putNode, putEdge, nodeId } from '../../hooks-core/wiki.mjs';
+
+let dir;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'compact-'));
+  // A low floor, so the test does not have to write eight megabytes to see the
+  // behaviour the production default is tuned for.
+  process.env.TOKEN_OPTIMIZER_GRAPH_COMPACT_BYTES = '20000';
+});
+
+afterEach(() => {
+  delete process.env.TOKEN_OPTIMIZER_GRAPH_COMPACT_BYTES;
+  try {
+    rmSync(dir, { recursive: true, force: true });
+  } catch {
+    /* windows */
+  }
+});
+
+/** Rewrites one node many times, which is what real churn looks like. */
+function churn(times, { snapshot = 'x'.repeat(400) } = {}) {
+  for (let i = 0; i < times; i++) {
+    putNode(dir, { kind: 'file', key: '/src/a.ts', hash: 'h' + i, snapshot });
+    putNode(dir, { kind: 'file', key: '/src/b.ts', hash: 'g' + i, snapshot });
+  }
+}
+
+const graphSize = () => statSync(join(dir, 'graph.jsonl')).size;
+
+describe('compaction reclaims superseded records', () => {
+  it('grows sublinearly in what is written, which is the whole point', () => {
+    // THE INVARIANT IS SUBLINEARITY, not a shrink on any given append.
+    // Compaction is amortised -- it runs once the file has doubled since the
+    // last one -- so the size sawtooths and comparing two adjacent measurements
+    // lands wherever the trigger happened to fall. My first attempt asserted
+    // exactly that and failed by 3%.
+    //
+    // What must hold is that rewriting the same nodes forever cannot grow the
+    // file without bound, which is what took the real graph to 206 MB across
+    // 41,810 records holding 6,125 live ids.
+    const SNAPSHOT = 'x'.repeat(400);
+    const WRITES = 240;
+    churn(WRITES / 2, { snapshot: SNAPSHOT });
+
+    // A generous lower bound on what an uncompacted log would have held.
+    const writtenBytes = WRITES * SNAPSHOT.length;
+    expect(graphSize()).toBeLessThan(writtenBytes / 4);
+
+    // And the live set is intact.
+    const live = load(dir).nodes;
+    expect(live.has(nodeId('file', '/src/a.ts'))).toBe(true);
+    expect(live.has(nodeId('file', '/src/b.ts'))).toBe(true);
+  });
+
+  it('holds far fewer records than were written, without losing a node', () => {
+    churn(120);
+    putNode(dir, { kind: 'file', key: '/src/c.ts', hash: 'z' });
+
+    const lines = readFileSync(join(dir, 'graph.jsonl'), 'utf8').split('\n').filter(Boolean);
+    const live = load(dir).nodes;
+
+    // 241 node writes went in; the file holds a small multiple of the live set
+    // rather than the history. Exact counts depend on where the amortised
+    // trigger fell, so this asserts the shape, not a brittle number.
+    expect(lines.length).toBeLessThan(60);
+    expect(live.has(nodeId('file', '/src/a.ts'))).toBe(true);
+    expect(live.has(nodeId('file', '/src/b.ts'))).toBe(true);
+    expect(live.has(nodeId('file', '/src/c.ts'))).toBe(true);
+    // The latest write wins, not an older superseded one.
+    expect(live.get(nodeId('file', '/src/a.ts')).hash).toBe('h119');
+  });
+
+  it('preserves edges, and does not duplicate them', () => {
+    const a = putNode(dir, { kind: 'file', key: '/src/a.ts', hash: 'h' });
+    const f = putNode(dir, { kind: 'finding', key: 'f1', claim: 'a claim', confidence: 0.9 });
+    putEdge(dir, f, 'derived_from', a);
+    // The same edge asserted repeatedly, as a re-harvest would.
+    for (let i = 0; i < 40; i++) putEdge(dir, f, 'derived_from', a);
+    churn(60);
+    putNode(dir, { kind: 'file', key: '/trigger.ts', hash: 't' });
+
+    const g = load(dir);
+    const derived = g.edges.filter((e) => e.edge === 'derived_from' && e.from === f && e.to === a);
+    expect(derived.length).toBe(1);
+    // And the finding is still anchored, which is the property that matters.
+    expect(g.nodes.has(f)).toBe(true);
+  });
+
+  it('does not compact a log that is merely large but not wasteful', () => {
+    // Distinct ids: nothing is superseded, so there is nothing to reclaim and
+    // rewriting would be pure cost. A size threshold alone would rewrite this
+    // on every append forever.
+    for (let i = 0; i < 80; i++) {
+      putNode(dir, { kind: 'file', key: `/src/f${i}.ts`, hash: 'h', snapshot: 'x'.repeat(400) });
+    }
+    const size = graphSize();
+    putNode(dir, { kind: 'file', key: '/src/last.ts', hash: 'h' });
+
+    // It may compact once (the baseline starts at the floor), but the result
+    // must still hold every distinct node.
+    const g = load(dir);
+    expect(g.nodes.size).toBeGreaterThanOrEqual(81);
+    expect(graphSize()).toBeGreaterThan(size * 0.5);
+  });
+
+  it('leaves the log intact when compaction cannot complete', () => {
+    churn(60);
+    const before = readFileSync(join(dir, 'graph.jsonl'), 'utf8');
+
+    // A directory where the temp file wants to be: the rename cannot succeed.
+    const blocker = join(dir, 'graph.jsonl.compact');
+    mkdirSync(blocker, { recursive: true });
+
+    expect(() => putNode(dir, { kind: 'file', key: '/src/d.ts', hash: 'd' })).not.toThrow();
+
+    // The original survives: a failed compaction costs space, never data.
+    const after = readFileSync(join(dir, 'graph.jsonl'), 'utf8');
+    expect(after.startsWith(before)).toBe(true);
+    expect(load(dir).nodes.has(nodeId('file', '/src/a.ts'))).toBe(true);
+  });
+
+  it('records a baseline so it cannot compact on every append', () => {
+    churn(60);
+    putNode(dir, { kind: 'file', key: '/src/c.ts', hash: 'z' });
+
+    const marker = join(dir, 'graph.compact.json');
+    expect(existsSync(marker)).toBe(true);
+    const { sizeAfter } = JSON.parse(readFileSync(marker, 'utf8'));
+    expect(sizeAfter).toBeGreaterThan(0);
+
+    // A second append right afterwards must NOT rewrite the file again.
+    const sizeBefore = graphSize();
+    putNode(dir, { kind: 'file', key: '/src/e.ts', hash: 'e' });
+    expect(graphSize()).toBeGreaterThan(sizeBefore);
+  });
+
+  it('keeps records from another schema version rather than deleting them', () => {
+    churn(60);
+    // A record load() will skip: compaction must not silently drop it.
+    writeFileSync(
+      join(dir, 'graph.jsonl'),
+      readFileSync(join(dir, 'graph.jsonl'), 'utf8') +
+        JSON.stringify({ t: 'n', v: 999, id: 'future:1', kind: 'file', key: '/future.ts' }) +
+        '\n'
+    );
+    putNode(dir, { kind: 'file', key: '/src/c.ts', hash: 'z' });
+
+    const raw = readFileSync(join(dir, 'graph.jsonl'), 'utf8');
+    expect(raw).toContain('future:1');
+  });
+});

--- a/tests/hooks/graph-compaction.test.mjs
+++ b/tests/hooks/graph-compaction.test.mjs
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * The graph log is append-only, and nothing was reclaiming it.
  *
  * MEASURED on this repository's own graph before this existed: 206.6 MB across
@@ -15,7 +15,15 @@
  * the graph after compaction must be indistinguishable from the graph before.
  */
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { mkdtempSync, rmSync, statSync, readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import {
+  mkdtempSync,
+  rmSync,
+  statSync,
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  mkdirSync,
+} from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { load, putNode, putEdge, nodeId } from '../../hooks-core/wiki.mjs';
@@ -87,7 +95,9 @@ describe('compaction reclaims superseded records', () => {
     churn(120);
     putNode(dir, { kind: 'file', key: '/src/c.ts', hash: 'z' });
 
-    const lines = readFileSync(join(dir, 'graph.jsonl'), 'utf8').split('\n').filter(Boolean);
+    const lines = readFileSync(join(dir, 'graph.jsonl'), 'utf8')
+      .split('\n')
+      .filter(Boolean);
     const live = load(dir).nodes;
 
     // 241 node writes went in; the file holds a small multiple of the live set
@@ -103,7 +113,12 @@ describe('compaction reclaims superseded records', () => {
 
   it('preserves edges, and does not duplicate them', () => {
     const a = putNode(dir, { kind: 'file', key: '/src/a.ts', hash: 'h' });
-    const f = putNode(dir, { kind: 'finding', key: 'f1', claim: 'a claim', confidence: 0.9 });
+    const f = putNode(dir, {
+      kind: 'finding',
+      key: 'f1',
+      claim: 'a claim',
+      confidence: 0.9,
+    });
     putEdge(dir, f, 'derived_from', a);
     // The same edge asserted repeatedly, as a re-harvest would.
     for (let i = 0; i < 40; i++) putEdge(dir, f, 'derived_from', a);
@@ -111,7 +126,9 @@ describe('compaction reclaims superseded records', () => {
     putNode(dir, { kind: 'file', key: '/trigger.ts', hash: 't' });
 
     const g = load(dir);
-    const derived = g.edges.filter((e) => e.edge === 'derived_from' && e.from === f && e.to === a);
+    const derived = g.edges.filter(
+      (e) => e.edge === 'derived_from' && e.from === f && e.to === a
+    );
     expect(derived.length).toBe(1);
     // And the finding is still anchored, which is the property that matters.
     expect(g.nodes.has(f)).toBe(true);
@@ -122,7 +139,12 @@ describe('compaction reclaims superseded records', () => {
     // rewriting would be pure cost. A size threshold alone would rewrite this
     // on every append forever.
     for (let i = 0; i < 80; i++) {
-      putNode(dir, { kind: 'file', key: `/src/f${i}.ts`, hash: 'h', snapshot: 'x'.repeat(400) });
+      putNode(dir, {
+        kind: 'file',
+        key: `/src/f${i}.ts`,
+        hash: 'h',
+        snapshot: 'x'.repeat(400),
+      });
     }
     const size = graphSize();
     putNode(dir, { kind: 'file', key: '/src/last.ts', hash: 'h' });
@@ -142,7 +164,9 @@ describe('compaction reclaims superseded records', () => {
     const blocker = join(dir, 'graph.jsonl.compact');
     mkdirSync(blocker, { recursive: true });
 
-    expect(() => putNode(dir, { kind: 'file', key: '/src/d.ts', hash: 'd' })).not.toThrow();
+    expect(() =>
+      putNode(dir, { kind: 'file', key: '/src/d.ts', hash: 'd' })
+    ).not.toThrow();
 
     // The original survives: a failed compaction costs space, never data.
     const after = readFileSync(join(dir, 'graph.jsonl'), 'utf8');
@@ -171,7 +195,13 @@ describe('compaction reclaims superseded records', () => {
     writeFileSync(
       join(dir, 'graph.jsonl'),
       readFileSync(join(dir, 'graph.jsonl'), 'utf8') +
-        JSON.stringify({ t: 'n', v: 999, id: 'future:1', kind: 'file', key: '/future.ts' }) +
+        JSON.stringify({
+          t: 'n',
+          v: 999,
+          id: 'future:1',
+          kind: 'file',
+          key: '/future.ts',
+        }) +
         '\n'
     );
     putNode(dir, { kind: 'file', key: '/src/c.ts', hash: 'z' });
@@ -195,15 +225,41 @@ describe('snapshots are bounded, because they are the whole file', () => {
   const SNAP = 'x'.repeat(1000);
 
   it('drops the oldest snapshots and keeps the node itself', () => {
+    // THE CLOCK IS DRIVEN, not passed as a field. `putNode` spreads the caller's
+    // properties FIRST and then writes `at: Date.now()`, deliberately, so that a
+    // caller cannot spoof bookkeeping -- which means an `at` argument here was
+    // silently discarded and all ten records took whatever timestamp the machine
+    // happened to be on.
+    //
+    // On a fast machine all ten land in one millisecond, the sort sees a tie and
+    // keeps insertion order; on a slower one they spread out. So which snapshots
+    // survived was a function of CPU speed. It passed on Node 22 locally and
+    // failed on Node 18 and 20 in CI, keeping f7 and f8 instead of f9 -- a real
+    // flake, not a platform difference.
+    //
     // Ten files, one KB of snapshot each, against a three KB budget.
-    for (let i = 0; i < 10; i++) {
-      putNode(dir, { kind: 'file', key: `/src/f${i}.ts`, hash: 'h' + i, snapshot: SNAP, at: 1000 + i });
+    const realNow = Date.now;
+    let clock = 1_700_000_000_000;
+    Date.now = () => (clock += 1000);
+    try {
+      for (let i = 0; i < 10; i++) {
+        putNode(dir, {
+          kind: 'file',
+          key: `/src/f${i}.ts`,
+          hash: 'h' + i,
+          snapshot: SNAP,
+        });
+      }
+    } finally {
+      Date.now = realNow;
     }
     // Churn to push the file past the compaction floor.
     churn(60);
 
     const g = load(dir, { snapshots: true });
-    const files = [...g.nodes.values()].filter((n) => n.kind === 'file' && /\/src\/f\d/.test(n.key));
+    const files = [...g.nodes.values()].filter(
+      (n) => n.kind === 'file' && /\/src\/f\d/.test(n.key)
+    );
 
     // EVERY node survives. Only the snapshot field is dropped.
     expect(files.length).toBe(10);
@@ -222,7 +278,13 @@ describe('snapshots are bounded, because they are the whole file', () => {
 
   it('never drops a snapshot a content-dependent finding relies on', () => {
     // An OLD file, which the budget would otherwise evict first.
-    const old = putNode(dir, { kind: 'file', key: '/src/anchored.ts', hash: 'h', snapshot: SNAP, at: 1 });
+    const old = putNode(dir, {
+      kind: 'file',
+      key: '/src/anchored.ts',
+      hash: 'h',
+      snapshot: SNAP,
+      at: 1,
+    });
     const f = putNode(dir, {
       kind: 'finding',
       key: 'about-anchored',
@@ -233,7 +295,13 @@ describe('snapshots are bounded, because they are the whole file', () => {
     putEdge(dir, f, 'derived_from', old);
 
     for (let i = 0; i < 10; i++) {
-      putNode(dir, { kind: 'file', key: `/src/n${i}.ts`, hash: 'h', snapshot: SNAP, at: 9000 + i });
+      putNode(dir, {
+        kind: 'file',
+        key: `/src/n${i}.ts`,
+        hash: 'h',
+        snapshot: SNAP,
+        at: 9000 + i,
+      });
     }
     churn(60);
 
@@ -248,13 +316,22 @@ describe('snapshots are bounded, because they are the whole file', () => {
   it('does not strip snapshots that fit inside the budget', () => {
     process.env.TOKEN_OPTIMIZER_GRAPH_SNAPSHOT_BYTES = '10000000';
     for (let i = 0; i < 6; i++) {
-      putNode(dir, { kind: 'file', key: `/src/keep${i}.ts`, hash: 'h', snapshot: SNAP, at: 2000 + i });
+      putNode(dir, {
+        kind: 'file',
+        key: `/src/keep${i}.ts`,
+        hash: 'h',
+        snapshot: SNAP,
+        at: 2000 + i,
+      });
     }
     churn(60);
 
     const g = load(dir, { snapshots: true });
     const kept = [...g.nodes.values()].filter(
-      (n) => n.kind === 'file' && /keep/.test(n.key) && typeof n.snapshot === 'string'
+      (n) =>
+        n.kind === 'file' &&
+        /keep/.test(n.key) &&
+        typeof n.snapshot === 'string'
     );
     expect(kept.length).toBe(6);
   });

--- a/tests/hooks/graph-compaction.test.mjs
+++ b/tests/hooks/graph-compaction.test.mjs
@@ -46,7 +46,17 @@ function churn(times, { snapshot = 'x'.repeat(400) } = {}) {
   }
 }
 
-const graphSize = () => statSync(join(dir, 'graph.jsonl')).size;
+// BOTH LOGS. Snapshots live in their own file now, and they are the bulk, so
+// measuring only graph.jsonl would report a shrink that merely moved bytes.
+const graphSize = () => {
+  let n = statSync(join(dir, 'graph.jsonl')).size;
+  try {
+    n += statSync(join(dir, 'snapshots.jsonl')).size;
+  } catch {
+    /* no sidecar yet */
+  }
+  return n;
+};
 
 describe('compaction reclaims superseded records', () => {
   it('grows sublinearly in what is written, which is the whole point', () => {
@@ -192,7 +202,7 @@ describe('snapshots are bounded, because they are the whole file', () => {
     // Churn to push the file past the compaction floor.
     churn(60);
 
-    const g = load(dir);
+    const g = load(dir, { snapshots: true });
     const files = [...g.nodes.values()].filter((n) => n.kind === 'file' && /\/src\/f\d/.test(n.key));
 
     // EVERY node survives. Only the snapshot field is dropped.
@@ -227,7 +237,7 @@ describe('snapshots are bounded, because they are the whole file', () => {
     }
     churn(60);
 
-    const g = load(dir);
+    const g = load(dir, { snapshots: true });
     const anchored = g.nodes.get(old);
     // Its evidence is what makes the staleness diff possible; losing it would
     // silently turn a checkable claim into an unbacked one.
@@ -242,7 +252,7 @@ describe('snapshots are bounded, because they are the whole file', () => {
     }
     churn(60);
 
-    const g = load(dir);
+    const g = load(dir, { snapshots: true });
     const kept = [...g.nodes.values()].filter(
       (n) => n.kind === 'file' && /keep/.test(n.key) && typeof n.snapshot === 'string'
     );

--- a/tests/hooks/injection.test.mjs
+++ b/tests/hooks/injection.test.mjs
@@ -155,7 +155,7 @@ describe('P4 -- the zero-turn refusal carries the answer', () => {
     const path = write('a.ts', 'export const a = 1;');
     putNode(dir, { kind: 'file', key: path, hash: 'h', snapshot: 'export const a = 1;' });
 
-    expect(refusalPayload(load(dir), path, { seenThisSession: true })).toContain('UNCHANGED');
+    expect(refusalPayload(load(dir, { snapshots: true }), path, { seenThisSession: true })).toContain('UNCHANGED');
   });
 
   test('a session that never read the file is told NEITHER of those things', () => {
@@ -172,7 +172,7 @@ describe('P4 -- the zero-turn refusal carries the answer', () => {
     // asking.
     const path = write('a.ts', 'export const a = 1;');
     putNode(dir, { kind: 'file', key: path, hash: 'h', snapshot: 'export const a = 1;' });
-    expect(refusalPayload(load(dir), path)).toBeNull();
+    expect(refusalPayload(load(dir, { snapshots: true }), path)).toBeNull();
 
     // Same for the diff branch: a diff against a baseline you never saw is not
     // an answer, it is a puzzle. Sized so the diff genuinely beats the file,
@@ -180,8 +180,8 @@ describe('P4 -- the zero-turn refusal carries the answer', () => {
     const lines = Array.from({ length: 400 }, (_, i) => `export const v${i} = ${i};`);
     const changed = write('b.ts', [...lines.slice(0, 100), 'export const CHANGED = true;', ...lines.slice(101)].join('\n'));
     putNode(dir, { kind: 'file', key: changed, hash: 'h', snapshot: lines.join('\n') });
-    expect(refusalPayload(load(dir), changed)).toBeNull();
-    expect(refusalPayload(load(dir), changed, { seenThisSession: true })).toContain('changed since');
+    expect(refusalPayload(load(dir, { snapshots: true }), changed)).toBeNull();
+    expect(refusalPayload(load(dir, { snapshots: true }), changed, { seenThisSession: true })).toContain('changed since');
   });
 
   test('a changed file yields the DIFF inside the refusal, not a redirect', () => {
@@ -198,7 +198,7 @@ describe('P4 -- the zero-turn refusal carries the answer', () => {
     const path = write('a.ts', after);
     putNode(dir, { kind: 'file', key: path, hash: 'h', snapshot: before });
 
-    const payload = refusalPayload(load(dir), path, { seenThisSession: true });
+    const payload = refusalPayload(load(dir, { snapshots: true }), path, { seenThisSession: true });
     expect(payload).toContain('+ export const CHANGED = true;');
     expect(payload).toContain('do not');
   });
@@ -211,12 +211,12 @@ describe('P4 -- the zero-turn refusal carries the answer', () => {
     const path = write('big.ts', after);
     putNode(dir, { kind: 'file', key: path, hash: 'h', snapshot: body.join('\n') });
 
-    expect(refusalPayload(load(dir), path, { seenThisSession: true }).length).toBeLessThan(after.length / 10);
+    expect(refusalPayload(load(dir, { snapshots: true }), path, { seenThisSession: true }).length).toBeLessThan(after.length / 10);
   });
 
   test('it falls back when there is no snapshot', () => {
     const path = write('a.ts', 'x');
-    expect(refusalPayload(load(dir), path, { seenThisSession: true })).toBeNull();
+    expect(refusalPayload(load(dir, { snapshots: true }), path, { seenThisSession: true })).toBeNull();
   });
 
   test('it falls back when the diff would not be cheaper than the file', () => {
@@ -226,7 +226,7 @@ describe('P4 -- the zero-turn refusal carries the answer', () => {
       kind: 'file', key: path, hash: 'h',
       snapshot: Array.from({ length: 50 }, (_, i) => `original ${i}`).join('\n'),
     });
-    expect(refusalPayload(load(dir), path, { seenThisSession: true })).toBeNull();
+    expect(refusalPayload(load(dir, { snapshots: true }), path, { seenThisSession: true })).toBeNull();
   });
 });
 

--- a/tests/hooks/path-cannot-abort-the-process.test.mjs
+++ b/tests/hooks/path-cannot-abort-the-process.test.mjs
@@ -1,7 +1,9 @@
-﻿import { describe, it, expect, beforeAll } from '@jest/globals';
+﻿import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
 import { pathToFileURL } from 'url';
 import { spawnSync } from 'child_process';
 import { join } from 'path';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
 
 /**
  * A path must never be able to ABORT the hook process.
@@ -33,6 +35,28 @@ const CORE = (name) =>
 
 /** The exact character libuv mishandles. */
 const ABORTS = String.fromCodePoint(0x10ffff);
+
+// AN ISOLATED, EMPTY GRAPH FOR EVERY SPAWN IN THIS SUITE.
+//
+// These spawns passed `cwd: process.cwd()`, so the hook resolved the project
+// root to this repository and parsed its real graph -- 207 MB at the time this
+// was written, 1.2-1.6 seconds per invocation. Four spawns against a 20 s
+// budget is fine alone and not fine alongside 139 other suites, which is why
+// this failed intermittently on a loaded machine and passed on a rerun.
+//
+// The suite is about whether a hostile PATH can abort the process. Nothing in
+// it needs the developer's accumulated graph, and depending on it made the
+// result a function of how much unrelated history happened to be on disk.
+const ISOLATED_GRAPH = mkdtempSync(join(tmpdir(), 'abort-probe-graph-'));
+const HOOK_ENV = { ...process.env, TOKEN_OPTIMIZER_WIKI_DIR: ISOLATED_GRAPH };
+
+afterAll(() => {
+  try {
+    rmSync(ISOLATED_GRAPH, { recursive: true, force: true });
+  } catch {
+    /* windows can hold a handle briefly */
+  }
+});
 /** Its neighbour, which is handled correctly -- the control for the guard. */
 const SAFE_NEIGHBOUR = String.fromCodePoint(0x10fffe);
 
@@ -122,6 +146,7 @@ describe('a path that would abort libuv', () => {
           session_id: 'abort-probe',
         }),
         encoding: 'utf8',
+        env: HOOK_ENV,
         timeout: 20_000,
       }
     );

--- a/tests/hooks/restore-marks-stale-like-inject.test.mjs
+++ b/tests/hooks/restore-marks-stale-like-inject.test.mjs
@@ -1,0 +1,50 @@
+﻿import { describe, it, expect } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * The restoration brief must mark a stale finding on the SAME rule the injector
+ * uses, or the two surfaces disagree about the same finding.
+ *
+ * `inject.mjs` demands both halves before it uses the strong framing:
+ *
+ *     if (!finding.staleEvidence || !finding.diff) { ...weak marker... }
+ *
+ * `restore.mjs` checked only `staleEvidence`, so a finding carrying evidence but
+ * no reconstructable diff was written `! STALE` in the brief and softened
+ * everywhere else. The strong marker is the one that tells a reader "this claim
+ * is contradicted and here is the proof" -- printing it with no proof to show is
+ * exactly the bare stale finding the staleness design calls worse than having no
+ * graph at all.
+ *
+ * Asserted against the SOURCE of both renderers rather than by rendering, because
+ * the defect is that two conditions drifted apart: comparing outputs would pass
+ * whenever a fixture happened to carry both fields.
+ */
+
+const core = (name) =>
+  readFileSync(join(process.cwd(), 'hooks-core', name), 'utf8');
+
+describe('the stale marker in the restoration brief', () => {
+  it('requires a diff, exactly as the injector does', () => {
+    const restore = core('restore.mjs');
+
+    // The CONDITION, not its punctuation. An earlier version of this test
+    // matched a parenthesised ternary and broke the moment prettier reformatted
+    // the same logic -- asserting shape rather than behaviour.
+    expect(restore).toMatch(/staleEvidence\s*&&\s*finding\.diff/);
+
+    // And the weak marker must still exist as the alternative, or the strong one
+    // is simply never reached.
+    expect(restore).toMatch(/'! STALE '/);
+    expect(restore).toMatch(/'~ '/);
+  });
+
+  it('still guards on staleEvidence, so the fix cannot be a blanket weakening', () => {
+    // Dropping to `finding.diff` alone would also satisfy a naive check while
+    // losing the distinction the marker exists to draw.
+    const inject = core('inject.mjs');
+
+    expect(inject).toMatch(/!finding\.staleEvidence \|\| !finding\.diff/);
+  });
+});

--- a/tests/hooks/review-fixes.test.mjs
+++ b/tests/hooks/review-fixes.test.mjs
@@ -86,14 +86,14 @@ describe('file nodes carry a snapshot, so the zero-turn refusal actually works',
 
     writeFileSync(path, [...body.slice(0, 100), 'export const CHANGED = true;', ...body.slice(101)].join('\n'));
 
-    const payload = refusalPayload(load(dir), path, { seenThisSession: true });
+    const payload = refusalPayload(load(dir, { snapshots: true }), path, { seenThisSession: true });
     expect(payload).toContain('+ export const CHANGED = true;');
   });
 
   test('an unchanged indexed file is reported as unchanged', () => {
     const path = write('a.ts', 'export const a = 1;\n');
     indexFile(dir, path);
-    expect(refusalPayload(load(dir), path, { seenThisSession: true })).toContain('UNCHANGED');
+    expect(refusalPayload(load(dir, { snapshots: true }), path, { seenThisSession: true })).toContain('UNCHANGED');
   });
 });
 

--- a/tests/hooks/staleness.test.mjs
+++ b/tests/hooks/staleness.test.mjs
@@ -14,6 +14,22 @@ import { extractSymbols, languageOf, spanText } from '../../hooks-core/symbols.m
 import { indexFile, checkAnchor, diffLines, serve, invalidateOnWrite } from '../../hooks-core/staleness.mjs';
 import { load, putNode, putEdge, nodeId } from '../../hooks-core/wiki.mjs';
 import { forTouch } from '../../hooks-core/inject.mjs';
+
+// THE HOLDOUT IS PINNED OFF IN THIS SUITE.
+//
+// `forTouch` takes part in the 10% holdout, so a temp anchor whose hash lands
+// in the withheld arm correctly returns null. This suite is about what a stale
+// finding SAYS, not about measurement.
+//
+// I introduced exactly this flake by running the suite locally with the
+// fraction already at 0, which masked it; CI runs with the default and the test
+// failed there. Verifying under a condition CI does not have is not verifying.
+const PRIOR_HOLDOUT = process.env.TOKEN_OPTIMIZER_HOLDOUT;
+process.env.TOKEN_OPTIMIZER_HOLDOUT = '0';
+afterAll(() => {
+  if (PRIOR_HOLDOUT === undefined) delete process.env.TOKEN_OPTIMIZER_HOLDOUT;
+  else process.env.TOKEN_OPTIMIZER_HOLDOUT = PRIOR_HOLDOUT;
+});
 import { canonicalPath } from '../../hooks-core/paths.mjs';
 
 let workspace;
@@ -182,6 +198,45 @@ describe('the diff invariant -- a stale finding never arrives bare', () => {
     expect(out.diff).toContain('- export function f() { return 1; }');
   });
 
+  test('a workflow rule is not invalidated by its anchor file changing', () => {
+    // MEASURED: 24 of 32 stale findings on real graphs were types whose truth
+    // cannot depend on the anchor's contents -- 75%. The clearest case is a
+    // `failure` reading "Edit hooks-core/, never the generated copies", marked
+    // stale because hooks-core/wiki.mjs changed. That rule is about process;
+    // the file's contents cannot make it wrong.
+    const path = write('churny.ts', 'export const a = 1;');
+    putNode(dir, { kind: 'file', key: path, hash: 'a-hash-that-no-longer-matches' });
+
+    const rule = putNode(dir, {
+      kind: 'finding',
+      key: 'process-rule',
+      type: 'failure',
+      claim: 'Edit hooks-core/, never the generated copies.',
+      confidence: 0.9,
+    });
+    putEdge(dir, rule, 'derived_from', nodeId('file', path));
+
+    // And a claim that IS about this file's contents, for contrast.
+    const about = putNode(dir, {
+      kind: 'finding',
+      key: 'about-the-file',
+      type: 'finding',
+      claim: 'churny.ts exports a single constant.',
+      confidence: 0.9,
+    });
+    putEdge(dir, about, 'derived_from', nodeId('file', path));
+
+    const graph = load(dir);
+    const [servedRule] = serve(graph, [graph.nodes.get(rule)]);
+    const [servedAbout] = serve(graph, [graph.nodes.get(about)]);
+
+    // The process rule stands: nothing about the file bears on it.
+    expect(servedRule.stale).toBeFalsy();
+
+    // The claim about the file's contents is still discounted, because that IS
+    // what changed. Losing this would trade one silent error for another.
+    expect(servedAbout.stale).toBe(true);
+  });
   test('a finding with genuinely unreconstructable evidence says so explicitly', () => {
     // No snapshot at all -- what a file above the snapshot limit looks like.
     const path = write('huge.ts', 'export const a = 1;');

--- a/tests/hooks/staleness.test.mjs
+++ b/tests/hooks/staleness.test.mjs
@@ -13,6 +13,7 @@ import { tmpdir } from 'node:os';
 import { extractSymbols, languageOf, spanText } from '../../hooks-core/symbols.mjs';
 import { indexFile, checkAnchor, diffLines, serve, invalidateOnWrite } from '../../hooks-core/staleness.mjs';
 import { load, putNode, putEdge, nodeId } from '../../hooks-core/wiki.mjs';
+import { forTouch } from '../../hooks-core/inject.mjs';
 import { canonicalPath } from '../../hooks-core/paths.mjs';
 
 let workspace;
@@ -191,28 +192,37 @@ describe('the diff invariant -- a stale finding never arrives bare', () => {
     const graph = load(dir);
     const [out] = serve(graph, [graph.nodes.get(finding)]);
     expect(out.stale).toBe(true);
-    // THE INVARIANT IS "never bare", not a particular sentence. The previous
-    // assertion pinned the word "unverified", which is how the wording survived
-    // long enough to be measured doing harm: identical findings scored 1/3
-    // dead-ends avoided when the model was told to treat them as unverified and
-    // 2/3 when it was not. Assert that the staleness is disclosed and that the
-    // evidence gap is named -- not the exact phrasing, which should be free to
-    // improve without a test standing in the way.
-    expect(out.diff).toBeTruthy();
-    expect(out.diff.length).toBeGreaterThan(20);
-    expect(out.diff).toMatch(/reconstruct/i);
-    // And it must carry NO instruction to abandon the claim, however phrased.
-    // The measured harm was the instruction, not one particular word, so this
-    // rejects the whole vocabulary rather than the sentence that was found
-    // doing damage -- otherwise the next rewording reintroduces it freely.
-    expect(out.diff).not.toMatch(
+
+    // THE GAP IS NAMED IN DATA, not in prose stuffed into `diff`. The previous
+    // assertion pinned the word 'reconstruct' to that field -- the very thing
+    // its own comment said should stay free to improve -- and it forced the
+    // renderer to wrap an apology in `STALE (...). What changed:`, announcing
+    // evidence and then presenting none.
+    expect(out.staleEvidence).toBe(false);
+
+    // THE INVARIANT IS ENFORCED ON THE DELIVERED TEXT, which is what a model
+    // actually reads.
+    const served = forTouch(dir, graph, path, {
+      sessionId: 'stale-render',
+      alreadyInjected: new Set(),
+    });
+    expect(served).toBeTruthy();
+
+    // Still disclosed: never served as though it were current.
+    expect(served).toMatch(/recorded earlier/i);
+
+    // But the strongest framing is not spent on the weakest evidence.
+    expect(served).not.toMatch(/STALE/);
+    expect(served).not.toMatch(/What changed:/);
+
+    // And no instruction to abandon the claim, however phrased. Measured:
+    // identical findings scored 1/3 dead-ends avoided with the discount wording
+    // and 2/3 without it.
+    expect(served).not.toMatch(
       /\b(unverified|unreliable|untrusted|discard|dismiss|disregard|ignore)\b/i
     );
-    expect(out.diff).not.toMatch(/\bdo not (trust|rely|use)\b/i);
-    // Nor may it assert a cause it has not established: `reason` carries
-    // whatever was actually determined, and this branch is also reached by
-    // eager marking and by an anchor that was never snapshotted.
-    expect(out.diff).not.toMatch(/the anchor changed/i);
+    expect(served).not.toMatch(/\bdo not (trust|rely|use)\b/i);
+    expect(served).not.toMatch(/the anchor changed/i);
   });
 });
 

--- a/tests/hooks/staleness.test.mjs
+++ b/tests/hooks/staleness.test.mjs
@@ -164,7 +164,7 @@ describe('the diff invariant -- a stale finding never arrives bare', () => {
 
   test('a fresh finding is served unmarked and without a diff', () => {
     const { finding } = seed();
-    const graph = load(dir);
+    const graph = load(dir, { snapshots: true });
     const [out] = serve(graph, [graph.nodes.get(finding)]);
     expect(out.stale).toBe(false);
     expect(out.diff).toBeUndefined();
@@ -174,7 +174,7 @@ describe('the diff invariant -- a stale finding never arrives bare', () => {
     const { path, finding } = seed();
     writeFileSync(path, 'export function f() { return 2; }');
 
-    const graph = load(dir);
+    const graph = load(dir, { snapshots: true });
     const [out] = serve(graph, [graph.nodes.get(finding)]);
 
     // Served, not dropped -- re-verifying against a diff beats re-deriving.
@@ -192,7 +192,7 @@ describe('the diff invariant -- a stale finding never arrives bare', () => {
     const { path, finding } = seed();
     rmSync(path);
 
-    const graph = load(dir);
+    const graph = load(dir, { snapshots: true });
     const [out] = serve(graph, [graph.nodes.get(finding)]);
     expect(out.stale).toBe(true);
     expect(out.diff).toContain('- export function f() { return 1; }');
@@ -226,7 +226,7 @@ describe('the diff invariant -- a stale finding never arrives bare', () => {
     });
     putEdge(dir, about, 'derived_from', nodeId('file', path));
 
-    const graph = load(dir);
+    const graph = load(dir, { snapshots: true });
     const [servedRule] = serve(graph, [graph.nodes.get(rule)]);
     const [servedAbout] = serve(graph, [graph.nodes.get(about)]);
 
@@ -244,7 +244,7 @@ describe('the diff invariant -- a stale finding never arrives bare', () => {
     const finding = putNode(dir, { kind: 'finding', key: 'f9', claim: 'about a huge file', confidence: 0.9 });
     putEdge(dir, finding, 'derived_from', nodeId('file', path));
 
-    const graph = load(dir);
+    const graph = load(dir, { snapshots: true });
     const [out] = serve(graph, [graph.nodes.get(finding)]);
     expect(out.stale).toBe(true);
 

--- a/tests/unit/token-counter.test.ts
+++ b/tests/unit/token-counter.test.ts
@@ -497,6 +497,20 @@ describe('a pathological line cannot stall the counter', () => {
     }
   });
 
+  it('counts real multi-line source exactly, not approximately', () => {
+    // The population this actually affects: files over one slice. Measured
+    // across all 344 in this repository over 8 KB, 98.0% match an exact encode
+    // and the aggregate difference is 0.00097% -- 19 tokens in 1,967,752.
+    const encoder = (counter as unknown as { encoder?: { encode(s: string): unknown[] } }).encoder;
+    if (!encoder) return;
+
+    const line = 'export const value = computeSomething(alpha, beta, gamma);';
+    const source = Array.from({ length: 400 }, (_, i) => `// ${i}` + '\n' + line).join('\n');
+    expect(source.length).toBeGreaterThan(8192);
+
+    expect(counter.count(source).tokens).toBe(encoder.encode(source).length);
+  });
+
   it('stays within a fraction of a percent of an exact encode', () => {
     // A merge cannot span a slice boundary, so the sliced count runs slightly
     // high. The bound is what makes that acceptable: if this drifts, the
@@ -508,6 +522,15 @@ describe('a pathological line cannot stall the counter', () => {
     const exact = encoder.encode(prose).length;
     const bounded = counter.count(prose).tokens;
 
+    expect(bounded).toBeGreaterThanOrEqual(exact);
+    // A TOLERANCE HERE, AND EXACTNESS IN THE TEST ABOVE, because the two
+    // inputs differ in the one way that matters: this sample is a single 96 KB
+    // line with no newline in it, so there is no boundary the pre-tokenizer
+    // respects to cut on and the slice falls where it must. Real multi-line
+    // source is exact -- 98.0% of 344 files in this repository over 8 KB.
+    //
+    // The direction is asserted too: slicing can only split a merge, never
+    // fuse one, so the count runs high and never low.
     expect(bounded).toBeGreaterThanOrEqual(exact);
     expect((bounded - exact) / exact).toBeLessThan(0.005);
   });

--- a/tests/unit/token-counter.test.ts
+++ b/tests/unit/token-counter.test.ts
@@ -462,3 +462,53 @@ describe('TokenCounter', () => {
     });
   });
 });
+
+describe('a pathological line cannot stall the counter', () => {
+  // BPE cost is superlinear in the length of a single run, and pathologically
+  // so on repetitive text. Measured before this bound, on 100,000 characters:
+  // a repeated single character took 23,004 ms and a 26-character cycle 6,856
+  // ms, while minified json, base64 and minified javascript were all under 30.
+  //
+  // `count_tokens` is the most-called tool in the product, so that is a stall
+  // reachable from ordinary use -- a padding run or a repetitive blob. It
+  // surfaced as a 38-second test suite with one 23-second case in it.
+  const counter = new TokenCounter();
+
+  it('counts a long repeated run in well under a second', () => {
+    const started = Date.now();
+    const result = counter.count('x'.repeat(100_000));
+    const elapsed = Date.now() - started;
+
+    expect(result.characters).toBe(100_000);
+    expect(result.tokens).toBeGreaterThan(0);
+    // Generous by design: this asserts the quadratic behaviour is gone, not a
+    // particular machine's speed. It was 23,004 ms.
+    expect(elapsed).toBeLessThan(3_000);
+  });
+
+  it('is unchanged for text shorter than one slice', () => {
+    // Below the slice length nothing is split, so the result must be exactly
+    // what an unsliced encode produces.
+    const text = 'The quick brown fox jumps over the lazy dog. '.repeat(20);
+    expect(text.length).toBeLessThan(8192);
+    const encoder = (counter as unknown as { encoder?: { encode(s: string): unknown[] } }).encoder;
+    if (encoder) {
+      expect(counter.count(text).tokens).toBe(encoder.encode(text).length);
+    }
+  });
+
+  it('stays within a fraction of a percent of an exact encode', () => {
+    // A merge cannot span a slice boundary, so the sliced count runs slightly
+    // high. The bound is what makes that acceptable: if this drifts, the
+    // savings numbers built on it drift too.
+    const encoder = (counter as unknown as { encoder?: { encode(s: string): unknown[] } }).encoder;
+    if (!encoder) return;
+
+    const prose = 'The quick brown fox jumps over the lazy dog. '.repeat(2200);
+    const exact = encoder.encode(prose).length;
+    const bounded = counter.count(prose).tokens;
+
+    expect(bounded).toBeGreaterThanOrEqual(exact);
+    expect((bounded - exact) / exact).toBeLessThan(0.005);
+  });
+});


### PR DESCRIPTION
Found by live-testing the newly published 5.4.3. The graph injected five findings into a real working session — and **four arrived marked STALE with no diff**, announcing evidence and then presenting an apology that none could be rebuilt.

## Measured, across every real graph on this machine

| | count | share of served |
|---|---|---|
| findings served | 241 | — |
| stale | 32 | 13.3% |
| stale **with** a real diff | 7 | 2.9% |
| stale with **no diff at all** | **25** | **10.4%** |

**78% of stale findings had no evidence behind them** — so the strongest wording available was being carried by the findings with the least justification for it.

## Why that matters

From a finding the graph itself delivered mid-session, recorded from an earlier A/B on a fresh subagent:

> identical findings scored **1/3** dead-ends avoided when rendered with the discount wording and **2/3** when rendered clean

No code changed, only the phrasing. The claims being discounted were correct every time; all that had changed was the anchor file, which says nothing about whether a claim still holds.

## The fix

The fallback prose had already been softened once. That wasn't enough, because the **renderer wraps it**: `STALE (reason). What changed:` in front of a paragraph explaining that nothing follows. The strong form was designed for the case where a diff exists and was being applied to the case where one does not.

So the prose moves out of `diff` and the fact moves into a flag. `staleEvidence` says whether anything survives; the wording becomes the renderer's business:

| evidence | rendering |
|---|---|
| diff exists | `STALE (reason). What changed:` + diff — earned |
| no diff | `(recorded earlier; <reason>, and no diff could be rebuilt)` — proportionate |

Same distinction in `restore.mjs`, which prefixed `! STALE` regardless.

## The invariant is unchanged, and now asserted where it matters

A stale finding is still never served as though it were current — but that is now checked against the **delivered text** from `forTouch`, rather than against a substring of an internal field. The old assertion pinned the word `reconstruct` to `diff`, which is exactly what its own comment said should stay free to improve.

Restoring the banner on the no-evidence path turns the test red.

```
Test Suites: 140 passed, 140 total
Tests:       4 skipped, 1779 passed, 1783 total
build 0 · format clean · hooks in sync
```

Two things caught me while writing this, both by guards already in the repo: a first-match `replace` overwrote the wrong test, and a heredoc turned `\b` into a literal backspace — the control-character test flagged it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
