### PR TITLE
fix(hooks): serve findings before re-indexing, so an external change shows stale

### DIFF
--- a/plugin/hooks/pretooluse-router.mjs
+++ b/plugin/hooks/pretooluse-router.mjs
@@ -47,6 +47,7 @@ import {
 } from './lib/inject.mjs';
 import { indexFile } from './lib/staleness.mjs';
 import { isArchived } from './lib/transcript.mjs';
+import { isFsSafePath } from './lib/paths.mjs';
 import { readFileSync } from 'node:fs';
 
 /**
@@ -238,6 +239,19 @@ try {
         if (size > HARVEST_MAX_BYTES) continue;
 
         const dir = dirFor(path);
+        // THE GUARD MUST BE HERE, not only in the helpers this read feeds.
+        //
+        // A path holding U+10FFFF ABORTS the process inside libuv rather than
+        // throwing, so the surrounding try/catch -- and the whole-hook catch
+        // that promises "a defect here costs the user nothing" -- does not hold
+        // for it. `touchedFiles` filters such paths at intake, but this line is
+        // a bare `readFileSync` and the two consumers below cannot cover it:
+        // `contentHash(path, source)` skips its own check precisely because the
+        // source was supplied, and `indexFile` checks only after this read has
+        // already happened. Defence at the call site, since this is where the
+        // syscall is.
+        if (!isFsSafePath(path)) continue;
+
         // ONE read, not two. harvest() hashed the file and indexFile() then
         // read it again, so every allowed call paid double the I/O on the
         // hook's critical path. Reading once here and handing the text to both

--- a/plugin/hooks/pretooluse-router.mjs
+++ b/plugin/hooks/pretooluse-router.mjs
@@ -134,6 +134,79 @@ try {
       }
     }
 
+    // DELIVER WHAT THE GRAPH ALREADY KNOWS -- BEFORE ANYTHING BELOW OVERWRITES
+    // IT. Nothing read from the graph on an allowed call at all once, so
+    // `forTouch` -- the injection the design calls "where the win lands" -- was
+    // imported by nothing but its own test. Measured over a full session on
+    // three real projects: 4,053 captures, 2,063 reads, findings served twice.
+    //
+    // READ BEFORE WRITE, and the order is load-bearing rather than tidy. The
+    // harvest loop below calls `indexFile`, which re-points every anchor at the
+    // bytes now on disk. Running it first destroyed the only evidence staleness
+    // has to work from: `forTouch` asked "did this file change since the claim
+    // was recorded?" against a snapshot `indexFile` had already refreshed, so
+    // the answer was always no and findings derived from the OLD content were
+    // served as current.
+    //
+    // The files that reach this path are exactly the ones where that matters. A
+    // write the hook observes is invalidated eagerly by `invalidateOnWrite`, so
+    // what is left is the file changed where the session could not see it -- a
+    // checkout, a rebase, a second agent, an editor outside the tool loop --
+    // which is where a stale claim is both most likely and least likely to be
+    // noticed. Serving it clean spends tokens to assert something false with
+    // the graph's authority behind it, which is worse than serving nothing.
+    //
+    // Nothing is lost by the swap: `indexFile` exists so the NEXT touch can be
+    // answered with structure, and the next touch still gets it.
+    //
+    // Both triggers fire here because findings answer two different questions.
+    // An anchor says which FILE a claim is about; a trigger says WHEN it is
+    // relevant. A claim about running something ("use npm test, not npx jest")
+    // is anchored to a file nobody opens at the moment they run the command,
+    // so file-touch injection alone could never deliver it -- and did not.
+    let context = null;
+    try {
+      // Once per session, per finding. Repeating advice on every call is how a
+      // real signal becomes wallpaper, and an ignored injection still costs its
+      // tokens every time.
+      state.injected = state.injected || [];
+      const alreadyInjected = new Set(state.injected);
+      const before = alreadyInjected.size;
+      const parts = [];
+
+      for (const { path } of touched) {
+        const dir = dirFor(path);
+        const note = forTouch(dir, load(dir), path, {
+          sessionId: payload.session_id,
+          alreadyInjected,
+        });
+        if (note) parts.push(note);
+      }
+
+      const command = payload.tool_input?.command;
+      if (command) {
+        // The project the COMMAND runs in, not the one the session sits in. A
+        // command that cds into a worktree or a second repository must consult
+        // that project's graph; keying on payload.cwd meant findings recorded
+        // there never fired -- no injection, no metrics row, no error.
+        const dir = wikiDir(commandProjectRoot(payload, payload.cwd));
+        const note = forCommand(dir, load(dir), command, {
+          sessionId: payload.session_id,
+          alreadyInjected,
+        });
+        if (note) parts.push(note);
+      }
+
+      if (alreadyInjected.size !== before) {
+        state.injected = [...alreadyInjected];
+        saveState(payload.session_id, state, agentScope);
+      }
+      if (parts.length) context = parts.join('\n\n');
+    } catch {
+      // Delivery is an optimization. A defect here must never cost the user
+      // their tool call, so a failure falls through to a plain allow.
+    }
+
     // THE MEMORY HALF. `harvest` records that this file was touched, at this
     // content hash, by this task -- and nothing had been calling it, anywhere.
     // The graph therefore accumulated no nodes and no task edges from ordinary
@@ -182,60 +255,6 @@ try {
       } catch {
         /* never let bookkeeping break an allowed call */
       }
