### PR TITLE
fix(disclose): never withhold content while reporting nothing omitted

### DIFF
--- a/hooks-core/disclose.mjs
+++ b/hooks-core/disclose.mjs
@@ -192,11 +192,23 @@ function splitJson(text) {
   }
 
   if (Array.isArray(parsed)) {
-    return [
-      section('shape', [`array of ${parsed.length}`], 9, 'summary'),
-      section('first element', JSON.stringify(parsed[0], null, 2).split('\n'), 6),
-      section('remaining elements', [`${Math.max(0, parsed.length - 1)} more`], 1),
-    ];
+    // THE REMAINING ELEMENTS ARE A REAL SECTION, not a placeholder string. As a
+    // placeholder they were discarded by this splitter itself, so the budget loop never
+    // saw them, no omission was recorded, and -- because the tail is skipped when there
+    // are no omissions -- the preview carried no expand ref either. Measured: a 30 KB
+    // array of 500 objects returned ~150 bytes, `omissions: []`, and no way to recover
+    // the other 499. Every other splitter in this file partitions all of its input.
+    const out = [section('shape', [`array of ${parsed.length}`], 9, 'summary')];
+    if (parsed.length) {
+      // `?? null` because JSON.stringify(undefined) returns undefined, and .split would
+      // then throw -- parseShape('[]') aborted the whole disclosure block.
+      out.push(section('first element', JSON.stringify(parsed[0] ?? null, null, 2).split('\n'), 6));
+    }
+    const rest = parsed.slice(1);
+    if (rest.length) {
+      out.push(section(`remaining ${rest.length} elements`, JSON.stringify(rest, null, 2).split('\n'), 1));
+    }
+    return out;
   }
 
   const sections = [];
@@ -336,6 +348,12 @@ export function disclose(dir, text, context = {}) {
 
   // LAYERS 2 and 3 -- structure, then relevance within it.
   const { shape, sections } = parseShape(raw);
+  // Counted from the SECTIONS, not from `raw`. A JSON envelope is one physical line
+  // however large its payload -- and the file's own comment says a JSON envelope is what
+  // everything this product returns -- so the header read "1 lines" directly above a tail
+  // reporting 3,000 omitted. The two numbers were in different units and the header was
+  // the smaller one, contradicting the safeguard immediately below it.
+  const totalLines = sections.reduce((n, s) => n + s.lines.length, 0);
   const ranked = rankSections(sections, { question, anchors, boosts });
   const budget = substitutionBudget(dir, anchors[0] || tool || 'output');
 
@@ -387,9 +405,15 @@ export function disclose(dir, text, context = {}) {
       }
 
       if (slice.length) {
-        kept.push({ label: s.label, lines: slice, kind: s.kind, partial: true });
+        // The budget check costs a section as one estimate over the joined body; this
+        // loop costs it as a sum of per-line estimates. Those roundings differ, so the
+        // loop can consume EVERY line of a section the budget check rejected. That is a
+        // complete section, and labelling it partial with "0 lines omitted" makes the two
+        // signals a reader is meant to trust fire on content that was not withheld.
+        const dropped = s.lines.length - slice.length;
+        kept.push({ label: s.label, lines: slice, kind: s.kind, partial: dropped > 0 });
         spent += used;
-        omissions.push({ label: s.label, lines: s.lines.length - slice.length, ref, partial: true });
+        if (dropped > 0) omissions.push({ label: s.label, lines: dropped, ref, partial: true });
         continue;
       }
     }
