### PR TITLE
fix(fleet): scope the scan, weight the comparison, read nothing before consent

### DIFF
--- a/hooks-core/fleet.mjs
+++ b/hooks-core/fleet.mjs
@@ -41,7 +41,7 @@ import { cacheHealth, readCacheUsage } from './cache.mjs';
 import { activeRules } from './remedy.mjs';
 import { monthly, money, priceNote } from './pricing.mjs';
 import { wikiDir } from './wiki.mjs';
-import { canonicalPath } from './paths.mjs';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
 
 /** How many projects an enumerating scan will read before it stops and says so. */
 export const DEFAULT_LIMIT = 25;
@@ -60,6 +60,7 @@ export function projectsRoot() {
  * is read, since `cwd` appears on the first rows.
  */
 export function projectCwd(transcript, { headBytes = 65_536 } = {}) {
+  if (!isFsSafePath(transcript)) return null;
   let fd;
   try {
     fd = openSync(transcript, 'r');
@@ -96,6 +97,7 @@ export function projectCwd(transcript, { headBytes = 65_536 } = {}) {
  */
 export function discoverProjects({
   mode = 'enumerate', root = projectsRoot(), only = [], exclude = [], limit = DEFAULT_LIMIT,
+  resolveCwd = true,
 } = {}) {
   if (mode === 'explicit') {
     return {
@@ -118,44 +120,145 @@ export function discoverProjects({
   for (const entry of entries) {
     const dir = join(root, entry.name);
     let newest = null;
+    let files = [];
     try {
-      for (const file of readdirSync(dir)) {
-        if (!file.endsWith('.jsonl')) continue;
-        const path = join(dir, file);
+      files = readdirSync(dir);
+    } catch { /* unreadable directory */ }
+
+    for (const file of files) {
+      if (!file.endsWith('.jsonl')) continue;
+      const path = join(dir, file);
+      // Scoped to the one file deliberately. Transcripts under the discovery root are being
+      // written and rotated by OTHER live sessions while this scan enumerates them, so a file
+      // present at readdirSync can be gone at statSync. Wrapping the whole loop meant one such
+      // race abandoned the directory's remaining transcripts -- reporting a project with several
+      // of them as 'no transcript', or silently deriving its cwd from a stale one.
+      try {
         const at = statSync(path).mtimeMs;
         if (!newest || at > newest.at) newest = { path, at };
-      }
-    } catch { /* unreadable directory */ }
+      } catch { /* rotated away mid-scan; the other transcripts still count */ }
+    }
 
     if (!newest) {
       skipped.push({ slug: entry.name, why: 'no transcript' });
       continue;
     }
-    if (exclude.some((pattern) => entry.name.includes(pattern))) {
+    if (isExcluded(entry.name, exclude)) {
       skipped.push({ slug: entry.name, why: 'excluded by pattern' });
       continue;
     }
 
-    projects.push({ slug: entry.name, transcript: newest.path, at: newest.at, cwd: projectCwd(newest.path) });
+    projects.push({ slug: entry.name, transcript: newest.path, at: newest.at });
   }
 
   projects.sort((a, b) => b.at - a.at);
 
+  let kept = projects;
   if (mode !== 'all' && projects.length > limit) {
     for (const extra of projects.slice(limit)) skipped.push({ slug: extra.slug, why: `beyond the limit of ${limit}` });
-    return { mode, projects: projects.slice(0, limit), skipped, root };
+    kept = projects.slice(0, limit);
   }
 
-  return { mode, projects, skipped, root };
+  // RESOLVED HERE, NOT DURING DISCOVERY. projectCwd opens a transcript and reads 64 KB of it, so
+  // resolving during the loop read every transcript on the machine and threw most of them away --
+  // 400 opened to keep 25. It also made the dry run a lie: fleet-tool.ts calls discoverProjects
+  // before it branches on dryRun, so "Nothing was read" was printed after reading the head of
+  // every transcript on the machine. Sorting needs only `at`, so nothing is lost by waiting.
+  //
+  // resolveCwd: false is what makes the dry run a real consent step. Reading 64 KB of a
+  // transcript IS reading the material consent is being asked about -- transcripts hold source
+  // code, paths and whatever has been pasted into a terminal -- so a gate that reads it before
+  // asking is not a gate. The slug is the cwd with its punctuation dashed out, so the listing
+  // still identifies each project.
+  if (!resolveCwd) return { mode, projects: kept.map((p) => ({ ...p, cwd: null })), skipped, root };
+
+  const resolved = [];
+  const seen = new Map();
+  for (const project of kept) {
+    const raw = projectCwd(project.transcript);
+    // Canonicalised as explicit mode already does. The client mints one directory per cwd
+    // SPELLING, so the same repo opened as C:\Users\me\repo, c:\users\me\repo and /c/Users/me/repo
+    // yields three slugs -- and wikiDir maps all three onto the same case-insensitive Windows
+    // directory, so readMetrics returns the SAME event log each time. Left undeduped, the project
+    // is counted once per spelling: its pareto share multiplies, and it contributes that many
+    // identical points to whichever arm of enforcementComparison it lands in.
+    const cwd = raw ? canonicalPath(raw) : null;
+    if (cwd && seen.has(cwd)) {
+      skipped.push({ slug: project.slug, why: `duplicate of ${seen.get(cwd)} (same cwd)` });
+      continue;
+    }
+    if (cwd) seen.set(cwd, project.slug);
+    resolved.push({ ...project, cwd });
+  }
+
+  return { mode, projects: resolved, skipped, root };
 }
 
-const sha256 = (path) => {
+/**
+ * The directory slug the client mints for a cwd: every non-alphanumeric character becomes a dash.
+ */
+export function slugifyCwd(cwd) {
+  return String(cwd).replace(/[^a-zA-Z0-9]/g, '-');
+}
+
+/**
+ * Does an exclude pattern apply to this project directory?
+ *
+ * Matched against the slugified form as well as the literal one. `exclude` is documented as
+ * "substrings to skip" and is the only scoping control the tool offers, but the thing being
+ * matched is the MANGLED slug -- so every pattern spelled the way a user would spell it could
+ * never match: `C:\work\private` (colon, backslashes), `~/work/private` (slashes, tilde),
+ * `node_modules` (underscore) and `my.project` (dot) all failed silently, and the project was
+ * scanned -- transcript head read, metrics and rules read, slug printed in the report -- with no
+ * diagnostic that the exclusion had not taken.
+ */
+function isExcluded(slug, exclude) {
+  return exclude.some((pattern) => {
+    const raw = String(pattern ?? '');
+    if (!raw) return false; // an empty pattern is in every string; excluding everything is never meant
+    return slug.includes(raw) || slug.includes(slugifyCwd(raw));
+  });
+}
+
+/**
+ * Size and content digest for one file, or null if it cannot be read.
+ *
+ * isFsSafePath first, and not as belt-and-braces: this is a copy of wiki.mjs's contentHash with
+ * that check dropped. libuv's UTF-8-to-UTF-16 conversion on Windows asserts
+ * `code_point < 0x10FFFF`, so a path containing U+10FFFF makes statSync/readFileSync **abort the
+ * process** rather than throw -- paths.mjs documents the assert and notes there is nothing to
+ * catch afterwards, so the try/catch below cannot save the scan. The paths reaching here are
+ * external input of exactly the guarded kind: `rule.anchor` out of a project's rules.json and
+ * `target.anchors` out of its event log. The blast radius is the whole MCP server process.
+ */
+function measure(path) {
+  if (!isFsSafePath(path)) return null;
   try {
-    return createHash('sha256').update(readFileSync(path)).digest('hex');
+    const size = statSync(path).size;
+    return { size, hash: createHash('sha256').update(readFileSync(path)).digest('hex') };
   } catch {
     return null;
   }
-};
+}
+
+/**
+ * Per-scan digest cache.
+ *
+ * `transferable` compares inside a triple loop -- every source project, every rule, every other
+ * project, every anchor whose basename matches -- and `target.anchors` is every distinct file the
+ * project read within the 5000-event window, routinely hundreds of paths. Common basenames
+ * (index.ts, package.json, __init__.py) match many of them. At the default cap of 25 projects
+ * with ~20 rules each that was tens of thousands of synchronous whole-file reads and SHA-256
+ * passes on the MCP server's only thread, with `mode: 'all'` removing the project cap entirely.
+ * The same file was re-read once per rule-project pair.
+ */
+function digestCache() {
+  const cache = new Map();
+  return (path) => {
+    if (!cache.has(path)) cache.set(path, measure(path));
+    return cache.get(path);
+  };
+}
 
 /**
  * What one project costs, and whether enforcement is on there.
@@ -174,7 +277,10 @@ function safeBalance(dir) {
 }
 
 export function scanProject(project) {
-  const dir = project.cwd ? wikiDir(project.cwd) : null;
+  // project.cwd comes out of a transcript's JSON -- the same external, unvalidated input that
+  // reaches sha256 -- and existsSync aborts the process rather than throwing on a path holding
+  // U+10FFFF. See measure() above.
+  const dir = project.cwd && isFsSafePath(project.cwd) ? wikiDir(project.cwd) : null;
   const events = dir && existsSync(dir) ? readMetrics(dir) : [];
 
   const reads = events.filter((e) => e.kind === 'read');
@@ -219,24 +325,44 @@ export function scanProject(project) {
  */
 export function transferable(scans) {
   const out = [];
+  const digest = digestCache();
 
   for (const source of scans) {
     for (const rule of source.rules) {
-      if (!rule.anchor) continue;
-      const hash = sha256(rule.anchor);
-      if (!hash) continue;
+      // BOTH SHAPES. `if (!rule.anchor) continue` skipped every composite rule: remedy.mjs lists
+      // 'composite' among the remedy types this product applies itself, and applyRemedy stores
+      // those with `anchors` plural and `anchor` undefined. So composites were invisible to
+      // transfer analysis -- never offered to another project, never in the report's "proven
+      // somewhere, available elsewhere" block, and never counted as skipped either.
+      const wanted = rule.anchors?.length ? rule.anchors : (rule.anchor ? [rule.anchor] : []);
+      if (!wanted.length) continue;
+
+      // A multi-anchor remedy is only meaningful where EVERY file it was proven against is
+      // present with matching contents; a partial match is a different situation, not a weaker
+      // version of this one.
+      const required = wanted.map((a) => ({ anchor: a, base: basename(a), measured: digest(a) }));
+      if (required.some((r) => !r.measured)) continue;
 
       const targets = [];
       for (const target of scans) {
         if (target.slug === source.slug) continue;
         if (target.rules.some((r) => r.id === rule.id)) continue; // already has it
 
-        for (const anchor of target.anchors) {
-          if (basename(anchor) !== basename(rule.anchor)) continue;
-          if (sha256(anchor) !== hash) continue;
-          targets.push({ slug: target.slug, cwd: target.cwd, anchor });
-          break;
+        const matched = [];
+        for (const need of required) {
+          const hit = target.anchors.find((anchor) => {
+            if (basename(anchor) !== need.base) return false;
+            const found = digest(anchor);
+            // Size first: two files of different lengths cannot share contents, and statSync is
+            // orders of magnitude cheaper than hashing a whole file that cannot match anyway.
+            return Boolean(found) && found.size === need.measured.size && found.hash === need.measured.hash;
+          });
+          if (!hit) break;
+          matched.push(hit);
         }
+        if (matched.length !== required.length) continue;
+
+        targets.push({ slug: target.slug, cwd: target.cwd, anchor: matched[0], anchors: matched });
       }
 
       if (targets.length) {
@@ -281,14 +407,36 @@ export function enforcementComparison(scans) {
     };
   }
 
-  const mean = (list) => Math.round(list.reduce((sum, s) => sum + s.perRead, 0) / list.length);
+  // POOLED, NOT AN AVERAGE OF AVERAGES.
+  //
+  // Averaging each project's per-read average gives every project equal weight regardless of how
+  // much evidence stands behind it: a project with 2 reads counted as much as one with 30,000.
+  // An enforcing arm of [2 reads totalling 300k -> 150,000/read; 5,000 reads at 500; 4,000 at 400]
+  // reported 50,300 tokens/read where the pooled figure over the same 9,002 reads is about 530.
+  // Set against a directive arm around 800, renderFleet then printed that enforcing costs ~60x
+  // MORE per read -- the exact inverse of the truth, under a heading calling this the check on
+  // the central claim of this product, with nothing in the caveat to hint that one two-read
+  // project drove the whole result. scanProject already returns both tokens and reads, so the
+  // pooled statistic needs no new measurement.
+  const pool = (list) => {
+    const tokens = list.reduce((sum, s) => sum + (s.tokens || 0), 0);
+    const reads = list.reduce((sum, s) => sum + (s.reads || 0), 0);
+    return { perRead: reads ? Math.round(tokens / reads) : null, reads, tokens };
+  };
+
+  const e = pool(enforcing);
+  const d = pool(directive);
 
   return {
     comparable: true,
-    enforcingPerRead: mean(enforcing),
-    directivePerRead: mean(directive),
+    enforcingPerRead: e.perRead,
+    directivePerRead: d.perRead,
     enforcingProjects: enforcing.length,
     directiveProjects: directive.length,
+    // The read counts are exposed rather than kept internal: they are how a reader tells a
+    // fleet-wide result from one project's noise, which is the whole question here.
+    enforcingReads: e.reads,
+    directiveReads: d.reads,
     caveat: 'Not a randomised comparison: people choose their client and the projects differ. ' +
       'Treat as suggestive, not causal -- the per-project holdout arm is the causal measurement.',
   };
@@ -350,8 +498,11 @@ export function renderFleet({ discovery, scans, tier = 'opus', sessionsPerMonth 
   const comparison = enforcementComparison(scans);
   lines.push('', 'Enforcing vs directive, measured across this fleet:');
   if (comparison.comparable) {
-    lines.push(`  enforcing  ${comparison.enforcingPerRead.toLocaleString()} tokens/read over ${comparison.enforcingProjects} project(s)`);
-    lines.push(`  directive  ${comparison.directivePerRead.toLocaleString()} tokens/read over ${comparison.directiveProjects} project(s)`);
+    const arm = (label, perRead, projects, reads) =>
+      `  ${label}  ${perRead == null ? 'no reads yet' : `${perRead.toLocaleString()} tokens/read`}` +
+      ` over ${projects} project(s), ${reads.toLocaleString()} read(s)`;
+    lines.push(arm('enforcing', comparison.enforcingPerRead, comparison.enforcingProjects, comparison.enforcingReads));
+    lines.push(arm('directive', comparison.directivePerRead, comparison.directiveProjects, comparison.directiveReads));
     lines.push(`  ! ${comparison.caveat}`);
   } else {
     lines.push(`  not comparable yet -- ${comparison.reason}`);

--- a/integrations/codex/hooks/lib/fleet.mjs
+++ b/integrations/codex/hooks/lib/fleet.mjs
@@ -43,7 +43,7 @@ import { cacheHealth, readCacheUsage } from './cache.mjs';
 import { activeRules } from './remedy.mjs';
 import { monthly, money, priceNote } from './pricing.mjs';
 import { wikiDir } from './wiki.mjs';
-import { canonicalPath } from './paths.mjs';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
 
 /** How many projects an enumerating scan will read before it stops and says so. */
 export const DEFAULT_LIMIT = 25;
@@ -62,6 +62,7 @@ export function projectsRoot() {
  * is read, since `cwd` appears on the first rows.
  */
 export function projectCwd(transcript, { headBytes = 65_536 } = {}) {
+  if (!isFsSafePath(transcript)) return null;
   let fd;
   try {
     fd = openSync(transcript, 'r');
@@ -98,6 +99,7 @@ export function projectCwd(transcript, { headBytes = 65_536 } = {}) {
  */
 export function discoverProjects({
   mode = 'enumerate', root = projectsRoot(), only = [], exclude = [], limit = DEFAULT_LIMIT,
+  resolveCwd = true,
 } = {}) {
   if (mode === 'explicit') {
     return {
@@ -120,44 +122,145 @@ export function discoverProjects({
   for (const entry of entries) {
     const dir = join(root, entry.name);
     let newest = null;
+    let files = [];
     try {
-      for (const file of readdirSync(dir)) {
-        if (!file.endsWith('.jsonl')) continue;
-        const path = join(dir, file);
+      files = readdirSync(dir);
+    } catch { /* unreadable directory */ }
+
+    for (const file of files) {
+      if (!file.endsWith('.jsonl')) continue;
+      const path = join(dir, file);
+      // Scoped to the one file deliberately. Transcripts under the discovery root are being
+      // written and rotated by OTHER live sessions while this scan enumerates them, so a file
+      // present at readdirSync can be gone at statSync. Wrapping the whole loop meant one such
+      // race abandoned the directory's remaining transcripts -- reporting a project with several
+      // of them as 'no transcript', or silently deriving its cwd from a stale one.
+      try {
         const at = statSync(path).mtimeMs;
         if (!newest || at > newest.at) newest = { path, at };
-      }
-    } catch { /* unreadable directory */ }
+      } catch { /* rotated away mid-scan; the other transcripts still count */ }
+    }
 
     if (!newest) {
       skipped.push({ slug: entry.name, why: 'no transcript' });
       continue;
     }
-    if (exclude.some((pattern) => entry.name.includes(pattern))) {
+    if (isExcluded(entry.name, exclude)) {
       skipped.push({ slug: entry.name, why: 'excluded by pattern' });
       continue;
     }
 
-    projects.push({ slug: entry.name, transcript: newest.path, at: newest.at, cwd: projectCwd(newest.path) });
+    projects.push({ slug: entry.name, transcript: newest.path, at: newest.at });
   }
 
   projects.sort((a, b) => b.at - a.at);
 
+  let kept = projects;
   if (mode !== 'all' && projects.length > limit) {
     for (const extra of projects.slice(limit)) skipped.push({ slug: extra.slug, why: `beyond the limit of ${limit}` });
-    return { mode, projects: projects.slice(0, limit), skipped, root };
+    kept = projects.slice(0, limit);
   }
 
-  return { mode, projects, skipped, root };
+  // RESOLVED HERE, NOT DURING DISCOVERY. projectCwd opens a transcript and reads 64 KB of it, so
+  // resolving during the loop read every transcript on the machine and threw most of them away --
+  // 400 opened to keep 25. It also made the dry run a lie: fleet-tool.ts calls discoverProjects
+  // before it branches on dryRun, so "Nothing was read" was printed after reading the head of
+  // every transcript on the machine. Sorting needs only `at`, so nothing is lost by waiting.
+  //
+  // resolveCwd: false is what makes the dry run a real consent step. Reading 64 KB of a
+  // transcript IS reading the material consent is being asked about -- transcripts hold source
+  // code, paths and whatever has been pasted into a terminal -- so a gate that reads it before
+  // asking is not a gate. The slug is the cwd with its punctuation dashed out, so the listing
+  // still identifies each project.
+  if (!resolveCwd) return { mode, projects: kept.map((p) => ({ ...p, cwd: null })), skipped, root };
+
+  const resolved = [];
+  const seen = new Map();
+  for (const project of kept) {
+    const raw = projectCwd(project.transcript);
+    // Canonicalised as explicit mode already does. The client mints one directory per cwd
+    // SPELLING, so the same repo opened as C:\Users\me\repo, c:\users\me\repo and /c/Users/me/repo
+    // yields three slugs -- and wikiDir maps all three onto the same case-insensitive Windows
+    // directory, so readMetrics returns the SAME event log each time. Left undeduped, the project
+    // is counted once per spelling: its pareto share multiplies, and it contributes that many
+    // identical points to whichever arm of enforcementComparison it lands in.
+    const cwd = raw ? canonicalPath(raw) : null;
+    if (cwd && seen.has(cwd)) {
+      skipped.push({ slug: project.slug, why: `duplicate of ${seen.get(cwd)} (same cwd)` });
+      continue;
+    }
+    if (cwd) seen.set(cwd, project.slug);
+    resolved.push({ ...project, cwd });
+  }
+
+  return { mode, projects: resolved, skipped, root };
 }
 
-const sha256 = (path) => {
+/**
+ * The directory slug the client mints for a cwd: every non-alphanumeric character becomes a dash.
+ */
+export function slugifyCwd(cwd) {
+  return String(cwd).replace(/[^a-zA-Z0-9]/g, '-');
+}
+
+/**
+ * Does an exclude pattern apply to this project directory?
+ *
+ * Matched against the slugified form as well as the literal one. `exclude` is documented as
+ * "substrings to skip" and is the only scoping control the tool offers, but the thing being
+ * matched is the MANGLED slug -- so every pattern spelled the way a user would spell it could
+ * never match: `C:\work\private` (colon, backslashes), `~/work/private` (slashes, tilde),
+ * `node_modules` (underscore) and `my.project` (dot) all failed silently, and the project was
+ * scanned -- transcript head read, metrics and rules read, slug printed in the report -- with no
+ * diagnostic that the exclusion had not taken.
+ */
+function isExcluded(slug, exclude) {
+  return exclude.some((pattern) => {
+    const raw = String(pattern ?? '');
+    if (!raw) return false; // an empty pattern is in every string; excluding everything is never meant
+    return slug.includes(raw) || slug.includes(slugifyCwd(raw));
+  });
+}
+
+/**
+ * Size and content digest for one file, or null if it cannot be read.
+ *
+ * isFsSafePath first, and not as belt-and-braces: this is a copy of wiki.mjs's contentHash with
+ * that check dropped. libuv's UTF-8-to-UTF-16 conversion on Windows asserts
+ * `code_point < 0x10FFFF`, so a path containing U+10FFFF makes statSync/readFileSync **abort the
+ * process** rather than throw -- paths.mjs documents the assert and notes there is nothing to
+ * catch afterwards, so the try/catch below cannot save the scan. The paths reaching here are
+ * external input of exactly the guarded kind: `rule.anchor` out of a project's rules.json and
+ * `target.anchors` out of its event log. The blast radius is the whole MCP server process.
+ */
+function measure(path) {
+  if (!isFsSafePath(path)) return null;
   try {
-    return createHash('sha256').update(readFileSync(path)).digest('hex');
+    const size = statSync(path).size;
+    return { size, hash: createHash('sha256').update(readFileSync(path)).digest('hex') };
   } catch {
     return null;
   }
-};
+}
+
+/**
+ * Per-scan digest cache.
+ *
+ * `transferable` compares inside a triple loop -- every source project, every rule, every other
+ * project, every anchor whose basename matches -- and `target.anchors` is every distinct file the
+ * project read within the 5000-event window, routinely hundreds of paths. Common basenames
+ * (index.ts, package.json, __init__.py) match many of them. At the default cap of 25 projects
+ * with ~20 rules each that was tens of thousands of synchronous whole-file reads and SHA-256
+ * passes on the MCP server's only thread, with `mode: 'all'` removing the project cap entirely.
+ * The same file was re-read once per rule-project pair.
+ */
+function digestCache() {
+  const cache = new Map();
+  return (path) => {
+    if (!cache.has(path)) cache.set(path, measure(path));
+    return cache.get(path);
+  };
+}
 
 /**
  * What one project costs, and whether enforcement is on there.
@@ -176,7 +279,10 @@ function safeBalance(dir) {
 }
 
 export function scanProject(project) {
-  const dir = project.cwd ? wikiDir(project.cwd) : null;
+  // project.cwd comes out of a transcript's JSON -- the same external, unvalidated input that
+  // reaches sha256 -- and existsSync aborts the process rather than throwing on a path holding
+  // U+10FFFF. See measure() above.
+  const dir = project.cwd && isFsSafePath(project.cwd) ? wikiDir(project.cwd) : null;
   const events = dir && existsSync(dir) ? readMetrics(dir) : [];
 
   const reads = events.filter((e) => e.kind === 'read');
@@ -221,24 +327,44 @@ export function scanProject(project) {
  */
 export function transferable(scans) {
   const out = [];
+  const digest = digestCache();
 
   for (const source of scans) {
     for (const rule of source.rules) {
-      if (!rule.anchor) continue;
-      const hash = sha256(rule.anchor);
-      if (!hash) continue;
+      // BOTH SHAPES. `if (!rule.anchor) continue` skipped every composite rule: remedy.mjs lists
+      // 'composite' among the remedy types this product applies itself, and applyRemedy stores
+      // those with `anchors` plural and `anchor` undefined. So composites were invisible to
+      // transfer analysis -- never offered to another project, never in the report's "proven
+      // somewhere, available elsewhere" block, and never counted as skipped either.
+      const wanted = rule.anchors?.length ? rule.anchors : (rule.anchor ? [rule.anchor] : []);
+      if (!wanted.length) continue;
+
+      // A multi-anchor remedy is only meaningful where EVERY file it was proven against is
+      // present with matching contents; a partial match is a different situation, not a weaker
+      // version of this one.
+      const required = wanted.map((a) => ({ anchor: a, base: basename(a), measured: digest(a) }));
+      if (required.some((r) => !r.measured)) continue;
 
       const targets = [];
       for (const target of scans) {
         if (target.slug === source.slug) continue;
         if (target.rules.some((r) => r.id === rule.id)) continue; // already has it
 
-        for (const anchor of target.anchors) {
-          if (basename(anchor) !== basename(rule.anchor)) continue;
-          if (sha256(anchor) !== hash) continue;
-          targets.push({ slug: target.slug, cwd: target.cwd, anchor });
-          break;
+        const matched = [];
+        for (const need of required) {
+          const hit = target.anchors.find((anchor) => {
+            if (basename(anchor) !== need.base) return false;
+            const found = digest(anchor);
+            // Size first: two files of different lengths cannot share contents, and statSync is
+            // orders of magnitude cheaper than hashing a whole file that cannot match anyway.
+            return Boolean(found) && found.size === need.measured.size && found.hash === need.measured.hash;
+          });
+          if (!hit) break;
+          matched.push(hit);
         }
+        if (matched.length !== required.length) continue;
+
+        targets.push({ slug: target.slug, cwd: target.cwd, anchor: matched[0], anchors: matched });
       }
 
       if (targets.length) {
@@ -283,14 +409,36 @@ export function enforcementComparison(scans) {
     };
   }
 
-  const mean = (list) => Math.round(list.reduce((sum, s) => sum + s.perRead, 0) / list.length);
+  // POOLED, NOT AN AVERAGE OF AVERAGES.
+  //
+  // Averaging each project's per-read average gives every project equal weight regardless of how
+  // much evidence stands behind it: a project with 2 reads counted as much as one with 30,000.
+  // An enforcing arm of [2 reads totalling 300k -> 150,000/read; 5,000 reads at 500; 4,000 at 400]
+  // reported 50,300 tokens/read where the pooled figure over the same 9,002 reads is about 530.
+  // Set against a directive arm around 800, renderFleet then printed that enforcing costs ~60x
+  // MORE per read -- the exact inverse of the truth, under a heading calling this the check on
+  // the central claim of this product, with nothing in the caveat to hint that one two-read
+  // project drove the whole result. scanProject already returns both tokens and reads, so the
+  // pooled statistic needs no new measurement.
+  const pool = (list) => {
+    const tokens = list.reduce((sum, s) => sum + (s.tokens || 0), 0);
+    const reads = list.reduce((sum, s) => sum + (s.reads || 0), 0);
+    return { perRead: reads ? Math.round(tokens / reads) : null, reads, tokens };
+  };
+
+  const e = pool(enforcing);
+  const d = pool(directive);
 
   return {
     comparable: true,
-    enforcingPerRead: mean(enforcing),
-    directivePerRead: mean(directive),
+    enforcingPerRead: e.perRead,
+    directivePerRead: d.perRead,
     enforcingProjects: enforcing.length,
     directiveProjects: directive.length,
+    // The read counts are exposed rather than kept internal: they are how a reader tells a
+    // fleet-wide result from one project's noise, which is the whole question here.
+    enforcingReads: e.reads,
+    directiveReads: d.reads,
     caveat: 'Not a randomised comparison: people choose their client and the projects differ. ' +
       'Treat as suggestive, not causal -- the per-project holdout arm is the causal measurement.',
   };
@@ -352,8 +500,11 @@ export function renderFleet({ discovery, scans, tier = 'opus', sessionsPerMonth 
   const comparison = enforcementComparison(scans);
   lines.push('', 'Enforcing vs directive, measured across this fleet:');
   if (comparison.comparable) {
-    lines.push(`  enforcing  ${comparison.enforcingPerRead.toLocaleString()} tokens/read over ${comparison.enforcingProjects} project(s)`);
-    lines.push(`  directive  ${comparison.directivePerRead.toLocaleString()} tokens/read over ${comparison.directiveProjects} project(s)`);
+    const arm = (label, perRead, projects, reads) =>
+      `  ${label}  ${perRead == null ? 'no reads yet' : `${perRead.toLocaleString()} tokens/read`}` +
+      ` over ${projects} project(s), ${reads.toLocaleString()} read(s)`;
+    lines.push(arm('enforcing', comparison.enforcingPerRead, comparison.enforcingProjects, comparison.enforcingReads));
+    lines.push(arm('directive', comparison.directivePerRead, comparison.directiveProjects, comparison.directiveReads));
     lines.push(`  ! ${comparison.caveat}`);
   } else {
     lines.push(`  not comparable yet -- ${comparison.reason}`);

--- a/integrations/codex/plugin/hooks/lib/fleet.mjs
+++ b/integrations/codex/plugin/hooks/lib/fleet.mjs
@@ -43,7 +43,7 @@ import { cacheHealth, readCacheUsage } from './cache.mjs';
 import { activeRules } from './remedy.mjs';
 import { monthly, money, priceNote } from './pricing.mjs';
 import { wikiDir } from './wiki.mjs';
-import { canonicalPath } from './paths.mjs';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
 
 /** How many projects an enumerating scan will read before it stops and says so. */
 export const DEFAULT_LIMIT = 25;
@@ -62,6 +62,7 @@ export function projectsRoot() {
  * is read, since `cwd` appears on the first rows.
  */
 export function projectCwd(transcript, { headBytes = 65_536 } = {}) {
+  if (!isFsSafePath(transcript)) return null;
   let fd;
   try {
     fd = openSync(transcript, 'r');
@@ -98,6 +99,7 @@ export function projectCwd(transcript, { headBytes = 65_536 } = {}) {
  */
 export function discoverProjects({
   mode = 'enumerate', root = projectsRoot(), only = [], exclude = [], limit = DEFAULT_LIMIT,
+  resolveCwd = true,
 } = {}) {
   if (mode === 'explicit') {
     return {
@@ -120,44 +122,145 @@ export function discoverProjects({
   for (const entry of entries) {
     const dir = join(root, entry.name);
     let newest = null;
+    let files = [];
     try {
-      for (const file of readdirSync(dir)) {
-        if (!file.endsWith('.jsonl')) continue;
-        const path = join(dir, file);
+      files = readdirSync(dir);
+    } catch { /* unreadable directory */ }
+
+    for (const file of files) {
+      if (!file.endsWith('.jsonl')) continue;
+      const path = join(dir, file);
+      // Scoped to the one file deliberately. Transcripts under the discovery root are being
+      // written and rotated by OTHER live sessions while this scan enumerates them, so a file
+      // present at readdirSync can be gone at statSync. Wrapping the whole loop meant one such
+      // race abandoned the directory's remaining transcripts -- reporting a project with several
+      // of them as 'no transcript', or silently deriving its cwd from a stale one.
+      try {
         const at = statSync(path).mtimeMs;
         if (!newest || at > newest.at) newest = { path, at };
-      }
-    } catch { /* unreadable directory */ }
+      } catch { /* rotated away mid-scan; the other transcripts still count */ }
+    }
 
     if (!newest) {
       skipped.push({ slug: entry.name, why: 'no transcript' });
       continue;
     }
-    if (exclude.some((pattern) => entry.name.includes(pattern))) {
+    if (isExcluded(entry.name, exclude)) {
       skipped.push({ slug: entry.name, why: 'excluded by pattern' });
       continue;
     }
 
-    projects.push({ slug: entry.name, transcript: newest.path, at: newest.at, cwd: projectCwd(newest.path) });
+    projects.push({ slug: entry.name, transcript: newest.path, at: newest.at });
   }
 
   projects.sort((a, b) => b.at - a.at);
 
+  let kept = projects;
   if (mode !== 'all' && projects.length > limit) {
     for (const extra of projects.slice(limit)) skipped.push({ slug: extra.slug, why: `beyond the limit of ${limit}` });
-    return { mode, projects: projects.slice(0, limit), skipped, root };
+    kept = projects.slice(0, limit);
   }
 
-  return { mode, projects, skipped, root };
+  // RESOLVED HERE, NOT DURING DISCOVERY. projectCwd opens a transcript and reads 64 KB of it, so
+  // resolving during the loop read every transcript on the machine and threw most of them away --
+  // 400 opened to keep 25. It also made the dry run a lie: fleet-tool.ts calls discoverProjects
+  // before it branches on dryRun, so "Nothing was read" was printed after reading the head of
+  // every transcript on the machine. Sorting needs only `at`, so nothing is lost by waiting.
+  //
+  // resolveCwd: false is what makes the dry run a real consent step. Reading 64 KB of a
+  // transcript IS reading the material consent is being asked about -- transcripts hold source
+  // code, paths and whatever has been pasted into a terminal -- so a gate that reads it before
+  // asking is not a gate. The slug is the cwd with its punctuation dashed out, so the listing
+  // still identifies each project.
+  if (!resolveCwd) return { mode, projects: kept.map((p) => ({ ...p, cwd: null })), skipped, root };
+
+  const resolved = [];
+  const seen = new Map();
+  for (const project of kept) {
+    const raw = projectCwd(project.transcript);
+    // Canonicalised as explicit mode already does. The client mints one directory per cwd
+    // SPELLING, so the same repo opened as C:\Users\me\repo, c:\users\me\repo and /c/Users/me/repo
+    // yields three slugs -- and wikiDir maps all three onto the same case-insensitive Windows
+    // directory, so readMetrics returns the SAME event log each time. Left undeduped, the project
+    // is counted once per spelling: its pareto share multiplies, and it contributes that many
+    // identical points to whichever arm of enforcementComparison it lands in.
+    const cwd = raw ? canonicalPath(raw) : null;
+    if (cwd && seen.has(cwd)) {
+      skipped.push({ slug: project.slug, why: `duplicate of ${seen.get(cwd)} (same cwd)` });
+      continue;
+    }
+    if (cwd) seen.set(cwd, project.slug);
+    resolved.push({ ...project, cwd });
+  }
+
+  return { mode, projects: resolved, skipped, root };
 }
 
-const sha256 = (path) => {
+/**
+ * The directory slug the client mints for a cwd: every non-alphanumeric character becomes a dash.
+ */
+export function slugifyCwd(cwd) {
+  return String(cwd).replace(/[^a-zA-Z0-9]/g, '-');
+}
+
+/**
+ * Does an exclude pattern apply to this project directory?
+ *
+ * Matched against the slugified form as well as the literal one. `exclude` is documented as
+ * "substrings to skip" and is the only scoping control the tool offers, but the thing being
+ * matched is the MANGLED slug -- so every pattern spelled the way a user would spell it could
+ * never match: `C:\work\private` (colon, backslashes), `~/work/private` (slashes, tilde),
+ * `node_modules` (underscore) and `my.project` (dot) all failed silently, and the project was
+ * scanned -- transcript head read, metrics and rules read, slug printed in the report -- with no
+ * diagnostic that the exclusion had not taken.
+ */
+function isExcluded(slug, exclude) {
+  return exclude.some((pattern) => {
+    const raw = String(pattern ?? '');
+    if (!raw) return false; // an empty pattern is in every string; excluding everything is never meant
+    return slug.includes(raw) || slug.includes(slugifyCwd(raw));
+  });
+}
+
+/**
+ * Size and content digest for one file, or null if it cannot be read.
+ *
+ * isFsSafePath first, and not as belt-and-braces: this is a copy of wiki.mjs's contentHash with
+ * that check dropped. libuv's UTF-8-to-UTF-16 conversion on Windows asserts
+ * `code_point < 0x10FFFF`, so a path containing U+10FFFF makes statSync/readFileSync **abort the
+ * process** rather than throw -- paths.mjs documents the assert and notes there is nothing to
+ * catch afterwards, so the try/catch below cannot save the scan. The paths reaching here are
+ * external input of exactly the guarded kind: `rule.anchor` out of a project's rules.json and
+ * `target.anchors` out of its event log. The blast radius is the whole MCP server process.
+ */
+function measure(path) {
+  if (!isFsSafePath(path)) return null;
   try {
-    return createHash('sha256').update(readFileSync(path)).digest('hex');
+    const size = statSync(path).size;
+    return { size, hash: createHash('sha256').update(readFileSync(path)).digest('hex') };
   } catch {
     return null;
   }
-};
+}
+
+/**
+ * Per-scan digest cache.
+ *
+ * `transferable` compares inside a triple loop -- every source project, every rule, every other
+ * project, every anchor whose basename matches -- and `target.anchors` is every distinct file the
+ * project read within the 5000-event window, routinely hundreds of paths. Common basenames
+ * (index.ts, package.json, __init__.py) match many of them. At the default cap of 25 projects
+ * with ~20 rules each that was tens of thousands of synchronous whole-file reads and SHA-256
+ * passes on the MCP server's only thread, with `mode: 'all'` removing the project cap entirely.
+ * The same file was re-read once per rule-project pair.
+ */
+function digestCache() {
+  const cache = new Map();
+  return (path) => {
+    if (!cache.has(path)) cache.set(path, measure(path));
+    return cache.get(path);
+  };
+}
 
 /**
  * What one project costs, and whether enforcement is on there.
@@ -176,7 +279,10 @@ function safeBalance(dir) {
 }
 
 export function scanProject(project) {
-  const dir = project.cwd ? wikiDir(project.cwd) : null;
+  // project.cwd comes out of a transcript's JSON -- the same external, unvalidated input that
+  // reaches sha256 -- and existsSync aborts the process rather than throwing on a path holding
+  // U+10FFFF. See measure() above.
+  const dir = project.cwd && isFsSafePath(project.cwd) ? wikiDir(project.cwd) : null;
   const events = dir && existsSync(dir) ? readMetrics(dir) : [];
 
   const reads = events.filter((e) => e.kind === 'read');
@@ -221,24 +327,44 @@ export function scanProject(project) {
  */
 export function transferable(scans) {
   const out = [];
+  const digest = digestCache();
 
   for (const source of scans) {
     for (const rule of source.rules) {
-      if (!rule.anchor) continue;
-      const hash = sha256(rule.anchor);
-      if (!hash) continue;
+      // BOTH SHAPES. `if (!rule.anchor) continue` skipped every composite rule: remedy.mjs lists
+      // 'composite' among the remedy types this product applies itself, and applyRemedy stores
+      // those with `anchors` plural and `anchor` undefined. So composites were invisible to
+      // transfer analysis -- never offered to another project, never in the report's "proven
+      // somewhere, available elsewhere" block, and never counted as skipped either.
+      const wanted = rule.anchors?.length ? rule.anchors : (rule.anchor ? [rule.anchor] : []);
+      if (!wanted.length) continue;
+
+      // A multi-anchor remedy is only meaningful where EVERY file it was proven against is
+      // present with matching contents; a partial match is a different situation, not a weaker
+      // version of this one.
+      const required = wanted.map((a) => ({ anchor: a, base: basename(a), measured: digest(a) }));
+      if (required.some((r) => !r.measured)) continue;
 
       const targets = [];
       for (const target of scans) {
         if (target.slug === source.slug) continue;
         if (target.rules.some((r) => r.id === rule.id)) continue; // already has it
 
-        for (const anchor of target.anchors) {
-          if (basename(anchor) !== basename(rule.anchor)) continue;
-          if (sha256(anchor) !== hash) continue;
-          targets.push({ slug: target.slug, cwd: target.cwd, anchor });
-          break;
+        const matched = [];
+        for (const need of required) {
+          const hit = target.anchors.find((anchor) => {
+            if (basename(anchor) !== need.base) return false;
+            const found = digest(anchor);
+            // Size first: two files of different lengths cannot share contents, and statSync is
+            // orders of magnitude cheaper than hashing a whole file that cannot match anyway.
+            return Boolean(found) && found.size === need.measured.size && found.hash === need.measured.hash;
+          });
+          if (!hit) break;
+          matched.push(hit);
         }
+        if (matched.length !== required.length) continue;
+
+        targets.push({ slug: target.slug, cwd: target.cwd, anchor: matched[0], anchors: matched });
       }
 
       if (targets.length) {
@@ -283,14 +409,36 @@ export function enforcementComparison(scans) {
     };
   }
 
-  const mean = (list) => Math.round(list.reduce((sum, s) => sum + s.perRead, 0) / list.length);
+  // POOLED, NOT AN AVERAGE OF AVERAGES.
+  //
+  // Averaging each project's per-read average gives every project equal weight regardless of how
+  // much evidence stands behind it: a project with 2 reads counted as much as one with 30,000.
+  // An enforcing arm of [2 reads totalling 300k -> 150,000/read; 5,000 reads at 500; 4,000 at 400]
+  // reported 50,300 tokens/read where the pooled figure over the same 9,002 reads is about 530.
+  // Set against a directive arm around 800, renderFleet then printed that enforcing costs ~60x
+  // MORE per read -- the exact inverse of the truth, under a heading calling this the check on
+  // the central claim of this product, with nothing in the caveat to hint that one two-read
+  // project drove the whole result. scanProject already returns both tokens and reads, so the
+  // pooled statistic needs no new measurement.
+  const pool = (list) => {
+    const tokens = list.reduce((sum, s) => sum + (s.tokens || 0), 0);
+    const reads = list.reduce((sum, s) => sum + (s.reads || 0), 0);
+    return { perRead: reads ? Math.round(tokens / reads) : null, reads, tokens };
+  };
+
+  const e = pool(enforcing);
+  const d = pool(directive);
 
   return {
     comparable: true,
-    enforcingPerRead: mean(enforcing),
-    directivePerRead: mean(directive),
+    enforcingPerRead: e.perRead,
+    directivePerRead: d.perRead,
     enforcingProjects: enforcing.length,
     directiveProjects: directive.length,
+    // The read counts are exposed rather than kept internal: they are how a reader tells a
+    // fleet-wide result from one project's noise, which is the whole question here.
+    enforcingReads: e.reads,
+    directiveReads: d.reads,
     caveat: 'Not a randomised comparison: people choose their client and the projects differ. ' +
       'Treat as suggestive, not causal -- the per-project holdout arm is the causal measurement.',
   };
@@ -352,8 +500,11 @@ export function renderFleet({ discovery, scans, tier = 'opus', sessionsPerMonth 
   const comparison = enforcementComparison(scans);
   lines.push('', 'Enforcing vs directive, measured across this fleet:');
   if (comparison.comparable) {
-    lines.push(`  enforcing  ${comparison.enforcingPerRead.toLocaleString()} tokens/read over ${comparison.enforcingProjects} project(s)`);
-    lines.push(`  directive  ${comparison.directivePerRead.toLocaleString()} tokens/read over ${comparison.directiveProjects} project(s)`);
+    const arm = (label, perRead, projects, reads) =>
+      `  ${label}  ${perRead == null ? 'no reads yet' : `${perRead.toLocaleString()} tokens/read`}` +
+      ` over ${projects} project(s), ${reads.toLocaleString()} read(s)`;
+    lines.push(arm('enforcing', comparison.enforcingPerRead, comparison.enforcingProjects, comparison.enforcingReads));
+    lines.push(arm('directive', comparison.directivePerRead, comparison.directiveProjects, comparison.directiveReads));
     lines.push(`  ! ${comparison.caveat}`);
   } else {
     lines.push(`  not comparable yet -- ${comparison.reason}`);

--- a/integrations/gemini/hooks/lib/fleet.mjs
+++ b/integrations/gemini/hooks/lib/fleet.mjs
@@ -43,7 +43,7 @@ import { cacheHealth, readCacheUsage } from './cache.mjs';
 import { activeRules } from './remedy.mjs';
 import { monthly, money, priceNote } from './pricing.mjs';
 import { wikiDir } from './wiki.mjs';
-import { canonicalPath } from './paths.mjs';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
 
 /** How many projects an enumerating scan will read before it stops and says so. */
 export const DEFAULT_LIMIT = 25;
@@ -62,6 +62,7 @@ export function projectsRoot() {
  * is read, since `cwd` appears on the first rows.
  */
 export function projectCwd(transcript, { headBytes = 65_536 } = {}) {
+  if (!isFsSafePath(transcript)) return null;
   let fd;
   try {
     fd = openSync(transcript, 'r');
@@ -98,6 +99,7 @@ export function projectCwd(transcript, { headBytes = 65_536 } = {}) {
  */
 export function discoverProjects({
   mode = 'enumerate', root = projectsRoot(), only = [], exclude = [], limit = DEFAULT_LIMIT,
+  resolveCwd = true,
 } = {}) {
   if (mode === 'explicit') {
     return {
@@ -120,44 +122,145 @@ export function discoverProjects({
   for (const entry of entries) {
     const dir = join(root, entry.name);
     let newest = null;
+    let files = [];
     try {
-      for (const file of readdirSync(dir)) {
-        if (!file.endsWith('.jsonl')) continue;
-        const path = join(dir, file);
+      files = readdirSync(dir);
+    } catch { /* unreadable directory */ }
+
+    for (const file of files) {
+      if (!file.endsWith('.jsonl')) continue;
+      const path = join(dir, file);
+      // Scoped to the one file deliberately. Transcripts under the discovery root are being
+      // written and rotated by OTHER live sessions while this scan enumerates them, so a file
+      // present at readdirSync can be gone at statSync. Wrapping the whole loop meant one such
+      // race abandoned the directory's remaining transcripts -- reporting a project with several
+      // of them as 'no transcript', or silently deriving its cwd from a stale one.
+      try {
         const at = statSync(path).mtimeMs;
         if (!newest || at > newest.at) newest = { path, at };
-      }
-    } catch { /* unreadable directory */ }
+      } catch { /* rotated away mid-scan; the other transcripts still count */ }
+    }
 
     if (!newest) {
       skipped.push({ slug: entry.name, why: 'no transcript' });
       continue;
     }
-    if (exclude.some((pattern) => entry.name.includes(pattern))) {
+    if (isExcluded(entry.name, exclude)) {
       skipped.push({ slug: entry.name, why: 'excluded by pattern' });
       continue;
     }
 
-    projects.push({ slug: entry.name, transcript: newest.path, at: newest.at, cwd: projectCwd(newest.path) });
+    projects.push({ slug: entry.name, transcript: newest.path, at: newest.at });
   }
 
   projects.sort((a, b) => b.at - a.at);
 
+  let kept = projects;
   if (mode !== 'all' && projects.length > limit) {
     for (const extra of projects.slice(limit)) skipped.push({ slug: extra.slug, why: `beyond the limit of ${limit}` });
-    return { mode, projects: projects.slice(0, limit), skipped, root };
+    kept = projects.slice(0, limit);
   }
 
-  return { mode, projects, skipped, root };
+  // RESOLVED HERE, NOT DURING DISCOVERY. projectCwd opens a transcript and reads 64 KB of it, so
+  // resolving during the loop read every transcript on the machine and threw most of them away --
+  // 400 opened to keep 25. It also made the dry run a lie: fleet-tool.ts calls discoverProjects
+  // before it branches on dryRun, so "Nothing was read" was printed after reading the head of
+  // every transcript on the machine. Sorting needs only `at`, so nothing is lost by waiting.
+  //
+  // resolveCwd: false is what makes the dry run a real consent step. Reading 64 KB of a
+  // transcript IS reading the material consent is being asked about -- transcripts hold source
+  // code, paths and whatever has been pasted into a terminal -- so a gate that reads it before
+  // asking is not a gate. The slug is the cwd with its punctuation dashed out, so the listing
+  // still identifies each project.
+  if (!resolveCwd) return { mode, projects: kept.map((p) => ({ ...p, cwd: null })), skipped, root };
+
+  const resolved = [];
+  const seen = new Map();
+  for (const project of kept) {
+    const raw = projectCwd(project.transcript);
+    // Canonicalised as explicit mode already does. The client mints one directory per cwd
+    // SPELLING, so the same repo opened as C:\Users\me\repo, c:\users\me\repo and /c/Users/me/repo
+    // yields three slugs -- and wikiDir maps all three onto the same case-insensitive Windows
+    // directory, so readMetrics returns the SAME event log each time. Left undeduped, the project
+    // is counted once per spelling: its pareto share multiplies, and it contributes that many
+    // identical points to whichever arm of enforcementComparison it lands in.
+    const cwd = raw ? canonicalPath(raw) : null;
+    if (cwd && seen.has(cwd)) {
+      skipped.push({ slug: project.slug, why: `duplicate of ${seen.get(cwd)} (same cwd)` });
+      continue;
+    }
+    if (cwd) seen.set(cwd, project.slug);
+    resolved.push({ ...project, cwd });
+  }
+
+  return { mode, projects: resolved, skipped, root };
 }
 
-const sha256 = (path) => {
+/**
+ * The directory slug the client mints for a cwd: every non-alphanumeric character becomes a dash.
+ */
+export function slugifyCwd(cwd) {
+  return String(cwd).replace(/[^a-zA-Z0-9]/g, '-');
+}
+
+/**
+ * Does an exclude pattern apply to this project directory?
+ *
+ * Matched against the slugified form as well as the literal one. `exclude` is documented as
+ * "substrings to skip" and is the only scoping control the tool offers, but the thing being
+ * matched is the MANGLED slug -- so every pattern spelled the way a user would spell it could
+ * never match: `C:\work\private` (colon, backslashes), `~/work/private` (slashes, tilde),
+ * `node_modules` (underscore) and `my.project` (dot) all failed silently, and the project was
+ * scanned -- transcript head read, metrics and rules read, slug printed in the report -- with no
+ * diagnostic that the exclusion had not taken.
+ */
+function isExcluded(slug, exclude) {
+  return exclude.some((pattern) => {
+    const raw = String(pattern ?? '');
+    if (!raw) return false; // an empty pattern is in every string; excluding everything is never meant
+    return slug.includes(raw) || slug.includes(slugifyCwd(raw));
+  });
+}
+
+/**
+ * Size and content digest for one file, or null if it cannot be read.
+ *
+ * isFsSafePath first, and not as belt-and-braces: this is a copy of wiki.mjs's contentHash with
+ * that check dropped. libuv's UTF-8-to-UTF-16 conversion on Windows asserts
+ * `code_point < 0x10FFFF`, so a path containing U+10FFFF makes statSync/readFileSync **abort the
+ * process** rather than throw -- paths.mjs documents the assert and notes there is nothing to
+ * catch afterwards, so the try/catch below cannot save the scan. The paths reaching here are
+ * external input of exactly the guarded kind: `rule.anchor` out of a project's rules.json and
+ * `target.anchors` out of its event log. The blast radius is the whole MCP server process.
+ */
+function measure(path) {
+  if (!isFsSafePath(path)) return null;
   try {
-    return createHash('sha256').update(readFileSync(path)).digest('hex');
+    const size = statSync(path).size;
+    return { size, hash: createHash('sha256').update(readFileSync(path)).digest('hex') };
   } catch {
     return null;
   }
-};
+}
+
+/**
+ * Per-scan digest cache.
+ *
+ * `transferable` compares inside a triple loop -- every source project, every rule, every other
+ * project, every anchor whose basename matches -- and `target.anchors` is every distinct file the
+ * project read within the 5000-event window, routinely hundreds of paths. Common basenames
+ * (index.ts, package.json, __init__.py) match many of them. At the default cap of 25 projects
+ * with ~20 rules each that was tens of thousands of synchronous whole-file reads and SHA-256
+ * passes on the MCP server's only thread, with `mode: 'all'` removing the project cap entirely.
+ * The same file was re-read once per rule-project pair.
+ */
+function digestCache() {
+  const cache = new Map();
+  return (path) => {
+    if (!cache.has(path)) cache.set(path, measure(path));
+    return cache.get(path);
+  };
+}
 
 /**
  * What one project costs, and whether enforcement is on there.
@@ -176,7 +279,10 @@ function safeBalance(dir) {
 }
 
 export function scanProject(project) {
-  const dir = project.cwd ? wikiDir(project.cwd) : null;
+  // project.cwd comes out of a transcript's JSON -- the same external, unvalidated input that
+  // reaches sha256 -- and existsSync aborts the process rather than throwing on a path holding
+  // U+10FFFF. See measure() above.
+  const dir = project.cwd && isFsSafePath(project.cwd) ? wikiDir(project.cwd) : null;
   const events = dir && existsSync(dir) ? readMetrics(dir) : [];
 
   const reads = events.filter((e) => e.kind === 'read');
@@ -221,24 +327,44 @@ export function scanProject(project) {
  */
 export function transferable(scans) {
   const out = [];
+  const digest = digestCache();
 
   for (const source of scans) {
     for (const rule of source.rules) {
-      if (!rule.anchor) continue;
-      const hash = sha256(rule.anchor);
-      if (!hash) continue;
+      // BOTH SHAPES. `if (!rule.anchor) continue` skipped every composite rule: remedy.mjs lists
+      // 'composite' among the remedy types this product applies itself, and applyRemedy stores
+      // those with `anchors` plural and `anchor` undefined. So composites were invisible to
+      // transfer analysis -- never offered to another project, never in the report's "proven
+      // somewhere, available elsewhere" block, and never counted as skipped either.
+      const wanted = rule.anchors?.length ? rule.anchors : (rule.anchor ? [rule.anchor] : []);
+      if (!wanted.length) continue;
+
+      // A multi-anchor remedy is only meaningful where EVERY file it was proven against is
+      // present with matching contents; a partial match is a different situation, not a weaker
+      // version of this one.
+      const required = wanted.map((a) => ({ anchor: a, base: basename(a), measured: digest(a) }));
+      if (required.some((r) => !r.measured)) continue;
 
       const targets = [];
       for (const target of scans) {
         if (target.slug === source.slug) continue;
         if (target.rules.some((r) => r.id === rule.id)) continue; // already has it
 
-        for (const anchor of target.anchors) {
-          if (basename(anchor) !== basename(rule.anchor)) continue;
-          if (sha256(anchor) !== hash) continue;
-          targets.push({ slug: target.slug, cwd: target.cwd, anchor });
-          break;
+        const matched = [];
+        for (const need of required) {
+          const hit = target.anchors.find((anchor) => {
+            if (basename(anchor) !== need.base) return false;
+            const found = digest(anchor);
+            // Size first: two files of different lengths cannot share contents, and statSync is
+            // orders of magnitude cheaper than hashing a whole file that cannot match anyway.
+            return Boolean(found) && found.size === need.measured.size && found.hash === need.measured.hash;
+          });
+          if (!hit) break;
+          matched.push(hit);
         }
+        if (matched.length !== required.length) continue;
+
+        targets.push({ slug: target.slug, cwd: target.cwd, anchor: matched[0], anchors: matched });
       }
 
       if (targets.length) {
@@ -283,14 +409,36 @@ export function enforcementComparison(scans) {
     };
   }
 
-  const mean = (list) => Math.round(list.reduce((sum, s) => sum + s.perRead, 0) / list.length);
+  // POOLED, NOT AN AVERAGE OF AVERAGES.
+  //
+  // Averaging each project's per-read average gives every project equal weight regardless of how
+  // much evidence stands behind it: a project with 2 reads counted as much as one with 30,000.
+  // An enforcing arm of [2 reads totalling 300k -> 150,000/read; 5,000 reads at 500; 4,000 at 400]
+  // reported 50,300 tokens/read where the pooled figure over the same 9,002 reads is about 530.
+  // Set against a directive arm around 800, renderFleet then printed that enforcing costs ~60x
+  // MORE per read -- the exact inverse of the truth, under a heading calling this the check on
+  // the central claim of this product, with nothing in the caveat to hint that one two-read
+  // project drove the whole result. scanProject already returns both tokens and reads, so the
+  // pooled statistic needs no new measurement.
+  const pool = (list) => {
+    const tokens = list.reduce((sum, s) => sum + (s.tokens || 0), 0);
+    const reads = list.reduce((sum, s) => sum + (s.reads || 0), 0);
+    return { perRead: reads ? Math.round(tokens / reads) : null, reads, tokens };
+  };
+
+  const e = pool(enforcing);
+  const d = pool(directive);
 
   return {
     comparable: true,
-    enforcingPerRead: mean(enforcing),
-    directivePerRead: mean(directive),
+    enforcingPerRead: e.perRead,
+    directivePerRead: d.perRead,
     enforcingProjects: enforcing.length,
     directiveProjects: directive.length,
+    // The read counts are exposed rather than kept internal: they are how a reader tells a
+    // fleet-wide result from one project's noise, which is the whole question here.
+    enforcingReads: e.reads,
+    directiveReads: d.reads,
     caveat: 'Not a randomised comparison: people choose their client and the projects differ. ' +
       'Treat as suggestive, not causal -- the per-project holdout arm is the causal measurement.',
   };
@@ -352,8 +500,11 @@ export function renderFleet({ discovery, scans, tier = 'opus', sessionsPerMonth 
   const comparison = enforcementComparison(scans);
   lines.push('', 'Enforcing vs directive, measured across this fleet:');
   if (comparison.comparable) {
-    lines.push(`  enforcing  ${comparison.enforcingPerRead.toLocaleString()} tokens/read over ${comparison.enforcingProjects} project(s)`);
-    lines.push(`  directive  ${comparison.directivePerRead.toLocaleString()} tokens/read over ${comparison.directiveProjects} project(s)`);
+    const arm = (label, perRead, projects, reads) =>
+      `  ${label}  ${perRead == null ? 'no reads yet' : `${perRead.toLocaleString()} tokens/read`}` +
+      ` over ${projects} project(s), ${reads.toLocaleString()} read(s)`;
+    lines.push(arm('enforcing', comparison.enforcingPerRead, comparison.enforcingProjects, comparison.enforcingReads));
+    lines.push(arm('directive', comparison.directivePerRead, comparison.directiveProjects, comparison.directiveReads));
     lines.push(`  ! ${comparison.caveat}`);
   } else {
     lines.push(`  not comparable yet -- ${comparison.reason}`);

--- a/integrations/opencode/hooks/lib/fleet.mjs
+++ b/integrations/opencode/hooks/lib/fleet.mjs
@@ -43,7 +43,7 @@ import { cacheHealth, readCacheUsage } from './cache.mjs';
 import { activeRules } from './remedy.mjs';
 import { monthly, money, priceNote } from './pricing.mjs';
 import { wikiDir } from './wiki.mjs';
-import { canonicalPath } from './paths.mjs';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
 
 /** How many projects an enumerating scan will read before it stops and says so. */
 export const DEFAULT_LIMIT = 25;
@@ -62,6 +62,7 @@ export function projectsRoot() {
  * is read, since `cwd` appears on the first rows.
  */
 export function projectCwd(transcript, { headBytes = 65_536 } = {}) {
+  if (!isFsSafePath(transcript)) return null;
   let fd;
   try {
     fd = openSync(transcript, 'r');
@@ -98,6 +99,7 @@ export function projectCwd(transcript, { headBytes = 65_536 } = {}) {
  */
 export function discoverProjects({
   mode = 'enumerate', root = projectsRoot(), only = [], exclude = [], limit = DEFAULT_LIMIT,
+  resolveCwd = true,
 } = {}) {
   if (mode === 'explicit') {
     return {
@@ -120,44 +122,145 @@ export function discoverProjects({
   for (const entry of entries) {
     const dir = join(root, entry.name);
     let newest = null;
+    let files = [];
     try {
-      for (const file of readdirSync(dir)) {
-        if (!file.endsWith('.jsonl')) continue;
-        const path = join(dir, file);
+      files = readdirSync(dir);
+    } catch { /* unreadable directory */ }
+
+    for (const file of files) {
+      if (!file.endsWith('.jsonl')) continue;
+      const path = join(dir, file);
+      // Scoped to the one file deliberately. Transcripts under the discovery root are being
+      // written and rotated by OTHER live sessions while this scan enumerates them, so a file
+      // present at readdirSync can be gone at statSync. Wrapping the whole loop meant one such
+      // race abandoned the directory's remaining transcripts -- reporting a project with several
+      // of them as 'no transcript', or silently deriving its cwd from a stale one.
+      try {
         const at = statSync(path).mtimeMs;
         if (!newest || at > newest.at) newest = { path, at };
-      }
-    } catch { /* unreadable directory */ }
+      } catch { /* rotated away mid-scan; the other transcripts still count */ }
+    }
 
     if (!newest) {
       skipped.push({ slug: entry.name, why: 'no transcript' });
       continue;
     }
-    if (exclude.some((pattern) => entry.name.includes(pattern))) {
+    if (isExcluded(entry.name, exclude)) {
       skipped.push({ slug: entry.name, why: 'excluded by pattern' });
       continue;
     }
 
-    projects.push({ slug: entry.name, transcript: newest.path, at: newest.at, cwd: projectCwd(newest.path) });
+    projects.push({ slug: entry.name, transcript: newest.path, at: newest.at });
   }
 
   projects.sort((a, b) => b.at - a.at);
 
+  let kept = projects;
   if (mode !== 'all' && projects.length > limit) {
     for (const extra of projects.slice(limit)) skipped.push({ slug: extra.slug, why: `beyond the limit of ${limit}` });
-    return { mode, projects: projects.slice(0, limit), skipped, root };
+    kept = projects.slice(0, limit);
   }
 
-  return { mode, projects, skipped, root };
+  // RESOLVED HERE, NOT DURING DISCOVERY. projectCwd opens a transcript and reads 64 KB of it, so
+  // resolving during the loop read every transcript on the machine and threw most of them away --
+  // 400 opened to keep 25. It also made the dry run a lie: fleet-tool.ts calls discoverProjects
+  // before it branches on dryRun, so "Nothing was read" was printed after reading the head of
+  // every transcript on the machine. Sorting needs only `at`, so nothing is lost by waiting.
+  //
+  // resolveCwd: false is what makes the dry run a real consent step. Reading 64 KB of a
+  // transcript IS reading the material consent is being asked about -- transcripts hold source
+  // code, paths and whatever has been pasted into a terminal -- so a gate that reads it before
+  // asking is not a gate. The slug is the cwd with its punctuation dashed out, so the listing
+  // still identifies each project.
+  if (!resolveCwd) return { mode, projects: kept.map((p) => ({ ...p, cwd: null })), skipped, root };
+
+  const resolved = [];
+  const seen = new Map();
+  for (const project of kept) {
+    const raw = projectCwd(project.transcript);
+    // Canonicalised as explicit mode already does. The client mints one directory per cwd
+    // SPELLING, so the same repo opened as C:\Users\me\repo, c:\users\me\repo and /c/Users/me/repo
+    // yields three slugs -- and wikiDir maps all three onto the same case-insensitive Windows
+    // directory, so readMetrics returns the SAME event log each time. Left undeduped, the project
+    // is counted once per spelling: its pareto share multiplies, and it contributes that many
+    // identical points to whichever arm of enforcementComparison it lands in.
+    const cwd = raw ? canonicalPath(raw) : null;
+    if (cwd && seen.has(cwd)) {
+      skipped.push({ slug: project.slug, why: `duplicate of ${seen.get(cwd)} (same cwd)` });
+      continue;
+    }
+    if (cwd) seen.set(cwd, project.slug);
+    resolved.push({ ...project, cwd });
+  }
+
+  return { mode, projects: resolved, skipped, root };
 }
 
-const sha256 = (path) => {
+/**
+ * The directory slug the client mints for a cwd: every non-alphanumeric character becomes a dash.
+ */
+export function slugifyCwd(cwd) {
+  return String(cwd).replace(/[^a-zA-Z0-9]/g, '-');
+}
+
+/**
+ * Does an exclude pattern apply to this project directory?
+ *
+ * Matched against the slugified form as well as the literal one. `exclude` is documented as
+ * "substrings to skip" and is the only scoping control the tool offers, but the thing being
+ * matched is the MANGLED slug -- so every pattern spelled the way a user would spell it could
+ * never match: `C:\work\private` (colon, backslashes), `~/work/private` (slashes, tilde),
+ * `node_modules` (underscore) and `my.project` (dot) all failed silently, and the project was
+ * scanned -- transcript head read, metrics and rules read, slug printed in the report -- with no
+ * diagnostic that the exclusion had not taken.
+ */
+function isExcluded(slug, exclude) {
+  return exclude.some((pattern) => {
+    const raw = String(pattern ?? '');
+    if (!raw) return false; // an empty pattern is in every string; excluding everything is never meant
+    return slug.includes(raw) || slug.includes(slugifyCwd(raw));
+  });
+}
+
+/**
+ * Size and content digest for one file, or null if it cannot be read.
+ *
+ * isFsSafePath first, and not as belt-and-braces: this is a copy of wiki.mjs's contentHash with
+ * that check dropped. libuv's UTF-8-to-UTF-16 conversion on Windows asserts
+ * `code_point < 0x10FFFF`, so a path containing U+10FFFF makes statSync/readFileSync **abort the
+ * process** rather than throw -- paths.mjs documents the assert and notes there is nothing to
+ * catch afterwards, so the try/catch below cannot save the scan. The paths reaching here are
+ * external input of exactly the guarded kind: `rule.anchor` out of a project's rules.json and
+ * `target.anchors` out of its event log. The blast radius is the whole MCP server process.
+ */
+function measure(path) {
+  if (!isFsSafePath(path)) return null;
   try {
-    return createHash('sha256').update(readFileSync(path)).digest('hex');
+    const size = statSync(path).size;
+    return { size, hash: createHash('sha256').update(readFileSync(path)).digest('hex') };
   } catch {
     return null;
   }
-};
+}
+
+/**
+ * Per-scan digest cache.
+ *
+ * `transferable` compares inside a triple loop -- every source project, every rule, every other
+ * project, every anchor whose basename matches -- and `target.anchors` is every distinct file the
+ * project read within the 5000-event window, routinely hundreds of paths. Common basenames
+ * (index.ts, package.json, __init__.py) match many of them. At the default cap of 25 projects
+ * with ~20 rules each that was tens of thousands of synchronous whole-file reads and SHA-256
+ * passes on the MCP server's only thread, with `mode: 'all'` removing the project cap entirely.
+ * The same file was re-read once per rule-project pair.
+ */
+function digestCache() {
+  const cache = new Map();
+  return (path) => {
+    if (!cache.has(path)) cache.set(path, measure(path));
+    return cache.get(path);
+  };
+}
 
 /**
  * What one project costs, and whether enforcement is on there.
@@ -176,7 +279,10 @@ function safeBalance(dir) {
 }
 
 export function scanProject(project) {
-  const dir = project.cwd ? wikiDir(project.cwd) : null;
+  // project.cwd comes out of a transcript's JSON -- the same external, unvalidated input that
+  // reaches sha256 -- and existsSync aborts the process rather than throwing on a path holding
+  // U+10FFFF. See measure() above.
+  const dir = project.cwd && isFsSafePath(project.cwd) ? wikiDir(project.cwd) : null;
   const events = dir && existsSync(dir) ? readMetrics(dir) : [];
 
   const reads = events.filter((e) => e.kind === 'read');
@@ -221,24 +327,44 @@ export function scanProject(project) {
  */
 export function transferable(scans) {
   const out = [];
+  const digest = digestCache();
 
   for (const source of scans) {
     for (const rule of source.rules) {
-      if (!rule.anchor) continue;
-      const hash = sha256(rule.anchor);
-      if (!hash) continue;
+      // BOTH SHAPES. `if (!rule.anchor) continue` skipped every composite rule: remedy.mjs lists
+      // 'composite' among the remedy types this product applies itself, and applyRemedy stores
+      // those with `anchors` plural and `anchor` undefined. So composites were invisible to
+      // transfer analysis -- never offered to another project, never in the report's "proven
+      // somewhere, available elsewhere" block, and never counted as skipped either.
+      const wanted = rule.anchors?.length ? rule.anchors : (rule.anchor ? [rule.anchor] : []);
+      if (!wanted.length) continue;
+
+      // A multi-anchor remedy is only meaningful where EVERY file it was proven against is
+      // present with matching contents; a partial match is a different situation, not a weaker
+      // version of this one.
+      const required = wanted.map((a) => ({ anchor: a, base: basename(a), measured: digest(a) }));
+      if (required.some((r) => !r.measured)) continue;
 
       const targets = [];
       for (const target of scans) {
         if (target.slug === source.slug) continue;
         if (target.rules.some((r) => r.id === rule.id)) continue; // already has it
 
-        for (const anchor of target.anchors) {
-          if (basename(anchor) !== basename(rule.anchor)) continue;
-          if (sha256(anchor) !== hash) continue;
-          targets.push({ slug: target.slug, cwd: target.cwd, anchor });
-          break;
+        const matched = [];
+        for (const need of required) {
+          const hit = target.anchors.find((anchor) => {
+            if (basename(anchor) !== need.base) return false;
+            const found = digest(anchor);
+            // Size first: two files of different lengths cannot share contents, and statSync is
+            // orders of magnitude cheaper than hashing a whole file that cannot match anyway.
+            return Boolean(found) && found.size === need.measured.size && found.hash === need.measured.hash;
+          });
+          if (!hit) break;
+          matched.push(hit);
         }
+        if (matched.length !== required.length) continue;
+
+        targets.push({ slug: target.slug, cwd: target.cwd, anchor: matched[0], anchors: matched });
       }
 
       if (targets.length) {
@@ -283,14 +409,36 @@ export function enforcementComparison(scans) {
     };
   }
 
-  const mean = (list) => Math.round(list.reduce((sum, s) => sum + s.perRead, 0) / list.length);
+  // POOLED, NOT AN AVERAGE OF AVERAGES.
+  //
+  // Averaging each project's per-read average gives every project equal weight regardless of how
+  // much evidence stands behind it: a project with 2 reads counted as much as one with 30,000.
+  // An enforcing arm of [2 reads totalling 300k -> 150,000/read; 5,000 reads at 500; 4,000 at 400]
+  // reported 50,300 tokens/read where the pooled figure over the same 9,002 reads is about 530.
+  // Set against a directive arm around 800, renderFleet then printed that enforcing costs ~60x
+  // MORE per read -- the exact inverse of the truth, under a heading calling this the check on
+  // the central claim of this product, with nothing in the caveat to hint that one two-read
+  // project drove the whole result. scanProject already returns both tokens and reads, so the
+  // pooled statistic needs no new measurement.
+  const pool = (list) => {
+    const tokens = list.reduce((sum, s) => sum + (s.tokens || 0), 0);
+    const reads = list.reduce((sum, s) => sum + (s.reads || 0), 0);
+    return { perRead: reads ? Math.round(tokens / reads) : null, reads, tokens };
+  };
+
+  const e = pool(enforcing);
+  const d = pool(directive);
 
   return {
     comparable: true,
-    enforcingPerRead: mean(enforcing),
-    directivePerRead: mean(directive),
+    enforcingPerRead: e.perRead,
+    directivePerRead: d.perRead,
     enforcingProjects: enforcing.length,
     directiveProjects: directive.length,
+    // The read counts are exposed rather than kept internal: they are how a reader tells a
+    // fleet-wide result from one project's noise, which is the whole question here.
+    enforcingReads: e.reads,
+    directiveReads: d.reads,
     caveat: 'Not a randomised comparison: people choose their client and the projects differ. ' +
       'Treat as suggestive, not causal -- the per-project holdout arm is the causal measurement.',
   };
@@ -352,8 +500,11 @@ export function renderFleet({ discovery, scans, tier = 'opus', sessionsPerMonth 
   const comparison = enforcementComparison(scans);
   lines.push('', 'Enforcing vs directive, measured across this fleet:');
   if (comparison.comparable) {
-    lines.push(`  enforcing  ${comparison.enforcingPerRead.toLocaleString()} tokens/read over ${comparison.enforcingProjects} project(s)`);
-    lines.push(`  directive  ${comparison.directivePerRead.toLocaleString()} tokens/read over ${comparison.directiveProjects} project(s)`);
+    const arm = (label, perRead, projects, reads) =>
+      `  ${label}  ${perRead == null ? 'no reads yet' : `${perRead.toLocaleString()} tokens/read`}` +
+      ` over ${projects} project(s), ${reads.toLocaleString()} read(s)`;
+    lines.push(arm('enforcing', comparison.enforcingPerRead, comparison.enforcingProjects, comparison.enforcingReads));
+    lines.push(arm('directive', comparison.directivePerRead, comparison.directiveProjects, comparison.directiveReads));
     lines.push(`  ! ${comparison.caveat}`);
   } else {
     lines.push(`  not comparable yet -- ${comparison.reason}`);

--- a/integrations/qwen/hooks/lib/fleet.mjs
+++ b/integrations/qwen/hooks/lib/fleet.mjs
@@ -43,7 +43,7 @@ import { cacheHealth, readCacheUsage } from './cache.mjs';
 import { activeRules } from './remedy.mjs';
 import { monthly, money, priceNote } from './pricing.mjs';
 import { wikiDir } from './wiki.mjs';
-import { canonicalPath } from './paths.mjs';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
 
 /** How many projects an enumerating scan will read before it stops and says so. */
 export const DEFAULT_LIMIT = 25;
@@ -62,6 +62,7 @@ export function projectsRoot() {
  * is read, since `cwd` appears on the first rows.
  */
 export function projectCwd(transcript, { headBytes = 65_536 } = {}) {
+  if (!isFsSafePath(transcript)) return null;
   let fd;
   try {
     fd = openSync(transcript, 'r');
@@ -98,6 +99,7 @@ export function projectCwd(transcript, { headBytes = 65_536 } = {}) {
  */
 export function discoverProjects({
   mode = 'enumerate', root = projectsRoot(), only = [], exclude = [], limit = DEFAULT_LIMIT,
+  resolveCwd = true,
 } = {}) {
   if (mode === 'explicit') {
     return {
@@ -120,44 +122,145 @@ export function discoverProjects({
   for (const entry of entries) {
     const dir = join(root, entry.name);
     let newest = null;
+    let files = [];
     try {
-      for (const file of readdirSync(dir)) {
-        if (!file.endsWith('.jsonl')) continue;
-        const path = join(dir, file);
+      files = readdirSync(dir);
+    } catch { /* unreadable directory */ }
+
+    for (const file of files) {
+      if (!file.endsWith('.jsonl')) continue;
+      const path = join(dir, file);
+      // Scoped to the one file deliberately. Transcripts under the discovery root are being
+      // written and rotated by OTHER live sessions while this scan enumerates them, so a file
+      // present at readdirSync can be gone at statSync. Wrapping the whole loop meant one such
+      // race abandoned the directory's remaining transcripts -- reporting a project with several
+      // of them as 'no transcript', or silently deriving its cwd from a stale one.
+      try {
         const at = statSync(path).mtimeMs;
         if (!newest || at > newest.at) newest = { path, at };
-      }
-    } catch { /* unreadable directory */ }
+      } catch { /* rotated away mid-scan; the other transcripts still count */ }
+    }
 
     if (!newest) {
       skipped.push({ slug: entry.name, why: 'no transcript' });
       continue;
     }
-    if (exclude.some((pattern) => entry.name.includes(pattern))) {
+    if (isExcluded(entry.name, exclude)) {
       skipped.push({ slug: entry.name, why: 'excluded by pattern' });
       continue;
     }
 
-    projects.push({ slug: entry.name, transcript: newest.path, at: newest.at, cwd: projectCwd(newest.path) });
+    projects.push({ slug: entry.name, transcript: newest.path, at: newest.at });
   }
 
   projects.sort((a, b) => b.at - a.at);
 
+  let kept = projects;
   if (mode !== 'all' && projects.length > limit) {
     for (const extra of projects.slice(limit)) skipped.push({ slug: extra.slug, why: `beyond the limit of ${limit}` });
-    return { mode, projects: projects.slice(0, limit), skipped, root };
+    kept = projects.slice(0, limit);
   }
 
-  return { mode, projects, skipped, root };
+  // RESOLVED HERE, NOT DURING DISCOVERY. projectCwd opens a transcript and reads 64 KB of it, so
+  // resolving during the loop read every transcript on the machine and threw most of them away --
+  // 400 opened to keep 25. It also made the dry run a lie: fleet-tool.ts calls discoverProjects
+  // before it branches on dryRun, so "Nothing was read" was printed after reading the head of
+  // every transcript on the machine. Sorting needs only `at`, so nothing is lost by waiting.
+  //
+  // resolveCwd: false is what makes the dry run a real consent step. Reading 64 KB of a
+  // transcript IS reading the material consent is being asked about -- transcripts hold source
+  // code, paths and whatever has been pasted into a terminal -- so a gate that reads it before
+  // asking is not a gate. The slug is the cwd with its punctuation dashed out, so the listing
+  // still identifies each project.
+  if (!resolveCwd) return { mode, projects: kept.map((p) => ({ ...p, cwd: null })), skipped, root };
+
+  const resolved = [];
+  const seen = new Map();
+  for (const project of kept) {
+    const raw = projectCwd(project.transcript);
+    // Canonicalised as explicit mode already does. The client mints one directory per cwd
+    // SPELLING, so the same repo opened as C:\Users\me\repo, c:\users\me\repo and /c/Users/me/repo
+    // yields three slugs -- and wikiDir maps all three onto the same case-insensitive Windows
+    // directory, so readMetrics returns the SAME event log each time. Left undeduped, the project
+    // is counted once per spelling: its pareto share multiplies, and it contributes that many
+    // identical points to whichever arm of enforcementComparison it lands in.
+    const cwd = raw ? canonicalPath(raw) : null;
+    if (cwd && seen.has(cwd)) {
+      skipped.push({ slug: project.slug, why: `duplicate of ${seen.get(cwd)} (same cwd)` });
+      continue;
+    }
+    if (cwd) seen.set(cwd, project.slug);
+    resolved.push({ ...project, cwd });
+  }
+
+  return { mode, projects: resolved, skipped, root };
 }
 
-const sha256 = (path) => {
+/**
+ * The directory slug the client mints for a cwd: every non-alphanumeric character becomes a dash.
+ */
+export function slugifyCwd(cwd) {
+  return String(cwd).replace(/[^a-zA-Z0-9]/g, '-');
+}
+
+/**
+ * Does an exclude pattern apply to this project directory?
+ *
+ * Matched against the slugified form as well as the literal one. `exclude` is documented as
+ * "substrings to skip" and is the only scoping control the tool offers, but the thing being
+ * matched is the MANGLED slug -- so every pattern spelled the way a user would spell it could
+ * never match: `C:\work\private` (colon, backslashes), `~/work/private` (slashes, tilde),
+ * `node_modules` (underscore) and `my.project` (dot) all failed silently, and the project was
+ * scanned -- transcript head read, metrics and rules read, slug printed in the report -- with no
+ * diagnostic that the exclusion had not taken.
+ */
+function isExcluded(slug, exclude) {
+  return exclude.some((pattern) => {
+    const raw = String(pattern ?? '');
+    if (!raw) return false; // an empty pattern is in every string; excluding everything is never meant
+    return slug.includes(raw) || slug.includes(slugifyCwd(raw));
+  });
+}
+
+/**
+ * Size and content digest for one file, or null if it cannot be read.
+ *
+ * isFsSafePath first, and not as belt-and-braces: this is a copy of wiki.mjs's contentHash with
+ * that check dropped. libuv's UTF-8-to-UTF-16 conversion on Windows asserts
+ * `code_point < 0x10FFFF`, so a path containing U+10FFFF makes statSync/readFileSync **abort the
+ * process** rather than throw -- paths.mjs documents the assert and notes there is nothing to
+ * catch afterwards, so the try/catch below cannot save the scan. The paths reaching here are
+ * external input of exactly the guarded kind: `rule.anchor` out of a project's rules.json and
+ * `target.anchors` out of its event log. The blast radius is the whole MCP server process.
+ */
+function measure(path) {
+  if (!isFsSafePath(path)) return null;
   try {
-    return createHash('sha256').update(readFileSync(path)).digest('hex');
+    const size = statSync(path).size;
+    return { size, hash: createHash('sha256').update(readFileSync(path)).digest('hex') };
   } catch {
     return null;
   }
-};
+}
+
+/**
+ * Per-scan digest cache.
+ *
+ * `transferable` compares inside a triple loop -- every source project, every rule, every other
+ * project, every anchor whose basename matches -- and `target.anchors` is every distinct file the
+ * project read within the 5000-event window, routinely hundreds of paths. Common basenames
+ * (index.ts, package.json, __init__.py) match many of them. At the default cap of 25 projects
+ * with ~20 rules each that was tens of thousands of synchronous whole-file reads and SHA-256
+ * passes on the MCP server's only thread, with `mode: 'all'` removing the project cap entirely.
+ * The same file was re-read once per rule-project pair.
+ */
+function digestCache() {
+  const cache = new Map();
+  return (path) => {
+    if (!cache.has(path)) cache.set(path, measure(path));
+    return cache.get(path);
+  };
+}
 
 /**
  * What one project costs, and whether enforcement is on there.
@@ -176,7 +279,10 @@ function safeBalance(dir) {
 }
 
 export function scanProject(project) {
-  const dir = project.cwd ? wikiDir(project.cwd) : null;
+  // project.cwd comes out of a transcript's JSON -- the same external, unvalidated input that
+  // reaches sha256 -- and existsSync aborts the process rather than throwing on a path holding
+  // U+10FFFF. See measure() above.
+  const dir = project.cwd && isFsSafePath(project.cwd) ? wikiDir(project.cwd) : null;
   const events = dir && existsSync(dir) ? readMetrics(dir) : [];
 
   const reads = events.filter((e) => e.kind === 'read');
@@ -221,24 +327,44 @@ export function scanProject(project) {
  */
 export function transferable(scans) {
   const out = [];
+  const digest = digestCache();
 
   for (const source of scans) {
     for (const rule of source.rules) {
-      if (!rule.anchor) continue;
-      const hash = sha256(rule.anchor);
-      if (!hash) continue;
+      // BOTH SHAPES. `if (!rule.anchor) continue` skipped every composite rule: remedy.mjs lists
+      // 'composite' among the remedy types this product applies itself, and applyRemedy stores
+      // those with `anchors` plural and `anchor` undefined. So composites were invisible to
+      // transfer analysis -- never offered to another project, never in the report's "proven
+      // somewhere, available elsewhere" block, and never counted as skipped either.
+      const wanted = rule.anchors?.length ? rule.anchors : (rule.anchor ? [rule.anchor] : []);
+      if (!wanted.length) continue;
+
+      // A multi-anchor remedy is only meaningful where EVERY file it was proven against is
+      // present with matching contents; a partial match is a different situation, not a weaker
+      // version of this one.
+      const required = wanted.map((a) => ({ anchor: a, base: basename(a), measured: digest(a) }));
+      if (required.some((r) => !r.measured)) continue;
 
       const targets = [];
       for (const target of scans) {
         if (target.slug === source.slug) continue;
         if (target.rules.some((r) => r.id === rule.id)) continue; // already has it
 
-        for (const anchor of target.anchors) {
-          if (basename(anchor) !== basename(rule.anchor)) continue;
-          if (sha256(anchor) !== hash) continue;
-          targets.push({ slug: target.slug, cwd: target.cwd, anchor });
-          break;
+        const matched = [];
+        for (const need of required) {
+          const hit = target.anchors.find((anchor) => {
+            if (basename(anchor) !== need.base) return false;
+            const found = digest(anchor);
+            // Size first: two files of different lengths cannot share contents, and statSync is
+            // orders of magnitude cheaper than hashing a whole file that cannot match anyway.
+            return Boolean(found) && found.size === need.measured.size && found.hash === need.measured.hash;
+          });
+          if (!hit) break;
+          matched.push(hit);
         }
+        if (matched.length !== required.length) continue;
+
+        targets.push({ slug: target.slug, cwd: target.cwd, anchor: matched[0], anchors: matched });
       }
 
       if (targets.length) {
@@ -283,14 +409,36 @@ export function enforcementComparison(scans) {
     };
   }
 
-  const mean = (list) => Math.round(list.reduce((sum, s) => sum + s.perRead, 0) / list.length);
+  // POOLED, NOT AN AVERAGE OF AVERAGES.
+  //
+  // Averaging each project's per-read average gives every project equal weight regardless of how
+  // much evidence stands behind it: a project with 2 reads counted as much as one with 30,000.
+  // An enforcing arm of [2 reads totalling 300k -> 150,000/read; 5,000 reads at 500; 4,000 at 400]
+  // reported 50,300 tokens/read where the pooled figure over the same 9,002 reads is about 530.
+  // Set against a directive arm around 800, renderFleet then printed that enforcing costs ~60x
+  // MORE per read -- the exact inverse of the truth, under a heading calling this the check on
+  // the central claim of this product, with nothing in the caveat to hint that one two-read
+  // project drove the whole result. scanProject already returns both tokens and reads, so the
+  // pooled statistic needs no new measurement.
+  const pool = (list) => {
+    const tokens = list.reduce((sum, s) => sum + (s.tokens || 0), 0);
+    const reads = list.reduce((sum, s) => sum + (s.reads || 0), 0);
+    return { perRead: reads ? Math.round(tokens / reads) : null, reads, tokens };
+  };
+
+  const e = pool(enforcing);
+  const d = pool(directive);
 
   return {
     comparable: true,
-    enforcingPerRead: mean(enforcing),
-    directivePerRead: mean(directive),
+    enforcingPerRead: e.perRead,
+    directivePerRead: d.perRead,
     enforcingProjects: enforcing.length,
     directiveProjects: directive.length,
+    // The read counts are exposed rather than kept internal: they are how a reader tells a
+    // fleet-wide result from one project's noise, which is the whole question here.
+    enforcingReads: e.reads,
+    directiveReads: d.reads,
     caveat: 'Not a randomised comparison: people choose their client and the projects differ. ' +
       'Treat as suggestive, not causal -- the per-project holdout arm is the causal measurement.',
   };
@@ -352,8 +500,11 @@ export function renderFleet({ discovery, scans, tier = 'opus', sessionsPerMonth 
   const comparison = enforcementComparison(scans);
   lines.push('', 'Enforcing vs directive, measured across this fleet:');
   if (comparison.comparable) {
-    lines.push(`  enforcing  ${comparison.enforcingPerRead.toLocaleString()} tokens/read over ${comparison.enforcingProjects} project(s)`);
-    lines.push(`  directive  ${comparison.directivePerRead.toLocaleString()} tokens/read over ${comparison.directiveProjects} project(s)`);
+    const arm = (label, perRead, projects, reads) =>
+      `  ${label}  ${perRead == null ? 'no reads yet' : `${perRead.toLocaleString()} tokens/read`}` +
+      ` over ${projects} project(s), ${reads.toLocaleString()} read(s)`;
+    lines.push(arm('enforcing', comparison.enforcingPerRead, comparison.enforcingProjects, comparison.enforcingReads));
+    lines.push(arm('directive', comparison.directivePerRead, comparison.directiveProjects, comparison.directiveReads));
     lines.push(`  ! ${comparison.caveat}`);
   } else {
     lines.push(`  not comparable yet -- ${comparison.reason}`);

--- a/plugin/hooks/lib/fleet.mjs
+++ b/plugin/hooks/lib/fleet.mjs
@@ -43,7 +43,7 @@ import { cacheHealth, readCacheUsage } from './cache.mjs';
 import { activeRules } from './remedy.mjs';
 import { monthly, money, priceNote } from './pricing.mjs';
 import { wikiDir } from './wiki.mjs';
-import { canonicalPath } from './paths.mjs';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
 
 /** How many projects an enumerating scan will read before it stops and says so. */
 export const DEFAULT_LIMIT = 25;
@@ -62,6 +62,7 @@ export function projectsRoot() {
  * is read, since `cwd` appears on the first rows.
  */
 export function projectCwd(transcript, { headBytes = 65_536 } = {}) {
+  if (!isFsSafePath(transcript)) return null;
   let fd;
   try {
     fd = openSync(transcript, 'r');
@@ -98,6 +99,7 @@ export function projectCwd(transcript, { headBytes = 65_536 } = {}) {
  */
 export function discoverProjects({
   mode = 'enumerate', root = projectsRoot(), only = [], exclude = [], limit = DEFAULT_LIMIT,
+  resolveCwd = true,
 } = {}) {
   if (mode === 'explicit') {
     return {
@@ -120,44 +122,145 @@ export function discoverProjects({
   for (const entry of entries) {
     const dir = join(root, entry.name);
     let newest = null;
+    let files = [];
     try {
-      for (const file of readdirSync(dir)) {
-        if (!file.endsWith('.jsonl')) continue;
-        const path = join(dir, file);
+      files = readdirSync(dir);
+    } catch { /* unreadable directory */ }
+
+    for (const file of files) {
+      if (!file.endsWith('.jsonl')) continue;
+      const path = join(dir, file);
+      // Scoped to the one file deliberately. Transcripts under the discovery root are being
+      // written and rotated by OTHER live sessions while this scan enumerates them, so a file
+      // present at readdirSync can be gone at statSync. Wrapping the whole loop meant one such
+      // race abandoned the directory's remaining transcripts -- reporting a project with several
+      // of them as 'no transcript', or silently deriving its cwd from a stale one.
+      try {
         const at = statSync(path).mtimeMs;
         if (!newest || at > newest.at) newest = { path, at };
-      }
-    } catch { /* unreadable directory */ }
+      } catch { /* rotated away mid-scan; the other transcripts still count */ }
+    }
 
     if (!newest) {
       skipped.push({ slug: entry.name, why: 'no transcript' });
       continue;
     }
-    if (exclude.some((pattern) => entry.name.includes(pattern))) {
+    if (isExcluded(entry.name, exclude)) {
       skipped.push({ slug: entry.name, why: 'excluded by pattern' });
       continue;
     }
 
-    projects.push({ slug: entry.name, transcript: newest.path, at: newest.at, cwd: projectCwd(newest.path) });
+    projects.push({ slug: entry.name, transcript: newest.path, at: newest.at });
   }
 
   projects.sort((a, b) => b.at - a.at);
 
+  let kept = projects;
   if (mode !== 'all' && projects.length > limit) {
     for (const extra of projects.slice(limit)) skipped.push({ slug: extra.slug, why: `beyond the limit of ${limit}` });
-    return { mode, projects: projects.slice(0, limit), skipped, root };
+    kept = projects.slice(0, limit);
   }
 
-  return { mode, projects, skipped, root };
+  // RESOLVED HERE, NOT DURING DISCOVERY. projectCwd opens a transcript and reads 64 KB of it, so
+  // resolving during the loop read every transcript on the machine and threw most of them away --
+  // 400 opened to keep 25. It also made the dry run a lie: fleet-tool.ts calls discoverProjects
+  // before it branches on dryRun, so "Nothing was read" was printed after reading the head of
+  // every transcript on the machine. Sorting needs only `at`, so nothing is lost by waiting.
+  //
+  // resolveCwd: false is what makes the dry run a real consent step. Reading 64 KB of a
+  // transcript IS reading the material consent is being asked about -- transcripts hold source
+  // code, paths and whatever has been pasted into a terminal -- so a gate that reads it before
+  // asking is not a gate. The slug is the cwd with its punctuation dashed out, so the listing
+  // still identifies each project.
+  if (!resolveCwd) return { mode, projects: kept.map((p) => ({ ...p, cwd: null })), skipped, root };
+
+  const resolved = [];
+  const seen = new Map();
+  for (const project of kept) {
+    const raw = projectCwd(project.transcript);
+    // Canonicalised as explicit mode already does. The client mints one directory per cwd
+    // SPELLING, so the same repo opened as C:\Users\me\repo, c:\users\me\repo and /c/Users/me/repo
+    // yields three slugs -- and wikiDir maps all three onto the same case-insensitive Windows
+    // directory, so readMetrics returns the SAME event log each time. Left undeduped, the project
+    // is counted once per spelling: its pareto share multiplies, and it contributes that many
+    // identical points to whichever arm of enforcementComparison it lands in.
+    const cwd = raw ? canonicalPath(raw) : null;
+    if (cwd && seen.has(cwd)) {
+      skipped.push({ slug: project.slug, why: `duplicate of ${seen.get(cwd)} (same cwd)` });
+      continue;
+    }
+    if (cwd) seen.set(cwd, project.slug);
+    resolved.push({ ...project, cwd });
+  }
+
+  return { mode, projects: resolved, skipped, root };
 }
 
-const sha256 = (path) => {
+/**
+ * The directory slug the client mints for a cwd: every non-alphanumeric character becomes a dash.
+ */
+export function slugifyCwd(cwd) {
+  return String(cwd).replace(/[^a-zA-Z0-9]/g, '-');
+}
+
+/**
+ * Does an exclude pattern apply to this project directory?
+ *
+ * Matched against the slugified form as well as the literal one. `exclude` is documented as
+ * "substrings to skip" and is the only scoping control the tool offers, but the thing being
+ * matched is the MANGLED slug -- so every pattern spelled the way a user would spell it could
+ * never match: `C:\work\private` (colon, backslashes), `~/work/private` (slashes, tilde),
+ * `node_modules` (underscore) and `my.project` (dot) all failed silently, and the project was
+ * scanned -- transcript head read, metrics and rules read, slug printed in the report -- with no
+ * diagnostic that the exclusion had not taken.
+ */
+function isExcluded(slug, exclude) {
+  return exclude.some((pattern) => {
+    const raw = String(pattern ?? '');
+    if (!raw) return false; // an empty pattern is in every string; excluding everything is never meant
+    return slug.includes(raw) || slug.includes(slugifyCwd(raw));
+  });
+}
+
+/**
+ * Size and content digest for one file, or null if it cannot be read.
+ *
+ * isFsSafePath first, and not as belt-and-braces: this is a copy of wiki.mjs's contentHash with
+ * that check dropped. libuv's UTF-8-to-UTF-16 conversion on Windows asserts
+ * `code_point < 0x10FFFF`, so a path containing U+10FFFF makes statSync/readFileSync **abort the
+ * process** rather than throw -- paths.mjs documents the assert and notes there is nothing to
+ * catch afterwards, so the try/catch below cannot save the scan. The paths reaching here are
+ * external input of exactly the guarded kind: `rule.anchor` out of a project's rules.json and
+ * `target.anchors` out of its event log. The blast radius is the whole MCP server process.
+ */
+function measure(path) {
+  if (!isFsSafePath(path)) return null;
   try {
-    return createHash('sha256').update(readFileSync(path)).digest('hex');
+    const size = statSync(path).size;
+    return { size, hash: createHash('sha256').update(readFileSync(path)).digest('hex') };
   } catch {
     return null;
   }
-};
+}
+
+/**
+ * Per-scan digest cache.
+ *
+ * `transferable` compares inside a triple loop -- every source project, every rule, every other
+ * project, every anchor whose basename matches -- and `target.anchors` is every distinct file the
+ * project read within the 5000-event window, routinely hundreds of paths. Common basenames
+ * (index.ts, package.json, __init__.py) match many of them. At the default cap of 25 projects
+ * with ~20 rules each that was tens of thousands of synchronous whole-file reads and SHA-256
+ * passes on the MCP server's only thread, with `mode: 'all'` removing the project cap entirely.
+ * The same file was re-read once per rule-project pair.
+ */
+function digestCache() {
+  const cache = new Map();
+  return (path) => {
+    if (!cache.has(path)) cache.set(path, measure(path));
+    return cache.get(path);
+  };
+}
 
 /**
  * What one project costs, and whether enforcement is on there.
@@ -176,7 +279,10 @@ function safeBalance(dir) {
 }
 
 export function scanProject(project) {
-  const dir = project.cwd ? wikiDir(project.cwd) : null;
+  // project.cwd comes out of a transcript's JSON -- the same external, unvalidated input that
+  // reaches sha256 -- and existsSync aborts the process rather than throwing on a path holding
+  // U+10FFFF. See measure() above.
+  const dir = project.cwd && isFsSafePath(project.cwd) ? wikiDir(project.cwd) : null;
   const events = dir && existsSync(dir) ? readMetrics(dir) : [];
 
   const reads = events.filter((e) => e.kind === 'read');
@@ -221,24 +327,44 @@ export function scanProject(project) {
  */
 export function transferable(scans) {
   const out = [];
+  const digest = digestCache();
 
   for (const source of scans) {
     for (const rule of source.rules) {
-      if (!rule.anchor) continue;
-      const hash = sha256(rule.anchor);
-      if (!hash) continue;
+      // BOTH SHAPES. `if (!rule.anchor) continue` skipped every composite rule: remedy.mjs lists
+      // 'composite' among the remedy types this product applies itself, and applyRemedy stores
+      // those with `anchors` plural and `anchor` undefined. So composites were invisible to
+      // transfer analysis -- never offered to another project, never in the report's "proven
+      // somewhere, available elsewhere" block, and never counted as skipped either.
+      const wanted = rule.anchors?.length ? rule.anchors : (rule.anchor ? [rule.anchor] : []);
+      if (!wanted.length) continue;
+
+      // A multi-anchor remedy is only meaningful where EVERY file it was proven against is
+      // present with matching contents; a partial match is a different situation, not a weaker
+      // version of this one.
+      const required = wanted.map((a) => ({ anchor: a, base: basename(a), measured: digest(a) }));
+      if (required.some((r) => !r.measured)) continue;
 
       const targets = [];
       for (const target of scans) {
         if (target.slug === source.slug) continue;
         if (target.rules.some((r) => r.id === rule.id)) continue; // already has it
 
-        for (const anchor of target.anchors) {
-          if (basename(anchor) !== basename(rule.anchor)) continue;
-          if (sha256(anchor) !== hash) continue;
-          targets.push({ slug: target.slug, cwd: target.cwd, anchor });
-          break;
+        const matched = [];
+        for (const need of required) {
+          const hit = target.anchors.find((anchor) => {
+            if (basename(anchor) !== need.base) return false;
+            const found = digest(anchor);
+            // Size first: two files of different lengths cannot share contents, and statSync is
+            // orders of magnitude cheaper than hashing a whole file that cannot match anyway.
+            return Boolean(found) && found.size === need.measured.size && found.hash === need.measured.hash;
+          });
+          if (!hit) break;
+          matched.push(hit);
         }
+        if (matched.length !== required.length) continue;
+
+        targets.push({ slug: target.slug, cwd: target.cwd, anchor: matched[0], anchors: matched });
       }
 
       if (targets.length) {
@@ -283,14 +409,36 @@ export function enforcementComparison(scans) {
     };
   }
 
-  const mean = (list) => Math.round(list.reduce((sum, s) => sum + s.perRead, 0) / list.length);
+  // POOLED, NOT AN AVERAGE OF AVERAGES.
+  //
+  // Averaging each project's per-read average gives every project equal weight regardless of how
+  // much evidence stands behind it: a project with 2 reads counted as much as one with 30,000.
+  // An enforcing arm of [2 reads totalling 300k -> 150,000/read; 5,000 reads at 500; 4,000 at 400]
+  // reported 50,300 tokens/read where the pooled figure over the same 9,002 reads is about 530.
+  // Set against a directive arm around 800, renderFleet then printed that enforcing costs ~60x
+  // MORE per read -- the exact inverse of the truth, under a heading calling this the check on
+  // the central claim of this product, with nothing in the caveat to hint that one two-read
+  // project drove the whole result. scanProject already returns both tokens and reads, so the
+  // pooled statistic needs no new measurement.
+  const pool = (list) => {
+    const tokens = list.reduce((sum, s) => sum + (s.tokens || 0), 0);
+    const reads = list.reduce((sum, s) => sum + (s.reads || 0), 0);
+    return { perRead: reads ? Math.round(tokens / reads) : null, reads, tokens };
+  };
+
+  const e = pool(enforcing);
+  const d = pool(directive);
 
   return {
     comparable: true,
-    enforcingPerRead: mean(enforcing),
-    directivePerRead: mean(directive),
+    enforcingPerRead: e.perRead,
+    directivePerRead: d.perRead,
     enforcingProjects: enforcing.length,
     directiveProjects: directive.length,
+    // The read counts are exposed rather than kept internal: they are how a reader tells a
+    // fleet-wide result from one project's noise, which is the whole question here.
+    enforcingReads: e.reads,
+    directiveReads: d.reads,
     caveat: 'Not a randomised comparison: people choose their client and the projects differ. ' +
       'Treat as suggestive, not causal -- the per-project holdout arm is the causal measurement.',
   };
@@ -352,8 +500,11 @@ export function renderFleet({ discovery, scans, tier = 'opus', sessionsPerMonth 
   const comparison = enforcementComparison(scans);
   lines.push('', 'Enforcing vs directive, measured across this fleet:');
   if (comparison.comparable) {
-    lines.push(`  enforcing  ${comparison.enforcingPerRead.toLocaleString()} tokens/read over ${comparison.enforcingProjects} project(s)`);
-    lines.push(`  directive  ${comparison.directivePerRead.toLocaleString()} tokens/read over ${comparison.directiveProjects} project(s)`);
+    const arm = (label, perRead, projects, reads) =>
+      `  ${label}  ${perRead == null ? 'no reads yet' : `${perRead.toLocaleString()} tokens/read`}` +
+      ` over ${projects} project(s), ${reads.toLocaleString()} read(s)`;
+    lines.push(arm('enforcing', comparison.enforcingPerRead, comparison.enforcingProjects, comparison.enforcingReads));
+    lines.push(arm('directive', comparison.directivePerRead, comparison.directiveProjects, comparison.directiveReads));
     lines.push(`  ! ${comparison.caveat}`);
   } else {
     lines.push(`  not comparable yet -- ${comparison.reason}`);

--- a/src/server/fleet-tool.ts
+++ b/src/server/fleet-tool.ts
@@ -59,6 +59,10 @@ export async function fleetAudit(input: {
     only: input?.projects || [],
     exclude: input?.exclude || [],
     limit: input?.limit,
+    // A dry run must not open a transcript. Resolving each project's cwd reads 64 KB from the
+    // head of its transcript, so leaving it on meant the consent step had already read the
+    // material it was asking permission for by the time it printed 'Nothing was read'.
+    resolveCwd: !input?.dryRun,
   });
 
   // The consent step: show what would be opened, open nothing.
@@ -80,7 +84,8 @@ export async function fleetAudit(input: {
             ]
           : []),
         '',
-        'Nothing was read. Run again without dryRun to scan.',
+        'Nothing was read -- not one transcript was opened. Slugs are each project directory ' +
+          'with its punctuation replaced by dashes. Run again without dryRun to scan.',
       ].join('\n')
     );
   }

--- a/tests/hooks/fleet.test.mjs
+++ b/tests/hooks/fleet.test.mjs
@@ -9,14 +9,15 @@
  * and the scan says what it read and reads nothing it was not asked to.
  */
 
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, symlinkSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
   discoverProjects, projectCwd, scanProject, transferable, enforcementComparison,
-  pareto, renderFleet, DEFAULT_LIMIT,
+  pareto, renderFleet, slugifyCwd, DEFAULT_LIMIT,
 } from '../../hooks-core/fleet.mjs';
 import { applyRemedy } from '../../hooks-core/remedy.mjs';
+import { canonicalPath } from '../../hooks-core/paths.mjs';
 
 let machine;
 
@@ -245,5 +246,241 @@ describe('the scan accounts for what it opened', () => {
     expect(text).toMatch(/Where the cost is:/);
     expect(text).toMatch(/\[enforcing\]/);
     expect(text).toMatch(/Enforcing vs directive/);
+  });
+});
+
+// --- scoping, weighting, and reading nothing before consent -------------------------
+
+/**
+ * Writes a transcript directly, so a test can control the exact SPELLING of the cwd it
+ * reports -- which is the thing the client varies and the thing dedupe has to survive.
+ */
+function transcriptFor(slug, cwd, { root = join(machine, 'projects'), name = 'session.jsonl' } = {}) {
+  const dir = join(root, slug);
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, name);
+  writeFileSync(path, `${JSON.stringify({ type: 'user', cwd, message: { role: 'user', content: 'hi' } })}\n`);
+  return path;
+}
+
+/** Can this machine make a dangling symlink? Needed to simulate the readdir/stat race. */
+const canSymlink = (() => {
+  const probe = mkdtempSync(join(tmpdir(), 'fleet-symlink-probe-'));
+  try {
+    symlinkSync(join(probe, 'does-not-exist'), join(probe, 'link'));
+    return true;
+  } catch {
+    return false;
+  } finally {
+    rmSync(probe, { recursive: true, force: true });
+  }
+})();
+
+describe('exclusion is matched against the shape the directory actually has', () => {
+  test('a pattern spelled as a path excludes the project it names', () => {
+    // THE DEFECT: exclude was matched against entry.name, which is the cwd with every
+    // non-alphanumeric character replaced by a dash. So every pattern spelled the way a user
+    // would spell it could never match, and the project was scanned anyway -- with no
+    // diagnostic that the exclusion had not taken.
+    const cwd = 'C:\\work\\private';
+    transcriptFor(slugifyCwd(cwd), cwd);
+    transcriptFor(slugifyCwd('C:\\work\\public'), 'C:\\work\\public');
+
+    const out = discoverProjects({ root: join(machine, 'projects'), exclude: [cwd] });
+    expect(out.projects.map((p) => p.slug)).toEqual([slugifyCwd('C:\\work\\public')]);
+    expect(out.skipped.find((s) => s.slug === slugifyCwd(cwd)).why).toMatch(/excluded/);
+  });
+
+  test('a pattern with an underscore or a dot still matches', () => {
+    transcriptFor(slugifyCwd('/src/node_modules/x'), '/src/node_modules/x');
+    transcriptFor(slugifyCwd('/src/my.project'), '/src/my.project');
+    transcriptFor(slugifyCwd('/src/keep'), '/src/keep');
+
+    const out = discoverProjects({
+      root: join(machine, 'projects'), exclude: ['node_modules', 'my.project'],
+    });
+    expect(out.projects.map((p) => p.slug)).toEqual([slugifyCwd('/src/keep')]);
+  });
+
+  test('the literal slug still works, since that is what people copy out of the report', () => {
+    project('keep-me', { reads: reads(2, '/a.ts', 100) });
+    project('drop-me', { reads: reads(2, '/b.ts', 100) });
+    const out = discoverProjects({ root: join(machine, 'projects'), exclude: ['drop-me'] });
+    expect(out.projects.map((p) => p.slug)).toEqual(['keep-me']);
+  });
+
+  test('an empty pattern excludes nothing rather than everything', () => {
+    // '' is a substring of every string, so a stray entry would silently scan zero projects
+    // and report them all as deliberately excluded.
+    project('keep-me', { reads: reads(2, '/a.ts', 100) });
+    const out = discoverProjects({ root: join(machine, 'projects'), exclude: ['', null] });
+    expect(out.projects.map((p) => p.slug)).toEqual(['keep-me']);
+  });
+});
+
+describe('a dry run reads nothing', () => {
+  test('resolveCwd: false opens no transcript at all', () => {
+    // THE DEFECT: the cwd was resolved during discovery, and resolving it reads 64 KB from the
+    // head of the transcript. fleet-tool calls discoverProjects BEFORE it branches on dryRun,
+    // so the consent step had already read the head of every transcript on the machine by the
+    // time it printed 'Nothing was read'.
+    const built = project('proj-a', { reads: reads(2, '/a.ts', 100) });
+    const dry = discoverProjects({ root: join(machine, 'projects'), resolveCwd: false });
+    expect(dry.projects).toHaveLength(1);
+    expect(dry.projects[0].cwd).toBeNull();
+    expect(dry.projects[0].slug).toBe('proj-a');
+
+    // and the same call with resolution on does find it, so the null above is the switch
+    // working rather than the fixture being unreadable.
+    const wet = discoverProjects({ root: join(machine, 'projects') });
+    expect(wet.projects[0].cwd).toBe(canonicalPath(built.cwd));
+  });
+
+  test('projects beyond the limit are never resolved', () => {
+    for (let i = 0; i < 4; i++) project(`p${i}`, { reads: reads(2, '/a.ts', 100) });
+    const out = discoverProjects({ root: join(machine, 'projects'), limit: 2 });
+    expect(out.projects).toHaveLength(2);
+    expect(out.projects.every((p) => p.cwd)).toBe(true);
+    expect(out.skipped.filter((s) => /beyond the limit/.test(s.why))).toHaveLength(2);
+  });
+});
+
+describe('one project is one project however its directory was spelled', () => {
+  test('two spellings of the same cwd are scanned once', () => {
+    // The client mints one directory per cwd SPELLING, and wikiDir maps every spelling onto the
+    // same case-insensitive directory -- so readMetrics returns the SAME event log for each.
+    // Undeduped, the project's pareto share multiplies and it contributes that many identical
+    // points to whichever arm of the enforcement comparison it lands in.
+    transcriptFor('spelling-one', 'C:\\Users\\me\\repo');
+    transcriptFor('spelling-two', 'C:/Users/me/repo');
+
+    const out = discoverProjects({ root: join(machine, 'projects') });
+    expect(out.projects).toHaveLength(1);
+    expect(out.skipped.some((s) => /duplicate of/.test(s.why))).toBe(true);
+  });
+
+  test('genuinely different projects are both kept', () => {
+    transcriptFor('one', 'C:\\Users\\me\\repo-a');
+    transcriptFor('two', 'C:\\Users\\me\\repo-b');
+    expect(discoverProjects({ root: join(machine, 'projects') }).projects).toHaveLength(2);
+  });
+});
+
+(canSymlink ? describe : describe.skip)('a transcript rotated away mid-scan costs only itself', () => {
+  test('the project survives, with its remaining transcripts', () => {
+    // Transcripts under the discovery root are written and rotated by other live sessions while
+    // the scan enumerates them, so a file present at readdirSync can be gone at statSync. The
+    // try wrapped the whole per-directory loop, so one such race abandoned the rest of the
+    // directory: 'no transcript' for a project that has several, or a stale cwd.
+    const built = project('racy', { reads: reads(2, '/a.ts', 100) });
+    const dir = join(machine, 'projects', 'racy');
+    const dangling = join(dir, 'aaa-rotated.jsonl'); // enumerated before session.jsonl
+    symlinkSync(join(dir, 'gone.jsonl'), dangling);
+
+    const out = discoverProjects({ root: join(machine, 'projects') });
+    expect(out.projects.map((p) => p.slug)).toEqual(['racy']);
+    expect(out.projects[0].cwd).toBe(canonicalPath(built.cwd));
+    unlinkSync(dangling);
+  });
+});
+
+describe('a multi-anchor remedy can transfer', () => {
+  const scanFor = (slug, { rules = [], anchors = [] }) => ({ slug, cwd: `/${slug}`, rules, anchors });
+
+  function shared(name, body) {
+    const dir = join(machine, 'shared');
+    mkdirSync(dir, { recursive: true });
+    const path = join(dir, name);
+    writeFileSync(path, body);
+    return path;
+  }
+
+  test('a composite rule transfers when every anchor matches', () => {
+    // THE DEFECT: `if (!rule.anchor) continue` skipped every composite rule. remedy.mjs lists
+    // composite among the remedy types this product applies itself, and applyRemedy stores those
+    // with `anchors` plural and `anchor` undefined -- so they were invisible to transfer
+    // analysis, and not reported as skipped either.
+    const a = shared('a.ts', 'AAA');
+    const b = shared('b.ts', 'BBB');
+    const copyDir = join(machine, 'copy');
+    mkdirSync(copyDir, { recursive: true });
+    writeFileSync(join(copyDir, 'a.ts'), 'AAA');
+    writeFileSync(join(copyDir, 'b.ts'), 'BBB');
+
+    const out = transferable([
+      scanFor('source', { rules: [{ id: 'composite:1', type: 'composite', anchors: [a, b], why: 'x' }] }),
+      scanFor('target', { anchors: [join(copyDir, 'a.ts'), join(copyDir, 'b.ts')] }),
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].targets.map((t) => t.slug)).toEqual(['target']);
+  });
+
+  test('a composite rule does not transfer on a partial match', () => {
+    const a = shared('pa.ts', 'AAA');
+    const b = shared('pb.ts', 'BBB');
+    const copyDir = join(machine, 'partial');
+    mkdirSync(copyDir, { recursive: true });
+    writeFileSync(join(copyDir, 'pa.ts'), 'AAA');
+    writeFileSync(join(copyDir, 'pb.ts'), 'DIFFERENT');
+
+    const out = transferable([
+      scanFor('source', { rules: [{ id: 'composite:2', type: 'composite', anchors: [a, b], why: 'x' }] }),
+      scanFor('target', { anchors: [join(copyDir, 'pa.ts'), join(copyDir, 'pb.ts')] }),
+    ]);
+    expect(out).toHaveLength(0);
+  });
+
+  test('same name and same length but different bytes does not transfer', () => {
+    // The size check added in front of the hash is an optimisation, not a relaxation.
+    const a = shared('same-size.ts', 'AAAA');
+    const copyDir = join(machine, 'samesize');
+    mkdirSync(copyDir, { recursive: true });
+    writeFileSync(join(copyDir, 'same-size.ts'), 'BBBB');
+
+    const out = transferable([
+      scanFor('source', { rules: [{ id: 'skip:3', type: 'skip', anchor: a, why: 'x' }] }),
+      scanFor('target', { anchors: [join(copyDir, 'same-size.ts')] }),
+    ]);
+    expect(out).toHaveLength(0);
+  });
+});
+
+describe('the enforcement comparison is pooled over reads', () => {
+  const arm = (slug, { reads: n, tokens, enforcing }) => ({
+    slug, reads: n, tokens, enforcing, perRead: n ? Math.round(tokens / n) : null,
+    rules: [], anchors: [],
+  });
+
+  test('a two-read outlier does not decide the fleet result', () => {
+    // THE DEFECT: averaging each project's per-read average gave every project equal weight
+    // regardless of evidence, so one project with 2 reads counted as much as one with 5,000 --
+    // and renderFleet printed the exact inverse of the truth under a heading that calls this the
+    // check on the central claim of this product.
+    const scans = [
+      arm('outlier', { reads: 2, tokens: 300_000, enforcing: true }),
+      arm('big-a', { reads: 5_000, tokens: 2_500_000, enforcing: true }),
+      arm('big-b', { reads: 4_000, tokens: 1_600_000, enforcing: true }),
+      arm('directive', { reads: 3_000, tokens: 2_400_000, enforcing: false }),
+    ];
+
+    // What the old unweighted mean reported: enforcing looks ~60x WORSE than directive's 800.
+    const unweighted = Math.round((150_000 + 500 + 400) / 3);
+    expect(unweighted).toBeGreaterThan(50_000);
+
+    const out = enforcementComparison(scans);
+    expect(out.enforcingReads).toBe(9_002);
+    expect(out.directiveReads).toBe(3_000);
+    expect(out.enforcingPerRead).toBe(Math.round(4_400_000 / 9_002));
+    expect(out.enforcingPerRead).toBeLessThan(out.directivePerRead);
+  });
+
+  test('the render names the read counts behind each arm', () => {
+    const scans = [
+      arm('e', { reads: 10, tokens: 1_000, enforcing: true }),
+      arm('d', { reads: 20, tokens: 8_000, enforcing: false }),
+    ];
+    const text = renderFleet({ discovery: { mode: 'enumerate', skipped: [] }, scans });
+    expect(text).toMatch(/enforcing {2}100 tokens\/read over 1 project\(s\), 10 read\(s\)/);
+    expect(text).toMatch(/directive {2}400 tokens\/read over 1 project\(s\), 20 read\(s\)/);
   });
 });


### PR DESCRIPTION
Eight defects in the module that has access to every project on the machine. Four change what the
report **says**, three change what it **reads**, and one is a live-machine race.

## What the report says

### 1. The enforcement comparison was inverted by one small project

`enforcementComparison` averaged each project's per-read average, so every project carried equal
weight regardless of how much evidence stood behind it — a project with 2 reads counted as much as
one with 5,000.

An enforcing arm of `[2 reads totalling 300k → 150,000/read; 5,000 reads at 500; 4,000 at 400]`
reported **50,300 tokens/read**. Pooled over the same 9,002 reads it is about **530**. Against a
directive arm near 800, `renderFleet` printed that enforcing costs **60× more** per read — the exact
inverse of the truth, under a heading that calls this *"the check on the central claim of this
product"*. The caveat discloses the client-choice confound and says nothing about weighting, so
nothing signalled that one two-read project drove the result.

Now pooled `sum(tokens)/sum(reads)`, with the read counts behind each arm printed so one project's
noise is visible as noise. `scanProject` already returned both numbers.

### 2. One project could be counted twice

Enumerate mode stored the transcript's cwd verbatim while explicit mode canonicalised it. The client
mints one directory per cwd **spelling**, and `wikiDir` maps every spelling onto the same
case-insensitive Windows directory — so `readMetrics` returned the *same event log* for
`C:\Users\me\repo`, `c:\users\me\repo` and `/c/Users/me/repo`. The project appeared that many times
in the pareto, multiplying its share, and contributed that many identical points to whichever arm of
the comparison it landed in. `canonicalPath` exists for exactly this. Duplicates are now dropped and
recorded in `skipped`.

### 3. Composite remedies never transferred

`if (!rule.anchor) continue` skipped every composite rule. `remedy.mjs` lists `composite` among the
remedy types this product applies itself, and `applyRemedy` stores those with `anchors` **plural**
and `anchor` undefined. So composites were invisible to transfer analysis — never offered to another
project, never in the *"proven somewhere, available elsewhere"* block, and not counted as skipped
either. They now transfer where **every** anchor is present with matching contents; a partial match
is a different situation, not a weaker version of this one.

### 4. Exclusions silently did not exclude

`entry.name.includes(pattern)` matched against the mangled slug — the cwd with every non-alphanumeric
character replaced by a dash. So every pattern spelled the way a user would spell it could never
match: `C:\work\private` (colon, backslashes), `~/work/private`, `node_modules` (underscore),
`my.project` (dot). The parameter is documented as *"substrings to skip"* and is the only scoping
control the tool offers, so a user excluding a sensitive project by path got it scanned — transcript
head read, metrics and rules read, slug printed — with **no diagnostic**. Patterns are now matched
against the slugified form as well as the literal one, and an empty pattern is ignored rather than
excluding everything.

## What it reads

### 5. The dry run read the material it was asking permission for

`projectCwd` opens a transcript and reads 64 KB, and it ran for every discovered directory before
the cap was applied — 400 opened to keep 25, with the discarded 375 then reported as "beyond the
limit". Worse, `fleet-tool.ts` calls `discoverProjects` **before** it branches on `dryRun`, so
`"Nothing was read. Run again without dryRun to scan."` was printed *after* reading the head of every
transcript on the machine, while the tool description promises *"use dryRun=true to see what it would
read before it reads anything"*.

Transcripts hold source code, paths and whatever has been pasted into a terminal. A gate that reads
them before asking is not a gate. Resolution now happens **after** the cap (sorting needs only the
mtime), and discovery takes `resolveCwd`, which the dry run passes as `false` — nothing is opened at
all. Slugs still identify each project.

### 6. Digests were recomputed once per rule-project pair

`sha256` did an unbounded `readFileSync` inside a triple loop with no memoisation: every source
project × every rule × every other project × every anchor whose basename matches. `target.anchors` is
every distinct file the project read inside the 5000-event window — routinely hundreds of paths — and
common basenames (`index.ts`, `package.json`, `__init__.py`) match many. At the default cap of 25
projects with ~20 rules each that is tens of thousands of synchronous whole-file reads and SHA-256
passes on the MCP server's only thread, and `mode: 'all'` removes the cap entirely.

Memoised per scan, with a `statSync` size comparison first: two files of different lengths cannot
share contents. A test confirms the size check is an optimisation, not a relaxation.

### 7. Paths reached the filesystem unguarded

`sha256` is a copy of `wiki.mjs`'s `contentHash` with the `isFsSafePath` check removed. That check
exists because libuv's UTF-8→UTF-16 conversion on Windows asserts `code_point < 0x10FFFF`, so a path
containing U+10FFFF makes `existsSync`/`statSync`/`readFileSync` **abort the process** rather than
throw — `paths.mjs` documents the assert and notes *"there is nothing to catch afterwards"*. The paths
reaching it are external input of exactly the guarded kind: `rule.anchor` from a project's rules.json,
`target.anchors` from its event log, `project.cwd` from a transcript's JSON. The blast radius is the
whole MCP server process.

## The race

### 8. One rotated transcript dropped the whole project

The `try` wrapped the entire per-directory loop, so a `statSync` failure on any single `.jsonl`
abandoned the rest of that directory. Landing on the first file left `newest` null and the project
skipped as **"no transcript"** — a wrong reason for a directory that has several. Landing mid-loop
silently derived the cwd from a stale transcript. This is a live-machine race: other sessions are
writing and rotating transcripts under the discovery root while the scan enumerates them, so a file
present at `readdirSync` can be gone at `statSync`. A project dropped here contributes nothing to the
pareto total or either comparison arm. The catch is now scoped to the one file.

---

**Verified:** `tests/hooks` — 717 passed, 3 skipped, 0 failed, with 14 new tests. `tsc --noEmit`
clean. Vendored copies re-synced via `npm run sync:hooks`.

One caveat stated plainly: the rotated-transcript test needs a dangling symlink, and is `describe.skip`ped
where the OS refuses to create one — which includes the Windows box this was written on. It is one of
the 3 skips above, and it runs on Linux CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)