-    }
-
-    // DELIVER WHAT THE GRAPH ALREADY KNOWS. Everything above this line WRITES
-    // to the graph; until now nothing read from it on an allowed call, so
-    // `forTouch` -- the injection the design calls "where the win lands" -- was
-    // imported by nothing but its own test. Measured over a full session on
-    // three real projects: 4,053 captures, 2,063 reads, findings served twice.
-    //
-    // Both triggers fire here because findings answer two different questions.
-    // An anchor says which FILE a claim is about; a trigger says WHEN it is
-    // relevant. A claim about running something ("use npm test, not npx jest")
-    // is anchored to a file nobody opens at the moment they run the command,
-    // so file-touch injection alone could never deliver it -- and did not.
-    let context = null;
-    try {
-      // Once per session, per finding. Repeating advice on every call is how a
-      // real signal becomes wallpaper, and an ignored injection still costs its
-      // tokens every time.
-      state.injected = state.injected || [];
-      const alreadyInjected = new Set(state.injected);
-      const before = alreadyInjected.size;
-      const parts = [];
-
-      for (const { path } of touched) {
-        const dir = dirFor(path);
-        const note = forTouch(dir, load(dir), path, {
-          sessionId: payload.session_id,
-          alreadyInjected,
-        });
-        if (note) parts.push(note);
-      }
-
-      const command = payload.tool_input?.command;
-      if (command) {
-        // The project the COMMAND runs in, not the one the session sits in. A
-        // command that cds into a worktree or a second repository must consult
-        // that project's graph; keying on payload.cwd meant findings recorded
-        // there never fired -- no injection, no metrics row, no error.
-        const dir = wikiDir(commandProjectRoot(payload, payload.cwd));
-        const note = forCommand(dir, load(dir), command, {
-          sessionId: payload.session_id,
-          alreadyInjected,
-        });
-        if (note) parts.push(note);
-      }
-
-      if (alreadyInjected.size !== before) {
-        state.injected = [...alreadyInjected];
-        saveState(payload.session_id, state, agentScope);
-      }
-      if (parts.length) context = parts.join('\n\n');
-    } catch {
-      // Delivery is an optimization. A defect here must never cost the user
-      // their tool call, so a failure falls through to a plain allow.
     }
 
     allowWithContext(context);