@@ -398,7 +422,7 @@ export function disclose(dir, text, context = {}) {
 
   const head = question
     ? `[selected against: "${question}"]`
-    : `[${shape} output, ${raw.split('\n').length} lines -- most relevant sections kept]`;
+    : `[${shape} output, ${totalLines.toLocaleString()} lines -- most relevant sections kept]`;
 
   const body = kept.map((k) => (k.partial
     ? [`--- ${k.label} (partial) ---`, ...k.lines]

--- a/integrations/codex/hooks/lib/disclose.mjs
+++ b/integrations/codex/hooks/lib/disclose.mjs
@@ -194,11 +194,23 @@ function splitJson(text) {
   }
 
   if (Array.isArray(parsed)) {
-    return [
-      section('shape', [`array of ${parsed.length}`], 9, 'summary'),
-      section('first element', JSON.stringify(parsed[0], null, 2).split('\n'), 6),
-      section('remaining elements', [`${Math.max(0, parsed.length - 1)} more`], 1),
-    ];
+    // THE REMAINING ELEMENTS ARE A REAL SECTION, not a placeholder string. As a
+    // placeholder they were discarded by this splitter itself, so the budget loop never
+    // saw them, no omission was recorded, and -- because the tail is skipped when there
+    // are no omissions -- the preview carried no expand ref either. Measured: a 30 KB
+    // array of 500 objects returned ~150 bytes, `omissions: []`, and no way to recover
+    // the other 499. Every other splitter in this file partitions all of its input.
+    const out = [section('shape', [`array of ${parsed.length}`], 9, 'summary')];
+    if (parsed.length) {
+      // `?? null` because JSON.stringify(undefined) returns undefined, and .split would
+      // then throw -- parseShape('[]') aborted the whole disclosure block.
+      out.push(section('first element', JSON.stringify(parsed[0] ?? null, null, 2).split('\n'), 6));
+    }
+    const rest = parsed.slice(1);
+    if (rest.length) {
+      out.push(section(`remaining ${rest.length} elements`, JSON.stringify(rest, null, 2).split('\n'), 1));
+    }
+    return out;
   }
 
   const sections = [];
@@ -338,6 +350,12 @@ export function disclose(dir, text, context = {}) {
 
   // LAYERS 2 and 3 -- structure, then relevance within it.
   const { shape, sections } = parseShape(raw);
+  // Counted from the SECTIONS, not from `raw`. A JSON envelope is one physical line
+  // however large its payload -- and the file's own comment says a JSON envelope is what
+  // everything this product returns -- so the header read "1 lines" directly above a tail
+  // reporting 3,000 omitted. The two numbers were in different units and the header was
+  // the smaller one, contradicting the safeguard immediately below it.
+  const totalLines = sections.reduce((n, s) => n + s.lines.length, 0);
   const ranked = rankSections(sections, { question, anchors, boosts });
   const budget = substitutionBudget(dir, anchors[0] || tool || 'output');
 
@@ -389,9 +407,15 @@ export function disclose(dir, text, context = {}) {
       }
 
       if (slice.length) {
-        kept.push({ label: s.label, lines: slice, kind: s.kind, partial: true });
+        // The budget check costs a section as one estimate over the joined body; this
+        // loop costs it as a sum of per-line estimates. Those roundings differ, so the
+        // loop can consume EVERY line of a section the budget check rejected. That is a
+        // complete section, and labelling it partial with "0 lines omitted" makes the two
+        // signals a reader is meant to trust fire on content that was not withheld.
+        const dropped = s.lines.length - slice.length;
+        kept.push({ label: s.label, lines: slice, kind: s.kind, partial: dropped > 0 });
         spent += used;
-        omissions.push({ label: s.label, lines: s.lines.length - slice.length, ref, partial: true });
+        if (dropped > 0) omissions.push({ label: s.label, lines: dropped, ref, partial: true });
         continue;
       }
     }
@@ -400,7 +424,7 @@ export function disclose(dir, text, context = {}) {
 
   const head = question
     ? `[selected against: "${question}"]`
-    : `[${shape} output, ${raw.split('\n').length} lines -- most relevant sections kept]`;
+    : `[${shape} output, ${totalLines.toLocaleString()} lines -- most relevant sections kept]`;
 
   const body = kept.map((k) => (k.partial
     ? [`--- ${k.label} (partial) ---`, ...k.lines]

--- a/integrations/codex/plugin/hooks/lib/disclose.mjs
+++ b/integrations/codex/plugin/hooks/lib/disclose.mjs
@@ -194,11 +194,23 @@ function splitJson(text) {
   }
 
   if (Array.isArray(parsed)) {
-    return [
-      section('shape', [`array of ${parsed.length}`], 9, 'summary'),
-      section('first element', JSON.stringify(parsed[0], null, 2).split('\n'), 6),
-      section('remaining elements', [`${Math.max(0, parsed.length - 1)} more`], 1),
-    ];
+    // THE REMAINING ELEMENTS ARE A REAL SECTION, not a placeholder string. As a
+    // placeholder they were discarded by this splitter itself, so the budget loop never
+    // saw them, no omission was recorded, and -- because the tail is skipped when there
+    // are no omissions -- the preview carried no expand ref either. Measured: a 30 KB
+    // array of 500 objects returned ~150 bytes, `omissions: []`, and no way to recover
+    // the other 499. Every other splitter in this file partitions all of its input.
+    const out = [section('shape', [`array of ${parsed.length}`], 9, 'summary')];
+    if (parsed.length) {
+      // `?? null` because JSON.stringify(undefined) returns undefined, and .split would
+      // then throw -- parseShape('[]') aborted the whole disclosure block.
+      out.push(section('first element', JSON.stringify(parsed[0] ?? null, null, 2).split('\n'), 6));
+    }
+    const rest = parsed.slice(1);
+    if (rest.length) {
+      out.push(section(`remaining ${rest.length} elements`, JSON.stringify(rest, null, 2).split('\n'), 1));
+    }
+    return out;
   }
 
   const sections = [];
@@ -338,6 +350,12 @@ export function disclose(dir, text, context = {}) {
 
   // LAYERS 2 and 3 -- structure, then relevance within it.
   const { shape, sections } = parseShape(raw);
+  // Counted from the SECTIONS, not from `raw`. A JSON envelope is one physical line
+  // however large its payload -- and the file's own comment says a JSON envelope is what
+  // everything this product returns -- so the header read "1 lines" directly above a tail
+  // reporting 3,000 omitted. The two numbers were in different units and the header was
+  // the smaller one, contradicting the safeguard immediately below it.
+  const totalLines = sections.reduce((n, s) => n + s.lines.length, 0);
   const ranked = rankSections(sections, { question, anchors, boosts });
   const budget = substitutionBudget(dir, anchors[0] || tool || 'output');
 
@@ -389,9 +407,15 @@ export function disclose(dir, text, context = {}) {
       }
 
       if (slice.length) {
-        kept.push({ label: s.label, lines: slice, kind: s.kind, partial: true });
+        // The budget check costs a section as one estimate over the joined body; this
+        // loop costs it as a sum of per-line estimates. Those roundings differ, so the
+        // loop can consume EVERY line of a section the budget check rejected. That is a
+        // complete section, and labelling it partial with "0 lines omitted" makes the two
+        // signals a reader is meant to trust fire on content that was not withheld.
+        const dropped = s.lines.length - slice.length;
+        kept.push({ label: s.label, lines: slice, kind: s.kind, partial: dropped > 0 });
         spent += used;
-        omissions.push({ label: s.label, lines: s.lines.length - slice.length, ref, partial: true });
+        if (dropped > 0) omissions.push({ label: s.label, lines: dropped, ref, partial: true });
         continue;
       }
     }
@@ -400,7 +424,7 @@ export function disclose(dir, text, context = {}) {
 
   const head = question
     ? `[selected against: "${question}"]`
-    : `[${shape} output, ${raw.split('\n').length} lines -- most relevant sections kept]`;
+    : `[${shape} output, ${totalLines.toLocaleString()} lines -- most relevant sections kept]`;
 
   const body = kept.map((k) => (k.partial
     ? [`--- ${k.label} (partial) ---`, ...k.lines]

--- a/integrations/gemini/hooks/lib/disclose.mjs
+++ b/integrations/gemini/hooks/lib/disclose.mjs
@@ -194,11 +194,23 @@ function splitJson(text) {
   }
 
   if (Array.isArray(parsed)) {
-    return [
-      section('shape', [`array of ${parsed.length}`], 9, 'summary'),
-      section('first element', JSON.stringify(parsed[0], null, 2).split('\n'), 6),
-      section('remaining elements', [`${Math.max(0, parsed.length - 1)} more`], 1),
-    ];
+    // THE REMAINING ELEMENTS ARE A REAL SECTION, not a placeholder string. As a
+    // placeholder they were discarded by this splitter itself, so the budget loop never
+    // saw them, no omission was recorded, and -- because the tail is skipped when there
+    // are no omissions -- the preview carried no expand ref either. Measured: a 30 KB
+    // array of 500 objects returned ~150 bytes, `omissions: []`, and no way to recover
+    // the other 499. Every other splitter in this file partitions all of its input.
+    const out = [section('shape', [`array of ${parsed.length}`], 9, 'summary')];
+    if (parsed.length) {
+      // `?? null` because JSON.stringify(undefined) returns undefined, and .split would
+      // then throw -- parseShape('[]') aborted the whole disclosure block.
+      out.push(section('first element', JSON.stringify(parsed[0] ?? null, null, 2).split('\n'), 6));
+    }
+    const rest = parsed.slice(1);
+    if (rest.length) {
+      out.push(section(`remaining ${rest.length} elements`, JSON.stringify(rest, null, 2).split('\n'), 1));
+    }
+    return out;
   }
 
   const sections = [];
@@ -338,6 +350,12 @@ export function disclose(dir, text, context = {}) {
 
   // LAYERS 2 and 3 -- structure, then relevance within it.
   const { shape, sections } = parseShape(raw);
+  // Counted from the SECTIONS, not from `raw`. A JSON envelope is one physical line
+  // however large its payload -- and the file's own comment says a JSON envelope is what
+  // everything this product returns -- so the header read "1 lines" directly above a tail
+  // reporting 3,000 omitted. The two numbers were in different units and the header was
+  // the smaller one, contradicting the safeguard immediately below it.
+  const totalLines = sections.reduce((n, s) => n + s.lines.length, 0);
   const ranked = rankSections(sections, { question, anchors, boosts });
   const budget = substitutionBudget(dir, anchors[0] || tool || 'output');
 
@@ -389,9 +407,15 @@ export function disclose(dir, text, context = {}) {
       }
 
       if (slice.length) {
-        kept.push({ label: s.label, lines: slice, kind: s.kind, partial: true });
+        // The budget check costs a section as one estimate over the joined body; this
+        // loop costs it as a sum of per-line estimates. Those roundings differ, so the
+        // loop can consume EVERY line of a section the budget check rejected. That is a
+        // complete section, and labelling it partial with "0 lines omitted" makes the two
+        // signals a reader is meant to trust fire on content that was not withheld.
+        const dropped = s.lines.length - slice.length;
+        kept.push({ label: s.label, lines: slice, kind: s.kind, partial: dropped > 0 });
         spent += used;
-        omissions.push({ label: s.label, lines: s.lines.length - slice.length, ref, partial: true });
+        if (dropped > 0) omissions.push({ label: s.label, lines: dropped, ref, partial: true });
         continue;
       }
     }
@@ -400,7 +424,7 @@ export function disclose(dir, text, context = {}) {
 
   const head = question
     ? `[selected against: "${question}"]`
-    : `[${shape} output, ${raw.split('\n').length} lines -- most relevant sections kept]`;
+    : `[${shape} output, ${totalLines.toLocaleString()} lines -- most relevant sections kept]`;
 
   const body = kept.map((k) => (k.partial
     ? [`--- ${k.label} (partial) ---`, ...k.lines]

--- a/integrations/opencode/hooks/lib/disclose.mjs
+++ b/integrations/opencode/hooks/lib/disclose.mjs
@@ -194,11 +194,23 @@ function splitJson(text) {
   }
 
   if (Array.isArray(parsed)) {
-    return [
-      section('shape', [`array of ${parsed.length}`], 9, 'summary'),
-      section('first element', JSON.stringify(parsed[0], null, 2).split('\n'), 6),
-      section('remaining elements', [`${Math.max(0, parsed.length - 1)} more`], 1),
-    ];
+    // THE REMAINING ELEMENTS ARE A REAL SECTION, not a placeholder string. As a
+    // placeholder they were discarded by this splitter itself, so the budget loop never
+    // saw them, no omission was recorded, and -- because the tail is skipped when there
+    // are no omissions -- the preview carried no expand ref either. Measured: a 30 KB
+    // array of 500 objects returned ~150 bytes, `omissions: []`, and no way to recover
+    // the other 499. Every other splitter in this file partitions all of its input.
+    const out = [section('shape', [`array of ${parsed.length}`], 9, 'summary')];
+    if (parsed.length) {
+      // `?? null` because JSON.stringify(undefined) returns undefined, and .split would
+      // then throw -- parseShape('[]') aborted the whole disclosure block.
+      out.push(section('first element', JSON.stringify(parsed[0] ?? null, null, 2).split('\n'), 6));
+    }
+    const rest = parsed.slice(1);
+    if (rest.length) {
+      out.push(section(`remaining ${rest.length} elements`, JSON.stringify(rest, null, 2).split('\n'), 1));
+    }
+    return out;
   }
 
   const sections = [];
@@ -338,6 +350,12 @@ export function disclose(dir, text, context = {}) {
 
   // LAYERS 2 and 3 -- structure, then relevance within it.
   const { shape, sections } = parseShape(raw);
+  // Counted from the SECTIONS, not from `raw`. A JSON envelope is one physical line
+  // however large its payload -- and the file's own comment says a JSON envelope is what
+  // everything this product returns -- so the header read "1 lines" directly above a tail
+  // reporting 3,000 omitted. The two numbers were in different units and the header was
+  // the smaller one, contradicting the safeguard immediately below it.
+  const totalLines = sections.reduce((n, s) => n + s.lines.length, 0);
   const ranked = rankSections(sections, { question, anchors, boosts });
   const budget = substitutionBudget(dir, anchors[0] || tool || 'output');
 
@@ -389,9 +407,15 @@ export function disclose(dir, text, context = {}) {
       }
 
       if (slice.length) {
-        kept.push({ label: s.label, lines: slice, kind: s.kind, partial: true });
+        // The budget check costs a section as one estimate over the joined body; this
+        // loop costs it as a sum of per-line estimates. Those roundings differ, so the
+        // loop can consume EVERY line of a section the budget check rejected. That is a
+        // complete section, and labelling it partial with "0 lines omitted" makes the two
+        // signals a reader is meant to trust fire on content that was not withheld.
+        const dropped = s.lines.length - slice.length;
+        kept.push({ label: s.label, lines: slice, kind: s.kind, partial: dropped > 0 });
         spent += used;
-        omissions.push({ label: s.label, lines: s.lines.length - slice.length, ref, partial: true });
+        if (dropped > 0) omissions.push({ label: s.label, lines: dropped, ref, partial: true });
         continue;
       }
     }
@@ -400,7 +424,7 @@ export function disclose(dir, text, context = {}) {
 
   const head = question
     ? `[selected against: "${question}"]`
-    : `[${shape} output, ${raw.split('\n').length} lines -- most relevant sections kept]`;
+    : `[${shape} output, ${totalLines.toLocaleString()} lines -- most relevant sections kept]`;
 
   const body = kept.map((k) => (k.partial
     ? [`--- ${k.label} (partial) ---`, ...k.lines]

--- a/integrations/qwen/hooks/lib/disclose.mjs
+++ b/integrations/qwen/hooks/lib/disclose.mjs
@@ -194,11 +194,23 @@ function splitJson(text) {
   }
 
   if (Array.isArray(parsed)) {
-    return [
-      section('shape', [`array of ${parsed.length}`], 9, 'summary'),
-      section('first element', JSON.stringify(parsed[0], null, 2).split('\n'), 6),
-      section('remaining elements', [`${Math.max(0, parsed.length - 1)} more`], 1),
-    ];
+    // THE REMAINING ELEMENTS ARE A REAL SECTION, not a placeholder string. As a
+    // placeholder they were discarded by this splitter itself, so the budget loop never
+    // saw them, no omission was recorded, and -- because the tail is skipped when there
+    // are no omissions -- the preview carried no expand ref either. Measured: a 30 KB
+    // array of 500 objects returned ~150 bytes, `omissions: []`, and no way to recover
+    // the other 499. Every other splitter in this file partitions all of its input.
+    const out = [section('shape', [`array of ${parsed.length}`], 9, 'summary')];
+    if (parsed.length) {
+      // `?? null` because JSON.stringify(undefined) returns undefined, and .split would
+      // then throw -- parseShape('[]') aborted the whole disclosure block.
+      out.push(section('first element', JSON.stringify(parsed[0] ?? null, null, 2).split('\n'), 6));
+    }
+    const rest = parsed.slice(1);
+    if (rest.length) {
+      out.push(section(`remaining ${rest.length} elements`, JSON.stringify(rest, null, 2).split('\n'), 1));
+    }
+    return out;
   }
 
   const sections = [];
@@ -338,6 +350,12 @@ export function disclose(dir, text, context = {}) {
 
   // LAYERS 2 and 3 -- structure, then relevance within it.
   const { shape, sections } = parseShape(raw);
+  // Counted from the SECTIONS, not from `raw`. A JSON envelope is one physical line
+  // however large its payload -- and the file's own comment says a JSON envelope is what
+  // everything this product returns -- so the header read "1 lines" directly above a tail
+  // reporting 3,000 omitted. The two numbers were in different units and the header was
+  // the smaller one, contradicting the safeguard immediately below it.
+  const totalLines = sections.reduce((n, s) => n + s.lines.length, 0);
   const ranked = rankSections(sections, { question, anchors, boosts });
   const budget = substitutionBudget(dir, anchors[0] || tool || 'output');
 
@@ -389,9 +407,15 @@ export function disclose(dir, text, context = {}) {
       }
 
       if (slice.length) {
-        kept.push({ label: s.label, lines: slice, kind: s.kind, partial: true });
+        // The budget check costs a section as one estimate over the joined body; this
+        // loop costs it as a sum of per-line estimates. Those roundings differ, so the
+        // loop can consume EVERY line of a section the budget check rejected. That is a
+        // complete section, and labelling it partial with "0 lines omitted" makes the two
+        // signals a reader is meant to trust fire on content that was not withheld.
+        const dropped = s.lines.length - slice.length;
+        kept.push({ label: s.label, lines: slice, kind: s.kind, partial: dropped > 0 });
         spent += used;
-        omissions.push({ label: s.label, lines: s.lines.length - slice.length, ref, partial: true });
+        if (dropped > 0) omissions.push({ label: s.label, lines: dropped, ref, partial: true });
         continue;
       }
     }
@@ -400,7 +424,7 @@ export function disclose(dir, text, context = {}) {
 
   const head = question
     ? `[selected against: "${question}"]`
-    : `[${shape} output, ${raw.split('\n').length} lines -- most relevant sections kept]`;
+    : `[${shape} output, ${totalLines.toLocaleString()} lines -- most relevant sections kept]`;
 
   const body = kept.map((k) => (k.partial
     ? [`--- ${k.label} (partial) ---`, ...k.lines]

--- a/plugin/hooks/lib/disclose.mjs
+++ b/plugin/hooks/lib/disclose.mjs
@@ -194,11 +194,23 @@ function splitJson(text) {
   }
 
   if (Array.isArray(parsed)) {
-    return [
-      section('shape', [`array of ${parsed.length}`], 9, 'summary'),
-      section('first element', JSON.stringify(parsed[0], null, 2).split('\n'), 6),
-      section('remaining elements', [`${Math.max(0, parsed.length - 1)} more`], 1),
-    ];
+    // THE REMAINING ELEMENTS ARE A REAL SECTION, not a placeholder string. As a
+    // placeholder they were discarded by this splitter itself, so the budget loop never
+    // saw them, no omission was recorded, and -- because the tail is skipped when there
+    // are no omissions -- the preview carried no expand ref either. Measured: a 30 KB
+    // array of 500 objects returned ~150 bytes, `omissions: []`, and no way to recover
+    // the other 499. Every other splitter in this file partitions all of its input.
+    const out = [section('shape', [`array of ${parsed.length}`], 9, 'summary')];
+    if (parsed.length) {
+      // `?? null` because JSON.stringify(undefined) returns undefined, and .split would
+      // then throw -- parseShape('[]') aborted the whole disclosure block.
+      out.push(section('first element', JSON.stringify(parsed[0] ?? null, null, 2).split('\n'), 6));
+    }
+    const rest = parsed.slice(1);
+    if (rest.length) {
+      out.push(section(`remaining ${rest.length} elements`, JSON.stringify(rest, null, 2).split('\n'), 1));
+    }
+    return out;
   }
 
   const sections = [];
@@ -338,6 +350,12 @@ export function disclose(dir, text, context = {}) {
 
   // LAYERS 2 and 3 -- structure, then relevance within it.
   const { shape, sections } = parseShape(raw);
+  // Counted from the SECTIONS, not from `raw`. A JSON envelope is one physical line
+  // however large its payload -- and the file's own comment says a JSON envelope is what
+  // everything this product returns -- so the header read "1 lines" directly above a tail
+  // reporting 3,000 omitted. The two numbers were in different units and the header was
+  // the smaller one, contradicting the safeguard immediately below it.
+  const totalLines = sections.reduce((n, s) => n + s.lines.length, 0);
   const ranked = rankSections(sections, { question, anchors, boosts });
   const budget = substitutionBudget(dir, anchors[0] || tool || 'output');
 
@@ -389,9 +407,15 @@ export function disclose(dir, text, context = {}) {
       }
 
       if (slice.length) {
-        kept.push({ label: s.label, lines: slice, kind: s.kind, partial: true });
+        // The budget check costs a section as one estimate over the joined body; this
+        // loop costs it as a sum of per-line estimates. Those roundings differ, so the
+        // loop can consume EVERY line of a section the budget check rejected. That is a
+        // complete section, and labelling it partial with "0 lines omitted" makes the two
+        // signals a reader is meant to trust fire on content that was not withheld.
+        const dropped = s.lines.length - slice.length;
+        kept.push({ label: s.label, lines: slice, kind: s.kind, partial: dropped > 0 });
         spent += used;
-        omissions.push({ label: s.label, lines: s.lines.length - slice.length, ref, partial: true });
+        if (dropped > 0) omissions.push({ label: s.label, lines: dropped, ref, partial: true });
         continue;
       }
     }
@@ -400,7 +424,7 @@ export function disclose(dir, text, context = {}) {
 
   const head = question
     ? `[selected against: "${question}"]`
-    : `[${shape} output, ${raw.split('\n').length} lines -- most relevant sections kept]`;
+    : `[${shape} output, ${totalLines.toLocaleString()} lines -- most relevant sections kept]`;
 
   const body = kept.map((k) => (k.partial
     ? [`--- ${k.label} (partial) ---`, ...k.lines]

--- a/tests/hooks/disclose.test.mjs
+++ b/tests/hooks/disclose.test.mjs
@@ -335,3 +335,58 @@ describe('preview quality is reported, not buried', () => {
     expect(quality.healthy).toBe(false);
   });
 });
+
+describe('an omission is never silent, and never invented', () => {
+  test('a large array reports the elements it withheld, with an expand ref', () => {
+    // MEASURED before the fix: a 30,281-byte array of 500 objects returned mode 'preview',
+    // `omissions: []`, ~150 bytes of text, and out.text did not contain the ref -- so 30 KB
+    // vanished, the machine-readable contract asserted nothing was omitted, and there was no
+    // pointer to recover it. Every other splitter partitions all of its input; this one did not.
+    const dir = mkdtempSync(join(tmpdir(), 'disc-arr-'));
+    try {
+      const body = JSON.stringify(Array.from({ length: 500 }, (_, i) => ({
+        id: i, name: `item-${i}`, detail: 'x'.repeat(20),
+      })));
+      const out = disclose(dir, body, { ref: 'abc123def4567890' });
+      expect(out).toBeTruthy();
+      expect(out.omissions.length).toBeGreaterThan(0);
+      expect(out.text).toContain('abc123def4567890');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('an empty array does not throw', () => {
+    // JSON.stringify(undefined) returns undefined, so `.split` threw and aborted the whole
+    // disclosure/capture block for any tool returning [].
+    expect(() => parseShape('[]')).not.toThrow();
+  });
+
+  test('the header line count agrees with the omission counts below it', () => {
+    // A JSON envelope is one physical line however large its payload, so the header read
+    // "1 lines" directly above a tail reporting thousands omitted.
+    const dir = mkdtempSync(join(tmpdir(), 'disc-hdr-'));
+    try {
+      const report = Array.from({ length: 3000 }, (_, i) => `  ok ${i} - passing test`).join('\n');
+      const out = disclose(dir, JSON.stringify({ output: report, path: 'x.ts' }), { ref: 'r9' });
+      expect(out).toBeTruthy();
+      const stated = Number(/output, ([\d,]+) lines/.exec(out.text)?.[1]?.replace(/,/g, '') ?? '0');
+      expect(stated).toBeGreaterThan(100);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('a section kept in full is not labelled partial with zero lines omitted', () => {
+    // The budget check and the slice loop round differently, so the loop could consume every
+    // line of a section the check rejected -- reporting "omitted: 0 lines" and inviting the
+    // reader to spend an expand call on nothing.
+    const dir = mkdtempSync(join(tmpdir(), 'disc-zero-'));
+    try {
+      const out = disclose(dir, Array.from({ length: 1100 }, () => 'abcd').join('\n'), { ref: 'r1' });
+      if (out) for (const o of out.omissions) expect(o.lines).toBeGreaterThan(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Three defects in the module whose entire purpose is **preventing a silent omission**. If the tool hides content and the disclosure is wrong, the reader believes they saw everything — so a bug here is worse than the same bug anywhere else, because this is the safeguard.

## 1. Array elements dropped, `omissions: []` — critical

`splitJson`'s array branch was the one splitter in the file that did not preserve its input: it kept element 0 and replaced the rest with the literal string `"N more"`. Those elements never became a section, so the budget loop never saw them, **no omission was recorded** — and because the tail is skipped when `omissions` is empty, the preview carried **no expand ref either**.

Reproduced on a 30,281-byte array of 500 objects:

```
mode:       'preview'
omissions:  []
text:       ~150 bytes
text.includes(ref):  false
```

Thirty kilobytes of tool output disappeared, the machine-readable contract asserted nothing was omitted, and there was no pointer to recover any of it. `disclosure.ts` makes `out.text` the entire tool result.

The remaining elements are now a real section — ranked, dropped by budget like anything else, and counted honestly.

**Same lines:** `JSON.stringify(undefined)` returns `undefined`, so an empty array made `.split` throw and aborted the whole disclosure/capture block. Confirmed: `parseShape('[]')` threw.

## 2. Header said "1 lines" above a tail saying 3,000 — major

The header counted with `raw.split('\n').length`. A JSON envelope is **one physical line** however large its payload — and this file's own comment says a JSON envelope is what everything this product returns — while the sections are built from the *unescaped* payload.

Different units, and the header was the smaller one:

```
HEAD: [json output, 1 lines -- most relevant sections kept]
TAIL: ---- omitted: 3,000 lines of output > passing tests (expand r9) ----
```

The first line a reader sees understated the size by three orders of magnitude and contradicted the safeguard immediately below it.

## 3. "omitted: 0 lines" on a complete section — minor

The budget check costs a section as one estimate over the joined body; the slice loop costs it as a sum of per-line estimates. Those roundings differ, so the loop could consume **every** line of a section the check had rejected — marking a complete section `partial: true` and emitting an omission of 0 lines, inviting the reader to spend an expand call on nothing.

Both signals a reader is meant to trust were firing on content that had not been withheld.

## Verification

- `tests/hooks` — **707 passed, 2 skipped, 0 failed**, including 4 new tests

**Honest note:** I tried to prove the array test load-bearing by reverting the fix in place, but my surgical revert broke the file so the suite did not run — that check was inconclusive. The empty-array test is self-evidently tied to its fix (the old code throws), and the ref assertion fails without the section change by construction, but I have **not** demonstrated the header test the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
