### PR TITLE
fix(graph): key unrooted files on a stable graph, not the caller cwd

### DIFF
--- a/hooks-core/wiki.mjs
+++ b/hooks-core/wiki.mjs
@@ -83,6 +83,29 @@ export function sharedDir() {
 }
 
 /**
+ * Where a claim about a file that belongs to NO repository is kept.
+ *
+ * The fallback used to be the caller's cwd, and cwd is a property of how the
+ * process was launched rather than of the file. Reproduced: the same file, in a
+ * tree with no VCS marker anywhere above it, resolved to `<plugin>` when the
+ * client started at the plugin root and to `<plugin>/mcp` when it started one
+ * level down -- 185 nodes in one graph and 284 in the other, neither able to
+ * serve the other, and the briefing only ever reads one. Every directory a
+ * session visits becomes another shard, so the fragmentation is unbounded.
+ *
+ * Deliberately NOT sharedDir(). That tier is for lessons that hold anywhere
+ * (SHAREABLE_TYPES); a claim about one unrooted file is not one, and mixing them
+ * would leak file-specific noise into every project's briefing.
+ */
+export function unrootedRoot() {
+  return (
+    process.env.TOKEN_OPTIMIZER_UNROOTED_DIR ||
+    join(homedir(), '.token-optimizer', 'unrooted')
+  );
+}
+
+
+/**
  * Is this project's graph ALSO the shared one?
  *
  * Both are redirectable by environment variable, and the suite points them at one
@@ -107,8 +130,9 @@ export function isSharedDir(dir) {
  * land in the wrong project's graph, or in none, and the per-project promise
  * quietly breaks. Observed live: work in another checkout recorded nothing.
  *
- * Walks up for a repository marker and falls back to the session cwd when the
- * file is not inside one, which is the honest answer for a scratch file.
+ * Walks up for a repository marker. When there is none the answer must still
+ * depend only on the FILE, so it goes to one stable machine-level graph rather
+ * than to wherever the caller happened to be -- see unrootedRoot.
  */
 export function projectRootFor(filePath, fallback) {
   // This walks UP the path calling existsSync at every level, so one character
@@ -139,7 +163,10 @@ export function projectRootFor(filePath, fallback) {
     if (parent === dir) break;
     dir = parent;
   }
-  return fallback ? canonicalPath(fallback) : null;
+  // No repository anywhere up the tree. `fallback` is deliberately NOT used here:
+  // it is the caller's cwd, which changes as a session moves between directories,
+  // so using it files the same file into a different graph on different runs.
+  return unrootedRoot();
 }
 
 const logPath = (dir) => join(dir, 'graph.jsonl');

--- a/integrations/codex/hooks/lib/wiki.mjs
+++ b/integrations/codex/hooks/lib/wiki.mjs
@@ -85,6 +85,29 @@ export function sharedDir() {
 }
 
 /**
+ * Where a claim about a file that belongs to NO repository is kept.
+ *
+ * The fallback used to be the caller's cwd, and cwd is a property of how the
+ * process was launched rather than of the file. Reproduced: the same file, in a
+ * tree with no VCS marker anywhere above it, resolved to `<plugin>` when the
+ * client started at the plugin root and to `<plugin>/mcp` when it started one
+ * level down -- 185 nodes in one graph and 284 in the other, neither able to
+ * serve the other, and the briefing only ever reads one. Every directory a
+ * session visits becomes another shard, so the fragmentation is unbounded.
+ *
+ * Deliberately NOT sharedDir(). That tier is for lessons that hold anywhere
+ * (SHAREABLE_TYPES); a claim about one unrooted file is not one, and mixing them
+ * would leak file-specific noise into every project's briefing.
+ */
+export function unrootedRoot() {
+  return (
+    process.env.TOKEN_OPTIMIZER_UNROOTED_DIR ||
+    join(homedir(), '.token-optimizer', 'unrooted')
+  );
+}
+
+
+/**
  * Is this project's graph ALSO the shared one?
  *
  * Both are redirectable by environment variable, and the suite points them at one
@@ -109,8 +132,9 @@ export function isSharedDir(dir) {
  * land in the wrong project's graph, or in none, and the per-project promise
  * quietly breaks. Observed live: work in another checkout recorded nothing.
  *
- * Walks up for a repository marker and falls back to the session cwd when the
- * file is not inside one, which is the honest answer for a scratch file.
+ * Walks up for a repository marker. When there is none the answer must still
+ * depend only on the FILE, so it goes to one stable machine-level graph rather
+ * than to wherever the caller happened to be -- see unrootedRoot.
  */
 export function projectRootFor(filePath, fallback) {
   // This walks UP the path calling existsSync at every level, so one character
@@ -141,7 +165,10 @@ export function projectRootFor(filePath, fallback) {
     if (parent === dir) break;
     dir = parent;
   }
-  return fallback ? canonicalPath(fallback) : null;
+  // No repository anywhere up the tree. `fallback` is deliberately NOT used here:
+  // it is the caller's cwd, which changes as a session moves between directories,
+  // so using it files the same file into a different graph on different runs.
+  return unrootedRoot();
 }
 
 const logPath = (dir) => join(dir, 'graph.jsonl');

