### PR TITLE
fix(ci): run every verification gate, and repair the four that had rotted

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -63,6 +63,14 @@ jobs:
       # overlaid the toolbar and list, so those controls could not be clicked at
       # all. They need a browser, which is why they were never wired; that is a
       # reason to add the install step, not a reason to leave a gate unrun.
+      # BUILD FIRST. verify-wiki-ui spawns dist/server/web-server.js -- its own
+      # comment says "The server serves from dist/, not src/" -- so without a
+      # build the server never comes up and the gate fails for a reason that has
+      # nothing to do with the dashboard. It passed locally only because dist/
+      # was already there.
+      - name: Build, because the UI gates serve from dist/
+        run: npm run build
+
       - name: Install Chromium for the UI gates
         run: npx playwright install --with-deps chromium
 

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -46,6 +46,32 @@ jobs:
       - name: Verify hook core, client entries, configs and pins are in sync
         run: npm run sync:hooks:check
 
+      # WIRED BECAUSE IT ROTTED WHILE UNWIRED. verify:clients asserts the SHAPE of
+      # every client integration -- that each declares the hooks and the launch
+      # spec its own documented format requires. No workflow ran it, so it kept
+      # asserting the numeric pin that #256 removed and sat at 104/129 checks,
+      # exit 1, for anyone who happened to run it by hand. A gate nothing runs is
+      # not a gate.
+      - name: Verify client integration shapes
+        run: npm run verify:clients
+
+      - name: Verify the harvest API contract
+        run: npm run verify:harvest
+
+      # BROWSER GATES. These verify the wiki dashboard actually works -- they
+      # caught a real defect the moment they were first run: an open detail panel
+      # overlaid the toolbar and list, so those controls could not be clicked at
+      # all. They need a browser, which is why they were never wired; that is a
+      # reason to add the install step, not a reason to leave a gate unrun.
+      - name: Install Chromium for the UI gates
+        run: npx playwright install --with-deps chromium
+
+      - name: Verify the wiki dashboard renders and behaves
+        run: npm run verify:ui
+
+      - name: Verify the wiki interactions
+        run: npm run verify:interactions
+
   bundle-size:
     name: Bundle Size Analysis
     runs-on: ubuntu-latest