--- a/tests/hooks/stale-before-reindex.test.mjs
+++ b/tests/hooks/stale-before-reindex.test.mjs
@@ -177,6 +177,11 @@ describe('a file changed outside the session', () => {
     // The claim is delivered, and it is delivered MARKED -- never as current.
     expect(context).toContain('RETRIES is 3');
     expect(context).toMatch(/recorded earlier; file changed/);
+    // AND THE CONTRACT IN THE NAME IS ASSERTED, not just implied by the wording.
+    // Checking only for the evidence-free phrasing would still pass if the
+    // router started shipping a diff alongside it -- which is the 232 ms per
+    // call this path exists to avoid. The new content must not appear.
+    expect(context).not.toContain('RETRIES = 12');
   });
 
   test('a file that did NOT change is still served clean', () => {

--- a/tests/hooks/stale-before-reindex.test.mjs
+++ b/tests/hooks/stale-before-reindex.test.mjs
@@ -1,0 +1,227 @@
+import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { pathToFileURL } from 'node:url';
+
+/**
+ * THE READ THAT MATTERS MOST IS THE ONE THE ROUTER USED TO GET WRONG.
+ *
+ * A finding is a claim about a file's CONTENT, and the only evidence that it may
+ * no longer hold is that the content changed since the claim was recorded. The
+ * router destroyed that evidence before it looked at it:
+ *
+ *     indexFile(dir, path, source)   // line 181 -- overwrites the stored hash
+ *     ...
+ *     forTouch(dir, load(dir), path) // line 210 -- compares stored hash to disk
+ *
+ * By the time `forTouch` asked "did this file change?", `indexFile` had already
+ * re-pointed the anchor at the NEW content, so the answer was always no. Findings
+ * derived from the old content were served CLEAN.
+ *
+ * The window is narrow and it is exactly the wrong window. A write the hook
+ * observes is invalidated eagerly by `invalidateOnWrite`, so the only files that
+ * reach this path are the ones changed where the session could not see it -- a
+ * git checkout, a rebase, a second agent, an editor outside the tool loop. That
+ * is precisely the case where a stale claim is most likely AND least likely to be
+ * caught by the reader, because nothing in the session hints that the file moved.
+ *
+ * A stale finding served as current is worse than no finding at all: it spends
+ * tokens to state something false with the graph's authority behind it. So the
+ * ordering is asserted end-to-end, against the real hook process, on the real
+ * payload shape Claude Code sends.
+ *
+ * WHY THE FULL PROCESS AND NOT `forTouch` DIRECTLY: the unit is not what broke.
+ * `forTouch` and `serve` were correct in isolation and had passing tests
+ * throughout -- the defect lived entirely in the order the router called them in,
+ * which is invisible to any test that calls them itself. Only a test that lets
+ * the ROUTER choose the order can fail on this.
+ */
+
+const ROUTER = join(process.cwd(), 'plugin', 'hooks', 'pretooluse-router.mjs');
+const CORE = (name) =>
+  pathToFileURL(join(process.cwd(), 'hooks-core', name)).href;
+
+let putNode, putEdge, nodeId;
+
+beforeEach(async () => {
+  ({ putNode, putEdge, nodeId } = await import(CORE('wiki.mjs')));
+});
+
+let project;
+let wiki;
+let stateDir;
+
+beforeEach(() => {
+  project = mkdtempSync(join(tmpdir(), 'stale-order-proj-'));
+  wiki = mkdtempSync(join(tmpdir(), 'stale-order-wiki-'));
+  // PER TEST, AND THE REASON IS NOT TIDINESS.
+  //
+  // Injection is once-per-session per finding, and the session state lives in a
+  // FIXED directory under the system temp dir keyed by session id. A test that
+  // names its sessions -- as this one must, since the gate is what it is
+  // measuring -- therefore inherits whatever a previous RUN of the same test
+  // recorded, and the second run of a passing assertion sees the finding
+  // suppressed and reports the feature broken.
+  //
+  // This cost an hour of chasing a phantom regression: the fix under test looked
+  // like it had destroyed injection entirely, and every run agreed, because the
+  // first run had consumed the session ids for all the ones that followed.
+  stateDir = mkdtempSync(join(tmpdir(), 'stale-order-state-'));
+});
+
+afterEach(() => {
+  for (const dir of [project, wiki, stateDir]) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* windows can hold a handle briefly */
+    }
+  }
+});
+
+/**
+ * Drives the real hook exactly as Claude Code does.
+ *
+ * HOLDOUT PINNED OFF. Ten percent of anchors are deliberately served nothing so
+ * the value of injection can be measured against a control, which means an
+ * unpinned run of this test would fail roughly one time in ten -- and a suite
+ * that fails one run in ten teaches people to re-run it rather than read it.
+ */
+function route(payload, { sessionId = 'stale-order' } = {}) {
+  const result = spawnSync(process.execPath, [ROUTER], {
+    input: JSON.stringify({ cwd: project, session_id: sessionId, ...payload }),
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      TOKEN_OPTIMIZER_WIKI_DIR: wiki,
+      TOKEN_OPTIMIZER_STATE_DIR: stateDir,
+      TOKEN_OPTIMIZER_HOLDOUT: '0',
+    },
+    timeout: 30_000,
+  });
+  expect(result.status).toBe(0);
+  let parsed = {};
+  try {
+    parsed = JSON.parse(result.stdout || '{}');
+  } catch {
+    throw new Error(`hook did not emit JSON: ${result.stdout}\n${result.stderr}`);
+  }
+  return parsed.hookSpecificOutput?.additionalContext ?? '';
+}
+
+/** A content claim: the only kind whose truth depends on the bytes on disk. */
+function seedFinding(file, claim) {
+  const id = putNode(wiki, {
+    kind: 'finding',
+    key: claim.slice(0, 16),
+    claim,
+    confidence: 0.9,
+    type: 'finding',
+  });
+  putEdge(wiki, id, 'derived_from', nodeId('file', file));
+  return id;
+}
+
+describe('a file changed outside the session', () => {
+  test('is marked STALE on the first read that follows, not served as current', () => {
+    const file = join(project, 'parser.ts');
+    writeFileSync(file, 'export function parse(x) {\n  return x.trim();\n}\n');
+
+    // First touch: the router indexes the file at its current content. This is
+    // the state a finding is recorded against.
+    route({ tool_name: 'Read', tool_input: { file_path: file } });
+    seedFinding(file, 'parse() trims its input before returning');
+
+    // THE CHANGE THE SESSION CANNOT SEE. No Write, no Edit, no hook invocation --
+    // a checkout or another process, which is the whole point.
+    writeFileSync(file, 'export function parse(x) {\n  return JSON.parse(x);\n}\n');
+
+    // A different session, because "once per session per finding" would suppress
+    // the second delivery inside the same one and hide the ordering entirely.
+    const context = route(
+      { tool_name: 'Read', tool_input: { file_path: file } },
+      { sessionId: 'stale-order-after' }
+    );
+
+    expect(context).toContain('parse() trims its input');
+    expect(context).toMatch(/file changed/);
+  });
+
+  test('is marked without a diff, because this path does not load snapshots', () => {
+    // NOT AN OVERSIGHT, AND WORTH PINNING SO IT STAYS A DECISION.
+    //
+    // The injection path loads the graph WITHOUT snapshots -- it runs ahead of
+    // every tool call, and parsing stored file contents there was measured at
+    // 232 ms per call. So staleness here is decided from the stored HASH, which
+    // is enough to know THAT the file changed and not enough to say WHAT
+    // changed. The renderer's evidence-free wording is what covers that gap.
+    //
+    // The refusal path, which is already paying for a large file, does load
+    // snapshots and does carry the diff. If lazy snapshot loading is added later
+    // this test is the one that should change, deliberately.
+    const file = join(project, 'config.ts');
+    writeFileSync(file, 'export const RETRIES = 3;\n');
+
+    route({ tool_name: 'Read', tool_input: { file_path: file } });
+    seedFinding(file, 'RETRIES is 3 and callers depend on that bound');
+
+    writeFileSync(file, 'export const RETRIES = 12;\n');
+
+    const context = route(
+      { tool_name: 'Read', tool_input: { file_path: file } },
+      { sessionId: 'stale-order-diff' }
+    );
+
+    // The claim is delivered, and it is delivered MARKED -- never as current.
+    expect(context).toContain('RETRIES is 3');
+    expect(context).toMatch(/recorded earlier; file changed/);
+  });
+
+  test('a file that did NOT change is still served clean', () => {
+    // The other half of the guard. Marking everything stale would pass the test
+    // above while destroying the feature: every finding would arrive discounted,
+    // which is indistinguishable from having no graph.
+    const file = join(project, 'stable.ts');
+    writeFileSync(file, 'export const NAME = "stable";\n');
+
+    route({ tool_name: 'Read', tool_input: { file_path: file } });
+    seedFinding(file, 'NAME is exported as a string literal');
+
+    const context = route(
+      { tool_name: 'Read', tool_input: { file_path: file } },
+      { sessionId: 'stale-order-clean' }
+    );
+
+    expect(context).toContain('NAME is exported');
+    expect(context).not.toMatch(/file changed|recorded earlier/);
+  });
+
+  test('indexing still happens, so the NEXT read compares against the new content', () => {
+    // Moving the read ahead of the write must not drop the write. If injection
+    // ran first and indexing never ran at all, this file would report stale
+    // forever -- permanently discounted against a snapshot nothing refreshes.
+    const file = join(project, 'drift.ts');
+    writeFileSync(file, 'export const V = 1;\n');
+
+    route({ tool_name: 'Read', tool_input: { file_path: file } });
+    seedFinding(file, 'V is a numeric constant');
+
+    writeFileSync(file, 'export const V = 2;\n');
+    const first = route(
+      { tool_name: 'Read', tool_input: { file_path: file } },
+      { sessionId: 'drift-1' }
+    );
+    expect(first).toMatch(/file changed/);
+
+    // Nothing changed since that read, so the re-index it performed must have
+    // landed and this read must be clean again.
+    const second = route(
+      { tool_name: 'Read', tool_input: { file_path: file } },
+      { sessionId: 'drift-2' }
+    );
+    expect(second).toContain('V is a numeric constant');
+    expect(second).not.toMatch(/file changed|recorded earlier/);
+  });
+});


