### PR TITLE
fix(decide): a dump redirected to a file is not a dump

### DIFF
--- a/hooks-core/decide.mjs
+++ b/hooks-core/decide.mjs
@@ -52,7 +52,41 @@ export function isContentDump(command) {
   // print foo.ts, and charging the session for its bytes would inflate the
   // measured cost -- the one number this project must never overstate.
   const runnable = stripHeredocs(command);
-  return DUMP_COMMANDS.test(runnable) || RECURSIVE_SEARCH.test(runnable);
+  if (RECURSIVE_SEARCH.test(runnable)) return true;
+  if (!DUMP_COMMANDS.test(runnable)) return false;
+
+  // A DUMP WHOSE STDOUT GOES TO A FILE PUTS NOTHING IN CONTEXT, and refusing it is a false
+  // positive that blocks ordinary work. `cat >> file <<'EOF'` is the standard way to APPEND a
+  // heredoc -- cat is WRITING there, not printing -- and stripping the heredoc body leaves
+  // `cat >> file <<'EOF'`, which still matched \bcat\b and was refused.
+  //
+  // Hit while appending a test file to this very repository. The whole Bash call was denied, so
+  // the git checkout and the python edit chained inside it silently never ran, and the change
+  // looked applied when nothing had happened. A false positive here does not merely annoy: it
+  // fails silently in the middle of a compound command.
+  //
+  // The same reasoning covers `head -100 big.log > out.txt` -- those bytes land on disk, not in
+  // the transcript. Segments are checked individually, so `cat big.ts | head`, where the output
+  // DOES reach context, is still caught.
+  return segmentsOf(runnable).some(
+    (segment) => DUMP_COMMANDS.test(segment) && !redirectsStdoutToFile(segment),
+  );
+}
+
+/** Command segments, split on the operators that end one command's stdout. */
+function segmentsOf(command) {
+  return String(command).split(/\|\||&&|[|;&\n]/).map((s) => s.trim()).filter(Boolean);
+}
+
+/**
+ * Does this segment send its stdout to a file?
+ *
+ * `2>` is stderr and does not count, and `>&1`/`>&2` duplicate a descriptor rather than naming a
+ * file. Anything else of the form `>` or `>>` followed by a path captures output that would
+ * otherwise have reached the transcript.
+ */
+function redirectsStdoutToFile(segment) {
+  return /(?:^|[^0-9&2])>>?\s*(?!&)\S+/.test(String(segment));
 }
 
 /**

--- a/integrations/codex/hooks/lib/decide.mjs
+++ b/integrations/codex/hooks/lib/decide.mjs
@@ -54,7 +54,41 @@ export function isContentDump(command) {
   // print foo.ts, and charging the session for its bytes would inflate the
   // measured cost -- the one number this project must never overstate.
   const runnable = stripHeredocs(command);
-  return DUMP_COMMANDS.test(runnable) || RECURSIVE_SEARCH.test(runnable);
+  if (RECURSIVE_SEARCH.test(runnable)) return true;
+  if (!DUMP_COMMANDS.test(runnable)) return false;
+
+  // A DUMP WHOSE STDOUT GOES TO A FILE PUTS NOTHING IN CONTEXT, and refusing it is a false
+  // positive that blocks ordinary work. `cat >> file <<'EOF'` is the standard way to APPEND a
+  // heredoc -- cat is WRITING there, not printing -- and stripping the heredoc body leaves
+  // `cat >> file <<'EOF'`, which still matched \bcat\b and was refused.
+  //
+  // Hit while appending a test file to this very repository. The whole Bash call was denied, so
+  // the git checkout and the python edit chained inside it silently never ran, and the change
+  // looked applied when nothing had happened. A false positive here does not merely annoy: it
+  // fails silently in the middle of a compound command.
+  //
+  // The same reasoning covers `head -100 big.log > out.txt` -- those bytes land on disk, not in
+  // the transcript. Segments are checked individually, so `cat big.ts | head`, where the output
+  // DOES reach context, is still caught.
+  return segmentsOf(runnable).some(
+    (segment) => DUMP_COMMANDS.test(segment) && !redirectsStdoutToFile(segment),
+  );
+}
+
+/** Command segments, split on the operators that end one command's stdout. */
+function segmentsOf(command) {
+  return String(command).split(/\|\||&&|[|;&\n]/).map((s) => s.trim()).filter(Boolean);
+}
+
+/**
+ * Does this segment send its stdout to a file?
+ *
+ * `2>` is stderr and does not count, and `>&1`/`>&2` duplicate a descriptor rather than naming a
+ * file. Anything else of the form `>` or `>>` followed by a path captures output that would
+ * otherwise have reached the transcript.
+ */
+function redirectsStdoutToFile(segment) {
+  return /(?:^|[^0-9&2])>>?\s*(?!&)\S+/.test(String(segment));
 }
 
 /**

--- a/integrations/codex/plugin/hooks/lib/decide.mjs
+++ b/integrations/codex/plugin/hooks/lib/decide.mjs
@@ -54,7 +54,41 @@ export function isContentDump(command) {
   // print foo.ts, and charging the session for its bytes would inflate the
   // measured cost -- the one number this project must never overstate.
   const runnable = stripHeredocs(command);
-  return DUMP_COMMANDS.test(runnable) || RECURSIVE_SEARCH.test(runnable);
+  if (RECURSIVE_SEARCH.test(runnable)) return true;
+  if (!DUMP_COMMANDS.test(runnable)) return false;
+
+  // A DUMP WHOSE STDOUT GOES TO A FILE PUTS NOTHING IN CONTEXT, and refusing it is a false
+  // positive that blocks ordinary work. `cat >> file <<'EOF'` is the standard way to APPEND a
+  // heredoc -- cat is WRITING there, not printing -- and stripping the heredoc body leaves
+  // `cat >> file <<'EOF'`, which still matched \bcat\b and was refused.
+  //
+  // Hit while appending a test file to this very repository. The whole Bash call was denied, so
+  // the git checkout and the python edit chained inside it silently never ran, and the change
+  // looked applied when nothing had happened. A false positive here does not merely annoy: it
+  // fails silently in the middle of a compound command.
+  //
+  // The same reasoning covers `head -100 big.log > out.txt` -- those bytes land on disk, not in
+  // the transcript. Segments are checked individually, so `cat big.ts | head`, where the output
+  // DOES reach context, is still caught.
+  return segmentsOf(runnable).some(
+    (segment) => DUMP_COMMANDS.test(segment) && !redirectsStdoutToFile(segment),
+  );
+}
+
+/** Command segments, split on the operators that end one command's stdout. */
+function segmentsOf(command) {
+  return String(command).split(/\|\||&&|[|;&\n]/).map((s) => s.trim()).filter(Boolean);
+}
+
+/**
+ * Does this segment send its stdout to a file?
+ *
+ * `2>` is stderr and does not count, and `>&1`/`>&2` duplicate a descriptor rather than naming a
+ * file. Anything else of the form `>` or `>>` followed by a path captures output that would
+ * otherwise have reached the transcript.
+ */
+function redirectsStdoutToFile(segment) {
+  return /(?:^|[^0-9&2])>>?\s*(?!&)\S+/.test(String(segment));
 }
 
 /**

--- a/integrations/gemini/hooks/lib/decide.mjs
+++ b/integrations/gemini/hooks/lib/decide.mjs
@@ -54,7 +54,41 @@ export function isContentDump(command) {
   // print foo.ts, and charging the session for its bytes would inflate the
   // measured cost -- the one number this project must never overstate.
   const runnable = stripHeredocs(command);
-  return DUMP_COMMANDS.test(runnable) || RECURSIVE_SEARCH.test(runnable);
+  if (RECURSIVE_SEARCH.test(runnable)) return true;
+  if (!DUMP_COMMANDS.test(runnable)) return false;
+
+  // A DUMP WHOSE STDOUT GOES TO A FILE PUTS NOTHING IN CONTEXT, and refusing it is a false
+  // positive that blocks ordinary work. `cat >> file <<'EOF'` is the standard way to APPEND a
+  // heredoc -- cat is WRITING there, not printing -- and stripping the heredoc body leaves
+  // `cat >> file <<'EOF'`, which still matched \bcat\b and was refused.
+  //
+  // Hit while appending a test file to this very repository. The whole Bash call was denied, so
+  // the git checkout and the python edit chained inside it silently never ran, and the change
+  // looked applied when nothing had happened. A false positive here does not merely annoy: it
+  // fails silently in the middle of a compound command.
+  //
+  // The same reasoning covers `head -100 big.log > out.txt` -- those bytes land on disk, not in
+  // the transcript. Segments are checked individually, so `cat big.ts | head`, where the output
+  // DOES reach context, is still caught.
+  return segmentsOf(runnable).some(
+    (segment) => DUMP_COMMANDS.test(segment) && !redirectsStdoutToFile(segment),
+  );
+}
+
+/** Command segments, split on the operators that end one command's stdout. */
+function segmentsOf(command) {
+  return String(command).split(/\|\||&&|[|;&\n]/).map((s) => s.trim()).filter(Boolean);
+}
+
+/**
+ * Does this segment send its stdout to a file?
+ *
+ * `2>` is stderr and does not count, and `>&1`/`>&2` duplicate a descriptor rather than naming a
+ * file. Anything else of the form `>` or `>>` followed by a path captures output that would
+ * otherwise have reached the transcript.
+ */
+function redirectsStdoutToFile(segment) {
+  return /(?:^|[^0-9&2])>>?\s*(?!&)\S+/.test(String(segment));
 }
 
 /**

--- a/integrations/opencode/hooks/lib/decide.mjs
+++ b/integrations/opencode/hooks/lib/decide.mjs
@@ -54,7 +54,41 @@ export function isContentDump(command) {
   // print foo.ts, and charging the session for its bytes would inflate the
   // measured cost -- the one number this project must never overstate.
   const runnable = stripHeredocs(command);
-  return DUMP_COMMANDS.test(runnable) || RECURSIVE_SEARCH.test(runnable);
+  if (RECURSIVE_SEARCH.test(runnable)) return true;
+  if (!DUMP_COMMANDS.test(runnable)) return false;
+
+  // A DUMP WHOSE STDOUT GOES TO A FILE PUTS NOTHING IN CONTEXT, and refusing it is a false
+  // positive that blocks ordinary work. `cat >> file <<'EOF'` is the standard way to APPEND a
+  // heredoc -- cat is WRITING there, not printing -- and stripping the heredoc body leaves
+  // `cat >> file <<'EOF'`, which still matched \bcat\b and was refused.
+  //
+  // Hit while appending a test file to this very repository. The whole Bash call was denied, so
+  // the git checkout and the python edit chained inside it silently never ran, and the change
+  // looked applied when nothing had happened. A false positive here does not merely annoy: it
+  // fails silently in the middle of a compound command.
+  //
+  // The same reasoning covers `head -100 big.log > out.txt` -- those bytes land on disk, not in
+  // the transcript. Segments are checked individually, so `cat big.ts | head`, where the output
+  // DOES reach context, is still caught.
+  return segmentsOf(runnable).some(
+    (segment) => DUMP_COMMANDS.test(segment) && !redirectsStdoutToFile(segment),
+  );
+}
+
+/** Command segments, split on the operators that end one command's stdout. */
+function segmentsOf(command) {
+  return String(command).split(/\|\||&&|[|;&\n]/).map((s) => s.trim()).filter(Boolean);
+}
+
+/**
+ * Does this segment send its stdout to a file?
+ *
+ * `2>` is stderr and does not count, and `>&1`/`>&2` duplicate a descriptor rather than naming a
+ * file. Anything else of the form `>` or `>>` followed by a path captures output that would
+ * otherwise have reached the transcript.
+ */
+function redirectsStdoutToFile(segment) {
+  return /(?:^|[^0-9&2])>>?\s*(?!&)\S+/.test(String(segment));
 }
 
 /**

--- a/integrations/qwen/hooks/lib/decide.mjs
+++ b/integrations/qwen/hooks/lib/decide.mjs
@@ -54,7 +54,41 @@ export function isContentDump(command) {
   // print foo.ts, and charging the session for its bytes would inflate the
   // measured cost -- the one number this project must never overstate.
   const runnable = stripHeredocs(command);
-  return DUMP_COMMANDS.test(runnable) || RECURSIVE_SEARCH.test(runnable);
+  if (RECURSIVE_SEARCH.test(runnable)) return true;
+  if (!DUMP_COMMANDS.test(runnable)) return false;
+
+  // A DUMP WHOSE STDOUT GOES TO A FILE PUTS NOTHING IN CONTEXT, and refusing it is a false
+  // positive that blocks ordinary work. `cat >> file <<'EOF'` is the standard way to APPEND a
+  // heredoc -- cat is WRITING there, not printing -- and stripping the heredoc body leaves
+  // `cat >> file <<'EOF'`, which still matched \bcat\b and was refused.
+  //
+  // Hit while appending a test file to this very repository. The whole Bash call was denied, so
+  // the git checkout and the python edit chained inside it silently never ran, and the change
+  // looked applied when nothing had happened. A false positive here does not merely annoy: it
+  // fails silently in the middle of a compound command.
+  //
+  // The same reasoning covers `head -100 big.log > out.txt` -- those bytes land on disk, not in
+  // the transcript. Segments are checked individually, so `cat big.ts | head`, where the output
+  // DOES reach context, is still caught.
+  return segmentsOf(runnable).some(
+    (segment) => DUMP_COMMANDS.test(segment) && !redirectsStdoutToFile(segment),
+  );
+}
+
+/** Command segments, split on the operators that end one command's stdout. */
+function segmentsOf(command) {
+  return String(command).split(/\|\||&&|[|;&\n]/).map((s) => s.trim()).filter(Boolean);
+}
+
+/**
+ * Does this segment send its stdout to a file?
+ *
+ * `2>` is stderr and does not count, and `>&1`/`>&2` duplicate a descriptor rather than naming a
+ * file. Anything else of the form `>` or `>>` followed by a path captures output that would
+ * otherwise have reached the transcript.
+ */
+function redirectsStdoutToFile(segment) {
+  return /(?:^|[^0-9&2])>>?\s*(?!&)\S+/.test(String(segment));
 }
 
 /**

--- a/plugin/hooks/lib/decide.mjs
+++ b/plugin/hooks/lib/decide.mjs
@@ -54,7 +54,41 @@ export function isContentDump(command) {
   // print foo.ts, and charging the session for its bytes would inflate the
   // measured cost -- the one number this project must never overstate.
   const runnable = stripHeredocs(command);
-  return DUMP_COMMANDS.test(runnable) || RECURSIVE_SEARCH.test(runnable);
+  if (RECURSIVE_SEARCH.test(runnable)) return true;
+  if (!DUMP_COMMANDS.test(runnable)) return false;
+
+  // A DUMP WHOSE STDOUT GOES TO A FILE PUTS NOTHING IN CONTEXT, and refusing it is a false
+  // positive that blocks ordinary work. `cat >> file <<'EOF'` is the standard way to APPEND a
+  // heredoc -- cat is WRITING there, not printing -- and stripping the heredoc body leaves
+  // `cat >> file <<'EOF'`, which still matched \bcat\b and was refused.
+  //
+  // Hit while appending a test file to this very repository. The whole Bash call was denied, so
+  // the git checkout and the python edit chained inside it silently never ran, and the change
+  // looked applied when nothing had happened. A false positive here does not merely annoy: it
+  // fails silently in the middle of a compound command.
+  //
+  // The same reasoning covers `head -100 big.log > out.txt` -- those bytes land on disk, not in
+  // the transcript. Segments are checked individually, so `cat big.ts | head`, where the output
+  // DOES reach context, is still caught.
+  return segmentsOf(runnable).some(
+    (segment) => DUMP_COMMANDS.test(segment) && !redirectsStdoutToFile(segment),
+  );
+}
+
+/** Command segments, split on the operators that end one command's stdout. */
+function segmentsOf(command) {
+  return String(command).split(/\|\||&&|[|;&\n]/).map((s) => s.trim()).filter(Boolean);
+}
+
+/**
+ * Does this segment send its stdout to a file?
+ *
+ * `2>` is stderr and does not count, and `>&1`/`>&2` duplicate a descriptor rather than naming a
+ * file. Anything else of the form `>` or `>>` followed by a path captures output that would
+ * otherwise have reached the transcript.
+ */
+function redirectsStdoutToFile(segment) {
+  return /(?:^|[^0-9&2])>>?\s*(?!&)\S+/.test(String(segment));
 }
 
 /**

--- a/tests/hooks/touched-paths.test.mjs
+++ b/tests/hooks/touched-paths.test.mjs
@@ -422,3 +422,46 @@ describe('a touch carries the size that was measured to find it', () => {
     expect(bashFiles('wc -l node_modules/pkg/index.js', repoA)).toEqual([]);
   });
 });
+
+describe('a dump whose output goes to a file is not a dump', () => {
+  it('a heredoc append is a WRITE, and was being refused as a read', () => {
+    // THE FALSE POSITIVE, hit while appending a test file to this repository. stripHeredocs
+    // removes the body and leaves `cat >> file <<'EOF'`, which still matched \bcat\b.
+    //
+    // The cost was not the refusal itself. The whole Bash call was denied, so a `git checkout` and
+    // a python edit chained inside it silently never ran -- and the change looked applied when
+    // nothing had happened. A false positive here fails silently in the middle of a compound
+    // command, which is worse than failing loudly.
+    expect(isContentDump("cat >> tests/x.test.mjs <<'EOF'\nbody\nEOF")).toBe(false);
+    expect(isContentDump('cat > new.txt <<EOF\nbody\nEOF')).toBe(false);
+  });
+
+  it('any dump redirected to a file puts nothing in context', () => {
+    expect(isContentDump('head -100 big.log > out.txt')).toBe(false);
+    expect(isContentDump('tail -n 500 server.log >> archive.log')).toBe(false);
+  });
+
+  it('but the same command printing to the terminal still is', () => {
+    // The bypass this rule exists to close: an agent that cannot Read a file will cat it instead.
+    expect(isContentDump('cat big.ts')).toBe(true);
+    expect(isContentDump('type big.txt')).toBe(true);
+    expect(isContentDump('Get-Content big.txt')).toBe(true);
+  });
+
+  it('a pipeline still reaches context even though a redirect appears elsewhere', () => {
+    // Segments are judged individually, so one redirected dump does not excuse an unredirected one.
+    expect(isContentDump('cat big.ts | head -20')).toBe(true);
+    expect(isContentDump('cat a.ts > out.txt && cat b.ts')).toBe(true);
+  });
+
+  it('stderr redirection is not stdout redirection', () => {
+    // `2>` sends errors to a file and leaves the content itself heading for the transcript.
+    expect(isContentDump('cat big.ts 2> err.log')).toBe(true);
+  });
+
+  it('a recursive search is unbounded regardless of redirection', () => {
+    // Kept deliberately: the refusal for these is about the search tool being the wrong instrument,
+    // not only about output size, and the router names smart_grep as the replacement.
+    expect(isContentDump('grep -r foo src')).toBe(true);
+  });
+});


### PR DESCRIPTION
`cat >> file <<'EOF'` is the standard way to append a heredoc. `cat` is **writing** there, not printing — but `stripHeredocs` removes only the body, leaving `cat >> file <<'EOF'`, which still matched `\bcat\b` and was refused as a content dump.

## The cost was not the refusal

The whole Bash call is denied. So a `git checkout` and a python edit chained inside the same command **silently never ran**, and the change looked applied when nothing had happened.

Found exactly that way while appending a test file to this repository: a later behavioural check returned the old value, and only then did the missing edit surface. A false positive here fails silently in the middle of a compound command, which is worse than failing loudly.

## The rule

A dump whose stdout goes to a file puts nothing in the transcript. That covers more than the heredoc case — `head -100 big.log > out.txt` costs no context either.

Segments are judged individually, so the bypass this rule exists to close stays closed:

| command | verdict |
|---|---|
| `cat >> tests/x.test.mjs <<'EOF'` | allowed — writing |
| `head -100 big.log > out.txt` | allowed — lands on disk |
| `cat big.ts` | **refused** |
| `cat big.ts \| head -20` | **refused** — reaches context through the pipe |
| `cat a.ts > out.txt && cat b.ts` | **refused** — for its second half |
| `cat big.ts 2> err.log` | **refused** — `2>` is stderr, not the content |
| `grep -r foo src` | **refused** — unconditionally |

Recursive searches stay unconditional: that refusal is about the search tool being the wrong instrument — the router names `smart_grep` as the replacement — not only about output size.

## Verification

Ten command shapes checked directly against the predicate, then pinned as six tests. `tests/hooks` 837 passed, 3 skipped, 0 failed. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)