--- a/scripts/verify-client-configs.mjs
+++ b/scripts/verify-client-configs.mjs
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+﻿#!/usr/bin/env node
 /**
  * Validates every generated client integration.
  *
@@ -69,7 +69,14 @@ const RETIRED = [
 ];
 
 const PACKAGE_VERSION = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8')).version;
-const PACKAGE = `@ooples/token-optimizer-mcp@${PACKAGE_VERSION}`;
+// `@latest`, not the package version. #256 removed the numeric pin because it
+// is a DERIVED value release-please never bumps: it went stale for four
+// consecutive releases and shipped a plugin that launched a server three
+// versions behind. This file kept asserting the abandoned invariant, so
+// `verify:clients` exited 1 with 104/129 checks passing -- unnoticed because no
+// workflow runs it. Supply-chain pinning happens at PUBLISH time (npm provenance
+// + OIDC), never as a value committed to git.
+const PACKAGE = '@ooples/token-optimizer-mcp@latest';
 
 /**
  * Parses JSON or JSONC.
@@ -123,7 +130,7 @@ for (const [key, expected] of Object.entries(EXPECTED)) {
     check(`${key}: ${expected.file} is valid JSON`, true);
     // A pinned spec, not @latest: a committed config that floats to whatever is
     // newest is a supply-chain hazard and makes two machines irreproducible.
-    check(`${key}: pins the package version`, !raw.includes('@latest'));
+    check(`${key}: resolves the package at launch`, raw.includes('@latest'));
 
     const servers = parsed[expected.topKey];
     check(`${key}: top-level key is "${expected.topKey}"`, Boolean(servers),
@@ -194,8 +201,8 @@ for (const relative of [
     continue;
   }
   const raw = readFileSync(path, 'utf8');
-  check(`${relative}: pins the package version`, !raw.includes('@latest'));
-  check(`${relative}: names the current version`, raw.includes(PACKAGE));
+  check(`${relative}: resolves the package at launch`, raw.includes('@latest'));
+  check(`${relative}: names the package`, raw.includes(PACKAGE));
 }
 
 for (const [key, file, why] of RETIRED) {

--- a/scripts/verify-client-configs.mjs
+++ b/scripts/verify-client-configs.mjs
@@ -128,9 +128,11 @@ for (const [key, expected] of Object.entries(EXPECTED)) {
       continue;
     }
     check(`${key}: ${expected.file} is valid JSON`, true);
-    // A pinned spec, not @latest: a committed config that floats to whatever is
-    // newest is a supply-chain hazard and makes two machines irreproducible.
-    check(`${key}: resolves the package at launch`, raw.includes('@latest'));
+    // THE FULL SPEC, not the bare `@latest` suffix. `raw.includes('@latest')`
+    // passes on any dependency pinned that way, so a config that had stopped
+    // naming this package at all would still satisfy it -- the same
+    // loose-substring weakness this file exists to catch elsewhere.
+    check(`${key}: launches ${PACKAGE}`, raw.includes(PACKAGE));
 
     const servers = parsed[expected.topKey];
     check(`${key}: top-level key is "${expected.topKey}"`, Boolean(servers),
@@ -201,7 +203,7 @@ for (const relative of [
     continue;
   }
   const raw = readFileSync(path, 'utf8');
-  check(`${relative}: resolves the package at launch`, raw.includes('@latest'));
+  check(`${relative}: launches ${PACKAGE}`, raw.includes(PACKAGE));
   check(`${relative}: names the package`, raw.includes(PACKAGE));
 }
 

--- a/scripts/verify-harvest-api.mjs
+++ b/scripts/verify-harvest-api.mjs
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+﻿#!/usr/bin/env node
 /**
  * Exercises the harvest HTTP path against a local server impersonating the
  * Anthropic Messages API.
@@ -142,12 +142,32 @@ try {
   const withKnown = validate(await extract(DIGEST), { knownFiles: new Set(['/other.ts']) });
   check('anchors are held against the real file list', withKnown.length === 0);
 
-  /* ---- No key means no request at all --------------------------------- */
+  /* ---- What a missing key does, per endpoint -------------------------- */
+
+  // BOTH HALVES, because the answer depends on WHERE the request would go.
+  // This check used to assert 'no key means no request' unconditionally, which
+  // predates the local-endpoint path: a request to localhost costs nothing and
+  // discloses nothing, so it deliberately needs neither a key nor an opt-in.
+  // The endpoint here IS local (127.0.0.1 stub), so the old assertion failed --
+  // and, being unwired from CI, failed unnoticed.
 
   delete process.env.TOKEN_OPTIMIZER_API_KEY;
   lastRequest = null;
-  const unkeyed = await extract(DIGEST);
-  check('without a key it makes NO request', lastRequest === null && unkeyed.length === 0);
+  const unkeyedLocal = await extract(DIGEST);
+  check('a LOCAL endpoint needs no key', lastRequest !== null && unkeyedLocal.length > 0);
+
+  // Remote is the case the original assertion was really protecting: spending
+  // money and sending a digest off the machine must never happen unkeyed.
+  const localEndpoint = process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT;
+  process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT = 'https://api.anthropic.com/v1/messages';
+  lastRequest = null;
+  const unkeyedRemote = await extract(DIGEST);
+  check(
+    'a REMOTE endpoint without a key makes NO request',
+    lastRequest === null && unkeyedRemote.length === 0
+  );
+
+  process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT = localEndpoint;
   process.env.TOKEN_OPTIMIZER_API_KEY = 'sk-ant-test-not-a-real-key';
 
   /* ---- The privacy claim, on a realistic transcript -------------------- */

--- a/src/dashboard/public/css/wiki.css
+++ b/src/dashboard/public/css/wiki.css
@@ -442,6 +442,30 @@ body.wiki-detail-open {
   overflow: hidden;
 }
 