--- a/integrations/codex/plugin/hooks/lib/wiki.mjs
+++ b/integrations/codex/plugin/hooks/lib/wiki.mjs
@@ -85,6 +85,29 @@ export function sharedDir() {
 }
 
 /**
+ * Where a claim about a file that belongs to NO repository is kept.
+ *
+ * The fallback used to be the caller's cwd, and cwd is a property of how the
+ * process was launched rather than of the file. Reproduced: the same file, in a
+ * tree with no VCS marker anywhere above it, resolved to `<plugin>` when the
+ * client started at the plugin root and to `<plugin>/mcp` when it started one
+ * level down -- 185 nodes in one graph and 284 in the other, neither able to
+ * serve the other, and the briefing only ever reads one. Every directory a
+ * session visits becomes another shard, so the fragmentation is unbounded.
+ *
+ * Deliberately NOT sharedDir(). That tier is for lessons that hold anywhere
+ * (SHAREABLE_TYPES); a claim about one unrooted file is not one, and mixing them
+ * would leak file-specific noise into every project's briefing.
+ */
+export function unrootedRoot() {
+  return (
+    process.env.TOKEN_OPTIMIZER_UNROOTED_DIR ||
+    join(homedir(), '.token-optimizer', 'unrooted')
+  );
+}
+
+
+/**
  * Is this project's graph ALSO the shared one?
  *
  * Both are redirectable by environment variable, and the suite points them at one
@@ -109,8 +132,9 @@ export function isSharedDir(dir) {
  * land in the wrong project's graph, or in none, and the per-project promise
  * quietly breaks. Observed live: work in another checkout recorded nothing.
  *
- * Walks up for a repository marker and falls back to the session cwd when the
- * file is not inside one, which is the honest answer for a scratch file.
+ * Walks up for a repository marker. When there is none the answer must still
+ * depend only on the FILE, so it goes to one stable machine-level graph rather
+ * than to wherever the caller happened to be -- see unrootedRoot.
  */
 export function projectRootFor(filePath, fallback) {
   // This walks UP the path calling existsSync at every level, so one character
@@ -141,7 +165,10 @@ export function projectRootFor(filePath, fallback) {
     if (parent === dir) break;
     dir = parent;
   }
-  return fallback ? canonicalPath(fallback) : null;
+  // No repository anywhere up the tree. `fallback` is deliberately NOT used here:
+  // it is the caller's cwd, which changes as a session moves between directories,
+  // so using it files the same file into a different graph on different runs.
+  return unrootedRoot();
 }
 
 const logPath = (dir) => join(dir, 'graph.jsonl');

