### PR TITLE
fix(audit): stop the report misstating its own numbers

### DIFF
--- a/hooks-core/audit.mjs
+++ b/hooks-core/audit.mjs
@@ -29,7 +29,6 @@
  */
 
 import { record, readMetrics } from './metrics.mjs';
-import { detect } from './waste.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 
@@ -67,7 +66,7 @@ const idOf = (finding) => finding.remedy
  * -- a trend computed from one session on each side is a coin flip with a
  * percentage sign.
  */
-export function habitTrend(dir, detector, { events = readMetrics(dir), minSessions = 2 } = {}) {
+export function habitTrend(dir, detector, { events = readMetrics(dir), minSessions = 2, anchors = null } = {}) {
   // SPLIT BY POSITION, NOT BY TIMESTAMP. The log is append-only, so its order is
   // authoritative -- while `at` has millisecond granularity, and a burst of
   // events inside one millisecond would land on the wrong side of the split or
@@ -75,11 +74,22 @@ export function habitTrend(dir, detector, { events = readMetrics(dir), minSessio
   const raisedAt = events.findIndex((e) => e.kind === 'advice' && e.detector === detector);
   if (raisedAt === -1) return null;
 
+  // SCOPED TO THE FILES THIS DETECTOR NAMED. Counting every read in the window
+  // made the "trend" the project's total read volume printed under one
+  // detector's name -- and because renderAudit raises every finding in one tight
+  // loop, each detector's advice event lands at an adjacent index, so all of them
+  // saw an identical set of reads and printed identical before/after numbers.
+  // Three detectors would each claim that habit specifically improved or worsened
+  // by the same amount. The existing test masked it by putting its reads on the
+  // same anchor as its finding.
+  const scope = anchors && anchors.length ? new Set(anchors) : null;
+
   const perSession = (from, to) => {
     const sessions = new Map();
     for (let i = from; i < Math.min(to, events.length); i++) {
       const event = events[i];
       if (event.kind !== 'read' || !event.tokens) continue;
+      if (scope && !scope.has(event.anchor)) continue;
       const key = event.sessionId || 'unknown';
       sessions.set(key, (sessions.get(key) || 0) + event.tokens);
     }
@@ -164,11 +174,21 @@ export function renderAudit(dir, findings = [], { tier = 'opus', full = false, s
     // know -- the same unknown-becomes-zero error the rest of this project
     // corrects, in the one unit that gets quoted to other people.
     const priced = item.costPerSession == null ? null : monthly(cost, { tier, sessionsPerMonth });
+    // The id appears on EVERY actionable line, not just the appliable ones. It is the only
+    // handle `decline` accepts and it cannot be guessed from the title, so omitting it made the
+    // advertised decline path unreachable for precisely the findings most likely to be
+    // unwanted -- model-routing findings carry no remedy, so they could never be suppressed no
+    // matter how many times a user declined them.
     const action = item.remedy?.kind === 'ours' ? `apply: waste_audit action="apply" id="${item.id}"`
-      : item.remedy?.kind === 'yours' ? 'proposed edit -- needs your yes, nothing changed'
-        : 'advice only -- no automatic fix';
+      : item.remedy?.kind === 'yours' ? `proposed edit -- needs your yes, nothing changed; decline: ${item.id}`
+        : `advice only -- no automatic fix; decline: ${item.id}`;
 
-    const text = `  ${item.title}\n      ${cost ? `${cost.toLocaleString()} tokens/session` : 'cost not yet measurable'}` +
+    // MEASURED ZERO IS NOT UNMEASURED. Testing `cost` for truthiness sent a real 0 down the
+    // "not yet measurable" branch while `priced` above, which tests for null, still rendered
+    // $0.00 beside it -- producing `cost not yet measurable (~$0.00/month)`, the exact string
+    // the test suite declares must never appear. waste.mjs defaults every finding to 0 and
+    // hard-sets it on the co-occurrence detector, so this is reachable, not theoretical.
+    const text = `  ${item.title}\n      ${item.costPerSession != null ? `${cost.toLocaleString()} tokens/session` : 'cost not yet measurable'}` +
       `${priced ? ` (~${money(priced.amount)}/month)` : ''}; ${action}`;
 
     const printCost = estimate(text);
@@ -209,6 +229,12 @@ export function renderAudit(dir, findings = [], { tier = 'opus', full = false, s
         ? 'not yet measurable (fewer than two sessions since)'
         : `measured ${saved.toLocaleString()} tokens/session${priced ? `, ~${money(priced.amount)}/month` : ''}`}`);
     }
+    // Never a silent cap: the withheld block above states its remainder and so must this one.
+    // Truncating to six with no disclosure showed a user six savings and let them conclude that
+    // was everything the tool had bought them, which understates its own measured value.
+    if (done.length > 6) {
+      body.push(`  ... and ${done.length - 6} more applied fix(es), not shown.`);
+    }
   }
 
   if (suppressed.length) {
@@ -218,8 +244,19 @@ export function renderAudit(dir, findings = [], { tier = 'opus', full = false, s
   }
 
   // Whether the advice changed anything.
+  // Scoped per detector to the anchors that detector actually named, or every trend line
+  // reports the project's total read volume and they all print the same numbers.
+  const anchorsBy = new Map();
+  for (const f of findings) {
+    const anchors = f.anchors || [f.anchor || f.file].filter(Boolean);
+    if (!anchors.length) continue;
+    if (!anchorsBy.has(f.id)) anchorsBy.set(f.id, new Set());
+    for (const a of anchors) anchorsBy.get(f.id).add(a);
+  }
   const trends = [...new Set(findings.map((f) => f.id))]
-    .map((detector) => habitTrend(dir, detector))
+    .map((detector) => habitTrend(dir, detector, {
+      anchors: anchorsBy.has(detector) ? [...anchorsBy.get(detector)] : null,
+    }))
     .filter(Boolean);
 
   if (trends.length) {
@@ -235,10 +272,15 @@ export function renderAudit(dir, findings = [], { tier = 'opus', full = false, s
   if (note) body.push('', note);
 
   // Held to its own standard.
-  const selfCost = estimate(body.join('\n'));
-  body.push('', `This report cost about ${selfCost.toLocaleString()} tokens and names ` +
+  // Held to its own standard -- INCLUDING the closing sentence. Measuring the body before
+  // pushing it left the report's longest line out of its own reported cost, understating it by
+  // 10-20% on a short audit. This figure exists to prove the audit is not a net loss, so
+  // understating the cost side biases exactly the comparison it was written to be honest about.
+  const closing = (n) => `This report cost about ${n.toLocaleString()} tokens and names ` +
     `${addressable.toLocaleString()} tokens/session of addressable waste` +
-    `${addressable ? ` (~${money(monthly(addressable, { tier, sessionsPerMonth })?.amount)}/month across ${sessionsPerMonth} sessions)` : ''}.`);
+    `${addressable ? ` (~${money(monthly(addressable, { tier, sessionsPerMonth })?.amount)}/month across ${sessionsPerMonth} sessions)` : ''}.`;
+  const selfCost = estimate([...body, '', closing(0)].join('\n'));
+  body.push('', closing(selfCost));
 
   return {
     text: body.join('\n'),
@@ -249,11 +291,6 @@ export function renderAudit(dir, findings = [], { tier = 'opus', full = false, s
     selfCostTokens: selfCost,
     printedTokens: printed,
   };
-}
-
-/** Convenience: the full pass over the waste detectors, for callers with a graph. */
-export function auditFindings(dir, graph) {
-  return detect(dir, graph);
 }
 
 export { applyRemedy, proposal, dollars };

--- a/integrations/codex/hooks/lib/audit.mjs
+++ b/integrations/codex/hooks/lib/audit.mjs
@@ -31,7 +31,6 @@
  */
 
 import { record, readMetrics } from './metrics.mjs';
-import { detect } from './waste.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 
@@ -69,7 +68,7 @@ const idOf = (finding) => finding.remedy
  * -- a trend computed from one session on each side is a coin flip with a
  * percentage sign.
  */
-export function habitTrend(dir, detector, { events = readMetrics(dir), minSessions = 2 } = {}) {
+export function habitTrend(dir, detector, { events = readMetrics(dir), minSessions = 2, anchors = null } = {}) {
   // SPLIT BY POSITION, NOT BY TIMESTAMP. The log is append-only, so its order is
   // authoritative -- while `at` has millisecond granularity, and a burst of
   // events inside one millisecond would land on the wrong side of the split or
@@ -77,11 +76,22 @@ export function habitTrend(dir, detector, { events = readMetrics(dir), minSessio
   const raisedAt = events.findIndex((e) => e.kind === 'advice' && e.detector === detector);
   if (raisedAt === -1) return null;
 
+  // SCOPED TO THE FILES THIS DETECTOR NAMED. Counting every read in the window
+  // made the "trend" the project's total read volume printed under one
+  // detector's name -- and because renderAudit raises every finding in one tight
+  // loop, each detector's advice event lands at an adjacent index, so all of them
+  // saw an identical set of reads and printed identical before/after numbers.
+  // Three detectors would each claim that habit specifically improved or worsened
+  // by the same amount. The existing test masked it by putting its reads on the
+  // same anchor as its finding.
+  const scope = anchors && anchors.length ? new Set(anchors) : null;
+
   const perSession = (from, to) => {
     const sessions = new Map();
     for (let i = from; i < Math.min(to, events.length); i++) {
       const event = events[i];
       if (event.kind !== 'read' || !event.tokens) continue;
+      if (scope && !scope.has(event.anchor)) continue;
       const key = event.sessionId || 'unknown';
       sessions.set(key, (sessions.get(key) || 0) + event.tokens);
     }
@@ -166,11 +176,21 @@ export function renderAudit(dir, findings = [], { tier = 'opus', full = false, s
     // know -- the same unknown-becomes-zero error the rest of this project
     // corrects, in the one unit that gets quoted to other people.
     const priced = item.costPerSession == null ? null : monthly(cost, { tier, sessionsPerMonth });
+    // The id appears on EVERY actionable line, not just the appliable ones. It is the only
+    // handle `decline` accepts and it cannot be guessed from the title, so omitting it made the
+    // advertised decline path unreachable for precisely the findings most likely to be
+    // unwanted -- model-routing findings carry no remedy, so they could never be suppressed no
+    // matter how many times a user declined them.
     const action = item.remedy?.kind === 'ours' ? `apply: waste_audit action="apply" id="${item.id}"`
-      : item.remedy?.kind === 'yours' ? 'proposed edit -- needs your yes, nothing changed'
-        : 'advice only -- no automatic fix';
+      : item.remedy?.kind === 'yours' ? `proposed edit -- needs your yes, nothing changed; decline: ${item.id}`
+        : `advice only -- no automatic fix; decline: ${item.id}`;
 
-    const text = `  ${item.title}\n      ${cost ? `${cost.toLocaleString()} tokens/session` : 'cost not yet measurable'}` +
+    // MEASURED ZERO IS NOT UNMEASURED. Testing `cost` for truthiness sent a real 0 down the
+    // "not yet measurable" branch while `priced` above, which tests for null, still rendered
+    // $0.00 beside it -- producing `cost not yet measurable (~$0.00/month)`, the exact string
+    // the test suite declares must never appear. waste.mjs defaults every finding to 0 and
+    // hard-sets it on the co-occurrence detector, so this is reachable, not theoretical.
+    const text = `  ${item.title}\n      ${item.costPerSession != null ? `${cost.toLocaleString()} tokens/session` : 'cost not yet measurable'}` +
       `${priced ? ` (~${money(priced.amount)}/month)` : ''}; ${action}`;
 
     const printCost = estimate(text);
@@ -211,6 +231,12 @@ export function renderAudit(dir, findings = [], { tier = 'opus', full = false, s
         ? 'not yet measurable (fewer than two sessions since)'
         : `measured ${saved.toLocaleString()} tokens/session${priced ? `, ~${money(priced.amount)}/month` : ''}`}`);
     }
+    // Never a silent cap: the withheld block above states its remainder and so must this one.
+    // Truncating to six with no disclosure showed a user six savings and let them conclude that
+    // was everything the tool had bought them, which understates its own measured value.
+    if (done.length > 6) {
+      body.push(`  ... and ${done.length - 6} more applied fix(es), not shown.`);
+    }
   }
 
   if (suppressed.length) {
@@ -220,8 +246,19 @@ export function renderAudit(dir, findings = [], { tier = 'opus', full = false, s
   }
 
   // Whether the advice changed anything.
+  // Scoped per detector to the anchors that detector actually named, or every trend line
+  // reports the project's total read volume and they all print the same numbers.
+  const anchorsBy = new Map();
+  for (const f of findings) {
+    const anchors = f.anchors || [f.anchor || f.file].filter(Boolean);
+    if (!anchors.length) continue;
+    if (!anchorsBy.has(f.id)) anchorsBy.set(f.id, new Set());
+    for (const a of anchors) anchorsBy.get(f.id).add(a);
+  }
   const trends = [...new Set(findings.map((f) => f.id))]
-    .map((detector) => habitTrend(dir, detector))
+    .map((detector) => habitTrend(dir, detector, {
+      anchors: anchorsBy.has(detector) ? [...anchorsBy.get(detector)] : null,
+    }))
     .filter(Boolean);
 
   if (trends.length) {
@@ -237,10 +274,15 @@ export function renderAudit(dir, findings = [], { tier = 'opus', full = false, s
   if (note) body.push('', note);
 
   // Held to its own standard.
-  const selfCost = estimate(body.join('\n'));
-  body.push('', `This report cost about ${selfCost.toLocaleString()} tokens and names ` +
+  // Held to its own standard -- INCLUDING the closing sentence. Measuring the body before
+  // pushing it left the report's longest line out of its own reported cost, understating it by
+  // 10-20% on a short audit. This figure exists to prove the audit is not a net loss, so
+  // understating the cost side biases exactly the comparison it was written to be honest about.
+  const closing = (n) => `This report cost about ${n.toLocaleString()} tokens and names ` +
     `${addressable.toLocaleString()} tokens/session of addressable waste` +
-    `${addressable ? ` (~${money(monthly(addressable, { tier, sessionsPerMonth })?.amount)}/month across ${sessionsPerMonth} sessions)` : ''}.`);
+    `${addressable ? ` (~${money(monthly(addressable, { tier, sessionsPerMonth })?.amount)}/month across ${sessionsPerMonth} sessions)` : ''}.`;
+  const selfCost = estimate([...body, '', closing(0)].join('\n'));
+  body.push('', closing(selfCost));
 
   return {
     text: body.join('\n'),
@@ -251,11 +293,6 @@ export function renderAudit(dir, findings = [], { tier = 'opus', full = false, s
     selfCostTokens: selfCost,
     printedTokens: printed,
   };
-}
-
-/** Convenience: the full pass over the waste detectors, for callers with a graph. */
-export function auditFindings(dir, graph) {
-  return detect(dir, graph);
 }
 
 export { applyRemedy, proposal, dollars };

--- a/integrations/codex/plugin/hooks/lib/audit.mjs
+++ b/integrations/codex/plugin/hooks/lib/audit.mjs
@@ -31,7 +31,6 @@
  */
 
 import { record, readMetrics } from './metrics.mjs';
-import { detect } from './waste.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 
@@ -69,7 +68,7 @@ const idOf = (finding) => finding.remedy
  * -- a trend computed from one session on each side is a coin flip with a
  * percentage sign.
  */
-export function habitTrend(dir, detector, { events = readMetrics(dir), minSessions = 2 } = {}) {
+export function habitTrend(dir, detector, { events = readMetrics(dir), minSessions = 2, anchors = null } = {}) {
   // SPLIT BY POSITION, NOT BY TIMESTAMP. The log is append-only, so its order is
   // authoritative -- while `at` has millisecond granularity, and a burst of
   // events inside one millisecond would land on the wrong side of the split or
@@ -77,11 +76,22 @@ export function habitTrend(dir, detector, { events = readMetrics(dir), minSessio
   const raisedAt = events.findIndex((e) => e.kind === 'advice' && e.detector === detector);
   if (raisedAt === -1) return null;
 
+  // SCOPED TO THE FILES THIS DETECTOR NAMED. Counting every read in the window
+  // made the "trend" the project's total read volume printed under one
+  // detector's name -- and because renderAudit raises every finding in one tight
+  // loop, each detector's advice event lands at an adjacent index, so all of them
+  // saw an identical set of reads and printed identical before/after numbers.
+  // Three detectors would each claim that habit specifically improved or worsened
+  // by the same amount. The existing test masked it by putting its reads on the
+  // same anchor as its finding.
+  const scope = anchors && anchors.length ? new Set(anchors) : null;
+
   const perSession = (from, to) => {
     const sessions = new Map();
     for (let i = from; i < Math.min(to, events.length); i++) {
       const event = events[i];
       if (event.kind !== 'read' || !event.tokens) continue;
+      if (scope && !scope.has(event.anchor)) continue;
       const key = event.sessionId || 'unknown';
       sessions.set(key, (sessions.get(key) || 0) + event.tokens);
     }
@@ -166,11 +176,21 @@ export function renderAudit(dir, findings = [], { tier = 'opus', full = false, s
     // know -- the same unknown-becomes-zero error the rest of this project
     // corrects, in the one unit that gets quoted to other people.
     const priced = item.costPerSession == null ? null : monthly(cost, { tier, sessionsPerMonth });
+    // The id appears on EVERY actionable line, not just the appliable ones. It is the only
+    // handle `decline` accepts and it cannot be guessed from the title, so omitting it made the
+    // advertised decline path unreachable for precisely the findings most likely to be
+    // unwanted -- model-routing findings carry no remedy, so they could never be suppressed no
+    // matter how many times a user declined them.
     const action = item.remedy?.kind === 'ours' ? `apply: waste_audit action="apply" id="${item.id}"`
-      : item.remedy?.kind === 'yours' ? 'proposed edit -- needs your yes, nothing changed'
-        : 'advice only -- no automatic fix';
+      : item.remedy?.kind === 'yours' ? `proposed edit -- needs your yes, nothing changed; decline: ${item.id}`
+        : `advice only -- no automatic fix; decline: ${item.id}`;
 
-    const text = `  ${item.title}\n      ${cost ? `${cost.toLocaleString()} tokens/session` : 'cost not yet measurable'}` +
+    // MEASURED ZERO IS NOT UNMEASURED. Testing `cost` for truthiness sent a real 0 down the
+    // "not yet measurable" branch while `priced` above, which tests for null, still rendered
+    // $0.00 beside it -- producing `cost not yet measurable (~$0.00/month)`, the exact string
+    // the test suite declares must never appear. waste.mjs defaults every finding to 0 and
+    // hard-sets it on the co-occurrence detector, so this is reachable, not theoretical.
+    const text = `  ${item.title}\n      ${item.costPerSession != null ? `${cost.toLocaleString()} tokens/session` : 'cost not yet measurable'}` +
       `${priced ? ` (~${money(priced.amount)}/month)` : ''}; ${action}`;
 
     const printCost = estimate(text);
@@ -211,6 +231,12 @@ export function renderAudit(dir, findings = [], { tier = 'opus', full = false, s
         ? 'not yet measurable (fewer than two sessions since)'
         : `measured ${saved.toLocaleString()} tokens/session${priced ? `, ~${money(priced.amount)}/month` : ''}`}`);
     }
+    // Never a silent cap: the withheld block above states its remainder and so must this one.
+    // Truncating to six with no disclosure showed a user six savings and let them conclude that
+    // was everything the tool had bought them, which understates its own measured value.
+    if (done.length > 6) {
+      body.push(`  ... and ${done.length - 6} more applied fix(es), not shown.`);
+    }
   }
 
   if (suppressed.length) {
@@ -220,8 +246,19 @@ export function renderAudit(dir, findings = [], { tier = 'opus', full = false, s
   }
 
   // Whether the advice changed anything.
+  // Scoped per detector to the anchors that detector actually named, or every trend line
+  // reports the project's total read volume and they all print the same numbers.
+  const anchorsBy = new Map();
+  for (const f of findings) {
+    const anchors = f.anchors || [f.anchor || f.file].filter(Boolean);
+    if (!anchors.length) continue;
+    if (!anchorsBy.has(f.id)) anchorsBy.set(f.id, new Set());
+    for (const a of anchors) anchorsBy.get(f.id).add(a);
+  }
   const trends = [...new Set(findings.map((f) => f.id))]
-    .map((detector) => habitTrend(dir, detector))
+    .map((detector) => habitTrend(dir, detector, {
+      anchors: anchorsBy.has(detector) ? [...anchorsBy.get(detector)] : null,
+    }))
     .filter(Boolean);
 
   if (trends.length) {
@@ -237,10 +274,15 @@ export function renderAudit(dir, findings = [], { tier = 'opus', full = false, s
   if (note) body.push('', note);
 
   // Held to its own standard.
-  const selfCost = estimate(body.join('\n'));
-  body.push('', `This report cost about ${selfCost.toLocaleString()} tokens and names ` +
+  // Held to its own standard -- INCLUDING the closing sentence. Measuring the body before
+  // pushing it left the report's longest line out of its own reported cost, understating it by
+  // 10-20% on a short audit. This figure exists to prove the audit is not a net loss, so
+  // understating the cost side biases exactly the comparison it was written to be honest about.
+  const closing = (n) => `This report cost about ${n.toLocaleString()} tokens and names ` +
     `${addressable.toLocaleString()} tokens/session of addressable waste` +
-    `${addressable ? ` (~${money(monthly(addressable, { tier, sessionsPerMonth })?.amount)}/month across ${sessionsPerMonth} sessions)` : ''}.`);
+    `${addressable ? ` (~${money(monthly(addressable, { tier, sessionsPerMonth })?.amount)}/month across ${sessionsPerMonth} sessions)` : ''}.`;
+  const selfCost = estimate([...body, '', closing(0)].join('\n'));
+  body.push('', closing(selfCost));
 
   return {
     text: body.join('\n'),
@@ -251,11 +293,6 @@ export function renderAudit(dir, findings = [], { tier = 'opus', full = false, s
     selfCostTokens: selfCost,
     printedTokens: printed,
   };
-}
-
-/** Convenience: the full pass over the waste detectors, for callers with a graph. */
-export function auditFindings(dir, graph) {
-  return detect(dir, graph);
 }
 
 export { applyRemedy, proposal, dollars };

--- a/integrations/gemini/hooks/lib/audit.mjs
+++ b/integrations/gemini/hooks/lib/audit.mjs
@@ -31,7 +31,6 @@
  */
 
 import { record, readMetrics } from './metrics.mjs';
-import { detect } from './waste.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 
@@ -69,7 +68,7 @@ const idOf = (finding) => finding.remedy
  * -- a trend computed from one session on each side is a coin flip with a
  * percentage sign.
  */
-export function habitTrend(dir, detector, { events = readMetrics(dir), minSessions = 2 } = {}) {
+export function habitTrend(dir, detector, { events = readMetrics(dir), minSessions = 2, anchors = null } = {}) {
   // SPLIT BY POSITION, NOT BY TIMESTAMP. The log is append-only, so its order is
   // authoritative -- while `at` has millisecond granularity, and a burst of
   // events inside one millisecond would land on the wrong side of the split or
@@ -77,11 +76,22 @@ export function habitTrend(dir, detector, { events = readMetrics(dir), minSessio
   const raisedAt = events.findIndex((e) => e.kind === 'advice' && e.detector === detector);
   if (raisedAt === -1) return null;
 
+  // SCOPED TO THE FILES THIS DETECTOR NAMED. Counting every read in the window
+  // made the "trend" the project's total read volume printed under one
+  // detector's name -- and because renderAudit raises every finding in one tight
+  // loop, each detector's advice event lands at an adjacent index, so all of them
+  // saw an identical set of reads and printed identical before/after numbers.
+  // Three detectors would each claim that habit specifically improved or worsened
+  // by the same amount. The existing test masked it by putting its reads on the
+  // same anchor as its finding.
+  const scope = anchors && anchors.length ? new Set(anchors) : null;
+
   const perSession = (from, to) => {
     const sessions = new Map();
     for (let i = from; i < Math.min(to, events.length); i++) {
       const event = events[i];
       if (event.kind !== 'read' || !event.tokens) continue;
+      if (scope && !scope.has(event.anchor)) continue;
       const key = event.sessionId || 'unknown';
       sessions.set(key, (sessions.get(key) || 0) + event.tokens);
     }
@@ -166,11 +176,21 @@ export function renderAudit(dir, findings = [], { tier = 'opus', full = false, s
     // know -- the same unknown-becomes-zero error the rest of this project
     // corrects, in the one unit that gets quoted to other people.
     const priced = item.costPerSession == null ? null : monthly(cost, { tier, sessionsPerMonth });
+    // The id appears on EVERY actionable line, not just the appliable ones. It is the only
+    // handle `decline` accepts and it cannot be guessed from the title, so omitting it made the
+    // advertised decline path unreachable for precisely the findings most likely to be
+    // unwanted -- model-routing findings carry no remedy, so they could never be suppressed no
+    // matter how many times a user declined them.
     const action = item.remedy?.kind === 'ours' ? `apply: waste_audit action="apply" id="${item.id}"`
-      : item.remedy?.kind === 'yours' ? 'proposed edit -- needs your yes, nothing changed'
-        : 'advice only -- no automatic fix';
+      : item.remedy?.kind === 'yours' ? `proposed edit -- needs your yes, nothing changed; decline: ${item.id}`
+        : `advice only -- no automatic fix; decline: ${item.id}`;
 
-    const text = `  ${item.title}\n      ${cost ? `${cost.toLocaleString()} tokens/session` : 'cost not yet measurable'}` +
+    // MEASURED ZERO IS NOT UNMEASURED. Testing `cost` for truthiness sent a real 0 down the
+    // "not yet measurable" branch while `priced` above, which tests for null, still rendered
+    // $0.00 beside it -- producing `cost not yet measurable (~$0.00/month)`, the exact string
+    // the test suite declares must never appear. waste.mjs defaults every finding to 0 and
+    // hard-sets it on the co-occurrence detector, so this is reachable, not theoretical.
+    const text = `  ${item.title}\n      ${item.costPerSession != null ? `${cost.toLocaleString()} tokens/session` : 'cost not yet measurable'}` +
       `${priced ? ` (~${money(priced.amount)}/month)` : ''}; ${action}`;
 
     const printCost = estimate(text);
@@ -211,6 +231,12 @@ export function renderAudit(dir, findings = [], { tier = 'opus', full = false, s
         ? 'not yet measurable (fewer than two sessions since)'
         : `measured ${saved.toLocaleString()} tokens/session${priced ? `, ~${money(priced.amount)}/month` : ''}`}`);
     }
+    // Never a silent cap: the withheld block above states its remainder and so must this one.
+    // Truncating to six with no disclosure showed a user six savings and let them conclude that
+    // was everything the tool had bought them, which understates its own measured value.
+    if (done.length > 6) {
+      body.push(`  ... and ${done.length - 6} more applied fix(es), not shown.`);
+    }
   }
 
   if (suppressed.length) {
@@ -220,8 +246,19 @@ export function renderAudit(dir, findings = [], { tier = 'opus', full = false, s
   }
 
   // Whether the advice changed anything.
+  // Scoped per detector to the anchors that detector actually named, or every trend line
+  // reports the project's total read volume and they all print the same numbers.
+  const anchorsBy = new Map();
+  for (const f of findings) {
+    const anchors = f.anchors || [f.anchor || f.file].filter(Boolean);
+    if (!anchors.length) continue;
+    if (!anchorsBy.has(f.id)) anchorsBy.set(f.id, new Set());
+    for (const a of anchors) anchorsBy.get(f.id).add(a);
+  }
   const trends = [...new Set(findings.map((f) => f.id))]
-    .map((detector) => habitTrend(dir, detector))
+    .map((detector) => habitTrend(dir, detector, {
+      anchors: anchorsBy.has(detector) ? [...anchorsBy.get(detector)] : null,
+    }))
     .filter(Boolean);
 
   if (trends.length) {
@@ -237,10 +274,15 @@ export function renderAudit(dir, findings = [], { tier = 'opus', full = false, s
   if (note) body.push('', note);
 
   // Held to its own standard.
-  const selfCost = estimate(body.join('\n'));
-  body.push('', `This report cost about ${selfCost.toLocaleString()} tokens and names ` +
+  // Held to its own standard -- INCLUDING the closing sentence. Measuring the body before
+  // pushing it left the report's longest line out of its own reported cost, understating it by
+  // 10-20% on a short audit. This figure exists to prove the audit is not a net loss, so
+  // understating the cost side biases exactly the comparison it was written to be honest about.
+  const closing = (n) => `This report cost about ${n.toLocaleString()} tokens and names ` +
     `${addressable.toLocaleString()} tokens/session of addressable waste` +
-    `${addressable ? ` (~${money(monthly(addressable, { tier, sessionsPerMonth })?.amount)}/month across ${sessionsPerMonth} sessions)` : ''}.`);
+    `${addressable ? ` (~${money(monthly(addressable, { tier, sessionsPerMonth })?.amount)}/month across ${sessionsPerMonth} sessions)` : ''}.`;
+  const selfCost = estimate([...body, '', closing(0)].join('\n'));
+  body.push('', closing(selfCost));
 
   return {
     text: body.join('\n'),
@@ -251,11 +293,6 @@ export function renderAudit(dir, findings = [], { tier = 'opus', full = false, s
     selfCostTokens: selfCost,
     printedTokens: printed,
   };
-}
-
-/** Convenience: the full pass over the waste detectors, for callers with a graph. */
-export function auditFindings(dir, graph) {
-  return detect(dir, graph);
 }
 
 export { applyRemedy, proposal, dollars };

--- a/integrations/opencode/hooks/lib/audit.mjs
+++ b/integrations/opencode/hooks/lib/audit.mjs
@@ -31,7 +31,6 @@
  */
 
 import { record, readMetrics } from './metrics.mjs';
-import { detect } from './waste.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 
@@ -69,7 +68,7 @@ const idOf = (finding) => finding.remedy
  * -- a trend computed from one session on each side is a coin flip with a
  * percentage sign.
  */
-export function habitTrend(dir, detector, { events = readMetrics(dir), minSessions = 2 } = {}) {
+export function habitTrend(dir, detector, { events = readMetrics(dir), minSessions = 2, anchors = null } = {}) {
   // SPLIT BY POSITION, NOT BY TIMESTAMP. The log is append-only, so its order is
   // authoritative -- while `at` has millisecond granularity, and a burst of
   // events inside one millisecond would land on the wrong side of the split or
@@ -77,11 +76,22 @@ export function habitTrend(dir, detector, { events = readMetrics(dir), minSessio
   const raisedAt = events.findIndex((e) => e.kind === 'advice' && e.detector === detector);
   if (raisedAt === -1) return null;
 
+  // SCOPED TO THE FILES THIS DETECTOR NAMED. Counting every read in the window
+  // made the "trend" the project's total read volume printed under one
+  // detector's name -- and because renderAudit raises every finding in one tight
+  // loop, each detector's advice event lands at an adjacent index, so all of them
+  // saw an identical set of reads and printed identical before/after numbers.
+  // Three detectors would each claim that habit specifically improved or worsened
+  // by the same amount. The existing test masked it by putting its reads on the
+  // same anchor as its finding.
+  const scope = anchors && anchors.length ? new Set(anchors) : null;
+
   const perSession = (from, to) => {
     const sessions = new Map();
     for (let i = from; i < Math.min(to, events.length); i++) {
       const event = events[i];
       if (event.kind !== 'read' || !event.tokens) continue;
+      if (scope && !scope.has(event.anchor)) continue;
       const key = event.sessionId || 'unknown';
       sessions.set(key, (sessions.get(key) || 0) + event.tokens);
     }
@@ -166,11 +176,21 @@ export function renderAudit(dir, findings = [], { tier = 'opus', full = false, s
     // know -- the same unknown-becomes-zero error the rest of this project
     // corrects, in the one unit that gets quoted to other people.
     const priced = item.costPerSession == null ? null : monthly(cost, { tier, sessionsPerMonth });
+    // The id appears on EVERY actionable line, not just the appliable ones. It is the only
+    // handle `decline` accepts and it cannot be guessed from the title, so omitting it made the
+    // advertised decline path unreachable for precisely the findings most likely to be
+    // unwanted -- model-routing findings carry no remedy, so they could never be suppressed no
+    // matter how many times a user declined them.
     const action = item.remedy?.kind === 'ours' ? `apply: waste_audit action="apply" id="${item.id}"`
-      : item.remedy?.kind === 'yours' ? 'proposed edit -- needs your yes, nothing changed'
-        : 'advice only -- no automatic fix';
+      : item.remedy?.kind === 'yours' ? `proposed edit -- needs your yes, nothing changed; decline: ${item.id}`
+        : `advice only -- no automatic fix; decline: ${item.id}`;
 
-    const text = `  ${item.title}\n      ${cost ? `${cost.toLocaleString()} tokens/session` : 'cost not yet measurable'}` +
+    // MEASURED ZERO IS NOT UNMEASURED. Testing `cost` for truthiness sent a real 0 down the
+    // "not yet measurable" branch while `priced` above, which tests for null, still rendered
+    // $0.00 beside it -- producing `cost not yet measurable (~$0.00/month)`, the exact string
+    // the test suite declares must never appear. waste.mjs defaults every finding to 0 and
+    // hard-sets it on the co-occurrence detector, so this is reachable, not theoretical.
+    const text = `  ${item.title}\n      ${item.costPerSession != null ? `${cost.toLocaleString()} tokens/session` : 'cost not yet measurable'}` +
       `${priced ? ` (~${money(priced.amount)}/month)` : ''}; ${action}`;
 
     const printCost = estimate(text);
@@ -211,6 +231,12 @@ export function renderAudit(dir, findings = [], { tier = 'opus', full = false, s
         ? 'not yet measurable (fewer than two sessions since)'
         : `measured ${saved.toLocaleString()} tokens/session${priced ? `, ~${money(priced.amount)}/month` : ''}`}`);
     }
+    // Never a silent cap: the withheld block above states its remainder and so must this one.
+    // Truncating to six with no disclosure showed a user six savings and let them conclude that
+    // was everything the tool had bought them, which understates its own measured value.
+    if (done.length > 6) {
+      body.push(`  ... and ${done.length - 6} more applied fix(es), not shown.`);
+    }
   }
 
   if (suppressed.length) {
@@ -220,8 +246,19 @@ export function renderAudit(dir, findings = [], { tier = 'opus', full = false, s
   }
 
   // Whether the advice changed anything.
+  // Scoped per detector to the anchors that detector actually named, or every trend line
+  // reports the project's total read volume and they all print the same numbers.
+  const anchorsBy = new Map();
+  for (const f of findings) {
+    const anchors = f.anchors || [f.anchor || f.file].filter(Boolean);
+    if (!anchors.length) continue;
+    if (!anchorsBy.has(f.id)) anchorsBy.set(f.id, new Set());
+    for (const a of anchors) anchorsBy.get(f.id).add(a);
+  }
   const trends = [...new Set(findings.map((f) => f.id))]
-    .map((detector) => habitTrend(dir, detector))
+    .map((detector) => habitTrend(dir, detector, {
+      anchors: anchorsBy.has(detector) ? [...anchorsBy.get(detector)] : null,
+    }))
     .filter(Boolean);
 
   if (trends.length) {
@@ -237,10 +274,15 @@ export function renderAudit(dir, findings = [], { tier = 'opus', full = false, s
   if (note) body.push('', note);
 
   // Held to its own standard.
-  const selfCost = estimate(body.join('\n'));
-  body.push('', `This report cost about ${selfCost.toLocaleString()} tokens and names ` +
+  // Held to its own standard -- INCLUDING the closing sentence. Measuring the body before
+  // pushing it left the report's longest line out of its own reported cost, understating it by
+  // 10-20% on a short audit. This figure exists to prove the audit is not a net loss, so
+  // understating the cost side biases exactly the comparison it was written to be honest about.
+  const closing = (n) => `This report cost about ${n.toLocaleString()} tokens and names ` +
     `${addressable.toLocaleString()} tokens/session of addressable waste` +
-    `${addressable ? ` (~${money(monthly(addressable, { tier, sessionsPerMonth })?.amount)}/month across ${sessionsPerMonth} sessions)` : ''}.`);
+    `${addressable ? ` (~${money(monthly(addressable, { tier, sessionsPerMonth })?.amount)}/month across ${sessionsPerMonth} sessions)` : ''}.`;
+  const selfCost = estimate([...body, '', closing(0)].join('\n'));
+  body.push('', closing(selfCost));
 
   return {
     text: body.join('\n'),
@@ -251,11 +293,6 @@ export function renderAudit(dir, findings = [], { tier = 'opus', full = false, s
     selfCostTokens: selfCost,
     printedTokens: printed,
   };
-}
-
-/** Convenience: the full pass over the waste detectors, for callers with a graph. */
-export function auditFindings(dir, graph) {
-  return detect(dir, graph);
 }
 
 export { applyRemedy, proposal, dollars };

--- a/integrations/qwen/hooks/lib/audit.mjs
+++ b/integrations/qwen/hooks/lib/audit.mjs
@@ -31,7 +31,6 @@
  */
 
 import { record, readMetrics } from './metrics.mjs';
-import { detect } from './waste.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 
@@ -69,7 +68,7 @@ const idOf = (finding) => finding.remedy
  * -- a trend computed from one session on each side is a coin flip with a
  * percentage sign.
  */
-export function habitTrend(dir, detector, { events = readMetrics(dir), minSessions = 2 } = {}) {
+export function habitTrend(dir, detector, { events = readMetrics(dir), minSessions = 2, anchors = null } = {}) {
   // SPLIT BY POSITION, NOT BY TIMESTAMP. The log is append-only, so its order is
   // authoritative -- while `at` has millisecond granularity, and a burst of
   // events inside one millisecond would land on the wrong side of the split or
@@ -77,11 +76,22 @@ export function habitTrend(dir, detector, { events = readMetrics(dir), minSessio
   const raisedAt = events.findIndex((e) => e.kind === 'advice' && e.detector === detector);
   if (raisedAt === -1) return null;
 
+  // SCOPED TO THE FILES THIS DETECTOR NAMED. Counting every read in the window
+  // made the "trend" the project's total read volume printed under one
+  // detector's name -- and because renderAudit raises every finding in one tight
+  // loop, each detector's advice event lands at an adjacent index, so all of them
+  // saw an identical set of reads and printed identical before/after numbers.
+  // Three detectors would each claim that habit specifically improved or worsened
+  // by the same amount. The existing test masked it by putting its reads on the
+  // same anchor as its finding.
+  const scope = anchors && anchors.length ? new Set(anchors) : null;
+
   const perSession = (from, to) => {
     const sessions = new Map();
     for (let i = from; i < Math.min(to, events.length); i++) {
       const event = events[i];
       if (event.kind !== 'read' || !event.tokens) continue;
+      if (scope && !scope.has(event.anchor)) continue;
       const key = event.sessionId || 'unknown';
       sessions.set(key, (sessions.get(key) || 0) + event.tokens);
     }
@@ -166,11 +176,21 @@ export function renderAudit(dir, findings = [], { tier = 'opus', full = false, s
     // know -- the same unknown-becomes-zero error the rest of this project
     // corrects, in the one unit that gets quoted to other people.
     const priced = item.costPerSession == null ? null : monthly(cost, { tier, sessionsPerMonth });
+    // The id appears on EVERY actionable line, not just the appliable ones. It is the only
+    // handle `decline` accepts and it cannot be guessed from the title, so omitting it made the
+    // advertised decline path unreachable for precisely the findings most likely to be
+    // unwanted -- model-routing findings carry no remedy, so they could never be suppressed no
+    // matter how many times a user declined them.
     const action = item.remedy?.kind === 'ours' ? `apply: waste_audit action="apply" id="${item.id}"`
-      : item.remedy?.kind === 'yours' ? 'proposed edit -- needs your yes, nothing changed'
-        : 'advice only -- no automatic fix';
+      : item.remedy?.kind === 'yours' ? `proposed edit -- needs your yes, nothing changed; decline: ${item.id}`
+        : `advice only -- no automatic fix; decline: ${item.id}`;
 
-    const text = `  ${item.title}\n      ${cost ? `${cost.toLocaleString()} tokens/session` : 'cost not yet measurable'}` +
+    // MEASURED ZERO IS NOT UNMEASURED. Testing `cost` for truthiness sent a real 0 down the
+    // "not yet measurable" branch while `priced` above, which tests for null, still rendered
+    // $0.00 beside it -- producing `cost not yet measurable (~$0.00/month)`, the exact string
+    // the test suite declares must never appear. waste.mjs defaults every finding to 0 and
+    // hard-sets it on the co-occurrence detector, so this is reachable, not theoretical.
+    const text = `  ${item.title}\n      ${item.costPerSession != null ? `${cost.toLocaleString()} tokens/session` : 'cost not yet measurable'}` +
       `${priced ? ` (~${money(priced.amount)}/month)` : ''}; ${action}`;
 
     const printCost = estimate(text);
@@ -211,6 +231,12 @@ export function renderAudit(dir, findings = [], { tier = 'opus', full = false, s
         ? 'not yet measurable (fewer than two sessions since)'
         : `measured ${saved.toLocaleString()} tokens/session${priced ? `, ~${money(priced.amount)}/month` : ''}`}`);
     }
+    // Never a silent cap: the withheld block above states its remainder and so must this one.
+    // Truncating to six with no disclosure showed a user six savings and let them conclude that
+    // was everything the tool had bought them, which understates its own measured value.
+    if (done.length > 6) {
+      body.push(`  ... and ${done.length - 6} more applied fix(es), not shown.`);
+    }
   }
 
   if (suppressed.length) {
@@ -220,8 +246,19 @@ export function renderAudit(dir, findings = [], { tier = 'opus', full = false, s
   }
 
   // Whether the advice changed anything.
+  // Scoped per detector to the anchors that detector actually named, or every trend line
+  // reports the project's total read volume and they all print the same numbers.
+  const anchorsBy = new Map();
+  for (const f of findings) {
+    const anchors = f.anchors || [f.anchor || f.file].filter(Boolean);
+    if (!anchors.length) continue;
+    if (!anchorsBy.has(f.id)) anchorsBy.set(f.id, new Set());
+    for (const a of anchors) anchorsBy.get(f.id).add(a);
+  }
   const trends = [...new Set(findings.map((f) => f.id))]
-    .map((detector) => habitTrend(dir, detector))
+    .map((detector) => habitTrend(dir, detector, {
+      anchors: anchorsBy.has(detector) ? [...anchorsBy.get(detector)] : null,
+    }))
     .filter(Boolean);
 
   if (trends.length) {
@@ -237,10 +274,15 @@ export function renderAudit(dir, findings = [], { tier = 'opus', full = false, s
   if (note) body.push('', note);
 
   // Held to its own standard.
-  const selfCost = estimate(body.join('\n'));
-  body.push('', `This report cost about ${selfCost.toLocaleString()} tokens and names ` +
+  // Held to its own standard -- INCLUDING the closing sentence. Measuring the body before
+  // pushing it left the report's longest line out of its own reported cost, understating it by
+  // 10-20% on a short audit. This figure exists to prove the audit is not a net loss, so
+  // understating the cost side biases exactly the comparison it was written to be honest about.
+  const closing = (n) => `This report cost about ${n.toLocaleString()} tokens and names ` +
     `${addressable.toLocaleString()} tokens/session of addressable waste` +
-    `${addressable ? ` (~${money(monthly(addressable, { tier, sessionsPerMonth })?.amount)}/month across ${sessionsPerMonth} sessions)` : ''}.`);
+    `${addressable ? ` (~${money(monthly(addressable, { tier, sessionsPerMonth })?.amount)}/month across ${sessionsPerMonth} sessions)` : ''}.`;
+  const selfCost = estimate([...body, '', closing(0)].join('\n'));
+  body.push('', closing(selfCost));
 
   return {
     text: body.join('\n'),
@@ -251,11 +293,6 @@ export function renderAudit(dir, findings = [], { tier = 'opus', full = false, s
     selfCostTokens: selfCost,
     printedTokens: printed,
   };
-}
-
-/** Convenience: the full pass over the waste detectors, for callers with a graph. */
-export function auditFindings(dir, graph) {
-  return detect(dir, graph);
 }
 
 export { applyRemedy, proposal, dollars };

--- a/plugin/hooks/lib/audit.mjs
+++ b/plugin/hooks/lib/audit.mjs
@@ -31,7 +31,6 @@
  */
 
 import { record, readMetrics } from './metrics.mjs';
-import { detect } from './waste.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 
@@ -69,7 +68,7 @@ const idOf = (finding) => finding.remedy
  * -- a trend computed from one session on each side is a coin flip with a
  * percentage sign.
  */
-export function habitTrend(dir, detector, { events = readMetrics(dir), minSessions = 2 } = {}) {
+export function habitTrend(dir, detector, { events = readMetrics(dir), minSessions = 2, anchors = null } = {}) {
   // SPLIT BY POSITION, NOT BY TIMESTAMP. The log is append-only, so its order is
   // authoritative -- while `at` has millisecond granularity, and a burst of
   // events inside one millisecond would land on the wrong side of the split or
@@ -77,11 +76,22 @@ export function habitTrend(dir, detector, { events = readMetrics(dir), minSessio
   const raisedAt = events.findIndex((e) => e.kind === 'advice' && e.detector === detector);
   if (raisedAt === -1) return null;
 
+  // SCOPED TO THE FILES THIS DETECTOR NAMED. Counting every read in the window
+  // made the "trend" the project's total read volume printed under one
+  // detector's name -- and because renderAudit raises every finding in one tight
+  // loop, each detector's advice event lands at an adjacent index, so all of them
+  // saw an identical set of reads and printed identical before/after numbers.
+  // Three detectors would each claim that habit specifically improved or worsened
+  // by the same amount. The existing test masked it by putting its reads on the
+  // same anchor as its finding.
+  const scope = anchors && anchors.length ? new Set(anchors) : null;
+
   const perSession = (from, to) => {
     const sessions = new Map();
     for (let i = from; i < Math.min(to, events.length); i++) {
       const event = events[i];
       if (event.kind !== 'read' || !event.tokens) continue;
+      if (scope && !scope.has(event.anchor)) continue;
       const key = event.sessionId || 'unknown';
       sessions.set(key, (sessions.get(key) || 0) + event.tokens);
     }
@@ -166,11 +176,21 @@ export function renderAudit(dir, findings = [], { tier = 'opus', full = false, s
     // know -- the same unknown-becomes-zero error the rest of this project
     // corrects, in the one unit that gets quoted to other people.
     const priced = item.costPerSession == null ? null : monthly(cost, { tier, sessionsPerMonth });
+    // The id appears on EVERY actionable line, not just the appliable ones. It is the only
+    // handle `decline` accepts and it cannot be guessed from the title, so omitting it made the
+    // advertised decline path unreachable for precisely the findings most likely to be
+    // unwanted -- model-routing findings carry no remedy, so they could never be suppressed no
+    // matter how many times a user declined them.
     const action = item.remedy?.kind === 'ours' ? `apply: waste_audit action="apply" id="${item.id}"`
-      : item.remedy?.kind === 'yours' ? 'proposed edit -- needs your yes, nothing changed'
-        : 'advice only -- no automatic fix';
+      : item.remedy?.kind === 'yours' ? `proposed edit -- needs your yes, nothing changed; decline: ${item.id}`
+        : `advice only -- no automatic fix; decline: ${item.id}`;
 
-    const text = `  ${item.title}\n      ${cost ? `${cost.toLocaleString()} tokens/session` : 'cost not yet measurable'}` +
+    // MEASURED ZERO IS NOT UNMEASURED. Testing `cost` for truthiness sent a real 0 down the
+    // "not yet measurable" branch while `priced` above, which tests for null, still rendered
+    // $0.00 beside it -- producing `cost not yet measurable (~$0.00/month)`, the exact string
+    // the test suite declares must never appear. waste.mjs defaults every finding to 0 and
+    // hard-sets it on the co-occurrence detector, so this is reachable, not theoretical.
+    const text = `  ${item.title}\n      ${item.costPerSession != null ? `${cost.toLocaleString()} tokens/session` : 'cost not yet measurable'}` +
       `${priced ? ` (~${money(priced.amount)}/month)` : ''}; ${action}`;
 
     const printCost = estimate(text);
@@ -211,6 +231,12 @@ export function renderAudit(dir, findings = [], { tier = 'opus', full = false, s
         ? 'not yet measurable (fewer than two sessions since)'
         : `measured ${saved.toLocaleString()} tokens/session${priced ? `, ~${money(priced.amount)}/month` : ''}`}`);
     }
+    // Never a silent cap: the withheld block above states its remainder and so must this one.
+    // Truncating to six with no disclosure showed a user six savings and let them conclude that
+    // was everything the tool had bought them, which understates its own measured value.
+    if (done.length > 6) {
+      body.push(`  ... and ${done.length - 6} more applied fix(es), not shown.`);
+    }
   }
 
   if (suppressed.length) {
@@ -220,8 +246,19 @@ export function renderAudit(dir, findings = [], { tier = 'opus', full = false, s
   }
 
   // Whether the advice changed anything.
+  // Scoped per detector to the anchors that detector actually named, or every trend line
+  // reports the project's total read volume and they all print the same numbers.
+  const anchorsBy = new Map();
+  for (const f of findings) {
+    const anchors = f.anchors || [f.anchor || f.file].filter(Boolean);
+    if (!anchors.length) continue;
+    if (!anchorsBy.has(f.id)) anchorsBy.set(f.id, new Set());
+    for (const a of anchors) anchorsBy.get(f.id).add(a);
+  }
   const trends = [...new Set(findings.map((f) => f.id))]
-    .map((detector) => habitTrend(dir, detector))
+    .map((detector) => habitTrend(dir, detector, {
+      anchors: anchorsBy.has(detector) ? [...anchorsBy.get(detector)] : null,
+    }))
     .filter(Boolean);
 
   if (trends.length) {
@@ -237,10 +274,15 @@ export function renderAudit(dir, findings = [], { tier = 'opus', full = false, s
   if (note) body.push('', note);
 
   // Held to its own standard.
-  const selfCost = estimate(body.join('\n'));
-  body.push('', `This report cost about ${selfCost.toLocaleString()} tokens and names ` +
+  // Held to its own standard -- INCLUDING the closing sentence. Measuring the body before
+  // pushing it left the report's longest line out of its own reported cost, understating it by
+  // 10-20% on a short audit. This figure exists to prove the audit is not a net loss, so
+  // understating the cost side biases exactly the comparison it was written to be honest about.
+  const closing = (n) => `This report cost about ${n.toLocaleString()} tokens and names ` +
     `${addressable.toLocaleString()} tokens/session of addressable waste` +
-    `${addressable ? ` (~${money(monthly(addressable, { tier, sessionsPerMonth })?.amount)}/month across ${sessionsPerMonth} sessions)` : ''}.`);
+    `${addressable ? ` (~${money(monthly(addressable, { tier, sessionsPerMonth })?.amount)}/month across ${sessionsPerMonth} sessions)` : ''}.`;
+  const selfCost = estimate([...body, '', closing(0)].join('\n'));
+  body.push('', closing(selfCost));
 
   return {
     text: body.join('\n'),
@@ -251,11 +293,6 @@ export function renderAudit(dir, findings = [], { tier = 'opus', full = false, s
     selfCostTokens: selfCost,
     printedTokens: printed,
   };
-}
-
-/** Convenience: the full pass over the waste detectors, for callers with a graph. */
-export function auditFindings(dir, graph) {
-  return detect(dir, graph);
 }
 
 export { applyRemedy, proposal, dollars };

--- a/tests/hooks/audit.test.mjs
+++ b/tests/hooks/audit.test.mjs
@@ -238,3 +238,55 @@ describe('the audit is held to its own standard', () => {
     expect(renderAudit(dir, [finding()]).text).toMatch(/prices: opus \$15\/\$75 per Mtok/);
   });
 });
+
+describe('the report does not misstate its own numbers', () => {
+  test('a measured cost of zero is not labelled unmeasurable', () => {
+    // The price branch tested `costPerSession == null` while the text branch tested truthiness,
+    // so a real 0 rendered "cost not yet measurable (~$0.00/month)" -- the exact contradiction
+    // the assertion below already forbids, reachable because waste.mjs defaults every finding
+    // to 0 and hard-sets it on the co-occurrence detector.
+    const dir = mkdtempSync(join(tmpdir(), 'auditzero-'));
+    try {
+      const out = renderAudit(dir,
+        [{ id: 'co-occurrence', title: 'a and b are always opened together', costPerSession: 0 }],
+        { full: true });
+      expect(out.text).not.toMatch(/cost not yet measurable \(~\$0\.00/);
+      expect(out.text).toMatch(/0 tokens\/session/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('an advice-only finding prints the id needed to decline it', () => {
+    // `decline` keys strictly on the recorded id, which is anchor-derived and unguessable. With
+    // the id printed only on the appliable branch, model-routing findings -- which carry no
+    // remedy -- could never be suppressed no matter how often a user declined them.
+    const dir = mkdtempSync(join(tmpdir(), 'auditid-'));
+    try {
+      const out = renderAudit(dir,
+        [{ id: 'model-routing', title: 'a cheaper model would do', costPerSession: 100, remedy: null }],
+        { full: true });
+      expect(out.text).toMatch(/decline: model-routing/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('the self-cost includes the closing sentence it reports', () => {
+    // Measuring the body before pushing the closing line left the longest line of the report
+    // out of its own cost -- biasing, in the tool's favour, the very comparison the figure
+    // exists to make honest.
+    const dir = mkdtempSync(join(tmpdir(), 'auditself-'));
+    try {
+      const out = renderAudit(dir,
+        [{ id: 'x', title: 'a finding with a reasonably long title to bulk the body', costPerSession: 5000 }],
+        { full: true });
+      const stated = Number(/cost about ([\d,]+) tokens/.exec(out.text)[1].replace(/,/g, ''));
+      const actual = Math.ceil(out.text.length / 4);
+      // The stated figure must not undercount the rendered report.
+      expect(stated).toBeGreaterThanOrEqual(actual * 0.9);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/hooks/reachability.test.mjs
+++ b/tests/hooks/reachability.test.mjs
@@ -119,7 +119,6 @@ const ALLOWED = new Map([
   ['cacheOrdered', 'UNWIRED: confines cache invalidation to the tail. A real optimisation with no caller.'],
   ['invalidateOnWrite', 'UNWIRED: the eager staleness path; invalidation currently happens only lazily, on the next touch.'],
   ['renderStanding', 'UNWIRED: renders the standing-context audit. auditStanding IS reachable, so only the report is orphaned.'],
-  ['auditFindings', 'UNWIRED: audits stored findings. Verified orphaned -- appears once, as its own declaration.'],
   ['recordRefresh', 'UNWIRED: records that a keep-warm refresh happened; pairs with recordRefreshOutcome, and neither is reached.'],
   ['manifestSize', 'UNWIRED: measures the installation manifest. Verified orphaned, and untested as well.'],
 


### PR DESCRIPTION
Six defects in the report the whole tool is judged by. The audit exists to prove the optimizer is not a net loss — so a number that is wrong **in the tool's favour** matters more here than almost anywhere else in the codebase.

## 1. `habitTrend` ignored the detector entirely — major

`perSession` filtered on kind and tokens and **never on which file the read touched**, so the "trend" was the project's *total* read volume, printed under one detector's name.

`renderAudit` raises every finding in one tight loop, so each detector's `advice` event lands at an adjacent index with no reads between — meaning all of them saw an identical set and printed **identical before/after numbers**, each asserting that *that* habit specifically improved or worsened.

The existing test masked this by putting its reads on the same anchor as its finding, so it passed whether or not the anchor was honoured. Now scoped to the anchors the detector actually named.

## 2. A measured zero rendered as unmeasurable — major

The price branch tested `costPerSession == null`; the text branch tested truthiness. They disagree on `0`, producing:

```
cost not yet measurable (~$0.00/month)
```

— the exact contradictory string an existing assertion already forbids. Reachable, not theoretical: `waste.mjs` defaults **every** finding to `costPerSession: 0` and hard-sets it on the co-occurrence detector, and the documented `full=true` input renders them.

## 3. The decline path was unreachable — minor

`item.id` was interpolated on exactly one branch — the appliable one. `decline` keys strictly on that id, which is anchor-derived and cannot be guessed from the title.

So the `decline="<id>"` input advertised in the tool description could not be used for advice-only findings — and those are precisely the ones most likely to be unwanted. **Model-routing findings carry `remedy: null`**, so they could never be suppressed no matter how many times a user declined them; `decline()` returns true regardless and the tool replies "Noted."

## 4. A silent cap on the applied list — minor

`done.slice(0, 6)` with no disclosure. A project with twenty remedies in force showed six, letting the reader conclude that was everything the tool had bought them — understating its own measured value.

The file's docstring says stating what was withheld *"keeps that from being a silent cap"*, and the withheld block does exactly that, with a test. This one had neither.

## 5. The self-cost omitted its own longest line — minor

`selfCost` was measured **before** the closing sentence was pushed, so the report's longest line was excluded from its own reported cost — a 10–20% understatement on a short audit, biasing in the tool's favour the very comparison the figure exists to make honest.

## 6. `auditFindings` — dead export

A one-line passthrough to `waste.detect` with no caller; `audit-tool.ts` calls `detect` directly. The reachability allowlist already recorded it as *"Verified orphaned"*, and that allowlist's own preamble says the honest action is to delete.

Removed along with its allowlist entry — **required**, since the guard fails on an entry naming a nonexistent export — and the now-unused `detect` import.

## Verification

- `tests/hooks` — **706 passed, 2 skipped, 0 failed** (49 suites), including 3 new tests
- `tsc --noEmit` clean; `sync:hooks` applied to all six vendored copies

🤖 Generated with [Claude Code](https://claude.com/claude-code)
