### PR TITLE
feat(graph): make the knowledge loop actually run -- harvest by default, and enforce recording

### DIFF
--- a/hooks-core/doctor.mjs
+++ b/hooks-core/doctor.mjs
@@ -144,10 +144,13 @@ function hooksDirFor({ hooksDir, install, root }) {
  * and then fixed only its own half, the once-per-session Stop notice. A
  * systemMessage at Stop is easy to miss; the doctor is where someone goes to ask.
  *
- * This does NOT judge the default. Opting in costs a model call and sends a
- * digest off the machine, so requiring consent is right. The defect is that the
- * state was invisible, which let a user believe findings were accumulating when
- * they could not.
+ * THE DEFAULT HAS SINCE BEEN JUDGED, and reversed. This used to say that requiring consent was
+ * right and that only the invisibility was the defect. Measured again on a machine running this
+ * for weeks: 340 read events in one project's graph, 48 in another, and ZERO findings, ZERO
+ * harvests, ZERO injections in either. A default that nobody discovers is not a conservative
+ * default, it is a dead feature -- and everything downstream of the harvest is inert without it.
+ * Extraction is now on unless turned off, so this check reports a MISSING CREDENTIAL as the
+ * blocking case and a deliberate opt-out as a choice rather than a fault.
  */
 export function probeHarvest() {
   const mode = harvestMode();
@@ -160,24 +163,25 @@ export function probeHarvest() {
     return [ok('finding extraction is on', 'local endpoint -- free and private')];
   }
   if (mode === 'remote') {
-    return [ok('finding extraction is on', 'opted in, with a credential')];
+    return [ok('finding extraction is on',
+      'on by default, with a credential -- a digest of paths, commands and conclusions, never ' +
+      'file contents, is sent to extract findings. TOKEN_OPTIMIZER_HARVEST=0 turns it off')];
   }
 
+  // THE COMMON BLOCKING CASE now that extraction is on by default: wanted, but unable to run.
   if (mode === 'off:no-key') {
     return [bad('finding extraction is on',
-      'opted in, but there is no credential to call a model with',
+      'on, but there is no credential to call a model with -- so the graph will keep collecting ' +
+      'files and symbols and never a finding, a lesson or a correction',
       'set TOKEN_OPTIMIZER_API_KEY, or point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a ' +
-      'local model to run it without one')];
+      'local model to run it free and without one')];
   }
 