+/*
+ * RESERVE THE PANEL'S SPACE WHILE IT IS OPEN.
+ *
+ * `.wiki-detail` is `position: fixed; right: 0` at z-index 60, so it is outside
+ * the flow and overlays whatever sits beneath it. Nothing reserved room for it,
+ * so at ordinary viewport widths an open panel covered the right-hand end of the
+ * content -- both list rows and the graph-mode buttons in the toolbar above them --
+ * and none of it could be clicked; the pointer landed on the panel instead.
+ *
+ * Caught by verify:ui, which had never run in CI: a click on a list item timed
+ * out with 'div#wiki-detail intercepts pointer events' after the panel opened --
+ * the button it could not reach was #mode-constellation, in the toolbar.
+ * That is a usability bug, not a test artefact -- a real user with the panel
+ * open cannot reach those rows either.
+ *
+ * Applied to `main` rather than the list pane because the toolbar is a sibling of
+ * the list, not a child -- shifting only the list left the buttons underneath.
+ * Margin rather than padding so backgrounds do not extend under the panel, and
+ * the same `min()` as the panel's width so the two cannot disagree.
+ */
+body.wiki-detail-open main {
+  margin-right: min(460px, 92vw);
+}
+
 .wiki-actions {
   display: flex;
   flex-wrap: wrap;

--- a/tests/unit/every-gate-is-actually-run.test.ts
+++ b/tests/unit/every-gate-is-actually-run.test.ts
@@ -1,0 +1,74 @@
+﻿import { describe, it, expect } from '@jest/globals';
+import { readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * A gate nothing runs is not a gate.
+ *
+ * `verify:clients` checks the shape of every client integration. No workflow
+ * invoked it, so nobody noticed when #256 removed the numeric version pin and
+ * left this script still asserting it. Anyone running it by hand got:
+ *
+ *     104/129 checks passed        (exit 1)
+ *
+ * for weeks, while CI stayed green. The script was not wrong about a real
+ * invariant — it was enforcing an invariant the project had deliberately
+ * abandoned, and being unrun is what let the two drift apart.
+ *
+ * Found by an agent doing something else entirely, which is the point: nothing
+ * in the repository could have told anyone, because nothing ran it.
+ *
+ * This asserts that every verification script package.json exposes is reachable
+ * from CI. A new one added and never wired fails here rather than rotting
+ * quietly until someone runs it by accident.
+ */
+
+const ROOT = process.cwd();
+
+const scripts = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8'))
+  .scripts as Record<string, string>;
+
+const workflowText = readdirSync(join(ROOT, '.github', 'workflows'))
+  .filter((f) => /\.ya?ml$/.test(f))
+  .map((f) => readFileSync(join(ROOT, '.github', 'workflows', f), 'utf8'))
+  .join('\n');
+
+/**
+ * Scripts whose whole job is to verify something and fail the build.
+ *
+ * Matched by name rather than listed by hand, so a newly added `verify:*` is
+ * covered the day it appears instead of the day someone remembers this file.
+ */
+const gates = Object.keys(scripts).filter((name) => /^verify:/.test(name));
+
+describe('verification scripts are reachable from CI', () => {
+  it('finds some gates to check, so this cannot pass vacuously', () => {
+    expect(gates.length).toBeGreaterThan(0);
+  });
+
+  it.each(gates)('%s is executed in CI', (gate) => {
+    const body = scripts[gate];
+
+    // An AGGREGATE is covered when everything it runs is covered. `verify:all`
+    // exists for humans -- it chains the others -- so wiring it as well would
+    // just run every gate twice. The invariant is that every verification
+    // EXECUTES in CI, not that every script name appears in a workflow.
+    const parts = gates.filter((g) => g !== gate && body.includes(g));
+
+    const runsInCi = (name: string): boolean => {
+      if (workflowText.includes(`npm run ${name}`)) return true;
+      // Or via any other script a workflow does run.
+      return Object.entries(scripts).some(
+        ([outer, outerBody]) =>
+          outer !== name &&
+          outerBody.includes(name) &&
+          workflowText.includes(`npm run ${outer}`)
+      );
+    };
+
+    const reachable =
+      runsInCi(gate) || (parts.length > 0 && parts.every(runsInCi));
+
+    expect({ gate, reachable }).toEqual({ gate, reachable: true });
+  });
+});

--- a/tests/unit/every-gate-is-actually-run.test.ts
+++ b/tests/unit/every-gate-is-actually-run.test.ts
@@ -46,28 +46,47 @@ describe('verification scripts are reachable from CI', () => {
     expect(gates.length).toBeGreaterThan(0);
   });
 
+  /**
+   * Script names a body actually INVOKES, parsed rather than substring-matched.
+   *
+   * `body.includes('verify:ui')` also matches a comment, an `echo`, and the
+   * longer name `verify:ui:extra` -- so a gate could read as covered when CI
+   * never runs it. Only `npm run <name>` occurrences count, and the name must
+   * end at a word boundary.
+   */
+  const invocations = (body: string): string[] =>
+    [...body.matchAll(/npm(?:\s+--\S+)*\s+run\s+([\w:.-]+)/g)].map((m) => m[1]);
+
+  const workflowInvocations = new Set(invocations(workflowText));
+
+  /**
+   * Does CI reach this script, through any depth of wrapper?
+   *
+   * Resolved RECURSIVELY. A single hop was enough today and would quietly stop
+   * being enough the moment someone wrapped a gate twice, which is the kind of
+   * silent gap this whole file exists to prevent. `seen` bounds a cycle.
+   */
+  const runsInCi = (name: string, seen = new Set<string>()): boolean => {
+    if (seen.has(name)) return false;
+    seen.add(name);
+    if (workflowInvocations.has(name)) return true;
+    return Object.entries(scripts).some(
+      ([outer, outerBody]) =>
+        outer !== name &&
+        invocations(outerBody).includes(name) &&
+        runsInCi(outer, seen)
+    );
+  };
+
   it.each(gates)('%s is executed in CI', (gate) => {
-    const body = scripts[gate];
-
-    // An AGGREGATE is covered when everything it runs is covered. `verify:all`
-    // exists for humans -- it chains the others -- so wiring it as well would
-    // just run every gate twice. The invariant is that every verification
-    // EXECUTES in CI, not that every script name appears in a workflow.
-    const parts = gates.filter((g) => g !== gate && body.includes(g));
-
-    const runsInCi = (name: string): boolean => {
-      if (workflowText.includes(`npm run ${name}`)) return true;
-      // Or via any other script a workflow does run.
-      return Object.entries(scripts).some(
-        ([outer, outerBody]) =>
-          outer !== name &&
-          outerBody.includes(name) &&
-          workflowText.includes(`npm run ${outer}`)
-      );
-    };
+    // An AGGREGATE is covered when everything it invokes is covered.
+    // `verify:all` chains the others, so wiring it too would run every gate
+    // twice. The invariant is that every verification EXECUTES, not that every
+    // script name appears somewhere in a workflow file.
+    const parts = invocations(scripts[gate]).filter((g) => gates.includes(g));
 
     const reachable =
-      runsInCi(gate) || (parts.length > 0 && parts.every(runsInCi));
+      runsInCi(gate) || (parts.length > 0 && parts.every((p) => runsInCi(p)));
 
     expect({ gate, reachable }).toEqual({ gate, reachable: true });
   });


### PR DESCRIPTION
`verify:all` was red and nobody knew, because **no workflow ran any of it**. Four of the five verification scripts had never executed in CI. Every one of them failed:

| gate | exit | detail |
| --- | --- | --- |
| `verify:clients` | 1 | 104/129 — asserting the numeric pin #256 removed |
| `verify:harvest` | 1 | 25/26 — asserting no-key-no-request, which the local-endpoint path deliberately changed |
| `verify:ui` | 1 | a real dashboard defect (below) |
| `verify:interactions` | 1 | same defect |

## Two were enforcing decisions the project had already reversed

That is the same shape twice: a decision was made, the gate enforcing the old rule was never updated, and **being unrun is what let them drift apart silently.**

Both now assert the current rule. The harvest one is strictly *stronger* than before — it checks that a **local** endpoint needs no key (free, private, deliberate) **and** that a **remote** one without a key still makes no request, which is the half that actually protects the user from surprise spend and disclosure.

## The UI gates caught a real bug the first time they ran

`.wiki-detail` is `position: fixed; right: 0` at `z-index: 60`, and nothing reserved room for it. An open detail panel overlaid the right-hand end of the content — including the graph-mode buttons in the toolbar — so none of it could be clicked:

```
div#wiki-detail intercepts pointer events   (click on #mode-constellation timed out)
```

A user with the panel open cannot reach those controls either. This is not a test artefact.

`main` now reserves the panel's width while it is open. That took two attempts: the margin first went on the list pane, but the toolbar is its **sibling**, not its child, so the buttons stayed underneath. Measuring which element the click actually hit is what settled it, rather than guessing at CSS again.

## All five now pass, and all five now run

```
clients      129/129
harvest       27/27
ui            22/22
interactions  57/57
verify:all    exit 0
```

Wired into `quality-gates.yml`, the browser ones behind a `playwright install --with-deps chromium` step. Needing a browser is a reason to add the step, not a reason to leave a gate unrun.

## A ratchet, so this cannot recur

`tests/unit/every-gate-is-actually-run.test.ts` asserts every `verify:*` script executes in CI, matched by name pattern so one added later is covered the day it appears rather than the day someone remembers. An aggregate counts as covered when everything it chains is covered, so `verify:all` does not force a duplicate run of all five.

Found by an agent doing something unrelated — which is the point. Nothing in the repository could have reported this, because nothing ran it.

## Gates

132 suites, 1,582 passed, 4 skipped. `tsc --noEmit` clean. eslint 0 errors. `prettier --check` clean. `sync:hooks:check` clean.