### PR TITLE
fix(consolidate): score against the inputs the module says it uses

### DIFF
--- a/hooks-core/consolidate.mjs
+++ b/hooks-core/consolidate.mjs
@@ -30,7 +30,7 @@
  */
 
 import { statSync } from 'node:fs';
-import { canonicalPath } from './paths.mjs';
+import { nodeId } from './wiki.mjs';
 
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
 
@@ -47,9 +47,17 @@ export function irrecoverability(entry) {
   const text = `${entry.summary || ''} ${entry.evidence || ''}`.toLowerCase();
 
   // Anything derived from a non-deterministic or long-running observation.
-  if (/flak|intermitten|race|timing|reproduc|only fails|sometimes/.test(text)) return 4;
+  //
+  // WORD-ANCHORED. The bare fragment `race` matched "stack trace", and a stack trace is among
+  // the most common things to appear in a finding's evidence -- so an ordinary reasoned finding
+  // scored 4, the tier reserved for observations that cannot be re-derived, instead of the 2 it
+  // earns. That is a 2x multiplier inflation on a very common input, and under budget pressure
+  // an inflated ordinary finding displaces a genuinely irrecoverable one.
+  if (/flak|intermitten|\brace\b|\btiming|\breproduc|only fails|sometimes/.test(text)) return 4;
   // Conclusions drawn from running something, not from reading it.
-  if (/benchmark|profil|measured|timed|ran the|test run|reproduced/.test(text)) return 3;
+  // `reproduced` is deliberately absent: the `\breproduc` prefix above returns first, so listing
+  // it here was unreachable.
+  if (/benchmark|\bprofil(?:ed|ing|er)\b|measured|timed|ran the|test run/.test(text)) return 3;
   // Reasoning over material that is on disk but had to be understood.
   if (/because|therefore|turns out|root cause|the reason/.test(text)) return 2;
   return 1;
@@ -87,10 +95,21 @@ export function reuseProbability(graph, anchors) {
 export function costToRederive(entry, previousAt) {
   if (typeof entry.tokensSpent === 'number') return entry.tokensSpent;
 
-  const window = (entry.at ?? 0) - (previousAt ?? entry.at ?? 0);
-  // Fall back to the size of the evidence when no spend is attributable, so a
+  // NO TRANSCRIPT ATTRIBUTION IS IMPLEMENTED. This previously computed an
+  // inter-conclusion window and then consumed it as `window > 0 ? 0 : 0` --
+  // zero on both branches -- so the value, and the `previousAt` parameter
+  // threaded through selectForConsolidation to produce it, had no effect on any
+  // output. The docstring above and the module header claimed cost was
+  // "measured from the transcript" and called that "exactly the quantity a
+  // competitor without session instrumentation cannot obtain"; it was not
+  // measured at all.
+  //
+  // `entry.at` is a millisecond timestamp, not a token count, so feeding the
+  // window in would substitute a fabricated ms-to-token conversion for the
+  // no-op. The only measured cost is `entry.tokensSpent`, which the extraction
+  // site must supply; otherwise fall back to the size of the evidence, so a
   // conclusion drawn from a large investigation still outranks an aside.
-  return Math.max(estimate(entry.evidence) * 4, window > 0 ? 0 : 0) || estimate(entry.summary) * 8;
+  return estimate(entry.evidence) * 4 || estimate(entry.summary) * 8;
 }
 
 /** Kinds that survive on the floor regardless of score. */
@@ -108,7 +127,17 @@ export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}
   let previousAt = null;
 
   for (const entry of candidates) {
-    const anchors = (entry.anchors || []).map((a) => canonicalPath(String(a).split('#')[0]));
+    // Graph edges hold NODE IDS -- wiki.mjs writes from/to as nodeId(kind, key), a hash --
+    // so an anchor must be hashed to the same identity before it can match anything.
+    // Comparing raw paths made `degree` zero for every candidate, which made the whole
+    // reuse-probability term a constant. Worse than inert: reuseProbability returns 0.5 for an
+    // EMPTY anchor list and 0.25 for a resolved-but-unmatched one, so every anchored candidate
+    // was penalised 2x against every unanchored aside -- and under budget pressure the anchored
+    // findings, the ones the graph can actually retrieve later, were dropped first.
+    const anchors = (entry.anchors || []).map((a) => {
+      const raw = String(a);
+      return nodeId(raw.includes('#') ? 'symbol' : 'file', raw);
+    });
     const cost = costToRederive(entry, previousAt);
     const score = cost * irrecoverability(entry) * reuseProbability(graph, entry.anchorIds || anchors);
     scored.push({ entry, score, cost, tokens: estimate(entry.summary) });

--- a/integrations/codex/hooks/lib/consolidate.mjs
+++ b/integrations/codex/hooks/lib/consolidate.mjs
@@ -32,7 +32,7 @@
  */
 
 import { statSync } from 'node:fs';
-import { canonicalPath } from './paths.mjs';
+import { nodeId } from './wiki.mjs';
 
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
 
@@ -49,9 +49,17 @@ export function irrecoverability(entry) {
   const text = `${entry.summary || ''} ${entry.evidence || ''}`.toLowerCase();
 
   // Anything derived from a non-deterministic or long-running observation.
-  if (/flak|intermitten|race|timing|reproduc|only fails|sometimes/.test(text)) return 4;
+  //
+  // WORD-ANCHORED. The bare fragment `race` matched "stack trace", and a stack trace is among
+  // the most common things to appear in a finding's evidence -- so an ordinary reasoned finding
+  // scored 4, the tier reserved for observations that cannot be re-derived, instead of the 2 it
+  // earns. That is a 2x multiplier inflation on a very common input, and under budget pressure
+  // an inflated ordinary finding displaces a genuinely irrecoverable one.
+  if (/flak|intermitten|\brace\b|\btiming|\breproduc|only fails|sometimes/.test(text)) return 4;
   // Conclusions drawn from running something, not from reading it.
-  if (/benchmark|profil|measured|timed|ran the|test run|reproduced/.test(text)) return 3;
+  // `reproduced` is deliberately absent: the `\breproduc` prefix above returns first, so listing
+  // it here was unreachable.
+  if (/benchmark|\bprofil(?:ed|ing|er)\b|measured|timed|ran the|test run/.test(text)) return 3;
   // Reasoning over material that is on disk but had to be understood.
   if (/because|therefore|turns out|root cause|the reason/.test(text)) return 2;
   return 1;
@@ -89,10 +97,21 @@ export function reuseProbability(graph, anchors) {
 export function costToRederive(entry, previousAt) {
   if (typeof entry.tokensSpent === 'number') return entry.tokensSpent;
 
-  const window = (entry.at ?? 0) - (previousAt ?? entry.at ?? 0);
-  // Fall back to the size of the evidence when no spend is attributable, so a
+  // NO TRANSCRIPT ATTRIBUTION IS IMPLEMENTED. This previously computed an
+  // inter-conclusion window and then consumed it as `window > 0 ? 0 : 0` --
+  // zero on both branches -- so the value, and the `previousAt` parameter
+  // threaded through selectForConsolidation to produce it, had no effect on any
+  // output. The docstring above and the module header claimed cost was
+  // "measured from the transcript" and called that "exactly the quantity a
+  // competitor without session instrumentation cannot obtain"; it was not
+  // measured at all.
+  //
+  // `entry.at` is a millisecond timestamp, not a token count, so feeding the
+  // window in would substitute a fabricated ms-to-token conversion for the
+  // no-op. The only measured cost is `entry.tokensSpent`, which the extraction
+  // site must supply; otherwise fall back to the size of the evidence, so a
   // conclusion drawn from a large investigation still outranks an aside.
-  return Math.max(estimate(entry.evidence) * 4, window > 0 ? 0 : 0) || estimate(entry.summary) * 8;
+  return estimate(entry.evidence) * 4 || estimate(entry.summary) * 8;
 }
 
 /** Kinds that survive on the floor regardless of score. */
@@ -110,7 +129,17 @@ export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}
   let previousAt = null;
 
   for (const entry of candidates) {
-    const anchors = (entry.anchors || []).map((a) => canonicalPath(String(a).split('#')[0]));
+    // Graph edges hold NODE IDS -- wiki.mjs writes from/to as nodeId(kind, key), a hash --
+    // so an anchor must be hashed to the same identity before it can match anything.
+    // Comparing raw paths made `degree` zero for every candidate, which made the whole
+    // reuse-probability term a constant. Worse than inert: reuseProbability returns 0.5 for an
+    // EMPTY anchor list and 0.25 for a resolved-but-unmatched one, so every anchored candidate
+    // was penalised 2x against every unanchored aside -- and under budget pressure the anchored
+    // findings, the ones the graph can actually retrieve later, were dropped first.
+    const anchors = (entry.anchors || []).map((a) => {
+      const raw = String(a);
+      return nodeId(raw.includes('#') ? 'symbol' : 'file', raw);
+    });
     const cost = costToRederive(entry, previousAt);
     const score = cost * irrecoverability(entry) * reuseProbability(graph, entry.anchorIds || anchors);
     scored.push({ entry, score, cost, tokens: estimate(entry.summary) });

--- a/integrations/codex/plugin/hooks/lib/consolidate.mjs
+++ b/integrations/codex/plugin/hooks/lib/consolidate.mjs
@@ -32,7 +32,7 @@
  */
 
 import { statSync } from 'node:fs';
-import { canonicalPath } from './paths.mjs';
+import { nodeId } from './wiki.mjs';
 
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
 
@@ -49,9 +49,17 @@ export function irrecoverability(entry) {
   const text = `${entry.summary || ''} ${entry.evidence || ''}`.toLowerCase();
 
   // Anything derived from a non-deterministic or long-running observation.
-  if (/flak|intermitten|race|timing|reproduc|only fails|sometimes/.test(text)) return 4;
+  //
+  // WORD-ANCHORED. The bare fragment `race` matched "stack trace", and a stack trace is among
+  // the most common things to appear in a finding's evidence -- so an ordinary reasoned finding
+  // scored 4, the tier reserved for observations that cannot be re-derived, instead of the 2 it
+  // earns. That is a 2x multiplier inflation on a very common input, and under budget pressure
+  // an inflated ordinary finding displaces a genuinely irrecoverable one.
+  if (/flak|intermitten|\brace\b|\btiming|\breproduc|only fails|sometimes/.test(text)) return 4;
   // Conclusions drawn from running something, not from reading it.
-  if (/benchmark|profil|measured|timed|ran the|test run|reproduced/.test(text)) return 3;
+  // `reproduced` is deliberately absent: the `\breproduc` prefix above returns first, so listing
+  // it here was unreachable.
+  if (/benchmark|\bprofil(?:ed|ing|er)\b|measured|timed|ran the|test run/.test(text)) return 3;
   // Reasoning over material that is on disk but had to be understood.
   if (/because|therefore|turns out|root cause|the reason/.test(text)) return 2;
   return 1;
@@ -89,10 +97,21 @@ export function reuseProbability(graph, anchors) {
 export function costToRederive(entry, previousAt) {
   if (typeof entry.tokensSpent === 'number') return entry.tokensSpent;
 
-  const window = (entry.at ?? 0) - (previousAt ?? entry.at ?? 0);
-  // Fall back to the size of the evidence when no spend is attributable, so a
+  // NO TRANSCRIPT ATTRIBUTION IS IMPLEMENTED. This previously computed an
+  // inter-conclusion window and then consumed it as `window > 0 ? 0 : 0` --
+  // zero on both branches -- so the value, and the `previousAt` parameter
+  // threaded through selectForConsolidation to produce it, had no effect on any
+  // output. The docstring above and the module header claimed cost was
+  // "measured from the transcript" and called that "exactly the quantity a
+  // competitor without session instrumentation cannot obtain"; it was not
+  // measured at all.
+  //
+  // `entry.at` is a millisecond timestamp, not a token count, so feeding the
+  // window in would substitute a fabricated ms-to-token conversion for the
+  // no-op. The only measured cost is `entry.tokensSpent`, which the extraction
+  // site must supply; otherwise fall back to the size of the evidence, so a
   // conclusion drawn from a large investigation still outranks an aside.
-  return Math.max(estimate(entry.evidence) * 4, window > 0 ? 0 : 0) || estimate(entry.summary) * 8;
+  return estimate(entry.evidence) * 4 || estimate(entry.summary) * 8;
 }
 
 /** Kinds that survive on the floor regardless of score. */
@@ -110,7 +129,17 @@ export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}
   let previousAt = null;
 
   for (const entry of candidates) {
-    const anchors = (entry.anchors || []).map((a) => canonicalPath(String(a).split('#')[0]));
+    // Graph edges hold NODE IDS -- wiki.mjs writes from/to as nodeId(kind, key), a hash --
+    // so an anchor must be hashed to the same identity before it can match anything.
+    // Comparing raw paths made `degree` zero for every candidate, which made the whole
+    // reuse-probability term a constant. Worse than inert: reuseProbability returns 0.5 for an
+    // EMPTY anchor list and 0.25 for a resolved-but-unmatched one, so every anchored candidate
+    // was penalised 2x against every unanchored aside -- and under budget pressure the anchored
+    // findings, the ones the graph can actually retrieve later, were dropped first.
+    const anchors = (entry.anchors || []).map((a) => {
+      const raw = String(a);
+      return nodeId(raw.includes('#') ? 'symbol' : 'file', raw);
+    });
     const cost = costToRederive(entry, previousAt);
     const score = cost * irrecoverability(entry) * reuseProbability(graph, entry.anchorIds || anchors);
     scored.push({ entry, score, cost, tokens: estimate(entry.summary) });

--- a/integrations/gemini/hooks/lib/consolidate.mjs
+++ b/integrations/gemini/hooks/lib/consolidate.mjs
@@ -32,7 +32,7 @@
  */
 
 import { statSync } from 'node:fs';
-import { canonicalPath } from './paths.mjs';
+import { nodeId } from './wiki.mjs';
 
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
 
@@ -49,9 +49,17 @@ export function irrecoverability(entry) {
   const text = `${entry.summary || ''} ${entry.evidence || ''}`.toLowerCase();
 
   // Anything derived from a non-deterministic or long-running observation.
-  if (/flak|intermitten|race|timing|reproduc|only fails|sometimes/.test(text)) return 4;
+  //
+  // WORD-ANCHORED. The bare fragment `race` matched "stack trace", and a stack trace is among
+  // the most common things to appear in a finding's evidence -- so an ordinary reasoned finding
+  // scored 4, the tier reserved for observations that cannot be re-derived, instead of the 2 it
+  // earns. That is a 2x multiplier inflation on a very common input, and under budget pressure
+  // an inflated ordinary finding displaces a genuinely irrecoverable one.
+  if (/flak|intermitten|\brace\b|\btiming|\breproduc|only fails|sometimes/.test(text)) return 4;
   // Conclusions drawn from running something, not from reading it.
-  if (/benchmark|profil|measured|timed|ran the|test run|reproduced/.test(text)) return 3;
+  // `reproduced` is deliberately absent: the `\breproduc` prefix above returns first, so listing
+  // it here was unreachable.
+  if (/benchmark|\bprofil(?:ed|ing|er)\b|measured|timed|ran the|test run/.test(text)) return 3;
   // Reasoning over material that is on disk but had to be understood.
   if (/because|therefore|turns out|root cause|the reason/.test(text)) return 2;
   return 1;
@@ -89,10 +97,21 @@ export function reuseProbability(graph, anchors) {
 export function costToRederive(entry, previousAt) {
   if (typeof entry.tokensSpent === 'number') return entry.tokensSpent;
 
-  const window = (entry.at ?? 0) - (previousAt ?? entry.at ?? 0);
-  // Fall back to the size of the evidence when no spend is attributable, so a
+  // NO TRANSCRIPT ATTRIBUTION IS IMPLEMENTED. This previously computed an
+  // inter-conclusion window and then consumed it as `window > 0 ? 0 : 0` --
+  // zero on both branches -- so the value, and the `previousAt` parameter
+  // threaded through selectForConsolidation to produce it, had no effect on any
+  // output. The docstring above and the module header claimed cost was
+  // "measured from the transcript" and called that "exactly the quantity a
+  // competitor without session instrumentation cannot obtain"; it was not
+  // measured at all.
+  //
+  // `entry.at` is a millisecond timestamp, not a token count, so feeding the
+  // window in would substitute a fabricated ms-to-token conversion for the
+  // no-op. The only measured cost is `entry.tokensSpent`, which the extraction
+  // site must supply; otherwise fall back to the size of the evidence, so a
   // conclusion drawn from a large investigation still outranks an aside.
-  return Math.max(estimate(entry.evidence) * 4, window > 0 ? 0 : 0) || estimate(entry.summary) * 8;
+  return estimate(entry.evidence) * 4 || estimate(entry.summary) * 8;
 }
 
 /** Kinds that survive on the floor regardless of score. */
@@ -110,7 +129,17 @@ export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}
   let previousAt = null;
 
   for (const entry of candidates) {
-    const anchors = (entry.anchors || []).map((a) => canonicalPath(String(a).split('#')[0]));
+    // Graph edges hold NODE IDS -- wiki.mjs writes from/to as nodeId(kind, key), a hash --
+    // so an anchor must be hashed to the same identity before it can match anything.
+    // Comparing raw paths made `degree` zero for every candidate, which made the whole
+    // reuse-probability term a constant. Worse than inert: reuseProbability returns 0.5 for an
+    // EMPTY anchor list and 0.25 for a resolved-but-unmatched one, so every anchored candidate
+    // was penalised 2x against every unanchored aside -- and under budget pressure the anchored
+    // findings, the ones the graph can actually retrieve later, were dropped first.
+    const anchors = (entry.anchors || []).map((a) => {
+      const raw = String(a);
+      return nodeId(raw.includes('#') ? 'symbol' : 'file', raw);
+    });
     const cost = costToRederive(entry, previousAt);
     const score = cost * irrecoverability(entry) * reuseProbability(graph, entry.anchorIds || anchors);
     scored.push({ entry, score, cost, tokens: estimate(entry.summary) });

--- a/integrations/opencode/hooks/lib/consolidate.mjs
+++ b/integrations/opencode/hooks/lib/consolidate.mjs
@@ -32,7 +32,7 @@
  */
 
 import { statSync } from 'node:fs';
-import { canonicalPath } from './paths.mjs';
+import { nodeId } from './wiki.mjs';
 
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
 
@@ -49,9 +49,17 @@ export function irrecoverability(entry) {
   const text = `${entry.summary || ''} ${entry.evidence || ''}`.toLowerCase();
 
   // Anything derived from a non-deterministic or long-running observation.
-  if (/flak|intermitten|race|timing|reproduc|only fails|sometimes/.test(text)) return 4;
+  //
+  // WORD-ANCHORED. The bare fragment `race` matched "stack trace", and a stack trace is among
+  // the most common things to appear in a finding's evidence -- so an ordinary reasoned finding
+  // scored 4, the tier reserved for observations that cannot be re-derived, instead of the 2 it
+  // earns. That is a 2x multiplier inflation on a very common input, and under budget pressure
+  // an inflated ordinary finding displaces a genuinely irrecoverable one.
+  if (/flak|intermitten|\brace\b|\btiming|\breproduc|only fails|sometimes/.test(text)) return 4;
   // Conclusions drawn from running something, not from reading it.
-  if (/benchmark|profil|measured|timed|ran the|test run|reproduced/.test(text)) return 3;
+  // `reproduced` is deliberately absent: the `\breproduc` prefix above returns first, so listing
+  // it here was unreachable.
+  if (/benchmark|\bprofil(?:ed|ing|er)\b|measured|timed|ran the|test run/.test(text)) return 3;
   // Reasoning over material that is on disk but had to be understood.
   if (/because|therefore|turns out|root cause|the reason/.test(text)) return 2;
   return 1;
@@ -89,10 +97,21 @@ export function reuseProbability(graph, anchors) {
 export function costToRederive(entry, previousAt) {
   if (typeof entry.tokensSpent === 'number') return entry.tokensSpent;
 
-  const window = (entry.at ?? 0) - (previousAt ?? entry.at ?? 0);
-  // Fall back to the size of the evidence when no spend is attributable, so a
+  // NO TRANSCRIPT ATTRIBUTION IS IMPLEMENTED. This previously computed an
+  // inter-conclusion window and then consumed it as `window > 0 ? 0 : 0` --
+  // zero on both branches -- so the value, and the `previousAt` parameter
+  // threaded through selectForConsolidation to produce it, had no effect on any
+  // output. The docstring above and the module header claimed cost was
+  // "measured from the transcript" and called that "exactly the quantity a
+  // competitor without session instrumentation cannot obtain"; it was not
+  // measured at all.
+  //
+  // `entry.at` is a millisecond timestamp, not a token count, so feeding the
+  // window in would substitute a fabricated ms-to-token conversion for the
+  // no-op. The only measured cost is `entry.tokensSpent`, which the extraction
+  // site must supply; otherwise fall back to the size of the evidence, so a
   // conclusion drawn from a large investigation still outranks an aside.
-  return Math.max(estimate(entry.evidence) * 4, window > 0 ? 0 : 0) || estimate(entry.summary) * 8;
+  return estimate(entry.evidence) * 4 || estimate(entry.summary) * 8;
 }
 
 /** Kinds that survive on the floor regardless of score. */
@@ -110,7 +129,17 @@ export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}
   let previousAt = null;
 
   for (const entry of candidates) {
-    const anchors = (entry.anchors || []).map((a) => canonicalPath(String(a).split('#')[0]));
+    // Graph edges hold NODE IDS -- wiki.mjs writes from/to as nodeId(kind, key), a hash --
+    // so an anchor must be hashed to the same identity before it can match anything.
+    // Comparing raw paths made `degree` zero for every candidate, which made the whole
+    // reuse-probability term a constant. Worse than inert: reuseProbability returns 0.5 for an
+    // EMPTY anchor list and 0.25 for a resolved-but-unmatched one, so every anchored candidate
+    // was penalised 2x against every unanchored aside -- and under budget pressure the anchored
+    // findings, the ones the graph can actually retrieve later, were dropped first.
+    const anchors = (entry.anchors || []).map((a) => {
+      const raw = String(a);
+      return nodeId(raw.includes('#') ? 'symbol' : 'file', raw);
+    });
     const cost = costToRederive(entry, previousAt);
     const score = cost * irrecoverability(entry) * reuseProbability(graph, entry.anchorIds || anchors);
     scored.push({ entry, score, cost, tokens: estimate(entry.summary) });

--- a/integrations/qwen/hooks/lib/consolidate.mjs
+++ b/integrations/qwen/hooks/lib/consolidate.mjs
@@ -32,7 +32,7 @@
  */
 
 import { statSync } from 'node:fs';
-import { canonicalPath } from './paths.mjs';
+import { nodeId } from './wiki.mjs';
 
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
 
@@ -49,9 +49,17 @@ export function irrecoverability(entry) {
   const text = `${entry.summary || ''} ${entry.evidence || ''}`.toLowerCase();
 
   // Anything derived from a non-deterministic or long-running observation.
-  if (/flak|intermitten|race|timing|reproduc|only fails|sometimes/.test(text)) return 4;
+  //
+  // WORD-ANCHORED. The bare fragment `race` matched "stack trace", and a stack trace is among
+  // the most common things to appear in a finding's evidence -- so an ordinary reasoned finding
+  // scored 4, the tier reserved for observations that cannot be re-derived, instead of the 2 it
+  // earns. That is a 2x multiplier inflation on a very common input, and under budget pressure
+  // an inflated ordinary finding displaces a genuinely irrecoverable one.
+  if (/flak|intermitten|\brace\b|\btiming|\breproduc|only fails|sometimes/.test(text)) return 4;
   // Conclusions drawn from running something, not from reading it.
-  if (/benchmark|profil|measured|timed|ran the|test run|reproduced/.test(text)) return 3;
+  // `reproduced` is deliberately absent: the `\breproduc` prefix above returns first, so listing
+  // it here was unreachable.
+  if (/benchmark|\bprofil(?:ed|ing|er)\b|measured|timed|ran the|test run/.test(text)) return 3;
   // Reasoning over material that is on disk but had to be understood.
   if (/because|therefore|turns out|root cause|the reason/.test(text)) return 2;
   return 1;
@@ -89,10 +97,21 @@ export function reuseProbability(graph, anchors) {
 export function costToRederive(entry, previousAt) {
   if (typeof entry.tokensSpent === 'number') return entry.tokensSpent;
 
-  const window = (entry.at ?? 0) - (previousAt ?? entry.at ?? 0);
-  // Fall back to the size of the evidence when no spend is attributable, so a
+  // NO TRANSCRIPT ATTRIBUTION IS IMPLEMENTED. This previously computed an
+  // inter-conclusion window and then consumed it as `window > 0 ? 0 : 0` --
+  // zero on both branches -- so the value, and the `previousAt` parameter
+  // threaded through selectForConsolidation to produce it, had no effect on any
+  // output. The docstring above and the module header claimed cost was
+  // "measured from the transcript" and called that "exactly the quantity a
+  // competitor without session instrumentation cannot obtain"; it was not
+  // measured at all.
+  //
+  // `entry.at` is a millisecond timestamp, not a token count, so feeding the
+  // window in would substitute a fabricated ms-to-token conversion for the
+  // no-op. The only measured cost is `entry.tokensSpent`, which the extraction
+  // site must supply; otherwise fall back to the size of the evidence, so a
   // conclusion drawn from a large investigation still outranks an aside.
-  return Math.max(estimate(entry.evidence) * 4, window > 0 ? 0 : 0) || estimate(entry.summary) * 8;
+  return estimate(entry.evidence) * 4 || estimate(entry.summary) * 8;
 }
 
 /** Kinds that survive on the floor regardless of score. */
@@ -110,7 +129,17 @@ export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}
   let previousAt = null;
 
   for (const entry of candidates) {
-    const anchors = (entry.anchors || []).map((a) => canonicalPath(String(a).split('#')[0]));
+    // Graph edges hold NODE IDS -- wiki.mjs writes from/to as nodeId(kind, key), a hash --
+    // so an anchor must be hashed to the same identity before it can match anything.
+    // Comparing raw paths made `degree` zero for every candidate, which made the whole
+    // reuse-probability term a constant. Worse than inert: reuseProbability returns 0.5 for an
+    // EMPTY anchor list and 0.25 for a resolved-but-unmatched one, so every anchored candidate
+    // was penalised 2x against every unanchored aside -- and under budget pressure the anchored
+    // findings, the ones the graph can actually retrieve later, were dropped first.
+    const anchors = (entry.anchors || []).map((a) => {
+      const raw = String(a);
+      return nodeId(raw.includes('#') ? 'symbol' : 'file', raw);
+    });
     const cost = costToRederive(entry, previousAt);
     const score = cost * irrecoverability(entry) * reuseProbability(graph, entry.anchorIds || anchors);
     scored.push({ entry, score, cost, tokens: estimate(entry.summary) });

--- a/plugin/hooks/lib/consolidate.mjs
+++ b/plugin/hooks/lib/consolidate.mjs
@@ -32,7 +32,7 @@
  */
 
 import { statSync } from 'node:fs';
-import { canonicalPath } from './paths.mjs';
+import { nodeId } from './wiki.mjs';
 
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
 
@@ -49,9 +49,17 @@ export function irrecoverability(entry) {
   const text = `${entry.summary || ''} ${entry.evidence || ''}`.toLowerCase();
 
   // Anything derived from a non-deterministic or long-running observation.
-  if (/flak|intermitten|race|timing|reproduc|only fails|sometimes/.test(text)) return 4;
+  //
+  // WORD-ANCHORED. The bare fragment `race` matched "stack trace", and a stack trace is among
+  // the most common things to appear in a finding's evidence -- so an ordinary reasoned finding
+  // scored 4, the tier reserved for observations that cannot be re-derived, instead of the 2 it
+  // earns. That is a 2x multiplier inflation on a very common input, and under budget pressure
+  // an inflated ordinary finding displaces a genuinely irrecoverable one.
+  if (/flak|intermitten|\brace\b|\btiming|\breproduc|only fails|sometimes/.test(text)) return 4;
   // Conclusions drawn from running something, not from reading it.
-  if (/benchmark|profil|measured|timed|ran the|test run|reproduced/.test(text)) return 3;
+  // `reproduced` is deliberately absent: the `\breproduc` prefix above returns first, so listing
+  // it here was unreachable.
+  if (/benchmark|\bprofil(?:ed|ing|er)\b|measured|timed|ran the|test run/.test(text)) return 3;
   // Reasoning over material that is on disk but had to be understood.
   if (/because|therefore|turns out|root cause|the reason/.test(text)) return 2;
   return 1;
@@ -89,10 +97,21 @@ export function reuseProbability(graph, anchors) {
 export function costToRederive(entry, previousAt) {
   if (typeof entry.tokensSpent === 'number') return entry.tokensSpent;
 
-  const window = (entry.at ?? 0) - (previousAt ?? entry.at ?? 0);
-  // Fall back to the size of the evidence when no spend is attributable, so a
+  // NO TRANSCRIPT ATTRIBUTION IS IMPLEMENTED. This previously computed an
+  // inter-conclusion window and then consumed it as `window > 0 ? 0 : 0` --
+  // zero on both branches -- so the value, and the `previousAt` parameter
+  // threaded through selectForConsolidation to produce it, had no effect on any
+  // output. The docstring above and the module header claimed cost was
+  // "measured from the transcript" and called that "exactly the quantity a
+  // competitor without session instrumentation cannot obtain"; it was not
+  // measured at all.
+  //
+  // `entry.at` is a millisecond timestamp, not a token count, so feeding the
+  // window in would substitute a fabricated ms-to-token conversion for the
+  // no-op. The only measured cost is `entry.tokensSpent`, which the extraction
+  // site must supply; otherwise fall back to the size of the evidence, so a
   // conclusion drawn from a large investigation still outranks an aside.
-  return Math.max(estimate(entry.evidence) * 4, window > 0 ? 0 : 0) || estimate(entry.summary) * 8;
+  return estimate(entry.evidence) * 4 || estimate(entry.summary) * 8;
 }
 
 /** Kinds that survive on the floor regardless of score. */
@@ -110,7 +129,17 @@ export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}
   let previousAt = null;
 
   for (const entry of candidates) {
-    const anchors = (entry.anchors || []).map((a) => canonicalPath(String(a).split('#')[0]));
+    // Graph edges hold NODE IDS -- wiki.mjs writes from/to as nodeId(kind, key), a hash --
+    // so an anchor must be hashed to the same identity before it can match anything.
+    // Comparing raw paths made `degree` zero for every candidate, which made the whole
+    // reuse-probability term a constant. Worse than inert: reuseProbability returns 0.5 for an
+    // EMPTY anchor list and 0.25 for a resolved-but-unmatched one, so every anchored candidate
+    // was penalised 2x against every unanchored aside -- and under budget pressure the anchored
+    // findings, the ones the graph can actually retrieve later, were dropped first.
+    const anchors = (entry.anchors || []).map((a) => {
+      const raw = String(a);
+      return nodeId(raw.includes('#') ? 'symbol' : 'file', raw);
+    });
     const cost = costToRederive(entry, previousAt);
     const score = cost * irrecoverability(entry) * reuseProbability(graph, entry.anchorIds || anchors);
     scored.push({ entry, score, cost, tokens: estimate(entry.summary) });

--- a/tests/hooks/consolidate.test.mjs
+++ b/tests/hooks/consolidate.test.mjs
@@ -13,7 +13,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
   selectForConsolidation, irrecoverability, reuseProbability,
-  consolidationRatio, aggregateConsolidation, contentAnchor,
+  consolidationRatio, aggregateConsolidation, contentAnchor, costToRederive,
 } from '../../hooks-core/consolidate.mjs';
 import { classifySituation, restorationPlan } from '../../hooks-core/restore.mjs';
 import { load, putNode, putEdge, nodeId } from '../../hooks-core/wiki.mjs';
@@ -224,5 +224,61 @@ describe('restoration adapts to the situation', () => {
     // A misread situation can shift the mix; it can never overspend, because the
     // ceiling is measured rather than situational.
     expect(plan.tokens).toBeLessThanOrEqual(1200);
+  });
+});
+
+describe('scoring inputs are the ones the module claims to use', () => {
+  test('an anchor reaches the graph, so a well-connected file outranks an isolated one', () => {
+    // The defect: anchors were canonical PATHS while graph edges hold nodeId hashes, so degree
+    // was zero for every candidate and the reuse term was a constant. Worse, an EMPTY anchor
+    // list scores 0.5 while a resolved-but-unmatched one scores 0.25 -- so every anchored
+    // candidate was penalised 2x against every unanchored aside, and budget pressure dropped
+    // the anchored findings first.
+    const dir = mkdtempSync(join(tmpdir(), 'consol-'));
+    try {
+      const hot = putNode(dir, { kind: 'file', key: '/hot.ts' });
+      const cold = putNode(dir, { kind: 'file', key: '/cold.ts' });
+      for (let i = 0; i < 8; i += 1) {
+        const other = putNode(dir, { kind: 'file', key: `/n${i}.ts` });
+        putEdge(dir, hot, 'related', other);
+      }
+      const graph = load(dir);
+
+      const entry = (anchor) => ({ type: 'finding', summary: 'the same claim, differently anchored', anchors: [anchor] });
+      // Budgeted so only one survives: the ranking, not the budget, decides which.
+      const { kept } = selectForConsolidation(graph, [entry('/cold.ts'), entry('/hot.ts')], { budget: 12 });
+      expect(kept).toHaveLength(1);
+      expect(kept[0].anchors[0]).toBe('/hot.ts');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('a stack trace does not score as an irrecoverable observation', () => {
+    // `race` matched "stack trace", putting an ordinary reasoned finding in the top tier.
+    const traced = irrecoverability({ summary: 'the stack trace shows the handler returns early because the guard is inverted' });
+    const flaky = irrecoverability({ summary: 'only fails intermittently under load' });
+    expect(traced).toBeLessThan(flaky);
+    expect(traced).toBe(2);
+  });
+
+  test('a profile in the non-performance sense does not score as a measurement', () => {
+    expect(irrecoverability({ summary: 'the user profile page renders the wrong avatar' })).toBeLessThan(3);
+  });
+
+  test('a genuine reproduction still scores at the top', () => {
+    // The word-anchoring must not disarm the detector it belongs to.
+    expect(irrecoverability({ summary: 'reproduced only under a race between the two writers' })).toBe(4);
+  });
+
+  test('costToRederive depends only on the entry, not on a dead previousAt', () => {
+    // `window > 0 ? 0 : 0` returned zero on both branches, so previousAt never affected
+    // anything while the docstring claimed cost was measured from the transcript.
+    const entry = { type: 'finding', summary: 'a claim', evidence: 'some evidence text' };
+    expect(costToRederive(entry, null)).toBe(costToRederive(entry, Date.now() - 50_000));
+  });
+
+  test('an explicitly measured spend still wins over the evidence-size fallback', () => {
+    expect(costToRederive({ summary: 'x', evidence: 'y', tokensSpent: 4242 })).toBe(4242);
   });
 });


### PR DESCRIPTION
Three defects in the ranking that decides which findings survive a consolidation. **Consolidation discards what it does not keep**, so a scoring bug here loses recorded knowledge permanently, and silently — nobody knows what used to be there.

## 1. Anchors never matched the graph — major

`selectForConsolidation` built anchors as canonical filesystem **paths** and compared them against `edge.from`/`edge.to`, which `wiki.mjs` writes as `nodeId(kind, key)` — a hash. A path can never equal a node id, so `degree` was **zero for every candidate** and the whole reuse-probability term was a constant.

Worse than inert. `reuseProbability` returns `0.5` for an **empty** anchor list and `0.25` for a resolved-but-unmatched one — so **every anchored candidate was penalised 2× against every unanchored aside**. Under budget pressure, the anchored findings — the only ones the graph can actually retrieve later — were dropped **first**.

(`entry.anchorIds`, the `||` fallback that would have carried real ids, is constructed nowhere in the repo, so the path branch was always taken.)

## 2. A ternary that returns zero on both branches — major

```js
const window = (entry.at ?? 0) - (previousAt ?? entry.at ?? 0);
return Math.max(estimate(entry.evidence) * 4, window > 0 ? 0 : 0) || …
```

`window > 0 ? 0 : 0`. The value — and the `previousAt` parameter threaded through `selectForConsolidation` to produce it — had **no effect on any output**, while the docstring said cost was *"Measured from the transcript: the work between the previous conclusion and this one"* and the module header called that *"exactly the quantity a competitor without session instrumentation cannot obtain."*

Removed, and the comment now says what the code does. Deliberately **not** replaced by feeding the window in: `entry.at` is a millisecond timestamp, not a token count, so that would swap a no-op for a fabricated ms-to-token conversion. The honest fix is `entry.tokensSpent` at the extraction site.

## 3. `race` matched "stack trace" — major

A stack trace is among the most common things to appear in a finding's evidence. So *"the stack trace shows the handler returns early"* scored **4** — the tier reserved for observations that cannot be re-derived — instead of the **2** it earns, and displaced genuinely irrecoverable findings under budget.

`reproduced` on the tier-3 line was also unreachable: the `reproduc` prefix on tier 4 returns first.

**Worth noting:** word-anchoring alone was not sufficient for `profil`. A leading `\b` does not stop a *prefix* match, so `\bprofil` still matched "user profile" — my first attempt at this fix, caught by its own test. Matching `profil(ed|ing|er)` keeps the performance senses and drops the noun.

## Tests

Six, each paired with a counter-test so a fix cannot disarm the detector it belongs to:

- a genuine reproduction still scores 4
- an explicit `tokensSpent` still beats the evidence-size fallback

Reverting the anchor hashing makes the ranking test fail — verified, so it pins the behaviour rather than describing it.

## Verification

- `tests/hooks` — **709 passed, 2 skipped, 0 failed** (49 suites)
- `npm run sync:hooks` applied to all six vendored copies

🤖 Generated with [Claude Code](https://claude.com/claude-code)
