### PR TITLE
fix(expand): serve only what the pointer actually points at

### DIFF
--- a/hooks-core/expand.mjs
+++ b/hooks-core/expand.mjs
@@ -149,7 +149,14 @@ export function capture(dir, text, meta = {}) {
  * that ever produced these bytes counts as staleness.
  */
 function captureOf(dir, ref) {
-  const rows = readMetrics(dir).filter((e) => e.kind === 'capture' && e.ref === ref);
+  const rows = readMetrics(dir)
+    .filter((e) => e.kind === 'capture' && e.ref === ref)
+    // SORTED, rather than trusting the reader's order. "Oldest hash per anchor wins" and "the
+    // latest capture supplies the rest of the record" are both statements about TIME, and
+    // readMetrics returns whatever order the log and its tail slice produce. Relying on write
+    // order makes the conservative direction accidental. Ties keep their relative order, since
+    // sort is stable and two rows in the same millisecond have no better ordering available.
+    .sort((a, b) => (a.at ?? 0) - (b.at ?? 0));
   if (!rows.length) return null;
   const byAnchor = new Map();
   for (const row of rows) {

--- a/hooks-core/expand.mjs
+++ b/hooks-core/expand.mjs
@@ -31,11 +31,13 @@
  */
 
 import { createHash } from 'node:crypto';
-import { readFileSync, writeFileSync, mkdirSync, existsSync, chmodSync } from 'node:fs';
+import {
+  readFileSync, writeFileSync, mkdirSync, existsSync, chmodSync,
+  readdirSync, statSync, unlinkSync,
+} from 'node:fs';
 import { join } from 'node:path';
 import { record, readMetrics } from './metrics.mjs';
 import { putNode, putEdge, nodeId } from './wiki.mjs';
-import { checkAnchor } from './staleness.mjs';
 import { canonicalPath } from './paths.mjs';
 
 /** A stale artifact cheaper than this to regenerate is refreshed, not served. */
@@ -44,7 +46,35 @@ export const CHEAP_REGEN_MS = 3000;
 /** Expansions below this rate mean the preview policy is working. */
 export const HEALTHY_HOLD_RATE = 0.85;
 
+/**
+ * How long an artifact is kept. STATED, not silent.
+ *
+ * The store was otherwise write-only: every disclosed tool result landed here forever, while its
+ * capture record ages out of the bounded metrics window -- so most files on disk were already
+ * unreachable and could not even be resolved usefully, only occupy space. Content addressing
+ * dedupes byte-identical bodies but not near-identical ones, so two runs of the same suite
+ * differing only in elapsed-ms are two files.
+ *
+ * A bound nobody can see would be worse than none, so it is exported and documented alongside
+ * the rest of the module's stated properties.
+ */
+export const ARTIFACT_TTL_MS = 30 * 86_400_000;
+
 const digest = (text) => createHash('sha256').update(String(text)).digest('hex').slice(0, 16);
+
+/** Removes artifacts past the TTL. A sweep must never break a capture. */
+function sweepArtifacts(path) {
+  try {
+    const cutoff = Date.now() - ARTIFACT_TTL_MS;
+    for (const name of readdirSync(path)) {
+      if (!name.endsWith('.txt')) continue;
+      const file = join(path, name);
+      try {
+        if (statSync(file).mtimeMs < cutoff) unlinkSync(file);
+      } catch { /* raced with another sweep or a reader */ }
+    }
+  } catch { /* no store yet, or unreadable -- neither is worth failing a capture over */ }
+}
 
 function artifactDir(dir) {
   const path = join(dir, 'artifacts');
@@ -70,7 +100,12 @@ export function capture(dir, text, meta = {}) {
 
   const ref = digest(body);
   const path = join(artifactDir(dir), `${ref}.txt`);
-  if (!existsSync(path)) writeFileSync(path, body, { mode: 0o600 });
+  if (!existsSync(path)) {
+    writeFileSync(path, body, { mode: 0o600 });
+    // Amortised off the digest rather than run on every capture, and deterministic rather than
+    // sampled at random: roughly one write in sixty-four pays for a readdir.
+    if (parseInt(ref.slice(0, 2), 16) < 4) sweepArtifacts(artifactDir(dir));
+  }
 
   const anchors = (meta.anchors || []).map((a) => canonicalPath(a));
   record(dir, {
@@ -99,9 +134,30 @@ export function capture(dir, text, meta = {}) {
   return ref;
 }
 
-/** The capture record for a reference, or null. */
+/**
+ * The capture record for a reference, or null.
+ *
+ * ANCHORS ARE UNIONED ACROSS EVERY CAPTURE OF THIS REF. The ref is the hash of the BODY, which
+ * is exactly what makes the store converge -- and it means one ref legitimately spans captures
+ * made against DIFFERENT anchors: two byte-identical files, one generated file vendored into six
+ * directories (this module is itself vendored six times), the same command output captured
+ * against two operands. Taking only the last record checked staleness against whichever copy
+ * happened to be captured most recently, so editing the copy the caller actually asked about
+ * produced no stale marker at all.
+ *
+ * The OLDEST hash per anchor wins, which is the conservative direction: any change to any file
+ * that ever produced these bytes counts as staleness.
+ */
 function captureOf(dir, ref) {
-  return readMetrics(dir).filter((e) => e.kind === 'capture' && e.ref === ref).pop() || null;
+  const rows = readMetrics(dir).filter((e) => e.kind === 'capture' && e.ref === ref);
+  if (!rows.length) return null;
+  const byAnchor = new Map();
+  for (const row of rows) {
+    for (const entry of row.anchorHashes || []) {
+      if (!byAnchor.has(entry.anchor)) byAnchor.set(entry.anchor, entry);
+    }
+  }
+  return { ...rows[rows.length - 1], anchorHashes: [...byAnchor.values()] };
 }
 
 /**
@@ -163,6 +219,13 @@ export function refreshDecision(state) {
  * rather than having it executed underneath them.
  */
 export function resolve(dir, ref, { section } = {}) {
+  // The ref reaches this function straight from a model-supplied tool argument -- index.ts
+  // dispatches `expand` with request.params.arguments unvalidated, and the tool schema declares
+  // ref as a bare string. It is a content digest and nothing else, so anything that is not one
+  // is refused rather than joined into a path: `join` resolves `..`, so '../../notes' would read
+  // notes.txt from anywhere on disk and return it as the expansion of the pointer the caller was
+  // holding. digest() always produces exactly 16 lowercase hex characters, so this is exact.
+  if (typeof ref !== 'string' || !/^[0-9a-f]{16}$/.test(ref)) return null;
   const path = join(artifactDir(dir), `${ref}.txt`);
   let body;
   try {
@@ -173,9 +236,16 @@ export function resolve(dir, ref, { section } = {}) {
 
   const state = freshness(dir, ref);
   const decision = refreshDecision(state);
-
   const notes = [];
-  if (decision.action === 'serve-stale') {
+  if (decision.action === 'unknown') {
+    // The artifact outlived its capture record: metrics.jsonl is read as a bounded tail and the
+    // artifact store is never pruned, so this is the ordinary steady state rather than an edge
+    // case. Staleness is then unanswerable -- and unanswerable must not render as fresh. Serving
+    // a month-old build log about a file that has since been rewritten, unmarked, is what the
+    // module header calls worse than serving nothing.
+    notes.push('! UNVERIFIED -- no capture record survives for this reference, so whether the '
+      + 'code it describes has changed since cannot be determined. Treat it as historical.');
+  } else if (decision.action === 'serve-stale') {
     notes.push(`! STALE -- ${decision.changed.join(', ')} changed after this was captured. ` +
       'Treat it as historical.');
   } else if (decision.action === 'refresh') {
@@ -186,6 +256,8 @@ export function resolve(dir, ref, { section } = {}) {
     ref,
     text: notes.length ? `${notes.join('\n')}\n${body}` : body,
     stale: Boolean(state.stale),
+    // Distinguishes "checked and unchanged" from "could not be checked".
+    known: state.known !== false,
     decision: decision.action,
     section: section || null,
     // Nothing was spent producing this a second time. That is the number the
@@ -202,7 +274,20 @@ export function resolve(dir, ref, { section } = {}) {
  * xunit output are wrong specifically by dropping the first failing trace".
  */
 export function recordExpansion(dir, { ref, tool, shape, asked, sessionId } = {}) {
-  record(dir, { kind: 'expand', ref: ref || null, tool: tool || null, shape: shape || null, asked: asked || null, sessionId: sessionId || null });
+  // BACKFILLED FROM THE CAPTURE, because the caller of `expand` holds a ref and nothing else.
+  // Written without tool and shape, every expand event filed as null/null -- and previewPolicy's
+  // per-(tool, shape) filter then matched none of them, pinning holdRate at 1, strength at 0 and
+  // boosts permanently {}. The refit was inert in production while the suite passed by supplying
+  // a shape the real caller never has.
+  const cap = ref ? captureOf(dir, ref) : null;
+  record(dir, {
+    kind: 'expand',
+    ref: ref || null,
+    tool: tool || cap?.tool || null,
+    shape: shape || cap?.shape || null,
+    asked: asked || null,
+    sessionId: sessionId || null,
+  });
 }
 
 /**
@@ -289,7 +374,11 @@ export function previewQuality(dir) {
     shapes.get(shape).served += 1;
   }
   for (const exp of expansions) {
-    const shape = exp.shape || 'plain';
+    // NOT `|| 'plain'`. 'plain' is a REAL shape parseShape returns, so folding shapeless events
+    // into it charges expansions to a shape that was never expanded -- and that is then the
+    // shape the panel names as the worst one. An 'unknown' bucket has served 0 and is skipped by
+    // the served < 3 guard below, which is the right treatment for an unattributable event.
+    const shape = exp.shape || 'unknown';
     if (!shapes.has(shape)) shapes.set(shape, { served: 0, expanded: 0 });
     shapes.get(shape).expanded += 1;
   }

--- a/integrations/codex/hooks/lib/expand.mjs
+++ b/integrations/codex/hooks/lib/expand.mjs
@@ -33,11 +33,13 @@
  */
 
 import { createHash } from 'node:crypto';
-import { readFileSync, writeFileSync, mkdirSync, existsSync, chmodSync } from 'node:fs';
+import {
+  readFileSync, writeFileSync, mkdirSync, existsSync, chmodSync,
+  readdirSync, statSync, unlinkSync,
+} from 'node:fs';
 import { join } from 'node:path';
 import { record, readMetrics } from './metrics.mjs';
 import { putNode, putEdge, nodeId } from './wiki.mjs';
-import { checkAnchor } from './staleness.mjs';
 import { canonicalPath } from './paths.mjs';
 
 /** A stale artifact cheaper than this to regenerate is refreshed, not served. */
@@ -46,7 +48,35 @@ export const CHEAP_REGEN_MS = 3000;
 /** Expansions below this rate mean the preview policy is working. */
 export const HEALTHY_HOLD_RATE = 0.85;
 
+/**
+ * How long an artifact is kept. STATED, not silent.
+ *
+ * The store was otherwise write-only: every disclosed tool result landed here forever, while its
+ * capture record ages out of the bounded metrics window -- so most files on disk were already
+ * unreachable and could not even be resolved usefully, only occupy space. Content addressing
+ * dedupes byte-identical bodies but not near-identical ones, so two runs of the same suite
+ * differing only in elapsed-ms are two files.
+ *
+ * A bound nobody can see would be worse than none, so it is exported and documented alongside
+ * the rest of the module's stated properties.
+ */
+export const ARTIFACT_TTL_MS = 30 * 86_400_000;
+
 const digest = (text) => createHash('sha256').update(String(text)).digest('hex').slice(0, 16);
+
+/** Removes artifacts past the TTL. A sweep must never break a capture. */
+function sweepArtifacts(path) {
+  try {
+    const cutoff = Date.now() - ARTIFACT_TTL_MS;
+    for (const name of readdirSync(path)) {
+      if (!name.endsWith('.txt')) continue;
+      const file = join(path, name);
+      try {
+        if (statSync(file).mtimeMs < cutoff) unlinkSync(file);
+      } catch { /* raced with another sweep or a reader */ }
+    }
+  } catch { /* no store yet, or unreadable -- neither is worth failing a capture over */ }
+}
 
 function artifactDir(dir) {
   const path = join(dir, 'artifacts');
@@ -72,7 +102,12 @@ export function capture(dir, text, meta = {}) {
 
   const ref = digest(body);
   const path = join(artifactDir(dir), `${ref}.txt`);
-  if (!existsSync(path)) writeFileSync(path, body, { mode: 0o600 });
+  if (!existsSync(path)) {
+    writeFileSync(path, body, { mode: 0o600 });
+    // Amortised off the digest rather than run on every capture, and deterministic rather than
+    // sampled at random: roughly one write in sixty-four pays for a readdir.
+    if (parseInt(ref.slice(0, 2), 16) < 4) sweepArtifacts(artifactDir(dir));
+  }
 
   const anchors = (meta.anchors || []).map((a) => canonicalPath(a));
   record(dir, {
@@ -101,9 +136,30 @@ export function capture(dir, text, meta = {}) {
   return ref;
 }
 
-/** The capture record for a reference, or null. */
+/**
+ * The capture record for a reference, or null.
+ *
+ * ANCHORS ARE UNIONED ACROSS EVERY CAPTURE OF THIS REF. The ref is the hash of the BODY, which
+ * is exactly what makes the store converge -- and it means one ref legitimately spans captures
+ * made against DIFFERENT anchors: two byte-identical files, one generated file vendored into six
+ * directories (this module is itself vendored six times), the same command output captured
+ * against two operands. Taking only the last record checked staleness against whichever copy
+ * happened to be captured most recently, so editing the copy the caller actually asked about
+ * produced no stale marker at all.
+ *
+ * The OLDEST hash per anchor wins, which is the conservative direction: any change to any file
+ * that ever produced these bytes counts as staleness.
+ */
 function captureOf(dir, ref) {
-  return readMetrics(dir).filter((e) => e.kind === 'capture' && e.ref === ref).pop() || null;
+  const rows = readMetrics(dir).filter((e) => e.kind === 'capture' && e.ref === ref);
+  if (!rows.length) return null;
+  const byAnchor = new Map();
+  for (const row of rows) {
+    for (const entry of row.anchorHashes || []) {
+      if (!byAnchor.has(entry.anchor)) byAnchor.set(entry.anchor, entry);
+    }
+  }
+  return { ...rows[rows.length - 1], anchorHashes: [...byAnchor.values()] };
 }
 
 /**
@@ -165,6 +221,13 @@ export function refreshDecision(state) {
  * rather than having it executed underneath them.
  */
 export function resolve(dir, ref, { section } = {}) {
+  // The ref reaches this function straight from a model-supplied tool argument -- index.ts
+  // dispatches `expand` with request.params.arguments unvalidated, and the tool schema declares
+  // ref as a bare string. It is a content digest and nothing else, so anything that is not one
+  // is refused rather than joined into a path: `join` resolves `..`, so '../../notes' would read
+  // notes.txt from anywhere on disk and return it as the expansion of the pointer the caller was
+  // holding. digest() always produces exactly 16 lowercase hex characters, so this is exact.
+  if (typeof ref !== 'string' || !/^[0-9a-f]{16}$/.test(ref)) return null;
   const path = join(artifactDir(dir), `${ref}.txt`);
   let body;
   try {
@@ -175,9 +238,16 @@ export function resolve(dir, ref, { section } = {}) {
 
   const state = freshness(dir, ref);
   const decision = refreshDecision(state);
-
   const notes = [];
-  if (decision.action === 'serve-stale') {
+  if (decision.action === 'unknown') {
+    // The artifact outlived its capture record: metrics.jsonl is read as a bounded tail and the
+    // artifact store is never pruned, so this is the ordinary steady state rather than an edge
+    // case. Staleness is then unanswerable -- and unanswerable must not render as fresh. Serving
+    // a month-old build log about a file that has since been rewritten, unmarked, is what the
+    // module header calls worse than serving nothing.
+    notes.push('! UNVERIFIED -- no capture record survives for this reference, so whether the '
+      + 'code it describes has changed since cannot be determined. Treat it as historical.');
+  } else if (decision.action === 'serve-stale') {
     notes.push(`! STALE -- ${decision.changed.join(', ')} changed after this was captured. ` +
       'Treat it as historical.');
   } else if (decision.action === 'refresh') {
@@ -188,6 +258,8 @@ export function resolve(dir, ref, { section } = {}) {
     ref,
     text: notes.length ? `${notes.join('\n')}\n${body}` : body,
     stale: Boolean(state.stale),
+    // Distinguishes "checked and unchanged" from "could not be checked".
+    known: state.known !== false,
     decision: decision.action,
     section: section || null,
     // Nothing was spent producing this a second time. That is the number the
@@ -204,7 +276,20 @@ export function resolve(dir, ref, { section } = {}) {
  * xunit output are wrong specifically by dropping the first failing trace".
  */
 export function recordExpansion(dir, { ref, tool, shape, asked, sessionId } = {}) {
-  record(dir, { kind: 'expand', ref: ref || null, tool: tool || null, shape: shape || null, asked: asked || null, sessionId: sessionId || null });
+  // BACKFILLED FROM THE CAPTURE, because the caller of `expand` holds a ref and nothing else.
+  // Written without tool and shape, every expand event filed as null/null -- and previewPolicy's
+  // per-(tool, shape) filter then matched none of them, pinning holdRate at 1, strength at 0 and
+  // boosts permanently {}. The refit was inert in production while the suite passed by supplying
+  // a shape the real caller never has.
+  const cap = ref ? captureOf(dir, ref) : null;
+  record(dir, {
+    kind: 'expand',
+    ref: ref || null,
+    tool: tool || cap?.tool || null,
+    shape: shape || cap?.shape || null,
+    asked: asked || null,
+    sessionId: sessionId || null,
+  });
 }
 
 /**
@@ -291,7 +376,11 @@ export function previewQuality(dir) {
     shapes.get(shape).served += 1;
   }
   for (const exp of expansions) {
-    const shape = exp.shape || 'plain';
+    // NOT `|| 'plain'`. 'plain' is a REAL shape parseShape returns, so folding shapeless events
+    // into it charges expansions to a shape that was never expanded -- and that is then the
+    // shape the panel names as the worst one. An 'unknown' bucket has served 0 and is skipped by
+    // the served < 3 guard below, which is the right treatment for an unattributable event.
+    const shape = exp.shape || 'unknown';
     if (!shapes.has(shape)) shapes.set(shape, { served: 0, expanded: 0 });
     shapes.get(shape).expanded += 1;
   }

--- a/integrations/codex/hooks/lib/expand.mjs
+++ b/integrations/codex/hooks/lib/expand.mjs
@@ -151,7 +151,14 @@ export function capture(dir, text, meta = {}) {
  * that ever produced these bytes counts as staleness.
  */
 function captureOf(dir, ref) {
-  const rows = readMetrics(dir).filter((e) => e.kind === 'capture' && e.ref === ref);
+  const rows = readMetrics(dir)
+    .filter((e) => e.kind === 'capture' && e.ref === ref)
+    // SORTED, rather than trusting the reader's order. "Oldest hash per anchor wins" and "the
+    // latest capture supplies the rest of the record" are both statements about TIME, and
+    // readMetrics returns whatever order the log and its tail slice produce. Relying on write
+    // order makes the conservative direction accidental. Ties keep their relative order, since
+    // sort is stable and two rows in the same millisecond have no better ordering available.
+    .sort((a, b) => (a.at ?? 0) - (b.at ?? 0));
   if (!rows.length) return null;
   const byAnchor = new Map();
   for (const row of rows) {

--- a/integrations/codex/plugin/hooks/lib/expand.mjs
+++ b/integrations/codex/plugin/hooks/lib/expand.mjs
@@ -33,11 +33,13 @@
  */
 
 import { createHash } from 'node:crypto';
-import { readFileSync, writeFileSync, mkdirSync, existsSync, chmodSync } from 'node:fs';
+import {
+  readFileSync, writeFileSync, mkdirSync, existsSync, chmodSync,
+  readdirSync, statSync, unlinkSync,
+} from 'node:fs';
 import { join } from 'node:path';
 import { record, readMetrics } from './metrics.mjs';
 import { putNode, putEdge, nodeId } from './wiki.mjs';
-import { checkAnchor } from './staleness.mjs';
 import { canonicalPath } from './paths.mjs';
 
 /** A stale artifact cheaper than this to regenerate is refreshed, not served. */
@@ -46,7 +48,35 @@ export const CHEAP_REGEN_MS = 3000;
 /** Expansions below this rate mean the preview policy is working. */
 export const HEALTHY_HOLD_RATE = 0.85;
 
+/**
+ * How long an artifact is kept. STATED, not silent.
+ *
+ * The store was otherwise write-only: every disclosed tool result landed here forever, while its
+ * capture record ages out of the bounded metrics window -- so most files on disk were already
+ * unreachable and could not even be resolved usefully, only occupy space. Content addressing
+ * dedupes byte-identical bodies but not near-identical ones, so two runs of the same suite
+ * differing only in elapsed-ms are two files.
+ *
+ * A bound nobody can see would be worse than none, so it is exported and documented alongside
+ * the rest of the module's stated properties.
+ */
+export const ARTIFACT_TTL_MS = 30 * 86_400_000;
+
 const digest = (text) => createHash('sha256').update(String(text)).digest('hex').slice(0, 16);
+
+/** Removes artifacts past the TTL. A sweep must never break a capture. */
+function sweepArtifacts(path) {
+  try {
+    const cutoff = Date.now() - ARTIFACT_TTL_MS;
+    for (const name of readdirSync(path)) {
+      if (!name.endsWith('.txt')) continue;
+      const file = join(path, name);
+      try {
+        if (statSync(file).mtimeMs < cutoff) unlinkSync(file);
+      } catch { /* raced with another sweep or a reader */ }
+    }
+  } catch { /* no store yet, or unreadable -- neither is worth failing a capture over */ }
+}
 
 function artifactDir(dir) {
   const path = join(dir, 'artifacts');
@@ -72,7 +102,12 @@ export function capture(dir, text, meta = {}) {
 
   const ref = digest(body);
   const path = join(artifactDir(dir), `${ref}.txt`);
-  if (!existsSync(path)) writeFileSync(path, body, { mode: 0o600 });
+  if (!existsSync(path)) {
+    writeFileSync(path, body, { mode: 0o600 });
+    // Amortised off the digest rather than run on every capture, and deterministic rather than
+    // sampled at random: roughly one write in sixty-four pays for a readdir.
+    if (parseInt(ref.slice(0, 2), 16) < 4) sweepArtifacts(artifactDir(dir));
+  }
 
   const anchors = (meta.anchors || []).map((a) => canonicalPath(a));
   record(dir, {
@@ -101,9 +136,30 @@ export function capture(dir, text, meta = {}) {
   return ref;
 }
 
-/** The capture record for a reference, or null. */
+/**
+ * The capture record for a reference, or null.
+ *
+ * ANCHORS ARE UNIONED ACROSS EVERY CAPTURE OF THIS REF. The ref is the hash of the BODY, which
+ * is exactly what makes the store converge -- and it means one ref legitimately spans captures
+ * made against DIFFERENT anchors: two byte-identical files, one generated file vendored into six
+ * directories (this module is itself vendored six times), the same command output captured
+ * against two operands. Taking only the last record checked staleness against whichever copy
+ * happened to be captured most recently, so editing the copy the caller actually asked about
+ * produced no stale marker at all.
+ *
+ * The OLDEST hash per anchor wins, which is the conservative direction: any change to any file
+ * that ever produced these bytes counts as staleness.
+ */
 function captureOf(dir, ref) {
-  return readMetrics(dir).filter((e) => e.kind === 'capture' && e.ref === ref).pop() || null;
+  const rows = readMetrics(dir).filter((e) => e.kind === 'capture' && e.ref === ref);
+  if (!rows.length) return null;
+  const byAnchor = new Map();
+  for (const row of rows) {
+    for (const entry of row.anchorHashes || []) {
+      if (!byAnchor.has(entry.anchor)) byAnchor.set(entry.anchor, entry);
+    }
+  }
+  return { ...rows[rows.length - 1], anchorHashes: [...byAnchor.values()] };
 }
 
 /**
@@ -165,6 +221,13 @@ export function refreshDecision(state) {
  * rather than having it executed underneath them.
  */
 export function resolve(dir, ref, { section } = {}) {
+  // The ref reaches this function straight from a model-supplied tool argument -- index.ts
+  // dispatches `expand` with request.params.arguments unvalidated, and the tool schema declares
+  // ref as a bare string. It is a content digest and nothing else, so anything that is not one
+  // is refused rather than joined into a path: `join` resolves `..`, so '../../notes' would read
+  // notes.txt from anywhere on disk and return it as the expansion of the pointer the caller was
+  // holding. digest() always produces exactly 16 lowercase hex characters, so this is exact.
+  if (typeof ref !== 'string' || !/^[0-9a-f]{16}$/.test(ref)) return null;
   const path = join(artifactDir(dir), `${ref}.txt`);
   let body;
   try {
@@ -175,9 +238,16 @@ export function resolve(dir, ref, { section } = {}) {
 
   const state = freshness(dir, ref);
   const decision = refreshDecision(state);
-
   const notes = [];
-  if (decision.action === 'serve-stale') {
+  if (decision.action === 'unknown') {
+    // The artifact outlived its capture record: metrics.jsonl is read as a bounded tail and the
+    // artifact store is never pruned, so this is the ordinary steady state rather than an edge
+    // case. Staleness is then unanswerable -- and unanswerable must not render as fresh. Serving
+    // a month-old build log about a file that has since been rewritten, unmarked, is what the
+    // module header calls worse than serving nothing.
+    notes.push('! UNVERIFIED -- no capture record survives for this reference, so whether the '
+      + 'code it describes has changed since cannot be determined. Treat it as historical.');
+  } else if (decision.action === 'serve-stale') {
     notes.push(`! STALE -- ${decision.changed.join(', ')} changed after this was captured. ` +
       'Treat it as historical.');
   } else if (decision.action === 'refresh') {
@@ -188,6 +258,8 @@ export function resolve(dir, ref, { section } = {}) {
     ref,
     text: notes.length ? `${notes.join('\n')}\n${body}` : body,
     stale: Boolean(state.stale),
+    // Distinguishes "checked and unchanged" from "could not be checked".
+    known: state.known !== false,
     decision: decision.action,
     section: section || null,
     // Nothing was spent producing this a second time. That is the number the
@@ -204,7 +276,20 @@ export function resolve(dir, ref, { section } = {}) {
  * xunit output are wrong specifically by dropping the first failing trace".
  */
 export function recordExpansion(dir, { ref, tool, shape, asked, sessionId } = {}) {
-  record(dir, { kind: 'expand', ref: ref || null, tool: tool || null, shape: shape || null, asked: asked || null, sessionId: sessionId || null });
+  // BACKFILLED FROM THE CAPTURE, because the caller of `expand` holds a ref and nothing else.
+  // Written without tool and shape, every expand event filed as null/null -- and previewPolicy's
+  // per-(tool, shape) filter then matched none of them, pinning holdRate at 1, strength at 0 and
+  // boosts permanently {}. The refit was inert in production while the suite passed by supplying
+  // a shape the real caller never has.
+  const cap = ref ? captureOf(dir, ref) : null;
+  record(dir, {
+    kind: 'expand',
+    ref: ref || null,
+    tool: tool || cap?.tool || null,
+    shape: shape || cap?.shape || null,
+    asked: asked || null,
+    sessionId: sessionId || null,
+  });
 }
 
 /**
@@ -291,7 +376,11 @@ export function previewQuality(dir) {
     shapes.get(shape).served += 1;
   }
   for (const exp of expansions) {
-    const shape = exp.shape || 'plain';
+    // NOT `|| 'plain'`. 'plain' is a REAL shape parseShape returns, so folding shapeless events
+    // into it charges expansions to a shape that was never expanded -- and that is then the
+    // shape the panel names as the worst one. An 'unknown' bucket has served 0 and is skipped by
+    // the served < 3 guard below, which is the right treatment for an unattributable event.
+    const shape = exp.shape || 'unknown';
     if (!shapes.has(shape)) shapes.set(shape, { served: 0, expanded: 0 });
     shapes.get(shape).expanded += 1;
   }

--- a/integrations/codex/plugin/hooks/lib/expand.mjs
+++ b/integrations/codex/plugin/hooks/lib/expand.mjs
@@ -151,7 +151,14 @@ export function capture(dir, text, meta = {}) {
  * that ever produced these bytes counts as staleness.
  */
 function captureOf(dir, ref) {
-  const rows = readMetrics(dir).filter((e) => e.kind === 'capture' && e.ref === ref);
+  const rows = readMetrics(dir)
+    .filter((e) => e.kind === 'capture' && e.ref === ref)
+    // SORTED, rather than trusting the reader's order. "Oldest hash per anchor wins" and "the
+    // latest capture supplies the rest of the record" are both statements about TIME, and
+    // readMetrics returns whatever order the log and its tail slice produce. Relying on write
+    // order makes the conservative direction accidental. Ties keep their relative order, since
+    // sort is stable and two rows in the same millisecond have no better ordering available.
+    .sort((a, b) => (a.at ?? 0) - (b.at ?? 0));
   if (!rows.length) return null;
   const byAnchor = new Map();
   for (const row of rows) {

--- a/integrations/gemini/hooks/lib/expand.mjs
+++ b/integrations/gemini/hooks/lib/expand.mjs
@@ -33,11 +33,13 @@
  */
 
 import { createHash } from 'node:crypto';
-import { readFileSync, writeFileSync, mkdirSync, existsSync, chmodSync } from 'node:fs';
+import {
+  readFileSync, writeFileSync, mkdirSync, existsSync, chmodSync,
+  readdirSync, statSync, unlinkSync,
+} from 'node:fs';
 import { join } from 'node:path';
 import { record, readMetrics } from './metrics.mjs';
 import { putNode, putEdge, nodeId } from './wiki.mjs';
-import { checkAnchor } from './staleness.mjs';
 import { canonicalPath } from './paths.mjs';
 
 /** A stale artifact cheaper than this to regenerate is refreshed, not served. */
@@ -46,7 +48,35 @@ export const CHEAP_REGEN_MS = 3000;
 /** Expansions below this rate mean the preview policy is working. */
 export const HEALTHY_HOLD_RATE = 0.85;
 
+/**
+ * How long an artifact is kept. STATED, not silent.
+ *
+ * The store was otherwise write-only: every disclosed tool result landed here forever, while its
+ * capture record ages out of the bounded metrics window -- so most files on disk were already
+ * unreachable and could not even be resolved usefully, only occupy space. Content addressing
+ * dedupes byte-identical bodies but not near-identical ones, so two runs of the same suite
+ * differing only in elapsed-ms are two files.
+ *
+ * A bound nobody can see would be worse than none, so it is exported and documented alongside
+ * the rest of the module's stated properties.
+ */
+export const ARTIFACT_TTL_MS = 30 * 86_400_000;
+
 const digest = (text) => createHash('sha256').update(String(text)).digest('hex').slice(0, 16);
+
+/** Removes artifacts past the TTL. A sweep must never break a capture. */
+function sweepArtifacts(path) {
+  try {
+    const cutoff = Date.now() - ARTIFACT_TTL_MS;
+    for (const name of readdirSync(path)) {
+      if (!name.endsWith('.txt')) continue;
+      const file = join(path, name);
+      try {
+        if (statSync(file).mtimeMs < cutoff) unlinkSync(file);
+      } catch { /* raced with another sweep or a reader */ }
+    }
+  } catch { /* no store yet, or unreadable -- neither is worth failing a capture over */ }
+}
 
 function artifactDir(dir) {
   const path = join(dir, 'artifacts');
@@ -72,7 +102,12 @@ export function capture(dir, text, meta = {}) {
 
   const ref = digest(body);
   const path = join(artifactDir(dir), `${ref}.txt`);
-  if (!existsSync(path)) writeFileSync(path, body, { mode: 0o600 });
+  if (!existsSync(path)) {
+    writeFileSync(path, body, { mode: 0o600 });
+    // Amortised off the digest rather than run on every capture, and deterministic rather than
+    // sampled at random: roughly one write in sixty-four pays for a readdir.
+    if (parseInt(ref.slice(0, 2), 16) < 4) sweepArtifacts(artifactDir(dir));
+  }
 
   const anchors = (meta.anchors || []).map((a) => canonicalPath(a));
   record(dir, {
@@ -101,9 +136,30 @@ export function capture(dir, text, meta = {}) {
   return ref;
 }
 
-/** The capture record for a reference, or null. */
+/**
+ * The capture record for a reference, or null.
+ *
+ * ANCHORS ARE UNIONED ACROSS EVERY CAPTURE OF THIS REF. The ref is the hash of the BODY, which
+ * is exactly what makes the store converge -- and it means one ref legitimately spans captures
+ * made against DIFFERENT anchors: two byte-identical files, one generated file vendored into six
+ * directories (this module is itself vendored six times), the same command output captured
+ * against two operands. Taking only the last record checked staleness against whichever copy
+ * happened to be captured most recently, so editing the copy the caller actually asked about
+ * produced no stale marker at all.
+ *
+ * The OLDEST hash per anchor wins, which is the conservative direction: any change to any file
+ * that ever produced these bytes counts as staleness.
+ */
 function captureOf(dir, ref) {
-  return readMetrics(dir).filter((e) => e.kind === 'capture' && e.ref === ref).pop() || null;
+  const rows = readMetrics(dir).filter((e) => e.kind === 'capture' && e.ref === ref);
+  if (!rows.length) return null;
+  const byAnchor = new Map();
+  for (const row of rows) {
+    for (const entry of row.anchorHashes || []) {
+      if (!byAnchor.has(entry.anchor)) byAnchor.set(entry.anchor, entry);
+    }
+  }
+  return { ...rows[rows.length - 1], anchorHashes: [...byAnchor.values()] };
 }
 
 /**
@@ -165,6 +221,13 @@ export function refreshDecision(state) {
  * rather than having it executed underneath them.
  */
 export function resolve(dir, ref, { section } = {}) {
+  // The ref reaches this function straight from a model-supplied tool argument -- index.ts
+  // dispatches `expand` with request.params.arguments unvalidated, and the tool schema declares
+  // ref as a bare string. It is a content digest and nothing else, so anything that is not one
+  // is refused rather than joined into a path: `join` resolves `..`, so '../../notes' would read
+  // notes.txt from anywhere on disk and return it as the expansion of the pointer the caller was
+  // holding. digest() always produces exactly 16 lowercase hex characters, so this is exact.
+  if (typeof ref !== 'string' || !/^[0-9a-f]{16}$/.test(ref)) return null;
   const path = join(artifactDir(dir), `${ref}.txt`);
   let body;
   try {
@@ -175,9 +238,16 @@ export function resolve(dir, ref, { section } = {}) {
 
   const state = freshness(dir, ref);
   const decision = refreshDecision(state);
-
   const notes = [];
-  if (decision.action === 'serve-stale') {
+  if (decision.action === 'unknown') {
+    // The artifact outlived its capture record: metrics.jsonl is read as a bounded tail and the
+    // artifact store is never pruned, so this is the ordinary steady state rather than an edge
+    // case. Staleness is then unanswerable -- and unanswerable must not render as fresh. Serving
+    // a month-old build log about a file that has since been rewritten, unmarked, is what the
+    // module header calls worse than serving nothing.
+    notes.push('! UNVERIFIED -- no capture record survives for this reference, so whether the '
+      + 'code it describes has changed since cannot be determined. Treat it as historical.');
+  } else if (decision.action === 'serve-stale') {
     notes.push(`! STALE -- ${decision.changed.join(', ')} changed after this was captured. ` +
       'Treat it as historical.');
   } else if (decision.action === 'refresh') {
@@ -188,6 +258,8 @@ export function resolve(dir, ref, { section } = {}) {
     ref,
     text: notes.length ? `${notes.join('\n')}\n${body}` : body,
     stale: Boolean(state.stale),
+    // Distinguishes "checked and unchanged" from "could not be checked".
+    known: state.known !== false,
     decision: decision.action,
     section: section || null,
     // Nothing was spent producing this a second time. That is the number the
@@ -204,7 +276,20 @@ export function resolve(dir, ref, { section } = {}) {
  * xunit output are wrong specifically by dropping the first failing trace".
  */
 export function recordExpansion(dir, { ref, tool, shape, asked, sessionId } = {}) {
-  record(dir, { kind: 'expand', ref: ref || null, tool: tool || null, shape: shape || null, asked: asked || null, sessionId: sessionId || null });
+  // BACKFILLED FROM THE CAPTURE, because the caller of `expand` holds a ref and nothing else.
+  // Written without tool and shape, every expand event filed as null/null -- and previewPolicy's
+  // per-(tool, shape) filter then matched none of them, pinning holdRate at 1, strength at 0 and
+  // boosts permanently {}. The refit was inert in production while the suite passed by supplying
+  // a shape the real caller never has.
+  const cap = ref ? captureOf(dir, ref) : null;
+  record(dir, {
+    kind: 'expand',
+    ref: ref || null,
+    tool: tool || cap?.tool || null,
+    shape: shape || cap?.shape || null,
+    asked: asked || null,
+    sessionId: sessionId || null,
+  });
 }
 
 /**
@@ -291,7 +376,11 @@ export function previewQuality(dir) {
     shapes.get(shape).served += 1;
   }
   for (const exp of expansions) {
-    const shape = exp.shape || 'plain';
+    // NOT `|| 'plain'`. 'plain' is a REAL shape parseShape returns, so folding shapeless events
+    // into it charges expansions to a shape that was never expanded -- and that is then the
+    // shape the panel names as the worst one. An 'unknown' bucket has served 0 and is skipped by
+    // the served < 3 guard below, which is the right treatment for an unattributable event.
+    const shape = exp.shape || 'unknown';
     if (!shapes.has(shape)) shapes.set(shape, { served: 0, expanded: 0 });
     shapes.get(shape).expanded += 1;
   }

--- a/integrations/gemini/hooks/lib/expand.mjs
+++ b/integrations/gemini/hooks/lib/expand.mjs
@@ -151,7 +151,14 @@ export function capture(dir, text, meta = {}) {
  * that ever produced these bytes counts as staleness.
  */
 function captureOf(dir, ref) {
-  const rows = readMetrics(dir).filter((e) => e.kind === 'capture' && e.ref === ref);
+  const rows = readMetrics(dir)
+    .filter((e) => e.kind === 'capture' && e.ref === ref)
+    // SORTED, rather than trusting the reader's order. "Oldest hash per anchor wins" and "the
+    // latest capture supplies the rest of the record" are both statements about TIME, and
+    // readMetrics returns whatever order the log and its tail slice produce. Relying on write
+    // order makes the conservative direction accidental. Ties keep their relative order, since
+    // sort is stable and two rows in the same millisecond have no better ordering available.
+    .sort((a, b) => (a.at ?? 0) - (b.at ?? 0));
   if (!rows.length) return null;
   const byAnchor = new Map();
   for (const row of rows) {

--- a/integrations/opencode/hooks/lib/expand.mjs
+++ b/integrations/opencode/hooks/lib/expand.mjs
@@ -33,11 +33,13 @@
  */
 
 import { createHash } from 'node:crypto';
-import { readFileSync, writeFileSync, mkdirSync, existsSync, chmodSync } from 'node:fs';
+import {
+  readFileSync, writeFileSync, mkdirSync, existsSync, chmodSync,
+  readdirSync, statSync, unlinkSync,
+} from 'node:fs';
 import { join } from 'node:path';
 import { record, readMetrics } from './metrics.mjs';
 import { putNode, putEdge, nodeId } from './wiki.mjs';
-import { checkAnchor } from './staleness.mjs';
 import { canonicalPath } from './paths.mjs';
 
 /** A stale artifact cheaper than this to regenerate is refreshed, not served. */
@@ -46,7 +48,35 @@ export const CHEAP_REGEN_MS = 3000;
 /** Expansions below this rate mean the preview policy is working. */
 export const HEALTHY_HOLD_RATE = 0.85;
 
+/**
+ * How long an artifact is kept. STATED, not silent.
+ *
+ * The store was otherwise write-only: every disclosed tool result landed here forever, while its
+ * capture record ages out of the bounded metrics window -- so most files on disk were already
+ * unreachable and could not even be resolved usefully, only occupy space. Content addressing
+ * dedupes byte-identical bodies but not near-identical ones, so two runs of the same suite
+ * differing only in elapsed-ms are two files.
+ *
+ * A bound nobody can see would be worse than none, so it is exported and documented alongside
+ * the rest of the module's stated properties.
+ */
+export const ARTIFACT_TTL_MS = 30 * 86_400_000;
+
 const digest = (text) => createHash('sha256').update(String(text)).digest('hex').slice(0, 16);
+
+/** Removes artifacts past the TTL. A sweep must never break a capture. */
+function sweepArtifacts(path) {
+  try {
+    const cutoff = Date.now() - ARTIFACT_TTL_MS;
+    for (const name of readdirSync(path)) {
+      if (!name.endsWith('.txt')) continue;
+      const file = join(path, name);
+      try {
+        if (statSync(file).mtimeMs < cutoff) unlinkSync(file);
+      } catch { /* raced with another sweep or a reader */ }
+    }
+  } catch { /* no store yet, or unreadable -- neither is worth failing a capture over */ }
+}
 
 function artifactDir(dir) {
   const path = join(dir, 'artifacts');
@@ -72,7 +102,12 @@ export function capture(dir, text, meta = {}) {
 
   const ref = digest(body);
   const path = join(artifactDir(dir), `${ref}.txt`);
-  if (!existsSync(path)) writeFileSync(path, body, { mode: 0o600 });
+  if (!existsSync(path)) {
+    writeFileSync(path, body, { mode: 0o600 });
+    // Amortised off the digest rather than run on every capture, and deterministic rather than
+    // sampled at random: roughly one write in sixty-four pays for a readdir.
+    if (parseInt(ref.slice(0, 2), 16) < 4) sweepArtifacts(artifactDir(dir));
+  }
 
   const anchors = (meta.anchors || []).map((a) => canonicalPath(a));
   record(dir, {
@@ -101,9 +136,30 @@ export function capture(dir, text, meta = {}) {
   return ref;
 }
 
-/** The capture record for a reference, or null. */
+/**
+ * The capture record for a reference, or null.
+ *
+ * ANCHORS ARE UNIONED ACROSS EVERY CAPTURE OF THIS REF. The ref is the hash of the BODY, which
+ * is exactly what makes the store converge -- and it means one ref legitimately spans captures
+ * made against DIFFERENT anchors: two byte-identical files, one generated file vendored into six
+ * directories (this module is itself vendored six times), the same command output captured
+ * against two operands. Taking only the last record checked staleness against whichever copy
+ * happened to be captured most recently, so editing the copy the caller actually asked about
+ * produced no stale marker at all.
+ *
+ * The OLDEST hash per anchor wins, which is the conservative direction: any change to any file
+ * that ever produced these bytes counts as staleness.
+ */
 function captureOf(dir, ref) {
-  return readMetrics(dir).filter((e) => e.kind === 'capture' && e.ref === ref).pop() || null;
+  const rows = readMetrics(dir).filter((e) => e.kind === 'capture' && e.ref === ref);
+  if (!rows.length) return null;
+  const byAnchor = new Map();
+  for (const row of rows) {
+    for (const entry of row.anchorHashes || []) {
+      if (!byAnchor.has(entry.anchor)) byAnchor.set(entry.anchor, entry);
+    }
+  }
+  return { ...rows[rows.length - 1], anchorHashes: [...byAnchor.values()] };
 }
 
 /**
@@ -165,6 +221,13 @@ export function refreshDecision(state) {
  * rather than having it executed underneath them.
  */
 export function resolve(dir, ref, { section } = {}) {
+  // The ref reaches this function straight from a model-supplied tool argument -- index.ts
+  // dispatches `expand` with request.params.arguments unvalidated, and the tool schema declares
+  // ref as a bare string. It is a content digest and nothing else, so anything that is not one
+  // is refused rather than joined into a path: `join` resolves `..`, so '../../notes' would read
+  // notes.txt from anywhere on disk and return it as the expansion of the pointer the caller was
+  // holding. digest() always produces exactly 16 lowercase hex characters, so this is exact.
+  if (typeof ref !== 'string' || !/^[0-9a-f]{16}$/.test(ref)) return null;
   const path = join(artifactDir(dir), `${ref}.txt`);
   let body;
   try {
@@ -175,9 +238,16 @@ export function resolve(dir, ref, { section } = {}) {
 
   const state = freshness(dir, ref);
   const decision = refreshDecision(state);
-
   const notes = [];
-  if (decision.action === 'serve-stale') {
+  if (decision.action === 'unknown') {
+    // The artifact outlived its capture record: metrics.jsonl is read as a bounded tail and the
+    // artifact store is never pruned, so this is the ordinary steady state rather than an edge
+    // case. Staleness is then unanswerable -- and unanswerable must not render as fresh. Serving
+    // a month-old build log about a file that has since been rewritten, unmarked, is what the
+    // module header calls worse than serving nothing.
+    notes.push('! UNVERIFIED -- no capture record survives for this reference, so whether the '
+      + 'code it describes has changed since cannot be determined. Treat it as historical.');
+  } else if (decision.action === 'serve-stale') {
     notes.push(`! STALE -- ${decision.changed.join(', ')} changed after this was captured. ` +
       'Treat it as historical.');
   } else if (decision.action === 'refresh') {
@@ -188,6 +258,8 @@ export function resolve(dir, ref, { section } = {}) {
     ref,
     text: notes.length ? `${notes.join('\n')}\n${body}` : body,
     stale: Boolean(state.stale),
+    // Distinguishes "checked and unchanged" from "could not be checked".
+    known: state.known !== false,
     decision: decision.action,
     section: section || null,
     // Nothing was spent producing this a second time. That is the number the
@@ -204,7 +276,20 @@ export function resolve(dir, ref, { section } = {}) {
  * xunit output are wrong specifically by dropping the first failing trace".
  */
 export function recordExpansion(dir, { ref, tool, shape, asked, sessionId } = {}) {
-  record(dir, { kind: 'expand', ref: ref || null, tool: tool || null, shape: shape || null, asked: asked || null, sessionId: sessionId || null });
+  // BACKFILLED FROM THE CAPTURE, because the caller of `expand` holds a ref and nothing else.
+  // Written without tool and shape, every expand event filed as null/null -- and previewPolicy's
+  // per-(tool, shape) filter then matched none of them, pinning holdRate at 1, strength at 0 and
+  // boosts permanently {}. The refit was inert in production while the suite passed by supplying
+  // a shape the real caller never has.
+  const cap = ref ? captureOf(dir, ref) : null;
+  record(dir, {
+    kind: 'expand',
+    ref: ref || null,
+    tool: tool || cap?.tool || null,
+    shape: shape || cap?.shape || null,
+    asked: asked || null,
+    sessionId: sessionId || null,
+  });
 }
 
 /**
@@ -291,7 +376,11 @@ export function previewQuality(dir) {
     shapes.get(shape).served += 1;
   }
   for (const exp of expansions) {
-    const shape = exp.shape || 'plain';
+    // NOT `|| 'plain'`. 'plain' is a REAL shape parseShape returns, so folding shapeless events
+    // into it charges expansions to a shape that was never expanded -- and that is then the
+    // shape the panel names as the worst one. An 'unknown' bucket has served 0 and is skipped by
+    // the served < 3 guard below, which is the right treatment for an unattributable event.
+    const shape = exp.shape || 'unknown';
     if (!shapes.has(shape)) shapes.set(shape, { served: 0, expanded: 0 });
     shapes.get(shape).expanded += 1;
   }

--- a/integrations/opencode/hooks/lib/expand.mjs
+++ b/integrations/opencode/hooks/lib/expand.mjs
@@ -151,7 +151,14 @@ export function capture(dir, text, meta = {}) {
  * that ever produced these bytes counts as staleness.
  */
 function captureOf(dir, ref) {
-  const rows = readMetrics(dir).filter((e) => e.kind === 'capture' && e.ref === ref);
+  const rows = readMetrics(dir)
+    .filter((e) => e.kind === 'capture' && e.ref === ref)
+    // SORTED, rather than trusting the reader's order. "Oldest hash per anchor wins" and "the
+    // latest capture supplies the rest of the record" are both statements about TIME, and
+    // readMetrics returns whatever order the log and its tail slice produce. Relying on write
+    // order makes the conservative direction accidental. Ties keep their relative order, since
+    // sort is stable and two rows in the same millisecond have no better ordering available.
+    .sort((a, b) => (a.at ?? 0) - (b.at ?? 0));
   if (!rows.length) return null;
   const byAnchor = new Map();
   for (const row of rows) {

--- a/integrations/qwen/hooks/lib/expand.mjs
+++ b/integrations/qwen/hooks/lib/expand.mjs
@@ -33,11 +33,13 @@
  */
 
 import { createHash } from 'node:crypto';
-import { readFileSync, writeFileSync, mkdirSync, existsSync, chmodSync } from 'node:fs';
+import {
+  readFileSync, writeFileSync, mkdirSync, existsSync, chmodSync,
+  readdirSync, statSync, unlinkSync,
+} from 'node:fs';
 import { join } from 'node:path';
 import { record, readMetrics } from './metrics.mjs';
 import { putNode, putEdge, nodeId } from './wiki.mjs';
-import { checkAnchor } from './staleness.mjs';
 import { canonicalPath } from './paths.mjs';
 
 /** A stale artifact cheaper than this to regenerate is refreshed, not served. */
@@ -46,7 +48,35 @@ export const CHEAP_REGEN_MS = 3000;
 /** Expansions below this rate mean the preview policy is working. */
 export const HEALTHY_HOLD_RATE = 0.85;
 
+/**
+ * How long an artifact is kept. STATED, not silent.
+ *
+ * The store was otherwise write-only: every disclosed tool result landed here forever, while its
+ * capture record ages out of the bounded metrics window -- so most files on disk were already
+ * unreachable and could not even be resolved usefully, only occupy space. Content addressing
+ * dedupes byte-identical bodies but not near-identical ones, so two runs of the same suite
+ * differing only in elapsed-ms are two files.
+ *
+ * A bound nobody can see would be worse than none, so it is exported and documented alongside
+ * the rest of the module's stated properties.
+ */
+export const ARTIFACT_TTL_MS = 30 * 86_400_000;
+
 const digest = (text) => createHash('sha256').update(String(text)).digest('hex').slice(0, 16);
+
+/** Removes artifacts past the TTL. A sweep must never break a capture. */
+function sweepArtifacts(path) {
+  try {
+    const cutoff = Date.now() - ARTIFACT_TTL_MS;
+    for (const name of readdirSync(path)) {
+      if (!name.endsWith('.txt')) continue;
+      const file = join(path, name);
+      try {
+        if (statSync(file).mtimeMs < cutoff) unlinkSync(file);
+      } catch { /* raced with another sweep or a reader */ }
+    }
+  } catch { /* no store yet, or unreadable -- neither is worth failing a capture over */ }
+}
 
 function artifactDir(dir) {
   const path = join(dir, 'artifacts');
@@ -72,7 +102,12 @@ export function capture(dir, text, meta = {}) {
 
   const ref = digest(body);
   const path = join(artifactDir(dir), `${ref}.txt`);
-  if (!existsSync(path)) writeFileSync(path, body, { mode: 0o600 });
+  if (!existsSync(path)) {
+    writeFileSync(path, body, { mode: 0o600 });
+    // Amortised off the digest rather than run on every capture, and deterministic rather than
+    // sampled at random: roughly one write in sixty-four pays for a readdir.
+    if (parseInt(ref.slice(0, 2), 16) < 4) sweepArtifacts(artifactDir(dir));
+  }
 
   const anchors = (meta.anchors || []).map((a) => canonicalPath(a));
   record(dir, {
@@ -101,9 +136,30 @@ export function capture(dir, text, meta = {}) {
   return ref;
 }
 
-/** The capture record for a reference, or null. */
+/**
+ * The capture record for a reference, or null.
+ *
+ * ANCHORS ARE UNIONED ACROSS EVERY CAPTURE OF THIS REF. The ref is the hash of the BODY, which
+ * is exactly what makes the store converge -- and it means one ref legitimately spans captures
+ * made against DIFFERENT anchors: two byte-identical files, one generated file vendored into six
+ * directories (this module is itself vendored six times), the same command output captured
+ * against two operands. Taking only the last record checked staleness against whichever copy
+ * happened to be captured most recently, so editing the copy the caller actually asked about
+ * produced no stale marker at all.
+ *
+ * The OLDEST hash per anchor wins, which is the conservative direction: any change to any file
+ * that ever produced these bytes counts as staleness.
+ */
 function captureOf(dir, ref) {
-  return readMetrics(dir).filter((e) => e.kind === 'capture' && e.ref === ref).pop() || null;
+  const rows = readMetrics(dir).filter((e) => e.kind === 'capture' && e.ref === ref);
+  if (!rows.length) return null;
+  const byAnchor = new Map();
+  for (const row of rows) {
+    for (const entry of row.anchorHashes || []) {
+      if (!byAnchor.has(entry.anchor)) byAnchor.set(entry.anchor, entry);
+    }
+  }
+  return { ...rows[rows.length - 1], anchorHashes: [...byAnchor.values()] };
 }
 
 /**
@@ -165,6 +221,13 @@ export function refreshDecision(state) {
  * rather than having it executed underneath them.
  */
 export function resolve(dir, ref, { section } = {}) {
+  // The ref reaches this function straight from a model-supplied tool argument -- index.ts
+  // dispatches `expand` with request.params.arguments unvalidated, and the tool schema declares
+  // ref as a bare string. It is a content digest and nothing else, so anything that is not one
+  // is refused rather than joined into a path: `join` resolves `..`, so '../../notes' would read
+  // notes.txt from anywhere on disk and return it as the expansion of the pointer the caller was
+  // holding. digest() always produces exactly 16 lowercase hex characters, so this is exact.
+  if (typeof ref !== 'string' || !/^[0-9a-f]{16}$/.test(ref)) return null;
   const path = join(artifactDir(dir), `${ref}.txt`);
   let body;
   try {
@@ -175,9 +238,16 @@ export function resolve(dir, ref, { section } = {}) {
 
   const state = freshness(dir, ref);
   const decision = refreshDecision(state);
-
   const notes = [];
-  if (decision.action === 'serve-stale') {
+  if (decision.action === 'unknown') {
+    // The artifact outlived its capture record: metrics.jsonl is read as a bounded tail and the
+    // artifact store is never pruned, so this is the ordinary steady state rather than an edge
+    // case. Staleness is then unanswerable -- and unanswerable must not render as fresh. Serving
+    // a month-old build log about a file that has since been rewritten, unmarked, is what the
+    // module header calls worse than serving nothing.
+    notes.push('! UNVERIFIED -- no capture record survives for this reference, so whether the '
+      + 'code it describes has changed since cannot be determined. Treat it as historical.');
+  } else if (decision.action === 'serve-stale') {
     notes.push(`! STALE -- ${decision.changed.join(', ')} changed after this was captured. ` +
       'Treat it as historical.');
   } else if (decision.action === 'refresh') {
@@ -188,6 +258,8 @@ export function resolve(dir, ref, { section } = {}) {
     ref,
     text: notes.length ? `${notes.join('\n')}\n${body}` : body,
     stale: Boolean(state.stale),
+    // Distinguishes "checked and unchanged" from "could not be checked".
+    known: state.known !== false,
     decision: decision.action,
     section: section || null,
     // Nothing was spent producing this a second time. That is the number the
@@ -204,7 +276,20 @@ export function resolve(dir, ref, { section } = {}) {
  * xunit output are wrong specifically by dropping the first failing trace".
  */
 export function recordExpansion(dir, { ref, tool, shape, asked, sessionId } = {}) {
-  record(dir, { kind: 'expand', ref: ref || null, tool: tool || null, shape: shape || null, asked: asked || null, sessionId: sessionId || null });
+  // BACKFILLED FROM THE CAPTURE, because the caller of `expand` holds a ref and nothing else.
+  // Written without tool and shape, every expand event filed as null/null -- and previewPolicy's
+  // per-(tool, shape) filter then matched none of them, pinning holdRate at 1, strength at 0 and
+  // boosts permanently {}. The refit was inert in production while the suite passed by supplying
+  // a shape the real caller never has.
+  const cap = ref ? captureOf(dir, ref) : null;
+  record(dir, {
+    kind: 'expand',
+    ref: ref || null,
+    tool: tool || cap?.tool || null,
+    shape: shape || cap?.shape || null,
+    asked: asked || null,
+    sessionId: sessionId || null,
+  });
 }
 
 /**
@@ -291,7 +376,11 @@ export function previewQuality(dir) {
     shapes.get(shape).served += 1;
   }
   for (const exp of expansions) {
-    const shape = exp.shape || 'plain';
+    // NOT `|| 'plain'`. 'plain' is a REAL shape parseShape returns, so folding shapeless events
+    // into it charges expansions to a shape that was never expanded -- and that is then the
+    // shape the panel names as the worst one. An 'unknown' bucket has served 0 and is skipped by
+    // the served < 3 guard below, which is the right treatment for an unattributable event.
+    const shape = exp.shape || 'unknown';
     if (!shapes.has(shape)) shapes.set(shape, { served: 0, expanded: 0 });
     shapes.get(shape).expanded += 1;
   }

--- a/integrations/qwen/hooks/lib/expand.mjs
+++ b/integrations/qwen/hooks/lib/expand.mjs
@@ -151,7 +151,14 @@ export function capture(dir, text, meta = {}) {
  * that ever produced these bytes counts as staleness.
  */
 function captureOf(dir, ref) {
-  const rows = readMetrics(dir).filter((e) => e.kind === 'capture' && e.ref === ref);
+  const rows = readMetrics(dir)
+    .filter((e) => e.kind === 'capture' && e.ref === ref)
+    // SORTED, rather than trusting the reader's order. "Oldest hash per anchor wins" and "the
+    // latest capture supplies the rest of the record" are both statements about TIME, and
+    // readMetrics returns whatever order the log and its tail slice produce. Relying on write
+    // order makes the conservative direction accidental. Ties keep their relative order, since
+    // sort is stable and two rows in the same millisecond have no better ordering available.
+    .sort((a, b) => (a.at ?? 0) - (b.at ?? 0));
   if (!rows.length) return null;
   const byAnchor = new Map();
   for (const row of rows) {

--- a/plugin/hooks/lib/expand.mjs
+++ b/plugin/hooks/lib/expand.mjs
@@ -33,11 +33,13 @@
  */
 
 import { createHash } from 'node:crypto';
-import { readFileSync, writeFileSync, mkdirSync, existsSync, chmodSync } from 'node:fs';
+import {
+  readFileSync, writeFileSync, mkdirSync, existsSync, chmodSync,
+  readdirSync, statSync, unlinkSync,
+} from 'node:fs';
 import { join } from 'node:path';
 import { record, readMetrics } from './metrics.mjs';
 import { putNode, putEdge, nodeId } from './wiki.mjs';
-import { checkAnchor } from './staleness.mjs';
 import { canonicalPath } from './paths.mjs';
 
 /** A stale artifact cheaper than this to regenerate is refreshed, not served. */
@@ -46,7 +48,35 @@ export const CHEAP_REGEN_MS = 3000;
 /** Expansions below this rate mean the preview policy is working. */
 export const HEALTHY_HOLD_RATE = 0.85;
 
+/**
+ * How long an artifact is kept. STATED, not silent.
+ *
+ * The store was otherwise write-only: every disclosed tool result landed here forever, while its
+ * capture record ages out of the bounded metrics window -- so most files on disk were already
+ * unreachable and could not even be resolved usefully, only occupy space. Content addressing
+ * dedupes byte-identical bodies but not near-identical ones, so two runs of the same suite
+ * differing only in elapsed-ms are two files.
+ *
+ * A bound nobody can see would be worse than none, so it is exported and documented alongside
+ * the rest of the module's stated properties.
+ */
+export const ARTIFACT_TTL_MS = 30 * 86_400_000;
+
 const digest = (text) => createHash('sha256').update(String(text)).digest('hex').slice(0, 16);
+
+/** Removes artifacts past the TTL. A sweep must never break a capture. */
+function sweepArtifacts(path) {
+  try {
+    const cutoff = Date.now() - ARTIFACT_TTL_MS;
+    for (const name of readdirSync(path)) {
+      if (!name.endsWith('.txt')) continue;
+      const file = join(path, name);
+      try {
+        if (statSync(file).mtimeMs < cutoff) unlinkSync(file);
+      } catch { /* raced with another sweep or a reader */ }
+    }
+  } catch { /* no store yet, or unreadable -- neither is worth failing a capture over */ }
+}
 
 function artifactDir(dir) {
   const path = join(dir, 'artifacts');
@@ -72,7 +102,12 @@ export function capture(dir, text, meta = {}) {
 
   const ref = digest(body);
   const path = join(artifactDir(dir), `${ref}.txt`);
-  if (!existsSync(path)) writeFileSync(path, body, { mode: 0o600 });
+  if (!existsSync(path)) {
+    writeFileSync(path, body, { mode: 0o600 });
+    // Amortised off the digest rather than run on every capture, and deterministic rather than
+    // sampled at random: roughly one write in sixty-four pays for a readdir.
+    if (parseInt(ref.slice(0, 2), 16) < 4) sweepArtifacts(artifactDir(dir));
+  }
 
   const anchors = (meta.anchors || []).map((a) => canonicalPath(a));
   record(dir, {
@@ -101,9 +136,30 @@ export function capture(dir, text, meta = {}) {
   return ref;
 }
 
-/** The capture record for a reference, or null. */
+/**
+ * The capture record for a reference, or null.
+ *
+ * ANCHORS ARE UNIONED ACROSS EVERY CAPTURE OF THIS REF. The ref is the hash of the BODY, which
+ * is exactly what makes the store converge -- and it means one ref legitimately spans captures
+ * made against DIFFERENT anchors: two byte-identical files, one generated file vendored into six
+ * directories (this module is itself vendored six times), the same command output captured
+ * against two operands. Taking only the last record checked staleness against whichever copy
+ * happened to be captured most recently, so editing the copy the caller actually asked about
+ * produced no stale marker at all.
+ *
+ * The OLDEST hash per anchor wins, which is the conservative direction: any change to any file
+ * that ever produced these bytes counts as staleness.
+ */
 function captureOf(dir, ref) {
-  return readMetrics(dir).filter((e) => e.kind === 'capture' && e.ref === ref).pop() || null;
+  const rows = readMetrics(dir).filter((e) => e.kind === 'capture' && e.ref === ref);
+  if (!rows.length) return null;
+  const byAnchor = new Map();
+  for (const row of rows) {
+    for (const entry of row.anchorHashes || []) {
+      if (!byAnchor.has(entry.anchor)) byAnchor.set(entry.anchor, entry);
+    }
+  }
+  return { ...rows[rows.length - 1], anchorHashes: [...byAnchor.values()] };
 }
 
 /**
@@ -165,6 +221,13 @@ export function refreshDecision(state) {
  * rather than having it executed underneath them.
  */
 export function resolve(dir, ref, { section } = {}) {
+  // The ref reaches this function straight from a model-supplied tool argument -- index.ts
+  // dispatches `expand` with request.params.arguments unvalidated, and the tool schema declares
+  // ref as a bare string. It is a content digest and nothing else, so anything that is not one
+  // is refused rather than joined into a path: `join` resolves `..`, so '../../notes' would read
+  // notes.txt from anywhere on disk and return it as the expansion of the pointer the caller was
+  // holding. digest() always produces exactly 16 lowercase hex characters, so this is exact.
+  if (typeof ref !== 'string' || !/^[0-9a-f]{16}$/.test(ref)) return null;
   const path = join(artifactDir(dir), `${ref}.txt`);
   let body;
   try {
@@ -175,9 +238,16 @@ export function resolve(dir, ref, { section } = {}) {
 
   const state = freshness(dir, ref);
   const decision = refreshDecision(state);
-
   const notes = [];
-  if (decision.action === 'serve-stale') {
+  if (decision.action === 'unknown') {
+    // The artifact outlived its capture record: metrics.jsonl is read as a bounded tail and the
+    // artifact store is never pruned, so this is the ordinary steady state rather than an edge
+    // case. Staleness is then unanswerable -- and unanswerable must not render as fresh. Serving
+    // a month-old build log about a file that has since been rewritten, unmarked, is what the
+    // module header calls worse than serving nothing.
+    notes.push('! UNVERIFIED -- no capture record survives for this reference, so whether the '
+      + 'code it describes has changed since cannot be determined. Treat it as historical.');
+  } else if (decision.action === 'serve-stale') {
     notes.push(`! STALE -- ${decision.changed.join(', ')} changed after this was captured. ` +
       'Treat it as historical.');
   } else if (decision.action === 'refresh') {
@@ -188,6 +258,8 @@ export function resolve(dir, ref, { section } = {}) {
     ref,
     text: notes.length ? `${notes.join('\n')}\n${body}` : body,
     stale: Boolean(state.stale),
+    // Distinguishes "checked and unchanged" from "could not be checked".
+    known: state.known !== false,
     decision: decision.action,
     section: section || null,
     // Nothing was spent producing this a second time. That is the number the
@@ -204,7 +276,20 @@ export function resolve(dir, ref, { section } = {}) {
  * xunit output are wrong specifically by dropping the first failing trace".
  */
 export function recordExpansion(dir, { ref, tool, shape, asked, sessionId } = {}) {
-  record(dir, { kind: 'expand', ref: ref || null, tool: tool || null, shape: shape || null, asked: asked || null, sessionId: sessionId || null });
+  // BACKFILLED FROM THE CAPTURE, because the caller of `expand` holds a ref and nothing else.
+  // Written without tool and shape, every expand event filed as null/null -- and previewPolicy's
+  // per-(tool, shape) filter then matched none of them, pinning holdRate at 1, strength at 0 and
+  // boosts permanently {}. The refit was inert in production while the suite passed by supplying
+  // a shape the real caller never has.
+  const cap = ref ? captureOf(dir, ref) : null;
+  record(dir, {
+    kind: 'expand',
+    ref: ref || null,
+    tool: tool || cap?.tool || null,
+    shape: shape || cap?.shape || null,
+    asked: asked || null,
+    sessionId: sessionId || null,
+  });
 }
 
 /**
@@ -291,7 +376,11 @@ export function previewQuality(dir) {
     shapes.get(shape).served += 1;
   }
   for (const exp of expansions) {
-    const shape = exp.shape || 'plain';
+    // NOT `|| 'plain'`. 'plain' is a REAL shape parseShape returns, so folding shapeless events
+    // into it charges expansions to a shape that was never expanded -- and that is then the
+    // shape the panel names as the worst one. An 'unknown' bucket has served 0 and is skipped by
+    // the served < 3 guard below, which is the right treatment for an unattributable event.
+    const shape = exp.shape || 'unknown';
     if (!shapes.has(shape)) shapes.set(shape, { served: 0, expanded: 0 });
     shapes.get(shape).expanded += 1;
   }

--- a/plugin/hooks/lib/expand.mjs
+++ b/plugin/hooks/lib/expand.mjs
@@ -151,7 +151,14 @@ export function capture(dir, text, meta = {}) {
  * that ever produced these bytes counts as staleness.
  */
 function captureOf(dir, ref) {
-  const rows = readMetrics(dir).filter((e) => e.kind === 'capture' && e.ref === ref);
+  const rows = readMetrics(dir)
+    .filter((e) => e.kind === 'capture' && e.ref === ref)
+    // SORTED, rather than trusting the reader's order. "Oldest hash per anchor wins" and "the
+    // latest capture supplies the rest of the record" are both statements about TIME, and
+    // readMetrics returns whatever order the log and its tail slice produce. Relying on write
+    // order makes the conservative direction accidental. Ties keep their relative order, since
+    // sort is stable and two rows in the same millisecond have no better ordering available.
+    .sort((a, b) => (a.at ?? 0) - (b.at ?? 0));
   if (!rows.length) return null;
   const byAnchor = new Map();
   for (const row of rows) {

--- a/tests/hooks/disclose.test.mjs
+++ b/tests/hooks/disclose.test.mjs
@@ -335,3 +335,56 @@ describe('preview quality is reported, not buried', () => {
     expect(quality.healthy).toBe(false);
   });
 });
+
+describe('expand serves what it claims to serve', () => {
+  test('a ref that is not a digest is refused, not joined into a path', async () => {
+    // The ref arrives straight from a model-supplied tool argument -- index.ts dispatches
+    // `expand` with request.params.arguments unvalidated and the schema declares a bare string.
+    // `join` resolves `..`, so '../../notes' read notes.txt from anywhere on disk and returned it
+    // as the expansion of the pointer the caller was holding.
+    const { resolve } = await import('../../hooks-core/expand.mjs');
+    const dir = mkdtempSync(join(tmpdir(), 'exp-ref-'));
+    try {
+      for (const bad of ['../../../etc/passwd', '..\..\notes', 'not-hex-at-all', 'ABCDEF0123456789', '', null, 42]) {
+        expect(resolve(dir, bad)).toBeNull();
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('a well-formed but unknown digest is still null, not an adjacent file', async () => {
+    const { resolve } = await import('../../hooks-core/expand.mjs');
+    const dir = mkdtempSync(join(tmpdir(), 'exp-miss-'));
+    try {
+      expect(resolve(dir, '0123456789abcdef')).toBeNull();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('an expansion whose capture record is gone is marked unverified, not served as fresh', async () => {
+    // The artifact store is never pruned while metrics is a bounded tail, so artifacts routinely
+    // outlive their capture records. Staleness is then unanswerable -- and unanswerable rendered
+    // as fresh, which the module header calls worse than serving nothing.
+    const { capture, resolve } = await import('../../hooks-core/expand.mjs');
+    const dir = mkdtempSync(join(tmpdir(), 'exp-unver-'));
+    try {
+      // Capture writes the artifact AND a metrics record; delete the metrics so only the
+      // artifact survives, which is exactly the steady state being reproduced.
+      const ref = capture(dir, 'some captured output', { anchors: [], tool: 'Bash', shape: 'log' });
+      rmSync(join(dir, 'metrics.jsonl'), { force: true });
+      const out = resolve(dir, ref);
+      expect(out).toBeTruthy();
+      expect(out.text).toMatch(/UNVERIFIED/);
+      expect(out.known).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('the artifact TTL is exported so the bound is not silent', async () => {
+    const { ARTIFACT_TTL_MS } = await import('../../hooks-core/expand.mjs');
+    expect(ARTIFACT_TTL_MS).toBeGreaterThan(0);
+  });
+});

--- a/tests/hooks/disclose.test.mjs
+++ b/tests/hooks/disclose.test.mjs
@@ -345,7 +345,18 @@ describe('expand serves what it claims to serve', () => {
     const { resolve } = await import('../../hooks-core/expand.mjs');
     const dir = mkdtempSync(join(tmpdir(), 'exp-ref-'));
     try {
-      for (const bad of ['../../../etc/passwd', '..\..\notes', 'not-hex-at-all', 'ABCDEF0123456789', '', null, 42]) {
+      // String.raw for the Windows case. Written as '..\..\notes' it collapsed to '....notes' --
+      // `\.` is not an escape sequence, so the backslashes vanished and the input duplicated the
+      // 'not-hex-at-all' case. The test still passed, so the gap was silent: the traversal shape
+      // this guard exists to refuse was never actually passed to it.
+      const windowsTraversal = String.raw`..\..\notes`;
+      expect(windowsTraversal).toContain('\\');
+
+      for (const bad of [
+        '../../../etc/passwd', windowsTraversal, 'not-hex-at-all',
+        'ABCDEF0123456789', // uppercase hex: right shape, wrong case, still refused
+        '', null, 42,
+      ]) {
         expect(resolve(dir, bad)).toBeNull();
       }
     } finally {


### PR DESCRIPTION
`expand` is the module that turns a pointer back into content. If it returns the wrong content,
stale content, or silently returns nothing, the model reasons about material that does not match
what it asked for **and has no way to detect that**. Seven defects, found by auditing the module
against the guarantee its own name makes.

### 1. Path traversal — `ref` went unvalidated into a `join`

```js
const file = join(artifactDir(dir), `${ref}.txt`);   // ref straight from the model
```

`ref` arrives entirely from the model: `server/index.ts` dispatches `expand` with
`request.params.arguments` unvalidated, and the tool schema declares `ref` as a bare string.
`join` resolves `..`, so `'../../../../Users/me/notes'` read `notes.txt` from anywhere on disk and
returned it as *the expansion of the pointer the caller was holding*.

The non-adversarial case is as bad: a hallucinated `ref` that happens to resolve reads whatever
`.txt` sits there and presents it as the disclosed content.

`digest()` always yields exactly 16 lowercase hex characters, so the guard is exact rather than a
heuristic:

```js
if (typeof ref !== 'string' || !/^[0-9a-f]{16}$/.test(ref)) return null;
```

### 2. Unverifiable staleness rendered as "current"

An expansion whose capture record had aged out of the bounded metrics window was served with no
marker and `stale: false`. **The artifact store is never pruned, so artifacts routinely outlive
their records — this is the steady state, not an edge case.** `refreshDecision` returns `'unknown'`
there, and the notes block handled only `'serve-stale'` and `'refresh'`, so "I cannot verify this"
rendered as "this is current". Now marked `UNVERIFIED`, with a `known` field distinguishing
checked-and-unchanged from could-not-be-checked.

### 3. `captureOf` took the last capture, but a ref spans captures

A ref is the digest of the **body** — which is what makes the store converge, and means one ref
legitimately spans captures against different anchors. This module is itself vendored six times
byte-identically. Editing the copy the caller asked about produced no stale marker, because
staleness was checked against whichever copy happened to be captured most recently. Anchors are now
unioned across every capture, oldest hash per anchor winning — the conservative direction.

### 4. The preview refit was inert in production

`recordExpansion` wrote `tool` and `shape` as `null` for every production event, because its only
caller passes a ref and nothing else. `previewPolicy`'s per-`(tool, shape)` filter therefore matched
zero events, **always** — pinning `holdRate` at 1, `strength` at 0 and `boosts` permanently `{}`.
The suite passed because it supplied a shape the real caller never has. Both fields are now
backfilled from the capture record.

### 5. Shapeless expansions were charged to a real shape

`previewQuality` bucketed them under `'plain'`, which is a shape `parseShape` genuinely returns — so
100% of expansions were charged to a shape that was never expanded, and the panel then named it as
the worst one. They now go to `'unknown'`, which has served 0 and is skipped by the `served < 3`
guard.

### 6. The artifact store grew without bound

No retention policy, no cap, no sweep, while every disclosed tool result lands in it. Most files
were already unreachable, their capture records having aged out. Now swept past an **exported**
`ARTIFACT_TTL_MS`, amortised off the digest so roughly one write in sixty-four pays for a `readdir`.
A bound nobody can see would be worse than none.

### 7. Dead `checkAnchor` import

Removed. It invited a reader to assume the staleness path routes through the shared checker when it
does not.

---

**Verified:** `tests/hooks` — 707 passed, 2 skipped, 0 failed, including 4 new tests covering the
traversal refusal, the unknown-digest path, the unverified marking, and the exported TTL.
Vendored copies re-synced via `npm run sync:hooks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)