--- a/integrations/gemini/hooks/lib/wiki.mjs
+++ b/integrations/gemini/hooks/lib/wiki.mjs
@@ -85,6 +85,29 @@ export function sharedDir() {
 }
 
 /**
+ * Where a claim about a file that belongs to NO repository is kept.
+ *
+ * The fallback used to be the caller's cwd, and cwd is a property of how the
+ * process was launched rather than of the file. Reproduced: the same file, in a
+ * tree with no VCS marker anywhere above it, resolved to `<plugin>` when the
+ * client started at the plugin root and to `<plugin>/mcp` when it started one
+ * level down -- 185 nodes in one graph and 284 in the other, neither able to
+ * serve the other, and the briefing only ever reads one. Every directory a
+ * session visits becomes another shard, so the fragmentation is unbounded.
+ *
+ * Deliberately NOT sharedDir(). That tier is for lessons that hold anywhere
+ * (SHAREABLE_TYPES); a claim about one unrooted file is not one, and mixing them
+ * would leak file-specific noise into every project's briefing.
+ */
+export function unrootedRoot() {
+  return (
+    process.env.TOKEN_OPTIMIZER_UNROOTED_DIR ||
+    join(homedir(), '.token-optimizer', 'unrooted')
+  );
+}
+
+
+/**
  * Is this project's graph ALSO the shared one?
  *
  * Both are redirectable by environment variable, and the suite points them at one
@@ -109,8 +132,9 @@ export function isSharedDir(dir) {
  * land in the wrong project's graph, or in none, and the per-project promise
  * quietly breaks. Observed live: work in another checkout recorded nothing.
  *
- * Walks up for a repository marker and falls back to the session cwd when the
- * file is not inside one, which is the honest answer for a scratch file.
+ * Walks up for a repository marker. When there is none the answer must still
+ * depend only on the FILE, so it goes to one stable machine-level graph rather
+ * than to wherever the caller happened to be -- see unrootedRoot.
  */
 export function projectRootFor(filePath, fallback) {
   // This walks UP the path calling existsSync at every level, so one character
@@ -141,7 +165,10 @@ export function projectRootFor(filePath, fallback) {
     if (parent === dir) break;
     dir = parent;
   }
-  return fallback ? canonicalPath(fallback) : null;
+  // No repository anywhere up the tree. `fallback` is deliberately NOT used here:
+  // it is the caller's cwd, which changes as a session moves between directories,
+  // so using it files the same file into a different graph on different runs.
+  return unrootedRoot();
 }
 
 const logPath = (dir) => join(dir, 'graph.jsonl');

--- a/integrations/opencode/hooks/lib/wiki.mjs
+++ b/integrations/opencode/hooks/lib/wiki.mjs
@@ -85,6 +85,29 @@ export function sharedDir() {
 }
 
 /**
+ * Where a claim about a file that belongs to NO repository is kept.
+ *
+ * The fallback used to be the caller's cwd, and cwd is a property of how the
+ * process was launched rather than of the file. Reproduced: the same file, in a
+ * tree with no VCS marker anywhere above it, resolved to `<plugin>` when the
+ * client started at the plugin root and to `<plugin>/mcp` when it started one
+ * level down -- 185 nodes in one graph and 284 in the other, neither able to
+ * serve the other, and the briefing only ever reads one. Every directory a
+ * session visits becomes another shard, so the fragmentation is unbounded.
+ *
+ * Deliberately NOT sharedDir(). That tier is for lessons that hold anywhere
+ * (SHAREABLE_TYPES); a claim about one unrooted file is not one, and mixing them
+ * would leak file-specific noise into every project's briefing.
+ */
+export function unrootedRoot() {
+  return (
+    process.env.TOKEN_OPTIMIZER_UNROOTED_DIR ||
+    join(homedir(), '.token-optimizer', 'unrooted')
+  );
+}
+
+
+/**
  * Is this project's graph ALSO the shared one?
  *
  * Both are redirectable by environment variable, and the suite points them at one
@@ -109,8 +132,9 @@ export function isSharedDir(dir) {
  * land in the wrong project's graph, or in none, and the per-project promise
  * quietly breaks. Observed live: work in another checkout recorded nothing.
  *
- * Walks up for a repository marker and falls back to the session cwd when the
- * file is not inside one, which is the honest answer for a scratch file.
+ * Walks up for a repository marker. When there is none the answer must still
+ * depend only on the FILE, so it goes to one stable machine-level graph rather
+ * than to wherever the caller happened to be -- see unrootedRoot.
  */
 export function projectRootFor(filePath, fallback) {
   // This walks UP the path calling existsSync at every level, so one character
@@ -141,7 +165,10 @@ export function projectRootFor(filePath, fallback) {
     if (parent === dir) break;
     dir = parent;
   }
-  return fallback ? canonicalPath(fallback) : null;
+  // No repository anywhere up the tree. `fallback` is deliberately NOT used here:
+  // it is the caller's cwd, which changes as a session moves between directories,
+  // so using it files the same file into a different graph on different runs.
+  return unrootedRoot();
 }
 
 const logPath = (dir) => join(dir, 'graph.jsonl');