### PR DESCRIPTION
## The bug

The router wrote to the graph before it read from it:

```
indexFile(dir, path, source)    // re-points the anchor at the bytes now on disk
...
forTouch(dir, load(dir), path)  // asks "did this file change?"
```

By the time `forTouch` asked, `indexFile` had already refreshed the snapshot it
compares against. The answer was always *no*, so findings derived from the **old**
content were served as **current**.

## Why this window is the one that matters

A write the hook observes is invalidated eagerly by `invalidateOnWrite`. What
reaches this path is the file changed where the session could not see it — a
checkout, a rebase, a second agent, an editor outside the tool loop. That is
exactly where a stale claim is both most likely and least likely to be noticed,
because nothing in the session hints the file moved.

A stale finding served as current is worse than no finding: it spends tokens to
assert something false with the graph's authority behind it.

## Before / after

| | claim after the file changed underneath it |
|---|---|
| before | `- [finding] RETRIES is 3 and callers depend on that bound` |
| after | `- [finding] RETRIES is 3 ...`<br>`  (recorded earlier; file changed, and no diff could be rebuilt)` |

Nothing is lost by the swap: `indexFile` exists so the **next** touch can be
answered with structure, and the next touch still gets it.

## Proof, both directions

`tests/hooks/stale-before-reindex.test.mjs` drives the **real hook process** on the
real payload shape — the units were never broken, the defect lived entirely in the
order the router called them in, which no test that calls them itself can catch.

```
master's router  ->  3 failed, 1 passed
this router      ->  4 passed
```

The one that passes under both is the **control**: an unchanged file must still be
served clean. The suite therefore cannot be satisfied by marking everything stale.

Full hooks suite: **47 suites, 683 passed, 0 failed**.

## A test-isolation bug found on the way

Hook session state lives in a fixed temp directory keyed by session id. A test
that names its sessions — as this one must, since the once-per-session gate is
part of what it measures — inherits whatever a previous **run** recorded. Without
`TOKEN_OPTIMIZER_STATE_DIR` isolation, the second run of a passing assertion sees
injection suppressed and reports the feature broken. That cost an hour chasing a
phantom regression, so it is pinned in a comment beside the fix.

## Known limit, pinned by a test rather than left implicit

The injection path loads the graph **without** snapshots — it runs ahead of every
tool call and parsing stored contents there was measured at 232 ms per call. So
staleness here is decided from the stored hash: enough to know *that* the file
changed, not *what* changed. The refusal path already loads snapshots and does
carry the diff. If lazy snapshot loading is added later, the test named
"is marked without a diff, because this path does not load snapshots" is the one
that should change, deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)