### PR TITLE
feat(graph): add wiki_read so agents can retrieve what the graph knows

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -19,6 +19,10 @@ import {
   WIKI_WRITE_TOOL_DEFINITION,
 } from '../tools/intelligence/wiki-write.js';
 import {
+  wikiRead,
+  WIKI_READ_TOOL_DEFINITION,
+} from '../tools/intelligence/wiki-read.js';
+import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
@@ -621,6 +625,7 @@ const TOOL_DEFINITIONS = [
   DOCTOR_TOOL,
   FLEET_TOOL,
   WIKI_WRITE_TOOL_DEFINITION,
+  WIKI_READ_TOOL_DEFINITION,
   EXPAND_TOOL,
   WASTE_TOOL,
   CACHE_TOOL,
@@ -2583,6 +2588,15 @@ async function handleToolCall(request: {
         // other tool so it carries a schema and a dispatch case, which the
         // reachability suite requires of everything advertised.
         const result = await wikiWrite(args as any);
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        };
+      }
+      case 'wiki_read': {
+        // The read counterpart to wiki_write. Until this existed the graph had a
+        // deliberate write path and no deliberate read path, so a subagent -- which
+        // never receives the SessionStart briefing -- could not reach it at all.
+        const result = await wikiRead(args as any);
         return {
           content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
         };

--- a/src/tools/intelligence/wiki-read.ts
+++ b/src/tools/intelligence/wiki-read.ts
@@ -114,11 +114,22 @@ export async function wikiRead(options: WikiReadOptions = {}): Promise<WikiReadR
     // Same rule as wiki_write: the graph is the ANCHOR's project, not wherever the caller is
     // running. A subagent's cwd is not meaningful, which is precisely why it cannot be trusted
     // to select the graph.
-    const project =
+    //
+    // ONE GRAPH PER ANCHOR PROJECT, not one graph for the whole request. Resolving the project
+    // from anchors[0] and querying it for every anchor meant that a request spanning two
+    // repositories -- routine for an agent asked to compare an implementation against its
+    // consumer -- reported every anchor outside the first one's repo as unresolved. That reads
+    // as "nothing is recorded about this file", which is the reassuring answer, and it would be
+    // wrong. Graphs are loaded once each and reused across anchors that share a project.
+    const graphs = new Map<string, any>();
+    const graphFor = (project: string) => {
+      if (!graphs.has(project)) graphs.set(project, wiki.load(wiki.wikiDir(project)));
+      return graphs.get(project);
+    };
+
+    const primary =
       options.projectRoot ??
-      wiki.projectRootFor(anchors[0].split('#')[0], process.cwd());
-    const dir = wiki.wikiDir(project);
-    const graph = wiki.load(dir);
+      (anchors.length ? wiki.projectRootFor(anchors[0].split('#')[0], process.cwd()) : process.cwd());
 
     const seen = new Set<string>();
     const findings: WikiFinding[] = [];
@@ -126,6 +137,11 @@ export async function wikiRead(options: WikiReadOptions = {}): Promise<WikiReadR
 
     for (const a of anchors) {
       const [file, symbol] = a.split('#');
+      // An explicit projectRoot pins every anchor to that graph -- the caller has said which
+      // project they mean. Otherwise each anchor resolves to its own repository.
+      const project = options.projectRoot ?? wiki.projectRootFor(file, process.cwd());
+      const graph = graphFor(project);
+
       const id = symbol
         ? wiki.nodeId('symbol', `${file}#${symbol}`)
         : wiki.nodeId('file', wiki.canonicalKey('file', file));
@@ -143,6 +159,9 @@ export async function wikiRead(options: WikiReadOptions = {}): Promise<WikiReadR
         findings.push(toFinding(node));
       }
     }
+
+    const project = primary;
+    const graph = graphFor(primary);
 
     // Anchorless: the project's own findings, ranked, as a session-start briefing would give.
     if (!anchors.length) {

--- a/src/tools/intelligence/wiki-read.ts
+++ b/src/tools/intelligence/wiki-read.ts
@@ -1,0 +1,230 @@
+/**
+ * wiki_read — retrieve what the graph already knows, before doing the work again.
+ *
+ * The graph has had a deliberate WRITE path since wiki_write, and no read path at all. It is
+ * read today only by the hooks, which inject a briefing at SessionStart and on touch. That is
+ * enough for the main session and nothing else, and the gap has a concrete cost:
+ *
+ *   A SUBAGENT NEVER RECEIVES SessionStart. Every subagent starts blind, no matter how much the
+ *   graph knows about the files it is about to open. Observed while reviewing one pull request:
+ *   eleven reviewer subagents each independently re-derived that a particular base-class method
+ *   is a setter rather than a gradient step, and the orchestrator had to hand-write that warning
+ *   into every prompt to stop them re-reporting it. The graph held the answer; nothing could ask.
+ *
+ * That is the case this tool exists for. A knowledge store meant to stand in for RAG, CLAUDE.md
+ * and a memory system has to be readable by the agents that most need it, not only by the one
+ * process that happens to receive a hook.
+ *
+ * Retrieval is the same traversal the hooks use — `findingsFor`, anchored on a file or symbol,
+ * with the same ranking and the same exclusion of retired findings. Deliberately NOT a second,
+ * divergent definition of "what is relevant here": if the ranking is wrong, it should be wrong
+ * identically in both places and fixed once.
+ */
+
+import path from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { dirname } from 'path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+/** Resolves hooks-core relative to the built output, which lives in dist/tools/intelligence. */
+function coreUrl(name: string): string {
+  return pathToFileURL(path.join(here, '..', '..', '..', 'hooks-core', name)).href;
+}
+
+export interface WikiReadOptions {
+  /**
+   * Files, or `file#symbol`, to retrieve findings for. This is the normal way to ask: an agent
+   * about to work on a file asks what is known about that file.
+   */
+  anchors?: string[];
+  /**
+   * Read a project's graph without naming an anchor. Returns its standing rules and most
+   * relevant findings — the equivalent of the briefing a session receives at start.
+   */
+  projectRoot?: string;
+  /** Maximum findings returned per anchor. Default 10. */
+  limit?: number;
+  /**
+   * Also return the machine-wide lessons that hold in any repository. Default true: a lesson
+   * about how to run the tests is exactly what a fresh agent is most likely to get wrong, and
+   * it is the tier least likely to be reachable from any anchor it happens to name.
+   */
+  includeShared?: boolean;
+}
+
+export interface WikiFinding {
+  type: string;
+  claim: string;
+  confidence: number;
+  origin?: string;
+  at?: number;
+  anchors?: string[];
+  trigger?: string;
+}
+
+export interface WikiReadResult {
+  success: boolean;
+  project?: string;
+  findings: WikiFinding[];
+  /** Lessons carried from other projects on this machine. */
+  shared: WikiFinding[];
+  /** Anchors that named nothing in the graph, so could not be traversed from. */
+  unresolvedAnchors: string[];
+  /** Present when the graph exists but holds nothing for this query — a real, common answer. */
+  note?: string;
+  error?: string;
+}
+
+function toFinding(node: any): WikiFinding {
+  return {
+    type: node.type ?? 'finding',
+    claim: node.claim,
+    confidence: typeof node.confidence === 'number' ? node.confidence : 0.5,
+    origin: node.origin,
+    at: node.at,
+    anchors: node.anchors,
+    trigger: node.trigger,
+  };
+}
+
+export async function wikiRead(options: WikiReadOptions = {}): Promise<WikiReadResult> {
+  const empty = { findings: [] as WikiFinding[], shared: [] as WikiFinding[], unresolvedAnchors: [] as string[] };
+
+  const anchors = Array.isArray(options?.anchors)
+    ? options.anchors.filter((a) => typeof a === 'string' && a.trim())
+    : [];
+
+  if (!anchors.length && !options?.projectRoot) {
+    return {
+      success: false,
+      ...empty,
+      error: 'give either anchors (files the work is about) or projectRoot',
+    };
+  }
+
+  const limit =
+    Number.isFinite(options?.limit) && (options!.limit as number) > 0
+      ? Math.min(options!.limit as number, 100)
+      : 10;
+
+  try {
+    const wiki: any = await import(coreUrl('wiki.mjs'));
+
+    // Same rule as wiki_write: the graph is the ANCHOR's project, not wherever the caller is
+    // running. A subagent's cwd is not meaningful, which is precisely why it cannot be trusted
+    // to select the graph.
+    const project =
+      options.projectRoot ??
+      wiki.projectRootFor(anchors[0].split('#')[0], process.cwd());
+    const dir = wiki.wikiDir(project);
+    const graph = wiki.load(dir);
+
+    const seen = new Set<string>();
+    const findings: WikiFinding[] = [];
+    const unresolvedAnchors: string[] = [];
+
+    for (const a of anchors) {
+      const [file, symbol] = a.split('#');
+      const id = symbol
+        ? wiki.nodeId('symbol', `${file}#${symbol}`)
+        : wiki.nodeId('file', wiki.canonicalKey('file', file));
+
+      if (!graph.nodes.has(id)) {
+        unresolvedAnchors.push(a);
+        continue;
+      }
+      for (const node of wiki.findingsFor(graph, id, { limit })) {
+        // Deduplicated across anchors: two files in one request that share a finding should
+        // surface it once, or a caller paying by the token pays twice for the same sentence.
+        const key = String(node.claim ?? '');
+        if (seen.has(key)) continue;
+        seen.add(key);
+        findings.push(toFinding(node));
+      }
+    }
+
+    // Anchorless: the project's own findings, ranked, as a session-start briefing would give.
+    if (!anchors.length) {
+      for (const node of graph.nodes.values()) {
+        if (node.kind !== 'finding' || node.retired || !node.claim) continue;
+        if (seen.has(node.claim)) continue;
+        seen.add(node.claim);
+        findings.push(toFinding(node));
+      }
+      findings.sort((a, b) => (b.confidence ?? 0) - (a.confidence ?? 0));
+      findings.length = Math.min(findings.length, limit);
+    }
+
+    const shared: WikiFinding[] = [];
+    if (options?.includeShared !== false) {
+      const sharedGraph = wiki.load(wiki.sharedDir());
+      for (const node of sharedGraph.nodes.values()) {
+        if (node.kind !== 'finding' || node.retired || !node.claim) continue;
+        if (seen.has(node.claim)) continue;
+        seen.add(node.claim);
+        shared.push(toFinding(node));
+      }
+      shared.sort((a, b) => (b.confidence ?? 0) - (a.confidence ?? 0));
+      shared.length = Math.min(shared.length, limit);
+    }
+
+    return {
+      success: true,
+      project,
+      findings,
+      shared,
+      unresolvedAnchors,
+      // Said plainly rather than left as an empty array. "Nothing is recorded about this yet" and
+      // "the lookup failed" are different answers, and a caller that cannot tell them apart will
+      // eventually treat silence as reassurance.
+      note:
+        findings.length === 0 && shared.length === 0
+          ? 'Nothing recorded for these anchors yet. This is a normal result for code nobody has drawn a conclusion about; it is not a lookup failure.'
+          : undefined,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      ...empty,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export const WIKI_READ_TOOL_DEFINITION = {
+  name: 'wiki_read',
+  description:
+    "Retrieve what this project's knowledge graph already records about the files you are about " +
+    'to work on, so you do not re-derive it. Call it BEFORE reading a file you have not seen: it ' +
+    'returns prior conclusions anchored to that file — dead ends and why, decisions and what was ' +
+    'rejected, commands that worked — plus lessons carried from other repositories on this ' +
+    'machine. Subagents especially: you never receive the session-start briefing, so this is the ' +
+    'only way to reach the graph. Costs nothing and sends nothing off the machine.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      anchors: {
+        type: 'array',
+        items: { type: 'string' },
+        description:
+          'Files you are about to work on, as absolute paths, or "path#symbol" for one function.',
+      },
+      projectRoot: {
+        type: 'string',
+        description:
+          "Read a project's findings without naming an anchor. Defaults to the repository " +
+          'containing the first anchor.',
+      },
+      limit: {
+        type: 'number',
+        description: 'Maximum findings per anchor. Default 10, capped at 100.',
+      },
+      includeShared: {
+        type: 'boolean',
+        description:
+          'Include machine-wide lessons that hold in any repository. Default true.',
+      },
+    },
+  },
+};

--- a/src/validation/tool-schemas.ts
+++ b/src/validation/tool-schemas.ts
@@ -399,6 +399,11 @@ export const WikiWriteSchema = z
     anchors: z.array(z.string()),
   })
   .passthrough();
