### PR TITLE
fix(doctor): stop reporting a broken install as healthy

### DIFF
--- a/hooks-core/doctor.mjs
+++ b/hooks-core/doctor.mjs
@@ -92,7 +92,14 @@ export function detectInstall({ pluginsDir, root } = {}) {
   if (record) {
     return {
       method: 'plugin',
-      hooksDir: pluginHooks && existsSync(pluginHooks) ? pluginHooks : packageHooks,
+      // AND IT MUST NOT FALL BACK TO THE PACKAGE COPY. plugin/hooks ships with
+      // every npm install (it is in package.json `files`), so substituting it
+      // here makes the checklist and the enforcement probe pass against a build
+      // Claude Code is not loading -- it loads from installPath, which is gone.
+      // The header records this exact defect as already fixed once: "The
+      // enforcement probe passed -- for a build that was not running." Point at
+      // where the hooks are supposed to be and let the checks fail loudly.
+      hooksDir: pluginHooks ?? packageHooks,
       installPath: record.installPath ?? null,
       installedVersion,
       availableVersion,
@@ -202,8 +209,10 @@ function probe(binary, payload, { timeoutMs = 8000, cwd } = {}) {
       stdio: ['pipe', 'pipe', 'ignore'],
     });
   } catch (error) {
-    // A hook that exits non-zero with output still told us something.
-    return error?.stdout ?? null;
+    // A hook that exits non-zero WITH OUTPUT still told us something. One that
+    // timed out, was killed, or never spawned told us nothing -- and null has to
+    // mean exactly that, because an empty string is a legitimate "allowed".
+    return error?.stdout || null;
   }
 }
 
