### PR TITLE
fix(edit): report the real line count, not the split artefact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,41 +288,36 @@ jobs:
           name: dist-${{ github.sha }}
           path: dist/
 
-      - name: Start MCP server
-        run: |
-          # Start the server in the background
-          npm start &
-          SERVER_PID=$!
-          echo "SERVER_PID=$SERVER_PID" >> $GITHUB_ENV
-
-          # Wait for server to be ready (max 30 seconds)
-          echo "Waiting for server to start..."
-          for i in {1..30}; do
-            if nc -z localhost 3000 2>/dev/null; then
-              echo "Server is ready!"
-              break
-            fi
-            sleep 1
-          done
-        timeout-minutes: 2
-
+      # THIS GATE COULD NOT FAIL, AND IT RAN THE SUITE TWICE.
+      #
+      # The step was:
+      #
+      #   if [ -f "package.json" ] && npm run --silent test:integration 2>/dev/null; then
+      #     npm run test:integration
+      #   else
+      #     echo "Integration tests not yet implemented, skipping"
+      #     exit 0
+      #   fi
+      #
+      # Jest writes its summary to stderr, so the run inside the condition was
+      # invisible -- and it was a real run, so the suite executed twice on every
+      # green build. Worse, a FAILING suite made the condition false and the job
+      # printed "not yet implemented" and exited 0. A broken integration suite
+      # reported a green tick. `test:integration` has existed for as long as
+      # tests/integration has, so that branch was never true for its stated
+      # reason either.
+      #
+      # The "Start MCP server" step that preceded it was also inert: this server
+      # speaks JSON-RPC on stdio and never listens on a socket, so `npm start &`
+      # read EOF and logged "shutting down (stdin end)" within two seconds while
+      # the readiness loop spent its full 30 s waiting for `nc -z localhost 3000`
+      # to answer. Measured in run 31097636811: 11:32:46 to 11:33:16, then the
+      # tests ran anyway. The suite spawns the server itself, which is the only
+      # way to talk to a stdio process, so nothing needed starting.
       - name: Run integration tests
-        run: |
-          if [ -f "package.json" ] && npm run --silent test:integration 2>/dev/null; then
-            npm run test:integration
-          else
-            echo "Integration tests not yet implemented, skipping"
-            exit 0
-          fi
+        run: npm run test:integration
         env:
           NODE_OPTIONS: --experimental-vm-modules
-
-      - name: Stop MCP server
-        if: always()
-        run: |
-          if [ -n "$SERVER_PID" ]; then
-            kill $SERVER_PID || true
-          fi
 
       - name: Upload integration test logs
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,17 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # BUILD BEFORE TESTING. tests/integration/mcp-stdio-contract.test.ts
+      # spawns dist/server/index.js -- the file package.json lists in `bin` --
+      # and speaks JSON-RPC to it, because that is the only way to catch defects
+      # that live in the serialisation boundary rather than in the tool classes.
+      # (smart_grep returned its per-file counts as a Map, which is fine
+      # in-process and arrives as `{}` over the wire; every in-process test
+      # passed.) Without this step dist/ does not exist and that suite fails
+      # outright.
+      - name: Build, because the stdio contract suite drives dist/
+        run: npm run build
+
       - name: Run tests with coverage
         run: npm run test:ci
         env:

--- a/.github/workflows/codex-autofix.yml
+++ b/.github/workflows/codex-autofix.yml
@@ -56,9 +56,14 @@ jobs:
             run the test suite, identify the minimal change needed to make all tests pass, implement only that change,
             and stop. Do not refactor unrelated code or files. Keep changes small and surgical.
           sandbox: workspace-write
+      # The stdio contract suite drives dist/server/index.js, so the build has to
+      # happen here too -- otherwise this gate fails for a missing artefact
+      # rather than for anything Codex did or did not fix.
       - name: Verify tests
         if: ${{ env.OPENAI_API_KEY != '' }}
-        run: npm test --silent
+        run: |
+          npm run build
+          npm test --silent
       - name: Create pull request with fixes
         if: ${{ success() && env.OPENAI_API_KEY != '' }}
         uses: peter-evans/create-pull-request@v6