--- a/integrations/qwen/hooks/lib/wiki.mjs
+++ b/integrations/qwen/hooks/lib/wiki.mjs
@@ -85,6 +85,29 @@ export function sharedDir() {
 }
 
 /**
+ * Where a claim about a file that belongs to NO repository is kept.
+ *
+ * The fallback used to be the caller's cwd, and cwd is a property of how the
+ * process was launched rather than of the file. Reproduced: the same file, in a
+ * tree with no VCS marker anywhere above it, resolved to `<plugin>` when the
+ * client started at the plugin root and to `<plugin>/mcp` when it started one
+ * level down -- 185 nodes in one graph and 284 in the other, neither able to
+ * serve the other, and the briefing only ever reads one. Every directory a
+ * session visits becomes another shard, so the fragmentation is unbounded.
+ *
+ * Deliberately NOT sharedDir(). That tier is for lessons that hold anywhere
+ * (SHAREABLE_TYPES); a claim about one unrooted file is not one, and mixing them
+ * would leak file-specific noise into every project's briefing.
+ */
+export function unrootedRoot() {
+  return (
+    process.env.TOKEN_OPTIMIZER_UNROOTED_DIR ||
+    join(homedir(), '.token-optimizer', 'unrooted')
+  );
+}
+
+
+/**
  * Is this project's graph ALSO the shared one?
  *
  * Both are redirectable by environment variable, and the suite points them at one
@@ -109,8 +132,9 @@ export function isSharedDir(dir) {
  * land in the wrong project's graph, or in none, and the per-project promise
  * quietly breaks. Observed live: work in another checkout recorded nothing.
  *
- * Walks up for a repository marker and falls back to the session cwd when the
- * file is not inside one, which is the honest answer for a scratch file.
+ * Walks up for a repository marker. When there is none the answer must still
+ * depend only on the FILE, so it goes to one stable machine-level graph rather
+ * than to wherever the caller happened to be -- see unrootedRoot.
  */
 export function projectRootFor(filePath, fallback) {
   // This walks UP the path calling existsSync at every level, so one character
@@ -141,7 +165,10 @@ export function projectRootFor(filePath, fallback) {
     if (parent === dir) break;
     dir = parent;
   }
-  return fallback ? canonicalPath(fallback) : null;
+  // No repository anywhere up the tree. `fallback` is deliberately NOT used here:
+  // it is the caller's cwd, which changes as a session moves between directories,
+  // so using it files the same file into a different graph on different runs.
+  return unrootedRoot();
 }
 
 const logPath = (dir) => join(dir, 'graph.jsonl');