@@ -324,11 +333,19 @@ export function probeEnforcement({ root, workspace, hooksDir, install }) {
     const allowed = probe(binary, {
       tool_name: 'Read', tool_input: { file_path: small }, cwd: workspace, session_id: probeId,
     });
-    const allowedOk = !allowed || !allowed.includes('deny');
+    // `allowed === null` is "the probe never ran", NOT "the hook allowed it".
+    // allow() writes nothing and exits 0, so '' is a legitimate allow -- but null
+    // is a spawn failure, an EPERM, or a timeout, and reporting a pass there is a
+    // green tick produced by an absent measurement. A hook that hangs on every
+    // small read is a catastrophic install, and this check used to call it fine.
+    const allowedOk = allowed !== null && !allowed.includes('deny');
     checks.push(allowedOk
       ? ok('small reads are left alone', 'no refusal, as intended')
-      : bad('small reads are left alone', 'the hook refused a tiny file',
-        'a hook that refuses everything is as broken as one that refuses nothing -- report this'));
+      : bad('small reads are left alone',
+        allowed === null
+          ? 'the hook produced no result at all -- it crashed, hung past the timeout, or could not be spawned'
+          : 'the hook refused a tiny file',
+        'a hook that refuses everything, or answers nothing, is as broken as one that refuses nothing -- report this'));
   } finally {
     for (const path of [big, small]) {
       try { unlinkSync(path); } catch { /* best effort */ }
@@ -345,7 +362,21 @@ export function probeSessionStart({ root, workspace, hooksDir, install }) {
     return [bad('session-start emits the policy', 'binary missing', 'reinstall the package')];
   }
 
+  // probeEnforcement normally creates this, but it returns early when the router
+  // binary is missing -- before its own mkdirSync -- and a cwd that does not
+  // exist makes the SPAWN fail rather than the hook. Do not depend on another
+  // check having run first.
+  mkdirSync(workspace, { recursive: true });
   const out = probe(binary, {}, { cwd: workspace });
+  // JSON.parse(null) coerces to the string 'null' and RETURNS null rather than
+  // throwing, so without this the never-ran case fell past the catch written for
+  // it and reported 'ran, but produced no policy text' -- sending the user after
+  // TOKEN_OPTIMIZER_MODE for what is a spawn failure.
+  if (out === null) {
+    return [bad('session-start emits the policy',
+      'the hook produced no output at all -- it did not run',
+      'reinstall the package; the binary is present but could not be executed')];
+  }
   try {
     const parsed = JSON.parse(out);
     const context = parsed?.hookSpecificOutput?.additionalContext || '';
@@ -457,6 +488,8 @@ export function diagnose({
 
   const failed = checks.filter((c) => !c.pass);
   return {
+    // Carried so the report can speak about the file that was examined.
+    settingsPath: settingsPath ?? null,
     checks,
     passed: checks.length - failed.length,
     total: checks.length,
@@ -472,7 +505,12 @@ export function renderDiagnosis(result) {
     (check.pass || !check.remedy ? '' : `\n          fix: ${check.remedy}`));
 
   const residueNote = [];
-  const settings = process.env.TOKEN_OPTIMIZER_SETTINGS;
+  // The path diagnose ACTUALLY EXAMINED. Reading the env override here meant the
+  // residue note printed for nobody who had not set one -- that is, almost
+  // everybody, since both callers compute a default. It is also the only line
+  // that covers settings entries at all: removalPlan handles manifest-recorded
+  // files and nothing else.
+  const settings = result.settingsPath || process.env.TOKEN_OPTIMIZER_SETTINGS;
   if (settings) {
     const found = residue(settings);
     residueNote.push('', found.clean

--- a/integrations/codex/hooks/lib/doctor.mjs
+++ b/integrations/codex/hooks/lib/doctor.mjs
@@ -94,7 +94,14 @@ export function detectInstall({ pluginsDir, root } = {}) {
   if (record) {
     return {
       method: 'plugin',
-      hooksDir: pluginHooks && existsSync(pluginHooks) ? pluginHooks : packageHooks,
+      // AND IT MUST NOT FALL BACK TO THE PACKAGE COPY. plugin/hooks ships with
+      // every npm install (it is in package.json `files`), so substituting it
+      // here makes the checklist and the enforcement probe pass against a build
+      // Claude Code is not loading -- it loads from installPath, which is gone.
+      // The header records this exact defect as already fixed once: "The
+      // enforcement probe passed -- for a build that was not running." Point at
+      // where the hooks are supposed to be and let the checks fail loudly.
+      hooksDir: pluginHooks ?? packageHooks,
       installPath: record.installPath ?? null,
       installedVersion,
       availableVersion,
@@ -204,8 +211,10 @@ function probe(binary, payload, { timeoutMs = 8000, cwd } = {}) {
       stdio: ['pipe', 'pipe', 'ignore'],
     });
   } catch (error) {
-    // A hook that exits non-zero with output still told us something.
-    return error?.stdout ?? null;
+    // A hook that exits non-zero WITH OUTPUT still told us something. One that
+    // timed out, was killed, or never spawned told us nothing -- and null has to
+    // mean exactly that, because an empty string is a legitimate "allowed".
+    return error?.stdout || null;
   }
 }
 
@@ -326,11 +335,19 @@ export function probeEnforcement({ root, workspace, hooksDir, install }) {
     const allowed = probe(binary, {
       tool_name: 'Read', tool_input: { file_path: small }, cwd: workspace, session_id: probeId,
     });
-    const allowedOk = !allowed || !allowed.includes('deny');
+    // `allowed === null` is "the probe never ran", NOT "the hook allowed it".
+    // allow() writes nothing and exits 0, so '' is a legitimate allow -- but null
+    // is a spawn failure, an EPERM, or a timeout, and reporting a pass there is a
+    // green tick produced by an absent measurement. A hook that hangs on every
+    // small read is a catastrophic install, and this check used to call it fine.
+    const allowedOk = allowed !== null && !allowed.includes('deny');
     checks.push(allowedOk
       ? ok('small reads are left alone', 'no refusal, as intended')
-      : bad('small reads are left alone', 'the hook refused a tiny file',
-        'a hook that refuses everything is as broken as one that refuses nothing -- report this'));
+      : bad('small reads are left alone',
+        allowed === null
+          ? 'the hook produced no result at all -- it crashed, hung past the timeout, or could not be spawned'
+          : 'the hook refused a tiny file',
+        'a hook that refuses everything, or answers nothing, is as broken as one that refuses nothing -- report this'));
   } finally {
     for (const path of [big, small]) {
       try { unlinkSync(path); } catch { /* best effort */ }
@@ -347,7 +364,21 @@ export function probeSessionStart({ root, workspace, hooksDir, install }) {
     return [bad('session-start emits the policy', 'binary missing', 'reinstall the package')];
   }
 
+  // probeEnforcement normally creates this, but it returns early when the router
+  // binary is missing -- before its own mkdirSync -- and a cwd that does not
+  // exist makes the SPAWN fail rather than the hook. Do not depend on another
+  // check having run first.
+  mkdirSync(workspace, { recursive: true });
   const out = probe(binary, {}, { cwd: workspace });
+  // JSON.parse(null) coerces to the string 'null' and RETURNS null rather than
+  // throwing, so without this the never-ran case fell past the catch written for
+  // it and reported 'ran, but produced no policy text' -- sending the user after
+  // TOKEN_OPTIMIZER_MODE for what is a spawn failure.
+  if (out === null) {
+    return [bad('session-start emits the policy',
+      'the hook produced no output at all -- it did not run',
+      'reinstall the package; the binary is present but could not be executed')];
+  }
   try {
     const parsed = JSON.parse(out);
     const context = parsed?.hookSpecificOutput?.additionalContext || '';
@@ -459,6 +490,8 @@ export function diagnose({
 
   const failed = checks.filter((c) => !c.pass);
   return {
+    // Carried so the report can speak about the file that was examined.
+    settingsPath: settingsPath ?? null,
     checks,
     passed: checks.length - failed.length,
     total: checks.length,
@@ -474,7 +507,12 @@ export function renderDiagnosis(result) {
     (check.pass || !check.remedy ? '' : `\n          fix: ${check.remedy}`));
 
   const residueNote = [];
-  const settings = process.env.TOKEN_OPTIMIZER_SETTINGS;
+  // The path diagnose ACTUALLY EXAMINED. Reading the env override here meant the
+  // residue note printed for nobody who had not set one -- that is, almost
+  // everybody, since both callers compute a default. It is also the only line
+  // that covers settings entries at all: removalPlan handles manifest-recorded
+  // files and nothing else.
+  const settings = result.settingsPath || process.env.TOKEN_OPTIMIZER_SETTINGS;
   if (settings) {
     const found = residue(settings);
     residueNote.push('', found.clean

--- a/integrations/codex/plugin/hooks/lib/doctor.mjs
+++ b/integrations/codex/plugin/hooks/lib/doctor.mjs
@@ -94,7 +94,14 @@ export function detectInstall({ pluginsDir, root } = {}) {
   if (record) {
     return {
       method: 'plugin',
-      hooksDir: pluginHooks && existsSync(pluginHooks) ? pluginHooks : packageHooks,
+      // AND IT MUST NOT FALL BACK TO THE PACKAGE COPY. plugin/hooks ships with
+      // every npm install (it is in package.json `files`), so substituting it
+      // here makes the checklist and the enforcement probe pass against a build
+      // Claude Code is not loading -- it loads from installPath, which is gone.
+      // The header records this exact defect as already fixed once: "The
+      // enforcement probe passed -- for a build that was not running." Point at
+      // where the hooks are supposed to be and let the checks fail loudly.
+      hooksDir: pluginHooks ?? packageHooks,
       installPath: record.installPath ?? null,
       installedVersion,
       availableVersion,
@@ -204,8 +211,10 @@ function probe(binary, payload, { timeoutMs = 8000, cwd } = {}) {
       stdio: ['pipe', 'pipe', 'ignore'],
     });
   } catch (error) {
-    // A hook that exits non-zero with output still told us something.
-    return error?.stdout ?? null;
+    // A hook that exits non-zero WITH OUTPUT still told us something. One that
+    // timed out, was killed, or never spawned told us nothing -- and null has to
+    // mean exactly that, because an empty string is a legitimate "allowed".
+    return error?.stdout || null;
   }
 }
 
@@ -326,11 +335,19 @@ export function probeEnforcement({ root, workspace, hooksDir, install }) {
     const allowed = probe(binary, {
       tool_name: 'Read', tool_input: { file_path: small }, cwd: workspace, session_id: probeId,
     });
-    const allowedOk = !allowed || !allowed.includes('deny');
+    // `allowed === null` is "the probe never ran", NOT "the hook allowed it".
+    // allow() writes nothing and exits 0, so '' is a legitimate allow -- but null
+    // is a spawn failure, an EPERM, or a timeout, and reporting a pass there is a
+    // green tick produced by an absent measurement. A hook that hangs on every
+    // small read is a catastrophic install, and this check used to call it fine.
+    const allowedOk = allowed !== null && !allowed.includes('deny');
     checks.push(allowedOk
       ? ok('small reads are left alone', 'no refusal, as intended')
-      : bad('small reads are left alone', 'the hook refused a tiny file',
-        'a hook that refuses everything is as broken as one that refuses nothing -- report this'));
+      : bad('small reads are left alone',
+        allowed === null
+          ? 'the hook produced no result at all -- it crashed, hung past the timeout, or could not be spawned'
+          : 'the hook refused a tiny file',
+        'a hook that refuses everything, or answers nothing, is as broken as one that refuses nothing -- report this'));
   } finally {
     for (const path of [big, small]) {
       try { unlinkSync(path); } catch { /* best effort */ }
@@ -347,7 +364,21 @@ export function probeSessionStart({ root, workspace, hooksDir, install }) {
     return [bad('session-start emits the policy', 'binary missing', 'reinstall the package')];
   }
 
+  // probeEnforcement normally creates this, but it returns early when the router
+  // binary is missing -- before its own mkdirSync -- and a cwd that does not
+  // exist makes the SPAWN fail rather than the hook. Do not depend on another
+  // check having run first.
+  mkdirSync(workspace, { recursive: true });
   const out = probe(binary, {}, { cwd: workspace });
+  // JSON.parse(null) coerces to the string 'null' and RETURNS null rather than
+  // throwing, so without this the never-ran case fell past the catch written for
+  // it and reported 'ran, but produced no policy text' -- sending the user after
+  // TOKEN_OPTIMIZER_MODE for what is a spawn failure.
+  if (out === null) {
+    return [bad('session-start emits the policy',
+      'the hook produced no output at all -- it did not run',
+      'reinstall the package; the binary is present but could not be executed')];
+  }
   try {
     const parsed = JSON.parse(out);
     const context = parsed?.hookSpecificOutput?.additionalContext || '';
@@ -459,6 +490,8 @@ export function diagnose({
 
   const failed = checks.filter((c) => !c.pass);
   return {
+    // Carried so the report can speak about the file that was examined.
+    settingsPath: settingsPath ?? null,
     checks,
     passed: checks.length - failed.length,
     total: checks.length,
@@ -474,7 +507,12 @@ export function renderDiagnosis(result) {
     (check.pass || !check.remedy ? '' : `\n          fix: ${check.remedy}`));
 
   const residueNote = [];
-  const settings = process.env.TOKEN_OPTIMIZER_SETTINGS;
+  // The path diagnose ACTUALLY EXAMINED. Reading the env override here meant the
+  // residue note printed for nobody who had not set one -- that is, almost
+  // everybody, since both callers compute a default. It is also the only line
+  // that covers settings entries at all: removalPlan handles manifest-recorded
+  // files and nothing else.
+  const settings = result.settingsPath || process.env.TOKEN_OPTIMIZER_SETTINGS;
   if (settings) {
     const found = residue(settings);
     residueNote.push('', found.clean

--- a/integrations/gemini/hooks/lib/doctor.mjs
+++ b/integrations/gemini/hooks/lib/doctor.mjs
@@ -94,7 +94,14 @@ export function detectInstall({ pluginsDir, root } = {}) {
   if (record) {
     return {
       method: 'plugin',
-      hooksDir: pluginHooks && existsSync(pluginHooks) ? pluginHooks : packageHooks,
+      // AND IT MUST NOT FALL BACK TO THE PACKAGE COPY. plugin/hooks ships with
+      // every npm install (it is in package.json `files`), so substituting it
+      // here makes the checklist and the enforcement probe pass against a build
+      // Claude Code is not loading -- it loads from installPath, which is gone.
+      // The header records this exact defect as already fixed once: "The
+      // enforcement probe passed -- for a build that was not running." Point at
+      // where the hooks are supposed to be and let the checks fail loudly.
+      hooksDir: pluginHooks ?? packageHooks,
       installPath: record.installPath ?? null,
       installedVersion,
       availableVersion,
@@ -204,8 +211,10 @@ function probe(binary, payload, { timeoutMs = 8000, cwd } = {}) {
       stdio: ['pipe', 'pipe', 'ignore'],
     });
   } catch (error) {
-    // A hook that exits non-zero with output still told us something.
-    return error?.stdout ?? null;
+    // A hook that exits non-zero WITH OUTPUT still told us something. One that
+    // timed out, was killed, or never spawned told us nothing -- and null has to
+    // mean exactly that, because an empty string is a legitimate "allowed".
+    return error?.stdout || null;
   }
 }
 
@@ -326,11 +335,19 @@ export function probeEnforcement({ root, workspace, hooksDir, install }) {
     const allowed = probe(binary, {
       tool_name: 'Read', tool_input: { file_path: small }, cwd: workspace, session_id: probeId,
     });
-    const allowedOk = !allowed || !allowed.includes('deny');
+    // `allowed === null` is "the probe never ran", NOT "the hook allowed it".
+    // allow() writes nothing and exits 0, so '' is a legitimate allow -- but null
+    // is a spawn failure, an EPERM, or a timeout, and reporting a pass there is a
+    // green tick produced by an absent measurement. A hook that hangs on every
+    // small read is a catastrophic install, and this check used to call it fine.
+    const allowedOk = allowed !== null && !allowed.includes('deny');
     checks.push(allowedOk
       ? ok('small reads are left alone', 'no refusal, as intended')
-      : bad('small reads are left alone', 'the hook refused a tiny file',
-        'a hook that refuses everything is as broken as one that refuses nothing -- report this'));
+      : bad('small reads are left alone',
+        allowed === null
+          ? 'the hook produced no result at all -- it crashed, hung past the timeout, or could not be spawned'
+          : 'the hook refused a tiny file',
+        'a hook that refuses everything, or answers nothing, is as broken as one that refuses nothing -- report this'));
   } finally {
     for (const path of [big, small]) {
       try { unlinkSync(path); } catch { /* best effort */ }
@@ -347,7 +364,21 @@ export function probeSessionStart({ root, workspace, hooksDir, install }) {
     return [bad('session-start emits the policy', 'binary missing', 'reinstall the package')];
   }
 
+  // probeEnforcement normally creates this, but it returns early when the router
+  // binary is missing -- before its own mkdirSync -- and a cwd that does not
+  // exist makes the SPAWN fail rather than the hook. Do not depend on another
+  // check having run first.
+  mkdirSync(workspace, { recursive: true });
   const out = probe(binary, {}, { cwd: workspace });
+  // JSON.parse(null) coerces to the string 'null' and RETURNS null rather than
+  // throwing, so without this the never-ran case fell past the catch written for
+  // it and reported 'ran, but produced no policy text' -- sending the user after
+  // TOKEN_OPTIMIZER_MODE for what is a spawn failure.
+  if (out === null) {
+    return [bad('session-start emits the policy',
+      'the hook produced no output at all -- it did not run',
+      'reinstall the package; the binary is present but could not be executed')];
+  }
   try {
     const parsed = JSON.parse(out);
     const context = parsed?.hookSpecificOutput?.additionalContext || '';
@@ -459,6 +490,8 @@ export function diagnose({
 
   const failed = checks.filter((c) => !c.pass);
   return {
+    // Carried so the report can speak about the file that was examined.
+    settingsPath: settingsPath ?? null,
     checks,
     passed: checks.length - failed.length,
     total: checks.length,
@@ -474,7 +507,12 @@ export function renderDiagnosis(result) {
     (check.pass || !check.remedy ? '' : `\n          fix: ${check.remedy}`));
 
   const residueNote = [];
-  const settings = process.env.TOKEN_OPTIMIZER_SETTINGS;
+  // The path diagnose ACTUALLY EXAMINED. Reading the env override here meant the
+  // residue note printed for nobody who had not set one -- that is, almost
+  // everybody, since both callers compute a default. It is also the only line
+  // that covers settings entries at all: removalPlan handles manifest-recorded
+  // files and nothing else.
+  const settings = result.settingsPath || process.env.TOKEN_OPTIMIZER_SETTINGS;
   if (settings) {
     const found = residue(settings);
     residueNote.push('', found.clean

--- a/integrations/opencode/hooks/lib/doctor.mjs
+++ b/integrations/opencode/hooks/lib/doctor.mjs
@@ -94,7 +94,14 @@ export function detectInstall({ pluginsDir, root } = {}) {
   if (record) {
     return {
       method: 'plugin',
-      hooksDir: pluginHooks && existsSync(pluginHooks) ? pluginHooks : packageHooks,
+      // AND IT MUST NOT FALL BACK TO THE PACKAGE COPY. plugin/hooks ships with
+      // every npm install (it is in package.json `files`), so substituting it
+      // here makes the checklist and the enforcement probe pass against a build
+      // Claude Code is not loading -- it loads from installPath, which is gone.
+      // The header records this exact defect as already fixed once: "The
+      // enforcement probe passed -- for a build that was not running." Point at
+      // where the hooks are supposed to be and let the checks fail loudly.
+      hooksDir: pluginHooks ?? packageHooks,
       installPath: record.installPath ?? null,
       installedVersion,
       availableVersion,
@@ -204,8 +211,10 @@ function probe(binary, payload, { timeoutMs = 8000, cwd } = {}) {
       stdio: ['pipe', 'pipe', 'ignore'],
     });
   } catch (error) {
-    // A hook that exits non-zero with output still told us something.
-    return error?.stdout ?? null;
+    // A hook that exits non-zero WITH OUTPUT still told us something. One that
+    // timed out, was killed, or never spawned told us nothing -- and null has to
+    // mean exactly that, because an empty string is a legitimate "allowed".
+    return error?.stdout || null;
   }
 }
 
@@ -326,11 +335,19 @@ export function probeEnforcement({ root, workspace, hooksDir, install }) {
     const allowed = probe(binary, {
       tool_name: 'Read', tool_input: { file_path: small }, cwd: workspace, session_id: probeId,
     });
-    const allowedOk = !allowed || !allowed.includes('deny');
+    // `allowed === null` is "the probe never ran", NOT "the hook allowed it".
+    // allow() writes nothing and exits 0, so '' is a legitimate allow -- but null
+    // is a spawn failure, an EPERM, or a timeout, and reporting a pass there is a
+    // green tick produced by an absent measurement. A hook that hangs on every
+    // small read is a catastrophic install, and this check used to call it fine.
+    const allowedOk = allowed !== null && !allowed.includes('deny');
     checks.push(allowedOk
       ? ok('small reads are left alone', 'no refusal, as intended')
-      : bad('small reads are left alone', 'the hook refused a tiny file',
-        'a hook that refuses everything is as broken as one that refuses nothing -- report this'));
+      : bad('small reads are left alone',
+        allowed === null
+          ? 'the hook produced no result at all -- it crashed, hung past the timeout, or could not be spawned'
+          : 'the hook refused a tiny file',
+        'a hook that refuses everything, or answers nothing, is as broken as one that refuses nothing -- report this'));
   } finally {
     for (const path of [big, small]) {
       try { unlinkSync(path); } catch { /* best effort */ }
@@ -347,7 +364,21 @@ export function probeSessionStart({ root, workspace, hooksDir, install }) {
     return [bad('session-start emits the policy', 'binary missing', 'reinstall the package')];
   }
 
+  // probeEnforcement normally creates this, but it returns early when the router
+  // binary is missing -- before its own mkdirSync -- and a cwd that does not
+  // exist makes the SPAWN fail rather than the hook. Do not depend on another
+  // check having run first.
+  mkdirSync(workspace, { recursive: true });
   const out = probe(binary, {}, { cwd: workspace });
+  // JSON.parse(null) coerces to the string 'null' and RETURNS null rather than
+  // throwing, so without this the never-ran case fell past the catch written for
+  // it and reported 'ran, but produced no policy text' -- sending the user after
+  // TOKEN_OPTIMIZER_MODE for what is a spawn failure.
+  if (out === null) {
+    return [bad('session-start emits the policy',
+      'the hook produced no output at all -- it did not run',
+      'reinstall the package; the binary is present but could not be executed')];
+  }
   try {
     const parsed = JSON.parse(out);
     const context = parsed?.hookSpecificOutput?.additionalContext || '';
@@ -459,6 +490,8 @@ export function diagnose({
 
   const failed = checks.filter((c) => !c.pass);
   return {
+    // Carried so the report can speak about the file that was examined.
+    settingsPath: settingsPath ?? null,
     checks,
     passed: checks.length - failed.length,
     total: checks.length,
@@ -474,7 +507,12 @@ export function renderDiagnosis(result) {
     (check.pass || !check.remedy ? '' : `\n          fix: ${check.remedy}`));
 
   const residueNote = [];
-  const settings = process.env.TOKEN_OPTIMIZER_SETTINGS;
+  // The path diagnose ACTUALLY EXAMINED. Reading the env override here meant the
+  // residue note printed for nobody who had not set one -- that is, almost
+  // everybody, since both callers compute a default. It is also the only line
+  // that covers settings entries at all: removalPlan handles manifest-recorded
+  // files and nothing else.
+  const settings = result.settingsPath || process.env.TOKEN_OPTIMIZER_SETTINGS;
   if (settings) {
     const found = residue(settings);
     residueNote.push('', found.clean

--- a/integrations/qwen/hooks/lib/doctor.mjs
+++ b/integrations/qwen/hooks/lib/doctor.mjs
@@ -94,7 +94,14 @@ export function detectInstall({ pluginsDir, root } = {}) {
   if (record) {
     return {
       method: 'plugin',
-      hooksDir: pluginHooks && existsSync(pluginHooks) ? pluginHooks : packageHooks,
+      // AND IT MUST NOT FALL BACK TO THE PACKAGE COPY. plugin/hooks ships with
+      // every npm install (it is in package.json `files`), so substituting it
+      // here makes the checklist and the enforcement probe pass against a build
+      // Claude Code is not loading -- it loads from installPath, which is gone.
+      // The header records this exact defect as already fixed once: "The
+      // enforcement probe passed -- for a build that was not running." Point at
+      // where the hooks are supposed to be and let the checks fail loudly.
+      hooksDir: pluginHooks ?? packageHooks,
       installPath: record.installPath ?? null,
       installedVersion,
       availableVersion,
@@ -204,8 +211,10 @@ function probe(binary, payload, { timeoutMs = 8000, cwd } = {}) {
       stdio: ['pipe', 'pipe', 'ignore'],
     });
   } catch (error) {
-    // A hook that exits non-zero with output still told us something.
-    return error?.stdout ?? null;
+    // A hook that exits non-zero WITH OUTPUT still told us something. One that
+    // timed out, was killed, or never spawned told us nothing -- and null has to
+    // mean exactly that, because an empty string is a legitimate "allowed".
+    return error?.stdout || null;
   }
 }
 
@@ -326,11 +335,19 @@ export function probeEnforcement({ root, workspace, hooksDir, install }) {
     const allowed = probe(binary, {
       tool_name: 'Read', tool_input: { file_path: small }, cwd: workspace, session_id: probeId,
     });
-    const allowedOk = !allowed || !allowed.includes('deny');
+    // `allowed === null` is "the probe never ran", NOT "the hook allowed it".
+    // allow() writes nothing and exits 0, so '' is a legitimate allow -- but null
+    // is a spawn failure, an EPERM, or a timeout, and reporting a pass there is a
+    // green tick produced by an absent measurement. A hook that hangs on every
+    // small read is a catastrophic install, and this check used to call it fine.
+    const allowedOk = allowed !== null && !allowed.includes('deny');
     checks.push(allowedOk
       ? ok('small reads are left alone', 'no refusal, as intended')
-      : bad('small reads are left alone', 'the hook refused a tiny file',
-        'a hook that refuses everything is as broken as one that refuses nothing -- report this'));
+      : bad('small reads are left alone',
+        allowed === null
+          ? 'the hook produced no result at all -- it crashed, hung past the timeout, or could not be spawned'
+          : 'the hook refused a tiny file',
+        'a hook that refuses everything, or answers nothing, is as broken as one that refuses nothing -- report this'));
   } finally {
     for (const path of [big, small]) {
       try { unlinkSync(path); } catch { /* best effort */ }
@@ -347,7 +364,21 @@ export function probeSessionStart({ root, workspace, hooksDir, install }) {
     return [bad('session-start emits the policy', 'binary missing', 'reinstall the package')];
   }
 
+  // probeEnforcement normally creates this, but it returns early when the router
+  // binary is missing -- before its own mkdirSync -- and a cwd that does not
+  // exist makes the SPAWN fail rather than the hook. Do not depend on another
+  // check having run first.
+  mkdirSync(workspace, { recursive: true });
   const out = probe(binary, {}, { cwd: workspace });
+  // JSON.parse(null) coerces to the string 'null' and RETURNS null rather than
+  // throwing, so without this the never-ran case fell past the catch written for
+  // it and reported 'ran, but produced no policy text' -- sending the user after
+  // TOKEN_OPTIMIZER_MODE for what is a spawn failure.
+  if (out === null) {
+    return [bad('session-start emits the policy',
+      'the hook produced no output at all -- it did not run',
+      'reinstall the package; the binary is present but could not be executed')];
+  }
   try {
     const parsed = JSON.parse(out);
     const context = parsed?.hookSpecificOutput?.additionalContext || '';
@@ -459,6 +490,8 @@ export function diagnose({
 
   const failed = checks.filter((c) => !c.pass);
   return {
+    // Carried so the report can speak about the file that was examined.
+    settingsPath: settingsPath ?? null,
     checks,
     passed: checks.length - failed.length,
     total: checks.length,
@@ -474,7 +507,12 @@ export function renderDiagnosis(result) {
     (check.pass || !check.remedy ? '' : `\n          fix: ${check.remedy}`));
 
   const residueNote = [];
-  const settings = process.env.TOKEN_OPTIMIZER_SETTINGS;
+  // The path diagnose ACTUALLY EXAMINED. Reading the env override here meant the
+  // residue note printed for nobody who had not set one -- that is, almost
+  // everybody, since both callers compute a default. It is also the only line
+  // that covers settings entries at all: removalPlan handles manifest-recorded
+  // files and nothing else.
+  const settings = result.settingsPath || process.env.TOKEN_OPTIMIZER_SETTINGS;
   if (settings) {
     const found = residue(settings);
     residueNote.push('', found.clean

--- a/plugin/hooks/lib/doctor.mjs
+++ b/plugin/hooks/lib/doctor.mjs
@@ -94,7 +94,14 @@ export function detectInstall({ pluginsDir, root } = {}) {
   if (record) {
     return {
       method: 'plugin',
-      hooksDir: pluginHooks && existsSync(pluginHooks) ? pluginHooks : packageHooks,
+      // AND IT MUST NOT FALL BACK TO THE PACKAGE COPY. plugin/hooks ships with
+      // every npm install (it is in package.json `files`), so substituting it
+      // here makes the checklist and the enforcement probe pass against a build
+      // Claude Code is not loading -- it loads from installPath, which is gone.
+      // The header records this exact defect as already fixed once: "The
+      // enforcement probe passed -- for a build that was not running." Point at
+      // where the hooks are supposed to be and let the checks fail loudly.
+      hooksDir: pluginHooks ?? packageHooks,
       installPath: record.installPath ?? null,
       installedVersion,
       availableVersion,
@@ -204,8 +211,10 @@ function probe(binary, payload, { timeoutMs = 8000, cwd } = {}) {
       stdio: ['pipe', 'pipe', 'ignore'],
     });
   } catch (error) {
-    // A hook that exits non-zero with output still told us something.
-    return error?.stdout ?? null;
+    // A hook that exits non-zero WITH OUTPUT still told us something. One that
+    // timed out, was killed, or never spawned told us nothing -- and null has to
+    // mean exactly that, because an empty string is a legitimate "allowed".
+    return error?.stdout || null;
   }
 }
 
@@ -326,11 +335,19 @@ export function probeEnforcement({ root, workspace, hooksDir, install }) {
     const allowed = probe(binary, {
       tool_name: 'Read', tool_input: { file_path: small }, cwd: workspace, session_id: probeId,
     });
-    const allowedOk = !allowed || !allowed.includes('deny');
+    // `allowed === null` is "the probe never ran", NOT "the hook allowed it".
+    // allow() writes nothing and exits 0, so '' is a legitimate allow -- but null
+    // is a spawn failure, an EPERM, or a timeout, and reporting a pass there is a
+    // green tick produced by an absent measurement. A hook that hangs on every
+    // small read is a catastrophic install, and this check used to call it fine.
+    const allowedOk = allowed !== null && !allowed.includes('deny');
     checks.push(allowedOk
       ? ok('small reads are left alone', 'no refusal, as intended')
-      : bad('small reads are left alone', 'the hook refused a tiny file',
-        'a hook that refuses everything is as broken as one that refuses nothing -- report this'));
+      : bad('small reads are left alone',
+        allowed === null
+          ? 'the hook produced no result at all -- it crashed, hung past the timeout, or could not be spawned'
+          : 'the hook refused a tiny file',
+        'a hook that refuses everything, or answers nothing, is as broken as one that refuses nothing -- report this'));
   } finally {
     for (const path of [big, small]) {
       try { unlinkSync(path); } catch { /* best effort */ }
@@ -347,7 +364,21 @@ export function probeSessionStart({ root, workspace, hooksDir, install }) {
     return [bad('session-start emits the policy', 'binary missing', 'reinstall the package')];
   }
 
+  // probeEnforcement normally creates this, but it returns early when the router
+  // binary is missing -- before its own mkdirSync -- and a cwd that does not
+  // exist makes the SPAWN fail rather than the hook. Do not depend on another
+  // check having run first.
+  mkdirSync(workspace, { recursive: true });
   const out = probe(binary, {}, { cwd: workspace });
+  // JSON.parse(null) coerces to the string 'null' and RETURNS null rather than
+  // throwing, so without this the never-ran case fell past the catch written for
+  // it and reported 'ran, but produced no policy text' -- sending the user after
+  // TOKEN_OPTIMIZER_MODE for what is a spawn failure.
+  if (out === null) {
+    return [bad('session-start emits the policy',
+      'the hook produced no output at all -- it did not run',
+      'reinstall the package; the binary is present but could not be executed')];
+  }
   try {
     const parsed = JSON.parse(out);
     const context = parsed?.hookSpecificOutput?.additionalContext || '';
@@ -459,6 +490,8 @@ export function diagnose({
 
   const failed = checks.filter((c) => !c.pass);
   return {
+    // Carried so the report can speak about the file that was examined.
+    settingsPath: settingsPath ?? null,
     checks,
     passed: checks.length - failed.length,
     total: checks.length,
@@ -474,7 +507,12 @@ export function renderDiagnosis(result) {
     (check.pass || !check.remedy ? '' : `\n          fix: ${check.remedy}`));
 
   const residueNote = [];
-  const settings = process.env.TOKEN_OPTIMIZER_SETTINGS;
+  // The path diagnose ACTUALLY EXAMINED. Reading the env override here meant the
+  // residue note printed for nobody who had not set one -- that is, almost
+  // everybody, since both callers compute a default. It is also the only line
+  // that covers settings entries at all: removalPlan handles manifest-recorded
+  // files and nothing else.
+  const settings = result.settingsPath || process.env.TOKEN_OPTIMIZER_SETTINGS;
   if (settings) {
     const found = residue(settings);
     residueNote.push('', found.clean

--- a/tests/unit/doctor-knows-plugin-installs.test.ts
+++ b/tests/unit/doctor-knows-plugin-installs.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
@@ -195,5 +195,28 @@ describe('checklist on a plugin install', () => {
     });
 
     expect(names(checks)).toContain('install method');
+  });
+});
+
+describe('the doctor cannot pass on a broken install', () => {
+  it('a plugin record whose hooks directory is gone does not fall back to the package copy', () => {
+    // THE DEFECT: hooksDir fell back to the npm package's own plugin/hooks, which ships with
+    // every install (it is in package.json `files`). So the binary-present checks passed, the
+    // enforcement probe ran THAT copy and got a real deny back, and the report said
+    // "Enforcement is live" -- while Claude Code loads from installPath, which is gone, and
+    // enforces nothing. The file's own header records this exact defect as fixed once before.
+    const { pluginsDir, installPath } = givenPluginInstall('5.3.6', '5.3.6');
+    rmSync(join(installPath, 'hooks'), { recursive: true, force: true });
+
+    const install = detectInstall({ pluginsDir, root: fixture });
+    expect(install.method).toBe('plugin');
+    // Points at the plugin path that is missing, not at a copy that happens to work.
+    expect(install.hooksDir).toContain('5.3.6');
+    expect(existsSync(install.hooksDir)).toBe(false);
+
+    // And the checklist must therefore FAIL rather than report the binary present.
+    const binaryCheck = checklist({ install, root: fixture })
+      .find((c: { name: string }) => c.name === 'hook binary present');
+    expect(binaryCheck?.pass).toBe(false);
   });
 });


### PR DESCRIPTION
Four defects in the check that stands between a silently broken install and the user.

The tool's own description sets the bar: it *"Runs the real hook binaries with synthetic payloads and asserts a large read is refused and a small one is not — rather than checking that config files exist, which can pass while the plugin saves nothing."* So **a check that passes when it should fail is the defining bug for this module**, and three of these are exactly that.

## 1. A broken plugin install reported as healthy — critical

```js
hooksDir: pluginHooks && existsSync(pluginHooks) ? pluginHooks : packageHooks
```

When a plugin record exists but its hooks directory is gone — pruned cache, interrupted update, partial removal — `hooksDir` silently became the npm package's own `plugin/hooks`. **That directory ships with every install** (`plugin/**/*` is in `package.json` `files`).

So every downstream check passed: binary present ✓, session-start present ✓, and an enforcement probe that ran *that* copy and got a genuine `deny` back ✓. `diagnose` set `healthy: true` and the report printed:

> Enforcement is live: the hook was run and the refusal came back.

Claude Code loads plugin hooks from `installPath`, which is gone. **Nothing was enforced at all.**

The file's own header records this defect as already fixed once: *"The enforcement probe passed — for a build that was not running."* It was reintroduced on the one path where the plugin is genuinely broken.

## 2. A hook that never ran, reported as an allow — major

`const allowedOk = !allowed || !allowed.includes('deny')`. `probe()` returns `null` when the child could not be measured — ENOENT spawn failure, EPERM from AV or ACLs, or a timeout at the 8 s ceiling.

So a router that **hangs on every small read** reports *"small reads are left alone: no refusal, as intended."* Combined with (1), that is an all-green report for a catastrophic install.

`''` is a legitimate allow — `allow()` writes nothing and exits 0 — so `null` and `''` must not share a representation. `probe` now returns `error?.stdout || null`.

## 3. A spawn failure blamed on an env var — minor

`probeSessionStart` spawned with `cwd: workspace` but never created it, relying on `probeEnforcement`'s `mkdirSync` — which it skips when the router binary is missing. A non-existent cwd fails the *spawn*, and `JSON.parse(null)` **returns null rather than throwing**, so the never-ran case fell past the catch written for it and reported *"ran, but produced no policy text"*, sending the user after `TOKEN_OPTIMIZER_MODE` for a spawn failure.

## 4. The residue note never printed — major

`renderDiagnosis` read `TOKEN_OPTIMIZER_SETTINGS` directly and gated the whole residue block on it — but **both callers compute a default** when it is unset. So the one line telling a user whether token-optimizer entries remain in their `settings.json` never printed on a normal install. It matters for the removal story `install_doctor` advertises: `removalPlan` covers only manifest-recorded files, so settings entries are covered by that line alone.

## On the process

The first version of (3) **deleted the `JSON.parse` line** it was inserting a guard above, so every session-start probe reported "unparseable output" for output that parsed fine. The existing suite caught it, and I confirmed against a clean tree that I had broken it rather than found something.

The new broken-install test is **verified load-bearing**: restoring the old fallback makes it fail.

## Verification

- `tests/hooks` + doctor unit tests — **713 passed, 2 skipped, 0 failed**
- `npm run sync:hooks` applied to all six vendored copies

🤖 Generated with [Claude Code](https://claude.com/claude-code)