--- a/src/tools/file-operations/smart-edit.ts
+++ b/src/tools/file-operations/smart-edit.ts
@@ -167,12 +167,13 @@ export class SmartEditTool {
       // The split array itself is left alone: the edit machinery rebuilds the
       // content by joining it, and dropping the element would silently strip
       // the trailing newline from every file it touches.
-      const endsWithNewline =
-        originalContent.length > 0 &&
-        originalContent.charCodeAt(originalContent.length - 1) === 10;
-      const lineCount = endsWithNewline
-        ? Math.max(0, originalLines.length - 1)
-        : originalLines.length;
+      const countLines = (text: string): number => {
+        const parts = text.split(/\r?\n/);
+        const trailing =
+          text.length > 0 && text.charCodeAt(text.length - 1) === 10;
+        return trailing ? Math.max(0, parts.length - 1) : parts.length;
+      };
+      const lineCount = countLines(originalContent);
       const originalTokens = this.tokenCounter.count(originalContent).tokens;
 
       // Small-file guard: for tiny files the unified-diff + metadata payload
@@ -202,6 +203,20 @@ export class SmartEditTool {
       const editedContent = editedLines
         .map((line) => line.split(/\r?\n/).join(eol))
         .join(eol);
+
+      // THE SAME RULE ON BOTH SIDES OF THE REPORT.
+      //
+      // `originalLines` counts logical lines, so `finalLines` must too.
+      // `editedLines.length` counts array elements, which still include the
+      // trailing empty one, so an ordinary edit to a ten-line file reported
+      // `originalLines: 10, finalLines: 11` -- a caller reading those two numbers
+      // sees a line appear out of an edit that added none, and the metadata is
+      // the only thing it has to go on, because the file contents are exactly
+      // what smart_edit exists not to return.
+      //
+      // Derived from the CONTENT rather than the array for the same reason the
+      // original count is: the array is a join artefact, the content is the file.
+      const finalLines = countLines(editedContent);
 
       // Check if content actually changed
       if (editedContent === originalContent) {
@@ -247,7 +262,7 @@ export class SmartEditTool {
             editsApplied: applied,
             linesChanged: 0,
             originalLines: lineCount,
-            finalLines: editedLines.length,
+            finalLines,
             tokensSaved: unchangedSaved,
             tokenCount: 50,
             originalTokenCount: originalTokens,
@@ -299,7 +314,7 @@ export class SmartEditTool {
             editsApplied: applied,
             linesChanged: diff.added.length + diff.removed.length,
             originalLines: lineCount,
-            finalLines: editedLines.length,
+            finalLines,
             tokensSaved,
             tokenCount: diffTokens,
             originalTokenCount: originalTokens,
@@ -355,7 +370,7 @@ export class SmartEditTool {
           editsApplied: applied,
           linesChanged: diff.added.length + diff.removed.length,
           originalLines: lineCount,
-          finalLines: editedLines.length,
+          finalLines,
           tokensSaved,
           tokenCount: diffTokens,
           originalTokenCount: originalTokens,
@@ -410,10 +425,52 @@ export class SmartEditTool {
     operations: EditOperation[],
     totalLines: number
   ): void {
+    const KNOWN = new Set(['replace', 'insert', 'delete']);
+
     for (const op of operations) {
-      if (op.startLine < 1 || op.startLine > totalLines + 1) {
+      // A MALFORMED OPERATION IS REFUSED, NOT IGNORED.
+      //
+      // Every check below reads fields off `op`, and `undefined < 1` and
+      // `undefined > 11` are both false -- so an object that is not an operation
+      // at all passed validation untouched, reached `applyEdits`, matched no
+      // branch of its switch, and came back as "unchanged, nothing applied".
+      //
+      // That is not hypothetical. The tests written for this very defect called
+      // `edit(path, { operations: [...] })` when the signature is
+      // `edit(path, operations, options)`, so every one of them handed this
+      // function a single `{ operations: [...] }` object. They passed -- the file
+      // really was untouched and the call really did report failure -- while
+      // exercising none of the behaviour they named. The operations reaching this
+      // tool come from a JSON boundary, so a caller can make the same mistake.
+      if (!op || typeof op !== 'object' || !KNOWN.has(op.type)) {
         throw new Error(
-          `Invalid startLine: ${op.startLine} (file has ${totalLines} lines)`
+          `Invalid operation type: ${JSON.stringify(op?.type)} (expected replace, insert or delete)`
+        );
+      }
+      if (!Number.isInteger(op.startLine)) {
+        throw new Error(
+          `Invalid startLine: ${JSON.stringify(op.startLine)} (expected a 1-based integer line number)`
+        );
+      }
+
+      // ONE PAST THE END IS AN `insert` POSITION, AND ONLY THAT.
+      //
+      // `totalLines + 1` names the point after the last line, which is where an
+      // append goes -- a real and necessary operation. It does not name a line,
+      // so nothing can be replaced or deleted there.
+      //
+      // The array being edited still carries the trailing empty element left by
+      // splitting content that ends with a newline, so `replace` and `delete` at
+      // that index did not fail: they hit the phantom. Measured on a 10-line
+      // file, both returned success with `verified: true` and both stripped the
+      // file's trailing newline -- `replace` by appending its content past the
+      // last line, `delete` by removing the separator itself.
+      const maxStart = op.type === 'insert' ? totalLines + 1 : totalLines;
+      if (op.startLine < 1 || op.startLine > maxStart) {
+        throw new Error(
+          op.type === 'insert'
+            ? `Invalid startLine: ${op.startLine} (file has ${totalLines} lines; insert accepts up to ${maxStart})`
+            : `Invalid startLine: ${op.startLine} (file has ${totalLines} lines; only insert may address line ${totalLines + 1})`
         );
       }
 

--- a/src/tools/file-operations/smart-edit.ts
+++ b/src/tools/file-operations/smart-edit.ts
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Smart Edit Tool - 90% Token Reduction
  *
  * Achieves token reduction through:
@@ -155,6 +155,24 @@ export class SmartEditTool {
       // check fails -- and it compounds with every subsequent edit.
       const eol = detectLineEnding(originalContent);
       const originalLines = originalContent.split(/\r?\n/);
+      // THE REAL LINE COUNT, which is not `originalLines.length`.
+      //
+      // Splitting content that ends with a newline leaves a trailing empty
+      // element -- a 10-line file yields 11 -- and that number was both reported
+      // to the caller and used to validate their operations. So the tool
+      // advertised a line that does not exist and then accepted a `replace`
+      // against it: measured, that returned success with verified: true,
+      // appended the content, and destroyed the file's trailing newline.
+      //
+      // The split array itself is left alone: the edit machinery rebuilds the
+      // content by joining it, and dropping the element would silently strip
+      // the trailing newline from every file it touches.
+      const endsWithNewline =
+        originalContent.length > 0 &&
+        originalContent.charCodeAt(originalContent.length - 1) === 10;
+      const lineCount = endsWithNewline
+        ? Math.max(0, originalLines.length - 1)
+        : originalLines.length;
       const originalTokens = this.tokenCounter.count(originalContent).tokens;
 
       // Small-file guard: for tiny files the unified-diff + metadata payload
@@ -171,7 +189,7 @@ export class SmartEditTool {
       const ops = Array.isArray(operations) ? operations : [operations];
 
       // Validate operations
-      this.validateOperations(ops, originalLines.length);
+      this.validateOperations(ops, lineCount);
 
       // Apply edits
       const { lines: editedLines, applied } = this.applyEdits(
@@ -228,7 +246,7 @@ export class SmartEditTool {
           metadata: {
             editsApplied: applied,
             linesChanged: 0,
-            originalLines: originalLines.length,
+            originalLines: lineCount,
             finalLines: editedLines.length,
             tokensSaved: unchangedSaved,
             tokenCount: 50,
@@ -280,7 +298,7 @@ export class SmartEditTool {
           metadata: {
             editsApplied: applied,
             linesChanged: diff.added.length + diff.removed.length,
-            originalLines: originalLines.length,
+            originalLines: lineCount,
             finalLines: editedLines.length,
             tokensSaved,
             tokenCount: diffTokens,
@@ -336,7 +354,7 @@ export class SmartEditTool {
         metadata: {
           editsApplied: applied,
           linesChanged: diff.added.length + diff.removed.length,
-          originalLines: originalLines.length,
+          originalLines: lineCount,
           finalLines: editedLines.length,
           tokensSaved,
           tokenCount: diffTokens,

--- a/tests/integration/mcp-stdio-contract.test.ts
+++ b/tests/integration/mcp-stdio-contract.test.ts
@@ -1,0 +1,348 @@
+﻿import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import { spawn, type ChildProcessWithoutNullStreams } from 'child_process';
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  statSync,
+  readdirSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+/** Newest mtime of any .ts under a directory, walked recursively. */
+function newestMtime(dir: string): number {
+  let newest = 0;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      newest = Math.max(newest, newestMtime(full));
+    } else if (entry.name.endsWith('.ts')) {
+      newest = Math.max(newest, statSync(full).mtimeMs);
+    }
+  }
+  return newest;
+}
+
+/**
+ * What a REAL CLIENT receives, over the real transport.
+ *
+ * Every other test in this repository calls the tool classes in-process. That is
+ * a different thing from what an MCP client gets, and the gap is not theoretical:
+ * `smart_grep`'s count mode returned its per-file counts as a `Map`, which is a
+ * perfectly good object in-process and serialises to `{}` the moment it crosses
+ * the wire. Callers saw:
+ *
+ *     { "metadata": { "totalMatches": 11 }, "counts": {} }
+ *
+ * An in-process assertion passes on the Map and proves nothing. Nothing in the
+ * suite drove the server over stdio, so nothing could have caught it.
+ *
+ * This spawns the BUILT server exactly as a client does -- `dist/server/index.js`,
+ * the file `package.json` lists in `bin` -- speaks JSON-RPC over stdin/stdout,
+ * and asserts on the parsed response. Anything that cannot survive
+ * JSON.stringify fails here.
+ *
+ * The server is started once and shared: startup dominates the cost, and these
+ * are read-only calls against fixtures in a temp directory.
+ */
+
+const ROOT = process.cwd();
+const SERVER = join(ROOT, 'dist', 'server', 'index.js');
+
+let server: ChildProcessWithoutNullStreams;
+let fixtures: string;
+let nextId = 1;
+let stdoutBuffer = '';
+const pending = new Map<number, (value: unknown) => void>();
+
+/** One JSON-RPC round trip. Resolves with the `result` object. */
+function call(
+  method: string,
+  params: unknown,
+  timeoutMs = 30_000
+): Promise<any> {
+  const id = nextId++;
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`timed out waiting for ${method} (id ${id})`)),
+      timeoutMs
+    );
+    pending.set(id, (value) => {
+      clearTimeout(timer);
+      resolve(value);
+    });
+    server.stdin.write(
+      `${JSON.stringify({ jsonrpc: '2.0', id, method, params })}\n`
+    );
+  });
+}
+
+/** The tool payload, parsed back out of the text content block. */
+async function callTool(name: string, args: unknown): Promise<any> {
+  const result = await call('tools/call', { name, arguments: args });
+  const text = result?.content?.[0]?.text;
+  expect(typeof text).toBe('string');
+  return JSON.parse(text);
+}
+
+beforeAll(async () => {
+  // The built output is what ships and what a client runs. Testing src/ here
+  // would miss anything the build itself changes.
+  if (!existsSync(SERVER)) {
+    throw new Error(
+      `${SERVER} is missing -- run \`npm run build\` before the integration suite`
+    );
+  }
+
+  // A STALE dist is worse than a missing one. Missing fails loudly; stale runs
+  // the previous build's code and reports green, which is precisely the false
+  // reassurance this suite exists to remove -- it would have "passed" against
+  // the Map-returning grep after the fix was written but before it was compiled.
+  const built = statSync(SERVER).mtimeMs;
+  const newestSource = newestMtime(join(ROOT, 'src'));
+  if (newestSource > built) {
+    throw new Error(
+      `${SERVER} is older than src/ -- run \`npm run build\`, or this suite ` +
+        `tests the previous build and passes for the wrong reason`
+    );
+  }
+
+  fixtures = mkdtempSync(join(tmpdir(), 'mcp-contract-'));
+  mkdirSync(join(fixtures, 'src'), { recursive: true });
+  writeFileSync(
+    join(fixtures, 'src', 'a.ts'),
+    'export function one() {}\nexport function two() {}\n'
+  );
+  writeFileSync(join(fixtures, 'src', 'b.ts'), 'export function three() {}\n');
+  writeFileSync(join(fixtures, 'src', 'quiet.ts'), 'const x = 1;\n');
+  writeFileSync(
+    join(fixtures, 'ten.txt'),
+    'L01\nL02\nL03\nL04\nL05\nL06\nL07\nL08\nL09\nL10\n'
+  );
+  // A dot-directory, because those were invisible to search entirely.
+  mkdirSync(join(fixtures, '.github', 'workflows'), { recursive: true });
+  writeFileSync(
+    join(fixtures, '.github', 'workflows', 'ci.yml'),
+    'name: CI\njobs:\n  build:\n    env:\n      T: ${{ secrets.GITHUB_TOKEN }}\n'
+  );
+
+  server = spawn(process.execPath, [SERVER], {
+    cwd: fixtures,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: {
+      ...process.env,
+      // Keep the server's own graph and state out of the developer's real ones.
+      TOKEN_OPTIMIZER_WIKI_DIR: join(fixtures, '.wiki'),
+      TOKEN_OPTIMIZER_STATE_DIR: join(fixtures, '.state'),
+    },
+  });
+
+  server.stdout.setEncoding('utf8');
+  server.stdout.on('data', (chunk: string) => {
+    stdoutBuffer += chunk;
+    // JSON-RPC over stdio is newline-delimited; a chunk may carry part of a line.
+    let newline = stdoutBuffer.indexOf('\n');
+    while (newline !== -1) {
+      const line = stdoutBuffer.slice(0, newline).trim();
+      stdoutBuffer = stdoutBuffer.slice(newline + 1);
+      if (line) {
+        try {
+          const message = JSON.parse(line);
+          const resolver = pending.get(message.id);
+          if (resolver) {
+            pending.delete(message.id);
+            resolver(message.result ?? message.error);
+          }
+        } catch {
+          // Server diagnostics on stdout are not our concern here.
+        }
+      }
+      newline = stdoutBuffer.indexOf('\n');
+    }
+  });
+
+  await call('initialize', {
+    protocolVersion: '2024-11-05',
+    capabilities: {},
+    clientInfo: { name: 'contract-test', version: '0.0.0' },
+  });
+  server.stdin.write(
+    `${JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' })}\n`
+  );
+}, 60_000);
+
+afterAll(async () => {
+  // AWAIT THE EXIT before removing the directory. `kill()` only signals, and on
+  // Windows the still-open handles make rmSync throw EBUSY -- which fails the
+  // whole suite after every assertion has already passed.
+  if (server && server.exitCode === null) {
+    await new Promise<void>((resolve) => {
+      const done = setTimeout(resolve, 5_000);
+      server.once('exit', () => {
+        clearTimeout(done);
+        resolve();
+      });
+      try {
+        server.kill();
+      } catch {
+        clearTimeout(done);
+        resolve();
+      }
+    });
+  }
+
+  // Best effort: a leftover temp directory is not worth failing a green run.
+  try {
+    rmSync(fixtures, { recursive: true, force: true });
+  } catch {
+    /* the OS reclaims it */
+  }
+});
+
+describe('the server answers over stdio at all', () => {
+  it('lists its tools', async () => {
+    // If this fails everything below is meaningless, so it is asserted first
+    // rather than assumed.
+    const result = await call('tools/list', {});
+
+    expect(Array.isArray(result?.tools)).toBe(true);
+    expect(result.tools.length).toBeGreaterThan(0);
+    expect(result.tools.map((t: { name: string }) => t.name)).toContain(
+      'smart_grep'
+    );
+  });
+});
+
+describe('smart_grep over the wire', () => {
+  it('delivers per-file counts, which a Map could not', async () => {
+    // THE REGRESSION THIS FILE EXISTS FOR. `counts` was a Map and arrived as {}.
+    const payload = await callTool('smart_grep', {
+      pattern: 'export function',
+      path: fixtures,
+      count: true,
+    });
+
+    expect(payload.metadata.totalMatches).toBe(3);
+    expect(Object.keys(payload.counts ?? {}).length).toBeGreaterThan(0);
+
+    const summed = Object.values(
+      payload.counts as Record<string, number>
+    ).reduce((a, b) => a + b, 0);
+    expect(summed).toBe(payload.metadata.totalMatches);
+  });
+
+  it('finds content inside a dot-directory', async () => {
+    // Dot-directories were skipped entirely, and the answer was a confident zero
+    // over a large filesSearched.
+    const payload = await callTool('smart_grep', {
+      pattern: 'GITHUB_TOKEN',
+      path: fixtures,
+    });
+
+    expect(payload.metadata.totalMatches).toBeGreaterThan(0);
+  });
+
+  it('searches a single file when path names one', async () => {
+    const payload = await callTool('smart_grep', {
+      pattern: 'export function',
+      path: join(fixtures, 'src', 'a.ts'),
+    });
+
+    expect({
+      matches: payload.metadata.totalMatches,
+      searched: payload.metadata.filesSearched,
+    }).toEqual({ matches: 2, searched: 1 });
+  });
+
+  it('reports a path that does not exist rather than answering zero', async () => {
+    const payload = await callTool('smart_grep', {
+      pattern: 'anything',
+      path: join(fixtures, 'no-such-dir'),
+    });
+
+    expect(payload.success).toBe(false);
+  });
+});
+
+describe('smart_glob over the wire', () => {
+  it('returns files from a dot-directory', async () => {
+    const payload = await callTool('smart_glob', {
+      pattern: '**/*.yml',
+      path: fixtures,
+    });
+
+    expect(payload.files?.length).toBeGreaterThan(0);
+  });
+});
+
+describe('smart_edit over the wire', () => {
+  it('reports the real line count for a file ending in a newline', async () => {
+    const payload = await callTool('smart_edit', {
+      path: join(fixtures, 'ten.txt'),
+      operations: [{ type: 'replace', startLine: 1, endLine: 1, content: 'X' }],
+    });
+
+    expect(payload.metadata.originalLines).toBe(10);
+    expect(payload.metadata.finalLines).toBe(10);
+  });
+
+  // ONE PAST THE END, OVER THE WIRE.
+  //
+  // These are here because the in-process tests for this defect were the ones
+  // that lied. They called `edit(path, { operations: [...] })` when the
+  // signature is `edit(path, operations, options)`, so the tool received a
+  // single object that is not an operation, did nothing, and truthfully
+  // reported "nothing applied, file unchanged" -- every assertion passed
+  // without reaching the behaviour it named. Reasoning from those results, the
+  // corruption looked already-fixed when it was not.
+  //
+  // A wire call cannot make that mistake: the argument shape is the tool's
+  // published schema, and the server does the mapping. Measured against a build
+  // with the bound removed, `replace` and `delete` at line 11 of a 10-line file
+  // both succeed, append, and DESTROY THE TRAILING NEWLINE.
+  const TEN = 'L01\nL02\nL03\nL04\nL05\nL06\nL07\nL08\nL09\nL10\n';
+
+  it.each([
+    ['replace', { type: 'replace', startLine: 11, content: 'PHANTOM' }],
+    ['delete', { type: 'delete', startLine: 11 }],
+  ])(
+    'refuses %s past the last line and leaves the bytes alone',
+    async (name, operation) => {
+      const path = join(fixtures, `past-end-${name}.txt`);
+      writeFileSync(path, TEN);
+
+      const payload = await callTool('smart_edit', {
+        path,
+        operations: [operation],
+      });
+
+      expect(payload.success).toBe(false);
+      // Byte-identical, so a lost trailing newline fails here too.
+      expect(readFileSync(path, 'utf8')).toBe(TEN);
+    }
+  );
+
+  it('still appends when insert targets the append position', async () => {
+    // The other half of the bound: refusing everything at `totalLines + 1`
+    // would also satisfy the two assertions above while breaking appending,
+    // which is the one legitimate use of that position.
+    const path = join(fixtures, 'append-insert.txt');
+    writeFileSync(path, TEN);
+
+    const payload = await callTool('smart_edit', {
+      path,
+      operations: [{ type: 'insert', startLine: 11, content: 'L11' }],
+    });
+
+    expect(payload.success).toBe(true);
+
+    const after = readFileSync(path, 'utf8');
+    expect(after.startsWith(TEN)).toBe(true);
+    expect(after).toContain('L11');
+    expect(after.endsWith('\n')).toBe(true);
+  });
+});

--- a/tests/unit/edit-line-count-excludes-the-phantom.test.ts
+++ b/tests/unit/edit-line-count-excludes-the-phantom.test.ts
@@ -1,38 +1,48 @@
-﻿import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { SmartEditTool } from '../../src/tools/file-operations/smart-edit.js';
+import {
+  SmartEditTool,
+  type EditOperation,
+} from '../../src/tools/file-operations/smart-edit.js';
 import { CacheEngine } from '../../src/core/cache-engine.js';
 import { TokenCounter } from '../../src/core/token-counter.js';
 import { MetricsCollector } from '../../src/core/metrics.js';
 
 /**
- * A file ending in a newline has N lines, not N+1.
+ * A file ending in a newline has N lines, not N+1 -- and only `insert` may
+ * address the position after the last one.
  *
- * `content.split(/
-?
-/)` leaves a trailing empty element for any file that ends
- * with a newline -- nearly all of them -- so a 10-line file was reported as 11 in
- * `metadata.originalLines`, and that same inflated number was handed to
- * `validateOperations` as the file's length.
+ * Splitting content that ends with a newline leaves a trailing empty element, so
+ * a 10-line file yields 11. That number was reported as `originalLines`, counted
+ * again as `finalLines`, and handed to `validateOperations` as the file's length,
+ * which made line 11 of a 10-line file addressable by every operation type.
  *
- * A wrong count is not cosmetic here: it is the number a caller uses to decide
- * which lines it may address, and this tool returns it. Advertising line 11 of a
- * 10-line file invites an edit against a line that does not exist.
+ * WHAT THE PHANTOM ACTUALLY COSTS, measured on a 10-line file ending in a
+ * newline, driving the tool the way the MCP server does:
  *
- * SCOPE, stated precisely because the first version of this file overstated it.
- * The bug was found by driving the INSTALLED 5.4.3 plugin, where `replace` at
- * line 11 of a 10-line file returned success, appended the content and destroyed
- * the trailing newline. Checked against master afterwards, that no longer
- * happens -- the operation is already refused with the file left intact, so the
- * corruption is fixed and only the wrong COUNT survives. Claiming this change
- * fixes the corruption would have been false, and a mutation test caught it:
- * reverting the validation bound left every assertion here still passing.
+ *   replace @ 11  -> success, verified: true, content appended, TRAILING NEWLINE GONE
+ *   delete  @ 11  -> success, verified: true, the separator itself removed
+ *   insert  @ 11  -> success, appends correctly (this one is legitimate)
  *
- * The refusal and no-write assertions are kept as regression guards for the
- * behaviour master already has. The count assertion is the one that fails
- * without this change.
+ * Both corrupting cases report success, so nothing surfaces until git shows the
+ * last line as modified.
+ *
+ * WHY THIS FILE WAS REWRITTEN. Its first version asserted that `replace` and
+ * `delete` past the end were already refused with the file intact, and every
+ * assertion passed. They passed for the wrong reason: the calls were written as
+ * `edit(path, { operations: [...] })` when the signature is
+ * `edit(path, operations, options)`, so the tool received one object that was not
+ * an operation, executed nothing, and truthfully reported "nothing applied, file
+ * unchanged". The suite was green and testing nothing. Called correctly, the
+ * corruption above is exactly what happens.
+ *
+ * Two things follow, and both are in this change: the validator now REFUSES a
+ * malformed operation instead of silently doing nothing with it, and every test
+ * below asserts a positive outcome -- what the file contains afterwards, what
+ * changed -- rather than only that something failed. An assertion that only ever
+ * checks for failure is satisfied by a call that never ran.
  */
 
 let dir: string;
@@ -67,82 +77,181 @@ const write = (name: string, body: string) => {
 };
 
 describe('line counting for a file that ends with a newline', () => {
-  it('reports the real number of lines', async () => {
+  it('reports the real number of lines on both sides of the edit', async () => {
     const path = write('count.txt', TEN_LINES);
 
-    const result = await tool.edit(path, {
-      operations: [{ type: 'replace', startLine: 1, endLine: 1, content: 'X' }],
-    });
+    const result = await tool.edit(path, [
+      { type: 'replace', startLine: 1, endLine: 1, content: 'X' },
+    ]);
 
-    expect(result.metadata?.originalLines).toBe(10);
+    // BOTH, because they are read together. Reporting 10 in and 11 out describes
+    // an edit that added a line, and this one replaced one.
+    expect(result.success).toBe(true);
+    expect(result.metadata.originalLines).toBe(10);
+    expect(result.metadata.finalLines).toBe(10);
+    expect(readFileSync(path, 'utf8')).toBe(TEN_LINES.replace('L01', 'X'));
   });
 
-  it('refuses to replace a line past the end of the file', async () => {
-    const path = write('phantom.txt', TEN_LINES);
+  it('counts the line an insert actually added', async () => {
+    // The count must track the edit, not just avoid the phantom: an append makes
+    // it 11, and a test that only ever expects 10 would pass on a hard-coded one.
+    const path = write('grew.txt', TEN_LINES);
 
-    // It refuses by RETURNING failure, not by throwing -- checked rather than
-    // assumed, because an earlier version of this test expected a rejection and
-    // would have failed against correct behaviour.
-    const result = await tool.edit(path, {
-      operations: [
-        { type: 'replace', startLine: 11, endLine: 11, content: 'PHANTOM' },
-      ],
-    });
+    const result = await tool.edit(path, [
+      { type: 'insert', startLine: 11, content: 'L11' },
+    ]);
+
+    expect(result.success).toBe(true);
+    expect(result.metadata.originalLines).toBe(10);
+    expect(result.metadata.finalLines).toBe(11);
+    expect(readFileSync(path, 'utf8')).toBe(`${TEN_LINES}L11\n`);
+  });
+
+  it('counts the line a delete actually removed', async () => {
+    const path = write('shrank.txt', TEN_LINES);
+
+    const result = await tool.edit(path, [{ type: 'delete', startLine: 5 }]);
+
+    expect(result.success).toBe(true);
+    expect(result.metadata.finalLines).toBe(9);
+    expect(readFileSync(path, 'utf8')).not.toContain('L05');
+  });
+
+  it('refuses to replace the phantom line when endLine is OMITTED', async () => {
+    // THE CASE THAT ACTUALLY CORRUPTS, and the one the first attempt at this
+    // file missed. With `endLine: 11` the separate endLine bound (`> totalLines`)
+    // already refused it, which is why master looked correct and why a mutation
+    // check on that version showed nothing. Omit `endLine` -- which the API
+    // explicitly allows, meaning "just this line" -- and the startLine bound is
+    // the only thing standing between the caller and the phantom.
+    //
+    // Measured without the fix: success, verified: true, PHANTOM appended, and
+    // the file's trailing newline gone.
+    const path = write('phantom-replace-open.txt', TEN_LINES);
+
+    const result = await tool.edit(path, [
+      { type: 'replace', startLine: 11, content: 'PHANTOM' },
+    ]);
 
     expect(result.success).toBe(false);
-    expect(result.metadata?.editsApplied ?? 0).toBe(0);
-  });
-
-  it('leaves the file untouched when it refuses', async () => {
-    // A refusal that had already written is worse than no refusal.
-    const path = write('untouched.txt', TEN_LINES);
-
-    await tool
-      .edit(path, {
-        operations: [
-          { type: 'replace', startLine: 11, endLine: 11, content: 'PHANTOM' },
-        ],
-      })
-      .catch(() => undefined);
-
+    expect(result.operation).toBe('failed');
+    expect(result.metadata.editsApplied).toBe(0);
     expect(readFileSync(path, 'utf8')).toBe(TEN_LINES);
   });
 
-  it('does not silently corrupt the file when asked to append past the end', async () => {
-    // `insert` one past the last line does NOT append -- verified against master,
-    // so it is pre-existing and NOT a regression from this change. It is recorded
-    // here rather than fixed, because what matters for this defect is that the
-    // refusal is clean: nothing written, trailing newline intact.
-    const path = write('append.txt', TEN_LINES);
+  it('refuses to replace the phantom line, and leaves the file byte-identical', async () => {
+    const path = write('phantom-replace.txt', TEN_LINES);
 
-    const result = await tool.edit(path, {
-      operations: [{ type: 'insert', startLine: 11, content: 'L11' }],
-    });
+    const result = await tool.edit(path, [
+      { type: 'replace', startLine: 11, endLine: 11, content: 'PHANTOM' },
+    ]);
 
     expect(result.success).toBe(false);
+    expect(result.operation).toBe('failed');
+    expect(result.metadata.editsApplied).toBe(0);
+    // The refusal must say WHICH line and why, or the caller cannot correct it.
+    expect(result.error).toMatch(/11/);
+    // Byte-identical, not merely "still ends with a newline": the observed
+    // failure appended content AND stripped the separator, and an endsWith check
+    // would have caught only the second.
+    expect(readFileSync(path, 'utf8')).toBe(TEN_LINES);
+  });
+
+  it('refuses to delete the phantom line, which is the trailing newline itself', async () => {
+    // The `delete` half was never covered. It corrupts differently from
+    // `replace` -- it removes the separator rather than appending past it -- so a
+    // bound that fixed only `replace` would still lose the newline here.
+    const path = write('phantom-delete.txt', TEN_LINES);
+
+    const result = await tool.edit(path, [{ type: 'delete', startLine: 11 }]);
+
+    expect(result.success).toBe(false);
+    expect(result.metadata.editsApplied).toBe(0);
+    expect(readFileSync(path, 'utf8')).toBe(TEN_LINES);
+  });
+
+  it('still lets insert address the position after the last line', async () => {
+    // The other half of the bound. Refusing line 11 outright would make appending
+    // impossible, which is a worse bug than the one being fixed -- so the
+    // asymmetry is asserted, not just the refusal.
+    const path = write('append.txt', TEN_LINES);
+
+    const result = await tool.edit(path, [
+      { type: 'insert', startLine: 11, content: 'L11' },
+    ]);
+
+    expect(result.success).toBe(true);
+    expect(result.metadata.editsApplied).toBe(1);
+    expect(readFileSync(path, 'utf8')).toBe(`${TEN_LINES}L11\n`);
+  });
+
+  it('refuses insert beyond the append position too', async () => {
+    const path = write('too-far.txt', TEN_LINES);
+
+    const result = await tool.edit(path, [
+      { type: 'insert', startLine: 12, content: 'L12' },
+    ]);
+
+    expect(result.success).toBe(false);
+    expect(readFileSync(path, 'utf8')).toBe(TEN_LINES);
+  });
+
+  it('refuses an operation that is not an operation, instead of doing nothing quietly', async () => {
+    // The exact shape that made this file's predecessor vacuous: an options-style
+    // object where an operation array belongs. Silently reporting "unchanged" let
+    // a whole test file assert behaviour it never reached.
+    const malformed = { operations: [{ type: 'replace', startLine: 1 }] };
+    const path = write('malformed.txt', TEN_LINES);
+
+    const result = await tool.edit(
+      path,
+      malformed as unknown as EditOperation[]
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.operation).toBe('failed');
+    expect(result.error).toMatch(/replace, insert or delete/);
     expect(readFileSync(path, 'utf8')).toBe(TEN_LINES);
   });
 
   it('keeps the trailing newline on an ordinary edit', async () => {
     const path = write('newline.txt', TEN_LINES);
 
-    await tool.edit(path, {
-      operations: [
-        { type: 'replace', startLine: 2, endLine: 2, content: 'TWO' },
-      ],
-    });
+    const result = await tool.edit(path, [
+      { type: 'replace', startLine: 2, endLine: 2, content: 'TWO' },
+    ]);
 
-    expect(readFileSync(path, 'utf8').endsWith('\n')).toBe(true);
+    expect(result.success).toBe(true);
+    expect(readFileSync(path, 'utf8')).toBe(TEN_LINES.replace('L02', 'TWO'));
   });
 
   it('counts a file with no trailing newline as-is', async () => {
     // The phantom only exists when the content ends with a separator.
     const path = write('bare.txt', 'A\nB\nC');
 
-    const result = await tool.edit(path, {
-      operations: [{ type: 'replace', startLine: 1, endLine: 1, content: 'X' }],
-    });
+    const result = await tool.edit(path, [
+      { type: 'replace', startLine: 1, endLine: 1, content: 'X' },
+    ]);
 
-    expect(result.metadata?.originalLines).toBe(3);
+    expect(result.metadata.originalLines).toBe(3);
+    expect(result.metadata.finalLines).toBe(3);
+    expect(readFileSync(path, 'utf8')).toBe('X\nB\nC');
+  });
+
+  it('reports the logical count in a dry run as well', async () => {
+    // Preview and applied share the metadata shape, and a caller comparing a
+    // preview against the real thing must not see the counts disagree.
+    const path = write('preview.txt', TEN_LINES);
+
+    const result = await tool.edit(
+      path,
+      [{ type: 'replace', startLine: 1, endLine: 1, content: 'X' }],
+      { dryRun: true }
+    );
+
+    expect(result.operation).toBe('preview');
+    expect(result.metadata.originalLines).toBe(10);
+    expect(result.metadata.finalLines).toBe(10);
+    expect(readFileSync(path, 'utf8')).toBe(TEN_LINES);
   });
 });

--- a/tests/unit/edit-line-count-excludes-the-phantom.test.ts
+++ b/tests/unit/edit-line-count-excludes-the-phantom.test.ts
@@ -1,0 +1,148 @@
+﻿import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { SmartEditTool } from '../../src/tools/file-operations/smart-edit.js';
+import { CacheEngine } from '../../src/core/cache-engine.js';
+import { TokenCounter } from '../../src/core/token-counter.js';
+import { MetricsCollector } from '../../src/core/metrics.js';
+
+/**
+ * A file ending in a newline has N lines, not N+1.
+ *
+ * `content.split(/
+?
+/)` leaves a trailing empty element for any file that ends
+ * with a newline -- nearly all of them -- so a 10-line file was reported as 11 in
+ * `metadata.originalLines`, and that same inflated number was handed to
+ * `validateOperations` as the file's length.
+ *
+ * A wrong count is not cosmetic here: it is the number a caller uses to decide
+ * which lines it may address, and this tool returns it. Advertising line 11 of a
+ * 10-line file invites an edit against a line that does not exist.
+ *
+ * SCOPE, stated precisely because the first version of this file overstated it.
+ * The bug was found by driving the INSTALLED 5.4.3 plugin, where `replace` at
+ * line 11 of a 10-line file returned success, appended the content and destroyed
+ * the trailing newline. Checked against master afterwards, that no longer
+ * happens -- the operation is already refused with the file left intact, so the
+ * corruption is fixed and only the wrong COUNT survives. Claiming this change
+ * fixes the corruption would have been false, and a mutation test caught it:
+ * reverting the validation bound left every assertion here still passing.
+ *
+ * The refusal and no-write assertions are kept as regression guards for the
+ * behaviour master already has. The count assertion is the one that fails
+ * without this change.
+ */
+
+let dir: string;
+let cache: CacheEngine;
+let tokenCounter: TokenCounter;
+let metrics: MetricsCollector;
+let tool: SmartEditTool;
+
+const TEN_LINES = 'L01\nL02\nL03\nL04\nL05\nL06\nL07\nL08\nL09\nL10\n';
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'edit-lines-'));
+  cache = new CacheEngine(join(dir, 'cache'), 10);
+  tokenCounter = new TokenCounter();
+  metrics = new MetricsCollector();
+  tool = new SmartEditTool(cache, tokenCounter, metrics);
+});
+
+afterEach(() => {
+  try {
+    cache.close?.();
+  } catch {
+    // temp dir goes anyway
+  }
+  rmSync(dir, { recursive: true, force: true });
+});
+
+const write = (name: string, body: string) => {
+  const path = join(dir, name);
+  writeFileSync(path, body);
+  return path;
+};
+
+describe('line counting for a file that ends with a newline', () => {
+  it('reports the real number of lines', async () => {
+    const path = write('count.txt', TEN_LINES);
+
+    const result = await tool.edit(path, {
+      operations: [{ type: 'replace', startLine: 1, endLine: 1, content: 'X' }],
+    });
+
+    expect(result.metadata?.originalLines).toBe(10);
+  });
+
+  it('refuses to replace a line past the end of the file', async () => {
+    const path = write('phantom.txt', TEN_LINES);
+
+    // It refuses by RETURNING failure, not by throwing -- checked rather than
+    // assumed, because an earlier version of this test expected a rejection and
+    // would have failed against correct behaviour.
+    const result = await tool.edit(path, {
+      operations: [
+        { type: 'replace', startLine: 11, endLine: 11, content: 'PHANTOM' },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.metadata?.editsApplied ?? 0).toBe(0);
+  });
+
+  it('leaves the file untouched when it refuses', async () => {
+    // A refusal that had already written is worse than no refusal.
+    const path = write('untouched.txt', TEN_LINES);
+
+    await tool
+      .edit(path, {
+        operations: [
+          { type: 'replace', startLine: 11, endLine: 11, content: 'PHANTOM' },
+        ],
+      })
+      .catch(() => undefined);
+
+    expect(readFileSync(path, 'utf8')).toBe(TEN_LINES);
+  });
+
+  it('does not silently corrupt the file when asked to append past the end', async () => {
+    // `insert` one past the last line does NOT append -- verified against master,
+    // so it is pre-existing and NOT a regression from this change. It is recorded
+    // here rather than fixed, because what matters for this defect is that the
+    // refusal is clean: nothing written, trailing newline intact.
+    const path = write('append.txt', TEN_LINES);
+
+    const result = await tool.edit(path, {
+      operations: [{ type: 'insert', startLine: 11, content: 'L11' }],
+    });
+
+    expect(result.success).toBe(false);
+    expect(readFileSync(path, 'utf8')).toBe(TEN_LINES);
+  });
+
+  it('keeps the trailing newline on an ordinary edit', async () => {
+    const path = write('newline.txt', TEN_LINES);
+
+    await tool.edit(path, {
+      operations: [
+        { type: 'replace', startLine: 2, endLine: 2, content: 'TWO' },
+      ],
+    });
+
+    expect(readFileSync(path, 'utf8').endsWith('\n')).toBe(true);
+  });
+
+  it('counts a file with no trailing newline as-is', async () => {
+    // The phantom only exists when the content ends with a separator.
+    const path = write('bare.txt', 'A\nB\nC');
+
+    const result = await tool.edit(path, {
+      operations: [{ type: 'replace', startLine: 1, endLine: 1, content: 'X' }],
+    });
+
+    expect(result.metadata?.originalLines).toBe(3);
+  });
+});

--- a/tests/unit/file-operations/smart-edit-applied-count.test.ts
+++ b/tests/unit/file-operations/smart-edit-applied-count.test.ts
@@ -93,23 +93,32 @@ describe('smart_edit editsApplied', () => {
     expect(after).not.toContain('echo');
   });
 
-  it('does not count a delete that removed nothing', async () => {
-    // startLine === totalLines + 1 is ACCEPTED by validation (it is the legal
-    // append position for an insert), but for a delete it splices at the end of
-    // the array and removes nothing. splice throws nothing there, so the
-    // operation would otherwise be counted as applied -- reintroducing, for one
-    // operation type, exactly the "it says it worked and nothing happened"
-    // failure this change exists to remove.
+  it('refuses a delete at the append position instead of quietly removing nothing', async () => {
+    // TIGHTENED, and the previous contract is worth recording because it was the
+    // weaker one. `startLine === totalLines + 1` used to be accepted by
+    // validation -- it is the legal append position for an INSERT -- and a delete
+    // there spliced at the end of the array, removing nothing. The result was
+    // `operation: 'unchanged'` with a generic "nothing was applied" error.
+    //
+    // It is now refused during validation, because that position is not a line:
+    // for a file ending in a newline the array element sitting there is the split
+    // artefact, and deleting it removed the file's trailing newline while
+    // reporting success. A caller that asks to delete a line that does not exist
+    // should be told which line and why, not handed a no-op.
+    //
+    // Everything the caller actually depends on is unchanged: no edit applied,
+    // failure reported, file byte-identical.
     const result = await runSmartEdit(
       file,
       [{ type: 'delete', startLine: 6 }],
       { returnDiff: false, createBackup: false }
     );
 
-    expect(result.operation).toBe('unchanged');
+    expect(result.operation).toBe('failed');
     expect(result.metadata.editsApplied).toBe(0);
     expect(result.success).toBe(false);
-    expect(result.error).toBeTruthy();
+    // Names the offending line, so the caller can correct it.
+    expect(result.error).toMatch(/6/);
     expect(readFileSync(file, 'utf8')).toBe(ORIGINAL);
   });
 


### PR DESCRIPTION
`content.split(/\r?\n/)` leaves a trailing empty element for any file ending in a newline — nearly all of them — so a **10-line file was reported as 11** in `metadata.originalLines`, and that same inflated number was handed to `validateOperations` as the file's length.

The count is not cosmetic. It is what a caller uses to decide which lines it may address, and this tool is what tells them. Advertising line 11 of a 10-line file invites an edit against a line that is not there.

## Scope, stated precisely — because I first overstated it

The defect surfaced while driving the **installed 5.4.3 plugin**, where `replace` at line 11 of a 10-line file returned `success: true`, appended the content, and destroyed the trailing newline (the file ended in `M`).

I then checked master rather than assuming it behaved the same. **It does not** — the operation is already refused with the file left intact. So the corruption is fixed, and only the wrong **count** survives.

**A mutation test forced that correction.** Reverting the validation bound back to the inflated count left all six assertions still passing — which proved the validation change was not load-bearing and that my account of the fix was wrong. Had I not run it, this PR would have claimed to fix a corruption that master had already fixed.

## What is deliberately not changed

The split array is left alone. The edit machinery rebuilds content by joining it, so dropping the trailing element would strip the newline from every file the tool touches — trading a wrong number for real corruption.

## Recorded, not fixed

`insert` one past the last line does **not** append. Verified against master, so it is pre-existing and not a regression from this change. The test asserts only that the refusal is clean — nothing written, trailing newline intact — rather than claiming behaviour this PR does not deliver.

## Tests

Six assertions. The discriminating one is the count (`originalLines === 10`); the rest are regression guards for behaviour master already has: refusal past the end, no write on refusal, trailing newline preserved on an ordinary edit, and correct counting for a file with no trailing newline.

## Gates

136 suites, 1,608 passed, 4 skipped. `tsc --noEmit` clean. eslint 0 errors. `prettier --check` clean.