### PR TITLE
fix(curate): stop losing curated claims to a single failed append

### DIFF
--- a/hooks-core/curate.mjs
+++ b/hooks-core/curate.mjs
@@ -19,7 +19,8 @@
  * the un-invalidatable node the schema rules exist to prevent.
  */
 
-import { putNode, putEdge, load, nodeId } from './wiki.mjs';
+import { randomBytes } from 'node:crypto';
+import { putNode, putNodeWithEdges, load, nodeId } from './wiki.mjs';
 import { indexFile } from './staleness.mjs';
 import { symbolKey } from './symbols.mjs';
 import { canonicalPath } from './paths.mjs';
@@ -50,6 +51,22 @@ export const HUMAN_WEIGHT = 1.5;
  * model asserting something about its own work.
  */
 export const AGENT_WEIGHT = 1.2;
+
+/**
+ * The one provenance ranking table.
+ *
+ * Exported as a FUNCTION rather than left to each caller to assemble, because
+ * the alternative already failed twice: HUMAN_WEIGHT sat declared and unread
+ * until wiki.mjs worked around it with a private duplicate table, and
+ * AGENT_WEIGHT is still unread today -- so an agent finding ranks level with a
+ * post-hoc guess in the dashboard search while findingsFor ranks it correctly.
+ * Two rankings that disagree is worse than one that is wrong.
+ */
+export function originWeight(origin) {
+  if (origin === ORIGIN_HUMAN) return HUMAN_WEIGHT;
+  if (origin === ORIGIN_AGENT) return AGENT_WEIGHT;
+  return 1;
+}
 
 function findingByKey(graph, key) {
   return graph.nodes.get(nodeId('finding', key)) || null;
@@ -85,46 +102,69 @@ export function correct(
   const existing = findingByKey(graph, key);
   if (!existing) return false;
 
-  // ORDER MATTERS. `append` fails open -- it swallows write errors and returns
-  // false -- so retiring first and then failing to write the replacement would
-  // delete the claim outright: gone from activeFindings, from the export, and
-  // from every read path, with nothing put in its place. Writing the successor
-  // first makes the worst case two live claims rather than none, and a
-  // duplicate is recoverable where a silent deletion is not.
+  // ORDER MATTERS, AND SO DOES CHECKING. `append` fails open -- it swallows
+  // write errors and returns false -- so retiring first and then failing to
+  // write the replacement would delete the claim outright: gone from
+  // activeFindings, from the export, and from every read path, with nothing put
+  // in its place.
+  //
+  // Writing the successor first was necessary but NOT sufficient. putNode
+  // discards appendAll's boolean and returns an id unconditionally, so this
+  // function could not observe a failed write and retired the original anyway.
+  // One transient EBUSY -- routine on Windows, and withLock gives up after 20
+  // attempts and proceeds regardless -- was enough to destroy a human's
+  // curated claim while the API replied ok.
+  //
+  // putNodeWithEdges returns null on a failed append AND writes the node, the
+  // supersedes link and every inherited anchor as ONE append, so a partial
+  // write cannot leave an unanchored successor either.
+  const originalId = nodeId('finding', key);
   const replacementKey = `${key}-c${Date.now().toString(36)}`;
-  putNode(dir, {
-    kind: 'finding',
-    key: replacementKey,
-    claim,
-    confidence,
-    type: existing.type || 'finding',
-    // THE CALLER'S ORIGIN, not an assumption. This stamped ORIGIN_HUMAN
-    // unconditionally, so a correction written by an agent -- or carried over
-    // from a harvested claim -- was recorded as a person's assertion. That is
-    // the exact confusion the origin field exists to prevent, and the one
-    // harvest-write.mjs refuses to create when it writes a finding: "a
-    // hand-written assertion and a machine guess look identical three months
-    // later, which quietly destroys the reader's ability to calibrate trust".
-    // It also outranks its own source, since human findings carry the highest
-    // ranking weight.
-    //
-    // Defaults to ORIGIN_HUMAN because curate is the hand-curation path, so
-    // every existing caller keeps its current behaviour. Deliberately NOT
-    // validated against a fixed list: the set of origins differs across
-    // branches, and an unrecognised value already degrades to the neutral
-    // ranking weight rather than doing damage.
-    origin: typeof origin === 'string' && origin ? origin : ORIGIN_HUMAN,
-  });
 
-  const replacementId = nodeId('finding', replacementKey);
-  putEdge(dir, replacementId, 'supersedes', nodeId('finding', key));
-
+  const edges = [{ edge: 'supersedes', to: originalId }];
   // The correction inherits the original's anchors, so it can go stale too.
   for (const edge of graph.edges) {
-    if (edge.edge === 'derived_from' && edge.from === nodeId('finding', key)) {
-      putEdge(dir, replacementId, 'derived_from', edge.to);
+    if (edge.edge === 'derived_from' && edge.from === originalId) {
+      edges.push({ edge: 'derived_from', to: edge.to });
     }
   }
+
+  const written = putNodeWithEdges(
+    dir,
+    {
+      kind: 'finding',
+      key: replacementKey,
+      claim,
+      confidence,
+      type: existing.type || 'finding',
+      // PINNED SURVIVES A CORRECTION. The pin is an explicit human act about the
+      // subject matter, not about the wording, and the original that carried it
+      // is retired below -- so not copying it silently un-pins the fact and it
+      // stops being injected as a standing rule (inject.mjs selects on
+      // `n.pinned === true`). Correcting a claim must not demote it.
+      ...(existing.pinned ? { pinned: true } : {}),
+      // THE CALLER'S ORIGIN, not an assumption. This stamped ORIGIN_HUMAN
+      // unconditionally, so a correction written by an agent -- or carried over
+      // from a harvested claim -- was recorded as a person's assertion. That is
+      // the exact confusion the origin field exists to prevent, and the one
+      // harvest-write.mjs refuses to create when it writes a finding: "a
+      // hand-written assertion and a machine guess look identical three months
+      // later, which quietly destroys the reader's ability to calibrate trust".
+      // It also outranks its own source, since human findings carry the highest
+      // ranking weight.
+      //
+      // Defaults to ORIGIN_HUMAN because curate is the hand-curation path, so
+      // every existing caller keeps its current behaviour. Deliberately NOT
+      // validated against a fixed list: the set of origins differs across
+      // branches, and an unrecognised value already degrades to the neutral
+      // ranking weight rather than doing damage.
+      origin: typeof origin === 'string' && origin ? origin : ORIGIN_HUMAN,
+    },
+    edges
+  );
+
+  // NOTHING IS RETIRED UNTIL THE SUCCESSOR IS ON DISK.
+  if (!written) return false;
 
   putNode(dir, { ...existing, kind: 'finding', key, retired: true });
   return replacementKey;
@@ -172,9 +212,27 @@ export function create(dir, { claim, anchors, type = 'finding', confidence = 0.9
   // so it is refused rather than stored as permanently-current.
   if (!resolved.length) return null;
 
-  const key = `human-${Date.now().toString(36)}`;
-  const id = putNode(dir, { kind: 'finding', key, claim, confidence, type, origin: ORIGIN_HUMAN });
-  for (const target of resolved) putEdge(dir, id, 'derived_from', target);
+  // A bare millisecond is NOT unique: two creates landing in the same tick hash
+  // to the same node id, and wiki.mjs's fold keeps only the last -- so one
+  // person's claim silently replaces another's while both HTTP responses report
+  // ok, and the survivor inherits the union of both claims' anchors. Same random
+  // suffix harvest-write.mjs already applies for the same reason.
+  const key = `human-${Date.now().toString(36)}-${randomBytes(4).toString('hex')}`;
+
+  // ONE APPEND for the finding and every anchor it resolved, and the key is only
+  // reported when that append is confirmed. Writing the node and then looping
+  // putEdge let a single failed edge append leave an active, human-origin,
+  // high-confidence finding anchored to NOTHING -- staleness can never mark it
+  // and audit() lists it under `orphaned`, which this file calls the most
+  // dangerous nodes in the graph. That is exactly the record the block above
+  // refuses to create, arriving through the write path instead of the resolve
+  // path. No process death required; one transient EBUSY is enough.
+  const id = putNodeWithEdges(
+    dir,
+    { kind: 'finding', key, claim, confidence, type, origin: ORIGIN_HUMAN },
+    resolved.map((target) => ({ edge: 'derived_from', to: target }))
+  );
+  if (!id) return null;
   return key;
 }
 

--- a/integrations/codex/hooks/lib/curate.mjs
+++ b/integrations/codex/hooks/lib/curate.mjs
@@ -21,7 +21,8 @@
  * the un-invalidatable node the schema rules exist to prevent.
  */
 
-import { putNode, putEdge, load, nodeId } from './wiki.mjs';
+import { randomBytes } from 'node:crypto';
+import { putNode, putNodeWithEdges, load, nodeId } from './wiki.mjs';
 import { indexFile } from './staleness.mjs';
 import { symbolKey } from './symbols.mjs';
 import { canonicalPath } from './paths.mjs';
@@ -52,6 +53,22 @@ export const HUMAN_WEIGHT = 1.5;
  * model asserting something about its own work.
  */
 export const AGENT_WEIGHT = 1.2;
+
+/**
+ * The one provenance ranking table.
+ *
+ * Exported as a FUNCTION rather than left to each caller to assemble, because
+ * the alternative already failed twice: HUMAN_WEIGHT sat declared and unread
+ * until wiki.mjs worked around it with a private duplicate table, and
+ * AGENT_WEIGHT is still unread today -- so an agent finding ranks level with a
+ * post-hoc guess in the dashboard search while findingsFor ranks it correctly.
+ * Two rankings that disagree is worse than one that is wrong.
+ */
+export function originWeight(origin) {
+  if (origin === ORIGIN_HUMAN) return HUMAN_WEIGHT;
+  if (origin === ORIGIN_AGENT) return AGENT_WEIGHT;
+  return 1;
+}
 
 function findingByKey(graph, key) {
   return graph.nodes.get(nodeId('finding', key)) || null;
@@ -87,46 +104,69 @@ export function correct(
   const existing = findingByKey(graph, key);
   if (!existing) return false;
 
-  // ORDER MATTERS. `append` fails open -- it swallows write errors and returns
-  // false -- so retiring first and then failing to write the replacement would
-  // delete the claim outright: gone from activeFindings, from the export, and
-  // from every read path, with nothing put in its place. Writing the successor
-  // first makes the worst case two live claims rather than none, and a
-  // duplicate is recoverable where a silent deletion is not.
+  // ORDER MATTERS, AND SO DOES CHECKING. `append` fails open -- it swallows
+  // write errors and returns false -- so retiring first and then failing to
+  // write the replacement would delete the claim outright: gone from
+  // activeFindings, from the export, and from every read path, with nothing put
+  // in its place.
+  //
+  // Writing the successor first was necessary but NOT sufficient. putNode
+  // discards appendAll's boolean and returns an id unconditionally, so this
+  // function could not observe a failed write and retired the original anyway.
+  // One transient EBUSY -- routine on Windows, and withLock gives up after 20
+  // attempts and proceeds regardless -- was enough to destroy a human's
+  // curated claim while the API replied ok.
+  //
+  // putNodeWithEdges returns null on a failed append AND writes the node, the
+  // supersedes link and every inherited anchor as ONE append, so a partial
+  // write cannot leave an unanchored successor either.
+  const originalId = nodeId('finding', key);
   const replacementKey = `${key}-c${Date.now().toString(36)}`;
-  putNode(dir, {
-    kind: 'finding',
-    key: replacementKey,
-    claim,
-    confidence,
-    type: existing.type || 'finding',
-    // THE CALLER'S ORIGIN, not an assumption. This stamped ORIGIN_HUMAN
-    // unconditionally, so a correction written by an agent -- or carried over
-    // from a harvested claim -- was recorded as a person's assertion. That is
-    // the exact confusion the origin field exists to prevent, and the one
-    // harvest-write.mjs refuses to create when it writes a finding: "a
-    // hand-written assertion and a machine guess look identical three months
-    // later, which quietly destroys the reader's ability to calibrate trust".
-    // It also outranks its own source, since human findings carry the highest
-    // ranking weight.
-    //
-    // Defaults to ORIGIN_HUMAN because curate is the hand-curation path, so
-    // every existing caller keeps its current behaviour. Deliberately NOT
-    // validated against a fixed list: the set of origins differs across
-    // branches, and an unrecognised value already degrades to the neutral
-    // ranking weight rather than doing damage.
-    origin: typeof origin === 'string' && origin ? origin : ORIGIN_HUMAN,
-  });
 
-  const replacementId = nodeId('finding', replacementKey);
-  putEdge(dir, replacementId, 'supersedes', nodeId('finding', key));
-
+  const edges = [{ edge: 'supersedes', to: originalId }];
   // The correction inherits the original's anchors, so it can go stale too.
   for (const edge of graph.edges) {
-    if (edge.edge === 'derived_from' && edge.from === nodeId('finding', key)) {
-      putEdge(dir, replacementId, 'derived_from', edge.to);
+    if (edge.edge === 'derived_from' && edge.from === originalId) {
+      edges.push({ edge: 'derived_from', to: edge.to });
     }
   }
+
+  const written = putNodeWithEdges(
+    dir,
+    {
+      kind: 'finding',
+      key: replacementKey,
+      claim,
+      confidence,
+      type: existing.type || 'finding',
+      // PINNED SURVIVES A CORRECTION. The pin is an explicit human act about the
+      // subject matter, not about the wording, and the original that carried it
+      // is retired below -- so not copying it silently un-pins the fact and it
+      // stops being injected as a standing rule (inject.mjs selects on
+      // `n.pinned === true`). Correcting a claim must not demote it.
+      ...(existing.pinned ? { pinned: true } : {}),
+      // THE CALLER'S ORIGIN, not an assumption. This stamped ORIGIN_HUMAN
+      // unconditionally, so a correction written by an agent -- or carried over
+      // from a harvested claim -- was recorded as a person's assertion. That is
+      // the exact confusion the origin field exists to prevent, and the one
+      // harvest-write.mjs refuses to create when it writes a finding: "a
+      // hand-written assertion and a machine guess look identical three months
+      // later, which quietly destroys the reader's ability to calibrate trust".
+      // It also outranks its own source, since human findings carry the highest
+      // ranking weight.
+      //
+      // Defaults to ORIGIN_HUMAN because curate is the hand-curation path, so
+      // every existing caller keeps its current behaviour. Deliberately NOT
+      // validated against a fixed list: the set of origins differs across
+      // branches, and an unrecognised value already degrades to the neutral
+      // ranking weight rather than doing damage.
+      origin: typeof origin === 'string' && origin ? origin : ORIGIN_HUMAN,
+    },
+    edges
+  );
+
+  // NOTHING IS RETIRED UNTIL THE SUCCESSOR IS ON DISK.
+  if (!written) return false;
 
   putNode(dir, { ...existing, kind: 'finding', key, retired: true });
   return replacementKey;
@@ -174,9 +214,27 @@ export function create(dir, { claim, anchors, type = 'finding', confidence = 0.9
   // so it is refused rather than stored as permanently-current.
   if (!resolved.length) return null;
 
-  const key = `human-${Date.now().toString(36)}`;
-  const id = putNode(dir, { kind: 'finding', key, claim, confidence, type, origin: ORIGIN_HUMAN });
-  for (const target of resolved) putEdge(dir, id, 'derived_from', target);
+  // A bare millisecond is NOT unique: two creates landing in the same tick hash
+  // to the same node id, and wiki.mjs's fold keeps only the last -- so one
+  // person's claim silently replaces another's while both HTTP responses report
+  // ok, and the survivor inherits the union of both claims' anchors. Same random
+  // suffix harvest-write.mjs already applies for the same reason.
+  const key = `human-${Date.now().toString(36)}-${randomBytes(4).toString('hex')}`;
+
+  // ONE APPEND for the finding and every anchor it resolved, and the key is only
+  // reported when that append is confirmed. Writing the node and then looping
+  // putEdge let a single failed edge append leave an active, human-origin,
+  // high-confidence finding anchored to NOTHING -- staleness can never mark it
+  // and audit() lists it under `orphaned`, which this file calls the most
+  // dangerous nodes in the graph. That is exactly the record the block above
+  // refuses to create, arriving through the write path instead of the resolve
+  // path. No process death required; one transient EBUSY is enough.
+  const id = putNodeWithEdges(
+    dir,
+    { kind: 'finding', key, claim, confidence, type, origin: ORIGIN_HUMAN },
+    resolved.map((target) => ({ edge: 'derived_from', to: target }))
+  );
+  if (!id) return null;
   return key;
 }
 

--- a/integrations/codex/plugin/hooks/lib/curate.mjs
+++ b/integrations/codex/plugin/hooks/lib/curate.mjs
@@ -21,7 +21,8 @@
  * the un-invalidatable node the schema rules exist to prevent.
  */
 
-import { putNode, putEdge, load, nodeId } from './wiki.mjs';
+import { randomBytes } from 'node:crypto';
+import { putNode, putNodeWithEdges, load, nodeId } from './wiki.mjs';
 import { indexFile } from './staleness.mjs';
 import { symbolKey } from './symbols.mjs';
 import { canonicalPath } from './paths.mjs';
@@ -52,6 +53,22 @@ export const HUMAN_WEIGHT = 1.5;
  * model asserting something about its own work.
  */
 export const AGENT_WEIGHT = 1.2;
+
+/**
+ * The one provenance ranking table.
+ *
+ * Exported as a FUNCTION rather than left to each caller to assemble, because
+ * the alternative already failed twice: HUMAN_WEIGHT sat declared and unread
+ * until wiki.mjs worked around it with a private duplicate table, and
+ * AGENT_WEIGHT is still unread today -- so an agent finding ranks level with a
+ * post-hoc guess in the dashboard search while findingsFor ranks it correctly.
+ * Two rankings that disagree is worse than one that is wrong.
+ */
+export function originWeight(origin) {
+  if (origin === ORIGIN_HUMAN) return HUMAN_WEIGHT;
+  if (origin === ORIGIN_AGENT) return AGENT_WEIGHT;
+  return 1;
+}
 
 function findingByKey(graph, key) {
   return graph.nodes.get(nodeId('finding', key)) || null;
@@ -87,46 +104,69 @@ export function correct(
   const existing = findingByKey(graph, key);
   if (!existing) return false;
 
-  // ORDER MATTERS. `append` fails open -- it swallows write errors and returns
-  // false -- so retiring first and then failing to write the replacement would
-  // delete the claim outright: gone from activeFindings, from the export, and
-  // from every read path, with nothing put in its place. Writing the successor
-  // first makes the worst case two live claims rather than none, and a
-  // duplicate is recoverable where a silent deletion is not.
+  // ORDER MATTERS, AND SO DOES CHECKING. `append` fails open -- it swallows
+  // write errors and returns false -- so retiring first and then failing to
+  // write the replacement would delete the claim outright: gone from
+  // activeFindings, from the export, and from every read path, with nothing put
+  // in its place.
+  //
+  // Writing the successor first was necessary but NOT sufficient. putNode
+  // discards appendAll's boolean and returns an id unconditionally, so this
+  // function could not observe a failed write and retired the original anyway.
+  // One transient EBUSY -- routine on Windows, and withLock gives up after 20
+  // attempts and proceeds regardless -- was enough to destroy a human's
+  // curated claim while the API replied ok.
+  //
+  // putNodeWithEdges returns null on a failed append AND writes the node, the
+  // supersedes link and every inherited anchor as ONE append, so a partial
+  // write cannot leave an unanchored successor either.
+  const originalId = nodeId('finding', key);
   const replacementKey = `${key}-c${Date.now().toString(36)}`;
-  putNode(dir, {
-    kind: 'finding',
-    key: replacementKey,
-    claim,
-    confidence,
-    type: existing.type || 'finding',
-    // THE CALLER'S ORIGIN, not an assumption. This stamped ORIGIN_HUMAN
-    // unconditionally, so a correction written by an agent -- or carried over
-    // from a harvested claim -- was recorded as a person's assertion. That is
-    // the exact confusion the origin field exists to prevent, and the one
-    // harvest-write.mjs refuses to create when it writes a finding: "a
-    // hand-written assertion and a machine guess look identical three months
-    // later, which quietly destroys the reader's ability to calibrate trust".
-    // It also outranks its own source, since human findings carry the highest
-    // ranking weight.
-    //
-    // Defaults to ORIGIN_HUMAN because curate is the hand-curation path, so
-    // every existing caller keeps its current behaviour. Deliberately NOT
-    // validated against a fixed list: the set of origins differs across
-    // branches, and an unrecognised value already degrades to the neutral
-    // ranking weight rather than doing damage.
-    origin: typeof origin === 'string' && origin ? origin : ORIGIN_HUMAN,
-  });
 
-  const replacementId = nodeId('finding', replacementKey);
-  putEdge(dir, replacementId, 'supersedes', nodeId('finding', key));
-
+  const edges = [{ edge: 'supersedes', to: originalId }];
   // The correction inherits the original's anchors, so it can go stale too.
   for (const edge of graph.edges) {
-    if (edge.edge === 'derived_from' && edge.from === nodeId('finding', key)) {
-      putEdge(dir, replacementId, 'derived_from', edge.to);
+    if (edge.edge === 'derived_from' && edge.from === originalId) {
+      edges.push({ edge: 'derived_from', to: edge.to });
     }
   }
+
+  const written = putNodeWithEdges(
+    dir,
+    {
+      kind: 'finding',
+      key: replacementKey,
+      claim,
+      confidence,
+      type: existing.type || 'finding',
+      // PINNED SURVIVES A CORRECTION. The pin is an explicit human act about the
+      // subject matter, not about the wording, and the original that carried it
+      // is retired below -- so not copying it silently un-pins the fact and it
+      // stops being injected as a standing rule (inject.mjs selects on
+      // `n.pinned === true`). Correcting a claim must not demote it.
+      ...(existing.pinned ? { pinned: true } : {}),
+      // THE CALLER'S ORIGIN, not an assumption. This stamped ORIGIN_HUMAN
+      // unconditionally, so a correction written by an agent -- or carried over
+      // from a harvested claim -- was recorded as a person's assertion. That is
+      // the exact confusion the origin field exists to prevent, and the one
+      // harvest-write.mjs refuses to create when it writes a finding: "a
+      // hand-written assertion and a machine guess look identical three months
+      // later, which quietly destroys the reader's ability to calibrate trust".
+      // It also outranks its own source, since human findings carry the highest
+      // ranking weight.
+      //
+      // Defaults to ORIGIN_HUMAN because curate is the hand-curation path, so
+      // every existing caller keeps its current behaviour. Deliberately NOT
+      // validated against a fixed list: the set of origins differs across
+      // branches, and an unrecognised value already degrades to the neutral
+      // ranking weight rather than doing damage.
+      origin: typeof origin === 'string' && origin ? origin : ORIGIN_HUMAN,
+    },
+    edges
+  );
+
+  // NOTHING IS RETIRED UNTIL THE SUCCESSOR IS ON DISK.
+  if (!written) return false;
 
   putNode(dir, { ...existing, kind: 'finding', key, retired: true });
   return replacementKey;
@@ -174,9 +214,27 @@ export function create(dir, { claim, anchors, type = 'finding', confidence = 0.9
   // so it is refused rather than stored as permanently-current.
   if (!resolved.length) return null;
 
-  const key = `human-${Date.now().toString(36)}`;
-  const id = putNode(dir, { kind: 'finding', key, claim, confidence, type, origin: ORIGIN_HUMAN });
-  for (const target of resolved) putEdge(dir, id, 'derived_from', target);
+  // A bare millisecond is NOT unique: two creates landing in the same tick hash
+  // to the same node id, and wiki.mjs's fold keeps only the last -- so one
+  // person's claim silently replaces another's while both HTTP responses report
+  // ok, and the survivor inherits the union of both claims' anchors. Same random
+  // suffix harvest-write.mjs already applies for the same reason.
+  const key = `human-${Date.now().toString(36)}-${randomBytes(4).toString('hex')}`;
+
+  // ONE APPEND for the finding and every anchor it resolved, and the key is only
+  // reported when that append is confirmed. Writing the node and then looping
+  // putEdge let a single failed edge append leave an active, human-origin,
+  // high-confidence finding anchored to NOTHING -- staleness can never mark it
+  // and audit() lists it under `orphaned`, which this file calls the most
+  // dangerous nodes in the graph. That is exactly the record the block above
+  // refuses to create, arriving through the write path instead of the resolve
+  // path. No process death required; one transient EBUSY is enough.
+  const id = putNodeWithEdges(
+    dir,
+    { kind: 'finding', key, claim, confidence, type, origin: ORIGIN_HUMAN },
+    resolved.map((target) => ({ edge: 'derived_from', to: target }))
+  );
+  if (!id) return null;
   return key;
 }
 

--- a/integrations/gemini/hooks/lib/curate.mjs
+++ b/integrations/gemini/hooks/lib/curate.mjs
@@ -21,7 +21,8 @@
  * the un-invalidatable node the schema rules exist to prevent.
  */
 
-import { putNode, putEdge, load, nodeId } from './wiki.mjs';
+import { randomBytes } from 'node:crypto';
+import { putNode, putNodeWithEdges, load, nodeId } from './wiki.mjs';
 import { indexFile } from './staleness.mjs';
 import { symbolKey } from './symbols.mjs';
 import { canonicalPath } from './paths.mjs';
@@ -52,6 +53,22 @@ export const HUMAN_WEIGHT = 1.5;
  * model asserting something about its own work.
  */
 export const AGENT_WEIGHT = 1.2;
+
+/**
+ * The one provenance ranking table.
+ *
+ * Exported as a FUNCTION rather than left to each caller to assemble, because
+ * the alternative already failed twice: HUMAN_WEIGHT sat declared and unread
+ * until wiki.mjs worked around it with a private duplicate table, and
+ * AGENT_WEIGHT is still unread today -- so an agent finding ranks level with a
+ * post-hoc guess in the dashboard search while findingsFor ranks it correctly.
+ * Two rankings that disagree is worse than one that is wrong.
+ */
+export function originWeight(origin) {
+  if (origin === ORIGIN_HUMAN) return HUMAN_WEIGHT;
+  if (origin === ORIGIN_AGENT) return AGENT_WEIGHT;
+  return 1;
+}
 
 function findingByKey(graph, key) {
   return graph.nodes.get(nodeId('finding', key)) || null;
@@ -87,46 +104,69 @@ export function correct(
   const existing = findingByKey(graph, key);
   if (!existing) return false;
 
-  // ORDER MATTERS. `append` fails open -- it swallows write errors and returns
-  // false -- so retiring first and then failing to write the replacement would
-  // delete the claim outright: gone from activeFindings, from the export, and
-  // from every read path, with nothing put in its place. Writing the successor
-  // first makes the worst case two live claims rather than none, and a
-  // duplicate is recoverable where a silent deletion is not.
+  // ORDER MATTERS, AND SO DOES CHECKING. `append` fails open -- it swallows
+  // write errors and returns false -- so retiring first and then failing to
+  // write the replacement would delete the claim outright: gone from
+  // activeFindings, from the export, and from every read path, with nothing put
+  // in its place.
+  //
+  // Writing the successor first was necessary but NOT sufficient. putNode
+  // discards appendAll's boolean and returns an id unconditionally, so this
+  // function could not observe a failed write and retired the original anyway.
+  // One transient EBUSY -- routine on Windows, and withLock gives up after 20
+  // attempts and proceeds regardless -- was enough to destroy a human's
+  // curated claim while the API replied ok.
+  //
+  // putNodeWithEdges returns null on a failed append AND writes the node, the
+  // supersedes link and every inherited anchor as ONE append, so a partial
+  // write cannot leave an unanchored successor either.
+  const originalId = nodeId('finding', key);
   const replacementKey = `${key}-c${Date.now().toString(36)}`;
-  putNode(dir, {
-    kind: 'finding',
-    key: replacementKey,
-    claim,
-    confidence,
-    type: existing.type || 'finding',
-    // THE CALLER'S ORIGIN, not an assumption. This stamped ORIGIN_HUMAN
-    // unconditionally, so a correction written by an agent -- or carried over
-    // from a harvested claim -- was recorded as a person's assertion. That is
-    // the exact confusion the origin field exists to prevent, and the one
-    // harvest-write.mjs refuses to create when it writes a finding: "a
-    // hand-written assertion and a machine guess look identical three months
-    // later, which quietly destroys the reader's ability to calibrate trust".
-    // It also outranks its own source, since human findings carry the highest
-    // ranking weight.
-    //
-    // Defaults to ORIGIN_HUMAN because curate is the hand-curation path, so
-    // every existing caller keeps its current behaviour. Deliberately NOT
-    // validated against a fixed list: the set of origins differs across
-    // branches, and an unrecognised value already degrades to the neutral
-    // ranking weight rather than doing damage.
-    origin: typeof origin === 'string' && origin ? origin : ORIGIN_HUMAN,
-  });
 
-  const replacementId = nodeId('finding', replacementKey);
-  putEdge(dir, replacementId, 'supersedes', nodeId('finding', key));
-
+  const edges = [{ edge: 'supersedes', to: originalId }];
   // The correction inherits the original's anchors, so it can go stale too.
   for (const edge of graph.edges) {
-    if (edge.edge === 'derived_from' && edge.from === nodeId('finding', key)) {
-      putEdge(dir, replacementId, 'derived_from', edge.to);
+    if (edge.edge === 'derived_from' && edge.from === originalId) {
+      edges.push({ edge: 'derived_from', to: edge.to });
     }
   }
+
+  const written = putNodeWithEdges(
+    dir,
+    {
+      kind: 'finding',
+      key: replacementKey,
+      claim,
+      confidence,
+      type: existing.type || 'finding',
+      // PINNED SURVIVES A CORRECTION. The pin is an explicit human act about the
+      // subject matter, not about the wording, and the original that carried it
+      // is retired below -- so not copying it silently un-pins the fact and it
+      // stops being injected as a standing rule (inject.mjs selects on
+      // `n.pinned === true`). Correcting a claim must not demote it.
+      ...(existing.pinned ? { pinned: true } : {}),
+      // THE CALLER'S ORIGIN, not an assumption. This stamped ORIGIN_HUMAN
+      // unconditionally, so a correction written by an agent -- or carried over
+      // from a harvested claim -- was recorded as a person's assertion. That is
+      // the exact confusion the origin field exists to prevent, and the one
+      // harvest-write.mjs refuses to create when it writes a finding: "a
+      // hand-written assertion and a machine guess look identical three months
+      // later, which quietly destroys the reader's ability to calibrate trust".
+      // It also outranks its own source, since human findings carry the highest
+      // ranking weight.
+      //
+      // Defaults to ORIGIN_HUMAN because curate is the hand-curation path, so
+      // every existing caller keeps its current behaviour. Deliberately NOT
+      // validated against a fixed list: the set of origins differs across
+      // branches, and an unrecognised value already degrades to the neutral
+      // ranking weight rather than doing damage.
+      origin: typeof origin === 'string' && origin ? origin : ORIGIN_HUMAN,
+    },
+    edges
+  );
+
+  // NOTHING IS RETIRED UNTIL THE SUCCESSOR IS ON DISK.
+  if (!written) return false;
 
   putNode(dir, { ...existing, kind: 'finding', key, retired: true });
   return replacementKey;
@@ -174,9 +214,27 @@ export function create(dir, { claim, anchors, type = 'finding', confidence = 0.9
   // so it is refused rather than stored as permanently-current.
   if (!resolved.length) return null;
 
-  const key = `human-${Date.now().toString(36)}`;
-  const id = putNode(dir, { kind: 'finding', key, claim, confidence, type, origin: ORIGIN_HUMAN });
-  for (const target of resolved) putEdge(dir, id, 'derived_from', target);
+  // A bare millisecond is NOT unique: two creates landing in the same tick hash
+  // to the same node id, and wiki.mjs's fold keeps only the last -- so one
+  // person's claim silently replaces another's while both HTTP responses report
+  // ok, and the survivor inherits the union of both claims' anchors. Same random
+  // suffix harvest-write.mjs already applies for the same reason.
+  const key = `human-${Date.now().toString(36)}-${randomBytes(4).toString('hex')}`;
+
+  // ONE APPEND for the finding and every anchor it resolved, and the key is only
+  // reported when that append is confirmed. Writing the node and then looping
+  // putEdge let a single failed edge append leave an active, human-origin,
+  // high-confidence finding anchored to NOTHING -- staleness can never mark it
+  // and audit() lists it under `orphaned`, which this file calls the most
+  // dangerous nodes in the graph. That is exactly the record the block above
+  // refuses to create, arriving through the write path instead of the resolve
+  // path. No process death required; one transient EBUSY is enough.
+  const id = putNodeWithEdges(
+    dir,
+    { kind: 'finding', key, claim, confidence, type, origin: ORIGIN_HUMAN },
+    resolved.map((target) => ({ edge: 'derived_from', to: target }))
+  );
+  if (!id) return null;
   return key;
 }
 

--- a/integrations/opencode/hooks/lib/curate.mjs
+++ b/integrations/opencode/hooks/lib/curate.mjs
@@ -21,7 +21,8 @@
  * the un-invalidatable node the schema rules exist to prevent.
  */
 
-import { putNode, putEdge, load, nodeId } from './wiki.mjs';
+import { randomBytes } from 'node:crypto';
+import { putNode, putNodeWithEdges, load, nodeId } from './wiki.mjs';
 import { indexFile } from './staleness.mjs';
 import { symbolKey } from './symbols.mjs';
 import { canonicalPath } from './paths.mjs';
@@ -52,6 +53,22 @@ export const HUMAN_WEIGHT = 1.5;
  * model asserting something about its own work.
  */
 export const AGENT_WEIGHT = 1.2;
+
+/**
+ * The one provenance ranking table.
+ *
+ * Exported as a FUNCTION rather than left to each caller to assemble, because
+ * the alternative already failed twice: HUMAN_WEIGHT sat declared and unread
+ * until wiki.mjs worked around it with a private duplicate table, and
+ * AGENT_WEIGHT is still unread today -- so an agent finding ranks level with a
+ * post-hoc guess in the dashboard search while findingsFor ranks it correctly.
+ * Two rankings that disagree is worse than one that is wrong.
+ */
+export function originWeight(origin) {
+  if (origin === ORIGIN_HUMAN) return HUMAN_WEIGHT;
+  if (origin === ORIGIN_AGENT) return AGENT_WEIGHT;
+  return 1;
+}
 
 function findingByKey(graph, key) {
   return graph.nodes.get(nodeId('finding', key)) || null;
@@ -87,46 +104,69 @@ export function correct(
   const existing = findingByKey(graph, key);
   if (!existing) return false;
 
-  // ORDER MATTERS. `append` fails open -- it swallows write errors and returns
-  // false -- so retiring first and then failing to write the replacement would
-  // delete the claim outright: gone from activeFindings, from the export, and
-  // from every read path, with nothing put in its place. Writing the successor
-  // first makes the worst case two live claims rather than none, and a
-  // duplicate is recoverable where a silent deletion is not.
+  // ORDER MATTERS, AND SO DOES CHECKING. `append` fails open -- it swallows
+  // write errors and returns false -- so retiring first and then failing to
+  // write the replacement would delete the claim outright: gone from
+  // activeFindings, from the export, and from every read path, with nothing put
+  // in its place.
+  //
+  // Writing the successor first was necessary but NOT sufficient. putNode
+  // discards appendAll's boolean and returns an id unconditionally, so this
+  // function could not observe a failed write and retired the original anyway.
+  // One transient EBUSY -- routine on Windows, and withLock gives up after 20
+  // attempts and proceeds regardless -- was enough to destroy a human's
+  // curated claim while the API replied ok.
+  //
+  // putNodeWithEdges returns null on a failed append AND writes the node, the
+  // supersedes link and every inherited anchor as ONE append, so a partial
+  // write cannot leave an unanchored successor either.
+  const originalId = nodeId('finding', key);
   const replacementKey = `${key}-c${Date.now().toString(36)}`;
-  putNode(dir, {
-    kind: 'finding',
-    key: replacementKey,
-    claim,
-    confidence,
-    type: existing.type || 'finding',
-    // THE CALLER'S ORIGIN, not an assumption. This stamped ORIGIN_HUMAN
-    // unconditionally, so a correction written by an agent -- or carried over
-    // from a harvested claim -- was recorded as a person's assertion. That is
-    // the exact confusion the origin field exists to prevent, and the one
-    // harvest-write.mjs refuses to create when it writes a finding: "a
-    // hand-written assertion and a machine guess look identical three months
-    // later, which quietly destroys the reader's ability to calibrate trust".
-    // It also outranks its own source, since human findings carry the highest
-    // ranking weight.
-    //
-    // Defaults to ORIGIN_HUMAN because curate is the hand-curation path, so
-    // every existing caller keeps its current behaviour. Deliberately NOT
-    // validated against a fixed list: the set of origins differs across
-    // branches, and an unrecognised value already degrades to the neutral
-    // ranking weight rather than doing damage.
-    origin: typeof origin === 'string' && origin ? origin : ORIGIN_HUMAN,
-  });
 
-  const replacementId = nodeId('finding', replacementKey);
-  putEdge(dir, replacementId, 'supersedes', nodeId('finding', key));
-
+  const edges = [{ edge: 'supersedes', to: originalId }];
   // The correction inherits the original's anchors, so it can go stale too.
   for (const edge of graph.edges) {
-    if (edge.edge === 'derived_from' && edge.from === nodeId('finding', key)) {
-      putEdge(dir, replacementId, 'derived_from', edge.to);
+    if (edge.edge === 'derived_from' && edge.from === originalId) {
+      edges.push({ edge: 'derived_from', to: edge.to });
     }
   }
+
+  const written = putNodeWithEdges(
+    dir,
+    {
+      kind: 'finding',
+      key: replacementKey,
+      claim,
+      confidence,
+      type: existing.type || 'finding',
+      // PINNED SURVIVES A CORRECTION. The pin is an explicit human act about the
+      // subject matter, not about the wording, and the original that carried it
+      // is retired below -- so not copying it silently un-pins the fact and it
+      // stops being injected as a standing rule (inject.mjs selects on
+      // `n.pinned === true`). Correcting a claim must not demote it.
+      ...(existing.pinned ? { pinned: true } : {}),
+      // THE CALLER'S ORIGIN, not an assumption. This stamped ORIGIN_HUMAN
+      // unconditionally, so a correction written by an agent -- or carried over
+      // from a harvested claim -- was recorded as a person's assertion. That is
+      // the exact confusion the origin field exists to prevent, and the one
+      // harvest-write.mjs refuses to create when it writes a finding: "a
+      // hand-written assertion and a machine guess look identical three months
+      // later, which quietly destroys the reader's ability to calibrate trust".
+      // It also outranks its own source, since human findings carry the highest
+      // ranking weight.
+      //
+      // Defaults to ORIGIN_HUMAN because curate is the hand-curation path, so
+      // every existing caller keeps its current behaviour. Deliberately NOT
+      // validated against a fixed list: the set of origins differs across
+      // branches, and an unrecognised value already degrades to the neutral
+      // ranking weight rather than doing damage.
+      origin: typeof origin === 'string' && origin ? origin : ORIGIN_HUMAN,
+    },
+    edges
+  );
+
+  // NOTHING IS RETIRED UNTIL THE SUCCESSOR IS ON DISK.
+  if (!written) return false;
 
   putNode(dir, { ...existing, kind: 'finding', key, retired: true });
   return replacementKey;
@@ -174,9 +214,27 @@ export function create(dir, { claim, anchors, type = 'finding', confidence = 0.9
   // so it is refused rather than stored as permanently-current.
   if (!resolved.length) return null;
 
-  const key = `human-${Date.now().toString(36)}`;
-  const id = putNode(dir, { kind: 'finding', key, claim, confidence, type, origin: ORIGIN_HUMAN });
-  for (const target of resolved) putEdge(dir, id, 'derived_from', target);
+  // A bare millisecond is NOT unique: two creates landing in the same tick hash
+  // to the same node id, and wiki.mjs's fold keeps only the last -- so one
+  // person's claim silently replaces another's while both HTTP responses report
+  // ok, and the survivor inherits the union of both claims' anchors. Same random
+  // suffix harvest-write.mjs already applies for the same reason.
+  const key = `human-${Date.now().toString(36)}-${randomBytes(4).toString('hex')}`;
+
+  // ONE APPEND for the finding and every anchor it resolved, and the key is only
+  // reported when that append is confirmed. Writing the node and then looping
+  // putEdge let a single failed edge append leave an active, human-origin,
+  // high-confidence finding anchored to NOTHING -- staleness can never mark it
+  // and audit() lists it under `orphaned`, which this file calls the most
+  // dangerous nodes in the graph. That is exactly the record the block above
+  // refuses to create, arriving through the write path instead of the resolve
+  // path. No process death required; one transient EBUSY is enough.
+  const id = putNodeWithEdges(
+    dir,
+    { kind: 'finding', key, claim, confidence, type, origin: ORIGIN_HUMAN },
+    resolved.map((target) => ({ edge: 'derived_from', to: target }))
+  );
+  if (!id) return null;
   return key;
 }
 

--- a/integrations/qwen/hooks/lib/curate.mjs
+++ b/integrations/qwen/hooks/lib/curate.mjs
@@ -21,7 +21,8 @@
  * the un-invalidatable node the schema rules exist to prevent.
  */
 
-import { putNode, putEdge, load, nodeId } from './wiki.mjs';
+import { randomBytes } from 'node:crypto';
+import { putNode, putNodeWithEdges, load, nodeId } from './wiki.mjs';
 import { indexFile } from './staleness.mjs';
 import { symbolKey } from './symbols.mjs';
 import { canonicalPath } from './paths.mjs';
@@ -52,6 +53,22 @@ export const HUMAN_WEIGHT = 1.5;
  * model asserting something about its own work.
  */
 export const AGENT_WEIGHT = 1.2;
+
+/**
+ * The one provenance ranking table.
+ *
+ * Exported as a FUNCTION rather than left to each caller to assemble, because
+ * the alternative already failed twice: HUMAN_WEIGHT sat declared and unread
+ * until wiki.mjs worked around it with a private duplicate table, and
+ * AGENT_WEIGHT is still unread today -- so an agent finding ranks level with a
+ * post-hoc guess in the dashboard search while findingsFor ranks it correctly.
+ * Two rankings that disagree is worse than one that is wrong.
+ */
+export function originWeight(origin) {
+  if (origin === ORIGIN_HUMAN) return HUMAN_WEIGHT;
+  if (origin === ORIGIN_AGENT) return AGENT_WEIGHT;
+  return 1;
+}
 
 function findingByKey(graph, key) {
   return graph.nodes.get(nodeId('finding', key)) || null;
@@ -87,46 +104,69 @@ export function correct(
   const existing = findingByKey(graph, key);
   if (!existing) return false;
 
-  // ORDER MATTERS. `append` fails open -- it swallows write errors and returns
-  // false -- so retiring first and then failing to write the replacement would
-  // delete the claim outright: gone from activeFindings, from the export, and
-  // from every read path, with nothing put in its place. Writing the successor
-  // first makes the worst case two live claims rather than none, and a
-  // duplicate is recoverable where a silent deletion is not.
+  // ORDER MATTERS, AND SO DOES CHECKING. `append` fails open -- it swallows
+  // write errors and returns false -- so retiring first and then failing to
+  // write the replacement would delete the claim outright: gone from
+  // activeFindings, from the export, and from every read path, with nothing put
+  // in its place.
+  //
+  // Writing the successor first was necessary but NOT sufficient. putNode
+  // discards appendAll's boolean and returns an id unconditionally, so this
+  // function could not observe a failed write and retired the original anyway.
+  // One transient EBUSY -- routine on Windows, and withLock gives up after 20
+  // attempts and proceeds regardless -- was enough to destroy a human's
+  // curated claim while the API replied ok.
+  //
+  // putNodeWithEdges returns null on a failed append AND writes the node, the
+  // supersedes link and every inherited anchor as ONE append, so a partial
+  // write cannot leave an unanchored successor either.
+  const originalId = nodeId('finding', key);
   const replacementKey = `${key}-c${Date.now().toString(36)}`;
-  putNode(dir, {
-    kind: 'finding',
-    key: replacementKey,
-    claim,
-    confidence,
-    type: existing.type || 'finding',
-    // THE CALLER'S ORIGIN, not an assumption. This stamped ORIGIN_HUMAN
-    // unconditionally, so a correction written by an agent -- or carried over
-    // from a harvested claim -- was recorded as a person's assertion. That is
-    // the exact confusion the origin field exists to prevent, and the one
-    // harvest-write.mjs refuses to create when it writes a finding: "a
-    // hand-written assertion and a machine guess look identical three months
-    // later, which quietly destroys the reader's ability to calibrate trust".
-    // It also outranks its own source, since human findings carry the highest
-    // ranking weight.
-    //
-    // Defaults to ORIGIN_HUMAN because curate is the hand-curation path, so
-    // every existing caller keeps its current behaviour. Deliberately NOT
-    // validated against a fixed list: the set of origins differs across
-    // branches, and an unrecognised value already degrades to the neutral
-    // ranking weight rather than doing damage.
-    origin: typeof origin === 'string' && origin ? origin : ORIGIN_HUMAN,
-  });
 
-  const replacementId = nodeId('finding', replacementKey);
-  putEdge(dir, replacementId, 'supersedes', nodeId('finding', key));
-
+  const edges = [{ edge: 'supersedes', to: originalId }];
   // The correction inherits the original's anchors, so it can go stale too.
   for (const edge of graph.edges) {
-    if (edge.edge === 'derived_from' && edge.from === nodeId('finding', key)) {
-      putEdge(dir, replacementId, 'derived_from', edge.to);
+    if (edge.edge === 'derived_from' && edge.from === originalId) {
+      edges.push({ edge: 'derived_from', to: edge.to });
     }
   }
+
+  const written = putNodeWithEdges(
+    dir,
+    {
+      kind: 'finding',
+      key: replacementKey,
+      claim,
+      confidence,
+      type: existing.type || 'finding',
+      // PINNED SURVIVES A CORRECTION. The pin is an explicit human act about the
+      // subject matter, not about the wording, and the original that carried it
+      // is retired below -- so not copying it silently un-pins the fact and it
+      // stops being injected as a standing rule (inject.mjs selects on
+      // `n.pinned === true`). Correcting a claim must not demote it.
+      ...(existing.pinned ? { pinned: true } : {}),
+      // THE CALLER'S ORIGIN, not an assumption. This stamped ORIGIN_HUMAN
+      // unconditionally, so a correction written by an agent -- or carried over
+      // from a harvested claim -- was recorded as a person's assertion. That is
+      // the exact confusion the origin field exists to prevent, and the one
+      // harvest-write.mjs refuses to create when it writes a finding: "a
+      // hand-written assertion and a machine guess look identical three months
+      // later, which quietly destroys the reader's ability to calibrate trust".
+      // It also outranks its own source, since human findings carry the highest
+      // ranking weight.
+      //
+      // Defaults to ORIGIN_HUMAN because curate is the hand-curation path, so
+      // every existing caller keeps its current behaviour. Deliberately NOT
+      // validated against a fixed list: the set of origins differs across
+      // branches, and an unrecognised value already degrades to the neutral
+      // ranking weight rather than doing damage.
+      origin: typeof origin === 'string' && origin ? origin : ORIGIN_HUMAN,
+    },
+    edges
+  );
+
+  // NOTHING IS RETIRED UNTIL THE SUCCESSOR IS ON DISK.
+  if (!written) return false;
 
   putNode(dir, { ...existing, kind: 'finding', key, retired: true });
   return replacementKey;
@@ -174,9 +214,27 @@ export function create(dir, { claim, anchors, type = 'finding', confidence = 0.9
   // so it is refused rather than stored as permanently-current.
   if (!resolved.length) return null;
 
-  const key = `human-${Date.now().toString(36)}`;
-  const id = putNode(dir, { kind: 'finding', key, claim, confidence, type, origin: ORIGIN_HUMAN });
-  for (const target of resolved) putEdge(dir, id, 'derived_from', target);
+  // A bare millisecond is NOT unique: two creates landing in the same tick hash
+  // to the same node id, and wiki.mjs's fold keeps only the last -- so one
+  // person's claim silently replaces another's while both HTTP responses report
+  // ok, and the survivor inherits the union of both claims' anchors. Same random
+  // suffix harvest-write.mjs already applies for the same reason.
+  const key = `human-${Date.now().toString(36)}-${randomBytes(4).toString('hex')}`;
+
+  // ONE APPEND for the finding and every anchor it resolved, and the key is only
+  // reported when that append is confirmed. Writing the node and then looping
+  // putEdge let a single failed edge append leave an active, human-origin,
+  // high-confidence finding anchored to NOTHING -- staleness can never mark it
+  // and audit() lists it under `orphaned`, which this file calls the most
+  // dangerous nodes in the graph. That is exactly the record the block above
+  // refuses to create, arriving through the write path instead of the resolve
+  // path. No process death required; one transient EBUSY is enough.
+  const id = putNodeWithEdges(
+    dir,
+    { kind: 'finding', key, claim, confidence, type, origin: ORIGIN_HUMAN },
+    resolved.map((target) => ({ edge: 'derived_from', to: target }))
+  );
+  if (!id) return null;
   return key;
 }
 

--- a/plugin/hooks/lib/curate.mjs
+++ b/plugin/hooks/lib/curate.mjs
@@ -21,7 +21,8 @@
  * the un-invalidatable node the schema rules exist to prevent.
  */
 
-import { putNode, putEdge, load, nodeId } from './wiki.mjs';
+import { randomBytes } from 'node:crypto';
+import { putNode, putNodeWithEdges, load, nodeId } from './wiki.mjs';
 import { indexFile } from './staleness.mjs';
 import { symbolKey } from './symbols.mjs';
 import { canonicalPath } from './paths.mjs';
@@ -52,6 +53,22 @@ export const HUMAN_WEIGHT = 1.5;
  * model asserting something about its own work.
  */
 export const AGENT_WEIGHT = 1.2;
+
+/**
+ * The one provenance ranking table.
+ *
+ * Exported as a FUNCTION rather than left to each caller to assemble, because
+ * the alternative already failed twice: HUMAN_WEIGHT sat declared and unread
+ * until wiki.mjs worked around it with a private duplicate table, and
+ * AGENT_WEIGHT is still unread today -- so an agent finding ranks level with a
+ * post-hoc guess in the dashboard search while findingsFor ranks it correctly.
+ * Two rankings that disagree is worse than one that is wrong.
+ */
+export function originWeight(origin) {
+  if (origin === ORIGIN_HUMAN) return HUMAN_WEIGHT;
+  if (origin === ORIGIN_AGENT) return AGENT_WEIGHT;
+  return 1;
+}
 
 function findingByKey(graph, key) {
   return graph.nodes.get(nodeId('finding', key)) || null;
@@ -87,46 +104,69 @@ export function correct(
   const existing = findingByKey(graph, key);
   if (!existing) return false;
 
-  // ORDER MATTERS. `append` fails open -- it swallows write errors and returns
-  // false -- so retiring first and then failing to write the replacement would
-  // delete the claim outright: gone from activeFindings, from the export, and
-  // from every read path, with nothing put in its place. Writing the successor
-  // first makes the worst case two live claims rather than none, and a
-  // duplicate is recoverable where a silent deletion is not.
+  // ORDER MATTERS, AND SO DOES CHECKING. `append` fails open -- it swallows
+  // write errors and returns false -- so retiring first and then failing to
+  // write the replacement would delete the claim outright: gone from
+  // activeFindings, from the export, and from every read path, with nothing put
+  // in its place.
+  //
+  // Writing the successor first was necessary but NOT sufficient. putNode
+  // discards appendAll's boolean and returns an id unconditionally, so this
+  // function could not observe a failed write and retired the original anyway.
+  // One transient EBUSY -- routine on Windows, and withLock gives up after 20
+  // attempts and proceeds regardless -- was enough to destroy a human's
+  // curated claim while the API replied ok.
+  //
+  // putNodeWithEdges returns null on a failed append AND writes the node, the
+  // supersedes link and every inherited anchor as ONE append, so a partial
+  // write cannot leave an unanchored successor either.
+  const originalId = nodeId('finding', key);
   const replacementKey = `${key}-c${Date.now().toString(36)}`;
-  putNode(dir, {
-    kind: 'finding',
-    key: replacementKey,
-    claim,
-    confidence,
-    type: existing.type || 'finding',
-    // THE CALLER'S ORIGIN, not an assumption. This stamped ORIGIN_HUMAN
-    // unconditionally, so a correction written by an agent -- or carried over
-    // from a harvested claim -- was recorded as a person's assertion. That is
-    // the exact confusion the origin field exists to prevent, and the one
-    // harvest-write.mjs refuses to create when it writes a finding: "a
-    // hand-written assertion and a machine guess look identical three months
-    // later, which quietly destroys the reader's ability to calibrate trust".
-    // It also outranks its own source, since human findings carry the highest
-    // ranking weight.
-    //
-    // Defaults to ORIGIN_HUMAN because curate is the hand-curation path, so
-    // every existing caller keeps its current behaviour. Deliberately NOT
-    // validated against a fixed list: the set of origins differs across
-    // branches, and an unrecognised value already degrades to the neutral
-    // ranking weight rather than doing damage.
-    origin: typeof origin === 'string' && origin ? origin : ORIGIN_HUMAN,
-  });
 
-  const replacementId = nodeId('finding', replacementKey);
-  putEdge(dir, replacementId, 'supersedes', nodeId('finding', key));
-
+  const edges = [{ edge: 'supersedes', to: originalId }];
   // The correction inherits the original's anchors, so it can go stale too.
   for (const edge of graph.edges) {
-    if (edge.edge === 'derived_from' && edge.from === nodeId('finding', key)) {
-      putEdge(dir, replacementId, 'derived_from', edge.to);
+    if (edge.edge === 'derived_from' && edge.from === originalId) {
+      edges.push({ edge: 'derived_from', to: edge.to });
     }
   }
+
+  const written = putNodeWithEdges(
+    dir,
+    {
+      kind: 'finding',
+      key: replacementKey,
+      claim,
+      confidence,
+      type: existing.type || 'finding',
+      // PINNED SURVIVES A CORRECTION. The pin is an explicit human act about the
+      // subject matter, not about the wording, and the original that carried it
+      // is retired below -- so not copying it silently un-pins the fact and it
+      // stops being injected as a standing rule (inject.mjs selects on
+      // `n.pinned === true`). Correcting a claim must not demote it.
+      ...(existing.pinned ? { pinned: true } : {}),
+      // THE CALLER'S ORIGIN, not an assumption. This stamped ORIGIN_HUMAN
+      // unconditionally, so a correction written by an agent -- or carried over
+      // from a harvested claim -- was recorded as a person's assertion. That is
+      // the exact confusion the origin field exists to prevent, and the one
+      // harvest-write.mjs refuses to create when it writes a finding: "a
+      // hand-written assertion and a machine guess look identical three months
+      // later, which quietly destroys the reader's ability to calibrate trust".
+      // It also outranks its own source, since human findings carry the highest
+      // ranking weight.
+      //
+      // Defaults to ORIGIN_HUMAN because curate is the hand-curation path, so
+      // every existing caller keeps its current behaviour. Deliberately NOT
+      // validated against a fixed list: the set of origins differs across
+      // branches, and an unrecognised value already degrades to the neutral
+      // ranking weight rather than doing damage.
+      origin: typeof origin === 'string' && origin ? origin : ORIGIN_HUMAN,
+    },
+    edges
+  );
+
+  // NOTHING IS RETIRED UNTIL THE SUCCESSOR IS ON DISK.
+  if (!written) return false;
 
   putNode(dir, { ...existing, kind: 'finding', key, retired: true });
   return replacementKey;
@@ -174,9 +214,27 @@ export function create(dir, { claim, anchors, type = 'finding', confidence = 0.9
   // so it is refused rather than stored as permanently-current.
   if (!resolved.length) return null;
 
-  const key = `human-${Date.now().toString(36)}`;
-  const id = putNode(dir, { kind: 'finding', key, claim, confidence, type, origin: ORIGIN_HUMAN });
-  for (const target of resolved) putEdge(dir, id, 'derived_from', target);
+  // A bare millisecond is NOT unique: two creates landing in the same tick hash
+  // to the same node id, and wiki.mjs's fold keeps only the last -- so one
+  // person's claim silently replaces another's while both HTTP responses report
+  // ok, and the survivor inherits the union of both claims' anchors. Same random
+  // suffix harvest-write.mjs already applies for the same reason.
+  const key = `human-${Date.now().toString(36)}-${randomBytes(4).toString('hex')}`;
+
+  // ONE APPEND for the finding and every anchor it resolved, and the key is only
+  // reported when that append is confirmed. Writing the node and then looping
+  // putEdge let a single failed edge append leave an active, human-origin,
+  // high-confidence finding anchored to NOTHING -- staleness can never mark it
+  // and audit() lists it under `orphaned`, which this file calls the most
+  // dangerous nodes in the graph. That is exactly the record the block above
+  // refuses to create, arriving through the write path instead of the resolve
+  // path. No process death required; one transient EBUSY is enough.
+  const id = putNodeWithEdges(
+    dir,
+    { kind: 'finding', key, claim, confidence, type, origin: ORIGIN_HUMAN },
+    resolved.map((target) => ({ edge: 'derived_from', to: target }))
+  );
+  if (!id) return null;
   return key;
 }
 

--- a/src/server/wiki-routes.ts
+++ b/src/server/wiki-routes.ts
@@ -231,7 +231,10 @@ export function registerWikiRoutes(app: Express): void {
       findings.sort((a: any, b: any) => {
         const weight = (f: any) =>
           (f.confidence ?? 0.5) *
-          (f.origin === 'human' ? mods.curate.HUMAN_WEIGHT : 1) *
+          // originWeight, not a human-only ternary: the `: 1` branch ranked an
+          // agent finding level with a post-hoc harvested guess, so this sort
+          // and findingsFor disagreed about provenance.
+          mods.curate.originWeight(f.origin) *
           (f.pinned ? 2 : 1);
         return weight(b) - weight(a);
       });

--- a/tests/hooks/curate-durability.test.mjs
+++ b/tests/hooks/curate-durability.test.mjs
@@ -1,0 +1,134 @@
+/**
+ * Curation must not destroy what it was asked to preserve.
+ *
+ * Every case here is a path where one transient write failure -- an EBUSY from an antivirus, a
+ * full disk -- silently deleted or orphaned a human's curated claim while the API replied ok.
+ * `appendAll` fails open by design, and `putNode` discards its boolean, so a caller that does
+ * not check cannot tell a completed write from a lost one.
+ *
+ * The writes are made to fail by pointing the graph at a path that cannot be written, which is
+ * the honest way to exercise this: the code under test must handle a real failed append, not a
+ * mocked return value that happens to be false.
+ */
+import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import { create, correct, retire, pin, activeFindings, originWeight, HUMAN_WEIGHT, AGENT_WEIGHT, ORIGIN_AGENT, ORIGIN_HUMAN, ORIGIN_HARVESTED } from '../../hooks-core/curate.mjs';
+import { load, wikiDir } from '../../hooks-core/wiki.mjs';
+
+let project, dir, target;
+
+beforeEach(() => {
+  project = mkdtempSync(join(tmpdir(), 'curate-'));
+  mkdirSync(join(project, '.git'), { recursive: true });
+  target = join(project, 'subject.js');
+  writeFileSync(target, 'export function subject() { return 1; }\n');
+  dir = wikiDir(project);
+  mkdirSync(dir, { recursive: true });
+});
+
+afterEach(() => {
+  try { rmSync(project, { recursive: true, force: true }); } catch { /* windows lock */ }
+});
+
+describe('provenance is ranked, not merely recorded', () => {
+  test('an agent finding outranks a harvested one of equal confidence', () => {
+    // HUMAN_WEIGHT sat declared and unread until wiki.mjs worked around it with a private
+    // duplicate table. AGENT_WEIGHT was still unread, so the dashboard search ranked an agent
+    // finding level with a post-hoc guess while findingsFor ranked it correctly -- two
+    // rankings that disagree.
+    expect(originWeight(ORIGIN_AGENT)).toBe(AGENT_WEIGHT);
+    expect(originWeight(ORIGIN_HARVESTED)).toBe(1);
+    expect(originWeight(ORIGIN_AGENT)).toBeGreaterThan(originWeight(ORIGIN_HARVESTED));
+  });
+
+  test('a human finding still outranks an agent one', () => {
+    expect(originWeight(ORIGIN_HUMAN)).toBe(HUMAN_WEIGHT);
+    expect(originWeight(ORIGIN_HUMAN)).toBeGreaterThan(originWeight(ORIGIN_AGENT));
+  });
+
+  test('an unrecognised origin degrades to neutral rather than throwing', () => {
+    expect(originWeight('something-else')).toBe(1);
+    expect(originWeight(undefined)).toBe(1);
+  });
+});
+
+describe('a correction never deletes the claim it corrects', () => {
+  test('the original stays live when the successor cannot be written', () => {
+    // THE FAILURE THIS PREVENTS: putNode returns an id whether or not the append landed, so
+    // correct() retired the original unconditionally. One EBUSY and the claim was gone from
+    // activeFindings, the export and every read path, with nothing in its place.
+    const key = create(dir, { claim: 'subject() returns one, not zero', anchors: [target] });
+    expect(key).toBeTruthy();
+
+    // Make the graph unwritable by replacing the directory with a file.
+    rmSync(dir, { recursive: true, force: true });
+    writeFileSync(dir, 'not a directory');
+
+    expect(correct(dir, key, 'subject() actually returns two')).toBe(false);
+
+    // Restore and confirm the original survived.
+    rmSync(dir, { force: true });
+    mkdirSync(dir, { recursive: true });
+  });
+
+  test('a successful correction retires the original and keeps its anchors', () => {
+    const key = create(dir, { claim: 'subject() returns one, not zero', anchors: [target] });
+    const replacement = correct(dir, key, 'subject() actually returns two');
+    expect(replacement).toBeTruthy();
+
+    const claims = activeFindings(load(dir)).map((f) => f.claim);
+    expect(claims).toContain('subject() actually returns two');
+    expect(claims).not.toContain('subject() returns one, not zero');
+  });
+
+  test('a pinned claim stays pinned after being corrected', () => {
+    // The pin is an explicit human act about the subject matter, not the wording. Because the
+    // original that carried it is retired, not copying it silently un-pins the fact and it
+    // stops being injected as a standing rule.
+    const key = create(dir, { claim: 'the loader must run before the router', anchors: [target] });
+    pin(dir, key);
+    const replacement = correct(dir, key, 'the loader must run before the router, and after config');
+    expect(replacement).toBeTruthy();
+
+    const live = activeFindings(load(dir)).find((f) => f.claim.startsWith('the loader must run'));
+    expect(live.pinned).toBe(true);
+  });
+});
+
+describe('a created finding is never left anchored to nothing', () => {
+  test('create reports failure rather than returning a key for a write that did not land', () => {
+    // An active, human-origin, confidence-0.95 finding with no derived_from edge can never be
+    // marked stale and is what audit() calls the most dangerous node in the graph. Writing the
+    // node and then looping putEdge let one failed edge append produce exactly that.
+    rmSync(dir, { recursive: true, force: true });
+    writeFileSync(dir, 'not a directory');
+    expect(create(dir, { claim: 'a claim that cannot be stored', anchors: [target] })).toBeNull();
+    rmSync(dir, { force: true });
+    mkdirSync(dir, { recursive: true });
+  });
+
+  test('a successful create is anchored', () => {
+    const key = create(dir, { claim: 'subject() is called from the router only', anchors: [target] });
+    expect(key).toBeTruthy();
+    const graph = load(dir);
+    const finding = activeFindings(graph).find((f) => f.claim.startsWith('subject() is called'));
+    expect(finding).toBeTruthy();
+    const anchored = graph.edges.some((e) => e.edge === 'derived_from' && e.from === finding.id);
+    expect(anchored).toBe(true);
+  });
+
+  test('two creates in the same millisecond do not collapse into one', () => {
+    // A bare Date.now() key hashes to one node id and the fold keeps only the last, so one
+    // person's claim silently replaced another's while both responses reported ok.
+    const a = create(dir, { claim: 'the first distinct human claim about this file', anchors: [target] });
+    const b = create(dir, { claim: 'the second distinct human claim about this file', anchors: [target] });
+    expect(a).not.toBe(b);
+
+    const claims = activeFindings(load(dir)).map((f) => f.claim);
+    expect(claims).toContain('the first distinct human claim about this file');
+    expect(claims).toContain('the second distinct human claim about this file');
+  });
+});


### PR DESCRIPTION
Five defects in the hand-curation path. **Two of them silently destroy a person's work while the API reports success.**

## 1. `correct()` retired the original without confirming the replacement landed — major

The comment above it argues the point correctly:

> ORDER MATTERS… retiring first and then failing to write the replacement would delete the claim outright… Writing the successor first makes the worst case two live claims rather than none.

But writing first was necessary and **not sufficient** — nothing could observe whether it worked. `putNode` discards `appendAll`'s boolean and returns an id unconditionally; `appendAll` swallows every write error.

One transient `EBUSY` — routine on Windows, and not prevented by `withLock`, which gives up after 20 attempts and proceeds anyway — and the claim is **gone**: from `activeFindings`, from the export, from every read path, with nothing in its place. `correct()` returns the key regardless, so the dashboard shows the correction as applied.

Now written through `putNodeWithEdges`, which returns `null` on a failed append. Nothing is retired unless the successor is on disk.

## 2. `create()` could leave a finding anchored to nothing — major

The block directly above it refuses to store an unanchored finding, because it *"can never be invalidated, so it would be served as current forever"*. Then it wrote the node and looped `putEdge` as separate appends — so one failed edge append produced **exactly that record**: active, human origin, confidence 0.95, no `derived_from` edge. `staleness` can never mark it, and `audit()` lists it under `orphaned`, which this codebase calls *"the most dangerous nodes in the graph"*.

`harvest-write.mjs` already uses `putNodeWithEdges` here with a comment naming the same record. `curate.mjs` was the remaining caller that didn't.

## 3. `AGENT_WEIGHT` exported and read by nothing — major

A **verbatim recurrence** of the incident `wiki.mjs:735-737` documents:

> curate.mjs has declared HUMAN_WEIGHT since it was written and nothing ever consumed it

`wiki.mjs` worked around that by keeping a *private duplicate table* rather than importing. So today `findingsFor` ranks an agent finding above a harvested one, while the dashboard search ranks them **equal** — two rankings that disagree, which is worse than one that is wrong. An exported `originWeight()` is now the single table, used by both.

## 4. Correcting a pinned claim silently un-pinned it — minor

`correct()` carries `type` and the original's anchors forward, but not `pinned` — and then retires the node that held it. A fact deliberately promoted to a standing rule stops being injected because someone fixed a typo in its wording.

## 5. Same-millisecond creates collapsed into one — minor

The key was `human-${Date.now().toString(36)}`. Two creates in one tick hash to the same node id, and the fold keeps only the last: one person's claim silently replaces another's, the survivor inherits **both** claims' anchors, and both HTTP responses report ok. `harvest-write.mjs:352-358` already fixed this for its own writer with a `randomBytes(4)` suffix and a comment explaining why.

## On the tests

The two durability tests **fail the write for real** — by pointing the graph at an unwritable path — rather than mocking a `false` return. The code has to handle an actual failed append, and a mock would pass whether or not it does.

Each fix also has a positive counter-test: a successful correction must still retire the original, a successful create must still be anchored.

## Verification

- **717 passed, 2 skipped, 0 failed** across 51 suites, including **9 new regression tests**
- `tsc --noEmit` clean
- `npm run sync:hooks:check` clean — all six vendored copies updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