--- a/plugin/hooks/lib/wiki.mjs
+++ b/plugin/hooks/lib/wiki.mjs
@@ -85,6 +85,29 @@ export function sharedDir() {
 }
 
 /**
+ * Where a claim about a file that belongs to NO repository is kept.
+ *
+ * The fallback used to be the caller's cwd, and cwd is a property of how the
+ * process was launched rather than of the file. Reproduced: the same file, in a
+ * tree with no VCS marker anywhere above it, resolved to `<plugin>` when the
+ * client started at the plugin root and to `<plugin>/mcp` when it started one
+ * level down -- 185 nodes in one graph and 284 in the other, neither able to
+ * serve the other, and the briefing only ever reads one. Every directory a
+ * session visits becomes another shard, so the fragmentation is unbounded.
+ *
+ * Deliberately NOT sharedDir(). That tier is for lessons that hold anywhere
+ * (SHAREABLE_TYPES); a claim about one unrooted file is not one, and mixing them
+ * would leak file-specific noise into every project's briefing.
+ */
+export function unrootedRoot() {
+  return (
+    process.env.TOKEN_OPTIMIZER_UNROOTED_DIR ||
+    join(homedir(), '.token-optimizer', 'unrooted')
+  );
+}
+
+
+/**
  * Is this project's graph ALSO the shared one?
  *
  * Both are redirectable by environment variable, and the suite points them at one
@@ -109,8 +132,9 @@ export function isSharedDir(dir) {
  * land in the wrong project's graph, or in none, and the per-project promise
  * quietly breaks. Observed live: work in another checkout recorded nothing.
  *
- * Walks up for a repository marker and falls back to the session cwd when the
- * file is not inside one, which is the honest answer for a scratch file.
+ * Walks up for a repository marker. When there is none the answer must still
+ * depend only on the FILE, so it goes to one stable machine-level graph rather
+ * than to wherever the caller happened to be -- see unrootedRoot.
  */
 export function projectRootFor(filePath, fallback) {
   // This walks UP the path calling existsSync at every level, so one character
@@ -141,7 +165,10 @@ export function projectRootFor(filePath, fallback) {
     if (parent === dir) break;
     dir = parent;
   }
-  return fallback ? canonicalPath(fallback) : null;
+  // No repository anywhere up the tree. `fallback` is deliberately NOT used here:
+  // it is the caller's cwd, which changes as a session moves between directories,
+  // so using it files the same file into a different graph on different runs.
+  return unrootedRoot();
 }
 
 const logPath = (dir) => join(dir, 'graph.jsonl');

