### PR TITLE
fix(search): make count mode actually return counts

### DIFF
--- a/src/tools/file-operations/smart-grep.ts
+++ b/src/tools/file-operations/smart-grep.ts
@@ -119,7 +119,14 @@ export interface SmartGrepResult {
   };
   matches?: GrepMatch[]; // Matches (if not filesWithMatches or count mode)
   files?: string[]; // Files with matches (if filesWithMatches mode)
-  counts?: Map<string, number>; // Match counts per file (if count mode)
+  /**
+   * Match counts per file, when `count` is set.
+   *
+   * A Record rather than a Map on purpose: this crosses a JSON boundary, and a
+   * Map serialises to `{}`. The type used to say Map, which was accurate about
+   * the value and wrong about what the caller received.
+   */
+  counts?: Record<string, number>;
   error?: string;
 }
 
@@ -462,7 +469,13 @@ export class SmartGrepTool {
           duration: 0, // Will be set below
           cacheHit: false,
         },
-        ...(opts.count ? { counts: matchCounts } : {}),
+        // PLAIN OBJECT, not the Map. This result is JSON-serialised on its way
+        // to every caller, and a Map stringifies to `{}` -- so count mode
+        // returned an empty counts map beside a correct totalMatches, which is
+        // the one thing the flag exists to provide. The cache path a few lines
+        // up already used Object.fromEntries; only the returned object was
+        // wrong, so the two disagreed about the same query.
+        ...(opts.count ? { counts: Object.fromEntries(matchCounts) } : {}),
         ...(opts.filesWithMatches
           ? { files: Array.from(filesWithMatches) }
           : {}),

--- a/tests/unit/grep-count-mode-survives-json.test.ts
+++ b/tests/unit/grep-count-mode-survives-json.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { SmartGrepTool } from '../../src/tools/file-operations/smart-grep.js';
+import { CacheEngine } from '../../src/core/cache-engine.js';
+import { TokenCounter } from '../../src/core/token-counter.js';
+import { MetricsCollector } from '../../src/core/metrics.js';
+
+/**
+ * `count: true` must actually deliver the counts.
+ *
+ * The result carried `counts` as a `Map`, and a Map does not survive
+ * `JSON.stringify` -- it serialises to `{}`. Every caller across the MCP
+ * boundary therefore received:
+ *
+ *     { success: true, metadata: { totalMatches: 11, filesWithMatches: 1 },
+ *       counts: {} }
+ *
+ * Totals present, per-file counts silently empty, which is the whole documented
+ * purpose of the flag ("Only return match counts per file").
+ *
+ * Found live: asked for counts over a file with 11 matches and got `{}` beside a
+ * `totalMatches: 11`. The internal cache path already did it correctly with
+ * `Object.fromEntries`; only the returned object was wrong, so the two disagreed
+ * about the same query.
+ *
+ * TypeScript could not catch it: `Map<string, number>` is a perfectly good type
+ * for a field that is about to be serialised, and nothing in the type system
+ * says this object crosses a JSON boundary.
+ */
+
+let dir: string;
+let cache: CacheEngine;
+let tokenCounter: TokenCounter;
+let metrics: MetricsCollector;
+
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), 'grep-count-'));
+  mkdirSync(join(dir, 'src'), { recursive: true });
+  writeFileSync(
+    join(dir, 'src', 'a.ts'),
+    'export function one() {}\nexport function two() {}\n'
+  );
+  writeFileSync(join(dir, 'src', 'b.ts'), 'export function three() {}\n');
+  writeFileSync(join(dir, 'src', 'none.ts'), 'const x = 1;\n');
+
+  cache = new CacheEngine(join(dir, 'cache'), 10);
+  tokenCounter = new TokenCounter();
+  metrics = new MetricsCollector();
+});
+
+afterAll(() => {
+  try {
+    cache.close?.();
+  } catch {
+    // temp dir goes anyway
+  }
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('smart_grep count mode', () => {
+  it('returns per-file counts that survive JSON serialisation', async () => {
+    const tool = new SmartGrepTool(cache, tokenCounter, metrics);
+
+    const result = await tool.grep('export function', {
+      path: dir,
+      count: true,
+    });
+
+    // THROUGH JSON, because that is how every real caller receives it. Asserting
+    // on the in-process object would pass with a Map and prove nothing.
+    const overTheWire = JSON.parse(JSON.stringify(result));
+
+    expect(Object.keys(overTheWire.counts ?? {}).length).toBeGreaterThan(0);
+  });
+
+  it('counts each file correctly', async () => {
+    const tool = new SmartGrepTool(cache, tokenCounter, metrics);
+
+    const result = await tool.grep('export function', {
+      path: dir,
+      count: true,
+    });
+    const counts = JSON.parse(JSON.stringify(result)).counts as Record<
+      string,
+      number
+    >;
+
+    const byName = Object.fromEntries(
+      Object.entries(counts).map(([path, n]) => [
+        path.replace(/^.*[\\/]/, ''),
+        n,
+      ])
+    );
+
+    expect(byName['a.ts']).toBe(2);
+    expect(byName['b.ts']).toBe(1);
+    expect(byName['none.ts']).toBeUndefined();
+  });
+
+  it('agrees with the totals it reports beside them', async () => {
+    // The two came from different code paths and disagreed: totals were right
+    // while counts were empty.
+    const tool = new SmartGrepTool(cache, tokenCounter, metrics);
+
+    const result = await tool.grep('export function', {
+      path: dir,
+      count: true,
+    });
+    const wire = JSON.parse(JSON.stringify(result));
+    const summed = Object.values(wire.counts as Record<string, number>).reduce(
+      (a, b) => a + b,
+      0
+    );
+
+    expect(summed).toBe(wire.metadata.totalMatches);
+  });
+});


### PR DESCRIPTION
`count: true` returned an empty map.

The result carried `counts` as a **`Map`**, and a Map does not survive `JSON.stringify` — it serialises to `{}`. So every caller across the MCP boundary received:

```json
{ "success": true,
  "metadata": { "totalMatches": 11, "filesWithMatches": 1 },
  "counts": {} }
```

Totals correct. Per-file counts silently empty — which is the entire documented purpose of the flag ("Only return match counts per file").

## Found by using the tool

Asked for counts over a file with 11 matches and got `{}` sitting beside `totalMatches: 11`.

The two came from **different code paths**: the cache path a few lines up already did `Object.fromEntries(matchCounts)`. So the same query disagreed with itself depending on which branch produced the answer — the cached result was right and the fresh one was empty.

## Why the type system was no help

`Map<string, number>` is a perfectly good type for the value. Nothing in TypeScript says "this object is about to cross a JSON boundary", so tsc had no reason to object. The declared type is now `Record<string, number>` — both what is actually sent and what a caller can rely on.

## The test asserts through the wire

```ts
const overTheWire = JSON.parse(JSON.stringify(result));
```

Asserting on the in-process object passes with a `Map` and proves nothing. That is precisely how this survived.

Three assertions: counts are non-empty, each file's count is right (`a.ts` 2, `b.ts` 1, `none.ts` absent), and the counts **sum to the `totalMatches` reported beside them** — the two numbers that previously disagreed.

## Defect class swept, not just the instance

Checked every `Map` in a result position across `src/tools`. All others are internal parameters or already converted — `smart-typescript` keeps a `Map` internally and exposes an `Array`. This was the only one crossing the boundary.

## Gates

136 suites, 1,605 passed, 4 skipped. `tsc --noEmit` clean. eslint 0 errors. `prettier --check` clean.