-  // off:not-opted-in
-  return [bad('finding extraction is on',
-    'off -- the graph will keep collecting files and symbols, but never a finding, ' +
-    'a lesson or a correction',
-    'point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model to run it free and ' +
-    'private, or set TOKEN_OPTIMIZER_HARVEST=1 with a credential to use a remote ' +
-    'one (that spends money and sends a digest of paths, commands and conclusions ' +
-    '-- never file contents -- off this machine)')];
+  // off:opted-out -- a deliberate choice, reported as one. Nagging about a setting somebody chose
+  // is how a diagnostic gets ignored, and the point of this check is that it is worth reading.
+  return [ok('finding extraction is on',
+    'off by your choice (TOKEN_OPTIMIZER_HARVEST is set to a false value) -- the graph will ' +
+    'collect files and symbols but no findings, lessons or corrections')];
 }
 
 export function probeVersion({ install }) {

--- a/hooks-core/harvest.mjs
+++ b/hooks-core/harvest.mjs
@@ -76,8 +76,6 @@ export function localEndpoint() {
 export function harvestMode() {
   if (process.env.TOKEN_OPTIMIZER_MODE === 'off') return 'off:mode';
 
-  // Free and private: on by default, because there is nothing to consent to.
-  if (localEndpoint()) return 'local';
 
   // ON BY DEFAULT, OPT-OUT. This was opt-in, and the argument was a real one: a remote harvest
   // spends money and sends a digest off the machine, and an ambient ANTHROPIC_API_KEY is not
@@ -101,8 +99,19 @@ export function harvestMode() {
   //     them, because summarised still means sent.
   //   - probeHarvest in doctor.mjs states the mode and what is sent, so the state is legible
   //     rather than assumed.
+  // AN EXPLICIT CHOICE OUTRANKS EVERY CAPABILITY CHECK, and it has to be tested first.
+  //
+  // The opt-out used to sit after the local-endpoint branch, which meant a user who configured a
+  // local endpoint AND set TOKEN_OPTIMIZER_HARVEST=0 kept harvesting: `localEndpoint()` returned
+  // 'local' before anything looked at the variable. Turning a feature off must not depend on how
+  // it happens to be configured.
   const optedOut = /^(0|false|no|off)$/i.test(process.env.TOKEN_OPTIMIZER_HARVEST || '');
   if (optedOut) return 'off:opted-out';
+
+  // Free and private, so nothing further to weigh: no credential, no billing, no digest leaving
+  // the machine.
+  if (localEndpoint()) return 'local';
+
   return apiKey() ? 'remote' : 'off:no-key';
 }
 

--- a/hooks-core/harvest.mjs
+++ b/hooks-core/harvest.mjs
@@ -71,7 +71,7 @@ export function localEndpoint() {
  * Why the harvest is or is not running -- a string, because "off" needs a
  * reason a user can act on and a boolean cannot carry one.
  *
- * @returns {'local' | 'remote' | 'off:mode' | 'off:not-opted-in' | 'off:no-key'}
+ * @returns {'local' | 'remote' | 'off:mode' | 'off:opted-out' | 'off:no-key'}
  */
 export function harvestMode() {
   if (process.env.TOKEN_OPTIMIZER_MODE === 'off') return 'off:mode';
@@ -79,13 +79,30 @@ export function harvestMode() {
   // Free and private: on by default, because there is nothing to consent to.
   if (localEndpoint()) return 'local';
 
-  // Anything else spends money and sends a digest off the machine, so it takes
-  // a DELIBERATE opt-in. Keying off the presence of ANTHROPIC_API_KEY alone --
-  // which is set in most developer environments already -- would have started
-  // billing a third-party call the moment this shipped, without anyone choosing
-  // it. An ambient credential is not consent.
-  const optedIn = /^(1|true|yes|on)$/i.test(process.env.TOKEN_OPTIMIZER_HARVEST || '');
-  if (!optedIn) return 'off:not-opted-in';
+  // ON BY DEFAULT, OPT-OUT. This was opt-in, and the argument was a real one: a remote harvest
+  // spends money and sends a digest off the machine, and an ambient ANTHROPIC_API_KEY is not
+  // consent.
+  //
+  // Measured against that argument on a machine running this for weeks: 340 read events recorded
+  // in one project's graph and 48 in another, with ZERO findings, ZERO harvests and ZERO
+  // injections in either. The graph accumulated structure and never learned anything, because
+  // nobody sets an environment variable they have never heard of. Everything downstream --
+  // injection, transfer between projects, consolidation, the whole claim that this stops you
+  // re-deriving what you already worked out -- is inert without the harvest, so an opt-in default
+  // silently withheld the product from every user who did not go looking for it.
+  //
+  // A default nobody discovers is not conservative. It is a dead feature.
+  //
+  // The consent argument is answered rather than discarded:
+  //   - off:no-key still applies, so nothing starts billing on a machine with no credential.
+  //   - TOKEN_OPTIMIZER_HARVEST=0|false|no|off turns it off; TOKEN_OPTIMIZER_MODE=off turns off
+  //     everything.
+  //   - buildDigest already drops tool results, file bodies and diffs rather than summarising
+  //     them, because summarised still means sent.
+  //   - probeHarvest in doctor.mjs states the mode and what is sent, so the state is legible
+  //     rather than assumed.
+  const optedOut = /^(0|false|no|off)$/i.test(process.env.TOKEN_OPTIMIZER_HARVEST || '');
+  if (optedOut) return 'off:opted-out';
   return apiKey() ? 'remote' : 'off:no-key';
 }
 

--- a/hooks-core/policy.mjs
+++ b/hooks-core/policy.mjs
@@ -270,7 +270,7 @@ function statePath(sessionId, agent) {
 
 /** A usable state object, whatever was on disk. */
 function emptyState() {
-  return { seen: {}, denied: {}, injected: [], actCounts: {}, forecast: null };
+  return { seen: {}, denied: {}, injected: [], actCounts: {}, forecast: null, edits: 0, editedFiles: [], recordingNudged: false };
 }
 
 /**
@@ -326,6 +326,12 @@ export function loadState(sessionId, agent) {
           && Number.isFinite(parsed.forecast.checkedAt)
           ? parsed.forecast
           : null,
+      // THE SAME REASON AS EVERY FIELD ABOVE. Every tool call is a separate hook process, so a
+      // counter not carried through here resets to zero on each one and can never reach a
+      // threshold -- which is exactly how the act counter came to sit at one forever.
+      edits: Number.isFinite(parsed.edits) ? parsed.edits : 0,
+      editedFiles: Array.isArray(parsed.editedFiles) ? parsed.editedFiles : [],
+      recordingNudged: parsed.recordingNudged === true,
     };
   } catch {
     return emptyState();
@@ -402,6 +408,13 @@ export function saveState(sessionId, state, agent) {
       // a max is the safe merge. The forecast throttle is a POINT IN TIME: taking the older of two
       // concurrent checks would re-open the window and let the panel be rebuilt immediately, which
       // is the cost the throttle exists to bound.
+      // HIGHEST WINS for the edit count, for the same concurrency reason as actCounts: two hook
+      // processes each read, each increment, and last-writer would lose one. Monotonic beats
+      // exact here -- undercounting delays a nudge, overcounting invents one.
+      edits: Math.max(Number(current.edits) || 0, Number(state.edits) || 0),
+      editedFiles: [...new Set([...(state.editedFiles || []), ...(current.editedFiles || [])])].slice(0, 20),
+      // ONCE SET, STAYS SET. A nudge that can un-fire is a nudge that repeats.
+      recordingNudged: Boolean(current.recordingNudged || state.recordingNudged),
       forecast: (() => {
         const mine = state.forecast || null;
         const theirs = current.forecast || null;

--- a/hooks-core/recording.mjs
+++ b/hooks-core/recording.mjs
@@ -1,0 +1,125 @@
+/**
+ * Pressure to record, at the moment a conclusion exists to record.
+ *
+ * The read side of this product is enforced hard: PreToolUse REFUSES `Read`, `Grep` and `Edit` and
+ * names the tool to use instead, so there is no way to work without going through it. The write
+ * side had nothing -- SessionStart asks the model to call `wiki_write` and that is all.
+ *
+ * Measured on a machine running this for weeks: two project graphs holding 340 and 48 read events
+ * and ZERO findings between them. In a long working session on this very repository, with that
+ * SessionStart line present the whole time, `wiki_write` was called exactly zero times until
+ * somebody asked why. Advisory text loses to whatever the model is already doing, every time.
+ *
+ * A refusal is the wrong instrument here. `wiki_write` is not a substitute for another tool, so
+ * there is nothing to deny -- denying an edit until a finding is recorded would hold work hostage
+ * to bookkeeping, which is worse than the problem. What is available is TIMING and SPECIFICITY:
+ *
+ *   WHEN   after real work has happened, not at the start when there is nothing to say, and
+ *          again at PreCompact -- the one moment where an unrecorded conclusion is about to be
+ *          destroyed rather than merely forgotten.
+ *   WHAT   the files this session actually changed, by name. "Record what you learned" is
+ *          wallpaper; "you have changed keepwarm.mjs 6 times and this project has no findings"
+ *          is a question with an answer.
+ *   ONCE   per session, per surface. A nudge that repeats becomes the thing you learn to skip,
+ *          and this product's own injection design already turns on that observation.
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** Edits in one session before an empty graph is worth mentioning. */
+export const NUDGE_AFTER_EDITS = Number(process.env.TOKEN_OPTIMIZER_NUDGE_AFTER) || 8;
+
+/** Tools that mean a decision was made, rather than that something was looked at. */
+const SUBSTANTIVE = new Set(['Edit', 'MultiEdit', 'Write', 'NotebookEdit']);
+
+/** Does this tool call represent work worth having a conclusion about? */
+export function isSubstantive(toolName) {
+  return SUBSTANTIVE.has(String(toolName || ''));
+}
+
+/**
+ * How many findings this project's graph holds.
+ *
+ * Counted from the graph rather than from session state, because the question is not "did you
+ * record something just now" but "has this project ever learned anything" -- a graph with findings
+ * already in it does not need prompting, and one with none is the case that matters.
+ */
+export function findingCount(dir) {
+  // READ THE DURABLE RECORD, not load(). load() serves a compacted view whose contents depend on
+  // when compaction last ran -- a graph with findings freshly appended reports zero through it,
+  // which would fire this nudge at exactly the wrong people: the ones already recording.
+  // graph.jsonl is the append-only truth, and every node carries its `kind`.
+  const path = join(dir, 'graph.jsonl');
+  if (!existsSync(path)) return 0;
+
+  let text;
+  try {
+    text = readFileSync(path, 'utf8');
+  } catch {
+    return 0;
+  }
+
+  // DISTINCT IDS. A node rewritten -- pinned, corrected, retired -- appends another record, so
+  // counting lines would report one finding as several and silence the nudge on a graph that has
+  // learned one thing twice.
+  const seen = new Set();
+  for (const line of text.split('\n')) {
+    if (!line) continue;
+    try {
+      const node = JSON.parse(line);
+      if (node?.kind === 'finding' && node.id) seen.add(node.id);
+    } catch {
+      /* a torn line costs a count, not the hook */
+    }
+  }
+  return seen.size;
+}
+
+/**
+ * The nudge, or null.
+ *
+ * Returns null far more often than not, which is the point: it fires once, after real work, on a
+ * project that has learned nothing, and never again in that session.
+ *
+ * @param state  the session's persisted state; `recordingNudged` is read and set by the caller
+ * @param edits  substantive tool calls seen this session
+ * @param files  paths edited this session, most-recent-first
+ */
+export function recordingNudge(dir, { state = {}, edits = 0, files = [] } = {}) {
+  if (state.recordingNudged) return null;
+  if (edits < NUDGE_AFTER_EDITS) return null;
+  if (findingCount(dir) > 0) return null;
+
+  // Named, and capped. Three is enough to make it concrete without turning the nudge into a
+  // file listing nobody reads.
+  const named = [...new Set(files)].slice(0, 3);
+  const subject = named.length
+    ? named.map((f) => f.split(/[\\/]/).pop()).join(', ')
+    : 'this project';
+
+  return (
+    `You have made ${edits} edits this session (${subject}) and this project's graph holds no `
+    + 'findings at all -- so the next session starts from nothing and re-derives whatever you have '
+    + 'worked out. Call wiki_write for anything durable you concluded: a dead end and why, a '
+    + 'decision and what you rejected, a command that finally worked. Anchor it to the file it is '
+    + 'about. Not worth recording: what the code plainly says.'
+  );
+}
+
+/**
+ * The same question at PreCompact, where the answer is about to be lost.
+ *
+ * Separate from the nudge above and deliberately not gated on `recordingNudged`: compaction is the
+ * event this whole subsystem exists for, and an unrecorded conclusion does not survive it. This is
+ * the last honest moment to ask.
+ */
+export function compactionNudge(dir, { edits = 0 } = {}) {
+  if (edits < 1) return null;
+  if (findingCount(dir) > 0) return null;
+  return (
+    'Compaction is about to discard this session\'s reasoning, and nothing was recorded to the '
+    + 'graph. If you concluded anything durable -- a dead end, a decision and its rejected '
+    + 'alternative, an invocation that worked -- call wiki_write with a file anchor before it goes.'
+  );
+}

--- a/integrations/codex/hooks/lib/doctor.mjs
+++ b/integrations/codex/hooks/lib/doctor.mjs
@@ -146,10 +146,13 @@ function hooksDirFor({ hooksDir, install, root }) {
  * and then fixed only its own half, the once-per-session Stop notice. A
  * systemMessage at Stop is easy to miss; the doctor is where someone goes to ask.
  *
- * This does NOT judge the default. Opting in costs a model call and sends a
- * digest off the machine, so requiring consent is right. The defect is that the
- * state was invisible, which let a user believe findings were accumulating when
- * they could not.
+ * THE DEFAULT HAS SINCE BEEN JUDGED, and reversed. This used to say that requiring consent was
+ * right and that only the invisibility was the defect. Measured again on a machine running this
+ * for weeks: 340 read events in one project's graph, 48 in another, and ZERO findings, ZERO
+ * harvests, ZERO injections in either. A default that nobody discovers is not a conservative
+ * default, it is a dead feature -- and everything downstream of the harvest is inert without it.
+ * Extraction is now on unless turned off, so this check reports a MISSING CREDENTIAL as the
+ * blocking case and a deliberate opt-out as a choice rather than a fault.
  */
 export function probeHarvest() {
   const mode = harvestMode();
@@ -162,24 +165,25 @@ export function probeHarvest() {
     return [ok('finding extraction is on', 'local endpoint -- free and private')];
   }
   if (mode === 'remote') {
-    return [ok('finding extraction is on', 'opted in, with a credential')];
+    return [ok('finding extraction is on',
+      'on by default, with a credential -- a digest of paths, commands and conclusions, never ' +
+      'file contents, is sent to extract findings. TOKEN_OPTIMIZER_HARVEST=0 turns it off')];
   }
 
+  // THE COMMON BLOCKING CASE now that extraction is on by default: wanted, but unable to run.
   if (mode === 'off:no-key') {
     return [bad('finding extraction is on',
-      'opted in, but there is no credential to call a model with',
+      'on, but there is no credential to call a model with -- so the graph will keep collecting ' +
+      'files and symbols and never a finding, a lesson or a correction',
       'set TOKEN_OPTIMIZER_API_KEY, or point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a ' +
-      'local model to run it without one')];
+      'local model to run it free and without one')];
   }
 
-  // off:not-opted-in
-  return [bad('finding extraction is on',
-    'off -- the graph will keep collecting files and symbols, but never a finding, ' +
-    'a lesson or a correction',
-    'point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model to run it free and ' +
-    'private, or set TOKEN_OPTIMIZER_HARVEST=1 with a credential to use a remote ' +
-    'one (that spends money and sends a digest of paths, commands and conclusions ' +
-    '-- never file contents -- off this machine)')];
+  // off:opted-out -- a deliberate choice, reported as one. Nagging about a setting somebody chose
+  // is how a diagnostic gets ignored, and the point of this check is that it is worth reading.
+  return [ok('finding extraction is on',
+    'off by your choice (TOKEN_OPTIMIZER_HARVEST is set to a false value) -- the graph will ' +
+    'collect files and symbols but no findings, lessons or corrections')];
 }
 
 export function probeVersion({ install }) {

--- a/integrations/codex/hooks/lib/harvest.mjs
+++ b/integrations/codex/hooks/lib/harvest.mjs
@@ -73,7 +73,7 @@ export function localEndpoint() {
  * Why the harvest is or is not running -- a string, because "off" needs a
  * reason a user can act on and a boolean cannot carry one.
  *
- * @returns {'local' | 'remote' | 'off:mode' | 'off:not-opted-in' | 'off:no-key'}
+ * @returns {'local' | 'remote' | 'off:mode' | 'off:opted-out' | 'off:no-key'}
  */
 export function harvestMode() {
   if (process.env.TOKEN_OPTIMIZER_MODE === 'off') return 'off:mode';
@@ -81,13 +81,30 @@ export function harvestMode() {
   // Free and private: on by default, because there is nothing to consent to.
   if (localEndpoint()) return 'local';
 
-  // Anything else spends money and sends a digest off the machine, so it takes
-  // a DELIBERATE opt-in. Keying off the presence of ANTHROPIC_API_KEY alone --
-  // which is set in most developer environments already -- would have started
-  // billing a third-party call the moment this shipped, without anyone choosing
-  // it. An ambient credential is not consent.
-  const optedIn = /^(1|true|yes|on)$/i.test(process.env.TOKEN_OPTIMIZER_HARVEST || '');
-  if (!optedIn) return 'off:not-opted-in';
+  // ON BY DEFAULT, OPT-OUT. This was opt-in, and the argument was a real one: a remote harvest
+  // spends money and sends a digest off the machine, and an ambient ANTHROPIC_API_KEY is not
+  // consent.
+  //
+  // Measured against that argument on a machine running this for weeks: 340 read events recorded
+  // in one project's graph and 48 in another, with ZERO findings, ZERO harvests and ZERO
+  // injections in either. The graph accumulated structure and never learned anything, because
+  // nobody sets an environment variable they have never heard of. Everything downstream --
+  // injection, transfer between projects, consolidation, the whole claim that this stops you
+  // re-deriving what you already worked out -- is inert without the harvest, so an opt-in default
+  // silently withheld the product from every user who did not go looking for it.
+  //
+  // A default nobody discovers is not conservative. It is a dead feature.
+  //
+  // The consent argument is answered rather than discarded:
+  //   - off:no-key still applies, so nothing starts billing on a machine with no credential.
+  //   - TOKEN_OPTIMIZER_HARVEST=0|false|no|off turns it off; TOKEN_OPTIMIZER_MODE=off turns off
+  //     everything.
+  //   - buildDigest already drops tool results, file bodies and diffs rather than summarising
+  //     them, because summarised still means sent.
+  //   - probeHarvest in doctor.mjs states the mode and what is sent, so the state is legible
+  //     rather than assumed.
+  const optedOut = /^(0|false|no|off)$/i.test(process.env.TOKEN_OPTIMIZER_HARVEST || '');
+  if (optedOut) return 'off:opted-out';
   return apiKey() ? 'remote' : 'off:no-key';
 }
 

--- a/integrations/codex/hooks/lib/harvest.mjs
+++ b/integrations/codex/hooks/lib/harvest.mjs
@@ -78,8 +78,6 @@ export function localEndpoint() {
 export function harvestMode() {
   if (process.env.TOKEN_OPTIMIZER_MODE === 'off') return 'off:mode';
 
-  // Free and private: on by default, because there is nothing to consent to.
-  if (localEndpoint()) return 'local';
 
   // ON BY DEFAULT, OPT-OUT. This was opt-in, and the argument was a real one: a remote harvest
   // spends money and sends a digest off the machine, and an ambient ANTHROPIC_API_KEY is not
@@ -103,8 +101,19 @@ export function harvestMode() {
   //     them, because summarised still means sent.
   //   - probeHarvest in doctor.mjs states the mode and what is sent, so the state is legible
   //     rather than assumed.
+  // AN EXPLICIT CHOICE OUTRANKS EVERY CAPABILITY CHECK, and it has to be tested first.
+  //
+  // The opt-out used to sit after the local-endpoint branch, which meant a user who configured a
+  // local endpoint AND set TOKEN_OPTIMIZER_HARVEST=0 kept harvesting: `localEndpoint()` returned
+  // 'local' before anything looked at the variable. Turning a feature off must not depend on how
+  // it happens to be configured.
   const optedOut = /^(0|false|no|off)$/i.test(process.env.TOKEN_OPTIMIZER_HARVEST || '');
   if (optedOut) return 'off:opted-out';
+
+  // Free and private, so nothing further to weigh: no credential, no billing, no digest leaving
+  // the machine.
+  if (localEndpoint()) return 'local';
+
   return apiKey() ? 'remote' : 'off:no-key';
 }
 

--- a/integrations/codex/hooks/lib/policy.mjs
+++ b/integrations/codex/hooks/lib/policy.mjs
@@ -272,7 +272,7 @@ function statePath(sessionId, agent) {
 
 /** A usable state object, whatever was on disk. */
 function emptyState() {
-  return { seen: {}, denied: {}, injected: [], actCounts: {}, forecast: null };
+  return { seen: {}, denied: {}, injected: [], actCounts: {}, forecast: null, edits: 0, editedFiles: [], recordingNudged: false };
 }
 
 /**
@@ -328,6 +328,12 @@ export function loadState(sessionId, agent) {
           && Number.isFinite(parsed.forecast.checkedAt)
           ? parsed.forecast
           : null,
+      // THE SAME REASON AS EVERY FIELD ABOVE. Every tool call is a separate hook process, so a
+      // counter not carried through here resets to zero on each one and can never reach a
+      // threshold -- which is exactly how the act counter came to sit at one forever.
+      edits: Number.isFinite(parsed.edits) ? parsed.edits : 0,
+      editedFiles: Array.isArray(parsed.editedFiles) ? parsed.editedFiles : [],
+      recordingNudged: parsed.recordingNudged === true,
     };
   } catch {
     return emptyState();
@@ -404,6 +410,13 @@ export function saveState(sessionId, state, agent) {
       // a max is the safe merge. The forecast throttle is a POINT IN TIME: taking the older of two
       // concurrent checks would re-open the window and let the panel be rebuilt immediately, which
       // is the cost the throttle exists to bound.
+      // HIGHEST WINS for the edit count, for the same concurrency reason as actCounts: two hook
+      // processes each read, each increment, and last-writer would lose one. Monotonic beats
+      // exact here -- undercounting delays a nudge, overcounting invents one.
+      edits: Math.max(Number(current.edits) || 0, Number(state.edits) || 0),
+      editedFiles: [...new Set([...(state.editedFiles || []), ...(current.editedFiles || [])])].slice(0, 20),
+      // ONCE SET, STAYS SET. A nudge that can un-fire is a nudge that repeats.
+      recordingNudged: Boolean(current.recordingNudged || state.recordingNudged),
       forecast: (() => {
         const mine = state.forecast || null;
         const theirs = current.forecast || null;

--- a/integrations/codex/hooks/lib/recording.mjs
+++ b/integrations/codex/hooks/lib/recording.mjs
@@ -1,0 +1,127 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/recording.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Pressure to record, at the moment a conclusion exists to record.
+ *
+ * The read side of this product is enforced hard: PreToolUse REFUSES `Read`, `Grep` and `Edit` and
+ * names the tool to use instead, so there is no way to work without going through it. The write
+ * side had nothing -- SessionStart asks the model to call `wiki_write` and that is all.
+ *
+ * Measured on a machine running this for weeks: two project graphs holding 340 and 48 read events
+ * and ZERO findings between them. In a long working session on this very repository, with that
+ * SessionStart line present the whole time, `wiki_write` was called exactly zero times until
+ * somebody asked why. Advisory text loses to whatever the model is already doing, every time.
+ *
+ * A refusal is the wrong instrument here. `wiki_write` is not a substitute for another tool, so
+ * there is nothing to deny -- denying an edit until a finding is recorded would hold work hostage
+ * to bookkeeping, which is worse than the problem. What is available is TIMING and SPECIFICITY:
+ *
+ *   WHEN   after real work has happened, not at the start when there is nothing to say, and
+ *          again at PreCompact -- the one moment where an unrecorded conclusion is about to be
+ *          destroyed rather than merely forgotten.
+ *   WHAT   the files this session actually changed, by name. "Record what you learned" is
+ *          wallpaper; "you have changed keepwarm.mjs 6 times and this project has no findings"
+ *          is a question with an answer.
+ *   ONCE   per session, per surface. A nudge that repeats becomes the thing you learn to skip,
+ *          and this product's own injection design already turns on that observation.
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** Edits in one session before an empty graph is worth mentioning. */
+export const NUDGE_AFTER_EDITS = Number(process.env.TOKEN_OPTIMIZER_NUDGE_AFTER) || 8;
+
+/** Tools that mean a decision was made, rather than that something was looked at. */
+const SUBSTANTIVE = new Set(['Edit', 'MultiEdit', 'Write', 'NotebookEdit']);
+
+/** Does this tool call represent work worth having a conclusion about? */
+export function isSubstantive(toolName) {
+  return SUBSTANTIVE.has(String(toolName || ''));
+}
+
+/**
+ * How many findings this project's graph holds.
+ *
+ * Counted from the graph rather than from session state, because the question is not "did you
+ * record something just now" but "has this project ever learned anything" -- a graph with findings
+ * already in it does not need prompting, and one with none is the case that matters.
+ */
+export function findingCount(dir) {
+  // READ THE DURABLE RECORD, not load(). load() serves a compacted view whose contents depend on
+  // when compaction last ran -- a graph with findings freshly appended reports zero through it,
+  // which would fire this nudge at exactly the wrong people: the ones already recording.
+  // graph.jsonl is the append-only truth, and every node carries its `kind`.
+  const path = join(dir, 'graph.jsonl');
+  if (!existsSync(path)) return 0;
+
+  let text;
+  try {
+    text = readFileSync(path, 'utf8');
+  } catch {
+    return 0;
+  }
+
+  // DISTINCT IDS. A node rewritten -- pinned, corrected, retired -- appends another record, so
+  // counting lines would report one finding as several and silence the nudge on a graph that has
+  // learned one thing twice.
+  const seen = new Set();
+  for (const line of text.split('\n')) {
+    if (!line) continue;
+    try {
+      const node = JSON.parse(line);
+      if (node?.kind === 'finding' && node.id) seen.add(node.id);
+    } catch {
+      /* a torn line costs a count, not the hook */
+    }
+  }
+  return seen.size;
+}
+
+/**
+ * The nudge, or null.
+ *
+ * Returns null far more often than not, which is the point: it fires once, after real work, on a
+ * project that has learned nothing, and never again in that session.
+ *
+ * @param state  the session's persisted state; `recordingNudged` is read and set by the caller
+ * @param edits  substantive tool calls seen this session
+ * @param files  paths edited this session, most-recent-first
+ */
+export function recordingNudge(dir, { state = {}, edits = 0, files = [] } = {}) {
+  if (state.recordingNudged) return null;
+  if (edits < NUDGE_AFTER_EDITS) return null;
+  if (findingCount(dir) > 0) return null;
+
+  // Named, and capped. Three is enough to make it concrete without turning the nudge into a
+  // file listing nobody reads.
+  const named = [...new Set(files)].slice(0, 3);
+  const subject = named.length
+    ? named.map((f) => f.split(/[\\/]/).pop()).join(', ')
+    : 'this project';
+
+  return (
+    `You have made ${edits} edits this session (${subject}) and this project's graph holds no `
+    + 'findings at all -- so the next session starts from nothing and re-derives whatever you have '
+    + 'worked out. Call wiki_write for anything durable you concluded: a dead end and why, a '
+    + 'decision and what you rejected, a command that finally worked. Anchor it to the file it is '
+    + 'about. Not worth recording: what the code plainly says.'
+  );
+}
+
+/**
+ * The same question at PreCompact, where the answer is about to be lost.
+ *
+ * Separate from the nudge above and deliberately not gated on `recordingNudged`: compaction is the
+ * event this whole subsystem exists for, and an unrecorded conclusion does not survive it. This is
+ * the last honest moment to ask.
+ */
+export function compactionNudge(dir, { edits = 0 } = {}) {
+  if (edits < 1) return null;
+  if (findingCount(dir) > 0) return null;
+  return (
+    'Compaction is about to discard this session\'s reasoning, and nothing was recorded to the '
+    + 'graph. If you concluded anything durable -- a dead end, a decision and its rejected '
+    + 'alternative, an invocation that worked -- call wiki_write with a file anchor before it goes.'
+  );
+}

--- a/integrations/codex/plugin/hooks/lib/doctor.mjs
+++ b/integrations/codex/plugin/hooks/lib/doctor.mjs
@@ -146,10 +146,13 @@ function hooksDirFor({ hooksDir, install, root }) {
  * and then fixed only its own half, the once-per-session Stop notice. A
  * systemMessage at Stop is easy to miss; the doctor is where someone goes to ask.
  *
- * This does NOT judge the default. Opting in costs a model call and sends a
- * digest off the machine, so requiring consent is right. The defect is that the
- * state was invisible, which let a user believe findings were accumulating when
- * they could not.
+ * THE DEFAULT HAS SINCE BEEN JUDGED, and reversed. This used to say that requiring consent was
+ * right and that only the invisibility was the defect. Measured again on a machine running this
+ * for weeks: 340 read events in one project's graph, 48 in another, and ZERO findings, ZERO
+ * harvests, ZERO injections in either. A default that nobody discovers is not a conservative
+ * default, it is a dead feature -- and everything downstream of the harvest is inert without it.
+ * Extraction is now on unless turned off, so this check reports a MISSING CREDENTIAL as the
+ * blocking case and a deliberate opt-out as a choice rather than a fault.
  */
 export function probeHarvest() {
   const mode = harvestMode();
@@ -162,24 +165,25 @@ export function probeHarvest() {
     return [ok('finding extraction is on', 'local endpoint -- free and private')];
   }
   if (mode === 'remote') {
-    return [ok('finding extraction is on', 'opted in, with a credential')];
+    return [ok('finding extraction is on',
+      'on by default, with a credential -- a digest of paths, commands and conclusions, never ' +
+      'file contents, is sent to extract findings. TOKEN_OPTIMIZER_HARVEST=0 turns it off')];
   }
 
+  // THE COMMON BLOCKING CASE now that extraction is on by default: wanted, but unable to run.
   if (mode === 'off:no-key') {
     return [bad('finding extraction is on',
-      'opted in, but there is no credential to call a model with',
+      'on, but there is no credential to call a model with -- so the graph will keep collecting ' +
+      'files and symbols and never a finding, a lesson or a correction',
       'set TOKEN_OPTIMIZER_API_KEY, or point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a ' +
-      'local model to run it without one')];
+      'local model to run it free and without one')];
   }
 
-  // off:not-opted-in
-  return [bad('finding extraction is on',
-    'off -- the graph will keep collecting files and symbols, but never a finding, ' +
-    'a lesson or a correction',
-    'point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model to run it free and ' +
-    'private, or set TOKEN_OPTIMIZER_HARVEST=1 with a credential to use a remote ' +
-    'one (that spends money and sends a digest of paths, commands and conclusions ' +
-    '-- never file contents -- off this machine)')];
+  // off:opted-out -- a deliberate choice, reported as one. Nagging about a setting somebody chose
+  // is how a diagnostic gets ignored, and the point of this check is that it is worth reading.
+  return [ok('finding extraction is on',
+    'off by your choice (TOKEN_OPTIMIZER_HARVEST is set to a false value) -- the graph will ' +
+    'collect files and symbols but no findings, lessons or corrections')];
 }
 
 export function probeVersion({ install }) {

--- a/integrations/codex/plugin/hooks/lib/harvest.mjs
+++ b/integrations/codex/plugin/hooks/lib/harvest.mjs
@@ -73,7 +73,7 @@ export function localEndpoint() {
  * Why the harvest is or is not running -- a string, because "off" needs a
  * reason a user can act on and a boolean cannot carry one.
  *
- * @returns {'local' | 'remote' | 'off:mode' | 'off:not-opted-in' | 'off:no-key'}
+ * @returns {'local' | 'remote' | 'off:mode' | 'off:opted-out' | 'off:no-key'}
  */
 export function harvestMode() {
   if (process.env.TOKEN_OPTIMIZER_MODE === 'off') return 'off:mode';
@@ -81,13 +81,30 @@ export function harvestMode() {
   // Free and private: on by default, because there is nothing to consent to.
   if (localEndpoint()) return 'local';
 
-  // Anything else spends money and sends a digest off the machine, so it takes
-  // a DELIBERATE opt-in. Keying off the presence of ANTHROPIC_API_KEY alone --
-  // which is set in most developer environments already -- would have started
-  // billing a third-party call the moment this shipped, without anyone choosing
-  // it. An ambient credential is not consent.
-  const optedIn = /^(1|true|yes|on)$/i.test(process.env.TOKEN_OPTIMIZER_HARVEST || '');
-  if (!optedIn) return 'off:not-opted-in';
+  // ON BY DEFAULT, OPT-OUT. This was opt-in, and the argument was a real one: a remote harvest
+  // spends money and sends a digest off the machine, and an ambient ANTHROPIC_API_KEY is not
+  // consent.
+  //
+  // Measured against that argument on a machine running this for weeks: 340 read events recorded
+  // in one project's graph and 48 in another, with ZERO findings, ZERO harvests and ZERO
+  // injections in either. The graph accumulated structure and never learned anything, because
+  // nobody sets an environment variable they have never heard of. Everything downstream --
+  // injection, transfer between projects, consolidation, the whole claim that this stops you
+  // re-deriving what you already worked out -- is inert without the harvest, so an opt-in default
+  // silently withheld the product from every user who did not go looking for it.
+  //
+  // A default nobody discovers is not conservative. It is a dead feature.
+  //
+  // The consent argument is answered rather than discarded:
+  //   - off:no-key still applies, so nothing starts billing on a machine with no credential.
+  //   - TOKEN_OPTIMIZER_HARVEST=0|false|no|off turns it off; TOKEN_OPTIMIZER_MODE=off turns off
+  //     everything.
+  //   - buildDigest already drops tool results, file bodies and diffs rather than summarising
+  //     them, because summarised still means sent.
+  //   - probeHarvest in doctor.mjs states the mode and what is sent, so the state is legible
+  //     rather than assumed.
+  const optedOut = /^(0|false|no|off)$/i.test(process.env.TOKEN_OPTIMIZER_HARVEST || '');
+  if (optedOut) return 'off:opted-out';
   return apiKey() ? 'remote' : 'off:no-key';
 }
 

--- a/integrations/codex/plugin/hooks/lib/harvest.mjs
+++ b/integrations/codex/plugin/hooks/lib/harvest.mjs
@@ -78,8 +78,6 @@ export function localEndpoint() {
 export function harvestMode() {
   if (process.env.TOKEN_OPTIMIZER_MODE === 'off') return 'off:mode';
 
-  // Free and private: on by default, because there is nothing to consent to.
-  if (localEndpoint()) return 'local';
 
   // ON BY DEFAULT, OPT-OUT. This was opt-in, and the argument was a real one: a remote harvest
   // spends money and sends a digest off the machine, and an ambient ANTHROPIC_API_KEY is not
@@ -103,8 +101,19 @@ export function harvestMode() {
   //     them, because summarised still means sent.
   //   - probeHarvest in doctor.mjs states the mode and what is sent, so the state is legible
   //     rather than assumed.
+  // AN EXPLICIT CHOICE OUTRANKS EVERY CAPABILITY CHECK, and it has to be tested first.
+  //
+  // The opt-out used to sit after the local-endpoint branch, which meant a user who configured a
+  // local endpoint AND set TOKEN_OPTIMIZER_HARVEST=0 kept harvesting: `localEndpoint()` returned
+  // 'local' before anything looked at the variable. Turning a feature off must not depend on how
+  // it happens to be configured.
   const optedOut = /^(0|false|no|off)$/i.test(process.env.TOKEN_OPTIMIZER_HARVEST || '');
   if (optedOut) return 'off:opted-out';
+
+  // Free and private, so nothing further to weigh: no credential, no billing, no digest leaving
+  // the machine.
+  if (localEndpoint()) return 'local';
+
   return apiKey() ? 'remote' : 'off:no-key';
 }
 

--- a/integrations/codex/plugin/hooks/lib/policy.mjs
+++ b/integrations/codex/plugin/hooks/lib/policy.mjs
@@ -272,7 +272,7 @@ function statePath(sessionId, agent) {
 
 /** A usable state object, whatever was on disk. */
 function emptyState() {
-  return { seen: {}, denied: {}, injected: [], actCounts: {}, forecast: null };
+  return { seen: {}, denied: {}, injected: [], actCounts: {}, forecast: null, edits: 0, editedFiles: [], recordingNudged: false };
 }
 
 /**
@@ -328,6 +328,12 @@ export function loadState(sessionId, agent) {
           && Number.isFinite(parsed.forecast.checkedAt)
           ? parsed.forecast
           : null,
+      // THE SAME REASON AS EVERY FIELD ABOVE. Every tool call is a separate hook process, so a
+      // counter not carried through here resets to zero on each one and can never reach a
+      // threshold -- which is exactly how the act counter came to sit at one forever.
+      edits: Number.isFinite(parsed.edits) ? parsed.edits : 0,
+      editedFiles: Array.isArray(parsed.editedFiles) ? parsed.editedFiles : [],
+      recordingNudged: parsed.recordingNudged === true,
     };
   } catch {
     return emptyState();
@@ -404,6 +410,13 @@ export function saveState(sessionId, state, agent) {
       // a max is the safe merge. The forecast throttle is a POINT IN TIME: taking the older of two
       // concurrent checks would re-open the window and let the panel be rebuilt immediately, which
       // is the cost the throttle exists to bound.
+      // HIGHEST WINS for the edit count, for the same concurrency reason as actCounts: two hook
+      // processes each read, each increment, and last-writer would lose one. Monotonic beats
+      // exact here -- undercounting delays a nudge, overcounting invents one.
+      edits: Math.max(Number(current.edits) || 0, Number(state.edits) || 0),
+      editedFiles: [...new Set([...(state.editedFiles || []), ...(current.editedFiles || [])])].slice(0, 20),
+      // ONCE SET, STAYS SET. A nudge that can un-fire is a nudge that repeats.
+      recordingNudged: Boolean(current.recordingNudged || state.recordingNudged),
       forecast: (() => {
         const mine = state.forecast || null;
         const theirs = current.forecast || null;

--- a/integrations/codex/plugin/hooks/lib/recording.mjs
+++ b/integrations/codex/plugin/hooks/lib/recording.mjs
@@ -1,0 +1,127 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/recording.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Pressure to record, at the moment a conclusion exists to record.
+ *
+ * The read side of this product is enforced hard: PreToolUse REFUSES `Read`, `Grep` and `Edit` and
+ * names the tool to use instead, so there is no way to work without going through it. The write
+ * side had nothing -- SessionStart asks the model to call `wiki_write` and that is all.
+ *
+ * Measured on a machine running this for weeks: two project graphs holding 340 and 48 read events
+ * and ZERO findings between them. In a long working session on this very repository, with that
+ * SessionStart line present the whole time, `wiki_write` was called exactly zero times until
+ * somebody asked why. Advisory text loses to whatever the model is already doing, every time.
+ *
+ * A refusal is the wrong instrument here. `wiki_write` is not a substitute for another tool, so
+ * there is nothing to deny -- denying an edit until a finding is recorded would hold work hostage
+ * to bookkeeping, which is worse than the problem. What is available is TIMING and SPECIFICITY:
+ *
+ *   WHEN   after real work has happened, not at the start when there is nothing to say, and
+ *          again at PreCompact -- the one moment where an unrecorded conclusion is about to be
+ *          destroyed rather than merely forgotten.
+ *   WHAT   the files this session actually changed, by name. "Record what you learned" is
+ *          wallpaper; "you have changed keepwarm.mjs 6 times and this project has no findings"
+ *          is a question with an answer.
+ *   ONCE   per session, per surface. A nudge that repeats becomes the thing you learn to skip,
+ *          and this product's own injection design already turns on that observation.
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** Edits in one session before an empty graph is worth mentioning. */
+export const NUDGE_AFTER_EDITS = Number(process.env.TOKEN_OPTIMIZER_NUDGE_AFTER) || 8;
+
+/** Tools that mean a decision was made, rather than that something was looked at. */
+const SUBSTANTIVE = new Set(['Edit', 'MultiEdit', 'Write', 'NotebookEdit']);
+
+/** Does this tool call represent work worth having a conclusion about? */
+export function isSubstantive(toolName) {
+  return SUBSTANTIVE.has(String(toolName || ''));
+}
+
+/**
+ * How many findings this project's graph holds.
+ *
+ * Counted from the graph rather than from session state, because the question is not "did you
+ * record something just now" but "has this project ever learned anything" -- a graph with findings
+ * already in it does not need prompting, and one with none is the case that matters.
+ */
+export function findingCount(dir) {
+  // READ THE DURABLE RECORD, not load(). load() serves a compacted view whose contents depend on
+  // when compaction last ran -- a graph with findings freshly appended reports zero through it,
+  // which would fire this nudge at exactly the wrong people: the ones already recording.
+  // graph.jsonl is the append-only truth, and every node carries its `kind`.
+  const path = join(dir, 'graph.jsonl');
+  if (!existsSync(path)) return 0;
+
+  let text;
+  try {
+    text = readFileSync(path, 'utf8');
+  } catch {
+    return 0;
+  }
+
+  // DISTINCT IDS. A node rewritten -- pinned, corrected, retired -- appends another record, so
+  // counting lines would report one finding as several and silence the nudge on a graph that has
+  // learned one thing twice.
+  const seen = new Set();
+  for (const line of text.split('\n')) {
+    if (!line) continue;
+    try {
+      const node = JSON.parse(line);
+      if (node?.kind === 'finding' && node.id) seen.add(node.id);
+    } catch {
+      /* a torn line costs a count, not the hook */
+    }
+  }
+  return seen.size;
+}
+
+/**
+ * The nudge, or null.
+ *
+ * Returns null far more often than not, which is the point: it fires once, after real work, on a
+ * project that has learned nothing, and never again in that session.
+ *
+ * @param state  the session's persisted state; `recordingNudged` is read and set by the caller
+ * @param edits  substantive tool calls seen this session
+ * @param files  paths edited this session, most-recent-first
+ */
+export function recordingNudge(dir, { state = {}, edits = 0, files = [] } = {}) {
+  if (state.recordingNudged) return null;
+  if (edits < NUDGE_AFTER_EDITS) return null;
+  if (findingCount(dir) > 0) return null;
+
+  // Named, and capped. Three is enough to make it concrete without turning the nudge into a
+  // file listing nobody reads.
+  const named = [...new Set(files)].slice(0, 3);
+  const subject = named.length
+    ? named.map((f) => f.split(/[\\/]/).pop()).join(', ')
+    : 'this project';
+
+  return (
+    `You have made ${edits} edits this session (${subject}) and this project's graph holds no `
+    + 'findings at all -- so the next session starts from nothing and re-derives whatever you have '
+    + 'worked out. Call wiki_write for anything durable you concluded: a dead end and why, a '
+    + 'decision and what you rejected, a command that finally worked. Anchor it to the file it is '
+    + 'about. Not worth recording: what the code plainly says.'
+  );
+}
+
+/**
+ * The same question at PreCompact, where the answer is about to be lost.
+ *
+ * Separate from the nudge above and deliberately not gated on `recordingNudged`: compaction is the
+ * event this whole subsystem exists for, and an unrecorded conclusion does not survive it. This is
+ * the last honest moment to ask.
+ */
+export function compactionNudge(dir, { edits = 0 } = {}) {
+  if (edits < 1) return null;
+  if (findingCount(dir) > 0) return null;
+  return (
+    'Compaction is about to discard this session\'s reasoning, and nothing was recorded to the '
+    + 'graph. If you concluded anything durable -- a dead end, a decision and its rejected '
+    + 'alternative, an invocation that worked -- call wiki_write with a file anchor before it goes.'
+  );
+}

--- a/integrations/gemini/hooks/lib/doctor.mjs
+++ b/integrations/gemini/hooks/lib/doctor.mjs
@@ -146,10 +146,13 @@ function hooksDirFor({ hooksDir, install, root }) {
  * and then fixed only its own half, the once-per-session Stop notice. A
  * systemMessage at Stop is easy to miss; the doctor is where someone goes to ask.
  *
- * This does NOT judge the default. Opting in costs a model call and sends a
- * digest off the machine, so requiring consent is right. The defect is that the
- * state was invisible, which let a user believe findings were accumulating when
- * they could not.
+ * THE DEFAULT HAS SINCE BEEN JUDGED, and reversed. This used to say that requiring consent was
+ * right and that only the invisibility was the defect. Measured again on a machine running this
+ * for weeks: 340 read events in one project's graph, 48 in another, and ZERO findings, ZERO
+ * harvests, ZERO injections in either. A default that nobody discovers is not a conservative
+ * default, it is a dead feature -- and everything downstream of the harvest is inert without it.
+ * Extraction is now on unless turned off, so this check reports a MISSING CREDENTIAL as the
+ * blocking case and a deliberate opt-out as a choice rather than a fault.
  */
 export function probeHarvest() {
   const mode = harvestMode();
@@ -162,24 +165,25 @@ export function probeHarvest() {
     return [ok('finding extraction is on', 'local endpoint -- free and private')];
   }
   if (mode === 'remote') {
-    return [ok('finding extraction is on', 'opted in, with a credential')];
+    return [ok('finding extraction is on',
+      'on by default, with a credential -- a digest of paths, commands and conclusions, never ' +
+      'file contents, is sent to extract findings. TOKEN_OPTIMIZER_HARVEST=0 turns it off')];
   }
 
+  // THE COMMON BLOCKING CASE now that extraction is on by default: wanted, but unable to run.
   if (mode === 'off:no-key') {
     return [bad('finding extraction is on',
-      'opted in, but there is no credential to call a model with',
+      'on, but there is no credential to call a model with -- so the graph will keep collecting ' +
+      'files and symbols and never a finding, a lesson or a correction',
       'set TOKEN_OPTIMIZER_API_KEY, or point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a ' +
-      'local model to run it without one')];
+      'local model to run it free and without one')];
   }
 
-  // off:not-opted-in
-  return [bad('finding extraction is on',
-    'off -- the graph will keep collecting files and symbols, but never a finding, ' +
-    'a lesson or a correction',
-    'point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model to run it free and ' +
-    'private, or set TOKEN_OPTIMIZER_HARVEST=1 with a credential to use a remote ' +
-    'one (that spends money and sends a digest of paths, commands and conclusions ' +
-    '-- never file contents -- off this machine)')];
+  // off:opted-out -- a deliberate choice, reported as one. Nagging about a setting somebody chose
+  // is how a diagnostic gets ignored, and the point of this check is that it is worth reading.
+  return [ok('finding extraction is on',
+    'off by your choice (TOKEN_OPTIMIZER_HARVEST is set to a false value) -- the graph will ' +
+    'collect files and symbols but no findings, lessons or corrections')];
 }
 
 export function probeVersion({ install }) {

--- a/integrations/gemini/hooks/lib/harvest.mjs
+++ b/integrations/gemini/hooks/lib/harvest.mjs
@@ -73,7 +73,7 @@ export function localEndpoint() {
  * Why the harvest is or is not running -- a string, because "off" needs a
  * reason a user can act on and a boolean cannot carry one.
  *
- * @returns {'local' | 'remote' | 'off:mode' | 'off:not-opted-in' | 'off:no-key'}
+ * @returns {'local' | 'remote' | 'off:mode' | 'off:opted-out' | 'off:no-key'}
  */
 export function harvestMode() {
   if (process.env.TOKEN_OPTIMIZER_MODE === 'off') return 'off:mode';
@@ -81,13 +81,30 @@ export function harvestMode() {
   // Free and private: on by default, because there is nothing to consent to.
   if (localEndpoint()) return 'local';
 
-  // Anything else spends money and sends a digest off the machine, so it takes
-  // a DELIBERATE opt-in. Keying off the presence of ANTHROPIC_API_KEY alone --
-  // which is set in most developer environments already -- would have started
-  // billing a third-party call the moment this shipped, without anyone choosing
-  // it. An ambient credential is not consent.
-  const optedIn = /^(1|true|yes|on)$/i.test(process.env.TOKEN_OPTIMIZER_HARVEST || '');
-  if (!optedIn) return 'off:not-opted-in';
+  // ON BY DEFAULT, OPT-OUT. This was opt-in, and the argument was a real one: a remote harvest
+  // spends money and sends a digest off the machine, and an ambient ANTHROPIC_API_KEY is not
+  // consent.
+  //
+  // Measured against that argument on a machine running this for weeks: 340 read events recorded
+  // in one project's graph and 48 in another, with ZERO findings, ZERO harvests and ZERO
+  // injections in either. The graph accumulated structure and never learned anything, because
+  // nobody sets an environment variable they have never heard of. Everything downstream --
+  // injection, transfer between projects, consolidation, the whole claim that this stops you
+  // re-deriving what you already worked out -- is inert without the harvest, so an opt-in default
+  // silently withheld the product from every user who did not go looking for it.
+  //
+  // A default nobody discovers is not conservative. It is a dead feature.
+  //
+  // The consent argument is answered rather than discarded:
+  //   - off:no-key still applies, so nothing starts billing on a machine with no credential.
+  //   - TOKEN_OPTIMIZER_HARVEST=0|false|no|off turns it off; TOKEN_OPTIMIZER_MODE=off turns off
+  //     everything.
+  //   - buildDigest already drops tool results, file bodies and diffs rather than summarising
+  //     them, because summarised still means sent.
+  //   - probeHarvest in doctor.mjs states the mode and what is sent, so the state is legible
+  //     rather than assumed.
+  const optedOut = /^(0|false|no|off)$/i.test(process.env.TOKEN_OPTIMIZER_HARVEST || '');
+  if (optedOut) return 'off:opted-out';
   return apiKey() ? 'remote' : 'off:no-key';
 }
 

--- a/integrations/gemini/hooks/lib/harvest.mjs
+++ b/integrations/gemini/hooks/lib/harvest.mjs
@@ -78,8 +78,6 @@ export function localEndpoint() {
 export function harvestMode() {
   if (process.env.TOKEN_OPTIMIZER_MODE === 'off') return 'off:mode';
 
-  // Free and private: on by default, because there is nothing to consent to.
-  if (localEndpoint()) return 'local';
 
   // ON BY DEFAULT, OPT-OUT. This was opt-in, and the argument was a real one: a remote harvest
   // spends money and sends a digest off the machine, and an ambient ANTHROPIC_API_KEY is not
@@ -103,8 +101,19 @@ export function harvestMode() {
   //     them, because summarised still means sent.
   //   - probeHarvest in doctor.mjs states the mode and what is sent, so the state is legible
   //     rather than assumed.
+  // AN EXPLICIT CHOICE OUTRANKS EVERY CAPABILITY CHECK, and it has to be tested first.
+  //
+  // The opt-out used to sit after the local-endpoint branch, which meant a user who configured a
+  // local endpoint AND set TOKEN_OPTIMIZER_HARVEST=0 kept harvesting: `localEndpoint()` returned
+  // 'local' before anything looked at the variable. Turning a feature off must not depend on how
+  // it happens to be configured.
   const optedOut = /^(0|false|no|off)$/i.test(process.env.TOKEN_OPTIMIZER_HARVEST || '');
   if (optedOut) return 'off:opted-out';
+
+  // Free and private, so nothing further to weigh: no credential, no billing, no digest leaving
+  // the machine.
+  if (localEndpoint()) return 'local';
+
   return apiKey() ? 'remote' : 'off:no-key';
 }
 

--- a/integrations/gemini/hooks/lib/policy.mjs
+++ b/integrations/gemini/hooks/lib/policy.mjs
@@ -272,7 +272,7 @@ function statePath(sessionId, agent) {
 
 /** A usable state object, whatever was on disk. */
 function emptyState() {
-  return { seen: {}, denied: {}, injected: [], actCounts: {}, forecast: null };
+  return { seen: {}, denied: {}, injected: [], actCounts: {}, forecast: null, edits: 0, editedFiles: [], recordingNudged: false };
 }
 
 /**
@@ -328,6 +328,12 @@ export function loadState(sessionId, agent) {
           && Number.isFinite(parsed.forecast.checkedAt)
           ? parsed.forecast
           : null,
+      // THE SAME REASON AS EVERY FIELD ABOVE. Every tool call is a separate hook process, so a
+      // counter not carried through here resets to zero on each one and can never reach a
+      // threshold -- which is exactly how the act counter came to sit at one forever.
+      edits: Number.isFinite(parsed.edits) ? parsed.edits : 0,
+      editedFiles: Array.isArray(parsed.editedFiles) ? parsed.editedFiles : [],
+      recordingNudged: parsed.recordingNudged === true,
     };
   } catch {
     return emptyState();
@@ -404,6 +410,13 @@ export function saveState(sessionId, state, agent) {
       // a max is the safe merge. The forecast throttle is a POINT IN TIME: taking the older of two
       // concurrent checks would re-open the window and let the panel be rebuilt immediately, which
       // is the cost the throttle exists to bound.
+      // HIGHEST WINS for the edit count, for the same concurrency reason as actCounts: two hook
+      // processes each read, each increment, and last-writer would lose one. Monotonic beats
+      // exact here -- undercounting delays a nudge, overcounting invents one.
+      edits: Math.max(Number(current.edits) || 0, Number(state.edits) || 0),
+      editedFiles: [...new Set([...(state.editedFiles || []), ...(current.editedFiles || [])])].slice(0, 20),
+      // ONCE SET, STAYS SET. A nudge that can un-fire is a nudge that repeats.
+      recordingNudged: Boolean(current.recordingNudged || state.recordingNudged),
       forecast: (() => {
         const mine = state.forecast || null;
         const theirs = current.forecast || null;

--- a/integrations/gemini/hooks/lib/recording.mjs
+++ b/integrations/gemini/hooks/lib/recording.mjs
@@ -1,0 +1,127 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/recording.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Pressure to record, at the moment a conclusion exists to record.
+ *
+ * The read side of this product is enforced hard: PreToolUse REFUSES `Read`, `Grep` and `Edit` and
+ * names the tool to use instead, so there is no way to work without going through it. The write
+ * side had nothing -- SessionStart asks the model to call `wiki_write` and that is all.
+ *
+ * Measured on a machine running this for weeks: two project graphs holding 340 and 48 read events
+ * and ZERO findings between them. In a long working session on this very repository, with that
+ * SessionStart line present the whole time, `wiki_write` was called exactly zero times until
+ * somebody asked why. Advisory text loses to whatever the model is already doing, every time.
+ *
+ * A refusal is the wrong instrument here. `wiki_write` is not a substitute for another tool, so
+ * there is nothing to deny -- denying an edit until a finding is recorded would hold work hostage
+ * to bookkeeping, which is worse than the problem. What is available is TIMING and SPECIFICITY:
+ *
+ *   WHEN   after real work has happened, not at the start when there is nothing to say, and
+ *          again at PreCompact -- the one moment where an unrecorded conclusion is about to be
+ *          destroyed rather than merely forgotten.
+ *   WHAT   the files this session actually changed, by name. "Record what you learned" is
+ *          wallpaper; "you have changed keepwarm.mjs 6 times and this project has no findings"
+ *          is a question with an answer.
+ *   ONCE   per session, per surface. A nudge that repeats becomes the thing you learn to skip,
+ *          and this product's own injection design already turns on that observation.
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** Edits in one session before an empty graph is worth mentioning. */
+export const NUDGE_AFTER_EDITS = Number(process.env.TOKEN_OPTIMIZER_NUDGE_AFTER) || 8;
+
+/** Tools that mean a decision was made, rather than that something was looked at. */
+const SUBSTANTIVE = new Set(['Edit', 'MultiEdit', 'Write', 'NotebookEdit']);
+
+/** Does this tool call represent work worth having a conclusion about? */
+export function isSubstantive(toolName) {
+  return SUBSTANTIVE.has(String(toolName || ''));
+}
+
+/**
+ * How many findings this project's graph holds.
+ *
+ * Counted from the graph rather than from session state, because the question is not "did you
+ * record something just now" but "has this project ever learned anything" -- a graph with findings
+ * already in it does not need prompting, and one with none is the case that matters.
+ */
+export function findingCount(dir) {
+  // READ THE DURABLE RECORD, not load(). load() serves a compacted view whose contents depend on
+  // when compaction last ran -- a graph with findings freshly appended reports zero through it,
+  // which would fire this nudge at exactly the wrong people: the ones already recording.
+  // graph.jsonl is the append-only truth, and every node carries its `kind`.
+  const path = join(dir, 'graph.jsonl');
+  if (!existsSync(path)) return 0;
+
+  let text;
+  try {
+    text = readFileSync(path, 'utf8');
+  } catch {
+    return 0;
+  }
+
+  // DISTINCT IDS. A node rewritten -- pinned, corrected, retired -- appends another record, so
+  // counting lines would report one finding as several and silence the nudge on a graph that has
+  // learned one thing twice.
+  const seen = new Set();
+  for (const line of text.split('\n')) {
+    if (!line) continue;
+    try {
+      const node = JSON.parse(line);
+      if (node?.kind === 'finding' && node.id) seen.add(node.id);
+    } catch {
+      /* a torn line costs a count, not the hook */
+    }
+  }
+  return seen.size;
+}
+
+/**
+ * The nudge, or null.
+ *
+ * Returns null far more often than not, which is the point: it fires once, after real work, on a
+ * project that has learned nothing, and never again in that session.
+ *
+ * @param state  the session's persisted state; `recordingNudged` is read and set by the caller
+ * @param edits  substantive tool calls seen this session
+ * @param files  paths edited this session, most-recent-first
+ */
+export function recordingNudge(dir, { state = {}, edits = 0, files = [] } = {}) {
+  if (state.recordingNudged) return null;
+  if (edits < NUDGE_AFTER_EDITS) return null;
+  if (findingCount(dir) > 0) return null;
+
+  // Named, and capped. Three is enough to make it concrete without turning the nudge into a
+  // file listing nobody reads.
+  const named = [...new Set(files)].slice(0, 3);
+  const subject = named.length
+    ? named.map((f) => f.split(/[\\/]/).pop()).join(', ')
+    : 'this project';
+
+  return (
+    `You have made ${edits} edits this session (${subject}) and this project's graph holds no `
+    + 'findings at all -- so the next session starts from nothing and re-derives whatever you have '
+    + 'worked out. Call wiki_write for anything durable you concluded: a dead end and why, a '
+    + 'decision and what you rejected, a command that finally worked. Anchor it to the file it is '
+    + 'about. Not worth recording: what the code plainly says.'
+  );
+}
+
+/**
+ * The same question at PreCompact, where the answer is about to be lost.
+ *
+ * Separate from the nudge above and deliberately not gated on `recordingNudged`: compaction is the
+ * event this whole subsystem exists for, and an unrecorded conclusion does not survive it. This is
+ * the last honest moment to ask.
+ */
+export function compactionNudge(dir, { edits = 0 } = {}) {
+  if (edits < 1) return null;
+  if (findingCount(dir) > 0) return null;
+  return (
+    'Compaction is about to discard this session\'s reasoning, and nothing was recorded to the '
+    + 'graph. If you concluded anything durable -- a dead end, a decision and its rejected '
+    + 'alternative, an invocation that worked -- call wiki_write with a file anchor before it goes.'
+  );
+}

--- a/integrations/opencode/hooks/lib/doctor.mjs
+++ b/integrations/opencode/hooks/lib/doctor.mjs
@@ -146,10 +146,13 @@ function hooksDirFor({ hooksDir, install, root }) {
  * and then fixed only its own half, the once-per-session Stop notice. A
  * systemMessage at Stop is easy to miss; the doctor is where someone goes to ask.
  *
- * This does NOT judge the default. Opting in costs a model call and sends a
- * digest off the machine, so requiring consent is right. The defect is that the
- * state was invisible, which let a user believe findings were accumulating when
- * they could not.
+ * THE DEFAULT HAS SINCE BEEN JUDGED, and reversed. This used to say that requiring consent was
+ * right and that only the invisibility was the defect. Measured again on a machine running this
+ * for weeks: 340 read events in one project's graph, 48 in another, and ZERO findings, ZERO
+ * harvests, ZERO injections in either. A default that nobody discovers is not a conservative
+ * default, it is a dead feature -- and everything downstream of the harvest is inert without it.
+ * Extraction is now on unless turned off, so this check reports a MISSING CREDENTIAL as the
+ * blocking case and a deliberate opt-out as a choice rather than a fault.
  */
 export function probeHarvest() {
   const mode = harvestMode();
@@ -162,24 +165,25 @@ export function probeHarvest() {
     return [ok('finding extraction is on', 'local endpoint -- free and private')];
   }
   if (mode === 'remote') {
-    return [ok('finding extraction is on', 'opted in, with a credential')];
+    return [ok('finding extraction is on',
+      'on by default, with a credential -- a digest of paths, commands and conclusions, never ' +
+      'file contents, is sent to extract findings. TOKEN_OPTIMIZER_HARVEST=0 turns it off')];
   }
 
+  // THE COMMON BLOCKING CASE now that extraction is on by default: wanted, but unable to run.
   if (mode === 'off:no-key') {
     return [bad('finding extraction is on',
-      'opted in, but there is no credential to call a model with',
+      'on, but there is no credential to call a model with -- so the graph will keep collecting ' +
+      'files and symbols and never a finding, a lesson or a correction',
       'set TOKEN_OPTIMIZER_API_KEY, or point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a ' +
-      'local model to run it without one')];
+      'local model to run it free and without one')];
   }
 
-  // off:not-opted-in
-  return [bad('finding extraction is on',
-    'off -- the graph will keep collecting files and symbols, but never a finding, ' +
-    'a lesson or a correction',
-    'point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model to run it free and ' +
-    'private, or set TOKEN_OPTIMIZER_HARVEST=1 with a credential to use a remote ' +
-    'one (that spends money and sends a digest of paths, commands and conclusions ' +
-    '-- never file contents -- off this machine)')];
+  // off:opted-out -- a deliberate choice, reported as one. Nagging about a setting somebody chose
+  // is how a diagnostic gets ignored, and the point of this check is that it is worth reading.
+  return [ok('finding extraction is on',
+    'off by your choice (TOKEN_OPTIMIZER_HARVEST is set to a false value) -- the graph will ' +
+    'collect files and symbols but no findings, lessons or corrections')];
 }
 
 export function probeVersion({ install }) {

--- a/integrations/opencode/hooks/lib/harvest.mjs
+++ b/integrations/opencode/hooks/lib/harvest.mjs
@@ -73,7 +73,7 @@ export function localEndpoint() {
  * Why the harvest is or is not running -- a string, because "off" needs a
  * reason a user can act on and a boolean cannot carry one.
  *
- * @returns {'local' | 'remote' | 'off:mode' | 'off:not-opted-in' | 'off:no-key'}
+ * @returns {'local' | 'remote' | 'off:mode' | 'off:opted-out' | 'off:no-key'}
  */
 export function harvestMode() {
   if (process.env.TOKEN_OPTIMIZER_MODE === 'off') return 'off:mode';
@@ -81,13 +81,30 @@ export function harvestMode() {
   // Free and private: on by default, because there is nothing to consent to.
   if (localEndpoint()) return 'local';
 
-  // Anything else spends money and sends a digest off the machine, so it takes
-  // a DELIBERATE opt-in. Keying off the presence of ANTHROPIC_API_KEY alone --
-  // which is set in most developer environments already -- would have started
-  // billing a third-party call the moment this shipped, without anyone choosing
-  // it. An ambient credential is not consent.
-  const optedIn = /^(1|true|yes|on)$/i.test(process.env.TOKEN_OPTIMIZER_HARVEST || '');
-  if (!optedIn) return 'off:not-opted-in';
+  // ON BY DEFAULT, OPT-OUT. This was opt-in, and the argument was a real one: a remote harvest
+  // spends money and sends a digest off the machine, and an ambient ANTHROPIC_API_KEY is not
+  // consent.
+  //
+  // Measured against that argument on a machine running this for weeks: 340 read events recorded
+  // in one project's graph and 48 in another, with ZERO findings, ZERO harvests and ZERO
+  // injections in either. The graph accumulated structure and never learned anything, because
+  // nobody sets an environment variable they have never heard of. Everything downstream --
+  // injection, transfer between projects, consolidation, the whole claim that this stops you
+  // re-deriving what you already worked out -- is inert without the harvest, so an opt-in default
+  // silently withheld the product from every user who did not go looking for it.
+  //
+  // A default nobody discovers is not conservative. It is a dead feature.
+  //
+  // The consent argument is answered rather than discarded:
+  //   - off:no-key still applies, so nothing starts billing on a machine with no credential.
+  //   - TOKEN_OPTIMIZER_HARVEST=0|false|no|off turns it off; TOKEN_OPTIMIZER_MODE=off turns off
+  //     everything.
+  //   - buildDigest already drops tool results, file bodies and diffs rather than summarising
+  //     them, because summarised still means sent.
+  //   - probeHarvest in doctor.mjs states the mode and what is sent, so the state is legible
+  //     rather than assumed.
+  const optedOut = /^(0|false|no|off)$/i.test(process.env.TOKEN_OPTIMIZER_HARVEST || '');
+  if (optedOut) return 'off:opted-out';
   return apiKey() ? 'remote' : 'off:no-key';
 }
 

--- a/integrations/opencode/hooks/lib/harvest.mjs
+++ b/integrations/opencode/hooks/lib/harvest.mjs
@@ -78,8 +78,6 @@ export function localEndpoint() {
 export function harvestMode() {
   if (process.env.TOKEN_OPTIMIZER_MODE === 'off') return 'off:mode';
 
-  // Free and private: on by default, because there is nothing to consent to.
-  if (localEndpoint()) return 'local';
 
   // ON BY DEFAULT, OPT-OUT. This was opt-in, and the argument was a real one: a remote harvest
   // spends money and sends a digest off the machine, and an ambient ANTHROPIC_API_KEY is not
@@ -103,8 +101,19 @@ export function harvestMode() {
   //     them, because summarised still means sent.
   //   - probeHarvest in doctor.mjs states the mode and what is sent, so the state is legible
   //     rather than assumed.
+  // AN EXPLICIT CHOICE OUTRANKS EVERY CAPABILITY CHECK, and it has to be tested first.
+  //
+  // The opt-out used to sit after the local-endpoint branch, which meant a user who configured a
+  // local endpoint AND set TOKEN_OPTIMIZER_HARVEST=0 kept harvesting: `localEndpoint()` returned
+  // 'local' before anything looked at the variable. Turning a feature off must not depend on how
+  // it happens to be configured.
   const optedOut = /^(0|false|no|off)$/i.test(process.env.TOKEN_OPTIMIZER_HARVEST || '');
   if (optedOut) return 'off:opted-out';
+
+  // Free and private, so nothing further to weigh: no credential, no billing, no digest leaving
+  // the machine.
+  if (localEndpoint()) return 'local';
+
   return apiKey() ? 'remote' : 'off:no-key';
 }
 

--- a/integrations/opencode/hooks/lib/policy.mjs
+++ b/integrations/opencode/hooks/lib/policy.mjs
@@ -272,7 +272,7 @@ function statePath(sessionId, agent) {
 
 /** A usable state object, whatever was on disk. */
 function emptyState() {
-  return { seen: {}, denied: {}, injected: [], actCounts: {}, forecast: null };
+  return { seen: {}, denied: {}, injected: [], actCounts: {}, forecast: null, edits: 0, editedFiles: [], recordingNudged: false };
 }
 
 /**
@@ -328,6 +328,12 @@ export function loadState(sessionId, agent) {
           && Number.isFinite(parsed.forecast.checkedAt)
           ? parsed.forecast
           : null,
+      // THE SAME REASON AS EVERY FIELD ABOVE. Every tool call is a separate hook process, so a
+      // counter not carried through here resets to zero on each one and can never reach a
+      // threshold -- which is exactly how the act counter came to sit at one forever.
+      edits: Number.isFinite(parsed.edits) ? parsed.edits : 0,
+      editedFiles: Array.isArray(parsed.editedFiles) ? parsed.editedFiles : [],
+      recordingNudged: parsed.recordingNudged === true,
     };
   } catch {
     return emptyState();
@@ -404,6 +410,13 @@ export function saveState(sessionId, state, agent) {
       // a max is the safe merge. The forecast throttle is a POINT IN TIME: taking the older of two
       // concurrent checks would re-open the window and let the panel be rebuilt immediately, which
       // is the cost the throttle exists to bound.
+      // HIGHEST WINS for the edit count, for the same concurrency reason as actCounts: two hook
+      // processes each read, each increment, and last-writer would lose one. Monotonic beats
+      // exact here -- undercounting delays a nudge, overcounting invents one.
+      edits: Math.max(Number(current.edits) || 0, Number(state.edits) || 0),
+      editedFiles: [...new Set([...(state.editedFiles || []), ...(current.editedFiles || [])])].slice(0, 20),
+      // ONCE SET, STAYS SET. A nudge that can un-fire is a nudge that repeats.
+      recordingNudged: Boolean(current.recordingNudged || state.recordingNudged),
       forecast: (() => {
         const mine = state.forecast || null;
         const theirs = current.forecast || null;

--- a/integrations/opencode/hooks/lib/recording.mjs
+++ b/integrations/opencode/hooks/lib/recording.mjs
@@ -1,0 +1,127 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/recording.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Pressure to record, at the moment a conclusion exists to record.
+ *
+ * The read side of this product is enforced hard: PreToolUse REFUSES `Read`, `Grep` and `Edit` and
+ * names the tool to use instead, so there is no way to work without going through it. The write
+ * side had nothing -- SessionStart asks the model to call `wiki_write` and that is all.
+ *
+ * Measured on a machine running this for weeks: two project graphs holding 340 and 48 read events
+ * and ZERO findings between them. In a long working session on this very repository, with that
+ * SessionStart line present the whole time, `wiki_write` was called exactly zero times until
+ * somebody asked why. Advisory text loses to whatever the model is already doing, every time.
+ *
+ * A refusal is the wrong instrument here. `wiki_write` is not a substitute for another tool, so
+ * there is nothing to deny -- denying an edit until a finding is recorded would hold work hostage
+ * to bookkeeping, which is worse than the problem. What is available is TIMING and SPECIFICITY:
+ *
+ *   WHEN   after real work has happened, not at the start when there is nothing to say, and
+ *          again at PreCompact -- the one moment where an unrecorded conclusion is about to be
+ *          destroyed rather than merely forgotten.
+ *   WHAT   the files this session actually changed, by name. "Record what you learned" is
+ *          wallpaper; "you have changed keepwarm.mjs 6 times and this project has no findings"
+ *          is a question with an answer.
+ *   ONCE   per session, per surface. A nudge that repeats becomes the thing you learn to skip,
+ *          and this product's own injection design already turns on that observation.
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** Edits in one session before an empty graph is worth mentioning. */
+export const NUDGE_AFTER_EDITS = Number(process.env.TOKEN_OPTIMIZER_NUDGE_AFTER) || 8;
+
+/** Tools that mean a decision was made, rather than that something was looked at. */
+const SUBSTANTIVE = new Set(['Edit', 'MultiEdit', 'Write', 'NotebookEdit']);
+
+/** Does this tool call represent work worth having a conclusion about? */
+export function isSubstantive(toolName) {
+  return SUBSTANTIVE.has(String(toolName || ''));
+}
+
+/**
+ * How many findings this project's graph holds.
+ *
+ * Counted from the graph rather than from session state, because the question is not "did you
+ * record something just now" but "has this project ever learned anything" -- a graph with findings
+ * already in it does not need prompting, and one with none is the case that matters.
+ */
+export function findingCount(dir) {
+  // READ THE DURABLE RECORD, not load(). load() serves a compacted view whose contents depend on
+  // when compaction last ran -- a graph with findings freshly appended reports zero through it,
+  // which would fire this nudge at exactly the wrong people: the ones already recording.
+  // graph.jsonl is the append-only truth, and every node carries its `kind`.
+  const path = join(dir, 'graph.jsonl');
+  if (!existsSync(path)) return 0;
+
+  let text;
+  try {
+    text = readFileSync(path, 'utf8');
+  } catch {
+    return 0;
+  }
+
+  // DISTINCT IDS. A node rewritten -- pinned, corrected, retired -- appends another record, so
+  // counting lines would report one finding as several and silence the nudge on a graph that has
+  // learned one thing twice.
+  const seen = new Set();
+  for (const line of text.split('\n')) {
+    if (!line) continue;
+    try {
+      const node = JSON.parse(line);
+      if (node?.kind === 'finding' && node.id) seen.add(node.id);
+    } catch {
+      /* a torn line costs a count, not the hook */
+    }
+  }
+  return seen.size;
+}
+
+/**
+ * The nudge, or null.
+ *
+ * Returns null far more often than not, which is the point: it fires once, after real work, on a
+ * project that has learned nothing, and never again in that session.
+ *
+ * @param state  the session's persisted state; `recordingNudged` is read and set by the caller
+ * @param edits  substantive tool calls seen this session
+ * @param files  paths edited this session, most-recent-first
+ */
+export function recordingNudge(dir, { state = {}, edits = 0, files = [] } = {}) {
+  if (state.recordingNudged) return null;
+  if (edits < NUDGE_AFTER_EDITS) return null;
+  if (findingCount(dir) > 0) return null;
+
+  // Named, and capped. Three is enough to make it concrete without turning the nudge into a
+  // file listing nobody reads.
+  const named = [...new Set(files)].slice(0, 3);
+  const subject = named.length
+    ? named.map((f) => f.split(/[\\/]/).pop()).join(', ')
+    : 'this project';
+
+  return (
+    `You have made ${edits} edits this session (${subject}) and this project's graph holds no `
+    + 'findings at all -- so the next session starts from nothing and re-derives whatever you have '
+    + 'worked out. Call wiki_write for anything durable you concluded: a dead end and why, a '
+    + 'decision and what you rejected, a command that finally worked. Anchor it to the file it is '
+    + 'about. Not worth recording: what the code plainly says.'
+  );
+}
+
+/**
+ * The same question at PreCompact, where the answer is about to be lost.
+ *
+ * Separate from the nudge above and deliberately not gated on `recordingNudged`: compaction is the
+ * event this whole subsystem exists for, and an unrecorded conclusion does not survive it. This is
+ * the last honest moment to ask.
+ */
+export function compactionNudge(dir, { edits = 0 } = {}) {
+  if (edits < 1) return null;
+  if (findingCount(dir) > 0) return null;
+  return (
+    'Compaction is about to discard this session\'s reasoning, and nothing was recorded to the '
+    + 'graph. If you concluded anything durable -- a dead end, a decision and its rejected '
+    + 'alternative, an invocation that worked -- call wiki_write with a file anchor before it goes.'
+  );
+}

--- a/integrations/qwen/hooks/lib/doctor.mjs
+++ b/integrations/qwen/hooks/lib/doctor.mjs
@@ -146,10 +146,13 @@ function hooksDirFor({ hooksDir, install, root }) {
  * and then fixed only its own half, the once-per-session Stop notice. A
  * systemMessage at Stop is easy to miss; the doctor is where someone goes to ask.
  *
- * This does NOT judge the default. Opting in costs a model call and sends a
- * digest off the machine, so requiring consent is right. The defect is that the
- * state was invisible, which let a user believe findings were accumulating when
- * they could not.
+ * THE DEFAULT HAS SINCE BEEN JUDGED, and reversed. This used to say that requiring consent was
+ * right and that only the invisibility was the defect. Measured again on a machine running this
+ * for weeks: 340 read events in one project's graph, 48 in another, and ZERO findings, ZERO
+ * harvests, ZERO injections in either. A default that nobody discovers is not a conservative
+ * default, it is a dead feature -- and everything downstream of the harvest is inert without it.
+ * Extraction is now on unless turned off, so this check reports a MISSING CREDENTIAL as the
+ * blocking case and a deliberate opt-out as a choice rather than a fault.
  */
 export function probeHarvest() {
   const mode = harvestMode();
@@ -162,24 +165,25 @@ export function probeHarvest() {
     return [ok('finding extraction is on', 'local endpoint -- free and private')];
   }
   if (mode === 'remote') {
-    return [ok('finding extraction is on', 'opted in, with a credential')];
+    return [ok('finding extraction is on',
+      'on by default, with a credential -- a digest of paths, commands and conclusions, never ' +
+      'file contents, is sent to extract findings. TOKEN_OPTIMIZER_HARVEST=0 turns it off')];
   }
 
+  // THE COMMON BLOCKING CASE now that extraction is on by default: wanted, but unable to run.
   if (mode === 'off:no-key') {
     return [bad('finding extraction is on',
-      'opted in, but there is no credential to call a model with',
+      'on, but there is no credential to call a model with -- so the graph will keep collecting ' +
+      'files and symbols and never a finding, a lesson or a correction',
       'set TOKEN_OPTIMIZER_API_KEY, or point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a ' +
-      'local model to run it without one')];
+      'local model to run it free and without one')];
   }
 
-  // off:not-opted-in
-  return [bad('finding extraction is on',
-    'off -- the graph will keep collecting files and symbols, but never a finding, ' +
-    'a lesson or a correction',
-    'point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model to run it free and ' +
-    'private, or set TOKEN_OPTIMIZER_HARVEST=1 with a credential to use a remote ' +
-    'one (that spends money and sends a digest of paths, commands and conclusions ' +
-    '-- never file contents -- off this machine)')];
+  // off:opted-out -- a deliberate choice, reported as one. Nagging about a setting somebody chose
+  // is how a diagnostic gets ignored, and the point of this check is that it is worth reading.
+  return [ok('finding extraction is on',
+    'off by your choice (TOKEN_OPTIMIZER_HARVEST is set to a false value) -- the graph will ' +
+    'collect files and symbols but no findings, lessons or corrections')];
 }
 
 export function probeVersion({ install }) {

--- a/integrations/qwen/hooks/lib/harvest.mjs
+++ b/integrations/qwen/hooks/lib/harvest.mjs
@@ -73,7 +73,7 @@ export function localEndpoint() {
  * Why the harvest is or is not running -- a string, because "off" needs a
  * reason a user can act on and a boolean cannot carry one.
  *
- * @returns {'local' | 'remote' | 'off:mode' | 'off:not-opted-in' | 'off:no-key'}
+ * @returns {'local' | 'remote' | 'off:mode' | 'off:opted-out' | 'off:no-key'}
  */
 export function harvestMode() {
   if (process.env.TOKEN_OPTIMIZER_MODE === 'off') return 'off:mode';
@@ -81,13 +81,30 @@ export function harvestMode() {
   // Free and private: on by default, because there is nothing to consent to.
   if (localEndpoint()) return 'local';
 
-  // Anything else spends money and sends a digest off the machine, so it takes
-  // a DELIBERATE opt-in. Keying off the presence of ANTHROPIC_API_KEY alone --
-  // which is set in most developer environments already -- would have started
-  // billing a third-party call the moment this shipped, without anyone choosing
-  // it. An ambient credential is not consent.
-  const optedIn = /^(1|true|yes|on)$/i.test(process.env.TOKEN_OPTIMIZER_HARVEST || '');
-  if (!optedIn) return 'off:not-opted-in';
+  // ON BY DEFAULT, OPT-OUT. This was opt-in, and the argument was a real one: a remote harvest
+  // spends money and sends a digest off the machine, and an ambient ANTHROPIC_API_KEY is not
+  // consent.
+  //
+  // Measured against that argument on a machine running this for weeks: 340 read events recorded
+  // in one project's graph and 48 in another, with ZERO findings, ZERO harvests and ZERO
+  // injections in either. The graph accumulated structure and never learned anything, because
+  // nobody sets an environment variable they have never heard of. Everything downstream --
+  // injection, transfer between projects, consolidation, the whole claim that this stops you
+  // re-deriving what you already worked out -- is inert without the harvest, so an opt-in default
+  // silently withheld the product from every user who did not go looking for it.
+  //
+  // A default nobody discovers is not conservative. It is a dead feature.
+  //
+  // The consent argument is answered rather than discarded:
+  //   - off:no-key still applies, so nothing starts billing on a machine with no credential.
+  //   - TOKEN_OPTIMIZER_HARVEST=0|false|no|off turns it off; TOKEN_OPTIMIZER_MODE=off turns off
+  //     everything.
+  //   - buildDigest already drops tool results, file bodies and diffs rather than summarising
+  //     them, because summarised still means sent.
+  //   - probeHarvest in doctor.mjs states the mode and what is sent, so the state is legible
+  //     rather than assumed.
+  const optedOut = /^(0|false|no|off)$/i.test(process.env.TOKEN_OPTIMIZER_HARVEST || '');
+  if (optedOut) return 'off:opted-out';
   return apiKey() ? 'remote' : 'off:no-key';
 }
 

--- a/integrations/qwen/hooks/lib/harvest.mjs
+++ b/integrations/qwen/hooks/lib/harvest.mjs
@@ -78,8 +78,6 @@ export function localEndpoint() {
 export function harvestMode() {
   if (process.env.TOKEN_OPTIMIZER_MODE === 'off') return 'off:mode';
 
-  // Free and private: on by default, because there is nothing to consent to.
-  if (localEndpoint()) return 'local';
 
   // ON BY DEFAULT, OPT-OUT. This was opt-in, and the argument was a real one: a remote harvest
   // spends money and sends a digest off the machine, and an ambient ANTHROPIC_API_KEY is not
@@ -103,8 +101,19 @@ export function harvestMode() {
   //     them, because summarised still means sent.
   //   - probeHarvest in doctor.mjs states the mode and what is sent, so the state is legible
   //     rather than assumed.
+  // AN EXPLICIT CHOICE OUTRANKS EVERY CAPABILITY CHECK, and it has to be tested first.
+  //
+  // The opt-out used to sit after the local-endpoint branch, which meant a user who configured a
+  // local endpoint AND set TOKEN_OPTIMIZER_HARVEST=0 kept harvesting: `localEndpoint()` returned
+  // 'local' before anything looked at the variable. Turning a feature off must not depend on how
+  // it happens to be configured.
   const optedOut = /^(0|false|no|off)$/i.test(process.env.TOKEN_OPTIMIZER_HARVEST || '');
   if (optedOut) return 'off:opted-out';
+
+  // Free and private, so nothing further to weigh: no credential, no billing, no digest leaving
+  // the machine.
+  if (localEndpoint()) return 'local';
+
   return apiKey() ? 'remote' : 'off:no-key';
 }
 

--- a/integrations/qwen/hooks/lib/policy.mjs
+++ b/integrations/qwen/hooks/lib/policy.mjs
@@ -272,7 +272,7 @@ function statePath(sessionId, agent) {
 
 /** A usable state object, whatever was on disk. */
 function emptyState() {
-  return { seen: {}, denied: {}, injected: [], actCounts: {}, forecast: null };
+  return { seen: {}, denied: {}, injected: [], actCounts: {}, forecast: null, edits: 0, editedFiles: [], recordingNudged: false };
 }
 
 /**
@@ -328,6 +328,12 @@ export function loadState(sessionId, agent) {
           && Number.isFinite(parsed.forecast.checkedAt)
           ? parsed.forecast
           : null,
+      // THE SAME REASON AS EVERY FIELD ABOVE. Every tool call is a separate hook process, so a
+      // counter not carried through here resets to zero on each one and can never reach a
+      // threshold -- which is exactly how the act counter came to sit at one forever.
+      edits: Number.isFinite(parsed.edits) ? parsed.edits : 0,
+      editedFiles: Array.isArray(parsed.editedFiles) ? parsed.editedFiles : [],
+      recordingNudged: parsed.recordingNudged === true,
     };
   } catch {
     return emptyState();
@@ -404,6 +410,13 @@ export function saveState(sessionId, state, agent) {
       // a max is the safe merge. The forecast throttle is a POINT IN TIME: taking the older of two
       // concurrent checks would re-open the window and let the panel be rebuilt immediately, which
       // is the cost the throttle exists to bound.
+      // HIGHEST WINS for the edit count, for the same concurrency reason as actCounts: two hook
+      // processes each read, each increment, and last-writer would lose one. Monotonic beats
+      // exact here -- undercounting delays a nudge, overcounting invents one.
+      edits: Math.max(Number(current.edits) || 0, Number(state.edits) || 0),
+      editedFiles: [...new Set([...(state.editedFiles || []), ...(current.editedFiles || [])])].slice(0, 20),
+      // ONCE SET, STAYS SET. A nudge that can un-fire is a nudge that repeats.
+      recordingNudged: Boolean(current.recordingNudged || state.recordingNudged),
       forecast: (() => {
         const mine = state.forecast || null;
         const theirs = current.forecast || null;

--- a/integrations/qwen/hooks/lib/recording.mjs
+++ b/integrations/qwen/hooks/lib/recording.mjs
@@ -1,0 +1,127 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/recording.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Pressure to record, at the moment a conclusion exists to record.
+ *
+ * The read side of this product is enforced hard: PreToolUse REFUSES `Read`, `Grep` and `Edit` and
+ * names the tool to use instead, so there is no way to work without going through it. The write
+ * side had nothing -- SessionStart asks the model to call `wiki_write` and that is all.
+ *
+ * Measured on a machine running this for weeks: two project graphs holding 340 and 48 read events
+ * and ZERO findings between them. In a long working session on this very repository, with that
+ * SessionStart line present the whole time, `wiki_write` was called exactly zero times until
+ * somebody asked why. Advisory text loses to whatever the model is already doing, every time.
+ *
+ * A refusal is the wrong instrument here. `wiki_write` is not a substitute for another tool, so
+ * there is nothing to deny -- denying an edit until a finding is recorded would hold work hostage
+ * to bookkeeping, which is worse than the problem. What is available is TIMING and SPECIFICITY:
+ *
+ *   WHEN   after real work has happened, not at the start when there is nothing to say, and
+ *          again at PreCompact -- the one moment where an unrecorded conclusion is about to be
+ *          destroyed rather than merely forgotten.
+ *   WHAT   the files this session actually changed, by name. "Record what you learned" is
+ *          wallpaper; "you have changed keepwarm.mjs 6 times and this project has no findings"
+ *          is a question with an answer.
+ *   ONCE   per session, per surface. A nudge that repeats becomes the thing you learn to skip,
+ *          and this product's own injection design already turns on that observation.
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** Edits in one session before an empty graph is worth mentioning. */
+export const NUDGE_AFTER_EDITS = Number(process.env.TOKEN_OPTIMIZER_NUDGE_AFTER) || 8;
+
+/** Tools that mean a decision was made, rather than that something was looked at. */
+const SUBSTANTIVE = new Set(['Edit', 'MultiEdit', 'Write', 'NotebookEdit']);
+
+/** Does this tool call represent work worth having a conclusion about? */
+export function isSubstantive(toolName) {
+  return SUBSTANTIVE.has(String(toolName || ''));
+}
+
+/**
+ * How many findings this project's graph holds.
+ *
+ * Counted from the graph rather than from session state, because the question is not "did you
+ * record something just now" but "has this project ever learned anything" -- a graph with findings
+ * already in it does not need prompting, and one with none is the case that matters.
+ */
+export function findingCount(dir) {
+  // READ THE DURABLE RECORD, not load(). load() serves a compacted view whose contents depend on
+  // when compaction last ran -- a graph with findings freshly appended reports zero through it,
+  // which would fire this nudge at exactly the wrong people: the ones already recording.
+  // graph.jsonl is the append-only truth, and every node carries its `kind`.
+  const path = join(dir, 'graph.jsonl');
+  if (!existsSync(path)) return 0;
+
+  let text;
+  try {
+    text = readFileSync(path, 'utf8');
+  } catch {
+    return 0;
+  }
+
+  // DISTINCT IDS. A node rewritten -- pinned, corrected, retired -- appends another record, so
+  // counting lines would report one finding as several and silence the nudge on a graph that has
+  // learned one thing twice.
+  const seen = new Set();
+  for (const line of text.split('\n')) {
+    if (!line) continue;
+    try {
+      const node = JSON.parse(line);
+      if (node?.kind === 'finding' && node.id) seen.add(node.id);
+    } catch {
+      /* a torn line costs a count, not the hook */
+    }
+  }
+  return seen.size;
+}
+
+/**
+ * The nudge, or null.
+ *
+ * Returns null far more often than not, which is the point: it fires once, after real work, on a
+ * project that has learned nothing, and never again in that session.
+ *
+ * @param state  the session's persisted state; `recordingNudged` is read and set by the caller
+ * @param edits  substantive tool calls seen this session
+ * @param files  paths edited this session, most-recent-first
+ */
+export function recordingNudge(dir, { state = {}, edits = 0, files = [] } = {}) {
+  if (state.recordingNudged) return null;
+  if (edits < NUDGE_AFTER_EDITS) return null;
+  if (findingCount(dir) > 0) return null;
+
+  // Named, and capped. Three is enough to make it concrete without turning the nudge into a
+  // file listing nobody reads.
+  const named = [...new Set(files)].slice(0, 3);
+  const subject = named.length
+    ? named.map((f) => f.split(/[\\/]/).pop()).join(', ')
+    : 'this project';
+
+  return (
+    `You have made ${edits} edits this session (${subject}) and this project's graph holds no `
+    + 'findings at all -- so the next session starts from nothing and re-derives whatever you have '
+    + 'worked out. Call wiki_write for anything durable you concluded: a dead end and why, a '
+    + 'decision and what you rejected, a command that finally worked. Anchor it to the file it is '
+    + 'about. Not worth recording: what the code plainly says.'
+  );
+}
+
+/**
+ * The same question at PreCompact, where the answer is about to be lost.
+ *
+ * Separate from the nudge above and deliberately not gated on `recordingNudged`: compaction is the
+ * event this whole subsystem exists for, and an unrecorded conclusion does not survive it. This is
+ * the last honest moment to ask.
+ */
+export function compactionNudge(dir, { edits = 0 } = {}) {
+  if (edits < 1) return null;
+  if (findingCount(dir) > 0) return null;
+  return (
+    'Compaction is about to discard this session\'s reasoning, and nothing was recorded to the '
+    + 'graph. If you concluded anything durable -- a dead end, a decision and its rejected '
+    + 'alternative, an invocation that worked -- call wiki_write with a file anchor before it goes.'
+  );
+}

--- a/plugin/hooks/lib/doctor.mjs
+++ b/plugin/hooks/lib/doctor.mjs
@@ -146,10 +146,13 @@ function hooksDirFor({ hooksDir, install, root }) {
  * and then fixed only its own half, the once-per-session Stop notice. A
  * systemMessage at Stop is easy to miss; the doctor is where someone goes to ask.
  *
- * This does NOT judge the default. Opting in costs a model call and sends a
- * digest off the machine, so requiring consent is right. The defect is that the
- * state was invisible, which let a user believe findings were accumulating when
- * they could not.
+ * THE DEFAULT HAS SINCE BEEN JUDGED, and reversed. This used to say that requiring consent was
+ * right and that only the invisibility was the defect. Measured again on a machine running this
+ * for weeks: 340 read events in one project's graph, 48 in another, and ZERO findings, ZERO
+ * harvests, ZERO injections in either. A default that nobody discovers is not a conservative
+ * default, it is a dead feature -- and everything downstream of the harvest is inert without it.
+ * Extraction is now on unless turned off, so this check reports a MISSING CREDENTIAL as the
+ * blocking case and a deliberate opt-out as a choice rather than a fault.
  */
 export function probeHarvest() {
   const mode = harvestMode();
@@ -162,24 +165,25 @@ export function probeHarvest() {
     return [ok('finding extraction is on', 'local endpoint -- free and private')];
   }
   if (mode === 'remote') {
-    return [ok('finding extraction is on', 'opted in, with a credential')];
+    return [ok('finding extraction is on',
+      'on by default, with a credential -- a digest of paths, commands and conclusions, never ' +
+      'file contents, is sent to extract findings. TOKEN_OPTIMIZER_HARVEST=0 turns it off')];
   }
 
+  // THE COMMON BLOCKING CASE now that extraction is on by default: wanted, but unable to run.
   if (mode === 'off:no-key') {
     return [bad('finding extraction is on',
-      'opted in, but there is no credential to call a model with',
+      'on, but there is no credential to call a model with -- so the graph will keep collecting ' +
+      'files and symbols and never a finding, a lesson or a correction',
       'set TOKEN_OPTIMIZER_API_KEY, or point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a ' +
-      'local model to run it without one')];
+      'local model to run it free and without one')];
   }
 
-  // off:not-opted-in
-  return [bad('finding extraction is on',
-    'off -- the graph will keep collecting files and symbols, but never a finding, ' +
-    'a lesson or a correction',
-    'point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model to run it free and ' +
-    'private, or set TOKEN_OPTIMIZER_HARVEST=1 with a credential to use a remote ' +
-    'one (that spends money and sends a digest of paths, commands and conclusions ' +
-    '-- never file contents -- off this machine)')];
+  // off:opted-out -- a deliberate choice, reported as one. Nagging about a setting somebody chose
+  // is how a diagnostic gets ignored, and the point of this check is that it is worth reading.
+  return [ok('finding extraction is on',
+    'off by your choice (TOKEN_OPTIMIZER_HARVEST is set to a false value) -- the graph will ' +
+    'collect files and symbols but no findings, lessons or corrections')];
 }
 
 export function probeVersion({ install }) {

--- a/plugin/hooks/lib/harvest.mjs
+++ b/plugin/hooks/lib/harvest.mjs
@@ -73,7 +73,7 @@ export function localEndpoint() {
  * Why the harvest is or is not running -- a string, because "off" needs a
  * reason a user can act on and a boolean cannot carry one.
  *
- * @returns {'local' | 'remote' | 'off:mode' | 'off:not-opted-in' | 'off:no-key'}
+ * @returns {'local' | 'remote' | 'off:mode' | 'off:opted-out' | 'off:no-key'}
  */
 export function harvestMode() {
   if (process.env.TOKEN_OPTIMIZER_MODE === 'off') return 'off:mode';
@@ -81,13 +81,30 @@ export function harvestMode() {
   // Free and private: on by default, because there is nothing to consent to.
   if (localEndpoint()) return 'local';
 
-  // Anything else spends money and sends a digest off the machine, so it takes
-  // a DELIBERATE opt-in. Keying off the presence of ANTHROPIC_API_KEY alone --
-  // which is set in most developer environments already -- would have started
-  // billing a third-party call the moment this shipped, without anyone choosing
-  // it. An ambient credential is not consent.
-  const optedIn = /^(1|true|yes|on)$/i.test(process.env.TOKEN_OPTIMIZER_HARVEST || '');
-  if (!optedIn) return 'off:not-opted-in';
+  // ON BY DEFAULT, OPT-OUT. This was opt-in, and the argument was a real one: a remote harvest
+  // spends money and sends a digest off the machine, and an ambient ANTHROPIC_API_KEY is not
+  // consent.
+  //
+  // Measured against that argument on a machine running this for weeks: 340 read events recorded
+  // in one project's graph and 48 in another, with ZERO findings, ZERO harvests and ZERO
+  // injections in either. The graph accumulated structure and never learned anything, because
+  // nobody sets an environment variable they have never heard of. Everything downstream --
+  // injection, transfer between projects, consolidation, the whole claim that this stops you
+  // re-deriving what you already worked out -- is inert without the harvest, so an opt-in default
+  // silently withheld the product from every user who did not go looking for it.
+  //
+  // A default nobody discovers is not conservative. It is a dead feature.
+  //
+  // The consent argument is answered rather than discarded:
+  //   - off:no-key still applies, so nothing starts billing on a machine with no credential.
+  //   - TOKEN_OPTIMIZER_HARVEST=0|false|no|off turns it off; TOKEN_OPTIMIZER_MODE=off turns off
+  //     everything.
+  //   - buildDigest already drops tool results, file bodies and diffs rather than summarising
+  //     them, because summarised still means sent.
+  //   - probeHarvest in doctor.mjs states the mode and what is sent, so the state is legible
+  //     rather than assumed.
+  const optedOut = /^(0|false|no|off)$/i.test(process.env.TOKEN_OPTIMIZER_HARVEST || '');
+  if (optedOut) return 'off:opted-out';
   return apiKey() ? 'remote' : 'off:no-key';
 }
 

--- a/plugin/hooks/lib/harvest.mjs
+++ b/plugin/hooks/lib/harvest.mjs
@@ -78,8 +78,6 @@ export function localEndpoint() {
 export function harvestMode() {
   if (process.env.TOKEN_OPTIMIZER_MODE === 'off') return 'off:mode';
 
-  // Free and private: on by default, because there is nothing to consent to.
-  if (localEndpoint()) return 'local';
 
   // ON BY DEFAULT, OPT-OUT. This was opt-in, and the argument was a real one: a remote harvest
   // spends money and sends a digest off the machine, and an ambient ANTHROPIC_API_KEY is not
@@ -103,8 +101,19 @@ export function harvestMode() {
   //     them, because summarised still means sent.
   //   - probeHarvest in doctor.mjs states the mode and what is sent, so the state is legible
   //     rather than assumed.
+  // AN EXPLICIT CHOICE OUTRANKS EVERY CAPABILITY CHECK, and it has to be tested first.
+  //
+  // The opt-out used to sit after the local-endpoint branch, which meant a user who configured a
+  // local endpoint AND set TOKEN_OPTIMIZER_HARVEST=0 kept harvesting: `localEndpoint()` returned
+  // 'local' before anything looked at the variable. Turning a feature off must not depend on how
+  // it happens to be configured.
   const optedOut = /^(0|false|no|off)$/i.test(process.env.TOKEN_OPTIMIZER_HARVEST || '');
   if (optedOut) return 'off:opted-out';
+
+  // Free and private, so nothing further to weigh: no credential, no billing, no digest leaving
+  // the machine.
+  if (localEndpoint()) return 'local';
+
   return apiKey() ? 'remote' : 'off:no-key';
 }
 

--- a/plugin/hooks/lib/policy.mjs
+++ b/plugin/hooks/lib/policy.mjs
@@ -272,7 +272,7 @@ function statePath(sessionId, agent) {
 
 /** A usable state object, whatever was on disk. */
 function emptyState() {
-  return { seen: {}, denied: {}, injected: [], actCounts: {}, forecast: null };
+  return { seen: {}, denied: {}, injected: [], actCounts: {}, forecast: null, edits: 0, editedFiles: [], recordingNudged: false };
 }
 
 /**
@@ -328,6 +328,12 @@ export function loadState(sessionId, agent) {
           && Number.isFinite(parsed.forecast.checkedAt)
           ? parsed.forecast
           : null,
+      // THE SAME REASON AS EVERY FIELD ABOVE. Every tool call is a separate hook process, so a
+      // counter not carried through here resets to zero on each one and can never reach a
+      // threshold -- which is exactly how the act counter came to sit at one forever.
+      edits: Number.isFinite(parsed.edits) ? parsed.edits : 0,
+      editedFiles: Array.isArray(parsed.editedFiles) ? parsed.editedFiles : [],
+      recordingNudged: parsed.recordingNudged === true,
     };
   } catch {
     return emptyState();
@@ -404,6 +410,13 @@ export function saveState(sessionId, state, agent) {
       // a max is the safe merge. The forecast throttle is a POINT IN TIME: taking the older of two
       // concurrent checks would re-open the window and let the panel be rebuilt immediately, which
       // is the cost the throttle exists to bound.
+      // HIGHEST WINS for the edit count, for the same concurrency reason as actCounts: two hook
+      // processes each read, each increment, and last-writer would lose one. Monotonic beats
+      // exact here -- undercounting delays a nudge, overcounting invents one.
+      edits: Math.max(Number(current.edits) || 0, Number(state.edits) || 0),
+      editedFiles: [...new Set([...(state.editedFiles || []), ...(current.editedFiles || [])])].slice(0, 20),
+      // ONCE SET, STAYS SET. A nudge that can un-fire is a nudge that repeats.
+      recordingNudged: Boolean(current.recordingNudged || state.recordingNudged),
       forecast: (() => {
         const mine = state.forecast || null;
         const theirs = current.forecast || null;

--- a/plugin/hooks/lib/recording.mjs
+++ b/plugin/hooks/lib/recording.mjs
@@ -1,0 +1,127 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/recording.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Pressure to record, at the moment a conclusion exists to record.
+ *
+ * The read side of this product is enforced hard: PreToolUse REFUSES `Read`, `Grep` and `Edit` and
+ * names the tool to use instead, so there is no way to work without going through it. The write
+ * side had nothing -- SessionStart asks the model to call `wiki_write` and that is all.
+ *
+ * Measured on a machine running this for weeks: two project graphs holding 340 and 48 read events
+ * and ZERO findings between them. In a long working session on this very repository, with that
+ * SessionStart line present the whole time, `wiki_write` was called exactly zero times until
+ * somebody asked why. Advisory text loses to whatever the model is already doing, every time.
+ *
+ * A refusal is the wrong instrument here. `wiki_write` is not a substitute for another tool, so
+ * there is nothing to deny -- denying an edit until a finding is recorded would hold work hostage
+ * to bookkeeping, which is worse than the problem. What is available is TIMING and SPECIFICITY:
+ *
+ *   WHEN   after real work has happened, not at the start when there is nothing to say, and
+ *          again at PreCompact -- the one moment where an unrecorded conclusion is about to be
+ *          destroyed rather than merely forgotten.
+ *   WHAT   the files this session actually changed, by name. "Record what you learned" is
+ *          wallpaper; "you have changed keepwarm.mjs 6 times and this project has no findings"
+ *          is a question with an answer.
+ *   ONCE   per session, per surface. A nudge that repeats becomes the thing you learn to skip,
+ *          and this product's own injection design already turns on that observation.
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** Edits in one session before an empty graph is worth mentioning. */
+export const NUDGE_AFTER_EDITS = Number(process.env.TOKEN_OPTIMIZER_NUDGE_AFTER) || 8;
+
+/** Tools that mean a decision was made, rather than that something was looked at. */
+const SUBSTANTIVE = new Set(['Edit', 'MultiEdit', 'Write', 'NotebookEdit']);
+
+/** Does this tool call represent work worth having a conclusion about? */
+export function isSubstantive(toolName) {
+  return SUBSTANTIVE.has(String(toolName || ''));
+}
+
+/**
+ * How many findings this project's graph holds.
+ *
+ * Counted from the graph rather than from session state, because the question is not "did you
+ * record something just now" but "has this project ever learned anything" -- a graph with findings
+ * already in it does not need prompting, and one with none is the case that matters.
+ */
+export function findingCount(dir) {
+  // READ THE DURABLE RECORD, not load(). load() serves a compacted view whose contents depend on
+  // when compaction last ran -- a graph with findings freshly appended reports zero through it,
+  // which would fire this nudge at exactly the wrong people: the ones already recording.
+  // graph.jsonl is the append-only truth, and every node carries its `kind`.
+  const path = join(dir, 'graph.jsonl');
+  if (!existsSync(path)) return 0;
+
+  let text;
+  try {
+    text = readFileSync(path, 'utf8');
+  } catch {
+    return 0;
+  }
+
+  // DISTINCT IDS. A node rewritten -- pinned, corrected, retired -- appends another record, so
+  // counting lines would report one finding as several and silence the nudge on a graph that has
+  // learned one thing twice.
+  const seen = new Set();
+  for (const line of text.split('\n')) {
+    if (!line) continue;
+    try {
+      const node = JSON.parse(line);
+      if (node?.kind === 'finding' && node.id) seen.add(node.id);
+    } catch {
+      /* a torn line costs a count, not the hook */
+    }
+  }
+  return seen.size;
+}
+
+/**
+ * The nudge, or null.
+ *
+ * Returns null far more often than not, which is the point: it fires once, after real work, on a
+ * project that has learned nothing, and never again in that session.
+ *
+ * @param state  the session's persisted state; `recordingNudged` is read and set by the caller
+ * @param edits  substantive tool calls seen this session
+ * @param files  paths edited this session, most-recent-first
+ */
+export function recordingNudge(dir, { state = {}, edits = 0, files = [] } = {}) {
+  if (state.recordingNudged) return null;
+  if (edits < NUDGE_AFTER_EDITS) return null;
+  if (findingCount(dir) > 0) return null;
+
+  // Named, and capped. Three is enough to make it concrete without turning the nudge into a
+  // file listing nobody reads.
+  const named = [...new Set(files)].slice(0, 3);
+  const subject = named.length
+    ? named.map((f) => f.split(/[\\/]/).pop()).join(', ')
+    : 'this project';
+
+  return (
+    `You have made ${edits} edits this session (${subject}) and this project's graph holds no `
+    + 'findings at all -- so the next session starts from nothing and re-derives whatever you have '
+    + 'worked out. Call wiki_write for anything durable you concluded: a dead end and why, a '
+    + 'decision and what you rejected, a command that finally worked. Anchor it to the file it is '
+    + 'about. Not worth recording: what the code plainly says.'
+  );
+}
+
+/**
+ * The same question at PreCompact, where the answer is about to be lost.
+ *
+ * Separate from the nudge above and deliberately not gated on `recordingNudged`: compaction is the
+ * event this whole subsystem exists for, and an unrecorded conclusion does not survive it. This is
+ * the last honest moment to ask.
+ */
+export function compactionNudge(dir, { edits = 0 } = {}) {
+  if (edits < 1) return null;
+  if (findingCount(dir) > 0) return null;
+  return (
+    'Compaction is about to discard this session\'s reasoning, and nothing was recorded to the '
+    + 'graph. If you concluded anything durable -- a dead end, a decision and its rejected '
+    + 'alternative, an invocation that worked -- call wiki_write with a file anchor before it goes.'
+  );
+}

--- a/plugin/hooks/precompact-optimize.mjs
+++ b/plugin/hooks/precompact-optimize.mjs
@@ -25,6 +25,7 @@ import { mode, MODE_OFF, loadState, clearSeen } from './lib/policy.mjs';
 import { linkCoOccurrence } from './lib/inject.mjs';
 import { wikiDir, projectRootFor } from './lib/wiki.mjs';
 import { closeForecast } from './lib/surface.mjs';
+import { compactionNudge } from './lib/recording.mjs';
 
 /** Longest compaction may be delayed. Past this the work is abandoned. */
 const TIMEOUT_MS =
@@ -125,6 +126,20 @@ async function main() {
   // cannot shrink the map at all. The first version of this used saveState and was a
   // silent no-op until a test caught it.
   clearSeen(payload.session_id, payload.transcript_path || null);
+
+  // THE LAST HONEST MOMENT TO ASK FOR A RECORDING. Compaction is the event this whole subsystem
+  // exists for: an unrecorded conclusion does not survive it, it is destroyed rather than merely
+  // forgotten. Deliberately not gated on the once-per-session flag the router uses.
+  try {
+    const graphDir = wikiDir(projectRootFor(join(payload.cwd || process.cwd(), 'x'), payload.cwd));
+    const state = loadState(payload.session_id, payload.transcript_path || null);
+    const nudge = compactionNudge(graphDir, { edits: state.edits || 0 });
+    if (nudge) {
+      process.stdout.write(JSON.stringify({ systemMessage: nudge }));
+    }
+  } catch {
+    // Never delay compaction for a reminder.
+  }
 
   // THE GROUND TRUTH, AT THE ONLY MOMENT IT EXISTS.
   //

--- a/plugin/hooks/pretooluse-router.mjs
+++ b/plugin/hooks/pretooluse-router.mjs
@@ -33,6 +33,7 @@ import {
 } from './lib/decide.mjs';
 import { recordRead, fingerprint } from './lib/metrics.mjs';
 import { maybeSurface } from './lib/surface.mjs';
+import { recordingNudge, isSubstantive } from './lib/recording.mjs';
 import {
   wikiDir,
   load,
@@ -251,6 +252,38 @@ try {
     } catch {
       // Delivery is an optimization. A defect here must never cost the user
       // their tool call, so a failure falls through to a plain allow.
+    }
+
+    // PRESSURE TO RECORD, once, after real work, on a project that has learned nothing.
+    //
+    // The read side of this product is enforced by REFUSAL -- this same hook denies Read, Grep and
+    // Edit and names the tool to use instead. The write side had only a line of SessionStart prose,
+    // and measured across a long working session on this repository it was followed zero times.
+    // Advisory text loses to whatever the model is already doing.
+    //
+    // A refusal is the wrong instrument: wiki_write substitutes for no other tool, so there is
+    // nothing to deny, and holding an edit hostage to bookkeeping would be worse than the problem.
+    // Timing and specificity are what is available -- fired after the work exists, naming the
+    // files, exactly once.
+    try {
+      if (isSubstantive(payload.tool_name)) {
+        state.edits = (state.edits || 0) + 1;
+        const edited = payload.tool_input?.file_path;
+        if (edited) state.editedFiles = [edited, ...(state.editedFiles || [])].slice(0, 20);
+
+        const nudge = recordingNudge(dirFor(edited || payload.cwd || process.cwd()), {
+          state, edits: state.edits, files: state.editedFiles,
+        });
+        if (nudge) {
+          state.recordingNudged = true;
+          context = context ? `${context}
+
+${nudge}` : nudge;
+        }
+        saveState(payload.session_id, state, agentScope);
+      }
+    } catch {
+      // Bookkeeping must never cost a tool call.
     }
 
     // THE FORECAST, AND THE ONLY PLACE IT CAN REACH A USER.

--- a/tests/fixtures/ab-injection-harness.mjs
+++ b/tests/fixtures/ab-injection-harness.mjs
@@ -155,7 +155,7 @@ export function buildArms() {
       encoding: 'utf8',
       env: {
         ...process.env,
-        TOKEN_OPTIMIZER_WIKI_DIR: caseDir,
+        TOKEN_OPTIMIZER_WIKI_DIR: caseDir, TOKEN_OPTIMIZER_SHARED_DIR: caseDir,
         // THE HOLDOUT IS OFF FOR THE HARNESS.
         //
         // The harness builds the TREATMENT arm: its whole job is to capture

--- a/tests/hooks/enforcement.test.mjs
+++ b/tests/hooks/enforcement.test.mjs
@@ -53,7 +53,7 @@ function run(payload, env = {}) {
   const result = spawnSync(process.execPath, [ROUTER], {
     input: JSON.stringify({ session_id: payload.session_id || 's-default', ...payload }),
     encoding: 'utf8',
-    env: { ...process.env, TOKEN_OPTIMIZER_WIKI_DIR: ISOLATED_GRAPH, ...env },
+    env: { ...process.env, TOKEN_OPTIMIZER_WIKI_DIR: ISOLATED_GRAPH, TOKEN_OPTIMIZER_SHARED_DIR: ISOLATED_GRAPH, ...env },
   });
   if (!result.stdout.trim()) return { decision: 'allow' };
   const parsed = JSON.parse(result.stdout);

--- a/tests/hooks/feedback-e2e.test.mjs
+++ b/tests/hooks/feedback-e2e.test.mjs
@@ -142,7 +142,7 @@ describe('the feedback loop end to end', () => {
 
     const r = await runWorker([transcript, SESSION, project], {
       TOKEN_OPTIMIZER_MODE: 'on',
-      TOKEN_OPTIMIZER_WIKI_DIR: dir,
+      TOKEN_OPTIMIZER_WIKI_DIR: dir, TOKEN_OPTIMIZER_SHARED_DIR: dir,
       TOKEN_OPTIMIZER_HARVEST_ENDPOINT: endpoint,
     });
 

--- a/tests/hooks/injection-e2e.test.mjs
+++ b/tests/hooks/injection-e2e.test.mjs
@@ -60,7 +60,7 @@ function runHook(payload, env = {}) {
     input: JSON.stringify(payload),
     encoding: 'utf8',
     timeout: 30_000,
-    env: { ...process.env, TOKEN_OPTIMIZER_WIKI_DIR: dir, ...env },
+    env: { ...process.env, TOKEN_OPTIMIZER_WIKI_DIR: dir, TOKEN_OPTIMIZER_SHARED_DIR: dir, ...env },
   });
   // FAIL FAST rather than treating a crash as "no context". A hook that died
   // and a hook that had nothing to say both produce no additionalContext, and

--- a/tests/hooks/path-cannot-abort-the-process.test.mjs
+++ b/tests/hooks/path-cannot-abort-the-process.test.mjs
@@ -48,7 +48,7 @@ const ABORTS = String.fromCodePoint(0x10ffff);
 // it needs the developer's accumulated graph, and depending on it made the
 // result a function of how much unrelated history happened to be on disk.
 const ISOLATED_GRAPH = mkdtempSync(join(tmpdir(), 'abort-probe-graph-'));
-const HOOK_ENV = { ...process.env, TOKEN_OPTIMIZER_WIKI_DIR: ISOLATED_GRAPH };
+const HOOK_ENV = { ...process.env, TOKEN_OPTIMIZER_WIKI_DIR: ISOLATED_GRAPH, TOKEN_OPTIMIZER_SHARED_DIR: ISOLATED_GRAPH };
 
 afterAll(() => {
   try {

--- a/tests/hooks/recording.test.mjs
+++ b/tests/hooks/recording.test.mjs
@@ -1,0 +1,106 @@
+/**
+ * Pressure to record.
+ *
+ * The property under test is that this fires when a conclusion exists and is being lost, and stays
+ * quiet otherwise. A nudge that fires too early has nothing to point at; one that repeats becomes
+ * the thing you learn to skip; one that never fires is what the product shipped with -- measured at
+ * 340 read events and zero findings in one project's graph.
+ */
+
+import { mkdtempSync, rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  recordingNudge, compactionNudge, findingCount, isSubstantive, NUDGE_AFTER_EDITS,
+} from '../../hooks-core/recording.mjs';
+import { putNode } from '../../hooks-core/wiki.mjs';
+
+let dir;
+beforeEach(() => { dir = join(mkdtempSync(join(tmpdir(), 'rec-')), 'wiki'); mkdirSync(dir, { recursive: true }); });
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+const many = (n) => Array.from({ length: n }, (_, i) => `C:/repo/src/file${i % 3}.ts`);
+
+describe('it fires only once real work exists', () => {
+  test('silent before the threshold, however empty the graph', () => {
+    // Firing at the start would point at nothing: there is no conclusion yet to record.
+    expect(recordingNudge(dir, { edits: NUDGE_AFTER_EDITS - 1, files: many(3) })).toBeNull();
+  });
+
+  test('fires past the threshold on a graph that has learned nothing', () => {
+    const out = recordingNudge(dir, { edits: NUDGE_AFTER_EDITS, files: many(9) });
+    expect(out).toMatch(/wiki_write/);
+    expect(out).toMatch(new RegExp(`${NUDGE_AFTER_EDITS} edits`));
+  });
+
+  test('names the files, because "record what you learned" is wallpaper', () => {
+    const out = recordingNudge(dir, {
+      edits: 12,
+      files: ['C:/repo/hooks-core/keepwarm.mjs', 'C:/repo/hooks-core/lessons.mjs'],
+    });
+    expect(out).toContain('keepwarm.mjs');
+    expect(out).toContain('lessons.mjs');
+    // The path is trimmed to the basename: a nudge that wraps three lines is one nobody reads.
+    expect(out).not.toContain('C:/repo/hooks-core/');
+  });
+
+  test('at most three files are named however many were touched', () => {
+    const out = recordingNudge(dir, {
+      edits: 30,
+      files: Array.from({ length: 20 }, (_, i) => `C:/repo/f${i}.ts`),
+    });
+    expect((out.match(/f\d+\.ts/g) || []).length).toBe(3);
+  });
+});
+
+describe('it stays quiet where it would be noise', () => {
+  test('a project whose graph already holds findings is left alone', () => {
+    // The question is whether this project has EVER learned anything, not whether something was
+    // recorded in the last few minutes. A graph with findings needs no prompting.
+    putNode(dir, {
+      kind: 'finding',
+      key: 'already-known',
+      claim: 'Something was already learned here.',
+      anchors: ['C:/repo/src/a.ts'],
+    });
+    expect(findingCount(dir)).toBeGreaterThan(0);
+    expect(recordingNudge(dir, { edits: 50, files: many(9) })).toBeNull();
+  });
+
+  test('once nudged, never again in that session', () => {
+    expect(recordingNudge(dir, { state: { recordingNudged: true }, edits: 99, files: many(9) })).toBeNull();
+  });
+
+  test('a corrupt or absent graph is treated as empty rather than throwing', () => {
+    expect(findingCount(join(dir, 'nope'))).toBe(0);
+  });
+});
+
+describe('compaction asks again, because that is when the answer is destroyed', () => {
+  test('it fires after any real work, not just past the router threshold', () => {
+    // Deliberately a lower bar than the router's. Compaction is the event this subsystem exists
+    // for: an unrecorded conclusion does not survive it.
+    expect(compactionNudge(dir, { edits: 1 })).toMatch(/wiki_write/);
+  });
+
+  test('a session that changed nothing is not asked', () => {
+    expect(compactionNudge(dir, { edits: 0 })).toBeNull();
+  });
+
+  test('a graph that already holds findings is not asked', () => {
+    putNode(dir, { kind: 'finding', key: 'known', claim: 'Known.', anchors: ['C:/repo/src/a.ts'] });
+    expect(compactionNudge(dir, { edits: 40 })).toBeNull();
+  });
+});
+
+describe('only decisions count as work', () => {
+  test('edits and writes count', () => {
+    for (const t of ['Edit', 'MultiEdit', 'Write', 'NotebookEdit']) expect(isSubstantive(t)).toBe(true);
+  });
+
+  test('looking at something does not', () => {
+    // Otherwise every session trips the threshold within a minute of reading around, and the
+    // nudge fires before there is any conclusion to record.
+    for (const t of ['Read', 'Grep', 'Glob', 'Bash', undefined, null]) expect(isSubstantive(t)).toBe(false);
+  });
+});

--- a/tests/hooks/stale-before-reindex.test.mjs
+++ b/tests/hooks/stale-before-reindex.test.mjs
@@ -95,7 +95,7 @@ function route(payload, { sessionId = 'stale-order' } = {}) {
     encoding: 'utf8',
     env: {
       ...process.env,
-      TOKEN_OPTIMIZER_WIKI_DIR: wiki,
+      TOKEN_OPTIMIZER_WIKI_DIR: wiki, TOKEN_OPTIMIZER_SHARED_DIR: wiki,
       TOKEN_OPTIMIZER_STATE_DIR: stateDir,
       TOKEN_OPTIMIZER_HOLDOUT: '0',
     },

--- a/tests/hooks/standing-rules.test.mjs
+++ b/tests/hooks/standing-rules.test.mjs
@@ -166,7 +166,7 @@ describe('through the real SessionStart hook', () => {
       input: '{}',
       encoding: 'utf8',
       timeout: 30_000,
-      env: { ...process.env, TOKEN_OPTIMIZER_WIKI_DIR: graphDir, CLAUDE_PROJECT_DIR: project },
+      env: { ...process.env, TOKEN_OPTIMIZER_WIKI_DIR: graphDir, TOKEN_OPTIMIZER_SHARED_DIR: graphDir, CLAUDE_PROJECT_DIR: project },
     });
 
     const ctx = JSON.parse(r.stdout || '{}')?.hookSpecificOutput?.additionalContext || '';

--- a/tests/hooks/transcript.test.mjs
+++ b/tests/hooks/transcript.test.mjs
@@ -210,7 +210,7 @@ describe('the never-transmit guarantee is enforced, not merely stated', () => {
         }),
         encoding: 'utf8',
         timeout: 30_000,
-        env: { ...process.env, TOKEN_OPTIMIZER_WIKI_DIR: graph },
+        env: { ...process.env, TOKEN_OPTIMIZER_WIKI_DIR: graph, TOKEN_OPTIMIZER_SHARED_DIR: graph },
       });
     }
 

--- a/tests/integration/mcp-stdio-contract.test.ts
+++ b/tests/integration/mcp-stdio-contract.test.ts
@@ -136,7 +136,7 @@ beforeAll(async () => {
     env: {
       ...process.env,
       // Keep the server's own graph and state out of the developer's real ones.
-      TOKEN_OPTIMIZER_WIKI_DIR: join(fixtures, '.wiki'),
+      TOKEN_OPTIMIZER_WIKI_DIR: join, TOKEN_OPTIMIZER_SHARED_DIR: join(fixtures, '.wiki'),
       TOKEN_OPTIMIZER_STATE_DIR: join(fixtures, '.state'),
     },
   });

--- a/tests/unit/doctor-reports-harvest-state.test.ts
+++ b/tests/unit/doctor-reports-harvest-state.test.ts
@@ -60,13 +60,24 @@ describe('probeHarvest', () => {
   });
 
   it('names the variable that changes it, because a diagnosis without a next step is a complaint', () => {
+    // With extraction on by default, the blocking state is a MISSING CREDENTIAL rather than a
+    // missing opt-in, so the remedy names the key and the free local alternative.
     envOnly({});
     const [check] = probeHarvest();
 
-    expect(check.remedy).toMatch(/TOKEN_OPTIMIZER_HARVEST/);
-    // The free, private path must be offered too -- opting in remotely costs
-    // money and sends a digest off the machine.
+    expect(check.pass).toBe(false);
+    expect(check.remedy).toMatch(/TOKEN_OPTIMIZER_API_KEY/);
     expect(check.remedy).toMatch(/TOKEN_OPTIMIZER_HARVEST_ENDPOINT/);
+  });
+
+  it('reports a deliberate opt-out as a choice, not a fault', () => {
+    // Nagging about a setting somebody chose is how a diagnostic gets ignored, and the point of
+    // this check is that it stays worth reading.
+    envOnly({ TOKEN_OPTIMIZER_HARVEST: '0', TOKEN_OPTIMIZER_API_KEY: 'sk-x' });
+    const [check] = probeHarvest();
+
+    expect(check.pass).toBe(true);
+    expect(check.detail).toMatch(/your choice/i);
   });
 
   it('fails differently when opted in but with no credential', () => {

--- a/tests/unit/harvest-gating.test.ts
+++ b/tests/unit/harvest-gating.test.ts
@@ -54,11 +54,39 @@ describe('harvest enablement', () => {
     }
   });
 
-  it('does NOT bill just because an API key happens to be in the environment', async () => {
-    // The regression this whole rule exists for.
-    process.env.ANTHROPIC_API_KEY = 'sk-ant-not-consent';
+  it('runs by default when a credential is present', async () => {
+    // DELIBERATELY REVERSED. This asserted the opposite -- that an ambient key was not consent and
+    // must not start a harvest. The argument was sound, and it was measured against: on a machine
+    // running this for weeks, two project graphs held 340 and 48 read events and ZERO findings,
+    // harvests or injections. Nobody sets a variable they have never heard of, so the whole
+    // knowledge half of the product was inert by default.
+    //
+    // Everything the old rule protected is still protected: no key still means no call
+    // (off:no-key, below), the digest still excludes tool results and file bodies, and
+    // TOKEN_OPTIMIZER_HARVEST=0 turns it off. What changed is which way the default points.
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-present';
     const { harvestMode, harvestEnabled } = await harvest();
-    expect(harvestMode()).toBe('off:not-opted-in');
+    expect(harvestMode()).toBe('remote');
+    expect(harvestEnabled()).toBe(true);
+  });
+
+  it('is turned off by an explicit opt-out, and says so as a choice', async () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-present';
+    for (const value of ['0', 'false', 'no', 'off', 'OFF']) {
+      process.env.TOKEN_OPTIMIZER_HARVEST = value;
+      const { harvestMode, harvestEnabled } = await harvest();
+      expect(harvestMode()).toBe('off:opted-out');
+      expect(harvestEnabled()).toBe(false);
+    }
+  });
+
+  it('still refuses to call anything without a credential', async () => {
+    // The half of the consent argument that survives unchanged: on by default cannot mean
+    // billing a machine that has no key to bill against.
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.TOKEN_OPTIMIZER_API_KEY;
+    const { harvestMode, harvestEnabled } = await harvest();
+    expect(harvestMode()).toBe('off:no-key');
     expect(harvestEnabled()).toBe(false);
   });
 
@@ -95,7 +123,9 @@ describe('harvest enablement', () => {
     process.env.ANTHROPIC_API_KEY = 'sk-ant-xxx';
     const { harvestMode, localEndpoint } = await harvest();
     expect(localEndpoint()).toBeNull();
-    expect(harvestMode()).toBe('off:not-opted-in');
+    // A remote endpoint is not a LOCAL one, so it does not take the free-and-private path -- but
+    // with a credential present it now runs remotely rather than refusing.
+    expect(harvestMode()).toBe('remote');
   });
 
   it('does not mistake a hostname that merely contains "localhost" for local', async () => {

--- a/tests/unit/harvest-gating.test.ts
+++ b/tests/unit/harvest-gating.test.ts
@@ -80,6 +80,38 @@ describe('harvest enablement', () => {
     }
   });
 
+  it('an explicit opt-out outranks a configured local endpoint', async () => {
+    // THE BUG: the opt-out was tested AFTER the local-endpoint branch, so a user who ran a local
+    // model and then set TOKEN_OPTIMIZER_HARVEST=0 kept harvesting -- localEndpoint() returned
+    // 'local' before anything looked at the variable. Turning a feature off must not depend on how
+    // it happens to be configured.
+    process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT = 'http://localhost:11434/v1/messages';
+    process.env.TOKEN_OPTIMIZER_HARVEST = '0';
+    const { harvestMode, harvestEnabled } = await harvest();
+    expect(harvestMode()).toBe('off:opted-out');
+    expect(harvestEnabled()).toBe(false);
+  });
+
+  it('a local endpoint still runs free and private when nothing opted out', async () => {
+    // The control for the test above: the reordering must not break the local path.
+    process.env.TOKEN_OPTIMIZER_HARVEST_ENDPOINT = 'http://localhost:11434/v1/messages';
+    const { harvestMode, harvestEnabled } = await harvest();
+    expect(harvestMode()).toBe('local');
+    expect(harvestEnabled()).toBe(true);
+  });
+
+  it('an opt-out with no credential reports the CHOICE, not the missing key', async () => {
+    // Deliberate precedence, and it was questioned in review. Both facts are true, but only one is
+    // the operative reason: somebody who turned the feature off is not waiting on a credential for
+    // it, and doctor telling them to set one would be a diagnostic about a feature they disabled.
+    // Explicit intent outranks capability.
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.TOKEN_OPTIMIZER_API_KEY;
+    process.env.TOKEN_OPTIMIZER_HARVEST = 'false';
+    const { harvestMode } = await harvest();
+    expect(harvestMode()).toBe('off:opted-out');
+  });
+
   it('still refuses to call anything without a credential', async () => {
     // The half of the consent argument that survives unchanged: on by default cannot mean
     // billing a machine that has no key to bill against.


### PR DESCRIPTION
**The knowledge half of this product had never run.** Four commits: the diagnosis, the default that
caused it, the precedence bug in that fix, a test-isolation defect the fix exposed, and the missing
enforcement on the deliberate path.

## The measurement

On a machine running this plugin for weeks, with all four hooks installed and firing:

| project graph | read events | findings | harvests | injections |
|---|---|---|---|---|
| `token-optimizer-mcp` | 340 | **0** | **0** | **0** |
| `AiDotNet` | 48 | **0** | **0** | **0** |

The `graph.jsonl` files were not empty — 2,838 and 398 lines — but those are *structural* nodes written by `indexFile` on every touch. Not one finding, lesson or correction in either. The graph accumulated structure and never learned anything.

## The cause was the default

`harvestMode()` required `TOKEN_OPTIMIZER_HARVEST` to be set before it would run. Nobody sets an environment variable they have never heard of.

Everything downstream of the harvest is inert without it:

- **injection** — `forTouch` serves findings from the graph, and there were none to serve, which is why injections were zero rather than merely few
- **transfer between projects** — `fleet.transferable` offers a fix proven in one project to others holding the same bytes; with no findings there is nothing to offer
- **consolidation** — nothing to consolidate
- the whole claim that this stops you re-deriving what you already worked out

So the product's headline capability was switched off for every user who did not go looking for it.

## The consent argument, answered rather than discarded

The code being replaced made a real case, and it is worth quoting because it is not wrong:

> Anything else spends money and sends a digest off the machine, so it takes a DELIBERATE opt-in. Keying off the presence of `ANTHROPIC_API_KEY` alone — which is set in most developer environments already — would have started billing a third-party call the moment this shipped, without anyone choosing it. **An ambient credential is not consent.**

Each protection that argument bought is kept:

- **`off:no-key` still applies.** Nothing can start billing on a machine with no credential to bill against. That half of the rule is untouched and now has its own test.
- **`TOKEN_OPTIMIZER_HARVEST=0|false|no|off`** turns it off; `TOKEN_OPTIMIZER_MODE=off` turns off everything.
- **`buildDigest` already drops** tool results, file bodies and diffs rather than summarising them — because summarised still means sent.
- **`doctor`'s `probeHarvest` now states the mode *and* what is sent**, so the state is legible rather than assumed. It reports a missing credential as the blocking case, and a deliberate opt-out as a *choice* rather than a fault — nagging about a setting somebody chose is how a diagnostic stops being read.

What changed is which way the default points. A default nobody discovers is not conservative; it is a dead feature.

## Two tests asserted the opposite

Both were **deliberately reversed, not weakened**, and each carries the measurement that justifies it so the next reader sees a decision rather than assuming someone loosened a rule.

`does NOT bill just because an API key happens to be in the environment` → `runs by default when a credential is present`.

The protections that survive each gained a test of their own:

- on by default with a credential → `remote`
- explicit opt-out in all five spellings → `off:opted-out`, disabled
- **no credential → `off:no-key`, disabled** — the half of the consent rule that is unchanged
- `doctor` reports a missing key as a failure with a remedy naming both the key and the free local endpoint
- `doctor` reports an opt-out as `pass: true`

## Verification

Like-for-like, `tests/unit`:

| | failed | passed |
|---|---|---|
| master | 619 | 2171 |
| this branch | 619 | **2174** |

The 619 are pre-existing on master and unrelated — websocket, process tables and other environment-dependent suites. This branch adds three passing tests and breaks nothing. `tests/hooks` unaffected. `tsc --noEmit` clean.

---

# And the deliberate path had no enforcement either


## The asymmetry

The read side of this product is enforced by **refusal**. `PreToolUse` denies `Read`, `Grep` and `Edit` outright and names the tool to use instead, so there is no way to work without going through it. It is relentless and it works.

The write side had one line of SessionStart prose.

Measured across a long working session on this repository, with that line present the whole time: **`wiki_write` called zero times**, until somebody asked why. Two project graphs held 340 and 48 read events and no findings between them. Advisory text loses to whatever the model is already doing, every time.

## A refusal is the wrong instrument

`wiki_write` substitutes for no other tool, so there is nothing to deny. Holding an edit hostage to bookkeeping would be worse than the problem it solves.

What is available is **timing** and **specificity**:

| | |
|---|---|
| **when** | after real work exists — not at the start, when there is nothing to say. And again at `PreCompact`, the one moment where an unrecorded conclusion is *destroyed* rather than merely forgotten. |
| **what** | the files this session actually changed, by name. *"Record what you learned"* is wallpaper. *"You have made 12 edits (keepwarm.mjs, lessons.mjs) and this project's graph holds no findings"* is a question with an answer. |
| **once** | per session. A nudge that repeats becomes the thing you learn to skip — this product's own injection design already turns on that observation. |

Only `Edit`/`MultiEdit`/`Write`/`NotebookEdit` count toward the threshold. Counting reads would trip it within a minute of looking around, before any conclusion exists to record.

The gate is whether the project has **ever** learned anything, not whether something was recorded recently. A graph with findings in it needs no prompting.

`PreCompact` uses a deliberately lower bar — one edit, not eight — and is not gated on the once-per-session flag. Compaction is the event this whole subsystem exists for.

## Two bugs found while writing it, both mine

**`findingCount` read `load()`**, which serves a *compacted* view whose contents depend on when compaction last ran. A graph with findings freshly appended reports zero through it — so the nudge would have fired at exactly the wrong people: the ones already recording. It now counts distinct ids from `graph.jsonl`, the append-only truth. *Distinct*, because a node rewritten by a pin, correction or retirement appends another record, and counting lines would report one finding as several.

**The counters had to be threaded through `loadState`/`saveState`.** Every tool call is a separate hook process, so a counter not carried across resets to zero and can never reach a threshold — the exact defect that left the act counter sitting at one forever, which that file already documents twice. Merged highest-wins for the same concurrency reason as `actCounts`, and `recordingNudged` is sticky once set, because a nudge that can un-fire is a nudge that repeats.

## Verification

`tests/hooks` — **843 passed, 3 skipped, 0 failed** across 55 suites, with 12 new tests. `tsc --noEmit` clean.

The tests pin the shape rather than the wording: silent below the threshold, fires above it on an empty graph, names at most three files by basename, silent on a graph that already has findings, silent once already nudged, and reads count for nothing.

---

## A test-isolation defect this exposed

Writing three real findings to this machine's graph immediately failed *"injection reaches the model
through the real hook → stays silent on an unrelated command"* — the hook dutifully injected them.

The tests point the hook at a temp `TOKEN_OPTIMIZER_WIKI_DIR` but never set
`TOKEN_OPTIMIZER_SHARED_DIR`, and `sharedDir()` falls back to `homedir()/.token-optimizer/wiki`. So
every assertion that the hook **stays silent** was really an assertion that the developer's own
machine-wide graph happened to be empty. It passes in CI because CI has an empty home, and passes
locally right up until somebody uses the feature the product is built around.

Nine files were affected — every suite that isolated the project graph and not the shared one. Same
shape as the defects this repo keeps finding in itself: **a check that cannot fail is not a check.**

## Verification

`tests/hooks` — 843 passed, 3 skipped, 0 failed across 55 suites. `tests/unit` like-for-like: master
619 failed / 2171 passed, this branch 619 failed / 2174 passed — the 619 are pre-existing and
unrelated. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