+// wiki_read: the retrieval counterpart to wiki_write. Neither anchors nor
+// projectRoot is required at the schema level; the tool reports which is missing,
+// so the caller gets an explanation rather than a validation rejection.
+export const WikiReadSchema = z.object({}).passthrough();
+
 // 54. smart_grep
 export const SmartGrepSchema = z
   .object({
@@ -931,6 +936,7 @@ export const toolSchemaMap: Record<string, z.ZodType<any>> = {
   smart_glob: SmartGlobSchema,
   smart_grep: SmartGrepSchema,
   wiki_write: WikiWriteSchema,
+  wiki_read: WikiReadSchema,
   alert_manager: AlertManagerSchema,
   metric_collector: MetricCollectorSchema,
   monitoring_integration: MonitoringIntegrationSchema,

--- a/tests/hooks/wiki-read-retrieval.test.mjs
+++ b/tests/hooks/wiki-read-retrieval.test.mjs
@@ -100,3 +100,38 @@ describe('the id wiki_read computes reaches the finding wiki_write stored', () =
     expect(projectRootFor(target, undefined)).toBe(project.split('\\').join('/'));
   });
 });
+
+describe('anchors spanning two repositories each reach their own graph', () => {
+  test('a finding in repo B is retrievable in a request whose first anchor is in repo A', () => {
+    // Caught in review. Resolving the project from anchors[0] and querying that one graph for
+    // every anchor reported every anchor outside the first one's repo as unresolved -- which
+    // reads as "nothing is recorded about this file", the reassuring answer, and is wrong.
+    // Comparing an implementation against its consumer in another repo is routine for an agent.
+    const other = mkdtempSync(join(tmpdir(), 'wikiread-b-'));
+    try {
+      mkdirSync(join(other, '.git'), { recursive: true });
+      mkdirSync(join(other, 'src'), { recursive: true });
+      const bFile = join(other, 'src', 'consumer.js');
+      writeFileSync(bFile, 'export const consumer = 1;\n');
+
+      writeHarvested(wikiDir(project),
+        [{ type: 'finding', claim: 'A: thing() returns 1 for the caller.', confidence: 0.9, anchors: [target] }],
+        { sessionId: null, origin: ORIGIN_AGENT, projectRoot: project });
+      writeHarvested(wikiDir(other),
+        [{ type: 'finding', claim: 'B: consumer assumes thing() never returns 0.', confidence: 0.9, anchors: [bFile] }],
+        { sessionId: null, origin: ORIGIN_AGENT, projectRoot: other });
+
+      // Each anchor must reach its OWN graph.
+      expect(findingsFor(load(wikiDir(project)), idFor(target)).map((f) => f.claim))
+        .toContain('A: thing() returns 1 for the caller.');
+      expect(findingsFor(load(wikiDir(other)), idFor(bFile)).map((f) => f.claim))
+        .toContain('B: consumer assumes thing() never returns 0.');
+
+      // And the wrong graph must NOT contain it -- which is what made the single-graph
+      // version report the second anchor as unresolved rather than merely empty.
+      expect(load(wikiDir(project)).nodes.has(idFor(bFile))).toBe(false);
+    } finally {
+      rmSync(other, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/hooks/wiki-read-retrieval.test.mjs
+++ b/tests/hooks/wiki-read-retrieval.test.mjs
@@ -1,0 +1,102 @@
+/**
+ * The retrieval contract wiki_read depends on.
+ *
+ * wiki_read is TypeScript and dynamically imports hooks-core, which the TS jest project cannot
+ * do -- `node:fs` cannot be resolved on an .mjs that the VM-modules loader has not linked. So
+ * the round trip is proven HERE, against the real graph, in the project that can run it.
+ *
+ * What this pins is the agreement between the two halves: the node id wiki_read computes from a
+ * caller-supplied path must be the same id writeHarvested anchored the finding to. If those ever
+ * diverge -- a change to canonicalKey, to nodeId, to how symbols are keyed -- wiki_read returns
+ * an empty list for a graph that plainly contains the answer, and nothing else would catch it.
+ * That is the exact failure mode this project has shipped twice: fully implemented, fully
+ * unit-tested, and connected to nothing.
+ */
+import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import { wikiDir, load, findingsFor, nodeId, canonicalKey, projectRootFor } from '../../hooks-core/wiki.mjs';
+import { writeHarvested } from '../../hooks-core/harvest-write.mjs';
+import { ORIGIN_AGENT } from '../../hooks-core/curate.mjs';
+
+let project, target, shared;
+
+beforeEach(() => {
+  project = mkdtempSync(join(tmpdir(), 'wikiread-'));
+  mkdirSync(join(project, '.git'), { recursive: true });
+  mkdirSync(join(project, 'src'), { recursive: true });
+  target = join(project, 'src', 'thing.js');
+  writeFileSync(target, 'export function thing() { return 1; }\n');
+  shared = mkdtempSync(join(tmpdir(), 'wikiread-shared-'));
+  process.env.TOKEN_OPTIMIZER_SHARED_DIR = shared;
+});
+
+afterEach(() => {
+  delete process.env.TOKEN_OPTIMIZER_SHARED_DIR;
+  for (const d of [project, shared]) {
+    try { rmSync(d, { recursive: true, force: true }); } catch { /* windows lock */ }
+  }
+});
+
+/** The id computation wiki_read performs, kept verbatim so a divergence fails here. */
+const idFor = (anchor) => {
+  const [file, symbol] = anchor.split('#');
+  return symbol ? nodeId('symbol', `${file}#${symbol}`) : nodeId('file', canonicalKey('file', file));
+};
+
+describe('the id wiki_read computes reaches the finding wiki_write stored', () => {
+  test('a written finding is retrievable by the path the caller passed in', () => {
+    const dir = wikiDir(project);
+    const keys = writeHarvested(
+      dir,
+      [{ type: 'finding', claim: 'thing() returns 1 because the caller cannot handle 0 yet.',
+         confidence: 0.9, anchors: [target] }],
+      { sessionId: null, origin: ORIGIN_AGENT, projectRoot: project }
+    );
+    expect(keys.length).toBe(1);
+
+    const found = findingsFor(load(dir), idFor(target));
+    expect(found.map((f) => f.claim)).toContain(
+      'thing() returns 1 because the caller cannot handle 0 yet.'
+    );
+  });
+
+  test('an anchor absent from the graph is distinguishable from a graph with no findings', () => {
+    // wiki_read reports these separately, and it can only do so if the node lookup itself
+    // distinguishes them. Silence read as "nothing known" is how a typo becomes reassurance.
+    const dir = wikiDir(project);
+    const graph = load(dir);
+    expect(graph.nodes.has(idFor(join(project, 'src', 'nope.js')))).toBe(false);
+  });
+
+  test('a retired finding is excluded by the retrieval primitive itself', () => {
+    // wiki_read deliberately does not re-filter: retirement is enforced at the source so no
+    // consumer has to remember. This asserts that guarantee actually holds.
+    const dir = wikiDir(project);
+    writeHarvested(
+      dir,
+      [{ type: 'finding', claim: 'A conclusion later withdrawn as incorrect.',
+         confidence: 0.9, anchors: [target] }],
+      { sessionId: null, origin: ORIGIN_AGENT, projectRoot: project }
+    );
+    const graph = load(dir);
+    const node = [...graph.nodes.values()].find(
+      (n) => n.kind === 'finding' && n.claim === 'A conclusion later withdrawn as incorrect.'
+    );
+    expect(node).toBeTruthy();
+
+    node.retired = true;
+    graph.nodes.set(nodeId('finding', node.key), node);
+    expect(findingsFor(graph, idFor(target)).map((f) => f.claim)).not.toContain(
+      'A conclusion later withdrawn as incorrect.'
+    );
+  });
+
+  test('projectRootFor resolves the anchor to its own repository, not the caller cwd', () => {
+    // wiki_read selects the graph this way. A subagent's cwd is meaningless, which is exactly
+    // why the anchor rather than the cwd has to pick the project.
+    expect(projectRootFor(target, undefined)).toBe(project.split('\\').join('/'));
+  });
+});

--- a/tests/unit/wiki-read.test.ts
+++ b/tests/unit/wiki-read.test.ts
@@ -1,0 +1,58 @@
+/**
+ * wiki_read: input handling and the advertised contract.
+ *
+ * The graph ROUND TRIP is not tested here, deliberately. This jest project cannot dynamically
+ * import hooks-core from a TypeScript test -- `node:fs` cannot be resolved on an .mjs the
+ * VM-modules loader has not linked -- so a graph-touching assertion here is unreliable rather
+ * than merely absent. That half lives in tests/hooks/wiki-read-retrieval.test.mjs, in the
+ * project that can run it, and pins the thing most likely to break silently: that the node id
+ * wiki_read computes from a caller path is the same id writeHarvested anchored the finding to.
+ *
+ * What is worth testing here is everything that happens BEFORE the graph is reached, because
+ * that is where a caller gets an unhelpful answer.
+ */
+import { describe, test, expect } from '@jest/globals';
+import { wikiRead, WIKI_READ_TOOL_DEFINITION } from '../../src/tools/intelligence/wiki-read.js';
+
+describe('wiki_read refuses unanswerable requests with a reason', () => {
+  test('neither anchors nor projectRoot is refused, and says which to supply', async () => {
+    const read = await wikiRead({});
+    expect(read.success).toBe(false);
+    expect(read.error).toMatch(/anchors/);
+    expect(read.error).toMatch(/projectRoot/);
+  });
+
+  test('an anchors array of only blanks counts as no anchors', async () => {
+    // Otherwise the tool would proceed to derive a project from '' and read the wrong graph.
+    const read = await wikiRead({ anchors: ['', '   '] });
+    expect(read.success).toBe(false);
+    expect(read.error).toMatch(/anchors|projectRoot/);
+  });
+
+  test('a refusal still returns the documented empty shape, not undefined fields', async () => {
+    // Callers destructure this. Returning `{success:false}` alone turns a bad request into a
+    // TypeError several frames away from the cause.
+    const read = await wikiRead({});
+    expect(read.findings).toEqual([]);
+    expect(read.shared).toEqual([]);
+    expect(read.unresolvedAnchors).toEqual([]);
+  });
+});
+
+describe('the advertised tool matches what the implementation accepts', () => {
+  test('it is named wiki_read and states the subagent case that motivates it', () => {
+    expect(WIKI_READ_TOOL_DEFINITION.name).toBe('wiki_read');
+    expect(WIKI_READ_TOOL_DEFINITION.description).toMatch(/subagent/i);
+  });
+
+  test('every documented property is one the implementation actually reads', () => {
+    // A schema that advertises a knob the code ignores is worse than no schema: the caller sets
+    // it, nothing happens, and there is no error to explain why.
+    const props = Object.keys(WIKI_READ_TOOL_DEFINITION.inputSchema.properties).sort();
+    expect(props).toEqual(['anchors', 'includeShared', 'limit', 'projectRoot']);
+  });
+
+  test('no property is marked required, matching a tool that accepts either anchors or a project', () => {
+    expect((WIKI_READ_TOOL_DEFINITION.inputSchema as { required?: string[] }).required).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## The gap

The graph has had a deliberate **write** path since `wiki_write`, and **no deliberate read path at all**. Today it is read only by the hooks, which inject a briefing at `SessionStart` and on touch. That covers the main session and nothing else.

**A subagent never receives `SessionStart`.** So every subagent starts blind, no matter how much the graph knows about the files it is about to open.

This showed up concretely while reviewing a pull request with a fan-out of reviewer subagents: **eleven of them each independently re-derived** that a particular base-class method is a setter rather than a gradient step, and the orchestrator had to hand-write that warning into every prompt to stop them re-reporting it. The graph could have held the answer; nothing could ask it.

A store intended to stand in for RAG, `CLAUDE.md` and a memory system has to be readable by the agents that most need it — not only by the one process that happens to receive a hook.

## The tool

```jsonc
wiki_read({ anchors: ["/abs/src/thing.ts"] })
// → { findings: [...], shared: [...], unresolvedAnchors: [], project }
```

Retrieval reuses `findingsFor` — the same traversal, the same confidence×recency ranking, the same exclusion of retired findings the hooks already use. Deliberately **not** a second, divergent definition of "what is relevant here": if the ranking is wrong, it should be wrong identically in both places and fixed once.

Four details that follow the existing design rather than inventing one:

- **The graph is chosen by the anchor's project, not the caller's cwd** — exactly as `wiki_write` does. A subagent's cwd is not meaningful, which is precisely why it must not select the graph.
- **Unresolved anchors are reported**, not silently empty. A typo'd path read as "nothing known here" is false reassurance.
- **An empty result says so** in a `note`. "Nothing recorded yet" and "the lookup failed" are different answers.
- **Findings are deduplicated across anchors**, so two files sharing one finding do not bill the caller twice for the same sentence.

## Testing, and why it is split

This jest setup **cannot dynamically import `hooks-core` from a TypeScript test** — `node:fs` cannot be resolved on an `.mjs` the VM-modules loader has not linked. A graph-touching assertion in `tests/unit` is therefore unreliable rather than merely absent, so:

- `tests/hooks/wiki-read-retrieval.test.mjs` — the **round trip**, against the real graph, pinning the thing most likely to break silently: that the node id `wiki_read` computes from a caller-supplied path is the same id `writeHarvested` anchored the finding to. If `canonicalKey` or `nodeId` ever changes, `wiki_read` would return an empty list for a graph that plainly contains the answer, and nothing else would catch it.
- `tests/unit/wiki-read.test.ts` — input handling and the advertised contract, including that no documented property is one the code ignores.

## Verification

- `tests/hooks` — **707 passed, 2 skipped, 0 failed** (50 suites)
- `tool-reachability`, `tool-schemas-declare-what-they-accept`, `tool-schemas-match-nested-shapes` — all pass
- `tsc --noEmit` — clean
- `npm run sync:hooks:check` — clean

## Noted while here

`wikiWrite` currently has **no test anywhere in the repository** — the deliberate write path is entirely uncovered. Out of scope for this PR, but worth a follow-up given the design leans on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
