### PR TITLE
fix(cache): stop reporting invented cache costs

### DIFF
--- a/hooks-core/cache.mjs
+++ b/hooks-core/cache.mjs
@@ -294,7 +294,15 @@ export function attributeInvalidation(cwd, prefixTokens = null, { files = null }
       // A prefix cache invalidates ONCE, at the earliest difference. A later
       // volatile line in the same file costs nothing extra until the first one
       // is fixed, so it is reported for context but not billed again.
-      const subsumedBy = index === 0 ? null : `${relative}:${found[0].line}`;
+      //
+      // Subsumption is measured against the earliest PRICED hit, not simply the
+      // first hit. An unpriced bare date at index 0 does not invalidate anything
+      // we are willing to bill for, so treating it as the subsumer zeroed the
+      // price of a genuine timestamp below it -- turning a real, fixable cost
+      // into a reported zero.
+      const firstPriced = found.find((h) => h.priced);
+      const subsumedBy =
+        hit.priced && firstPriced && firstPriced !== hit ? `${relative}:${firstPriced.line}` : null;
       out.push({
         file: relative,
         line: hit.line,

--- a/hooks-core/cache.mjs
+++ b/hooks-core/cache.mjs
@@ -28,13 +28,28 @@
  * cache-safety-by-construction half of this file.
  */
 
-import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { readFileSync, readdirSync, statSync, existsSync, openSync, readSync, closeSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 
 /** Anthropic prompt-cache pricing multipliers, relative to a plain input token. */
 export const WRITE_MULTIPLIER = 1.25;
 export const READ_MULTIPLIER = 0.1;
+
+/**
+ * The client's own placeholder for a row it wrote itself -- an interrupt, an
+ * auth error, "No response requested." at the end of a session. It carries a
+ * full all-zero `usage` object, so it survives every filter below, but it is
+ * not a model and no prefix was ever written under it.
+ *
+ * Measured across the four real transcripts on one machine: all four contain
+ * these rows, and three used exactly one real model yet would report two --
+ * a false "2 models used in this session" costing an invented ~767,000 tokens.
+ */
+const SYNTHETIC_MODEL = '<synthetic>';
+
+/** True for a turn naming a model an inference actually ran under. */
+const realModel = (turn) => Boolean(turn.model) && turn.model !== SYNTHETIC_MODEL;
 
 /* -------------------------------------------------------------- MEASUREMENT */
 
@@ -75,8 +90,27 @@ export function readCacheUsage(path, { maxBytes = 4_000_000 } = {}) {
   let text;
   try {
     const size = statSync(path).size;
-    const fd = readFileSync(path, 'utf8');
-    text = size > maxBytes ? fd.slice(size - maxBytes) : fd;
+    if (size <= maxBytes) {
+      text = readFileSync(path, 'utf8');
+    } else {
+      // Read the tail OFF DISK. readFileSync loaded the whole file first, which
+      // on a real 147 MB transcript measured 361 ms and 334 MB of RSS to keep
+      // 4 MB, and throws ERR_STRING_TOO_LONG past ~512 MB -- which the catch
+      // below silently turns into "no cache measurements available" for a
+      // perfectly readable file. It also sliced a BYTE offset out of a UTF-16
+      // string: on that same file bytes-minus-chars was 140,264, so 3.5% of the
+      // requested window was quietly discarded.
+      const handle = openSync(path, 'r');
+      try {
+        const buffer = Buffer.allocUnsafe(maxBytes);
+        const got = readSync(handle, buffer, 0, maxBytes, size - maxBytes);
+        // A partial UTF-8 sequence at the cut is discarded by the startsWith('{')
+        // and JSON.parse guards below, exactly as the old first-line slice was.
+        text = buffer.toString('utf8', 0, got);
+      } finally {
+        closeSync(handle);
+      }
+    }
   } catch {
     return [];
   }
@@ -120,7 +154,7 @@ export function cacheHealth(turns) {
   for (const turn of turns) {
     read += turn.read;
     written += turn.written;
-    if (!turn.model) continue;
+    if (!realModel(turn)) continue;
     if (!models.has(turn.model)) models.set(turn.model, { read: 0, written: 0, turns: 0 });
     const entry = models.get(turn.model);
     entry.read += turn.read;
@@ -128,7 +162,14 @@ export function cacheHealth(turns) {
     entry.turns += 1;
   }
 
-  const last = turns[turns.length - 1];
+  // The last turn that actually CARRIED a prefix. A session routinely ends on a
+  // zero-usage row -- the client's '<synthetic>' placeholders, an interrupted
+  // turn -- and reading turns[length - 1] literally reported a 0-token prefix
+  // for a session whose prefix was 600,000 tokens. That zeroed every
+  // attribution price, made keepWarm answer "unknown", and returned null from
+  // modelSwitchCost under a guard its caller does not share, which crashed
+  // cache_audit outright with "Cannot read properties of null".
+  const last = turns.reduce((best, turn) => (turn.read + turn.written > 0 ? turn : best), turns[turns.length - 1]);
   const total = read + written;
 
   return {
@@ -157,7 +198,7 @@ export function modelSwitchCost(turns) {
   const health = cacheHealth(turns);
   if (!health?.prefixTokens) return null;
 
-  const switched = new Set(turns.map((t) => t.model).filter(Boolean)).size > 1;
+  const switched = new Set(turns.filter(realModel).map((t) => t.model)).size > 1;
   return {
     prefixTokens: health.prefixTokens,
     rewriteCost: Math.round(health.prefixTokens * WRITE_MULTIPLIER),
@@ -180,7 +221,12 @@ export function modelSwitchCost(turns) {
 const VOLATILE = [
   { id: 'timestamp', re: /\b\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}/, why: 'an embedded timestamp' },
   { id: 'date', re: /\b(?:today|current date)\b[^\n]{0,40}\d{4}-\d{2}-\d{2}/i, why: 'an embedded current date' },
-  { id: 'iso-date', re: /\b\d{4}-\d{2}-\d{2}\b/, why: 'an embedded date' },
+  // A bare date is a SUSPICION, not a measurement: "- 2025-10-31: reworked the
+  // loader" is byte-identical every session. Kept, because stableText fails
+  // closed over our own output and dropping a line there costs little -- but
+  // NOT priced, because in the blame report a false positive invents a
+  // per-session cost and tells the user to delete their changelog.
+  { id: 'iso-date', re: /\b\d{4}-\d{2}-\d{2}\b/, why: 'an embedded date', priced: false },
   { id: 'session-id', re: /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/i, why: 'a session id' },
   { id: 'git-sha', re: /\b[0-9a-f]{40}\b/, why: 'a git sha' },
   { id: 'counter', re: /\b(?:run|build|attempt|iteration)\s*#?\d+\b/i, why: 'a run counter' },
@@ -194,7 +240,7 @@ export function volatileLines(text) {
   for (let i = 0; i < lines.length; i++) {
     for (const rule of VOLATILE) {
       if (!rule.re.test(lines[i])) continue;
-      out.push({ line: i + 1, id: rule.id, why: rule.why, text: lines[i].trim().slice(0, 120) });
+      out.push({ line: i + 1, id: rule.id, why: rule.why, priced: rule.priced !== false, text: lines[i].trim().slice(0, 120) });
       break; // one cause per line is enough to act on
     }
   }
@@ -233,19 +279,36 @@ export function attributeInvalidation(cwd, prefixTokens = null, { files = null }
     }
 
     const size = estimate(text);
+    const lines = text.split('\n');
     const found = volatileLines(text);
-    for (const hit of found) {
-      // Everything after this file's start is re-written. Conservative: the
-      // preamble ahead of it is not counted, so this is a floor rather than a
-      // flattering estimate.
-      const downstream = prefixTokens != null ? Math.max(0, prefixTokens - offset) : null;
+    for (const [index, hit] of found.entries()) {
+      // Everything after THIS LINE is re-written -- not everything after the
+      // file, which priced every hit in a file identically and, because each is
+      // emitted as its own record and audit.mjs sums them, billed the same
+      // tokens once per line. Measured before this fix: a three-line changelog
+      // in CLAUDE.md priced at 2,301,093 tokens/session against a 613,625-token
+      // prefix -- 3.75x the entire prefix. Conservative still: the preamble
+      // ahead of the file is not counted, so this remains a floor.
+      const ahead = offset + estimate(lines.slice(0, hit.line - 1).join('\n'));
+      const downstream = prefixTokens != null ? Math.max(0, prefixTokens - ahead) : null;
+      // A prefix cache invalidates ONCE, at the earliest difference. A later
+      // volatile line in the same file costs nothing extra until the first one
+      // is fixed, so it is reported for context but not billed again.
+      const subsumedBy = index === 0 ? null : `${relative}:${found[0].line}`;
       out.push({
         file: relative,
         line: hit.line,
         why: hit.why,
         excerpt: hit.text,
         downstreamTokens: downstream,
-        costPerSession: downstream == null ? null : Math.round(downstream * WRITE_MULTIPLIER),
+        subsumedBy,
+        // null means NOT MEASURABLE -- no prefix measurement, or a construct we
+        // decline to price. 0 means measured and genuinely free, which is what a
+        // subsumed hit is: real, but already billed by the earlier line. Folding
+        // those two into one value is the same mistake this file warns about.
+        costPerSession: downstream == null || !hit.priced
+          ? null
+          : (subsumedBy ? 0 : Math.round(downstream * WRITE_MULTIPLIER)),
         remedy: {
           kind: 'yours',
           type: 'edit',

--- a/integrations/codex/hooks/lib/cache.mjs
+++ b/integrations/codex/hooks/lib/cache.mjs
@@ -296,7 +296,15 @@ export function attributeInvalidation(cwd, prefixTokens = null, { files = null }
       // A prefix cache invalidates ONCE, at the earliest difference. A later
       // volatile line in the same file costs nothing extra until the first one
       // is fixed, so it is reported for context but not billed again.
-      const subsumedBy = index === 0 ? null : `${relative}:${found[0].line}`;
+      //
+      // Subsumption is measured against the earliest PRICED hit, not simply the
+      // first hit. An unpriced bare date at index 0 does not invalidate anything
+      // we are willing to bill for, so treating it as the subsumer zeroed the
+      // price of a genuine timestamp below it -- turning a real, fixable cost
+      // into a reported zero.
+      const firstPriced = found.find((h) => h.priced);
+      const subsumedBy =
+        hit.priced && firstPriced && firstPriced !== hit ? `${relative}:${firstPriced.line}` : null;
       out.push({
         file: relative,
         line: hit.line,

--- a/integrations/codex/hooks/lib/cache.mjs
+++ b/integrations/codex/hooks/lib/cache.mjs
@@ -30,13 +30,28 @@
  * cache-safety-by-construction half of this file.
  */
 
-import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { readFileSync, readdirSync, statSync, existsSync, openSync, readSync, closeSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 
 /** Anthropic prompt-cache pricing multipliers, relative to a plain input token. */
 export const WRITE_MULTIPLIER = 1.25;
 export const READ_MULTIPLIER = 0.1;
+
+/**
+ * The client's own placeholder for a row it wrote itself -- an interrupt, an
+ * auth error, "No response requested." at the end of a session. It carries a
+ * full all-zero `usage` object, so it survives every filter below, but it is
+ * not a model and no prefix was ever written under it.
+ *
+ * Measured across the four real transcripts on one machine: all four contain
+ * these rows, and three used exactly one real model yet would report two --
+ * a false "2 models used in this session" costing an invented ~767,000 tokens.
+ */
+const SYNTHETIC_MODEL = '<synthetic>';
+
+/** True for a turn naming a model an inference actually ran under. */
+const realModel = (turn) => Boolean(turn.model) && turn.model !== SYNTHETIC_MODEL;
 
 /* -------------------------------------------------------------- MEASUREMENT */
 
@@ -77,8 +92,27 @@ export function readCacheUsage(path, { maxBytes = 4_000_000 } = {}) {
   let text;
   try {
     const size = statSync(path).size;
-    const fd = readFileSync(path, 'utf8');
-    text = size > maxBytes ? fd.slice(size - maxBytes) : fd;
+    if (size <= maxBytes) {
+      text = readFileSync(path, 'utf8');
+    } else {
+      // Read the tail OFF DISK. readFileSync loaded the whole file first, which
+      // on a real 147 MB transcript measured 361 ms and 334 MB of RSS to keep
+      // 4 MB, and throws ERR_STRING_TOO_LONG past ~512 MB -- which the catch
+      // below silently turns into "no cache measurements available" for a
+      // perfectly readable file. It also sliced a BYTE offset out of a UTF-16
+      // string: on that same file bytes-minus-chars was 140,264, so 3.5% of the
+      // requested window was quietly discarded.
+      const handle = openSync(path, 'r');
+      try {
+        const buffer = Buffer.allocUnsafe(maxBytes);
+        const got = readSync(handle, buffer, 0, maxBytes, size - maxBytes);
+        // A partial UTF-8 sequence at the cut is discarded by the startsWith('{')
+        // and JSON.parse guards below, exactly as the old first-line slice was.
+        text = buffer.toString('utf8', 0, got);
+      } finally {
+        closeSync(handle);
+      }
+    }
   } catch {
     return [];
   }
@@ -122,7 +156,7 @@ export function cacheHealth(turns) {
   for (const turn of turns) {
     read += turn.read;
     written += turn.written;
-    if (!turn.model) continue;
+    if (!realModel(turn)) continue;
     if (!models.has(turn.model)) models.set(turn.model, { read: 0, written: 0, turns: 0 });
     const entry = models.get(turn.model);
     entry.read += turn.read;
@@ -130,7 +164,14 @@ export function cacheHealth(turns) {
     entry.turns += 1;
   }
 
-  const last = turns[turns.length - 1];
+  // The last turn that actually CARRIED a prefix. A session routinely ends on a
+  // zero-usage row -- the client's '<synthetic>' placeholders, an interrupted
+  // turn -- and reading turns[length - 1] literally reported a 0-token prefix
+  // for a session whose prefix was 600,000 tokens. That zeroed every
+  // attribution price, made keepWarm answer "unknown", and returned null from
+  // modelSwitchCost under a guard its caller does not share, which crashed
+  // cache_audit outright with "Cannot read properties of null".
+  const last = turns.reduce((best, turn) => (turn.read + turn.written > 0 ? turn : best), turns[turns.length - 1]);
   const total = read + written;
 
   return {
@@ -159,7 +200,7 @@ export function modelSwitchCost(turns) {
   const health = cacheHealth(turns);
   if (!health?.prefixTokens) return null;
 
-  const switched = new Set(turns.map((t) => t.model).filter(Boolean)).size > 1;
+  const switched = new Set(turns.filter(realModel).map((t) => t.model)).size > 1;
   return {
     prefixTokens: health.prefixTokens,
     rewriteCost: Math.round(health.prefixTokens * WRITE_MULTIPLIER),
@@ -182,7 +223,12 @@ export function modelSwitchCost(turns) {
 const VOLATILE = [
   { id: 'timestamp', re: /\b\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}/, why: 'an embedded timestamp' },
   { id: 'date', re: /\b(?:today|current date)\b[^\n]{0,40}\d{4}-\d{2}-\d{2}/i, why: 'an embedded current date' },
-  { id: 'iso-date', re: /\b\d{4}-\d{2}-\d{2}\b/, why: 'an embedded date' },
+  // A bare date is a SUSPICION, not a measurement: "- 2025-10-31: reworked the
+  // loader" is byte-identical every session. Kept, because stableText fails
+  // closed over our own output and dropping a line there costs little -- but
+  // NOT priced, because in the blame report a false positive invents a
+  // per-session cost and tells the user to delete their changelog.
+  { id: 'iso-date', re: /\b\d{4}-\d{2}-\d{2}\b/, why: 'an embedded date', priced: false },
   { id: 'session-id', re: /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/i, why: 'a session id' },
   { id: 'git-sha', re: /\b[0-9a-f]{40}\b/, why: 'a git sha' },
   { id: 'counter', re: /\b(?:run|build|attempt|iteration)\s*#?\d+\b/i, why: 'a run counter' },
@@ -196,7 +242,7 @@ export function volatileLines(text) {
   for (let i = 0; i < lines.length; i++) {
     for (const rule of VOLATILE) {
       if (!rule.re.test(lines[i])) continue;
-      out.push({ line: i + 1, id: rule.id, why: rule.why, text: lines[i].trim().slice(0, 120) });
+      out.push({ line: i + 1, id: rule.id, why: rule.why, priced: rule.priced !== false, text: lines[i].trim().slice(0, 120) });
       break; // one cause per line is enough to act on
     }
   }
@@ -235,19 +281,36 @@ export function attributeInvalidation(cwd, prefixTokens = null, { files = null }
     }
 
     const size = estimate(text);
+    const lines = text.split('\n');
     const found = volatileLines(text);
-    for (const hit of found) {
-      // Everything after this file's start is re-written. Conservative: the
-      // preamble ahead of it is not counted, so this is a floor rather than a
-      // flattering estimate.
-      const downstream = prefixTokens != null ? Math.max(0, prefixTokens - offset) : null;
+    for (const [index, hit] of found.entries()) {
+      // Everything after THIS LINE is re-written -- not everything after the
+      // file, which priced every hit in a file identically and, because each is
+      // emitted as its own record and audit.mjs sums them, billed the same
+      // tokens once per line. Measured before this fix: a three-line changelog
+      // in CLAUDE.md priced at 2,301,093 tokens/session against a 613,625-token
+      // prefix -- 3.75x the entire prefix. Conservative still: the preamble
+      // ahead of the file is not counted, so this remains a floor.
+      const ahead = offset + estimate(lines.slice(0, hit.line - 1).join('\n'));
+      const downstream = prefixTokens != null ? Math.max(0, prefixTokens - ahead) : null;
+      // A prefix cache invalidates ONCE, at the earliest difference. A later
+      // volatile line in the same file costs nothing extra until the first one
+      // is fixed, so it is reported for context but not billed again.
+      const subsumedBy = index === 0 ? null : `${relative}:${found[0].line}`;
       out.push({
         file: relative,
         line: hit.line,
         why: hit.why,
         excerpt: hit.text,
         downstreamTokens: downstream,
-        costPerSession: downstream == null ? null : Math.round(downstream * WRITE_MULTIPLIER),
+        subsumedBy,
+        // null means NOT MEASURABLE -- no prefix measurement, or a construct we
+        // decline to price. 0 means measured and genuinely free, which is what a
+        // subsumed hit is: real, but already billed by the earlier line. Folding
+        // those two into one value is the same mistake this file warns about.
+        costPerSession: downstream == null || !hit.priced
+          ? null
+          : (subsumedBy ? 0 : Math.round(downstream * WRITE_MULTIPLIER)),
         remedy: {
           kind: 'yours',
           type: 'edit',

--- a/integrations/codex/plugin/hooks/lib/cache.mjs
+++ b/integrations/codex/plugin/hooks/lib/cache.mjs
@@ -296,7 +296,15 @@ export function attributeInvalidation(cwd, prefixTokens = null, { files = null }
       // A prefix cache invalidates ONCE, at the earliest difference. A later
       // volatile line in the same file costs nothing extra until the first one
       // is fixed, so it is reported for context but not billed again.
-      const subsumedBy = index === 0 ? null : `${relative}:${found[0].line}`;
+      //
+      // Subsumption is measured against the earliest PRICED hit, not simply the
+      // first hit. An unpriced bare date at index 0 does not invalidate anything
+      // we are willing to bill for, so treating it as the subsumer zeroed the
+      // price of a genuine timestamp below it -- turning a real, fixable cost
+      // into a reported zero.
+      const firstPriced = found.find((h) => h.priced);
+      const subsumedBy =
+        hit.priced && firstPriced && firstPriced !== hit ? `${relative}:${firstPriced.line}` : null;
       out.push({
         file: relative,
         line: hit.line,

--- a/integrations/codex/plugin/hooks/lib/cache.mjs
+++ b/integrations/codex/plugin/hooks/lib/cache.mjs
@@ -30,13 +30,28 @@
  * cache-safety-by-construction half of this file.
  */
 
-import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { readFileSync, readdirSync, statSync, existsSync, openSync, readSync, closeSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 
 /** Anthropic prompt-cache pricing multipliers, relative to a plain input token. */
 export const WRITE_MULTIPLIER = 1.25;
 export const READ_MULTIPLIER = 0.1;
+
+/**
+ * The client's own placeholder for a row it wrote itself -- an interrupt, an
+ * auth error, "No response requested." at the end of a session. It carries a
+ * full all-zero `usage` object, so it survives every filter below, but it is
+ * not a model and no prefix was ever written under it.
+ *
+ * Measured across the four real transcripts on one machine: all four contain
+ * these rows, and three used exactly one real model yet would report two --
+ * a false "2 models used in this session" costing an invented ~767,000 tokens.
+ */
+const SYNTHETIC_MODEL = '<synthetic>';
+
+/** True for a turn naming a model an inference actually ran under. */
+const realModel = (turn) => Boolean(turn.model) && turn.model !== SYNTHETIC_MODEL;
 
 /* -------------------------------------------------------------- MEASUREMENT */
 
@@ -77,8 +92,27 @@ export function readCacheUsage(path, { maxBytes = 4_000_000 } = {}) {
   let text;
   try {
     const size = statSync(path).size;
-    const fd = readFileSync(path, 'utf8');
-    text = size > maxBytes ? fd.slice(size - maxBytes) : fd;
+    if (size <= maxBytes) {
+      text = readFileSync(path, 'utf8');
+    } else {
+      // Read the tail OFF DISK. readFileSync loaded the whole file first, which
+      // on a real 147 MB transcript measured 361 ms and 334 MB of RSS to keep
+      // 4 MB, and throws ERR_STRING_TOO_LONG past ~512 MB -- which the catch
+      // below silently turns into "no cache measurements available" for a
+      // perfectly readable file. It also sliced a BYTE offset out of a UTF-16
+      // string: on that same file bytes-minus-chars was 140,264, so 3.5% of the
+      // requested window was quietly discarded.
+      const handle = openSync(path, 'r');
+      try {
+        const buffer = Buffer.allocUnsafe(maxBytes);
+        const got = readSync(handle, buffer, 0, maxBytes, size - maxBytes);
+        // A partial UTF-8 sequence at the cut is discarded by the startsWith('{')
+        // and JSON.parse guards below, exactly as the old first-line slice was.
+        text = buffer.toString('utf8', 0, got);
+      } finally {
+        closeSync(handle);
+      }
+    }
   } catch {
     return [];
   }
@@ -122,7 +156,7 @@ export function cacheHealth(turns) {
   for (const turn of turns) {
     read += turn.read;
     written += turn.written;
-    if (!turn.model) continue;
+    if (!realModel(turn)) continue;
     if (!models.has(turn.model)) models.set(turn.model, { read: 0, written: 0, turns: 0 });
     const entry = models.get(turn.model);
     entry.read += turn.read;
@@ -130,7 +164,14 @@ export function cacheHealth(turns) {
     entry.turns += 1;
   }
 
-  const last = turns[turns.length - 1];
+  // The last turn that actually CARRIED a prefix. A session routinely ends on a
+  // zero-usage row -- the client's '<synthetic>' placeholders, an interrupted
+  // turn -- and reading turns[length - 1] literally reported a 0-token prefix
+  // for a session whose prefix was 600,000 tokens. That zeroed every
+  // attribution price, made keepWarm answer "unknown", and returned null from
+  // modelSwitchCost under a guard its caller does not share, which crashed
+  // cache_audit outright with "Cannot read properties of null".
+  const last = turns.reduce((best, turn) => (turn.read + turn.written > 0 ? turn : best), turns[turns.length - 1]);
   const total = read + written;
 
   return {
@@ -159,7 +200,7 @@ export function modelSwitchCost(turns) {
   const health = cacheHealth(turns);
   if (!health?.prefixTokens) return null;
 
-  const switched = new Set(turns.map((t) => t.model).filter(Boolean)).size > 1;
+  const switched = new Set(turns.filter(realModel).map((t) => t.model)).size > 1;
   return {
     prefixTokens: health.prefixTokens,
     rewriteCost: Math.round(health.prefixTokens * WRITE_MULTIPLIER),
@@ -182,7 +223,12 @@ export function modelSwitchCost(turns) {
 const VOLATILE = [
   { id: 'timestamp', re: /\b\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}/, why: 'an embedded timestamp' },
   { id: 'date', re: /\b(?:today|current date)\b[^\n]{0,40}\d{4}-\d{2}-\d{2}/i, why: 'an embedded current date' },
-  { id: 'iso-date', re: /\b\d{4}-\d{2}-\d{2}\b/, why: 'an embedded date' },
+  // A bare date is a SUSPICION, not a measurement: "- 2025-10-31: reworked the
+  // loader" is byte-identical every session. Kept, because stableText fails
+  // closed over our own output and dropping a line there costs little -- but
+  // NOT priced, because in the blame report a false positive invents a
+  // per-session cost and tells the user to delete their changelog.
+  { id: 'iso-date', re: /\b\d{4}-\d{2}-\d{2}\b/, why: 'an embedded date', priced: false },
   { id: 'session-id', re: /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/i, why: 'a session id' },
   { id: 'git-sha', re: /\b[0-9a-f]{40}\b/, why: 'a git sha' },
   { id: 'counter', re: /\b(?:run|build|attempt|iteration)\s*#?\d+\b/i, why: 'a run counter' },
@@ -196,7 +242,7 @@ export function volatileLines(text) {
   for (let i = 0; i < lines.length; i++) {
     for (const rule of VOLATILE) {
       if (!rule.re.test(lines[i])) continue;
-      out.push({ line: i + 1, id: rule.id, why: rule.why, text: lines[i].trim().slice(0, 120) });
+      out.push({ line: i + 1, id: rule.id, why: rule.why, priced: rule.priced !== false, text: lines[i].trim().slice(0, 120) });
       break; // one cause per line is enough to act on
     }
   }
@@ -235,19 +281,36 @@ export function attributeInvalidation(cwd, prefixTokens = null, { files = null }
     }
 
     const size = estimate(text);
+    const lines = text.split('\n');
     const found = volatileLines(text);
-    for (const hit of found) {
-      // Everything after this file's start is re-written. Conservative: the
-      // preamble ahead of it is not counted, so this is a floor rather than a
-      // flattering estimate.
-      const downstream = prefixTokens != null ? Math.max(0, prefixTokens - offset) : null;
+    for (const [index, hit] of found.entries()) {
+      // Everything after THIS LINE is re-written -- not everything after the
+      // file, which priced every hit in a file identically and, because each is
+      // emitted as its own record and audit.mjs sums them, billed the same
+      // tokens once per line. Measured before this fix: a three-line changelog
+      // in CLAUDE.md priced at 2,301,093 tokens/session against a 613,625-token
+      // prefix -- 3.75x the entire prefix. Conservative still: the preamble
+      // ahead of the file is not counted, so this remains a floor.
+      const ahead = offset + estimate(lines.slice(0, hit.line - 1).join('\n'));
+      const downstream = prefixTokens != null ? Math.max(0, prefixTokens - ahead) : null;
+      // A prefix cache invalidates ONCE, at the earliest difference. A later
+      // volatile line in the same file costs nothing extra until the first one
+      // is fixed, so it is reported for context but not billed again.
+      const subsumedBy = index === 0 ? null : `${relative}:${found[0].line}`;
       out.push({
         file: relative,
         line: hit.line,
         why: hit.why,
         excerpt: hit.text,
         downstreamTokens: downstream,
-        costPerSession: downstream == null ? null : Math.round(downstream * WRITE_MULTIPLIER),
+        subsumedBy,
+        // null means NOT MEASURABLE -- no prefix measurement, or a construct we
+        // decline to price. 0 means measured and genuinely free, which is what a
+        // subsumed hit is: real, but already billed by the earlier line. Folding
+        // those two into one value is the same mistake this file warns about.
+        costPerSession: downstream == null || !hit.priced
+          ? null
+          : (subsumedBy ? 0 : Math.round(downstream * WRITE_MULTIPLIER)),
         remedy: {
           kind: 'yours',
           type: 'edit',

--- a/integrations/gemini/hooks/lib/cache.mjs
+++ b/integrations/gemini/hooks/lib/cache.mjs
@@ -296,7 +296,15 @@ export function attributeInvalidation(cwd, prefixTokens = null, { files = null }
       // A prefix cache invalidates ONCE, at the earliest difference. A later
       // volatile line in the same file costs nothing extra until the first one
       // is fixed, so it is reported for context but not billed again.
-      const subsumedBy = index === 0 ? null : `${relative}:${found[0].line}`;
+      //
+      // Subsumption is measured against the earliest PRICED hit, not simply the
+      // first hit. An unpriced bare date at index 0 does not invalidate anything
+      // we are willing to bill for, so treating it as the subsumer zeroed the
+      // price of a genuine timestamp below it -- turning a real, fixable cost
+      // into a reported zero.
+      const firstPriced = found.find((h) => h.priced);
+      const subsumedBy =
+        hit.priced && firstPriced && firstPriced !== hit ? `${relative}:${firstPriced.line}` : null;
       out.push({
         file: relative,
         line: hit.line,

--- a/integrations/gemini/hooks/lib/cache.mjs
+++ b/integrations/gemini/hooks/lib/cache.mjs
@@ -30,13 +30,28 @@
  * cache-safety-by-construction half of this file.
  */
 
-import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { readFileSync, readdirSync, statSync, existsSync, openSync, readSync, closeSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 
 /** Anthropic prompt-cache pricing multipliers, relative to a plain input token. */
 export const WRITE_MULTIPLIER = 1.25;
 export const READ_MULTIPLIER = 0.1;
+
+/**
+ * The client's own placeholder for a row it wrote itself -- an interrupt, an
+ * auth error, "No response requested." at the end of a session. It carries a
+ * full all-zero `usage` object, so it survives every filter below, but it is
+ * not a model and no prefix was ever written under it.
+ *
+ * Measured across the four real transcripts on one machine: all four contain
+ * these rows, and three used exactly one real model yet would report two --
+ * a false "2 models used in this session" costing an invented ~767,000 tokens.
+ */
+const SYNTHETIC_MODEL = '<synthetic>';
+
+/** True for a turn naming a model an inference actually ran under. */
+const realModel = (turn) => Boolean(turn.model) && turn.model !== SYNTHETIC_MODEL;
 
 /* -------------------------------------------------------------- MEASUREMENT */
 
@@ -77,8 +92,27 @@ export function readCacheUsage(path, { maxBytes = 4_000_000 } = {}) {
   let text;
   try {
     const size = statSync(path).size;
-    const fd = readFileSync(path, 'utf8');
-    text = size > maxBytes ? fd.slice(size - maxBytes) : fd;
+    if (size <= maxBytes) {
+      text = readFileSync(path, 'utf8');
+    } else {
+      // Read the tail OFF DISK. readFileSync loaded the whole file first, which
+      // on a real 147 MB transcript measured 361 ms and 334 MB of RSS to keep
+      // 4 MB, and throws ERR_STRING_TOO_LONG past ~512 MB -- which the catch
+      // below silently turns into "no cache measurements available" for a
+      // perfectly readable file. It also sliced a BYTE offset out of a UTF-16
+      // string: on that same file bytes-minus-chars was 140,264, so 3.5% of the
+      // requested window was quietly discarded.
+      const handle = openSync(path, 'r');
+      try {
+        const buffer = Buffer.allocUnsafe(maxBytes);
+        const got = readSync(handle, buffer, 0, maxBytes, size - maxBytes);
+        // A partial UTF-8 sequence at the cut is discarded by the startsWith('{')
+        // and JSON.parse guards below, exactly as the old first-line slice was.
+        text = buffer.toString('utf8', 0, got);
+      } finally {
+        closeSync(handle);
+      }
+    }
   } catch {
     return [];
   }
@@ -122,7 +156,7 @@ export function cacheHealth(turns) {
   for (const turn of turns) {
     read += turn.read;
     written += turn.written;
-    if (!turn.model) continue;
+    if (!realModel(turn)) continue;
     if (!models.has(turn.model)) models.set(turn.model, { read: 0, written: 0, turns: 0 });
     const entry = models.get(turn.model);
     entry.read += turn.read;
@@ -130,7 +164,14 @@ export function cacheHealth(turns) {
     entry.turns += 1;
   }
 
-  const last = turns[turns.length - 1];
+  // The last turn that actually CARRIED a prefix. A session routinely ends on a
+  // zero-usage row -- the client's '<synthetic>' placeholders, an interrupted
+  // turn -- and reading turns[length - 1] literally reported a 0-token prefix
+  // for a session whose prefix was 600,000 tokens. That zeroed every
+  // attribution price, made keepWarm answer "unknown", and returned null from
+  // modelSwitchCost under a guard its caller does not share, which crashed
+  // cache_audit outright with "Cannot read properties of null".
+  const last = turns.reduce((best, turn) => (turn.read + turn.written > 0 ? turn : best), turns[turns.length - 1]);
   const total = read + written;
 
   return {
@@ -159,7 +200,7 @@ export function modelSwitchCost(turns) {
   const health = cacheHealth(turns);
   if (!health?.prefixTokens) return null;
 
-  const switched = new Set(turns.map((t) => t.model).filter(Boolean)).size > 1;
+  const switched = new Set(turns.filter(realModel).map((t) => t.model)).size > 1;
   return {
     prefixTokens: health.prefixTokens,
     rewriteCost: Math.round(health.prefixTokens * WRITE_MULTIPLIER),
@@ -182,7 +223,12 @@ export function modelSwitchCost(turns) {
 const VOLATILE = [
   { id: 'timestamp', re: /\b\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}/, why: 'an embedded timestamp' },
   { id: 'date', re: /\b(?:today|current date)\b[^\n]{0,40}\d{4}-\d{2}-\d{2}/i, why: 'an embedded current date' },
-  { id: 'iso-date', re: /\b\d{4}-\d{2}-\d{2}\b/, why: 'an embedded date' },
+  // A bare date is a SUSPICION, not a measurement: "- 2025-10-31: reworked the
+  // loader" is byte-identical every session. Kept, because stableText fails
+  // closed over our own output and dropping a line there costs little -- but
+  // NOT priced, because in the blame report a false positive invents a
+  // per-session cost and tells the user to delete their changelog.
+  { id: 'iso-date', re: /\b\d{4}-\d{2}-\d{2}\b/, why: 'an embedded date', priced: false },
   { id: 'session-id', re: /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/i, why: 'a session id' },
   { id: 'git-sha', re: /\b[0-9a-f]{40}\b/, why: 'a git sha' },
   { id: 'counter', re: /\b(?:run|build|attempt|iteration)\s*#?\d+\b/i, why: 'a run counter' },
@@ -196,7 +242,7 @@ export function volatileLines(text) {
   for (let i = 0; i < lines.length; i++) {
     for (const rule of VOLATILE) {
       if (!rule.re.test(lines[i])) continue;
-      out.push({ line: i + 1, id: rule.id, why: rule.why, text: lines[i].trim().slice(0, 120) });
+      out.push({ line: i + 1, id: rule.id, why: rule.why, priced: rule.priced !== false, text: lines[i].trim().slice(0, 120) });
       break; // one cause per line is enough to act on
     }
   }
@@ -235,19 +281,36 @@ export function attributeInvalidation(cwd, prefixTokens = null, { files = null }
     }
 
     const size = estimate(text);
+    const lines = text.split('\n');
     const found = volatileLines(text);
-    for (const hit of found) {
-      // Everything after this file's start is re-written. Conservative: the
-      // preamble ahead of it is not counted, so this is a floor rather than a
-      // flattering estimate.
-      const downstream = prefixTokens != null ? Math.max(0, prefixTokens - offset) : null;
+    for (const [index, hit] of found.entries()) {
+      // Everything after THIS LINE is re-written -- not everything after the
+      // file, which priced every hit in a file identically and, because each is
+      // emitted as its own record and audit.mjs sums them, billed the same
+      // tokens once per line. Measured before this fix: a three-line changelog
+      // in CLAUDE.md priced at 2,301,093 tokens/session against a 613,625-token
+      // prefix -- 3.75x the entire prefix. Conservative still: the preamble
+      // ahead of the file is not counted, so this remains a floor.
+      const ahead = offset + estimate(lines.slice(0, hit.line - 1).join('\n'));
+      const downstream = prefixTokens != null ? Math.max(0, prefixTokens - ahead) : null;
+      // A prefix cache invalidates ONCE, at the earliest difference. A later
+      // volatile line in the same file costs nothing extra until the first one
+      // is fixed, so it is reported for context but not billed again.
+      const subsumedBy = index === 0 ? null : `${relative}:${found[0].line}`;
       out.push({
         file: relative,
         line: hit.line,
         why: hit.why,
         excerpt: hit.text,
         downstreamTokens: downstream,
-        costPerSession: downstream == null ? null : Math.round(downstream * WRITE_MULTIPLIER),
+        subsumedBy,
+        // null means NOT MEASURABLE -- no prefix measurement, or a construct we
+        // decline to price. 0 means measured and genuinely free, which is what a
+        // subsumed hit is: real, but already billed by the earlier line. Folding
+        // those two into one value is the same mistake this file warns about.
+        costPerSession: downstream == null || !hit.priced
+          ? null
+          : (subsumedBy ? 0 : Math.round(downstream * WRITE_MULTIPLIER)),
         remedy: {
           kind: 'yours',
           type: 'edit',

--- a/integrations/opencode/hooks/lib/cache.mjs
+++ b/integrations/opencode/hooks/lib/cache.mjs
@@ -296,7 +296,15 @@ export function attributeInvalidation(cwd, prefixTokens = null, { files = null }
       // A prefix cache invalidates ONCE, at the earliest difference. A later
       // volatile line in the same file costs nothing extra until the first one
       // is fixed, so it is reported for context but not billed again.
-      const subsumedBy = index === 0 ? null : `${relative}:${found[0].line}`;
+      //
+      // Subsumption is measured against the earliest PRICED hit, not simply the
+      // first hit. An unpriced bare date at index 0 does not invalidate anything
+      // we are willing to bill for, so treating it as the subsumer zeroed the
+      // price of a genuine timestamp below it -- turning a real, fixable cost
+      // into a reported zero.
+      const firstPriced = found.find((h) => h.priced);
+      const subsumedBy =
+        hit.priced && firstPriced && firstPriced !== hit ? `${relative}:${firstPriced.line}` : null;
       out.push({
         file: relative,
         line: hit.line,

--- a/integrations/opencode/hooks/lib/cache.mjs
+++ b/integrations/opencode/hooks/lib/cache.mjs
@@ -30,13 +30,28 @@
  * cache-safety-by-construction half of this file.
  */
 
-import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { readFileSync, readdirSync, statSync, existsSync, openSync, readSync, closeSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 
 /** Anthropic prompt-cache pricing multipliers, relative to a plain input token. */
 export const WRITE_MULTIPLIER = 1.25;
 export const READ_MULTIPLIER = 0.1;
+
+/**
+ * The client's own placeholder for a row it wrote itself -- an interrupt, an
+ * auth error, "No response requested." at the end of a session. It carries a
+ * full all-zero `usage` object, so it survives every filter below, but it is
+ * not a model and no prefix was ever written under it.
+ *
+ * Measured across the four real transcripts on one machine: all four contain
+ * these rows, and three used exactly one real model yet would report two --
+ * a false "2 models used in this session" costing an invented ~767,000 tokens.
+ */
+const SYNTHETIC_MODEL = '<synthetic>';
+
+/** True for a turn naming a model an inference actually ran under. */
+const realModel = (turn) => Boolean(turn.model) && turn.model !== SYNTHETIC_MODEL;
 
 /* -------------------------------------------------------------- MEASUREMENT */
 
@@ -77,8 +92,27 @@ export function readCacheUsage(path, { maxBytes = 4_000_000 } = {}) {
   let text;
   try {
     const size = statSync(path).size;
-    const fd = readFileSync(path, 'utf8');
-    text = size > maxBytes ? fd.slice(size - maxBytes) : fd;
+    if (size <= maxBytes) {
+      text = readFileSync(path, 'utf8');
+    } else {
+      // Read the tail OFF DISK. readFileSync loaded the whole file first, which
+      // on a real 147 MB transcript measured 361 ms and 334 MB of RSS to keep
+      // 4 MB, and throws ERR_STRING_TOO_LONG past ~512 MB -- which the catch
+      // below silently turns into "no cache measurements available" for a
+      // perfectly readable file. It also sliced a BYTE offset out of a UTF-16
+      // string: on that same file bytes-minus-chars was 140,264, so 3.5% of the
+      // requested window was quietly discarded.
+      const handle = openSync(path, 'r');
+      try {
+        const buffer = Buffer.allocUnsafe(maxBytes);
+        const got = readSync(handle, buffer, 0, maxBytes, size - maxBytes);
+        // A partial UTF-8 sequence at the cut is discarded by the startsWith('{')
+        // and JSON.parse guards below, exactly as the old first-line slice was.
+        text = buffer.toString('utf8', 0, got);
+      } finally {
+        closeSync(handle);
+      }
+    }
   } catch {
     return [];
   }
@@ -122,7 +156,7 @@ export function cacheHealth(turns) {
   for (const turn of turns) {
     read += turn.read;
     written += turn.written;
-    if (!turn.model) continue;
+    if (!realModel(turn)) continue;
     if (!models.has(turn.model)) models.set(turn.model, { read: 0, written: 0, turns: 0 });
     const entry = models.get(turn.model);
     entry.read += turn.read;
@@ -130,7 +164,14 @@ export function cacheHealth(turns) {
     entry.turns += 1;
   }
 
-  const last = turns[turns.length - 1];
+  // The last turn that actually CARRIED a prefix. A session routinely ends on a
+  // zero-usage row -- the client's '<synthetic>' placeholders, an interrupted
+  // turn -- and reading turns[length - 1] literally reported a 0-token prefix
+  // for a session whose prefix was 600,000 tokens. That zeroed every
+  // attribution price, made keepWarm answer "unknown", and returned null from
+  // modelSwitchCost under a guard its caller does not share, which crashed
+  // cache_audit outright with "Cannot read properties of null".
+  const last = turns.reduce((best, turn) => (turn.read + turn.written > 0 ? turn : best), turns[turns.length - 1]);
   const total = read + written;
 
   return {
@@ -159,7 +200,7 @@ export function modelSwitchCost(turns) {
   const health = cacheHealth(turns);
   if (!health?.prefixTokens) return null;
 
-  const switched = new Set(turns.map((t) => t.model).filter(Boolean)).size > 1;
+  const switched = new Set(turns.filter(realModel).map((t) => t.model)).size > 1;
   return {
     prefixTokens: health.prefixTokens,
     rewriteCost: Math.round(health.prefixTokens * WRITE_MULTIPLIER),
@@ -182,7 +223,12 @@ export function modelSwitchCost(turns) {
 const VOLATILE = [
   { id: 'timestamp', re: /\b\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}/, why: 'an embedded timestamp' },
   { id: 'date', re: /\b(?:today|current date)\b[^\n]{0,40}\d{4}-\d{2}-\d{2}/i, why: 'an embedded current date' },
-  { id: 'iso-date', re: /\b\d{4}-\d{2}-\d{2}\b/, why: 'an embedded date' },
+  // A bare date is a SUSPICION, not a measurement: "- 2025-10-31: reworked the
+  // loader" is byte-identical every session. Kept, because stableText fails
+  // closed over our own output and dropping a line there costs little -- but
+  // NOT priced, because in the blame report a false positive invents a
+  // per-session cost and tells the user to delete their changelog.
+  { id: 'iso-date', re: /\b\d{4}-\d{2}-\d{2}\b/, why: 'an embedded date', priced: false },
   { id: 'session-id', re: /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/i, why: 'a session id' },
   { id: 'git-sha', re: /\b[0-9a-f]{40}\b/, why: 'a git sha' },
   { id: 'counter', re: /\b(?:run|build|attempt|iteration)\s*#?\d+\b/i, why: 'a run counter' },
@@ -196,7 +242,7 @@ export function volatileLines(text) {
   for (let i = 0; i < lines.length; i++) {
     for (const rule of VOLATILE) {
       if (!rule.re.test(lines[i])) continue;
-      out.push({ line: i + 1, id: rule.id, why: rule.why, text: lines[i].trim().slice(0, 120) });
+      out.push({ line: i + 1, id: rule.id, why: rule.why, priced: rule.priced !== false, text: lines[i].trim().slice(0, 120) });
       break; // one cause per line is enough to act on
     }
   }
@@ -235,19 +281,36 @@ export function attributeInvalidation(cwd, prefixTokens = null, { files = null }
     }
 
     const size = estimate(text);
+    const lines = text.split('\n');
     const found = volatileLines(text);
-    for (const hit of found) {
-      // Everything after this file's start is re-written. Conservative: the
-      // preamble ahead of it is not counted, so this is a floor rather than a
-      // flattering estimate.
-      const downstream = prefixTokens != null ? Math.max(0, prefixTokens - offset) : null;
+    for (const [index, hit] of found.entries()) {
+      // Everything after THIS LINE is re-written -- not everything after the
+      // file, which priced every hit in a file identically and, because each is
+      // emitted as its own record and audit.mjs sums them, billed the same
+      // tokens once per line. Measured before this fix: a three-line changelog
+      // in CLAUDE.md priced at 2,301,093 tokens/session against a 613,625-token
+      // prefix -- 3.75x the entire prefix. Conservative still: the preamble
+      // ahead of the file is not counted, so this remains a floor.
+      const ahead = offset + estimate(lines.slice(0, hit.line - 1).join('\n'));
+      const downstream = prefixTokens != null ? Math.max(0, prefixTokens - ahead) : null;
+      // A prefix cache invalidates ONCE, at the earliest difference. A later
+      // volatile line in the same file costs nothing extra until the first one
+      // is fixed, so it is reported for context but not billed again.
+      const subsumedBy = index === 0 ? null : `${relative}:${found[0].line}`;
       out.push({
         file: relative,
         line: hit.line,
         why: hit.why,
         excerpt: hit.text,
         downstreamTokens: downstream,
-        costPerSession: downstream == null ? null : Math.round(downstream * WRITE_MULTIPLIER),
+        subsumedBy,
+        // null means NOT MEASURABLE -- no prefix measurement, or a construct we
+        // decline to price. 0 means measured and genuinely free, which is what a
+        // subsumed hit is: real, but already billed by the earlier line. Folding
+        // those two into one value is the same mistake this file warns about.
+        costPerSession: downstream == null || !hit.priced
+          ? null
+          : (subsumedBy ? 0 : Math.round(downstream * WRITE_MULTIPLIER)),
         remedy: {
           kind: 'yours',
           type: 'edit',

--- a/integrations/qwen/hooks/lib/cache.mjs
+++ b/integrations/qwen/hooks/lib/cache.mjs
@@ -296,7 +296,15 @@ export function attributeInvalidation(cwd, prefixTokens = null, { files = null }
       // A prefix cache invalidates ONCE, at the earliest difference. A later
       // volatile line in the same file costs nothing extra until the first one
       // is fixed, so it is reported for context but not billed again.
-      const subsumedBy = index === 0 ? null : `${relative}:${found[0].line}`;
+      //
+      // Subsumption is measured against the earliest PRICED hit, not simply the
+      // first hit. An unpriced bare date at index 0 does not invalidate anything
+      // we are willing to bill for, so treating it as the subsumer zeroed the
+      // price of a genuine timestamp below it -- turning a real, fixable cost
+      // into a reported zero.
+      const firstPriced = found.find((h) => h.priced);
+      const subsumedBy =
+        hit.priced && firstPriced && firstPriced !== hit ? `${relative}:${firstPriced.line}` : null;
       out.push({
         file: relative,
         line: hit.line,

--- a/integrations/qwen/hooks/lib/cache.mjs
+++ b/integrations/qwen/hooks/lib/cache.mjs
@@ -30,13 +30,28 @@
  * cache-safety-by-construction half of this file.
  */
 
-import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { readFileSync, readdirSync, statSync, existsSync, openSync, readSync, closeSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 
 /** Anthropic prompt-cache pricing multipliers, relative to a plain input token. */
 export const WRITE_MULTIPLIER = 1.25;
 export const READ_MULTIPLIER = 0.1;
+
+/**
+ * The client's own placeholder for a row it wrote itself -- an interrupt, an
+ * auth error, "No response requested." at the end of a session. It carries a
+ * full all-zero `usage` object, so it survives every filter below, but it is
+ * not a model and no prefix was ever written under it.
+ *
+ * Measured across the four real transcripts on one machine: all four contain
+ * these rows, and three used exactly one real model yet would report two --
+ * a false "2 models used in this session" costing an invented ~767,000 tokens.
+ */
+const SYNTHETIC_MODEL = '<synthetic>';
+
+/** True for a turn naming a model an inference actually ran under. */
+const realModel = (turn) => Boolean(turn.model) && turn.model !== SYNTHETIC_MODEL;
 
 /* -------------------------------------------------------------- MEASUREMENT */
 
@@ -77,8 +92,27 @@ export function readCacheUsage(path, { maxBytes = 4_000_000 } = {}) {
   let text;
   try {
     const size = statSync(path).size;
-    const fd = readFileSync(path, 'utf8');
-    text = size > maxBytes ? fd.slice(size - maxBytes) : fd;
+    if (size <= maxBytes) {
+      text = readFileSync(path, 'utf8');
+    } else {
+      // Read the tail OFF DISK. readFileSync loaded the whole file first, which
+      // on a real 147 MB transcript measured 361 ms and 334 MB of RSS to keep
+      // 4 MB, and throws ERR_STRING_TOO_LONG past ~512 MB -- which the catch
+      // below silently turns into "no cache measurements available" for a
+      // perfectly readable file. It also sliced a BYTE offset out of a UTF-16
+      // string: on that same file bytes-minus-chars was 140,264, so 3.5% of the
+      // requested window was quietly discarded.
+      const handle = openSync(path, 'r');
+      try {
+        const buffer = Buffer.allocUnsafe(maxBytes);
+        const got = readSync(handle, buffer, 0, maxBytes, size - maxBytes);
+        // A partial UTF-8 sequence at the cut is discarded by the startsWith('{')
+        // and JSON.parse guards below, exactly as the old first-line slice was.
+        text = buffer.toString('utf8', 0, got);
+      } finally {
+        closeSync(handle);
+      }
+    }
   } catch {
     return [];
   }
@@ -122,7 +156,7 @@ export function cacheHealth(turns) {
   for (const turn of turns) {
     read += turn.read;
     written += turn.written;
-    if (!turn.model) continue;
+    if (!realModel(turn)) continue;
     if (!models.has(turn.model)) models.set(turn.model, { read: 0, written: 0, turns: 0 });
     const entry = models.get(turn.model);
     entry.read += turn.read;
@@ -130,7 +164,14 @@ export function cacheHealth(turns) {
     entry.turns += 1;
   }
 
-  const last = turns[turns.length - 1];
+  // The last turn that actually CARRIED a prefix. A session routinely ends on a
+  // zero-usage row -- the client's '<synthetic>' placeholders, an interrupted
+  // turn -- and reading turns[length - 1] literally reported a 0-token prefix
+  // for a session whose prefix was 600,000 tokens. That zeroed every
+  // attribution price, made keepWarm answer "unknown", and returned null from
+  // modelSwitchCost under a guard its caller does not share, which crashed
+  // cache_audit outright with "Cannot read properties of null".
+  const last = turns.reduce((best, turn) => (turn.read + turn.written > 0 ? turn : best), turns[turns.length - 1]);
   const total = read + written;
 
   return {
@@ -159,7 +200,7 @@ export function modelSwitchCost(turns) {
   const health = cacheHealth(turns);
   if (!health?.prefixTokens) return null;
 
-  const switched = new Set(turns.map((t) => t.model).filter(Boolean)).size > 1;
+  const switched = new Set(turns.filter(realModel).map((t) => t.model)).size > 1;
   return {
     prefixTokens: health.prefixTokens,
     rewriteCost: Math.round(health.prefixTokens * WRITE_MULTIPLIER),
@@ -182,7 +223,12 @@ export function modelSwitchCost(turns) {
 const VOLATILE = [
   { id: 'timestamp', re: /\b\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}/, why: 'an embedded timestamp' },
   { id: 'date', re: /\b(?:today|current date)\b[^\n]{0,40}\d{4}-\d{2}-\d{2}/i, why: 'an embedded current date' },
-  { id: 'iso-date', re: /\b\d{4}-\d{2}-\d{2}\b/, why: 'an embedded date' },
+  // A bare date is a SUSPICION, not a measurement: "- 2025-10-31: reworked the
+  // loader" is byte-identical every session. Kept, because stableText fails
+  // closed over our own output and dropping a line there costs little -- but
+  // NOT priced, because in the blame report a false positive invents a
+  // per-session cost and tells the user to delete their changelog.
+  { id: 'iso-date', re: /\b\d{4}-\d{2}-\d{2}\b/, why: 'an embedded date', priced: false },
   { id: 'session-id', re: /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/i, why: 'a session id' },
   { id: 'git-sha', re: /\b[0-9a-f]{40}\b/, why: 'a git sha' },
   { id: 'counter', re: /\b(?:run|build|attempt|iteration)\s*#?\d+\b/i, why: 'a run counter' },
@@ -196,7 +242,7 @@ export function volatileLines(text) {
   for (let i = 0; i < lines.length; i++) {
     for (const rule of VOLATILE) {
       if (!rule.re.test(lines[i])) continue;
-      out.push({ line: i + 1, id: rule.id, why: rule.why, text: lines[i].trim().slice(0, 120) });
+      out.push({ line: i + 1, id: rule.id, why: rule.why, priced: rule.priced !== false, text: lines[i].trim().slice(0, 120) });
       break; // one cause per line is enough to act on
     }
   }
@@ -235,19 +281,36 @@ export function attributeInvalidation(cwd, prefixTokens = null, { files = null }
     }
 
     const size = estimate(text);
+    const lines = text.split('\n');
     const found = volatileLines(text);
-    for (const hit of found) {
-      // Everything after this file's start is re-written. Conservative: the
-      // preamble ahead of it is not counted, so this is a floor rather than a
-      // flattering estimate.
-      const downstream = prefixTokens != null ? Math.max(0, prefixTokens - offset) : null;
+    for (const [index, hit] of found.entries()) {
+      // Everything after THIS LINE is re-written -- not everything after the
+      // file, which priced every hit in a file identically and, because each is
+      // emitted as its own record and audit.mjs sums them, billed the same
+      // tokens once per line. Measured before this fix: a three-line changelog
+      // in CLAUDE.md priced at 2,301,093 tokens/session against a 613,625-token
+      // prefix -- 3.75x the entire prefix. Conservative still: the preamble
+      // ahead of the file is not counted, so this remains a floor.
+      const ahead = offset + estimate(lines.slice(0, hit.line - 1).join('\n'));
+      const downstream = prefixTokens != null ? Math.max(0, prefixTokens - ahead) : null;
+      // A prefix cache invalidates ONCE, at the earliest difference. A later
+      // volatile line in the same file costs nothing extra until the first one
+      // is fixed, so it is reported for context but not billed again.
+      const subsumedBy = index === 0 ? null : `${relative}:${found[0].line}`;
       out.push({
         file: relative,
         line: hit.line,
         why: hit.why,
         excerpt: hit.text,
         downstreamTokens: downstream,
-        costPerSession: downstream == null ? null : Math.round(downstream * WRITE_MULTIPLIER),
+        subsumedBy,
+        // null means NOT MEASURABLE -- no prefix measurement, or a construct we
+        // decline to price. 0 means measured and genuinely free, which is what a
+        // subsumed hit is: real, but already billed by the earlier line. Folding
+        // those two into one value is the same mistake this file warns about.
+        costPerSession: downstream == null || !hit.priced
+          ? null
+          : (subsumedBy ? 0 : Math.round(downstream * WRITE_MULTIPLIER)),
         remedy: {
           kind: 'yours',
           type: 'edit',

--- a/plugin/hooks/lib/cache.mjs
+++ b/plugin/hooks/lib/cache.mjs
@@ -296,7 +296,15 @@ export function attributeInvalidation(cwd, prefixTokens = null, { files = null }
       // A prefix cache invalidates ONCE, at the earliest difference. A later
       // volatile line in the same file costs nothing extra until the first one
       // is fixed, so it is reported for context but not billed again.
-      const subsumedBy = index === 0 ? null : `${relative}:${found[0].line}`;
+      //
+      // Subsumption is measured against the earliest PRICED hit, not simply the
+      // first hit. An unpriced bare date at index 0 does not invalidate anything
+      // we are willing to bill for, so treating it as the subsumer zeroed the
+      // price of a genuine timestamp below it -- turning a real, fixable cost
+      // into a reported zero.
+      const firstPriced = found.find((h) => h.priced);
+      const subsumedBy =
+        hit.priced && firstPriced && firstPriced !== hit ? `${relative}:${firstPriced.line}` : null;
       out.push({
         file: relative,
         line: hit.line,

--- a/plugin/hooks/lib/cache.mjs
+++ b/plugin/hooks/lib/cache.mjs
@@ -30,13 +30,28 @@
  * cache-safety-by-construction half of this file.
  */
 
-import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { readFileSync, readdirSync, statSync, existsSync, openSync, readSync, closeSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 
 /** Anthropic prompt-cache pricing multipliers, relative to a plain input token. */
 export const WRITE_MULTIPLIER = 1.25;
 export const READ_MULTIPLIER = 0.1;
+
+/**
+ * The client's own placeholder for a row it wrote itself -- an interrupt, an
+ * auth error, "No response requested." at the end of a session. It carries a
+ * full all-zero `usage` object, so it survives every filter below, but it is
+ * not a model and no prefix was ever written under it.
+ *
+ * Measured across the four real transcripts on one machine: all four contain
+ * these rows, and three used exactly one real model yet would report two --
+ * a false "2 models used in this session" costing an invented ~767,000 tokens.
+ */
+const SYNTHETIC_MODEL = '<synthetic>';
+
+/** True for a turn naming a model an inference actually ran under. */
+const realModel = (turn) => Boolean(turn.model) && turn.model !== SYNTHETIC_MODEL;
 
 /* -------------------------------------------------------------- MEASUREMENT */
 
@@ -77,8 +92,27 @@ export function readCacheUsage(path, { maxBytes = 4_000_000 } = {}) {
   let text;
   try {
     const size = statSync(path).size;
-    const fd = readFileSync(path, 'utf8');
-    text = size > maxBytes ? fd.slice(size - maxBytes) : fd;
+    if (size <= maxBytes) {
+      text = readFileSync(path, 'utf8');
+    } else {
+      // Read the tail OFF DISK. readFileSync loaded the whole file first, which
+      // on a real 147 MB transcript measured 361 ms and 334 MB of RSS to keep
+      // 4 MB, and throws ERR_STRING_TOO_LONG past ~512 MB -- which the catch
+      // below silently turns into "no cache measurements available" for a
+      // perfectly readable file. It also sliced a BYTE offset out of a UTF-16
+      // string: on that same file bytes-minus-chars was 140,264, so 3.5% of the
+      // requested window was quietly discarded.
+      const handle = openSync(path, 'r');
+      try {
+        const buffer = Buffer.allocUnsafe(maxBytes);
+        const got = readSync(handle, buffer, 0, maxBytes, size - maxBytes);
+        // A partial UTF-8 sequence at the cut is discarded by the startsWith('{')
+        // and JSON.parse guards below, exactly as the old first-line slice was.
+        text = buffer.toString('utf8', 0, got);
+      } finally {
+        closeSync(handle);
+      }
+    }
   } catch {
     return [];
   }
@@ -122,7 +156,7 @@ export function cacheHealth(turns) {
   for (const turn of turns) {
     read += turn.read;
     written += turn.written;
-    if (!turn.model) continue;
+    if (!realModel(turn)) continue;
     if (!models.has(turn.model)) models.set(turn.model, { read: 0, written: 0, turns: 0 });
     const entry = models.get(turn.model);
     entry.read += turn.read;
@@ -130,7 +164,14 @@ export function cacheHealth(turns) {
     entry.turns += 1;
   }
 
-  const last = turns[turns.length - 1];
+  // The last turn that actually CARRIED a prefix. A session routinely ends on a
+  // zero-usage row -- the client's '<synthetic>' placeholders, an interrupted
+  // turn -- and reading turns[length - 1] literally reported a 0-token prefix
+  // for a session whose prefix was 600,000 tokens. That zeroed every
+  // attribution price, made keepWarm answer "unknown", and returned null from
+  // modelSwitchCost under a guard its caller does not share, which crashed
+  // cache_audit outright with "Cannot read properties of null".
+  const last = turns.reduce((best, turn) => (turn.read + turn.written > 0 ? turn : best), turns[turns.length - 1]);
   const total = read + written;
 
   return {
@@ -159,7 +200,7 @@ export function modelSwitchCost(turns) {
   const health = cacheHealth(turns);
   if (!health?.prefixTokens) return null;
 
-  const switched = new Set(turns.map((t) => t.model).filter(Boolean)).size > 1;
+  const switched = new Set(turns.filter(realModel).map((t) => t.model)).size > 1;
   return {
     prefixTokens: health.prefixTokens,
     rewriteCost: Math.round(health.prefixTokens * WRITE_MULTIPLIER),
@@ -182,7 +223,12 @@ export function modelSwitchCost(turns) {
 const VOLATILE = [
   { id: 'timestamp', re: /\b\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}/, why: 'an embedded timestamp' },
   { id: 'date', re: /\b(?:today|current date)\b[^\n]{0,40}\d{4}-\d{2}-\d{2}/i, why: 'an embedded current date' },
-  { id: 'iso-date', re: /\b\d{4}-\d{2}-\d{2}\b/, why: 'an embedded date' },
+  // A bare date is a SUSPICION, not a measurement: "- 2025-10-31: reworked the
+  // loader" is byte-identical every session. Kept, because stableText fails
+  // closed over our own output and dropping a line there costs little -- but
+  // NOT priced, because in the blame report a false positive invents a
+  // per-session cost and tells the user to delete their changelog.
+  { id: 'iso-date', re: /\b\d{4}-\d{2}-\d{2}\b/, why: 'an embedded date', priced: false },
   { id: 'session-id', re: /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/i, why: 'a session id' },
   { id: 'git-sha', re: /\b[0-9a-f]{40}\b/, why: 'a git sha' },
   { id: 'counter', re: /\b(?:run|build|attempt|iteration)\s*#?\d+\b/i, why: 'a run counter' },
@@ -196,7 +242,7 @@ export function volatileLines(text) {
   for (let i = 0; i < lines.length; i++) {
     for (const rule of VOLATILE) {
       if (!rule.re.test(lines[i])) continue;
-      out.push({ line: i + 1, id: rule.id, why: rule.why, text: lines[i].trim().slice(0, 120) });
+      out.push({ line: i + 1, id: rule.id, why: rule.why, priced: rule.priced !== false, text: lines[i].trim().slice(0, 120) });
       break; // one cause per line is enough to act on
     }
   }
@@ -235,19 +281,36 @@ export function attributeInvalidation(cwd, prefixTokens = null, { files = null }
     }
 
     const size = estimate(text);
+    const lines = text.split('\n');
     const found = volatileLines(text);
-    for (const hit of found) {
-      // Everything after this file's start is re-written. Conservative: the
-      // preamble ahead of it is not counted, so this is a floor rather than a
-      // flattering estimate.
-      const downstream = prefixTokens != null ? Math.max(0, prefixTokens - offset) : null;
+    for (const [index, hit] of found.entries()) {
+      // Everything after THIS LINE is re-written -- not everything after the
+      // file, which priced every hit in a file identically and, because each is
+      // emitted as its own record and audit.mjs sums them, billed the same
+      // tokens once per line. Measured before this fix: a three-line changelog
+      // in CLAUDE.md priced at 2,301,093 tokens/session against a 613,625-token
+      // prefix -- 3.75x the entire prefix. Conservative still: the preamble
+      // ahead of the file is not counted, so this remains a floor.
+      const ahead = offset + estimate(lines.slice(0, hit.line - 1).join('\n'));
+      const downstream = prefixTokens != null ? Math.max(0, prefixTokens - ahead) : null;
+      // A prefix cache invalidates ONCE, at the earliest difference. A later
+      // volatile line in the same file costs nothing extra until the first one
+      // is fixed, so it is reported for context but not billed again.
+      const subsumedBy = index === 0 ? null : `${relative}:${found[0].line}`;
       out.push({
         file: relative,
         line: hit.line,
         why: hit.why,
         excerpt: hit.text,
         downstreamTokens: downstream,
-        costPerSession: downstream == null ? null : Math.round(downstream * WRITE_MULTIPLIER),
+        subsumedBy,
+        // null means NOT MEASURABLE -- no prefix measurement, or a construct we
+        // decline to price. 0 means measured and genuinely free, which is what a
+        // subsumed hit is: real, but already billed by the earlier line. Folding
+        // those two into one value is the same mistake this file warns about.
+        costPerSession: downstream == null || !hit.priced
+          ? null
+          : (subsumedBy ? 0 : Math.round(downstream * WRITE_MULTIPLIER)),
         remedy: {
           kind: 'yours',
           type: 'edit',

--- a/tests/hooks/cache-measurement.test.mjs
+++ b/tests/hooks/cache-measurement.test.mjs
@@ -1,0 +1,172 @@
+/**
+ * Cache measurement must not invent costs.
+ *
+ * Every case here was found by auditing this module against the four real Claude Code
+ * transcripts on one machine and re-running the module over them. They are regression tests for
+ * numbers that were wrong in a specific, quotable direction: a model switch that never happened,
+ * a prefix reported as zero, and a three-line changelog priced at 3.75x the entire prefix.
+ *
+ * The direction matters. Every one of these overstated waste or understated the prefix, and
+ * audit.mjs sums the result into a dollar figure a user is expected to act on.
+ */
+import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import { cacheHealth, modelSwitchCost, readCacheUsage, attributeInvalidation } from '../../hooks-core/cache.mjs';
+
+let dir;
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'cachefix-')); });
+afterEach(() => { try { rmSync(dir, { recursive: true, force: true }); } catch { /* windows lock */ } });
+
+/** A transcript row in the shape the client actually writes. */
+const row = (model, read, written) => JSON.stringify({
+  timestamp: new Date(1700000000000).toISOString(),
+  message: {
+    model,
+    usage: {
+      cache_read_input_tokens: read,
+      cache_creation_input_tokens: written,
+      input_tokens: 0,
+      output_tokens: 0,
+    },
+  },
+});
+
+/** The placeholder the client appends verbatim: a real usage object, all zeros. */
+const synthetic = () => row('<synthetic>', 0, 0);
+
+function transcript(...rows) {
+  const path = join(dir, 'session.jsonl');
+  writeFileSync(path, rows.join('\n') + '\n');
+  return path;
+}
+
+describe("the client's <synthetic> placeholder is not a model", () => {
+  test('a single-model session reports one model, not two', () => {
+    // All four real transcripts on this machine contain these rows; three used exactly one
+    // real model and would still have reported two, which cache-tool.ts renders as
+    // "2 models used in this session" with an invented re-write cost beside it.
+    const turns = readCacheUsage(transcript(row('claude-opus-5', 1000, 500), synthetic()));
+    expect(Object.keys(cacheHealth(turns).models)).toEqual(['claude-opus-5']);
+  });
+
+  test('modelSwitchCost does not claim a switch that never happened', () => {
+    const turns = readCacheUsage(transcript(row('claude-opus-5', 1000, 500), synthetic()));
+    expect(modelSwitchCost(turns)?.alreadySwitched).toBe(false);
+  });
+
+  test('a genuine two-model session is still reported', () => {
+    // The fix must not suppress the real case it exists to distinguish from.
+    const turns = readCacheUsage(transcript(row('claude-opus-5', 1000, 500), row('claude-haiku-4-5', 800, 200)));
+    expect(Object.keys(cacheHealth(turns).models)).toHaveLength(2);
+    expect(modelSwitchCost(turns).alreadySwitched).toBe(true);
+  });
+});
+
+describe('prefixTokens comes from a turn that carried a prefix', () => {
+  test('a session ending on a zero-usage row keeps the real prefix', () => {
+    // Reading turns[length - 1] literally reported 0 for a session whose prefix was 600,000+
+    // tokens, which zeroed every attribution price downstream.
+    const turns = readCacheUsage(transcript(row('claude-opus-5', 600_000, 13_625), synthetic()));
+    expect(cacheHealth(turns).prefixTokens).toBe(613_625);
+  });
+
+  test('modelSwitchCost is not null for such a session, so its caller cannot crash', () => {
+    // cache-tool.ts guards this dereference with models.length > 1, a DIFFERENT condition from
+    // the !prefixTokens that returned null -- so the pair produced a live
+    // "Cannot read properties of null (reading 'rewriteCost')" and took down cache_audit.
+    const turns = readCacheUsage(transcript(
+      row('claude-opus-5', 600_000, 13_625), row('claude-haiku-4-5', 400, 100), synthetic(),
+    ));
+    const cost = modelSwitchCost(turns);
+    expect(cost).not.toBeNull();
+    expect(cost.rewriteCost).toBeGreaterThan(0);
+  });
+
+  test('an all-empty transcript still reports zero rather than throwing', () => {
+    const turns = readCacheUsage(transcript(synthetic(), synthetic()));
+    expect(cacheHealth(turns).prefixTokens).toBe(0);
+  });
+});
+
+describe('invalidation is priced per line, and billed once', () => {
+  const withFile = (contents) => {
+    const project = mkdtempSync(join(tmpdir(), 'cacheproj-'));
+    writeFileSync(join(project, 'CLAUDE.md'), contents);
+    return project;
+  };
+
+  test('three volatile lines in one file never bill more than the prefix', () => {
+    // MEASURED before the fix: a three-line changelog priced at 2,301,093 tokens/session
+    // against a 613,625-token prefix -- 3.75x the whole prefix -- because every hit was
+    // charged the full downstream and audit.mjs sums them.
+    const project = withFile('Generated 2025-10-31T09:00\nGenerated 2025-11-01T09:00\nGenerated 2025-12-01T09:00\n');
+    try {
+      const hits = attributeInvalidation(project, 613_625);
+      const total = hits.reduce((sum, h) => sum + (h.costPerSession || 0), 0);
+      expect(hits.length).toBeGreaterThan(1);
+      expect(total).toBeLessThanOrEqual(Math.round(613_625 * 1.25));
+    } finally {
+      rmSync(project, { recursive: true, force: true });
+    }
+  });
+
+  test('a later hit in the same file is reported but costs zero, naming what subsumes it', () => {
+    // A prefix cache invalidates once, at the earliest difference: fixing the second line
+    // while the first still changes saves nothing.
+    const project = withFile('Generated 2025-10-31T09:00\nGenerated 2025-11-01T09:00\n');
+    try {
+      const hits = attributeInvalidation(project, 100_000);
+      expect(hits[0].costPerSession).toBeGreaterThan(0);
+      expect(hits[1].costPerSession).toBe(0);
+      expect(hits[1].subsumedBy).toMatch(/CLAUDE\.md:1/);
+    } finally {
+      rmSync(project, { recursive: true, force: true });
+    }
+  });
+
+  test('a bare changelog date is reported without a fabricated price', () => {
+    // "- 2025-10-31: reworked the loader" is byte-identical every session. Pricing it invents
+    // a per-session cost and tells the user to delete their changelog.
+    const project = withFile('- 2025-10-31: reworked the loader\n- 2024-06-11: initial release\n');
+    try {
+      const hits = attributeInvalidation(project, 100_000);
+      expect(hits.length).toBeGreaterThan(0);
+      for (const hit of hits) expect(hit.costPerSession).toBeNull();
+    } finally {
+      rmSync(project, { recursive: true, force: true });
+    }
+  });
+
+  test('a real timestamp is still priced', () => {
+    // The unpriced rule must not disarm the detector it belongs to.
+    const project = withFile('Generated 2025-10-31T09:00 by the build\n');
+    try {
+      expect(attributeInvalidation(project, 100_000)[0].costPerSession).toBeGreaterThan(0);
+    } finally {
+      rmSync(project, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('the transcript tail is read off disk', () => {
+  test('multibyte content near the cut does not lose turns', () => {
+    // The old path sliced a BYTE offset out of a UTF-16 string: on a real 147 MB transcript
+    // bytes-minus-chars was 140,264, so 3.5% of the requested window was silently discarded.
+    const padding = Array.from({ length: 200 }, () => row('claude-opus-5', 1, 1)).join('\n');
+    const path = join(dir, 'wide.jsonl');
+    writeFileSync(path, `${'é'.repeat(5000)}\n${padding}\n${row('claude-opus-5', 42, 7)}\n`);
+    const turns = readCacheUsage(path, { maxBytes: 4096 });
+    expect(turns.length).toBeGreaterThan(0);
+    const last = turns[turns.length - 1];
+    expect(last.read).toBe(42);
+    expect(last.written).toBe(7);
+  });
+
+  test('a small file is still read whole', () => {
+    const turns = readCacheUsage(transcript(row('claude-opus-5', 5, 6)), { maxBytes: 4_000_000 });
+    expect(turns).toHaveLength(1);
+  });
+});

--- a/tests/hooks/cache-measurement.test.mjs
+++ b/tests/hooks/cache-measurement.test.mjs
@@ -170,3 +170,43 @@ describe('the transcript tail is read off disk', () => {
     expect(turns).toHaveLength(1);
   });
 });
+
+describe('an unpriced hit does not subsume a priced one', () => {
+  const withFile = (contents) => {
+    const project = mkdtempSync(join(tmpdir(), 'cachemix-'));
+    writeFileSync(join(project, 'CLAUDE.md'), contents);
+    return project;
+  };
+
+  test('a bare date above a real timestamp does not zero the timestamp price', () => {
+    // Caught in review of the fix itself. subsumedBy was derived from found[0] rather than the
+    // earliest PRICED hit, so an unpriced changelog date at the top of the file zeroed the
+    // price of a genuine timestamp below it -- converting a real, fixable cost into a
+    // reported zero, which is the same class of error the unpriced rule exists to avoid.
+    const project = withFile('- 2024-06-11: initial release\nGenerated 2025-10-31T09:00 by the build\n');
+    try {
+      const hits = attributeInvalidation(project, 100_000);
+      const date = hits.find((h) => h.line === 1);
+      const stamp = hits.find((h) => h.line === 2);
+      expect(date.costPerSession).toBeNull();
+      expect(date.subsumedBy).toBeNull();
+      expect(stamp.costPerSession).toBeGreaterThan(0);
+      expect(stamp.subsumedBy).toBeNull();
+    } finally {
+      rmSync(project, { recursive: true, force: true });
+    }
+  });
+
+  test('a second priced hit is still subsumed by the first priced one', () => {
+    const project = withFile('- 2024-06-11: initial release\nGenerated 2025-10-31T09:00\nGenerated 2025-11-01T09:00\n');
+    try {
+      const hits = attributeInvalidation(project, 100_000);
+      expect(hits.find((h) => h.line === 2).costPerSession).toBeGreaterThan(0);
+      const third = hits.find((h) => h.line === 3);
+      expect(third.costPerSession).toBe(0);
+      expect(third.subsumedBy).toMatch(/CLAUDE\.md:2/);
+    } finally {
+      rmSync(project, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Five measurement defects in `hooks-core/cache.mjs`, every one overstating waste or understating the prefix, and every one reaching the user as a dollar figure via `audit.mjs`.

Found by auditing this module against **the four real Claude Code transcripts on one machine** and re-running the module over them — so the numbers below are measured, not argued.

## 1. `<synthetic>` counted as a model — major

The client writes placeholder rows with `model: "<synthetic>"` and a complete **all-zero** usage object. They survive every filter, and the only guard was `if (!turn.model)`, which a non-empty string passes.

All four real transcripts contain these rows. **Three used exactly one model and still reported two**, which `cache-tool.ts` renders as *"2 models used in this session — each switch re-writes the prefix"*. On the 25 MB transcript: a false claim of **~767,000 wasted tokens** for a session that never left `claude-opus-5`.

## 2. `prefixTokens` collapsed to zero — major, and a live crash

`turns[turns.length - 1]` was taken literally. Sessions routinely end on a zero-usage row — those same synthetic placeholders — so a session with a 600,000+ token prefix reported **0**.

That zeroed every attribution price and made `shouldKeepWarm` answer "unknown". Worse, it returned `null` from `modelSwitchCost` under a guard **its caller does not share**: `cache-tool.ts` tests `models.length > 1`, then dereferences `cost.rewriteCost`. Combined with (1), which makes that guard true for nearly every session, this crashed `cache_audit` outright:

```
TypeError: Cannot read properties of null (reading 'rewriteCost')
```

## 3. The same tokens billed once per line — major

`offset` advanced once per **file**, so every volatile line in a file was priced at the full downstream prefix. But a prefix cache invalidates **once, at the earliest difference** — fixing line 7 while line 6 still changes saves nothing. And `audit.mjs:233` sums these into a monetised total.

Measured: a CLAUDE.md whose only volatile content is a three-line changelog priced at **2,301,093 tokens/session against a 613,625-token prefix — 3.75× the entire prefix.**

Now priced from each hit's own line position, with later hits reported at cost `0` and a `subsumedBy` naming the line that already accounts for them.

## 4. Bare changelog dates priced — minor

`- 2025-10-31: reworked the loader` is byte-identical every session. Pricing it invents a per-session cost and emits a diff telling the user to delete their changelog. Your own global CLAUDE.md has exactly this shape.

Still detected for `stableText`, which fails closed over our own output; no longer priced in the blame report.

## 5. Whole transcript loaded to keep 4 MB — major

The docstring promises the read is "bounded to the tail… this runs on a hook path". It wasn't: measured **361 ms and 334 MB RSS on a 147 MB file**, with `fleet.mjs:208` paying it once per project.

It also sliced a **byte** offset out of a **UTF-16** string — bytes-minus-chars on that file was 140,264, so 3.5% of the requested window was silently discarded — and threw `ERR_STRING_TOO_LONG` past ~512 MB into a bare `catch` that reports "No cache measurements available" for a perfectly readable transcript. Now a positional tail read.

## A regression this PR caught in itself

The existing test *"reports the construct WITHOUT a price"* failed on my first version of (3), where a subsumed hit and an unmeasurable one both returned `0`. **`null` means not measurable; `0` means measured and genuinely free.** Collapsing them is precisely the error this file warns about elsewhere — the test was right and the first fix was wrong.

## Verification

- `tests/hooks` — **715 passed, 2 skipped, 0 failed** (50 suites), including **12 new regression tests**
- Each of the five has a test asserting the *old* wrong number is no longer produced, plus a counter-test that the real case it must still detect (a genuine two-model session, a real timestamp) is unaffected
- `npm run sync:hooks` applied to all six vendored copies

🤖 Generated with [Claude Code](https://claude.com/claude-code)