--- a/tests/hooks/shared-tier.test.mjs
+++ b/tests/hooks/shared-tier.test.mjs
@@ -45,6 +45,13 @@ let projectA, projectB, wikiA, wikiB, shared, stateDir;
 beforeEach(() => {
   projectA = mkdtempSync(join(tmpdir(), 'shared-projA-'));
   projectB = mkdtempSync(join(tmpdir(), 'shared-projB-'));
+  // These fixtures stand in for the repositories the docstring above describes, so
+  // they carry a VCS marker. Without one, projectRootFor resolves them to the
+  // machine-wide unrooted graph instead of to themselves, and the "learned here"
+  // identity these tests turn on collapses -- projectA would no longer recognise
+  // its own lesson and would be told about it as foreign news.
+  mkdirSync(join(projectA, '.git'), { recursive: true });
+  mkdirSync(join(projectB, '.git'), { recursive: true });
   wikiA = join(projectA, '.token-optimizer', 'wiki');
   wikiB = join(projectB, '.token-optimizer', 'wiki');
   mkdirSync(wikiA, { recursive: true });

--- a/tests/hooks/touched-paths.test.mjs
+++ b/tests/hooks/touched-paths.test.mjs
@@ -18,7 +18,7 @@ import { touchedFiles, isContentDump, decide, isRecursiveSearch, normalizePayloa
 // the test that existed to check it. The paths are what this suite is about, so
 // it derives them directly now.
 const touchedPaths = (payload) => touchedFiles(payload).map((f) => f.path);
-import { projectRootFor } from '../../hooks-core/wiki.mjs';
+import { projectRootFor, unrootedRoot } from '../../hooks-core/wiki.mjs';
 import { isMachineOwned } from '../../hooks-core/policy.mjs';
 
 let home;
@@ -93,10 +93,24 @@ describe('the graph a touch belongs to is the FILE\'s project', () => {
     expect(root).toBe(repoB.split('\\').join('/'));
   });
 
-  test('a file outside any repository falls back to the session project', () => {
+  test('a file outside any repository routes to the stable unrooted graph', () => {
+    // This used to fall back to the caller's cwd. That made the answer depend on
+    // where the process was launched rather than on the file: the same file
+    // resolved to `<plugin>` from one directory and `<plugin>/mcp` from another,
+    // producing two graphs (185 and 284 nodes) for one logical project, with the
+    // briefing only ever reading one of them. Every directory a session visits
+    // became another shard.
     const loose = join(home, 'scratch.ts');
     writeFileSync(loose, 'x');
-    expect(projectRootFor(loose, repoA)).toBe(repoA.split('\\').join('/'));
+    expect(projectRootFor(loose, repoA)).toBe(unrootedRoot());
+  });
+
+  test('an unrooted file resolves the same regardless of the caller cwd', () => {
+    // The actual property being bought: determinism per FILE, not per caller.
+    const loose = join(home, 'scratch2.ts');
+    writeFileSync(loose, 'x');
+    expect(projectRootFor(loose, repoA)).toBe(projectRootFor(loose, repoB));
+    expect(projectRootFor(loose, undefined)).toBe(projectRootFor(loose, repoA));
   });
 
   test('the marker search does not run away up the tree', () => {
@@ -108,9 +122,9 @@ describe('the graph a touch belongs to is the FILE\'s project', () => {
     const buried = join(deep, 'main.ts');
     writeFileSync(buried, 'x');
 
-    // No marker anywhere above it within the bound, so it must fall back rather
-    // than walk to the filesystem root.
-    expect(projectRootFor(buried, repoA)).toBe(repoA.split('\\').join('/'));
+    // No marker anywhere above it within the bound, so it must stop and take the
+    // unrooted graph rather than walk to the filesystem root.
+    expect(projectRootFor(buried, repoA)).toBe(unrootedRoot());
   });
 
   test('a nested package.json does NOT shadow the repository root', () => {


### PR DESCRIPTION
## The bug

`projectRootFor` fell back to the caller's `cwd` when a file had no VCS marker above it. `cwd` is a property of how the process was launched, not of the file — so the same file resolves differently depending on where the session happens to be, and the graph shards once per directory visited.

Found while live-testing the graph capture against a plugin directory that has no VCS marker anywhere above it:

```
file: <plugin>/mcp/lib/queue.mjs

client started at <plugin>       -> root <plugin>       -> <plugin>/.token-optimizer/wiki
client started at <plugin>/mcp   -> root <plugin>/mcp   -> <plugin>/mcp/.token-optimizer/wiki
```

Both graphs exist on disk right now, holding **185** and **284** nodes for one logical project. The briefing reads `wikiDir(payload.cwd)`, so it only ever sees one of them; the other 185 nodes are stranded. The fragmentation is unbounded — every new directory a session visits becomes another shard.

## The fix

Unrooted files resolve to one machine-level graph, `~/.token-optimizer/unrooted`, overridable via `TOKEN_OPTIMIZER_UNROOTED_DIR`. The answer now depends only on the file.

Deliberately **not** `sharedDir()`. That tier carries lessons that hold anywhere (`SHAREABLE_TYPES`); a claim about one unrooted file is not one, and mixing them would leak file-specific noise into every project's briefing.

## Tests

Two tests asserted the old cwd fallback directly. They encode the behaviour being fixed rather than a spec the fix violates, so they are updated with the reasoning recorded inline, and a new test pins the property actually wanted:

```js
test('an unrooted file resolves the same regardless of the caller cwd', ...)
```

The `shared-tier` fixtures now create a `.git` marker. They stand in for the repositories that suite's docstring describes; without a marker they resolved to the machine-wide graph instead of to themselves, collapsing the "learned here" identity those tests turn on. **Their assertions are unchanged.**

## Verification

- `tests/hooks` — **704 passed, 2 skipped, 0 failed** (49 suites)
- `npm run sync:hooks:check` — core in sync across all 6 client integrations
- `tests/unit` — **identical to master on this machine**: 46 suites fail before and after, all on a missing `better-sqlite3` native build (no Visual Studio present). Baselined by stashing the change and re-running.

## Note on scope

This changes project *identity* for unrooted directories, not just graph location — which is what surfaced the `shared-tier` fixture issue. Worth a second opinion on whether any other caller depends on the old fallback; I checked `decide.mjs` (`forCommand`) and `adapter.mjs`, and the hooks suite covers both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
