### PR TITLE
fix(keepwarm,lessons): score refreshes with the model that bought them

### DIFF
--- a/hooks-core/keepwarm.mjs
+++ b/hooks-core/keepwarm.mjs
@@ -174,9 +174,21 @@ export function recordRefresh(dir, { tier, prefixTokens, expectedValue }) {
  */
 export function recordRefreshOutcome(dir, { tier, prefixTokens, hit }) {
   const tierSpec = TIERS.find((t) => t.name === tier) || TIERS[0];
+  // THE SAME LEDGER keepWarmDecision BUYS THE REFRESH WITH. That function is explicit that a
+  // refresh is a PING, which READS the prefix -- costOfPing = prefixTokens * READ_MULTIPLIER --
+  // and its comment warns that pricing the ping as a write "overstates its cost by more than
+  // twelvefold". This scored the very same refresh as a re-WRITE, charging (writeMultiplier - 1)
+  // on both branches.
+  //
+  // The disagreement runs in the direction that kills the feature. Mean realised per refresh under
+  // the old lines was p*(0.9h - 0.25), negative below a 27.8% hit rate, while the decision's own
+  // model makes the ping pay above 8.7%. For any project whose gaps fall in that band, `tripwire`
+  // accumulates a negative balance and permanently disables a policy that is genuinely paying --
+  // and tells the user "keep-warm has lost N tokens ... stopping". The backstop fired on its own
+  // accounting error rather than on a distribution shift.
   const realised = hit
-    ? prefixTokens * (1 - READ_MULTIPLIER) - prefixTokens * (tierSpec.writeMultiplier - 1)
-    : -prefixTokens * (tierSpec.writeMultiplier - 1);
+    ? prefixTokens * (tierSpec.writeMultiplier - READ_MULTIPLIER) - prefixTokens * READ_MULTIPLIER
+    : -prefixTokens * READ_MULTIPLIER;
   record(dir, { kind: 'keepwarm', action: 'outcome', tier, prefixTokens, hit: Boolean(hit), realised: Math.round(realised) });
 }
 

--- a/hooks-core/keepwarm.mjs
+++ b/hooks-core/keepwarm.mjs
@@ -135,7 +135,14 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
   const costOf = (tier) => {
     const hit = gaps.probabilityWithin(tier.ms);
     const perTurn = hit * READ_MULTIPLIER + (1 - hit) * tier.writeMultiplier;
-    const turns = Math.max(1, turnsPerSession);
+    // THE SUPPLIED VALUE, not only the computed one. Math.max(1, NaN) is NaN -- Math.max
+    // propagates it rather than clamping -- so perTurn became NaN, the `perTurn >= 1` guard below
+    // read `NaN >= 1` as false and PASSED, and this returned action:'refresh' with an
+    // expectedValue of NaN and a reason string reading "NaN% of gaps land inside 5m". A positive
+    // verdict built entirely out of NaN. The guard was on the wrong side of the computation.
+    const turns = Number.isFinite(turnsPerSession) && turnsPerSession >= 1
+      ? turnsPerSession
+      : DEFAULT_TURNS;
     return {
       tier,
       hit,
@@ -232,7 +239,15 @@ export function shouldKeepWarm(dir, { prefixTokens, events = readMetrics(dir) } 
   const gaps = gapDistribution(dir, { events });
   const best = ttlTier({ prefixTokens, gaps });
   if (!best) {
+    // THE TWO MODELS ANSWER DIFFERENT QUESTIONS, so they may legitimately disagree. ttlTier asks
+    // whether holding a cache beats not caching at all; keepWarmDecision asks whether ONE ping
+    // beats letting the entry lapse -- and a ping can pay where no tier does. Coercing everything
+    // that was not 'unknown' to 'skip' while keeping the decision's reason verbatim produced a
+    // refusal justified by a GAIN: `{ action: 'skip', reason: '...expected gain 130 tokens' }`.
+    // This module's own docstring says a refusal that cannot be checked is indistinguishable from
+    // a bug; one that contradicts itself is worse.
     const decision = keepWarmDecision({ prefixTokens, gaps });
+    if (decision.action === 'refresh') return decision;
     return { action: decision.action === 'unknown' ? 'unknown' : 'skip', reason: decision.reason };
   }
   return best;

--- a/hooks-core/lessons.mjs
+++ b/hooks-core/lessons.mjs
@@ -208,7 +208,9 @@ export function validateLessons(raw, turns) {
     // THE SAME GATE THE INJECTOR USES. `new RegExp` only proves the pattern COMPILES. inject.mjs
     // additionally refuses sources over 200 characters and nested-quantifier ReDoS shapes -- and
     // when it refuses, appliesToCommand falls back to a LITERAL substring search of the regex
-    // SOURCE against the command. `npx\s+jest` never appears literally in `npx jest --watch`,
+    // SOURCE against the command. A regex source is not a substring of any real command --
+    // a word-boundary-anchored pattern for the jest runner does not appear literally inside
+    // `npx jest --watch` --
     // so a lesson stored with such a trigger is written to the graph, counted as delivered in the
     // metrics record, and can never surface for the rest of its life. Both rejection shapes are
     // realistic from the extraction prompt: a long alternation over test runners passes 200

--- a/hooks-core/lessons.mjs
+++ b/hooks-core/lessons.mjs
@@ -89,6 +89,13 @@ export function buildFeedbackDigest(turns, { maxChars = 40_000 } = {}) {
   let total = 0;
   for (let i = rendered.length - 1; i >= 0; i--) {
     const piece = rendered[i];
+    // A SINGLE oversize turn must not end the digest. One pasted stack trace in the last turn
+    // made the budget test below true on the FIRST iteration, so `out` stayed empty, this
+    // returned null, and harvest-worker skipped the entire feedback pass for that session --
+    // no extraction, no lesson validation, no metrics record, no signal anywhere. The loop runs
+    // backwards precisely to keep the end, and a big terminal turn is exactly what a session
+    // that went wrong tends to produce.
+    if (piece.length > maxChars) continue;
     if (total + piece.length > maxChars) break;
     out.unshift(piece);
     total += piece.length;

--- a/hooks-core/lessons.mjs
+++ b/hooks-core/lessons.mjs
@@ -28,6 +28,7 @@
  */
 
 import { ORIGIN_HARVESTED, ORIGIN_HUMAN } from './curate.mjs';
+import { safeTrigger } from './inject.mjs';
 
 /** Lessons longer than this are prose, not instructions. */
 const MAX_CLAIM = 400;
@@ -204,9 +205,15 @@ export function validateLessons(raw, turns) {
       rejected.push({ reason: 'no-trigger', claim: claim.slice(0, 80) });
       continue;
     }
-    try {
-      new RegExp(trigger);
-    } catch {
+    // THE SAME GATE THE INJECTOR USES. `new RegExp` only proves the pattern COMPILES. inject.mjs
+    // additionally refuses sources over 200 characters and nested-quantifier ReDoS shapes -- and
+    // when it refuses, appliesToCommand falls back to a LITERAL substring search of the regex
+    // SOURCE against the command. `npx\s+jest` never appears literally in `npx jest --watch`,
+    // so a lesson stored with such a trigger is written to the graph, counted as delivered in the
+    // metrics record, and can never surface for the rest of its life. Both rejection shapes are
+    // realistic from the extraction prompt: a long alternation over test runners passes 200
+    // characters easily, and `(\w+\s*)+\.csproj` is the kind of thing a model emits unprompted.
+    if (!safeTrigger(trigger)) {
       rejected.push({ reason: 'bad-trigger-regex', trigger });
       continue;
     }

--- a/integrations/codex/hooks/lib/keepwarm.mjs
+++ b/integrations/codex/hooks/lib/keepwarm.mjs
@@ -176,9 +176,21 @@ export function recordRefresh(dir, { tier, prefixTokens, expectedValue }) {
  */
 export function recordRefreshOutcome(dir, { tier, prefixTokens, hit }) {
   const tierSpec = TIERS.find((t) => t.name === tier) || TIERS[0];
+  // THE SAME LEDGER keepWarmDecision BUYS THE REFRESH WITH. That function is explicit that a
+  // refresh is a PING, which READS the prefix -- costOfPing = prefixTokens * READ_MULTIPLIER --
+  // and its comment warns that pricing the ping as a write "overstates its cost by more than
+  // twelvefold". This scored the very same refresh as a re-WRITE, charging (writeMultiplier - 1)
+  // on both branches.
+  //
+  // The disagreement runs in the direction that kills the feature. Mean realised per refresh under
+  // the old lines was p*(0.9h - 0.25), negative below a 27.8% hit rate, while the decision's own
+  // model makes the ping pay above 8.7%. For any project whose gaps fall in that band, `tripwire`
+  // accumulates a negative balance and permanently disables a policy that is genuinely paying --
+  // and tells the user "keep-warm has lost N tokens ... stopping". The backstop fired on its own
+  // accounting error rather than on a distribution shift.
   const realised = hit
-    ? prefixTokens * (1 - READ_MULTIPLIER) - prefixTokens * (tierSpec.writeMultiplier - 1)
-    : -prefixTokens * (tierSpec.writeMultiplier - 1);
+    ? prefixTokens * (tierSpec.writeMultiplier - READ_MULTIPLIER) - prefixTokens * READ_MULTIPLIER
+    : -prefixTokens * READ_MULTIPLIER;
   record(dir, { kind: 'keepwarm', action: 'outcome', tier, prefixTokens, hit: Boolean(hit), realised: Math.round(realised) });
 }
 

--- a/integrations/codex/hooks/lib/keepwarm.mjs
+++ b/integrations/codex/hooks/lib/keepwarm.mjs
@@ -137,7 +137,14 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
   const costOf = (tier) => {
     const hit = gaps.probabilityWithin(tier.ms);
     const perTurn = hit * READ_MULTIPLIER + (1 - hit) * tier.writeMultiplier;
-    const turns = Math.max(1, turnsPerSession);
+    // THE SUPPLIED VALUE, not only the computed one. Math.max(1, NaN) is NaN -- Math.max
+    // propagates it rather than clamping -- so perTurn became NaN, the `perTurn >= 1` guard below
+    // read `NaN >= 1` as false and PASSED, and this returned action:'refresh' with an
+    // expectedValue of NaN and a reason string reading "NaN% of gaps land inside 5m". A positive
+    // verdict built entirely out of NaN. The guard was on the wrong side of the computation.
+    const turns = Number.isFinite(turnsPerSession) && turnsPerSession >= 1
+      ? turnsPerSession
+      : DEFAULT_TURNS;
     return {
       tier,
       hit,
@@ -234,7 +241,15 @@ export function shouldKeepWarm(dir, { prefixTokens, events = readMetrics(dir) } 
   const gaps = gapDistribution(dir, { events });
   const best = ttlTier({ prefixTokens, gaps });
   if (!best) {
+    // THE TWO MODELS ANSWER DIFFERENT QUESTIONS, so they may legitimately disagree. ttlTier asks
+    // whether holding a cache beats not caching at all; keepWarmDecision asks whether ONE ping
+    // beats letting the entry lapse -- and a ping can pay where no tier does. Coercing everything
+    // that was not 'unknown' to 'skip' while keeping the decision's reason verbatim produced a
+    // refusal justified by a GAIN: `{ action: 'skip', reason: '...expected gain 130 tokens' }`.
+    // This module's own docstring says a refusal that cannot be checked is indistinguishable from
+    // a bug; one that contradicts itself is worse.
     const decision = keepWarmDecision({ prefixTokens, gaps });
+    if (decision.action === 'refresh') return decision;
     return { action: decision.action === 'unknown' ? 'unknown' : 'skip', reason: decision.reason };
   }
   return best;

--- a/integrations/codex/hooks/lib/lessons.mjs
+++ b/integrations/codex/hooks/lib/lessons.mjs
@@ -30,6 +30,7 @@
  */
 
 import { ORIGIN_HARVESTED, ORIGIN_HUMAN } from './curate.mjs';
+import { safeTrigger } from './inject.mjs';
 
 /** Lessons longer than this are prose, not instructions. */
 const MAX_CLAIM = 400;
@@ -206,9 +207,15 @@ export function validateLessons(raw, turns) {
       rejected.push({ reason: 'no-trigger', claim: claim.slice(0, 80) });
       continue;
     }
-    try {
-      new RegExp(trigger);
-    } catch {
+    // THE SAME GATE THE INJECTOR USES. `new RegExp` only proves the pattern COMPILES. inject.mjs
+    // additionally refuses sources over 200 characters and nested-quantifier ReDoS shapes -- and
+    // when it refuses, appliesToCommand falls back to a LITERAL substring search of the regex
+    // SOURCE against the command. `npx\s+jest` never appears literally in `npx jest --watch`,
+    // so a lesson stored with such a trigger is written to the graph, counted as delivered in the
+    // metrics record, and can never surface for the rest of its life. Both rejection shapes are
+    // realistic from the extraction prompt: a long alternation over test runners passes 200
+    // characters easily, and `(\w+\s*)+\.csproj` is the kind of thing a model emits unprompted.
+    if (!safeTrigger(trigger)) {
       rejected.push({ reason: 'bad-trigger-regex', trigger });
       continue;
     }

--- a/integrations/codex/hooks/lib/lessons.mjs
+++ b/integrations/codex/hooks/lib/lessons.mjs
@@ -91,6 +91,13 @@ export function buildFeedbackDigest(turns, { maxChars = 40_000 } = {}) {
   let total = 0;
   for (let i = rendered.length - 1; i >= 0; i--) {
     const piece = rendered[i];
+    // A SINGLE oversize turn must not end the digest. One pasted stack trace in the last turn
+    // made the budget test below true on the FIRST iteration, so `out` stayed empty, this
+    // returned null, and harvest-worker skipped the entire feedback pass for that session --
+    // no extraction, no lesson validation, no metrics record, no signal anywhere. The loop runs
+    // backwards precisely to keep the end, and a big terminal turn is exactly what a session
+    // that went wrong tends to produce.
+    if (piece.length > maxChars) continue;
     if (total + piece.length > maxChars) break;
     out.unshift(piece);
     total += piece.length;

--- a/integrations/codex/hooks/lib/lessons.mjs
+++ b/integrations/codex/hooks/lib/lessons.mjs
@@ -210,7 +210,9 @@ export function validateLessons(raw, turns) {
     // THE SAME GATE THE INJECTOR USES. `new RegExp` only proves the pattern COMPILES. inject.mjs
     // additionally refuses sources over 200 characters and nested-quantifier ReDoS shapes -- and
     // when it refuses, appliesToCommand falls back to a LITERAL substring search of the regex
-    // SOURCE against the command. `npx\s+jest` never appears literally in `npx jest --watch`,
+    // SOURCE against the command. A regex source is not a substring of any real command --
+    // a word-boundary-anchored pattern for the jest runner does not appear literally inside
+    // `npx jest --watch` --
     // so a lesson stored with such a trigger is written to the graph, counted as delivered in the
     // metrics record, and can never surface for the rest of its life. Both rejection shapes are
     // realistic from the extraction prompt: a long alternation over test runners passes 200

--- a/integrations/codex/plugin/hooks/lib/keepwarm.mjs
+++ b/integrations/codex/plugin/hooks/lib/keepwarm.mjs
@@ -176,9 +176,21 @@ export function recordRefresh(dir, { tier, prefixTokens, expectedValue }) {
  */
 export function recordRefreshOutcome(dir, { tier, prefixTokens, hit }) {
   const tierSpec = TIERS.find((t) => t.name === tier) || TIERS[0];
+  // THE SAME LEDGER keepWarmDecision BUYS THE REFRESH WITH. That function is explicit that a
+  // refresh is a PING, which READS the prefix -- costOfPing = prefixTokens * READ_MULTIPLIER --
+  // and its comment warns that pricing the ping as a write "overstates its cost by more than
+  // twelvefold". This scored the very same refresh as a re-WRITE, charging (writeMultiplier - 1)
+  // on both branches.
+  //
+  // The disagreement runs in the direction that kills the feature. Mean realised per refresh under
+  // the old lines was p*(0.9h - 0.25), negative below a 27.8% hit rate, while the decision's own
+  // model makes the ping pay above 8.7%. For any project whose gaps fall in that band, `tripwire`
+  // accumulates a negative balance and permanently disables a policy that is genuinely paying --
+  // and tells the user "keep-warm has lost N tokens ... stopping". The backstop fired on its own
+  // accounting error rather than on a distribution shift.
   const realised = hit
-    ? prefixTokens * (1 - READ_MULTIPLIER) - prefixTokens * (tierSpec.writeMultiplier - 1)
-    : -prefixTokens * (tierSpec.writeMultiplier - 1);
+    ? prefixTokens * (tierSpec.writeMultiplier - READ_MULTIPLIER) - prefixTokens * READ_MULTIPLIER
+    : -prefixTokens * READ_MULTIPLIER;
   record(dir, { kind: 'keepwarm', action: 'outcome', tier, prefixTokens, hit: Boolean(hit), realised: Math.round(realised) });
 }
 

--- a/integrations/codex/plugin/hooks/lib/keepwarm.mjs
+++ b/integrations/codex/plugin/hooks/lib/keepwarm.mjs
@@ -137,7 +137,14 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
   const costOf = (tier) => {
     const hit = gaps.probabilityWithin(tier.ms);
     const perTurn = hit * READ_MULTIPLIER + (1 - hit) * tier.writeMultiplier;
-    const turns = Math.max(1, turnsPerSession);
+    // THE SUPPLIED VALUE, not only the computed one. Math.max(1, NaN) is NaN -- Math.max
+    // propagates it rather than clamping -- so perTurn became NaN, the `perTurn >= 1` guard below
+    // read `NaN >= 1` as false and PASSED, and this returned action:'refresh' with an
+    // expectedValue of NaN and a reason string reading "NaN% of gaps land inside 5m". A positive
+    // verdict built entirely out of NaN. The guard was on the wrong side of the computation.
+    const turns = Number.isFinite(turnsPerSession) && turnsPerSession >= 1
+      ? turnsPerSession
+      : DEFAULT_TURNS;
     return {
       tier,
       hit,
@@ -234,7 +241,15 @@ export function shouldKeepWarm(dir, { prefixTokens, events = readMetrics(dir) } 
   const gaps = gapDistribution(dir, { events });
   const best = ttlTier({ prefixTokens, gaps });
   if (!best) {
+    // THE TWO MODELS ANSWER DIFFERENT QUESTIONS, so they may legitimately disagree. ttlTier asks
+    // whether holding a cache beats not caching at all; keepWarmDecision asks whether ONE ping
+    // beats letting the entry lapse -- and a ping can pay where no tier does. Coercing everything
+    // that was not 'unknown' to 'skip' while keeping the decision's reason verbatim produced a
+    // refusal justified by a GAIN: `{ action: 'skip', reason: '...expected gain 130 tokens' }`.
+    // This module's own docstring says a refusal that cannot be checked is indistinguishable from
+    // a bug; one that contradicts itself is worse.
     const decision = keepWarmDecision({ prefixTokens, gaps });
+    if (decision.action === 'refresh') return decision;
     return { action: decision.action === 'unknown' ? 'unknown' : 'skip', reason: decision.reason };
   }
   return best;

--- a/integrations/codex/plugin/hooks/lib/lessons.mjs
+++ b/integrations/codex/plugin/hooks/lib/lessons.mjs
@@ -30,6 +30,7 @@
  */
 
 import { ORIGIN_HARVESTED, ORIGIN_HUMAN } from './curate.mjs';
+import { safeTrigger } from './inject.mjs';
 
 /** Lessons longer than this are prose, not instructions. */
 const MAX_CLAIM = 400;
@@ -206,9 +207,15 @@ export function validateLessons(raw, turns) {
       rejected.push({ reason: 'no-trigger', claim: claim.slice(0, 80) });
       continue;
     }
-    try {
-      new RegExp(trigger);
-    } catch {
+    // THE SAME GATE THE INJECTOR USES. `new RegExp` only proves the pattern COMPILES. inject.mjs
+    // additionally refuses sources over 200 characters and nested-quantifier ReDoS shapes -- and
+    // when it refuses, appliesToCommand falls back to a LITERAL substring search of the regex
+    // SOURCE against the command. `npx\s+jest` never appears literally in `npx jest --watch`,
+    // so a lesson stored with such a trigger is written to the graph, counted as delivered in the
+    // metrics record, and can never surface for the rest of its life. Both rejection shapes are
+    // realistic from the extraction prompt: a long alternation over test runners passes 200
+    // characters easily, and `(\w+\s*)+\.csproj` is the kind of thing a model emits unprompted.
+    if (!safeTrigger(trigger)) {
       rejected.push({ reason: 'bad-trigger-regex', trigger });
       continue;
     }

--- a/integrations/codex/plugin/hooks/lib/lessons.mjs
+++ b/integrations/codex/plugin/hooks/lib/lessons.mjs
@@ -91,6 +91,13 @@ export function buildFeedbackDigest(turns, { maxChars = 40_000 } = {}) {
   let total = 0;
   for (let i = rendered.length - 1; i >= 0; i--) {
     const piece = rendered[i];
+    // A SINGLE oversize turn must not end the digest. One pasted stack trace in the last turn
+    // made the budget test below true on the FIRST iteration, so `out` stayed empty, this
+    // returned null, and harvest-worker skipped the entire feedback pass for that session --
+    // no extraction, no lesson validation, no metrics record, no signal anywhere. The loop runs
+    // backwards precisely to keep the end, and a big terminal turn is exactly what a session
+    // that went wrong tends to produce.
+    if (piece.length > maxChars) continue;
     if (total + piece.length > maxChars) break;
     out.unshift(piece);
     total += piece.length;

--- a/integrations/codex/plugin/hooks/lib/lessons.mjs
+++ b/integrations/codex/plugin/hooks/lib/lessons.mjs
@@ -210,7 +210,9 @@ export function validateLessons(raw, turns) {
     // THE SAME GATE THE INJECTOR USES. `new RegExp` only proves the pattern COMPILES. inject.mjs
     // additionally refuses sources over 200 characters and nested-quantifier ReDoS shapes -- and
     // when it refuses, appliesToCommand falls back to a LITERAL substring search of the regex
-    // SOURCE against the command. `npx\s+jest` never appears literally in `npx jest --watch`,
+    // SOURCE against the command. A regex source is not a substring of any real command --
+    // a word-boundary-anchored pattern for the jest runner does not appear literally inside
+    // `npx jest --watch` --
     // so a lesson stored with such a trigger is written to the graph, counted as delivered in the
     // metrics record, and can never surface for the rest of its life. Both rejection shapes are
     // realistic from the extraction prompt: a long alternation over test runners passes 200

--- a/integrations/gemini/hooks/lib/keepwarm.mjs
+++ b/integrations/gemini/hooks/lib/keepwarm.mjs
@@ -176,9 +176,21 @@ export function recordRefresh(dir, { tier, prefixTokens, expectedValue }) {
  */
 export function recordRefreshOutcome(dir, { tier, prefixTokens, hit }) {
   const tierSpec = TIERS.find((t) => t.name === tier) || TIERS[0];
+  // THE SAME LEDGER keepWarmDecision BUYS THE REFRESH WITH. That function is explicit that a
+  // refresh is a PING, which READS the prefix -- costOfPing = prefixTokens * READ_MULTIPLIER --
+  // and its comment warns that pricing the ping as a write "overstates its cost by more than
+  // twelvefold". This scored the very same refresh as a re-WRITE, charging (writeMultiplier - 1)
+  // on both branches.
+  //
+  // The disagreement runs in the direction that kills the feature. Mean realised per refresh under
+  // the old lines was p*(0.9h - 0.25), negative below a 27.8% hit rate, while the decision's own
+  // model makes the ping pay above 8.7%. For any project whose gaps fall in that band, `tripwire`
+  // accumulates a negative balance and permanently disables a policy that is genuinely paying --
+  // and tells the user "keep-warm has lost N tokens ... stopping". The backstop fired on its own
+  // accounting error rather than on a distribution shift.
   const realised = hit
-    ? prefixTokens * (1 - READ_MULTIPLIER) - prefixTokens * (tierSpec.writeMultiplier - 1)
-    : -prefixTokens * (tierSpec.writeMultiplier - 1);
+    ? prefixTokens * (tierSpec.writeMultiplier - READ_MULTIPLIER) - prefixTokens * READ_MULTIPLIER
+    : -prefixTokens * READ_MULTIPLIER;
   record(dir, { kind: 'keepwarm', action: 'outcome', tier, prefixTokens, hit: Boolean(hit), realised: Math.round(realised) });
 }
 

--- a/integrations/gemini/hooks/lib/keepwarm.mjs
+++ b/integrations/gemini/hooks/lib/keepwarm.mjs
@@ -137,7 +137,14 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
   const costOf = (tier) => {
     const hit = gaps.probabilityWithin(tier.ms);
     const perTurn = hit * READ_MULTIPLIER + (1 - hit) * tier.writeMultiplier;
-    const turns = Math.max(1, turnsPerSession);
+    // THE SUPPLIED VALUE, not only the computed one. Math.max(1, NaN) is NaN -- Math.max
+    // propagates it rather than clamping -- so perTurn became NaN, the `perTurn >= 1` guard below
+    // read `NaN >= 1` as false and PASSED, and this returned action:'refresh' with an
+    // expectedValue of NaN and a reason string reading "NaN% of gaps land inside 5m". A positive
+    // verdict built entirely out of NaN. The guard was on the wrong side of the computation.
+    const turns = Number.isFinite(turnsPerSession) && turnsPerSession >= 1
+      ? turnsPerSession
+      : DEFAULT_TURNS;
     return {
       tier,
       hit,
@@ -234,7 +241,15 @@ export function shouldKeepWarm(dir, { prefixTokens, events = readMetrics(dir) } 
   const gaps = gapDistribution(dir, { events });
   const best = ttlTier({ prefixTokens, gaps });
   if (!best) {
+    // THE TWO MODELS ANSWER DIFFERENT QUESTIONS, so they may legitimately disagree. ttlTier asks
+    // whether holding a cache beats not caching at all; keepWarmDecision asks whether ONE ping
+    // beats letting the entry lapse -- and a ping can pay where no tier does. Coercing everything
+    // that was not 'unknown' to 'skip' while keeping the decision's reason verbatim produced a
+    // refusal justified by a GAIN: `{ action: 'skip', reason: '...expected gain 130 tokens' }`.
+    // This module's own docstring says a refusal that cannot be checked is indistinguishable from
+    // a bug; one that contradicts itself is worse.
     const decision = keepWarmDecision({ prefixTokens, gaps });
+    if (decision.action === 'refresh') return decision;
     return { action: decision.action === 'unknown' ? 'unknown' : 'skip', reason: decision.reason };
   }
   return best;

--- a/integrations/gemini/hooks/lib/lessons.mjs
+++ b/integrations/gemini/hooks/lib/lessons.mjs
@@ -30,6 +30,7 @@
  */
 
 import { ORIGIN_HARVESTED, ORIGIN_HUMAN } from './curate.mjs';
+import { safeTrigger } from './inject.mjs';
 
 /** Lessons longer than this are prose, not instructions. */
 const MAX_CLAIM = 400;
@@ -206,9 +207,15 @@ export function validateLessons(raw, turns) {
       rejected.push({ reason: 'no-trigger', claim: claim.slice(0, 80) });
       continue;
     }
-    try {
-      new RegExp(trigger);
-    } catch {
+    // THE SAME GATE THE INJECTOR USES. `new RegExp` only proves the pattern COMPILES. inject.mjs
+    // additionally refuses sources over 200 characters and nested-quantifier ReDoS shapes -- and
+    // when it refuses, appliesToCommand falls back to a LITERAL substring search of the regex
+    // SOURCE against the command. `npx\s+jest` never appears literally in `npx jest --watch`,
+    // so a lesson stored with such a trigger is written to the graph, counted as delivered in the
+    // metrics record, and can never surface for the rest of its life. Both rejection shapes are
+    // realistic from the extraction prompt: a long alternation over test runners passes 200
+    // characters easily, and `(\w+\s*)+\.csproj` is the kind of thing a model emits unprompted.
+    if (!safeTrigger(trigger)) {
       rejected.push({ reason: 'bad-trigger-regex', trigger });
       continue;
     }

--- a/integrations/gemini/hooks/lib/lessons.mjs
+++ b/integrations/gemini/hooks/lib/lessons.mjs
@@ -91,6 +91,13 @@ export function buildFeedbackDigest(turns, { maxChars = 40_000 } = {}) {
   let total = 0;
   for (let i = rendered.length - 1; i >= 0; i--) {
     const piece = rendered[i];
+    // A SINGLE oversize turn must not end the digest. One pasted stack trace in the last turn
+    // made the budget test below true on the FIRST iteration, so `out` stayed empty, this
+    // returned null, and harvest-worker skipped the entire feedback pass for that session --
+    // no extraction, no lesson validation, no metrics record, no signal anywhere. The loop runs
+    // backwards precisely to keep the end, and a big terminal turn is exactly what a session
+    // that went wrong tends to produce.
+    if (piece.length > maxChars) continue;
     if (total + piece.length > maxChars) break;
     out.unshift(piece);
     total += piece.length;

--- a/integrations/gemini/hooks/lib/lessons.mjs
+++ b/integrations/gemini/hooks/lib/lessons.mjs
@@ -210,7 +210,9 @@ export function validateLessons(raw, turns) {
     // THE SAME GATE THE INJECTOR USES. `new RegExp` only proves the pattern COMPILES. inject.mjs
     // additionally refuses sources over 200 characters and nested-quantifier ReDoS shapes -- and
     // when it refuses, appliesToCommand falls back to a LITERAL substring search of the regex
-    // SOURCE against the command. `npx\s+jest` never appears literally in `npx jest --watch`,
+    // SOURCE against the command. A regex source is not a substring of any real command --
+    // a word-boundary-anchored pattern for the jest runner does not appear literally inside
+    // `npx jest --watch` --
     // so a lesson stored with such a trigger is written to the graph, counted as delivered in the
     // metrics record, and can never surface for the rest of its life. Both rejection shapes are
     // realistic from the extraction prompt: a long alternation over test runners passes 200

--- a/integrations/opencode/hooks/lib/keepwarm.mjs
+++ b/integrations/opencode/hooks/lib/keepwarm.mjs
@@ -176,9 +176,21 @@ export function recordRefresh(dir, { tier, prefixTokens, expectedValue }) {
  */
 export function recordRefreshOutcome(dir, { tier, prefixTokens, hit }) {
   const tierSpec = TIERS.find((t) => t.name === tier) || TIERS[0];
+  // THE SAME LEDGER keepWarmDecision BUYS THE REFRESH WITH. That function is explicit that a
+  // refresh is a PING, which READS the prefix -- costOfPing = prefixTokens * READ_MULTIPLIER --
+  // and its comment warns that pricing the ping as a write "overstates its cost by more than
+  // twelvefold". This scored the very same refresh as a re-WRITE, charging (writeMultiplier - 1)
+  // on both branches.
+  //
+  // The disagreement runs in the direction that kills the feature. Mean realised per refresh under
+  // the old lines was p*(0.9h - 0.25), negative below a 27.8% hit rate, while the decision's own
+  // model makes the ping pay above 8.7%. For any project whose gaps fall in that band, `tripwire`
+  // accumulates a negative balance and permanently disables a policy that is genuinely paying --
+  // and tells the user "keep-warm has lost N tokens ... stopping". The backstop fired on its own
+  // accounting error rather than on a distribution shift.
   const realised = hit
-    ? prefixTokens * (1 - READ_MULTIPLIER) - prefixTokens * (tierSpec.writeMultiplier - 1)
-    : -prefixTokens * (tierSpec.writeMultiplier - 1);
+    ? prefixTokens * (tierSpec.writeMultiplier - READ_MULTIPLIER) - prefixTokens * READ_MULTIPLIER
+    : -prefixTokens * READ_MULTIPLIER;
   record(dir, { kind: 'keepwarm', action: 'outcome', tier, prefixTokens, hit: Boolean(hit), realised: Math.round(realised) });
 }
 

--- a/integrations/opencode/hooks/lib/keepwarm.mjs
+++ b/integrations/opencode/hooks/lib/keepwarm.mjs
@@ -137,7 +137,14 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
   const costOf = (tier) => {
     const hit = gaps.probabilityWithin(tier.ms);
     const perTurn = hit * READ_MULTIPLIER + (1 - hit) * tier.writeMultiplier;
-    const turns = Math.max(1, turnsPerSession);
+    // THE SUPPLIED VALUE, not only the computed one. Math.max(1, NaN) is NaN -- Math.max
+    // propagates it rather than clamping -- so perTurn became NaN, the `perTurn >= 1` guard below
+    // read `NaN >= 1` as false and PASSED, and this returned action:'refresh' with an
+    // expectedValue of NaN and a reason string reading "NaN% of gaps land inside 5m". A positive
+    // verdict built entirely out of NaN. The guard was on the wrong side of the computation.
+    const turns = Number.isFinite(turnsPerSession) && turnsPerSession >= 1
+      ? turnsPerSession
+      : DEFAULT_TURNS;
     return {
       tier,
       hit,
@@ -234,7 +241,15 @@ export function shouldKeepWarm(dir, { prefixTokens, events = readMetrics(dir) } 
   const gaps = gapDistribution(dir, { events });
   const best = ttlTier({ prefixTokens, gaps });
   if (!best) {
+    // THE TWO MODELS ANSWER DIFFERENT QUESTIONS, so they may legitimately disagree. ttlTier asks
+    // whether holding a cache beats not caching at all; keepWarmDecision asks whether ONE ping
+    // beats letting the entry lapse -- and a ping can pay where no tier does. Coercing everything
+    // that was not 'unknown' to 'skip' while keeping the decision's reason verbatim produced a
+    // refusal justified by a GAIN: `{ action: 'skip', reason: '...expected gain 130 tokens' }`.
+    // This module's own docstring says a refusal that cannot be checked is indistinguishable from
+    // a bug; one that contradicts itself is worse.
     const decision = keepWarmDecision({ prefixTokens, gaps });
+    if (decision.action === 'refresh') return decision;
     return { action: decision.action === 'unknown' ? 'unknown' : 'skip', reason: decision.reason };
   }
   return best;

--- a/integrations/opencode/hooks/lib/lessons.mjs
+++ b/integrations/opencode/hooks/lib/lessons.mjs
@@ -30,6 +30,7 @@
  */
 
 import { ORIGIN_HARVESTED, ORIGIN_HUMAN } from './curate.mjs';
+import { safeTrigger } from './inject.mjs';
 
 /** Lessons longer than this are prose, not instructions. */
 const MAX_CLAIM = 400;
@@ -206,9 +207,15 @@ export function validateLessons(raw, turns) {
       rejected.push({ reason: 'no-trigger', claim: claim.slice(0, 80) });
       continue;
     }
-    try {
-      new RegExp(trigger);
-    } catch {
+    // THE SAME GATE THE INJECTOR USES. `new RegExp` only proves the pattern COMPILES. inject.mjs
+    // additionally refuses sources over 200 characters and nested-quantifier ReDoS shapes -- and
+    // when it refuses, appliesToCommand falls back to a LITERAL substring search of the regex
+    // SOURCE against the command. `npx\s+jest` never appears literally in `npx jest --watch`,
+    // so a lesson stored with such a trigger is written to the graph, counted as delivered in the
+    // metrics record, and can never surface for the rest of its life. Both rejection shapes are
+    // realistic from the extraction prompt: a long alternation over test runners passes 200
+    // characters easily, and `(\w+\s*)+\.csproj` is the kind of thing a model emits unprompted.
+    if (!safeTrigger(trigger)) {
       rejected.push({ reason: 'bad-trigger-regex', trigger });
       continue;
     }

--- a/integrations/opencode/hooks/lib/lessons.mjs
+++ b/integrations/opencode/hooks/lib/lessons.mjs
@@ -91,6 +91,13 @@ export function buildFeedbackDigest(turns, { maxChars = 40_000 } = {}) {
   let total = 0;
   for (let i = rendered.length - 1; i >= 0; i--) {
     const piece = rendered[i];
+    // A SINGLE oversize turn must not end the digest. One pasted stack trace in the last turn
+    // made the budget test below true on the FIRST iteration, so `out` stayed empty, this
+    // returned null, and harvest-worker skipped the entire feedback pass for that session --
+    // no extraction, no lesson validation, no metrics record, no signal anywhere. The loop runs
+    // backwards precisely to keep the end, and a big terminal turn is exactly what a session
+    // that went wrong tends to produce.
+    if (piece.length > maxChars) continue;
     if (total + piece.length > maxChars) break;
     out.unshift(piece);
     total += piece.length;

--- a/integrations/opencode/hooks/lib/lessons.mjs
+++ b/integrations/opencode/hooks/lib/lessons.mjs
@@ -210,7 +210,9 @@ export function validateLessons(raw, turns) {
     // THE SAME GATE THE INJECTOR USES. `new RegExp` only proves the pattern COMPILES. inject.mjs
     // additionally refuses sources over 200 characters and nested-quantifier ReDoS shapes -- and
     // when it refuses, appliesToCommand falls back to a LITERAL substring search of the regex
-    // SOURCE against the command. `npx\s+jest` never appears literally in `npx jest --watch`,
+    // SOURCE against the command. A regex source is not a substring of any real command --
+    // a word-boundary-anchored pattern for the jest runner does not appear literally inside
+    // `npx jest --watch` --
     // so a lesson stored with such a trigger is written to the graph, counted as delivered in the
     // metrics record, and can never surface for the rest of its life. Both rejection shapes are
     // realistic from the extraction prompt: a long alternation over test runners passes 200

--- a/integrations/qwen/hooks/lib/keepwarm.mjs
+++ b/integrations/qwen/hooks/lib/keepwarm.mjs
@@ -176,9 +176,21 @@ export function recordRefresh(dir, { tier, prefixTokens, expectedValue }) {
  */
 export function recordRefreshOutcome(dir, { tier, prefixTokens, hit }) {
   const tierSpec = TIERS.find((t) => t.name === tier) || TIERS[0];
+  // THE SAME LEDGER keepWarmDecision BUYS THE REFRESH WITH. That function is explicit that a
+  // refresh is a PING, which READS the prefix -- costOfPing = prefixTokens * READ_MULTIPLIER --
+  // and its comment warns that pricing the ping as a write "overstates its cost by more than
+  // twelvefold". This scored the very same refresh as a re-WRITE, charging (writeMultiplier - 1)
+  // on both branches.
+  //
+  // The disagreement runs in the direction that kills the feature. Mean realised per refresh under
+  // the old lines was p*(0.9h - 0.25), negative below a 27.8% hit rate, while the decision's own
+  // model makes the ping pay above 8.7%. For any project whose gaps fall in that band, `tripwire`
+  // accumulates a negative balance and permanently disables a policy that is genuinely paying --
+  // and tells the user "keep-warm has lost N tokens ... stopping". The backstop fired on its own
+  // accounting error rather than on a distribution shift.
   const realised = hit
-    ? prefixTokens * (1 - READ_MULTIPLIER) - prefixTokens * (tierSpec.writeMultiplier - 1)
-    : -prefixTokens * (tierSpec.writeMultiplier - 1);
+    ? prefixTokens * (tierSpec.writeMultiplier - READ_MULTIPLIER) - prefixTokens * READ_MULTIPLIER
+    : -prefixTokens * READ_MULTIPLIER;
   record(dir, { kind: 'keepwarm', action: 'outcome', tier, prefixTokens, hit: Boolean(hit), realised: Math.round(realised) });
 }
 

--- a/integrations/qwen/hooks/lib/keepwarm.mjs
+++ b/integrations/qwen/hooks/lib/keepwarm.mjs
@@ -137,7 +137,14 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
   const costOf = (tier) => {
     const hit = gaps.probabilityWithin(tier.ms);
     const perTurn = hit * READ_MULTIPLIER + (1 - hit) * tier.writeMultiplier;
-    const turns = Math.max(1, turnsPerSession);
+    // THE SUPPLIED VALUE, not only the computed one. Math.max(1, NaN) is NaN -- Math.max
+    // propagates it rather than clamping -- so perTurn became NaN, the `perTurn >= 1` guard below
+    // read `NaN >= 1` as false and PASSED, and this returned action:'refresh' with an
+    // expectedValue of NaN and a reason string reading "NaN% of gaps land inside 5m". A positive
+    // verdict built entirely out of NaN. The guard was on the wrong side of the computation.
+    const turns = Number.isFinite(turnsPerSession) && turnsPerSession >= 1
+      ? turnsPerSession
+      : DEFAULT_TURNS;
     return {
       tier,
       hit,
@@ -234,7 +241,15 @@ export function shouldKeepWarm(dir, { prefixTokens, events = readMetrics(dir) } 
   const gaps = gapDistribution(dir, { events });
   const best = ttlTier({ prefixTokens, gaps });
   if (!best) {
+    // THE TWO MODELS ANSWER DIFFERENT QUESTIONS, so they may legitimately disagree. ttlTier asks
+    // whether holding a cache beats not caching at all; keepWarmDecision asks whether ONE ping
+    // beats letting the entry lapse -- and a ping can pay where no tier does. Coercing everything
+    // that was not 'unknown' to 'skip' while keeping the decision's reason verbatim produced a
+    // refusal justified by a GAIN: `{ action: 'skip', reason: '...expected gain 130 tokens' }`.
+    // This module's own docstring says a refusal that cannot be checked is indistinguishable from
+    // a bug; one that contradicts itself is worse.
     const decision = keepWarmDecision({ prefixTokens, gaps });
+    if (decision.action === 'refresh') return decision;
     return { action: decision.action === 'unknown' ? 'unknown' : 'skip', reason: decision.reason };
   }
   return best;

--- a/integrations/qwen/hooks/lib/lessons.mjs
+++ b/integrations/qwen/hooks/lib/lessons.mjs
@@ -30,6 +30,7 @@
  */
 
 import { ORIGIN_HARVESTED, ORIGIN_HUMAN } from './curate.mjs';
+import { safeTrigger } from './inject.mjs';
 
 /** Lessons longer than this are prose, not instructions. */
 const MAX_CLAIM = 400;
@@ -206,9 +207,15 @@ export function validateLessons(raw, turns) {
       rejected.push({ reason: 'no-trigger', claim: claim.slice(0, 80) });
       continue;
     }
-    try {
-      new RegExp(trigger);
-    } catch {
+    // THE SAME GATE THE INJECTOR USES. `new RegExp` only proves the pattern COMPILES. inject.mjs
+    // additionally refuses sources over 200 characters and nested-quantifier ReDoS shapes -- and
+    // when it refuses, appliesToCommand falls back to a LITERAL substring search of the regex
+    // SOURCE against the command. `npx\s+jest` never appears literally in `npx jest --watch`,
+    // so a lesson stored with such a trigger is written to the graph, counted as delivered in the
+    // metrics record, and can never surface for the rest of its life. Both rejection shapes are
+    // realistic from the extraction prompt: a long alternation over test runners passes 200
+    // characters easily, and `(\w+\s*)+\.csproj` is the kind of thing a model emits unprompted.
+    if (!safeTrigger(trigger)) {
       rejected.push({ reason: 'bad-trigger-regex', trigger });
       continue;
     }

--- a/integrations/qwen/hooks/lib/lessons.mjs
+++ b/integrations/qwen/hooks/lib/lessons.mjs
@@ -91,6 +91,13 @@ export function buildFeedbackDigest(turns, { maxChars = 40_000 } = {}) {
   let total = 0;
   for (let i = rendered.length - 1; i >= 0; i--) {
     const piece = rendered[i];
+    // A SINGLE oversize turn must not end the digest. One pasted stack trace in the last turn
+    // made the budget test below true on the FIRST iteration, so `out` stayed empty, this
+    // returned null, and harvest-worker skipped the entire feedback pass for that session --
+    // no extraction, no lesson validation, no metrics record, no signal anywhere. The loop runs
+    // backwards precisely to keep the end, and a big terminal turn is exactly what a session
+    // that went wrong tends to produce.
+    if (piece.length > maxChars) continue;
     if (total + piece.length > maxChars) break;
     out.unshift(piece);
     total += piece.length;

--- a/integrations/qwen/hooks/lib/lessons.mjs
+++ b/integrations/qwen/hooks/lib/lessons.mjs
@@ -210,7 +210,9 @@ export function validateLessons(raw, turns) {
     // THE SAME GATE THE INJECTOR USES. `new RegExp` only proves the pattern COMPILES. inject.mjs
     // additionally refuses sources over 200 characters and nested-quantifier ReDoS shapes -- and
     // when it refuses, appliesToCommand falls back to a LITERAL substring search of the regex
-    // SOURCE against the command. `npx\s+jest` never appears literally in `npx jest --watch`,
+    // SOURCE against the command. A regex source is not a substring of any real command --
+    // a word-boundary-anchored pattern for the jest runner does not appear literally inside
+    // `npx jest --watch` --
     // so a lesson stored with such a trigger is written to the graph, counted as delivered in the
     // metrics record, and can never surface for the rest of its life. Both rejection shapes are
     // realistic from the extraction prompt: a long alternation over test runners passes 200

--- a/plugin/hooks/lib/keepwarm.mjs
+++ b/plugin/hooks/lib/keepwarm.mjs
@@ -176,9 +176,21 @@ export function recordRefresh(dir, { tier, prefixTokens, expectedValue }) {
  */
 export function recordRefreshOutcome(dir, { tier, prefixTokens, hit }) {
   const tierSpec = TIERS.find((t) => t.name === tier) || TIERS[0];
+  // THE SAME LEDGER keepWarmDecision BUYS THE REFRESH WITH. That function is explicit that a
+  // refresh is a PING, which READS the prefix -- costOfPing = prefixTokens * READ_MULTIPLIER --
+  // and its comment warns that pricing the ping as a write "overstates its cost by more than
+  // twelvefold". This scored the very same refresh as a re-WRITE, charging (writeMultiplier - 1)
+  // on both branches.
+  //
+  // The disagreement runs in the direction that kills the feature. Mean realised per refresh under
+  // the old lines was p*(0.9h - 0.25), negative below a 27.8% hit rate, while the decision's own
+  // model makes the ping pay above 8.7%. For any project whose gaps fall in that band, `tripwire`
+  // accumulates a negative balance and permanently disables a policy that is genuinely paying --
+  // and tells the user "keep-warm has lost N tokens ... stopping". The backstop fired on its own
+  // accounting error rather than on a distribution shift.
   const realised = hit
-    ? prefixTokens * (1 - READ_MULTIPLIER) - prefixTokens * (tierSpec.writeMultiplier - 1)
-    : -prefixTokens * (tierSpec.writeMultiplier - 1);
+    ? prefixTokens * (tierSpec.writeMultiplier - READ_MULTIPLIER) - prefixTokens * READ_MULTIPLIER
+    : -prefixTokens * READ_MULTIPLIER;
   record(dir, { kind: 'keepwarm', action: 'outcome', tier, prefixTokens, hit: Boolean(hit), realised: Math.round(realised) });
 }
 

--- a/plugin/hooks/lib/keepwarm.mjs
+++ b/plugin/hooks/lib/keepwarm.mjs
@@ -137,7 +137,14 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
   const costOf = (tier) => {
     const hit = gaps.probabilityWithin(tier.ms);
     const perTurn = hit * READ_MULTIPLIER + (1 - hit) * tier.writeMultiplier;
-    const turns = Math.max(1, turnsPerSession);
+    // THE SUPPLIED VALUE, not only the computed one. Math.max(1, NaN) is NaN -- Math.max
+    // propagates it rather than clamping -- so perTurn became NaN, the `perTurn >= 1` guard below
+    // read `NaN >= 1` as false and PASSED, and this returned action:'refresh' with an
+    // expectedValue of NaN and a reason string reading "NaN% of gaps land inside 5m". A positive
+    // verdict built entirely out of NaN. The guard was on the wrong side of the computation.
+    const turns = Number.isFinite(turnsPerSession) && turnsPerSession >= 1
+      ? turnsPerSession
+      : DEFAULT_TURNS;
     return {
       tier,
       hit,
@@ -234,7 +241,15 @@ export function shouldKeepWarm(dir, { prefixTokens, events = readMetrics(dir) } 
   const gaps = gapDistribution(dir, { events });
   const best = ttlTier({ prefixTokens, gaps });
   if (!best) {
+    // THE TWO MODELS ANSWER DIFFERENT QUESTIONS, so they may legitimately disagree. ttlTier asks
+    // whether holding a cache beats not caching at all; keepWarmDecision asks whether ONE ping
+    // beats letting the entry lapse -- and a ping can pay where no tier does. Coercing everything
+    // that was not 'unknown' to 'skip' while keeping the decision's reason verbatim produced a
+    // refusal justified by a GAIN: `{ action: 'skip', reason: '...expected gain 130 tokens' }`.
+    // This module's own docstring says a refusal that cannot be checked is indistinguishable from
+    // a bug; one that contradicts itself is worse.
     const decision = keepWarmDecision({ prefixTokens, gaps });
+    if (decision.action === 'refresh') return decision;
     return { action: decision.action === 'unknown' ? 'unknown' : 'skip', reason: decision.reason };
   }
   return best;

--- a/plugin/hooks/lib/lessons.mjs
+++ b/plugin/hooks/lib/lessons.mjs
@@ -30,6 +30,7 @@
  */
 
 import { ORIGIN_HARVESTED, ORIGIN_HUMAN } from './curate.mjs';
+import { safeTrigger } from './inject.mjs';
 
 /** Lessons longer than this are prose, not instructions. */
 const MAX_CLAIM = 400;
@@ -206,9 +207,15 @@ export function validateLessons(raw, turns) {
       rejected.push({ reason: 'no-trigger', claim: claim.slice(0, 80) });
       continue;
     }
-    try {
-      new RegExp(trigger);
-    } catch {
+    // THE SAME GATE THE INJECTOR USES. `new RegExp` only proves the pattern COMPILES. inject.mjs
+    // additionally refuses sources over 200 characters and nested-quantifier ReDoS shapes -- and
+    // when it refuses, appliesToCommand falls back to a LITERAL substring search of the regex
+    // SOURCE against the command. `npx\s+jest` never appears literally in `npx jest --watch`,
+    // so a lesson stored with such a trigger is written to the graph, counted as delivered in the
+    // metrics record, and can never surface for the rest of its life. Both rejection shapes are
+    // realistic from the extraction prompt: a long alternation over test runners passes 200
+    // characters easily, and `(\w+\s*)+\.csproj` is the kind of thing a model emits unprompted.
+    if (!safeTrigger(trigger)) {
       rejected.push({ reason: 'bad-trigger-regex', trigger });
       continue;
     }

--- a/plugin/hooks/lib/lessons.mjs
+++ b/plugin/hooks/lib/lessons.mjs
@@ -91,6 +91,13 @@ export function buildFeedbackDigest(turns, { maxChars = 40_000 } = {}) {
   let total = 0;
   for (let i = rendered.length - 1; i >= 0; i--) {
     const piece = rendered[i];
+    // A SINGLE oversize turn must not end the digest. One pasted stack trace in the last turn
+    // made the budget test below true on the FIRST iteration, so `out` stayed empty, this
+    // returned null, and harvest-worker skipped the entire feedback pass for that session --
+    // no extraction, no lesson validation, no metrics record, no signal anywhere. The loop runs
+    // backwards precisely to keep the end, and a big terminal turn is exactly what a session
+    // that went wrong tends to produce.
+    if (piece.length > maxChars) continue;
     if (total + piece.length > maxChars) break;
     out.unshift(piece);
     total += piece.length;

--- a/plugin/hooks/lib/lessons.mjs
+++ b/plugin/hooks/lib/lessons.mjs
@@ -210,7 +210,9 @@ export function validateLessons(raw, turns) {
     // THE SAME GATE THE INJECTOR USES. `new RegExp` only proves the pattern COMPILES. inject.mjs
     // additionally refuses sources over 200 characters and nested-quantifier ReDoS shapes -- and
     // when it refuses, appliesToCommand falls back to a LITERAL substring search of the regex
-    // SOURCE against the command. `npx\s+jest` never appears literally in `npx jest --watch`,
+    // SOURCE against the command. A regex source is not a substring of any real command --
+    // a word-boundary-anchored pattern for the jest runner does not appear literally inside
+    // `npx jest --watch` --
     // so a lesson stored with such a trigger is written to the graph, counted as delivered in the
     // metrics record, and can never surface for the rest of its life. Both rejection shapes are
     // realistic from the extraction prompt: a long alternation over test runners passes 200

--- a/src/tools/intelligence/wiki-read.ts
+++ b/src/tools/intelligence/wiki-read.ts
@@ -29,7 +29,8 @@ const here = dirname(fileURLToPath(import.meta.url));
 
 /** Resolves hooks-core relative to the built output, which lives in dist/tools/intelligence. */
 function coreUrl(name: string): string {
-  return pathToFileURL(path.join(here, '..', '..', '..', 'hooks-core', name)).href;
+  return pathToFileURL(path.join(here, '..', '..', '..', 'hooks-core', name))
+    .href;
 }
 
 export interface WikiReadOptions {
@@ -88,8 +89,14 @@ function toFinding(node: any): WikiFinding {
   };
 }
 
-export async function wikiRead(options: WikiReadOptions = {}): Promise<WikiReadResult> {
-  const empty = { findings: [] as WikiFinding[], shared: [] as WikiFinding[], unresolvedAnchors: [] as string[] };
+export async function wikiRead(
+  options: WikiReadOptions = {}
+): Promise<WikiReadResult> {
+  const empty = {
+    findings: [] as WikiFinding[],
+    shared: [] as WikiFinding[],
+    unresolvedAnchors: [] as string[],
+  };
 
   const anchors = Array.isArray(options?.anchors)
     ? options.anchors.filter((a) => typeof a === 'string' && a.trim())
@@ -123,13 +130,16 @@ export async function wikiRead(options: WikiReadOptions = {}): Promise<WikiReadR
     // wrong. Graphs are loaded once each and reused across anchors that share a project.
     const graphs = new Map<string, any>();
     const graphFor = (project: string) => {
-      if (!graphs.has(project)) graphs.set(project, wiki.load(wiki.wikiDir(project)));
+      if (!graphs.has(project))
+        graphs.set(project, wiki.load(wiki.wikiDir(project)));
       return graphs.get(project);
     };
 
     const primary =
       options.projectRoot ??
-      (anchors.length ? wiki.projectRootFor(anchors[0].split('#')[0], process.cwd()) : process.cwd());
+      (anchors.length
+        ? wiki.projectRootFor(anchors[0].split('#')[0], process.cwd())
+        : process.cwd());
 
     const seen = new Set<string>();
     const findings: WikiFinding[] = [];
@@ -139,7 +149,8 @@ export async function wikiRead(options: WikiReadOptions = {}): Promise<WikiReadR
       const [file, symbol] = a.split('#');
       // An explicit projectRoot pins every anchor to that graph -- the caller has said which
       // project they mean. Otherwise each anchor resolves to its own repository.
-      const project = options.projectRoot ?? wiki.projectRootFor(file, process.cwd());
+      const project =
+        options.projectRoot ?? wiki.projectRootFor(file, process.cwd());
       const graph = graphFor(project);
 
       const id = symbol

--- a/tests/hooks/cache.test.mjs
+++ b/tests/hooks/cache.test.mjs
@@ -20,7 +20,7 @@ import {
   gapDistribution, keepWarmDecision, ttlTier, tripwire, shouldKeepWarm,
   recordRefreshOutcome, TIERS, TRIPWIRE_MIN,
 } from '../../hooks-core/keepwarm.mjs';
-import { record } from '../../hooks-core/metrics.mjs';
+import { record, readMetrics } from '../../hooks-core/metrics.mjs';
 import { policyText } from '../../hooks-core/adapter.mjs';
 
 let workspace;
@@ -268,5 +268,83 @@ describe('our own contribution to the prefix is stable by construction', () => {
       { id: 'settled', fresh: false },
     ]);
     expect(ordered.map((i) => i.id)).toEqual(['settled', 'fresh']);
+  });
+});
+
+// --- the two keep-warm ledgers must agree ------------------------------------------
+
+describe('keep-warm scores refreshes with the model it bought them under', () => {
+  const READ = 0.1;
+
+  test('a realised outcome matches what keepWarmDecision predicted', () => {
+    // THE DEFECT: keepWarmDecision prices a refresh as a PING that READS the prefix
+    // (costOfPing = prefixTokens * READ_MULTIPLIER) and warns in its own comment that pricing it
+    // as a write "overstates its cost by more than twelvefold". recordRefreshOutcome then scored
+    // the very same refresh as a re-WRITE. The two disagreed in the direction that kills the
+    // feature: mean realised was negative below a 27.8% hit rate while the decision's model makes
+    // the ping pay above 8.7%, so for any project in that band the tripwire accumulated a negative
+    // balance and permanently disabled a policy that was genuinely paying -- reporting it as
+    // "keep-warm has lost N tokens ... stopping". The backstop fired on its own accounting error.
+    const prefixTokens = 10_000;
+    const tier = TIERS[0];
+
+    recordRefreshOutcome(dir, { tier: tier.name, prefixTokens, hit: true });
+    recordRefreshOutcome(dir, { tier: tier.name, prefixTokens, hit: false });
+
+    const rows = readMetrics(dir).filter((e) => e.kind === 'keepwarm' && e.action === 'outcome');
+    const hit = rows.find((r) => r.hit);
+    const miss = rows.find((r) => !r.hit);
+
+    // Exactly the decision's arithmetic: saving-if-used minus the cost of the ping, and on a miss
+    // the cost of the ping alone.
+    const costOfPing = prefixTokens * READ;
+    const savingIfUsed = prefixTokens * (tier.writeMultiplier - READ);
+    expect(hit.realised).toBe(Math.round(savingIfUsed - costOfPing));
+    expect(miss.realised).toBe(Math.round(-costOfPing));
+  });
+
+  test('the break-even hit rate agrees between the two functions', () => {
+    // The property that actually matters: the rate above which the tripwire stops complaining is
+    // the same rate above which the decision says to refresh. Previously 27.8% versus 8.7%.
+    const prefixTokens = 10_000;
+    const tier = TIERS[0];
+    const costOfPing = prefixTokens * READ;
+    const savingIfUsed = prefixTokens * (tier.writeMultiplier - READ);
+    const breakEven = costOfPing / savingIfUsed;
+
+    // realised over N refreshes at exactly the break-even rate nets to zero.
+    const net = breakEven * (savingIfUsed - costOfPing) + (1 - breakEven) * -costOfPing;
+    expect(Math.abs(net)).toBeLessThan(1e-9);
+  });
+});
+
+describe('keep-warm never returns a verdict that contradicts its own reason', () => {
+  test('a refresh that pays is not rewritten into a skip', () => {
+    // ttlTier asks whether holding a cache beats not caching; keepWarmDecision asks whether ONE
+    // ping beats letting the entry lapse. They can legitimately disagree, and coercing the second
+    // to 'skip' while keeping its reason string produced `{ action: 'skip', reason: '...expected
+    // gain 130 tokens' }` -- a refusal justified by a gain.
+    const gaps = {
+      probabilityWithin: (ms) => (ms <= 5 * 60 * 1000 ? 0.2 : ms <= 10 * 60 * 1000 ? 0.4 : 0.5),
+    };
+    const decision = keepWarmDecision({ prefixTokens: 10_000, gaps });
+    if (decision.action !== 'refresh') return; // the fixture must exercise the disagreement
+    expect(ttlTier({ prefixTokens: 10_000, gaps })).toBeNull();
+
+    // Whatever shouldKeepWarm returns, action and reason must not disagree.
+    const verdict = { action: decision.action, reason: decision.reason };
+    if (/expected gain/.test(verdict.reason)) expect(verdict.action).not.toBe('skip');
+  });
+
+  test('a non-finite turn count cannot produce a refresh built from NaN', () => {
+    // Math.max(1, NaN) is NaN, so perTurn was NaN, `NaN >= 1` was false, and the guard PASSED --
+    // returning action:'refresh' with expectedValue NaN and "NaN% of gaps land inside 5m".
+    const gaps = { probabilityWithin: () => 0.9 };
+    const out = ttlTier({ prefixTokens: 10_000, gaps, turnsPerSession: Number.NaN });
+    if (out) {
+      expect(Number.isFinite(out.expectedValue)).toBe(true);
+      expect(Number.isFinite(out.expectedCostPerTurn)).toBe(true);
+      expect(out.reason).not.toMatch(/NaN/);
+    }
   });
 });

--- a/tests/hooks/cache.test.mjs
+++ b/tests/hooks/cache.test.mjs
@@ -303,37 +303,87 @@ describe('keep-warm scores refreshes with the model it bought them under', () =>
     expect(miss.realised).toBe(Math.round(-costOfPing));
   });
 
-  test('the break-even hit rate agrees between the two functions', () => {
-    // The property that actually matters: the rate above which the tripwire stops complaining is
-    // the same rate above which the decision says to refresh. Previously 27.8% versus 8.7%.
+  test('the tripwire does not stop a policy the decision says is paying', () => {
+    // THE PROPERTY, exercised through both production functions rather than restated as local
+    // arithmetic. A hit rate the decision calls profitable must not accumulate a negative realised
+    // balance in the tripwire. At the old pricing the two disagreed between 8.7% and 27.8%, so
+    // every rate in that band tripped the wire on a policy that was genuinely paying.
     const prefixTokens = 10_000;
-    const tier = TIERS[0];
-    const costOfPing = prefixTokens * READ;
-    const savingIfUsed = prefixTokens * (tier.writeMultiplier - READ);
-    const breakEven = costOfPing / savingIfUsed;
+    const hitRate = 0.15; // inside the old disagreement band
 
-    // realised over N refreshes at exactly the break-even rate nets to zero.
-    const net = breakEven * (savingIfUsed - costOfPing) + (1 - breakEven) * -costOfPing;
-    expect(Math.abs(net)).toBeLessThan(1e-9);
+    // What the decision thinks of a gap profile with that much of its mass in the refresh window.
+    const gaps = {
+      probabilityWithin: (ms) => (ms <= TIERS[0].ms ? 0 : ms <= TIERS[0].ms * 2 ? hitRate : 1),
+    };
+    expect(keepWarmDecision({ prefixTokens, gaps }).action).toBe('refresh');
+
+    // Now record real outcomes at that rate and ask the tripwire, which reads them back.
+    const refreshes = 20;
+    for (let i = 0; i < refreshes; i++) {
+      recordRefreshOutcome(dir, {
+        tier: TIERS[0].name, prefixTokens, hit: i < Math.round(refreshes * hitRate),
+      });
+    }
+    const trip = tripwire(dir);
+    expect(trip.observed).toBeGreaterThanOrEqual(TRIPWIRE_MIN);
+    expect(trip.tripped).toBe(false);
+    expect(trip.realised).toBeGreaterThan(0);
+  });
+
+  test('and it still stops one that is genuinely losing', () => {
+    // The guard must not have been turned into a rubber stamp: below the true break-even the wire
+    // still fires, which is the whole reason it exists.
+    for (let i = 0; i < 20; i++) {
+      recordRefreshOutcome(dir, { tier: TIERS[0].name, prefixTokens: 10_000, hit: false });
+    }
+    const trip = tripwire(dir);
+    expect(trip.tripped).toBe(true);
+    expect(trip.realised).toBeLessThan(0);
   });
 });
 
 describe('keep-warm never returns a verdict that contradicts its own reason', () => {
+  /** Seeds events `gapMs` apart so the distribution is known. Same helper as above, re-scoped. */
+  const seedGaps = (gapMs, count = 20) => {
+    const base = Date.now() - count * gapMs;
+    const path = join(dir, 'metrics.jsonl');
+    record(dir, { kind: 'seed' });
+    const lines = Array.from({ length: count }, (_, i) => JSON.stringify({ kind: 'read', at: base + i * gapMs }));
+    writeFileSync(path, lines.join('\n') + '\n');
+  };
+
   test('a refresh that pays is not rewritten into a skip', () => {
     // ttlTier asks whether holding a cache beats not caching; keepWarmDecision asks whether ONE
     // ping beats letting the entry lapse. They can legitimately disagree, and coercing the second
     // to 'skip' while keeping its reason string produced `{ action: 'skip', reason: '...expected
     // gain 130 tokens' }` -- a refusal justified by a gain.
-    const gaps = {
-      probabilityWithin: (ms) => (ms <= 5 * 60 * 1000 ? 0.2 : ms <= 10 * 60 * 1000 ? 0.4 : 0.5),
-    };
-    const decision = keepWarmDecision({ prefixTokens: 10_000, gaps });
-    if (decision.action !== 'refresh') return; // the fixture must exercise the disagreement
-    expect(ttlTier({ prefixTokens: 10_000, gaps })).toBeNull();
+    // Driven through shouldKeepWarm with real recorded events, not a hand-built verdict -- the
+    // first version of this test constructed the object itself and so could pass while the
+    // production path regressed.
+    //
+    // A MIXED distribution, because a uniform one cannot produce the disagreement. Uniform 9m gaps
+    // make the 1h tier cheap (every gap lands inside it), so ttlTier pays and there is nothing to
+    // disagree about. What is needed is a profile where NO tier pays across the session as a whole
+    // -- most gaps are hours long -- while a real slice still sits in the 5m-to-10m window that one
+    // ping reaches. 30% at seven minutes, 70% at three hours.
+    const mixed = [];
+    let at = Date.now() - 300 * 60 * 1000;
+    for (let i = 0; i < 30; i++) {
+      at += (i % 10 < 3 ? 7 : 180) * 60 * 1000;
+      mixed.push(JSON.stringify({ kind: 'read', at }));
+    }
+    record(dir, { kind: 'seed' });
+    writeFileSync(join(dir, 'metrics.jsonl'), `${mixed.join('\n')}\n`);
 
-    // Whatever shouldKeepWarm returns, action and reason must not disagree.
-    const verdict = { action: decision.action, reason: decision.reason };
-    if (/expected gain/.test(verdict.reason)) expect(verdict.action).not.toBe('skip');
+    const gaps = gapDistribution(dir);
+    expect(ttlTier({ prefixTokens: 47_000, gaps })).toBeNull();
+    expect(keepWarmDecision({ prefixTokens: 47_000, gaps }).action).toBe('refresh');
+
+    const verdict = shouldKeepWarm(dir, { prefixTokens: 47_000 });
+    expect(verdict.action).toBe('refresh');
+    // And the invariant that failed before: no verdict may contradict its own stated reason.
+    if (/expected gain/.test(verdict.reason || '')) expect(verdict.action).not.toBe('skip');
+    if (/expected loss/.test(verdict.reason || '')) expect(verdict.action).not.toBe('refresh');
   });
 
   test('a non-finite turn count cannot produce a refresh built from NaN', () => {

--- a/tests/hooks/lessons.test.mjs
+++ b/tests/hooks/lessons.test.mjs
@@ -16,7 +16,7 @@ import {
 } from '../../hooks-core/lessons.mjs';
 import { ORIGIN_HUMAN, ORIGIN_HARVESTED } from '../../hooks-core/curate.mjs';
 import { writeHarvested } from '../../hooks-core/harvest-write.mjs';
-import { standingRules } from '../../hooks-core/inject.mjs';
+import { standingRules, safeTrigger } from '../../hooks-core/inject.mjs';
 import { wikiDir, load, putNode } from '../../hooks-core/wiki.mjs';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
@@ -176,119 +176,119 @@ describe('malformed extractor output', () => {
     expect(lessons[0].origin).toBe(ORIGIN_HUMAN);
   });
 });
-
-describe('the checks the review found were passable without passing', () => {
-  const TURNS = [{ role: 'user', text: 'no, use npm test not npx jest' }];
-
-  it('rejects a quote whose capitalisation never occurred', () => {
-    // Both sides were lower-cased before comparing, so a quote the user never
-    // typed satisfied a VERBATIM check -- and then earned ORIGIN_HUMAN and 0.95
-    // confidence on the strength of it. The prompt asks for an exact copy.
-    expect(quoteIsVerbatim('use npm test not npx jest', TURNS)).toBe(true);
-    expect(quoteIsVerbatim('USE NPM TEST NOT NPX JEST', TURNS)).toBe(false);
-    expect(quoteIsVerbatim('Use Npm Test Not Npx Jest', TURNS)).toBe(false);
-  });
-
-  it('still forgives whitespace, which the storage layer chose, not the user', () => {
-    expect(quoteIsVerbatim('use  npm   test' + String.fromCharCode(92) + 'n not npx jest'.trim(), TURNS)).toBe(false);
-    expect(quoteIsVerbatim('use  npm  test  not  npx  jest', TURNS)).toBe(true);
-  });
-
-  it('does not throw when there is no archive to check against', () => {
-    expect(() => quoteIsVerbatim('use npm test', null)).not.toThrow();
-    expect(quoteIsVerbatim('use npm test', null)).toBe(false);
-    expect(quoteIsVerbatim('use npm test', undefined)).toBe(false);
-  });
-
-  it('rejects a noun-led description that merely avoids the denylist', () => {
-    // The old rule listed the openings a paraphrase usually starts with and
-    // accepted everything else, so any noun-led sentence walked through and was
-    // stored as a standing rule despite describing rather than instructing.
-    expect(isImperative('npm test is preferred over npx jest.')).toBe(false);
-    expect(isImperative('jest runs faster than the npm wrapper.')).toBe(false);
-    expect(isImperative('builds should be run from the worktree.')).toBe(false);
-
-    // And still accepts the shape a real instruction has.
-    expect(isImperative('Use npm test, not npx jest.')).toBe(true);
-    expect(isImperative('Never force-push a shared branch.')).toBe(true);
-    expect(isImperative('Verify the refspec before trusting a fetch.')).toBe(true);
-  });
-
-  it('fails closed on an opening it does not recognise', () => {
-    // The direction matters more than the coverage: this text becomes an
-    // always-on instruction, so an unrecognised opening is refused rather than
-    // admitted.
-    expect(isImperative('frobnicate the widget.')).toBe(false);
-    expect(isImperative('')).toBe(false);
-  });
+
+describe('the checks the review found were passable without passing', () => {
+  const TURNS = [{ role: 'user', text: 'no, use npm test not npx jest' }];
+
+  it('rejects a quote whose capitalisation never occurred', () => {
+    // Both sides were lower-cased before comparing, so a quote the user never
+    // typed satisfied a VERBATIM check -- and then earned ORIGIN_HUMAN and 0.95
+    // confidence on the strength of it. The prompt asks for an exact copy.
+    expect(quoteIsVerbatim('use npm test not npx jest', TURNS)).toBe(true);
+    expect(quoteIsVerbatim('USE NPM TEST NOT NPX JEST', TURNS)).toBe(false);
+    expect(quoteIsVerbatim('Use Npm Test Not Npx Jest', TURNS)).toBe(false);
+  });
+
+  it('still forgives whitespace, which the storage layer chose, not the user', () => {
+    expect(quoteIsVerbatim('use  npm   test' + String.fromCharCode(92) + 'n not npx jest'.trim(), TURNS)).toBe(false);
+    expect(quoteIsVerbatim('use  npm  test  not  npx  jest', TURNS)).toBe(true);
+  });
+
+  it('does not throw when there is no archive to check against', () => {
+    expect(() => quoteIsVerbatim('use npm test', null)).not.toThrow();
+    expect(quoteIsVerbatim('use npm test', null)).toBe(false);
+    expect(quoteIsVerbatim('use npm test', undefined)).toBe(false);
+  });
+
+  it('rejects a noun-led description that merely avoids the denylist', () => {
+    // The old rule listed the openings a paraphrase usually starts with and
+    // accepted everything else, so any noun-led sentence walked through and was
+    // stored as a standing rule despite describing rather than instructing.
+    expect(isImperative('npm test is preferred over npx jest.')).toBe(false);
+    expect(isImperative('jest runs faster than the npm wrapper.')).toBe(false);
+    expect(isImperative('builds should be run from the worktree.')).toBe(false);
+
+    // And still accepts the shape a real instruction has.
+    expect(isImperative('Use npm test, not npx jest.')).toBe(true);
+    expect(isImperative('Never force-push a shared branch.')).toBe(true);
+    expect(isImperative('Verify the refspec before trusting a fetch.')).toBe(true);
+  });
+
+  it('fails closed on an opening it does not recognise', () => {
+    // The direction matters more than the coverage: this text becomes an
+    // always-on instruction, so an unrecognised opening is refused rather than
+    // admitted.
+    expect(isImperative('frobnicate the widget.')).toBe(false);
+    expect(isImperative('')).toBe(false);
+  });
 });
-
-describe('a verified correction survives the write boundary', () => {
-  // THE FINDING THAT MADE THE WHOLE FEATURE INERT. `validateLessons` computed a
-  // per-lesson origin and kept the verified quote; `writeHarvested` took ONE
-  // origin from its options and persisted no quote at all. So every lesson
-  // landed as ORIGIN_HARVESTED, the standing-rules layer selects on human
-  // origin, and it therefore matched nothing this pipeline had ever written.
-  // The verbatim check ran and had no observable effect.
-  //
-  // This drives the real write path and then the real selector, because both
-  // halves passed their own unit tests for the entire time the pair did nothing.
-  it('is stored as human, keeps its evidence, and reaches the standing rules', () => {
-    const project = mkdtempSync(join(tmpdir(), 'lesson-origin-'));
-    mkdirSync(join(project, '.git'), { recursive: true });
-    const dir = join(project, '.token-optimizer', 'wiki');
-    mkdirSync(dir, { recursive: true });
-
-    const anchor = join(project, 'a.ts');
-    writeFileSync(anchor, 'export const a = 1;');
-    putNode(dir, { kind: 'file', key: anchor, hash: 'h' });
-
-    const written = writeHarvested(
-      dir,
-      [
-        {
-          type: 'feedback',
-          claim: 'Use npm test, not npx jest.',
-          confidence: 0.95,
-          origin: ORIGIN_HUMAN,
-          quote: 'no, use npm test not npx jest',
-          anchors: [anchor],
-        },
-        {
-          type: 'feedback',
-          claim: 'Prefer the worktree build.',
-          confidence: 0.6,
-          origin: ORIGIN_HARVESTED,
-          anchors: [anchor],
-        },
-      ],
-      // The batch default is still HARVESTED, exactly as the worker passes it.
-      { sessionId: 's1', origin: ORIGIN_HARVESTED }
-    );
-    expect(written).toHaveLength(2);
-
-    const graph = load(dir);
-    const findings = [...graph.nodes.values()].filter((n) => n.kind === 'finding');
-    const verified = findings.find((n) => n.claim.startsWith('Use npm test'));
-    const paraphrase = findings.find((n) => n.claim.startsWith('Prefer the worktree'));
-
-    // The verified one is promoted, and carries the evidence that promoted it.
-    expect(verified.origin).toBe(ORIGIN_HUMAN);
-    expect(verified.quote).toBe('no, use npm test not npx jest');
-
-    // The unverified one is NOT promoted. A caller cannot simply declare
-    // machine output human; it is the quote that earns it.
-    expect(paraphrase.origin).toBe(ORIGIN_HARVESTED);
-    expect(paraphrase.quote).toBeUndefined();
-
-    // And the selector that exists to consume it now finds it.
-    const rules = standingRules(dir, load(dir));
-    expect(rules).toContain('Use npm test, not npx jest.');
-    expect(rules).not.toContain('Prefer the worktree build.');
-
-    rmSync(project, { recursive: true, force: true });
-  }, 60_000);
-});
+
+describe('a verified correction survives the write boundary', () => {
+  // THE FINDING THAT MADE THE WHOLE FEATURE INERT. `validateLessons` computed a
+  // per-lesson origin and kept the verified quote; `writeHarvested` took ONE
+  // origin from its options and persisted no quote at all. So every lesson
+  // landed as ORIGIN_HARVESTED, the standing-rules layer selects on human
+  // origin, and it therefore matched nothing this pipeline had ever written.
+  // The verbatim check ran and had no observable effect.
+  //
+  // This drives the real write path and then the real selector, because both
+  // halves passed their own unit tests for the entire time the pair did nothing.
+  it('is stored as human, keeps its evidence, and reaches the standing rules', () => {
+    const project = mkdtempSync(join(tmpdir(), 'lesson-origin-'));
+    mkdirSync(join(project, '.git'), { recursive: true });
+    const dir = join(project, '.token-optimizer', 'wiki');
+    mkdirSync(dir, { recursive: true });
+
+    const anchor = join(project, 'a.ts');
+    writeFileSync(anchor, 'export const a = 1;');
+    putNode(dir, { kind: 'file', key: anchor, hash: 'h' });
+
+    const written = writeHarvested(
+      dir,
+      [
+        {
+          type: 'feedback',
+          claim: 'Use npm test, not npx jest.',
+          confidence: 0.95,
+          origin: ORIGIN_HUMAN,
+          quote: 'no, use npm test not npx jest',
+          anchors: [anchor],
+        },
+        {
+          type: 'feedback',
+          claim: 'Prefer the worktree build.',
+          confidence: 0.6,
+          origin: ORIGIN_HARVESTED,
+          anchors: [anchor],
+        },
+      ],
+      // The batch default is still HARVESTED, exactly as the worker passes it.
+      { sessionId: 's1', origin: ORIGIN_HARVESTED }
+    );
+    expect(written).toHaveLength(2);
+
+    const graph = load(dir);
+    const findings = [...graph.nodes.values()].filter((n) => n.kind === 'finding');
+    const verified = findings.find((n) => n.claim.startsWith('Use npm test'));
+    const paraphrase = findings.find((n) => n.claim.startsWith('Prefer the worktree'));
+
+    // The verified one is promoted, and carries the evidence that promoted it.
+    expect(verified.origin).toBe(ORIGIN_HUMAN);
+    expect(verified.quote).toBe('no, use npm test not npx jest');
+
+    // The unverified one is NOT promoted. A caller cannot simply declare
+    // machine output human; it is the quote that earns it.
+    expect(paraphrase.origin).toBe(ORIGIN_HARVESTED);
+    expect(paraphrase.quote).toBeUndefined();
+
+    // And the selector that exists to consume it now finds it.
+    const rules = standingRules(dir, load(dir));
+    expect(rules).toContain('Use npm test, not npx jest.');
+    expect(rules).not.toContain('Prefer the worktree build.');
+
+    rmSync(project, { recursive: true, force: true });
+  }, 60_000);
+});
 
 describe('a session whose corrections are worth keeping is not skipped for its size', () => {
   it('one oversize turn does not abort the whole digest', () => {
@@ -334,8 +334,16 @@ describe('a lesson is only stored if its trigger can ever fire', () => {
     // shapes -- and when it refuses, appliesToCommand falls back to a LITERAL substring search of
     // the regex SOURCE against the command. A regex source is not a substring of any real command,
     // so such a lesson was written to the graph, counted as delivered, and could never surface.
-    const nested = '(\w+\s*)+\.csproj';
-    const tooLong = `\b(${Array.from({ length: 40 }, (_, i) => `runner${i}`).join('|')})\b`;
+    // String.raw, because these are REGEX SOURCES. Written as ordinary quoted strings, JavaScript
+    // turns `\b` into U+0008 and drops the backslash from `\w`, `\s` and `\.` -- so the first
+    // version of this test exercised `(w+s*)+.csproj` and a backspace-delimited `npxs+jest`,
+    // neither of which is the pattern named. The repo's own no-stray-control-characters guard is
+    // what caught it.
+    const nested = String.raw`(\w+\s*)+\.csproj`;
+    const tooLong = String.raw`\b(`
+      + Array.from({ length: 40 }, (_, i) => `runner${i}`).join('|')
+      + String.raw`)\b`;
+
     for (const bad of [nested, tooLong]) {
       const out = validateLessons(lesson(bad), []);
       expect(out.lessons).toHaveLength(0);
@@ -343,8 +351,21 @@ describe('a lesson is only stored if its trigger can ever fire', () => {
     }
   });
 
+  it('the rejection agrees with what the injector would actually do', () => {
+    // The property, rather than a restatement of the implementation: anything this stores must be
+    // something safeTrigger will run. Asserting against safeTrigger directly means the test still
+    // holds if the rejection reason or the validator's internals change.
+    // safeTrigger returns the compiled RegExp it would run, or null when it refuses -- which is
+    // why the production check is `if (!safeTrigger(trigger))` rather than a boolean comparison.
+    const nested = String.raw`(\w+\s*)+\.csproj`;
+    expect(safeTrigger(nested)).toBeNull();
+    expect(validateLessons(lesson(nested), []).lessons).toHaveLength(0);
+  });
+
   it('an ordinary trigger the injector accepts still passes', () => {
-    const out = validateLessons(lesson('\bnpx\s+jest\b'), []);
+    const good = String.raw`\bnpx\s+jest\b`;
+    expect(safeTrigger(good)).toBeInstanceOf(RegExp);
+    const out = validateLessons(lesson(good), []);
     expect(out.rejected.filter((r) => r.reason === 'bad-trigger-regex')).toHaveLength(0);
   });
 });

--- a/tests/hooks/lessons.test.mjs
+++ b/tests/hooks/lessons.test.mjs
@@ -289,3 +289,62 @@ describe('a verified correction survives the write boundary', () => {
     rmSync(project, { recursive: true, force: true });
   }, 60_000);
 });
+
+describe('a session whose corrections are worth keeping is not skipped for its size', () => {
+  it('one oversize turn does not abort the whole digest', () => {
+    // THE DEFECT: the loop walks turns backwards to keep the END -- the module's own reasoning is
+    // that corrections cluster where the work went wrong -- and `break`s the moment a turn would
+    // overflow the budget. When the NEWEST turn is on its own larger than maxChars (one pasted
+    // stack trace, one dumped file, one long diff), the break fired on the FIRST iteration, `out`
+    // stayed empty and this returned null. harvest-worker guards on `if (feedback)`, so the entire
+    // feedback pass was skipped: no extraction, no lesson validation, no metrics record, no signal
+    // anywhere. And a big terminal turn is exactly what a session that went wrong tends to produce.
+    const turns = [
+      { role: 'user', text: 'use npm test, not npx jest' },
+      { role: 'assistant', text: 'understood' },
+      { role: 'assistant', text: 'X'.repeat(50_000) },
+    ];
+    const digest = buildFeedbackDigest(turns, { maxChars: 1_000 });
+    expect(digest).not.toBeNull();
+    expect(digest).toContain('use npm test');
+    expect(digest).not.toContain('X'.repeat(200));
+  });
+
+  it('the budget is still respected for turns that fit', () => {
+    const turns = Array.from({ length: 40 }, (_, i) => ({ role: 'user', text: `line ${i} `.repeat(20) }));
+    const digest = buildFeedbackDigest(turns, { maxChars: 1_000 });
+    expect(digest.length).toBeLessThanOrEqual(1_200);
+  });
+
+  it('a genuinely empty set of turns is still null', () => {
+    expect(buildFeedbackDigest([], { maxChars: 1_000 })).toBeNull();
+  });
+});
+
+describe('a lesson is only stored if its trigger can ever fire', () => {
+  const lesson = (trigger) => JSON.stringify([{
+    claim: 'Use npm test rather than npx jest for this repository.',
+    trigger,
+    anchors: ['package.json'],
+  }]);
+
+  it('a trigger the injector would refuse is rejected at store time', () => {
+    // THE DEFECT: this validated with a bare `new RegExp`, which only proves the pattern COMPILES.
+    // inject.mjs additionally refuses sources over 200 characters and nested-quantifier ReDoS
+    // shapes -- and when it refuses, appliesToCommand falls back to a LITERAL substring search of
+    // the regex SOURCE against the command. A regex source is not a substring of any real command,
+    // so such a lesson was written to the graph, counted as delivered, and could never surface.
+    const nested = '(\w+\s*)+\.csproj';
+    const tooLong = `\b(${Array.from({ length: 40 }, (_, i) => `runner${i}`).join('|')})\b`;
+    for (const bad of [nested, tooLong]) {
+      const out = validateLessons(lesson(bad), []);
+      expect(out.lessons).toHaveLength(0);
+      expect(out.rejected.some((r) => r.reason === 'bad-trigger-regex')).toBe(true);
+    }
+  });
+
+  it('an ordinary trigger the injector accepts still passes', () => {
+    const out = validateLessons(lesson('\bnpx\s+jest\b'), []);
+    expect(out.rejected.filter((r) => r.reason === 'bad-trigger-regex')).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Five defects across two modules, found by auditing them whole rather than by reading a diff.

The first two were applied and build-verified by this project's own autofix — **the first time that path has run end to end on a real repository.** The commits below are the ones it produced.

## Keep-warm was scored against a different ledger than it was bought with

`keepWarmDecision` is explicit that a refresh is a **ping**, which *reads* the prefix:

```js
const costOfPing = prefixTokens * READ_MULTIPLIER;   // 0.1x
```

and its own comment warns that pricing the ping as a write *"overstates its cost by more than twelvefold and rejects refreshes that are clearly worth buying"*.

`recordRefreshOutcome` then scored that same refresh as a re-**write**, charging `(writeMultiplier - 1)` = 0.25x on both the hit and the miss branch.

The two ledgers disagree in the direction that kills the feature:

| | break-even hit rate |
|---|---|
| what `keepWarmDecision` buys the refresh at | **8.7%** |
| what `recordRefreshOutcome` scored it at | **27.8%** |

For any project whose gaps land in that band, `tripwire` accumulates a negative balance and **permanently disables a policy that is genuinely paying** — reporting it to the user as *"keep-warm has lost N tokens over N refreshes; stopping"*. The backstop fires on its own accounting error rather than on the distribution shift it exists to catch.

Two tests now pin this: one asserts both branches equal the decision's own arithmetic, the other asserts the two break-even rates agree. A numeric relationship between two functions is exactly what drifts silently.

## A single oversize turn discarded a whole session's corrections

`buildFeedbackDigest` walks turns **backwards** to keep the end — the module's own argument is that corrections cluster where the work went wrong — and `break`s the moment one would overflow the budget.

When the newest turn is on its own larger than `maxChars` (one pasted stack trace, one dumped file, one long diff), the break fires on the **first iteration**, `out` stays empty, and it returns null. `harvest-worker.mjs` guards on `if (feedback)`, so the entire feedback pass is skipped: no extraction, no lesson validation, no metrics record, **no signal anywhere**.

A large terminal turn is exactly what a session that went wrong tends to produce, so this failed hardest on precisely the sessions worth learning from.

## Three more

- **`ttlTier` validated the computed cost but not the supplied turn count.** `Math.max(1, NaN)` is `NaN`, not 1 — `Math.max` propagates rather than clamps. So `perTurn` was NaN, the `perTurn >= 1` guard read `NaN >= 1` as false and **passed**, and the function returned `action: 'refresh'` with `expectedValue: NaN` and a reason reading *"NaN% of gaps land inside 5m"*. A positive verdict built entirely out of NaN. The guard was on the wrong side of the computation.

- **`shouldKeepWarm` returned refusals justified by a gain.** It coerced anything not `unknown` to `skip` while keeping `keepWarmDecision`'s reason string verbatim, producing `{ action: 'skip', reason: '…expected gain 130 tokens' }`. The two functions answer *different questions* and may legitimately disagree — `ttlTier` asks whether holding a cache beats not caching at all, `keepWarmDecision` whether **one ping** beats letting the entry lapse — so a ping that pays is now honoured. This module's docstring says a refusal that cannot be checked is indistinguishable from a bug; one that contradicts itself is worse.

- **`validateLessons` accepted triggers the injector will never run.** It checked with a bare `new RegExp`, which only proves the pattern *compiles*. `inject.mjs` additionally refuses sources over 200 characters and nested-quantifier ReDoS shapes — and when it refuses, `appliesToCommand` falls back to a **literal substring search of the regex source** against the command. `\bnpx\s+jest\b` never appears literally in `npx jest --watch`, so such a lesson was written to the graph, counted as delivered in the metrics record, and **could never surface for the rest of its life**. Both rejection shapes are realistic from the extraction prompt: a long alternation over test runners passes 200 characters easily, and `(\w+\s*)+\.csproj` is the kind of thing a model emits unprompted. Now validated with `safeTrigger`, the gate that actually decides. No import cycle — `inject.mjs` does not import `lessons.mjs`, and both are vendored together.

## The three that were briefly listed as follow-ups

An earlier revision of this description listed these as known and deferred. Listing a defect is not
fixing it, so they are fixed here.

**The tripwire could never reach its own threshold.** It read outcomes through `readMetrics`, whose
window is 5000 events and 2 MB — and there is one `keepwarm` outcome per refresh, in a log dominated
by reads and captures. On any busy project the ten `TRIPWIRE_MIN` demands aged out before the tenth
was written, so it returned *"only N/10 refreshes observed"* for the life of the project and
`shouldKeepWarm` could never be vetoed. `'keepwarm'` is now a balance kind, mirrored into
`balance.jsonl` and read back unwindowed.

That in turn required splitting `shouldKeepWarm`'s event sources, which passed **one** array to both
consumers. They want opposite things: `gapDistribution` wants the firehose, because every event is a
timestamp and the recent ones describe the current rhythm; the tripwire wants the unwindowed log,
because its outcomes are exactly what the window evicts. Whichever reader was chosen was wrong for
one of them.

**A gap between two sessions is not a gap between turns.** Every timestamp was sorted and
differenced, so the interval between the last event of one session and the first of the next —
routinely sixteen hours — was counted as a turn gap. It dominated `p90`/`p99` and diluted
`probabilityWithin` in the conservative direction, so `ttlTier` answered *"neither tier pays"* on
projects where it would have paid. Silent, because that bias only ever declines to act.

Long gaps **inside** a session are deliberately kept: they are real evidence that caching does not
pay there, and dropping them would bias the answer the other way — making keep-warm look better than
it is, which is the direction this project cares about most. Events with no `sessionId` are pooled
rather than discarded, since most kinds carry one.

**Lesson anchors are held to the files the session touched.** The finding path in the same worker
already passes `knownFiles: filesIn(digest)` and explains why in its own comment — *"a model that
invents a plausible path cannot anchor a finding to it"* — while the lesson path accepted any
non-empty string, so the identical hallucination walked straight through. A lesson anchored to a file
nobody opened is then injected on **every future touch of that file**: a permanent instruction
attached to code it was never about. Anchors are also checked with `isFsSafePath`, because these
strings reach the filesystem later through the graph and a path holding U+10FFFF aborts the process
rather than throwing.

## Verification

`tests/hooks` — 787 passed, 3 skipped, 0 failed, with **16 new tests**. `tsc --noEmit` clean. Vendored copies re-synced via `npm run sync:hooks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
