### PR TITLE
feat: add causal evidence and cross-client effectiveness

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Verify client integration shapes
         run: npm run verify:clients
 
+      - name: Certify all client capability tiers
+        run: npm run verify:certification
+
       - name: Verify the harvest API contract
         run: npm run verify:harvest
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,11 @@ and what contradicts it.
 Contradictions, stale findings, and anything the graph believes that the code no
 longer supports — each with the diff that invalidated it.
 
+**Evidence console**
+Client/model/task cohorts, matched four-arm effects with 95% intervals, live
+injection-to-outcome traces, harm feedback, and the honest capability tier for
+all sixteen supported CLIs. Insufficient evidence stays visibly insufficient.
+
 **One-click Markdown export**
 Your agent's accumulated knowledge as documentation you can review, edit and
 commit. The graph stops being a black box the moment you can read it as prose.
@@ -177,6 +182,10 @@ Server-side by design: the browser asks for a neighbourhood, a search result or
 a page. A mature graph holds thousands of nodes, and shipping it wholesale would
 make every page load a multi-megabyte download for a view that shows twenty
 things.
+
+See [the causal evidence protocol](docs/EVIDENCE_PROTOCOL.md), the
+[cross-client capability contract](docs/CLIENT_SUPPORT.md), and the
+[live evaluation suite](evals/README.md).
 
 ---
 
@@ -1812,4 +1821,4 @@ MIT License - see [LICENSE](./LICENSE) for details
 
 ## Author
 
-Built for optimal Claude Code token efficiency by the ooples team.
+Built for measurable token efficiency across supported coding agents by the ooples team.

--- a/docs/CLIENT_SUPPORT.md
+++ b/docs/CLIENT_SUPPORT.md
@@ -7,24 +7,19 @@ surfaces.
 
 ## Capability matrix
 
-| Client | Expensive-call routing | Structural capture + finding delivery | Active-model semantic harvest |
-|---|---|---|---|
-| Claude Code | native `PreToolUse` veto | native hooks | native `Stop` continuation |
-| Codex | native `PreToolUse` veto | native hooks | native `Stop` continuation |
-| GitHub Copilot CLI | native `preToolUse` veto | native hooks | native `agentStop` continuation |
-| Gemini CLI | native `BeforeTool` veto | native hooks | native `AfterAgent` retry |
-| Qwen Code | native `PreToolUse` veto | native hooks | native `Stop` continuation |
-| Cursor | native `preToolUse` veto | native hooks | native `stop` follow-up |
-| Cline | native `PreToolUse` veto | native pre/post hooks | active-model rule at completion |
-| OpenCode | native plugin before-hook | native plugin bridge | active-model rule at completion |
-| Kilo | native plugin before-hook | native plugin bridge | active-model rule at completion |
-| Windsurf | native exit-2 veto | native structural hooks + rules | active-model rule at completion |
-| Roo Code | always-on rules | MCP + rules | active-model rule at completion |
-| Zed | always-on `AGENTS.md` | MCP + rules | active-model rule at completion |
-| Amp | always-on `AGENTS.md` | MCP + rules | active-model rule at completion |
-| Continue | always-on rules | MCP + rules | active-model rule at completion |
-| Crush | always-on `AGENTS.md` | MCP + rules | active-model rule at completion |
-| Droid (Factory) | always-on `AGENTS.md` | MCP + rules | active-model rule at completion |
+The tier is a protocol guarantee, not a product preference. A rules/MCP-only
+client cannot observe arbitrary built-in shell or file operations, so it is
+never presented as having native automatic capture.
+
+| Client group | Tier | Automatic guarantee |
+|---|---|---|
+| Claude Code, Codex, Copilot CLI, Gemini CLI, Qwen Code, Cursor | lifecycle continuation | native routing/capture/delivery and one active-model completion reflection |
+| Cline, OpenCode, Kilo, Windsurf | native observation | native routing/capture/delivery; semantic write through the active-model rule |
+| Roo Code, Zed, Amp, Continue, Crush, Droid | MCP + rules | MCP-visible activity and explicit graph tools; no claim over hidden built-in calls |
+
+The executable registry in `hooks-core/capabilities.mjs` contains the exact
+per-client surfaces and prevents the adapter, generator, verifier, dashboard,
+and certification report from inventing different matrices.
 
 “Active-model semantic harvest” always means the model doing the work decides
 whether a durable, non-obvious conclusion exists and calls `wiki_write` itself.
@@ -45,6 +40,8 @@ drifted. Client integrations now differ only where the protocol differs.
 ```bash
 npm run sync:hooks          # regenerate vendored copies, entries, and configs
 npm run sync:hooks:check    # CI gate: fails if any copy has drifted
+npm run verify:certification # structured protocol certification for all 16
+node scripts/certify-clients.mjs --json # also detects installed exact versions
 ```
 
 The core is vendored into each native client directory rather than imported, because

--- a/docs/EVIDENCE_PROTOCOL.md
+++ b/docs/EVIDENCE_PROTOCOL.md
@@ -1,0 +1,109 @@
+# Causal evidence protocol
+
+Token Optimizer does not use “smarter” as an unqualified score. The evidence
+system tests four separate claims:
+
+1. Client wiring captures the lifecycle events its protocol exposes.
+2. Retrieval selects relevant, current, non-harmful findings.
+3. A treated task improves without reducing correctness.
+4. A finding remains useful across sessions or projects.
+
+## Four arms
+
+| Arm | Routing/optimization | Graph retrieval | Semantic harvest |
+| --- | --- | --- | --- |
+| `baseline` | no | no | no |
+| `optimizer` | yes | no | no |
+| `retrieval` | yes | yes | no |
+| `full` | yes | yes | active model |
+
+`TOKEN_OPTIMIZER_EXPERIMENT_ARM` gates both native hooks and the MCP tool
+catalog. A real baseline must additionally start the CLI without the user's
+installed hooks, MCP servers, rules, or plugins. The evaluation runner refuses
+a runner profile that does not document and supply baseline-isolation flags.
+
+Runs are paired by task and repetition, use fresh graph/state directories, and
+rotate arm order. Only paired `eval-run` records can produce causal effect
+intervals. Deterministic configuration verification is never counted as causal
+model evidence.
+
+## Episode schema
+
+Every causal record uses schema version 2 and carries the identifiers available
+on its client surface:
+
+```text
+episodeId, sessionId, turnId, toolCallId, injectionId
+client, clientVersion, model, modelVersion
+taskId, pairId, arm
+findingIds, shadowFindingIds
+deliveredTokens, shadowTokens
+success, correct, latencyMs, costUsd
+uncachedInputTokens, cachedInputTokens, outputTokens, totalTokens
+```
+
+An exact tool-call-id join is preferred. Clients that omit it use an explicitly
+labelled episode/anchor fallback. The dashboard reports causal join coverage so
+missing linkage cannot silently become “savings.”
+
+## Metrics and sufficiency
+
+Correctness is primary. Token, tool-call, latency, and cost changes are
+secondary and are never considered a win when the task grader regresses.
+
+- Scalar effects use deterministic percentile-bootstrap 95% intervals.
+- Correctness rates use Wilson 95% intervals.
+- Missing usage values remain `null`; they are never converted to zero.
+- The default causal gate requires five paired runs in a cohort. Production
+  studies should first estimate variance and then pre-register a powered sample
+  size with `TOKEN_OPTIMIZER_EVAL_MIN_PAIRS`.
+- Cohorts are separated by client, client version, model, model version, and
+  task. Results from unlike surfaces are never pooled into one headline.
+
+## Retrieval economics and safety
+
+Before delivery, each finding is scored from relevance, confidence, provenance,
+recency, observed outcomes, feedback, context cost, and stale/speculative risk.
+It is injected only when expected benefit exceeds delivery cost and risk.
+
+The default one-minute episode cooldown backs up the persisted once-per-session
+gate. Two harmful ratings quarantine a finding from automatic retrieval. A
+quarantined finding remains in the append-only graph and dashboard audit trail;
+it is not silently deleted.
+
+Holdouts record the candidate finding IDs and shadow token cost without
+delivering them. This makes treatment/control selection observable while
+preserving the control condition.
+
+## Semantic finding contract
+
+Active-model `wiki_write` calls require:
+
+- `claim`: compact, durable conclusion;
+- `anchors`: real files or symbols;
+- `evidence`: the concrete observation that established it;
+- `applicability`: when a later model should use it;
+- `confidenceLabel`: `verified`, `probable`, or `speculative`;
+- `scope`: `project`, `organization`, or `global`;
+- `invalidators`: changes or assumptions that require re-validation.
+
+Exact normalized duplicates collapse to one active finding. Project scope is
+the default; cross-project reuse must be chosen deliberately. Anchor changes
+still drive the existing staleness mechanism.
+
+## Reproduction
+
+```bash
+npm run eval:evidence:plan
+node scripts/certify-clients.mjs --json
+node scripts/run-evidence-eval.mjs \
+  --runner path/to/local-runners.json \
+  --client codex \
+  --model exact-model-id \
+  --repetitions 8
+```
+
+The runner writes a redacted JSONL artifact by default: prompt, stdout, and
+stderr hashes are retained, but transcripts are included only with the explicit
+`--include-transcript` option. Raw records are also appended to the aggregate
+graph's evidence log for `/api/wiki/evidence` and the dashboard.

--- a/docs/LIVE_MODEL_EVALUATION.md
+++ b/docs/LIVE_MODEL_EVALUATION.md
@@ -4,6 +4,13 @@ This report records the August 9, 2026 live validation of automatic graph
 capture and retrieval. It separates model-observed evidence from deterministic
 fixtures so that dashboard claims are not based on seeded data alone.
 
+This remains a historical pilot report. The follow-on
+[causal evidence protocol](EVIDENCE_PROTOCOL.md) adds four isolated arms,
+episode/tool/injection identity, shadow candidates, paired confidence intervals,
+cross-client cohorts, harm feedback, and a representative task suite. Those
+later mechanisms do not retroactively turn the three-pair pilot into a
+statistical conclusion.
+
 ## Scope
 
 - Model: `gpt-5.6-sol`, invoked through Codex CLI 0.147.0 in fresh sessions.

--- a/docs/LIVE_MODEL_EVALUATION.md
+++ b/docs/LIVE_MODEL_EVALUATION.md
@@ -11,6 +11,12 @@ cross-client cohorts, harm feedback, and a representative task suite. Those
 later mechanisms do not retroactively turn the three-pair pilot into a
 statistical conclusion.
 
+The follow-on PR also produced a redacted
+[five-pair Claude Sonnet 5 cohort](../evals/results/2026-08-09-claude-sonnet-5-command-recovery.md).
+That cohort found equal correctness, uncertain incremental retrieval effects,
+and a measurable full-system token overhead on its one task; it is retained as
+evidence rather than summarized as a win.
+
 ## Scope
 
 - Model: `gpt-5.6-sol`, invoked through Codex CLI 0.147.0 in fresh sessions.

--- a/evals/README.md
+++ b/evals/README.md
@@ -29,3 +29,7 @@ node scripts/run-evidence-eval.mjs \
 Each arm receives a fresh fixture copy, graph, and hook-state directory. The
 aggregate result is a schema-v2 `eval-run` record. Use `--include-transcript`
 only when raw model output is appropriate to retain locally.
+
+Published, redacted live cohorts:
+
+- [Claude Code 2.1.225 / Claude Sonnet 5 / command recovery / five pairs](results/2026-08-09-claude-sonnet-5-command-recovery.md)

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,31 @@
+# Live evidence suite
+
+`task-suite.json` is the pre-registered cross-client task set. It covers command
+recovery, repeated reads, noisy search, cross-session recall, cross-project
+transfer, staleness, harmful-findings quarantine, active-model harvesting, a
+no-benefit control, and long-session/compaction behavior.
+
+Copy `runners.example.json` outside the repository and replace every model,
+version, and baseline-isolation placeholder with the exact local CLI values.
+Do not weaken the baseline: it must load no Token Optimizer MCP server, hooks,
+plugin, rules, or user instructions.
+
+First inspect the counterbalanced schedule without launching a model:
+
+```bash
+npm run eval:evidence:plan
+```
+
+Then run one client/model cohort:
+
+```bash
+node scripts/run-evidence-eval.mjs \
+  --runner C:/private/token-optimizer-runners.json \
+  --client codex \
+  --model gpt-5.6-sol \
+  --repetitions 8
+```
+
+Each arm receives a fresh fixture copy, graph, and hook-state directory. The
+aggregate result is a schema-v2 `eval-run` record. Use `--include-transcript`
+only when raw model output is appropriate to retain locally.

--- a/evals/fixtures/cross-project/source/RUNBOOK.md
+++ b/evals/fixtures/cross-project/source/RUNBOOK.md
@@ -1,0 +1,4 @@
+# Source project lesson
+
+The supported verification entry point is `npm test`; direct execution of
+internal scripts bypasses environment setup.

--- a/evals/fixtures/cross-project/target/README.md
+++ b/evals/fixtures/cross-project/target/README.md
@@ -1,0 +1,4 @@
+# Target project
+
+This project deliberately omits a runbook. The evaluation checks whether a
+portable command lesson learned in another repository transfers safely.

--- a/evals/fixtures/cross-project/target/package.json
+++ b/evals/fixtures/cross-project/target/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cross-project-target",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node test.mjs"
+  }
+}

--- a/evals/fixtures/cross-project/target/test.mjs
+++ b/evals/fixtures/cross-project/target/test.mjs
@@ -1,0 +1,1 @@
+console.log('cross-project verification passed');

--- a/evals/fixtures/system-project/ARCHITECTURE.md
+++ b/evals/fixtures/system-project/ARCHITECTURE.md
@@ -1,0 +1,4 @@
+# Architecture
+
+`src/auth/verify.ts` owns token validation. `src/transport/client.ts` retries
+only transport failures. Validation failures must never enter the retry loop.

--- a/evals/fixtures/system-project/RUNBOOK.md
+++ b/evals/fixtures/system-project/RUNBOOK.md
@@ -1,0 +1,7 @@
+# Runbook
+
+Run verification from the repository root with `npm test`. Do not run
+`node scripts/verify.mjs`; that file is an intentionally unsupported probe.
+
+Authentication failures with code `CLOCK_SKEW` mean the supplied timestamp is
+being compared with the local monotonic clock in `src/auth/verify.ts`.

--- a/evals/fixtures/system-project/package.json
+++ b/evals/fixtures/system-project/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "token-optimizer-eval-fixture",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node scripts/test.mjs"
+  }
+}

--- a/evals/fixtures/system-project/scripts/test.mjs
+++ b/evals/fixtures/system-project/scripts/test.mjs
@@ -1,0 +1,1 @@
+console.log('fixture verification passed');

--- a/evals/fixtures/system-project/scripts/verify.mjs
+++ b/evals/fixtures/system-project/scripts/verify.mjs
@@ -1,0 +1,2 @@
+console.error('unsupported probe: use npm test from the repository root');
+process.exit(1);

--- a/evals/fixtures/system-project/src/auth/verify.ts
+++ b/evals/fixtures/system-project/src/auth/verify.ts
@@ -1,0 +1,3 @@
+export function verify(timestamp: number, now: number): boolean {
+  return Math.abs(now - timestamp) < 30_000;
+}

--- a/evals/fixtures/system-project/src/transport/client.ts
+++ b/evals/fixtures/system-project/src/transport/client.ts
@@ -1,0 +1,1 @@
+export const retryable = new Set(['ECONNRESET', 'ETIMEDOUT']);

--- a/evals/results/2026-08-09-claude-sonnet-5-command-recovery.md
+++ b/evals/results/2026-08-09-claude-sonnet-5-command-recovery.md
@@ -1,0 +1,97 @@
+# Claude Sonnet 5 command-recovery cohort — August 9, 2026
+
+This is the first live cohort produced while developing the four-arm evidence
+system in PR #301. It records the result even though the result is mixed and
+does not establish that the full system is more token-efficient.
+
+## Protocol
+
+- Client: Claude Code `2.1.225`.
+- Observed model: `claude-sonnet-5` (`sonnet` runner alias).
+- Task: `command-recovery` from `evals/task-suite.json`.
+- Runs: five matched repetitions, 20 fresh sessions total.
+- Order: Latin rotation; every arm occupied every order position in the first
+  four repetitions. The fifth repetition supplied the configured minimum fifth
+  pair.
+- Baseline: `--setting-sources project`, strict empty MCP configuration, no
+  plugin. An isolation smoke confirmed zero loaded plugins and zero MCP servers.
+- Treated arms: the same setting source plus an explicit `--plugin-dir` for this
+  checkout and a strict, uniquely named MCP configuration pointing to this
+  checkout's built server. A smoke confirmed the local plugin and MCP server,
+  and recorded a 24-token finding delivery.
+- Transcripts: excluded. The artifact retained response hashes, session IDs,
+  usage, grades, arm, pair, and order.
+- Redacted JSONL SHA-256:
+  `CAC6EEA6A2C4B1818B0B6D7EF166B1363C067EB78A5DAF34A75EE964117B50CF`.
+
+The run used the measurement, comparison, Claude usage parsing, PowerShell
+matching, and experiment-gating changes later committed in `1b09101`. The run
+preceded the final artifact-provenance and aggregate-trace preservation edits
+in that commit, so its raw rows report a dirty working tree and the previous
+HEAD. No grading or effect calculation was changed after the run.
+
+## Arm means
+
+| Arm | Correct | Total tokens mean (95% bootstrap interval) | Tool calls | Latency | Cost | Finding tokens |
+| --- | :---: | ---: | ---: | ---: | ---: | ---: |
+| Baseline | 5/5 | 58,885 (58,537–59,214) | 4.8 | 16.390 s | $0.272727 | 0 |
+| Optimizer | 5/5 | 59,898 (59,301–60,467) | 4.2 | 19.172 s | $0.269654 | 0 |
+| Retrieval | 5/5 | 59,731 (59,367–60,308) | 3.4 | 17.839 s | $0.251858 | 24 |
+| Full | 5/5 | 59,554 (59,114–60,235) | 3.2 | 16.798 s | $0.250657 | 24 |
+
+Each arm's correctness Wilson interval is 56.6%–100% at `n=5`. That wide
+interval is one reason this minimum-sufficiency cohort is not called a powered
+study.
+
+## Matched effects
+
+Positive values mean the treatment improved the metric. Intervals are the
+dashboard's deterministic paired percentile-bootstrap 95% intervals.
+
+| Comparison | Tokens saved | Tool calls avoided | Latency saved | Cost saved | Correctness delta |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Optimizer vs baseline | -1,012 (-1,627 to -517) | 0.6 (-1.2 to 1.8) | -2.782 s (-5.631 to -0.739) | $0.003073 (-$0.023449 to $0.029596) | 0 |
+| Retrieval vs optimizer | 167 (-761 to 1,166) | 0.8 (-2.0 to 4.2) | 1.334 s (-1.994 to 4.789) | $0.017795 (-$0.020217 to $0.057976) | 0 |
+| Full vs retrieval | 177 (-14 to 424) | 0.2 (0.0 to 0.6) | 1.041 s (-0.613 to 2.322) | $0.001201 (-$0.012692 to $0.016090) | 0 |
+| Full vs baseline | -668 (-1,205 to -230) | 1.6 (-0.2 to 3.2) | -0.408 s (-4.226 to 4.487) | $0.022070 ($0.000935 to $0.039046) | 0 |
+
+Interpretation:
+
+- All 20 sessions were correct, so this task produced no evidence of a
+  correctness improvement or regression.
+- Retrieval delivered the seeded finding in all five retrieval and all five
+  full runs. It did not deliver findings in baseline or optimizer.
+- Retrieval's incremental token, tool-call, latency, and cost intervals crossed
+  zero. The cohort does not establish a retrieval benefit.
+- The full system used 668 more tokens than baseline on average, and that token
+  interval did not cross zero. It nevertheless cost about $0.022 less because
+  Claude's cached-token pricing differs from raw token count.
+- The direction for tool calls favored full, but its interval crossed zero.
+- This is one task, one client version, one model, and five pairs. It meets the
+  dashboard's minimum display threshold; it is not a cross-task, cross-client,
+  or statistically powered conclusion.
+
+## Redacted run ledger
+
+| Pair | Order | Arm | Correct | Total tokens | Tool calls | Failed | Latency ms | Cost USD | Injected | Session | Stdout SHA-256 |
+|---:|---:|---|:---:|---:|---:|---:|---:|---:|---:|---|---|
+| 1 | 1 | baseline | yes | 58952 | 5 | 1 | 15057 | 0.269255 | 0 | ec6a248e-afe1-4963-86f5-9b6493e8fdb9 | f6819e8929367767eec2f490435f07592233624219c966f440f258074d7f2ed8 |
+| 1 | 2 | optimizer | yes | 60981 | 8 | 1 | 23292 | 0.309967 | 0 | 6d18e3b6-b52e-46cb-b689-6c09a5d6a4ec | 0945dc1f59c5a3b49971e89b5aa2a7aed463b5db4f7481fc77b47a6ca2bd8733 |
+| 1 | 3 | retrieval | yes | 59449 | 2 | 1 | 18503 | 0.233175 | 24 | 3ac45a98-b9a8-4d85-b87b-97c2b2c674e0 | d8b16154f97bf14ba6df9c861e9dc8276644b5966460194056e285029e12a1bf |
+| 1 | 4 | full | yes | 59246 | 2 | 1 | 15796 | 0.232961 | 24 | b1ccc65e-9640-41f7-92e9-0b62edaef1b4 | 28f6449ab2919ad0210d336ab65a5153340d1f4270e56621df1602ff16e97aa9 |
+| 2 | 1 | optimizer | yes | 59112 | 2 | 1 | 14042 | 0.232497 | 0 | a41812f5-3e87-4fb3-b47c-777518946068 | c2fda5854bbe7d16be3093bdeb93cb07c538801740898f24ae9695d40843f7bb |
+| 2 | 2 | retrieval | yes | 59642 | 3 | 1 | 16429 | 0.254194 | 24 | 704513d0-9a34-43db-b0b5-4474478bc5df | 5888d609bd108c149b75d2b4d093db7c9520dcf2ff344e843ebda027e79e31af |
+| 2 | 3 | full | yes | 58979 | 2 | 1 | 14399 | 0.227507 | 24 | 7b09cd0e-bda1-4fc0-b9df-11fb4308db15 | e4073529f49ea34af234b7e4fef863ef47956c7cb362cbb9ed6ac71ba1d93c5f |
+| 2 | 4 | baseline | yes | 58326 | 4 | 1 | 13588 | 0.262676 | 0 | d078bb07-0b38-4bbb-8ca6-219465d1500d | 4671818768715dc43accd63e0146db54d42ad150bb5cd54a4c7062cecf7badb5 |
+| 3 | 1 | retrieval | yes | 59222 | 2 | 1 | 15418 | 0.232830 | 24 | f3f6e5ba-419d-43ba-aabe-b2372d612004 | 55aca41f14af201797082627ad8415dbbe6e0bb45fa064fe9855f8459bd5a5e4 |
+| 3 | 2 | full | yes | 59295 | 2 | 1 | 13335 | 0.231842 | 24 | 702cbed4-1f1e-4faa-b5c2-6dc9b1871764 | 749529fa32add888fa9ed50cb9a99a51dacc5b77f17129813778a6ed50fb776b |
+| 3 | 3 | baseline | yes | 59341 | 6 | 0 | 21354 | 0.275579 | 0 | 433926fa-6151-4bec-aef4-d064e04e6bc3 | 2f890dcf95ca9c22ef4a5961f7204532e757e3c612879417bbd3da99dbf2184f |
+| 3 | 4 | optimizer | yes | 60395 | 5 | 1 | 21862 | 0.299266 | 0 | 38a64d09-fc21-417f-a3a8-d7f008cef50d | 8c7a103230faf939c7bda590d6a46a2cda18482bca82b453ffcd851d8019f06c |
+| 4 | 1 | full | yes | 59386 | 3 | 1 | 15996 | 0.252178 | 24 | eb453f6f-76a3-446d-a0ab-26e9d4048ccc | db5e7cbed486d459c2f214c91c0b2db38a78e23d9b8ba9dd1ad8cb1da650d34c |
+| 4 | 2 | baseline | yes | 58590 | 4 | 1 | 13991 | 0.266553 | 0 | a1e8bd2b-9b24-4764-9e3f-41fecdf0634a | b38517d60d524ceb4af9e0a18a325c084b4e5ff272715570271ec544dab45431 |
+| 4 | 3 | optimizer | yes | 59585 | 3 | 1 | 16988 | 0.255003 | 0 | 28a1bd29-d29f-4277-bbaf-189e6a64466a | 37f200dae00c5b7e9e536fbe179690009cc8a126fbf73a3b43d4acae492043df |
+| 4 | 4 | retrieval | yes | 59525 | 3 | 1 | 16148 | 0.251578 | 24 | e9a53f35-9b96-46d2-88c9-944b857d325e | 3d2647d0e449bbd0b2686da41991cc25215c18f3b6b714cd2c47e6fc0202a010 |
+| 5 | 1 | baseline | yes | 59217 | 5 | 1 | 17960 | 0.289571 | 0 | cf5708a2-d934-4124-bc85-c37024d256bc | 207533a66f5f2bda2033baa626993e8578f1707196fab26f9ee73635082972d7 |
+| 5 | 2 | optimizer | yes | 59415 | 3 | 1 | 19677 | 0.251536 | 0 | 5709afd3-9043-4bee-b7ce-c26f74019847 | 37d85165e2ea26f88a6c8634bc69b0d31bd316a1f9f437e93bafa2ccbadfc6aa |
+| 5 | 3 | retrieval | yes | 60817 | 7 | 1 | 22695 | 0.287513 | 24 | cad14682-5b04-411b-ae52-ddc80fb3ec78 | 78c1005c52dd6a17fdde55a77c28d0183678965eeef057532c8ad5934e9c7ff6 |
+| 5 | 4 | full | yes | 60862 | 7 | 1 | 24462 | 0.308797 | 24 | 9f0a3096-e4bd-4c7f-9ea3-3c0daa616806 | 6560605eda62d7f2d88b9e0731452d9687809e12cd7ef64563cc388c8ea8b9ce |

--- a/evals/runners.example.json
+++ b/evals/runners.example.json
@@ -9,6 +9,7 @@
       "full": []
     },
     "baselineIsolation": "--ignore-user-config prevents installed plugins and MCP servers from entering the baseline",
+    "treatmentConfiguration": "replace with the exact local plugin, hook, rules, and MCP configuration under test",
     "model": "set-the-exact-model",
     "version": "record-codex-version-here",
     "timeoutMs": 600000,
@@ -27,6 +28,7 @@
       "full": []
     },
     "baselineIsolation": "replace the placeholder with settings that load no hooks, MCP servers, or user instructions",
+    "treatmentConfiguration": "replace with explicit --plugin-dir and --mcp-config values for the checkout under test",
     "model": "set-the-exact-model",
     "version": "record-claude-code-version-here",
     "timeoutMs": 600000

--- a/evals/runners.example.json
+++ b/evals/runners.example.json
@@ -1,0 +1,34 @@
+{
+  "codex": {
+    "command": "codex",
+    "args": ["exec", "--json", "--cwd", "{workspace}", "{prompt}"],
+    "armArgs": {
+      "baseline": ["--ignore-user-config"],
+      "optimizer": [],
+      "retrieval": [],
+      "full": []
+    },
+    "baselineIsolation": "--ignore-user-config prevents installed plugins and MCP servers from entering the baseline",
+    "model": "set-the-exact-model",
+    "version": "record-codex-version-here",
+    "timeoutMs": 600000,
+    "tokenPatterns": {
+      "total": "tokens used[:\\s]+([0-9,]+)",
+      "costUsd": "cost[:\\s]+\\$?([0-9.]+)"
+    }
+  },
+  "claude-code": {
+    "command": "claude",
+    "args": ["-p", "{prompt}", "--output-format", "json"],
+    "armArgs": {
+      "baseline": ["--settings", "path-to-an-empty-isolated-settings-file"],
+      "optimizer": [],
+      "retrieval": [],
+      "full": []
+    },
+    "baselineIsolation": "replace the placeholder with settings that load no hooks, MCP servers, or user instructions",
+    "model": "set-the-exact-model",
+    "version": "record-claude-code-version-here",
+    "timeoutMs": 600000
+  }
+}

--- a/evals/task-suite.json
+++ b/evals/task-suite.json
@@ -1,0 +1,207 @@
+{
+  "name": "token-optimizer-cross-client-evidence",
+  "version": 1,
+  "preregisteredMetrics": [
+    "correctness",
+    "uncachedInputTokens",
+    "cachedInputTokens",
+    "outputTokens",
+    "totalTokens",
+    "toolCalls",
+    "failedToolCalls",
+    "latencyMs",
+    "costUsd",
+    "injectedTokens",
+    "harmfulFindings"
+  ],
+  "exclusionRules": [
+    "runner timeout",
+    "client authentication outage",
+    "fixture setup failure before the model starts",
+    "missing token usage is retained as null, never converted to zero"
+  ],
+  "tasks": [
+    {
+      "id": "command-recovery",
+      "family": "failed-command-recovery",
+      "fixture": "evals/fixtures/system-project",
+      "benefitExpectation": "positive",
+      "prompt": "Run node scripts/verify.mjs exactly once, recover using the supported verification command without opening RUNBOOK.md, and report the successful command and result.",
+      "seedFindings": [{
+        "type": "command",
+        "claim": "Run npm test from the repository root; scripts/verify.mjs is an unsupported probe.",
+        "evidence": "The direct probe exits 1 and the package test exits 0.",
+        "applicability": "When verification is attempted with scripts/verify.mjs or from the scripts directory.",
+        "confidenceLabel": "verified",
+        "confidence": 0.98,
+        "scope": "project",
+        "invalidators": ["package.json test script changes"],
+        "trigger": "scripts[\\\\/]verify\\.mjs",
+        "anchors": ["RUNBOOK.md"]
+      }],
+      "grader": { "responseIncludes": ["npm test", "passed"] }
+    },
+    {
+      "id": "repeated-large-read",
+      "family": "repeated-read",
+      "fixture": "evals/fixtures/system-project",
+      "benefitExpectation": "positive",
+      "prompt": "Inspect RUNBOOK.md twice while determining the supported verification command. State the command and avoid reproducing the entire file in the final answer.",
+      "seedFindings": [{
+        "type": "finding",
+        "claim": "The project-level test script is the supported verification boundary.",
+        "evidence": "RUNBOOK.md explicitly rejects the internal probe and package.json defines npm test.",
+        "applicability": "When selecting a verification entry point.",
+        "confidenceLabel": "verified",
+        "scope": "project",
+        "invalidators": ["RUNBOOK.md or package.json changes"],
+        "anchors": ["RUNBOOK.md", "package.json"]
+      }],
+      "grader": { "responseIncludes": ["npm test"] }
+    },
+    {
+      "id": "noisy-search",
+      "family": "repository-search",
+      "fixture": "evals/fixtures/system-project",
+      "benefitExpectation": "positive",
+      "prompt": "Find the source file that owns CLOCK_SKEW validation and report its path and threshold without recursively dumping the repository.",
+      "seedFindings": [{
+        "type": "map",
+        "claim": "Authentication clock-skew validation is owned by src/auth/verify.ts and uses a 30-second threshold.",
+        "evidence": "The verify function compares the timestamp delta with 30000 milliseconds.",
+        "applicability": "When investigating CLOCK_SKEW or authentication timestamp failures.",
+        "confidenceLabel": "verified",
+        "scope": "project",
+        "invalidators": ["src/auth/verify.ts changes"],
+        "anchors": ["src/auth/verify.ts"]
+      }],
+      "grader": { "responseIncludes": ["src/auth/verify.ts", "30"] }
+    },
+    {
+      "id": "cross-session-recall",
+      "family": "cross-session",
+      "fixture": "evals/fixtures/system-project",
+      "benefitExpectation": "positive",
+      "prompt": "Without opening ARCHITECTURE.md, explain whether authentication validation failures should enter the transport retry loop.",
+      "seedFindings": [{
+        "type": "decision",
+        "claim": "Authentication validation failures must not enter the transport retry loop.",
+        "evidence": "ARCHITECTURE.md assigns validation to auth and retries only transport failures.",
+        "applicability": "When changing retry classification or handling authentication failures.",
+        "confidenceLabel": "verified",
+        "scope": "project",
+        "invalidators": ["retry ownership changes"],
+        "anchors": ["ARCHITECTURE.md", "src/transport/client.ts"]
+      }],
+      "grader": { "responseIncludes": ["must not", "retry"] }
+    },
+    {
+      "id": "cross-project-transfer",
+      "family": "cross-project",
+      "fixture": "evals/fixtures/cross-project",
+      "workspace": "target",
+      "seedWorkspace": "source",
+      "benefitExpectation": "positive",
+      "prompt": "Run the most likely supported verification command once and report the result.",
+      "seedFindings": [{
+        "type": "command",
+        "claim": "Prefer npm test to direct execution of an internal verification script.",
+        "evidence": "A prior project required package-level environment setup and its internal script failed directly.",
+        "applicability": "When a Node project exposes an npm test script and an internal verification file.",
+        "confidenceLabel": "probable",
+        "scope": "global",
+        "invalidators": ["the target package has no test script"],
+        "trigger": "(?:node .*verify|npm test)",
+        "anchors": ["RUNBOOK.md"]
+      }],
+      "grader": { "responseIncludes": ["npm test", "passed"] }
+    },
+    {
+      "id": "stale-finding",
+      "family": "staleness",
+      "fixture": "evals/fixtures/system-project",
+      "benefitExpectation": "harm-avoidance",
+      "prompt": "Determine the current clock-skew threshold from src/auth/verify.ts and mention whether stored guidance required re-checking.",
+      "seedFindings": [{
+        "type": "finding",
+        "claim": "Clock skew is accepted for 30 seconds.",
+        "evidence": "The anchored implementation used 30000 milliseconds when observed.",
+        "applicability": "When diagnosing authentication clock skew.",
+        "confidenceLabel": "verified",
+        "scope": "project",
+        "invalidators": ["src/auth/verify.ts changes"],
+        "anchors": ["src/auth/verify.ts"]
+      }],
+      "mutateAfterSeed": [{ "path": "src/auth/verify.ts", "append": "\n// evaluation mutation forces stale evidence\n" }],
+      "grader": { "responseIncludes": ["30", "stale"] }
+    },
+    {
+      "id": "harmful-finding-quarantine",
+      "family": "adversarial-retrieval",
+      "fixture": "evals/fixtures/system-project",
+      "benefitExpectation": "harm-avoidance",
+      "prompt": "Report the supported verification command. Do not use a previously rejected direct probe.",
+      "seedFindings": [{
+        "type": "command",
+        "claim": "Run node scripts/verify.mjs directly for complete verification.",
+        "evidence": "An earlier speculative session guessed this without running it.",
+        "applicability": "When verifying the project.",
+        "confidenceLabel": "speculative",
+        "scope": "project",
+        "invalidators": ["the probe exits non-zero"],
+        "trigger": "(?:verify|test)",
+        "anchors": ["scripts/verify.mjs"]
+      }],
+      "seedFeedback": [
+        { "findingIndex": 0, "rating": "harmful" },
+        { "findingIndex": 0, "rating": "harmful" }
+      ],
+      "grader": { "responseIncludes": ["npm test"], "responseExcludes": ["run node scripts/verify.mjs"] }
+    },
+    {
+      "id": "semantic-harvest-contract",
+      "family": "semantic-harvest",
+      "fixture": "evals/fixtures/system-project",
+      "benefitExpectation": "quality",
+      "prompt": "Inspect the retry ownership, make a harmless documentation clarification if useful, and finish only after following the active-model semantic harvest policy.",
+      "grader": { "graphFinding": true }
+    },
+    {
+      "id": "irrelevant-negative-control",
+      "family": "negative-control",
+      "fixture": "evals/fixtures/system-project",
+      "benefitExpectation": "neutral",
+      "prompt": "Read package.json and report only the package name.",
+      "seedFindings": [{
+        "type": "command",
+        "claim": "Transport retries are limited to ECONNRESET and ETIMEDOUT.",
+        "evidence": "src/transport/client.ts contains exactly those retryable codes.",
+        "applicability": "When changing transport error retry classification.",
+        "confidenceLabel": "verified",
+        "scope": "project",
+        "invalidators": ["src/transport/client.ts changes"],
+        "trigger": "transport-retry-only",
+        "anchors": ["src/transport/client.ts"]
+      }],
+      "grader": { "responseIncludes": ["token-optimizer-eval-fixture"], "maxDeliveredTokens": 0 }
+    },
+    {
+      "id": "long-session-compaction",
+      "family": "long-session",
+      "fixture": "evals/fixtures/system-project",
+      "benefitExpectation": "positive",
+      "prompt": "Inspect the runbook, authentication verifier, transport retry list, and package test entry point. Reconcile their responsibilities, then report a compact verification and failure-triage plan suitable after context compaction.",
+      "seedFindings": [{
+        "type": "map",
+        "claim": "Verification runs through npm test; clock skew belongs to auth validation and transport retries exclude validation failures.",
+        "evidence": "RUNBOOK.md, verify.ts, client.ts, and package.json establish those separate responsibilities.",
+        "applicability": "When resuming verification or failure triage after a long or compacted session.",
+        "confidenceLabel": "verified",
+        "scope": "project",
+        "invalidators": ["any anchored responsibility changes"],
+        "anchors": ["RUNBOOK.md", "src/auth/verify.ts", "src/transport/client.ts", "package.json"]
+      }],
+      "grader": { "responseIncludes": ["npm test", "clock", "transport"] }
+    }
+  ]
+}

--- a/hooks-core/adapter.mjs
+++ b/hooks-core/adapter.mjs
@@ -29,7 +29,9 @@ import {
   readCostBytes,
   touchedFiles,
 } from './decide.mjs';
-import { recordRead, fingerprint } from './metrics.mjs';
+import {
+  recordRead, fingerprint, recordToolOutcome, recordEpisodeOutcome,
+} from './metrics.mjs';
 import {
   contentHash,
   harvest,
@@ -55,6 +57,8 @@ import { isFsSafePath } from './paths.mjs';
 import {
   isSubstantive, recordingNudge, semanticHarvestPrompt,
 } from './recording.mjs';
+import { nativeClientProfiles } from './capabilities.mjs';
+import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 
 /**
  * Per-client capability.
@@ -63,41 +67,7 @@ import {
  * it true where the client has no pre-execution veto would make the product
  * claim enforcement it cannot deliver.
  */
-export const CLIENTS = {
-  'claude-code': { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  codex: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  cline: {
-    canDeny: true,
-    contextStyle: 'cline',
-    denyStyle: 'cline',
-    stopDecision: 'block',
-  },
-  copilot: {
-    canDeny: true,
-    contextStyle: 'top-level',
-    denyStyle: 'top-level-permission',
-    stopDecision: 'block',
-  },
-  cursor: {
-    canDeny: true,
-    contextStyle: 'cursor',
-    denyStyle: 'cursor',
-    stopStyle: 'followup',
-    stopDecision: 'block',
-  },
-  // Gemini's BeforeTool and AfterAgent decisions are top-level. Treating it
-  // like Codex produced well-formed JSON that Gemini ignored.
-  gemini: { canDeny: true, denyStyle: 'top-level', stopDecision: 'deny' },
-  kilo: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  opencode: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  qwen: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  windsurf: {
-    canDeny: true,
-    contextStyle: 'silent',
-    denyStyle: 'exit-2',
-    stopDecision: 'block',
-  },
-};
+export const CLIENTS = nativeClientProfiles();
 
 /** Never synchronously hash an unbounded build artifact on a hook path. */
 const HARVEST_MAX_BYTES =
@@ -133,6 +103,24 @@ export function mutationSucceeded(clientName, raw) {
   // or are called by our in-process bridge only from its successful after hook.
   return new Set(['claude-code', 'qwen', 'opencode', 'kilo', 'windsurf'])
     .has(clientName);
+}
+
+/** Conservative success classification for any completed tool call. */
+export function toolSucceeded(raw) {
+  if (raw?.error || raw?.tool_response?.error || raw?.toolResponse?.error)
+    return false;
+  if (raw?.postToolUse?.success === false || raw?.success === false) return false;
+  const status =
+    raw?.tool_response?.status ?? raw?.toolResponse?.status ??
+    raw?.tool_result?.status ?? raw?.toolResult?.status;
+  if (status !== undefined) {
+    if (/^(?:error|failed|failure|cancelled|canceled|denied)$/i.test(String(status))) return false;
+    if (/^(?:ok|success|succeeded|complete|completed)$/i.test(String(status))) return true;
+  }
+  // A post-tool lifecycle event is evidence that the call completed, but not
+  // that its output proved the task.  `success` here is deliberately scoped to
+  // the tool call; task correctness comes only from an eval grader.
+  return true;
 }
 
 function contextOutput(client, eventName, additionalContext) {
@@ -251,8 +239,10 @@ refused.
 
 Worth recording: a decision and why the alternative was rejected, a failure and
 what actually caused it, a command that turned out to be the one that works.
-Not worth recording: what the code plainly says. Prefer the thing someone had to
-work out, because that exists nowhere in the source tree.${projectBriefing()}`;
+Not worth recording: what the code plainly says. Every wiki_write must include
+the concrete evidence, when it applies, a calibrated confidence label, its
+scope, and what would invalidate it. Prefer the thing someone had to work out,
+because that exists nowhere in the source tree.${projectBriefing()}`;
 }
 
 /**
@@ -313,7 +303,7 @@ function projectBriefing() {
  * metrics. It never called forTouch/forCommand, so four advertised clients
  * accumulated a graph that their active model could not receive.
  */
-function observeAndInject(payload, state) {
+function observeAndInject(payload, state, episode, features) {
   const touched = touchedFiles(payload);
   const dirFor = (path) => wikiDir(projectRootFor(path, payload.cwd));
 
@@ -342,45 +332,51 @@ function observeAndInject(payload, state) {
   state.injected = state.injected || [];
   const alreadyInjected = new Set(state.injected);
 
-  for (const { path } of touched) {
-    const dir = dirFor(path);
-    const note = forTouch(dir, load(dir), path, {
-      sessionId: payload.session_id,
-      alreadyInjected,
-    });
-    if (note) parts.push(note);
-  }
+  if (features.retrieval) {
+    for (const { path } of touched) {
+      const dir = dirFor(path);
+      const note = forTouch(dir, load(dir), path, {
+        sessionId: payload.session_id,
+        alreadyInjected,
+        episode,
+      });
+      if (note) parts.push(note);
+    }
 
-  const command = payload.tool_input?.command;
-  if (command) {
-    const root = commandProjectRoot(payload, payload.cwd);
-    const dir = wikiDir(root);
-    const local = forCommand(dir, load(dir), command, {
-      sessionId: payload.session_id,
-      alreadyInjected,
-    });
-    if (local) parts.push(local);
+    const command = payload.tool_input?.command;
+    if (command) {
+      const root = commandProjectRoot(payload, payload.cwd);
+      const dir = wikiDir(root);
+      const local = forCommand(dir, load(dir), command, {
+        sessionId: payload.session_id,
+        alreadyInjected,
+        episode,
+      });
+      if (local) parts.push(local);
 
-    const shared = forSharedCommand(dir, command, {
-      sessionId: payload.session_id,
-      alreadyInjected,
-      projectRoot: root,
-    });
-    if (shared) parts.push(shared);
+      const shared = forSharedCommand(dir, command, {
+        sessionId: payload.session_id,
+        alreadyInjected,
+        projectRoot: root,
+        episode,
+      });
+      if (shared) parts.push(shared);
 
-    const crossed = noteActClasses(state, command);
-    const repeated = forRepeatedAct(dir, command, crossed, {
-      sessionId: payload.session_id,
-      projectRoot: root,
-    });
-    if (repeated) parts.push(repeated);
+      const crossed = noteActClasses(state, command);
+      const repeated = forRepeatedAct(dir, command, crossed, {
+        sessionId: payload.session_id,
+        projectRoot: root,
+        episode,
+      });
+      if (repeated) parts.push(repeated);
+    }
   }
   state.injected = [...alreadyInjected];
 
   // Structural capture is evidence about what was touched, not a semantic
   // conclusion. It is therefore safe to automate for every client and leaves
   // the active model responsible for wiki_write at completion.
-  for (const { path, size } of touched) {
+  if (features.capture) for (const { path, size } of touched) {
     try {
       if (isArchived(path) || size > HARVEST_MAX_BYTES || !isFsSafePath(path))
         continue;
@@ -418,7 +414,10 @@ export async function run(clientName, event) {
 
   if (mode() === MODE_OFF) process.exit(0);
 
+  const features = featuresForArm();
+
   if (event === 'session-start') {
+    if (!features.routing && !features.retrieval && !features.harvest) process.exit(0);
     const output = contextOutput(client, eventName, policyText(client.canDeny));
     if (output) emit(output);
     process.exit(0);
@@ -435,10 +434,22 @@ export async function run(clientName, event) {
     const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? 'default';
     const agentScope = raw.transcript_path ?? raw.transcriptPath ?? null;
     const state = loadState(sessionId, agentScope);
+    const episode = episodeMeta({ client: clientName, raw });
+    try {
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+      recordEpisodeOutcome(dir, {
+        ...episode,
+        status: 'completed',
+        ...usageFrom(raw),
+      });
+    } catch {
+      // Evidence is best effort and must never stop a session from finishing.
+    }
     const alreadyHarvested =
       Number(state.edits || 0) > 0 &&
       Number(state.harvestedEdits || 0) >= Number(state.edits || 0);
-    const prompt = semanticHarvestPrompt({
+    const prompt = features.harvest ? semanticHarvestPrompt({
       edits: state.edits,
       files: state.editedFiles,
       model: raw.model,
@@ -447,7 +458,7 @@ export async function run(clientName, event) {
         raw.stopHookActive === true ||
         alreadyHarvested ||
         (clientName === 'cursor' && Number(raw.loop_count || 0) > 0),
-    });
+    }) : null;
     if (prompt) {
       state.harvestedEdits = Number(state.edits || 0);
       saveState(sessionId, state, agentScope);
@@ -464,6 +475,7 @@ export async function run(clientName, event) {
     process.exit(0);
   const payload = normalizePayload(normalizeClientPayload(clientName, event, raw));
   if (!payload.tool_name) process.exit(0);
+  const episode = episodeMeta({ client: clientName, raw, payload });
 
   // THE AGENT, not just the session -- the same scope the Claude Code router
   // applies. Subagents inherit the parent's session id, so keying state on the
@@ -504,17 +516,41 @@ export async function run(clientName, event) {
       const anchor = state.editedFiles[0]
         || join(payload.cwd || process.cwd(), '__recording__');
       const dir = wikiDir(projectRootFor(anchor, payload.cwd));
-      recordingContext = recordingNudge(dir, {
+      recordingContext = features.harvest ? recordingNudge(dir, {
         state,
         edits: state.edits,
         files: state.editedFiles,
-      });
+      }) : null;
       if (recordingContext) state.recordingNudged = true;
     } catch {
       // Recording pressure is an optimization and must never cost a tool call.
     }
   }
-  const verdict = decide(payload, state);
+  if (event === 'post-tool') {
+    try {
+      const command = payload.tool_input?.command;
+      const touched = touchedFiles(payload);
+      const anchor = command
+        ? String(command).slice(0, 120)
+        : touched[0]?.path || payload.tool_input?.file_path || '';
+      const root = command
+        ? commandProjectRoot(payload, payload.cwd)
+        : projectRootFor(anchor || join(payload.cwd || process.cwd(), '__tool__'), payload.cwd);
+      recordToolOutcome(wikiDir(root), {
+        ...episode,
+        surface: command ? 'command' : 'file',
+        anchor,
+        toolName: payload.tool_name,
+        success: toolSucceeded(raw),
+        durationMs: Number(raw.duration_ms ?? raw.durationMs ?? raw.elapsed_ms ?? raw.elapsedMs) || null,
+        ...usageFrom(raw),
+      });
+    } catch {
+      // Causal tracing is fail-open like every other hook optimization.
+    }
+  }
+
+  const verdict = features.routing ? decide(payload, state) : null;
   const repeat = verdict && event === 'pre-tool'
     ? alreadyDenied(state, verdict.key)
     : false;
@@ -569,7 +605,7 @@ export async function run(clientName, event) {
   remember(payload, state);
   let graphContext = null;
   try {
-    graphContext = observeAndInject(payload, state);
+    graphContext = observeAndInject(payload, state, episode, features);
   } catch {
     // Delivery is an optimization. Fail open.
   }

--- a/hooks-core/capabilities.mjs
+++ b/hooks-core/capabilities.mjs
@@ -1,0 +1,128 @@
+/**
+ * The product's honest cross-client capability contract.
+ *
+ * A client is listed at the strongest surface its public lifecycle protocol can
+ * actually support.  This registry is consumed by the adapter, certification
+ * tooling, and evidence reports so a rules-only integration can never be
+ * presented as equivalent to a native stop-continuation integration.
+ */
+
+export const CAPABILITY_TIERS = Object.freeze({
+  CONTINUATION: 'lifecycle-continuation',
+  OBSERVATION: 'native-observation',
+  RULES: 'mcp-rules',
+});
+
+const native = (profile) => ({
+  structuralCapture: 'native',
+  findingDelivery: 'native',
+  routing: 'native-veto',
+  ...profile,
+});
+
+export const CLIENT_CAPABILITIES = Object.freeze({
+  'claude-code': native({
+    name: 'Claude Code', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-continuation', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  codex: native({
+    name: 'Codex', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-continuation', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  copilot: native({
+    name: 'GitHub Copilot CLI', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'agent-stop-continuation', canDeny: true,
+    contextStyle: 'top-level', denyStyle: 'top-level-permission', stopDecision: 'block',
+  }),
+  gemini: native({
+    name: 'Gemini CLI', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'after-agent-retry', canDeny: true,
+    denyStyle: 'top-level', stopDecision: 'deny',
+  }),
+  qwen: native({
+    name: 'Qwen Code', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-continuation', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  cursor: native({
+    name: 'Cursor', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-followup', canDeny: true,
+    contextStyle: 'cursor', denyStyle: 'cursor', stopStyle: 'followup', stopDecision: 'block',
+  }),
+  cline: native({
+    name: 'Cline', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    contextStyle: 'cline', denyStyle: 'cline', stopDecision: 'block',
+  }),
+  opencode: native({
+    name: 'OpenCode', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  kilo: native({
+    name: 'Kilo', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  windsurf: native({
+    name: 'Windsurf', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    contextStyle: 'silent', denyStyle: 'exit-2', stopDecision: 'block',
+  }),
+  roo: {
+    name: 'Roo Code', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  zed: {
+    name: 'Zed', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  amp: {
+    name: 'Amp', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  continue: {
+    name: 'Continue', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  crush: {
+    name: 'Crush', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  droid: {
+    name: 'Droid (Factory)', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+});
+
+export function capabilityFor(client) {
+  return CLIENT_CAPABILITIES[String(client || '').toLowerCase()] || null;
+}
+
+export function nativeClientProfiles() {
+  return Object.fromEntries(
+    Object.entries(CLIENT_CAPABILITIES)
+      .filter(([, profile]) => profile.structuralCapture === 'native')
+      .map(([key, profile]) => [key, { ...profile }])
+  );
+}
+
+export function capabilitySummary() {
+  return Object.entries(CLIENT_CAPABILITIES).map(([client, profile]) => ({
+    client,
+    name: profile.name,
+    tier: profile.tier,
+    routing: profile.routing,
+    structuralCapture: profile.structuralCapture,
+    findingDelivery: profile.findingDelivery,
+    semanticHarvest: profile.semanticHarvest,
+  }));
+}

--- a/hooks-core/decide.mjs
+++ b/hooks-core/decide.mjs
@@ -511,6 +511,8 @@ const TOOL_ALIASES = new Map(
     create_file: 'Write',
 
     bash: 'Bash',
+    powershell: 'Bash',
+    pwsh: 'Bash',
     shell: 'Bash',
     run_command: 'Bash',
     execute_command: 'Bash',

--- a/hooks-core/experiment.mjs
+++ b/hooks-core/experiment.mjs
@@ -1,0 +1,80 @@
+/** Explicit, reproducible feature arms and causal episode identity. */
+
+export const EXPERIMENT_ARMS = Object.freeze([
+  'baseline',
+  'optimizer',
+  'retrieval',
+  'full',
+]);
+
+const FEATURES = Object.freeze({
+  baseline: Object.freeze({ routing: false, retrieval: false, capture: false, harvest: false }),
+  optimizer: Object.freeze({ routing: true, retrieval: false, capture: false, harvest: false }),
+  retrieval: Object.freeze({ routing: true, retrieval: true, capture: true, harvest: false }),
+  full: Object.freeze({ routing: true, retrieval: true, capture: true, harvest: true }),
+});
+
+export function experimentArm(env = process.env) {
+  const requested = String(env.TOKEN_OPTIMIZER_EXPERIMENT_ARM || '').trim().toLowerCase();
+  return EXPERIMENT_ARMS.includes(requested) ? requested : 'full';
+}
+
+export function featuresForArm(arm = experimentArm()) {
+  return FEATURES[arm] || FEATURES.full;
+}
+
+const first = (...values) => values.find((value) => value !== undefined && value !== null && value !== '');
+
+/**
+ * Normalises identifiers exposed under different names by lifecycle clients.
+ * Environment overrides let the live evaluation harness pin a pair/task id
+ * without asking each CLI to support experiment-specific payload fields.
+ */
+export function episodeMeta({ client, raw = {}, payload = {}, env = process.env } = {}) {
+  const sessionId = String(first(
+    payload.session_id, raw.session_id, raw.sessionId, raw.conversation_id,
+    raw.conversationId, raw.taskId, raw.task_id, raw.trajectory_id, 'default'
+  ));
+  const episodeId = String(first(
+    env.TOKEN_OPTIMIZER_EPISODE_ID, raw.episode_id, raw.episodeId, sessionId
+  ));
+  const toolCallId = first(
+    raw.tool_use_id, raw.toolUseId, raw.tool_call_id, raw.toolCallId,
+    raw.call_id, raw.callId, raw.postToolUse?.toolUseId, raw.preToolUse?.toolUseId
+  );
+  const model = first(payload.model, raw.model?.slug, raw.model, raw.model_name, env.TOKEN_OPTIMIZER_MODEL);
+  const clientVersion = first(
+    raw.client_version, raw.clientVersion, raw.version, env.TOKEN_OPTIMIZER_CLIENT_VERSION
+  );
+  const modelVersion = first(raw.model_version, raw.modelVersion, env.TOKEN_OPTIMIZER_MODEL_VERSION);
+
+  return {
+    schemaVersion: 2,
+    episodeId,
+    sessionId,
+    turnId: first(raw.turn_id, raw.turnId, raw.message_id, raw.messageId) ?? null,
+    toolCallId: toolCallId == null ? null : String(toolCallId),
+    taskId: first(env.TOKEN_OPTIMIZER_TASK_ID, raw.task_id, raw.taskId) ?? null,
+    pairId: first(env.TOKEN_OPTIMIZER_PAIR_ID, raw.pair_id, raw.pairId) ?? null,
+    arm: experimentArm(env),
+    client: String(client || first(raw.client, raw.client_name, 'unknown')),
+    clientVersion: clientVersion == null ? null : String(clientVersion),
+    model: model == null ? null : String(model),
+    modelVersion: modelVersion == null ? null : String(modelVersion),
+  };
+}
+
+export function usageFrom(raw = {}) {
+  const usage = raw.usage || raw.token_usage || raw.tokenUsage || raw.metrics?.usage || {};
+  const number = (...values) => {
+    const value = first(...values);
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+  };
+  return {
+    uncachedInputTokens: number(usage.uncached_input_tokens, usage.uncachedInputTokens),
+    cachedInputTokens: number(usage.cached_input_tokens, usage.cachedInputTokens, usage.cache_read_input_tokens),
+    outputTokens: number(usage.output_tokens, usage.outputTokens),
+    totalTokens: number(usage.total_tokens, usage.totalTokens, raw.tokens_used, raw.tokensUsed),
+  };
+}

--- a/hooks-core/harvest-write.mjs
+++ b/hooks-core/harvest-write.mjs
@@ -94,8 +94,13 @@ function promoteToShared(finding, { projectRoot, sessionId, provenance, key }) {
           key: `shared-${key}`,
           claim: finding.claim,
           confidence: finding.confidence,
+          confidenceLabel: finding.confidenceLabel,
           type: finding.type,
           trigger: typeof finding.trigger === 'string' && finding.trigger ? finding.trigger : undefined,
+          applicability: finding.applicability,
+          evidence: finding.evidence,
+          invalidators: Array.isArray(finding.invalidators) ? finding.invalidators : [],
+          scope: finding.scope || 'global',
           origin: provenance,
           quote: typeof finding.quote === 'string' && finding.quote.trim() ? finding.quote : undefined,
           // WHERE IT WAS LEARNED, carried so the reader can discount it. A lesson
@@ -349,6 +354,26 @@ export function writeHarvested(
     // anything, so it is dropped rather than kept as unfalsifiable.
     if (!resolved.length) continue;
 
+    // Exact semantic duplicates collapse to the existing active record.  The
+    // normalisation intentionally ignores punctuation/formatting noise but not
+    // meaning-bearing words; near-duplicates that need judgement remain visible
+    // to curation rather than being silently merged by a fuzzy heuristic.
+    const fingerprint = claimFingerprint(finding.claim);
+    const currentGraph = load(dir);
+    const duplicate = [...currentGraph.nodes.values()].find((node) =>
+      node.kind === 'finding'
+      && !node.retired
+      && node.type === finding.type
+      && claimFingerprint(node.claim) === fingerprint
+      && resolved.every((target) => currentGraph.edges.some((edge) =>
+        edge.from === node.id && edge.edge === 'derived_from' && edge.to === target
+      ))
+    );
+    if (duplicate) {
+      written.push(duplicate.key);
+      continue;
+    }
+
     // Date.now() plus an index is not unique across CONCURRENT detached
     // workers: two Stop hooks finishing in the same millisecond produce the
     // same key, and putNode keeps the last write for an id -- so one session's
@@ -369,6 +394,7 @@ export function writeHarvested(
         key,
         claim: finding.claim,
         confidence: finding.confidence,
+        confidenceLabel: finding.confidenceLabel,
         type: finding.type,
         // WHEN this finding is relevant, not just what it is about. Anchors
         // answer "which file", which is the wrong question for a claim about
@@ -378,6 +404,16 @@ export function writeHarvested(
         trigger: typeof finding.trigger === 'string' && finding.trigger
           ? finding.trigger
           : undefined,
+        applicability: typeof finding.applicability === 'string'
+          ? finding.applicability
+          : undefined,
+        evidence: typeof finding.evidence === 'string'
+          ? finding.evidence
+          : undefined,
+        invalidators: Array.isArray(finding.invalidators)
+          ? finding.invalidators
+          : [],
+        scope: finding.scope || 'project',
         origin: provenance,
         // THE EVIDENCE TRAVELS WITH THE CLAIM. Without it a human-origin
         // finding asserts its own provenance and nothing can check it.
@@ -396,7 +432,11 @@ export function writeHarvested(
     // record of what happened here; the shared tier is a copy for the lessons
     // that are not about here. Skipped when the two are the same directory,
     // which is the suite's usual arrangement.
-    if (id && !isSharedDir(dir)) {
+    if (
+      id
+      && !isSharedDir(dir)
+      && (finding.scope === undefined || finding.scope === 'organization' || finding.scope === 'global')
+    ) {
       promoteToShared(finding, { projectRoot, sessionId, provenance, key });
     }
   }

--- a/hooks-core/harvest.mjs
+++ b/hooks-core/harvest.mjs
@@ -199,7 +199,11 @@ const PROMPT = `Extract durable findings from this coding session for a project 
 Return ONLY a JSON array. Each element:
 {"type": "finding|decision|failure|command|map",
  "claim": "one sentence, specific and checkable",
- "confidence": 0.0-1.0,
+ "evidence": "the concrete observation, command result, or rejected approach that proved it",
+ "applicability": "the condition under which a future model should use it",
+ "confidenceLabel": "verified|probable|speculative",
+ "scope": "project|organization|global",
+ "invalidators": ["what change would require this to be checked again"],
  "anchors": ["absolute/file/path" or "absolute/file/path#symbolName"]}
 
 RULES:
@@ -209,7 +213,9 @@ RULES:
 - Prefer "failure" and "decision" entries. What was TRIED AND REJECTED, and WHY,
   is the most valuable thing here because it exists nowhere in the source tree.
 - Do not restate what the code plainly says. Record what someone had to work out.
-- confidence reflects how well established the claim is, not how important.
+- verified requires direct evidence; probable means strong but incomplete evidence;
+  speculative is a hypothesis and must be labelled as such.
+- Use project scope unless the lesson is genuinely independent of this repository.
 - If nothing durable was learned, return [].`;
 
 /**
@@ -230,8 +236,29 @@ export function validate(raw, { knownFiles = null } = {}) {
     if (!FINDING_TYPES.includes(item.type)) continue;
     if (typeof item.claim !== 'string' || item.claim.trim().length < 8) continue;
 
-    const confidence = Number(item.confidence);
-    if (!Number.isFinite(confidence) || confidence <= 0 || confidence > 1) continue;
+    const evidence = typeof item.evidence === 'string' ? item.evidence.trim() : '';
+    const applicability = typeof item.applicability === 'string' ? item.applicability.trim() : '';
+    if (evidence.length < 8 || applicability.length < 8) continue;
+
+    const confidenceLabel = ['verified', 'probable', 'speculative'].includes(item.confidenceLabel)
+      ? item.confidenceLabel
+      : null;
+    if (!confidenceLabel) continue;
+    const defaults = { verified: 0.95, probable: 0.75, speculative: 0.45 };
+    const supplied = Number(item.confidence);
+    if (
+      item.confidence !== undefined
+      && (!Number.isFinite(supplied) || supplied <= 0 || supplied > 1)
+    ) continue;
+    const confidence = item.confidence === undefined
+      ? defaults[confidenceLabel]
+      : supplied;
+    const scope = ['project', 'organization', 'global'].includes(item.scope)
+      ? item.scope
+      : 'project';
+    const invalidators = Array.isArray(item.invalidators)
+      ? item.invalidators.filter((value) => typeof value === 'string' && value.trim()).slice(0, 10)
+      : [];
 
     let anchors = Array.isArray(item.anchors) ? item.anchors.filter((a) => typeof a === 'string' && a) : [];
     // A model asked for file paths will sometimes invent them. When the caller
@@ -239,7 +266,18 @@ export function validate(raw, { knownFiles = null } = {}) {
     if (knownFiles) anchors = anchors.filter((a) => knownFiles.has(a.split('#')[0]));
     if (!anchors.length) continue;
 
-    accepted.push({ type: item.type, claim: item.claim.trim(), confidence, anchors });
+    accepted.push({
+      type: item.type,
+      claim: item.claim.trim(),
+      evidence,
+      applicability,
+      confidence,
+      confidenceLabel,
+      scope,
+      invalidators,
+      anchors,
+      trigger: typeof item.trigger === 'string' ? item.trigger : undefined,
+    });
   }
   return accepted;
 }

--- a/hooks-core/inject.mjs
+++ b/hooks-core/inject.mjs
@@ -28,6 +28,7 @@ import { inHoldout, record, indexBudget } from './metrics.mjs';
 import { canonicalPath, resolvableCandidates } from './paths.mjs';
 import { annotatedSkeleton } from './skeleton.mjs';
 import { substitutionBudget } from './metrics.mjs';
+import { assessFindings } from './utility.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
@@ -148,7 +149,7 @@ export function forTouch(
   dir,
   graph,
   rawPath,
-  { budget = touchBudget(), sessionId, alreadyInjected = new Set() } = {}
+  { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
   // Canonical, so a touch finds findings anchored under any other spelling.
   const filePath = canonicalPath(rawPath);
@@ -167,16 +168,36 @@ export function forTouch(
   // variance drops out. A session-pinned arm would destroy that.
   const holdout = inHoldout(filePath);
   const served = serve(graph, candidates);
-  const { kept, spent } = fit(served, budget);
+  const assessed = assessFindings(dir, served, {
+    episodeId: episode.episodeId || sessionId,
+    relevanceFor: () => 1,
+    costFor: (finding) => estimate(render(finding)),
+  });
+  if (assessed.rejected.length) {
+    record(dir, {
+      kind: 'retrieval-decision', ...episode, sessionId,
+      surface: 'file', anchor: filePath,
+      rejected: assessed.rejected.map(({ key, reason }) => ({ key, reason })),
+    });
+    for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
+  }
+  const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
+  if (!kept.length) return null;
 
   record(dir, {
     kind: 'inject',
+    ...episode,
     // The surface whose saving CAN be measured: reads of this anchor afterwards.
     surface: 'file',
     anchor: filePath,
     holdout,
     tokens: holdout ? 0 : spent,
-    count: kept.length,
+    deliveredTokens: holdout ? 0 : spent,
+    shadowTokens: spent,
+    count: holdout ? 0 : kept.length,
+    candidateCount: kept.length,
+    findingIds: holdout ? [] : kept.map((finding) => finding.key),
+    shadowFindingIds: kept.map((finding) => finding.key),
     stale: kept.some((f) => f.stale),
     sessionId,
   });
@@ -295,7 +316,7 @@ export function forCommand(
   dir,
   graph,
   command,
-  { budget = touchBudget(), sessionId, alreadyInjected = new Set() } = {}
+  { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
   if (!command) return null;
 
@@ -333,7 +354,20 @@ export function forCommand(
   const considered = candidates.slice(0, MAX_COMMAND_CANDIDATES);
 
   const served = serve(graph, considered);
-  const { kept, spent } = fit(served, budget);
+  const assessed = assessFindings(dir, served, {
+    episodeId: episode.episodeId || sessionId,
+    relevanceFor: (finding) => explicit(finding) ? 1 : 0.6,
+    costFor: (finding) => estimate(render(finding)),
+  });
+  if (assessed.rejected.length) {
+    record(dir, {
+      kind: 'retrieval-decision', ...episode, sessionId,
+      surface: 'command', anchor: String(command).slice(0, 120),
+      rejected: assessed.rejected.map(({ key: findingKey, reason }) => ({ key: findingKey, reason })),
+    });
+    for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
+  }
+  const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
   if (!kept.length) return null;
 
   // THE COMMAND PATH TAKES PART IN THE HOLDOUT TOO.
@@ -351,6 +385,7 @@ export function forCommand(
 
   record(dir, {
     kind: 'inject',
+    ...episode,
     trigger: 'command',
     // The surface the report needs to keep these OUT of the file-read balance:
     // a command has no anchor that read events can be joined to.
@@ -358,7 +393,12 @@ export function forCommand(
     anchor: String(command).slice(0, 120),
     holdout,
     tokens: holdout ? 0 : spent,
+    deliveredTokens: holdout ? 0 : spent,
+    shadowTokens: spent,
     count: holdout ? 0 : kept.length,
+    candidateCount: kept.length,
+    findingIds: holdout ? [] : kept.map((finding) => finding.key),
+    shadowFindingIds: kept.map((finding) => finding.key),
     stale: kept.some((f) => f.stale),
     sessionId,
   });
@@ -507,7 +547,7 @@ export function forRepeatedAct(
   projectDir,
   command,
   crossedClasses,
-  { sessionId = null, projectRoot = null } = {}
+  { sessionId = null, projectRoot = null, episode = {} } = {}
 ) {
   if (!crossedClasses || !crossedClasses.size) return null;
 
@@ -525,14 +565,33 @@ export function forRepeatedAct(
       if (![...crossedClasses].some((c) => claimClasses.has(c))) continue;
 
       const cls = [...crossedClasses].find((c) => claimClasses.has(c));
+      const assessed = assessFindings(projectDir, [node], {
+        episodeId: episode.episodeId || sessionId,
+        relevanceFor: () => 1,
+        costFor: (finding) => estimate(render(finding)),
+      });
+      if (!assessed.eligible.length) {
+        record(projectDir, {
+          kind: 'retrieval-decision', ...episode, sessionId,
+          surface: 'shared', anchor: String(command).slice(0, 120),
+          rejected: assessed.rejected.map(({ key, reason }) => ({ key, reason })),
+        });
+        continue;
+      }
       record(projectDir, {
         kind: 'inject',
+        ...episode,
         trigger: 'repeat',
         surface: 'shared',
         anchor: String(command).slice(0, 120),
         holdout: false,
         tokens: estimate(node.claim),
+        deliveredTokens: estimate(node.claim),
+        shadowTokens: estimate(node.claim),
         count: 1,
+        candidateCount: 1,
+        findingIds: [node.key],
+        shadowFindingIds: [node.key],
         stale: false,
         sessionId,
       });
@@ -583,7 +642,10 @@ function appliesCrossProject(finding, command) {
 export function forSharedCommand(
   projectDir,
   command,
-  { budget = sharedBudget(), sessionId = null, alreadyInjected = new Set(), projectRoot = null } = {}
+  {
+    budget = sharedBudget(), sessionId = null, alreadyInjected = new Set(),
+    projectRoot = null, episode = {},
+  } = {}
 ) {
   if (!command) return null;
 
@@ -620,7 +682,21 @@ export function forSharedCommand(
     // No serve() here: these types are not content-dependent, so there is no
     // anchor to re-read and nothing to diff. serve() would spend a file read per
     // finding to answer a question that does not apply to them.
-    const { kept, spent } = fit(candidates.slice(0, MAX_SHARED), budget);
+    const considered = candidates.slice(0, MAX_SHARED);
+    const assessed = assessFindings(projectDir, considered, {
+      episodeId: episode.episodeId || sessionId,
+      relevanceFor: (finding) => explicit(finding) ? 0.8 : 0.5,
+      costFor: (finding) => estimate(render(finding)),
+    });
+    if (assessed.rejected.length) {
+      record(projectDir, {
+        kind: 'retrieval-decision', ...episode, sessionId,
+        surface: 'shared', anchor: String(command).slice(0, 120),
+        rejected: assessed.rejected.map(({ key, reason }) => ({ key, reason })),
+      });
+      for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
+    }
+    const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
     if (!kept.length) return null;
 
     // THE SAME ARM AS THE LOCAL PATH, KEYED THE SAME WAY.
@@ -642,6 +718,7 @@ export function forSharedCommand(
 
     record(projectDir, {
       kind: 'inject',
+      ...episode,
       trigger: 'command',
       // ITS OWN SURFACE. The balance sheet joins `file` injections to later read
       // events; a shared lesson has no anchor in this project to join to, and
@@ -651,7 +728,12 @@ export function forSharedCommand(
       anchor: String(command).slice(0, 120),
       holdout,
       tokens: holdout ? 0 : spent,
+      deliveredTokens: holdout ? 0 : spent,
+      shadowTokens: spent,
       count: holdout ? 0 : kept.length,
+      candidateCount: kept.length,
+      findingIds: holdout ? [] : kept.map((finding) => finding.key),
+      shadowFindingIds: kept.map((finding) => finding.key),
       stale: false,
       sessionId,
     });

--- a/hooks-core/inject.mjs
+++ b/hooks-core/inject.mjs
@@ -569,6 +569,10 @@ export function forRepeatedAct(
         episodeId: episode.episodeId || sessionId,
         relevanceFor: () => 1,
         costFor: (finding) => estimate(render(finding)),
+        // This surface exists specifically to re-surface a lesson once the
+        // session crosses the repeat threshold. Ordinary retrieval remains
+        // cooldown-protected; harm quarantine and utility gating still apply.
+        bypassCooldown: true,
       });
       if (!assessed.eligible.length) {
         record(projectDir, {

--- a/hooks-core/metrics.mjs
+++ b/hooks-core/metrics.mjs
@@ -59,6 +59,7 @@ const metricsPath = (dir) => join(dir, 'metrics.jsonl');
  * on it drops BOTH arms proportionally instead of starving the rare one.
  */
 const balancePath = (dir) => join(dir, 'balance.jsonl');
+const evidencePath = (dir) => join(dir, 'evidence.jsonl');
 
 /** Kinds the net balance is computed from, and which therefore must survive. */
 /**
@@ -81,6 +82,24 @@ export const BALANCE_KINDS = new Set([
   // aged out before it was written and the backstop was structurally unable to fire, reporting
   // "only N/10 refreshes observed" for the life of the project.
   'keepwarm',
+]);
+
+/**
+ * Causal records have their own bounded log.  Tool outcomes are much rarer
+ * than read/capture telemetry but more frequent than balance records; mixing
+ * them into either window would eventually evict the evidence needed to join
+ * an injection to its result.
+ */
+export const EVIDENCE_KINDS = new Set([
+  'inject',
+  'harvest',
+  'tool-outcome',
+  'episode-outcome',
+  'eval-run',
+  'finding-feedback',
+  'retrieval-decision',
+  'mcp-client',
+  'mcp-tool',
 ]);
 
 /**
@@ -196,15 +215,30 @@ export function record(dir, event) {
     // single millisecond collapsed to ONE, so a graph with ample data reported
     // 'insufficient data (2 treated, 1 holdout)'. Real events were being
     // discarded by the deduplicator, silently.
-    const line =
-      JSON.stringify({ id: nextId(), ...event, at: event.at ?? Date.now() }) + '\n';
+    const id = event.id || nextId();
+    const complete = {
+      schemaVersion: event.schemaVersion || 2,
+      id,
+      ...event,
+      // An injection id is first-class rather than an inference from the log
+      // record id.  Exporters may rewrite record ids while preserving causal
+      // identity, and downstream tool outcomes refer to this value explicitly.
+      ...(event.kind === 'inject'
+        ? { injectionId: event.injectionId || id }
+        : {}),
+      at: event.at ?? Date.now(),
+    };
+    const line = JSON.stringify(complete) + '\n';
     appendFileSync(metricsPath(dir), line);
     // Balance-critical records go to their own log as well, so the windows on
     // the firehose can never starve the measurement. Written SECOND: a torn
     // write here costs a duplicate the reader dedupes, not a lost event.
     if (BALANCE_KINDS.has(event.kind)) appendFileSync(balancePath(dir), line);
+    if (EVIDENCE_KINDS.has(event.kind)) appendFileSync(evidencePath(dir), line);
+    return complete;
   } catch {
     // Metrics must never break a tool call.
+    return null;
   }
 }
 
@@ -400,6 +434,92 @@ export function readBalance(dir) {
     out.push(e);
   }
   return out;
+}
+
+/** Every causal evidence record inside the byte cap, deduplicated by id. */
+export function readEvidence(dir) {
+  const path = evidencePath(dir);
+  if (!existsSync(path)) return [];
+
+  let text = '';
+  try {
+    const { size } = statSync(path);
+    if (size <= MAX_BYTES) {
+      text = readFileSync(path, 'utf8');
+    } else {
+      const fd = openSync(path, 'r');
+      try {
+        const buffer = Buffer.allocUnsafe(MAX_BYTES);
+        const read = readSync(fd, buffer, 0, MAX_BYTES, size - MAX_BYTES);
+        text = buffer.subarray(0, read).toString('utf8');
+      } finally {
+        closeSync(fd);
+      }
+      text = text.slice(text.indexOf('\n') + 1);
+    }
+  } catch {
+    return [];
+  }
+
+  const seen = new Set();
+  const out = [];
+  for (const line of text.split('\n')) {
+    if (!line) continue;
+    try {
+      const event = JSON.parse(line);
+      if (!EVIDENCE_KINDS.has(event.kind)) continue;
+      const id = event.id || JSON.stringify(event);
+      if (seen.has(id)) continue;
+      seen.add(id);
+      out.push(event);
+    } catch {
+      // A concurrently appended final line may be torn.  It costs one record,
+      // never the user's tool call or the rest of the evidence report.
+    }
+  }
+  return out;
+}
+
+/**
+ * Joins a post-tool result to the most recent matching injection.  The exact
+ * tool-call id wins; clients that omit it fall back to episode + surface +
+ * anchor, in timestamp order, and the report states the weaker join method.
+ */
+export function recordToolOutcome(dir, outcome) {
+  const evidence = readEvidence(dir);
+  const anchor = String(outcome.anchor || '').slice(0, 120);
+  const candidates = evidence
+    .filter((event) => event.kind === 'inject' && event.episodeId === outcome.episodeId)
+    .filter((event) => {
+      if (outcome.toolCallId && event.toolCallId)
+        return String(event.toolCallId) === String(outcome.toolCallId);
+      return event.surface === outcome.surface && String(event.anchor || '').slice(0, 120) === anchor;
+    })
+    .sort((a, b) => (b.at || 0) - (a.at || 0));
+  const injection = candidates[0] || null;
+  const joinMethod = injection
+    ? (outcome.toolCallId && injection.toolCallId ? 'tool-call-id' : 'episode-anchor')
+    : 'none';
+
+  return record(dir, {
+    kind: 'tool-outcome',
+    ...outcome,
+    anchor,
+    injectionId: injection?.injectionId || null,
+    findingIds: injection?.findingIds || [],
+    joinMethod,
+  });
+}
+
+export function recordEpisodeOutcome(dir, outcome) {
+  return record(dir, { kind: 'episode-outcome', ...outcome });
+}
+
+export function recordFindingFeedback(dir, feedback) {
+  const rating = ['helpful', 'neutral', 'harmful'].includes(feedback?.rating)
+    ? feedback.rating
+    : 'neutral';
+  return record(dir, { kind: 'finding-feedback', ...feedback, rating });
 }
 
 /**
@@ -811,4 +931,241 @@ export function indexBudget(dir, { floor = 150, base = 300, ceiling = 1200 } = {
   // 0% hit rate falls to the floor; ~50% and above reaches the ceiling.
   const scaled = Math.round(floor + (ceiling - floor) * Math.min(1, hitRate * 2));
   return Math.max(floor, Math.min(ceiling, scaled));
+}
+
+/* ----------------------------------------------------------------------
+ * Episode-level causal evidence
+ * ------------------------------------------------------------------- */
+
+const numeric = (value) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const average = (values) => {
+  const finite = values.map(numeric).filter((value) => value !== null);
+  return finite.length
+    ? finite.reduce((sum, value) => sum + value, 0) / finite.length
+    : null;
+};
+
+/** Deterministic PRNG so regenerating a report does not move its interval. */
+function seededRandom(seedText) {
+  let seed = 2166136261;
+  for (const char of String(seedText)) {
+    seed ^= char.charCodeAt(0);
+    seed = Math.imul(seed, 16777619);
+  }
+  return () => {
+    seed += 0x6d2b79f5;
+    let value = seed;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Percentile bootstrap interval for a mean, paired delta, or other scalar. */
+export function bootstrapMeanInterval(values, { samples = 1000, seed = 'token-optimizer' } = {}) {
+  const finite = values.map(numeric).filter((value) => value !== null);
+  if (!finite.length) return { mean: null, low: null, high: null, n: 0 };
+  if (finite.length === 1) {
+    return { mean: finite[0], low: finite[0], high: finite[0], n: 1 };
+  }
+
+  const random = seededRandom(`${seed}:${finite.join(',')}`);
+  const means = [];
+  for (let sample = 0; sample < samples; sample++) {
+    let total = 0;
+    for (let index = 0; index < finite.length; index++) {
+      total += finite[Math.floor(random() * finite.length)];
+    }
+    means.push(total / finite.length);
+  }
+  means.sort((a, b) => a - b);
+  return {
+    mean: average(finite),
+    low: means[Math.floor(means.length * 0.025)],
+    high: means[Math.min(means.length - 1, Math.floor(means.length * 0.975))],
+    n: finite.length,
+  };
+}
+
+/** Wilson interval keeps small correctness samples honest and inside 0..1. */
+export function proportionInterval(successes, total, z = 1.96) {
+  if (!total) return { rate: null, low: null, high: null, n: 0 };
+  const rate = successes / total;
+  const denominator = 1 + (z * z) / total;
+  const centre = (rate + (z * z) / (2 * total)) / denominator;
+  const radius =
+    (z / denominator) * Math.sqrt((rate * (1 - rate)) / total + (z * z) / (4 * total * total));
+  return { rate, low: Math.max(0, centre - radius), high: Math.min(1, centre + radius), n: total };
+}
+
+const cohortKey = (run) => [
+  run.client || 'unknown',
+  run.clientVersion || 'unknown',
+  run.model || 'unknown',
+  run.modelVersion || 'unknown',
+  run.taskId || 'unknown',
+].join('|');
+
+function armMetrics(runs) {
+  const correct = runs.filter((run) => run.correct === true).length;
+  const interval = (field) => bootstrapMeanInterval(
+    runs.map((run) => run[field]).filter((value) => numeric(value) !== null),
+    { seed: field }
+  );
+  return {
+    runs: runs.length,
+    correctness: proportionInterval(correct, runs.length),
+    uncachedInputTokens: interval('uncachedInputTokens'),
+    cachedInputTokens: interval('cachedInputTokens'),
+    outputTokens: interval('outputTokens'),
+    totalTokens: interval('totalTokens'),
+    toolCalls: interval('toolCalls'),
+    failedToolCalls: interval('failedToolCalls'),
+    latencyMs: interval('latencyMs'),
+    costUsd: interval('costUsd'),
+    injectedTokens: interval('injectedTokens'),
+    harmfulFindings: runs.reduce((sum, run) => sum + (numeric(run.harmfulFindings) || 0), 0),
+  };
+}
+
+function pairedEffects(runs, treatmentArm) {
+  const pairs = new Map();
+  for (const run of runs) {
+    if (!run.pairId || !['baseline', treatmentArm].includes(run.arm)) continue;
+    if (!pairs.has(run.pairId)) pairs.set(run.pairId, {});
+    pairs.get(run.pairId)[run.arm] = run;
+  }
+  const complete = [...pairs.values()].filter((pair) => pair.baseline && pair[treatmentArm]);
+  const delta = (field, lowerIsBetter = true) => bootstrapMeanInterval(
+    complete
+      .map((pair) => {
+        const baseline = numeric(pair.baseline[field]);
+        const treatment = numeric(pair[treatmentArm][field]);
+        if (baseline === null || treatment === null) return null;
+        return lowerIsBetter ? baseline - treatment : treatment - baseline;
+      })
+      .filter((value) => value !== null),
+    { seed: `${treatmentArm}:${field}` }
+  );
+  return {
+    arm: treatmentArm,
+    pairs: complete.length,
+    // Positive values always mean the treatment improved the metric.
+    totalTokensSaved: delta('totalTokens'),
+    uncachedInputTokensSaved: delta('uncachedInputTokens'),
+    toolCallsAvoided: delta('toolCalls'),
+    latencyMsSaved: delta('latencyMs'),
+    costUsdSaved: delta('costUsd'),
+    correctnessDelta: delta('correct', false),
+  };
+}
+
+function matchesFilters(event, filters) {
+  for (const field of ['client', 'clientVersion', 'model', 'modelVersion', 'taskId', 'arm']) {
+    if (filters[field] && String(event[field] || '') !== String(filters[field])) return false;
+  }
+  return true;
+}
+
+/**
+ * The dashboard-facing evidence console.  Deterministic fixture verification,
+ * live hook traces, and randomized model evals remain visibly distinct: only
+ * `eval-run` records with paired arms can produce a causal effect interval.
+ */
+export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
+  const evidence = readEvidence(dir).filter((event) => matchesFilters(event, filters));
+  const runs = evidence.filter((event) => event.kind === 'eval-run');
+  const injections = evidence.filter((event) => event.kind === 'inject');
+  const outcomes = evidence.filter((event) => event.kind === 'tool-outcome');
+  const feedback = evidence.filter((event) => event.kind === 'finding-feedback');
+
+  const byInjection = new Map(
+    outcomes.filter((event) => event.injectionId).map((event) => [event.injectionId, event])
+  );
+  const traced = injections
+    .slice()
+    .sort((a, b) => (b.at || 0) - (a.at || 0))
+    .slice(0, Math.max(1, Math.min(500, episodeLimit)))
+    .map((injection) => ({
+      injectionId: injection.injectionId,
+      episodeId: injection.episodeId || injection.sessionId || null,
+      at: injection.at,
+      arm: injection.arm || (injection.holdout ? 'holdout' : 'treated'),
+      client: injection.client || 'unknown',
+      clientVersion: injection.clientVersion || null,
+      model: injection.model || null,
+      taskId: injection.taskId || null,
+      surface: injection.surface || injection.trigger || 'file',
+      anchor: injection.anchor,
+      findingIds: injection.findingIds || [],
+      deliveredTokens: injection.deliveredTokens ?? injection.tokens ?? 0,
+      shadowTokens: injection.shadowTokens ?? injection.tokens ?? 0,
+      outcome: byInjection.get(injection.injectionId) || null,
+    }));
+
+  const grouped = new Map();
+  for (const run of runs) {
+    const key = cohortKey(run);
+    if (!grouped.has(key)) grouped.set(key, []);
+    grouped.get(key).push(run);
+  }
+
+  const minimumPairs = Math.max(2, Number(process.env.TOKEN_OPTIMIZER_EVAL_MIN_PAIRS) || 5);
+  const cohorts = [...grouped.entries()].map(([key, cohortRuns]) => {
+    const arms = Object.fromEntries(
+      ['baseline', 'optimizer', 'retrieval', 'full'].map((arm) => [
+        arm,
+        armMetrics(cohortRuns.filter((run) => run.arm === arm)),
+      ])
+    );
+    const effects = ['optimizer', 'retrieval', 'full'].map((arm) => pairedEffects(cohortRuns, arm));
+    const enough = effects.some((effect) => effect.pairs >= minimumPairs);
+    return {
+      key,
+      client: cohortRuns[0]?.client || 'unknown',
+      clientVersion: cohortRuns[0]?.clientVersion || null,
+      model: cohortRuns[0]?.model || null,
+      modelVersion: cohortRuns[0]?.modelVersion || null,
+      taskId: cohortRuns[0]?.taskId || null,
+      arms,
+      effects,
+      evidenceStatus: enough
+        ? 'causal estimate available'
+        : `insufficient paired runs (need ${minimumPairs})`,
+    };
+  });
+
+  const joined = injections.filter((injection) =>
+    byInjection.has(injection.injectionId)
+  ).length;
+  const harmful = feedback.filter((event) => event.rating === 'harmful').length;
+  return {
+    schemaVersion: 2,
+    generatedAt: new Date().toISOString(),
+    filters,
+    summary: {
+      liveInjections: injections.length,
+      joinedOutcomes: joined,
+      causalJoinCoverage: injections.length ? joined / injections.length : null,
+      evalRuns: runs.length,
+      cohorts: cohorts.length,
+      harmfulFeedback: harmful,
+      harmRate: feedback.length ? harmful / feedback.length : null,
+      evidenceStatus: cohorts.some((cohort) => cohort.evidenceStatus === 'causal estimate available')
+        ? 'causal estimates available'
+        : 'insufficient randomized evidence',
+    },
+    cohorts,
+    episodes: traced,
+    methodology: {
+      intervals: 'deterministic percentile bootstrap (95%); Wilson interval for correctness',
+      causalRule: 'only matched eval-run pairs compare an arm with baseline',
+      minimumPairs,
+      deterministicChecksAreCausalProof: false,
+    },
+  };
 }

--- a/hooks-core/metrics.mjs
+++ b/hooks-core/metrics.mjs
@@ -1020,6 +1020,7 @@ function armMetrics(runs) {
     runs: runs.length,
     correctness: proportionInterval(correct, runs.length),
     uncachedInputTokens: interval('uncachedInputTokens'),
+    cacheCreationInputTokens: interval('cacheCreationInputTokens'),
     cachedInputTokens: interval('cachedInputTokens'),
     outputTokens: interval('outputTokens'),
     totalTokens: interval('totalTokens'),
@@ -1032,31 +1033,37 @@ function armMetrics(runs) {
   };
 }
 
-function pairedEffects(runs, treatmentArm) {
+function pairedEffects(runs, controlArm, treatmentArm, contrastType = 'incremental') {
   const pairs = new Map();
   for (const run of runs) {
-    if (!run.pairId || !['baseline', treatmentArm].includes(run.arm)) continue;
+    if (!run.pairId || ![controlArm, treatmentArm].includes(run.arm)) continue;
     if (!pairs.has(run.pairId)) pairs.set(run.pairId, {});
     pairs.get(run.pairId)[run.arm] = run;
   }
-  const complete = [...pairs.values()].filter((pair) => pair.baseline && pair[treatmentArm]);
+  const complete = [...pairs.values()].filter((pair) => pair[controlArm] && pair[treatmentArm]);
   const delta = (field, lowerIsBetter = true) => bootstrapMeanInterval(
     complete
       .map((pair) => {
-        const baseline = numeric(pair.baseline[field]);
+        const baseline = numeric(pair[controlArm][field]);
         const treatment = numeric(pair[treatmentArm][field]);
         if (baseline === null || treatment === null) return null;
         return lowerIsBetter ? baseline - treatment : treatment - baseline;
       })
       .filter((value) => value !== null),
-    { seed: `${treatmentArm}:${field}` }
+    { seed: `${controlArm}:${treatmentArm}:${field}` }
   );
   return {
     arm: treatmentArm,
+    controlArm,
+    comparison: `${treatmentArm} vs ${controlArm}`,
+    contrastType,
     pairs: complete.length,
     // Positive values always mean the treatment improved the metric.
     totalTokensSaved: delta('totalTokens'),
     uncachedInputTokensSaved: delta('uncachedInputTokens'),
+    cacheCreationInputTokensSaved: delta('cacheCreationInputTokens'),
+    cachedInputTokensSaved: delta('cachedInputTokens'),
+    outputTokensSaved: delta('outputTokens'),
     toolCallsAvoided: delta('toolCalls'),
     latencyMsSaved: delta('latencyMs'),
     costUsdSaved: delta('costUsd'),
@@ -1122,8 +1129,13 @@ export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
         armMetrics(cohortRuns.filter((run) => run.arm === arm)),
       ])
     );
-    const effects = ['optimizer', 'retrieval', 'full'].map((arm) => pairedEffects(cohortRuns, arm));
-    const enough = effects.some((effect) => effect.pairs >= minimumPairs);
+    const effects = [
+      pairedEffects(cohortRuns, 'baseline', 'optimizer'),
+      pairedEffects(cohortRuns, 'optimizer', 'retrieval'),
+      pairedEffects(cohortRuns, 'retrieval', 'full'),
+      pairedEffects(cohortRuns, 'baseline', 'full', 'total-system'),
+    ];
+    const enough = effects.every((effect) => effect.pairs >= minimumPairs);
     return {
       key,
       client: cohortRuns[0]?.client || 'unknown',
@@ -1163,7 +1175,8 @@ export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
     episodes: traced,
     methodology: {
       intervals: 'deterministic percentile bootstrap (95%); Wilson interval for correctness',
-      causalRule: 'only matched eval-run pairs compare an arm with baseline',
+      causalRule:
+        'matched pairs estimate optimizer vs baseline, retrieval vs optimizer, full vs retrieval, and full vs baseline',
       minimumPairs,
       deterministicChecksAreCausalProof: false,
     },

--- a/hooks-core/recording.mjs
+++ b/hooks-core/recording.mjs
@@ -157,6 +157,9 @@ export function semanticHarvestPrompt({
     + ' If this work produced a durable, non-obvious conclusion -- a failed approach and why, '
     + 'a decision and its rejected alternative, or a command that finally worked -- call '
     + 'wiki_write now with a real file anchor. Do not delegate this to another model or an '
-    + 'external harvester. If there is no such conclusion, do not invent one; finish normally.'
+    + 'external harvester. Include: the concrete evidence, when the finding applies, a calibrated '
+    + 'confidenceLabel (verified/probable/speculative), its project/organization/global scope, '
+    + 'and anything that would invalidate it. If there is no such conclusion, do not invent one; '
+    + 'finish normally.'
   );
 }

--- a/hooks-core/utility.mjs
+++ b/hooks-core/utility.mjs
@@ -1,0 +1,133 @@
+/**
+ * Evidence-aware retrieval economics.
+ *
+ * Relevance alone is not enough: a true finding can still cost more context
+ * than it saves.  Every candidate receives a conservative expected-benefit
+ * estimate, its delivery cost and risk are subtracted, and harmful findings
+ * are quarantined from automatic delivery while remaining visible for audit.
+ */
+
+import { readEvidence } from './metrics.mjs';
+
+const DAY = 86_400_000;
+const ORIGIN_WEIGHT = { human: 1.2, agent: 1.08, harvested: 1 };
+
+const envNumber = (name, fallback) => {
+  const value = Number(process.env[name]);
+  return Number.isFinite(value) && value >= 0 ? value : fallback;
+};
+
+export const retrievalPolicy = () => ({
+  baseBenefitTokens: envNumber('TOKEN_OPTIMIZER_EXPECTED_BENEFIT_TOKENS', 400),
+  minimumNetUtility: envNumber('TOKEN_OPTIMIZER_MIN_EXPECTED_UTILITY', 20),
+  cooldownMs: envNumber('TOKEN_OPTIMIZER_INJECTION_COOLDOWN_MS', 60_000),
+  quarantineHarmCount: Math.max(1, envNumber('TOKEN_OPTIMIZER_QUARANTINE_HARM_COUNT', 2)),
+});
+
+function feedbackFor(events, key) {
+  return events.filter((event) =>
+    event.kind === 'finding-feedback'
+    && (event.findingId === key || (event.findingIds || []).includes(key))
+  );
+}
+
+function outcomesFor(events, key) {
+  return events.filter((event) =>
+    event.kind === 'tool-outcome' && (event.findingIds || []).includes(key)
+  );
+}
+
+function deliveredRecently(events, key, episodeId, now, cooldownMs) {
+  if (!episodeId || cooldownMs <= 0) return false;
+  return events.some((event) =>
+    event.kind === 'inject'
+    && event.episodeId === episodeId
+    && (event.findingIds || []).includes(key)
+    && !event.holdout
+    && now - (event.at || 0) < cooldownMs
+  );
+}
+
+/**
+ * Returns eligible candidates in utility order plus every rejection reason.
+ * `costFor` is supplied by inject.mjs so the gate prices the exact rendered
+ * text rather than a second approximation that could drift.
+ */
+export function assessFindings(
+  dir,
+  findings,
+  {
+    relevanceFor = () => 1,
+    costFor = () => 0,
+    episodeId = null,
+    now = Date.now(),
+    policy = retrievalPolicy(),
+  } = {}
+) {
+  const events = readEvidence(dir);
+  const eligible = [];
+  const rejected = [];
+
+  for (const finding of findings) {
+    const key = finding.key;
+    const feedback = feedbackFor(events, key);
+    const outcomes = outcomesFor(events, key);
+    const helpful = feedback.filter((event) => event.rating === 'helpful').length;
+    const neutral = feedback.filter((event) => event.rating === 'neutral').length;
+    const harmful = feedback.filter((event) => event.rating === 'harmful').length;
+    const successfulUses = outcomes.filter((event) => event.success === true).length;
+    const failedUses = outcomes.filter((event) => event.success === false).length;
+
+    if (harmful >= policy.quarantineHarmCount && harmful >= helpful + neutral) {
+      rejected.push({ key, reason: 'quarantined-harm', helpful, neutral, harmful });
+      continue;
+    }
+    if (deliveredRecently(events, key, episodeId, now, policy.cooldownMs)) {
+      rejected.push({ key, reason: 'cooldown' });
+      continue;
+    }
+
+    const confidence = Number.isFinite(finding.confidence) ? finding.confidence : 0.5;
+    const relevance = Math.max(0, Math.min(1, Number(relevanceFor(finding)) || 0));
+    const ageDays = Math.max(0, (now - (finding.at || now)) / DAY);
+    const recency = finding.pinned ? 1 : Math.pow(0.5, ageDays / 90);
+    const provenance = ORIGIN_WEIGHT[finding.origin] || 1;
+    // Outcome evidence moves the estimate gradually. Explicit harmful feedback
+    // is handled above; a failed command alone is not labelled harmful because
+    // the model may have ignored correct advice.
+    const observed = successfulUses + failedUses;
+    const successFactor = observed
+      ? 0.75 + 0.5 * (successfulUses / observed)
+      : 1;
+    const feedbackFactor = Math.max(0.25, 1 + helpful * 0.12 - harmful * 0.35);
+    const expectedBenefit =
+      policy.baseBenefitTokens * confidence * relevance * recency * provenance * successFactor * feedbackFactor;
+    const deliveryCost = Math.max(0, Number(costFor(finding)) || 0);
+    const riskPenalty =
+      (finding.stale ? 160 : 0)
+      + (finding.confidenceLabel === 'speculative' ? 100 : 0)
+      + harmful * 100;
+    const netUtility = expectedBenefit - deliveryCost - riskPenalty;
+
+    const assessed = {
+      finding,
+      expectedBenefit,
+      deliveryCost,
+      riskPenalty,
+      netUtility,
+      helpful,
+      neutral,
+      harmful,
+      successfulUses,
+      failedUses,
+    };
+    if (netUtility < policy.minimumNetUtility) {
+      rejected.push({ key, reason: 'negative-expected-value', ...assessed, finding: undefined });
+      continue;
+    }
+    eligible.push(assessed);
+  }
+
+  eligible.sort((a, b) => b.netUtility - a.netUtility);
+  return { eligible, rejected };
+}

--- a/hooks-core/utility.mjs
+++ b/hooks-core/utility.mjs
@@ -62,6 +62,7 @@ export function assessFindings(
     episodeId = null,
     now = Date.now(),
     policy = retrievalPolicy(),
+    bypassCooldown = false,
   } = {}
 ) {
   const events = readEvidence(dir);
@@ -82,7 +83,7 @@ export function assessFindings(
       rejected.push({ key, reason: 'quarantined-harm', helpful, neutral, harmful });
       continue;
     }
-    if (deliveredRecently(events, key, episodeId, now, policy.cooldownMs)) {
+    if (!bypassCooldown && deliveredRecently(events, key, episodeId, now, policy.cooldownMs)) {
       rejected.push({ key, reason: 'cooldown' });
       continue;
     }

--- a/hooks-core/wire.mjs
+++ b/hooks-core/wire.mjs
@@ -26,7 +26,7 @@ export const MARKER = 'token-optimizer';
 /** The events we wire, and which hook file serves each. */
 export const WIRING = [
   { event: 'SessionStart', file: 'session-start.mjs', matcher: null },
-  { event: 'PreToolUse', file: 'pretooluse-router.mjs', matcher: 'Read|Grep|Glob|Edit|MultiEdit|Write|Bash' },
+  { event: 'PreToolUse', file: 'pretooluse-router.mjs', matcher: 'Read|Grep|Glob|Edit|MultiEdit|Write|Bash|PowerShell' },
   { event: 'PreCompact', file: 'precompact-optimize.mjs', matcher: null },
 ];
 

--- a/integrations/amp/AGENTS.md
+++ b/integrations/amp/AGENTS.md
@@ -25,6 +25,10 @@ LIVE GRAPH — THE ACTIVE MODEL DOES THE SEMANTIC HARVEST:
   command that finally worked.
 - Anchor every claim to a real file path or path#symbol. Never invent a claim
   merely to populate the graph, and do not delegate harvesting to another model.
+- Include the concrete evidence, when it applies, confidenceLabel
+  (verified/probable/speculative), scope (project/organization/global), and any
+  condition that would invalidate it. Use project scope unless transfer is
+  genuinely justified.
 - Before finishing substantive work, reflect once and write any still-unrecorded
   conclusion while you hold the reasoning. This is what makes the lesson
   available across sessions and projects instead of losing it to compaction.

--- a/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
@@ -31,7 +31,9 @@ import {
   readCostBytes,
   touchedFiles,
 } from './decide.mjs';
-import { recordRead, fingerprint } from './metrics.mjs';
+import {
+  recordRead, fingerprint, recordToolOutcome, recordEpisodeOutcome,
+} from './metrics.mjs';
 import {
   contentHash,
   harvest,
@@ -57,6 +59,8 @@ import { isFsSafePath } from './paths.mjs';
 import {
   isSubstantive, recordingNudge, semanticHarvestPrompt,
 } from './recording.mjs';
+import { nativeClientProfiles } from './capabilities.mjs';
+import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 
 /**
  * Per-client capability.
@@ -65,41 +69,7 @@ import {
  * it true where the client has no pre-execution veto would make the product
  * claim enforcement it cannot deliver.
  */
-export const CLIENTS = {
-  'claude-code': { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  codex: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  cline: {
-    canDeny: true,
-    contextStyle: 'cline',
-    denyStyle: 'cline',
-    stopDecision: 'block',
-  },
-  copilot: {
-    canDeny: true,
-    contextStyle: 'top-level',
-    denyStyle: 'top-level-permission',
-    stopDecision: 'block',
-  },
-  cursor: {
-    canDeny: true,
-    contextStyle: 'cursor',
-    denyStyle: 'cursor',
-    stopStyle: 'followup',
-    stopDecision: 'block',
-  },
-  // Gemini's BeforeTool and AfterAgent decisions are top-level. Treating it
-  // like Codex produced well-formed JSON that Gemini ignored.
-  gemini: { canDeny: true, denyStyle: 'top-level', stopDecision: 'deny' },
-  kilo: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  opencode: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  qwen: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  windsurf: {
-    canDeny: true,
-    contextStyle: 'silent',
-    denyStyle: 'exit-2',
-    stopDecision: 'block',
-  },
-};
+export const CLIENTS = nativeClientProfiles();
 
 /** Never synchronously hash an unbounded build artifact on a hook path. */
 const HARVEST_MAX_BYTES =
@@ -135,6 +105,24 @@ export function mutationSucceeded(clientName, raw) {
   // or are called by our in-process bridge only from its successful after hook.
   return new Set(['claude-code', 'qwen', 'opencode', 'kilo', 'windsurf'])
     .has(clientName);
+}
+
+/** Conservative success classification for any completed tool call. */
+export function toolSucceeded(raw) {
+  if (raw?.error || raw?.tool_response?.error || raw?.toolResponse?.error)
+    return false;
+  if (raw?.postToolUse?.success === false || raw?.success === false) return false;
+  const status =
+    raw?.tool_response?.status ?? raw?.toolResponse?.status ??
+    raw?.tool_result?.status ?? raw?.toolResult?.status;
+  if (status !== undefined) {
+    if (/^(?:error|failed|failure|cancelled|canceled|denied)$/i.test(String(status))) return false;
+    if (/^(?:ok|success|succeeded|complete|completed)$/i.test(String(status))) return true;
+  }
+  // A post-tool lifecycle event is evidence that the call completed, but not
+  // that its output proved the task.  `success` here is deliberately scoped to
+  // the tool call; task correctness comes only from an eval grader.
+  return true;
 }
 
 function contextOutput(client, eventName, additionalContext) {
@@ -253,8 +241,10 @@ refused.
 
 Worth recording: a decision and why the alternative was rejected, a failure and
 what actually caused it, a command that turned out to be the one that works.
-Not worth recording: what the code plainly says. Prefer the thing someone had to
-work out, because that exists nowhere in the source tree.${projectBriefing()}`;
+Not worth recording: what the code plainly says. Every wiki_write must include
+the concrete evidence, when it applies, a calibrated confidence label, its
+scope, and what would invalidate it. Prefer the thing someone had to work out,
+because that exists nowhere in the source tree.${projectBriefing()}`;
 }
 
 /**
@@ -315,7 +305,7 @@ function projectBriefing() {
  * metrics. It never called forTouch/forCommand, so four advertised clients
  * accumulated a graph that their active model could not receive.
  */
-function observeAndInject(payload, state) {
+function observeAndInject(payload, state, episode, features) {
   const touched = touchedFiles(payload);
   const dirFor = (path) => wikiDir(projectRootFor(path, payload.cwd));
 
@@ -344,45 +334,51 @@ function observeAndInject(payload, state) {
   state.injected = state.injected || [];
   const alreadyInjected = new Set(state.injected);
 
-  for (const { path } of touched) {
-    const dir = dirFor(path);
-    const note = forTouch(dir, load(dir), path, {
-      sessionId: payload.session_id,
-      alreadyInjected,
-    });
-    if (note) parts.push(note);
-  }
+  if (features.retrieval) {
+    for (const { path } of touched) {
+      const dir = dirFor(path);
+      const note = forTouch(dir, load(dir), path, {
+        sessionId: payload.session_id,
+        alreadyInjected,
+        episode,
+      });
+      if (note) parts.push(note);
+    }
 
-  const command = payload.tool_input?.command;
-  if (command) {
-    const root = commandProjectRoot(payload, payload.cwd);
-    const dir = wikiDir(root);
-    const local = forCommand(dir, load(dir), command, {
-      sessionId: payload.session_id,
-      alreadyInjected,
-    });
-    if (local) parts.push(local);
+    const command = payload.tool_input?.command;
+    if (command) {
+      const root = commandProjectRoot(payload, payload.cwd);
+      const dir = wikiDir(root);
+      const local = forCommand(dir, load(dir), command, {
+        sessionId: payload.session_id,
+        alreadyInjected,
+        episode,
+      });
+      if (local) parts.push(local);
 
-    const shared = forSharedCommand(dir, command, {
-      sessionId: payload.session_id,
-      alreadyInjected,
-      projectRoot: root,
-    });
-    if (shared) parts.push(shared);
+      const shared = forSharedCommand(dir, command, {
+        sessionId: payload.session_id,
+        alreadyInjected,
+        projectRoot: root,
+        episode,
+      });
+      if (shared) parts.push(shared);
 
-    const crossed = noteActClasses(state, command);
-    const repeated = forRepeatedAct(dir, command, crossed, {
-      sessionId: payload.session_id,
-      projectRoot: root,
-    });
-    if (repeated) parts.push(repeated);
+      const crossed = noteActClasses(state, command);
+      const repeated = forRepeatedAct(dir, command, crossed, {
+        sessionId: payload.session_id,
+        projectRoot: root,
+        episode,
+      });
+      if (repeated) parts.push(repeated);
+    }
   }
   state.injected = [...alreadyInjected];
 
   // Structural capture is evidence about what was touched, not a semantic
   // conclusion. It is therefore safe to automate for every client and leaves
   // the active model responsible for wiki_write at completion.
-  for (const { path, size } of touched) {
+  if (features.capture) for (const { path, size } of touched) {
     try {
       if (isArchived(path) || size > HARVEST_MAX_BYTES || !isFsSafePath(path))
         continue;
@@ -420,7 +416,10 @@ export async function run(clientName, event) {
 
   if (mode() === MODE_OFF) process.exit(0);
 
+  const features = featuresForArm();
+
   if (event === 'session-start') {
+    if (!features.routing && !features.retrieval && !features.harvest) process.exit(0);
     const output = contextOutput(client, eventName, policyText(client.canDeny));
     if (output) emit(output);
     process.exit(0);
@@ -437,10 +436,22 @@ export async function run(clientName, event) {
     const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? 'default';
     const agentScope = raw.transcript_path ?? raw.transcriptPath ?? null;
     const state = loadState(sessionId, agentScope);
+    const episode = episodeMeta({ client: clientName, raw });
+    try {
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+      recordEpisodeOutcome(dir, {
+        ...episode,
+        status: 'completed',
+        ...usageFrom(raw),
+      });
+    } catch {
+      // Evidence is best effort and must never stop a session from finishing.
+    }
     const alreadyHarvested =
       Number(state.edits || 0) > 0 &&
       Number(state.harvestedEdits || 0) >= Number(state.edits || 0);
-    const prompt = semanticHarvestPrompt({
+    const prompt = features.harvest ? semanticHarvestPrompt({
       edits: state.edits,
       files: state.editedFiles,
       model: raw.model,
@@ -449,7 +460,7 @@ export async function run(clientName, event) {
         raw.stopHookActive === true ||
         alreadyHarvested ||
         (clientName === 'cursor' && Number(raw.loop_count || 0) > 0),
-    });
+    }) : null;
     if (prompt) {
       state.harvestedEdits = Number(state.edits || 0);
       saveState(sessionId, state, agentScope);
@@ -466,6 +477,7 @@ export async function run(clientName, event) {
     process.exit(0);
   const payload = normalizePayload(normalizeClientPayload(clientName, event, raw));
   if (!payload.tool_name) process.exit(0);
+  const episode = episodeMeta({ client: clientName, raw, payload });
 
   // THE AGENT, not just the session -- the same scope the Claude Code router
   // applies. Subagents inherit the parent's session id, so keying state on the
@@ -506,17 +518,41 @@ export async function run(clientName, event) {
       const anchor = state.editedFiles[0]
         || join(payload.cwd || process.cwd(), '__recording__');
       const dir = wikiDir(projectRootFor(anchor, payload.cwd));
-      recordingContext = recordingNudge(dir, {
+      recordingContext = features.harvest ? recordingNudge(dir, {
         state,
         edits: state.edits,
         files: state.editedFiles,
-      });
+      }) : null;
       if (recordingContext) state.recordingNudged = true;
     } catch {
       // Recording pressure is an optimization and must never cost a tool call.
     }
   }
-  const verdict = decide(payload, state);
+  if (event === 'post-tool') {
+    try {
+      const command = payload.tool_input?.command;
+      const touched = touchedFiles(payload);
+      const anchor = command
+        ? String(command).slice(0, 120)
+        : touched[0]?.path || payload.tool_input?.file_path || '';
+      const root = command
+        ? commandProjectRoot(payload, payload.cwd)
+        : projectRootFor(anchor || join(payload.cwd || process.cwd(), '__tool__'), payload.cwd);
+      recordToolOutcome(wikiDir(root), {
+        ...episode,
+        surface: command ? 'command' : 'file',
+        anchor,
+        toolName: payload.tool_name,
+        success: toolSucceeded(raw),
+        durationMs: Number(raw.duration_ms ?? raw.durationMs ?? raw.elapsed_ms ?? raw.elapsedMs) || null,
+        ...usageFrom(raw),
+      });
+    } catch {
+      // Causal tracing is fail-open like every other hook optimization.
+    }
+  }
+
+  const verdict = features.routing ? decide(payload, state) : null;
   const repeat = verdict && event === 'pre-tool'
     ? alreadyDenied(state, verdict.key)
     : false;
@@ -571,7 +607,7 @@ export async function run(clientName, event) {
   remember(payload, state);
   let graphContext = null;
   try {
-    graphContext = observeAndInject(payload, state);
+    graphContext = observeAndInject(payload, state, episode, features);
   } catch {
     // Delivery is an optimization. Fail open.
   }

--- a/integrations/cline/hooks/token-optimizer/lib/capabilities.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/capabilities.mjs
@@ -1,0 +1,130 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/capabilities.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * The product's honest cross-client capability contract.
+ *
+ * A client is listed at the strongest surface its public lifecycle protocol can
+ * actually support.  This registry is consumed by the adapter, certification
+ * tooling, and evidence reports so a rules-only integration can never be
+ * presented as equivalent to a native stop-continuation integration.
+ */
+
+export const CAPABILITY_TIERS = Object.freeze({
+  CONTINUATION: 'lifecycle-continuation',
+  OBSERVATION: 'native-observation',
+  RULES: 'mcp-rules',
+});
+
+const native = (profile) => ({
+  structuralCapture: 'native',
+  findingDelivery: 'native',
+  routing: 'native-veto',
+  ...profile,
+});
+
+export const CLIENT_CAPABILITIES = Object.freeze({
+  'claude-code': native({
+    name: 'Claude Code', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-continuation', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  codex: native({
+    name: 'Codex', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-continuation', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  copilot: native({
+    name: 'GitHub Copilot CLI', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'agent-stop-continuation', canDeny: true,
+    contextStyle: 'top-level', denyStyle: 'top-level-permission', stopDecision: 'block',
+  }),
+  gemini: native({
+    name: 'Gemini CLI', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'after-agent-retry', canDeny: true,
+    denyStyle: 'top-level', stopDecision: 'deny',
+  }),
+  qwen: native({
+    name: 'Qwen Code', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-continuation', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  cursor: native({
+    name: 'Cursor', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-followup', canDeny: true,
+    contextStyle: 'cursor', denyStyle: 'cursor', stopStyle: 'followup', stopDecision: 'block',
+  }),
+  cline: native({
+    name: 'Cline', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    contextStyle: 'cline', denyStyle: 'cline', stopDecision: 'block',
+  }),
+  opencode: native({
+    name: 'OpenCode', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  kilo: native({
+    name: 'Kilo', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  windsurf: native({
+    name: 'Windsurf', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    contextStyle: 'silent', denyStyle: 'exit-2', stopDecision: 'block',
+  }),
+  roo: {
+    name: 'Roo Code', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  zed: {
+    name: 'Zed', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  amp: {
+    name: 'Amp', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  continue: {
+    name: 'Continue', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  crush: {
+    name: 'Crush', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  droid: {
+    name: 'Droid (Factory)', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+});
+
+export function capabilityFor(client) {
+  return CLIENT_CAPABILITIES[String(client || '').toLowerCase()] || null;
+}
+
+export function nativeClientProfiles() {
+  return Object.fromEntries(
+    Object.entries(CLIENT_CAPABILITIES)
+      .filter(([, profile]) => profile.structuralCapture === 'native')
+      .map(([key, profile]) => [key, { ...profile }])
+  );
+}
+
+export function capabilitySummary() {
+  return Object.entries(CLIENT_CAPABILITIES).map(([client, profile]) => ({
+    client,
+    name: profile.name,
+    tier: profile.tier,
+    routing: profile.routing,
+    structuralCapture: profile.structuralCapture,
+    findingDelivery: profile.findingDelivery,
+    semanticHarvest: profile.semanticHarvest,
+  }));
+}

--- a/integrations/cline/hooks/token-optimizer/lib/decide.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/decide.mjs
@@ -513,6 +513,8 @@ const TOOL_ALIASES = new Map(
     create_file: 'Write',
 
     bash: 'Bash',
+    powershell: 'Bash',
+    pwsh: 'Bash',
     shell: 'Bash',
     run_command: 'Bash',
     execute_command: 'Bash',

--- a/integrations/cline/hooks/token-optimizer/lib/experiment.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/experiment.mjs
@@ -1,0 +1,82 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/experiment.mjs. Regenerate with `npm run sync:hooks`.
+/** Explicit, reproducible feature arms and causal episode identity. */
+
+export const EXPERIMENT_ARMS = Object.freeze([
+  'baseline',
+  'optimizer',
+  'retrieval',
+  'full',
+]);
+
+const FEATURES = Object.freeze({
+  baseline: Object.freeze({ routing: false, retrieval: false, capture: false, harvest: false }),
+  optimizer: Object.freeze({ routing: true, retrieval: false, capture: false, harvest: false }),
+  retrieval: Object.freeze({ routing: true, retrieval: true, capture: true, harvest: false }),
+  full: Object.freeze({ routing: true, retrieval: true, capture: true, harvest: true }),
+});
+
+export function experimentArm(env = process.env) {
+  const requested = String(env.TOKEN_OPTIMIZER_EXPERIMENT_ARM || '').trim().toLowerCase();
+  return EXPERIMENT_ARMS.includes(requested) ? requested : 'full';
+}
+
+export function featuresForArm(arm = experimentArm()) {
+  return FEATURES[arm] || FEATURES.full;
+}
+
+const first = (...values) => values.find((value) => value !== undefined && value !== null && value !== '');
+
+/**
+ * Normalises identifiers exposed under different names by lifecycle clients.
+ * Environment overrides let the live evaluation harness pin a pair/task id
+ * without asking each CLI to support experiment-specific payload fields.
+ */
+export function episodeMeta({ client, raw = {}, payload = {}, env = process.env } = {}) {
+  const sessionId = String(first(
+    payload.session_id, raw.session_id, raw.sessionId, raw.conversation_id,
+    raw.conversationId, raw.taskId, raw.task_id, raw.trajectory_id, 'default'
+  ));
+  const episodeId = String(first(
+    env.TOKEN_OPTIMIZER_EPISODE_ID, raw.episode_id, raw.episodeId, sessionId
+  ));
+  const toolCallId = first(
+    raw.tool_use_id, raw.toolUseId, raw.tool_call_id, raw.toolCallId,
+    raw.call_id, raw.callId, raw.postToolUse?.toolUseId, raw.preToolUse?.toolUseId
+  );
+  const model = first(payload.model, raw.model?.slug, raw.model, raw.model_name, env.TOKEN_OPTIMIZER_MODEL);
+  const clientVersion = first(
+    raw.client_version, raw.clientVersion, raw.version, env.TOKEN_OPTIMIZER_CLIENT_VERSION
+  );
+  const modelVersion = first(raw.model_version, raw.modelVersion, env.TOKEN_OPTIMIZER_MODEL_VERSION);
+
+  return {
+    schemaVersion: 2,
+    episodeId,
+    sessionId,
+    turnId: first(raw.turn_id, raw.turnId, raw.message_id, raw.messageId) ?? null,
+    toolCallId: toolCallId == null ? null : String(toolCallId),
+    taskId: first(env.TOKEN_OPTIMIZER_TASK_ID, raw.task_id, raw.taskId) ?? null,
+    pairId: first(env.TOKEN_OPTIMIZER_PAIR_ID, raw.pair_id, raw.pairId) ?? null,
+    arm: experimentArm(env),
+    client: String(client || first(raw.client, raw.client_name, 'unknown')),
+    clientVersion: clientVersion == null ? null : String(clientVersion),
+    model: model == null ? null : String(model),
+    modelVersion: modelVersion == null ? null : String(modelVersion),
+  };
+}
+
+export function usageFrom(raw = {}) {
+  const usage = raw.usage || raw.token_usage || raw.tokenUsage || raw.metrics?.usage || {};
+  const number = (...values) => {
+    const value = first(...values);
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+  };
+  return {
+    uncachedInputTokens: number(usage.uncached_input_tokens, usage.uncachedInputTokens),
+    cachedInputTokens: number(usage.cached_input_tokens, usage.cachedInputTokens, usage.cache_read_input_tokens),
+    outputTokens: number(usage.output_tokens, usage.outputTokens),
+    totalTokens: number(usage.total_tokens, usage.totalTokens, raw.tokens_used, raw.tokensUsed),
+  };
+}

--- a/integrations/cline/hooks/token-optimizer/lib/harvest-write.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/harvest-write.mjs
@@ -96,8 +96,13 @@ function promoteToShared(finding, { projectRoot, sessionId, provenance, key }) {
           key: `shared-${key}`,
           claim: finding.claim,
           confidence: finding.confidence,
+          confidenceLabel: finding.confidenceLabel,
           type: finding.type,
           trigger: typeof finding.trigger === 'string' && finding.trigger ? finding.trigger : undefined,
+          applicability: finding.applicability,
+          evidence: finding.evidence,
+          invalidators: Array.isArray(finding.invalidators) ? finding.invalidators : [],
+          scope: finding.scope || 'global',
           origin: provenance,
           quote: typeof finding.quote === 'string' && finding.quote.trim() ? finding.quote : undefined,
           // WHERE IT WAS LEARNED, carried so the reader can discount it. A lesson
@@ -351,6 +356,26 @@ export function writeHarvested(
     // anything, so it is dropped rather than kept as unfalsifiable.
     if (!resolved.length) continue;
 
+    // Exact semantic duplicates collapse to the existing active record.  The
+    // normalisation intentionally ignores punctuation/formatting noise but not
+    // meaning-bearing words; near-duplicates that need judgement remain visible
+    // to curation rather than being silently merged by a fuzzy heuristic.
+    const fingerprint = claimFingerprint(finding.claim);
+    const currentGraph = load(dir);
+    const duplicate = [...currentGraph.nodes.values()].find((node) =>
+      node.kind === 'finding'
+      && !node.retired
+      && node.type === finding.type
+      && claimFingerprint(node.claim) === fingerprint
+      && resolved.every((target) => currentGraph.edges.some((edge) =>
+        edge.from === node.id && edge.edge === 'derived_from' && edge.to === target
+      ))
+    );
+    if (duplicate) {
+      written.push(duplicate.key);
+      continue;
+    }
+
     // Date.now() plus an index is not unique across CONCURRENT detached
     // workers: two Stop hooks finishing in the same millisecond produce the
     // same key, and putNode keeps the last write for an id -- so one session's
@@ -371,6 +396,7 @@ export function writeHarvested(
         key,
         claim: finding.claim,
         confidence: finding.confidence,
+        confidenceLabel: finding.confidenceLabel,
         type: finding.type,
         // WHEN this finding is relevant, not just what it is about. Anchors
         // answer "which file", which is the wrong question for a claim about
@@ -380,6 +406,16 @@ export function writeHarvested(
         trigger: typeof finding.trigger === 'string' && finding.trigger
           ? finding.trigger
           : undefined,
+        applicability: typeof finding.applicability === 'string'
+          ? finding.applicability
+          : undefined,
+        evidence: typeof finding.evidence === 'string'
+          ? finding.evidence
+          : undefined,
+        invalidators: Array.isArray(finding.invalidators)
+          ? finding.invalidators
+          : [],
+        scope: finding.scope || 'project',
         origin: provenance,
         // THE EVIDENCE TRAVELS WITH THE CLAIM. Without it a human-origin
         // finding asserts its own provenance and nothing can check it.
@@ -398,7 +434,11 @@ export function writeHarvested(
     // record of what happened here; the shared tier is a copy for the lessons
     // that are not about here. Skipped when the two are the same directory,
     // which is the suite's usual arrangement.
-    if (id && !isSharedDir(dir)) {
+    if (
+      id
+      && !isSharedDir(dir)
+      && (finding.scope === undefined || finding.scope === 'organization' || finding.scope === 'global')
+    ) {
       promoteToShared(finding, { projectRoot, sessionId, provenance, key });
     }
   }

--- a/integrations/cline/hooks/token-optimizer/lib/harvest.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/harvest.mjs
@@ -201,7 +201,11 @@ const PROMPT = `Extract durable findings from this coding session for a project 
 Return ONLY a JSON array. Each element:
 {"type": "finding|decision|failure|command|map",
  "claim": "one sentence, specific and checkable",
- "confidence": 0.0-1.0,
+ "evidence": "the concrete observation, command result, or rejected approach that proved it",
+ "applicability": "the condition under which a future model should use it",
+ "confidenceLabel": "verified|probable|speculative",
+ "scope": "project|organization|global",
+ "invalidators": ["what change would require this to be checked again"],
  "anchors": ["absolute/file/path" or "absolute/file/path#symbolName"]}
 
 RULES:
@@ -211,7 +215,9 @@ RULES:
 - Prefer "failure" and "decision" entries. What was TRIED AND REJECTED, and WHY,
   is the most valuable thing here because it exists nowhere in the source tree.
 - Do not restate what the code plainly says. Record what someone had to work out.
-- confidence reflects how well established the claim is, not how important.
+- verified requires direct evidence; probable means strong but incomplete evidence;
+  speculative is a hypothesis and must be labelled as such.
+- Use project scope unless the lesson is genuinely independent of this repository.
 - If nothing durable was learned, return [].`;
 
 /**
@@ -232,8 +238,29 @@ export function validate(raw, { knownFiles = null } = {}) {
     if (!FINDING_TYPES.includes(item.type)) continue;
     if (typeof item.claim !== 'string' || item.claim.trim().length < 8) continue;
 
-    const confidence = Number(item.confidence);
-    if (!Number.isFinite(confidence) || confidence <= 0 || confidence > 1) continue;
+    const evidence = typeof item.evidence === 'string' ? item.evidence.trim() : '';
+    const applicability = typeof item.applicability === 'string' ? item.applicability.trim() : '';
+    if (evidence.length < 8 || applicability.length < 8) continue;
+
+    const confidenceLabel = ['verified', 'probable', 'speculative'].includes(item.confidenceLabel)
+      ? item.confidenceLabel
+      : null;
+    if (!confidenceLabel) continue;
+    const defaults = { verified: 0.95, probable: 0.75, speculative: 0.45 };
+    const supplied = Number(item.confidence);
+    if (
+      item.confidence !== undefined
+      && (!Number.isFinite(supplied) || supplied <= 0 || supplied > 1)
+    ) continue;
+    const confidence = item.confidence === undefined
+      ? defaults[confidenceLabel]
+      : supplied;
+    const scope = ['project', 'organization', 'global'].includes(item.scope)
+      ? item.scope
+      : 'project';
+    const invalidators = Array.isArray(item.invalidators)
+      ? item.invalidators.filter((value) => typeof value === 'string' && value.trim()).slice(0, 10)
+      : [];
 
     let anchors = Array.isArray(item.anchors) ? item.anchors.filter((a) => typeof a === 'string' && a) : [];
     // A model asked for file paths will sometimes invent them. When the caller
@@ -241,7 +268,18 @@ export function validate(raw, { knownFiles = null } = {}) {
     if (knownFiles) anchors = anchors.filter((a) => knownFiles.has(a.split('#')[0]));
     if (!anchors.length) continue;
 
-    accepted.push({ type: item.type, claim: item.claim.trim(), confidence, anchors });
+    accepted.push({
+      type: item.type,
+      claim: item.claim.trim(),
+      evidence,
+      applicability,
+      confidence,
+      confidenceLabel,
+      scope,
+      invalidators,
+      anchors,
+      trigger: typeof item.trigger === 'string' ? item.trigger : undefined,
+    });
   }
   return accepted;
 }

--- a/integrations/cline/hooks/token-optimizer/lib/inject.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/inject.mjs
@@ -30,6 +30,7 @@ import { inHoldout, record, indexBudget } from './metrics.mjs';
 import { canonicalPath, resolvableCandidates } from './paths.mjs';
 import { annotatedSkeleton } from './skeleton.mjs';
 import { substitutionBudget } from './metrics.mjs';
+import { assessFindings } from './utility.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
@@ -150,7 +151,7 @@ export function forTouch(
   dir,
   graph,
   rawPath,
-  { budget = touchBudget(), sessionId, alreadyInjected = new Set() } = {}
+  { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
   // Canonical, so a touch finds findings anchored under any other spelling.
   const filePath = canonicalPath(rawPath);
@@ -169,16 +170,36 @@ export function forTouch(
   // variance drops out. A session-pinned arm would destroy that.
   const holdout = inHoldout(filePath);
   const served = serve(graph, candidates);
-  const { kept, spent } = fit(served, budget);
+  const assessed = assessFindings(dir, served, {
+    episodeId: episode.episodeId || sessionId,
+    relevanceFor: () => 1,
+    costFor: (finding) => estimate(render(finding)),
+  });
+  if (assessed.rejected.length) {
+    record(dir, {
+      kind: 'retrieval-decision', ...episode, sessionId,
+      surface: 'file', anchor: filePath,
+      rejected: assessed.rejected.map(({ key, reason }) => ({ key, reason })),
+    });
+    for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
+  }
+  const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
+  if (!kept.length) return null;
 
   record(dir, {
     kind: 'inject',
+    ...episode,
     // The surface whose saving CAN be measured: reads of this anchor afterwards.
     surface: 'file',
     anchor: filePath,
     holdout,
     tokens: holdout ? 0 : spent,
-    count: kept.length,
+    deliveredTokens: holdout ? 0 : spent,
+    shadowTokens: spent,
+    count: holdout ? 0 : kept.length,
+    candidateCount: kept.length,
+    findingIds: holdout ? [] : kept.map((finding) => finding.key),
+    shadowFindingIds: kept.map((finding) => finding.key),
     stale: kept.some((f) => f.stale),
     sessionId,
   });
@@ -297,7 +318,7 @@ export function forCommand(
   dir,
   graph,
   command,
-  { budget = touchBudget(), sessionId, alreadyInjected = new Set() } = {}
+  { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
   if (!command) return null;
 
@@ -335,7 +356,20 @@ export function forCommand(
   const considered = candidates.slice(0, MAX_COMMAND_CANDIDATES);
 
   const served = serve(graph, considered);
-  const { kept, spent } = fit(served, budget);
+  const assessed = assessFindings(dir, served, {
+    episodeId: episode.episodeId || sessionId,
+    relevanceFor: (finding) => explicit(finding) ? 1 : 0.6,
+    costFor: (finding) => estimate(render(finding)),
+  });
+  if (assessed.rejected.length) {
+    record(dir, {
+      kind: 'retrieval-decision', ...episode, sessionId,
+      surface: 'command', anchor: String(command).slice(0, 120),
+      rejected: assessed.rejected.map(({ key: findingKey, reason }) => ({ key: findingKey, reason })),
+    });
+    for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
+  }
+  const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
   if (!kept.length) return null;
 
   // THE COMMAND PATH TAKES PART IN THE HOLDOUT TOO.
@@ -353,6 +387,7 @@ export function forCommand(
 
   record(dir, {
     kind: 'inject',
+    ...episode,
     trigger: 'command',
     // The surface the report needs to keep these OUT of the file-read balance:
     // a command has no anchor that read events can be joined to.
@@ -360,7 +395,12 @@ export function forCommand(
     anchor: String(command).slice(0, 120),
     holdout,
     tokens: holdout ? 0 : spent,
+    deliveredTokens: holdout ? 0 : spent,
+    shadowTokens: spent,
     count: holdout ? 0 : kept.length,
+    candidateCount: kept.length,
+    findingIds: holdout ? [] : kept.map((finding) => finding.key),
+    shadowFindingIds: kept.map((finding) => finding.key),
     stale: kept.some((f) => f.stale),
     sessionId,
   });
@@ -509,7 +549,7 @@ export function forRepeatedAct(
   projectDir,
   command,
   crossedClasses,
-  { sessionId = null, projectRoot = null } = {}
+  { sessionId = null, projectRoot = null, episode = {} } = {}
 ) {
   if (!crossedClasses || !crossedClasses.size) return null;
 
@@ -527,14 +567,33 @@ export function forRepeatedAct(
       if (![...crossedClasses].some((c) => claimClasses.has(c))) continue;
 
       const cls = [...crossedClasses].find((c) => claimClasses.has(c));
+      const assessed = assessFindings(projectDir, [node], {
+        episodeId: episode.episodeId || sessionId,
+        relevanceFor: () => 1,
+        costFor: (finding) => estimate(render(finding)),
+      });
+      if (!assessed.eligible.length) {
+        record(projectDir, {
+          kind: 'retrieval-decision', ...episode, sessionId,
+          surface: 'shared', anchor: String(command).slice(0, 120),
+          rejected: assessed.rejected.map(({ key, reason }) => ({ key, reason })),
+        });
+        continue;
+      }
       record(projectDir, {
         kind: 'inject',
+        ...episode,
         trigger: 'repeat',
         surface: 'shared',
         anchor: String(command).slice(0, 120),
         holdout: false,
         tokens: estimate(node.claim),
+        deliveredTokens: estimate(node.claim),
+        shadowTokens: estimate(node.claim),
         count: 1,
+        candidateCount: 1,
+        findingIds: [node.key],
+        shadowFindingIds: [node.key],
         stale: false,
         sessionId,
       });
@@ -585,7 +644,10 @@ function appliesCrossProject(finding, command) {
 export function forSharedCommand(
   projectDir,
   command,
-  { budget = sharedBudget(), sessionId = null, alreadyInjected = new Set(), projectRoot = null } = {}
+  {
+    budget = sharedBudget(), sessionId = null, alreadyInjected = new Set(),
+    projectRoot = null, episode = {},
+  } = {}
 ) {
   if (!command) return null;
 
@@ -622,7 +684,21 @@ export function forSharedCommand(
     // No serve() here: these types are not content-dependent, so there is no
     // anchor to re-read and nothing to diff. serve() would spend a file read per
     // finding to answer a question that does not apply to them.
-    const { kept, spent } = fit(candidates.slice(0, MAX_SHARED), budget);
+    const considered = candidates.slice(0, MAX_SHARED);
+    const assessed = assessFindings(projectDir, considered, {
+      episodeId: episode.episodeId || sessionId,
+      relevanceFor: (finding) => explicit(finding) ? 0.8 : 0.5,
+      costFor: (finding) => estimate(render(finding)),
+    });
+    if (assessed.rejected.length) {
+      record(projectDir, {
+        kind: 'retrieval-decision', ...episode, sessionId,
+        surface: 'shared', anchor: String(command).slice(0, 120),
+        rejected: assessed.rejected.map(({ key, reason }) => ({ key, reason })),
+      });
+      for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
+    }
+    const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
     if (!kept.length) return null;
 
     // THE SAME ARM AS THE LOCAL PATH, KEYED THE SAME WAY.
@@ -644,6 +720,7 @@ export function forSharedCommand(
 
     record(projectDir, {
       kind: 'inject',
+      ...episode,
       trigger: 'command',
       // ITS OWN SURFACE. The balance sheet joins `file` injections to later read
       // events; a shared lesson has no anchor in this project to join to, and
@@ -653,7 +730,12 @@ export function forSharedCommand(
       anchor: String(command).slice(0, 120),
       holdout,
       tokens: holdout ? 0 : spent,
+      deliveredTokens: holdout ? 0 : spent,
+      shadowTokens: spent,
       count: holdout ? 0 : kept.length,
+      candidateCount: kept.length,
+      findingIds: holdout ? [] : kept.map((finding) => finding.key),
+      shadowFindingIds: kept.map((finding) => finding.key),
       stale: false,
       sessionId,
     });

--- a/integrations/cline/hooks/token-optimizer/lib/inject.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/inject.mjs
@@ -571,6 +571,10 @@ export function forRepeatedAct(
         episodeId: episode.episodeId || sessionId,
         relevanceFor: () => 1,
         costFor: (finding) => estimate(render(finding)),
+        // This surface exists specifically to re-surface a lesson once the
+        // session crosses the repeat threshold. Ordinary retrieval remains
+        // cooldown-protected; harm quarantine and utility gating still apply.
+        bypassCooldown: true,
       });
       if (!assessed.eligible.length) {
         record(projectDir, {

--- a/integrations/cline/hooks/token-optimizer/lib/metrics.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/metrics.mjs
@@ -1022,6 +1022,7 @@ function armMetrics(runs) {
     runs: runs.length,
     correctness: proportionInterval(correct, runs.length),
     uncachedInputTokens: interval('uncachedInputTokens'),
+    cacheCreationInputTokens: interval('cacheCreationInputTokens'),
     cachedInputTokens: interval('cachedInputTokens'),
     outputTokens: interval('outputTokens'),
     totalTokens: interval('totalTokens'),
@@ -1034,31 +1035,37 @@ function armMetrics(runs) {
   };
 }
 
-function pairedEffects(runs, treatmentArm) {
+function pairedEffects(runs, controlArm, treatmentArm, contrastType = 'incremental') {
   const pairs = new Map();
   for (const run of runs) {
-    if (!run.pairId || !['baseline', treatmentArm].includes(run.arm)) continue;
+    if (!run.pairId || ![controlArm, treatmentArm].includes(run.arm)) continue;
     if (!pairs.has(run.pairId)) pairs.set(run.pairId, {});
     pairs.get(run.pairId)[run.arm] = run;
   }
-  const complete = [...pairs.values()].filter((pair) => pair.baseline && pair[treatmentArm]);
+  const complete = [...pairs.values()].filter((pair) => pair[controlArm] && pair[treatmentArm]);
   const delta = (field, lowerIsBetter = true) => bootstrapMeanInterval(
     complete
       .map((pair) => {
-        const baseline = numeric(pair.baseline[field]);
+        const baseline = numeric(pair[controlArm][field]);
         const treatment = numeric(pair[treatmentArm][field]);
         if (baseline === null || treatment === null) return null;
         return lowerIsBetter ? baseline - treatment : treatment - baseline;
       })
       .filter((value) => value !== null),
-    { seed: `${treatmentArm}:${field}` }
+    { seed: `${controlArm}:${treatmentArm}:${field}` }
   );
   return {
     arm: treatmentArm,
+    controlArm,
+    comparison: `${treatmentArm} vs ${controlArm}`,
+    contrastType,
     pairs: complete.length,
     // Positive values always mean the treatment improved the metric.
     totalTokensSaved: delta('totalTokens'),
     uncachedInputTokensSaved: delta('uncachedInputTokens'),
+    cacheCreationInputTokensSaved: delta('cacheCreationInputTokens'),
+    cachedInputTokensSaved: delta('cachedInputTokens'),
+    outputTokensSaved: delta('outputTokens'),
     toolCallsAvoided: delta('toolCalls'),
     latencyMsSaved: delta('latencyMs'),
     costUsdSaved: delta('costUsd'),
@@ -1124,8 +1131,13 @@ export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
         armMetrics(cohortRuns.filter((run) => run.arm === arm)),
       ])
     );
-    const effects = ['optimizer', 'retrieval', 'full'].map((arm) => pairedEffects(cohortRuns, arm));
-    const enough = effects.some((effect) => effect.pairs >= minimumPairs);
+    const effects = [
+      pairedEffects(cohortRuns, 'baseline', 'optimizer'),
+      pairedEffects(cohortRuns, 'optimizer', 'retrieval'),
+      pairedEffects(cohortRuns, 'retrieval', 'full'),
+      pairedEffects(cohortRuns, 'baseline', 'full', 'total-system'),
+    ];
+    const enough = effects.every((effect) => effect.pairs >= minimumPairs);
     return {
       key,
       client: cohortRuns[0]?.client || 'unknown',
@@ -1165,7 +1177,8 @@ export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
     episodes: traced,
     methodology: {
       intervals: 'deterministic percentile bootstrap (95%); Wilson interval for correctness',
-      causalRule: 'only matched eval-run pairs compare an arm with baseline',
+      causalRule:
+        'matched pairs estimate optimizer vs baseline, retrieval vs optimizer, full vs retrieval, and full vs baseline',
       minimumPairs,
       deterministicChecksAreCausalProof: false,
     },

--- a/integrations/cline/hooks/token-optimizer/lib/metrics.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/metrics.mjs
@@ -61,6 +61,7 @@ const metricsPath = (dir) => join(dir, 'metrics.jsonl');
  * on it drops BOTH arms proportionally instead of starving the rare one.
  */
 const balancePath = (dir) => join(dir, 'balance.jsonl');
+const evidencePath = (dir) => join(dir, 'evidence.jsonl');
 
 /** Kinds the net balance is computed from, and which therefore must survive. */
 /**
@@ -83,6 +84,24 @@ export const BALANCE_KINDS = new Set([
   // aged out before it was written and the backstop was structurally unable to fire, reporting
   // "only N/10 refreshes observed" for the life of the project.
   'keepwarm',
+]);
+
+/**
+ * Causal records have their own bounded log.  Tool outcomes are much rarer
+ * than read/capture telemetry but more frequent than balance records; mixing
+ * them into either window would eventually evict the evidence needed to join
+ * an injection to its result.
+ */
+export const EVIDENCE_KINDS = new Set([
+  'inject',
+  'harvest',
+  'tool-outcome',
+  'episode-outcome',
+  'eval-run',
+  'finding-feedback',
+  'retrieval-decision',
+  'mcp-client',
+  'mcp-tool',
 ]);
 
 /**
@@ -198,15 +217,30 @@ export function record(dir, event) {
     // single millisecond collapsed to ONE, so a graph with ample data reported
     // 'insufficient data (2 treated, 1 holdout)'. Real events were being
     // discarded by the deduplicator, silently.
-    const line =
-      JSON.stringify({ id: nextId(), ...event, at: event.at ?? Date.now() }) + '\n';
+    const id = event.id || nextId();
+    const complete = {
+      schemaVersion: event.schemaVersion || 2,
+      id,
+      ...event,
+      // An injection id is first-class rather than an inference from the log
+      // record id.  Exporters may rewrite record ids while preserving causal
+      // identity, and downstream tool outcomes refer to this value explicitly.
+      ...(event.kind === 'inject'
+        ? { injectionId: event.injectionId || id }
+        : {}),
+      at: event.at ?? Date.now(),
+    };
+    const line = JSON.stringify(complete) + '\n';
     appendFileSync(metricsPath(dir), line);
     // Balance-critical records go to their own log as well, so the windows on
     // the firehose can never starve the measurement. Written SECOND: a torn
     // write here costs a duplicate the reader dedupes, not a lost event.
     if (BALANCE_KINDS.has(event.kind)) appendFileSync(balancePath(dir), line);
+    if (EVIDENCE_KINDS.has(event.kind)) appendFileSync(evidencePath(dir), line);
+    return complete;
   } catch {
     // Metrics must never break a tool call.
+    return null;
   }
 }
 
@@ -402,6 +436,92 @@ export function readBalance(dir) {
     out.push(e);
   }
   return out;
+}
+
+/** Every causal evidence record inside the byte cap, deduplicated by id. */
+export function readEvidence(dir) {
+  const path = evidencePath(dir);
+  if (!existsSync(path)) return [];
+
+  let text = '';
+  try {
+    const { size } = statSync(path);
+    if (size <= MAX_BYTES) {
+      text = readFileSync(path, 'utf8');
+    } else {
+      const fd = openSync(path, 'r');
+      try {
+        const buffer = Buffer.allocUnsafe(MAX_BYTES);
+        const read = readSync(fd, buffer, 0, MAX_BYTES, size - MAX_BYTES);
+        text = buffer.subarray(0, read).toString('utf8');
+      } finally {
+        closeSync(fd);
+      }
+      text = text.slice(text.indexOf('\n') + 1);
+    }
+  } catch {
+    return [];
+  }
+
+  const seen = new Set();
+  const out = [];
+  for (const line of text.split('\n')) {
+    if (!line) continue;
+    try {
+      const event = JSON.parse(line);
+      if (!EVIDENCE_KINDS.has(event.kind)) continue;
+      const id = event.id || JSON.stringify(event);
+      if (seen.has(id)) continue;
+      seen.add(id);
+      out.push(event);
+    } catch {
+      // A concurrently appended final line may be torn.  It costs one record,
+      // never the user's tool call or the rest of the evidence report.
+    }
+  }
+  return out;
+}
+
+/**
+ * Joins a post-tool result to the most recent matching injection.  The exact
+ * tool-call id wins; clients that omit it fall back to episode + surface +
+ * anchor, in timestamp order, and the report states the weaker join method.
+ */
+export function recordToolOutcome(dir, outcome) {
+  const evidence = readEvidence(dir);
+  const anchor = String(outcome.anchor || '').slice(0, 120);
+  const candidates = evidence
+    .filter((event) => event.kind === 'inject' && event.episodeId === outcome.episodeId)
+    .filter((event) => {
+      if (outcome.toolCallId && event.toolCallId)
+        return String(event.toolCallId) === String(outcome.toolCallId);
+      return event.surface === outcome.surface && String(event.anchor || '').slice(0, 120) === anchor;
+    })
+    .sort((a, b) => (b.at || 0) - (a.at || 0));
+  const injection = candidates[0] || null;
+  const joinMethod = injection
+    ? (outcome.toolCallId && injection.toolCallId ? 'tool-call-id' : 'episode-anchor')
+    : 'none';
+
+  return record(dir, {
+    kind: 'tool-outcome',
+    ...outcome,
+    anchor,
+    injectionId: injection?.injectionId || null,
+    findingIds: injection?.findingIds || [],
+    joinMethod,
+  });
+}
+
+export function recordEpisodeOutcome(dir, outcome) {
+  return record(dir, { kind: 'episode-outcome', ...outcome });
+}
+
+export function recordFindingFeedback(dir, feedback) {
+  const rating = ['helpful', 'neutral', 'harmful'].includes(feedback?.rating)
+    ? feedback.rating
+    : 'neutral';
+  return record(dir, { kind: 'finding-feedback', ...feedback, rating });
 }
 
 /**
@@ -813,4 +933,241 @@ export function indexBudget(dir, { floor = 150, base = 300, ceiling = 1200 } = {
   // 0% hit rate falls to the floor; ~50% and above reaches the ceiling.
   const scaled = Math.round(floor + (ceiling - floor) * Math.min(1, hitRate * 2));
   return Math.max(floor, Math.min(ceiling, scaled));
+}
+
+/* ----------------------------------------------------------------------
+ * Episode-level causal evidence
+ * ------------------------------------------------------------------- */
+
+const numeric = (value) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const average = (values) => {
+  const finite = values.map(numeric).filter((value) => value !== null);
+  return finite.length
+    ? finite.reduce((sum, value) => sum + value, 0) / finite.length
+    : null;
+};
+
+/** Deterministic PRNG so regenerating a report does not move its interval. */
+function seededRandom(seedText) {
+  let seed = 2166136261;
+  for (const char of String(seedText)) {
+    seed ^= char.charCodeAt(0);
+    seed = Math.imul(seed, 16777619);
+  }
+  return () => {
+    seed += 0x6d2b79f5;
+    let value = seed;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Percentile bootstrap interval for a mean, paired delta, or other scalar. */
+export function bootstrapMeanInterval(values, { samples = 1000, seed = 'token-optimizer' } = {}) {
+  const finite = values.map(numeric).filter((value) => value !== null);
+  if (!finite.length) return { mean: null, low: null, high: null, n: 0 };
+  if (finite.length === 1) {
+    return { mean: finite[0], low: finite[0], high: finite[0], n: 1 };
+  }
+
+  const random = seededRandom(`${seed}:${finite.join(',')}`);
+  const means = [];
+  for (let sample = 0; sample < samples; sample++) {
+    let total = 0;
+    for (let index = 0; index < finite.length; index++) {
+      total += finite[Math.floor(random() * finite.length)];
+    }
+    means.push(total / finite.length);
+  }
+  means.sort((a, b) => a - b);
+  return {
+    mean: average(finite),
+    low: means[Math.floor(means.length * 0.025)],
+    high: means[Math.min(means.length - 1, Math.floor(means.length * 0.975))],
+    n: finite.length,
+  };
+}
+
+/** Wilson interval keeps small correctness samples honest and inside 0..1. */
+export function proportionInterval(successes, total, z = 1.96) {
+  if (!total) return { rate: null, low: null, high: null, n: 0 };
+  const rate = successes / total;
+  const denominator = 1 + (z * z) / total;
+  const centre = (rate + (z * z) / (2 * total)) / denominator;
+  const radius =
+    (z / denominator) * Math.sqrt((rate * (1 - rate)) / total + (z * z) / (4 * total * total));
+  return { rate, low: Math.max(0, centre - radius), high: Math.min(1, centre + radius), n: total };
+}
+
+const cohortKey = (run) => [
+  run.client || 'unknown',
+  run.clientVersion || 'unknown',
+  run.model || 'unknown',
+  run.modelVersion || 'unknown',
+  run.taskId || 'unknown',
+].join('|');
+
+function armMetrics(runs) {
+  const correct = runs.filter((run) => run.correct === true).length;
+  const interval = (field) => bootstrapMeanInterval(
+    runs.map((run) => run[field]).filter((value) => numeric(value) !== null),
+    { seed: field }
+  );
+  return {
+    runs: runs.length,
+    correctness: proportionInterval(correct, runs.length),
+    uncachedInputTokens: interval('uncachedInputTokens'),
+    cachedInputTokens: interval('cachedInputTokens'),
+    outputTokens: interval('outputTokens'),
+    totalTokens: interval('totalTokens'),
+    toolCalls: interval('toolCalls'),
+    failedToolCalls: interval('failedToolCalls'),
+    latencyMs: interval('latencyMs'),
+    costUsd: interval('costUsd'),
+    injectedTokens: interval('injectedTokens'),
+    harmfulFindings: runs.reduce((sum, run) => sum + (numeric(run.harmfulFindings) || 0), 0),
+  };
+}
+
+function pairedEffects(runs, treatmentArm) {
+  const pairs = new Map();
+  for (const run of runs) {
+    if (!run.pairId || !['baseline', treatmentArm].includes(run.arm)) continue;
+    if (!pairs.has(run.pairId)) pairs.set(run.pairId, {});
+    pairs.get(run.pairId)[run.arm] = run;
+  }
+  const complete = [...pairs.values()].filter((pair) => pair.baseline && pair[treatmentArm]);
+  const delta = (field, lowerIsBetter = true) => bootstrapMeanInterval(
+    complete
+      .map((pair) => {
+        const baseline = numeric(pair.baseline[field]);
+        const treatment = numeric(pair[treatmentArm][field]);
+        if (baseline === null || treatment === null) return null;
+        return lowerIsBetter ? baseline - treatment : treatment - baseline;
+      })
+      .filter((value) => value !== null),
+    { seed: `${treatmentArm}:${field}` }
+  );
+  return {
+    arm: treatmentArm,
+    pairs: complete.length,
+    // Positive values always mean the treatment improved the metric.
+    totalTokensSaved: delta('totalTokens'),
+    uncachedInputTokensSaved: delta('uncachedInputTokens'),
+    toolCallsAvoided: delta('toolCalls'),
+    latencyMsSaved: delta('latencyMs'),
+    costUsdSaved: delta('costUsd'),
+    correctnessDelta: delta('correct', false),
+  };
+}
+
+function matchesFilters(event, filters) {
+  for (const field of ['client', 'clientVersion', 'model', 'modelVersion', 'taskId', 'arm']) {
+    if (filters[field] && String(event[field] || '') !== String(filters[field])) return false;
+  }
+  return true;
+}
+
+/**
+ * The dashboard-facing evidence console.  Deterministic fixture verification,
+ * live hook traces, and randomized model evals remain visibly distinct: only
+ * `eval-run` records with paired arms can produce a causal effect interval.
+ */
+export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
+  const evidence = readEvidence(dir).filter((event) => matchesFilters(event, filters));
+  const runs = evidence.filter((event) => event.kind === 'eval-run');
+  const injections = evidence.filter((event) => event.kind === 'inject');
+  const outcomes = evidence.filter((event) => event.kind === 'tool-outcome');
+  const feedback = evidence.filter((event) => event.kind === 'finding-feedback');
+
+  const byInjection = new Map(
+    outcomes.filter((event) => event.injectionId).map((event) => [event.injectionId, event])
+  );
+  const traced = injections
+    .slice()
+    .sort((a, b) => (b.at || 0) - (a.at || 0))
+    .slice(0, Math.max(1, Math.min(500, episodeLimit)))
+    .map((injection) => ({
+      injectionId: injection.injectionId,
+      episodeId: injection.episodeId || injection.sessionId || null,
+      at: injection.at,
+      arm: injection.arm || (injection.holdout ? 'holdout' : 'treated'),
+      client: injection.client || 'unknown',
+      clientVersion: injection.clientVersion || null,
+      model: injection.model || null,
+      taskId: injection.taskId || null,
+      surface: injection.surface || injection.trigger || 'file',
+      anchor: injection.anchor,
+      findingIds: injection.findingIds || [],
+      deliveredTokens: injection.deliveredTokens ?? injection.tokens ?? 0,
+      shadowTokens: injection.shadowTokens ?? injection.tokens ?? 0,
+      outcome: byInjection.get(injection.injectionId) || null,
+    }));
+
+  const grouped = new Map();
+  for (const run of runs) {
+    const key = cohortKey(run);
+    if (!grouped.has(key)) grouped.set(key, []);
+    grouped.get(key).push(run);
+  }
+
+  const minimumPairs = Math.max(2, Number(process.env.TOKEN_OPTIMIZER_EVAL_MIN_PAIRS) || 5);
+  const cohorts = [...grouped.entries()].map(([key, cohortRuns]) => {
+    const arms = Object.fromEntries(
+      ['baseline', 'optimizer', 'retrieval', 'full'].map((arm) => [
+        arm,
+        armMetrics(cohortRuns.filter((run) => run.arm === arm)),
+      ])
+    );
+    const effects = ['optimizer', 'retrieval', 'full'].map((arm) => pairedEffects(cohortRuns, arm));
+    const enough = effects.some((effect) => effect.pairs >= minimumPairs);
+    return {
+      key,
+      client: cohortRuns[0]?.client || 'unknown',
+      clientVersion: cohortRuns[0]?.clientVersion || null,
+      model: cohortRuns[0]?.model || null,
+      modelVersion: cohortRuns[0]?.modelVersion || null,
+      taskId: cohortRuns[0]?.taskId || null,
+      arms,
+      effects,
+      evidenceStatus: enough
+        ? 'causal estimate available'
+        : `insufficient paired runs (need ${minimumPairs})`,
+    };
+  });
+
+  const joined = injections.filter((injection) =>
+    byInjection.has(injection.injectionId)
+  ).length;
+  const harmful = feedback.filter((event) => event.rating === 'harmful').length;
+  return {
+    schemaVersion: 2,
+    generatedAt: new Date().toISOString(),
+    filters,
+    summary: {
+      liveInjections: injections.length,
+      joinedOutcomes: joined,
+      causalJoinCoverage: injections.length ? joined / injections.length : null,
+      evalRuns: runs.length,
+      cohorts: cohorts.length,
+      harmfulFeedback: harmful,
+      harmRate: feedback.length ? harmful / feedback.length : null,
+      evidenceStatus: cohorts.some((cohort) => cohort.evidenceStatus === 'causal estimate available')
+        ? 'causal estimates available'
+        : 'insufficient randomized evidence',
+    },
+    cohorts,
+    episodes: traced,
+    methodology: {
+      intervals: 'deterministic percentile bootstrap (95%); Wilson interval for correctness',
+      causalRule: 'only matched eval-run pairs compare an arm with baseline',
+      minimumPairs,
+      deterministicChecksAreCausalProof: false,
+    },
+  };
 }

--- a/integrations/cline/hooks/token-optimizer/lib/recording.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/recording.mjs
@@ -159,6 +159,9 @@ export function semanticHarvestPrompt({
     + ' If this work produced a durable, non-obvious conclusion -- a failed approach and why, '
     + 'a decision and its rejected alternative, or a command that finally worked -- call '
     + 'wiki_write now with a real file anchor. Do not delegate this to another model or an '
-    + 'external harvester. If there is no such conclusion, do not invent one; finish normally.'
+    + 'external harvester. Include: the concrete evidence, when the finding applies, a calibrated '
+    + 'confidenceLabel (verified/probable/speculative), its project/organization/global scope, '
+    + 'and anything that would invalidate it. If there is no such conclusion, do not invent one; '
+    + 'finish normally.'
   );
 }

--- a/integrations/cline/hooks/token-optimizer/lib/utility.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/utility.mjs
@@ -1,0 +1,135 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/utility.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Evidence-aware retrieval economics.
+ *
+ * Relevance alone is not enough: a true finding can still cost more context
+ * than it saves.  Every candidate receives a conservative expected-benefit
+ * estimate, its delivery cost and risk are subtracted, and harmful findings
+ * are quarantined from automatic delivery while remaining visible for audit.
+ */
+
+import { readEvidence } from './metrics.mjs';
+
+const DAY = 86_400_000;
+const ORIGIN_WEIGHT = { human: 1.2, agent: 1.08, harvested: 1 };
+
+const envNumber = (name, fallback) => {
+  const value = Number(process.env[name]);
+  return Number.isFinite(value) && value >= 0 ? value : fallback;
+};
+
+export const retrievalPolicy = () => ({
+  baseBenefitTokens: envNumber('TOKEN_OPTIMIZER_EXPECTED_BENEFIT_TOKENS', 400),
+  minimumNetUtility: envNumber('TOKEN_OPTIMIZER_MIN_EXPECTED_UTILITY', 20),
+  cooldownMs: envNumber('TOKEN_OPTIMIZER_INJECTION_COOLDOWN_MS', 60_000),
+  quarantineHarmCount: Math.max(1, envNumber('TOKEN_OPTIMIZER_QUARANTINE_HARM_COUNT', 2)),
+});
+
+function feedbackFor(events, key) {
+  return events.filter((event) =>
+    event.kind === 'finding-feedback'
+    && (event.findingId === key || (event.findingIds || []).includes(key))
+  );
+}
+
+function outcomesFor(events, key) {
+  return events.filter((event) =>
+    event.kind === 'tool-outcome' && (event.findingIds || []).includes(key)
+  );
+}
+
+function deliveredRecently(events, key, episodeId, now, cooldownMs) {
+  if (!episodeId || cooldownMs <= 0) return false;
+  return events.some((event) =>
+    event.kind === 'inject'
+    && event.episodeId === episodeId
+    && (event.findingIds || []).includes(key)
+    && !event.holdout
+    && now - (event.at || 0) < cooldownMs
+  );
+}
+
+/**
+ * Returns eligible candidates in utility order plus every rejection reason.
+ * `costFor` is supplied by inject.mjs so the gate prices the exact rendered
+ * text rather than a second approximation that could drift.
+ */
+export function assessFindings(
+  dir,
+  findings,
+  {
+    relevanceFor = () => 1,
+    costFor = () => 0,
+    episodeId = null,
+    now = Date.now(),
+    policy = retrievalPolicy(),
+  } = {}
+) {
+  const events = readEvidence(dir);
+  const eligible = [];
+  const rejected = [];
+
+  for (const finding of findings) {
+    const key = finding.key;
+    const feedback = feedbackFor(events, key);
+    const outcomes = outcomesFor(events, key);
+    const helpful = feedback.filter((event) => event.rating === 'helpful').length;
+    const neutral = feedback.filter((event) => event.rating === 'neutral').length;
+    const harmful = feedback.filter((event) => event.rating === 'harmful').length;
+    const successfulUses = outcomes.filter((event) => event.success === true).length;
+    const failedUses = outcomes.filter((event) => event.success === false).length;
+
+    if (harmful >= policy.quarantineHarmCount && harmful >= helpful + neutral) {
+      rejected.push({ key, reason: 'quarantined-harm', helpful, neutral, harmful });
+      continue;
+    }
+    if (deliveredRecently(events, key, episodeId, now, policy.cooldownMs)) {
+      rejected.push({ key, reason: 'cooldown' });
+      continue;
+    }
+
+    const confidence = Number.isFinite(finding.confidence) ? finding.confidence : 0.5;
+    const relevance = Math.max(0, Math.min(1, Number(relevanceFor(finding)) || 0));
+    const ageDays = Math.max(0, (now - (finding.at || now)) / DAY);
+    const recency = finding.pinned ? 1 : Math.pow(0.5, ageDays / 90);
+    const provenance = ORIGIN_WEIGHT[finding.origin] || 1;
+    // Outcome evidence moves the estimate gradually. Explicit harmful feedback
+    // is handled above; a failed command alone is not labelled harmful because
+    // the model may have ignored correct advice.
+    const observed = successfulUses + failedUses;
+    const successFactor = observed
+      ? 0.75 + 0.5 * (successfulUses / observed)
+      : 1;
+    const feedbackFactor = Math.max(0.25, 1 + helpful * 0.12 - harmful * 0.35);
+    const expectedBenefit =
+      policy.baseBenefitTokens * confidence * relevance * recency * provenance * successFactor * feedbackFactor;
+    const deliveryCost = Math.max(0, Number(costFor(finding)) || 0);
+    const riskPenalty =
+      (finding.stale ? 160 : 0)
+      + (finding.confidenceLabel === 'speculative' ? 100 : 0)
+      + harmful * 100;
+    const netUtility = expectedBenefit - deliveryCost - riskPenalty;
+
+    const assessed = {
+      finding,
+      expectedBenefit,
+      deliveryCost,
+      riskPenalty,
+      netUtility,
+      helpful,
+      neutral,
+      harmful,
+      successfulUses,
+      failedUses,
+    };
+    if (netUtility < policy.minimumNetUtility) {
+      rejected.push({ key, reason: 'negative-expected-value', ...assessed, finding: undefined });
+      continue;
+    }
+    eligible.push(assessed);
+  }
+
+  eligible.sort((a, b) => b.netUtility - a.netUtility);
+  return { eligible, rejected };
+}

--- a/integrations/cline/hooks/token-optimizer/lib/utility.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/utility.mjs
@@ -64,6 +64,7 @@ export function assessFindings(
     episodeId = null,
     now = Date.now(),
     policy = retrievalPolicy(),
+    bypassCooldown = false,
   } = {}
 ) {
   const events = readEvidence(dir);
@@ -84,7 +85,7 @@ export function assessFindings(
       rejected.push({ key, reason: 'quarantined-harm', helpful, neutral, harmful });
       continue;
     }
-    if (deliveredRecently(events, key, episodeId, now, policy.cooldownMs)) {
+    if (!bypassCooldown && deliveredRecently(events, key, episodeId, now, policy.cooldownMs)) {
       rejected.push({ key, reason: 'cooldown' });
       continue;
     }

--- a/integrations/cline/hooks/token-optimizer/lib/wire.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/wire.mjs
@@ -28,7 +28,7 @@ export const MARKER = 'token-optimizer';
 /** The events we wire, and which hook file serves each. */
 export const WIRING = [
   { event: 'SessionStart', file: 'session-start.mjs', matcher: null },
-  { event: 'PreToolUse', file: 'pretooluse-router.mjs', matcher: 'Read|Grep|Glob|Edit|MultiEdit|Write|Bash' },
+  { event: 'PreToolUse', file: 'pretooluse-router.mjs', matcher: 'Read|Grep|Glob|Edit|MultiEdit|Write|Bash|PowerShell' },
   { event: 'PreCompact', file: 'precompact-optimize.mjs', matcher: null },
 ];
 

--- a/integrations/cline/token-optimizer.md
+++ b/integrations/cline/token-optimizer.md
@@ -25,6 +25,10 @@ LIVE GRAPH — THE ACTIVE MODEL DOES THE SEMANTIC HARVEST:
   command that finally worked.
 - Anchor every claim to a real file path or path#symbol. Never invent a claim
   merely to populate the graph, and do not delegate harvesting to another model.
+- Include the concrete evidence, when it applies, confidenceLabel
+  (verified/probable/speculative), scope (project/organization/global), and any
+  condition that would invalidate it. Use project scope unless transfer is
+  genuinely justified.
 - Before finishing substantive work, reflect once and write any still-unrecorded
   conclusion while you hold the reasoning. This is what makes the lesson
   available across sessions and projects instead of losing it to compaction.

--- a/integrations/codex/hooks/lib/adapter.mjs
+++ b/integrations/codex/hooks/lib/adapter.mjs
@@ -31,7 +31,9 @@ import {
   readCostBytes,
   touchedFiles,
 } from './decide.mjs';
-import { recordRead, fingerprint } from './metrics.mjs';
+import {
+  recordRead, fingerprint, recordToolOutcome, recordEpisodeOutcome,
+} from './metrics.mjs';
 import {
   contentHash,
   harvest,
@@ -57,6 +59,8 @@ import { isFsSafePath } from './paths.mjs';
 import {
   isSubstantive, recordingNudge, semanticHarvestPrompt,
 } from './recording.mjs';
+import { nativeClientProfiles } from './capabilities.mjs';
+import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 
 /**
  * Per-client capability.
@@ -65,41 +69,7 @@ import {
  * it true where the client has no pre-execution veto would make the product
  * claim enforcement it cannot deliver.
  */
-export const CLIENTS = {
-  'claude-code': { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  codex: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  cline: {
-    canDeny: true,
-    contextStyle: 'cline',
-    denyStyle: 'cline',
-    stopDecision: 'block',
-  },
-  copilot: {
-    canDeny: true,
-    contextStyle: 'top-level',
-    denyStyle: 'top-level-permission',
-    stopDecision: 'block',
-  },
-  cursor: {
-    canDeny: true,
-    contextStyle: 'cursor',
-    denyStyle: 'cursor',
-    stopStyle: 'followup',
-    stopDecision: 'block',
-  },
-  // Gemini's BeforeTool and AfterAgent decisions are top-level. Treating it
-  // like Codex produced well-formed JSON that Gemini ignored.
-  gemini: { canDeny: true, denyStyle: 'top-level', stopDecision: 'deny' },
-  kilo: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  opencode: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  qwen: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  windsurf: {
-    canDeny: true,
-    contextStyle: 'silent',
-    denyStyle: 'exit-2',
-    stopDecision: 'block',
-  },
-};
+export const CLIENTS = nativeClientProfiles();
 
 /** Never synchronously hash an unbounded build artifact on a hook path. */
 const HARVEST_MAX_BYTES =
@@ -135,6 +105,24 @@ export function mutationSucceeded(clientName, raw) {
   // or are called by our in-process bridge only from its successful after hook.
   return new Set(['claude-code', 'qwen', 'opencode', 'kilo', 'windsurf'])
     .has(clientName);
+}
+
+/** Conservative success classification for any completed tool call. */
+export function toolSucceeded(raw) {
+  if (raw?.error || raw?.tool_response?.error || raw?.toolResponse?.error)
+    return false;
+  if (raw?.postToolUse?.success === false || raw?.success === false) return false;
+  const status =
+    raw?.tool_response?.status ?? raw?.toolResponse?.status ??
+    raw?.tool_result?.status ?? raw?.toolResult?.status;
+  if (status !== undefined) {
+    if (/^(?:error|failed|failure|cancelled|canceled|denied)$/i.test(String(status))) return false;
+    if (/^(?:ok|success|succeeded|complete|completed)$/i.test(String(status))) return true;
+  }
+  // A post-tool lifecycle event is evidence that the call completed, but not
+  // that its output proved the task.  `success` here is deliberately scoped to
+  // the tool call; task correctness comes only from an eval grader.
+  return true;
 }
 
 function contextOutput(client, eventName, additionalContext) {
@@ -253,8 +241,10 @@ refused.
 
 Worth recording: a decision and why the alternative was rejected, a failure and
 what actually caused it, a command that turned out to be the one that works.
-Not worth recording: what the code plainly says. Prefer the thing someone had to
-work out, because that exists nowhere in the source tree.${projectBriefing()}`;
+Not worth recording: what the code plainly says. Every wiki_write must include
+the concrete evidence, when it applies, a calibrated confidence label, its
+scope, and what would invalidate it. Prefer the thing someone had to work out,
+because that exists nowhere in the source tree.${projectBriefing()}`;
 }
 
 /**
@@ -315,7 +305,7 @@ function projectBriefing() {
  * metrics. It never called forTouch/forCommand, so four advertised clients
  * accumulated a graph that their active model could not receive.
  */
-function observeAndInject(payload, state) {
+function observeAndInject(payload, state, episode, features) {
   const touched = touchedFiles(payload);
   const dirFor = (path) => wikiDir(projectRootFor(path, payload.cwd));
 
@@ -344,45 +334,51 @@ function observeAndInject(payload, state) {
   state.injected = state.injected || [];
   const alreadyInjected = new Set(state.injected);
 
-  for (const { path } of touched) {
-    const dir = dirFor(path);
-    const note = forTouch(dir, load(dir), path, {
-      sessionId: payload.session_id,
-      alreadyInjected,
-    });
-    if (note) parts.push(note);
-  }
+  if (features.retrieval) {
+    for (const { path } of touched) {
+      const dir = dirFor(path);
+      const note = forTouch(dir, load(dir), path, {
+        sessionId: payload.session_id,
+        alreadyInjected,
+        episode,
+      });
+      if (note) parts.push(note);
+    }
 
-  const command = payload.tool_input?.command;
-  if (command) {
-    const root = commandProjectRoot(payload, payload.cwd);
-    const dir = wikiDir(root);
-    const local = forCommand(dir, load(dir), command, {
-      sessionId: payload.session_id,
-      alreadyInjected,
-    });
-    if (local) parts.push(local);
+    const command = payload.tool_input?.command;
+    if (command) {
+      const root = commandProjectRoot(payload, payload.cwd);
+      const dir = wikiDir(root);
+      const local = forCommand(dir, load(dir), command, {
+        sessionId: payload.session_id,
+        alreadyInjected,
+        episode,
+      });
+      if (local) parts.push(local);
 
-    const shared = forSharedCommand(dir, command, {
-      sessionId: payload.session_id,
-      alreadyInjected,
-      projectRoot: root,
-    });
-    if (shared) parts.push(shared);
+      const shared = forSharedCommand(dir, command, {
+        sessionId: payload.session_id,
+        alreadyInjected,
+        projectRoot: root,
+        episode,
+      });
+      if (shared) parts.push(shared);
 
-    const crossed = noteActClasses(state, command);
-    const repeated = forRepeatedAct(dir, command, crossed, {
-      sessionId: payload.session_id,
-      projectRoot: root,
-    });
-    if (repeated) parts.push(repeated);
+      const crossed = noteActClasses(state, command);
+      const repeated = forRepeatedAct(dir, command, crossed, {
+        sessionId: payload.session_id,
+        projectRoot: root,
+        episode,
+      });
+      if (repeated) parts.push(repeated);
+    }
   }
   state.injected = [...alreadyInjected];
 
   // Structural capture is evidence about what was touched, not a semantic
   // conclusion. It is therefore safe to automate for every client and leaves
   // the active model responsible for wiki_write at completion.
-  for (const { path, size } of touched) {
+  if (features.capture) for (const { path, size } of touched) {
     try {
       if (isArchived(path) || size > HARVEST_MAX_BYTES || !isFsSafePath(path))
         continue;
@@ -420,7 +416,10 @@ export async function run(clientName, event) {
 
   if (mode() === MODE_OFF) process.exit(0);
 
+  const features = featuresForArm();
+
   if (event === 'session-start') {
+    if (!features.routing && !features.retrieval && !features.harvest) process.exit(0);
     const output = contextOutput(client, eventName, policyText(client.canDeny));
     if (output) emit(output);
     process.exit(0);
@@ -437,10 +436,22 @@ export async function run(clientName, event) {
     const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? 'default';
     const agentScope = raw.transcript_path ?? raw.transcriptPath ?? null;
     const state = loadState(sessionId, agentScope);
+    const episode = episodeMeta({ client: clientName, raw });
+    try {
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+      recordEpisodeOutcome(dir, {
+        ...episode,
+        status: 'completed',
+        ...usageFrom(raw),
+      });
+    } catch {
+      // Evidence is best effort and must never stop a session from finishing.
+    }
     const alreadyHarvested =
       Number(state.edits || 0) > 0 &&
       Number(state.harvestedEdits || 0) >= Number(state.edits || 0);
-    const prompt = semanticHarvestPrompt({
+    const prompt = features.harvest ? semanticHarvestPrompt({
       edits: state.edits,
       files: state.editedFiles,
       model: raw.model,
@@ -449,7 +460,7 @@ export async function run(clientName, event) {
         raw.stopHookActive === true ||
         alreadyHarvested ||
         (clientName === 'cursor' && Number(raw.loop_count || 0) > 0),
-    });
+    }) : null;
     if (prompt) {
       state.harvestedEdits = Number(state.edits || 0);
       saveState(sessionId, state, agentScope);
@@ -466,6 +477,7 @@ export async function run(clientName, event) {
     process.exit(0);
   const payload = normalizePayload(normalizeClientPayload(clientName, event, raw));
   if (!payload.tool_name) process.exit(0);
+  const episode = episodeMeta({ client: clientName, raw, payload });
 
   // THE AGENT, not just the session -- the same scope the Claude Code router
   // applies. Subagents inherit the parent's session id, so keying state on the
@@ -506,17 +518,41 @@ export async function run(clientName, event) {
       const anchor = state.editedFiles[0]
         || join(payload.cwd || process.cwd(), '__recording__');
       const dir = wikiDir(projectRootFor(anchor, payload.cwd));
-      recordingContext = recordingNudge(dir, {
+      recordingContext = features.harvest ? recordingNudge(dir, {
         state,
         edits: state.edits,
         files: state.editedFiles,
-      });
+      }) : null;
       if (recordingContext) state.recordingNudged = true;
     } catch {
       // Recording pressure is an optimization and must never cost a tool call.
     }
   }
-  const verdict = decide(payload, state);
+  if (event === 'post-tool') {
+    try {
+      const command = payload.tool_input?.command;
+      const touched = touchedFiles(payload);
+      const anchor = command
+        ? String(command).slice(0, 120)
+        : touched[0]?.path || payload.tool_input?.file_path || '';
+      const root = command
+        ? commandProjectRoot(payload, payload.cwd)
+        : projectRootFor(anchor || join(payload.cwd || process.cwd(), '__tool__'), payload.cwd);
+      recordToolOutcome(wikiDir(root), {
+        ...episode,
+        surface: command ? 'command' : 'file',
+        anchor,
+        toolName: payload.tool_name,
+        success: toolSucceeded(raw),
+        durationMs: Number(raw.duration_ms ?? raw.durationMs ?? raw.elapsed_ms ?? raw.elapsedMs) || null,
+        ...usageFrom(raw),
+      });
+    } catch {
+      // Causal tracing is fail-open like every other hook optimization.
+    }
+  }
+
+  const verdict = features.routing ? decide(payload, state) : null;
   const repeat = verdict && event === 'pre-tool'
     ? alreadyDenied(state, verdict.key)
     : false;
@@ -571,7 +607,7 @@ export async function run(clientName, event) {
   remember(payload, state);
   let graphContext = null;
   try {
-    graphContext = observeAndInject(payload, state);
+    graphContext = observeAndInject(payload, state, episode, features);
   } catch {
     // Delivery is an optimization. Fail open.
   }

--- a/integrations/codex/hooks/lib/capabilities.mjs
+++ b/integrations/codex/hooks/lib/capabilities.mjs
@@ -1,0 +1,130 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/capabilities.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * The product's honest cross-client capability contract.
+ *
+ * A client is listed at the strongest surface its public lifecycle protocol can
+ * actually support.  This registry is consumed by the adapter, certification
+ * tooling, and evidence reports so a rules-only integration can never be
+ * presented as equivalent to a native stop-continuation integration.
+ */
+
+export const CAPABILITY_TIERS = Object.freeze({
+  CONTINUATION: 'lifecycle-continuation',
+  OBSERVATION: 'native-observation',
+  RULES: 'mcp-rules',
+});
+
+const native = (profile) => ({
+  structuralCapture: 'native',
+  findingDelivery: 'native',
+  routing: 'native-veto',
+  ...profile,
+});
+
+export const CLIENT_CAPABILITIES = Object.freeze({
+  'claude-code': native({
+    name: 'Claude Code', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-continuation', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  codex: native({
+    name: 'Codex', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-continuation', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  copilot: native({
+    name: 'GitHub Copilot CLI', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'agent-stop-continuation', canDeny: true,
+    contextStyle: 'top-level', denyStyle: 'top-level-permission', stopDecision: 'block',
+  }),
+  gemini: native({
+    name: 'Gemini CLI', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'after-agent-retry', canDeny: true,
+    denyStyle: 'top-level', stopDecision: 'deny',
+  }),
+  qwen: native({
+    name: 'Qwen Code', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-continuation', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  cursor: native({
+    name: 'Cursor', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-followup', canDeny: true,
+    contextStyle: 'cursor', denyStyle: 'cursor', stopStyle: 'followup', stopDecision: 'block',
+  }),
+  cline: native({
+    name: 'Cline', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    contextStyle: 'cline', denyStyle: 'cline', stopDecision: 'block',
+  }),
+  opencode: native({
+    name: 'OpenCode', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  kilo: native({
+    name: 'Kilo', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  windsurf: native({
+    name: 'Windsurf', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    contextStyle: 'silent', denyStyle: 'exit-2', stopDecision: 'block',
+  }),
+  roo: {
+    name: 'Roo Code', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  zed: {
+    name: 'Zed', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  amp: {
+    name: 'Amp', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  continue: {
+    name: 'Continue', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  crush: {
+    name: 'Crush', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  droid: {
+    name: 'Droid (Factory)', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+});
+
+export function capabilityFor(client) {
+  return CLIENT_CAPABILITIES[String(client || '').toLowerCase()] || null;
+}
+
+export function nativeClientProfiles() {
+  return Object.fromEntries(
+    Object.entries(CLIENT_CAPABILITIES)
+      .filter(([, profile]) => profile.structuralCapture === 'native')
+      .map(([key, profile]) => [key, { ...profile }])
+  );
+}
+
+export function capabilitySummary() {
+  return Object.entries(CLIENT_CAPABILITIES).map(([client, profile]) => ({
+    client,
+    name: profile.name,
+    tier: profile.tier,
+    routing: profile.routing,
+    structuralCapture: profile.structuralCapture,
+    findingDelivery: profile.findingDelivery,
+    semanticHarvest: profile.semanticHarvest,
+  }));
+}

--- a/integrations/codex/hooks/lib/decide.mjs
+++ b/integrations/codex/hooks/lib/decide.mjs
@@ -513,6 +513,8 @@ const TOOL_ALIASES = new Map(
     create_file: 'Write',
 
     bash: 'Bash',
+    powershell: 'Bash',
+    pwsh: 'Bash',
     shell: 'Bash',
     run_command: 'Bash',
     execute_command: 'Bash',

--- a/integrations/codex/hooks/lib/experiment.mjs
+++ b/integrations/codex/hooks/lib/experiment.mjs
@@ -1,0 +1,82 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/experiment.mjs. Regenerate with `npm run sync:hooks`.
+/** Explicit, reproducible feature arms and causal episode identity. */
+
+export const EXPERIMENT_ARMS = Object.freeze([
+  'baseline',
+  'optimizer',
+  'retrieval',
+  'full',
+]);
+
+const FEATURES = Object.freeze({
+  baseline: Object.freeze({ routing: false, retrieval: false, capture: false, harvest: false }),
+  optimizer: Object.freeze({ routing: true, retrieval: false, capture: false, harvest: false }),
+  retrieval: Object.freeze({ routing: true, retrieval: true, capture: true, harvest: false }),
+  full: Object.freeze({ routing: true, retrieval: true, capture: true, harvest: true }),
+});
+
+export function experimentArm(env = process.env) {
+  const requested = String(env.TOKEN_OPTIMIZER_EXPERIMENT_ARM || '').trim().toLowerCase();
+  return EXPERIMENT_ARMS.includes(requested) ? requested : 'full';
+}
+
+export function featuresForArm(arm = experimentArm()) {
+  return FEATURES[arm] || FEATURES.full;
+}
+
+const first = (...values) => values.find((value) => value !== undefined && value !== null && value !== '');
+
+/**
+ * Normalises identifiers exposed under different names by lifecycle clients.
+ * Environment overrides let the live evaluation harness pin a pair/task id
+ * without asking each CLI to support experiment-specific payload fields.
+ */
+export function episodeMeta({ client, raw = {}, payload = {}, env = process.env } = {}) {
+  const sessionId = String(first(
+    payload.session_id, raw.session_id, raw.sessionId, raw.conversation_id,
+    raw.conversationId, raw.taskId, raw.task_id, raw.trajectory_id, 'default'
+  ));
+  const episodeId = String(first(
+    env.TOKEN_OPTIMIZER_EPISODE_ID, raw.episode_id, raw.episodeId, sessionId
+  ));
+  const toolCallId = first(
+    raw.tool_use_id, raw.toolUseId, raw.tool_call_id, raw.toolCallId,
+    raw.call_id, raw.callId, raw.postToolUse?.toolUseId, raw.preToolUse?.toolUseId
+  );
+  const model = first(payload.model, raw.model?.slug, raw.model, raw.model_name, env.TOKEN_OPTIMIZER_MODEL);
+  const clientVersion = first(
+    raw.client_version, raw.clientVersion, raw.version, env.TOKEN_OPTIMIZER_CLIENT_VERSION
+  );
+  const modelVersion = first(raw.model_version, raw.modelVersion, env.TOKEN_OPTIMIZER_MODEL_VERSION);
+
+  return {
+    schemaVersion: 2,
+    episodeId,
+    sessionId,
+    turnId: first(raw.turn_id, raw.turnId, raw.message_id, raw.messageId) ?? null,
+    toolCallId: toolCallId == null ? null : String(toolCallId),
+    taskId: first(env.TOKEN_OPTIMIZER_TASK_ID, raw.task_id, raw.taskId) ?? null,
+    pairId: first(env.TOKEN_OPTIMIZER_PAIR_ID, raw.pair_id, raw.pairId) ?? null,
+    arm: experimentArm(env),
+    client: String(client || first(raw.client, raw.client_name, 'unknown')),
+    clientVersion: clientVersion == null ? null : String(clientVersion),
+    model: model == null ? null : String(model),
+    modelVersion: modelVersion == null ? null : String(modelVersion),
+  };
+}
+
+export function usageFrom(raw = {}) {
+  const usage = raw.usage || raw.token_usage || raw.tokenUsage || raw.metrics?.usage || {};
+  const number = (...values) => {
+    const value = first(...values);
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+  };
+  return {
+    uncachedInputTokens: number(usage.uncached_input_tokens, usage.uncachedInputTokens),
+    cachedInputTokens: number(usage.cached_input_tokens, usage.cachedInputTokens, usage.cache_read_input_tokens),
+    outputTokens: number(usage.output_tokens, usage.outputTokens),
+    totalTokens: number(usage.total_tokens, usage.totalTokens, raw.tokens_used, raw.tokensUsed),
+  };
+}

--- a/integrations/codex/hooks/lib/harvest-write.mjs
+++ b/integrations/codex/hooks/lib/harvest-write.mjs
@@ -96,8 +96,13 @@ function promoteToShared(finding, { projectRoot, sessionId, provenance, key }) {
           key: `shared-${key}`,
           claim: finding.claim,
           confidence: finding.confidence,
+          confidenceLabel: finding.confidenceLabel,
           type: finding.type,
           trigger: typeof finding.trigger === 'string' && finding.trigger ? finding.trigger : undefined,
+          applicability: finding.applicability,
+          evidence: finding.evidence,
+          invalidators: Array.isArray(finding.invalidators) ? finding.invalidators : [],
+          scope: finding.scope || 'global',
           origin: provenance,
           quote: typeof finding.quote === 'string' && finding.quote.trim() ? finding.quote : undefined,
           // WHERE IT WAS LEARNED, carried so the reader can discount it. A lesson
@@ -351,6 +356,26 @@ export function writeHarvested(
     // anything, so it is dropped rather than kept as unfalsifiable.
     if (!resolved.length) continue;
 
+    // Exact semantic duplicates collapse to the existing active record.  The
+    // normalisation intentionally ignores punctuation/formatting noise but not
+    // meaning-bearing words; near-duplicates that need judgement remain visible
+    // to curation rather than being silently merged by a fuzzy heuristic.
+    const fingerprint = claimFingerprint(finding.claim);
+    const currentGraph = load(dir);
+    const duplicate = [...currentGraph.nodes.values()].find((node) =>
+      node.kind === 'finding'
+      && !node.retired
+      && node.type === finding.type
+      && claimFingerprint(node.claim) === fingerprint
+      && resolved.every((target) => currentGraph.edges.some((edge) =>
+        edge.from === node.id && edge.edge === 'derived_from' && edge.to === target
+      ))
+    );
+    if (duplicate) {
+      written.push(duplicate.key);
+      continue;
+    }
+
     // Date.now() plus an index is not unique across CONCURRENT detached
     // workers: two Stop hooks finishing in the same millisecond produce the
     // same key, and putNode keeps the last write for an id -- so one session's
@@ -371,6 +396,7 @@ export function writeHarvested(
         key,
         claim: finding.claim,
         confidence: finding.confidence,
+        confidenceLabel: finding.confidenceLabel,
         type: finding.type,
         // WHEN this finding is relevant, not just what it is about. Anchors
         // answer "which file", which is the wrong question for a claim about
@@ -380,6 +406,16 @@ export function writeHarvested(
         trigger: typeof finding.trigger === 'string' && finding.trigger
           ? finding.trigger
           : undefined,
+        applicability: typeof finding.applicability === 'string'
+          ? finding.applicability
+          : undefined,
+        evidence: typeof finding.evidence === 'string'
+          ? finding.evidence
+          : undefined,
+        invalidators: Array.isArray(finding.invalidators)
+          ? finding.invalidators
+          : [],
+        scope: finding.scope || 'project',
         origin: provenance,
         // THE EVIDENCE TRAVELS WITH THE CLAIM. Without it a human-origin
         // finding asserts its own provenance and nothing can check it.
@@ -398,7 +434,11 @@ export function writeHarvested(
     // record of what happened here; the shared tier is a copy for the lessons
     // that are not about here. Skipped when the two are the same directory,
     // which is the suite's usual arrangement.
-    if (id && !isSharedDir(dir)) {
+    if (
+      id
+      && !isSharedDir(dir)
+      && (finding.scope === undefined || finding.scope === 'organization' || finding.scope === 'global')
+    ) {
       promoteToShared(finding, { projectRoot, sessionId, provenance, key });
     }
   }

--- a/integrations/codex/hooks/lib/harvest.mjs
+++ b/integrations/codex/hooks/lib/harvest.mjs
@@ -201,7 +201,11 @@ const PROMPT = `Extract durable findings from this coding session for a project 
 Return ONLY a JSON array. Each element:
 {"type": "finding|decision|failure|command|map",
  "claim": "one sentence, specific and checkable",
- "confidence": 0.0-1.0,
+ "evidence": "the concrete observation, command result, or rejected approach that proved it",
+ "applicability": "the condition under which a future model should use it",
+ "confidenceLabel": "verified|probable|speculative",
+ "scope": "project|organization|global",
+ "invalidators": ["what change would require this to be checked again"],
  "anchors": ["absolute/file/path" or "absolute/file/path#symbolName"]}
 
 RULES:
@@ -211,7 +215,9 @@ RULES:
 - Prefer "failure" and "decision" entries. What was TRIED AND REJECTED, and WHY,
   is the most valuable thing here because it exists nowhere in the source tree.
 - Do not restate what the code plainly says. Record what someone had to work out.
-- confidence reflects how well established the claim is, not how important.
+- verified requires direct evidence; probable means strong but incomplete evidence;
+  speculative is a hypothesis and must be labelled as such.
+- Use project scope unless the lesson is genuinely independent of this repository.
 - If nothing durable was learned, return [].`;
 
 /**
@@ -232,8 +238,29 @@ export function validate(raw, { knownFiles = null } = {}) {
     if (!FINDING_TYPES.includes(item.type)) continue;
     if (typeof item.claim !== 'string' || item.claim.trim().length < 8) continue;
 
-    const confidence = Number(item.confidence);
-    if (!Number.isFinite(confidence) || confidence <= 0 || confidence > 1) continue;
+    const evidence = typeof item.evidence === 'string' ? item.evidence.trim() : '';
+    const applicability = typeof item.applicability === 'string' ? item.applicability.trim() : '';
+    if (evidence.length < 8 || applicability.length < 8) continue;
+
+    const confidenceLabel = ['verified', 'probable', 'speculative'].includes(item.confidenceLabel)
+      ? item.confidenceLabel
+      : null;
+    if (!confidenceLabel) continue;
+    const defaults = { verified: 0.95, probable: 0.75, speculative: 0.45 };
+    const supplied = Number(item.confidence);
+    if (
+      item.confidence !== undefined
+      && (!Number.isFinite(supplied) || supplied <= 0 || supplied > 1)
+    ) continue;
+    const confidence = item.confidence === undefined
+      ? defaults[confidenceLabel]
+      : supplied;
+    const scope = ['project', 'organization', 'global'].includes(item.scope)
+      ? item.scope
+      : 'project';
+    const invalidators = Array.isArray(item.invalidators)
+      ? item.invalidators.filter((value) => typeof value === 'string' && value.trim()).slice(0, 10)
+      : [];
 
     let anchors = Array.isArray(item.anchors) ? item.anchors.filter((a) => typeof a === 'string' && a) : [];
     // A model asked for file paths will sometimes invent them. When the caller
@@ -241,7 +268,18 @@ export function validate(raw, { knownFiles = null } = {}) {
     if (knownFiles) anchors = anchors.filter((a) => knownFiles.has(a.split('#')[0]));
     if (!anchors.length) continue;
 
-    accepted.push({ type: item.type, claim: item.claim.trim(), confidence, anchors });
+    accepted.push({
+      type: item.type,
+      claim: item.claim.trim(),
+      evidence,
+      applicability,
+      confidence,
+      confidenceLabel,
+      scope,
+      invalidators,
+      anchors,
+      trigger: typeof item.trigger === 'string' ? item.trigger : undefined,
+    });
   }
   return accepted;
 }

--- a/integrations/codex/hooks/lib/inject.mjs
+++ b/integrations/codex/hooks/lib/inject.mjs
@@ -30,6 +30,7 @@ import { inHoldout, record, indexBudget } from './metrics.mjs';
 import { canonicalPath, resolvableCandidates } from './paths.mjs';
 import { annotatedSkeleton } from './skeleton.mjs';
 import { substitutionBudget } from './metrics.mjs';
+import { assessFindings } from './utility.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
@@ -150,7 +151,7 @@ export function forTouch(
   dir,
   graph,
   rawPath,
-  { budget = touchBudget(), sessionId, alreadyInjected = new Set() } = {}
+  { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
   // Canonical, so a touch finds findings anchored under any other spelling.
   const filePath = canonicalPath(rawPath);
@@ -169,16 +170,36 @@ export function forTouch(
   // variance drops out. A session-pinned arm would destroy that.
   const holdout = inHoldout(filePath);
   const served = serve(graph, candidates);
-  const { kept, spent } = fit(served, budget);
+  const assessed = assessFindings(dir, served, {
+    episodeId: episode.episodeId || sessionId,
+    relevanceFor: () => 1,
+    costFor: (finding) => estimate(render(finding)),
+  });
+  if (assessed.rejected.length) {
+    record(dir, {
+      kind: 'retrieval-decision', ...episode, sessionId,
+      surface: 'file', anchor: filePath,
+      rejected: assessed.rejected.map(({ key, reason }) => ({ key, reason })),
+    });
+    for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
+  }
+  const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
+  if (!kept.length) return null;
 
   record(dir, {
     kind: 'inject',
+    ...episode,
     // The surface whose saving CAN be measured: reads of this anchor afterwards.
     surface: 'file',
     anchor: filePath,
     holdout,
     tokens: holdout ? 0 : spent,
-    count: kept.length,
+    deliveredTokens: holdout ? 0 : spent,
+    shadowTokens: spent,
+    count: holdout ? 0 : kept.length,
+    candidateCount: kept.length,
+    findingIds: holdout ? [] : kept.map((finding) => finding.key),
+    shadowFindingIds: kept.map((finding) => finding.key),
     stale: kept.some((f) => f.stale),
     sessionId,
   });
@@ -297,7 +318,7 @@ export function forCommand(
   dir,
   graph,
   command,
-  { budget = touchBudget(), sessionId, alreadyInjected = new Set() } = {}
+  { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
   if (!command) return null;
 
@@ -335,7 +356,20 @@ export function forCommand(
   const considered = candidates.slice(0, MAX_COMMAND_CANDIDATES);
 
   const served = serve(graph, considered);
-  const { kept, spent } = fit(served, budget);
+  const assessed = assessFindings(dir, served, {
+    episodeId: episode.episodeId || sessionId,
+    relevanceFor: (finding) => explicit(finding) ? 1 : 0.6,
+    costFor: (finding) => estimate(render(finding)),
+  });
+  if (assessed.rejected.length) {
+    record(dir, {
+      kind: 'retrieval-decision', ...episode, sessionId,
+      surface: 'command', anchor: String(command).slice(0, 120),
+      rejected: assessed.rejected.map(({ key: findingKey, reason }) => ({ key: findingKey, reason })),
+    });
+    for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
+  }
+  const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
   if (!kept.length) return null;
 
   // THE COMMAND PATH TAKES PART IN THE HOLDOUT TOO.
@@ -353,6 +387,7 @@ export function forCommand(
 
   record(dir, {
     kind: 'inject',
+    ...episode,
     trigger: 'command',
     // The surface the report needs to keep these OUT of the file-read balance:
     // a command has no anchor that read events can be joined to.
@@ -360,7 +395,12 @@ export function forCommand(
     anchor: String(command).slice(0, 120),
     holdout,
     tokens: holdout ? 0 : spent,
+    deliveredTokens: holdout ? 0 : spent,
+    shadowTokens: spent,
     count: holdout ? 0 : kept.length,
+    candidateCount: kept.length,
+    findingIds: holdout ? [] : kept.map((finding) => finding.key),
+    shadowFindingIds: kept.map((finding) => finding.key),
     stale: kept.some((f) => f.stale),
     sessionId,
   });
@@ -509,7 +549,7 @@ export function forRepeatedAct(
   projectDir,
   command,
   crossedClasses,
-  { sessionId = null, projectRoot = null } = {}
+  { sessionId = null, projectRoot = null, episode = {} } = {}
 ) {
   if (!crossedClasses || !crossedClasses.size) return null;
 
@@ -527,14 +567,33 @@ export function forRepeatedAct(
       if (![...crossedClasses].some((c) => claimClasses.has(c))) continue;
 
       const cls = [...crossedClasses].find((c) => claimClasses.has(c));
+      const assessed = assessFindings(projectDir, [node], {
+        episodeId: episode.episodeId || sessionId,
+        relevanceFor: () => 1,
+        costFor: (finding) => estimate(render(finding)),
+      });
+      if (!assessed.eligible.length) {
+        record(projectDir, {
+          kind: 'retrieval-decision', ...episode, sessionId,
+          surface: 'shared', anchor: String(command).slice(0, 120),
+          rejected: assessed.rejected.map(({ key, reason }) => ({ key, reason })),
+        });
+        continue;
+      }
       record(projectDir, {
         kind: 'inject',
+        ...episode,
         trigger: 'repeat',
         surface: 'shared',
         anchor: String(command).slice(0, 120),
         holdout: false,
         tokens: estimate(node.claim),
+        deliveredTokens: estimate(node.claim),
+        shadowTokens: estimate(node.claim),
         count: 1,
+        candidateCount: 1,
+        findingIds: [node.key],
+        shadowFindingIds: [node.key],
         stale: false,
         sessionId,
       });
@@ -585,7 +644,10 @@ function appliesCrossProject(finding, command) {
 export function forSharedCommand(
   projectDir,
   command,
-  { budget = sharedBudget(), sessionId = null, alreadyInjected = new Set(), projectRoot = null } = {}
+  {
+    budget = sharedBudget(), sessionId = null, alreadyInjected = new Set(),
+    projectRoot = null, episode = {},
+  } = {}
 ) {
   if (!command) return null;
 
@@ -622,7 +684,21 @@ export function forSharedCommand(
     // No serve() here: these types are not content-dependent, so there is no
     // anchor to re-read and nothing to diff. serve() would spend a file read per
     // finding to answer a question that does not apply to them.
-    const { kept, spent } = fit(candidates.slice(0, MAX_SHARED), budget);
+    const considered = candidates.slice(0, MAX_SHARED);
+    const assessed = assessFindings(projectDir, considered, {
+      episodeId: episode.episodeId || sessionId,
+      relevanceFor: (finding) => explicit(finding) ? 0.8 : 0.5,
+      costFor: (finding) => estimate(render(finding)),
+    });
+    if (assessed.rejected.length) {
+      record(projectDir, {
+        kind: 'retrieval-decision', ...episode, sessionId,
+        surface: 'shared', anchor: String(command).slice(0, 120),
+        rejected: assessed.rejected.map(({ key, reason }) => ({ key, reason })),
+      });
+      for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
+    }
+    const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
     if (!kept.length) return null;
 
     // THE SAME ARM AS THE LOCAL PATH, KEYED THE SAME WAY.
@@ -644,6 +720,7 @@ export function forSharedCommand(
 
     record(projectDir, {
       kind: 'inject',
+      ...episode,
       trigger: 'command',
       // ITS OWN SURFACE. The balance sheet joins `file` injections to later read
       // events; a shared lesson has no anchor in this project to join to, and
@@ -653,7 +730,12 @@ export function forSharedCommand(
       anchor: String(command).slice(0, 120),
       holdout,
       tokens: holdout ? 0 : spent,
+      deliveredTokens: holdout ? 0 : spent,
+      shadowTokens: spent,
       count: holdout ? 0 : kept.length,
+      candidateCount: kept.length,
+      findingIds: holdout ? [] : kept.map((finding) => finding.key),
+      shadowFindingIds: kept.map((finding) => finding.key),
       stale: false,
       sessionId,
     });

--- a/integrations/codex/hooks/lib/inject.mjs
+++ b/integrations/codex/hooks/lib/inject.mjs
@@ -571,6 +571,10 @@ export function forRepeatedAct(
         episodeId: episode.episodeId || sessionId,
         relevanceFor: () => 1,
         costFor: (finding) => estimate(render(finding)),
+        // This surface exists specifically to re-surface a lesson once the
+        // session crosses the repeat threshold. Ordinary retrieval remains
+        // cooldown-protected; harm quarantine and utility gating still apply.
+        bypassCooldown: true,
       });
       if (!assessed.eligible.length) {
         record(projectDir, {

--- a/integrations/codex/hooks/lib/metrics.mjs
+++ b/integrations/codex/hooks/lib/metrics.mjs
@@ -1022,6 +1022,7 @@ function armMetrics(runs) {
     runs: runs.length,
     correctness: proportionInterval(correct, runs.length),
     uncachedInputTokens: interval('uncachedInputTokens'),
+    cacheCreationInputTokens: interval('cacheCreationInputTokens'),
     cachedInputTokens: interval('cachedInputTokens'),
     outputTokens: interval('outputTokens'),
     totalTokens: interval('totalTokens'),
@@ -1034,31 +1035,37 @@ function armMetrics(runs) {
   };
 }
 
-function pairedEffects(runs, treatmentArm) {
+function pairedEffects(runs, controlArm, treatmentArm, contrastType = 'incremental') {
   const pairs = new Map();
   for (const run of runs) {
-    if (!run.pairId || !['baseline', treatmentArm].includes(run.arm)) continue;
+    if (!run.pairId || ![controlArm, treatmentArm].includes(run.arm)) continue;
     if (!pairs.has(run.pairId)) pairs.set(run.pairId, {});
     pairs.get(run.pairId)[run.arm] = run;
   }
-  const complete = [...pairs.values()].filter((pair) => pair.baseline && pair[treatmentArm]);
+  const complete = [...pairs.values()].filter((pair) => pair[controlArm] && pair[treatmentArm]);
   const delta = (field, lowerIsBetter = true) => bootstrapMeanInterval(
     complete
       .map((pair) => {
-        const baseline = numeric(pair.baseline[field]);
+        const baseline = numeric(pair[controlArm][field]);
         const treatment = numeric(pair[treatmentArm][field]);
         if (baseline === null || treatment === null) return null;
         return lowerIsBetter ? baseline - treatment : treatment - baseline;
       })
       .filter((value) => value !== null),
-    { seed: `${treatmentArm}:${field}` }
+    { seed: `${controlArm}:${treatmentArm}:${field}` }
   );
   return {
     arm: treatmentArm,
+    controlArm,
+    comparison: `${treatmentArm} vs ${controlArm}`,
+    contrastType,
     pairs: complete.length,
     // Positive values always mean the treatment improved the metric.
     totalTokensSaved: delta('totalTokens'),
     uncachedInputTokensSaved: delta('uncachedInputTokens'),
+    cacheCreationInputTokensSaved: delta('cacheCreationInputTokens'),
+    cachedInputTokensSaved: delta('cachedInputTokens'),
+    outputTokensSaved: delta('outputTokens'),
     toolCallsAvoided: delta('toolCalls'),
     latencyMsSaved: delta('latencyMs'),
     costUsdSaved: delta('costUsd'),
@@ -1124,8 +1131,13 @@ export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
         armMetrics(cohortRuns.filter((run) => run.arm === arm)),
       ])
     );
-    const effects = ['optimizer', 'retrieval', 'full'].map((arm) => pairedEffects(cohortRuns, arm));
-    const enough = effects.some((effect) => effect.pairs >= minimumPairs);
+    const effects = [
+      pairedEffects(cohortRuns, 'baseline', 'optimizer'),
+      pairedEffects(cohortRuns, 'optimizer', 'retrieval'),
+      pairedEffects(cohortRuns, 'retrieval', 'full'),
+      pairedEffects(cohortRuns, 'baseline', 'full', 'total-system'),
+    ];
+    const enough = effects.every((effect) => effect.pairs >= minimumPairs);
     return {
       key,
       client: cohortRuns[0]?.client || 'unknown',
@@ -1165,7 +1177,8 @@ export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
     episodes: traced,
     methodology: {
       intervals: 'deterministic percentile bootstrap (95%); Wilson interval for correctness',
-      causalRule: 'only matched eval-run pairs compare an arm with baseline',
+      causalRule:
+        'matched pairs estimate optimizer vs baseline, retrieval vs optimizer, full vs retrieval, and full vs baseline',
       minimumPairs,
       deterministicChecksAreCausalProof: false,
     },

--- a/integrations/codex/hooks/lib/metrics.mjs
+++ b/integrations/codex/hooks/lib/metrics.mjs
@@ -61,6 +61,7 @@ const metricsPath = (dir) => join(dir, 'metrics.jsonl');
  * on it drops BOTH arms proportionally instead of starving the rare one.
  */
 const balancePath = (dir) => join(dir, 'balance.jsonl');
+const evidencePath = (dir) => join(dir, 'evidence.jsonl');
 
 /** Kinds the net balance is computed from, and which therefore must survive. */
 /**
@@ -83,6 +84,24 @@ export const BALANCE_KINDS = new Set([
   // aged out before it was written and the backstop was structurally unable to fire, reporting
   // "only N/10 refreshes observed" for the life of the project.
   'keepwarm',
+]);
+
+/**
+ * Causal records have their own bounded log.  Tool outcomes are much rarer
+ * than read/capture telemetry but more frequent than balance records; mixing
+ * them into either window would eventually evict the evidence needed to join
+ * an injection to its result.
+ */
+export const EVIDENCE_KINDS = new Set([
+  'inject',
+  'harvest',
+  'tool-outcome',
+  'episode-outcome',
+  'eval-run',
+  'finding-feedback',
+  'retrieval-decision',
+  'mcp-client',
+  'mcp-tool',
 ]);
 
 /**
@@ -198,15 +217,30 @@ export function record(dir, event) {
     // single millisecond collapsed to ONE, so a graph with ample data reported
     // 'insufficient data (2 treated, 1 holdout)'. Real events were being
     // discarded by the deduplicator, silently.
-    const line =
-      JSON.stringify({ id: nextId(), ...event, at: event.at ?? Date.now() }) + '\n';
+    const id = event.id || nextId();
+    const complete = {
+      schemaVersion: event.schemaVersion || 2,
+      id,
+      ...event,
+      // An injection id is first-class rather than an inference from the log
+      // record id.  Exporters may rewrite record ids while preserving causal
+      // identity, and downstream tool outcomes refer to this value explicitly.
+      ...(event.kind === 'inject'
+        ? { injectionId: event.injectionId || id }
+        : {}),
+      at: event.at ?? Date.now(),
+    };
+    const line = JSON.stringify(complete) + '\n';
     appendFileSync(metricsPath(dir), line);
     // Balance-critical records go to their own log as well, so the windows on
     // the firehose can never starve the measurement. Written SECOND: a torn
     // write here costs a duplicate the reader dedupes, not a lost event.
     if (BALANCE_KINDS.has(event.kind)) appendFileSync(balancePath(dir), line);
+    if (EVIDENCE_KINDS.has(event.kind)) appendFileSync(evidencePath(dir), line);
+    return complete;
   } catch {
     // Metrics must never break a tool call.
+    return null;
   }
 }
 
@@ -402,6 +436,92 @@ export function readBalance(dir) {
     out.push(e);
   }
   return out;
+}
+
+/** Every causal evidence record inside the byte cap, deduplicated by id. */
+export function readEvidence(dir) {
+  const path = evidencePath(dir);
+  if (!existsSync(path)) return [];
+
+  let text = '';
+  try {
+    const { size } = statSync(path);
+    if (size <= MAX_BYTES) {
+      text = readFileSync(path, 'utf8');
+    } else {
+      const fd = openSync(path, 'r');
+      try {
+        const buffer = Buffer.allocUnsafe(MAX_BYTES);
+        const read = readSync(fd, buffer, 0, MAX_BYTES, size - MAX_BYTES);
+        text = buffer.subarray(0, read).toString('utf8');
+      } finally {
+        closeSync(fd);
+      }
+      text = text.slice(text.indexOf('\n') + 1);
+    }
+  } catch {
+    return [];
+  }
+
+  const seen = new Set();
+  const out = [];
+  for (const line of text.split('\n')) {
+    if (!line) continue;
+    try {
+      const event = JSON.parse(line);
+      if (!EVIDENCE_KINDS.has(event.kind)) continue;
+      const id = event.id || JSON.stringify(event);
+      if (seen.has(id)) continue;
+      seen.add(id);
+      out.push(event);
+    } catch {
+      // A concurrently appended final line may be torn.  It costs one record,
+      // never the user's tool call or the rest of the evidence report.
+    }
+  }
+  return out;
+}
+
+/**
+ * Joins a post-tool result to the most recent matching injection.  The exact
+ * tool-call id wins; clients that omit it fall back to episode + surface +
+ * anchor, in timestamp order, and the report states the weaker join method.
+ */
+export function recordToolOutcome(dir, outcome) {
+  const evidence = readEvidence(dir);
+  const anchor = String(outcome.anchor || '').slice(0, 120);
+  const candidates = evidence
+    .filter((event) => event.kind === 'inject' && event.episodeId === outcome.episodeId)
+    .filter((event) => {
+      if (outcome.toolCallId && event.toolCallId)
+        return String(event.toolCallId) === String(outcome.toolCallId);
+      return event.surface === outcome.surface && String(event.anchor || '').slice(0, 120) === anchor;
+    })
+    .sort((a, b) => (b.at || 0) - (a.at || 0));
+  const injection = candidates[0] || null;
+  const joinMethod = injection
+    ? (outcome.toolCallId && injection.toolCallId ? 'tool-call-id' : 'episode-anchor')
+    : 'none';
+
+  return record(dir, {
+    kind: 'tool-outcome',
+    ...outcome,
+    anchor,
+    injectionId: injection?.injectionId || null,
+    findingIds: injection?.findingIds || [],
+    joinMethod,
+  });
+}
+
+export function recordEpisodeOutcome(dir, outcome) {
+  return record(dir, { kind: 'episode-outcome', ...outcome });
+}
+
+export function recordFindingFeedback(dir, feedback) {
+  const rating = ['helpful', 'neutral', 'harmful'].includes(feedback?.rating)
+    ? feedback.rating
+    : 'neutral';
+  return record(dir, { kind: 'finding-feedback', ...feedback, rating });
 }
 
 /**
@@ -813,4 +933,241 @@ export function indexBudget(dir, { floor = 150, base = 300, ceiling = 1200 } = {
   // 0% hit rate falls to the floor; ~50% and above reaches the ceiling.
   const scaled = Math.round(floor + (ceiling - floor) * Math.min(1, hitRate * 2));
   return Math.max(floor, Math.min(ceiling, scaled));
+}
+
+/* ----------------------------------------------------------------------
+ * Episode-level causal evidence
+ * ------------------------------------------------------------------- */
+
+const numeric = (value) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const average = (values) => {
+  const finite = values.map(numeric).filter((value) => value !== null);
+  return finite.length
+    ? finite.reduce((sum, value) => sum + value, 0) / finite.length
+    : null;
+};
+
+/** Deterministic PRNG so regenerating a report does not move its interval. */
+function seededRandom(seedText) {
+  let seed = 2166136261;
+  for (const char of String(seedText)) {
+    seed ^= char.charCodeAt(0);
+    seed = Math.imul(seed, 16777619);
+  }
+  return () => {
+    seed += 0x6d2b79f5;
+    let value = seed;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Percentile bootstrap interval for a mean, paired delta, or other scalar. */
+export function bootstrapMeanInterval(values, { samples = 1000, seed = 'token-optimizer' } = {}) {
+  const finite = values.map(numeric).filter((value) => value !== null);
+  if (!finite.length) return { mean: null, low: null, high: null, n: 0 };
+  if (finite.length === 1) {
+    return { mean: finite[0], low: finite[0], high: finite[0], n: 1 };
+  }
+
+  const random = seededRandom(`${seed}:${finite.join(',')}`);
+  const means = [];
+  for (let sample = 0; sample < samples; sample++) {
+    let total = 0;
+    for (let index = 0; index < finite.length; index++) {
+      total += finite[Math.floor(random() * finite.length)];
+    }
+    means.push(total / finite.length);
+  }
+  means.sort((a, b) => a - b);
+  return {
+    mean: average(finite),
+    low: means[Math.floor(means.length * 0.025)],
+    high: means[Math.min(means.length - 1, Math.floor(means.length * 0.975))],
+    n: finite.length,
+  };
+}
+
+/** Wilson interval keeps small correctness samples honest and inside 0..1. */
+export function proportionInterval(successes, total, z = 1.96) {
+  if (!total) return { rate: null, low: null, high: null, n: 0 };
+  const rate = successes / total;
+  const denominator = 1 + (z * z) / total;
+  const centre = (rate + (z * z) / (2 * total)) / denominator;
+  const radius =
+    (z / denominator) * Math.sqrt((rate * (1 - rate)) / total + (z * z) / (4 * total * total));
+  return { rate, low: Math.max(0, centre - radius), high: Math.min(1, centre + radius), n: total };
+}
+
+const cohortKey = (run) => [
+  run.client || 'unknown',
+  run.clientVersion || 'unknown',
+  run.model || 'unknown',
+  run.modelVersion || 'unknown',
+  run.taskId || 'unknown',
+].join('|');
+
+function armMetrics(runs) {
+  const correct = runs.filter((run) => run.correct === true).length;
+  const interval = (field) => bootstrapMeanInterval(
+    runs.map((run) => run[field]).filter((value) => numeric(value) !== null),
+    { seed: field }
+  );
+  return {
+    runs: runs.length,
+    correctness: proportionInterval(correct, runs.length),
+    uncachedInputTokens: interval('uncachedInputTokens'),
+    cachedInputTokens: interval('cachedInputTokens'),
+    outputTokens: interval('outputTokens'),
+    totalTokens: interval('totalTokens'),
+    toolCalls: interval('toolCalls'),
+    failedToolCalls: interval('failedToolCalls'),
+    latencyMs: interval('latencyMs'),
+    costUsd: interval('costUsd'),
+    injectedTokens: interval('injectedTokens'),
+    harmfulFindings: runs.reduce((sum, run) => sum + (numeric(run.harmfulFindings) || 0), 0),
+  };
+}
+
+function pairedEffects(runs, treatmentArm) {
+  const pairs = new Map();
+  for (const run of runs) {
+    if (!run.pairId || !['baseline', treatmentArm].includes(run.arm)) continue;
+    if (!pairs.has(run.pairId)) pairs.set(run.pairId, {});
+    pairs.get(run.pairId)[run.arm] = run;
+  }
+  const complete = [...pairs.values()].filter((pair) => pair.baseline && pair[treatmentArm]);
+  const delta = (field, lowerIsBetter = true) => bootstrapMeanInterval(
+    complete
+      .map((pair) => {
+        const baseline = numeric(pair.baseline[field]);
+        const treatment = numeric(pair[treatmentArm][field]);
+        if (baseline === null || treatment === null) return null;
+        return lowerIsBetter ? baseline - treatment : treatment - baseline;
+      })
+      .filter((value) => value !== null),
+    { seed: `${treatmentArm}:${field}` }
+  );
+  return {
+    arm: treatmentArm,
+    pairs: complete.length,
+    // Positive values always mean the treatment improved the metric.
+    totalTokensSaved: delta('totalTokens'),
+    uncachedInputTokensSaved: delta('uncachedInputTokens'),
+    toolCallsAvoided: delta('toolCalls'),
+    latencyMsSaved: delta('latencyMs'),
+    costUsdSaved: delta('costUsd'),
+    correctnessDelta: delta('correct', false),
+  };
+}
+
+function matchesFilters(event, filters) {
+  for (const field of ['client', 'clientVersion', 'model', 'modelVersion', 'taskId', 'arm']) {
+    if (filters[field] && String(event[field] || '') !== String(filters[field])) return false;
+  }
+  return true;
+}
+
+/**
+ * The dashboard-facing evidence console.  Deterministic fixture verification,
+ * live hook traces, and randomized model evals remain visibly distinct: only
+ * `eval-run` records with paired arms can produce a causal effect interval.
+ */
+export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
+  const evidence = readEvidence(dir).filter((event) => matchesFilters(event, filters));
+  const runs = evidence.filter((event) => event.kind === 'eval-run');
+  const injections = evidence.filter((event) => event.kind === 'inject');
+  const outcomes = evidence.filter((event) => event.kind === 'tool-outcome');
+  const feedback = evidence.filter((event) => event.kind === 'finding-feedback');
+
+  const byInjection = new Map(
+    outcomes.filter((event) => event.injectionId).map((event) => [event.injectionId, event])
+  );
+  const traced = injections
+    .slice()
+    .sort((a, b) => (b.at || 0) - (a.at || 0))
+    .slice(0, Math.max(1, Math.min(500, episodeLimit)))
+    .map((injection) => ({
+      injectionId: injection.injectionId,
+      episodeId: injection.episodeId || injection.sessionId || null,
+      at: injection.at,
+      arm: injection.arm || (injection.holdout ? 'holdout' : 'treated'),
+      client: injection.client || 'unknown',
+      clientVersion: injection.clientVersion || null,
+      model: injection.model || null,
+      taskId: injection.taskId || null,
+      surface: injection.surface || injection.trigger || 'file',
+      anchor: injection.anchor,
+      findingIds: injection.findingIds || [],
+      deliveredTokens: injection.deliveredTokens ?? injection.tokens ?? 0,
+      shadowTokens: injection.shadowTokens ?? injection.tokens ?? 0,
+      outcome: byInjection.get(injection.injectionId) || null,
+    }));
+
+  const grouped = new Map();
+  for (const run of runs) {
+    const key = cohortKey(run);
+    if (!grouped.has(key)) grouped.set(key, []);
+    grouped.get(key).push(run);
+  }
+
+  const minimumPairs = Math.max(2, Number(process.env.TOKEN_OPTIMIZER_EVAL_MIN_PAIRS) || 5);
+  const cohorts = [...grouped.entries()].map(([key, cohortRuns]) => {
+    const arms = Object.fromEntries(
+      ['baseline', 'optimizer', 'retrieval', 'full'].map((arm) => [
+        arm,
+        armMetrics(cohortRuns.filter((run) => run.arm === arm)),
+      ])
+    );
+    const effects = ['optimizer', 'retrieval', 'full'].map((arm) => pairedEffects(cohortRuns, arm));
+    const enough = effects.some((effect) => effect.pairs >= minimumPairs);
+    return {
+      key,
+      client: cohortRuns[0]?.client || 'unknown',
+      clientVersion: cohortRuns[0]?.clientVersion || null,
+      model: cohortRuns[0]?.model || null,
+      modelVersion: cohortRuns[0]?.modelVersion || null,
+      taskId: cohortRuns[0]?.taskId || null,
+      arms,
+      effects,
+      evidenceStatus: enough
+        ? 'causal estimate available'
+        : `insufficient paired runs (need ${minimumPairs})`,
+    };
+  });
+
+  const joined = injections.filter((injection) =>
+    byInjection.has(injection.injectionId)
+  ).length;
+  const harmful = feedback.filter((event) => event.rating === 'harmful').length;
+  return {
+    schemaVersion: 2,
+    generatedAt: new Date().toISOString(),
+    filters,
+    summary: {
+      liveInjections: injections.length,
+      joinedOutcomes: joined,
+      causalJoinCoverage: injections.length ? joined / injections.length : null,
+      evalRuns: runs.length,
+      cohorts: cohorts.length,
+      harmfulFeedback: harmful,
+      harmRate: feedback.length ? harmful / feedback.length : null,
+      evidenceStatus: cohorts.some((cohort) => cohort.evidenceStatus === 'causal estimate available')
+        ? 'causal estimates available'
+        : 'insufficient randomized evidence',
+    },
+    cohorts,
+    episodes: traced,
+    methodology: {
+      intervals: 'deterministic percentile bootstrap (95%); Wilson interval for correctness',
+      causalRule: 'only matched eval-run pairs compare an arm with baseline',
+      minimumPairs,
+      deterministicChecksAreCausalProof: false,
+    },
+  };
 }

--- a/integrations/codex/hooks/lib/recording.mjs
+++ b/integrations/codex/hooks/lib/recording.mjs
@@ -159,6 +159,9 @@ export function semanticHarvestPrompt({
     + ' If this work produced a durable, non-obvious conclusion -- a failed approach and why, '
     + 'a decision and its rejected alternative, or a command that finally worked -- call '
     + 'wiki_write now with a real file anchor. Do not delegate this to another model or an '
-    + 'external harvester. If there is no such conclusion, do not invent one; finish normally.'
+    + 'external harvester. Include: the concrete evidence, when the finding applies, a calibrated '
+    + 'confidenceLabel (verified/probable/speculative), its project/organization/global scope, '
+    + 'and anything that would invalidate it. If there is no such conclusion, do not invent one; '
+    + 'finish normally.'
   );
 }

--- a/integrations/codex/hooks/lib/utility.mjs
+++ b/integrations/codex/hooks/lib/utility.mjs
@@ -1,0 +1,135 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/utility.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Evidence-aware retrieval economics.
+ *
+ * Relevance alone is not enough: a true finding can still cost more context
+ * than it saves.  Every candidate receives a conservative expected-benefit
+ * estimate, its delivery cost and risk are subtracted, and harmful findings
+ * are quarantined from automatic delivery while remaining visible for audit.
+ */
+
+import { readEvidence } from './metrics.mjs';
+
+const DAY = 86_400_000;
+const ORIGIN_WEIGHT = { human: 1.2, agent: 1.08, harvested: 1 };
+
+const envNumber = (name, fallback) => {
+  const value = Number(process.env[name]);
+  return Number.isFinite(value) && value >= 0 ? value : fallback;
+};
+
+export const retrievalPolicy = () => ({
+  baseBenefitTokens: envNumber('TOKEN_OPTIMIZER_EXPECTED_BENEFIT_TOKENS', 400),
+  minimumNetUtility: envNumber('TOKEN_OPTIMIZER_MIN_EXPECTED_UTILITY', 20),
+  cooldownMs: envNumber('TOKEN_OPTIMIZER_INJECTION_COOLDOWN_MS', 60_000),
+  quarantineHarmCount: Math.max(1, envNumber('TOKEN_OPTIMIZER_QUARANTINE_HARM_COUNT', 2)),
+});
+
+function feedbackFor(events, key) {
+  return events.filter((event) =>
+    event.kind === 'finding-feedback'
+    && (event.findingId === key || (event.findingIds || []).includes(key))
+  );
+}
+
+function outcomesFor(events, key) {
+  return events.filter((event) =>
+    event.kind === 'tool-outcome' && (event.findingIds || []).includes(key)
+  );
+}
+
+function deliveredRecently(events, key, episodeId, now, cooldownMs) {
+  if (!episodeId || cooldownMs <= 0) return false;
+  return events.some((event) =>
+    event.kind === 'inject'
+    && event.episodeId === episodeId
+    && (event.findingIds || []).includes(key)
+    && !event.holdout
+    && now - (event.at || 0) < cooldownMs
+  );
+}
+
+/**
+ * Returns eligible candidates in utility order plus every rejection reason.
+ * `costFor` is supplied by inject.mjs so the gate prices the exact rendered
+ * text rather than a second approximation that could drift.
+ */
+export function assessFindings(
+  dir,
+  findings,
+  {
+    relevanceFor = () => 1,
+    costFor = () => 0,
+    episodeId = null,
+    now = Date.now(),
+    policy = retrievalPolicy(),
+  } = {}
+) {
+  const events = readEvidence(dir);
+  const eligible = [];
+  const rejected = [];
+
+  for (const finding of findings) {
+    const key = finding.key;
+    const feedback = feedbackFor(events, key);
+    const outcomes = outcomesFor(events, key);
+    const helpful = feedback.filter((event) => event.rating === 'helpful').length;
+    const neutral = feedback.filter((event) => event.rating === 'neutral').length;
+    const harmful = feedback.filter((event) => event.rating === 'harmful').length;
+    const successfulUses = outcomes.filter((event) => event.success === true).length;
+    const failedUses = outcomes.filter((event) => event.success === false).length;
+
+    if (harmful >= policy.quarantineHarmCount && harmful >= helpful + neutral) {
+      rejected.push({ key, reason: 'quarantined-harm', helpful, neutral, harmful });
+      continue;
+    }
+    if (deliveredRecently(events, key, episodeId, now, policy.cooldownMs)) {
+      rejected.push({ key, reason: 'cooldown' });
+      continue;
+    }
+
+    const confidence = Number.isFinite(finding.confidence) ? finding.confidence : 0.5;
+    const relevance = Math.max(0, Math.min(1, Number(relevanceFor(finding)) || 0));
+    const ageDays = Math.max(0, (now - (finding.at || now)) / DAY);
+    const recency = finding.pinned ? 1 : Math.pow(0.5, ageDays / 90);
+    const provenance = ORIGIN_WEIGHT[finding.origin] || 1;
+    // Outcome evidence moves the estimate gradually. Explicit harmful feedback
+    // is handled above; a failed command alone is not labelled harmful because
+    // the model may have ignored correct advice.
+    const observed = successfulUses + failedUses;
+    const successFactor = observed
+      ? 0.75 + 0.5 * (successfulUses / observed)
+      : 1;
+    const feedbackFactor = Math.max(0.25, 1 + helpful * 0.12 - harmful * 0.35);
+    const expectedBenefit =
+      policy.baseBenefitTokens * confidence * relevance * recency * provenance * successFactor * feedbackFactor;
+    const deliveryCost = Math.max(0, Number(costFor(finding)) || 0);
+    const riskPenalty =
+      (finding.stale ? 160 : 0)
+      + (finding.confidenceLabel === 'speculative' ? 100 : 0)
+      + harmful * 100;
+    const netUtility = expectedBenefit - deliveryCost - riskPenalty;
+
+    const assessed = {
+      finding,
+      expectedBenefit,
+      deliveryCost,
+      riskPenalty,
+      netUtility,
+      helpful,
+      neutral,
+      harmful,
+      successfulUses,
+      failedUses,
+    };
+    if (netUtility < policy.minimumNetUtility) {
+      rejected.push({ key, reason: 'negative-expected-value', ...assessed, finding: undefined });
+      continue;
+    }
+    eligible.push(assessed);
+  }
+
+  eligible.sort((a, b) => b.netUtility - a.netUtility);
+  return { eligible, rejected };
+}

--- a/integrations/codex/hooks/lib/utility.mjs
+++ b/integrations/codex/hooks/lib/utility.mjs
@@ -64,6 +64,7 @@ export function assessFindings(
     episodeId = null,
     now = Date.now(),
     policy = retrievalPolicy(),
+    bypassCooldown = false,
   } = {}
 ) {
   const events = readEvidence(dir);
@@ -84,7 +85,7 @@ export function assessFindings(
       rejected.push({ key, reason: 'quarantined-harm', helpful, neutral, harmful });
       continue;
     }
-    if (deliveredRecently(events, key, episodeId, now, policy.cooldownMs)) {
+    if (!bypassCooldown && deliveredRecently(events, key, episodeId, now, policy.cooldownMs)) {
       rejected.push({ key, reason: 'cooldown' });
       continue;
     }

--- a/integrations/codex/hooks/lib/wire.mjs
+++ b/integrations/codex/hooks/lib/wire.mjs
@@ -28,7 +28,7 @@ export const MARKER = 'token-optimizer';
 /** The events we wire, and which hook file serves each. */
 export const WIRING = [
   { event: 'SessionStart', file: 'session-start.mjs', matcher: null },
-  { event: 'PreToolUse', file: 'pretooluse-router.mjs', matcher: 'Read|Grep|Glob|Edit|MultiEdit|Write|Bash' },
+  { event: 'PreToolUse', file: 'pretooluse-router.mjs', matcher: 'Read|Grep|Glob|Edit|MultiEdit|Write|Bash|PowerShell' },
   { event: 'PreCompact', file: 'precompact-optimize.mjs', matcher: null },
 ];
 

--- a/integrations/codex/plugin/hooks/lib/adapter.mjs
+++ b/integrations/codex/plugin/hooks/lib/adapter.mjs
@@ -31,7 +31,9 @@ import {
   readCostBytes,
   touchedFiles,
 } from './decide.mjs';
-import { recordRead, fingerprint } from './metrics.mjs';
+import {
+  recordRead, fingerprint, recordToolOutcome, recordEpisodeOutcome,
+} from './metrics.mjs';
 import {
   contentHash,
   harvest,
@@ -57,6 +59,8 @@ import { isFsSafePath } from './paths.mjs';
 import {
   isSubstantive, recordingNudge, semanticHarvestPrompt,
 } from './recording.mjs';
+import { nativeClientProfiles } from './capabilities.mjs';
+import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 
 /**
  * Per-client capability.
@@ -65,41 +69,7 @@ import {
  * it true where the client has no pre-execution veto would make the product
  * claim enforcement it cannot deliver.
  */
-export const CLIENTS = {
-  'claude-code': { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  codex: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  cline: {
-    canDeny: true,
-    contextStyle: 'cline',
-    denyStyle: 'cline',
-    stopDecision: 'block',
-  },
-  copilot: {
-    canDeny: true,
-    contextStyle: 'top-level',
-    denyStyle: 'top-level-permission',
-    stopDecision: 'block',
-  },
-  cursor: {
-    canDeny: true,
-    contextStyle: 'cursor',
-    denyStyle: 'cursor',
-    stopStyle: 'followup',
-    stopDecision: 'block',
-  },
-  // Gemini's BeforeTool and AfterAgent decisions are top-level. Treating it
-  // like Codex produced well-formed JSON that Gemini ignored.
-  gemini: { canDeny: true, denyStyle: 'top-level', stopDecision: 'deny' },
-  kilo: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  opencode: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  qwen: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  windsurf: {
-    canDeny: true,
-    contextStyle: 'silent',
-    denyStyle: 'exit-2',
-    stopDecision: 'block',
-  },
-};
+export const CLIENTS = nativeClientProfiles();
 
 /** Never synchronously hash an unbounded build artifact on a hook path. */
 const HARVEST_MAX_BYTES =
@@ -135,6 +105,24 @@ export function mutationSucceeded(clientName, raw) {
   // or are called by our in-process bridge only from its successful after hook.
   return new Set(['claude-code', 'qwen', 'opencode', 'kilo', 'windsurf'])
     .has(clientName);
+}
+
+/** Conservative success classification for any completed tool call. */
+export function toolSucceeded(raw) {
+  if (raw?.error || raw?.tool_response?.error || raw?.toolResponse?.error)
+    return false;
+  if (raw?.postToolUse?.success === false || raw?.success === false) return false;
+  const status =
+    raw?.tool_response?.status ?? raw?.toolResponse?.status ??
+    raw?.tool_result?.status ?? raw?.toolResult?.status;
+  if (status !== undefined) {
+    if (/^(?:error|failed|failure|cancelled|canceled|denied)$/i.test(String(status))) return false;
+    if (/^(?:ok|success|succeeded|complete|completed)$/i.test(String(status))) return true;
+  }
+  // A post-tool lifecycle event is evidence that the call completed, but not
+  // that its output proved the task.  `success` here is deliberately scoped to
+  // the tool call; task correctness comes only from an eval grader.
+  return true;
 }
 
 function contextOutput(client, eventName, additionalContext) {
@@ -253,8 +241,10 @@ refused.
 
 Worth recording: a decision and why the alternative was rejected, a failure and
 what actually caused it, a command that turned out to be the one that works.
-Not worth recording: what the code plainly says. Prefer the thing someone had to
-work out, because that exists nowhere in the source tree.${projectBriefing()}`;
+Not worth recording: what the code plainly says. Every wiki_write must include
+the concrete evidence, when it applies, a calibrated confidence label, its
+scope, and what would invalidate it. Prefer the thing someone had to work out,
+because that exists nowhere in the source tree.${projectBriefing()}`;
 }
 
 /**
@@ -315,7 +305,7 @@ function projectBriefing() {
  * metrics. It never called forTouch/forCommand, so four advertised clients
  * accumulated a graph that their active model could not receive.
  */
-function observeAndInject(payload, state) {
+function observeAndInject(payload, state, episode, features) {
   const touched = touchedFiles(payload);
   const dirFor = (path) => wikiDir(projectRootFor(path, payload.cwd));
 
@@ -344,45 +334,51 @@ function observeAndInject(payload, state) {
   state.injected = state.injected || [];
   const alreadyInjected = new Set(state.injected);
 
-  for (const { path } of touched) {
-    const dir = dirFor(path);
-    const note = forTouch(dir, load(dir), path, {
-      sessionId: payload.session_id,
-      alreadyInjected,
-    });
-    if (note) parts.push(note);
-  }
+  if (features.retrieval) {
+    for (const { path } of touched) {
+      const dir = dirFor(path);
+      const note = forTouch(dir, load(dir), path, {
+        sessionId: payload.session_id,
+        alreadyInjected,
+        episode,
+      });
+      if (note) parts.push(note);
+    }
 
-  const command = payload.tool_input?.command;
-  if (command) {
-    const root = commandProjectRoot(payload, payload.cwd);
-    const dir = wikiDir(root);
-    const local = forCommand(dir, load(dir), command, {
-      sessionId: payload.session_id,
-      alreadyInjected,
-    });
-    if (local) parts.push(local);
+    const command = payload.tool_input?.command;
+    if (command) {
+      const root = commandProjectRoot(payload, payload.cwd);
+      const dir = wikiDir(root);
+      const local = forCommand(dir, load(dir), command, {
+        sessionId: payload.session_id,
+        alreadyInjected,
+        episode,
+      });
+      if (local) parts.push(local);
 
-    const shared = forSharedCommand(dir, command, {
-      sessionId: payload.session_id,
-      alreadyInjected,
-      projectRoot: root,
-    });
-    if (shared) parts.push(shared);
+      const shared = forSharedCommand(dir, command, {
+        sessionId: payload.session_id,
+        alreadyInjected,
+        projectRoot: root,
+        episode,
+      });
+      if (shared) parts.push(shared);
 
-    const crossed = noteActClasses(state, command);
-    const repeated = forRepeatedAct(dir, command, crossed, {
-      sessionId: payload.session_id,
-      projectRoot: root,
-    });
-    if (repeated) parts.push(repeated);
+      const crossed = noteActClasses(state, command);
+      const repeated = forRepeatedAct(dir, command, crossed, {
+        sessionId: payload.session_id,
+        projectRoot: root,
+        episode,
+      });
+      if (repeated) parts.push(repeated);
+    }
   }
   state.injected = [...alreadyInjected];
 
   // Structural capture is evidence about what was touched, not a semantic
   // conclusion. It is therefore safe to automate for every client and leaves
   // the active model responsible for wiki_write at completion.
-  for (const { path, size } of touched) {
+  if (features.capture) for (const { path, size } of touched) {
     try {
       if (isArchived(path) || size > HARVEST_MAX_BYTES || !isFsSafePath(path))
         continue;
@@ -420,7 +416,10 @@ export async function run(clientName, event) {
 
   if (mode() === MODE_OFF) process.exit(0);
 
+  const features = featuresForArm();
+
   if (event === 'session-start') {
+    if (!features.routing && !features.retrieval && !features.harvest) process.exit(0);
     const output = contextOutput(client, eventName, policyText(client.canDeny));
     if (output) emit(output);
     process.exit(0);
@@ -437,10 +436,22 @@ export async function run(clientName, event) {
     const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? 'default';
     const agentScope = raw.transcript_path ?? raw.transcriptPath ?? null;
     const state = loadState(sessionId, agentScope);
+    const episode = episodeMeta({ client: clientName, raw });
+    try {
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+      recordEpisodeOutcome(dir, {
+        ...episode,
+        status: 'completed',
+        ...usageFrom(raw),
+      });
+    } catch {
+      // Evidence is best effort and must never stop a session from finishing.
+    }
     const alreadyHarvested =
       Number(state.edits || 0) > 0 &&
       Number(state.harvestedEdits || 0) >= Number(state.edits || 0);
-    const prompt = semanticHarvestPrompt({
+    const prompt = features.harvest ? semanticHarvestPrompt({
       edits: state.edits,
       files: state.editedFiles,
       model: raw.model,
@@ -449,7 +460,7 @@ export async function run(clientName, event) {
         raw.stopHookActive === true ||
         alreadyHarvested ||
         (clientName === 'cursor' && Number(raw.loop_count || 0) > 0),
-    });
+    }) : null;
     if (prompt) {
       state.harvestedEdits = Number(state.edits || 0);
       saveState(sessionId, state, agentScope);
@@ -466,6 +477,7 @@ export async function run(clientName, event) {
     process.exit(0);
   const payload = normalizePayload(normalizeClientPayload(clientName, event, raw));
   if (!payload.tool_name) process.exit(0);
+  const episode = episodeMeta({ client: clientName, raw, payload });
 
   // THE AGENT, not just the session -- the same scope the Claude Code router
   // applies. Subagents inherit the parent's session id, so keying state on the
@@ -506,17 +518,41 @@ export async function run(clientName, event) {
       const anchor = state.editedFiles[0]
         || join(payload.cwd || process.cwd(), '__recording__');
       const dir = wikiDir(projectRootFor(anchor, payload.cwd));
-      recordingContext = recordingNudge(dir, {
+      recordingContext = features.harvest ? recordingNudge(dir, {
         state,
         edits: state.edits,
         files: state.editedFiles,
-      });
+      }) : null;
       if (recordingContext) state.recordingNudged = true;
     } catch {
       // Recording pressure is an optimization and must never cost a tool call.
     }
   }
-  const verdict = decide(payload, state);
+  if (event === 'post-tool') {
+    try {
+      const command = payload.tool_input?.command;
+      const touched = touchedFiles(payload);
+      const anchor = command
+        ? String(command).slice(0, 120)
+        : touched[0]?.path || payload.tool_input?.file_path || '';
+      const root = command
+        ? commandProjectRoot(payload, payload.cwd)
+        : projectRootFor(anchor || join(payload.cwd || process.cwd(), '__tool__'), payload.cwd);
+      recordToolOutcome(wikiDir(root), {
+        ...episode,
+        surface: command ? 'command' : 'file',
+        anchor,
+        toolName: payload.tool_name,
+        success: toolSucceeded(raw),
+        durationMs: Number(raw.duration_ms ?? raw.durationMs ?? raw.elapsed_ms ?? raw.elapsedMs) || null,
+        ...usageFrom(raw),
+      });
+    } catch {
+      // Causal tracing is fail-open like every other hook optimization.
+    }
+  }
+
+  const verdict = features.routing ? decide(payload, state) : null;
   const repeat = verdict && event === 'pre-tool'
     ? alreadyDenied(state, verdict.key)
     : false;
@@ -571,7 +607,7 @@ export async function run(clientName, event) {
   remember(payload, state);
   let graphContext = null;
   try {
-    graphContext = observeAndInject(payload, state);
+    graphContext = observeAndInject(payload, state, episode, features);
   } catch {
     // Delivery is an optimization. Fail open.
   }

--- a/integrations/codex/plugin/hooks/lib/capabilities.mjs
+++ b/integrations/codex/plugin/hooks/lib/capabilities.mjs
@@ -1,0 +1,130 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/capabilities.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * The product's honest cross-client capability contract.
+ *
+ * A client is listed at the strongest surface its public lifecycle protocol can
+ * actually support.  This registry is consumed by the adapter, certification
+ * tooling, and evidence reports so a rules-only integration can never be
+ * presented as equivalent to a native stop-continuation integration.
+ */
+
+export const CAPABILITY_TIERS = Object.freeze({
+  CONTINUATION: 'lifecycle-continuation',
+  OBSERVATION: 'native-observation',
+  RULES: 'mcp-rules',
+});
+
+const native = (profile) => ({
+  structuralCapture: 'native',
+  findingDelivery: 'native',
+  routing: 'native-veto',
+  ...profile,
+});
+
+export const CLIENT_CAPABILITIES = Object.freeze({
+  'claude-code': native({
+    name: 'Claude Code', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-continuation', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  codex: native({
+    name: 'Codex', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-continuation', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  copilot: native({
+    name: 'GitHub Copilot CLI', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'agent-stop-continuation', canDeny: true,
+    contextStyle: 'top-level', denyStyle: 'top-level-permission', stopDecision: 'block',
+  }),
+  gemini: native({
+    name: 'Gemini CLI', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'after-agent-retry', canDeny: true,
+    denyStyle: 'top-level', stopDecision: 'deny',
+  }),
+  qwen: native({
+    name: 'Qwen Code', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-continuation', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  cursor: native({
+    name: 'Cursor', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-followup', canDeny: true,
+    contextStyle: 'cursor', denyStyle: 'cursor', stopStyle: 'followup', stopDecision: 'block',
+  }),
+  cline: native({
+    name: 'Cline', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    contextStyle: 'cline', denyStyle: 'cline', stopDecision: 'block',
+  }),
+  opencode: native({
+    name: 'OpenCode', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  kilo: native({
+    name: 'Kilo', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  windsurf: native({
+    name: 'Windsurf', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    contextStyle: 'silent', denyStyle: 'exit-2', stopDecision: 'block',
+  }),
+  roo: {
+    name: 'Roo Code', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  zed: {
+    name: 'Zed', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  amp: {
+    name: 'Amp', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  continue: {
+    name: 'Continue', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  crush: {
+    name: 'Crush', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  droid: {
+    name: 'Droid (Factory)', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+});
+
+export function capabilityFor(client) {
+  return CLIENT_CAPABILITIES[String(client || '').toLowerCase()] || null;
+}
+
+export function nativeClientProfiles() {
+  return Object.fromEntries(
+    Object.entries(CLIENT_CAPABILITIES)
+      .filter(([, profile]) => profile.structuralCapture === 'native')
+      .map(([key, profile]) => [key, { ...profile }])
+  );
+}
+
+export function capabilitySummary() {
+  return Object.entries(CLIENT_CAPABILITIES).map(([client, profile]) => ({
+    client,
+    name: profile.name,
+    tier: profile.tier,
+    routing: profile.routing,
+    structuralCapture: profile.structuralCapture,
+    findingDelivery: profile.findingDelivery,
+    semanticHarvest: profile.semanticHarvest,
+  }));
+}

--- a/integrations/codex/plugin/hooks/lib/decide.mjs
+++ b/integrations/codex/plugin/hooks/lib/decide.mjs
@@ -513,6 +513,8 @@ const TOOL_ALIASES = new Map(
     create_file: 'Write',
 
     bash: 'Bash',
+    powershell: 'Bash',
+    pwsh: 'Bash',
     shell: 'Bash',
     run_command: 'Bash',
     execute_command: 'Bash',

--- a/integrations/codex/plugin/hooks/lib/experiment.mjs
+++ b/integrations/codex/plugin/hooks/lib/experiment.mjs
@@ -1,0 +1,82 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/experiment.mjs. Regenerate with `npm run sync:hooks`.
+/** Explicit, reproducible feature arms and causal episode identity. */
+
+export const EXPERIMENT_ARMS = Object.freeze([
+  'baseline',
+  'optimizer',
+  'retrieval',
+  'full',
+]);
+
+const FEATURES = Object.freeze({
+  baseline: Object.freeze({ routing: false, retrieval: false, capture: false, harvest: false }),
+  optimizer: Object.freeze({ routing: true, retrieval: false, capture: false, harvest: false }),
+  retrieval: Object.freeze({ routing: true, retrieval: true, capture: true, harvest: false }),
+  full: Object.freeze({ routing: true, retrieval: true, capture: true, harvest: true }),
+});
+
+export function experimentArm(env = process.env) {
+  const requested = String(env.TOKEN_OPTIMIZER_EXPERIMENT_ARM || '').trim().toLowerCase();
+  return EXPERIMENT_ARMS.includes(requested) ? requested : 'full';
+}
+
+export function featuresForArm(arm = experimentArm()) {
+  return FEATURES[arm] || FEATURES.full;
+}
+
+const first = (...values) => values.find((value) => value !== undefined && value !== null && value !== '');
+
+/**
+ * Normalises identifiers exposed under different names by lifecycle clients.
+ * Environment overrides let the live evaluation harness pin a pair/task id
+ * without asking each CLI to support experiment-specific payload fields.
+ */
+export function episodeMeta({ client, raw = {}, payload = {}, env = process.env } = {}) {
+  const sessionId = String(first(
+    payload.session_id, raw.session_id, raw.sessionId, raw.conversation_id,
+    raw.conversationId, raw.taskId, raw.task_id, raw.trajectory_id, 'default'
+  ));
+  const episodeId = String(first(
+    env.TOKEN_OPTIMIZER_EPISODE_ID, raw.episode_id, raw.episodeId, sessionId
+  ));
+  const toolCallId = first(
+    raw.tool_use_id, raw.toolUseId, raw.tool_call_id, raw.toolCallId,
+    raw.call_id, raw.callId, raw.postToolUse?.toolUseId, raw.preToolUse?.toolUseId
+  );
+  const model = first(payload.model, raw.model?.slug, raw.model, raw.model_name, env.TOKEN_OPTIMIZER_MODEL);
+  const clientVersion = first(
+    raw.client_version, raw.clientVersion, raw.version, env.TOKEN_OPTIMIZER_CLIENT_VERSION
+  );
+  const modelVersion = first(raw.model_version, raw.modelVersion, env.TOKEN_OPTIMIZER_MODEL_VERSION);
+
+  return {
+    schemaVersion: 2,
+    episodeId,
+    sessionId,
+    turnId: first(raw.turn_id, raw.turnId, raw.message_id, raw.messageId) ?? null,
+    toolCallId: toolCallId == null ? null : String(toolCallId),
+    taskId: first(env.TOKEN_OPTIMIZER_TASK_ID, raw.task_id, raw.taskId) ?? null,
+    pairId: first(env.TOKEN_OPTIMIZER_PAIR_ID, raw.pair_id, raw.pairId) ?? null,
+    arm: experimentArm(env),
+    client: String(client || first(raw.client, raw.client_name, 'unknown')),
+    clientVersion: clientVersion == null ? null : String(clientVersion),
+    model: model == null ? null : String(model),
+    modelVersion: modelVersion == null ? null : String(modelVersion),
+  };
+}
+
+export function usageFrom(raw = {}) {
+  const usage = raw.usage || raw.token_usage || raw.tokenUsage || raw.metrics?.usage || {};
+  const number = (...values) => {
+    const value = first(...values);
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+  };
+  return {
+    uncachedInputTokens: number(usage.uncached_input_tokens, usage.uncachedInputTokens),
+    cachedInputTokens: number(usage.cached_input_tokens, usage.cachedInputTokens, usage.cache_read_input_tokens),
+    outputTokens: number(usage.output_tokens, usage.outputTokens),
+    totalTokens: number(usage.total_tokens, usage.totalTokens, raw.tokens_used, raw.tokensUsed),
+  };
+}

--- a/integrations/codex/plugin/hooks/lib/harvest-write.mjs
+++ b/integrations/codex/plugin/hooks/lib/harvest-write.mjs
@@ -96,8 +96,13 @@ function promoteToShared(finding, { projectRoot, sessionId, provenance, key }) {
           key: `shared-${key}`,
           claim: finding.claim,
           confidence: finding.confidence,
+          confidenceLabel: finding.confidenceLabel,
           type: finding.type,
           trigger: typeof finding.trigger === 'string' && finding.trigger ? finding.trigger : undefined,
+          applicability: finding.applicability,
+          evidence: finding.evidence,
+          invalidators: Array.isArray(finding.invalidators) ? finding.invalidators : [],
+          scope: finding.scope || 'global',
           origin: provenance,
           quote: typeof finding.quote === 'string' && finding.quote.trim() ? finding.quote : undefined,
           // WHERE IT WAS LEARNED, carried so the reader can discount it. A lesson
@@ -351,6 +356,26 @@ export function writeHarvested(
     // anything, so it is dropped rather than kept as unfalsifiable.
     if (!resolved.length) continue;
 
+    // Exact semantic duplicates collapse to the existing active record.  The
+    // normalisation intentionally ignores punctuation/formatting noise but not
+    // meaning-bearing words; near-duplicates that need judgement remain visible
+    // to curation rather than being silently merged by a fuzzy heuristic.
+    const fingerprint = claimFingerprint(finding.claim);
+    const currentGraph = load(dir);
+    const duplicate = [...currentGraph.nodes.values()].find((node) =>
+      node.kind === 'finding'
+      && !node.retired
+      && node.type === finding.type
+      && claimFingerprint(node.claim) === fingerprint
+      && resolved.every((target) => currentGraph.edges.some((edge) =>
+        edge.from === node.id && edge.edge === 'derived_from' && edge.to === target
+      ))
+    );
+    if (duplicate) {
+      written.push(duplicate.key);
+      continue;
+    }
+
     // Date.now() plus an index is not unique across CONCURRENT detached
     // workers: two Stop hooks finishing in the same millisecond produce the
     // same key, and putNode keeps the last write for an id -- so one session's
@@ -371,6 +396,7 @@ export function writeHarvested(
         key,
         claim: finding.claim,
         confidence: finding.confidence,
+        confidenceLabel: finding.confidenceLabel,
         type: finding.type,
         // WHEN this finding is relevant, not just what it is about. Anchors
         // answer "which file", which is the wrong question for a claim about
@@ -380,6 +406,16 @@ export function writeHarvested(
         trigger: typeof finding.trigger === 'string' && finding.trigger
           ? finding.trigger
           : undefined,
+        applicability: typeof finding.applicability === 'string'
+          ? finding.applicability
+          : undefined,
+        evidence: typeof finding.evidence === 'string'
+          ? finding.evidence
+          : undefined,
+        invalidators: Array.isArray(finding.invalidators)
+          ? finding.invalidators
+          : [],
+        scope: finding.scope || 'project',
         origin: provenance,
         // THE EVIDENCE TRAVELS WITH THE CLAIM. Without it a human-origin
         // finding asserts its own provenance and nothing can check it.
@@ -398,7 +434,11 @@ export function writeHarvested(
     // record of what happened here; the shared tier is a copy for the lessons
     // that are not about here. Skipped when the two are the same directory,
     // which is the suite's usual arrangement.
-    if (id && !isSharedDir(dir)) {
+    if (
+      id
+      && !isSharedDir(dir)
+      && (finding.scope === undefined || finding.scope === 'organization' || finding.scope === 'global')
+    ) {
       promoteToShared(finding, { projectRoot, sessionId, provenance, key });
     }
   }

--- a/integrations/codex/plugin/hooks/lib/harvest.mjs
+++ b/integrations/codex/plugin/hooks/lib/harvest.mjs
@@ -201,7 +201,11 @@ const PROMPT = `Extract durable findings from this coding session for a project 
 Return ONLY a JSON array. Each element:
 {"type": "finding|decision|failure|command|map",
  "claim": "one sentence, specific and checkable",
- "confidence": 0.0-1.0,
+ "evidence": "the concrete observation, command result, or rejected approach that proved it",
+ "applicability": "the condition under which a future model should use it",
+ "confidenceLabel": "verified|probable|speculative",
+ "scope": "project|organization|global",
+ "invalidators": ["what change would require this to be checked again"],
  "anchors": ["absolute/file/path" or "absolute/file/path#symbolName"]}
 
 RULES:
@@ -211,7 +215,9 @@ RULES:
 - Prefer "failure" and "decision" entries. What was TRIED AND REJECTED, and WHY,
   is the most valuable thing here because it exists nowhere in the source tree.
 - Do not restate what the code plainly says. Record what someone had to work out.
-- confidence reflects how well established the claim is, not how important.
+- verified requires direct evidence; probable means strong but incomplete evidence;
+  speculative is a hypothesis and must be labelled as such.
+- Use project scope unless the lesson is genuinely independent of this repository.
 - If nothing durable was learned, return [].`;
 
 /**
@@ -232,8 +238,29 @@ export function validate(raw, { knownFiles = null } = {}) {
     if (!FINDING_TYPES.includes(item.type)) continue;
     if (typeof item.claim !== 'string' || item.claim.trim().length < 8) continue;
 
-    const confidence = Number(item.confidence);
-    if (!Number.isFinite(confidence) || confidence <= 0 || confidence > 1) continue;
+    const evidence = typeof item.evidence === 'string' ? item.evidence.trim() : '';
+    const applicability = typeof item.applicability === 'string' ? item.applicability.trim() : '';
+    if (evidence.length < 8 || applicability.length < 8) continue;
+
+    const confidenceLabel = ['verified', 'probable', 'speculative'].includes(item.confidenceLabel)
+      ? item.confidenceLabel
+      : null;
+    if (!confidenceLabel) continue;
+    const defaults = { verified: 0.95, probable: 0.75, speculative: 0.45 };
+    const supplied = Number(item.confidence);
+    if (
+      item.confidence !== undefined
+      && (!Number.isFinite(supplied) || supplied <= 0 || supplied > 1)
+    ) continue;
+    const confidence = item.confidence === undefined
+      ? defaults[confidenceLabel]
+      : supplied;
+    const scope = ['project', 'organization', 'global'].includes(item.scope)
+      ? item.scope
+      : 'project';
+    const invalidators = Array.isArray(item.invalidators)
+      ? item.invalidators.filter((value) => typeof value === 'string' && value.trim()).slice(0, 10)
+      : [];
 
     let anchors = Array.isArray(item.anchors) ? item.anchors.filter((a) => typeof a === 'string' && a) : [];
     // A model asked for file paths will sometimes invent them. When the caller
@@ -241,7 +268,18 @@ export function validate(raw, { knownFiles = null } = {}) {
     if (knownFiles) anchors = anchors.filter((a) => knownFiles.has(a.split('#')[0]));
     if (!anchors.length) continue;
 
-    accepted.push({ type: item.type, claim: item.claim.trim(), confidence, anchors });
+    accepted.push({
+      type: item.type,
+      claim: item.claim.trim(),
+      evidence,
+      applicability,
+      confidence,
+      confidenceLabel,
+      scope,
+      invalidators,
+      anchors,
+      trigger: typeof item.trigger === 'string' ? item.trigger : undefined,
+    });
   }
   return accepted;
 }

--- a/integrations/codex/plugin/hooks/lib/inject.mjs
+++ b/integrations/codex/plugin/hooks/lib/inject.mjs
@@ -30,6 +30,7 @@ import { inHoldout, record, indexBudget } from './metrics.mjs';
 import { canonicalPath, resolvableCandidates } from './paths.mjs';
 import { annotatedSkeleton } from './skeleton.mjs';
 import { substitutionBudget } from './metrics.mjs';
+import { assessFindings } from './utility.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
@@ -150,7 +151,7 @@ export function forTouch(
   dir,
   graph,
   rawPath,
-  { budget = touchBudget(), sessionId, alreadyInjected = new Set() } = {}
+  { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
   // Canonical, so a touch finds findings anchored under any other spelling.
   const filePath = canonicalPath(rawPath);
@@ -169,16 +170,36 @@ export function forTouch(
   // variance drops out. A session-pinned arm would destroy that.
   const holdout = inHoldout(filePath);
   const served = serve(graph, candidates);
-  const { kept, spent } = fit(served, budget);
+  const assessed = assessFindings(dir, served, {
+    episodeId: episode.episodeId || sessionId,
+    relevanceFor: () => 1,
+    costFor: (finding) => estimate(render(finding)),
+  });
+  if (assessed.rejected.length) {
+    record(dir, {
+      kind: 'retrieval-decision', ...episode, sessionId,
+      surface: 'file', anchor: filePath,
+      rejected: assessed.rejected.map(({ key, reason }) => ({ key, reason })),
+    });
+    for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
+  }
+  const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
+  if (!kept.length) return null;
 
   record(dir, {
     kind: 'inject',
+    ...episode,
     // The surface whose saving CAN be measured: reads of this anchor afterwards.
     surface: 'file',
     anchor: filePath,
     holdout,
     tokens: holdout ? 0 : spent,
-    count: kept.length,
+    deliveredTokens: holdout ? 0 : spent,
+    shadowTokens: spent,
+    count: holdout ? 0 : kept.length,
+    candidateCount: kept.length,
+    findingIds: holdout ? [] : kept.map((finding) => finding.key),
+    shadowFindingIds: kept.map((finding) => finding.key),
     stale: kept.some((f) => f.stale),
     sessionId,
   });
@@ -297,7 +318,7 @@ export function forCommand(
   dir,
   graph,
   command,
-  { budget = touchBudget(), sessionId, alreadyInjected = new Set() } = {}
+  { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
   if (!command) return null;
 
@@ -335,7 +356,20 @@ export function forCommand(
   const considered = candidates.slice(0, MAX_COMMAND_CANDIDATES);
 
   const served = serve(graph, considered);
-  const { kept, spent } = fit(served, budget);
+  const assessed = assessFindings(dir, served, {
+    episodeId: episode.episodeId || sessionId,
+    relevanceFor: (finding) => explicit(finding) ? 1 : 0.6,
+    costFor: (finding) => estimate(render(finding)),
+  });
+  if (assessed.rejected.length) {
+    record(dir, {
+      kind: 'retrieval-decision', ...episode, sessionId,
+      surface: 'command', anchor: String(command).slice(0, 120),
+      rejected: assessed.rejected.map(({ key: findingKey, reason }) => ({ key: findingKey, reason })),
+    });
+    for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
+  }
+  const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
   if (!kept.length) return null;
 
   // THE COMMAND PATH TAKES PART IN THE HOLDOUT TOO.
@@ -353,6 +387,7 @@ export function forCommand(
 
   record(dir, {
     kind: 'inject',
+    ...episode,
     trigger: 'command',
     // The surface the report needs to keep these OUT of the file-read balance:
     // a command has no anchor that read events can be joined to.
@@ -360,7 +395,12 @@ export function forCommand(
     anchor: String(command).slice(0, 120),
     holdout,
     tokens: holdout ? 0 : spent,
+    deliveredTokens: holdout ? 0 : spent,
+    shadowTokens: spent,
     count: holdout ? 0 : kept.length,
+    candidateCount: kept.length,
+    findingIds: holdout ? [] : kept.map((finding) => finding.key),
+    shadowFindingIds: kept.map((finding) => finding.key),
     stale: kept.some((f) => f.stale),
     sessionId,
   });
@@ -509,7 +549,7 @@ export function forRepeatedAct(
   projectDir,
   command,
   crossedClasses,
-  { sessionId = null, projectRoot = null } = {}
+  { sessionId = null, projectRoot = null, episode = {} } = {}
 ) {
   if (!crossedClasses || !crossedClasses.size) return null;
 
@@ -527,14 +567,33 @@ export function forRepeatedAct(
       if (![...crossedClasses].some((c) => claimClasses.has(c))) continue;
 
       const cls = [...crossedClasses].find((c) => claimClasses.has(c));
+      const assessed = assessFindings(projectDir, [node], {
+        episodeId: episode.episodeId || sessionId,
+        relevanceFor: () => 1,
+        costFor: (finding) => estimate(render(finding)),
+      });
+      if (!assessed.eligible.length) {
+        record(projectDir, {
+          kind: 'retrieval-decision', ...episode, sessionId,
+          surface: 'shared', anchor: String(command).slice(0, 120),
+          rejected: assessed.rejected.map(({ key, reason }) => ({ key, reason })),
+        });
+        continue;
+      }
       record(projectDir, {
         kind: 'inject',
+        ...episode,
         trigger: 'repeat',
         surface: 'shared',
         anchor: String(command).slice(0, 120),
         holdout: false,
         tokens: estimate(node.claim),
+        deliveredTokens: estimate(node.claim),
+        shadowTokens: estimate(node.claim),
         count: 1,
+        candidateCount: 1,
+        findingIds: [node.key],
+        shadowFindingIds: [node.key],
         stale: false,
         sessionId,
       });
@@ -585,7 +644,10 @@ function appliesCrossProject(finding, command) {
 export function forSharedCommand(
   projectDir,
   command,
-  { budget = sharedBudget(), sessionId = null, alreadyInjected = new Set(), projectRoot = null } = {}
+  {
+    budget = sharedBudget(), sessionId = null, alreadyInjected = new Set(),
+    projectRoot = null, episode = {},
+  } = {}
 ) {
   if (!command) return null;
 
@@ -622,7 +684,21 @@ export function forSharedCommand(
     // No serve() here: these types are not content-dependent, so there is no
     // anchor to re-read and nothing to diff. serve() would spend a file read per
     // finding to answer a question that does not apply to them.
-    const { kept, spent } = fit(candidates.slice(0, MAX_SHARED), budget);
+    const considered = candidates.slice(0, MAX_SHARED);
+    const assessed = assessFindings(projectDir, considered, {
+      episodeId: episode.episodeId || sessionId,
+      relevanceFor: (finding) => explicit(finding) ? 0.8 : 0.5,
+      costFor: (finding) => estimate(render(finding)),
+    });
+    if (assessed.rejected.length) {
+      record(projectDir, {
+        kind: 'retrieval-decision', ...episode, sessionId,
+        surface: 'shared', anchor: String(command).slice(0, 120),
+        rejected: assessed.rejected.map(({ key, reason }) => ({ key, reason })),
+      });
+      for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
+    }
+    const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
     if (!kept.length) return null;
 
     // THE SAME ARM AS THE LOCAL PATH, KEYED THE SAME WAY.
@@ -644,6 +720,7 @@ export function forSharedCommand(
 
     record(projectDir, {
       kind: 'inject',
+      ...episode,
       trigger: 'command',
       // ITS OWN SURFACE. The balance sheet joins `file` injections to later read
       // events; a shared lesson has no anchor in this project to join to, and
@@ -653,7 +730,12 @@ export function forSharedCommand(
       anchor: String(command).slice(0, 120),
       holdout,
       tokens: holdout ? 0 : spent,
+      deliveredTokens: holdout ? 0 : spent,
+      shadowTokens: spent,
       count: holdout ? 0 : kept.length,
+      candidateCount: kept.length,
+      findingIds: holdout ? [] : kept.map((finding) => finding.key),
+      shadowFindingIds: kept.map((finding) => finding.key),
       stale: false,
       sessionId,
     });

--- a/integrations/codex/plugin/hooks/lib/inject.mjs
+++ b/integrations/codex/plugin/hooks/lib/inject.mjs
@@ -571,6 +571,10 @@ export function forRepeatedAct(
         episodeId: episode.episodeId || sessionId,
         relevanceFor: () => 1,
         costFor: (finding) => estimate(render(finding)),
+        // This surface exists specifically to re-surface a lesson once the
+        // session crosses the repeat threshold. Ordinary retrieval remains
+        // cooldown-protected; harm quarantine and utility gating still apply.
+        bypassCooldown: true,
       });
       if (!assessed.eligible.length) {
         record(projectDir, {

--- a/integrations/codex/plugin/hooks/lib/metrics.mjs
+++ b/integrations/codex/plugin/hooks/lib/metrics.mjs
@@ -1022,6 +1022,7 @@ function armMetrics(runs) {
     runs: runs.length,
     correctness: proportionInterval(correct, runs.length),
     uncachedInputTokens: interval('uncachedInputTokens'),
+    cacheCreationInputTokens: interval('cacheCreationInputTokens'),
     cachedInputTokens: interval('cachedInputTokens'),
     outputTokens: interval('outputTokens'),
     totalTokens: interval('totalTokens'),
@@ -1034,31 +1035,37 @@ function armMetrics(runs) {
   };
 }
 
-function pairedEffects(runs, treatmentArm) {
+function pairedEffects(runs, controlArm, treatmentArm, contrastType = 'incremental') {
   const pairs = new Map();
   for (const run of runs) {
-    if (!run.pairId || !['baseline', treatmentArm].includes(run.arm)) continue;
+    if (!run.pairId || ![controlArm, treatmentArm].includes(run.arm)) continue;
     if (!pairs.has(run.pairId)) pairs.set(run.pairId, {});
     pairs.get(run.pairId)[run.arm] = run;
   }
-  const complete = [...pairs.values()].filter((pair) => pair.baseline && pair[treatmentArm]);
+  const complete = [...pairs.values()].filter((pair) => pair[controlArm] && pair[treatmentArm]);
   const delta = (field, lowerIsBetter = true) => bootstrapMeanInterval(
     complete
       .map((pair) => {
-        const baseline = numeric(pair.baseline[field]);
+        const baseline = numeric(pair[controlArm][field]);
         const treatment = numeric(pair[treatmentArm][field]);
         if (baseline === null || treatment === null) return null;
         return lowerIsBetter ? baseline - treatment : treatment - baseline;
       })
       .filter((value) => value !== null),
-    { seed: `${treatmentArm}:${field}` }
+    { seed: `${controlArm}:${treatmentArm}:${field}` }
   );
   return {
     arm: treatmentArm,
+    controlArm,
+    comparison: `${treatmentArm} vs ${controlArm}`,
+    contrastType,
     pairs: complete.length,
     // Positive values always mean the treatment improved the metric.
     totalTokensSaved: delta('totalTokens'),
     uncachedInputTokensSaved: delta('uncachedInputTokens'),
+    cacheCreationInputTokensSaved: delta('cacheCreationInputTokens'),
+    cachedInputTokensSaved: delta('cachedInputTokens'),
+    outputTokensSaved: delta('outputTokens'),
     toolCallsAvoided: delta('toolCalls'),
     latencyMsSaved: delta('latencyMs'),
     costUsdSaved: delta('costUsd'),
@@ -1124,8 +1131,13 @@ export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
         armMetrics(cohortRuns.filter((run) => run.arm === arm)),
       ])
     );
-    const effects = ['optimizer', 'retrieval', 'full'].map((arm) => pairedEffects(cohortRuns, arm));
-    const enough = effects.some((effect) => effect.pairs >= minimumPairs);
+    const effects = [
+      pairedEffects(cohortRuns, 'baseline', 'optimizer'),
+      pairedEffects(cohortRuns, 'optimizer', 'retrieval'),
+      pairedEffects(cohortRuns, 'retrieval', 'full'),
+      pairedEffects(cohortRuns, 'baseline', 'full', 'total-system'),
+    ];
+    const enough = effects.every((effect) => effect.pairs >= minimumPairs);
     return {
       key,
       client: cohortRuns[0]?.client || 'unknown',
@@ -1165,7 +1177,8 @@ export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
     episodes: traced,
     methodology: {
       intervals: 'deterministic percentile bootstrap (95%); Wilson interval for correctness',
-      causalRule: 'only matched eval-run pairs compare an arm with baseline',
+      causalRule:
+        'matched pairs estimate optimizer vs baseline, retrieval vs optimizer, full vs retrieval, and full vs baseline',
       minimumPairs,
       deterministicChecksAreCausalProof: false,
     },

--- a/integrations/codex/plugin/hooks/lib/metrics.mjs
+++ b/integrations/codex/plugin/hooks/lib/metrics.mjs
@@ -61,6 +61,7 @@ const metricsPath = (dir) => join(dir, 'metrics.jsonl');
  * on it drops BOTH arms proportionally instead of starving the rare one.
  */
 const balancePath = (dir) => join(dir, 'balance.jsonl');
+const evidencePath = (dir) => join(dir, 'evidence.jsonl');
 
 /** Kinds the net balance is computed from, and which therefore must survive. */
 /**
@@ -83,6 +84,24 @@ export const BALANCE_KINDS = new Set([
   // aged out before it was written and the backstop was structurally unable to fire, reporting
   // "only N/10 refreshes observed" for the life of the project.
   'keepwarm',
+]);
+
+/**
+ * Causal records have their own bounded log.  Tool outcomes are much rarer
+ * than read/capture telemetry but more frequent than balance records; mixing
+ * them into either window would eventually evict the evidence needed to join
+ * an injection to its result.
+ */
+export const EVIDENCE_KINDS = new Set([
+  'inject',
+  'harvest',
+  'tool-outcome',
+  'episode-outcome',
+  'eval-run',
+  'finding-feedback',
+  'retrieval-decision',
+  'mcp-client',
+  'mcp-tool',
 ]);
 
 /**
@@ -198,15 +217,30 @@ export function record(dir, event) {
     // single millisecond collapsed to ONE, so a graph with ample data reported
     // 'insufficient data (2 treated, 1 holdout)'. Real events were being
     // discarded by the deduplicator, silently.
-    const line =
-      JSON.stringify({ id: nextId(), ...event, at: event.at ?? Date.now() }) + '\n';
+    const id = event.id || nextId();
+    const complete = {
+      schemaVersion: event.schemaVersion || 2,
+      id,
+      ...event,
+      // An injection id is first-class rather than an inference from the log
+      // record id.  Exporters may rewrite record ids while preserving causal
+      // identity, and downstream tool outcomes refer to this value explicitly.
+      ...(event.kind === 'inject'
+        ? { injectionId: event.injectionId || id }
+        : {}),
+      at: event.at ?? Date.now(),
+    };
+    const line = JSON.stringify(complete) + '\n';
     appendFileSync(metricsPath(dir), line);
     // Balance-critical records go to their own log as well, so the windows on
     // the firehose can never starve the measurement. Written SECOND: a torn
     // write here costs a duplicate the reader dedupes, not a lost event.
     if (BALANCE_KINDS.has(event.kind)) appendFileSync(balancePath(dir), line);
+    if (EVIDENCE_KINDS.has(event.kind)) appendFileSync(evidencePath(dir), line);
+    return complete;
   } catch {
     // Metrics must never break a tool call.
+    return null;
   }
 }
 
@@ -402,6 +436,92 @@ export function readBalance(dir) {
     out.push(e);
   }
   return out;
+}
+
+/** Every causal evidence record inside the byte cap, deduplicated by id. */
+export function readEvidence(dir) {
+  const path = evidencePath(dir);
+  if (!existsSync(path)) return [];
+
+  let text = '';
+  try {
+    const { size } = statSync(path);
+    if (size <= MAX_BYTES) {
+      text = readFileSync(path, 'utf8');
+    } else {
+      const fd = openSync(path, 'r');
+      try {
+        const buffer = Buffer.allocUnsafe(MAX_BYTES);
+        const read = readSync(fd, buffer, 0, MAX_BYTES, size - MAX_BYTES);
+        text = buffer.subarray(0, read).toString('utf8');
+      } finally {
+        closeSync(fd);
+      }
+      text = text.slice(text.indexOf('\n') + 1);
+    }
+  } catch {
+    return [];
+  }
+
+  const seen = new Set();
+  const out = [];
+  for (const line of text.split('\n')) {
+    if (!line) continue;
+    try {
+      const event = JSON.parse(line);
+      if (!EVIDENCE_KINDS.has(event.kind)) continue;
+      const id = event.id || JSON.stringify(event);
+      if (seen.has(id)) continue;
+      seen.add(id);
+      out.push(event);
+    } catch {
+      // A concurrently appended final line may be torn.  It costs one record,
+      // never the user's tool call or the rest of the evidence report.
+    }
+  }
+  return out;
+}
+
+/**
+ * Joins a post-tool result to the most recent matching injection.  The exact
+ * tool-call id wins; clients that omit it fall back to episode + surface +
+ * anchor, in timestamp order, and the report states the weaker join method.
+ */
+export function recordToolOutcome(dir, outcome) {
+  const evidence = readEvidence(dir);
+  const anchor = String(outcome.anchor || '').slice(0, 120);
+  const candidates = evidence
+    .filter((event) => event.kind === 'inject' && event.episodeId === outcome.episodeId)
+    .filter((event) => {
+      if (outcome.toolCallId && event.toolCallId)
+        return String(event.toolCallId) === String(outcome.toolCallId);
+      return event.surface === outcome.surface && String(event.anchor || '').slice(0, 120) === anchor;
+    })
+    .sort((a, b) => (b.at || 0) - (a.at || 0));
+  const injection = candidates[0] || null;
+  const joinMethod = injection
+    ? (outcome.toolCallId && injection.toolCallId ? 'tool-call-id' : 'episode-anchor')
+    : 'none';
+
+  return record(dir, {
+    kind: 'tool-outcome',
+    ...outcome,
+    anchor,
+    injectionId: injection?.injectionId || null,
+    findingIds: injection?.findingIds || [],
+    joinMethod,
+  });
+}
+
+export function recordEpisodeOutcome(dir, outcome) {
+  return record(dir, { kind: 'episode-outcome', ...outcome });
+}
+
+export function recordFindingFeedback(dir, feedback) {
+  const rating = ['helpful', 'neutral', 'harmful'].includes(feedback?.rating)
+    ? feedback.rating
+    : 'neutral';
+  return record(dir, { kind: 'finding-feedback', ...feedback, rating });
 }
 
 /**
@@ -813,4 +933,241 @@ export function indexBudget(dir, { floor = 150, base = 300, ceiling = 1200 } = {
   // 0% hit rate falls to the floor; ~50% and above reaches the ceiling.
   const scaled = Math.round(floor + (ceiling - floor) * Math.min(1, hitRate * 2));
   return Math.max(floor, Math.min(ceiling, scaled));
+}
+
+/* ----------------------------------------------------------------------
+ * Episode-level causal evidence
+ * ------------------------------------------------------------------- */
+
+const numeric = (value) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const average = (values) => {
+  const finite = values.map(numeric).filter((value) => value !== null);
+  return finite.length
+    ? finite.reduce((sum, value) => sum + value, 0) / finite.length
+    : null;
+};
+
+/** Deterministic PRNG so regenerating a report does not move its interval. */
+function seededRandom(seedText) {
+  let seed = 2166136261;
+  for (const char of String(seedText)) {
+    seed ^= char.charCodeAt(0);
+    seed = Math.imul(seed, 16777619);
+  }
+  return () => {
+    seed += 0x6d2b79f5;
+    let value = seed;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Percentile bootstrap interval for a mean, paired delta, or other scalar. */
+export function bootstrapMeanInterval(values, { samples = 1000, seed = 'token-optimizer' } = {}) {
+  const finite = values.map(numeric).filter((value) => value !== null);
+  if (!finite.length) return { mean: null, low: null, high: null, n: 0 };
+  if (finite.length === 1) {
+    return { mean: finite[0], low: finite[0], high: finite[0], n: 1 };
+  }
+
+  const random = seededRandom(`${seed}:${finite.join(',')}`);
+  const means = [];
+  for (let sample = 0; sample < samples; sample++) {
+    let total = 0;
+    for (let index = 0; index < finite.length; index++) {
+      total += finite[Math.floor(random() * finite.length)];
+    }
+    means.push(total / finite.length);
+  }
+  means.sort((a, b) => a - b);
+  return {
+    mean: average(finite),
+    low: means[Math.floor(means.length * 0.025)],
+    high: means[Math.min(means.length - 1, Math.floor(means.length * 0.975))],
+    n: finite.length,
+  };
+}
+
+/** Wilson interval keeps small correctness samples honest and inside 0..1. */
+export function proportionInterval(successes, total, z = 1.96) {
+  if (!total) return { rate: null, low: null, high: null, n: 0 };
+  const rate = successes / total;
+  const denominator = 1 + (z * z) / total;
+  const centre = (rate + (z * z) / (2 * total)) / denominator;
+  const radius =
+    (z / denominator) * Math.sqrt((rate * (1 - rate)) / total + (z * z) / (4 * total * total));
+  return { rate, low: Math.max(0, centre - radius), high: Math.min(1, centre + radius), n: total };
+}
+
+const cohortKey = (run) => [
+  run.client || 'unknown',
+  run.clientVersion || 'unknown',
+  run.model || 'unknown',
+  run.modelVersion || 'unknown',
+  run.taskId || 'unknown',
+].join('|');
+
+function armMetrics(runs) {
+  const correct = runs.filter((run) => run.correct === true).length;
+  const interval = (field) => bootstrapMeanInterval(
+    runs.map((run) => run[field]).filter((value) => numeric(value) !== null),
+    { seed: field }
+  );
+  return {
+    runs: runs.length,
+    correctness: proportionInterval(correct, runs.length),
+    uncachedInputTokens: interval('uncachedInputTokens'),
+    cachedInputTokens: interval('cachedInputTokens'),
+    outputTokens: interval('outputTokens'),
+    totalTokens: interval('totalTokens'),
+    toolCalls: interval('toolCalls'),
+    failedToolCalls: interval('failedToolCalls'),
+    latencyMs: interval('latencyMs'),
+    costUsd: interval('costUsd'),
+    injectedTokens: interval('injectedTokens'),
+    harmfulFindings: runs.reduce((sum, run) => sum + (numeric(run.harmfulFindings) || 0), 0),
+  };
+}
+
+function pairedEffects(runs, treatmentArm) {
+  const pairs = new Map();
+  for (const run of runs) {
+    if (!run.pairId || !['baseline', treatmentArm].includes(run.arm)) continue;
+    if (!pairs.has(run.pairId)) pairs.set(run.pairId, {});
+    pairs.get(run.pairId)[run.arm] = run;
+  }
+  const complete = [...pairs.values()].filter((pair) => pair.baseline && pair[treatmentArm]);
+  const delta = (field, lowerIsBetter = true) => bootstrapMeanInterval(
+    complete
+      .map((pair) => {
+        const baseline = numeric(pair.baseline[field]);
+        const treatment = numeric(pair[treatmentArm][field]);
+        if (baseline === null || treatment === null) return null;
+        return lowerIsBetter ? baseline - treatment : treatment - baseline;
+      })
+      .filter((value) => value !== null),
+    { seed: `${treatmentArm}:${field}` }
+  );
+  return {
+    arm: treatmentArm,
+    pairs: complete.length,
+    // Positive values always mean the treatment improved the metric.
+    totalTokensSaved: delta('totalTokens'),
+    uncachedInputTokensSaved: delta('uncachedInputTokens'),
+    toolCallsAvoided: delta('toolCalls'),
+    latencyMsSaved: delta('latencyMs'),
+    costUsdSaved: delta('costUsd'),
+    correctnessDelta: delta('correct', false),
+  };
+}
+
+function matchesFilters(event, filters) {
+  for (const field of ['client', 'clientVersion', 'model', 'modelVersion', 'taskId', 'arm']) {
+    if (filters[field] && String(event[field] || '') !== String(filters[field])) return false;
+  }
+  return true;
+}
+
+/**
+ * The dashboard-facing evidence console.  Deterministic fixture verification,
+ * live hook traces, and randomized model evals remain visibly distinct: only
+ * `eval-run` records with paired arms can produce a causal effect interval.
+ */
+export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
+  const evidence = readEvidence(dir).filter((event) => matchesFilters(event, filters));
+  const runs = evidence.filter((event) => event.kind === 'eval-run');
+  const injections = evidence.filter((event) => event.kind === 'inject');
+  const outcomes = evidence.filter((event) => event.kind === 'tool-outcome');
+  const feedback = evidence.filter((event) => event.kind === 'finding-feedback');
+
+  const byInjection = new Map(
+    outcomes.filter((event) => event.injectionId).map((event) => [event.injectionId, event])
+  );
+  const traced = injections
+    .slice()
+    .sort((a, b) => (b.at || 0) - (a.at || 0))
+    .slice(0, Math.max(1, Math.min(500, episodeLimit)))
+    .map((injection) => ({
+      injectionId: injection.injectionId,
+      episodeId: injection.episodeId || injection.sessionId || null,
+      at: injection.at,
+      arm: injection.arm || (injection.holdout ? 'holdout' : 'treated'),
+      client: injection.client || 'unknown',
+      clientVersion: injection.clientVersion || null,
+      model: injection.model || null,
+      taskId: injection.taskId || null,
+      surface: injection.surface || injection.trigger || 'file',
+      anchor: injection.anchor,
+      findingIds: injection.findingIds || [],
+      deliveredTokens: injection.deliveredTokens ?? injection.tokens ?? 0,
+      shadowTokens: injection.shadowTokens ?? injection.tokens ?? 0,
+      outcome: byInjection.get(injection.injectionId) || null,
+    }));
+
+  const grouped = new Map();
+  for (const run of runs) {
+    const key = cohortKey(run);
+    if (!grouped.has(key)) grouped.set(key, []);
+    grouped.get(key).push(run);
+  }
+
+  const minimumPairs = Math.max(2, Number(process.env.TOKEN_OPTIMIZER_EVAL_MIN_PAIRS) || 5);
+  const cohorts = [...grouped.entries()].map(([key, cohortRuns]) => {
+    const arms = Object.fromEntries(
+      ['baseline', 'optimizer', 'retrieval', 'full'].map((arm) => [
+        arm,
+        armMetrics(cohortRuns.filter((run) => run.arm === arm)),
+      ])
+    );
+    const effects = ['optimizer', 'retrieval', 'full'].map((arm) => pairedEffects(cohortRuns, arm));
+    const enough = effects.some((effect) => effect.pairs >= minimumPairs);
+    return {
+      key,
+      client: cohortRuns[0]?.client || 'unknown',
+      clientVersion: cohortRuns[0]?.clientVersion || null,
+      model: cohortRuns[0]?.model || null,
+      modelVersion: cohortRuns[0]?.modelVersion || null,
+      taskId: cohortRuns[0]?.taskId || null,
+      arms,
+      effects,
+      evidenceStatus: enough
+        ? 'causal estimate available'
+        : `insufficient paired runs (need ${minimumPairs})`,
+    };
+  });
+
+  const joined = injections.filter((injection) =>
+    byInjection.has(injection.injectionId)
+  ).length;
+  const harmful = feedback.filter((event) => event.rating === 'harmful').length;
+  return {
+    schemaVersion: 2,
+    generatedAt: new Date().toISOString(),
+    filters,
+    summary: {
+      liveInjections: injections.length,
+      joinedOutcomes: joined,
+      causalJoinCoverage: injections.length ? joined / injections.length : null,
+      evalRuns: runs.length,
+      cohorts: cohorts.length,
+      harmfulFeedback: harmful,
+      harmRate: feedback.length ? harmful / feedback.length : null,
+      evidenceStatus: cohorts.some((cohort) => cohort.evidenceStatus === 'causal estimate available')
+        ? 'causal estimates available'
+        : 'insufficient randomized evidence',
+    },
+    cohorts,
+    episodes: traced,
+    methodology: {
+      intervals: 'deterministic percentile bootstrap (95%); Wilson interval for correctness',
+      causalRule: 'only matched eval-run pairs compare an arm with baseline',
+      minimumPairs,
+      deterministicChecksAreCausalProof: false,
+    },
+  };
 }

--- a/integrations/codex/plugin/hooks/lib/recording.mjs
+++ b/integrations/codex/plugin/hooks/lib/recording.mjs
@@ -159,6 +159,9 @@ export function semanticHarvestPrompt({
     + ' If this work produced a durable, non-obvious conclusion -- a failed approach and why, '
     + 'a decision and its rejected alternative, or a command that finally worked -- call '
     + 'wiki_write now with a real file anchor. Do not delegate this to another model or an '
-    + 'external harvester. If there is no such conclusion, do not invent one; finish normally.'
+    + 'external harvester. Include: the concrete evidence, when the finding applies, a calibrated '
+    + 'confidenceLabel (verified/probable/speculative), its project/organization/global scope, '
+    + 'and anything that would invalidate it. If there is no such conclusion, do not invent one; '
+    + 'finish normally.'
   );
 }

--- a/integrations/codex/plugin/hooks/lib/utility.mjs
+++ b/integrations/codex/plugin/hooks/lib/utility.mjs
@@ -1,0 +1,135 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/utility.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Evidence-aware retrieval economics.
+ *
+ * Relevance alone is not enough: a true finding can still cost more context
+ * than it saves.  Every candidate receives a conservative expected-benefit
+ * estimate, its delivery cost and risk are subtracted, and harmful findings
+ * are quarantined from automatic delivery while remaining visible for audit.
+ */
+
+import { readEvidence } from './metrics.mjs';
+
+const DAY = 86_400_000;
+const ORIGIN_WEIGHT = { human: 1.2, agent: 1.08, harvested: 1 };
+
+const envNumber = (name, fallback) => {
+  const value = Number(process.env[name]);
+  return Number.isFinite(value) && value >= 0 ? value : fallback;
+};
+
+export const retrievalPolicy = () => ({
+  baseBenefitTokens: envNumber('TOKEN_OPTIMIZER_EXPECTED_BENEFIT_TOKENS', 400),
+  minimumNetUtility: envNumber('TOKEN_OPTIMIZER_MIN_EXPECTED_UTILITY', 20),
+  cooldownMs: envNumber('TOKEN_OPTIMIZER_INJECTION_COOLDOWN_MS', 60_000),
+  quarantineHarmCount: Math.max(1, envNumber('TOKEN_OPTIMIZER_QUARANTINE_HARM_COUNT', 2)),
+});
+
+function feedbackFor(events, key) {
+  return events.filter((event) =>
+    event.kind === 'finding-feedback'
+    && (event.findingId === key || (event.findingIds || []).includes(key))
+  );
+}
+
+function outcomesFor(events, key) {
+  return events.filter((event) =>
+    event.kind === 'tool-outcome' && (event.findingIds || []).includes(key)
+  );
+}
+
+function deliveredRecently(events, key, episodeId, now, cooldownMs) {
+  if (!episodeId || cooldownMs <= 0) return false;
+  return events.some((event) =>
+    event.kind === 'inject'
+    && event.episodeId === episodeId
+    && (event.findingIds || []).includes(key)
+    && !event.holdout
+    && now - (event.at || 0) < cooldownMs
+  );
+}
+
+/**
+ * Returns eligible candidates in utility order plus every rejection reason.
+ * `costFor` is supplied by inject.mjs so the gate prices the exact rendered
+ * text rather than a second approximation that could drift.
+ */
+export function assessFindings(
+  dir,
+  findings,
+  {
+    relevanceFor = () => 1,
+    costFor = () => 0,
+    episodeId = null,
+    now = Date.now(),
+    policy = retrievalPolicy(),
+  } = {}
+) {
+  const events = readEvidence(dir);
+  const eligible = [];
+  const rejected = [];
+
+  for (const finding of findings) {
+    const key = finding.key;
+    const feedback = feedbackFor(events, key);
+    const outcomes = outcomesFor(events, key);
+    const helpful = feedback.filter((event) => event.rating === 'helpful').length;
+    const neutral = feedback.filter((event) => event.rating === 'neutral').length;
+    const harmful = feedback.filter((event) => event.rating === 'harmful').length;
+    const successfulUses = outcomes.filter((event) => event.success === true).length;
+    const failedUses = outcomes.filter((event) => event.success === false).length;
+
+    if (harmful >= policy.quarantineHarmCount && harmful >= helpful + neutral) {
+      rejected.push({ key, reason: 'quarantined-harm', helpful, neutral, harmful });
+      continue;
+    }
+    if (deliveredRecently(events, key, episodeId, now, policy.cooldownMs)) {
+      rejected.push({ key, reason: 'cooldown' });
+      continue;
+    }
+
+    const confidence = Number.isFinite(finding.confidence) ? finding.confidence : 0.5;
+    const relevance = Math.max(0, Math.min(1, Number(relevanceFor(finding)) || 0));
+    const ageDays = Math.max(0, (now - (finding.at || now)) / DAY);
+    const recency = finding.pinned ? 1 : Math.pow(0.5, ageDays / 90);
+    const provenance = ORIGIN_WEIGHT[finding.origin] || 1;
+    // Outcome evidence moves the estimate gradually. Explicit harmful feedback
+    // is handled above; a failed command alone is not labelled harmful because
+    // the model may have ignored correct advice.
+    const observed = successfulUses + failedUses;
+    const successFactor = observed
+      ? 0.75 + 0.5 * (successfulUses / observed)
+      : 1;
+    const feedbackFactor = Math.max(0.25, 1 + helpful * 0.12 - harmful * 0.35);
+    const expectedBenefit =
+      policy.baseBenefitTokens * confidence * relevance * recency * provenance * successFactor * feedbackFactor;
+    const deliveryCost = Math.max(0, Number(costFor(finding)) || 0);
+    const riskPenalty =
+      (finding.stale ? 160 : 0)
+      + (finding.confidenceLabel === 'speculative' ? 100 : 0)
+      + harmful * 100;
+    const netUtility = expectedBenefit - deliveryCost - riskPenalty;
+
+    const assessed = {
+      finding,
+      expectedBenefit,
+      deliveryCost,
+      riskPenalty,
+      netUtility,
+      helpful,
+      neutral,
+      harmful,
+      successfulUses,
+      failedUses,
+    };
+    if (netUtility < policy.minimumNetUtility) {
+      rejected.push({ key, reason: 'negative-expected-value', ...assessed, finding: undefined });
+      continue;
+    }
+    eligible.push(assessed);
+  }
+
+  eligible.sort((a, b) => b.netUtility - a.netUtility);
+  return { eligible, rejected };
+}

--- a/integrations/codex/plugin/hooks/lib/utility.mjs
+++ b/integrations/codex/plugin/hooks/lib/utility.mjs
@@ -64,6 +64,7 @@ export function assessFindings(
     episodeId = null,
     now = Date.now(),
     policy = retrievalPolicy(),
+    bypassCooldown = false,
   } = {}
 ) {
   const events = readEvidence(dir);
@@ -84,7 +85,7 @@ export function assessFindings(
       rejected.push({ key, reason: 'quarantined-harm', helpful, neutral, harmful });
       continue;
     }
-    if (deliveredRecently(events, key, episodeId, now, policy.cooldownMs)) {
+    if (!bypassCooldown && deliveredRecently(events, key, episodeId, now, policy.cooldownMs)) {
       rejected.push({ key, reason: 'cooldown' });
       continue;
     }

--- a/integrations/codex/plugin/hooks/lib/wire.mjs
+++ b/integrations/codex/plugin/hooks/lib/wire.mjs
@@ -28,7 +28,7 @@ export const MARKER = 'token-optimizer';
 /** The events we wire, and which hook file serves each. */
 export const WIRING = [
   { event: 'SessionStart', file: 'session-start.mjs', matcher: null },
-  { event: 'PreToolUse', file: 'pretooluse-router.mjs', matcher: 'Read|Grep|Glob|Edit|MultiEdit|Write|Bash' },
+  { event: 'PreToolUse', file: 'pretooluse-router.mjs', matcher: 'Read|Grep|Glob|Edit|MultiEdit|Write|Bash|PowerShell' },
   { event: 'PreCompact', file: 'precompact-optimize.mjs', matcher: null },
 ];
 

--- a/integrations/codex/plugin/skills/token-optimization/SKILL.md
+++ b/integrations/codex/plugin/skills/token-optimization/SKILL.md
@@ -48,7 +48,9 @@ tool call itself.
 
 - Call **`wiki_write`** when you establish a durable, non-obvious conclusion:
   a failed approach and why, a decision and its rejected alternative, or a
-  command that finally worked. Anchor it to a real file or `path#symbol`.
+  command that finally worked. Anchor it to a real file or `path#symbol`, and
+  include its concrete evidence, applicability, calibrated `confidenceLabel`,
+  scope, and invalidators.
 - Perform this semantic harvest yourself while you still hold the reasoning.
   Do not delegate it to another model, and do not invent a finding merely to
   populate the graph.

--- a/integrations/continue/token-optimizer.md
+++ b/integrations/continue/token-optimizer.md
@@ -25,6 +25,10 @@ LIVE GRAPH — THE ACTIVE MODEL DOES THE SEMANTIC HARVEST:
   command that finally worked.
 - Anchor every claim to a real file path or path#symbol. Never invent a claim
   merely to populate the graph, and do not delegate harvesting to another model.
+- Include the concrete evidence, when it applies, confidenceLabel
+  (verified/probable/speculative), scope (project/organization/global), and any
+  condition that would invalidate it. Use project scope unless transfer is
+  genuinely justified.
 - Before finishing substantive work, reflect once and write any still-unrecorded
   conclusion while you hold the reasoning. This is what makes the lesson
   available across sessions and projects instead of losing it to compaction.

--- a/integrations/copilot/.github/hooks/lib/adapter.mjs
+++ b/integrations/copilot/.github/hooks/lib/adapter.mjs
@@ -31,7 +31,9 @@ import {
   readCostBytes,
   touchedFiles,
 } from './decide.mjs';
-import { recordRead, fingerprint } from './metrics.mjs';
+import {
+  recordRead, fingerprint, recordToolOutcome, recordEpisodeOutcome,
+} from './metrics.mjs';
 import {
   contentHash,
   harvest,
@@ -57,6 +59,8 @@ import { isFsSafePath } from './paths.mjs';
 import {
   isSubstantive, recordingNudge, semanticHarvestPrompt,
 } from './recording.mjs';
+import { nativeClientProfiles } from './capabilities.mjs';
+import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 
 /**
  * Per-client capability.
@@ -65,41 +69,7 @@ import {
  * it true where the client has no pre-execution veto would make the product
  * claim enforcement it cannot deliver.
  */
-export const CLIENTS = {
-  'claude-code': { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  codex: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  cline: {
-    canDeny: true,
-    contextStyle: 'cline',
-    denyStyle: 'cline',
-    stopDecision: 'block',
-  },
-  copilot: {
-    canDeny: true,
-    contextStyle: 'top-level',
-    denyStyle: 'top-level-permission',
-    stopDecision: 'block',
-  },
-  cursor: {
-    canDeny: true,
-    contextStyle: 'cursor',
-    denyStyle: 'cursor',
-    stopStyle: 'followup',
-    stopDecision: 'block',
-  },
-  // Gemini's BeforeTool and AfterAgent decisions are top-level. Treating it
-  // like Codex produced well-formed JSON that Gemini ignored.
-  gemini: { canDeny: true, denyStyle: 'top-level', stopDecision: 'deny' },
-  kilo: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  opencode: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  qwen: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  windsurf: {
-    canDeny: true,
-    contextStyle: 'silent',
-    denyStyle: 'exit-2',
-    stopDecision: 'block',
-  },
-};
+export const CLIENTS = nativeClientProfiles();
 
 /** Never synchronously hash an unbounded build artifact on a hook path. */
 const HARVEST_MAX_BYTES =
@@ -135,6 +105,24 @@ export function mutationSucceeded(clientName, raw) {
   // or are called by our in-process bridge only from its successful after hook.
   return new Set(['claude-code', 'qwen', 'opencode', 'kilo', 'windsurf'])
     .has(clientName);
+}
+
+/** Conservative success classification for any completed tool call. */
+export function toolSucceeded(raw) {
+  if (raw?.error || raw?.tool_response?.error || raw?.toolResponse?.error)
+    return false;
+  if (raw?.postToolUse?.success === false || raw?.success === false) return false;
+  const status =
+    raw?.tool_response?.status ?? raw?.toolResponse?.status ??
+    raw?.tool_result?.status ?? raw?.toolResult?.status;
+  if (status !== undefined) {
+    if (/^(?:error|failed|failure|cancelled|canceled|denied)$/i.test(String(status))) return false;
+    if (/^(?:ok|success|succeeded|complete|completed)$/i.test(String(status))) return true;
+  }
+  // A post-tool lifecycle event is evidence that the call completed, but not
+  // that its output proved the task.  `success` here is deliberately scoped to
+  // the tool call; task correctness comes only from an eval grader.
+  return true;
 }
 
 function contextOutput(client, eventName, additionalContext) {
@@ -253,8 +241,10 @@ refused.
 
 Worth recording: a decision and why the alternative was rejected, a failure and
 what actually caused it, a command that turned out to be the one that works.
-Not worth recording: what the code plainly says. Prefer the thing someone had to
-work out, because that exists nowhere in the source tree.${projectBriefing()}`;
+Not worth recording: what the code plainly says. Every wiki_write must include
+the concrete evidence, when it applies, a calibrated confidence label, its
+scope, and what would invalidate it. Prefer the thing someone had to work out,
+because that exists nowhere in the source tree.${projectBriefing()}`;
 }
 
 /**
@@ -315,7 +305,7 @@ function projectBriefing() {
  * metrics. It never called forTouch/forCommand, so four advertised clients
  * accumulated a graph that their active model could not receive.
  */
-function observeAndInject(payload, state) {
+function observeAndInject(payload, state, episode, features) {
   const touched = touchedFiles(payload);
   const dirFor = (path) => wikiDir(projectRootFor(path, payload.cwd));
 
@@ -344,45 +334,51 @@ function observeAndInject(payload, state) {
   state.injected = state.injected || [];
   const alreadyInjected = new Set(state.injected);
 
-  for (const { path } of touched) {
-    const dir = dirFor(path);
-    const note = forTouch(dir, load(dir), path, {
-      sessionId: payload.session_id,
-      alreadyInjected,
-    });
-    if (note) parts.push(note);
-  }
+  if (features.retrieval) {
+    for (const { path } of touched) {
+      const dir = dirFor(path);
+      const note = forTouch(dir, load(dir), path, {
+        sessionId: payload.session_id,
+        alreadyInjected,
+        episode,
+      });
+      if (note) parts.push(note);
+    }
 
-  const command = payload.tool_input?.command;
-  if (command) {
-    const root = commandProjectRoot(payload, payload.cwd);
-    const dir = wikiDir(root);
-    const local = forCommand(dir, load(dir), command, {
-      sessionId: payload.session_id,
-      alreadyInjected,
-    });
-    if (local) parts.push(local);
+    const command = payload.tool_input?.command;
+    if (command) {
+      const root = commandProjectRoot(payload, payload.cwd);
+      const dir = wikiDir(root);
+      const local = forCommand(dir, load(dir), command, {
+        sessionId: payload.session_id,
+        alreadyInjected,
+        episode,
+      });
+      if (local) parts.push(local);
 
-    const shared = forSharedCommand(dir, command, {
-      sessionId: payload.session_id,
-      alreadyInjected,
-      projectRoot: root,
-    });
-    if (shared) parts.push(shared);
+      const shared = forSharedCommand(dir, command, {
+        sessionId: payload.session_id,
+        alreadyInjected,
+        projectRoot: root,
+        episode,
+      });
+      if (shared) parts.push(shared);
 
-    const crossed = noteActClasses(state, command);
-    const repeated = forRepeatedAct(dir, command, crossed, {
-      sessionId: payload.session_id,
-      projectRoot: root,
-    });
-    if (repeated) parts.push(repeated);
+      const crossed = noteActClasses(state, command);
+      const repeated = forRepeatedAct(dir, command, crossed, {
+        sessionId: payload.session_id,
+        projectRoot: root,
+        episode,
+      });
+      if (repeated) parts.push(repeated);
+    }
   }
   state.injected = [...alreadyInjected];
 
   // Structural capture is evidence about what was touched, not a semantic
   // conclusion. It is therefore safe to automate for every client and leaves
   // the active model responsible for wiki_write at completion.
-  for (const { path, size } of touched) {
+  if (features.capture) for (const { path, size } of touched) {
     try {
       if (isArchived(path) || size > HARVEST_MAX_BYTES || !isFsSafePath(path))
         continue;
@@ -420,7 +416,10 @@ export async function run(clientName, event) {
 
   if (mode() === MODE_OFF) process.exit(0);
 
+  const features = featuresForArm();
+
   if (event === 'session-start') {
+    if (!features.routing && !features.retrieval && !features.harvest) process.exit(0);
     const output = contextOutput(client, eventName, policyText(client.canDeny));
     if (output) emit(output);
     process.exit(0);
@@ -437,10 +436,22 @@ export async function run(clientName, event) {
     const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? 'default';
     const agentScope = raw.transcript_path ?? raw.transcriptPath ?? null;
     const state = loadState(sessionId, agentScope);
+    const episode = episodeMeta({ client: clientName, raw });
+    try {
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+      recordEpisodeOutcome(dir, {
+        ...episode,
+        status: 'completed',
+        ...usageFrom(raw),
+      });
+    } catch {
+      // Evidence is best effort and must never stop a session from finishing.
+    }
     const alreadyHarvested =
       Number(state.edits || 0) > 0 &&
       Number(state.harvestedEdits || 0) >= Number(state.edits || 0);
-    const prompt = semanticHarvestPrompt({
+    const prompt = features.harvest ? semanticHarvestPrompt({
       edits: state.edits,
       files: state.editedFiles,
       model: raw.model,
@@ -449,7 +460,7 @@ export async function run(clientName, event) {
         raw.stopHookActive === true ||
         alreadyHarvested ||
         (clientName === 'cursor' && Number(raw.loop_count || 0) > 0),
-    });
+    }) : null;
     if (prompt) {
       state.harvestedEdits = Number(state.edits || 0);
       saveState(sessionId, state, agentScope);
@@ -466,6 +477,7 @@ export async function run(clientName, event) {
     process.exit(0);
   const payload = normalizePayload(normalizeClientPayload(clientName, event, raw));
   if (!payload.tool_name) process.exit(0);
+  const episode = episodeMeta({ client: clientName, raw, payload });
 
   // THE AGENT, not just the session -- the same scope the Claude Code router
   // applies. Subagents inherit the parent's session id, so keying state on the
@@ -506,17 +518,41 @@ export async function run(clientName, event) {
       const anchor = state.editedFiles[0]
         || join(payload.cwd || process.cwd(), '__recording__');
       const dir = wikiDir(projectRootFor(anchor, payload.cwd));
-      recordingContext = recordingNudge(dir, {
+      recordingContext = features.harvest ? recordingNudge(dir, {
         state,
         edits: state.edits,
         files: state.editedFiles,
-      });
+      }) : null;
       if (recordingContext) state.recordingNudged = true;
     } catch {
       // Recording pressure is an optimization and must never cost a tool call.
     }
   }
-  const verdict = decide(payload, state);
+  if (event === 'post-tool') {
+    try {
+      const command = payload.tool_input?.command;
+      const touched = touchedFiles(payload);
+      const anchor = command
+        ? String(command).slice(0, 120)
+        : touched[0]?.path || payload.tool_input?.file_path || '';
+      const root = command
+        ? commandProjectRoot(payload, payload.cwd)
+        : projectRootFor(anchor || join(payload.cwd || process.cwd(), '__tool__'), payload.cwd);
+      recordToolOutcome(wikiDir(root), {
+        ...episode,
+        surface: command ? 'command' : 'file',
+        anchor,
+        toolName: payload.tool_name,
+        success: toolSucceeded(raw),
+        durationMs: Number(raw.duration_ms ?? raw.durationMs ?? raw.elapsed_ms ?? raw.elapsedMs) || null,
+        ...usageFrom(raw),
+      });
+    } catch {
+      // Causal tracing is fail-open like every other hook optimization.
+    }
+  }
+
+  const verdict = features.routing ? decide(payload, state) : null;
   const repeat = verdict && event === 'pre-tool'
     ? alreadyDenied(state, verdict.key)
     : false;
@@ -571,7 +607,7 @@ export async function run(clientName, event) {
   remember(payload, state);
   let graphContext = null;
   try {
-    graphContext = observeAndInject(payload, state);
+    graphContext = observeAndInject(payload, state, episode, features);
   } catch {
     // Delivery is an optimization. Fail open.
   }

--- a/integrations/copilot/.github/hooks/lib/capabilities.mjs
+++ b/integrations/copilot/.github/hooks/lib/capabilities.mjs
@@ -1,0 +1,130 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/capabilities.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * The product's honest cross-client capability contract.
+ *
+ * A client is listed at the strongest surface its public lifecycle protocol can
+ * actually support.  This registry is consumed by the adapter, certification
+ * tooling, and evidence reports so a rules-only integration can never be
+ * presented as equivalent to a native stop-continuation integration.
+ */
+
+export const CAPABILITY_TIERS = Object.freeze({
+  CONTINUATION: 'lifecycle-continuation',
+  OBSERVATION: 'native-observation',
+  RULES: 'mcp-rules',
+});
+
+const native = (profile) => ({
+  structuralCapture: 'native',
+  findingDelivery: 'native',
+  routing: 'native-veto',
+  ...profile,
+});
+
+export const CLIENT_CAPABILITIES = Object.freeze({
+  'claude-code': native({
+    name: 'Claude Code', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-continuation', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  codex: native({
+    name: 'Codex', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-continuation', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  copilot: native({
+    name: 'GitHub Copilot CLI', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'agent-stop-continuation', canDeny: true,
+    contextStyle: 'top-level', denyStyle: 'top-level-permission', stopDecision: 'block',
+  }),
+  gemini: native({
+    name: 'Gemini CLI', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'after-agent-retry', canDeny: true,
+    denyStyle: 'top-level', stopDecision: 'deny',
+  }),
+  qwen: native({
+    name: 'Qwen Code', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-continuation', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  cursor: native({
+    name: 'Cursor', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-followup', canDeny: true,
+    contextStyle: 'cursor', denyStyle: 'cursor', stopStyle: 'followup', stopDecision: 'block',
+  }),
+  cline: native({
+    name: 'Cline', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    contextStyle: 'cline', denyStyle: 'cline', stopDecision: 'block',
+  }),
+  opencode: native({
+    name: 'OpenCode', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  kilo: native({
+    name: 'Kilo', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  windsurf: native({
+    name: 'Windsurf', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    contextStyle: 'silent', denyStyle: 'exit-2', stopDecision: 'block',
+  }),
+  roo: {
+    name: 'Roo Code', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  zed: {
+    name: 'Zed', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  amp: {
+    name: 'Amp', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  continue: {
+    name: 'Continue', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  crush: {
+    name: 'Crush', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  droid: {
+    name: 'Droid (Factory)', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+});
+
+export function capabilityFor(client) {
+  return CLIENT_CAPABILITIES[String(client || '').toLowerCase()] || null;
+}
+
+export function nativeClientProfiles() {
+  return Object.fromEntries(
+    Object.entries(CLIENT_CAPABILITIES)
+      .filter(([, profile]) => profile.structuralCapture === 'native')
+      .map(([key, profile]) => [key, { ...profile }])
+  );
+}
+
+export function capabilitySummary() {
+  return Object.entries(CLIENT_CAPABILITIES).map(([client, profile]) => ({
+    client,
+    name: profile.name,
+    tier: profile.tier,
+    routing: profile.routing,
+    structuralCapture: profile.structuralCapture,
+    findingDelivery: profile.findingDelivery,
+    semanticHarvest: profile.semanticHarvest,
+  }));
+}

--- a/integrations/copilot/.github/hooks/lib/decide.mjs
+++ b/integrations/copilot/.github/hooks/lib/decide.mjs
@@ -513,6 +513,8 @@ const TOOL_ALIASES = new Map(
     create_file: 'Write',
 
     bash: 'Bash',
+    powershell: 'Bash',
+    pwsh: 'Bash',
     shell: 'Bash',
     run_command: 'Bash',
     execute_command: 'Bash',

--- a/integrations/copilot/.github/hooks/lib/experiment.mjs
+++ b/integrations/copilot/.github/hooks/lib/experiment.mjs
@@ -1,0 +1,82 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/experiment.mjs. Regenerate with `npm run sync:hooks`.
+/** Explicit, reproducible feature arms and causal episode identity. */
+
+export const EXPERIMENT_ARMS = Object.freeze([
+  'baseline',
+  'optimizer',
+  'retrieval',
+  'full',
+]);
+
+const FEATURES = Object.freeze({
+  baseline: Object.freeze({ routing: false, retrieval: false, capture: false, harvest: false }),
+  optimizer: Object.freeze({ routing: true, retrieval: false, capture: false, harvest: false }),
+  retrieval: Object.freeze({ routing: true, retrieval: true, capture: true, harvest: false }),
+  full: Object.freeze({ routing: true, retrieval: true, capture: true, harvest: true }),
+});
+
+export function experimentArm(env = process.env) {
+  const requested = String(env.TOKEN_OPTIMIZER_EXPERIMENT_ARM || '').trim().toLowerCase();
+  return EXPERIMENT_ARMS.includes(requested) ? requested : 'full';
+}
+
+export function featuresForArm(arm = experimentArm()) {
+  return FEATURES[arm] || FEATURES.full;
+}
+
+const first = (...values) => values.find((value) => value !== undefined && value !== null && value !== '');
+
+/**
+ * Normalises identifiers exposed under different names by lifecycle clients.
+ * Environment overrides let the live evaluation harness pin a pair/task id
+ * without asking each CLI to support experiment-specific payload fields.
+ */
+export function episodeMeta({ client, raw = {}, payload = {}, env = process.env } = {}) {
+  const sessionId = String(first(
+    payload.session_id, raw.session_id, raw.sessionId, raw.conversation_id,
+    raw.conversationId, raw.taskId, raw.task_id, raw.trajectory_id, 'default'
+  ));
+  const episodeId = String(first(
+    env.TOKEN_OPTIMIZER_EPISODE_ID, raw.episode_id, raw.episodeId, sessionId
+  ));
+  const toolCallId = first(
+    raw.tool_use_id, raw.toolUseId, raw.tool_call_id, raw.toolCallId,
+    raw.call_id, raw.callId, raw.postToolUse?.toolUseId, raw.preToolUse?.toolUseId
+  );
+  const model = first(payload.model, raw.model?.slug, raw.model, raw.model_name, env.TOKEN_OPTIMIZER_MODEL);
+  const clientVersion = first(
+    raw.client_version, raw.clientVersion, raw.version, env.TOKEN_OPTIMIZER_CLIENT_VERSION
+  );
+  const modelVersion = first(raw.model_version, raw.modelVersion, env.TOKEN_OPTIMIZER_MODEL_VERSION);
+
+  return {
+    schemaVersion: 2,
+    episodeId,
+    sessionId,
+    turnId: first(raw.turn_id, raw.turnId, raw.message_id, raw.messageId) ?? null,
+    toolCallId: toolCallId == null ? null : String(toolCallId),
+    taskId: first(env.TOKEN_OPTIMIZER_TASK_ID, raw.task_id, raw.taskId) ?? null,
+    pairId: first(env.TOKEN_OPTIMIZER_PAIR_ID, raw.pair_id, raw.pairId) ?? null,
+    arm: experimentArm(env),
+    client: String(client || first(raw.client, raw.client_name, 'unknown')),
+    clientVersion: clientVersion == null ? null : String(clientVersion),
+    model: model == null ? null : String(model),
+    modelVersion: modelVersion == null ? null : String(modelVersion),
+  };
+}
+
+export function usageFrom(raw = {}) {
+  const usage = raw.usage || raw.token_usage || raw.tokenUsage || raw.metrics?.usage || {};
+  const number = (...values) => {
+    const value = first(...values);
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+  };
+  return {
+    uncachedInputTokens: number(usage.uncached_input_tokens, usage.uncachedInputTokens),
+    cachedInputTokens: number(usage.cached_input_tokens, usage.cachedInputTokens, usage.cache_read_input_tokens),
+    outputTokens: number(usage.output_tokens, usage.outputTokens),
+    totalTokens: number(usage.total_tokens, usage.totalTokens, raw.tokens_used, raw.tokensUsed),
+  };
+}

--- a/integrations/copilot/.github/hooks/lib/harvest-write.mjs
+++ b/integrations/copilot/.github/hooks/lib/harvest-write.mjs
@@ -96,8 +96,13 @@ function promoteToShared(finding, { projectRoot, sessionId, provenance, key }) {
           key: `shared-${key}`,
           claim: finding.claim,
           confidence: finding.confidence,
+          confidenceLabel: finding.confidenceLabel,
           type: finding.type,
           trigger: typeof finding.trigger === 'string' && finding.trigger ? finding.trigger : undefined,
+          applicability: finding.applicability,
+          evidence: finding.evidence,
+          invalidators: Array.isArray(finding.invalidators) ? finding.invalidators : [],
+          scope: finding.scope || 'global',
           origin: provenance,
           quote: typeof finding.quote === 'string' && finding.quote.trim() ? finding.quote : undefined,
           // WHERE IT WAS LEARNED, carried so the reader can discount it. A lesson
@@ -351,6 +356,26 @@ export function writeHarvested(
     // anything, so it is dropped rather than kept as unfalsifiable.
     if (!resolved.length) continue;
 
+    // Exact semantic duplicates collapse to the existing active record.  The
+    // normalisation intentionally ignores punctuation/formatting noise but not
+    // meaning-bearing words; near-duplicates that need judgement remain visible
+    // to curation rather than being silently merged by a fuzzy heuristic.
+    const fingerprint = claimFingerprint(finding.claim);
+    const currentGraph = load(dir);
+    const duplicate = [...currentGraph.nodes.values()].find((node) =>
+      node.kind === 'finding'
+      && !node.retired
+      && node.type === finding.type
+      && claimFingerprint(node.claim) === fingerprint
+      && resolved.every((target) => currentGraph.edges.some((edge) =>
+        edge.from === node.id && edge.edge === 'derived_from' && edge.to === target
+      ))
+    );
+    if (duplicate) {
+      written.push(duplicate.key);
+      continue;
+    }
+
     // Date.now() plus an index is not unique across CONCURRENT detached
     // workers: two Stop hooks finishing in the same millisecond produce the
     // same key, and putNode keeps the last write for an id -- so one session's
@@ -371,6 +396,7 @@ export function writeHarvested(
         key,
         claim: finding.claim,
         confidence: finding.confidence,
+        confidenceLabel: finding.confidenceLabel,
         type: finding.type,
         // WHEN this finding is relevant, not just what it is about. Anchors
         // answer "which file", which is the wrong question for a claim about
@@ -380,6 +406,16 @@ export function writeHarvested(
         trigger: typeof finding.trigger === 'string' && finding.trigger
           ? finding.trigger
           : undefined,
+        applicability: typeof finding.applicability === 'string'
+          ? finding.applicability
+          : undefined,
+        evidence: typeof finding.evidence === 'string'
+          ? finding.evidence
+          : undefined,
+        invalidators: Array.isArray(finding.invalidators)
+          ? finding.invalidators
+          : [],
+        scope: finding.scope || 'project',
         origin: provenance,
         // THE EVIDENCE TRAVELS WITH THE CLAIM. Without it a human-origin
         // finding asserts its own provenance and nothing can check it.
@@ -398,7 +434,11 @@ export function writeHarvested(
     // record of what happened here; the shared tier is a copy for the lessons
     // that are not about here. Skipped when the two are the same directory,
     // which is the suite's usual arrangement.
-    if (id && !isSharedDir(dir)) {
+    if (
+      id
+      && !isSharedDir(dir)
+      && (finding.scope === undefined || finding.scope === 'organization' || finding.scope === 'global')
+    ) {
       promoteToShared(finding, { projectRoot, sessionId, provenance, key });
     }
   }

--- a/integrations/copilot/.github/hooks/lib/harvest.mjs
+++ b/integrations/copilot/.github/hooks/lib/harvest.mjs
@@ -201,7 +201,11 @@ const PROMPT = `Extract durable findings from this coding session for a project 
 Return ONLY a JSON array. Each element:
 {"type": "finding|decision|failure|command|map",
  "claim": "one sentence, specific and checkable",
- "confidence": 0.0-1.0,
+ "evidence": "the concrete observation, command result, or rejected approach that proved it",
+ "applicability": "the condition under which a future model should use it",
+ "confidenceLabel": "verified|probable|speculative",
+ "scope": "project|organization|global",
+ "invalidators": ["what change would require this to be checked again"],
  "anchors": ["absolute/file/path" or "absolute/file/path#symbolName"]}
 
 RULES:
@@ -211,7 +215,9 @@ RULES:
 - Prefer "failure" and "decision" entries. What was TRIED AND REJECTED, and WHY,
   is the most valuable thing here because it exists nowhere in the source tree.
 - Do not restate what the code plainly says. Record what someone had to work out.
-- confidence reflects how well established the claim is, not how important.
+- verified requires direct evidence; probable means strong but incomplete evidence;
+  speculative is a hypothesis and must be labelled as such.
+- Use project scope unless the lesson is genuinely independent of this repository.
 - If nothing durable was learned, return [].`;
 
 /**
@@ -232,8 +238,29 @@ export function validate(raw, { knownFiles = null } = {}) {
     if (!FINDING_TYPES.includes(item.type)) continue;
     if (typeof item.claim !== 'string' || item.claim.trim().length < 8) continue;
 
-    const confidence = Number(item.confidence);
-    if (!Number.isFinite(confidence) || confidence <= 0 || confidence > 1) continue;
+    const evidence = typeof item.evidence === 'string' ? item.evidence.trim() : '';
+    const applicability = typeof item.applicability === 'string' ? item.applicability.trim() : '';
+    if (evidence.length < 8 || applicability.length < 8) continue;
+
+    const confidenceLabel = ['verified', 'probable', 'speculative'].includes(item.confidenceLabel)
+      ? item.confidenceLabel
+      : null;
+    if (!confidenceLabel) continue;
+    const defaults = { verified: 0.95, probable: 0.75, speculative: 0.45 };
+    const supplied = Number(item.confidence);
+    if (
+      item.confidence !== undefined
+      && (!Number.isFinite(supplied) || supplied <= 0 || supplied > 1)
+    ) continue;
+    const confidence = item.confidence === undefined
+      ? defaults[confidenceLabel]
+      : supplied;
+    const scope = ['project', 'organization', 'global'].includes(item.scope)
+      ? item.scope
+      : 'project';
+    const invalidators = Array.isArray(item.invalidators)
+      ? item.invalidators.filter((value) => typeof value === 'string' && value.trim()).slice(0, 10)
+      : [];
 
     let anchors = Array.isArray(item.anchors) ? item.anchors.filter((a) => typeof a === 'string' && a) : [];
     // A model asked for file paths will sometimes invent them. When the caller
@@ -241,7 +268,18 @@ export function validate(raw, { knownFiles = null } = {}) {
     if (knownFiles) anchors = anchors.filter((a) => knownFiles.has(a.split('#')[0]));
     if (!anchors.length) continue;
 
-    accepted.push({ type: item.type, claim: item.claim.trim(), confidence, anchors });
+    accepted.push({
+      type: item.type,
+      claim: item.claim.trim(),
+      evidence,
+      applicability,
+      confidence,
+      confidenceLabel,
+      scope,
+      invalidators,
+      anchors,
+      trigger: typeof item.trigger === 'string' ? item.trigger : undefined,
+    });
   }
   return accepted;
 }

--- a/integrations/copilot/.github/hooks/lib/inject.mjs
+++ b/integrations/copilot/.github/hooks/lib/inject.mjs
@@ -30,6 +30,7 @@ import { inHoldout, record, indexBudget } from './metrics.mjs';
 import { canonicalPath, resolvableCandidates } from './paths.mjs';
 import { annotatedSkeleton } from './skeleton.mjs';
 import { substitutionBudget } from './metrics.mjs';
+import { assessFindings } from './utility.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
@@ -150,7 +151,7 @@ export function forTouch(
   dir,
   graph,
   rawPath,
-  { budget = touchBudget(), sessionId, alreadyInjected = new Set() } = {}
+  { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
   // Canonical, so a touch finds findings anchored under any other spelling.
   const filePath = canonicalPath(rawPath);
@@ -169,16 +170,36 @@ export function forTouch(
   // variance drops out. A session-pinned arm would destroy that.
   const holdout = inHoldout(filePath);
   const served = serve(graph, candidates);
-  const { kept, spent } = fit(served, budget);
+  const assessed = assessFindings(dir, served, {
+    episodeId: episode.episodeId || sessionId,
+    relevanceFor: () => 1,
+    costFor: (finding) => estimate(render(finding)),
+  });
+  if (assessed.rejected.length) {
+    record(dir, {
+      kind: 'retrieval-decision', ...episode, sessionId,
+      surface: 'file', anchor: filePath,
+      rejected: assessed.rejected.map(({ key, reason }) => ({ key, reason })),
+    });
+    for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
+  }
+  const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
+  if (!kept.length) return null;
 
   record(dir, {
     kind: 'inject',
+    ...episode,
     // The surface whose saving CAN be measured: reads of this anchor afterwards.
     surface: 'file',
     anchor: filePath,
     holdout,
     tokens: holdout ? 0 : spent,
-    count: kept.length,
+    deliveredTokens: holdout ? 0 : spent,
+    shadowTokens: spent,
+    count: holdout ? 0 : kept.length,
+    candidateCount: kept.length,
+    findingIds: holdout ? [] : kept.map((finding) => finding.key),
+    shadowFindingIds: kept.map((finding) => finding.key),
     stale: kept.some((f) => f.stale),
     sessionId,
   });
@@ -297,7 +318,7 @@ export function forCommand(
   dir,
   graph,
   command,
-  { budget = touchBudget(), sessionId, alreadyInjected = new Set() } = {}
+  { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
   if (!command) return null;
 
@@ -335,7 +356,20 @@ export function forCommand(
   const considered = candidates.slice(0, MAX_COMMAND_CANDIDATES);
 
   const served = serve(graph, considered);
-  const { kept, spent } = fit(served, budget);
+  const assessed = assessFindings(dir, served, {
+    episodeId: episode.episodeId || sessionId,
+    relevanceFor: (finding) => explicit(finding) ? 1 : 0.6,
+    costFor: (finding) => estimate(render(finding)),
+  });
+  if (assessed.rejected.length) {
+    record(dir, {
+      kind: 'retrieval-decision', ...episode, sessionId,
+      surface: 'command', anchor: String(command).slice(0, 120),
+      rejected: assessed.rejected.map(({ key: findingKey, reason }) => ({ key: findingKey, reason })),
+    });
+    for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
+  }
+  const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
   if (!kept.length) return null;
 
   // THE COMMAND PATH TAKES PART IN THE HOLDOUT TOO.
@@ -353,6 +387,7 @@ export function forCommand(
 
   record(dir, {
     kind: 'inject',
+    ...episode,
     trigger: 'command',
     // The surface the report needs to keep these OUT of the file-read balance:
     // a command has no anchor that read events can be joined to.
@@ -360,7 +395,12 @@ export function forCommand(
     anchor: String(command).slice(0, 120),
     holdout,
     tokens: holdout ? 0 : spent,
+    deliveredTokens: holdout ? 0 : spent,
+    shadowTokens: spent,
     count: holdout ? 0 : kept.length,
+    candidateCount: kept.length,
+    findingIds: holdout ? [] : kept.map((finding) => finding.key),
+    shadowFindingIds: kept.map((finding) => finding.key),
     stale: kept.some((f) => f.stale),
     sessionId,
   });
@@ -509,7 +549,7 @@ export function forRepeatedAct(
   projectDir,
   command,
   crossedClasses,
-  { sessionId = null, projectRoot = null } = {}
+  { sessionId = null, projectRoot = null, episode = {} } = {}
 ) {
   if (!crossedClasses || !crossedClasses.size) return null;
 
@@ -527,14 +567,33 @@ export function forRepeatedAct(
       if (![...crossedClasses].some((c) => claimClasses.has(c))) continue;
 
       const cls = [...crossedClasses].find((c) => claimClasses.has(c));
+      const assessed = assessFindings(projectDir, [node], {
+        episodeId: episode.episodeId || sessionId,
+        relevanceFor: () => 1,
+        costFor: (finding) => estimate(render(finding)),
+      });
+      if (!assessed.eligible.length) {
+        record(projectDir, {
+          kind: 'retrieval-decision', ...episode, sessionId,
+          surface: 'shared', anchor: String(command).slice(0, 120),
+          rejected: assessed.rejected.map(({ key, reason }) => ({ key, reason })),
+        });
+        continue;
+      }
       record(projectDir, {
         kind: 'inject',
+        ...episode,
         trigger: 'repeat',
         surface: 'shared',
         anchor: String(command).slice(0, 120),
         holdout: false,
         tokens: estimate(node.claim),
+        deliveredTokens: estimate(node.claim),
+        shadowTokens: estimate(node.claim),
         count: 1,
+        candidateCount: 1,
+        findingIds: [node.key],
+        shadowFindingIds: [node.key],
         stale: false,
         sessionId,
       });
@@ -585,7 +644,10 @@ function appliesCrossProject(finding, command) {
 export function forSharedCommand(
   projectDir,
   command,
-  { budget = sharedBudget(), sessionId = null, alreadyInjected = new Set(), projectRoot = null } = {}
+  {
+    budget = sharedBudget(), sessionId = null, alreadyInjected = new Set(),
+    projectRoot = null, episode = {},
+  } = {}
 ) {
   if (!command) return null;
 
@@ -622,7 +684,21 @@ export function forSharedCommand(
     // No serve() here: these types are not content-dependent, so there is no
     // anchor to re-read and nothing to diff. serve() would spend a file read per
     // finding to answer a question that does not apply to them.
-    const { kept, spent } = fit(candidates.slice(0, MAX_SHARED), budget);
+    const considered = candidates.slice(0, MAX_SHARED);
+    const assessed = assessFindings(projectDir, considered, {
+      episodeId: episode.episodeId || sessionId,
+      relevanceFor: (finding) => explicit(finding) ? 0.8 : 0.5,
+      costFor: (finding) => estimate(render(finding)),
+    });
+    if (assessed.rejected.length) {
+      record(projectDir, {
+        kind: 'retrieval-decision', ...episode, sessionId,
+        surface: 'shared', anchor: String(command).slice(0, 120),
+        rejected: assessed.rejected.map(({ key, reason }) => ({ key, reason })),
+      });
+      for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
+    }
+    const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
     if (!kept.length) return null;
 
     // THE SAME ARM AS THE LOCAL PATH, KEYED THE SAME WAY.
@@ -644,6 +720,7 @@ export function forSharedCommand(
 
     record(projectDir, {
       kind: 'inject',
+      ...episode,
       trigger: 'command',
       // ITS OWN SURFACE. The balance sheet joins `file` injections to later read
       // events; a shared lesson has no anchor in this project to join to, and
@@ -653,7 +730,12 @@ export function forSharedCommand(
       anchor: String(command).slice(0, 120),
       holdout,
       tokens: holdout ? 0 : spent,
+      deliveredTokens: holdout ? 0 : spent,
+      shadowTokens: spent,
       count: holdout ? 0 : kept.length,
+      candidateCount: kept.length,
+      findingIds: holdout ? [] : kept.map((finding) => finding.key),
+      shadowFindingIds: kept.map((finding) => finding.key),
       stale: false,
       sessionId,
     });

--- a/integrations/copilot/.github/hooks/lib/inject.mjs
+++ b/integrations/copilot/.github/hooks/lib/inject.mjs
@@ -571,6 +571,10 @@ export function forRepeatedAct(
         episodeId: episode.episodeId || sessionId,
         relevanceFor: () => 1,
         costFor: (finding) => estimate(render(finding)),
+        // This surface exists specifically to re-surface a lesson once the
+        // session crosses the repeat threshold. Ordinary retrieval remains
+        // cooldown-protected; harm quarantine and utility gating still apply.
+        bypassCooldown: true,
       });
       if (!assessed.eligible.length) {
         record(projectDir, {

--- a/integrations/copilot/.github/hooks/lib/metrics.mjs
+++ b/integrations/copilot/.github/hooks/lib/metrics.mjs
@@ -1022,6 +1022,7 @@ function armMetrics(runs) {
     runs: runs.length,
     correctness: proportionInterval(correct, runs.length),
     uncachedInputTokens: interval('uncachedInputTokens'),
+    cacheCreationInputTokens: interval('cacheCreationInputTokens'),
     cachedInputTokens: interval('cachedInputTokens'),
     outputTokens: interval('outputTokens'),
     totalTokens: interval('totalTokens'),
@@ -1034,31 +1035,37 @@ function armMetrics(runs) {
   };
 }
 
-function pairedEffects(runs, treatmentArm) {
+function pairedEffects(runs, controlArm, treatmentArm, contrastType = 'incremental') {
   const pairs = new Map();
   for (const run of runs) {
-    if (!run.pairId || !['baseline', treatmentArm].includes(run.arm)) continue;
+    if (!run.pairId || ![controlArm, treatmentArm].includes(run.arm)) continue;
     if (!pairs.has(run.pairId)) pairs.set(run.pairId, {});
     pairs.get(run.pairId)[run.arm] = run;
   }
-  const complete = [...pairs.values()].filter((pair) => pair.baseline && pair[treatmentArm]);
+  const complete = [...pairs.values()].filter((pair) => pair[controlArm] && pair[treatmentArm]);
   const delta = (field, lowerIsBetter = true) => bootstrapMeanInterval(
     complete
       .map((pair) => {
-        const baseline = numeric(pair.baseline[field]);
+        const baseline = numeric(pair[controlArm][field]);
         const treatment = numeric(pair[treatmentArm][field]);
         if (baseline === null || treatment === null) return null;
         return lowerIsBetter ? baseline - treatment : treatment - baseline;
       })
       .filter((value) => value !== null),
-    { seed: `${treatmentArm}:${field}` }
+    { seed: `${controlArm}:${treatmentArm}:${field}` }
   );
   return {
     arm: treatmentArm,
+    controlArm,
+    comparison: `${treatmentArm} vs ${controlArm}`,
+    contrastType,
     pairs: complete.length,
     // Positive values always mean the treatment improved the metric.
     totalTokensSaved: delta('totalTokens'),
     uncachedInputTokensSaved: delta('uncachedInputTokens'),
+    cacheCreationInputTokensSaved: delta('cacheCreationInputTokens'),
+    cachedInputTokensSaved: delta('cachedInputTokens'),
+    outputTokensSaved: delta('outputTokens'),
     toolCallsAvoided: delta('toolCalls'),
     latencyMsSaved: delta('latencyMs'),
     costUsdSaved: delta('costUsd'),
@@ -1124,8 +1131,13 @@ export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
         armMetrics(cohortRuns.filter((run) => run.arm === arm)),
       ])
     );
-    const effects = ['optimizer', 'retrieval', 'full'].map((arm) => pairedEffects(cohortRuns, arm));
-    const enough = effects.some((effect) => effect.pairs >= minimumPairs);
+    const effects = [
+      pairedEffects(cohortRuns, 'baseline', 'optimizer'),
+      pairedEffects(cohortRuns, 'optimizer', 'retrieval'),
+      pairedEffects(cohortRuns, 'retrieval', 'full'),
+      pairedEffects(cohortRuns, 'baseline', 'full', 'total-system'),
+    ];
+    const enough = effects.every((effect) => effect.pairs >= minimumPairs);
     return {
       key,
       client: cohortRuns[0]?.client || 'unknown',
@@ -1165,7 +1177,8 @@ export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
     episodes: traced,
     methodology: {
       intervals: 'deterministic percentile bootstrap (95%); Wilson interval for correctness',
-      causalRule: 'only matched eval-run pairs compare an arm with baseline',
+      causalRule:
+        'matched pairs estimate optimizer vs baseline, retrieval vs optimizer, full vs retrieval, and full vs baseline',
       minimumPairs,
       deterministicChecksAreCausalProof: false,
     },

--- a/integrations/copilot/.github/hooks/lib/metrics.mjs
+++ b/integrations/copilot/.github/hooks/lib/metrics.mjs
@@ -61,6 +61,7 @@ const metricsPath = (dir) => join(dir, 'metrics.jsonl');
  * on it drops BOTH arms proportionally instead of starving the rare one.
  */
 const balancePath = (dir) => join(dir, 'balance.jsonl');
+const evidencePath = (dir) => join(dir, 'evidence.jsonl');
 
 /** Kinds the net balance is computed from, and which therefore must survive. */
 /**
@@ -83,6 +84,24 @@ export const BALANCE_KINDS = new Set([
   // aged out before it was written and the backstop was structurally unable to fire, reporting
   // "only N/10 refreshes observed" for the life of the project.
   'keepwarm',
+]);
+
+/**
+ * Causal records have their own bounded log.  Tool outcomes are much rarer
+ * than read/capture telemetry but more frequent than balance records; mixing
+ * them into either window would eventually evict the evidence needed to join
+ * an injection to its result.
+ */
+export const EVIDENCE_KINDS = new Set([
+  'inject',
+  'harvest',
+  'tool-outcome',
+  'episode-outcome',
+  'eval-run',
+  'finding-feedback',
+  'retrieval-decision',
+  'mcp-client',
+  'mcp-tool',
 ]);
 
 /**
@@ -198,15 +217,30 @@ export function record(dir, event) {
     // single millisecond collapsed to ONE, so a graph with ample data reported
     // 'insufficient data (2 treated, 1 holdout)'. Real events were being
     // discarded by the deduplicator, silently.
-    const line =
-      JSON.stringify({ id: nextId(), ...event, at: event.at ?? Date.now() }) + '\n';
+    const id = event.id || nextId();
+    const complete = {
+      schemaVersion: event.schemaVersion || 2,
+      id,
+      ...event,
+      // An injection id is first-class rather than an inference from the log
+      // record id.  Exporters may rewrite record ids while preserving causal
+      // identity, and downstream tool outcomes refer to this value explicitly.
+      ...(event.kind === 'inject'
+        ? { injectionId: event.injectionId || id }
+        : {}),
+      at: event.at ?? Date.now(),
+    };
+    const line = JSON.stringify(complete) + '\n';
     appendFileSync(metricsPath(dir), line);
     // Balance-critical records go to their own log as well, so the windows on
     // the firehose can never starve the measurement. Written SECOND: a torn
     // write here costs a duplicate the reader dedupes, not a lost event.
     if (BALANCE_KINDS.has(event.kind)) appendFileSync(balancePath(dir), line);
+    if (EVIDENCE_KINDS.has(event.kind)) appendFileSync(evidencePath(dir), line);
+    return complete;
   } catch {
     // Metrics must never break a tool call.
+    return null;
   }
 }
 
@@ -402,6 +436,92 @@ export function readBalance(dir) {
     out.push(e);
   }
   return out;
+}
+
+/** Every causal evidence record inside the byte cap, deduplicated by id. */
+export function readEvidence(dir) {
+  const path = evidencePath(dir);
+  if (!existsSync(path)) return [];
+
+  let text = '';
+  try {
+    const { size } = statSync(path);
+    if (size <= MAX_BYTES) {
+      text = readFileSync(path, 'utf8');
+    } else {
+      const fd = openSync(path, 'r');
+      try {
+        const buffer = Buffer.allocUnsafe(MAX_BYTES);
+        const read = readSync(fd, buffer, 0, MAX_BYTES, size - MAX_BYTES);
+        text = buffer.subarray(0, read).toString('utf8');
+      } finally {
+        closeSync(fd);
+      }
+      text = text.slice(text.indexOf('\n') + 1);
+    }
+  } catch {
+    return [];
+  }
+
+  const seen = new Set();
+  const out = [];
+  for (const line of text.split('\n')) {
+    if (!line) continue;
+    try {
+      const event = JSON.parse(line);
+      if (!EVIDENCE_KINDS.has(event.kind)) continue;
+      const id = event.id || JSON.stringify(event);
+      if (seen.has(id)) continue;
+      seen.add(id);
+      out.push(event);
+    } catch {
+      // A concurrently appended final line may be torn.  It costs one record,
+      // never the user's tool call or the rest of the evidence report.
+    }
+  }
+  return out;
+}
+
+/**
+ * Joins a post-tool result to the most recent matching injection.  The exact
+ * tool-call id wins; clients that omit it fall back to episode + surface +
+ * anchor, in timestamp order, and the report states the weaker join method.
+ */
+export function recordToolOutcome(dir, outcome) {
+  const evidence = readEvidence(dir);
+  const anchor = String(outcome.anchor || '').slice(0, 120);
+  const candidates = evidence
+    .filter((event) => event.kind === 'inject' && event.episodeId === outcome.episodeId)
+    .filter((event) => {
+      if (outcome.toolCallId && event.toolCallId)
+        return String(event.toolCallId) === String(outcome.toolCallId);
+      return event.surface === outcome.surface && String(event.anchor || '').slice(0, 120) === anchor;
+    })
+    .sort((a, b) => (b.at || 0) - (a.at || 0));
+  const injection = candidates[0] || null;
+  const joinMethod = injection
+    ? (outcome.toolCallId && injection.toolCallId ? 'tool-call-id' : 'episode-anchor')
+    : 'none';
+
+  return record(dir, {
+    kind: 'tool-outcome',
+    ...outcome,
+    anchor,
+    injectionId: injection?.injectionId || null,
+    findingIds: injection?.findingIds || [],
+    joinMethod,
+  });
+}
+
+export function recordEpisodeOutcome(dir, outcome) {
+  return record(dir, { kind: 'episode-outcome', ...outcome });
+}
+
+export function recordFindingFeedback(dir, feedback) {
+  const rating = ['helpful', 'neutral', 'harmful'].includes(feedback?.rating)
+    ? feedback.rating
+    : 'neutral';
+  return record(dir, { kind: 'finding-feedback', ...feedback, rating });
 }
 
 /**
@@ -813,4 +933,241 @@ export function indexBudget(dir, { floor = 150, base = 300, ceiling = 1200 } = {
   // 0% hit rate falls to the floor; ~50% and above reaches the ceiling.
   const scaled = Math.round(floor + (ceiling - floor) * Math.min(1, hitRate * 2));
   return Math.max(floor, Math.min(ceiling, scaled));
+}
+
+/* ----------------------------------------------------------------------
+ * Episode-level causal evidence
+ * ------------------------------------------------------------------- */
+
+const numeric = (value) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const average = (values) => {
+  const finite = values.map(numeric).filter((value) => value !== null);
+  return finite.length
+    ? finite.reduce((sum, value) => sum + value, 0) / finite.length
+    : null;
+};
+
+/** Deterministic PRNG so regenerating a report does not move its interval. */
+function seededRandom(seedText) {
+  let seed = 2166136261;
+  for (const char of String(seedText)) {
+    seed ^= char.charCodeAt(0);
+    seed = Math.imul(seed, 16777619);
+  }
+  return () => {
+    seed += 0x6d2b79f5;
+    let value = seed;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Percentile bootstrap interval for a mean, paired delta, or other scalar. */
+export function bootstrapMeanInterval(values, { samples = 1000, seed = 'token-optimizer' } = {}) {
+  const finite = values.map(numeric).filter((value) => value !== null);
+  if (!finite.length) return { mean: null, low: null, high: null, n: 0 };
+  if (finite.length === 1) {
+    return { mean: finite[0], low: finite[0], high: finite[0], n: 1 };
+  }
+
+  const random = seededRandom(`${seed}:${finite.join(',')}`);
+  const means = [];
+  for (let sample = 0; sample < samples; sample++) {
+    let total = 0;
+    for (let index = 0; index < finite.length; index++) {
+      total += finite[Math.floor(random() * finite.length)];
+    }
+    means.push(total / finite.length);
+  }
+  means.sort((a, b) => a - b);
+  return {
+    mean: average(finite),
+    low: means[Math.floor(means.length * 0.025)],
+    high: means[Math.min(means.length - 1, Math.floor(means.length * 0.975))],
+    n: finite.length,
+  };
+}
+
+/** Wilson interval keeps small correctness samples honest and inside 0..1. */
+export function proportionInterval(successes, total, z = 1.96) {
+  if (!total) return { rate: null, low: null, high: null, n: 0 };
+  const rate = successes / total;
+  const denominator = 1 + (z * z) / total;
+  const centre = (rate + (z * z) / (2 * total)) / denominator;
+  const radius =
+    (z / denominator) * Math.sqrt((rate * (1 - rate)) / total + (z * z) / (4 * total * total));
+  return { rate, low: Math.max(0, centre - radius), high: Math.min(1, centre + radius), n: total };
+}
+
+const cohortKey = (run) => [
+  run.client || 'unknown',
+  run.clientVersion || 'unknown',
+  run.model || 'unknown',
+  run.modelVersion || 'unknown',
+  run.taskId || 'unknown',
+].join('|');
+
+function armMetrics(runs) {
+  const correct = runs.filter((run) => run.correct === true).length;
+  const interval = (field) => bootstrapMeanInterval(
+    runs.map((run) => run[field]).filter((value) => numeric(value) !== null),
+    { seed: field }
+  );
+  return {
+    runs: runs.length,
+    correctness: proportionInterval(correct, runs.length),
+    uncachedInputTokens: interval('uncachedInputTokens'),
+    cachedInputTokens: interval('cachedInputTokens'),
+    outputTokens: interval('outputTokens'),
+    totalTokens: interval('totalTokens'),
+    toolCalls: interval('toolCalls'),
+    failedToolCalls: interval('failedToolCalls'),
+    latencyMs: interval('latencyMs'),
+    costUsd: interval('costUsd'),
+    injectedTokens: interval('injectedTokens'),
+    harmfulFindings: runs.reduce((sum, run) => sum + (numeric(run.harmfulFindings) || 0), 0),
+  };
+}
+
+function pairedEffects(runs, treatmentArm) {
+  const pairs = new Map();
+  for (const run of runs) {
+    if (!run.pairId || !['baseline', treatmentArm].includes(run.arm)) continue;
+    if (!pairs.has(run.pairId)) pairs.set(run.pairId, {});
+    pairs.get(run.pairId)[run.arm] = run;
+  }
+  const complete = [...pairs.values()].filter((pair) => pair.baseline && pair[treatmentArm]);
+  const delta = (field, lowerIsBetter = true) => bootstrapMeanInterval(
+    complete
+      .map((pair) => {
+        const baseline = numeric(pair.baseline[field]);
+        const treatment = numeric(pair[treatmentArm][field]);
+        if (baseline === null || treatment === null) return null;
+        return lowerIsBetter ? baseline - treatment : treatment - baseline;
+      })
+      .filter((value) => value !== null),
+    { seed: `${treatmentArm}:${field}` }
+  );
+  return {
+    arm: treatmentArm,
+    pairs: complete.length,
+    // Positive values always mean the treatment improved the metric.
+    totalTokensSaved: delta('totalTokens'),
+    uncachedInputTokensSaved: delta('uncachedInputTokens'),
+    toolCallsAvoided: delta('toolCalls'),
+    latencyMsSaved: delta('latencyMs'),
+    costUsdSaved: delta('costUsd'),
+    correctnessDelta: delta('correct', false),
+  };
+}
+
+function matchesFilters(event, filters) {
+  for (const field of ['client', 'clientVersion', 'model', 'modelVersion', 'taskId', 'arm']) {
+    if (filters[field] && String(event[field] || '') !== String(filters[field])) return false;
+  }
+  return true;
+}
+
+/**
+ * The dashboard-facing evidence console.  Deterministic fixture verification,
+ * live hook traces, and randomized model evals remain visibly distinct: only
+ * `eval-run` records with paired arms can produce a causal effect interval.
+ */
+export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
+  const evidence = readEvidence(dir).filter((event) => matchesFilters(event, filters));
+  const runs = evidence.filter((event) => event.kind === 'eval-run');
+  const injections = evidence.filter((event) => event.kind === 'inject');
+  const outcomes = evidence.filter((event) => event.kind === 'tool-outcome');
+  const feedback = evidence.filter((event) => event.kind === 'finding-feedback');
+
+  const byInjection = new Map(
+    outcomes.filter((event) => event.injectionId).map((event) => [event.injectionId, event])
+  );
+  const traced = injections
+    .slice()
+    .sort((a, b) => (b.at || 0) - (a.at || 0))
+    .slice(0, Math.max(1, Math.min(500, episodeLimit)))
+    .map((injection) => ({
+      injectionId: injection.injectionId,
+      episodeId: injection.episodeId || injection.sessionId || null,
+      at: injection.at,
+      arm: injection.arm || (injection.holdout ? 'holdout' : 'treated'),
+      client: injection.client || 'unknown',
+      clientVersion: injection.clientVersion || null,
+      model: injection.model || null,
+      taskId: injection.taskId || null,
+      surface: injection.surface || injection.trigger || 'file',
+      anchor: injection.anchor,
+      findingIds: injection.findingIds || [],
+      deliveredTokens: injection.deliveredTokens ?? injection.tokens ?? 0,
+      shadowTokens: injection.shadowTokens ?? injection.tokens ?? 0,
+      outcome: byInjection.get(injection.injectionId) || null,
+    }));
+
+  const grouped = new Map();
+  for (const run of runs) {
+    const key = cohortKey(run);
+    if (!grouped.has(key)) grouped.set(key, []);
+    grouped.get(key).push(run);
+  }
+
+  const minimumPairs = Math.max(2, Number(process.env.TOKEN_OPTIMIZER_EVAL_MIN_PAIRS) || 5);
+  const cohorts = [...grouped.entries()].map(([key, cohortRuns]) => {
+    const arms = Object.fromEntries(
+      ['baseline', 'optimizer', 'retrieval', 'full'].map((arm) => [
+        arm,
+        armMetrics(cohortRuns.filter((run) => run.arm === arm)),
+      ])
+    );
+    const effects = ['optimizer', 'retrieval', 'full'].map((arm) => pairedEffects(cohortRuns, arm));
+    const enough = effects.some((effect) => effect.pairs >= minimumPairs);
+    return {
+      key,
+      client: cohortRuns[0]?.client || 'unknown',
+      clientVersion: cohortRuns[0]?.clientVersion || null,
+      model: cohortRuns[0]?.model || null,
+      modelVersion: cohortRuns[0]?.modelVersion || null,
+      taskId: cohortRuns[0]?.taskId || null,
+      arms,
+      effects,
+      evidenceStatus: enough
+        ? 'causal estimate available'
+        : `insufficient paired runs (need ${minimumPairs})`,
+    };
+  });
+
+  const joined = injections.filter((injection) =>
+    byInjection.has(injection.injectionId)
+  ).length;
+  const harmful = feedback.filter((event) => event.rating === 'harmful').length;
+  return {
+    schemaVersion: 2,
+    generatedAt: new Date().toISOString(),
+    filters,
+    summary: {
+      liveInjections: injections.length,
+      joinedOutcomes: joined,
+      causalJoinCoverage: injections.length ? joined / injections.length : null,
+      evalRuns: runs.length,
+      cohorts: cohorts.length,
+      harmfulFeedback: harmful,
+      harmRate: feedback.length ? harmful / feedback.length : null,
+      evidenceStatus: cohorts.some((cohort) => cohort.evidenceStatus === 'causal estimate available')
+        ? 'causal estimates available'
+        : 'insufficient randomized evidence',
+    },
+    cohorts,
+    episodes: traced,
+    methodology: {
+      intervals: 'deterministic percentile bootstrap (95%); Wilson interval for correctness',
+      causalRule: 'only matched eval-run pairs compare an arm with baseline',
+      minimumPairs,
+      deterministicChecksAreCausalProof: false,
+    },
+  };
 }

--- a/integrations/copilot/.github/hooks/lib/recording.mjs
+++ b/integrations/copilot/.github/hooks/lib/recording.mjs
@@ -159,6 +159,9 @@ export function semanticHarvestPrompt({
     + ' If this work produced a durable, non-obvious conclusion -- a failed approach and why, '
     + 'a decision and its rejected alternative, or a command that finally worked -- call '
     + 'wiki_write now with a real file anchor. Do not delegate this to another model or an '
-    + 'external harvester. If there is no such conclusion, do not invent one; finish normally.'
+    + 'external harvester. Include: the concrete evidence, when the finding applies, a calibrated '
+    + 'confidenceLabel (verified/probable/speculative), its project/organization/global scope, '
+    + 'and anything that would invalidate it. If there is no such conclusion, do not invent one; '
+    + 'finish normally.'
   );
 }

--- a/integrations/copilot/.github/hooks/lib/utility.mjs
+++ b/integrations/copilot/.github/hooks/lib/utility.mjs
@@ -1,0 +1,135 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/utility.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Evidence-aware retrieval economics.
+ *
+ * Relevance alone is not enough: a true finding can still cost more context
+ * than it saves.  Every candidate receives a conservative expected-benefit
+ * estimate, its delivery cost and risk are subtracted, and harmful findings
+ * are quarantined from automatic delivery while remaining visible for audit.
+ */
+
+import { readEvidence } from './metrics.mjs';
+
+const DAY = 86_400_000;
+const ORIGIN_WEIGHT = { human: 1.2, agent: 1.08, harvested: 1 };
+
+const envNumber = (name, fallback) => {
+  const value = Number(process.env[name]);
+  return Number.isFinite(value) && value >= 0 ? value : fallback;
+};
+
+export const retrievalPolicy = () => ({
+  baseBenefitTokens: envNumber('TOKEN_OPTIMIZER_EXPECTED_BENEFIT_TOKENS', 400),
+  minimumNetUtility: envNumber('TOKEN_OPTIMIZER_MIN_EXPECTED_UTILITY', 20),
+  cooldownMs: envNumber('TOKEN_OPTIMIZER_INJECTION_COOLDOWN_MS', 60_000),
+  quarantineHarmCount: Math.max(1, envNumber('TOKEN_OPTIMIZER_QUARANTINE_HARM_COUNT', 2)),
+});
+
+function feedbackFor(events, key) {
+  return events.filter((event) =>
+    event.kind === 'finding-feedback'
+    && (event.findingId === key || (event.findingIds || []).includes(key))
+  );
+}
+
+function outcomesFor(events, key) {
+  return events.filter((event) =>
+    event.kind === 'tool-outcome' && (event.findingIds || []).includes(key)
+  );
+}
+
+function deliveredRecently(events, key, episodeId, now, cooldownMs) {
+  if (!episodeId || cooldownMs <= 0) return false;
+  return events.some((event) =>
+    event.kind === 'inject'
+    && event.episodeId === episodeId
+    && (event.findingIds || []).includes(key)
+    && !event.holdout
+    && now - (event.at || 0) < cooldownMs
+  );
+}
+
+/**
+ * Returns eligible candidates in utility order plus every rejection reason.
+ * `costFor` is supplied by inject.mjs so the gate prices the exact rendered
+ * text rather than a second approximation that could drift.
+ */
+export function assessFindings(
+  dir,
+  findings,
+  {
+    relevanceFor = () => 1,
+    costFor = () => 0,
+    episodeId = null,
+    now = Date.now(),
+    policy = retrievalPolicy(),
+  } = {}
+) {
+  const events = readEvidence(dir);
+  const eligible = [];
+  const rejected = [];
+
+  for (const finding of findings) {
+    const key = finding.key;
+    const feedback = feedbackFor(events, key);
+    const outcomes = outcomesFor(events, key);
+    const helpful = feedback.filter((event) => event.rating === 'helpful').length;
+    const neutral = feedback.filter((event) => event.rating === 'neutral').length;
+    const harmful = feedback.filter((event) => event.rating === 'harmful').length;
+    const successfulUses = outcomes.filter((event) => event.success === true).length;
+    const failedUses = outcomes.filter((event) => event.success === false).length;
+
+    if (harmful >= policy.quarantineHarmCount && harmful >= helpful + neutral) {
+      rejected.push({ key, reason: 'quarantined-harm', helpful, neutral, harmful });
+      continue;
+    }
+    if (deliveredRecently(events, key, episodeId, now, policy.cooldownMs)) {
+      rejected.push({ key, reason: 'cooldown' });
+      continue;
+    }
+
+    const confidence = Number.isFinite(finding.confidence) ? finding.confidence : 0.5;
+    const relevance = Math.max(0, Math.min(1, Number(relevanceFor(finding)) || 0));
+    const ageDays = Math.max(0, (now - (finding.at || now)) / DAY);
+    const recency = finding.pinned ? 1 : Math.pow(0.5, ageDays / 90);
+    const provenance = ORIGIN_WEIGHT[finding.origin] || 1;
+    // Outcome evidence moves the estimate gradually. Explicit harmful feedback
+    // is handled above; a failed command alone is not labelled harmful because
+    // the model may have ignored correct advice.
+    const observed = successfulUses + failedUses;
+    const successFactor = observed
+      ? 0.75 + 0.5 * (successfulUses / observed)
+      : 1;
+    const feedbackFactor = Math.max(0.25, 1 + helpful * 0.12 - harmful * 0.35);
+    const expectedBenefit =
+      policy.baseBenefitTokens * confidence * relevance * recency * provenance * successFactor * feedbackFactor;
+    const deliveryCost = Math.max(0, Number(costFor(finding)) || 0);
+    const riskPenalty =
+      (finding.stale ? 160 : 0)
+      + (finding.confidenceLabel === 'speculative' ? 100 : 0)
+      + harmful * 100;
+    const netUtility = expectedBenefit - deliveryCost - riskPenalty;
+
+    const assessed = {
+      finding,
+      expectedBenefit,
+      deliveryCost,
+      riskPenalty,
+      netUtility,
+      helpful,
+      neutral,
+      harmful,
+      successfulUses,
+      failedUses,
+    };
+    if (netUtility < policy.minimumNetUtility) {
+      rejected.push({ key, reason: 'negative-expected-value', ...assessed, finding: undefined });
+      continue;
+    }
+    eligible.push(assessed);
+  }
+
+  eligible.sort((a, b) => b.netUtility - a.netUtility);
+  return { eligible, rejected };
+}

--- a/integrations/copilot/.github/hooks/lib/utility.mjs
+++ b/integrations/copilot/.github/hooks/lib/utility.mjs
@@ -64,6 +64,7 @@ export function assessFindings(
     episodeId = null,
     now = Date.now(),
     policy = retrievalPolicy(),
+    bypassCooldown = false,
   } = {}
 ) {
   const events = readEvidence(dir);
@@ -84,7 +85,7 @@ export function assessFindings(
       rejected.push({ key, reason: 'quarantined-harm', helpful, neutral, harmful });
       continue;
     }
-    if (deliveredRecently(events, key, episodeId, now, policy.cooldownMs)) {
+    if (!bypassCooldown && deliveredRecently(events, key, episodeId, now, policy.cooldownMs)) {
       rejected.push({ key, reason: 'cooldown' });
       continue;
     }

--- a/integrations/copilot/.github/hooks/lib/wire.mjs
+++ b/integrations/copilot/.github/hooks/lib/wire.mjs
@@ -28,7 +28,7 @@ export const MARKER = 'token-optimizer';
 /** The events we wire, and which hook file serves each. */
 export const WIRING = [
   { event: 'SessionStart', file: 'session-start.mjs', matcher: null },
-  { event: 'PreToolUse', file: 'pretooluse-router.mjs', matcher: 'Read|Grep|Glob|Edit|MultiEdit|Write|Bash' },
+  { event: 'PreToolUse', file: 'pretooluse-router.mjs', matcher: 'Read|Grep|Glob|Edit|MultiEdit|Write|Bash|PowerShell' },
   { event: 'PreCompact', file: 'precompact-optimize.mjs', matcher: null },
 ];
 

--- a/integrations/crush/AGENTS.md
+++ b/integrations/crush/AGENTS.md
@@ -25,6 +25,10 @@ LIVE GRAPH — THE ACTIVE MODEL DOES THE SEMANTIC HARVEST:
   command that finally worked.
 - Anchor every claim to a real file path or path#symbol. Never invent a claim
   merely to populate the graph, and do not delegate harvesting to another model.
+- Include the concrete evidence, when it applies, confidenceLabel
+  (verified/probable/speculative), scope (project/organization/global), and any
+  condition that would invalidate it. Use project scope unless transfer is
+  genuinely justified.
 - Before finishing substantive work, reflect once and write any still-unrecorded
   conclusion while you hold the reasoning. This is what makes the lesson
   available across sessions and projects instead of losing it to compaction.

--- a/integrations/cursor/hooks/lib/adapter.mjs
+++ b/integrations/cursor/hooks/lib/adapter.mjs
@@ -31,7 +31,9 @@ import {
   readCostBytes,
   touchedFiles,
 } from './decide.mjs';
-import { recordRead, fingerprint } from './metrics.mjs';
+import {
+  recordRead, fingerprint, recordToolOutcome, recordEpisodeOutcome,
+} from './metrics.mjs';
 import {
   contentHash,
   harvest,
@@ -57,6 +59,8 @@ import { isFsSafePath } from './paths.mjs';
 import {
   isSubstantive, recordingNudge, semanticHarvestPrompt,
 } from './recording.mjs';
+import { nativeClientProfiles } from './capabilities.mjs';
+import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 
 /**
  * Per-client capability.
@@ -65,41 +69,7 @@ import {
  * it true where the client has no pre-execution veto would make the product
  * claim enforcement it cannot deliver.
  */
-export const CLIENTS = {
-  'claude-code': { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  codex: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  cline: {
-    canDeny: true,
-    contextStyle: 'cline',
-    denyStyle: 'cline',
-    stopDecision: 'block',
-  },
-  copilot: {
-    canDeny: true,
-    contextStyle: 'top-level',
-    denyStyle: 'top-level-permission',
-    stopDecision: 'block',
-  },
-  cursor: {
-    canDeny: true,
-    contextStyle: 'cursor',
-    denyStyle: 'cursor',
-    stopStyle: 'followup',
-    stopDecision: 'block',
-  },
-  // Gemini's BeforeTool and AfterAgent decisions are top-level. Treating it
-  // like Codex produced well-formed JSON that Gemini ignored.
-  gemini: { canDeny: true, denyStyle: 'top-level', stopDecision: 'deny' },
-  kilo: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  opencode: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  qwen: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  windsurf: {
-    canDeny: true,
-    contextStyle: 'silent',
-    denyStyle: 'exit-2',
-    stopDecision: 'block',
-  },
-};
+export const CLIENTS = nativeClientProfiles();
 
 /** Never synchronously hash an unbounded build artifact on a hook path. */
 const HARVEST_MAX_BYTES =
@@ -135,6 +105,24 @@ export function mutationSucceeded(clientName, raw) {
   // or are called by our in-process bridge only from its successful after hook.
   return new Set(['claude-code', 'qwen', 'opencode', 'kilo', 'windsurf'])
     .has(clientName);
+}
+
+/** Conservative success classification for any completed tool call. */
+export function toolSucceeded(raw) {
+  if (raw?.error || raw?.tool_response?.error || raw?.toolResponse?.error)
+    return false;
+  if (raw?.postToolUse?.success === false || raw?.success === false) return false;
+  const status =
+    raw?.tool_response?.status ?? raw?.toolResponse?.status ??
+    raw?.tool_result?.status ?? raw?.toolResult?.status;
+  if (status !== undefined) {
+    if (/^(?:error|failed|failure|cancelled|canceled|denied)$/i.test(String(status))) return false;
+    if (/^(?:ok|success|succeeded|complete|completed)$/i.test(String(status))) return true;
+  }
+  // A post-tool lifecycle event is evidence that the call completed, but not
+  // that its output proved the task.  `success` here is deliberately scoped to
+  // the tool call; task correctness comes only from an eval grader.
+  return true;
 }
 
 function contextOutput(client, eventName, additionalContext) {
@@ -253,8 +241,10 @@ refused.
 
 Worth recording: a decision and why the alternative was rejected, a failure and
 what actually caused it, a command that turned out to be the one that works.
-Not worth recording: what the code plainly says. Prefer the thing someone had to
-work out, because that exists nowhere in the source tree.${projectBriefing()}`;
+Not worth recording: what the code plainly says. Every wiki_write must include
+the concrete evidence, when it applies, a calibrated confidence label, its
+scope, and what would invalidate it. Prefer the thing someone had to work out,
+because that exists nowhere in the source tree.${projectBriefing()}`;
 }
 
 /**
@@ -315,7 +305,7 @@ function projectBriefing() {
  * metrics. It never called forTouch/forCommand, so four advertised clients
  * accumulated a graph that their active model could not receive.
  */
-function observeAndInject(payload, state) {
+function observeAndInject(payload, state, episode, features) {
   const touched = touchedFiles(payload);
   const dirFor = (path) => wikiDir(projectRootFor(path, payload.cwd));
 
@@ -344,45 +334,51 @@ function observeAndInject(payload, state) {
   state.injected = state.injected || [];
   const alreadyInjected = new Set(state.injected);
 
-  for (const { path } of touched) {
-    const dir = dirFor(path);
-    const note = forTouch(dir, load(dir), path, {
-      sessionId: payload.session_id,
-      alreadyInjected,
-    });
-    if (note) parts.push(note);
-  }
+  if (features.retrieval) {
+    for (const { path } of touched) {
+      const dir = dirFor(path);
+      const note = forTouch(dir, load(dir), path, {
+        sessionId: payload.session_id,
+        alreadyInjected,
+        episode,
+      });
+      if (note) parts.push(note);
+    }
 
-  const command = payload.tool_input?.command;
-  if (command) {
-    const root = commandProjectRoot(payload, payload.cwd);
-    const dir = wikiDir(root);
-    const local = forCommand(dir, load(dir), command, {
-      sessionId: payload.session_id,
-      alreadyInjected,
-    });
-    if (local) parts.push(local);
+    const command = payload.tool_input?.command;
+    if (command) {
+      const root = commandProjectRoot(payload, payload.cwd);
+      const dir = wikiDir(root);
+      const local = forCommand(dir, load(dir), command, {
+        sessionId: payload.session_id,
+        alreadyInjected,
+        episode,
+      });
+      if (local) parts.push(local);
 
-    const shared = forSharedCommand(dir, command, {
-      sessionId: payload.session_id,
-      alreadyInjected,
-      projectRoot: root,
-    });
-    if (shared) parts.push(shared);
+      const shared = forSharedCommand(dir, command, {
+        sessionId: payload.session_id,
+        alreadyInjected,
+        projectRoot: root,
+        episode,
+      });
+      if (shared) parts.push(shared);
 
-    const crossed = noteActClasses(state, command);
-    const repeated = forRepeatedAct(dir, command, crossed, {
-      sessionId: payload.session_id,
-      projectRoot: root,
-    });
-    if (repeated) parts.push(repeated);
+      const crossed = noteActClasses(state, command);
+      const repeated = forRepeatedAct(dir, command, crossed, {
+        sessionId: payload.session_id,
+        projectRoot: root,
+        episode,
+      });
+      if (repeated) parts.push(repeated);
+    }
   }
   state.injected = [...alreadyInjected];
 
   // Structural capture is evidence about what was touched, not a semantic
   // conclusion. It is therefore safe to automate for every client and leaves
   // the active model responsible for wiki_write at completion.
-  for (const { path, size } of touched) {
+  if (features.capture) for (const { path, size } of touched) {
     try {
       if (isArchived(path) || size > HARVEST_MAX_BYTES || !isFsSafePath(path))
         continue;
@@ -420,7 +416,10 @@ export async function run(clientName, event) {
 
   if (mode() === MODE_OFF) process.exit(0);
 
+  const features = featuresForArm();
+
   if (event === 'session-start') {
+    if (!features.routing && !features.retrieval && !features.harvest) process.exit(0);
     const output = contextOutput(client, eventName, policyText(client.canDeny));
     if (output) emit(output);
     process.exit(0);
@@ -437,10 +436,22 @@ export async function run(clientName, event) {
     const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? 'default';
     const agentScope = raw.transcript_path ?? raw.transcriptPath ?? null;
     const state = loadState(sessionId, agentScope);
+    const episode = episodeMeta({ client: clientName, raw });
+    try {
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+      recordEpisodeOutcome(dir, {
+        ...episode,
+        status: 'completed',
+        ...usageFrom(raw),
+      });
+    } catch {
+      // Evidence is best effort and must never stop a session from finishing.
+    }
     const alreadyHarvested =
       Number(state.edits || 0) > 0 &&
       Number(state.harvestedEdits || 0) >= Number(state.edits || 0);
-    const prompt = semanticHarvestPrompt({
+    const prompt = features.harvest ? semanticHarvestPrompt({
       edits: state.edits,
       files: state.editedFiles,
       model: raw.model,
@@ -449,7 +460,7 @@ export async function run(clientName, event) {
         raw.stopHookActive === true ||
         alreadyHarvested ||
         (clientName === 'cursor' && Number(raw.loop_count || 0) > 0),
-    });
+    }) : null;
     if (prompt) {
       state.harvestedEdits = Number(state.edits || 0);
       saveState(sessionId, state, agentScope);
@@ -466,6 +477,7 @@ export async function run(clientName, event) {
     process.exit(0);
   const payload = normalizePayload(normalizeClientPayload(clientName, event, raw));
   if (!payload.tool_name) process.exit(0);
+  const episode = episodeMeta({ client: clientName, raw, payload });
 
   // THE AGENT, not just the session -- the same scope the Claude Code router
   // applies. Subagents inherit the parent's session id, so keying state on the
@@ -506,17 +518,41 @@ export async function run(clientName, event) {
       const anchor = state.editedFiles[0]
         || join(payload.cwd || process.cwd(), '__recording__');
       const dir = wikiDir(projectRootFor(anchor, payload.cwd));
-      recordingContext = recordingNudge(dir, {
+      recordingContext = features.harvest ? recordingNudge(dir, {
         state,
         edits: state.edits,
         files: state.editedFiles,
-      });
+      }) : null;
       if (recordingContext) state.recordingNudged = true;
     } catch {
       // Recording pressure is an optimization and must never cost a tool call.
     }
   }
-  const verdict = decide(payload, state);
+  if (event === 'post-tool') {
+    try {
+      const command = payload.tool_input?.command;
+      const touched = touchedFiles(payload);
+      const anchor = command
+        ? String(command).slice(0, 120)
+        : touched[0]?.path || payload.tool_input?.file_path || '';
+      const root = command
+        ? commandProjectRoot(payload, payload.cwd)
+        : projectRootFor(anchor || join(payload.cwd || process.cwd(), '__tool__'), payload.cwd);
+      recordToolOutcome(wikiDir(root), {
+        ...episode,
+        surface: command ? 'command' : 'file',
+        anchor,
+        toolName: payload.tool_name,
+        success: toolSucceeded(raw),
+        durationMs: Number(raw.duration_ms ?? raw.durationMs ?? raw.elapsed_ms ?? raw.elapsedMs) || null,
+        ...usageFrom(raw),
+      });
+    } catch {
+      // Causal tracing is fail-open like every other hook optimization.
+    }
+  }
+
+  const verdict = features.routing ? decide(payload, state) : null;
   const repeat = verdict && event === 'pre-tool'
     ? alreadyDenied(state, verdict.key)
     : false;
@@ -571,7 +607,7 @@ export async function run(clientName, event) {
   remember(payload, state);
   let graphContext = null;
   try {
-    graphContext = observeAndInject(payload, state);
+    graphContext = observeAndInject(payload, state, episode, features);
   } catch {
     // Delivery is an optimization. Fail open.
   }

--- a/integrations/cursor/hooks/lib/capabilities.mjs
+++ b/integrations/cursor/hooks/lib/capabilities.mjs
@@ -1,0 +1,130 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/capabilities.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * The product's honest cross-client capability contract.
+ *
+ * A client is listed at the strongest surface its public lifecycle protocol can
+ * actually support.  This registry is consumed by the adapter, certification
+ * tooling, and evidence reports so a rules-only integration can never be
+ * presented as equivalent to a native stop-continuation integration.
+ */
+
+export const CAPABILITY_TIERS = Object.freeze({
+  CONTINUATION: 'lifecycle-continuation',
+  OBSERVATION: 'native-observation',
+  RULES: 'mcp-rules',
+});
+
+const native = (profile) => ({
+  structuralCapture: 'native',
+  findingDelivery: 'native',
+  routing: 'native-veto',
+  ...profile,
+});
+
+export const CLIENT_CAPABILITIES = Object.freeze({
+  'claude-code': native({
+    name: 'Claude Code', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-continuation', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  codex: native({
+    name: 'Codex', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-continuation', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  copilot: native({
+    name: 'GitHub Copilot CLI', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'agent-stop-continuation', canDeny: true,
+    contextStyle: 'top-level', denyStyle: 'top-level-permission', stopDecision: 'block',
+  }),
+  gemini: native({
+    name: 'Gemini CLI', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'after-agent-retry', canDeny: true,
+    denyStyle: 'top-level', stopDecision: 'deny',
+  }),
+  qwen: native({
+    name: 'Qwen Code', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-continuation', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  cursor: native({
+    name: 'Cursor', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-followup', canDeny: true,
+    contextStyle: 'cursor', denyStyle: 'cursor', stopStyle: 'followup', stopDecision: 'block',
+  }),
+  cline: native({
+    name: 'Cline', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    contextStyle: 'cline', denyStyle: 'cline', stopDecision: 'block',
+  }),
+  opencode: native({
+    name: 'OpenCode', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  kilo: native({
+    name: 'Kilo', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  windsurf: native({
+    name: 'Windsurf', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    contextStyle: 'silent', denyStyle: 'exit-2', stopDecision: 'block',
+  }),
+  roo: {
+    name: 'Roo Code', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  zed: {
+    name: 'Zed', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  amp: {
+    name: 'Amp', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  continue: {
+    name: 'Continue', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  crush: {
+    name: 'Crush', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  droid: {
+    name: 'Droid (Factory)', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+});
+
+export function capabilityFor(client) {
+  return CLIENT_CAPABILITIES[String(client || '').toLowerCase()] || null;
+}
+
+export function nativeClientProfiles() {
+  return Object.fromEntries(
+    Object.entries(CLIENT_CAPABILITIES)
+      .filter(([, profile]) => profile.structuralCapture === 'native')
+      .map(([key, profile]) => [key, { ...profile }])
+  );
+}
+
+export function capabilitySummary() {
+  return Object.entries(CLIENT_CAPABILITIES).map(([client, profile]) => ({
+    client,
+    name: profile.name,
+    tier: profile.tier,
+    routing: profile.routing,
+    structuralCapture: profile.structuralCapture,
+    findingDelivery: profile.findingDelivery,
+    semanticHarvest: profile.semanticHarvest,
+  }));
+}

--- a/integrations/cursor/hooks/lib/decide.mjs
+++ b/integrations/cursor/hooks/lib/decide.mjs
@@ -513,6 +513,8 @@ const TOOL_ALIASES = new Map(
     create_file: 'Write',
 
     bash: 'Bash',
+    powershell: 'Bash',
+    pwsh: 'Bash',
     shell: 'Bash',
     run_command: 'Bash',
     execute_command: 'Bash',

--- a/integrations/cursor/hooks/lib/experiment.mjs
+++ b/integrations/cursor/hooks/lib/experiment.mjs
@@ -1,0 +1,82 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/experiment.mjs. Regenerate with `npm run sync:hooks`.
+/** Explicit, reproducible feature arms and causal episode identity. */
+
+export const EXPERIMENT_ARMS = Object.freeze([
+  'baseline',
+  'optimizer',
+  'retrieval',
+  'full',
+]);
+
+const FEATURES = Object.freeze({
+  baseline: Object.freeze({ routing: false, retrieval: false, capture: false, harvest: false }),
+  optimizer: Object.freeze({ routing: true, retrieval: false, capture: false, harvest: false }),
+  retrieval: Object.freeze({ routing: true, retrieval: true, capture: true, harvest: false }),
+  full: Object.freeze({ routing: true, retrieval: true, capture: true, harvest: true }),
+});
+
+export function experimentArm(env = process.env) {
+  const requested = String(env.TOKEN_OPTIMIZER_EXPERIMENT_ARM || '').trim().toLowerCase();
+  return EXPERIMENT_ARMS.includes(requested) ? requested : 'full';
+}
+
+export function featuresForArm(arm = experimentArm()) {
+  return FEATURES[arm] || FEATURES.full;
+}
+
+const first = (...values) => values.find((value) => value !== undefined && value !== null && value !== '');
+
+/**
+ * Normalises identifiers exposed under different names by lifecycle clients.
+ * Environment overrides let the live evaluation harness pin a pair/task id
+ * without asking each CLI to support experiment-specific payload fields.
+ */
+export function episodeMeta({ client, raw = {}, payload = {}, env = process.env } = {}) {
+  const sessionId = String(first(
+    payload.session_id, raw.session_id, raw.sessionId, raw.conversation_id,
+    raw.conversationId, raw.taskId, raw.task_id, raw.trajectory_id, 'default'
+  ));
+  const episodeId = String(first(
+    env.TOKEN_OPTIMIZER_EPISODE_ID, raw.episode_id, raw.episodeId, sessionId
+  ));
+  const toolCallId = first(
+    raw.tool_use_id, raw.toolUseId, raw.tool_call_id, raw.toolCallId,
+    raw.call_id, raw.callId, raw.postToolUse?.toolUseId, raw.preToolUse?.toolUseId
+  );
+  const model = first(payload.model, raw.model?.slug, raw.model, raw.model_name, env.TOKEN_OPTIMIZER_MODEL);
+  const clientVersion = first(
+    raw.client_version, raw.clientVersion, raw.version, env.TOKEN_OPTIMIZER_CLIENT_VERSION
+  );
+  const modelVersion = first(raw.model_version, raw.modelVersion, env.TOKEN_OPTIMIZER_MODEL_VERSION);
+
+  return {
+    schemaVersion: 2,
+    episodeId,
+    sessionId,
+    turnId: first(raw.turn_id, raw.turnId, raw.message_id, raw.messageId) ?? null,
+    toolCallId: toolCallId == null ? null : String(toolCallId),
+    taskId: first(env.TOKEN_OPTIMIZER_TASK_ID, raw.task_id, raw.taskId) ?? null,
+    pairId: first(env.TOKEN_OPTIMIZER_PAIR_ID, raw.pair_id, raw.pairId) ?? null,
+    arm: experimentArm(env),
+    client: String(client || first(raw.client, raw.client_name, 'unknown')),
+    clientVersion: clientVersion == null ? null : String(clientVersion),
+    model: model == null ? null : String(model),
+    modelVersion: modelVersion == null ? null : String(modelVersion),
+  };
+}
+
+export function usageFrom(raw = {}) {
+  const usage = raw.usage || raw.token_usage || raw.tokenUsage || raw.metrics?.usage || {};
+  const number = (...values) => {
+    const value = first(...values);
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+  };
+  return {
+    uncachedInputTokens: number(usage.uncached_input_tokens, usage.uncachedInputTokens),
+    cachedInputTokens: number(usage.cached_input_tokens, usage.cachedInputTokens, usage.cache_read_input_tokens),
+    outputTokens: number(usage.output_tokens, usage.outputTokens),
+    totalTokens: number(usage.total_tokens, usage.totalTokens, raw.tokens_used, raw.tokensUsed),
+  };
+}

--- a/integrations/cursor/hooks/lib/harvest-write.mjs
+++ b/integrations/cursor/hooks/lib/harvest-write.mjs
@@ -96,8 +96,13 @@ function promoteToShared(finding, { projectRoot, sessionId, provenance, key }) {
           key: `shared-${key}`,
           claim: finding.claim,
           confidence: finding.confidence,
+          confidenceLabel: finding.confidenceLabel,
           type: finding.type,
           trigger: typeof finding.trigger === 'string' && finding.trigger ? finding.trigger : undefined,
+          applicability: finding.applicability,
+          evidence: finding.evidence,
+          invalidators: Array.isArray(finding.invalidators) ? finding.invalidators : [],
+          scope: finding.scope || 'global',
           origin: provenance,
           quote: typeof finding.quote === 'string' && finding.quote.trim() ? finding.quote : undefined,
           // WHERE IT WAS LEARNED, carried so the reader can discount it. A lesson
@@ -351,6 +356,26 @@ export function writeHarvested(
     // anything, so it is dropped rather than kept as unfalsifiable.
     if (!resolved.length) continue;
 
+    // Exact semantic duplicates collapse to the existing active record.  The
+    // normalisation intentionally ignores punctuation/formatting noise but not
+    // meaning-bearing words; near-duplicates that need judgement remain visible
+    // to curation rather than being silently merged by a fuzzy heuristic.
+    const fingerprint = claimFingerprint(finding.claim);
+    const currentGraph = load(dir);
+    const duplicate = [...currentGraph.nodes.values()].find((node) =>
+      node.kind === 'finding'
+      && !node.retired
+      && node.type === finding.type
+      && claimFingerprint(node.claim) === fingerprint
+      && resolved.every((target) => currentGraph.edges.some((edge) =>
+        edge.from === node.id && edge.edge === 'derived_from' && edge.to === target
+      ))
+    );
+    if (duplicate) {
+      written.push(duplicate.key);
+      continue;
+    }
+
     // Date.now() plus an index is not unique across CONCURRENT detached
     // workers: two Stop hooks finishing in the same millisecond produce the
     // same key, and putNode keeps the last write for an id -- so one session's
@@ -371,6 +396,7 @@ export function writeHarvested(
         key,
         claim: finding.claim,
         confidence: finding.confidence,
+        confidenceLabel: finding.confidenceLabel,
         type: finding.type,
         // WHEN this finding is relevant, not just what it is about. Anchors
         // answer "which file", which is the wrong question for a claim about
@@ -380,6 +406,16 @@ export function writeHarvested(
         trigger: typeof finding.trigger === 'string' && finding.trigger
           ? finding.trigger
           : undefined,
+        applicability: typeof finding.applicability === 'string'
+          ? finding.applicability
+          : undefined,
+        evidence: typeof finding.evidence === 'string'
+          ? finding.evidence
+          : undefined,
+        invalidators: Array.isArray(finding.invalidators)
+          ? finding.invalidators
+          : [],
+        scope: finding.scope || 'project',
         origin: provenance,
         // THE EVIDENCE TRAVELS WITH THE CLAIM. Without it a human-origin
         // finding asserts its own provenance and nothing can check it.
@@ -398,7 +434,11 @@ export function writeHarvested(
     // record of what happened here; the shared tier is a copy for the lessons
     // that are not about here. Skipped when the two are the same directory,
     // which is the suite's usual arrangement.
-    if (id && !isSharedDir(dir)) {
+    if (
+      id
+      && !isSharedDir(dir)
+      && (finding.scope === undefined || finding.scope === 'organization' || finding.scope === 'global')
+    ) {
       promoteToShared(finding, { projectRoot, sessionId, provenance, key });
     }
   }

--- a/integrations/cursor/hooks/lib/harvest.mjs
+++ b/integrations/cursor/hooks/lib/harvest.mjs
@@ -201,7 +201,11 @@ const PROMPT = `Extract durable findings from this coding session for a project 
 Return ONLY a JSON array. Each element:
 {"type": "finding|decision|failure|command|map",
  "claim": "one sentence, specific and checkable",
- "confidence": 0.0-1.0,
+ "evidence": "the concrete observation, command result, or rejected approach that proved it",
+ "applicability": "the condition under which a future model should use it",
+ "confidenceLabel": "verified|probable|speculative",
+ "scope": "project|organization|global",
+ "invalidators": ["what change would require this to be checked again"],
  "anchors": ["absolute/file/path" or "absolute/file/path#symbolName"]}
 
 RULES:
@@ -211,7 +215,9 @@ RULES:
 - Prefer "failure" and "decision" entries. What was TRIED AND REJECTED, and WHY,
   is the most valuable thing here because it exists nowhere in the source tree.
 - Do not restate what the code plainly says. Record what someone had to work out.
-- confidence reflects how well established the claim is, not how important.
+- verified requires direct evidence; probable means strong but incomplete evidence;
+  speculative is a hypothesis and must be labelled as such.
+- Use project scope unless the lesson is genuinely independent of this repository.
 - If nothing durable was learned, return [].`;
 
 /**
@@ -232,8 +238,29 @@ export function validate(raw, { knownFiles = null } = {}) {
     if (!FINDING_TYPES.includes(item.type)) continue;
     if (typeof item.claim !== 'string' || item.claim.trim().length < 8) continue;
 
-    const confidence = Number(item.confidence);
-    if (!Number.isFinite(confidence) || confidence <= 0 || confidence > 1) continue;
+    const evidence = typeof item.evidence === 'string' ? item.evidence.trim() : '';
+    const applicability = typeof item.applicability === 'string' ? item.applicability.trim() : '';
+    if (evidence.length < 8 || applicability.length < 8) continue;
+
+    const confidenceLabel = ['verified', 'probable', 'speculative'].includes(item.confidenceLabel)
+      ? item.confidenceLabel
+      : null;
+    if (!confidenceLabel) continue;
+    const defaults = { verified: 0.95, probable: 0.75, speculative: 0.45 };
+    const supplied = Number(item.confidence);
+    if (
+      item.confidence !== undefined
+      && (!Number.isFinite(supplied) || supplied <= 0 || supplied > 1)
+    ) continue;
+    const confidence = item.confidence === undefined
+      ? defaults[confidenceLabel]
+      : supplied;
+    const scope = ['project', 'organization', 'global'].includes(item.scope)
+      ? item.scope
+      : 'project';
+    const invalidators = Array.isArray(item.invalidators)
+      ? item.invalidators.filter((value) => typeof value === 'string' && value.trim()).slice(0, 10)
+      : [];
 
     let anchors = Array.isArray(item.anchors) ? item.anchors.filter((a) => typeof a === 'string' && a) : [];
     // A model asked for file paths will sometimes invent them. When the caller
@@ -241,7 +268,18 @@ export function validate(raw, { knownFiles = null } = {}) {
     if (knownFiles) anchors = anchors.filter((a) => knownFiles.has(a.split('#')[0]));
     if (!anchors.length) continue;
 
-    accepted.push({ type: item.type, claim: item.claim.trim(), confidence, anchors });
+    accepted.push({
+      type: item.type,
+      claim: item.claim.trim(),
+      evidence,
+      applicability,
+      confidence,
+      confidenceLabel,
+      scope,
+      invalidators,
+      anchors,
+      trigger: typeof item.trigger === 'string' ? item.trigger : undefined,
+    });
   }
   return accepted;
 }

--- a/integrations/cursor/hooks/lib/inject.mjs
+++ b/integrations/cursor/hooks/lib/inject.mjs
@@ -30,6 +30,7 @@ import { inHoldout, record, indexBudget } from './metrics.mjs';
 import { canonicalPath, resolvableCandidates } from './paths.mjs';
 import { annotatedSkeleton } from './skeleton.mjs';
 import { substitutionBudget } from './metrics.mjs';
+import { assessFindings } from './utility.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
@@ -150,7 +151,7 @@ export function forTouch(
   dir,
   graph,
   rawPath,
-  { budget = touchBudget(), sessionId, alreadyInjected = new Set() } = {}
+  { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
   // Canonical, so a touch finds findings anchored under any other spelling.
   const filePath = canonicalPath(rawPath);
@@ -169,16 +170,36 @@ export function forTouch(
   // variance drops out. A session-pinned arm would destroy that.
   const holdout = inHoldout(filePath);
   const served = serve(graph, candidates);
-  const { kept, spent } = fit(served, budget);
+  const assessed = assessFindings(dir, served, {
+    episodeId: episode.episodeId || sessionId,
+    relevanceFor: () => 1,
+    costFor: (finding) => estimate(render(finding)),
+  });
+  if (assessed.rejected.length) {
+    record(dir, {
+      kind: 'retrieval-decision', ...episode, sessionId,
+      surface: 'file', anchor: filePath,
+      rejected: assessed.rejected.map(({ key, reason }) => ({ key, reason })),
+    });
+    for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
+  }
+  const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
+  if (!kept.length) return null;
 
   record(dir, {
     kind: 'inject',
+    ...episode,
     // The surface whose saving CAN be measured: reads of this anchor afterwards.
     surface: 'file',
     anchor: filePath,
     holdout,
     tokens: holdout ? 0 : spent,
-    count: kept.length,
+    deliveredTokens: holdout ? 0 : spent,
+    shadowTokens: spent,
+    count: holdout ? 0 : kept.length,
+    candidateCount: kept.length,
+    findingIds: holdout ? [] : kept.map((finding) => finding.key),
+    shadowFindingIds: kept.map((finding) => finding.key),
     stale: kept.some((f) => f.stale),
     sessionId,
   });
@@ -297,7 +318,7 @@ export function forCommand(
   dir,
   graph,
   command,
-  { budget = touchBudget(), sessionId, alreadyInjected = new Set() } = {}
+  { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
   if (!command) return null;
 
@@ -335,7 +356,20 @@ export function forCommand(
   const considered = candidates.slice(0, MAX_COMMAND_CANDIDATES);
 
   const served = serve(graph, considered);
-  const { kept, spent } = fit(served, budget);
+  const assessed = assessFindings(dir, served, {
+    episodeId: episode.episodeId || sessionId,
+    relevanceFor: (finding) => explicit(finding) ? 1 : 0.6,
+    costFor: (finding) => estimate(render(finding)),
+  });
+  if (assessed.rejected.length) {
+    record(dir, {
+      kind: 'retrieval-decision', ...episode, sessionId,
+      surface: 'command', anchor: String(command).slice(0, 120),
+      rejected: assessed.rejected.map(({ key: findingKey, reason }) => ({ key: findingKey, reason })),
+    });
+    for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
+  }
+  const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
   if (!kept.length) return null;
 
   // THE COMMAND PATH TAKES PART IN THE HOLDOUT TOO.
@@ -353,6 +387,7 @@ export function forCommand(
 
   record(dir, {
     kind: 'inject',
+    ...episode,
     trigger: 'command',
     // The surface the report needs to keep these OUT of the file-read balance:
     // a command has no anchor that read events can be joined to.
@@ -360,7 +395,12 @@ export function forCommand(
     anchor: String(command).slice(0, 120),
     holdout,
     tokens: holdout ? 0 : spent,
+    deliveredTokens: holdout ? 0 : spent,
+    shadowTokens: spent,
     count: holdout ? 0 : kept.length,
+    candidateCount: kept.length,
+    findingIds: holdout ? [] : kept.map((finding) => finding.key),
+    shadowFindingIds: kept.map((finding) => finding.key),
     stale: kept.some((f) => f.stale),
     sessionId,
   });
@@ -509,7 +549,7 @@ export function forRepeatedAct(
   projectDir,
   command,
   crossedClasses,
-  { sessionId = null, projectRoot = null } = {}
+  { sessionId = null, projectRoot = null, episode = {} } = {}
 ) {
   if (!crossedClasses || !crossedClasses.size) return null;
 
@@ -527,14 +567,33 @@ export function forRepeatedAct(
       if (![...crossedClasses].some((c) => claimClasses.has(c))) continue;
 
       const cls = [...crossedClasses].find((c) => claimClasses.has(c));
+      const assessed = assessFindings(projectDir, [node], {
+        episodeId: episode.episodeId || sessionId,
+        relevanceFor: () => 1,
+        costFor: (finding) => estimate(render(finding)),
+      });
+      if (!assessed.eligible.length) {
+        record(projectDir, {
+          kind: 'retrieval-decision', ...episode, sessionId,
+          surface: 'shared', anchor: String(command).slice(0, 120),
+          rejected: assessed.rejected.map(({ key, reason }) => ({ key, reason })),
+        });
+        continue;
+      }
       record(projectDir, {
         kind: 'inject',
+        ...episode,
         trigger: 'repeat',
         surface: 'shared',
         anchor: String(command).slice(0, 120),
         holdout: false,
         tokens: estimate(node.claim),
+        deliveredTokens: estimate(node.claim),
+        shadowTokens: estimate(node.claim),
         count: 1,
+        candidateCount: 1,
+        findingIds: [node.key],
+        shadowFindingIds: [node.key],
         stale: false,
         sessionId,
       });
@@ -585,7 +644,10 @@ function appliesCrossProject(finding, command) {
 export function forSharedCommand(
   projectDir,
   command,
-  { budget = sharedBudget(), sessionId = null, alreadyInjected = new Set(), projectRoot = null } = {}
+  {
+    budget = sharedBudget(), sessionId = null, alreadyInjected = new Set(),
+    projectRoot = null, episode = {},
+  } = {}
 ) {
   if (!command) return null;
 
@@ -622,7 +684,21 @@ export function forSharedCommand(
     // No serve() here: these types are not content-dependent, so there is no
     // anchor to re-read and nothing to diff. serve() would spend a file read per
     // finding to answer a question that does not apply to them.
-    const { kept, spent } = fit(candidates.slice(0, MAX_SHARED), budget);
+    const considered = candidates.slice(0, MAX_SHARED);
+    const assessed = assessFindings(projectDir, considered, {
+      episodeId: episode.episodeId || sessionId,
+      relevanceFor: (finding) => explicit(finding) ? 0.8 : 0.5,
+      costFor: (finding) => estimate(render(finding)),
+    });
+    if (assessed.rejected.length) {
+      record(projectDir, {
+        kind: 'retrieval-decision', ...episode, sessionId,
+        surface: 'shared', anchor: String(command).slice(0, 120),
+        rejected: assessed.rejected.map(({ key, reason }) => ({ key, reason })),
+      });
+      for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
+    }
+    const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
     if (!kept.length) return null;
 
     // THE SAME ARM AS THE LOCAL PATH, KEYED THE SAME WAY.
@@ -644,6 +720,7 @@ export function forSharedCommand(
 
     record(projectDir, {
       kind: 'inject',
+      ...episode,
       trigger: 'command',
       // ITS OWN SURFACE. The balance sheet joins `file` injections to later read
       // events; a shared lesson has no anchor in this project to join to, and
@@ -653,7 +730,12 @@ export function forSharedCommand(
       anchor: String(command).slice(0, 120),
       holdout,
       tokens: holdout ? 0 : spent,
+      deliveredTokens: holdout ? 0 : spent,
+      shadowTokens: spent,
       count: holdout ? 0 : kept.length,
+      candidateCount: kept.length,
+      findingIds: holdout ? [] : kept.map((finding) => finding.key),
+      shadowFindingIds: kept.map((finding) => finding.key),
       stale: false,
       sessionId,
     });

--- a/integrations/cursor/hooks/lib/inject.mjs
+++ b/integrations/cursor/hooks/lib/inject.mjs
@@ -571,6 +571,10 @@ export function forRepeatedAct(
         episodeId: episode.episodeId || sessionId,
         relevanceFor: () => 1,
         costFor: (finding) => estimate(render(finding)),
+        // This surface exists specifically to re-surface a lesson once the
+        // session crosses the repeat threshold. Ordinary retrieval remains
+        // cooldown-protected; harm quarantine and utility gating still apply.
+        bypassCooldown: true,
       });
       if (!assessed.eligible.length) {
         record(projectDir, {

--- a/integrations/cursor/hooks/lib/metrics.mjs
+++ b/integrations/cursor/hooks/lib/metrics.mjs
@@ -1022,6 +1022,7 @@ function armMetrics(runs) {
     runs: runs.length,
     correctness: proportionInterval(correct, runs.length),
     uncachedInputTokens: interval('uncachedInputTokens'),
+    cacheCreationInputTokens: interval('cacheCreationInputTokens'),
     cachedInputTokens: interval('cachedInputTokens'),
     outputTokens: interval('outputTokens'),
     totalTokens: interval('totalTokens'),
@@ -1034,31 +1035,37 @@ function armMetrics(runs) {
   };
 }
 
-function pairedEffects(runs, treatmentArm) {
+function pairedEffects(runs, controlArm, treatmentArm, contrastType = 'incremental') {
   const pairs = new Map();
   for (const run of runs) {
-    if (!run.pairId || !['baseline', treatmentArm].includes(run.arm)) continue;
+    if (!run.pairId || ![controlArm, treatmentArm].includes(run.arm)) continue;
     if (!pairs.has(run.pairId)) pairs.set(run.pairId, {});
     pairs.get(run.pairId)[run.arm] = run;
   }
-  const complete = [...pairs.values()].filter((pair) => pair.baseline && pair[treatmentArm]);
+  const complete = [...pairs.values()].filter((pair) => pair[controlArm] && pair[treatmentArm]);
   const delta = (field, lowerIsBetter = true) => bootstrapMeanInterval(
     complete
       .map((pair) => {
-        const baseline = numeric(pair.baseline[field]);
+        const baseline = numeric(pair[controlArm][field]);
         const treatment = numeric(pair[treatmentArm][field]);
         if (baseline === null || treatment === null) return null;
         return lowerIsBetter ? baseline - treatment : treatment - baseline;
       })
       .filter((value) => value !== null),
-    { seed: `${treatmentArm}:${field}` }
+    { seed: `${controlArm}:${treatmentArm}:${field}` }
   );
   return {
     arm: treatmentArm,
+    controlArm,
+    comparison: `${treatmentArm} vs ${controlArm}`,
+    contrastType,
     pairs: complete.length,
     // Positive values always mean the treatment improved the metric.
     totalTokensSaved: delta('totalTokens'),
     uncachedInputTokensSaved: delta('uncachedInputTokens'),
+    cacheCreationInputTokensSaved: delta('cacheCreationInputTokens'),
+    cachedInputTokensSaved: delta('cachedInputTokens'),
+    outputTokensSaved: delta('outputTokens'),
     toolCallsAvoided: delta('toolCalls'),
     latencyMsSaved: delta('latencyMs'),
     costUsdSaved: delta('costUsd'),
@@ -1124,8 +1131,13 @@ export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
         armMetrics(cohortRuns.filter((run) => run.arm === arm)),
       ])
     );
-    const effects = ['optimizer', 'retrieval', 'full'].map((arm) => pairedEffects(cohortRuns, arm));
-    const enough = effects.some((effect) => effect.pairs >= minimumPairs);
+    const effects = [
+      pairedEffects(cohortRuns, 'baseline', 'optimizer'),
+      pairedEffects(cohortRuns, 'optimizer', 'retrieval'),
+      pairedEffects(cohortRuns, 'retrieval', 'full'),
+      pairedEffects(cohortRuns, 'baseline', 'full', 'total-system'),
+    ];
+    const enough = effects.every((effect) => effect.pairs >= minimumPairs);
     return {
       key,
       client: cohortRuns[0]?.client || 'unknown',
@@ -1165,7 +1177,8 @@ export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
     episodes: traced,
     methodology: {
       intervals: 'deterministic percentile bootstrap (95%); Wilson interval for correctness',
-      causalRule: 'only matched eval-run pairs compare an arm with baseline',
+      causalRule:
+        'matched pairs estimate optimizer vs baseline, retrieval vs optimizer, full vs retrieval, and full vs baseline',
       minimumPairs,
       deterministicChecksAreCausalProof: false,
     },

--- a/integrations/cursor/hooks/lib/metrics.mjs
+++ b/integrations/cursor/hooks/lib/metrics.mjs
@@ -61,6 +61,7 @@ const metricsPath = (dir) => join(dir, 'metrics.jsonl');
  * on it drops BOTH arms proportionally instead of starving the rare one.
  */
 const balancePath = (dir) => join(dir, 'balance.jsonl');
+const evidencePath = (dir) => join(dir, 'evidence.jsonl');
 
 /** Kinds the net balance is computed from, and which therefore must survive. */
 /**
@@ -83,6 +84,24 @@ export const BALANCE_KINDS = new Set([
   // aged out before it was written and the backstop was structurally unable to fire, reporting
   // "only N/10 refreshes observed" for the life of the project.
   'keepwarm',
+]);
+
+/**
+ * Causal records have their own bounded log.  Tool outcomes are much rarer
+ * than read/capture telemetry but more frequent than balance records; mixing
+ * them into either window would eventually evict the evidence needed to join
+ * an injection to its result.
+ */
+export const EVIDENCE_KINDS = new Set([
+  'inject',
+  'harvest',
+  'tool-outcome',
+  'episode-outcome',
+  'eval-run',
+  'finding-feedback',
+  'retrieval-decision',
+  'mcp-client',
+  'mcp-tool',
 ]);
 
 /**
@@ -198,15 +217,30 @@ export function record(dir, event) {
     // single millisecond collapsed to ONE, so a graph with ample data reported
     // 'insufficient data (2 treated, 1 holdout)'. Real events were being
     // discarded by the deduplicator, silently.
-    const line =
-      JSON.stringify({ id: nextId(), ...event, at: event.at ?? Date.now() }) + '\n';
+    const id = event.id || nextId();
+    const complete = {
+      schemaVersion: event.schemaVersion || 2,
+      id,
+      ...event,
+      // An injection id is first-class rather than an inference from the log
+      // record id.  Exporters may rewrite record ids while preserving causal
+      // identity, and downstream tool outcomes refer to this value explicitly.
+      ...(event.kind === 'inject'
+        ? { injectionId: event.injectionId || id }
+        : {}),
+      at: event.at ?? Date.now(),
+    };
+    const line = JSON.stringify(complete) + '\n';
     appendFileSync(metricsPath(dir), line);
     // Balance-critical records go to their own log as well, so the windows on
     // the firehose can never starve the measurement. Written SECOND: a torn
     // write here costs a duplicate the reader dedupes, not a lost event.
     if (BALANCE_KINDS.has(event.kind)) appendFileSync(balancePath(dir), line);
+    if (EVIDENCE_KINDS.has(event.kind)) appendFileSync(evidencePath(dir), line);
+    return complete;
   } catch {
     // Metrics must never break a tool call.
+    return null;
   }
 }
 
@@ -402,6 +436,92 @@ export function readBalance(dir) {
     out.push(e);
   }
   return out;
+}
+
+/** Every causal evidence record inside the byte cap, deduplicated by id. */
+export function readEvidence(dir) {
+  const path = evidencePath(dir);
+  if (!existsSync(path)) return [];
+
+  let text = '';
+  try {
+    const { size } = statSync(path);
+    if (size <= MAX_BYTES) {
+      text = readFileSync(path, 'utf8');
+    } else {
+      const fd = openSync(path, 'r');
+      try {
+        const buffer = Buffer.allocUnsafe(MAX_BYTES);
+        const read = readSync(fd, buffer, 0, MAX_BYTES, size - MAX_BYTES);
+        text = buffer.subarray(0, read).toString('utf8');
+      } finally {
+        closeSync(fd);
+      }
+      text = text.slice(text.indexOf('\n') + 1);
+    }
+  } catch {
+    return [];
+  }
+
+  const seen = new Set();
+  const out = [];
+  for (const line of text.split('\n')) {
+    if (!line) continue;
+    try {
+      const event = JSON.parse(line);
+      if (!EVIDENCE_KINDS.has(event.kind)) continue;
+      const id = event.id || JSON.stringify(event);
+      if (seen.has(id)) continue;
+      seen.add(id);
+      out.push(event);
+    } catch {
+      // A concurrently appended final line may be torn.  It costs one record,
+      // never the user's tool call or the rest of the evidence report.
+    }
+  }
+  return out;
+}
+
+/**
+ * Joins a post-tool result to the most recent matching injection.  The exact
+ * tool-call id wins; clients that omit it fall back to episode + surface +
+ * anchor, in timestamp order, and the report states the weaker join method.
+ */
+export function recordToolOutcome(dir, outcome) {
+  const evidence = readEvidence(dir);
+  const anchor = String(outcome.anchor || '').slice(0, 120);
+  const candidates = evidence
+    .filter((event) => event.kind === 'inject' && event.episodeId === outcome.episodeId)
+    .filter((event) => {
+      if (outcome.toolCallId && event.toolCallId)
+        return String(event.toolCallId) === String(outcome.toolCallId);
+      return event.surface === outcome.surface && String(event.anchor || '').slice(0, 120) === anchor;
+    })
+    .sort((a, b) => (b.at || 0) - (a.at || 0));
+  const injection = candidates[0] || null;
+  const joinMethod = injection
+    ? (outcome.toolCallId && injection.toolCallId ? 'tool-call-id' : 'episode-anchor')
+    : 'none';
+
+  return record(dir, {
+    kind: 'tool-outcome',
+    ...outcome,
+    anchor,
+    injectionId: injection?.injectionId || null,
+    findingIds: injection?.findingIds || [],
+    joinMethod,
+  });
+}
+
+export function recordEpisodeOutcome(dir, outcome) {
+  return record(dir, { kind: 'episode-outcome', ...outcome });
+}
+
+export function recordFindingFeedback(dir, feedback) {
+  const rating = ['helpful', 'neutral', 'harmful'].includes(feedback?.rating)
+    ? feedback.rating
+    : 'neutral';
+  return record(dir, { kind: 'finding-feedback', ...feedback, rating });
 }
 
 /**
@@ -813,4 +933,241 @@ export function indexBudget(dir, { floor = 150, base = 300, ceiling = 1200 } = {
   // 0% hit rate falls to the floor; ~50% and above reaches the ceiling.
   const scaled = Math.round(floor + (ceiling - floor) * Math.min(1, hitRate * 2));
   return Math.max(floor, Math.min(ceiling, scaled));
+}
+
+/* ----------------------------------------------------------------------
+ * Episode-level causal evidence
+ * ------------------------------------------------------------------- */
+
+const numeric = (value) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const average = (values) => {
+  const finite = values.map(numeric).filter((value) => value !== null);
+  return finite.length
+    ? finite.reduce((sum, value) => sum + value, 0) / finite.length
+    : null;
+};
+
+/** Deterministic PRNG so regenerating a report does not move its interval. */
+function seededRandom(seedText) {
+  let seed = 2166136261;
+  for (const char of String(seedText)) {
+    seed ^= char.charCodeAt(0);
+    seed = Math.imul(seed, 16777619);
+  }
+  return () => {
+    seed += 0x6d2b79f5;
+    let value = seed;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Percentile bootstrap interval for a mean, paired delta, or other scalar. */
+export function bootstrapMeanInterval(values, { samples = 1000, seed = 'token-optimizer' } = {}) {
+  const finite = values.map(numeric).filter((value) => value !== null);
+  if (!finite.length) return { mean: null, low: null, high: null, n: 0 };
+  if (finite.length === 1) {
+    return { mean: finite[0], low: finite[0], high: finite[0], n: 1 };
+  }
+
+  const random = seededRandom(`${seed}:${finite.join(',')}`);
+  const means = [];
+  for (let sample = 0; sample < samples; sample++) {
+    let total = 0;
+    for (let index = 0; index < finite.length; index++) {
+      total += finite[Math.floor(random() * finite.length)];
+    }
+    means.push(total / finite.length);
+  }
+  means.sort((a, b) => a - b);
+  return {
+    mean: average(finite),
+    low: means[Math.floor(means.length * 0.025)],
+    high: means[Math.min(means.length - 1, Math.floor(means.length * 0.975))],
+    n: finite.length,
+  };
+}
+
+/** Wilson interval keeps small correctness samples honest and inside 0..1. */
+export function proportionInterval(successes, total, z = 1.96) {
+  if (!total) return { rate: null, low: null, high: null, n: 0 };
+  const rate = successes / total;
+  const denominator = 1 + (z * z) / total;
+  const centre = (rate + (z * z) / (2 * total)) / denominator;
+  const radius =
+    (z / denominator) * Math.sqrt((rate * (1 - rate)) / total + (z * z) / (4 * total * total));
+  return { rate, low: Math.max(0, centre - radius), high: Math.min(1, centre + radius), n: total };
+}
+
+const cohortKey = (run) => [
+  run.client || 'unknown',
+  run.clientVersion || 'unknown',
+  run.model || 'unknown',
+  run.modelVersion || 'unknown',
+  run.taskId || 'unknown',
+].join('|');
+
+function armMetrics(runs) {
+  const correct = runs.filter((run) => run.correct === true).length;
+  const interval = (field) => bootstrapMeanInterval(
+    runs.map((run) => run[field]).filter((value) => numeric(value) !== null),
+    { seed: field }
+  );
+  return {
+    runs: runs.length,
+    correctness: proportionInterval(correct, runs.length),
+    uncachedInputTokens: interval('uncachedInputTokens'),
+    cachedInputTokens: interval('cachedInputTokens'),
+    outputTokens: interval('outputTokens'),
+    totalTokens: interval('totalTokens'),
+    toolCalls: interval('toolCalls'),
+    failedToolCalls: interval('failedToolCalls'),
+    latencyMs: interval('latencyMs'),
+    costUsd: interval('costUsd'),
+    injectedTokens: interval('injectedTokens'),
+    harmfulFindings: runs.reduce((sum, run) => sum + (numeric(run.harmfulFindings) || 0), 0),
+  };
+}
+
+function pairedEffects(runs, treatmentArm) {
+  const pairs = new Map();
+  for (const run of runs) {
+    if (!run.pairId || !['baseline', treatmentArm].includes(run.arm)) continue;
+    if (!pairs.has(run.pairId)) pairs.set(run.pairId, {});
+    pairs.get(run.pairId)[run.arm] = run;
+  }
+  const complete = [...pairs.values()].filter((pair) => pair.baseline && pair[treatmentArm]);
+  const delta = (field, lowerIsBetter = true) => bootstrapMeanInterval(
+    complete
+      .map((pair) => {
+        const baseline = numeric(pair.baseline[field]);
+        const treatment = numeric(pair[treatmentArm][field]);
+        if (baseline === null || treatment === null) return null;
+        return lowerIsBetter ? baseline - treatment : treatment - baseline;
+      })
+      .filter((value) => value !== null),
+    { seed: `${treatmentArm}:${field}` }
+  );
+  return {
+    arm: treatmentArm,
+    pairs: complete.length,
+    // Positive values always mean the treatment improved the metric.
+    totalTokensSaved: delta('totalTokens'),
+    uncachedInputTokensSaved: delta('uncachedInputTokens'),
+    toolCallsAvoided: delta('toolCalls'),
+    latencyMsSaved: delta('latencyMs'),
+    costUsdSaved: delta('costUsd'),
+    correctnessDelta: delta('correct', false),
+  };
+}
+
+function matchesFilters(event, filters) {
+  for (const field of ['client', 'clientVersion', 'model', 'modelVersion', 'taskId', 'arm']) {
+    if (filters[field] && String(event[field] || '') !== String(filters[field])) return false;
+  }
+  return true;
+}
+
+/**
+ * The dashboard-facing evidence console.  Deterministic fixture verification,
+ * live hook traces, and randomized model evals remain visibly distinct: only
+ * `eval-run` records with paired arms can produce a causal effect interval.
+ */
+export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
+  const evidence = readEvidence(dir).filter((event) => matchesFilters(event, filters));
+  const runs = evidence.filter((event) => event.kind === 'eval-run');
+  const injections = evidence.filter((event) => event.kind === 'inject');
+  const outcomes = evidence.filter((event) => event.kind === 'tool-outcome');
+  const feedback = evidence.filter((event) => event.kind === 'finding-feedback');
+
+  const byInjection = new Map(
+    outcomes.filter((event) => event.injectionId).map((event) => [event.injectionId, event])
+  );
+  const traced = injections
+    .slice()
+    .sort((a, b) => (b.at || 0) - (a.at || 0))
+    .slice(0, Math.max(1, Math.min(500, episodeLimit)))
+    .map((injection) => ({
+      injectionId: injection.injectionId,
+      episodeId: injection.episodeId || injection.sessionId || null,
+      at: injection.at,
+      arm: injection.arm || (injection.holdout ? 'holdout' : 'treated'),
+      client: injection.client || 'unknown',
+      clientVersion: injection.clientVersion || null,
+      model: injection.model || null,
+      taskId: injection.taskId || null,
+      surface: injection.surface || injection.trigger || 'file',
+      anchor: injection.anchor,
+      findingIds: injection.findingIds || [],
+      deliveredTokens: injection.deliveredTokens ?? injection.tokens ?? 0,
+      shadowTokens: injection.shadowTokens ?? injection.tokens ?? 0,
+      outcome: byInjection.get(injection.injectionId) || null,
+    }));
+
+  const grouped = new Map();
+  for (const run of runs) {
+    const key = cohortKey(run);
+    if (!grouped.has(key)) grouped.set(key, []);
+    grouped.get(key).push(run);
+  }
+
+  const minimumPairs = Math.max(2, Number(process.env.TOKEN_OPTIMIZER_EVAL_MIN_PAIRS) || 5);
+  const cohorts = [...grouped.entries()].map(([key, cohortRuns]) => {
+    const arms = Object.fromEntries(
+      ['baseline', 'optimizer', 'retrieval', 'full'].map((arm) => [
+        arm,
+        armMetrics(cohortRuns.filter((run) => run.arm === arm)),
+      ])
+    );
+    const effects = ['optimizer', 'retrieval', 'full'].map((arm) => pairedEffects(cohortRuns, arm));
+    const enough = effects.some((effect) => effect.pairs >= minimumPairs);
+    return {
+      key,
+      client: cohortRuns[0]?.client || 'unknown',
+      clientVersion: cohortRuns[0]?.clientVersion || null,
+      model: cohortRuns[0]?.model || null,
+      modelVersion: cohortRuns[0]?.modelVersion || null,
+      taskId: cohortRuns[0]?.taskId || null,
+      arms,
+      effects,
+      evidenceStatus: enough
+        ? 'causal estimate available'
+        : `insufficient paired runs (need ${minimumPairs})`,
+    };
+  });
+
+  const joined = injections.filter((injection) =>
+    byInjection.has(injection.injectionId)
+  ).length;
+  const harmful = feedback.filter((event) => event.rating === 'harmful').length;
+  return {
+    schemaVersion: 2,
+    generatedAt: new Date().toISOString(),
+    filters,
+    summary: {
+      liveInjections: injections.length,
+      joinedOutcomes: joined,
+      causalJoinCoverage: injections.length ? joined / injections.length : null,
+      evalRuns: runs.length,
+      cohorts: cohorts.length,
+      harmfulFeedback: harmful,
+      harmRate: feedback.length ? harmful / feedback.length : null,
+      evidenceStatus: cohorts.some((cohort) => cohort.evidenceStatus === 'causal estimate available')
+        ? 'causal estimates available'
+        : 'insufficient randomized evidence',
+    },
+    cohorts,
+    episodes: traced,
+    methodology: {
+      intervals: 'deterministic percentile bootstrap (95%); Wilson interval for correctness',
+      causalRule: 'only matched eval-run pairs compare an arm with baseline',
+      minimumPairs,
+      deterministicChecksAreCausalProof: false,
+    },
+  };
 }

--- a/integrations/cursor/hooks/lib/recording.mjs
+++ b/integrations/cursor/hooks/lib/recording.mjs
@@ -159,6 +159,9 @@ export function semanticHarvestPrompt({
     + ' If this work produced a durable, non-obvious conclusion -- a failed approach and why, '
     + 'a decision and its rejected alternative, or a command that finally worked -- call '
     + 'wiki_write now with a real file anchor. Do not delegate this to another model or an '
-    + 'external harvester. If there is no such conclusion, do not invent one; finish normally.'
+    + 'external harvester. Include: the concrete evidence, when the finding applies, a calibrated '
+    + 'confidenceLabel (verified/probable/speculative), its project/organization/global scope, '
+    + 'and anything that would invalidate it. If there is no such conclusion, do not invent one; '
+    + 'finish normally.'
   );
 }

--- a/integrations/cursor/hooks/lib/utility.mjs
+++ b/integrations/cursor/hooks/lib/utility.mjs
@@ -1,0 +1,135 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/utility.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Evidence-aware retrieval economics.
+ *
+ * Relevance alone is not enough: a true finding can still cost more context
+ * than it saves.  Every candidate receives a conservative expected-benefit
+ * estimate, its delivery cost and risk are subtracted, and harmful findings
+ * are quarantined from automatic delivery while remaining visible for audit.
+ */
+
+import { readEvidence } from './metrics.mjs';
+
+const DAY = 86_400_000;
+const ORIGIN_WEIGHT = { human: 1.2, agent: 1.08, harvested: 1 };
+
+const envNumber = (name, fallback) => {
+  const value = Number(process.env[name]);
+  return Number.isFinite(value) && value >= 0 ? value : fallback;
+};
+
+export const retrievalPolicy = () => ({
+  baseBenefitTokens: envNumber('TOKEN_OPTIMIZER_EXPECTED_BENEFIT_TOKENS', 400),
+  minimumNetUtility: envNumber('TOKEN_OPTIMIZER_MIN_EXPECTED_UTILITY', 20),
+  cooldownMs: envNumber('TOKEN_OPTIMIZER_INJECTION_COOLDOWN_MS', 60_000),
+  quarantineHarmCount: Math.max(1, envNumber('TOKEN_OPTIMIZER_QUARANTINE_HARM_COUNT', 2)),
+});
+
+function feedbackFor(events, key) {
+  return events.filter((event) =>
+    event.kind === 'finding-feedback'
+    && (event.findingId === key || (event.findingIds || []).includes(key))
+  );
+}
+
+function outcomesFor(events, key) {
+  return events.filter((event) =>
+    event.kind === 'tool-outcome' && (event.findingIds || []).includes(key)
+  );
+}
+
+function deliveredRecently(events, key, episodeId, now, cooldownMs) {
+  if (!episodeId || cooldownMs <= 0) return false;
+  return events.some((event) =>
+    event.kind === 'inject'
+    && event.episodeId === episodeId
+    && (event.findingIds || []).includes(key)
+    && !event.holdout
+    && now - (event.at || 0) < cooldownMs
+  );
+}
+
+/**
+ * Returns eligible candidates in utility order plus every rejection reason.
+ * `costFor` is supplied by inject.mjs so the gate prices the exact rendered
+ * text rather than a second approximation that could drift.
+ */
+export function assessFindings(
+  dir,
+  findings,
+  {
+    relevanceFor = () => 1,
+    costFor = () => 0,
+    episodeId = null,
+    now = Date.now(),
+    policy = retrievalPolicy(),
+  } = {}
+) {
+  const events = readEvidence(dir);
+  const eligible = [];
+  const rejected = [];
+
+  for (const finding of findings) {
+    const key = finding.key;
+    const feedback = feedbackFor(events, key);
+    const outcomes = outcomesFor(events, key);
+    const helpful = feedback.filter((event) => event.rating === 'helpful').length;
+    const neutral = feedback.filter((event) => event.rating === 'neutral').length;
+    const harmful = feedback.filter((event) => event.rating === 'harmful').length;
+    const successfulUses = outcomes.filter((event) => event.success === true).length;
+    const failedUses = outcomes.filter((event) => event.success === false).length;
+
+    if (harmful >= policy.quarantineHarmCount && harmful >= helpful + neutral) {
+      rejected.push({ key, reason: 'quarantined-harm', helpful, neutral, harmful });
+      continue;
+    }
+    if (deliveredRecently(events, key, episodeId, now, policy.cooldownMs)) {
+      rejected.push({ key, reason: 'cooldown' });
+      continue;
+    }
+
+    const confidence = Number.isFinite(finding.confidence) ? finding.confidence : 0.5;
+    const relevance = Math.max(0, Math.min(1, Number(relevanceFor(finding)) || 0));
+    const ageDays = Math.max(0, (now - (finding.at || now)) / DAY);
+    const recency = finding.pinned ? 1 : Math.pow(0.5, ageDays / 90);
+    const provenance = ORIGIN_WEIGHT[finding.origin] || 1;
+    // Outcome evidence moves the estimate gradually. Explicit harmful feedback
+    // is handled above; a failed command alone is not labelled harmful because
+    // the model may have ignored correct advice.
+    const observed = successfulUses + failedUses;
+    const successFactor = observed
+      ? 0.75 + 0.5 * (successfulUses / observed)
+      : 1;
+    const feedbackFactor = Math.max(0.25, 1 + helpful * 0.12 - harmful * 0.35);
+    const expectedBenefit =
+      policy.baseBenefitTokens * confidence * relevance * recency * provenance * successFactor * feedbackFactor;
+    const deliveryCost = Math.max(0, Number(costFor(finding)) || 0);
+    const riskPenalty =
+      (finding.stale ? 160 : 0)
+      + (finding.confidenceLabel === 'speculative' ? 100 : 0)
+      + harmful * 100;
+    const netUtility = expectedBenefit - deliveryCost - riskPenalty;
+
+    const assessed = {
+      finding,
+      expectedBenefit,
+      deliveryCost,
+      riskPenalty,
+      netUtility,
+      helpful,
+      neutral,
+      harmful,
+      successfulUses,
+      failedUses,
+    };
+    if (netUtility < policy.minimumNetUtility) {
+      rejected.push({ key, reason: 'negative-expected-value', ...assessed, finding: undefined });
+      continue;
+    }
+    eligible.push(assessed);
+  }
+
+  eligible.sort((a, b) => b.netUtility - a.netUtility);
+  return { eligible, rejected };
+}

--- a/integrations/cursor/hooks/lib/utility.mjs
+++ b/integrations/cursor/hooks/lib/utility.mjs
@@ -64,6 +64,7 @@ export function assessFindings(
     episodeId = null,
     now = Date.now(),
     policy = retrievalPolicy(),
+    bypassCooldown = false,
   } = {}
 ) {
   const events = readEvidence(dir);
@@ -84,7 +85,7 @@ export function assessFindings(
       rejected.push({ key, reason: 'quarantined-harm', helpful, neutral, harmful });
       continue;
     }
-    if (deliveredRecently(events, key, episodeId, now, policy.cooldownMs)) {
+    if (!bypassCooldown && deliveredRecently(events, key, episodeId, now, policy.cooldownMs)) {
       rejected.push({ key, reason: 'cooldown' });
       continue;
     }

--- a/integrations/cursor/hooks/lib/wire.mjs
+++ b/integrations/cursor/hooks/lib/wire.mjs
@@ -28,7 +28,7 @@ export const MARKER = 'token-optimizer';
 /** The events we wire, and which hook file serves each. */
 export const WIRING = [
   { event: 'SessionStart', file: 'session-start.mjs', matcher: null },
-  { event: 'PreToolUse', file: 'pretooluse-router.mjs', matcher: 'Read|Grep|Glob|Edit|MultiEdit|Write|Bash' },
+  { event: 'PreToolUse', file: 'pretooluse-router.mjs', matcher: 'Read|Grep|Glob|Edit|MultiEdit|Write|Bash|PowerShell' },
   { event: 'PreCompact', file: 'precompact-optimize.mjs', matcher: null },
 ];
 

--- a/integrations/cursor/token-optimizer.mdc
+++ b/integrations/cursor/token-optimizer.mdc
@@ -28,6 +28,10 @@ LIVE GRAPH — THE ACTIVE MODEL DOES THE SEMANTIC HARVEST:
   command that finally worked.
 - Anchor every claim to a real file path or path#symbol. Never invent a claim
   merely to populate the graph, and do not delegate harvesting to another model.
+- Include the concrete evidence, when it applies, confidenceLabel
+  (verified/probable/speculative), scope (project/organization/global), and any
+  condition that would invalidate it. Use project scope unless transfer is
+  genuinely justified.
 - Before finishing substantive work, reflect once and write any still-unrecorded
   conclusion while you hold the reasoning. This is what makes the lesson
   available across sessions and projects instead of losing it to compaction.

--- a/integrations/droid/AGENTS.md
+++ b/integrations/droid/AGENTS.md
@@ -25,6 +25,10 @@ LIVE GRAPH — THE ACTIVE MODEL DOES THE SEMANTIC HARVEST:
   command that finally worked.
 - Anchor every claim to a real file path or path#symbol. Never invent a claim
   merely to populate the graph, and do not delegate harvesting to another model.
+- Include the concrete evidence, when it applies, confidenceLabel
+  (verified/probable/speculative), scope (project/organization/global), and any
+  condition that would invalidate it. Use project scope unless transfer is
+  genuinely justified.
 - Before finishing substantive work, reflect once and write any still-unrecorded
   conclusion while you hold the reasoning. This is what makes the lesson
   available across sessions and projects instead of losing it to compaction.

--- a/integrations/gemini/hooks/lib/adapter.mjs
+++ b/integrations/gemini/hooks/lib/adapter.mjs
@@ -31,7 +31,9 @@ import {
   readCostBytes,
   touchedFiles,
 } from './decide.mjs';
-import { recordRead, fingerprint } from './metrics.mjs';
+import {
+  recordRead, fingerprint, recordToolOutcome, recordEpisodeOutcome,
+} from './metrics.mjs';
 import {
   contentHash,
   harvest,
@@ -57,6 +59,8 @@ import { isFsSafePath } from './paths.mjs';
 import {
   isSubstantive, recordingNudge, semanticHarvestPrompt,
 } from './recording.mjs';
+import { nativeClientProfiles } from './capabilities.mjs';
+import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 
 /**
  * Per-client capability.
@@ -65,41 +69,7 @@ import {
  * it true where the client has no pre-execution veto would make the product
  * claim enforcement it cannot deliver.
  */
-export const CLIENTS = {
-  'claude-code': { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  codex: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  cline: {
-    canDeny: true,
-    contextStyle: 'cline',
-    denyStyle: 'cline',
-    stopDecision: 'block',
-  },
-  copilot: {
-    canDeny: true,
-    contextStyle: 'top-level',
-    denyStyle: 'top-level-permission',
-    stopDecision: 'block',
-  },
-  cursor: {
-    canDeny: true,
-    contextStyle: 'cursor',
-    denyStyle: 'cursor',
-    stopStyle: 'followup',
-    stopDecision: 'block',
-  },
-  // Gemini's BeforeTool and AfterAgent decisions are top-level. Treating it
-  // like Codex produced well-formed JSON that Gemini ignored.
-  gemini: { canDeny: true, denyStyle: 'top-level', stopDecision: 'deny' },
-  kilo: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  opencode: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  qwen: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  windsurf: {
-    canDeny: true,
-    contextStyle: 'silent',
-    denyStyle: 'exit-2',
-    stopDecision: 'block',
-  },
-};
+export const CLIENTS = nativeClientProfiles();
 
 /** Never synchronously hash an unbounded build artifact on a hook path. */
 const HARVEST_MAX_BYTES =
@@ -135,6 +105,24 @@ export function mutationSucceeded(clientName, raw) {
   // or are called by our in-process bridge only from its successful after hook.
   return new Set(['claude-code', 'qwen', 'opencode', 'kilo', 'windsurf'])
     .has(clientName);
+}
+
+/** Conservative success classification for any completed tool call. */
+export function toolSucceeded(raw) {
+  if (raw?.error || raw?.tool_response?.error || raw?.toolResponse?.error)
+    return false;
+  if (raw?.postToolUse?.success === false || raw?.success === false) return false;
+  const status =
+    raw?.tool_response?.status ?? raw?.toolResponse?.status ??
+    raw?.tool_result?.status ?? raw?.toolResult?.status;
+  if (status !== undefined) {
+    if (/^(?:error|failed|failure|cancelled|canceled|denied)$/i.test(String(status))) return false;
+    if (/^(?:ok|success|succeeded|complete|completed)$/i.test(String(status))) return true;
+  }
+  // A post-tool lifecycle event is evidence that the call completed, but not
+  // that its output proved the task.  `success` here is deliberately scoped to
+  // the tool call; task correctness comes only from an eval grader.
+  return true;
 }
 
 function contextOutput(client, eventName, additionalContext) {
@@ -253,8 +241,10 @@ refused.
 
 Worth recording: a decision and why the alternative was rejected, a failure and
 what actually caused it, a command that turned out to be the one that works.
-Not worth recording: what the code plainly says. Prefer the thing someone had to
-work out, because that exists nowhere in the source tree.${projectBriefing()}`;
+Not worth recording: what the code plainly says. Every wiki_write must include
+the concrete evidence, when it applies, a calibrated confidence label, its
+scope, and what would invalidate it. Prefer the thing someone had to work out,
+because that exists nowhere in the source tree.${projectBriefing()}`;
 }
 
 /**
@@ -315,7 +305,7 @@ function projectBriefing() {
  * metrics. It never called forTouch/forCommand, so four advertised clients
  * accumulated a graph that their active model could not receive.
  */
-function observeAndInject(payload, state) {
+function observeAndInject(payload, state, episode, features) {
   const touched = touchedFiles(payload);
   const dirFor = (path) => wikiDir(projectRootFor(path, payload.cwd));
 
@@ -344,45 +334,51 @@ function observeAndInject(payload, state) {
   state.injected = state.injected || [];
   const alreadyInjected = new Set(state.injected);
 
-  for (const { path } of touched) {
-    const dir = dirFor(path);
-    const note = forTouch(dir, load(dir), path, {
-      sessionId: payload.session_id,
-      alreadyInjected,
-    });
-    if (note) parts.push(note);
-  }
+  if (features.retrieval) {
+    for (const { path } of touched) {
+      const dir = dirFor(path);
+      const note = forTouch(dir, load(dir), path, {
+        sessionId: payload.session_id,
+        alreadyInjected,
+        episode,
+      });
+      if (note) parts.push(note);
+    }
 
-  const command = payload.tool_input?.command;
-  if (command) {
-    const root = commandProjectRoot(payload, payload.cwd);
-    const dir = wikiDir(root);
-    const local = forCommand(dir, load(dir), command, {
-      sessionId: payload.session_id,
-      alreadyInjected,
-    });
-    if (local) parts.push(local);
+    const command = payload.tool_input?.command;
+    if (command) {
+      const root = commandProjectRoot(payload, payload.cwd);
+      const dir = wikiDir(root);
+      const local = forCommand(dir, load(dir), command, {
+        sessionId: payload.session_id,
+        alreadyInjected,
+        episode,
+      });
+      if (local) parts.push(local);
 
-    const shared = forSharedCommand(dir, command, {
-      sessionId: payload.session_id,
-      alreadyInjected,
-      projectRoot: root,
-    });
-    if (shared) parts.push(shared);
+      const shared = forSharedCommand(dir, command, {
+        sessionId: payload.session_id,
+        alreadyInjected,
+        projectRoot: root,
+        episode,
+      });
+      if (shared) parts.push(shared);
 
-    const crossed = noteActClasses(state, command);
-    const repeated = forRepeatedAct(dir, command, crossed, {
-      sessionId: payload.session_id,
-      projectRoot: root,
-    });
-    if (repeated) parts.push(repeated);
+      const crossed = noteActClasses(state, command);
+      const repeated = forRepeatedAct(dir, command, crossed, {
+        sessionId: payload.session_id,
+        projectRoot: root,
+        episode,
+      });
+      if (repeated) parts.push(repeated);
+    }
   }
   state.injected = [...alreadyInjected];
 
   // Structural capture is evidence about what was touched, not a semantic
   // conclusion. It is therefore safe to automate for every client and leaves
   // the active model responsible for wiki_write at completion.
-  for (const { path, size } of touched) {
+  if (features.capture) for (const { path, size } of touched) {
     try {
       if (isArchived(path) || size > HARVEST_MAX_BYTES || !isFsSafePath(path))
         continue;
@@ -420,7 +416,10 @@ export async function run(clientName, event) {
 
   if (mode() === MODE_OFF) process.exit(0);
 
+  const features = featuresForArm();
+
   if (event === 'session-start') {
+    if (!features.routing && !features.retrieval && !features.harvest) process.exit(0);
     const output = contextOutput(client, eventName, policyText(client.canDeny));
     if (output) emit(output);
     process.exit(0);
@@ -437,10 +436,22 @@ export async function run(clientName, event) {
     const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? 'default';
     const agentScope = raw.transcript_path ?? raw.transcriptPath ?? null;
     const state = loadState(sessionId, agentScope);
+    const episode = episodeMeta({ client: clientName, raw });
+    try {
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+      recordEpisodeOutcome(dir, {
+        ...episode,
+        status: 'completed',
+        ...usageFrom(raw),
+      });
+    } catch {
+      // Evidence is best effort and must never stop a session from finishing.
+    }
     const alreadyHarvested =
       Number(state.edits || 0) > 0 &&
       Number(state.harvestedEdits || 0) >= Number(state.edits || 0);
-    const prompt = semanticHarvestPrompt({
+    const prompt = features.harvest ? semanticHarvestPrompt({
       edits: state.edits,
       files: state.editedFiles,
       model: raw.model,
@@ -449,7 +460,7 @@ export async function run(clientName, event) {
         raw.stopHookActive === true ||
         alreadyHarvested ||
         (clientName === 'cursor' && Number(raw.loop_count || 0) > 0),
-    });
+    }) : null;
     if (prompt) {
       state.harvestedEdits = Number(state.edits || 0);
       saveState(sessionId, state, agentScope);
@@ -466,6 +477,7 @@ export async function run(clientName, event) {
     process.exit(0);
   const payload = normalizePayload(normalizeClientPayload(clientName, event, raw));
   if (!payload.tool_name) process.exit(0);
+  const episode = episodeMeta({ client: clientName, raw, payload });
 
   // THE AGENT, not just the session -- the same scope the Claude Code router
   // applies. Subagents inherit the parent's session id, so keying state on the
@@ -506,17 +518,41 @@ export async function run(clientName, event) {
       const anchor = state.editedFiles[0]
         || join(payload.cwd || process.cwd(), '__recording__');
       const dir = wikiDir(projectRootFor(anchor, payload.cwd));
-      recordingContext = recordingNudge(dir, {
+      recordingContext = features.harvest ? recordingNudge(dir, {
         state,
         edits: state.edits,
         files: state.editedFiles,
-      });
+      }) : null;
       if (recordingContext) state.recordingNudged = true;
     } catch {
       // Recording pressure is an optimization and must never cost a tool call.
     }
   }
-  const verdict = decide(payload, state);
+  if (event === 'post-tool') {
+    try {
+      const command = payload.tool_input?.command;
+      const touched = touchedFiles(payload);
+      const anchor = command
+        ? String(command).slice(0, 120)
+        : touched[0]?.path || payload.tool_input?.file_path || '';
+      const root = command
+        ? commandProjectRoot(payload, payload.cwd)
+        : projectRootFor(anchor || join(payload.cwd || process.cwd(), '__tool__'), payload.cwd);
+      recordToolOutcome(wikiDir(root), {
+        ...episode,
+        surface: command ? 'command' : 'file',
+        anchor,
+        toolName: payload.tool_name,
+        success: toolSucceeded(raw),
+        durationMs: Number(raw.duration_ms ?? raw.durationMs ?? raw.elapsed_ms ?? raw.elapsedMs) || null,
+        ...usageFrom(raw),
+      });
+    } catch {
+      // Causal tracing is fail-open like every other hook optimization.
+    }
+  }
+
+  const verdict = features.routing ? decide(payload, state) : null;
   const repeat = verdict && event === 'pre-tool'
     ? alreadyDenied(state, verdict.key)
     : false;
@@ -571,7 +607,7 @@ export async function run(clientName, event) {
   remember(payload, state);
   let graphContext = null;
   try {
-    graphContext = observeAndInject(payload, state);
+    graphContext = observeAndInject(payload, state, episode, features);
   } catch {
     // Delivery is an optimization. Fail open.
   }

--- a/integrations/gemini/hooks/lib/capabilities.mjs
+++ b/integrations/gemini/hooks/lib/capabilities.mjs
@@ -1,0 +1,130 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/capabilities.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * The product's honest cross-client capability contract.
+ *
+ * A client is listed at the strongest surface its public lifecycle protocol can
+ * actually support.  This registry is consumed by the adapter, certification
+ * tooling, and evidence reports so a rules-only integration can never be
+ * presented as equivalent to a native stop-continuation integration.
+ */
+
+export const CAPABILITY_TIERS = Object.freeze({
+  CONTINUATION: 'lifecycle-continuation',
+  OBSERVATION: 'native-observation',
+  RULES: 'mcp-rules',
+});
+
+const native = (profile) => ({
+  structuralCapture: 'native',
+  findingDelivery: 'native',
+  routing: 'native-veto',
+  ...profile,
+});
+
+export const CLIENT_CAPABILITIES = Object.freeze({
+  'claude-code': native({
+    name: 'Claude Code', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-continuation', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  codex: native({
+    name: 'Codex', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-continuation', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  copilot: native({
+    name: 'GitHub Copilot CLI', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'agent-stop-continuation', canDeny: true,
+    contextStyle: 'top-level', denyStyle: 'top-level-permission', stopDecision: 'block',
+  }),
+  gemini: native({
+    name: 'Gemini CLI', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'after-agent-retry', canDeny: true,
+    denyStyle: 'top-level', stopDecision: 'deny',
+  }),
+  qwen: native({
+    name: 'Qwen Code', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-continuation', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  cursor: native({
+    name: 'Cursor', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-followup', canDeny: true,
+    contextStyle: 'cursor', denyStyle: 'cursor', stopStyle: 'followup', stopDecision: 'block',
+  }),
+  cline: native({
+    name: 'Cline', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    contextStyle: 'cline', denyStyle: 'cline', stopDecision: 'block',
+  }),
+  opencode: native({
+    name: 'OpenCode', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  kilo: native({
+    name: 'Kilo', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  windsurf: native({
+    name: 'Windsurf', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    contextStyle: 'silent', denyStyle: 'exit-2', stopDecision: 'block',
+  }),
+  roo: {
+    name: 'Roo Code', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  zed: {
+    name: 'Zed', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  amp: {
+    name: 'Amp', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  continue: {
+    name: 'Continue', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  crush: {
+    name: 'Crush', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  droid: {
+    name: 'Droid (Factory)', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+});
+
+export function capabilityFor(client) {
+  return CLIENT_CAPABILITIES[String(client || '').toLowerCase()] || null;
+}
+
+export function nativeClientProfiles() {
+  return Object.fromEntries(
+    Object.entries(CLIENT_CAPABILITIES)
+      .filter(([, profile]) => profile.structuralCapture === 'native')
+      .map(([key, profile]) => [key, { ...profile }])
+  );
+}
+
+export function capabilitySummary() {
+  return Object.entries(CLIENT_CAPABILITIES).map(([client, profile]) => ({
+    client,
+    name: profile.name,
+    tier: profile.tier,
+    routing: profile.routing,
+    structuralCapture: profile.structuralCapture,
+    findingDelivery: profile.findingDelivery,
+    semanticHarvest: profile.semanticHarvest,
+  }));
+}

--- a/integrations/gemini/hooks/lib/decide.mjs
+++ b/integrations/gemini/hooks/lib/decide.mjs
@@ -513,6 +513,8 @@ const TOOL_ALIASES = new Map(
     create_file: 'Write',
 
     bash: 'Bash',
+    powershell: 'Bash',
+    pwsh: 'Bash',
     shell: 'Bash',
     run_command: 'Bash',
     execute_command: 'Bash',

--- a/integrations/gemini/hooks/lib/experiment.mjs
+++ b/integrations/gemini/hooks/lib/experiment.mjs
@@ -1,0 +1,82 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/experiment.mjs. Regenerate with `npm run sync:hooks`.
+/** Explicit, reproducible feature arms and causal episode identity. */
+
+export const EXPERIMENT_ARMS = Object.freeze([
+  'baseline',
+  'optimizer',
+  'retrieval',
+  'full',
+]);
+
+const FEATURES = Object.freeze({
+  baseline: Object.freeze({ routing: false, retrieval: false, capture: false, harvest: false }),
+  optimizer: Object.freeze({ routing: true, retrieval: false, capture: false, harvest: false }),
+  retrieval: Object.freeze({ routing: true, retrieval: true, capture: true, harvest: false }),
+  full: Object.freeze({ routing: true, retrieval: true, capture: true, harvest: true }),
+});
+
+export function experimentArm(env = process.env) {
+  const requested = String(env.TOKEN_OPTIMIZER_EXPERIMENT_ARM || '').trim().toLowerCase();
+  return EXPERIMENT_ARMS.includes(requested) ? requested : 'full';
+}
+
+export function featuresForArm(arm = experimentArm()) {
+  return FEATURES[arm] || FEATURES.full;
+}
+
+const first = (...values) => values.find((value) => value !== undefined && value !== null && value !== '');
+
+/**
+ * Normalises identifiers exposed under different names by lifecycle clients.
+ * Environment overrides let the live evaluation harness pin a pair/task id
+ * without asking each CLI to support experiment-specific payload fields.
+ */
+export function episodeMeta({ client, raw = {}, payload = {}, env = process.env } = {}) {
+  const sessionId = String(first(
+    payload.session_id, raw.session_id, raw.sessionId, raw.conversation_id,
+    raw.conversationId, raw.taskId, raw.task_id, raw.trajectory_id, 'default'
+  ));
+  const episodeId = String(first(
+    env.TOKEN_OPTIMIZER_EPISODE_ID, raw.episode_id, raw.episodeId, sessionId
+  ));
+  const toolCallId = first(
+    raw.tool_use_id, raw.toolUseId, raw.tool_call_id, raw.toolCallId,
+    raw.call_id, raw.callId, raw.postToolUse?.toolUseId, raw.preToolUse?.toolUseId
+  );
+  const model = first(payload.model, raw.model?.slug, raw.model, raw.model_name, env.TOKEN_OPTIMIZER_MODEL);
+  const clientVersion = first(
+    raw.client_version, raw.clientVersion, raw.version, env.TOKEN_OPTIMIZER_CLIENT_VERSION
+  );
+  const modelVersion = first(raw.model_version, raw.modelVersion, env.TOKEN_OPTIMIZER_MODEL_VERSION);
+
+  return {
+    schemaVersion: 2,
+    episodeId,
+    sessionId,
+    turnId: first(raw.turn_id, raw.turnId, raw.message_id, raw.messageId) ?? null,
+    toolCallId: toolCallId == null ? null : String(toolCallId),
+    taskId: first(env.TOKEN_OPTIMIZER_TASK_ID, raw.task_id, raw.taskId) ?? null,
+    pairId: first(env.TOKEN_OPTIMIZER_PAIR_ID, raw.pair_id, raw.pairId) ?? null,
+    arm: experimentArm(env),
+    client: String(client || first(raw.client, raw.client_name, 'unknown')),
+    clientVersion: clientVersion == null ? null : String(clientVersion),
+    model: model == null ? null : String(model),
+    modelVersion: modelVersion == null ? null : String(modelVersion),
+  };
+}
+
+export function usageFrom(raw = {}) {
+  const usage = raw.usage || raw.token_usage || raw.tokenUsage || raw.metrics?.usage || {};
+  const number = (...values) => {
+    const value = first(...values);
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+  };
+  return {
+    uncachedInputTokens: number(usage.uncached_input_tokens, usage.uncachedInputTokens),
+    cachedInputTokens: number(usage.cached_input_tokens, usage.cachedInputTokens, usage.cache_read_input_tokens),
+    outputTokens: number(usage.output_tokens, usage.outputTokens),
+    totalTokens: number(usage.total_tokens, usage.totalTokens, raw.tokens_used, raw.tokensUsed),
+  };
+}

--- a/integrations/gemini/hooks/lib/harvest-write.mjs
+++ b/integrations/gemini/hooks/lib/harvest-write.mjs
@@ -96,8 +96,13 @@ function promoteToShared(finding, { projectRoot, sessionId, provenance, key }) {
           key: `shared-${key}`,
           claim: finding.claim,
           confidence: finding.confidence,
+          confidenceLabel: finding.confidenceLabel,
           type: finding.type,
           trigger: typeof finding.trigger === 'string' && finding.trigger ? finding.trigger : undefined,
+          applicability: finding.applicability,
+          evidence: finding.evidence,
+          invalidators: Array.isArray(finding.invalidators) ? finding.invalidators : [],
+          scope: finding.scope || 'global',
           origin: provenance,
           quote: typeof finding.quote === 'string' && finding.quote.trim() ? finding.quote : undefined,
           // WHERE IT WAS LEARNED, carried so the reader can discount it. A lesson
@@ -351,6 +356,26 @@ export function writeHarvested(
     // anything, so it is dropped rather than kept as unfalsifiable.
     if (!resolved.length) continue;
 
+    // Exact semantic duplicates collapse to the existing active record.  The
+    // normalisation intentionally ignores punctuation/formatting noise but not
+    // meaning-bearing words; near-duplicates that need judgement remain visible
+    // to curation rather than being silently merged by a fuzzy heuristic.
+    const fingerprint = claimFingerprint(finding.claim);
+    const currentGraph = load(dir);
+    const duplicate = [...currentGraph.nodes.values()].find((node) =>
+      node.kind === 'finding'
+      && !node.retired
+      && node.type === finding.type
+      && claimFingerprint(node.claim) === fingerprint
+      && resolved.every((target) => currentGraph.edges.some((edge) =>
+        edge.from === node.id && edge.edge === 'derived_from' && edge.to === target
+      ))
+    );
+    if (duplicate) {
+      written.push(duplicate.key);
+      continue;
+    }
+
     // Date.now() plus an index is not unique across CONCURRENT detached
     // workers: two Stop hooks finishing in the same millisecond produce the
     // same key, and putNode keeps the last write for an id -- so one session's
@@ -371,6 +396,7 @@ export function writeHarvested(
         key,
         claim: finding.claim,
         confidence: finding.confidence,
+        confidenceLabel: finding.confidenceLabel,
         type: finding.type,
         // WHEN this finding is relevant, not just what it is about. Anchors
         // answer "which file", which is the wrong question for a claim about
@@ -380,6 +406,16 @@ export function writeHarvested(
         trigger: typeof finding.trigger === 'string' && finding.trigger
           ? finding.trigger
           : undefined,
+        applicability: typeof finding.applicability === 'string'
+          ? finding.applicability
+          : undefined,
+        evidence: typeof finding.evidence === 'string'
+          ? finding.evidence
+          : undefined,
+        invalidators: Array.isArray(finding.invalidators)
+          ? finding.invalidators
+          : [],
+        scope: finding.scope || 'project',
         origin: provenance,
         // THE EVIDENCE TRAVELS WITH THE CLAIM. Without it a human-origin
         // finding asserts its own provenance and nothing can check it.
@@ -398,7 +434,11 @@ export function writeHarvested(
     // record of what happened here; the shared tier is a copy for the lessons
     // that are not about here. Skipped when the two are the same directory,
     // which is the suite's usual arrangement.
-    if (id && !isSharedDir(dir)) {
+    if (
+      id
+      && !isSharedDir(dir)
+      && (finding.scope === undefined || finding.scope === 'organization' || finding.scope === 'global')
+    ) {
       promoteToShared(finding, { projectRoot, sessionId, provenance, key });
     }
   }

--- a/integrations/gemini/hooks/lib/harvest.mjs
+++ b/integrations/gemini/hooks/lib/harvest.mjs
@@ -201,7 +201,11 @@ const PROMPT = `Extract durable findings from this coding session for a project 
 Return ONLY a JSON array. Each element:
 {"type": "finding|decision|failure|command|map",
  "claim": "one sentence, specific and checkable",
- "confidence": 0.0-1.0,
+ "evidence": "the concrete observation, command result, or rejected approach that proved it",
+ "applicability": "the condition under which a future model should use it",
+ "confidenceLabel": "verified|probable|speculative",
+ "scope": "project|organization|global",
+ "invalidators": ["what change would require this to be checked again"],
  "anchors": ["absolute/file/path" or "absolute/file/path#symbolName"]}
 
 RULES:
@@ -211,7 +215,9 @@ RULES:
 - Prefer "failure" and "decision" entries. What was TRIED AND REJECTED, and WHY,
   is the most valuable thing here because it exists nowhere in the source tree.
 - Do not restate what the code plainly says. Record what someone had to work out.
-- confidence reflects how well established the claim is, not how important.
+- verified requires direct evidence; probable means strong but incomplete evidence;
+  speculative is a hypothesis and must be labelled as such.
+- Use project scope unless the lesson is genuinely independent of this repository.
 - If nothing durable was learned, return [].`;
 
 /**
@@ -232,8 +238,29 @@ export function validate(raw, { knownFiles = null } = {}) {
     if (!FINDING_TYPES.includes(item.type)) continue;
     if (typeof item.claim !== 'string' || item.claim.trim().length < 8) continue;
 
-    const confidence = Number(item.confidence);
-    if (!Number.isFinite(confidence) || confidence <= 0 || confidence > 1) continue;
+    const evidence = typeof item.evidence === 'string' ? item.evidence.trim() : '';
+    const applicability = typeof item.applicability === 'string' ? item.applicability.trim() : '';
+    if (evidence.length < 8 || applicability.length < 8) continue;
+
+    const confidenceLabel = ['verified', 'probable', 'speculative'].includes(item.confidenceLabel)
+      ? item.confidenceLabel
+      : null;
+    if (!confidenceLabel) continue;
+    const defaults = { verified: 0.95, probable: 0.75, speculative: 0.45 };
+    const supplied = Number(item.confidence);
+    if (
+      item.confidence !== undefined
+      && (!Number.isFinite(supplied) || supplied <= 0 || supplied > 1)
+    ) continue;
+    const confidence = item.confidence === undefined
+      ? defaults[confidenceLabel]
+      : supplied;
+    const scope = ['project', 'organization', 'global'].includes(item.scope)
+      ? item.scope
+      : 'project';
+    const invalidators = Array.isArray(item.invalidators)
+      ? item.invalidators.filter((value) => typeof value === 'string' && value.trim()).slice(0, 10)
+      : [];
 
     let anchors = Array.isArray(item.anchors) ? item.anchors.filter((a) => typeof a === 'string' && a) : [];
     // A model asked for file paths will sometimes invent them. When the caller
@@ -241,7 +268,18 @@ export function validate(raw, { knownFiles = null } = {}) {
     if (knownFiles) anchors = anchors.filter((a) => knownFiles.has(a.split('#')[0]));
     if (!anchors.length) continue;
 
-    accepted.push({ type: item.type, claim: item.claim.trim(), confidence, anchors });
+    accepted.push({
+      type: item.type,
+      claim: item.claim.trim(),
+      evidence,
+      applicability,
+      confidence,
+      confidenceLabel,
+      scope,
+      invalidators,
+      anchors,
+      trigger: typeof item.trigger === 'string' ? item.trigger : undefined,
+    });
   }
   return accepted;
 }

--- a/integrations/gemini/hooks/lib/inject.mjs
+++ b/integrations/gemini/hooks/lib/inject.mjs
@@ -30,6 +30,7 @@ import { inHoldout, record, indexBudget } from './metrics.mjs';
 import { canonicalPath, resolvableCandidates } from './paths.mjs';
 import { annotatedSkeleton } from './skeleton.mjs';
 import { substitutionBudget } from './metrics.mjs';
+import { assessFindings } from './utility.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
@@ -150,7 +151,7 @@ export function forTouch(
   dir,
   graph,
   rawPath,
-  { budget = touchBudget(), sessionId, alreadyInjected = new Set() } = {}
+  { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
   // Canonical, so a touch finds findings anchored under any other spelling.
   const filePath = canonicalPath(rawPath);
@@ -169,16 +170,36 @@ export function forTouch(
   // variance drops out. A session-pinned arm would destroy that.
   const holdout = inHoldout(filePath);
   const served = serve(graph, candidates);
-  const { kept, spent } = fit(served, budget);
+  const assessed = assessFindings(dir, served, {
+    episodeId: episode.episodeId || sessionId,
+    relevanceFor: () => 1,
+    costFor: (finding) => estimate(render(finding)),
+  });
+  if (assessed.rejected.length) {
+    record(dir, {
+      kind: 'retrieval-decision', ...episode, sessionId,
+      surface: 'file', anchor: filePath,
+      rejected: assessed.rejected.map(({ key, reason }) => ({ key, reason })),
+    });
+    for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
+  }
+  const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
+  if (!kept.length) return null;
 
   record(dir, {
     kind: 'inject',
+    ...episode,
     // The surface whose saving CAN be measured: reads of this anchor afterwards.
     surface: 'file',
     anchor: filePath,
     holdout,
     tokens: holdout ? 0 : spent,
-    count: kept.length,
+    deliveredTokens: holdout ? 0 : spent,
+    shadowTokens: spent,
+    count: holdout ? 0 : kept.length,
+    candidateCount: kept.length,
+    findingIds: holdout ? [] : kept.map((finding) => finding.key),
+    shadowFindingIds: kept.map((finding) => finding.key),
     stale: kept.some((f) => f.stale),
     sessionId,
   });
@@ -297,7 +318,7 @@ export function forCommand(
   dir,
   graph,
   command,
-  { budget = touchBudget(), sessionId, alreadyInjected = new Set() } = {}
+  { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
   if (!command) return null;
 
@@ -335,7 +356,20 @@ export function forCommand(
   const considered = candidates.slice(0, MAX_COMMAND_CANDIDATES);
 
   const served = serve(graph, considered);
-  const { kept, spent } = fit(served, budget);
+  const assessed = assessFindings(dir, served, {
+    episodeId: episode.episodeId || sessionId,
+    relevanceFor: (finding) => explicit(finding) ? 1 : 0.6,
+    costFor: (finding) => estimate(render(finding)),
+  });
+  if (assessed.rejected.length) {
+    record(dir, {
+      kind: 'retrieval-decision', ...episode, sessionId,
+      surface: 'command', anchor: String(command).slice(0, 120),
+      rejected: assessed.rejected.map(({ key: findingKey, reason }) => ({ key: findingKey, reason })),
+    });
+    for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
+  }
+  const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
   if (!kept.length) return null;
 
   // THE COMMAND PATH TAKES PART IN THE HOLDOUT TOO.
@@ -353,6 +387,7 @@ export function forCommand(
 
   record(dir, {
     kind: 'inject',
+    ...episode,
     trigger: 'command',
     // The surface the report needs to keep these OUT of the file-read balance:
     // a command has no anchor that read events can be joined to.
@@ -360,7 +395,12 @@ export function forCommand(
     anchor: String(command).slice(0, 120),
     holdout,
     tokens: holdout ? 0 : spent,
+    deliveredTokens: holdout ? 0 : spent,
+    shadowTokens: spent,
     count: holdout ? 0 : kept.length,
+    candidateCount: kept.length,
+    findingIds: holdout ? [] : kept.map((finding) => finding.key),
+    shadowFindingIds: kept.map((finding) => finding.key),
     stale: kept.some((f) => f.stale),
     sessionId,
   });
@@ -509,7 +549,7 @@ export function forRepeatedAct(
   projectDir,
   command,
   crossedClasses,
-  { sessionId = null, projectRoot = null } = {}
+  { sessionId = null, projectRoot = null, episode = {} } = {}
 ) {
   if (!crossedClasses || !crossedClasses.size) return null;
 
@@ -527,14 +567,33 @@ export function forRepeatedAct(
       if (![...crossedClasses].some((c) => claimClasses.has(c))) continue;
 
       const cls = [...crossedClasses].find((c) => claimClasses.has(c));
+      const assessed = assessFindings(projectDir, [node], {
+        episodeId: episode.episodeId || sessionId,
+        relevanceFor: () => 1,
+        costFor: (finding) => estimate(render(finding)),
+      });
+      if (!assessed.eligible.length) {
+        record(projectDir, {
+          kind: 'retrieval-decision', ...episode, sessionId,
+          surface: 'shared', anchor: String(command).slice(0, 120),
+          rejected: assessed.rejected.map(({ key, reason }) => ({ key, reason })),
+        });
+        continue;
+      }
       record(projectDir, {
         kind: 'inject',
+        ...episode,
         trigger: 'repeat',
         surface: 'shared',
         anchor: String(command).slice(0, 120),
         holdout: false,
         tokens: estimate(node.claim),
+        deliveredTokens: estimate(node.claim),
+        shadowTokens: estimate(node.claim),
         count: 1,
+        candidateCount: 1,
+        findingIds: [node.key],
+        shadowFindingIds: [node.key],
         stale: false,
         sessionId,
       });
@@ -585,7 +644,10 @@ function appliesCrossProject(finding, command) {
 export function forSharedCommand(
   projectDir,
   command,
-  { budget = sharedBudget(), sessionId = null, alreadyInjected = new Set(), projectRoot = null } = {}
+  {
+    budget = sharedBudget(), sessionId = null, alreadyInjected = new Set(),
+    projectRoot = null, episode = {},
+  } = {}
 ) {
   if (!command) return null;
 
@@ -622,7 +684,21 @@ export function forSharedCommand(
     // No serve() here: these types are not content-dependent, so there is no
     // anchor to re-read and nothing to diff. serve() would spend a file read per
     // finding to answer a question that does not apply to them.
-    const { kept, spent } = fit(candidates.slice(0, MAX_SHARED), budget);
+    const considered = candidates.slice(0, MAX_SHARED);
+    const assessed = assessFindings(projectDir, considered, {
+      episodeId: episode.episodeId || sessionId,
+      relevanceFor: (finding) => explicit(finding) ? 0.8 : 0.5,
+      costFor: (finding) => estimate(render(finding)),
+    });
+    if (assessed.rejected.length) {
+      record(projectDir, {
+        kind: 'retrieval-decision', ...episode, sessionId,
+        surface: 'shared', anchor: String(command).slice(0, 120),
+        rejected: assessed.rejected.map(({ key, reason }) => ({ key, reason })),
+      });
+      for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
+    }
+    const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
     if (!kept.length) return null;
 
     // THE SAME ARM AS THE LOCAL PATH, KEYED THE SAME WAY.
@@ -644,6 +720,7 @@ export function forSharedCommand(
 
     record(projectDir, {
       kind: 'inject',
+      ...episode,
       trigger: 'command',
       // ITS OWN SURFACE. The balance sheet joins `file` injections to later read
       // events; a shared lesson has no anchor in this project to join to, and
@@ -653,7 +730,12 @@ export function forSharedCommand(
       anchor: String(command).slice(0, 120),
       holdout,
       tokens: holdout ? 0 : spent,
+      deliveredTokens: holdout ? 0 : spent,
+      shadowTokens: spent,
       count: holdout ? 0 : kept.length,
+      candidateCount: kept.length,
+      findingIds: holdout ? [] : kept.map((finding) => finding.key),
+      shadowFindingIds: kept.map((finding) => finding.key),
       stale: false,
       sessionId,
     });

--- a/integrations/gemini/hooks/lib/inject.mjs
+++ b/integrations/gemini/hooks/lib/inject.mjs
@@ -571,6 +571,10 @@ export function forRepeatedAct(
         episodeId: episode.episodeId || sessionId,
         relevanceFor: () => 1,
         costFor: (finding) => estimate(render(finding)),
+        // This surface exists specifically to re-surface a lesson once the
+        // session crosses the repeat threshold. Ordinary retrieval remains
+        // cooldown-protected; harm quarantine and utility gating still apply.
+        bypassCooldown: true,
       });
       if (!assessed.eligible.length) {
         record(projectDir, {

--- a/integrations/gemini/hooks/lib/metrics.mjs
+++ b/integrations/gemini/hooks/lib/metrics.mjs
@@ -1022,6 +1022,7 @@ function armMetrics(runs) {
     runs: runs.length,
     correctness: proportionInterval(correct, runs.length),
     uncachedInputTokens: interval('uncachedInputTokens'),
+    cacheCreationInputTokens: interval('cacheCreationInputTokens'),
     cachedInputTokens: interval('cachedInputTokens'),
     outputTokens: interval('outputTokens'),
     totalTokens: interval('totalTokens'),
@@ -1034,31 +1035,37 @@ function armMetrics(runs) {
   };
 }
 
-function pairedEffects(runs, treatmentArm) {
+function pairedEffects(runs, controlArm, treatmentArm, contrastType = 'incremental') {
   const pairs = new Map();
   for (const run of runs) {
-    if (!run.pairId || !['baseline', treatmentArm].includes(run.arm)) continue;
+    if (!run.pairId || ![controlArm, treatmentArm].includes(run.arm)) continue;
     if (!pairs.has(run.pairId)) pairs.set(run.pairId, {});
     pairs.get(run.pairId)[run.arm] = run;
   }
-  const complete = [...pairs.values()].filter((pair) => pair.baseline && pair[treatmentArm]);
+  const complete = [...pairs.values()].filter((pair) => pair[controlArm] && pair[treatmentArm]);
   const delta = (field, lowerIsBetter = true) => bootstrapMeanInterval(
     complete
       .map((pair) => {
-        const baseline = numeric(pair.baseline[field]);
+        const baseline = numeric(pair[controlArm][field]);
         const treatment = numeric(pair[treatmentArm][field]);
         if (baseline === null || treatment === null) return null;
         return lowerIsBetter ? baseline - treatment : treatment - baseline;
       })
       .filter((value) => value !== null),
-    { seed: `${treatmentArm}:${field}` }
+    { seed: `${controlArm}:${treatmentArm}:${field}` }
   );
   return {
     arm: treatmentArm,
+    controlArm,
+    comparison: `${treatmentArm} vs ${controlArm}`,
+    contrastType,
     pairs: complete.length,
     // Positive values always mean the treatment improved the metric.
     totalTokensSaved: delta('totalTokens'),
     uncachedInputTokensSaved: delta('uncachedInputTokens'),
+    cacheCreationInputTokensSaved: delta('cacheCreationInputTokens'),
+    cachedInputTokensSaved: delta('cachedInputTokens'),
+    outputTokensSaved: delta('outputTokens'),
     toolCallsAvoided: delta('toolCalls'),
     latencyMsSaved: delta('latencyMs'),
     costUsdSaved: delta('costUsd'),
@@ -1124,8 +1131,13 @@ export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
         armMetrics(cohortRuns.filter((run) => run.arm === arm)),
       ])
     );
-    const effects = ['optimizer', 'retrieval', 'full'].map((arm) => pairedEffects(cohortRuns, arm));
-    const enough = effects.some((effect) => effect.pairs >= minimumPairs);
+    const effects = [
+      pairedEffects(cohortRuns, 'baseline', 'optimizer'),
+      pairedEffects(cohortRuns, 'optimizer', 'retrieval'),
+      pairedEffects(cohortRuns, 'retrieval', 'full'),
+      pairedEffects(cohortRuns, 'baseline', 'full', 'total-system'),
+    ];
+    const enough = effects.every((effect) => effect.pairs >= minimumPairs);
     return {
       key,
       client: cohortRuns[0]?.client || 'unknown',
@@ -1165,7 +1177,8 @@ export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
     episodes: traced,
     methodology: {
       intervals: 'deterministic percentile bootstrap (95%); Wilson interval for correctness',
-      causalRule: 'only matched eval-run pairs compare an arm with baseline',
+      causalRule:
+        'matched pairs estimate optimizer vs baseline, retrieval vs optimizer, full vs retrieval, and full vs baseline',
       minimumPairs,
       deterministicChecksAreCausalProof: false,
     },

--- a/integrations/gemini/hooks/lib/metrics.mjs
+++ b/integrations/gemini/hooks/lib/metrics.mjs
@@ -61,6 +61,7 @@ const metricsPath = (dir) => join(dir, 'metrics.jsonl');
  * on it drops BOTH arms proportionally instead of starving the rare one.
  */
 const balancePath = (dir) => join(dir, 'balance.jsonl');
+const evidencePath = (dir) => join(dir, 'evidence.jsonl');
 
 /** Kinds the net balance is computed from, and which therefore must survive. */
 /**
@@ -83,6 +84,24 @@ export const BALANCE_KINDS = new Set([
   // aged out before it was written and the backstop was structurally unable to fire, reporting
   // "only N/10 refreshes observed" for the life of the project.
   'keepwarm',
+]);
+
+/**
+ * Causal records have their own bounded log.  Tool outcomes are much rarer
+ * than read/capture telemetry but more frequent than balance records; mixing
+ * them into either window would eventually evict the evidence needed to join
+ * an injection to its result.
+ */
+export const EVIDENCE_KINDS = new Set([
+  'inject',
+  'harvest',
+  'tool-outcome',
+  'episode-outcome',
+  'eval-run',
+  'finding-feedback',
+  'retrieval-decision',
+  'mcp-client',
+  'mcp-tool',
 ]);
 
 /**
@@ -198,15 +217,30 @@ export function record(dir, event) {
     // single millisecond collapsed to ONE, so a graph with ample data reported
     // 'insufficient data (2 treated, 1 holdout)'. Real events were being
     // discarded by the deduplicator, silently.
-    const line =
-      JSON.stringify({ id: nextId(), ...event, at: event.at ?? Date.now() }) + '\n';
+    const id = event.id || nextId();
+    const complete = {
+      schemaVersion: event.schemaVersion || 2,
+      id,
+      ...event,
+      // An injection id is first-class rather than an inference from the log
+      // record id.  Exporters may rewrite record ids while preserving causal
+      // identity, and downstream tool outcomes refer to this value explicitly.
+      ...(event.kind === 'inject'
+        ? { injectionId: event.injectionId || id }
+        : {}),
+      at: event.at ?? Date.now(),
+    };
+    const line = JSON.stringify(complete) + '\n';
     appendFileSync(metricsPath(dir), line);
     // Balance-critical records go to their own log as well, so the windows on
     // the firehose can never starve the measurement. Written SECOND: a torn
     // write here costs a duplicate the reader dedupes, not a lost event.
     if (BALANCE_KINDS.has(event.kind)) appendFileSync(balancePath(dir), line);
+    if (EVIDENCE_KINDS.has(event.kind)) appendFileSync(evidencePath(dir), line);
+    return complete;
   } catch {
     // Metrics must never break a tool call.
+    return null;
   }
 }
 
@@ -402,6 +436,92 @@ export function readBalance(dir) {
     out.push(e);
   }
   return out;
+}
+
+/** Every causal evidence record inside the byte cap, deduplicated by id. */
+export function readEvidence(dir) {
+  const path = evidencePath(dir);
+  if (!existsSync(path)) return [];
+
+  let text = '';
+  try {
+    const { size } = statSync(path);
+    if (size <= MAX_BYTES) {
+      text = readFileSync(path, 'utf8');
+    } else {
+      const fd = openSync(path, 'r');
+      try {
+        const buffer = Buffer.allocUnsafe(MAX_BYTES);
+        const read = readSync(fd, buffer, 0, MAX_BYTES, size - MAX_BYTES);
+        text = buffer.subarray(0, read).toString('utf8');
+      } finally {
+        closeSync(fd);
+      }
+      text = text.slice(text.indexOf('\n') + 1);
+    }
+  } catch {
+    return [];
+  }
+
+  const seen = new Set();
+  const out = [];
+  for (const line of text.split('\n')) {
+    if (!line) continue;
+    try {
+      const event = JSON.parse(line);
+      if (!EVIDENCE_KINDS.has(event.kind)) continue;
+      const id = event.id || JSON.stringify(event);
+      if (seen.has(id)) continue;
+      seen.add(id);
+      out.push(event);
+    } catch {
+      // A concurrently appended final line may be torn.  It costs one record,
+      // never the user's tool call or the rest of the evidence report.
+    }
+  }
+  return out;
+}
+
+/**
+ * Joins a post-tool result to the most recent matching injection.  The exact
+ * tool-call id wins; clients that omit it fall back to episode + surface +
+ * anchor, in timestamp order, and the report states the weaker join method.
+ */
+export function recordToolOutcome(dir, outcome) {
+  const evidence = readEvidence(dir);
+  const anchor = String(outcome.anchor || '').slice(0, 120);
+  const candidates = evidence
+    .filter((event) => event.kind === 'inject' && event.episodeId === outcome.episodeId)
+    .filter((event) => {
+      if (outcome.toolCallId && event.toolCallId)
+        return String(event.toolCallId) === String(outcome.toolCallId);
+      return event.surface === outcome.surface && String(event.anchor || '').slice(0, 120) === anchor;
+    })
+    .sort((a, b) => (b.at || 0) - (a.at || 0));
+  const injection = candidates[0] || null;
+  const joinMethod = injection
+    ? (outcome.toolCallId && injection.toolCallId ? 'tool-call-id' : 'episode-anchor')
+    : 'none';
+
+  return record(dir, {
+    kind: 'tool-outcome',
+    ...outcome,
+    anchor,
+    injectionId: injection?.injectionId || null,
+    findingIds: injection?.findingIds || [],
+    joinMethod,
+  });
+}
+
+export function recordEpisodeOutcome(dir, outcome) {
+  return record(dir, { kind: 'episode-outcome', ...outcome });
+}
+
+export function recordFindingFeedback(dir, feedback) {
+  const rating = ['helpful', 'neutral', 'harmful'].includes(feedback?.rating)
+    ? feedback.rating
+    : 'neutral';
+  return record(dir, { kind: 'finding-feedback', ...feedback, rating });
 }
 
 /**
@@ -813,4 +933,241 @@ export function indexBudget(dir, { floor = 150, base = 300, ceiling = 1200 } = {
   // 0% hit rate falls to the floor; ~50% and above reaches the ceiling.
   const scaled = Math.round(floor + (ceiling - floor) * Math.min(1, hitRate * 2));
   return Math.max(floor, Math.min(ceiling, scaled));
+}
+
+/* ----------------------------------------------------------------------
+ * Episode-level causal evidence
+ * ------------------------------------------------------------------- */
+
+const numeric = (value) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const average = (values) => {
+  const finite = values.map(numeric).filter((value) => value !== null);
+  return finite.length
+    ? finite.reduce((sum, value) => sum + value, 0) / finite.length
+    : null;
+};
+
+/** Deterministic PRNG so regenerating a report does not move its interval. */
+function seededRandom(seedText) {
+  let seed = 2166136261;
+  for (const char of String(seedText)) {
+    seed ^= char.charCodeAt(0);
+    seed = Math.imul(seed, 16777619);
+  }
+  return () => {
+    seed += 0x6d2b79f5;
+    let value = seed;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Percentile bootstrap interval for a mean, paired delta, or other scalar. */
+export function bootstrapMeanInterval(values, { samples = 1000, seed = 'token-optimizer' } = {}) {
+  const finite = values.map(numeric).filter((value) => value !== null);
+  if (!finite.length) return { mean: null, low: null, high: null, n: 0 };
+  if (finite.length === 1) {
+    return { mean: finite[0], low: finite[0], high: finite[0], n: 1 };
+  }
+
+  const random = seededRandom(`${seed}:${finite.join(',')}`);
+  const means = [];
+  for (let sample = 0; sample < samples; sample++) {
+    let total = 0;
+    for (let index = 0; index < finite.length; index++) {
+      total += finite[Math.floor(random() * finite.length)];
+    }
+    means.push(total / finite.length);
+  }
+  means.sort((a, b) => a - b);
+  return {
+    mean: average(finite),
+    low: means[Math.floor(means.length * 0.025)],
+    high: means[Math.min(means.length - 1, Math.floor(means.length * 0.975))],
+    n: finite.length,
+  };
+}
+
+/** Wilson interval keeps small correctness samples honest and inside 0..1. */
+export function proportionInterval(successes, total, z = 1.96) {
+  if (!total) return { rate: null, low: null, high: null, n: 0 };
+  const rate = successes / total;
+  const denominator = 1 + (z * z) / total;
+  const centre = (rate + (z * z) / (2 * total)) / denominator;
+  const radius =
+    (z / denominator) * Math.sqrt((rate * (1 - rate)) / total + (z * z) / (4 * total * total));
+  return { rate, low: Math.max(0, centre - radius), high: Math.min(1, centre + radius), n: total };
+}
+
+const cohortKey = (run) => [
+  run.client || 'unknown',
+  run.clientVersion || 'unknown',
+  run.model || 'unknown',
+  run.modelVersion || 'unknown',
+  run.taskId || 'unknown',
+].join('|');
+
+function armMetrics(runs) {
+  const correct = runs.filter((run) => run.correct === true).length;
+  const interval = (field) => bootstrapMeanInterval(
+    runs.map((run) => run[field]).filter((value) => numeric(value) !== null),
+    { seed: field }
+  );
+  return {
+    runs: runs.length,
+    correctness: proportionInterval(correct, runs.length),
+    uncachedInputTokens: interval('uncachedInputTokens'),
+    cachedInputTokens: interval('cachedInputTokens'),
+    outputTokens: interval('outputTokens'),
+    totalTokens: interval('totalTokens'),
+    toolCalls: interval('toolCalls'),
+    failedToolCalls: interval('failedToolCalls'),
+    latencyMs: interval('latencyMs'),
+    costUsd: interval('costUsd'),
+    injectedTokens: interval('injectedTokens'),
+    harmfulFindings: runs.reduce((sum, run) => sum + (numeric(run.harmfulFindings) || 0), 0),
+  };
+}
+
+function pairedEffects(runs, treatmentArm) {
+  const pairs = new Map();
+  for (const run of runs) {
+    if (!run.pairId || !['baseline', treatmentArm].includes(run.arm)) continue;
+    if (!pairs.has(run.pairId)) pairs.set(run.pairId, {});
+    pairs.get(run.pairId)[run.arm] = run;
+  }
+  const complete = [...pairs.values()].filter((pair) => pair.baseline && pair[treatmentArm]);
+  const delta = (field, lowerIsBetter = true) => bootstrapMeanInterval(
+    complete
+      .map((pair) => {
+        const baseline = numeric(pair.baseline[field]);
+        const treatment = numeric(pair[treatmentArm][field]);
+        if (baseline === null || treatment === null) return null;
+        return lowerIsBetter ? baseline - treatment : treatment - baseline;
+      })
+      .filter((value) => value !== null),
+    { seed: `${treatmentArm}:${field}` }
+  );
+  return {
+    arm: treatmentArm,
+    pairs: complete.length,
+    // Positive values always mean the treatment improved the metric.
+    totalTokensSaved: delta('totalTokens'),
+    uncachedInputTokensSaved: delta('uncachedInputTokens'),
+    toolCallsAvoided: delta('toolCalls'),
+    latencyMsSaved: delta('latencyMs'),
+    costUsdSaved: delta('costUsd'),
+    correctnessDelta: delta('correct', false),
+  };
+}
+
+function matchesFilters(event, filters) {
+  for (const field of ['client', 'clientVersion', 'model', 'modelVersion', 'taskId', 'arm']) {
+    if (filters[field] && String(event[field] || '') !== String(filters[field])) return false;
+  }
+  return true;
+}
+
+/**
+ * The dashboard-facing evidence console.  Deterministic fixture verification,
+ * live hook traces, and randomized model evals remain visibly distinct: only
+ * `eval-run` records with paired arms can produce a causal effect interval.
+ */
+export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
+  const evidence = readEvidence(dir).filter((event) => matchesFilters(event, filters));
+  const runs = evidence.filter((event) => event.kind === 'eval-run');
+  const injections = evidence.filter((event) => event.kind === 'inject');
+  const outcomes = evidence.filter((event) => event.kind === 'tool-outcome');
+  const feedback = evidence.filter((event) => event.kind === 'finding-feedback');
+
+  const byInjection = new Map(
+    outcomes.filter((event) => event.injectionId).map((event) => [event.injectionId, event])
+  );
+  const traced = injections
+    .slice()
+    .sort((a, b) => (b.at || 0) - (a.at || 0))
+    .slice(0, Math.max(1, Math.min(500, episodeLimit)))
+    .map((injection) => ({
+      injectionId: injection.injectionId,
+      episodeId: injection.episodeId || injection.sessionId || null,
+      at: injection.at,
+      arm: injection.arm || (injection.holdout ? 'holdout' : 'treated'),
+      client: injection.client || 'unknown',
+      clientVersion: injection.clientVersion || null,
+      model: injection.model || null,
+      taskId: injection.taskId || null,
+      surface: injection.surface || injection.trigger || 'file',
+      anchor: injection.anchor,
+      findingIds: injection.findingIds || [],
+      deliveredTokens: injection.deliveredTokens ?? injection.tokens ?? 0,
+      shadowTokens: injection.shadowTokens ?? injection.tokens ?? 0,
+      outcome: byInjection.get(injection.injectionId) || null,
+    }));
+
+  const grouped = new Map();
+  for (const run of runs) {
+    const key = cohortKey(run);
+    if (!grouped.has(key)) grouped.set(key, []);
+    grouped.get(key).push(run);
+  }
+
+  const minimumPairs = Math.max(2, Number(process.env.TOKEN_OPTIMIZER_EVAL_MIN_PAIRS) || 5);
+  const cohorts = [...grouped.entries()].map(([key, cohortRuns]) => {
+    const arms = Object.fromEntries(
+      ['baseline', 'optimizer', 'retrieval', 'full'].map((arm) => [
+        arm,
+        armMetrics(cohortRuns.filter((run) => run.arm === arm)),
+      ])
+    );
+    const effects = ['optimizer', 'retrieval', 'full'].map((arm) => pairedEffects(cohortRuns, arm));
+    const enough = effects.some((effect) => effect.pairs >= minimumPairs);
+    return {
+      key,
+      client: cohortRuns[0]?.client || 'unknown',
+      clientVersion: cohortRuns[0]?.clientVersion || null,
+      model: cohortRuns[0]?.model || null,
+      modelVersion: cohortRuns[0]?.modelVersion || null,
+      taskId: cohortRuns[0]?.taskId || null,
+      arms,
+      effects,
+      evidenceStatus: enough
+        ? 'causal estimate available'
+        : `insufficient paired runs (need ${minimumPairs})`,
+    };
+  });
+
+  const joined = injections.filter((injection) =>
+    byInjection.has(injection.injectionId)
+  ).length;
+  const harmful = feedback.filter((event) => event.rating === 'harmful').length;
+  return {
+    schemaVersion: 2,
+    generatedAt: new Date().toISOString(),
+    filters,
+    summary: {
+      liveInjections: injections.length,
+      joinedOutcomes: joined,
+      causalJoinCoverage: injections.length ? joined / injections.length : null,
+      evalRuns: runs.length,
+      cohorts: cohorts.length,
+      harmfulFeedback: harmful,
+      harmRate: feedback.length ? harmful / feedback.length : null,
+      evidenceStatus: cohorts.some((cohort) => cohort.evidenceStatus === 'causal estimate available')
+        ? 'causal estimates available'
+        : 'insufficient randomized evidence',
+    },
+    cohorts,
+    episodes: traced,
+    methodology: {
+      intervals: 'deterministic percentile bootstrap (95%); Wilson interval for correctness',
+      causalRule: 'only matched eval-run pairs compare an arm with baseline',
+      minimumPairs,
+      deterministicChecksAreCausalProof: false,
+    },
+  };
 }

--- a/integrations/gemini/hooks/lib/recording.mjs
+++ b/integrations/gemini/hooks/lib/recording.mjs
@@ -159,6 +159,9 @@ export function semanticHarvestPrompt({
     + ' If this work produced a durable, non-obvious conclusion -- a failed approach and why, '
     + 'a decision and its rejected alternative, or a command that finally worked -- call '
     + 'wiki_write now with a real file anchor. Do not delegate this to another model or an '
-    + 'external harvester. If there is no such conclusion, do not invent one; finish normally.'
+    + 'external harvester. Include: the concrete evidence, when the finding applies, a calibrated '
+    + 'confidenceLabel (verified/probable/speculative), its project/organization/global scope, '
+    + 'and anything that would invalidate it. If there is no such conclusion, do not invent one; '
+    + 'finish normally.'
   );
 }

--- a/integrations/gemini/hooks/lib/utility.mjs
+++ b/integrations/gemini/hooks/lib/utility.mjs
@@ -1,0 +1,135 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/utility.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Evidence-aware retrieval economics.
+ *
+ * Relevance alone is not enough: a true finding can still cost more context
+ * than it saves.  Every candidate receives a conservative expected-benefit
+ * estimate, its delivery cost and risk are subtracted, and harmful findings
+ * are quarantined from automatic delivery while remaining visible for audit.
+ */
+
+import { readEvidence } from './metrics.mjs';
+
+const DAY = 86_400_000;
+const ORIGIN_WEIGHT = { human: 1.2, agent: 1.08, harvested: 1 };
+
+const envNumber = (name, fallback) => {
+  const value = Number(process.env[name]);
+  return Number.isFinite(value) && value >= 0 ? value : fallback;
+};
+
+export const retrievalPolicy = () => ({
+  baseBenefitTokens: envNumber('TOKEN_OPTIMIZER_EXPECTED_BENEFIT_TOKENS', 400),
+  minimumNetUtility: envNumber('TOKEN_OPTIMIZER_MIN_EXPECTED_UTILITY', 20),
+  cooldownMs: envNumber('TOKEN_OPTIMIZER_INJECTION_COOLDOWN_MS', 60_000),
+  quarantineHarmCount: Math.max(1, envNumber('TOKEN_OPTIMIZER_QUARANTINE_HARM_COUNT', 2)),
+});
+
+function feedbackFor(events, key) {
+  return events.filter((event) =>
+    event.kind === 'finding-feedback'
+    && (event.findingId === key || (event.findingIds || []).includes(key))
+  );
+}
+
+function outcomesFor(events, key) {
+  return events.filter((event) =>
+    event.kind === 'tool-outcome' && (event.findingIds || []).includes(key)
+  );
+}
+
+function deliveredRecently(events, key, episodeId, now, cooldownMs) {
+  if (!episodeId || cooldownMs <= 0) return false;
+  return events.some((event) =>
+    event.kind === 'inject'
+    && event.episodeId === episodeId
+    && (event.findingIds || []).includes(key)
+    && !event.holdout
+    && now - (event.at || 0) < cooldownMs
+  );
+}
+
+/**
+ * Returns eligible candidates in utility order plus every rejection reason.
+ * `costFor` is supplied by inject.mjs so the gate prices the exact rendered
+ * text rather than a second approximation that could drift.
+ */
+export function assessFindings(
+  dir,
+  findings,
+  {
+    relevanceFor = () => 1,
+    costFor = () => 0,
+    episodeId = null,
+    now = Date.now(),
+    policy = retrievalPolicy(),
+  } = {}
+) {
+  const events = readEvidence(dir);
+  const eligible = [];
+  const rejected = [];
+
+  for (const finding of findings) {
+    const key = finding.key;
+    const feedback = feedbackFor(events, key);
+    const outcomes = outcomesFor(events, key);
+    const helpful = feedback.filter((event) => event.rating === 'helpful').length;
+    const neutral = feedback.filter((event) => event.rating === 'neutral').length;
+    const harmful = feedback.filter((event) => event.rating === 'harmful').length;
+    const successfulUses = outcomes.filter((event) => event.success === true).length;
+    const failedUses = outcomes.filter((event) => event.success === false).length;
+
+    if (harmful >= policy.quarantineHarmCount && harmful >= helpful + neutral) {
+      rejected.push({ key, reason: 'quarantined-harm', helpful, neutral, harmful });
+      continue;
+    }
+    if (deliveredRecently(events, key, episodeId, now, policy.cooldownMs)) {
+      rejected.push({ key, reason: 'cooldown' });
+      continue;
+    }
+
+    const confidence = Number.isFinite(finding.confidence) ? finding.confidence : 0.5;
+    const relevance = Math.max(0, Math.min(1, Number(relevanceFor(finding)) || 0));
+    const ageDays = Math.max(0, (now - (finding.at || now)) / DAY);
+    const recency = finding.pinned ? 1 : Math.pow(0.5, ageDays / 90);
+    const provenance = ORIGIN_WEIGHT[finding.origin] || 1;
+    // Outcome evidence moves the estimate gradually. Explicit harmful feedback
+    // is handled above; a failed command alone is not labelled harmful because
+    // the model may have ignored correct advice.
+    const observed = successfulUses + failedUses;
+    const successFactor = observed
+      ? 0.75 + 0.5 * (successfulUses / observed)
+      : 1;
+    const feedbackFactor = Math.max(0.25, 1 + helpful * 0.12 - harmful * 0.35);
+    const expectedBenefit =
+      policy.baseBenefitTokens * confidence * relevance * recency * provenance * successFactor * feedbackFactor;
+    const deliveryCost = Math.max(0, Number(costFor(finding)) || 0);
+    const riskPenalty =
+      (finding.stale ? 160 : 0)
+      + (finding.confidenceLabel === 'speculative' ? 100 : 0)
+      + harmful * 100;
+    const netUtility = expectedBenefit - deliveryCost - riskPenalty;
+
+    const assessed = {
+      finding,
+      expectedBenefit,
+      deliveryCost,
+      riskPenalty,
+      netUtility,
+      helpful,
+      neutral,
+      harmful,
+      successfulUses,
+      failedUses,
+    };
+    if (netUtility < policy.minimumNetUtility) {
+      rejected.push({ key, reason: 'negative-expected-value', ...assessed, finding: undefined });
+      continue;
+    }
+    eligible.push(assessed);
+  }
+
+  eligible.sort((a, b) => b.netUtility - a.netUtility);
+  return { eligible, rejected };
+}

--- a/integrations/gemini/hooks/lib/utility.mjs
+++ b/integrations/gemini/hooks/lib/utility.mjs
@@ -64,6 +64,7 @@ export function assessFindings(
     episodeId = null,
     now = Date.now(),
     policy = retrievalPolicy(),
+    bypassCooldown = false,
   } = {}
 ) {
   const events = readEvidence(dir);
@@ -84,7 +85,7 @@ export function assessFindings(
       rejected.push({ key, reason: 'quarantined-harm', helpful, neutral, harmful });
       continue;
     }
-    if (deliveredRecently(events, key, episodeId, now, policy.cooldownMs)) {
+    if (!bypassCooldown && deliveredRecently(events, key, episodeId, now, policy.cooldownMs)) {
       rejected.push({ key, reason: 'cooldown' });
       continue;
     }

--- a/integrations/gemini/hooks/lib/wire.mjs
+++ b/integrations/gemini/hooks/lib/wire.mjs
@@ -28,7 +28,7 @@ export const MARKER = 'token-optimizer';
 /** The events we wire, and which hook file serves each. */
 export const WIRING = [
   { event: 'SessionStart', file: 'session-start.mjs', matcher: null },
-  { event: 'PreToolUse', file: 'pretooluse-router.mjs', matcher: 'Read|Grep|Glob|Edit|MultiEdit|Write|Bash' },
+  { event: 'PreToolUse', file: 'pretooluse-router.mjs', matcher: 'Read|Grep|Glob|Edit|MultiEdit|Write|Bash|PowerShell' },
   { event: 'PreCompact', file: 'precompact-optimize.mjs', matcher: null },
 ];
 

--- a/integrations/kilo/hooks/lib/adapter.mjs
+++ b/integrations/kilo/hooks/lib/adapter.mjs
@@ -31,7 +31,9 @@ import {
   readCostBytes,
   touchedFiles,
 } from './decide.mjs';
-import { recordRead, fingerprint } from './metrics.mjs';
+import {
+  recordRead, fingerprint, recordToolOutcome, recordEpisodeOutcome,
+} from './metrics.mjs';
 import {
   contentHash,
   harvest,
@@ -57,6 +59,8 @@ import { isFsSafePath } from './paths.mjs';
 import {
   isSubstantive, recordingNudge, semanticHarvestPrompt,
 } from './recording.mjs';
+import { nativeClientProfiles } from './capabilities.mjs';
+import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 
 /**
  * Per-client capability.
@@ -65,41 +69,7 @@ import {
  * it true where the client has no pre-execution veto would make the product
  * claim enforcement it cannot deliver.
  */
-export const CLIENTS = {
-  'claude-code': { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  codex: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  cline: {
-    canDeny: true,
-    contextStyle: 'cline',
-    denyStyle: 'cline',
-    stopDecision: 'block',
-  },
-  copilot: {
-    canDeny: true,
-    contextStyle: 'top-level',
-    denyStyle: 'top-level-permission',
-    stopDecision: 'block',
-  },
-  cursor: {
-    canDeny: true,
-    contextStyle: 'cursor',
-    denyStyle: 'cursor',
-    stopStyle: 'followup',
-    stopDecision: 'block',
-  },
-  // Gemini's BeforeTool and AfterAgent decisions are top-level. Treating it
-  // like Codex produced well-formed JSON that Gemini ignored.
-  gemini: { canDeny: true, denyStyle: 'top-level', stopDecision: 'deny' },
-  kilo: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  opencode: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  qwen: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  windsurf: {
-    canDeny: true,
-    contextStyle: 'silent',
-    denyStyle: 'exit-2',
-    stopDecision: 'block',
-  },
-};
+export const CLIENTS = nativeClientProfiles();
 
 /** Never synchronously hash an unbounded build artifact on a hook path. */
 const HARVEST_MAX_BYTES =
@@ -135,6 +105,24 @@ export function mutationSucceeded(clientName, raw) {
   // or are called by our in-process bridge only from its successful after hook.
   return new Set(['claude-code', 'qwen', 'opencode', 'kilo', 'windsurf'])
     .has(clientName);
+}
+
+/** Conservative success classification for any completed tool call. */
+export function toolSucceeded(raw) {
+  if (raw?.error || raw?.tool_response?.error || raw?.toolResponse?.error)
+    return false;
+  if (raw?.postToolUse?.success === false || raw?.success === false) return false;
+  const status =
+    raw?.tool_response?.status ?? raw?.toolResponse?.status ??
+    raw?.tool_result?.status ?? raw?.toolResult?.status;
+  if (status !== undefined) {
+    if (/^(?:error|failed|failure|cancelled|canceled|denied)$/i.test(String(status))) return false;
+    if (/^(?:ok|success|succeeded|complete|completed)$/i.test(String(status))) return true;
+  }
+  // A post-tool lifecycle event is evidence that the call completed, but not
+  // that its output proved the task.  `success` here is deliberately scoped to
+  // the tool call; task correctness comes only from an eval grader.
+  return true;
 }
 
 function contextOutput(client, eventName, additionalContext) {
@@ -253,8 +241,10 @@ refused.
 
 Worth recording: a decision and why the alternative was rejected, a failure and
 what actually caused it, a command that turned out to be the one that works.
-Not worth recording: what the code plainly says. Prefer the thing someone had to
-work out, because that exists nowhere in the source tree.${projectBriefing()}`;
+Not worth recording: what the code plainly says. Every wiki_write must include
+the concrete evidence, when it applies, a calibrated confidence label, its
+scope, and what would invalidate it. Prefer the thing someone had to work out,
+because that exists nowhere in the source tree.${projectBriefing()}`;
 }
 
 /**
@@ -315,7 +305,7 @@ function projectBriefing() {
  * metrics. It never called forTouch/forCommand, so four advertised clients
  * accumulated a graph that their active model could not receive.
  */
-function observeAndInject(payload, state) {
+function observeAndInject(payload, state, episode, features) {
   const touched = touchedFiles(payload);
   const dirFor = (path) => wikiDir(projectRootFor(path, payload.cwd));
 
@@ -344,45 +334,51 @@ function observeAndInject(payload, state) {
   state.injected = state.injected || [];
   const alreadyInjected = new Set(state.injected);
 
-  for (const { path } of touched) {
-    const dir = dirFor(path);
-    const note = forTouch(dir, load(dir), path, {
-      sessionId: payload.session_id,
-      alreadyInjected,
-    });
-    if (note) parts.push(note);
-  }
+  if (features.retrieval) {
+    for (const { path } of touched) {
+      const dir = dirFor(path);
+      const note = forTouch(dir, load(dir), path, {
+        sessionId: payload.session_id,
+        alreadyInjected,
+        episode,
+      });
+      if (note) parts.push(note);
+    }
 
-  const command = payload.tool_input?.command;
-  if (command) {
-    const root = commandProjectRoot(payload, payload.cwd);
-    const dir = wikiDir(root);
-    const local = forCommand(dir, load(dir), command, {
-      sessionId: payload.session_id,
-      alreadyInjected,
-    });
-    if (local) parts.push(local);
+    const command = payload.tool_input?.command;
+    if (command) {
+      const root = commandProjectRoot(payload, payload.cwd);
+      const dir = wikiDir(root);
+      const local = forCommand(dir, load(dir), command, {
+        sessionId: payload.session_id,
+        alreadyInjected,
+        episode,
+      });
+      if (local) parts.push(local);
 
-    const shared = forSharedCommand(dir, command, {
-      sessionId: payload.session_id,
-      alreadyInjected,
-      projectRoot: root,
-    });
-    if (shared) parts.push(shared);
+      const shared = forSharedCommand(dir, command, {
+        sessionId: payload.session_id,
+        alreadyInjected,
+        projectRoot: root,
+        episode,
+      });
+      if (shared) parts.push(shared);
 
-    const crossed = noteActClasses(state, command);
-    const repeated = forRepeatedAct(dir, command, crossed, {
-      sessionId: payload.session_id,
-      projectRoot: root,
-    });
-    if (repeated) parts.push(repeated);
+      const crossed = noteActClasses(state, command);
+      const repeated = forRepeatedAct(dir, command, crossed, {
+        sessionId: payload.session_id,
+        projectRoot: root,
+        episode,
+      });
+      if (repeated) parts.push(repeated);
+    }
   }
   state.injected = [...alreadyInjected];
 
   // Structural capture is evidence about what was touched, not a semantic
   // conclusion. It is therefore safe to automate for every client and leaves
   // the active model responsible for wiki_write at completion.
-  for (const { path, size } of touched) {
+  if (features.capture) for (const { path, size } of touched) {
     try {
       if (isArchived(path) || size > HARVEST_MAX_BYTES || !isFsSafePath(path))
         continue;
@@ -420,7 +416,10 @@ export async function run(clientName, event) {
 
   if (mode() === MODE_OFF) process.exit(0);
 
+  const features = featuresForArm();
+
   if (event === 'session-start') {
+    if (!features.routing && !features.retrieval && !features.harvest) process.exit(0);
     const output = contextOutput(client, eventName, policyText(client.canDeny));
     if (output) emit(output);
     process.exit(0);
@@ -437,10 +436,22 @@ export async function run(clientName, event) {
     const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? 'default';
     const agentScope = raw.transcript_path ?? raw.transcriptPath ?? null;
     const state = loadState(sessionId, agentScope);
+    const episode = episodeMeta({ client: clientName, raw });
+    try {
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+      recordEpisodeOutcome(dir, {
+        ...episode,
+        status: 'completed',
+        ...usageFrom(raw),
+      });
+    } catch {
+      // Evidence is best effort and must never stop a session from finishing.
+    }
     const alreadyHarvested =
       Number(state.edits || 0) > 0 &&
       Number(state.harvestedEdits || 0) >= Number(state.edits || 0);
-    const prompt = semanticHarvestPrompt({
+    const prompt = features.harvest ? semanticHarvestPrompt({
       edits: state.edits,
       files: state.editedFiles,
       model: raw.model,
@@ -449,7 +460,7 @@ export async function run(clientName, event) {
         raw.stopHookActive === true ||
         alreadyHarvested ||
         (clientName === 'cursor' && Number(raw.loop_count || 0) > 0),
-    });
+    }) : null;
     if (prompt) {
       state.harvestedEdits = Number(state.edits || 0);
       saveState(sessionId, state, agentScope);
@@ -466,6 +477,7 @@ export async function run(clientName, event) {
     process.exit(0);
   const payload = normalizePayload(normalizeClientPayload(clientName, event, raw));
   if (!payload.tool_name) process.exit(0);
+  const episode = episodeMeta({ client: clientName, raw, payload });
 
   // THE AGENT, not just the session -- the same scope the Claude Code router
   // applies. Subagents inherit the parent's session id, so keying state on the
@@ -506,17 +518,41 @@ export async function run(clientName, event) {
       const anchor = state.editedFiles[0]
         || join(payload.cwd || process.cwd(), '__recording__');
       const dir = wikiDir(projectRootFor(anchor, payload.cwd));
-      recordingContext = recordingNudge(dir, {
+      recordingContext = features.harvest ? recordingNudge(dir, {
         state,
         edits: state.edits,
         files: state.editedFiles,
-      });
+      }) : null;
       if (recordingContext) state.recordingNudged = true;
     } catch {
       // Recording pressure is an optimization and must never cost a tool call.
     }
   }
-  const verdict = decide(payload, state);
+  if (event === 'post-tool') {
+    try {
+      const command = payload.tool_input?.command;
+      const touched = touchedFiles(payload);
+      const anchor = command
+        ? String(command).slice(0, 120)
+        : touched[0]?.path || payload.tool_input?.file_path || '';
+      const root = command
+        ? commandProjectRoot(payload, payload.cwd)
+        : projectRootFor(anchor || join(payload.cwd || process.cwd(), '__tool__'), payload.cwd);
+      recordToolOutcome(wikiDir(root), {
+        ...episode,
+        surface: command ? 'command' : 'file',
+        anchor,
+        toolName: payload.tool_name,
+        success: toolSucceeded(raw),
+        durationMs: Number(raw.duration_ms ?? raw.durationMs ?? raw.elapsed_ms ?? raw.elapsedMs) || null,
+        ...usageFrom(raw),
+      });
+    } catch {
+      // Causal tracing is fail-open like every other hook optimization.
+    }
+  }
+
+  const verdict = features.routing ? decide(payload, state) : null;
   const repeat = verdict && event === 'pre-tool'
     ? alreadyDenied(state, verdict.key)
     : false;
@@ -571,7 +607,7 @@ export async function run(clientName, event) {
   remember(payload, state);
   let graphContext = null;
   try {
-    graphContext = observeAndInject(payload, state);
+    graphContext = observeAndInject(payload, state, episode, features);
   } catch {
     // Delivery is an optimization. Fail open.
   }

--- a/integrations/kilo/hooks/lib/capabilities.mjs
+++ b/integrations/kilo/hooks/lib/capabilities.mjs
@@ -1,0 +1,130 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/capabilities.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * The product's honest cross-client capability contract.
+ *
+ * A client is listed at the strongest surface its public lifecycle protocol can
+ * actually support.  This registry is consumed by the adapter, certification
+ * tooling, and evidence reports so a rules-only integration can never be
+ * presented as equivalent to a native stop-continuation integration.
+ */
+
+export const CAPABILITY_TIERS = Object.freeze({
+  CONTINUATION: 'lifecycle-continuation',
+  OBSERVATION: 'native-observation',
+  RULES: 'mcp-rules',
+});
+
+const native = (profile) => ({
+  structuralCapture: 'native',
+  findingDelivery: 'native',
+  routing: 'native-veto',
+  ...profile,
+});
+
+export const CLIENT_CAPABILITIES = Object.freeze({
+  'claude-code': native({
+    name: 'Claude Code', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-continuation', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  codex: native({
+    name: 'Codex', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-continuation', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  copilot: native({
+    name: 'GitHub Copilot CLI', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'agent-stop-continuation', canDeny: true,
+    contextStyle: 'top-level', denyStyle: 'top-level-permission', stopDecision: 'block',
+  }),
+  gemini: native({
+    name: 'Gemini CLI', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'after-agent-retry', canDeny: true,
+    denyStyle: 'top-level', stopDecision: 'deny',
+  }),
+  qwen: native({
+    name: 'Qwen Code', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-continuation', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  cursor: native({
+    name: 'Cursor', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-followup', canDeny: true,
+    contextStyle: 'cursor', denyStyle: 'cursor', stopStyle: 'followup', stopDecision: 'block',
+  }),
+  cline: native({
+    name: 'Cline', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    contextStyle: 'cline', denyStyle: 'cline', stopDecision: 'block',
+  }),
+  opencode: native({
+    name: 'OpenCode', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  kilo: native({
+    name: 'Kilo', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  windsurf: native({
+    name: 'Windsurf', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    contextStyle: 'silent', denyStyle: 'exit-2', stopDecision: 'block',
+  }),
+  roo: {
+    name: 'Roo Code', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  zed: {
+    name: 'Zed', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  amp: {
+    name: 'Amp', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  continue: {
+    name: 'Continue', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  crush: {
+    name: 'Crush', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  droid: {
+    name: 'Droid (Factory)', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+});
+
+export function capabilityFor(client) {
+  return CLIENT_CAPABILITIES[String(client || '').toLowerCase()] || null;
+}
+
+export function nativeClientProfiles() {
+  return Object.fromEntries(
+    Object.entries(CLIENT_CAPABILITIES)
+      .filter(([, profile]) => profile.structuralCapture === 'native')
+      .map(([key, profile]) => [key, { ...profile }])
+  );
+}
+
+export function capabilitySummary() {
+  return Object.entries(CLIENT_CAPABILITIES).map(([client, profile]) => ({
+    client,
+    name: profile.name,
+    tier: profile.tier,
+    routing: profile.routing,
+    structuralCapture: profile.structuralCapture,
+    findingDelivery: profile.findingDelivery,
+    semanticHarvest: profile.semanticHarvest,
+  }));
+}

--- a/integrations/kilo/hooks/lib/decide.mjs
+++ b/integrations/kilo/hooks/lib/decide.mjs
@@ -513,6 +513,8 @@ const TOOL_ALIASES = new Map(
     create_file: 'Write',
 
     bash: 'Bash',
+    powershell: 'Bash',
+    pwsh: 'Bash',
     shell: 'Bash',
     run_command: 'Bash',
     execute_command: 'Bash',

--- a/integrations/kilo/hooks/lib/experiment.mjs
+++ b/integrations/kilo/hooks/lib/experiment.mjs
@@ -1,0 +1,82 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/experiment.mjs. Regenerate with `npm run sync:hooks`.
+/** Explicit, reproducible feature arms and causal episode identity. */
+
+export const EXPERIMENT_ARMS = Object.freeze([
+  'baseline',
+  'optimizer',
+  'retrieval',
+  'full',
+]);
+
+const FEATURES = Object.freeze({
+  baseline: Object.freeze({ routing: false, retrieval: false, capture: false, harvest: false }),
+  optimizer: Object.freeze({ routing: true, retrieval: false, capture: false, harvest: false }),
+  retrieval: Object.freeze({ routing: true, retrieval: true, capture: true, harvest: false }),
+  full: Object.freeze({ routing: true, retrieval: true, capture: true, harvest: true }),
+});
+
+export function experimentArm(env = process.env) {
+  const requested = String(env.TOKEN_OPTIMIZER_EXPERIMENT_ARM || '').trim().toLowerCase();
+  return EXPERIMENT_ARMS.includes(requested) ? requested : 'full';
+}
+
+export function featuresForArm(arm = experimentArm()) {
+  return FEATURES[arm] || FEATURES.full;
+}
+
+const first = (...values) => values.find((value) => value !== undefined && value !== null && value !== '');
+
+/**
+ * Normalises identifiers exposed under different names by lifecycle clients.
+ * Environment overrides let the live evaluation harness pin a pair/task id
+ * without asking each CLI to support experiment-specific payload fields.
+ */
+export function episodeMeta({ client, raw = {}, payload = {}, env = process.env } = {}) {
+  const sessionId = String(first(
+    payload.session_id, raw.session_id, raw.sessionId, raw.conversation_id,
+    raw.conversationId, raw.taskId, raw.task_id, raw.trajectory_id, 'default'
+  ));
+  const episodeId = String(first(
+    env.TOKEN_OPTIMIZER_EPISODE_ID, raw.episode_id, raw.episodeId, sessionId
+  ));
+  const toolCallId = first(
+    raw.tool_use_id, raw.toolUseId, raw.tool_call_id, raw.toolCallId,
+    raw.call_id, raw.callId, raw.postToolUse?.toolUseId, raw.preToolUse?.toolUseId
+  );
+  const model = first(payload.model, raw.model?.slug, raw.model, raw.model_name, env.TOKEN_OPTIMIZER_MODEL);
+  const clientVersion = first(
+    raw.client_version, raw.clientVersion, raw.version, env.TOKEN_OPTIMIZER_CLIENT_VERSION
+  );
+  const modelVersion = first(raw.model_version, raw.modelVersion, env.TOKEN_OPTIMIZER_MODEL_VERSION);
+
+  return {
+    schemaVersion: 2,
+    episodeId,
+    sessionId,
+    turnId: first(raw.turn_id, raw.turnId, raw.message_id, raw.messageId) ?? null,
+    toolCallId: toolCallId == null ? null : String(toolCallId),
+    taskId: first(env.TOKEN_OPTIMIZER_TASK_ID, raw.task_id, raw.taskId) ?? null,
+    pairId: first(env.TOKEN_OPTIMIZER_PAIR_ID, raw.pair_id, raw.pairId) ?? null,
+    arm: experimentArm(env),
+    client: String(client || first(raw.client, raw.client_name, 'unknown')),
+    clientVersion: clientVersion == null ? null : String(clientVersion),
+    model: model == null ? null : String(model),
+    modelVersion: modelVersion == null ? null : String(modelVersion),
+  };
+}
+
+export function usageFrom(raw = {}) {
+  const usage = raw.usage || raw.token_usage || raw.tokenUsage || raw.metrics?.usage || {};
+  const number = (...values) => {
+    const value = first(...values);
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+  };
+  return {
+    uncachedInputTokens: number(usage.uncached_input_tokens, usage.uncachedInputTokens),
+    cachedInputTokens: number(usage.cached_input_tokens, usage.cachedInputTokens, usage.cache_read_input_tokens),
+    outputTokens: number(usage.output_tokens, usage.outputTokens),
+    totalTokens: number(usage.total_tokens, usage.totalTokens, raw.tokens_used, raw.tokensUsed),
+  };
+}

--- a/integrations/kilo/hooks/lib/harvest-write.mjs
+++ b/integrations/kilo/hooks/lib/harvest-write.mjs
@@ -96,8 +96,13 @@ function promoteToShared(finding, { projectRoot, sessionId, provenance, key }) {
           key: `shared-${key}`,
           claim: finding.claim,
           confidence: finding.confidence,
+          confidenceLabel: finding.confidenceLabel,
           type: finding.type,
           trigger: typeof finding.trigger === 'string' && finding.trigger ? finding.trigger : undefined,
+          applicability: finding.applicability,
+          evidence: finding.evidence,
+          invalidators: Array.isArray(finding.invalidators) ? finding.invalidators : [],
+          scope: finding.scope || 'global',
           origin: provenance,
           quote: typeof finding.quote === 'string' && finding.quote.trim() ? finding.quote : undefined,
           // WHERE IT WAS LEARNED, carried so the reader can discount it. A lesson
@@ -351,6 +356,26 @@ export function writeHarvested(
     // anything, so it is dropped rather than kept as unfalsifiable.
     if (!resolved.length) continue;
 
+    // Exact semantic duplicates collapse to the existing active record.  The
+    // normalisation intentionally ignores punctuation/formatting noise but not
+    // meaning-bearing words; near-duplicates that need judgement remain visible
+    // to curation rather than being silently merged by a fuzzy heuristic.
+    const fingerprint = claimFingerprint(finding.claim);
+    const currentGraph = load(dir);
+    const duplicate = [...currentGraph.nodes.values()].find((node) =>
+      node.kind === 'finding'
+      && !node.retired
+      && node.type === finding.type
+      && claimFingerprint(node.claim) === fingerprint
+      && resolved.every((target) => currentGraph.edges.some((edge) =>
+        edge.from === node.id && edge.edge === 'derived_from' && edge.to === target
+      ))
+    );
+    if (duplicate) {
+      written.push(duplicate.key);
+      continue;
+    }
+
     // Date.now() plus an index is not unique across CONCURRENT detached
     // workers: two Stop hooks finishing in the same millisecond produce the
     // same key, and putNode keeps the last write for an id -- so one session's
@@ -371,6 +396,7 @@ export function writeHarvested(
         key,
         claim: finding.claim,
         confidence: finding.confidence,
+        confidenceLabel: finding.confidenceLabel,
         type: finding.type,
         // WHEN this finding is relevant, not just what it is about. Anchors
         // answer "which file", which is the wrong question for a claim about
@@ -380,6 +406,16 @@ export function writeHarvested(
         trigger: typeof finding.trigger === 'string' && finding.trigger
           ? finding.trigger
           : undefined,
+        applicability: typeof finding.applicability === 'string'
+          ? finding.applicability
+          : undefined,
+        evidence: typeof finding.evidence === 'string'
+          ? finding.evidence
+          : undefined,
+        invalidators: Array.isArray(finding.invalidators)
+          ? finding.invalidators
+          : [],
+        scope: finding.scope || 'project',
         origin: provenance,
         // THE EVIDENCE TRAVELS WITH THE CLAIM. Without it a human-origin
         // finding asserts its own provenance and nothing can check it.
@@ -398,7 +434,11 @@ export function writeHarvested(
     // record of what happened here; the shared tier is a copy for the lessons
     // that are not about here. Skipped when the two are the same directory,
     // which is the suite's usual arrangement.
-    if (id && !isSharedDir(dir)) {
+    if (
+      id
+      && !isSharedDir(dir)
+      && (finding.scope === undefined || finding.scope === 'organization' || finding.scope === 'global')
+    ) {
       promoteToShared(finding, { projectRoot, sessionId, provenance, key });
     }
   }

--- a/integrations/kilo/hooks/lib/harvest.mjs
+++ b/integrations/kilo/hooks/lib/harvest.mjs
@@ -201,7 +201,11 @@ const PROMPT = `Extract durable findings from this coding session for a project 
 Return ONLY a JSON array. Each element:
 {"type": "finding|decision|failure|command|map",
  "claim": "one sentence, specific and checkable",
- "confidence": 0.0-1.0,
+ "evidence": "the concrete observation, command result, or rejected approach that proved it",
+ "applicability": "the condition under which a future model should use it",
+ "confidenceLabel": "verified|probable|speculative",
+ "scope": "project|organization|global",
+ "invalidators": ["what change would require this to be checked again"],
  "anchors": ["absolute/file/path" or "absolute/file/path#symbolName"]}
 
 RULES:
@@ -211,7 +215,9 @@ RULES:
 - Prefer "failure" and "decision" entries. What was TRIED AND REJECTED, and WHY,
   is the most valuable thing here because it exists nowhere in the source tree.
 - Do not restate what the code plainly says. Record what someone had to work out.
-- confidence reflects how well established the claim is, not how important.
+- verified requires direct evidence; probable means strong but incomplete evidence;
+  speculative is a hypothesis and must be labelled as such.
+- Use project scope unless the lesson is genuinely independent of this repository.
 - If nothing durable was learned, return [].`;
 
 /**
@@ -232,8 +238,29 @@ export function validate(raw, { knownFiles = null } = {}) {
     if (!FINDING_TYPES.includes(item.type)) continue;
     if (typeof item.claim !== 'string' || item.claim.trim().length < 8) continue;
 
-    const confidence = Number(item.confidence);
-    if (!Number.isFinite(confidence) || confidence <= 0 || confidence > 1) continue;
+    const evidence = typeof item.evidence === 'string' ? item.evidence.trim() : '';
+    const applicability = typeof item.applicability === 'string' ? item.applicability.trim() : '';
+    if (evidence.length < 8 || applicability.length < 8) continue;
+
+    const confidenceLabel = ['verified', 'probable', 'speculative'].includes(item.confidenceLabel)
+      ? item.confidenceLabel
+      : null;
+    if (!confidenceLabel) continue;
+    const defaults = { verified: 0.95, probable: 0.75, speculative: 0.45 };
+    const supplied = Number(item.confidence);
+    if (
+      item.confidence !== undefined
+      && (!Number.isFinite(supplied) || supplied <= 0 || supplied > 1)
+    ) continue;
+    const confidence = item.confidence === undefined
+      ? defaults[confidenceLabel]
+      : supplied;
+    const scope = ['project', 'organization', 'global'].includes(item.scope)
+      ? item.scope
+      : 'project';
+    const invalidators = Array.isArray(item.invalidators)
+      ? item.invalidators.filter((value) => typeof value === 'string' && value.trim()).slice(0, 10)
+      : [];
 
     let anchors = Array.isArray(item.anchors) ? item.anchors.filter((a) => typeof a === 'string' && a) : [];
     // A model asked for file paths will sometimes invent them. When the caller
@@ -241,7 +268,18 @@ export function validate(raw, { knownFiles = null } = {}) {
     if (knownFiles) anchors = anchors.filter((a) => knownFiles.has(a.split('#')[0]));
     if (!anchors.length) continue;
 
-    accepted.push({ type: item.type, claim: item.claim.trim(), confidence, anchors });
+    accepted.push({
+      type: item.type,
+      claim: item.claim.trim(),
+      evidence,
+      applicability,
+      confidence,
+      confidenceLabel,
+      scope,
+      invalidators,
+      anchors,
+      trigger: typeof item.trigger === 'string' ? item.trigger : undefined,
+    });
   }
   return accepted;
 }

--- a/integrations/kilo/hooks/lib/inject.mjs
+++ b/integrations/kilo/hooks/lib/inject.mjs
@@ -30,6 +30,7 @@ import { inHoldout, record, indexBudget } from './metrics.mjs';
 import { canonicalPath, resolvableCandidates } from './paths.mjs';
 import { annotatedSkeleton } from './skeleton.mjs';
 import { substitutionBudget } from './metrics.mjs';
+import { assessFindings } from './utility.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
@@ -150,7 +151,7 @@ export function forTouch(
   dir,
   graph,
   rawPath,
-  { budget = touchBudget(), sessionId, alreadyInjected = new Set() } = {}
+  { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
   // Canonical, so a touch finds findings anchored under any other spelling.
   const filePath = canonicalPath(rawPath);
@@ -169,16 +170,36 @@ export function forTouch(
   // variance drops out. A session-pinned arm would destroy that.
   const holdout = inHoldout(filePath);
   const served = serve(graph, candidates);
-  const { kept, spent } = fit(served, budget);
+  const assessed = assessFindings(dir, served, {
+    episodeId: episode.episodeId || sessionId,
+    relevanceFor: () => 1,
+    costFor: (finding) => estimate(render(finding)),
+  });
+  if (assessed.rejected.length) {
+    record(dir, {
+      kind: 'retrieval-decision', ...episode, sessionId,
+      surface: 'file', anchor: filePath,
+      rejected: assessed.rejected.map(({ key, reason }) => ({ key, reason })),
+    });
+    for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
+  }
+  const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
+  if (!kept.length) return null;
 
   record(dir, {
     kind: 'inject',
+    ...episode,
     // The surface whose saving CAN be measured: reads of this anchor afterwards.
     surface: 'file',
     anchor: filePath,
     holdout,
     tokens: holdout ? 0 : spent,
-    count: kept.length,
+    deliveredTokens: holdout ? 0 : spent,
+    shadowTokens: spent,
+    count: holdout ? 0 : kept.length,
+    candidateCount: kept.length,
+    findingIds: holdout ? [] : kept.map((finding) => finding.key),
+    shadowFindingIds: kept.map((finding) => finding.key),
     stale: kept.some((f) => f.stale),
     sessionId,
   });
@@ -297,7 +318,7 @@ export function forCommand(
   dir,
   graph,
   command,
-  { budget = touchBudget(), sessionId, alreadyInjected = new Set() } = {}
+  { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
   if (!command) return null;
 
@@ -335,7 +356,20 @@ export function forCommand(
   const considered = candidates.slice(0, MAX_COMMAND_CANDIDATES);
 
   const served = serve(graph, considered);
-  const { kept, spent } = fit(served, budget);
+  const assessed = assessFindings(dir, served, {
+    episodeId: episode.episodeId || sessionId,
+    relevanceFor: (finding) => explicit(finding) ? 1 : 0.6,
+    costFor: (finding) => estimate(render(finding)),
+  });
+  if (assessed.rejected.length) {
+    record(dir, {
+      kind: 'retrieval-decision', ...episode, sessionId,
+      surface: 'command', anchor: String(command).slice(0, 120),
+      rejected: assessed.rejected.map(({ key: findingKey, reason }) => ({ key: findingKey, reason })),
+    });
+    for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
+  }
+  const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
   if (!kept.length) return null;
 
   // THE COMMAND PATH TAKES PART IN THE HOLDOUT TOO.
@@ -353,6 +387,7 @@ export function forCommand(
 
   record(dir, {
     kind: 'inject',
+    ...episode,
     trigger: 'command',
     // The surface the report needs to keep these OUT of the file-read balance:
     // a command has no anchor that read events can be joined to.
@@ -360,7 +395,12 @@ export function forCommand(
     anchor: String(command).slice(0, 120),
     holdout,
     tokens: holdout ? 0 : spent,
+    deliveredTokens: holdout ? 0 : spent,
+    shadowTokens: spent,
     count: holdout ? 0 : kept.length,
+    candidateCount: kept.length,
+    findingIds: holdout ? [] : kept.map((finding) => finding.key),
+    shadowFindingIds: kept.map((finding) => finding.key),
     stale: kept.some((f) => f.stale),
     sessionId,
   });
@@ -509,7 +549,7 @@ export function forRepeatedAct(
   projectDir,
   command,
   crossedClasses,
-  { sessionId = null, projectRoot = null } = {}
+  { sessionId = null, projectRoot = null, episode = {} } = {}
 ) {
   if (!crossedClasses || !crossedClasses.size) return null;
 
@@ -527,14 +567,33 @@ export function forRepeatedAct(
       if (![...crossedClasses].some((c) => claimClasses.has(c))) continue;
 
       const cls = [...crossedClasses].find((c) => claimClasses.has(c));
+      const assessed = assessFindings(projectDir, [node], {
+        episodeId: episode.episodeId || sessionId,
+        relevanceFor: () => 1,
+        costFor: (finding) => estimate(render(finding)),
+      });
+      if (!assessed.eligible.length) {
+        record(projectDir, {
+          kind: 'retrieval-decision', ...episode, sessionId,
+          surface: 'shared', anchor: String(command).slice(0, 120),
+          rejected: assessed.rejected.map(({ key, reason }) => ({ key, reason })),
+        });
+        continue;
+      }
       record(projectDir, {
         kind: 'inject',
+        ...episode,
         trigger: 'repeat',
         surface: 'shared',
         anchor: String(command).slice(0, 120),
         holdout: false,
         tokens: estimate(node.claim),
+        deliveredTokens: estimate(node.claim),
+        shadowTokens: estimate(node.claim),
         count: 1,
+        candidateCount: 1,
+        findingIds: [node.key],
+        shadowFindingIds: [node.key],
         stale: false,
         sessionId,
       });
@@ -585,7 +644,10 @@ function appliesCrossProject(finding, command) {
 export function forSharedCommand(
   projectDir,
   command,
-  { budget = sharedBudget(), sessionId = null, alreadyInjected = new Set(), projectRoot = null } = {}
+  {
+    budget = sharedBudget(), sessionId = null, alreadyInjected = new Set(),
+    projectRoot = null, episode = {},
+  } = {}
 ) {
   if (!command) return null;
 
@@ -622,7 +684,21 @@ export function forSharedCommand(
     // No serve() here: these types are not content-dependent, so there is no
     // anchor to re-read and nothing to diff. serve() would spend a file read per
     // finding to answer a question that does not apply to them.
-    const { kept, spent } = fit(candidates.slice(0, MAX_SHARED), budget);
+    const considered = candidates.slice(0, MAX_SHARED);
+    const assessed = assessFindings(projectDir, considered, {
+      episodeId: episode.episodeId || sessionId,
+      relevanceFor: (finding) => explicit(finding) ? 0.8 : 0.5,
+      costFor: (finding) => estimate(render(finding)),
+    });
+    if (assessed.rejected.length) {
+      record(projectDir, {
+        kind: 'retrieval-decision', ...episode, sessionId,
+        surface: 'shared', anchor: String(command).slice(0, 120),
+        rejected: assessed.rejected.map(({ key, reason }) => ({ key, reason })),
+      });
+      for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
+    }
+    const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
     if (!kept.length) return null;
 
     // THE SAME ARM AS THE LOCAL PATH, KEYED THE SAME WAY.
@@ -644,6 +720,7 @@ export function forSharedCommand(
 
     record(projectDir, {
       kind: 'inject',
+      ...episode,
       trigger: 'command',
       // ITS OWN SURFACE. The balance sheet joins `file` injections to later read
       // events; a shared lesson has no anchor in this project to join to, and
@@ -653,7 +730,12 @@ export function forSharedCommand(
       anchor: String(command).slice(0, 120),
       holdout,
       tokens: holdout ? 0 : spent,
+      deliveredTokens: holdout ? 0 : spent,
+      shadowTokens: spent,
       count: holdout ? 0 : kept.length,
+      candidateCount: kept.length,
+      findingIds: holdout ? [] : kept.map((finding) => finding.key),
+      shadowFindingIds: kept.map((finding) => finding.key),
       stale: false,
       sessionId,
     });

--- a/integrations/kilo/hooks/lib/inject.mjs
+++ b/integrations/kilo/hooks/lib/inject.mjs
@@ -571,6 +571,10 @@ export function forRepeatedAct(
         episodeId: episode.episodeId || sessionId,
         relevanceFor: () => 1,
         costFor: (finding) => estimate(render(finding)),
+        // This surface exists specifically to re-surface a lesson once the
+        // session crosses the repeat threshold. Ordinary retrieval remains
+        // cooldown-protected; harm quarantine and utility gating still apply.
+        bypassCooldown: true,
       });
       if (!assessed.eligible.length) {
         record(projectDir, {

--- a/integrations/kilo/hooks/lib/metrics.mjs
+++ b/integrations/kilo/hooks/lib/metrics.mjs
@@ -1022,6 +1022,7 @@ function armMetrics(runs) {
     runs: runs.length,
     correctness: proportionInterval(correct, runs.length),
     uncachedInputTokens: interval('uncachedInputTokens'),
+    cacheCreationInputTokens: interval('cacheCreationInputTokens'),
     cachedInputTokens: interval('cachedInputTokens'),
     outputTokens: interval('outputTokens'),
     totalTokens: interval('totalTokens'),
@@ -1034,31 +1035,37 @@ function armMetrics(runs) {
   };
 }
 
-function pairedEffects(runs, treatmentArm) {
+function pairedEffects(runs, controlArm, treatmentArm, contrastType = 'incremental') {
   const pairs = new Map();
   for (const run of runs) {
-    if (!run.pairId || !['baseline', treatmentArm].includes(run.arm)) continue;
+    if (!run.pairId || ![controlArm, treatmentArm].includes(run.arm)) continue;
     if (!pairs.has(run.pairId)) pairs.set(run.pairId, {});
     pairs.get(run.pairId)[run.arm] = run;
   }
-  const complete = [...pairs.values()].filter((pair) => pair.baseline && pair[treatmentArm]);
+  const complete = [...pairs.values()].filter((pair) => pair[controlArm] && pair[treatmentArm]);
   const delta = (field, lowerIsBetter = true) => bootstrapMeanInterval(
     complete
       .map((pair) => {
-        const baseline = numeric(pair.baseline[field]);
+        const baseline = numeric(pair[controlArm][field]);
         const treatment = numeric(pair[treatmentArm][field]);
         if (baseline === null || treatment === null) return null;
         return lowerIsBetter ? baseline - treatment : treatment - baseline;
       })
       .filter((value) => value !== null),
-    { seed: `${treatmentArm}:${field}` }
+    { seed: `${controlArm}:${treatmentArm}:${field}` }
   );
   return {
     arm: treatmentArm,
+    controlArm,
+    comparison: `${treatmentArm} vs ${controlArm}`,
+    contrastType,
     pairs: complete.length,
     // Positive values always mean the treatment improved the metric.
     totalTokensSaved: delta('totalTokens'),
     uncachedInputTokensSaved: delta('uncachedInputTokens'),
+    cacheCreationInputTokensSaved: delta('cacheCreationInputTokens'),
+    cachedInputTokensSaved: delta('cachedInputTokens'),
+    outputTokensSaved: delta('outputTokens'),
     toolCallsAvoided: delta('toolCalls'),
     latencyMsSaved: delta('latencyMs'),
     costUsdSaved: delta('costUsd'),
@@ -1124,8 +1131,13 @@ export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
         armMetrics(cohortRuns.filter((run) => run.arm === arm)),
       ])
     );
-    const effects = ['optimizer', 'retrieval', 'full'].map((arm) => pairedEffects(cohortRuns, arm));
-    const enough = effects.some((effect) => effect.pairs >= minimumPairs);
+    const effects = [
+      pairedEffects(cohortRuns, 'baseline', 'optimizer'),
+      pairedEffects(cohortRuns, 'optimizer', 'retrieval'),
+      pairedEffects(cohortRuns, 'retrieval', 'full'),
+      pairedEffects(cohortRuns, 'baseline', 'full', 'total-system'),
+    ];
+    const enough = effects.every((effect) => effect.pairs >= minimumPairs);
     return {
       key,
       client: cohortRuns[0]?.client || 'unknown',
@@ -1165,7 +1177,8 @@ export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
     episodes: traced,
     methodology: {
       intervals: 'deterministic percentile bootstrap (95%); Wilson interval for correctness',
-      causalRule: 'only matched eval-run pairs compare an arm with baseline',
+      causalRule:
+        'matched pairs estimate optimizer vs baseline, retrieval vs optimizer, full vs retrieval, and full vs baseline',
       minimumPairs,
       deterministicChecksAreCausalProof: false,
     },

--- a/integrations/kilo/hooks/lib/metrics.mjs
+++ b/integrations/kilo/hooks/lib/metrics.mjs
@@ -61,6 +61,7 @@ const metricsPath = (dir) => join(dir, 'metrics.jsonl');
  * on it drops BOTH arms proportionally instead of starving the rare one.
  */
 const balancePath = (dir) => join(dir, 'balance.jsonl');
+const evidencePath = (dir) => join(dir, 'evidence.jsonl');
 
 /** Kinds the net balance is computed from, and which therefore must survive. */
 /**
@@ -83,6 +84,24 @@ export const BALANCE_KINDS = new Set([
   // aged out before it was written and the backstop was structurally unable to fire, reporting
   // "only N/10 refreshes observed" for the life of the project.
   'keepwarm',
+]);
+
+/**
+ * Causal records have their own bounded log.  Tool outcomes are much rarer
+ * than read/capture telemetry but more frequent than balance records; mixing
+ * them into either window would eventually evict the evidence needed to join
+ * an injection to its result.
+ */
+export const EVIDENCE_KINDS = new Set([
+  'inject',
+  'harvest',
+  'tool-outcome',
+  'episode-outcome',
+  'eval-run',
+  'finding-feedback',
+  'retrieval-decision',
+  'mcp-client',
+  'mcp-tool',
 ]);
 
 /**
@@ -198,15 +217,30 @@ export function record(dir, event) {
     // single millisecond collapsed to ONE, so a graph with ample data reported
     // 'insufficient data (2 treated, 1 holdout)'. Real events were being
     // discarded by the deduplicator, silently.
-    const line =
-      JSON.stringify({ id: nextId(), ...event, at: event.at ?? Date.now() }) + '\n';
+    const id = event.id || nextId();
+    const complete = {
+      schemaVersion: event.schemaVersion || 2,
+      id,
+      ...event,
+      // An injection id is first-class rather than an inference from the log
+      // record id.  Exporters may rewrite record ids while preserving causal
+      // identity, and downstream tool outcomes refer to this value explicitly.
+      ...(event.kind === 'inject'
+        ? { injectionId: event.injectionId || id }
+        : {}),
+      at: event.at ?? Date.now(),
+    };
+    const line = JSON.stringify(complete) + '\n';
     appendFileSync(metricsPath(dir), line);
     // Balance-critical records go to their own log as well, so the windows on
     // the firehose can never starve the measurement. Written SECOND: a torn
     // write here costs a duplicate the reader dedupes, not a lost event.
     if (BALANCE_KINDS.has(event.kind)) appendFileSync(balancePath(dir), line);
+    if (EVIDENCE_KINDS.has(event.kind)) appendFileSync(evidencePath(dir), line);
+    return complete;
   } catch {
     // Metrics must never break a tool call.
+    return null;
   }
 }
 
@@ -402,6 +436,92 @@ export function readBalance(dir) {
     out.push(e);
   }
   return out;
+}
+
+/** Every causal evidence record inside the byte cap, deduplicated by id. */
+export function readEvidence(dir) {
+  const path = evidencePath(dir);
+  if (!existsSync(path)) return [];
+
+  let text = '';
+  try {
+    const { size } = statSync(path);
+    if (size <= MAX_BYTES) {
+      text = readFileSync(path, 'utf8');
+    } else {
+      const fd = openSync(path, 'r');
+      try {
+        const buffer = Buffer.allocUnsafe(MAX_BYTES);
+        const read = readSync(fd, buffer, 0, MAX_BYTES, size - MAX_BYTES);
+        text = buffer.subarray(0, read).toString('utf8');
+      } finally {
+        closeSync(fd);
+      }
+      text = text.slice(text.indexOf('\n') + 1);
+    }
+  } catch {
+    return [];
+  }
+
+  const seen = new Set();
+  const out = [];
+  for (const line of text.split('\n')) {
+    if (!line) continue;
+    try {
+      const event = JSON.parse(line);
+      if (!EVIDENCE_KINDS.has(event.kind)) continue;
+      const id = event.id || JSON.stringify(event);
+      if (seen.has(id)) continue;
+      seen.add(id);
+      out.push(event);
+    } catch {
+      // A concurrently appended final line may be torn.  It costs one record,
+      // never the user's tool call or the rest of the evidence report.
+    }
+  }
+  return out;
+}
+
+/**
+ * Joins a post-tool result to the most recent matching injection.  The exact
+ * tool-call id wins; clients that omit it fall back to episode + surface +
+ * anchor, in timestamp order, and the report states the weaker join method.
+ */
+export function recordToolOutcome(dir, outcome) {
+  const evidence = readEvidence(dir);
+  const anchor = String(outcome.anchor || '').slice(0, 120);
+  const candidates = evidence
+    .filter((event) => event.kind === 'inject' && event.episodeId === outcome.episodeId)
+    .filter((event) => {
+      if (outcome.toolCallId && event.toolCallId)
+        return String(event.toolCallId) === String(outcome.toolCallId);
+      return event.surface === outcome.surface && String(event.anchor || '').slice(0, 120) === anchor;
+    })
+    .sort((a, b) => (b.at || 0) - (a.at || 0));
+  const injection = candidates[0] || null;
+  const joinMethod = injection
+    ? (outcome.toolCallId && injection.toolCallId ? 'tool-call-id' : 'episode-anchor')
+    : 'none';
+
+  return record(dir, {
+    kind: 'tool-outcome',
+    ...outcome,
+    anchor,
+    injectionId: injection?.injectionId || null,
+    findingIds: injection?.findingIds || [],
+    joinMethod,
+  });
+}
+
+export function recordEpisodeOutcome(dir, outcome) {
+  return record(dir, { kind: 'episode-outcome', ...outcome });
+}
+
+export function recordFindingFeedback(dir, feedback) {
+  const rating = ['helpful', 'neutral', 'harmful'].includes(feedback?.rating)
+    ? feedback.rating
+    : 'neutral';
+  return record(dir, { kind: 'finding-feedback', ...feedback, rating });
 }
 
 /**
@@ -813,4 +933,241 @@ export function indexBudget(dir, { floor = 150, base = 300, ceiling = 1200 } = {
   // 0% hit rate falls to the floor; ~50% and above reaches the ceiling.
   const scaled = Math.round(floor + (ceiling - floor) * Math.min(1, hitRate * 2));
   return Math.max(floor, Math.min(ceiling, scaled));
+}
+
+/* ----------------------------------------------------------------------
+ * Episode-level causal evidence
+ * ------------------------------------------------------------------- */
+
+const numeric = (value) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const average = (values) => {
+  const finite = values.map(numeric).filter((value) => value !== null);
+  return finite.length
+    ? finite.reduce((sum, value) => sum + value, 0) / finite.length
+    : null;
+};
+
+/** Deterministic PRNG so regenerating a report does not move its interval. */
+function seededRandom(seedText) {
+  let seed = 2166136261;
+  for (const char of String(seedText)) {
+    seed ^= char.charCodeAt(0);
+    seed = Math.imul(seed, 16777619);
+  }
+  return () => {
+    seed += 0x6d2b79f5;
+    let value = seed;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Percentile bootstrap interval for a mean, paired delta, or other scalar. */
+export function bootstrapMeanInterval(values, { samples = 1000, seed = 'token-optimizer' } = {}) {
+  const finite = values.map(numeric).filter((value) => value !== null);
+  if (!finite.length) return { mean: null, low: null, high: null, n: 0 };
+  if (finite.length === 1) {
+    return { mean: finite[0], low: finite[0], high: finite[0], n: 1 };
+  }
+
+  const random = seededRandom(`${seed}:${finite.join(',')}`);
+  const means = [];
+  for (let sample = 0; sample < samples; sample++) {
+    let total = 0;
+    for (let index = 0; index < finite.length; index++) {
+      total += finite[Math.floor(random() * finite.length)];
+    }
+    means.push(total / finite.length);
+  }
+  means.sort((a, b) => a - b);
+  return {
+    mean: average(finite),
+    low: means[Math.floor(means.length * 0.025)],
+    high: means[Math.min(means.length - 1, Math.floor(means.length * 0.975))],
+    n: finite.length,
+  };
+}
+
+/** Wilson interval keeps small correctness samples honest and inside 0..1. */
+export function proportionInterval(successes, total, z = 1.96) {
+  if (!total) return { rate: null, low: null, high: null, n: 0 };
+  const rate = successes / total;
+  const denominator = 1 + (z * z) / total;
+  const centre = (rate + (z * z) / (2 * total)) / denominator;
+  const radius =
+    (z / denominator) * Math.sqrt((rate * (1 - rate)) / total + (z * z) / (4 * total * total));
+  return { rate, low: Math.max(0, centre - radius), high: Math.min(1, centre + radius), n: total };
+}
+
+const cohortKey = (run) => [
+  run.client || 'unknown',
+  run.clientVersion || 'unknown',
+  run.model || 'unknown',
+  run.modelVersion || 'unknown',
+  run.taskId || 'unknown',
+].join('|');
+
+function armMetrics(runs) {
+  const correct = runs.filter((run) => run.correct === true).length;
+  const interval = (field) => bootstrapMeanInterval(
+    runs.map((run) => run[field]).filter((value) => numeric(value) !== null),
+    { seed: field }
+  );
+  return {
+    runs: runs.length,
+    correctness: proportionInterval(correct, runs.length),
+    uncachedInputTokens: interval('uncachedInputTokens'),
+    cachedInputTokens: interval('cachedInputTokens'),
+    outputTokens: interval('outputTokens'),
+    totalTokens: interval('totalTokens'),
+    toolCalls: interval('toolCalls'),
+    failedToolCalls: interval('failedToolCalls'),
+    latencyMs: interval('latencyMs'),
+    costUsd: interval('costUsd'),
+    injectedTokens: interval('injectedTokens'),
+    harmfulFindings: runs.reduce((sum, run) => sum + (numeric(run.harmfulFindings) || 0), 0),
+  };
+}
+
+function pairedEffects(runs, treatmentArm) {
+  const pairs = new Map();
+  for (const run of runs) {
+    if (!run.pairId || !['baseline', treatmentArm].includes(run.arm)) continue;
+    if (!pairs.has(run.pairId)) pairs.set(run.pairId, {});
+    pairs.get(run.pairId)[run.arm] = run;
+  }
+  const complete = [...pairs.values()].filter((pair) => pair.baseline && pair[treatmentArm]);
+  const delta = (field, lowerIsBetter = true) => bootstrapMeanInterval(
+    complete
+      .map((pair) => {
+        const baseline = numeric(pair.baseline[field]);
+        const treatment = numeric(pair[treatmentArm][field]);
+        if (baseline === null || treatment === null) return null;
+        return lowerIsBetter ? baseline - treatment : treatment - baseline;
+      })
+      .filter((value) => value !== null),
+    { seed: `${treatmentArm}:${field}` }
+  );
+  return {
+    arm: treatmentArm,
+    pairs: complete.length,
+    // Positive values always mean the treatment improved the metric.
+    totalTokensSaved: delta('totalTokens'),
+    uncachedInputTokensSaved: delta('uncachedInputTokens'),
+    toolCallsAvoided: delta('toolCalls'),
+    latencyMsSaved: delta('latencyMs'),
+    costUsdSaved: delta('costUsd'),
+    correctnessDelta: delta('correct', false),
+  };
+}
+
+function matchesFilters(event, filters) {
+  for (const field of ['client', 'clientVersion', 'model', 'modelVersion', 'taskId', 'arm']) {
+    if (filters[field] && String(event[field] || '') !== String(filters[field])) return false;
+  }
+  return true;
+}
+
+/**
+ * The dashboard-facing evidence console.  Deterministic fixture verification,
+ * live hook traces, and randomized model evals remain visibly distinct: only
+ * `eval-run` records with paired arms can produce a causal effect interval.
+ */
+export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
+  const evidence = readEvidence(dir).filter((event) => matchesFilters(event, filters));
+  const runs = evidence.filter((event) => event.kind === 'eval-run');
+  const injections = evidence.filter((event) => event.kind === 'inject');
+  const outcomes = evidence.filter((event) => event.kind === 'tool-outcome');
+  const feedback = evidence.filter((event) => event.kind === 'finding-feedback');
+
+  const byInjection = new Map(
+    outcomes.filter((event) => event.injectionId).map((event) => [event.injectionId, event])
+  );
+  const traced = injections
+    .slice()
+    .sort((a, b) => (b.at || 0) - (a.at || 0))
+    .slice(0, Math.max(1, Math.min(500, episodeLimit)))
+    .map((injection) => ({
+      injectionId: injection.injectionId,
+      episodeId: injection.episodeId || injection.sessionId || null,
+      at: injection.at,
+      arm: injection.arm || (injection.holdout ? 'holdout' : 'treated'),
+      client: injection.client || 'unknown',
+      clientVersion: injection.clientVersion || null,
+      model: injection.model || null,
+      taskId: injection.taskId || null,
+      surface: injection.surface || injection.trigger || 'file',
+      anchor: injection.anchor,
+      findingIds: injection.findingIds || [],
+      deliveredTokens: injection.deliveredTokens ?? injection.tokens ?? 0,
+      shadowTokens: injection.shadowTokens ?? injection.tokens ?? 0,
+      outcome: byInjection.get(injection.injectionId) || null,
+    }));
+
+  const grouped = new Map();
+  for (const run of runs) {
+    const key = cohortKey(run);
+    if (!grouped.has(key)) grouped.set(key, []);
+    grouped.get(key).push(run);
+  }
+
+  const minimumPairs = Math.max(2, Number(process.env.TOKEN_OPTIMIZER_EVAL_MIN_PAIRS) || 5);
+  const cohorts = [...grouped.entries()].map(([key, cohortRuns]) => {
+    const arms = Object.fromEntries(
+      ['baseline', 'optimizer', 'retrieval', 'full'].map((arm) => [
+        arm,
+        armMetrics(cohortRuns.filter((run) => run.arm === arm)),
+      ])
+    );
+    const effects = ['optimizer', 'retrieval', 'full'].map((arm) => pairedEffects(cohortRuns, arm));
+    const enough = effects.some((effect) => effect.pairs >= minimumPairs);
+    return {
+      key,
+      client: cohortRuns[0]?.client || 'unknown',
+      clientVersion: cohortRuns[0]?.clientVersion || null,
+      model: cohortRuns[0]?.model || null,
+      modelVersion: cohortRuns[0]?.modelVersion || null,
+      taskId: cohortRuns[0]?.taskId || null,
+      arms,
+      effects,
+      evidenceStatus: enough
+        ? 'causal estimate available'
+        : `insufficient paired runs (need ${minimumPairs})`,
+    };
+  });
+
+  const joined = injections.filter((injection) =>
+    byInjection.has(injection.injectionId)
+  ).length;
+  const harmful = feedback.filter((event) => event.rating === 'harmful').length;
+  return {
+    schemaVersion: 2,
+    generatedAt: new Date().toISOString(),
+    filters,
+    summary: {
+      liveInjections: injections.length,
+      joinedOutcomes: joined,
+      causalJoinCoverage: injections.length ? joined / injections.length : null,
+      evalRuns: runs.length,
+      cohorts: cohorts.length,
+      harmfulFeedback: harmful,
+      harmRate: feedback.length ? harmful / feedback.length : null,
+      evidenceStatus: cohorts.some((cohort) => cohort.evidenceStatus === 'causal estimate available')
+        ? 'causal estimates available'
+        : 'insufficient randomized evidence',
+    },
+    cohorts,
+    episodes: traced,
+    methodology: {
+      intervals: 'deterministic percentile bootstrap (95%); Wilson interval for correctness',
+      causalRule: 'only matched eval-run pairs compare an arm with baseline',
+      minimumPairs,
+      deterministicChecksAreCausalProof: false,
+    },
+  };
 }

--- a/integrations/kilo/hooks/lib/recording.mjs
+++ b/integrations/kilo/hooks/lib/recording.mjs
@@ -159,6 +159,9 @@ export function semanticHarvestPrompt({
     + ' If this work produced a durable, non-obvious conclusion -- a failed approach and why, '
     + 'a decision and its rejected alternative, or a command that finally worked -- call '
     + 'wiki_write now with a real file anchor. Do not delegate this to another model or an '
-    + 'external harvester. If there is no such conclusion, do not invent one; finish normally.'
+    + 'external harvester. Include: the concrete evidence, when the finding applies, a calibrated '
+    + 'confidenceLabel (verified/probable/speculative), its project/organization/global scope, '
+    + 'and anything that would invalidate it. If there is no such conclusion, do not invent one; '
+    + 'finish normally.'
   );
 }

--- a/integrations/kilo/hooks/lib/utility.mjs
+++ b/integrations/kilo/hooks/lib/utility.mjs
@@ -1,0 +1,135 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/utility.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Evidence-aware retrieval economics.
+ *
+ * Relevance alone is not enough: a true finding can still cost more context
+ * than it saves.  Every candidate receives a conservative expected-benefit
+ * estimate, its delivery cost and risk are subtracted, and harmful findings
+ * are quarantined from automatic delivery while remaining visible for audit.
+ */
+
+import { readEvidence } from './metrics.mjs';
+
+const DAY = 86_400_000;
+const ORIGIN_WEIGHT = { human: 1.2, agent: 1.08, harvested: 1 };
+
+const envNumber = (name, fallback) => {
+  const value = Number(process.env[name]);
+  return Number.isFinite(value) && value >= 0 ? value : fallback;
+};
+
+export const retrievalPolicy = () => ({
+  baseBenefitTokens: envNumber('TOKEN_OPTIMIZER_EXPECTED_BENEFIT_TOKENS', 400),
+  minimumNetUtility: envNumber('TOKEN_OPTIMIZER_MIN_EXPECTED_UTILITY', 20),
+  cooldownMs: envNumber('TOKEN_OPTIMIZER_INJECTION_COOLDOWN_MS', 60_000),
+  quarantineHarmCount: Math.max(1, envNumber('TOKEN_OPTIMIZER_QUARANTINE_HARM_COUNT', 2)),
+});
+
+function feedbackFor(events, key) {
+  return events.filter((event) =>
+    event.kind === 'finding-feedback'
+    && (event.findingId === key || (event.findingIds || []).includes(key))
+  );
+}
+
+function outcomesFor(events, key) {
+  return events.filter((event) =>
+    event.kind === 'tool-outcome' && (event.findingIds || []).includes(key)
+  );
+}
+
+function deliveredRecently(events, key, episodeId, now, cooldownMs) {
+  if (!episodeId || cooldownMs <= 0) return false;
+  return events.some((event) =>
+    event.kind === 'inject'
+    && event.episodeId === episodeId
+    && (event.findingIds || []).includes(key)
+    && !event.holdout
+    && now - (event.at || 0) < cooldownMs
+  );
+}
+
+/**
+ * Returns eligible candidates in utility order plus every rejection reason.
+ * `costFor` is supplied by inject.mjs so the gate prices the exact rendered
+ * text rather than a second approximation that could drift.
+ */
+export function assessFindings(
+  dir,
+  findings,
+  {
+    relevanceFor = () => 1,
+    costFor = () => 0,
+    episodeId = null,
+    now = Date.now(),
+    policy = retrievalPolicy(),
+  } = {}
+) {
+  const events = readEvidence(dir);
+  const eligible = [];
+  const rejected = [];
+
+  for (const finding of findings) {
+    const key = finding.key;
+    const feedback = feedbackFor(events, key);
+    const outcomes = outcomesFor(events, key);
+    const helpful = feedback.filter((event) => event.rating === 'helpful').length;
+    const neutral = feedback.filter((event) => event.rating === 'neutral').length;
+    const harmful = feedback.filter((event) => event.rating === 'harmful').length;
+    const successfulUses = outcomes.filter((event) => event.success === true).length;
+    const failedUses = outcomes.filter((event) => event.success === false).length;
+
+    if (harmful >= policy.quarantineHarmCount && harmful >= helpful + neutral) {
+      rejected.push({ key, reason: 'quarantined-harm', helpful, neutral, harmful });
+      continue;
+    }
+    if (deliveredRecently(events, key, episodeId, now, policy.cooldownMs)) {
+      rejected.push({ key, reason: 'cooldown' });
+      continue;
+    }
+
+    const confidence = Number.isFinite(finding.confidence) ? finding.confidence : 0.5;
+    const relevance = Math.max(0, Math.min(1, Number(relevanceFor(finding)) || 0));
+    const ageDays = Math.max(0, (now - (finding.at || now)) / DAY);
+    const recency = finding.pinned ? 1 : Math.pow(0.5, ageDays / 90);
+    const provenance = ORIGIN_WEIGHT[finding.origin] || 1;
+    // Outcome evidence moves the estimate gradually. Explicit harmful feedback
+    // is handled above; a failed command alone is not labelled harmful because
+    // the model may have ignored correct advice.
+    const observed = successfulUses + failedUses;
+    const successFactor = observed
+      ? 0.75 + 0.5 * (successfulUses / observed)
+      : 1;
+    const feedbackFactor = Math.max(0.25, 1 + helpful * 0.12 - harmful * 0.35);
+    const expectedBenefit =
+      policy.baseBenefitTokens * confidence * relevance * recency * provenance * successFactor * feedbackFactor;
+    const deliveryCost = Math.max(0, Number(costFor(finding)) || 0);
+    const riskPenalty =
+      (finding.stale ? 160 : 0)
+      + (finding.confidenceLabel === 'speculative' ? 100 : 0)
+      + harmful * 100;
+    const netUtility = expectedBenefit - deliveryCost - riskPenalty;
+
+    const assessed = {
+      finding,
+      expectedBenefit,
+      deliveryCost,
+      riskPenalty,
+      netUtility,
+      helpful,
+      neutral,
+      harmful,
+      successfulUses,
+      failedUses,
+    };
+    if (netUtility < policy.minimumNetUtility) {
+      rejected.push({ key, reason: 'negative-expected-value', ...assessed, finding: undefined });
+      continue;
+    }
+    eligible.push(assessed);
+  }
+
+  eligible.sort((a, b) => b.netUtility - a.netUtility);
+  return { eligible, rejected };
+}

--- a/integrations/kilo/hooks/lib/utility.mjs
+++ b/integrations/kilo/hooks/lib/utility.mjs
@@ -64,6 +64,7 @@ export function assessFindings(
     episodeId = null,
     now = Date.now(),
     policy = retrievalPolicy(),
+    bypassCooldown = false,
   } = {}
 ) {
   const events = readEvidence(dir);
@@ -84,7 +85,7 @@ export function assessFindings(
       rejected.push({ key, reason: 'quarantined-harm', helpful, neutral, harmful });
       continue;
     }
-    if (deliveredRecently(events, key, episodeId, now, policy.cooldownMs)) {
+    if (!bypassCooldown && deliveredRecently(events, key, episodeId, now, policy.cooldownMs)) {
       rejected.push({ key, reason: 'cooldown' });
       continue;
     }

--- a/integrations/kilo/hooks/lib/wire.mjs
+++ b/integrations/kilo/hooks/lib/wire.mjs
@@ -28,7 +28,7 @@ export const MARKER = 'token-optimizer';
 /** The events we wire, and which hook file serves each. */
 export const WIRING = [
   { event: 'SessionStart', file: 'session-start.mjs', matcher: null },
-  { event: 'PreToolUse', file: 'pretooluse-router.mjs', matcher: 'Read|Grep|Glob|Edit|MultiEdit|Write|Bash' },
+  { event: 'PreToolUse', file: 'pretooluse-router.mjs', matcher: 'Read|Grep|Glob|Edit|MultiEdit|Write|Bash|PowerShell' },
   { event: 'PreCompact', file: 'precompact-optimize.mjs', matcher: null },
 ];
 

--- a/integrations/kilo/token-optimizer.md
+++ b/integrations/kilo/token-optimizer.md
@@ -25,6 +25,10 @@ LIVE GRAPH — THE ACTIVE MODEL DOES THE SEMANTIC HARVEST:
   command that finally worked.
 - Anchor every claim to a real file path or path#symbol. Never invent a claim
   merely to populate the graph, and do not delegate harvesting to another model.
+- Include the concrete evidence, when it applies, confidenceLabel
+  (verified/probable/speculative), scope (project/organization/global), and any
+  condition that would invalidate it. Use project scope unless transfer is
+  genuinely justified.
 - Before finishing substantive work, reflect once and write any still-unrecorded
   conclusion while you hold the reasoning. This is what makes the lesson
   available across sessions and projects instead of losing it to compaction.

--- a/integrations/opencode/hooks/lib/adapter.mjs
+++ b/integrations/opencode/hooks/lib/adapter.mjs
@@ -31,7 +31,9 @@ import {
   readCostBytes,
   touchedFiles,
 } from './decide.mjs';
-import { recordRead, fingerprint } from './metrics.mjs';
+import {
+  recordRead, fingerprint, recordToolOutcome, recordEpisodeOutcome,
+} from './metrics.mjs';
 import {
   contentHash,
   harvest,
@@ -57,6 +59,8 @@ import { isFsSafePath } from './paths.mjs';
 import {
   isSubstantive, recordingNudge, semanticHarvestPrompt,
 } from './recording.mjs';
+import { nativeClientProfiles } from './capabilities.mjs';
+import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 
 /**
  * Per-client capability.
@@ -65,41 +69,7 @@ import {
  * it true where the client has no pre-execution veto would make the product
  * claim enforcement it cannot deliver.
  */
-export const CLIENTS = {
-  'claude-code': { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  codex: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  cline: {
-    canDeny: true,
-    contextStyle: 'cline',
-    denyStyle: 'cline',
-    stopDecision: 'block',
-  },
-  copilot: {
-    canDeny: true,
-    contextStyle: 'top-level',
-    denyStyle: 'top-level-permission',
-    stopDecision: 'block',
-  },
-  cursor: {
-    canDeny: true,
-    contextStyle: 'cursor',
-    denyStyle: 'cursor',
-    stopStyle: 'followup',
-    stopDecision: 'block',
-  },
-  // Gemini's BeforeTool and AfterAgent decisions are top-level. Treating it
-  // like Codex produced well-formed JSON that Gemini ignored.
-  gemini: { canDeny: true, denyStyle: 'top-level', stopDecision: 'deny' },
-  kilo: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  opencode: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  qwen: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  windsurf: {
-    canDeny: true,
-    contextStyle: 'silent',
-    denyStyle: 'exit-2',
-    stopDecision: 'block',
-  },
-};
+export const CLIENTS = nativeClientProfiles();
 
 /** Never synchronously hash an unbounded build artifact on a hook path. */
 const HARVEST_MAX_BYTES =
@@ -135,6 +105,24 @@ export function mutationSucceeded(clientName, raw) {
   // or are called by our in-process bridge only from its successful after hook.
   return new Set(['claude-code', 'qwen', 'opencode', 'kilo', 'windsurf'])
     .has(clientName);
+}
+
+/** Conservative success classification for any completed tool call. */
+export function toolSucceeded(raw) {
+  if (raw?.error || raw?.tool_response?.error || raw?.toolResponse?.error)
+    return false;
+  if (raw?.postToolUse?.success === false || raw?.success === false) return false;
+  const status =
+    raw?.tool_response?.status ?? raw?.toolResponse?.status ??
+    raw?.tool_result?.status ?? raw?.toolResult?.status;
+  if (status !== undefined) {
+    if (/^(?:error|failed|failure|cancelled|canceled|denied)$/i.test(String(status))) return false;
+    if (/^(?:ok|success|succeeded|complete|completed)$/i.test(String(status))) return true;
+  }
+  // A post-tool lifecycle event is evidence that the call completed, but not
+  // that its output proved the task.  `success` here is deliberately scoped to
+  // the tool call; task correctness comes only from an eval grader.
+  return true;
 }
 
 function contextOutput(client, eventName, additionalContext) {
@@ -253,8 +241,10 @@ refused.
 
 Worth recording: a decision and why the alternative was rejected, a failure and
 what actually caused it, a command that turned out to be the one that works.
-Not worth recording: what the code plainly says. Prefer the thing someone had to
-work out, because that exists nowhere in the source tree.${projectBriefing()}`;
+Not worth recording: what the code plainly says. Every wiki_write must include
+the concrete evidence, when it applies, a calibrated confidence label, its
+scope, and what would invalidate it. Prefer the thing someone had to work out,
+because that exists nowhere in the source tree.${projectBriefing()}`;
 }
 
 /**
@@ -315,7 +305,7 @@ function projectBriefing() {
  * metrics. It never called forTouch/forCommand, so four advertised clients
  * accumulated a graph that their active model could not receive.
  */
-function observeAndInject(payload, state) {
+function observeAndInject(payload, state, episode, features) {
   const touched = touchedFiles(payload);
   const dirFor = (path) => wikiDir(projectRootFor(path, payload.cwd));
 
@@ -344,45 +334,51 @@ function observeAndInject(payload, state) {
   state.injected = state.injected || [];
   const alreadyInjected = new Set(state.injected);
 
-  for (const { path } of touched) {
-    const dir = dirFor(path);
-    const note = forTouch(dir, load(dir), path, {
-      sessionId: payload.session_id,
-      alreadyInjected,
-    });
-    if (note) parts.push(note);
-  }
+  if (features.retrieval) {
+    for (const { path } of touched) {
+      const dir = dirFor(path);
+      const note = forTouch(dir, load(dir), path, {
+        sessionId: payload.session_id,
+        alreadyInjected,
+        episode,
+      });
+      if (note) parts.push(note);
+    }
 
-  const command = payload.tool_input?.command;
-  if (command) {
-    const root = commandProjectRoot(payload, payload.cwd);
-    const dir = wikiDir(root);
-    const local = forCommand(dir, load(dir), command, {
-      sessionId: payload.session_id,
-      alreadyInjected,
-    });
-    if (local) parts.push(local);
+    const command = payload.tool_input?.command;
+    if (command) {
+      const root = commandProjectRoot(payload, payload.cwd);
+      const dir = wikiDir(root);
+      const local = forCommand(dir, load(dir), command, {
+        sessionId: payload.session_id,
+        alreadyInjected,
+        episode,
+      });
+      if (local) parts.push(local);
 
-    const shared = forSharedCommand(dir, command, {
-      sessionId: payload.session_id,
-      alreadyInjected,
-      projectRoot: root,
-    });
-    if (shared) parts.push(shared);
+      const shared = forSharedCommand(dir, command, {
+        sessionId: payload.session_id,
+        alreadyInjected,
+        projectRoot: root,
+        episode,
+      });
+      if (shared) parts.push(shared);
 
-    const crossed = noteActClasses(state, command);
-    const repeated = forRepeatedAct(dir, command, crossed, {
-      sessionId: payload.session_id,
-      projectRoot: root,
-    });
-    if (repeated) parts.push(repeated);
+      const crossed = noteActClasses(state, command);
+      const repeated = forRepeatedAct(dir, command, crossed, {
+        sessionId: payload.session_id,
+        projectRoot: root,
+        episode,
+      });
+      if (repeated) parts.push(repeated);
+    }
   }
   state.injected = [...alreadyInjected];
 
   // Structural capture is evidence about what was touched, not a semantic
   // conclusion. It is therefore safe to automate for every client and leaves
   // the active model responsible for wiki_write at completion.
-  for (const { path, size } of touched) {
+  if (features.capture) for (const { path, size } of touched) {
     try {
       if (isArchived(path) || size > HARVEST_MAX_BYTES || !isFsSafePath(path))
         continue;
@@ -420,7 +416,10 @@ export async function run(clientName, event) {
 
   if (mode() === MODE_OFF) process.exit(0);
 
+  const features = featuresForArm();
+
   if (event === 'session-start') {
+    if (!features.routing && !features.retrieval && !features.harvest) process.exit(0);
     const output = contextOutput(client, eventName, policyText(client.canDeny));
     if (output) emit(output);
     process.exit(0);
@@ -437,10 +436,22 @@ export async function run(clientName, event) {
     const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? 'default';
     const agentScope = raw.transcript_path ?? raw.transcriptPath ?? null;
     const state = loadState(sessionId, agentScope);
+    const episode = episodeMeta({ client: clientName, raw });
+    try {
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+      recordEpisodeOutcome(dir, {
+        ...episode,
+        status: 'completed',
+        ...usageFrom(raw),
+      });
+    } catch {
+      // Evidence is best effort and must never stop a session from finishing.
+    }
     const alreadyHarvested =
       Number(state.edits || 0) > 0 &&
       Number(state.harvestedEdits || 0) >= Number(state.edits || 0);
-    const prompt = semanticHarvestPrompt({
+    const prompt = features.harvest ? semanticHarvestPrompt({
       edits: state.edits,
       files: state.editedFiles,
       model: raw.model,
@@ -449,7 +460,7 @@ export async function run(clientName, event) {
         raw.stopHookActive === true ||
         alreadyHarvested ||
         (clientName === 'cursor' && Number(raw.loop_count || 0) > 0),
-    });
+    }) : null;
     if (prompt) {
       state.harvestedEdits = Number(state.edits || 0);
       saveState(sessionId, state, agentScope);
@@ -466,6 +477,7 @@ export async function run(clientName, event) {
     process.exit(0);
   const payload = normalizePayload(normalizeClientPayload(clientName, event, raw));
   if (!payload.tool_name) process.exit(0);
+  const episode = episodeMeta({ client: clientName, raw, payload });
 
   // THE AGENT, not just the session -- the same scope the Claude Code router
   // applies. Subagents inherit the parent's session id, so keying state on the
@@ -506,17 +518,41 @@ export async function run(clientName, event) {
       const anchor = state.editedFiles[0]
         || join(payload.cwd || process.cwd(), '__recording__');
       const dir = wikiDir(projectRootFor(anchor, payload.cwd));
-      recordingContext = recordingNudge(dir, {
+      recordingContext = features.harvest ? recordingNudge(dir, {
         state,
         edits: state.edits,
         files: state.editedFiles,
-      });
+      }) : null;
       if (recordingContext) state.recordingNudged = true;
     } catch {
       // Recording pressure is an optimization and must never cost a tool call.
     }
   }
-  const verdict = decide(payload, state);
+  if (event === 'post-tool') {
+    try {
+      const command = payload.tool_input?.command;
+      const touched = touchedFiles(payload);
+      const anchor = command
+        ? String(command).slice(0, 120)
+        : touched[0]?.path || payload.tool_input?.file_path || '';
+      const root = command
+        ? commandProjectRoot(payload, payload.cwd)
+        : projectRootFor(anchor || join(payload.cwd || process.cwd(), '__tool__'), payload.cwd);
+      recordToolOutcome(wikiDir(root), {
+        ...episode,
+        surface: command ? 'command' : 'file',
+        anchor,
+        toolName: payload.tool_name,
+        success: toolSucceeded(raw),
+        durationMs: Number(raw.duration_ms ?? raw.durationMs ?? raw.elapsed_ms ?? raw.elapsedMs) || null,
+        ...usageFrom(raw),
+      });
+    } catch {
+      // Causal tracing is fail-open like every other hook optimization.
+    }
+  }
+
+  const verdict = features.routing ? decide(payload, state) : null;
   const repeat = verdict && event === 'pre-tool'
     ? alreadyDenied(state, verdict.key)
     : false;
@@ -571,7 +607,7 @@ export async function run(clientName, event) {
   remember(payload, state);
   let graphContext = null;
   try {
-    graphContext = observeAndInject(payload, state);
+    graphContext = observeAndInject(payload, state, episode, features);
   } catch {
     // Delivery is an optimization. Fail open.
   }

--- a/integrations/opencode/hooks/lib/capabilities.mjs
+++ b/integrations/opencode/hooks/lib/capabilities.mjs
@@ -1,0 +1,130 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/capabilities.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * The product's honest cross-client capability contract.
+ *
+ * A client is listed at the strongest surface its public lifecycle protocol can
+ * actually support.  This registry is consumed by the adapter, certification
+ * tooling, and evidence reports so a rules-only integration can never be
+ * presented as equivalent to a native stop-continuation integration.
+ */
+
+export const CAPABILITY_TIERS = Object.freeze({
+  CONTINUATION: 'lifecycle-continuation',
+  OBSERVATION: 'native-observation',
+  RULES: 'mcp-rules',
+});
+
+const native = (profile) => ({
+  structuralCapture: 'native',
+  findingDelivery: 'native',
+  routing: 'native-veto',
+  ...profile,
+});
+
+export const CLIENT_CAPABILITIES = Object.freeze({
+  'claude-code': native({
+    name: 'Claude Code', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-continuation', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  codex: native({
+    name: 'Codex', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-continuation', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  copilot: native({
+    name: 'GitHub Copilot CLI', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'agent-stop-continuation', canDeny: true,
+    contextStyle: 'top-level', denyStyle: 'top-level-permission', stopDecision: 'block',
+  }),
+  gemini: native({
+    name: 'Gemini CLI', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'after-agent-retry', canDeny: true,
+    denyStyle: 'top-level', stopDecision: 'deny',
+  }),
+  qwen: native({
+    name: 'Qwen Code', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-continuation', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  cursor: native({
+    name: 'Cursor', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-followup', canDeny: true,
+    contextStyle: 'cursor', denyStyle: 'cursor', stopStyle: 'followup', stopDecision: 'block',
+  }),
+  cline: native({
+    name: 'Cline', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    contextStyle: 'cline', denyStyle: 'cline', stopDecision: 'block',
+  }),
+  opencode: native({
+    name: 'OpenCode', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  kilo: native({
+    name: 'Kilo', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  windsurf: native({
+    name: 'Windsurf', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    contextStyle: 'silent', denyStyle: 'exit-2', stopDecision: 'block',
+  }),
+  roo: {
+    name: 'Roo Code', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  zed: {
+    name: 'Zed', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  amp: {
+    name: 'Amp', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  continue: {
+    name: 'Continue', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  crush: {
+    name: 'Crush', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  droid: {
+    name: 'Droid (Factory)', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+});
+
+export function capabilityFor(client) {
+  return CLIENT_CAPABILITIES[String(client || '').toLowerCase()] || null;
+}
+
+export function nativeClientProfiles() {
+  return Object.fromEntries(
+    Object.entries(CLIENT_CAPABILITIES)
+      .filter(([, profile]) => profile.structuralCapture === 'native')
+      .map(([key, profile]) => [key, { ...profile }])
+  );
+}
+
+export function capabilitySummary() {
+  return Object.entries(CLIENT_CAPABILITIES).map(([client, profile]) => ({
+    client,
+    name: profile.name,
+    tier: profile.tier,
+    routing: profile.routing,
+    structuralCapture: profile.structuralCapture,
+    findingDelivery: profile.findingDelivery,
+    semanticHarvest: profile.semanticHarvest,
+  }));
+}

--- a/integrations/opencode/hooks/lib/decide.mjs
+++ b/integrations/opencode/hooks/lib/decide.mjs
@@ -513,6 +513,8 @@ const TOOL_ALIASES = new Map(
     create_file: 'Write',
 
     bash: 'Bash',
+    powershell: 'Bash',
+    pwsh: 'Bash',
     shell: 'Bash',
     run_command: 'Bash',
     execute_command: 'Bash',

--- a/integrations/opencode/hooks/lib/experiment.mjs
+++ b/integrations/opencode/hooks/lib/experiment.mjs
@@ -1,0 +1,82 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/experiment.mjs. Regenerate with `npm run sync:hooks`.
+/** Explicit, reproducible feature arms and causal episode identity. */
+
+export const EXPERIMENT_ARMS = Object.freeze([
+  'baseline',
+  'optimizer',
+  'retrieval',
+  'full',
+]);
+
+const FEATURES = Object.freeze({
+  baseline: Object.freeze({ routing: false, retrieval: false, capture: false, harvest: false }),
+  optimizer: Object.freeze({ routing: true, retrieval: false, capture: false, harvest: false }),
+  retrieval: Object.freeze({ routing: true, retrieval: true, capture: true, harvest: false }),
+  full: Object.freeze({ routing: true, retrieval: true, capture: true, harvest: true }),
+});
+
+export function experimentArm(env = process.env) {
+  const requested = String(env.TOKEN_OPTIMIZER_EXPERIMENT_ARM || '').trim().toLowerCase();
+  return EXPERIMENT_ARMS.includes(requested) ? requested : 'full';
+}
+
+export function featuresForArm(arm = experimentArm()) {
+  return FEATURES[arm] || FEATURES.full;
+}
+
+const first = (...values) => values.find((value) => value !== undefined && value !== null && value !== '');
+
+/**
+ * Normalises identifiers exposed under different names by lifecycle clients.
+ * Environment overrides let the live evaluation harness pin a pair/task id
+ * without asking each CLI to support experiment-specific payload fields.
+ */
+export function episodeMeta({ client, raw = {}, payload = {}, env = process.env } = {}) {
+  const sessionId = String(first(
+    payload.session_id, raw.session_id, raw.sessionId, raw.conversation_id,
+    raw.conversationId, raw.taskId, raw.task_id, raw.trajectory_id, 'default'
+  ));
+  const episodeId = String(first(
+    env.TOKEN_OPTIMIZER_EPISODE_ID, raw.episode_id, raw.episodeId, sessionId
+  ));
+  const toolCallId = first(
+    raw.tool_use_id, raw.toolUseId, raw.tool_call_id, raw.toolCallId,
+    raw.call_id, raw.callId, raw.postToolUse?.toolUseId, raw.preToolUse?.toolUseId
+  );
+  const model = first(payload.model, raw.model?.slug, raw.model, raw.model_name, env.TOKEN_OPTIMIZER_MODEL);
+  const clientVersion = first(
+    raw.client_version, raw.clientVersion, raw.version, env.TOKEN_OPTIMIZER_CLIENT_VERSION
+  );
+  const modelVersion = first(raw.model_version, raw.modelVersion, env.TOKEN_OPTIMIZER_MODEL_VERSION);
+
+  return {
+    schemaVersion: 2,
+    episodeId,
+    sessionId,
+    turnId: first(raw.turn_id, raw.turnId, raw.message_id, raw.messageId) ?? null,
+    toolCallId: toolCallId == null ? null : String(toolCallId),
+    taskId: first(env.TOKEN_OPTIMIZER_TASK_ID, raw.task_id, raw.taskId) ?? null,
+    pairId: first(env.TOKEN_OPTIMIZER_PAIR_ID, raw.pair_id, raw.pairId) ?? null,
+    arm: experimentArm(env),
+    client: String(client || first(raw.client, raw.client_name, 'unknown')),
+    clientVersion: clientVersion == null ? null : String(clientVersion),
+    model: model == null ? null : String(model),
+    modelVersion: modelVersion == null ? null : String(modelVersion),
+  };
+}
+
+export function usageFrom(raw = {}) {
+  const usage = raw.usage || raw.token_usage || raw.tokenUsage || raw.metrics?.usage || {};
+  const number = (...values) => {
+    const value = first(...values);
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+  };
+  return {
+    uncachedInputTokens: number(usage.uncached_input_tokens, usage.uncachedInputTokens),
+    cachedInputTokens: number(usage.cached_input_tokens, usage.cachedInputTokens, usage.cache_read_input_tokens),
+    outputTokens: number(usage.output_tokens, usage.outputTokens),
+    totalTokens: number(usage.total_tokens, usage.totalTokens, raw.tokens_used, raw.tokensUsed),
+  };
+}

--- a/integrations/opencode/hooks/lib/harvest-write.mjs
+++ b/integrations/opencode/hooks/lib/harvest-write.mjs
@@ -96,8 +96,13 @@ function promoteToShared(finding, { projectRoot, sessionId, provenance, key }) {
           key: `shared-${key}`,
           claim: finding.claim,
           confidence: finding.confidence,
+          confidenceLabel: finding.confidenceLabel,
           type: finding.type,
           trigger: typeof finding.trigger === 'string' && finding.trigger ? finding.trigger : undefined,
+          applicability: finding.applicability,
+          evidence: finding.evidence,
+          invalidators: Array.isArray(finding.invalidators) ? finding.invalidators : [],
+          scope: finding.scope || 'global',
           origin: provenance,
           quote: typeof finding.quote === 'string' && finding.quote.trim() ? finding.quote : undefined,
           // WHERE IT WAS LEARNED, carried so the reader can discount it. A lesson
@@ -351,6 +356,26 @@ export function writeHarvested(
     // anything, so it is dropped rather than kept as unfalsifiable.
     if (!resolved.length) continue;
 
+    // Exact semantic duplicates collapse to the existing active record.  The
+    // normalisation intentionally ignores punctuation/formatting noise but not
+    // meaning-bearing words; near-duplicates that need judgement remain visible
+    // to curation rather than being silently merged by a fuzzy heuristic.
+    const fingerprint = claimFingerprint(finding.claim);
+    const currentGraph = load(dir);
+    const duplicate = [...currentGraph.nodes.values()].find((node) =>
+      node.kind === 'finding'
+      && !node.retired
+      && node.type === finding.type
+      && claimFingerprint(node.claim) === fingerprint
+      && resolved.every((target) => currentGraph.edges.some((edge) =>
+        edge.from === node.id && edge.edge === 'derived_from' && edge.to === target
+      ))
+    );
+    if (duplicate) {
+      written.push(duplicate.key);
+      continue;
+    }
+
     // Date.now() plus an index is not unique across CONCURRENT detached
     // workers: two Stop hooks finishing in the same millisecond produce the
     // same key, and putNode keeps the last write for an id -- so one session's
@@ -371,6 +396,7 @@ export function writeHarvested(
         key,
         claim: finding.claim,
         confidence: finding.confidence,
+        confidenceLabel: finding.confidenceLabel,
         type: finding.type,
         // WHEN this finding is relevant, not just what it is about. Anchors
         // answer "which file", which is the wrong question for a claim about
@@ -380,6 +406,16 @@ export function writeHarvested(
         trigger: typeof finding.trigger === 'string' && finding.trigger
           ? finding.trigger
           : undefined,
+        applicability: typeof finding.applicability === 'string'
+          ? finding.applicability
+          : undefined,
+        evidence: typeof finding.evidence === 'string'
+          ? finding.evidence
+          : undefined,
+        invalidators: Array.isArray(finding.invalidators)
+          ? finding.invalidators
+          : [],
+        scope: finding.scope || 'project',
         origin: provenance,
         // THE EVIDENCE TRAVELS WITH THE CLAIM. Without it a human-origin
         // finding asserts its own provenance and nothing can check it.
@@ -398,7 +434,11 @@ export function writeHarvested(
     // record of what happened here; the shared tier is a copy for the lessons
     // that are not about here. Skipped when the two are the same directory,
     // which is the suite's usual arrangement.
-    if (id && !isSharedDir(dir)) {
+    if (
+      id
+      && !isSharedDir(dir)
+      && (finding.scope === undefined || finding.scope === 'organization' || finding.scope === 'global')
+    ) {
       promoteToShared(finding, { projectRoot, sessionId, provenance, key });
     }
   }

--- a/integrations/opencode/hooks/lib/harvest.mjs
+++ b/integrations/opencode/hooks/lib/harvest.mjs
@@ -201,7 +201,11 @@ const PROMPT = `Extract durable findings from this coding session for a project 
 Return ONLY a JSON array. Each element:
 {"type": "finding|decision|failure|command|map",
  "claim": "one sentence, specific and checkable",
- "confidence": 0.0-1.0,
+ "evidence": "the concrete observation, command result, or rejected approach that proved it",
+ "applicability": "the condition under which a future model should use it",
+ "confidenceLabel": "verified|probable|speculative",
+ "scope": "project|organization|global",
+ "invalidators": ["what change would require this to be checked again"],
  "anchors": ["absolute/file/path" or "absolute/file/path#symbolName"]}
 
 RULES:
@@ -211,7 +215,9 @@ RULES:
 - Prefer "failure" and "decision" entries. What was TRIED AND REJECTED, and WHY,
   is the most valuable thing here because it exists nowhere in the source tree.
 - Do not restate what the code plainly says. Record what someone had to work out.
-- confidence reflects how well established the claim is, not how important.
+- verified requires direct evidence; probable means strong but incomplete evidence;
+  speculative is a hypothesis and must be labelled as such.
+- Use project scope unless the lesson is genuinely independent of this repository.
 - If nothing durable was learned, return [].`;
 
 /**
@@ -232,8 +238,29 @@ export function validate(raw, { knownFiles = null } = {}) {
     if (!FINDING_TYPES.includes(item.type)) continue;
     if (typeof item.claim !== 'string' || item.claim.trim().length < 8) continue;
 
-    const confidence = Number(item.confidence);
-    if (!Number.isFinite(confidence) || confidence <= 0 || confidence > 1) continue;
+    const evidence = typeof item.evidence === 'string' ? item.evidence.trim() : '';
+    const applicability = typeof item.applicability === 'string' ? item.applicability.trim() : '';
+    if (evidence.length < 8 || applicability.length < 8) continue;
+
+    const confidenceLabel = ['verified', 'probable', 'speculative'].includes(item.confidenceLabel)
+      ? item.confidenceLabel
+      : null;
+    if (!confidenceLabel) continue;
+    const defaults = { verified: 0.95, probable: 0.75, speculative: 0.45 };
+    const supplied = Number(item.confidence);
+    if (
+      item.confidence !== undefined
+      && (!Number.isFinite(supplied) || supplied <= 0 || supplied > 1)
+    ) continue;
+    const confidence = item.confidence === undefined
+      ? defaults[confidenceLabel]
+      : supplied;
+    const scope = ['project', 'organization', 'global'].includes(item.scope)
+      ? item.scope
+      : 'project';
+    const invalidators = Array.isArray(item.invalidators)
+      ? item.invalidators.filter((value) => typeof value === 'string' && value.trim()).slice(0, 10)
+      : [];
 
     let anchors = Array.isArray(item.anchors) ? item.anchors.filter((a) => typeof a === 'string' && a) : [];
     // A model asked for file paths will sometimes invent them. When the caller
@@ -241,7 +268,18 @@ export function validate(raw, { knownFiles = null } = {}) {
     if (knownFiles) anchors = anchors.filter((a) => knownFiles.has(a.split('#')[0]));
     if (!anchors.length) continue;
 
-    accepted.push({ type: item.type, claim: item.claim.trim(), confidence, anchors });
+    accepted.push({
+      type: item.type,
+      claim: item.claim.trim(),
+      evidence,
+      applicability,
+      confidence,
+      confidenceLabel,
+      scope,
+      invalidators,
+      anchors,
+      trigger: typeof item.trigger === 'string' ? item.trigger : undefined,
+    });
   }
   return accepted;
 }

--- a/integrations/opencode/hooks/lib/inject.mjs
+++ b/integrations/opencode/hooks/lib/inject.mjs
@@ -30,6 +30,7 @@ import { inHoldout, record, indexBudget } from './metrics.mjs';
 import { canonicalPath, resolvableCandidates } from './paths.mjs';
 import { annotatedSkeleton } from './skeleton.mjs';
 import { substitutionBudget } from './metrics.mjs';
+import { assessFindings } from './utility.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
@@ -150,7 +151,7 @@ export function forTouch(
   dir,
   graph,
   rawPath,
-  { budget = touchBudget(), sessionId, alreadyInjected = new Set() } = {}
+  { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
   // Canonical, so a touch finds findings anchored under any other spelling.
   const filePath = canonicalPath(rawPath);
@@ -169,16 +170,36 @@ export function forTouch(
   // variance drops out. A session-pinned arm would destroy that.
   const holdout = inHoldout(filePath);
   const served = serve(graph, candidates);
-  const { kept, spent } = fit(served, budget);
+  const assessed = assessFindings(dir, served, {
+    episodeId: episode.episodeId || sessionId,
+    relevanceFor: () => 1,
+    costFor: (finding) => estimate(render(finding)),
+  });
+  if (assessed.rejected.length) {
+    record(dir, {
+      kind: 'retrieval-decision', ...episode, sessionId,
+      surface: 'file', anchor: filePath,
+      rejected: assessed.rejected.map(({ key, reason }) => ({ key, reason })),
+    });
+    for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
+  }
+  const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
+  if (!kept.length) return null;
 
   record(dir, {
     kind: 'inject',
+    ...episode,
     // The surface whose saving CAN be measured: reads of this anchor afterwards.
     surface: 'file',
     anchor: filePath,
     holdout,
     tokens: holdout ? 0 : spent,
-    count: kept.length,
+    deliveredTokens: holdout ? 0 : spent,
+    shadowTokens: spent,
+    count: holdout ? 0 : kept.length,
+    candidateCount: kept.length,
+    findingIds: holdout ? [] : kept.map((finding) => finding.key),
+    shadowFindingIds: kept.map((finding) => finding.key),
     stale: kept.some((f) => f.stale),
     sessionId,
   });
@@ -297,7 +318,7 @@ export function forCommand(
   dir,
   graph,
   command,
-  { budget = touchBudget(), sessionId, alreadyInjected = new Set() } = {}
+  { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
   if (!command) return null;
 
@@ -335,7 +356,20 @@ export function forCommand(
   const considered = candidates.slice(0, MAX_COMMAND_CANDIDATES);
 
   const served = serve(graph, considered);
-  const { kept, spent } = fit(served, budget);
+  const assessed = assessFindings(dir, served, {
+    episodeId: episode.episodeId || sessionId,
+    relevanceFor: (finding) => explicit(finding) ? 1 : 0.6,
+    costFor: (finding) => estimate(render(finding)),
+  });
+  if (assessed.rejected.length) {
+    record(dir, {
+      kind: 'retrieval-decision', ...episode, sessionId,
+      surface: 'command', anchor: String(command).slice(0, 120),
+      rejected: assessed.rejected.map(({ key: findingKey, reason }) => ({ key: findingKey, reason })),
+    });
+    for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
+  }
+  const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
   if (!kept.length) return null;
 
   // THE COMMAND PATH TAKES PART IN THE HOLDOUT TOO.
@@ -353,6 +387,7 @@ export function forCommand(
 
   record(dir, {
     kind: 'inject',
+    ...episode,
     trigger: 'command',
     // The surface the report needs to keep these OUT of the file-read balance:
     // a command has no anchor that read events can be joined to.
@@ -360,7 +395,12 @@ export function forCommand(
     anchor: String(command).slice(0, 120),
     holdout,
     tokens: holdout ? 0 : spent,
+    deliveredTokens: holdout ? 0 : spent,
+    shadowTokens: spent,
     count: holdout ? 0 : kept.length,
+    candidateCount: kept.length,
+    findingIds: holdout ? [] : kept.map((finding) => finding.key),
+    shadowFindingIds: kept.map((finding) => finding.key),
     stale: kept.some((f) => f.stale),
     sessionId,
   });
@@ -509,7 +549,7 @@ export function forRepeatedAct(
   projectDir,
   command,
   crossedClasses,
-  { sessionId = null, projectRoot = null } = {}
+  { sessionId = null, projectRoot = null, episode = {} } = {}
 ) {
   if (!crossedClasses || !crossedClasses.size) return null;
 
@@ -527,14 +567,33 @@ export function forRepeatedAct(
       if (![...crossedClasses].some((c) => claimClasses.has(c))) continue;
 
       const cls = [...crossedClasses].find((c) => claimClasses.has(c));
+      const assessed = assessFindings(projectDir, [node], {
+        episodeId: episode.episodeId || sessionId,
+        relevanceFor: () => 1,
+        costFor: (finding) => estimate(render(finding)),
+      });
+      if (!assessed.eligible.length) {
+        record(projectDir, {
+          kind: 'retrieval-decision', ...episode, sessionId,
+          surface: 'shared', anchor: String(command).slice(0, 120),
+          rejected: assessed.rejected.map(({ key, reason }) => ({ key, reason })),
+        });
+        continue;
+      }
       record(projectDir, {
         kind: 'inject',
+        ...episode,
         trigger: 'repeat',
         surface: 'shared',
         anchor: String(command).slice(0, 120),
         holdout: false,
         tokens: estimate(node.claim),
+        deliveredTokens: estimate(node.claim),
+        shadowTokens: estimate(node.claim),
         count: 1,
+        candidateCount: 1,
+        findingIds: [node.key],
+        shadowFindingIds: [node.key],
         stale: false,
         sessionId,
       });
@@ -585,7 +644,10 @@ function appliesCrossProject(finding, command) {
 export function forSharedCommand(
   projectDir,
   command,
-  { budget = sharedBudget(), sessionId = null, alreadyInjected = new Set(), projectRoot = null } = {}
+  {
+    budget = sharedBudget(), sessionId = null, alreadyInjected = new Set(),
+    projectRoot = null, episode = {},
+  } = {}
 ) {
   if (!command) return null;
 
@@ -622,7 +684,21 @@ export function forSharedCommand(
     // No serve() here: these types are not content-dependent, so there is no
     // anchor to re-read and nothing to diff. serve() would spend a file read per
     // finding to answer a question that does not apply to them.
-    const { kept, spent } = fit(candidates.slice(0, MAX_SHARED), budget);
+    const considered = candidates.slice(0, MAX_SHARED);
+    const assessed = assessFindings(projectDir, considered, {
+      episodeId: episode.episodeId || sessionId,
+      relevanceFor: (finding) => explicit(finding) ? 0.8 : 0.5,
+      costFor: (finding) => estimate(render(finding)),
+    });
+    if (assessed.rejected.length) {
+      record(projectDir, {
+        kind: 'retrieval-decision', ...episode, sessionId,
+        surface: 'shared', anchor: String(command).slice(0, 120),
+        rejected: assessed.rejected.map(({ key, reason }) => ({ key, reason })),
+      });
+      for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
+    }
+    const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
     if (!kept.length) return null;
 
     // THE SAME ARM AS THE LOCAL PATH, KEYED THE SAME WAY.
@@ -644,6 +720,7 @@ export function forSharedCommand(
 
     record(projectDir, {
       kind: 'inject',
+      ...episode,
       trigger: 'command',
       // ITS OWN SURFACE. The balance sheet joins `file` injections to later read
       // events; a shared lesson has no anchor in this project to join to, and
@@ -653,7 +730,12 @@ export function forSharedCommand(
       anchor: String(command).slice(0, 120),
       holdout,
       tokens: holdout ? 0 : spent,
+      deliveredTokens: holdout ? 0 : spent,
+      shadowTokens: spent,
       count: holdout ? 0 : kept.length,
+      candidateCount: kept.length,
+      findingIds: holdout ? [] : kept.map((finding) => finding.key),
+      shadowFindingIds: kept.map((finding) => finding.key),
       stale: false,
       sessionId,
     });

--- a/integrations/opencode/hooks/lib/inject.mjs
+++ b/integrations/opencode/hooks/lib/inject.mjs
@@ -571,6 +571,10 @@ export function forRepeatedAct(
         episodeId: episode.episodeId || sessionId,
         relevanceFor: () => 1,
         costFor: (finding) => estimate(render(finding)),
+        // This surface exists specifically to re-surface a lesson once the
+        // session crosses the repeat threshold. Ordinary retrieval remains
+        // cooldown-protected; harm quarantine and utility gating still apply.
+        bypassCooldown: true,
       });
       if (!assessed.eligible.length) {
         record(projectDir, {

--- a/integrations/opencode/hooks/lib/metrics.mjs
+++ b/integrations/opencode/hooks/lib/metrics.mjs
@@ -1022,6 +1022,7 @@ function armMetrics(runs) {
     runs: runs.length,
     correctness: proportionInterval(correct, runs.length),
     uncachedInputTokens: interval('uncachedInputTokens'),
+    cacheCreationInputTokens: interval('cacheCreationInputTokens'),
     cachedInputTokens: interval('cachedInputTokens'),
     outputTokens: interval('outputTokens'),
     totalTokens: interval('totalTokens'),
@@ -1034,31 +1035,37 @@ function armMetrics(runs) {
   };
 }
 
-function pairedEffects(runs, treatmentArm) {
+function pairedEffects(runs, controlArm, treatmentArm, contrastType = 'incremental') {
   const pairs = new Map();
   for (const run of runs) {
-    if (!run.pairId || !['baseline', treatmentArm].includes(run.arm)) continue;
+    if (!run.pairId || ![controlArm, treatmentArm].includes(run.arm)) continue;
     if (!pairs.has(run.pairId)) pairs.set(run.pairId, {});
     pairs.get(run.pairId)[run.arm] = run;
   }
-  const complete = [...pairs.values()].filter((pair) => pair.baseline && pair[treatmentArm]);
+  const complete = [...pairs.values()].filter((pair) => pair[controlArm] && pair[treatmentArm]);
   const delta = (field, lowerIsBetter = true) => bootstrapMeanInterval(
     complete
       .map((pair) => {
-        const baseline = numeric(pair.baseline[field]);
+        const baseline = numeric(pair[controlArm][field]);
         const treatment = numeric(pair[treatmentArm][field]);
         if (baseline === null || treatment === null) return null;
         return lowerIsBetter ? baseline - treatment : treatment - baseline;
       })
       .filter((value) => value !== null),
-    { seed: `${treatmentArm}:${field}` }
+    { seed: `${controlArm}:${treatmentArm}:${field}` }
   );
   return {
     arm: treatmentArm,
+    controlArm,
+    comparison: `${treatmentArm} vs ${controlArm}`,
+    contrastType,
     pairs: complete.length,
     // Positive values always mean the treatment improved the metric.
     totalTokensSaved: delta('totalTokens'),
     uncachedInputTokensSaved: delta('uncachedInputTokens'),
+    cacheCreationInputTokensSaved: delta('cacheCreationInputTokens'),
+    cachedInputTokensSaved: delta('cachedInputTokens'),
+    outputTokensSaved: delta('outputTokens'),
     toolCallsAvoided: delta('toolCalls'),
     latencyMsSaved: delta('latencyMs'),
     costUsdSaved: delta('costUsd'),
@@ -1124,8 +1131,13 @@ export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
         armMetrics(cohortRuns.filter((run) => run.arm === arm)),
       ])
     );
-    const effects = ['optimizer', 'retrieval', 'full'].map((arm) => pairedEffects(cohortRuns, arm));
-    const enough = effects.some((effect) => effect.pairs >= minimumPairs);
+    const effects = [
+      pairedEffects(cohortRuns, 'baseline', 'optimizer'),
+      pairedEffects(cohortRuns, 'optimizer', 'retrieval'),
+      pairedEffects(cohortRuns, 'retrieval', 'full'),
+      pairedEffects(cohortRuns, 'baseline', 'full', 'total-system'),
+    ];
+    const enough = effects.every((effect) => effect.pairs >= minimumPairs);
     return {
       key,
       client: cohortRuns[0]?.client || 'unknown',
@@ -1165,7 +1177,8 @@ export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
     episodes: traced,
     methodology: {
       intervals: 'deterministic percentile bootstrap (95%); Wilson interval for correctness',
-      causalRule: 'only matched eval-run pairs compare an arm with baseline',
+      causalRule:
+        'matched pairs estimate optimizer vs baseline, retrieval vs optimizer, full vs retrieval, and full vs baseline',
       minimumPairs,
       deterministicChecksAreCausalProof: false,
     },

--- a/integrations/opencode/hooks/lib/metrics.mjs
+++ b/integrations/opencode/hooks/lib/metrics.mjs
@@ -61,6 +61,7 @@ const metricsPath = (dir) => join(dir, 'metrics.jsonl');
  * on it drops BOTH arms proportionally instead of starving the rare one.
  */
 const balancePath = (dir) => join(dir, 'balance.jsonl');
+const evidencePath = (dir) => join(dir, 'evidence.jsonl');
 
 /** Kinds the net balance is computed from, and which therefore must survive. */
 /**
@@ -83,6 +84,24 @@ export const BALANCE_KINDS = new Set([
   // aged out before it was written and the backstop was structurally unable to fire, reporting
   // "only N/10 refreshes observed" for the life of the project.
   'keepwarm',
+]);
+
+/**
+ * Causal records have their own bounded log.  Tool outcomes are much rarer
+ * than read/capture telemetry but more frequent than balance records; mixing
+ * them into either window would eventually evict the evidence needed to join
+ * an injection to its result.
+ */
+export const EVIDENCE_KINDS = new Set([
+  'inject',
+  'harvest',
+  'tool-outcome',
+  'episode-outcome',
+  'eval-run',
+  'finding-feedback',
+  'retrieval-decision',
+  'mcp-client',
+  'mcp-tool',
 ]);
 
 /**
@@ -198,15 +217,30 @@ export function record(dir, event) {
     // single millisecond collapsed to ONE, so a graph with ample data reported
     // 'insufficient data (2 treated, 1 holdout)'. Real events were being
     // discarded by the deduplicator, silently.
-    const line =
-      JSON.stringify({ id: nextId(), ...event, at: event.at ?? Date.now() }) + '\n';
+    const id = event.id || nextId();
+    const complete = {
+      schemaVersion: event.schemaVersion || 2,
+      id,
+      ...event,
+      // An injection id is first-class rather than an inference from the log
+      // record id.  Exporters may rewrite record ids while preserving causal
+      // identity, and downstream tool outcomes refer to this value explicitly.
+      ...(event.kind === 'inject'
+        ? { injectionId: event.injectionId || id }
+        : {}),
+      at: event.at ?? Date.now(),
+    };
+    const line = JSON.stringify(complete) + '\n';
     appendFileSync(metricsPath(dir), line);
     // Balance-critical records go to their own log as well, so the windows on
     // the firehose can never starve the measurement. Written SECOND: a torn
     // write here costs a duplicate the reader dedupes, not a lost event.
     if (BALANCE_KINDS.has(event.kind)) appendFileSync(balancePath(dir), line);
+    if (EVIDENCE_KINDS.has(event.kind)) appendFileSync(evidencePath(dir), line);
+    return complete;
   } catch {
     // Metrics must never break a tool call.
+    return null;
   }
 }
 
@@ -402,6 +436,92 @@ export function readBalance(dir) {
     out.push(e);
   }
   return out;
+}
+
+/** Every causal evidence record inside the byte cap, deduplicated by id. */
+export function readEvidence(dir) {
+  const path = evidencePath(dir);
+  if (!existsSync(path)) return [];
+
+  let text = '';
+  try {
+    const { size } = statSync(path);
+    if (size <= MAX_BYTES) {
+      text = readFileSync(path, 'utf8');
+    } else {
+      const fd = openSync(path, 'r');
+      try {
+        const buffer = Buffer.allocUnsafe(MAX_BYTES);
+        const read = readSync(fd, buffer, 0, MAX_BYTES, size - MAX_BYTES);
+        text = buffer.subarray(0, read).toString('utf8');
+      } finally {
+        closeSync(fd);
+      }
+      text = text.slice(text.indexOf('\n') + 1);
+    }
+  } catch {
+    return [];
+  }
+
+  const seen = new Set();
+  const out = [];
+  for (const line of text.split('\n')) {
+    if (!line) continue;
+    try {
+      const event = JSON.parse(line);
+      if (!EVIDENCE_KINDS.has(event.kind)) continue;
+      const id = event.id || JSON.stringify(event);
+      if (seen.has(id)) continue;
+      seen.add(id);
+      out.push(event);
+    } catch {
+      // A concurrently appended final line may be torn.  It costs one record,
+      // never the user's tool call or the rest of the evidence report.
+    }
+  }
+  return out;
+}
+
+/**
+ * Joins a post-tool result to the most recent matching injection.  The exact
+ * tool-call id wins; clients that omit it fall back to episode + surface +
+ * anchor, in timestamp order, and the report states the weaker join method.
+ */
+export function recordToolOutcome(dir, outcome) {
+  const evidence = readEvidence(dir);
+  const anchor = String(outcome.anchor || '').slice(0, 120);
+  const candidates = evidence
+    .filter((event) => event.kind === 'inject' && event.episodeId === outcome.episodeId)
+    .filter((event) => {
+      if (outcome.toolCallId && event.toolCallId)
+        return String(event.toolCallId) === String(outcome.toolCallId);
+      return event.surface === outcome.surface && String(event.anchor || '').slice(0, 120) === anchor;
+    })
+    .sort((a, b) => (b.at || 0) - (a.at || 0));
+  const injection = candidates[0] || null;
+  const joinMethod = injection
+    ? (outcome.toolCallId && injection.toolCallId ? 'tool-call-id' : 'episode-anchor')
+    : 'none';
+
+  return record(dir, {
+    kind: 'tool-outcome',
+    ...outcome,
+    anchor,
+    injectionId: injection?.injectionId || null,
+    findingIds: injection?.findingIds || [],
+    joinMethod,
+  });
+}
+
+export function recordEpisodeOutcome(dir, outcome) {
+  return record(dir, { kind: 'episode-outcome', ...outcome });
+}
+
+export function recordFindingFeedback(dir, feedback) {
+  const rating = ['helpful', 'neutral', 'harmful'].includes(feedback?.rating)
+    ? feedback.rating
+    : 'neutral';
+  return record(dir, { kind: 'finding-feedback', ...feedback, rating });
 }
 
 /**
@@ -813,4 +933,241 @@ export function indexBudget(dir, { floor = 150, base = 300, ceiling = 1200 } = {
   // 0% hit rate falls to the floor; ~50% and above reaches the ceiling.
   const scaled = Math.round(floor + (ceiling - floor) * Math.min(1, hitRate * 2));
   return Math.max(floor, Math.min(ceiling, scaled));
+}
+
+/* ----------------------------------------------------------------------
+ * Episode-level causal evidence
+ * ------------------------------------------------------------------- */
+
+const numeric = (value) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const average = (values) => {
+  const finite = values.map(numeric).filter((value) => value !== null);
+  return finite.length
+    ? finite.reduce((sum, value) => sum + value, 0) / finite.length
+    : null;
+};
+
+/** Deterministic PRNG so regenerating a report does not move its interval. */
+function seededRandom(seedText) {
+  let seed = 2166136261;
+  for (const char of String(seedText)) {
+    seed ^= char.charCodeAt(0);
+    seed = Math.imul(seed, 16777619);
+  }
+  return () => {
+    seed += 0x6d2b79f5;
+    let value = seed;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Percentile bootstrap interval for a mean, paired delta, or other scalar. */
+export function bootstrapMeanInterval(values, { samples = 1000, seed = 'token-optimizer' } = {}) {
+  const finite = values.map(numeric).filter((value) => value !== null);
+  if (!finite.length) return { mean: null, low: null, high: null, n: 0 };
+  if (finite.length === 1) {
+    return { mean: finite[0], low: finite[0], high: finite[0], n: 1 };
+  }
+
+  const random = seededRandom(`${seed}:${finite.join(',')}`);
+  const means = [];
+  for (let sample = 0; sample < samples; sample++) {
+    let total = 0;
+    for (let index = 0; index < finite.length; index++) {
+      total += finite[Math.floor(random() * finite.length)];
+    }
+    means.push(total / finite.length);
+  }
+  means.sort((a, b) => a - b);
+  return {
+    mean: average(finite),
+    low: means[Math.floor(means.length * 0.025)],
+    high: means[Math.min(means.length - 1, Math.floor(means.length * 0.975))],
+    n: finite.length,
+  };
+}
+
+/** Wilson interval keeps small correctness samples honest and inside 0..1. */
+export function proportionInterval(successes, total, z = 1.96) {
+  if (!total) return { rate: null, low: null, high: null, n: 0 };
+  const rate = successes / total;
+  const denominator = 1 + (z * z) / total;
+  const centre = (rate + (z * z) / (2 * total)) / denominator;
+  const radius =
+    (z / denominator) * Math.sqrt((rate * (1 - rate)) / total + (z * z) / (4 * total * total));
+  return { rate, low: Math.max(0, centre - radius), high: Math.min(1, centre + radius), n: total };
+}
+
+const cohortKey = (run) => [
+  run.client || 'unknown',
+  run.clientVersion || 'unknown',
+  run.model || 'unknown',
+  run.modelVersion || 'unknown',
+  run.taskId || 'unknown',
+].join('|');
+
+function armMetrics(runs) {
+  const correct = runs.filter((run) => run.correct === true).length;
+  const interval = (field) => bootstrapMeanInterval(
+    runs.map((run) => run[field]).filter((value) => numeric(value) !== null),
+    { seed: field }
+  );
+  return {
+    runs: runs.length,
+    correctness: proportionInterval(correct, runs.length),
+    uncachedInputTokens: interval('uncachedInputTokens'),
+    cachedInputTokens: interval('cachedInputTokens'),
+    outputTokens: interval('outputTokens'),
+    totalTokens: interval('totalTokens'),
+    toolCalls: interval('toolCalls'),
+    failedToolCalls: interval('failedToolCalls'),
+    latencyMs: interval('latencyMs'),
+    costUsd: interval('costUsd'),
+    injectedTokens: interval('injectedTokens'),
+    harmfulFindings: runs.reduce((sum, run) => sum + (numeric(run.harmfulFindings) || 0), 0),
+  };
+}
+
+function pairedEffects(runs, treatmentArm) {
+  const pairs = new Map();
+  for (const run of runs) {
+    if (!run.pairId || !['baseline', treatmentArm].includes(run.arm)) continue;
+    if (!pairs.has(run.pairId)) pairs.set(run.pairId, {});
+    pairs.get(run.pairId)[run.arm] = run;
+  }
+  const complete = [...pairs.values()].filter((pair) => pair.baseline && pair[treatmentArm]);
+  const delta = (field, lowerIsBetter = true) => bootstrapMeanInterval(
+    complete
+      .map((pair) => {
+        const baseline = numeric(pair.baseline[field]);
+        const treatment = numeric(pair[treatmentArm][field]);
+        if (baseline === null || treatment === null) return null;
+        return lowerIsBetter ? baseline - treatment : treatment - baseline;
+      })
+      .filter((value) => value !== null),
+    { seed: `${treatmentArm}:${field}` }
+  );
+  return {
+    arm: treatmentArm,
+    pairs: complete.length,
+    // Positive values always mean the treatment improved the metric.
+    totalTokensSaved: delta('totalTokens'),
+    uncachedInputTokensSaved: delta('uncachedInputTokens'),
+    toolCallsAvoided: delta('toolCalls'),
+    latencyMsSaved: delta('latencyMs'),
+    costUsdSaved: delta('costUsd'),
+    correctnessDelta: delta('correct', false),
+  };
+}
+
+function matchesFilters(event, filters) {
+  for (const field of ['client', 'clientVersion', 'model', 'modelVersion', 'taskId', 'arm']) {
+    if (filters[field] && String(event[field] || '') !== String(filters[field])) return false;
+  }
+  return true;
+}
+
+/**
+ * The dashboard-facing evidence console.  Deterministic fixture verification,
+ * live hook traces, and randomized model evals remain visibly distinct: only
+ * `eval-run` records with paired arms can produce a causal effect interval.
+ */
+export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
+  const evidence = readEvidence(dir).filter((event) => matchesFilters(event, filters));
+  const runs = evidence.filter((event) => event.kind === 'eval-run');
+  const injections = evidence.filter((event) => event.kind === 'inject');
+  const outcomes = evidence.filter((event) => event.kind === 'tool-outcome');
+  const feedback = evidence.filter((event) => event.kind === 'finding-feedback');
+
+  const byInjection = new Map(
+    outcomes.filter((event) => event.injectionId).map((event) => [event.injectionId, event])
+  );
+  const traced = injections
+    .slice()
+    .sort((a, b) => (b.at || 0) - (a.at || 0))
+    .slice(0, Math.max(1, Math.min(500, episodeLimit)))
+    .map((injection) => ({
+      injectionId: injection.injectionId,
+      episodeId: injection.episodeId || injection.sessionId || null,
+      at: injection.at,
+      arm: injection.arm || (injection.holdout ? 'holdout' : 'treated'),
+      client: injection.client || 'unknown',
+      clientVersion: injection.clientVersion || null,
+      model: injection.model || null,
+      taskId: injection.taskId || null,
+      surface: injection.surface || injection.trigger || 'file',
+      anchor: injection.anchor,
+      findingIds: injection.findingIds || [],
+      deliveredTokens: injection.deliveredTokens ?? injection.tokens ?? 0,
+      shadowTokens: injection.shadowTokens ?? injection.tokens ?? 0,
+      outcome: byInjection.get(injection.injectionId) || null,
+    }));
+
+  const grouped = new Map();
+  for (const run of runs) {
+    const key = cohortKey(run);
+    if (!grouped.has(key)) grouped.set(key, []);
+    grouped.get(key).push(run);
+  }
+
+  const minimumPairs = Math.max(2, Number(process.env.TOKEN_OPTIMIZER_EVAL_MIN_PAIRS) || 5);
+  const cohorts = [...grouped.entries()].map(([key, cohortRuns]) => {
+    const arms = Object.fromEntries(
+      ['baseline', 'optimizer', 'retrieval', 'full'].map((arm) => [
+        arm,
+        armMetrics(cohortRuns.filter((run) => run.arm === arm)),
+      ])
+    );
+    const effects = ['optimizer', 'retrieval', 'full'].map((arm) => pairedEffects(cohortRuns, arm));
+    const enough = effects.some((effect) => effect.pairs >= minimumPairs);
+    return {
+      key,
+      client: cohortRuns[0]?.client || 'unknown',
+      clientVersion: cohortRuns[0]?.clientVersion || null,
+      model: cohortRuns[0]?.model || null,
+      modelVersion: cohortRuns[0]?.modelVersion || null,
+      taskId: cohortRuns[0]?.taskId || null,
+      arms,
+      effects,
+      evidenceStatus: enough
+        ? 'causal estimate available'
+        : `insufficient paired runs (need ${minimumPairs})`,
+    };
+  });
+
+  const joined = injections.filter((injection) =>
+    byInjection.has(injection.injectionId)
+  ).length;
+  const harmful = feedback.filter((event) => event.rating === 'harmful').length;
+  return {
+    schemaVersion: 2,
+    generatedAt: new Date().toISOString(),
+    filters,
+    summary: {
+      liveInjections: injections.length,
+      joinedOutcomes: joined,
+      causalJoinCoverage: injections.length ? joined / injections.length : null,
+      evalRuns: runs.length,
+      cohorts: cohorts.length,
+      harmfulFeedback: harmful,
+      harmRate: feedback.length ? harmful / feedback.length : null,
+      evidenceStatus: cohorts.some((cohort) => cohort.evidenceStatus === 'causal estimate available')
+        ? 'causal estimates available'
+        : 'insufficient randomized evidence',
+    },
+    cohorts,
+    episodes: traced,
+    methodology: {
+      intervals: 'deterministic percentile bootstrap (95%); Wilson interval for correctness',
+      causalRule: 'only matched eval-run pairs compare an arm with baseline',
+      minimumPairs,
+      deterministicChecksAreCausalProof: false,
+    },
+  };
 }

--- a/integrations/opencode/hooks/lib/recording.mjs
+++ b/integrations/opencode/hooks/lib/recording.mjs
@@ -159,6 +159,9 @@ export function semanticHarvestPrompt({
     + ' If this work produced a durable, non-obvious conclusion -- a failed approach and why, '
     + 'a decision and its rejected alternative, or a command that finally worked -- call '
     + 'wiki_write now with a real file anchor. Do not delegate this to another model or an '
-    + 'external harvester. If there is no such conclusion, do not invent one; finish normally.'
+    + 'external harvester. Include: the concrete evidence, when the finding applies, a calibrated '
+    + 'confidenceLabel (verified/probable/speculative), its project/organization/global scope, '
+    + 'and anything that would invalidate it. If there is no such conclusion, do not invent one; '
+    + 'finish normally.'
   );
 }

--- a/integrations/opencode/hooks/lib/utility.mjs
+++ b/integrations/opencode/hooks/lib/utility.mjs
@@ -1,0 +1,135 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/utility.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Evidence-aware retrieval economics.
+ *
+ * Relevance alone is not enough: a true finding can still cost more context
+ * than it saves.  Every candidate receives a conservative expected-benefit
+ * estimate, its delivery cost and risk are subtracted, and harmful findings
+ * are quarantined from automatic delivery while remaining visible for audit.
+ */
+
+import { readEvidence } from './metrics.mjs';
+
+const DAY = 86_400_000;
+const ORIGIN_WEIGHT = { human: 1.2, agent: 1.08, harvested: 1 };
+
+const envNumber = (name, fallback) => {
+  const value = Number(process.env[name]);
+  return Number.isFinite(value) && value >= 0 ? value : fallback;
+};
+
+export const retrievalPolicy = () => ({
+  baseBenefitTokens: envNumber('TOKEN_OPTIMIZER_EXPECTED_BENEFIT_TOKENS', 400),
+  minimumNetUtility: envNumber('TOKEN_OPTIMIZER_MIN_EXPECTED_UTILITY', 20),
+  cooldownMs: envNumber('TOKEN_OPTIMIZER_INJECTION_COOLDOWN_MS', 60_000),
+  quarantineHarmCount: Math.max(1, envNumber('TOKEN_OPTIMIZER_QUARANTINE_HARM_COUNT', 2)),
+});
+
+function feedbackFor(events, key) {
+  return events.filter((event) =>
+    event.kind === 'finding-feedback'
+    && (event.findingId === key || (event.findingIds || []).includes(key))
+  );
+}
+
+function outcomesFor(events, key) {
+  return events.filter((event) =>
+    event.kind === 'tool-outcome' && (event.findingIds || []).includes(key)
+  );
+}
+
+function deliveredRecently(events, key, episodeId, now, cooldownMs) {
+  if (!episodeId || cooldownMs <= 0) return false;
+  return events.some((event) =>
+    event.kind === 'inject'
+    && event.episodeId === episodeId
+    && (event.findingIds || []).includes(key)
+    && !event.holdout
+    && now - (event.at || 0) < cooldownMs
+  );
+}
+
+/**
+ * Returns eligible candidates in utility order plus every rejection reason.
+ * `costFor` is supplied by inject.mjs so the gate prices the exact rendered
+ * text rather than a second approximation that could drift.
+ */
+export function assessFindings(
+  dir,
+  findings,
+  {
+    relevanceFor = () => 1,
+    costFor = () => 0,
+    episodeId = null,
+    now = Date.now(),
+    policy = retrievalPolicy(),
+  } = {}
+) {
+  const events = readEvidence(dir);
+  const eligible = [];
+  const rejected = [];
+
+  for (const finding of findings) {
+    const key = finding.key;
+    const feedback = feedbackFor(events, key);
+    const outcomes = outcomesFor(events, key);
+    const helpful = feedback.filter((event) => event.rating === 'helpful').length;
+    const neutral = feedback.filter((event) => event.rating === 'neutral').length;
+    const harmful = feedback.filter((event) => event.rating === 'harmful').length;
+    const successfulUses = outcomes.filter((event) => event.success === true).length;
+    const failedUses = outcomes.filter((event) => event.success === false).length;
+
+    if (harmful >= policy.quarantineHarmCount && harmful >= helpful + neutral) {
+      rejected.push({ key, reason: 'quarantined-harm', helpful, neutral, harmful });
+      continue;
+    }
+    if (deliveredRecently(events, key, episodeId, now, policy.cooldownMs)) {
+      rejected.push({ key, reason: 'cooldown' });
+      continue;
+    }
+
+    const confidence = Number.isFinite(finding.confidence) ? finding.confidence : 0.5;
+    const relevance = Math.max(0, Math.min(1, Number(relevanceFor(finding)) || 0));
+    const ageDays = Math.max(0, (now - (finding.at || now)) / DAY);
+    const recency = finding.pinned ? 1 : Math.pow(0.5, ageDays / 90);
+    const provenance = ORIGIN_WEIGHT[finding.origin] || 1;
+    // Outcome evidence moves the estimate gradually. Explicit harmful feedback
+    // is handled above; a failed command alone is not labelled harmful because
+    // the model may have ignored correct advice.
+    const observed = successfulUses + failedUses;
+    const successFactor = observed
+      ? 0.75 + 0.5 * (successfulUses / observed)
+      : 1;
+    const feedbackFactor = Math.max(0.25, 1 + helpful * 0.12 - harmful * 0.35);
+    const expectedBenefit =
+      policy.baseBenefitTokens * confidence * relevance * recency * provenance * successFactor * feedbackFactor;
+    const deliveryCost = Math.max(0, Number(costFor(finding)) || 0);
+    const riskPenalty =
+      (finding.stale ? 160 : 0)
+      + (finding.confidenceLabel === 'speculative' ? 100 : 0)
+      + harmful * 100;
+    const netUtility = expectedBenefit - deliveryCost - riskPenalty;
+
+    const assessed = {
+      finding,
+      expectedBenefit,
+      deliveryCost,
+      riskPenalty,
+      netUtility,
+      helpful,
+      neutral,
+      harmful,
+      successfulUses,
+      failedUses,
+    };
+    if (netUtility < policy.minimumNetUtility) {
+      rejected.push({ key, reason: 'negative-expected-value', ...assessed, finding: undefined });
+      continue;
+    }
+    eligible.push(assessed);
+  }
+
+  eligible.sort((a, b) => b.netUtility - a.netUtility);
+  return { eligible, rejected };
+}

--- a/integrations/opencode/hooks/lib/utility.mjs
+++ b/integrations/opencode/hooks/lib/utility.mjs
@@ -64,6 +64,7 @@ export function assessFindings(
     episodeId = null,
     now = Date.now(),
     policy = retrievalPolicy(),
+    bypassCooldown = false,
   } = {}
 ) {
   const events = readEvidence(dir);
@@ -84,7 +85,7 @@ export function assessFindings(
       rejected.push({ key, reason: 'quarantined-harm', helpful, neutral, harmful });
       continue;
     }
-    if (deliveredRecently(events, key, episodeId, now, policy.cooldownMs)) {
+    if (!bypassCooldown && deliveredRecently(events, key, episodeId, now, policy.cooldownMs)) {
       rejected.push({ key, reason: 'cooldown' });
       continue;
     }

--- a/integrations/opencode/hooks/lib/wire.mjs
+++ b/integrations/opencode/hooks/lib/wire.mjs
@@ -28,7 +28,7 @@ export const MARKER = 'token-optimizer';
 /** The events we wire, and which hook file serves each. */
 export const WIRING = [
   { event: 'SessionStart', file: 'session-start.mjs', matcher: null },
-  { event: 'PreToolUse', file: 'pretooluse-router.mjs', matcher: 'Read|Grep|Glob|Edit|MultiEdit|Write|Bash' },
+  { event: 'PreToolUse', file: 'pretooluse-router.mjs', matcher: 'Read|Grep|Glob|Edit|MultiEdit|Write|Bash|PowerShell' },
   { event: 'PreCompact', file: 'precompact-optimize.mjs', matcher: null },
 ];
 

--- a/integrations/qwen/hooks/lib/adapter.mjs
+++ b/integrations/qwen/hooks/lib/adapter.mjs
@@ -31,7 +31,9 @@ import {
   readCostBytes,
   touchedFiles,
 } from './decide.mjs';
-import { recordRead, fingerprint } from './metrics.mjs';
+import {
+  recordRead, fingerprint, recordToolOutcome, recordEpisodeOutcome,
+} from './metrics.mjs';
 import {
   contentHash,
   harvest,
@@ -57,6 +59,8 @@ import { isFsSafePath } from './paths.mjs';
 import {
   isSubstantive, recordingNudge, semanticHarvestPrompt,
 } from './recording.mjs';
+import { nativeClientProfiles } from './capabilities.mjs';
+import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 
 /**
  * Per-client capability.
@@ -65,41 +69,7 @@ import {
  * it true where the client has no pre-execution veto would make the product
  * claim enforcement it cannot deliver.
  */
-export const CLIENTS = {
-  'claude-code': { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  codex: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  cline: {
-    canDeny: true,
-    contextStyle: 'cline',
-    denyStyle: 'cline',
-    stopDecision: 'block',
-  },
-  copilot: {
-    canDeny: true,
-    contextStyle: 'top-level',
-    denyStyle: 'top-level-permission',
-    stopDecision: 'block',
-  },
-  cursor: {
-    canDeny: true,
-    contextStyle: 'cursor',
-    denyStyle: 'cursor',
-    stopStyle: 'followup',
-    stopDecision: 'block',
-  },
-  // Gemini's BeforeTool and AfterAgent decisions are top-level. Treating it
-  // like Codex produced well-formed JSON that Gemini ignored.
-  gemini: { canDeny: true, denyStyle: 'top-level', stopDecision: 'deny' },
-  kilo: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  opencode: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  qwen: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  windsurf: {
-    canDeny: true,
-    contextStyle: 'silent',
-    denyStyle: 'exit-2',
-    stopDecision: 'block',
-  },
-};
+export const CLIENTS = nativeClientProfiles();
 
 /** Never synchronously hash an unbounded build artifact on a hook path. */
 const HARVEST_MAX_BYTES =
@@ -135,6 +105,24 @@ export function mutationSucceeded(clientName, raw) {
   // or are called by our in-process bridge only from its successful after hook.
   return new Set(['claude-code', 'qwen', 'opencode', 'kilo', 'windsurf'])
     .has(clientName);
+}
+
+/** Conservative success classification for any completed tool call. */
+export function toolSucceeded(raw) {
+  if (raw?.error || raw?.tool_response?.error || raw?.toolResponse?.error)
+    return false;
+  if (raw?.postToolUse?.success === false || raw?.success === false) return false;
+  const status =
+    raw?.tool_response?.status ?? raw?.toolResponse?.status ??
+    raw?.tool_result?.status ?? raw?.toolResult?.status;
+  if (status !== undefined) {
+    if (/^(?:error|failed|failure|cancelled|canceled|denied)$/i.test(String(status))) return false;
+    if (/^(?:ok|success|succeeded|complete|completed)$/i.test(String(status))) return true;
+  }
+  // A post-tool lifecycle event is evidence that the call completed, but not
+  // that its output proved the task.  `success` here is deliberately scoped to
+  // the tool call; task correctness comes only from an eval grader.
+  return true;
 }
 
 function contextOutput(client, eventName, additionalContext) {
@@ -253,8 +241,10 @@ refused.
 
 Worth recording: a decision and why the alternative was rejected, a failure and
 what actually caused it, a command that turned out to be the one that works.
-Not worth recording: what the code plainly says. Prefer the thing someone had to
-work out, because that exists nowhere in the source tree.${projectBriefing()}`;
+Not worth recording: what the code plainly says. Every wiki_write must include
+the concrete evidence, when it applies, a calibrated confidence label, its
+scope, and what would invalidate it. Prefer the thing someone had to work out,
+because that exists nowhere in the source tree.${projectBriefing()}`;
 }
 
 /**
@@ -315,7 +305,7 @@ function projectBriefing() {
  * metrics. It never called forTouch/forCommand, so four advertised clients
  * accumulated a graph that their active model could not receive.
  */
-function observeAndInject(payload, state) {
+function observeAndInject(payload, state, episode, features) {
   const touched = touchedFiles(payload);
   const dirFor = (path) => wikiDir(projectRootFor(path, payload.cwd));
 
@@ -344,45 +334,51 @@ function observeAndInject(payload, state) {
   state.injected = state.injected || [];
   const alreadyInjected = new Set(state.injected);
 
-  for (const { path } of touched) {
-    const dir = dirFor(path);
-    const note = forTouch(dir, load(dir), path, {
-      sessionId: payload.session_id,
-      alreadyInjected,
-    });
-    if (note) parts.push(note);
-  }
+  if (features.retrieval) {
+    for (const { path } of touched) {
+      const dir = dirFor(path);
+      const note = forTouch(dir, load(dir), path, {
+        sessionId: payload.session_id,
+        alreadyInjected,
+        episode,
+      });
+      if (note) parts.push(note);
+    }
 
-  const command = payload.tool_input?.command;
-  if (command) {
-    const root = commandProjectRoot(payload, payload.cwd);
-    const dir = wikiDir(root);
-    const local = forCommand(dir, load(dir), command, {
-      sessionId: payload.session_id,
-      alreadyInjected,
-    });
-    if (local) parts.push(local);
+    const command = payload.tool_input?.command;
+    if (command) {
+      const root = commandProjectRoot(payload, payload.cwd);
+      const dir = wikiDir(root);
+      const local = forCommand(dir, load(dir), command, {
+        sessionId: payload.session_id,
+        alreadyInjected,
+        episode,
+      });
+      if (local) parts.push(local);
 
-    const shared = forSharedCommand(dir, command, {
-      sessionId: payload.session_id,
-      alreadyInjected,
-      projectRoot: root,
-    });
-    if (shared) parts.push(shared);
+      const shared = forSharedCommand(dir, command, {
+        sessionId: payload.session_id,
+        alreadyInjected,
+        projectRoot: root,
+        episode,
+      });
+      if (shared) parts.push(shared);
 
-    const crossed = noteActClasses(state, command);
-    const repeated = forRepeatedAct(dir, command, crossed, {
-      sessionId: payload.session_id,
-      projectRoot: root,
-    });
-    if (repeated) parts.push(repeated);
+      const crossed = noteActClasses(state, command);
+      const repeated = forRepeatedAct(dir, command, crossed, {
+        sessionId: payload.session_id,
+        projectRoot: root,
+        episode,
+      });
+      if (repeated) parts.push(repeated);
+    }
   }
   state.injected = [...alreadyInjected];
 
   // Structural capture is evidence about what was touched, not a semantic
   // conclusion. It is therefore safe to automate for every client and leaves
   // the active model responsible for wiki_write at completion.
-  for (const { path, size } of touched) {
+  if (features.capture) for (const { path, size } of touched) {
     try {
       if (isArchived(path) || size > HARVEST_MAX_BYTES || !isFsSafePath(path))
         continue;
@@ -420,7 +416,10 @@ export async function run(clientName, event) {
 
   if (mode() === MODE_OFF) process.exit(0);
 
+  const features = featuresForArm();
+
   if (event === 'session-start') {
+    if (!features.routing && !features.retrieval && !features.harvest) process.exit(0);
     const output = contextOutput(client, eventName, policyText(client.canDeny));
     if (output) emit(output);
     process.exit(0);
@@ -437,10 +436,22 @@ export async function run(clientName, event) {
     const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? 'default';
     const agentScope = raw.transcript_path ?? raw.transcriptPath ?? null;
     const state = loadState(sessionId, agentScope);
+    const episode = episodeMeta({ client: clientName, raw });
+    try {
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+      recordEpisodeOutcome(dir, {
+        ...episode,
+        status: 'completed',
+        ...usageFrom(raw),
+      });
+    } catch {
+      // Evidence is best effort and must never stop a session from finishing.
+    }
     const alreadyHarvested =
       Number(state.edits || 0) > 0 &&
       Number(state.harvestedEdits || 0) >= Number(state.edits || 0);
-    const prompt = semanticHarvestPrompt({
+    const prompt = features.harvest ? semanticHarvestPrompt({
       edits: state.edits,
       files: state.editedFiles,
       model: raw.model,
@@ -449,7 +460,7 @@ export async function run(clientName, event) {
         raw.stopHookActive === true ||
         alreadyHarvested ||
         (clientName === 'cursor' && Number(raw.loop_count || 0) > 0),
-    });
+    }) : null;
     if (prompt) {
       state.harvestedEdits = Number(state.edits || 0);
       saveState(sessionId, state, agentScope);
@@ -466,6 +477,7 @@ export async function run(clientName, event) {
     process.exit(0);
   const payload = normalizePayload(normalizeClientPayload(clientName, event, raw));
   if (!payload.tool_name) process.exit(0);
+  const episode = episodeMeta({ client: clientName, raw, payload });
 
   // THE AGENT, not just the session -- the same scope the Claude Code router
   // applies. Subagents inherit the parent's session id, so keying state on the
@@ -506,17 +518,41 @@ export async function run(clientName, event) {
       const anchor = state.editedFiles[0]
         || join(payload.cwd || process.cwd(), '__recording__');
       const dir = wikiDir(projectRootFor(anchor, payload.cwd));
-      recordingContext = recordingNudge(dir, {
+      recordingContext = features.harvest ? recordingNudge(dir, {
         state,
         edits: state.edits,
         files: state.editedFiles,
-      });
+      }) : null;
       if (recordingContext) state.recordingNudged = true;
     } catch {
       // Recording pressure is an optimization and must never cost a tool call.
     }
   }
-  const verdict = decide(payload, state);
+  if (event === 'post-tool') {
+    try {
+      const command = payload.tool_input?.command;
+      const touched = touchedFiles(payload);
+      const anchor = command
+        ? String(command).slice(0, 120)
+        : touched[0]?.path || payload.tool_input?.file_path || '';
+      const root = command
+        ? commandProjectRoot(payload, payload.cwd)
+        : projectRootFor(anchor || join(payload.cwd || process.cwd(), '__tool__'), payload.cwd);
+      recordToolOutcome(wikiDir(root), {
+        ...episode,
+        surface: command ? 'command' : 'file',
+        anchor,
+        toolName: payload.tool_name,
+        success: toolSucceeded(raw),
+        durationMs: Number(raw.duration_ms ?? raw.durationMs ?? raw.elapsed_ms ?? raw.elapsedMs) || null,
+        ...usageFrom(raw),
+      });
+    } catch {
+      // Causal tracing is fail-open like every other hook optimization.
+    }
+  }
+
+  const verdict = features.routing ? decide(payload, state) : null;
   const repeat = verdict && event === 'pre-tool'
     ? alreadyDenied(state, verdict.key)
     : false;
@@ -571,7 +607,7 @@ export async function run(clientName, event) {
   remember(payload, state);
   let graphContext = null;
   try {
-    graphContext = observeAndInject(payload, state);
+    graphContext = observeAndInject(payload, state, episode, features);
   } catch {
     // Delivery is an optimization. Fail open.
   }

--- a/integrations/qwen/hooks/lib/capabilities.mjs
+++ b/integrations/qwen/hooks/lib/capabilities.mjs
@@ -1,0 +1,130 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/capabilities.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * The product's honest cross-client capability contract.
+ *
+ * A client is listed at the strongest surface its public lifecycle protocol can
+ * actually support.  This registry is consumed by the adapter, certification
+ * tooling, and evidence reports so a rules-only integration can never be
+ * presented as equivalent to a native stop-continuation integration.
+ */
+
+export const CAPABILITY_TIERS = Object.freeze({
+  CONTINUATION: 'lifecycle-continuation',
+  OBSERVATION: 'native-observation',
+  RULES: 'mcp-rules',
+});
+
+const native = (profile) => ({
+  structuralCapture: 'native',
+  findingDelivery: 'native',
+  routing: 'native-veto',
+  ...profile,
+});
+
+export const CLIENT_CAPABILITIES = Object.freeze({
+  'claude-code': native({
+    name: 'Claude Code', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-continuation', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  codex: native({
+    name: 'Codex', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-continuation', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  copilot: native({
+    name: 'GitHub Copilot CLI', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'agent-stop-continuation', canDeny: true,
+    contextStyle: 'top-level', denyStyle: 'top-level-permission', stopDecision: 'block',
+  }),
+  gemini: native({
+    name: 'Gemini CLI', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'after-agent-retry', canDeny: true,
+    denyStyle: 'top-level', stopDecision: 'deny',
+  }),
+  qwen: native({
+    name: 'Qwen Code', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-continuation', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  cursor: native({
+    name: 'Cursor', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-followup', canDeny: true,
+    contextStyle: 'cursor', denyStyle: 'cursor', stopStyle: 'followup', stopDecision: 'block',
+  }),
+  cline: native({
+    name: 'Cline', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    contextStyle: 'cline', denyStyle: 'cline', stopDecision: 'block',
+  }),
+  opencode: native({
+    name: 'OpenCode', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  kilo: native({
+    name: 'Kilo', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  windsurf: native({
+    name: 'Windsurf', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    contextStyle: 'silent', denyStyle: 'exit-2', stopDecision: 'block',
+  }),
+  roo: {
+    name: 'Roo Code', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  zed: {
+    name: 'Zed', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  amp: {
+    name: 'Amp', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  continue: {
+    name: 'Continue', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  crush: {
+    name: 'Crush', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  droid: {
+    name: 'Droid (Factory)', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+});
+
+export function capabilityFor(client) {
+  return CLIENT_CAPABILITIES[String(client || '').toLowerCase()] || null;
+}
+
+export function nativeClientProfiles() {
+  return Object.fromEntries(
+    Object.entries(CLIENT_CAPABILITIES)
+      .filter(([, profile]) => profile.structuralCapture === 'native')
+      .map(([key, profile]) => [key, { ...profile }])
+  );
+}
+
+export function capabilitySummary() {
+  return Object.entries(CLIENT_CAPABILITIES).map(([client, profile]) => ({
+    client,
+    name: profile.name,
+    tier: profile.tier,
+    routing: profile.routing,
+    structuralCapture: profile.structuralCapture,
+    findingDelivery: profile.findingDelivery,
+    semanticHarvest: profile.semanticHarvest,
+  }));
+}

--- a/integrations/qwen/hooks/lib/decide.mjs
+++ b/integrations/qwen/hooks/lib/decide.mjs
@@ -513,6 +513,8 @@ const TOOL_ALIASES = new Map(
     create_file: 'Write',
 
     bash: 'Bash',
+    powershell: 'Bash',
+    pwsh: 'Bash',
     shell: 'Bash',
     run_command: 'Bash',
     execute_command: 'Bash',

--- a/integrations/qwen/hooks/lib/experiment.mjs
+++ b/integrations/qwen/hooks/lib/experiment.mjs
@@ -1,0 +1,82 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/experiment.mjs. Regenerate with `npm run sync:hooks`.
+/** Explicit, reproducible feature arms and causal episode identity. */
+
+export const EXPERIMENT_ARMS = Object.freeze([
+  'baseline',
+  'optimizer',
+  'retrieval',
+  'full',
+]);
+
+const FEATURES = Object.freeze({
+  baseline: Object.freeze({ routing: false, retrieval: false, capture: false, harvest: false }),
+  optimizer: Object.freeze({ routing: true, retrieval: false, capture: false, harvest: false }),
+  retrieval: Object.freeze({ routing: true, retrieval: true, capture: true, harvest: false }),
+  full: Object.freeze({ routing: true, retrieval: true, capture: true, harvest: true }),
+});
+
+export function experimentArm(env = process.env) {
+  const requested = String(env.TOKEN_OPTIMIZER_EXPERIMENT_ARM || '').trim().toLowerCase();
+  return EXPERIMENT_ARMS.includes(requested) ? requested : 'full';
+}
+
+export function featuresForArm(arm = experimentArm()) {
+  return FEATURES[arm] || FEATURES.full;
+}
+
+const first = (...values) => values.find((value) => value !== undefined && value !== null && value !== '');
+
+/**
+ * Normalises identifiers exposed under different names by lifecycle clients.
+ * Environment overrides let the live evaluation harness pin a pair/task id
+ * without asking each CLI to support experiment-specific payload fields.
+ */
+export function episodeMeta({ client, raw = {}, payload = {}, env = process.env } = {}) {
+  const sessionId = String(first(
+    payload.session_id, raw.session_id, raw.sessionId, raw.conversation_id,
+    raw.conversationId, raw.taskId, raw.task_id, raw.trajectory_id, 'default'
+  ));
+  const episodeId = String(first(
+    env.TOKEN_OPTIMIZER_EPISODE_ID, raw.episode_id, raw.episodeId, sessionId
+  ));
+  const toolCallId = first(
+    raw.tool_use_id, raw.toolUseId, raw.tool_call_id, raw.toolCallId,
+    raw.call_id, raw.callId, raw.postToolUse?.toolUseId, raw.preToolUse?.toolUseId
+  );
+  const model = first(payload.model, raw.model?.slug, raw.model, raw.model_name, env.TOKEN_OPTIMIZER_MODEL);
+  const clientVersion = first(
+    raw.client_version, raw.clientVersion, raw.version, env.TOKEN_OPTIMIZER_CLIENT_VERSION
+  );
+  const modelVersion = first(raw.model_version, raw.modelVersion, env.TOKEN_OPTIMIZER_MODEL_VERSION);
+
+  return {
+    schemaVersion: 2,
+    episodeId,
+    sessionId,
+    turnId: first(raw.turn_id, raw.turnId, raw.message_id, raw.messageId) ?? null,
+    toolCallId: toolCallId == null ? null : String(toolCallId),
+    taskId: first(env.TOKEN_OPTIMIZER_TASK_ID, raw.task_id, raw.taskId) ?? null,
+    pairId: first(env.TOKEN_OPTIMIZER_PAIR_ID, raw.pair_id, raw.pairId) ?? null,
+    arm: experimentArm(env),
+    client: String(client || first(raw.client, raw.client_name, 'unknown')),
+    clientVersion: clientVersion == null ? null : String(clientVersion),
+    model: model == null ? null : String(model),
+    modelVersion: modelVersion == null ? null : String(modelVersion),
+  };
+}
+
+export function usageFrom(raw = {}) {
+  const usage = raw.usage || raw.token_usage || raw.tokenUsage || raw.metrics?.usage || {};
+  const number = (...values) => {
+    const value = first(...values);
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+  };
+  return {
+    uncachedInputTokens: number(usage.uncached_input_tokens, usage.uncachedInputTokens),
+    cachedInputTokens: number(usage.cached_input_tokens, usage.cachedInputTokens, usage.cache_read_input_tokens),
+    outputTokens: number(usage.output_tokens, usage.outputTokens),
+    totalTokens: number(usage.total_tokens, usage.totalTokens, raw.tokens_used, raw.tokensUsed),
+  };
+}

--- a/integrations/qwen/hooks/lib/harvest-write.mjs
+++ b/integrations/qwen/hooks/lib/harvest-write.mjs
@@ -96,8 +96,13 @@ function promoteToShared(finding, { projectRoot, sessionId, provenance, key }) {
           key: `shared-${key}`,
           claim: finding.claim,
           confidence: finding.confidence,
+          confidenceLabel: finding.confidenceLabel,
           type: finding.type,
           trigger: typeof finding.trigger === 'string' && finding.trigger ? finding.trigger : undefined,
+          applicability: finding.applicability,
+          evidence: finding.evidence,
+          invalidators: Array.isArray(finding.invalidators) ? finding.invalidators : [],
+          scope: finding.scope || 'global',
           origin: provenance,
           quote: typeof finding.quote === 'string' && finding.quote.trim() ? finding.quote : undefined,
           // WHERE IT WAS LEARNED, carried so the reader can discount it. A lesson
@@ -351,6 +356,26 @@ export function writeHarvested(
     // anything, so it is dropped rather than kept as unfalsifiable.
     if (!resolved.length) continue;
 
+    // Exact semantic duplicates collapse to the existing active record.  The
+    // normalisation intentionally ignores punctuation/formatting noise but not
+    // meaning-bearing words; near-duplicates that need judgement remain visible
+    // to curation rather than being silently merged by a fuzzy heuristic.
+    const fingerprint = claimFingerprint(finding.claim);
+    const currentGraph = load(dir);
+    const duplicate = [...currentGraph.nodes.values()].find((node) =>
+      node.kind === 'finding'
+      && !node.retired
+      && node.type === finding.type
+      && claimFingerprint(node.claim) === fingerprint
+      && resolved.every((target) => currentGraph.edges.some((edge) =>
+        edge.from === node.id && edge.edge === 'derived_from' && edge.to === target
+      ))
+    );
+    if (duplicate) {
+      written.push(duplicate.key);
+      continue;
+    }
+
     // Date.now() plus an index is not unique across CONCURRENT detached
     // workers: two Stop hooks finishing in the same millisecond produce the
     // same key, and putNode keeps the last write for an id -- so one session's
@@ -371,6 +396,7 @@ export function writeHarvested(
         key,
         claim: finding.claim,
         confidence: finding.confidence,
+        confidenceLabel: finding.confidenceLabel,
         type: finding.type,
         // WHEN this finding is relevant, not just what it is about. Anchors
         // answer "which file", which is the wrong question for a claim about
@@ -380,6 +406,16 @@ export function writeHarvested(
         trigger: typeof finding.trigger === 'string' && finding.trigger
           ? finding.trigger
           : undefined,
+        applicability: typeof finding.applicability === 'string'
+          ? finding.applicability
+          : undefined,
+        evidence: typeof finding.evidence === 'string'
+          ? finding.evidence
+          : undefined,
+        invalidators: Array.isArray(finding.invalidators)
+          ? finding.invalidators
+          : [],
+        scope: finding.scope || 'project',
         origin: provenance,
         // THE EVIDENCE TRAVELS WITH THE CLAIM. Without it a human-origin
         // finding asserts its own provenance and nothing can check it.
@@ -398,7 +434,11 @@ export function writeHarvested(
     // record of what happened here; the shared tier is a copy for the lessons
     // that are not about here. Skipped when the two are the same directory,
     // which is the suite's usual arrangement.
-    if (id && !isSharedDir(dir)) {
+    if (
+      id
+      && !isSharedDir(dir)
+      && (finding.scope === undefined || finding.scope === 'organization' || finding.scope === 'global')
+    ) {
       promoteToShared(finding, { projectRoot, sessionId, provenance, key });
     }
   }

--- a/integrations/qwen/hooks/lib/harvest.mjs
+++ b/integrations/qwen/hooks/lib/harvest.mjs
@@ -201,7 +201,11 @@ const PROMPT = `Extract durable findings from this coding session for a project 
 Return ONLY a JSON array. Each element:
 {"type": "finding|decision|failure|command|map",
  "claim": "one sentence, specific and checkable",
- "confidence": 0.0-1.0,
+ "evidence": "the concrete observation, command result, or rejected approach that proved it",
+ "applicability": "the condition under which a future model should use it",
+ "confidenceLabel": "verified|probable|speculative",
+ "scope": "project|organization|global",
+ "invalidators": ["what change would require this to be checked again"],
  "anchors": ["absolute/file/path" or "absolute/file/path#symbolName"]}
 
 RULES:
@@ -211,7 +215,9 @@ RULES:
 - Prefer "failure" and "decision" entries. What was TRIED AND REJECTED, and WHY,
   is the most valuable thing here because it exists nowhere in the source tree.
 - Do not restate what the code plainly says. Record what someone had to work out.
-- confidence reflects how well established the claim is, not how important.
+- verified requires direct evidence; probable means strong but incomplete evidence;
+  speculative is a hypothesis and must be labelled as such.
+- Use project scope unless the lesson is genuinely independent of this repository.
 - If nothing durable was learned, return [].`;
 
 /**
@@ -232,8 +238,29 @@ export function validate(raw, { knownFiles = null } = {}) {
     if (!FINDING_TYPES.includes(item.type)) continue;
     if (typeof item.claim !== 'string' || item.claim.trim().length < 8) continue;
 
-    const confidence = Number(item.confidence);
-    if (!Number.isFinite(confidence) || confidence <= 0 || confidence > 1) continue;
+    const evidence = typeof item.evidence === 'string' ? item.evidence.trim() : '';
+    const applicability = typeof item.applicability === 'string' ? item.applicability.trim() : '';
+    if (evidence.length < 8 || applicability.length < 8) continue;
+
+    const confidenceLabel = ['verified', 'probable', 'speculative'].includes(item.confidenceLabel)
+      ? item.confidenceLabel
+      : null;
+    if (!confidenceLabel) continue;
+    const defaults = { verified: 0.95, probable: 0.75, speculative: 0.45 };
+    const supplied = Number(item.confidence);
+    if (
+      item.confidence !== undefined
+      && (!Number.isFinite(supplied) || supplied <= 0 || supplied > 1)
+    ) continue;
+    const confidence = item.confidence === undefined
+      ? defaults[confidenceLabel]
+      : supplied;
+    const scope = ['project', 'organization', 'global'].includes(item.scope)
+      ? item.scope
+      : 'project';
+    const invalidators = Array.isArray(item.invalidators)
+      ? item.invalidators.filter((value) => typeof value === 'string' && value.trim()).slice(0, 10)
+      : [];
 
     let anchors = Array.isArray(item.anchors) ? item.anchors.filter((a) => typeof a === 'string' && a) : [];
     // A model asked for file paths will sometimes invent them. When the caller
@@ -241,7 +268,18 @@ export function validate(raw, { knownFiles = null } = {}) {
     if (knownFiles) anchors = anchors.filter((a) => knownFiles.has(a.split('#')[0]));
     if (!anchors.length) continue;
 
-    accepted.push({ type: item.type, claim: item.claim.trim(), confidence, anchors });
+    accepted.push({
+      type: item.type,
+      claim: item.claim.trim(),
+      evidence,
+      applicability,
+      confidence,
+      confidenceLabel,
+      scope,
+      invalidators,
+      anchors,
+      trigger: typeof item.trigger === 'string' ? item.trigger : undefined,
+    });
   }
   return accepted;
 }

--- a/integrations/qwen/hooks/lib/inject.mjs
+++ b/integrations/qwen/hooks/lib/inject.mjs
@@ -30,6 +30,7 @@ import { inHoldout, record, indexBudget } from './metrics.mjs';
 import { canonicalPath, resolvableCandidates } from './paths.mjs';
 import { annotatedSkeleton } from './skeleton.mjs';
 import { substitutionBudget } from './metrics.mjs';
+import { assessFindings } from './utility.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
@@ -150,7 +151,7 @@ export function forTouch(
   dir,
   graph,
   rawPath,
-  { budget = touchBudget(), sessionId, alreadyInjected = new Set() } = {}
+  { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
   // Canonical, so a touch finds findings anchored under any other spelling.
   const filePath = canonicalPath(rawPath);
@@ -169,16 +170,36 @@ export function forTouch(
   // variance drops out. A session-pinned arm would destroy that.
   const holdout = inHoldout(filePath);
   const served = serve(graph, candidates);
-  const { kept, spent } = fit(served, budget);
+  const assessed = assessFindings(dir, served, {
+    episodeId: episode.episodeId || sessionId,
+    relevanceFor: () => 1,
+    costFor: (finding) => estimate(render(finding)),
+  });
+  if (assessed.rejected.length) {
+    record(dir, {
+      kind: 'retrieval-decision', ...episode, sessionId,
+      surface: 'file', anchor: filePath,
+      rejected: assessed.rejected.map(({ key, reason }) => ({ key, reason })),
+    });
+    for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
+  }
+  const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
+  if (!kept.length) return null;
 
   record(dir, {
     kind: 'inject',
+    ...episode,
     // The surface whose saving CAN be measured: reads of this anchor afterwards.
     surface: 'file',
     anchor: filePath,
     holdout,
     tokens: holdout ? 0 : spent,
-    count: kept.length,
+    deliveredTokens: holdout ? 0 : spent,
+    shadowTokens: spent,
+    count: holdout ? 0 : kept.length,
+    candidateCount: kept.length,
+    findingIds: holdout ? [] : kept.map((finding) => finding.key),
+    shadowFindingIds: kept.map((finding) => finding.key),
     stale: kept.some((f) => f.stale),
     sessionId,
   });
@@ -297,7 +318,7 @@ export function forCommand(
   dir,
   graph,
   command,
-  { budget = touchBudget(), sessionId, alreadyInjected = new Set() } = {}
+  { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
   if (!command) return null;
 
@@ -335,7 +356,20 @@ export function forCommand(
   const considered = candidates.slice(0, MAX_COMMAND_CANDIDATES);
 
   const served = serve(graph, considered);
-  const { kept, spent } = fit(served, budget);
+  const assessed = assessFindings(dir, served, {
+    episodeId: episode.episodeId || sessionId,
+    relevanceFor: (finding) => explicit(finding) ? 1 : 0.6,
+    costFor: (finding) => estimate(render(finding)),
+  });
+  if (assessed.rejected.length) {
+    record(dir, {
+      kind: 'retrieval-decision', ...episode, sessionId,
+      surface: 'command', anchor: String(command).slice(0, 120),
+      rejected: assessed.rejected.map(({ key: findingKey, reason }) => ({ key: findingKey, reason })),
+    });
+    for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
+  }
+  const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
   if (!kept.length) return null;
 
   // THE COMMAND PATH TAKES PART IN THE HOLDOUT TOO.
@@ -353,6 +387,7 @@ export function forCommand(
 
   record(dir, {
     kind: 'inject',
+    ...episode,
     trigger: 'command',
     // The surface the report needs to keep these OUT of the file-read balance:
     // a command has no anchor that read events can be joined to.
@@ -360,7 +395,12 @@ export function forCommand(
     anchor: String(command).slice(0, 120),
     holdout,
     tokens: holdout ? 0 : spent,
+    deliveredTokens: holdout ? 0 : spent,
+    shadowTokens: spent,
     count: holdout ? 0 : kept.length,
+    candidateCount: kept.length,
+    findingIds: holdout ? [] : kept.map((finding) => finding.key),
+    shadowFindingIds: kept.map((finding) => finding.key),
     stale: kept.some((f) => f.stale),
     sessionId,
   });
@@ -509,7 +549,7 @@ export function forRepeatedAct(
   projectDir,
   command,
   crossedClasses,
-  { sessionId = null, projectRoot = null } = {}
+  { sessionId = null, projectRoot = null, episode = {} } = {}
 ) {
   if (!crossedClasses || !crossedClasses.size) return null;
 
@@ -527,14 +567,33 @@ export function forRepeatedAct(
       if (![...crossedClasses].some((c) => claimClasses.has(c))) continue;
 
       const cls = [...crossedClasses].find((c) => claimClasses.has(c));
+      const assessed = assessFindings(projectDir, [node], {
+        episodeId: episode.episodeId || sessionId,
+        relevanceFor: () => 1,
+        costFor: (finding) => estimate(render(finding)),
+      });
+      if (!assessed.eligible.length) {
+        record(projectDir, {
+          kind: 'retrieval-decision', ...episode, sessionId,
+          surface: 'shared', anchor: String(command).slice(0, 120),
+          rejected: assessed.rejected.map(({ key, reason }) => ({ key, reason })),
+        });
+        continue;
+      }
       record(projectDir, {
         kind: 'inject',
+        ...episode,
         trigger: 'repeat',
         surface: 'shared',
         anchor: String(command).slice(0, 120),
         holdout: false,
         tokens: estimate(node.claim),
+        deliveredTokens: estimate(node.claim),
+        shadowTokens: estimate(node.claim),
         count: 1,
+        candidateCount: 1,
+        findingIds: [node.key],
+        shadowFindingIds: [node.key],
         stale: false,
         sessionId,
       });
@@ -585,7 +644,10 @@ function appliesCrossProject(finding, command) {
 export function forSharedCommand(
   projectDir,
   command,
-  { budget = sharedBudget(), sessionId = null, alreadyInjected = new Set(), projectRoot = null } = {}
+  {
+    budget = sharedBudget(), sessionId = null, alreadyInjected = new Set(),
+    projectRoot = null, episode = {},
+  } = {}
 ) {
   if (!command) return null;
 
@@ -622,7 +684,21 @@ export function forSharedCommand(
     // No serve() here: these types are not content-dependent, so there is no
     // anchor to re-read and nothing to diff. serve() would spend a file read per
     // finding to answer a question that does not apply to them.
-    const { kept, spent } = fit(candidates.slice(0, MAX_SHARED), budget);
+    const considered = candidates.slice(0, MAX_SHARED);
+    const assessed = assessFindings(projectDir, considered, {
+      episodeId: episode.episodeId || sessionId,
+      relevanceFor: (finding) => explicit(finding) ? 0.8 : 0.5,
+      costFor: (finding) => estimate(render(finding)),
+    });
+    if (assessed.rejected.length) {
+      record(projectDir, {
+        kind: 'retrieval-decision', ...episode, sessionId,
+        surface: 'shared', anchor: String(command).slice(0, 120),
+        rejected: assessed.rejected.map(({ key, reason }) => ({ key, reason })),
+      });
+      for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
+    }
+    const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
     if (!kept.length) return null;
 
     // THE SAME ARM AS THE LOCAL PATH, KEYED THE SAME WAY.
@@ -644,6 +720,7 @@ export function forSharedCommand(
 
     record(projectDir, {
       kind: 'inject',
+      ...episode,
       trigger: 'command',
       // ITS OWN SURFACE. The balance sheet joins `file` injections to later read
       // events; a shared lesson has no anchor in this project to join to, and
@@ -653,7 +730,12 @@ export function forSharedCommand(
       anchor: String(command).slice(0, 120),
       holdout,
       tokens: holdout ? 0 : spent,
+      deliveredTokens: holdout ? 0 : spent,
+      shadowTokens: spent,
       count: holdout ? 0 : kept.length,
+      candidateCount: kept.length,
+      findingIds: holdout ? [] : kept.map((finding) => finding.key),
+      shadowFindingIds: kept.map((finding) => finding.key),
       stale: false,
       sessionId,
     });

--- a/integrations/qwen/hooks/lib/inject.mjs
+++ b/integrations/qwen/hooks/lib/inject.mjs
@@ -571,6 +571,10 @@ export function forRepeatedAct(
         episodeId: episode.episodeId || sessionId,
         relevanceFor: () => 1,
         costFor: (finding) => estimate(render(finding)),
+        // This surface exists specifically to re-surface a lesson once the
+        // session crosses the repeat threshold. Ordinary retrieval remains
+        // cooldown-protected; harm quarantine and utility gating still apply.
+        bypassCooldown: true,
       });
       if (!assessed.eligible.length) {
         record(projectDir, {

--- a/integrations/qwen/hooks/lib/metrics.mjs
+++ b/integrations/qwen/hooks/lib/metrics.mjs
@@ -1022,6 +1022,7 @@ function armMetrics(runs) {
     runs: runs.length,
     correctness: proportionInterval(correct, runs.length),
     uncachedInputTokens: interval('uncachedInputTokens'),
+    cacheCreationInputTokens: interval('cacheCreationInputTokens'),
     cachedInputTokens: interval('cachedInputTokens'),
     outputTokens: interval('outputTokens'),
     totalTokens: interval('totalTokens'),
@@ -1034,31 +1035,37 @@ function armMetrics(runs) {
   };
 }
 
-function pairedEffects(runs, treatmentArm) {
+function pairedEffects(runs, controlArm, treatmentArm, contrastType = 'incremental') {
   const pairs = new Map();
   for (const run of runs) {
-    if (!run.pairId || !['baseline', treatmentArm].includes(run.arm)) continue;
+    if (!run.pairId || ![controlArm, treatmentArm].includes(run.arm)) continue;
     if (!pairs.has(run.pairId)) pairs.set(run.pairId, {});
     pairs.get(run.pairId)[run.arm] = run;
   }
-  const complete = [...pairs.values()].filter((pair) => pair.baseline && pair[treatmentArm]);
+  const complete = [...pairs.values()].filter((pair) => pair[controlArm] && pair[treatmentArm]);
   const delta = (field, lowerIsBetter = true) => bootstrapMeanInterval(
     complete
       .map((pair) => {
-        const baseline = numeric(pair.baseline[field]);
+        const baseline = numeric(pair[controlArm][field]);
         const treatment = numeric(pair[treatmentArm][field]);
         if (baseline === null || treatment === null) return null;
         return lowerIsBetter ? baseline - treatment : treatment - baseline;
       })
       .filter((value) => value !== null),
-    { seed: `${treatmentArm}:${field}` }
+    { seed: `${controlArm}:${treatmentArm}:${field}` }
   );
   return {
     arm: treatmentArm,
+    controlArm,
+    comparison: `${treatmentArm} vs ${controlArm}`,
+    contrastType,
     pairs: complete.length,
     // Positive values always mean the treatment improved the metric.
     totalTokensSaved: delta('totalTokens'),
     uncachedInputTokensSaved: delta('uncachedInputTokens'),
+    cacheCreationInputTokensSaved: delta('cacheCreationInputTokens'),
+    cachedInputTokensSaved: delta('cachedInputTokens'),
+    outputTokensSaved: delta('outputTokens'),
     toolCallsAvoided: delta('toolCalls'),
     latencyMsSaved: delta('latencyMs'),
     costUsdSaved: delta('costUsd'),
@@ -1124,8 +1131,13 @@ export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
         armMetrics(cohortRuns.filter((run) => run.arm === arm)),
       ])
     );
-    const effects = ['optimizer', 'retrieval', 'full'].map((arm) => pairedEffects(cohortRuns, arm));
-    const enough = effects.some((effect) => effect.pairs >= minimumPairs);
+    const effects = [
+      pairedEffects(cohortRuns, 'baseline', 'optimizer'),
+      pairedEffects(cohortRuns, 'optimizer', 'retrieval'),
+      pairedEffects(cohortRuns, 'retrieval', 'full'),
+      pairedEffects(cohortRuns, 'baseline', 'full', 'total-system'),
+    ];
+    const enough = effects.every((effect) => effect.pairs >= minimumPairs);
     return {
       key,
       client: cohortRuns[0]?.client || 'unknown',
@@ -1165,7 +1177,8 @@ export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
     episodes: traced,
     methodology: {
       intervals: 'deterministic percentile bootstrap (95%); Wilson interval for correctness',
-      causalRule: 'only matched eval-run pairs compare an arm with baseline',
+      causalRule:
+        'matched pairs estimate optimizer vs baseline, retrieval vs optimizer, full vs retrieval, and full vs baseline',
       minimumPairs,
       deterministicChecksAreCausalProof: false,
     },

--- a/integrations/qwen/hooks/lib/metrics.mjs
+++ b/integrations/qwen/hooks/lib/metrics.mjs
@@ -61,6 +61,7 @@ const metricsPath = (dir) => join(dir, 'metrics.jsonl');
  * on it drops BOTH arms proportionally instead of starving the rare one.
  */
 const balancePath = (dir) => join(dir, 'balance.jsonl');
+const evidencePath = (dir) => join(dir, 'evidence.jsonl');
 
 /** Kinds the net balance is computed from, and which therefore must survive. */
 /**
@@ -83,6 +84,24 @@ export const BALANCE_KINDS = new Set([
   // aged out before it was written and the backstop was structurally unable to fire, reporting
   // "only N/10 refreshes observed" for the life of the project.
   'keepwarm',
+]);
+
+/**
+ * Causal records have their own bounded log.  Tool outcomes are much rarer
+ * than read/capture telemetry but more frequent than balance records; mixing
+ * them into either window would eventually evict the evidence needed to join
+ * an injection to its result.
+ */
+export const EVIDENCE_KINDS = new Set([
+  'inject',
+  'harvest',
+  'tool-outcome',
+  'episode-outcome',
+  'eval-run',
+  'finding-feedback',
+  'retrieval-decision',
+  'mcp-client',
+  'mcp-tool',
 ]);
 
 /**
@@ -198,15 +217,30 @@ export function record(dir, event) {
     // single millisecond collapsed to ONE, so a graph with ample data reported
     // 'insufficient data (2 treated, 1 holdout)'. Real events were being
     // discarded by the deduplicator, silently.
-    const line =
-      JSON.stringify({ id: nextId(), ...event, at: event.at ?? Date.now() }) + '\n';
+    const id = event.id || nextId();
+    const complete = {
+      schemaVersion: event.schemaVersion || 2,
+      id,
+      ...event,
+      // An injection id is first-class rather than an inference from the log
+      // record id.  Exporters may rewrite record ids while preserving causal
+      // identity, and downstream tool outcomes refer to this value explicitly.
+      ...(event.kind === 'inject'
+        ? { injectionId: event.injectionId || id }
+        : {}),
+      at: event.at ?? Date.now(),
+    };
+    const line = JSON.stringify(complete) + '\n';
     appendFileSync(metricsPath(dir), line);
     // Balance-critical records go to their own log as well, so the windows on
     // the firehose can never starve the measurement. Written SECOND: a torn
     // write here costs a duplicate the reader dedupes, not a lost event.
     if (BALANCE_KINDS.has(event.kind)) appendFileSync(balancePath(dir), line);
+    if (EVIDENCE_KINDS.has(event.kind)) appendFileSync(evidencePath(dir), line);
+    return complete;
   } catch {
     // Metrics must never break a tool call.
+    return null;
   }
 }
 
@@ -402,6 +436,92 @@ export function readBalance(dir) {
     out.push(e);
   }
   return out;
+}
+
+/** Every causal evidence record inside the byte cap, deduplicated by id. */
+export function readEvidence(dir) {
+  const path = evidencePath(dir);
+  if (!existsSync(path)) return [];
+
+  let text = '';
+  try {
+    const { size } = statSync(path);
+    if (size <= MAX_BYTES) {
+      text = readFileSync(path, 'utf8');
+    } else {
+      const fd = openSync(path, 'r');
+      try {
+        const buffer = Buffer.allocUnsafe(MAX_BYTES);
+        const read = readSync(fd, buffer, 0, MAX_BYTES, size - MAX_BYTES);
+        text = buffer.subarray(0, read).toString('utf8');
+      } finally {
+        closeSync(fd);
+      }
+      text = text.slice(text.indexOf('\n') + 1);
+    }
+  } catch {
+    return [];
+  }
+
+  const seen = new Set();
+  const out = [];
+  for (const line of text.split('\n')) {
+    if (!line) continue;
+    try {
+      const event = JSON.parse(line);
+      if (!EVIDENCE_KINDS.has(event.kind)) continue;
+      const id = event.id || JSON.stringify(event);
+      if (seen.has(id)) continue;
+      seen.add(id);
+      out.push(event);
+    } catch {
+      // A concurrently appended final line may be torn.  It costs one record,
+      // never the user's tool call or the rest of the evidence report.
+    }
+  }
+  return out;
+}
+
+/**
+ * Joins a post-tool result to the most recent matching injection.  The exact
+ * tool-call id wins; clients that omit it fall back to episode + surface +
+ * anchor, in timestamp order, and the report states the weaker join method.
+ */
+export function recordToolOutcome(dir, outcome) {
+  const evidence = readEvidence(dir);
+  const anchor = String(outcome.anchor || '').slice(0, 120);
+  const candidates = evidence
+    .filter((event) => event.kind === 'inject' && event.episodeId === outcome.episodeId)
+    .filter((event) => {
+      if (outcome.toolCallId && event.toolCallId)
+        return String(event.toolCallId) === String(outcome.toolCallId);
+      return event.surface === outcome.surface && String(event.anchor || '').slice(0, 120) === anchor;
+    })
+    .sort((a, b) => (b.at || 0) - (a.at || 0));
+  const injection = candidates[0] || null;
+  const joinMethod = injection
+    ? (outcome.toolCallId && injection.toolCallId ? 'tool-call-id' : 'episode-anchor')
+    : 'none';
+
+  return record(dir, {
+    kind: 'tool-outcome',
+    ...outcome,
+    anchor,
+    injectionId: injection?.injectionId || null,
+    findingIds: injection?.findingIds || [],
+    joinMethod,
+  });
+}
+
+export function recordEpisodeOutcome(dir, outcome) {
+  return record(dir, { kind: 'episode-outcome', ...outcome });
+}
+
+export function recordFindingFeedback(dir, feedback) {
+  const rating = ['helpful', 'neutral', 'harmful'].includes(feedback?.rating)
+    ? feedback.rating
+    : 'neutral';
+  return record(dir, { kind: 'finding-feedback', ...feedback, rating });
 }
 
 /**
@@ -813,4 +933,241 @@ export function indexBudget(dir, { floor = 150, base = 300, ceiling = 1200 } = {
   // 0% hit rate falls to the floor; ~50% and above reaches the ceiling.
   const scaled = Math.round(floor + (ceiling - floor) * Math.min(1, hitRate * 2));
   return Math.max(floor, Math.min(ceiling, scaled));
+}
+
+/* ----------------------------------------------------------------------
+ * Episode-level causal evidence
+ * ------------------------------------------------------------------- */
+
+const numeric = (value) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const average = (values) => {
+  const finite = values.map(numeric).filter((value) => value !== null);
+  return finite.length
+    ? finite.reduce((sum, value) => sum + value, 0) / finite.length
+    : null;
+};
+
+/** Deterministic PRNG so regenerating a report does not move its interval. */
+function seededRandom(seedText) {
+  let seed = 2166136261;
+  for (const char of String(seedText)) {
+    seed ^= char.charCodeAt(0);
+    seed = Math.imul(seed, 16777619);
+  }
+  return () => {
+    seed += 0x6d2b79f5;
+    let value = seed;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Percentile bootstrap interval for a mean, paired delta, or other scalar. */
+export function bootstrapMeanInterval(values, { samples = 1000, seed = 'token-optimizer' } = {}) {
+  const finite = values.map(numeric).filter((value) => value !== null);
+  if (!finite.length) return { mean: null, low: null, high: null, n: 0 };
+  if (finite.length === 1) {
+    return { mean: finite[0], low: finite[0], high: finite[0], n: 1 };
+  }
+
+  const random = seededRandom(`${seed}:${finite.join(',')}`);
+  const means = [];
+  for (let sample = 0; sample < samples; sample++) {
+    let total = 0;
+    for (let index = 0; index < finite.length; index++) {
+      total += finite[Math.floor(random() * finite.length)];
+    }
+    means.push(total / finite.length);
+  }
+  means.sort((a, b) => a - b);
+  return {
+    mean: average(finite),
+    low: means[Math.floor(means.length * 0.025)],
+    high: means[Math.min(means.length - 1, Math.floor(means.length * 0.975))],
+    n: finite.length,
+  };
+}
+
+/** Wilson interval keeps small correctness samples honest and inside 0..1. */
+export function proportionInterval(successes, total, z = 1.96) {
+  if (!total) return { rate: null, low: null, high: null, n: 0 };
+  const rate = successes / total;
+  const denominator = 1 + (z * z) / total;
+  const centre = (rate + (z * z) / (2 * total)) / denominator;
+  const radius =
+    (z / denominator) * Math.sqrt((rate * (1 - rate)) / total + (z * z) / (4 * total * total));
+  return { rate, low: Math.max(0, centre - radius), high: Math.min(1, centre + radius), n: total };
+}
+
+const cohortKey = (run) => [
+  run.client || 'unknown',
+  run.clientVersion || 'unknown',
+  run.model || 'unknown',
+  run.modelVersion || 'unknown',
+  run.taskId || 'unknown',
+].join('|');
+
+function armMetrics(runs) {
+  const correct = runs.filter((run) => run.correct === true).length;
+  const interval = (field) => bootstrapMeanInterval(
+    runs.map((run) => run[field]).filter((value) => numeric(value) !== null),
+    { seed: field }
+  );
+  return {
+    runs: runs.length,
+    correctness: proportionInterval(correct, runs.length),
+    uncachedInputTokens: interval('uncachedInputTokens'),
+    cachedInputTokens: interval('cachedInputTokens'),
+    outputTokens: interval('outputTokens'),
+    totalTokens: interval('totalTokens'),
+    toolCalls: interval('toolCalls'),
+    failedToolCalls: interval('failedToolCalls'),
+    latencyMs: interval('latencyMs'),
+    costUsd: interval('costUsd'),
+    injectedTokens: interval('injectedTokens'),
+    harmfulFindings: runs.reduce((sum, run) => sum + (numeric(run.harmfulFindings) || 0), 0),
+  };
+}
+
+function pairedEffects(runs, treatmentArm) {
+  const pairs = new Map();
+  for (const run of runs) {
+    if (!run.pairId || !['baseline', treatmentArm].includes(run.arm)) continue;
+    if (!pairs.has(run.pairId)) pairs.set(run.pairId, {});
+    pairs.get(run.pairId)[run.arm] = run;
+  }
+  const complete = [...pairs.values()].filter((pair) => pair.baseline && pair[treatmentArm]);
+  const delta = (field, lowerIsBetter = true) => bootstrapMeanInterval(
+    complete
+      .map((pair) => {
+        const baseline = numeric(pair.baseline[field]);
+        const treatment = numeric(pair[treatmentArm][field]);
+        if (baseline === null || treatment === null) return null;
+        return lowerIsBetter ? baseline - treatment : treatment - baseline;
+      })
+      .filter((value) => value !== null),
+    { seed: `${treatmentArm}:${field}` }
+  );
+  return {
+    arm: treatmentArm,
+    pairs: complete.length,
+    // Positive values always mean the treatment improved the metric.
+    totalTokensSaved: delta('totalTokens'),
+    uncachedInputTokensSaved: delta('uncachedInputTokens'),
+    toolCallsAvoided: delta('toolCalls'),
+    latencyMsSaved: delta('latencyMs'),
+    costUsdSaved: delta('costUsd'),
+    correctnessDelta: delta('correct', false),
+  };
+}
+
+function matchesFilters(event, filters) {
+  for (const field of ['client', 'clientVersion', 'model', 'modelVersion', 'taskId', 'arm']) {
+    if (filters[field] && String(event[field] || '') !== String(filters[field])) return false;
+  }
+  return true;
+}
+
+/**
+ * The dashboard-facing evidence console.  Deterministic fixture verification,
+ * live hook traces, and randomized model evals remain visibly distinct: only
+ * `eval-run` records with paired arms can produce a causal effect interval.
+ */
+export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
+  const evidence = readEvidence(dir).filter((event) => matchesFilters(event, filters));
+  const runs = evidence.filter((event) => event.kind === 'eval-run');
+  const injections = evidence.filter((event) => event.kind === 'inject');
+  const outcomes = evidence.filter((event) => event.kind === 'tool-outcome');
+  const feedback = evidence.filter((event) => event.kind === 'finding-feedback');
+
+  const byInjection = new Map(
+    outcomes.filter((event) => event.injectionId).map((event) => [event.injectionId, event])
+  );
+  const traced = injections
+    .slice()
+    .sort((a, b) => (b.at || 0) - (a.at || 0))
+    .slice(0, Math.max(1, Math.min(500, episodeLimit)))
+    .map((injection) => ({
+      injectionId: injection.injectionId,
+      episodeId: injection.episodeId || injection.sessionId || null,
+      at: injection.at,
+      arm: injection.arm || (injection.holdout ? 'holdout' : 'treated'),
+      client: injection.client || 'unknown',
+      clientVersion: injection.clientVersion || null,
+      model: injection.model || null,
+      taskId: injection.taskId || null,
+      surface: injection.surface || injection.trigger || 'file',
+      anchor: injection.anchor,
+      findingIds: injection.findingIds || [],
+      deliveredTokens: injection.deliveredTokens ?? injection.tokens ?? 0,
+      shadowTokens: injection.shadowTokens ?? injection.tokens ?? 0,
+      outcome: byInjection.get(injection.injectionId) || null,
+    }));
+
+  const grouped = new Map();
+  for (const run of runs) {
+    const key = cohortKey(run);
+    if (!grouped.has(key)) grouped.set(key, []);
+    grouped.get(key).push(run);
+  }
+
+  const minimumPairs = Math.max(2, Number(process.env.TOKEN_OPTIMIZER_EVAL_MIN_PAIRS) || 5);
+  const cohorts = [...grouped.entries()].map(([key, cohortRuns]) => {
+    const arms = Object.fromEntries(
+      ['baseline', 'optimizer', 'retrieval', 'full'].map((arm) => [
+        arm,
+        armMetrics(cohortRuns.filter((run) => run.arm === arm)),
+      ])
+    );
+    const effects = ['optimizer', 'retrieval', 'full'].map((arm) => pairedEffects(cohortRuns, arm));
+    const enough = effects.some((effect) => effect.pairs >= minimumPairs);
+    return {
+      key,
+      client: cohortRuns[0]?.client || 'unknown',
+      clientVersion: cohortRuns[0]?.clientVersion || null,
+      model: cohortRuns[0]?.model || null,
+      modelVersion: cohortRuns[0]?.modelVersion || null,
+      taskId: cohortRuns[0]?.taskId || null,
+      arms,
+      effects,
+      evidenceStatus: enough
+        ? 'causal estimate available'
+        : `insufficient paired runs (need ${minimumPairs})`,
+    };
+  });
+
+  const joined = injections.filter((injection) =>
+    byInjection.has(injection.injectionId)
+  ).length;
+  const harmful = feedback.filter((event) => event.rating === 'harmful').length;
+  return {
+    schemaVersion: 2,
+    generatedAt: new Date().toISOString(),
+    filters,
+    summary: {
+      liveInjections: injections.length,
+      joinedOutcomes: joined,
+      causalJoinCoverage: injections.length ? joined / injections.length : null,
+      evalRuns: runs.length,
+      cohorts: cohorts.length,
+      harmfulFeedback: harmful,
+      harmRate: feedback.length ? harmful / feedback.length : null,
+      evidenceStatus: cohorts.some((cohort) => cohort.evidenceStatus === 'causal estimate available')
+        ? 'causal estimates available'
+        : 'insufficient randomized evidence',
+    },
+    cohorts,
+    episodes: traced,
+    methodology: {
+      intervals: 'deterministic percentile bootstrap (95%); Wilson interval for correctness',
+      causalRule: 'only matched eval-run pairs compare an arm with baseline',
+      minimumPairs,
+      deterministicChecksAreCausalProof: false,
+    },
+  };
 }

--- a/integrations/qwen/hooks/lib/recording.mjs
+++ b/integrations/qwen/hooks/lib/recording.mjs
@@ -159,6 +159,9 @@ export function semanticHarvestPrompt({
     + ' If this work produced a durable, non-obvious conclusion -- a failed approach and why, '
     + 'a decision and its rejected alternative, or a command that finally worked -- call '
     + 'wiki_write now with a real file anchor. Do not delegate this to another model or an '
-    + 'external harvester. If there is no such conclusion, do not invent one; finish normally.'
+    + 'external harvester. Include: the concrete evidence, when the finding applies, a calibrated '
+    + 'confidenceLabel (verified/probable/speculative), its project/organization/global scope, '
+    + 'and anything that would invalidate it. If there is no such conclusion, do not invent one; '
+    + 'finish normally.'
   );
 }

--- a/integrations/qwen/hooks/lib/utility.mjs
+++ b/integrations/qwen/hooks/lib/utility.mjs
@@ -1,0 +1,135 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/utility.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Evidence-aware retrieval economics.
+ *
+ * Relevance alone is not enough: a true finding can still cost more context
+ * than it saves.  Every candidate receives a conservative expected-benefit
+ * estimate, its delivery cost and risk are subtracted, and harmful findings
+ * are quarantined from automatic delivery while remaining visible for audit.
+ */
+
+import { readEvidence } from './metrics.mjs';
+
+const DAY = 86_400_000;
+const ORIGIN_WEIGHT = { human: 1.2, agent: 1.08, harvested: 1 };
+
+const envNumber = (name, fallback) => {
+  const value = Number(process.env[name]);
+  return Number.isFinite(value) && value >= 0 ? value : fallback;
+};
+
+export const retrievalPolicy = () => ({
+  baseBenefitTokens: envNumber('TOKEN_OPTIMIZER_EXPECTED_BENEFIT_TOKENS', 400),
+  minimumNetUtility: envNumber('TOKEN_OPTIMIZER_MIN_EXPECTED_UTILITY', 20),
+  cooldownMs: envNumber('TOKEN_OPTIMIZER_INJECTION_COOLDOWN_MS', 60_000),
+  quarantineHarmCount: Math.max(1, envNumber('TOKEN_OPTIMIZER_QUARANTINE_HARM_COUNT', 2)),
+});
+
+function feedbackFor(events, key) {
+  return events.filter((event) =>
+    event.kind === 'finding-feedback'
+    && (event.findingId === key || (event.findingIds || []).includes(key))
+  );
+}
+
+function outcomesFor(events, key) {
+  return events.filter((event) =>
+    event.kind === 'tool-outcome' && (event.findingIds || []).includes(key)
+  );
+}
+
+function deliveredRecently(events, key, episodeId, now, cooldownMs) {
+  if (!episodeId || cooldownMs <= 0) return false;
+  return events.some((event) =>
+    event.kind === 'inject'
+    && event.episodeId === episodeId
+    && (event.findingIds || []).includes(key)
+    && !event.holdout
+    && now - (event.at || 0) < cooldownMs
+  );
+}
+
+/**
+ * Returns eligible candidates in utility order plus every rejection reason.
+ * `costFor` is supplied by inject.mjs so the gate prices the exact rendered
+ * text rather than a second approximation that could drift.
+ */
+export function assessFindings(
+  dir,
+  findings,
+  {
+    relevanceFor = () => 1,
+    costFor = () => 0,
+    episodeId = null,
+    now = Date.now(),
+    policy = retrievalPolicy(),
+  } = {}
+) {
+  const events = readEvidence(dir);
+  const eligible = [];
+  const rejected = [];
+
+  for (const finding of findings) {
+    const key = finding.key;
+    const feedback = feedbackFor(events, key);
+    const outcomes = outcomesFor(events, key);
+    const helpful = feedback.filter((event) => event.rating === 'helpful').length;
+    const neutral = feedback.filter((event) => event.rating === 'neutral').length;
+    const harmful = feedback.filter((event) => event.rating === 'harmful').length;
+    const successfulUses = outcomes.filter((event) => event.success === true).length;
+    const failedUses = outcomes.filter((event) => event.success === false).length;
+
+    if (harmful >= policy.quarantineHarmCount && harmful >= helpful + neutral) {
+      rejected.push({ key, reason: 'quarantined-harm', helpful, neutral, harmful });
+      continue;
+    }
+    if (deliveredRecently(events, key, episodeId, now, policy.cooldownMs)) {
+      rejected.push({ key, reason: 'cooldown' });
+      continue;
+    }
+
+    const confidence = Number.isFinite(finding.confidence) ? finding.confidence : 0.5;
+    const relevance = Math.max(0, Math.min(1, Number(relevanceFor(finding)) || 0));
+    const ageDays = Math.max(0, (now - (finding.at || now)) / DAY);
+    const recency = finding.pinned ? 1 : Math.pow(0.5, ageDays / 90);
+    const provenance = ORIGIN_WEIGHT[finding.origin] || 1;
+    // Outcome evidence moves the estimate gradually. Explicit harmful feedback
+    // is handled above; a failed command alone is not labelled harmful because
+    // the model may have ignored correct advice.
+    const observed = successfulUses + failedUses;
+    const successFactor = observed
+      ? 0.75 + 0.5 * (successfulUses / observed)
+      : 1;
+    const feedbackFactor = Math.max(0.25, 1 + helpful * 0.12 - harmful * 0.35);
+    const expectedBenefit =
+      policy.baseBenefitTokens * confidence * relevance * recency * provenance * successFactor * feedbackFactor;
+    const deliveryCost = Math.max(0, Number(costFor(finding)) || 0);
+    const riskPenalty =
+      (finding.stale ? 160 : 0)
+      + (finding.confidenceLabel === 'speculative' ? 100 : 0)
+      + harmful * 100;
+    const netUtility = expectedBenefit - deliveryCost - riskPenalty;
+
+    const assessed = {
+      finding,
+      expectedBenefit,
+      deliveryCost,
+      riskPenalty,
+      netUtility,
+      helpful,
+      neutral,
+      harmful,
+      successfulUses,
+      failedUses,
+    };
+    if (netUtility < policy.minimumNetUtility) {
+      rejected.push({ key, reason: 'negative-expected-value', ...assessed, finding: undefined });
+      continue;
+    }
+    eligible.push(assessed);
+  }
+
+  eligible.sort((a, b) => b.netUtility - a.netUtility);
+  return { eligible, rejected };
+}

--- a/integrations/qwen/hooks/lib/utility.mjs
+++ b/integrations/qwen/hooks/lib/utility.mjs
@@ -64,6 +64,7 @@ export function assessFindings(
     episodeId = null,
     now = Date.now(),
     policy = retrievalPolicy(),
+    bypassCooldown = false,
   } = {}
 ) {
   const events = readEvidence(dir);
@@ -84,7 +85,7 @@ export function assessFindings(
       rejected.push({ key, reason: 'quarantined-harm', helpful, neutral, harmful });
       continue;
     }
-    if (deliveredRecently(events, key, episodeId, now, policy.cooldownMs)) {
+    if (!bypassCooldown && deliveredRecently(events, key, episodeId, now, policy.cooldownMs)) {
       rejected.push({ key, reason: 'cooldown' });
       continue;
     }

--- a/integrations/qwen/hooks/lib/wire.mjs
+++ b/integrations/qwen/hooks/lib/wire.mjs
@@ -28,7 +28,7 @@ export const MARKER = 'token-optimizer';
 /** The events we wire, and which hook file serves each. */
 export const WIRING = [
   { event: 'SessionStart', file: 'session-start.mjs', matcher: null },
-  { event: 'PreToolUse', file: 'pretooluse-router.mjs', matcher: 'Read|Grep|Glob|Edit|MultiEdit|Write|Bash' },
+  { event: 'PreToolUse', file: 'pretooluse-router.mjs', matcher: 'Read|Grep|Glob|Edit|MultiEdit|Write|Bash|PowerShell' },
   { event: 'PreCompact', file: 'precompact-optimize.mjs', matcher: null },
 ];
 

--- a/integrations/roo/token-optimizer.md
+++ b/integrations/roo/token-optimizer.md
@@ -25,6 +25,10 @@ LIVE GRAPH — THE ACTIVE MODEL DOES THE SEMANTIC HARVEST:
   command that finally worked.
 - Anchor every claim to a real file path or path#symbol. Never invent a claim
   merely to populate the graph, and do not delegate harvesting to another model.
+- Include the concrete evidence, when it applies, confidenceLabel
+  (verified/probable/speculative), scope (project/organization/global), and any
+  condition that would invalidate it. Use project scope unless transfer is
+  genuinely justified.
 - Before finishing substantive work, reflect once and write any still-unrecorded
   conclusion while you hold the reasoning. This is what makes the lesson
   available across sessions and projects instead of losing it to compaction.

--- a/integrations/windsurf/hooks/lib/adapter.mjs
+++ b/integrations/windsurf/hooks/lib/adapter.mjs
@@ -31,7 +31,9 @@ import {
   readCostBytes,
   touchedFiles,
 } from './decide.mjs';
-import { recordRead, fingerprint } from './metrics.mjs';
+import {
+  recordRead, fingerprint, recordToolOutcome, recordEpisodeOutcome,
+} from './metrics.mjs';
 import {
   contentHash,
   harvest,
@@ -57,6 +59,8 @@ import { isFsSafePath } from './paths.mjs';
 import {
   isSubstantive, recordingNudge, semanticHarvestPrompt,
 } from './recording.mjs';
+import { nativeClientProfiles } from './capabilities.mjs';
+import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 
 /**
  * Per-client capability.
@@ -65,41 +69,7 @@ import {
  * it true where the client has no pre-execution veto would make the product
  * claim enforcement it cannot deliver.
  */
-export const CLIENTS = {
-  'claude-code': { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  codex: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  cline: {
-    canDeny: true,
-    contextStyle: 'cline',
-    denyStyle: 'cline',
-    stopDecision: 'block',
-  },
-  copilot: {
-    canDeny: true,
-    contextStyle: 'top-level',
-    denyStyle: 'top-level-permission',
-    stopDecision: 'block',
-  },
-  cursor: {
-    canDeny: true,
-    contextStyle: 'cursor',
-    denyStyle: 'cursor',
-    stopStyle: 'followup',
-    stopDecision: 'block',
-  },
-  // Gemini's BeforeTool and AfterAgent decisions are top-level. Treating it
-  // like Codex produced well-formed JSON that Gemini ignored.
-  gemini: { canDeny: true, denyStyle: 'top-level', stopDecision: 'deny' },
-  kilo: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  opencode: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  qwen: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  windsurf: {
-    canDeny: true,
-    contextStyle: 'silent',
-    denyStyle: 'exit-2',
-    stopDecision: 'block',
-  },
-};
+export const CLIENTS = nativeClientProfiles();
 
 /** Never synchronously hash an unbounded build artifact on a hook path. */
 const HARVEST_MAX_BYTES =
@@ -135,6 +105,24 @@ export function mutationSucceeded(clientName, raw) {
   // or are called by our in-process bridge only from its successful after hook.
   return new Set(['claude-code', 'qwen', 'opencode', 'kilo', 'windsurf'])
     .has(clientName);
+}
+
+/** Conservative success classification for any completed tool call. */
+export function toolSucceeded(raw) {
+  if (raw?.error || raw?.tool_response?.error || raw?.toolResponse?.error)
+    return false;
+  if (raw?.postToolUse?.success === false || raw?.success === false) return false;
+  const status =
+    raw?.tool_response?.status ?? raw?.toolResponse?.status ??
+    raw?.tool_result?.status ?? raw?.toolResult?.status;
+  if (status !== undefined) {
+    if (/^(?:error|failed|failure|cancelled|canceled|denied)$/i.test(String(status))) return false;
+    if (/^(?:ok|success|succeeded|complete|completed)$/i.test(String(status))) return true;
+  }
+  // A post-tool lifecycle event is evidence that the call completed, but not
+  // that its output proved the task.  `success` here is deliberately scoped to
+  // the tool call; task correctness comes only from an eval grader.
+  return true;
 }
 
 function contextOutput(client, eventName, additionalContext) {
@@ -253,8 +241,10 @@ refused.
 
 Worth recording: a decision and why the alternative was rejected, a failure and
 what actually caused it, a command that turned out to be the one that works.
-Not worth recording: what the code plainly says. Prefer the thing someone had to
-work out, because that exists nowhere in the source tree.${projectBriefing()}`;
+Not worth recording: what the code plainly says. Every wiki_write must include
+the concrete evidence, when it applies, a calibrated confidence label, its
+scope, and what would invalidate it. Prefer the thing someone had to work out,
+because that exists nowhere in the source tree.${projectBriefing()}`;
 }
 
 /**
@@ -315,7 +305,7 @@ function projectBriefing() {
  * metrics. It never called forTouch/forCommand, so four advertised clients
  * accumulated a graph that their active model could not receive.
  */
-function observeAndInject(payload, state) {
+function observeAndInject(payload, state, episode, features) {
   const touched = touchedFiles(payload);
   const dirFor = (path) => wikiDir(projectRootFor(path, payload.cwd));
 
@@ -344,45 +334,51 @@ function observeAndInject(payload, state) {
   state.injected = state.injected || [];
   const alreadyInjected = new Set(state.injected);
 
-  for (const { path } of touched) {
-    const dir = dirFor(path);
-    const note = forTouch(dir, load(dir), path, {
-      sessionId: payload.session_id,
-      alreadyInjected,
-    });
-    if (note) parts.push(note);
-  }
+  if (features.retrieval) {
+    for (const { path } of touched) {
+      const dir = dirFor(path);
+      const note = forTouch(dir, load(dir), path, {
+        sessionId: payload.session_id,
+        alreadyInjected,
+        episode,
+      });
+      if (note) parts.push(note);
+    }
 
-  const command = payload.tool_input?.command;
-  if (command) {
-    const root = commandProjectRoot(payload, payload.cwd);
-    const dir = wikiDir(root);
-    const local = forCommand(dir, load(dir), command, {
-      sessionId: payload.session_id,
-      alreadyInjected,
-    });
-    if (local) parts.push(local);
+    const command = payload.tool_input?.command;
+    if (command) {
+      const root = commandProjectRoot(payload, payload.cwd);
+      const dir = wikiDir(root);
+      const local = forCommand(dir, load(dir), command, {
+        sessionId: payload.session_id,
+        alreadyInjected,
+        episode,
+      });
+      if (local) parts.push(local);
 
-    const shared = forSharedCommand(dir, command, {
-      sessionId: payload.session_id,
-      alreadyInjected,
-      projectRoot: root,
-    });
-    if (shared) parts.push(shared);
+      const shared = forSharedCommand(dir, command, {
+        sessionId: payload.session_id,
+        alreadyInjected,
+        projectRoot: root,
+        episode,
+      });
+      if (shared) parts.push(shared);
 
-    const crossed = noteActClasses(state, command);
-    const repeated = forRepeatedAct(dir, command, crossed, {
-      sessionId: payload.session_id,
-      projectRoot: root,
-    });
-    if (repeated) parts.push(repeated);
+      const crossed = noteActClasses(state, command);
+      const repeated = forRepeatedAct(dir, command, crossed, {
+        sessionId: payload.session_id,
+        projectRoot: root,
+        episode,
+      });
+      if (repeated) parts.push(repeated);
+    }
   }
   state.injected = [...alreadyInjected];
 
   // Structural capture is evidence about what was touched, not a semantic
   // conclusion. It is therefore safe to automate for every client and leaves
   // the active model responsible for wiki_write at completion.
-  for (const { path, size } of touched) {
+  if (features.capture) for (const { path, size } of touched) {
     try {
       if (isArchived(path) || size > HARVEST_MAX_BYTES || !isFsSafePath(path))
         continue;
@@ -420,7 +416,10 @@ export async function run(clientName, event) {
 
   if (mode() === MODE_OFF) process.exit(0);
 
+  const features = featuresForArm();
+
   if (event === 'session-start') {
+    if (!features.routing && !features.retrieval && !features.harvest) process.exit(0);
     const output = contextOutput(client, eventName, policyText(client.canDeny));
     if (output) emit(output);
     process.exit(0);
@@ -437,10 +436,22 @@ export async function run(clientName, event) {
     const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? 'default';
     const agentScope = raw.transcript_path ?? raw.transcriptPath ?? null;
     const state = loadState(sessionId, agentScope);
+    const episode = episodeMeta({ client: clientName, raw });
+    try {
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+      recordEpisodeOutcome(dir, {
+        ...episode,
+        status: 'completed',
+        ...usageFrom(raw),
+      });
+    } catch {
+      // Evidence is best effort and must never stop a session from finishing.
+    }
     const alreadyHarvested =
       Number(state.edits || 0) > 0 &&
       Number(state.harvestedEdits || 0) >= Number(state.edits || 0);
-    const prompt = semanticHarvestPrompt({
+    const prompt = features.harvest ? semanticHarvestPrompt({
       edits: state.edits,
       files: state.editedFiles,
       model: raw.model,
@@ -449,7 +460,7 @@ export async function run(clientName, event) {
         raw.stopHookActive === true ||
         alreadyHarvested ||
         (clientName === 'cursor' && Number(raw.loop_count || 0) > 0),
-    });
+    }) : null;
     if (prompt) {
       state.harvestedEdits = Number(state.edits || 0);
       saveState(sessionId, state, agentScope);
@@ -466,6 +477,7 @@ export async function run(clientName, event) {
     process.exit(0);
   const payload = normalizePayload(normalizeClientPayload(clientName, event, raw));
   if (!payload.tool_name) process.exit(0);
+  const episode = episodeMeta({ client: clientName, raw, payload });
 
   // THE AGENT, not just the session -- the same scope the Claude Code router
   // applies. Subagents inherit the parent's session id, so keying state on the
@@ -506,17 +518,41 @@ export async function run(clientName, event) {
       const anchor = state.editedFiles[0]
         || join(payload.cwd || process.cwd(), '__recording__');
       const dir = wikiDir(projectRootFor(anchor, payload.cwd));
-      recordingContext = recordingNudge(dir, {
+      recordingContext = features.harvest ? recordingNudge(dir, {
         state,
         edits: state.edits,
         files: state.editedFiles,
-      });
+      }) : null;
       if (recordingContext) state.recordingNudged = true;
     } catch {
       // Recording pressure is an optimization and must never cost a tool call.
     }
   }
-  const verdict = decide(payload, state);
+  if (event === 'post-tool') {
+    try {
+      const command = payload.tool_input?.command;
+      const touched = touchedFiles(payload);
+      const anchor = command
+        ? String(command).slice(0, 120)
+        : touched[0]?.path || payload.tool_input?.file_path || '';
+      const root = command
+        ? commandProjectRoot(payload, payload.cwd)
+        : projectRootFor(anchor || join(payload.cwd || process.cwd(), '__tool__'), payload.cwd);
+      recordToolOutcome(wikiDir(root), {
+        ...episode,
+        surface: command ? 'command' : 'file',
+        anchor,
+        toolName: payload.tool_name,
+        success: toolSucceeded(raw),
+        durationMs: Number(raw.duration_ms ?? raw.durationMs ?? raw.elapsed_ms ?? raw.elapsedMs) || null,
+        ...usageFrom(raw),
+      });
+    } catch {
+      // Causal tracing is fail-open like every other hook optimization.
+    }
+  }
+
+  const verdict = features.routing ? decide(payload, state) : null;
   const repeat = verdict && event === 'pre-tool'
     ? alreadyDenied(state, verdict.key)
     : false;
@@ -571,7 +607,7 @@ export async function run(clientName, event) {
   remember(payload, state);
   let graphContext = null;
   try {
-    graphContext = observeAndInject(payload, state);
+    graphContext = observeAndInject(payload, state, episode, features);
   } catch {
     // Delivery is an optimization. Fail open.
   }

--- a/integrations/windsurf/hooks/lib/capabilities.mjs
+++ b/integrations/windsurf/hooks/lib/capabilities.mjs
@@ -1,0 +1,130 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/capabilities.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * The product's honest cross-client capability contract.
+ *
+ * A client is listed at the strongest surface its public lifecycle protocol can
+ * actually support.  This registry is consumed by the adapter, certification
+ * tooling, and evidence reports so a rules-only integration can never be
+ * presented as equivalent to a native stop-continuation integration.
+ */
+
+export const CAPABILITY_TIERS = Object.freeze({
+  CONTINUATION: 'lifecycle-continuation',
+  OBSERVATION: 'native-observation',
+  RULES: 'mcp-rules',
+});
+
+const native = (profile) => ({
+  structuralCapture: 'native',
+  findingDelivery: 'native',
+  routing: 'native-veto',
+  ...profile,
+});
+
+export const CLIENT_CAPABILITIES = Object.freeze({
+  'claude-code': native({
+    name: 'Claude Code', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-continuation', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  codex: native({
+    name: 'Codex', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-continuation', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  copilot: native({
+    name: 'GitHub Copilot CLI', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'agent-stop-continuation', canDeny: true,
+    contextStyle: 'top-level', denyStyle: 'top-level-permission', stopDecision: 'block',
+  }),
+  gemini: native({
+    name: 'Gemini CLI', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'after-agent-retry', canDeny: true,
+    denyStyle: 'top-level', stopDecision: 'deny',
+  }),
+  qwen: native({
+    name: 'Qwen Code', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-continuation', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  cursor: native({
+    name: 'Cursor', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-followup', canDeny: true,
+    contextStyle: 'cursor', denyStyle: 'cursor', stopStyle: 'followup', stopDecision: 'block',
+  }),
+  cline: native({
+    name: 'Cline', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    contextStyle: 'cline', denyStyle: 'cline', stopDecision: 'block',
+  }),
+  opencode: native({
+    name: 'OpenCode', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  kilo: native({
+    name: 'Kilo', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  windsurf: native({
+    name: 'Windsurf', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    contextStyle: 'silent', denyStyle: 'exit-2', stopDecision: 'block',
+  }),
+  roo: {
+    name: 'Roo Code', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  zed: {
+    name: 'Zed', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  amp: {
+    name: 'Amp', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  continue: {
+    name: 'Continue', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  crush: {
+    name: 'Crush', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  droid: {
+    name: 'Droid (Factory)', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+});
+
+export function capabilityFor(client) {
+  return CLIENT_CAPABILITIES[String(client || '').toLowerCase()] || null;
+}
+
+export function nativeClientProfiles() {
+  return Object.fromEntries(
+    Object.entries(CLIENT_CAPABILITIES)
+      .filter(([, profile]) => profile.structuralCapture === 'native')
+      .map(([key, profile]) => [key, { ...profile }])
+  );
+}
+
+export function capabilitySummary() {
+  return Object.entries(CLIENT_CAPABILITIES).map(([client, profile]) => ({
+    client,
+    name: profile.name,
+    tier: profile.tier,
+    routing: profile.routing,
+    structuralCapture: profile.structuralCapture,
+    findingDelivery: profile.findingDelivery,
+    semanticHarvest: profile.semanticHarvest,
+  }));
+}

--- a/integrations/windsurf/hooks/lib/decide.mjs
+++ b/integrations/windsurf/hooks/lib/decide.mjs
@@ -513,6 +513,8 @@ const TOOL_ALIASES = new Map(
     create_file: 'Write',
 
     bash: 'Bash',
+    powershell: 'Bash',
+    pwsh: 'Bash',
     shell: 'Bash',
     run_command: 'Bash',
     execute_command: 'Bash',

--- a/integrations/windsurf/hooks/lib/experiment.mjs
+++ b/integrations/windsurf/hooks/lib/experiment.mjs
@@ -1,0 +1,82 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/experiment.mjs. Regenerate with `npm run sync:hooks`.
+/** Explicit, reproducible feature arms and causal episode identity. */
+
+export const EXPERIMENT_ARMS = Object.freeze([
+  'baseline',
+  'optimizer',
+  'retrieval',
+  'full',
+]);
+
+const FEATURES = Object.freeze({
+  baseline: Object.freeze({ routing: false, retrieval: false, capture: false, harvest: false }),
+  optimizer: Object.freeze({ routing: true, retrieval: false, capture: false, harvest: false }),
+  retrieval: Object.freeze({ routing: true, retrieval: true, capture: true, harvest: false }),
+  full: Object.freeze({ routing: true, retrieval: true, capture: true, harvest: true }),
+});
+
+export function experimentArm(env = process.env) {
+  const requested = String(env.TOKEN_OPTIMIZER_EXPERIMENT_ARM || '').trim().toLowerCase();
+  return EXPERIMENT_ARMS.includes(requested) ? requested : 'full';
+}
+
+export function featuresForArm(arm = experimentArm()) {
+  return FEATURES[arm] || FEATURES.full;
+}
+
+const first = (...values) => values.find((value) => value !== undefined && value !== null && value !== '');
+
+/**
+ * Normalises identifiers exposed under different names by lifecycle clients.
+ * Environment overrides let the live evaluation harness pin a pair/task id
+ * without asking each CLI to support experiment-specific payload fields.
+ */
+export function episodeMeta({ client, raw = {}, payload = {}, env = process.env } = {}) {
+  const sessionId = String(first(
+    payload.session_id, raw.session_id, raw.sessionId, raw.conversation_id,
+    raw.conversationId, raw.taskId, raw.task_id, raw.trajectory_id, 'default'
+  ));
+  const episodeId = String(first(
+    env.TOKEN_OPTIMIZER_EPISODE_ID, raw.episode_id, raw.episodeId, sessionId
+  ));
+  const toolCallId = first(
+    raw.tool_use_id, raw.toolUseId, raw.tool_call_id, raw.toolCallId,
+    raw.call_id, raw.callId, raw.postToolUse?.toolUseId, raw.preToolUse?.toolUseId
+  );
+  const model = first(payload.model, raw.model?.slug, raw.model, raw.model_name, env.TOKEN_OPTIMIZER_MODEL);
+  const clientVersion = first(
+    raw.client_version, raw.clientVersion, raw.version, env.TOKEN_OPTIMIZER_CLIENT_VERSION
+  );
+  const modelVersion = first(raw.model_version, raw.modelVersion, env.TOKEN_OPTIMIZER_MODEL_VERSION);
+
+  return {
+    schemaVersion: 2,
+    episodeId,
+    sessionId,
+    turnId: first(raw.turn_id, raw.turnId, raw.message_id, raw.messageId) ?? null,
+    toolCallId: toolCallId == null ? null : String(toolCallId),
+    taskId: first(env.TOKEN_OPTIMIZER_TASK_ID, raw.task_id, raw.taskId) ?? null,
+    pairId: first(env.TOKEN_OPTIMIZER_PAIR_ID, raw.pair_id, raw.pairId) ?? null,
+    arm: experimentArm(env),
+    client: String(client || first(raw.client, raw.client_name, 'unknown')),
+    clientVersion: clientVersion == null ? null : String(clientVersion),
+    model: model == null ? null : String(model),
+    modelVersion: modelVersion == null ? null : String(modelVersion),
+  };
+}
+
+export function usageFrom(raw = {}) {
+  const usage = raw.usage || raw.token_usage || raw.tokenUsage || raw.metrics?.usage || {};
+  const number = (...values) => {
+    const value = first(...values);
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+  };
+  return {
+    uncachedInputTokens: number(usage.uncached_input_tokens, usage.uncachedInputTokens),
+    cachedInputTokens: number(usage.cached_input_tokens, usage.cachedInputTokens, usage.cache_read_input_tokens),
+    outputTokens: number(usage.output_tokens, usage.outputTokens),
+    totalTokens: number(usage.total_tokens, usage.totalTokens, raw.tokens_used, raw.tokensUsed),
+  };
+}

--- a/integrations/windsurf/hooks/lib/harvest-write.mjs
+++ b/integrations/windsurf/hooks/lib/harvest-write.mjs
@@ -96,8 +96,13 @@ function promoteToShared(finding, { projectRoot, sessionId, provenance, key }) {
           key: `shared-${key}`,
           claim: finding.claim,
           confidence: finding.confidence,
+          confidenceLabel: finding.confidenceLabel,
           type: finding.type,
           trigger: typeof finding.trigger === 'string' && finding.trigger ? finding.trigger : undefined,
+          applicability: finding.applicability,
+          evidence: finding.evidence,
+          invalidators: Array.isArray(finding.invalidators) ? finding.invalidators : [],
+          scope: finding.scope || 'global',
           origin: provenance,
           quote: typeof finding.quote === 'string' && finding.quote.trim() ? finding.quote : undefined,
           // WHERE IT WAS LEARNED, carried so the reader can discount it. A lesson
@@ -351,6 +356,26 @@ export function writeHarvested(
     // anything, so it is dropped rather than kept as unfalsifiable.
     if (!resolved.length) continue;
 
+    // Exact semantic duplicates collapse to the existing active record.  The
+    // normalisation intentionally ignores punctuation/formatting noise but not
+    // meaning-bearing words; near-duplicates that need judgement remain visible
+    // to curation rather than being silently merged by a fuzzy heuristic.
+    const fingerprint = claimFingerprint(finding.claim);
+    const currentGraph = load(dir);
+    const duplicate = [...currentGraph.nodes.values()].find((node) =>
+      node.kind === 'finding'
+      && !node.retired
+      && node.type === finding.type
+      && claimFingerprint(node.claim) === fingerprint
+      && resolved.every((target) => currentGraph.edges.some((edge) =>
+        edge.from === node.id && edge.edge === 'derived_from' && edge.to === target
+      ))
+    );
+    if (duplicate) {
+      written.push(duplicate.key);
+      continue;
+    }
+
     // Date.now() plus an index is not unique across CONCURRENT detached
     // workers: two Stop hooks finishing in the same millisecond produce the
     // same key, and putNode keeps the last write for an id -- so one session's
@@ -371,6 +396,7 @@ export function writeHarvested(
         key,
         claim: finding.claim,
         confidence: finding.confidence,
+        confidenceLabel: finding.confidenceLabel,
         type: finding.type,
         // WHEN this finding is relevant, not just what it is about. Anchors
         // answer "which file", which is the wrong question for a claim about
@@ -380,6 +406,16 @@ export function writeHarvested(
         trigger: typeof finding.trigger === 'string' && finding.trigger
           ? finding.trigger
           : undefined,
+        applicability: typeof finding.applicability === 'string'
+          ? finding.applicability
+          : undefined,
+        evidence: typeof finding.evidence === 'string'
+          ? finding.evidence
+          : undefined,
+        invalidators: Array.isArray(finding.invalidators)
+          ? finding.invalidators
+          : [],
+        scope: finding.scope || 'project',
         origin: provenance,
         // THE EVIDENCE TRAVELS WITH THE CLAIM. Without it a human-origin
         // finding asserts its own provenance and nothing can check it.
@@ -398,7 +434,11 @@ export function writeHarvested(
     // record of what happened here; the shared tier is a copy for the lessons
     // that are not about here. Skipped when the two are the same directory,
     // which is the suite's usual arrangement.
-    if (id && !isSharedDir(dir)) {
+    if (
+      id
+      && !isSharedDir(dir)
+      && (finding.scope === undefined || finding.scope === 'organization' || finding.scope === 'global')
+    ) {
       promoteToShared(finding, { projectRoot, sessionId, provenance, key });
     }
   }

--- a/integrations/windsurf/hooks/lib/harvest.mjs
+++ b/integrations/windsurf/hooks/lib/harvest.mjs
@@ -201,7 +201,11 @@ const PROMPT = `Extract durable findings from this coding session for a project 
 Return ONLY a JSON array. Each element:
 {"type": "finding|decision|failure|command|map",
  "claim": "one sentence, specific and checkable",
- "confidence": 0.0-1.0,
+ "evidence": "the concrete observation, command result, or rejected approach that proved it",
+ "applicability": "the condition under which a future model should use it",
+ "confidenceLabel": "verified|probable|speculative",
+ "scope": "project|organization|global",
+ "invalidators": ["what change would require this to be checked again"],
  "anchors": ["absolute/file/path" or "absolute/file/path#symbolName"]}
 
 RULES:
@@ -211,7 +215,9 @@ RULES:
 - Prefer "failure" and "decision" entries. What was TRIED AND REJECTED, and WHY,
   is the most valuable thing here because it exists nowhere in the source tree.
 - Do not restate what the code plainly says. Record what someone had to work out.
-- confidence reflects how well established the claim is, not how important.
+- verified requires direct evidence; probable means strong but incomplete evidence;
+  speculative is a hypothesis and must be labelled as such.
+- Use project scope unless the lesson is genuinely independent of this repository.
 - If nothing durable was learned, return [].`;
 
 /**
@@ -232,8 +238,29 @@ export function validate(raw, { knownFiles = null } = {}) {
     if (!FINDING_TYPES.includes(item.type)) continue;
     if (typeof item.claim !== 'string' || item.claim.trim().length < 8) continue;
 
-    const confidence = Number(item.confidence);
-    if (!Number.isFinite(confidence) || confidence <= 0 || confidence > 1) continue;
+    const evidence = typeof item.evidence === 'string' ? item.evidence.trim() : '';
+    const applicability = typeof item.applicability === 'string' ? item.applicability.trim() : '';
+    if (evidence.length < 8 || applicability.length < 8) continue;
+
+    const confidenceLabel = ['verified', 'probable', 'speculative'].includes(item.confidenceLabel)
+      ? item.confidenceLabel
+      : null;
+    if (!confidenceLabel) continue;
+    const defaults = { verified: 0.95, probable: 0.75, speculative: 0.45 };
+    const supplied = Number(item.confidence);
+    if (
+      item.confidence !== undefined
+      && (!Number.isFinite(supplied) || supplied <= 0 || supplied > 1)
+    ) continue;
+    const confidence = item.confidence === undefined
+      ? defaults[confidenceLabel]
+      : supplied;
+    const scope = ['project', 'organization', 'global'].includes(item.scope)
+      ? item.scope
+      : 'project';
+    const invalidators = Array.isArray(item.invalidators)
+      ? item.invalidators.filter((value) => typeof value === 'string' && value.trim()).slice(0, 10)
+      : [];
 
     let anchors = Array.isArray(item.anchors) ? item.anchors.filter((a) => typeof a === 'string' && a) : [];
     // A model asked for file paths will sometimes invent them. When the caller
@@ -241,7 +268,18 @@ export function validate(raw, { knownFiles = null } = {}) {
     if (knownFiles) anchors = anchors.filter((a) => knownFiles.has(a.split('#')[0]));
     if (!anchors.length) continue;
 
-    accepted.push({ type: item.type, claim: item.claim.trim(), confidence, anchors });
+    accepted.push({
+      type: item.type,
+      claim: item.claim.trim(),
+      evidence,
+      applicability,
+      confidence,
+      confidenceLabel,
+      scope,
+      invalidators,
+      anchors,
+      trigger: typeof item.trigger === 'string' ? item.trigger : undefined,
+    });
   }
   return accepted;
 }

--- a/integrations/windsurf/hooks/lib/inject.mjs
+++ b/integrations/windsurf/hooks/lib/inject.mjs
@@ -30,6 +30,7 @@ import { inHoldout, record, indexBudget } from './metrics.mjs';
 import { canonicalPath, resolvableCandidates } from './paths.mjs';
 import { annotatedSkeleton } from './skeleton.mjs';
 import { substitutionBudget } from './metrics.mjs';
+import { assessFindings } from './utility.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
@@ -150,7 +151,7 @@ export function forTouch(
   dir,
   graph,
   rawPath,
-  { budget = touchBudget(), sessionId, alreadyInjected = new Set() } = {}
+  { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
   // Canonical, so a touch finds findings anchored under any other spelling.
   const filePath = canonicalPath(rawPath);
@@ -169,16 +170,36 @@ export function forTouch(
   // variance drops out. A session-pinned arm would destroy that.
   const holdout = inHoldout(filePath);
   const served = serve(graph, candidates);
-  const { kept, spent } = fit(served, budget);
+  const assessed = assessFindings(dir, served, {
+    episodeId: episode.episodeId || sessionId,
+    relevanceFor: () => 1,
+    costFor: (finding) => estimate(render(finding)),
+  });
+  if (assessed.rejected.length) {
+    record(dir, {
+      kind: 'retrieval-decision', ...episode, sessionId,
+      surface: 'file', anchor: filePath,
+      rejected: assessed.rejected.map(({ key, reason }) => ({ key, reason })),
+    });
+    for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
+  }
+  const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
+  if (!kept.length) return null;
 
   record(dir, {
     kind: 'inject',
+    ...episode,
     // The surface whose saving CAN be measured: reads of this anchor afterwards.
     surface: 'file',
     anchor: filePath,
     holdout,
     tokens: holdout ? 0 : spent,
-    count: kept.length,
+    deliveredTokens: holdout ? 0 : spent,
+    shadowTokens: spent,
+    count: holdout ? 0 : kept.length,
+    candidateCount: kept.length,
+    findingIds: holdout ? [] : kept.map((finding) => finding.key),
+    shadowFindingIds: kept.map((finding) => finding.key),
     stale: kept.some((f) => f.stale),
     sessionId,
   });
@@ -297,7 +318,7 @@ export function forCommand(
   dir,
   graph,
   command,
-  { budget = touchBudget(), sessionId, alreadyInjected = new Set() } = {}
+  { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
   if (!command) return null;
 
@@ -335,7 +356,20 @@ export function forCommand(
   const considered = candidates.slice(0, MAX_COMMAND_CANDIDATES);
 
   const served = serve(graph, considered);
-  const { kept, spent } = fit(served, budget);
+  const assessed = assessFindings(dir, served, {
+    episodeId: episode.episodeId || sessionId,
+    relevanceFor: (finding) => explicit(finding) ? 1 : 0.6,
+    costFor: (finding) => estimate(render(finding)),
+  });
+  if (assessed.rejected.length) {
+    record(dir, {
+      kind: 'retrieval-decision', ...episode, sessionId,
+      surface: 'command', anchor: String(command).slice(0, 120),
+      rejected: assessed.rejected.map(({ key: findingKey, reason }) => ({ key: findingKey, reason })),
+    });
+    for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
+  }
+  const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
   if (!kept.length) return null;
 
   // THE COMMAND PATH TAKES PART IN THE HOLDOUT TOO.
@@ -353,6 +387,7 @@ export function forCommand(
 
   record(dir, {
     kind: 'inject',
+    ...episode,
     trigger: 'command',
     // The surface the report needs to keep these OUT of the file-read balance:
     // a command has no anchor that read events can be joined to.
@@ -360,7 +395,12 @@ export function forCommand(
     anchor: String(command).slice(0, 120),
     holdout,
     tokens: holdout ? 0 : spent,
+    deliveredTokens: holdout ? 0 : spent,
+    shadowTokens: spent,
     count: holdout ? 0 : kept.length,
+    candidateCount: kept.length,
+    findingIds: holdout ? [] : kept.map((finding) => finding.key),
+    shadowFindingIds: kept.map((finding) => finding.key),
     stale: kept.some((f) => f.stale),
     sessionId,
   });
@@ -509,7 +549,7 @@ export function forRepeatedAct(
   projectDir,
   command,
   crossedClasses,
-  { sessionId = null, projectRoot = null } = {}
+  { sessionId = null, projectRoot = null, episode = {} } = {}
 ) {
   if (!crossedClasses || !crossedClasses.size) return null;
 
@@ -527,14 +567,33 @@ export function forRepeatedAct(
       if (![...crossedClasses].some((c) => claimClasses.has(c))) continue;
 
       const cls = [...crossedClasses].find((c) => claimClasses.has(c));
+      const assessed = assessFindings(projectDir, [node], {
+        episodeId: episode.episodeId || sessionId,
+        relevanceFor: () => 1,
+        costFor: (finding) => estimate(render(finding)),
+      });
+      if (!assessed.eligible.length) {
+        record(projectDir, {
+          kind: 'retrieval-decision', ...episode, sessionId,
+          surface: 'shared', anchor: String(command).slice(0, 120),
+          rejected: assessed.rejected.map(({ key, reason }) => ({ key, reason })),
+        });
+        continue;
+      }
       record(projectDir, {
         kind: 'inject',
+        ...episode,
         trigger: 'repeat',
         surface: 'shared',
         anchor: String(command).slice(0, 120),
         holdout: false,
         tokens: estimate(node.claim),
+        deliveredTokens: estimate(node.claim),
+        shadowTokens: estimate(node.claim),
         count: 1,
+        candidateCount: 1,
+        findingIds: [node.key],
+        shadowFindingIds: [node.key],
         stale: false,
         sessionId,
       });
@@ -585,7 +644,10 @@ function appliesCrossProject(finding, command) {
 export function forSharedCommand(
   projectDir,
   command,
-  { budget = sharedBudget(), sessionId = null, alreadyInjected = new Set(), projectRoot = null } = {}
+  {
+    budget = sharedBudget(), sessionId = null, alreadyInjected = new Set(),
+    projectRoot = null, episode = {},
+  } = {}
 ) {
   if (!command) return null;
 
@@ -622,7 +684,21 @@ export function forSharedCommand(
     // No serve() here: these types are not content-dependent, so there is no
     // anchor to re-read and nothing to diff. serve() would spend a file read per
     // finding to answer a question that does not apply to them.
-    const { kept, spent } = fit(candidates.slice(0, MAX_SHARED), budget);
+    const considered = candidates.slice(0, MAX_SHARED);
+    const assessed = assessFindings(projectDir, considered, {
+      episodeId: episode.episodeId || sessionId,
+      relevanceFor: (finding) => explicit(finding) ? 0.8 : 0.5,
+      costFor: (finding) => estimate(render(finding)),
+    });
+    if (assessed.rejected.length) {
+      record(projectDir, {
+        kind: 'retrieval-decision', ...episode, sessionId,
+        surface: 'shared', anchor: String(command).slice(0, 120),
+        rejected: assessed.rejected.map(({ key, reason }) => ({ key, reason })),
+      });
+      for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
+    }
+    const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
     if (!kept.length) return null;
 
     // THE SAME ARM AS THE LOCAL PATH, KEYED THE SAME WAY.
@@ -644,6 +720,7 @@ export function forSharedCommand(
 
     record(projectDir, {
       kind: 'inject',
+      ...episode,
       trigger: 'command',
       // ITS OWN SURFACE. The balance sheet joins `file` injections to later read
       // events; a shared lesson has no anchor in this project to join to, and
@@ -653,7 +730,12 @@ export function forSharedCommand(
       anchor: String(command).slice(0, 120),
       holdout,
       tokens: holdout ? 0 : spent,
+      deliveredTokens: holdout ? 0 : spent,
+      shadowTokens: spent,
       count: holdout ? 0 : kept.length,
+      candidateCount: kept.length,
+      findingIds: holdout ? [] : kept.map((finding) => finding.key),
+      shadowFindingIds: kept.map((finding) => finding.key),
       stale: false,
       sessionId,
     });

--- a/integrations/windsurf/hooks/lib/inject.mjs
+++ b/integrations/windsurf/hooks/lib/inject.mjs
@@ -571,6 +571,10 @@ export function forRepeatedAct(
         episodeId: episode.episodeId || sessionId,
         relevanceFor: () => 1,
         costFor: (finding) => estimate(render(finding)),
+        // This surface exists specifically to re-surface a lesson once the
+        // session crosses the repeat threshold. Ordinary retrieval remains
+        // cooldown-protected; harm quarantine and utility gating still apply.
+        bypassCooldown: true,
       });
       if (!assessed.eligible.length) {
         record(projectDir, {

--- a/integrations/windsurf/hooks/lib/metrics.mjs
+++ b/integrations/windsurf/hooks/lib/metrics.mjs
@@ -1022,6 +1022,7 @@ function armMetrics(runs) {
     runs: runs.length,
     correctness: proportionInterval(correct, runs.length),
     uncachedInputTokens: interval('uncachedInputTokens'),
+    cacheCreationInputTokens: interval('cacheCreationInputTokens'),
     cachedInputTokens: interval('cachedInputTokens'),
     outputTokens: interval('outputTokens'),
     totalTokens: interval('totalTokens'),
@@ -1034,31 +1035,37 @@ function armMetrics(runs) {
   };
 }
 
-function pairedEffects(runs, treatmentArm) {
+function pairedEffects(runs, controlArm, treatmentArm, contrastType = 'incremental') {
   const pairs = new Map();
   for (const run of runs) {
-    if (!run.pairId || !['baseline', treatmentArm].includes(run.arm)) continue;
+    if (!run.pairId || ![controlArm, treatmentArm].includes(run.arm)) continue;
     if (!pairs.has(run.pairId)) pairs.set(run.pairId, {});
     pairs.get(run.pairId)[run.arm] = run;
   }
-  const complete = [...pairs.values()].filter((pair) => pair.baseline && pair[treatmentArm]);
+  const complete = [...pairs.values()].filter((pair) => pair[controlArm] && pair[treatmentArm]);
   const delta = (field, lowerIsBetter = true) => bootstrapMeanInterval(
     complete
       .map((pair) => {
-        const baseline = numeric(pair.baseline[field]);
+        const baseline = numeric(pair[controlArm][field]);
         const treatment = numeric(pair[treatmentArm][field]);
         if (baseline === null || treatment === null) return null;
         return lowerIsBetter ? baseline - treatment : treatment - baseline;
       })
       .filter((value) => value !== null),
-    { seed: `${treatmentArm}:${field}` }
+    { seed: `${controlArm}:${treatmentArm}:${field}` }
   );
   return {
     arm: treatmentArm,
+    controlArm,
+    comparison: `${treatmentArm} vs ${controlArm}`,
+    contrastType,
     pairs: complete.length,
     // Positive values always mean the treatment improved the metric.
     totalTokensSaved: delta('totalTokens'),
     uncachedInputTokensSaved: delta('uncachedInputTokens'),
+    cacheCreationInputTokensSaved: delta('cacheCreationInputTokens'),
+    cachedInputTokensSaved: delta('cachedInputTokens'),
+    outputTokensSaved: delta('outputTokens'),
     toolCallsAvoided: delta('toolCalls'),
     latencyMsSaved: delta('latencyMs'),
     costUsdSaved: delta('costUsd'),
@@ -1124,8 +1131,13 @@ export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
         armMetrics(cohortRuns.filter((run) => run.arm === arm)),
       ])
     );
-    const effects = ['optimizer', 'retrieval', 'full'].map((arm) => pairedEffects(cohortRuns, arm));
-    const enough = effects.some((effect) => effect.pairs >= minimumPairs);
+    const effects = [
+      pairedEffects(cohortRuns, 'baseline', 'optimizer'),
+      pairedEffects(cohortRuns, 'optimizer', 'retrieval'),
+      pairedEffects(cohortRuns, 'retrieval', 'full'),
+      pairedEffects(cohortRuns, 'baseline', 'full', 'total-system'),
+    ];
+    const enough = effects.every((effect) => effect.pairs >= minimumPairs);
     return {
       key,
       client: cohortRuns[0]?.client || 'unknown',
@@ -1165,7 +1177,8 @@ export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
     episodes: traced,
     methodology: {
       intervals: 'deterministic percentile bootstrap (95%); Wilson interval for correctness',
-      causalRule: 'only matched eval-run pairs compare an arm with baseline',
+      causalRule:
+        'matched pairs estimate optimizer vs baseline, retrieval vs optimizer, full vs retrieval, and full vs baseline',
       minimumPairs,
       deterministicChecksAreCausalProof: false,
     },

--- a/integrations/windsurf/hooks/lib/metrics.mjs
+++ b/integrations/windsurf/hooks/lib/metrics.mjs
@@ -61,6 +61,7 @@ const metricsPath = (dir) => join(dir, 'metrics.jsonl');
  * on it drops BOTH arms proportionally instead of starving the rare one.
  */
 const balancePath = (dir) => join(dir, 'balance.jsonl');
+const evidencePath = (dir) => join(dir, 'evidence.jsonl');
 
 /** Kinds the net balance is computed from, and which therefore must survive. */
 /**
@@ -83,6 +84,24 @@ export const BALANCE_KINDS = new Set([
   // aged out before it was written and the backstop was structurally unable to fire, reporting
   // "only N/10 refreshes observed" for the life of the project.
   'keepwarm',
+]);
+
+/**
+ * Causal records have their own bounded log.  Tool outcomes are much rarer
+ * than read/capture telemetry but more frequent than balance records; mixing
+ * them into either window would eventually evict the evidence needed to join
+ * an injection to its result.
+ */
+export const EVIDENCE_KINDS = new Set([
+  'inject',
+  'harvest',
+  'tool-outcome',
+  'episode-outcome',
+  'eval-run',
+  'finding-feedback',
+  'retrieval-decision',
+  'mcp-client',
+  'mcp-tool',
 ]);
 
 /**
@@ -198,15 +217,30 @@ export function record(dir, event) {
     // single millisecond collapsed to ONE, so a graph with ample data reported
     // 'insufficient data (2 treated, 1 holdout)'. Real events were being
     // discarded by the deduplicator, silently.
-    const line =
-      JSON.stringify({ id: nextId(), ...event, at: event.at ?? Date.now() }) + '\n';
+    const id = event.id || nextId();
+    const complete = {
+      schemaVersion: event.schemaVersion || 2,
+      id,
+      ...event,
+      // An injection id is first-class rather than an inference from the log
+      // record id.  Exporters may rewrite record ids while preserving causal
+      // identity, and downstream tool outcomes refer to this value explicitly.
+      ...(event.kind === 'inject'
+        ? { injectionId: event.injectionId || id }
+        : {}),
+      at: event.at ?? Date.now(),
+    };
+    const line = JSON.stringify(complete) + '\n';
     appendFileSync(metricsPath(dir), line);
     // Balance-critical records go to their own log as well, so the windows on
     // the firehose can never starve the measurement. Written SECOND: a torn
     // write here costs a duplicate the reader dedupes, not a lost event.
     if (BALANCE_KINDS.has(event.kind)) appendFileSync(balancePath(dir), line);
+    if (EVIDENCE_KINDS.has(event.kind)) appendFileSync(evidencePath(dir), line);
+    return complete;
   } catch {
     // Metrics must never break a tool call.
+    return null;
   }
 }
 
@@ -402,6 +436,92 @@ export function readBalance(dir) {
     out.push(e);
   }
   return out;
+}
+
+/** Every causal evidence record inside the byte cap, deduplicated by id. */
+export function readEvidence(dir) {
+  const path = evidencePath(dir);
+  if (!existsSync(path)) return [];
+
+  let text = '';
+  try {
+    const { size } = statSync(path);
+    if (size <= MAX_BYTES) {
+      text = readFileSync(path, 'utf8');
+    } else {
+      const fd = openSync(path, 'r');
+      try {
+        const buffer = Buffer.allocUnsafe(MAX_BYTES);
+        const read = readSync(fd, buffer, 0, MAX_BYTES, size - MAX_BYTES);
+        text = buffer.subarray(0, read).toString('utf8');
+      } finally {
+        closeSync(fd);
+      }
+      text = text.slice(text.indexOf('\n') + 1);
+    }
+  } catch {
+    return [];
+  }
+
+  const seen = new Set();
+  const out = [];
+  for (const line of text.split('\n')) {
+    if (!line) continue;
+    try {
+      const event = JSON.parse(line);
+      if (!EVIDENCE_KINDS.has(event.kind)) continue;
+      const id = event.id || JSON.stringify(event);
+      if (seen.has(id)) continue;
+      seen.add(id);
+      out.push(event);
+    } catch {
+      // A concurrently appended final line may be torn.  It costs one record,
+      // never the user's tool call or the rest of the evidence report.
+    }
+  }
+  return out;
+}
+
+/**
+ * Joins a post-tool result to the most recent matching injection.  The exact
+ * tool-call id wins; clients that omit it fall back to episode + surface +
+ * anchor, in timestamp order, and the report states the weaker join method.
+ */
+export function recordToolOutcome(dir, outcome) {
+  const evidence = readEvidence(dir);
+  const anchor = String(outcome.anchor || '').slice(0, 120);
+  const candidates = evidence
+    .filter((event) => event.kind === 'inject' && event.episodeId === outcome.episodeId)
+    .filter((event) => {
+      if (outcome.toolCallId && event.toolCallId)
+        return String(event.toolCallId) === String(outcome.toolCallId);
+      return event.surface === outcome.surface && String(event.anchor || '').slice(0, 120) === anchor;
+    })
+    .sort((a, b) => (b.at || 0) - (a.at || 0));
+  const injection = candidates[0] || null;
+  const joinMethod = injection
+    ? (outcome.toolCallId && injection.toolCallId ? 'tool-call-id' : 'episode-anchor')
+    : 'none';
+
+  return record(dir, {
+    kind: 'tool-outcome',
+    ...outcome,
+    anchor,
+    injectionId: injection?.injectionId || null,
+    findingIds: injection?.findingIds || [],
+    joinMethod,
+  });
+}
+
+export function recordEpisodeOutcome(dir, outcome) {
+  return record(dir, { kind: 'episode-outcome', ...outcome });
+}
+
+export function recordFindingFeedback(dir, feedback) {
+  const rating = ['helpful', 'neutral', 'harmful'].includes(feedback?.rating)
+    ? feedback.rating
+    : 'neutral';
+  return record(dir, { kind: 'finding-feedback', ...feedback, rating });
 }
 
 /**
@@ -813,4 +933,241 @@ export function indexBudget(dir, { floor = 150, base = 300, ceiling = 1200 } = {
   // 0% hit rate falls to the floor; ~50% and above reaches the ceiling.
   const scaled = Math.round(floor + (ceiling - floor) * Math.min(1, hitRate * 2));
   return Math.max(floor, Math.min(ceiling, scaled));
+}
+
+/* ----------------------------------------------------------------------
+ * Episode-level causal evidence
+ * ------------------------------------------------------------------- */
+
+const numeric = (value) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const average = (values) => {
+  const finite = values.map(numeric).filter((value) => value !== null);
+  return finite.length
+    ? finite.reduce((sum, value) => sum + value, 0) / finite.length
+    : null;
+};
+
+/** Deterministic PRNG so regenerating a report does not move its interval. */
+function seededRandom(seedText) {
+  let seed = 2166136261;
+  for (const char of String(seedText)) {
+    seed ^= char.charCodeAt(0);
+    seed = Math.imul(seed, 16777619);
+  }
+  return () => {
+    seed += 0x6d2b79f5;
+    let value = seed;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Percentile bootstrap interval for a mean, paired delta, or other scalar. */
+export function bootstrapMeanInterval(values, { samples = 1000, seed = 'token-optimizer' } = {}) {
+  const finite = values.map(numeric).filter((value) => value !== null);
+  if (!finite.length) return { mean: null, low: null, high: null, n: 0 };
+  if (finite.length === 1) {
+    return { mean: finite[0], low: finite[0], high: finite[0], n: 1 };
+  }
+
+  const random = seededRandom(`${seed}:${finite.join(',')}`);
+  const means = [];
+  for (let sample = 0; sample < samples; sample++) {
+    let total = 0;
+    for (let index = 0; index < finite.length; index++) {
+      total += finite[Math.floor(random() * finite.length)];
+    }
+    means.push(total / finite.length);
+  }
+  means.sort((a, b) => a - b);
+  return {
+    mean: average(finite),
+    low: means[Math.floor(means.length * 0.025)],
+    high: means[Math.min(means.length - 1, Math.floor(means.length * 0.975))],
+    n: finite.length,
+  };
+}
+
+/** Wilson interval keeps small correctness samples honest and inside 0..1. */
+export function proportionInterval(successes, total, z = 1.96) {
+  if (!total) return { rate: null, low: null, high: null, n: 0 };
+  const rate = successes / total;
+  const denominator = 1 + (z * z) / total;
+  const centre = (rate + (z * z) / (2 * total)) / denominator;
+  const radius =
+    (z / denominator) * Math.sqrt((rate * (1 - rate)) / total + (z * z) / (4 * total * total));
+  return { rate, low: Math.max(0, centre - radius), high: Math.min(1, centre + radius), n: total };
+}
+
+const cohortKey = (run) => [
+  run.client || 'unknown',
+  run.clientVersion || 'unknown',
+  run.model || 'unknown',
+  run.modelVersion || 'unknown',
+  run.taskId || 'unknown',
+].join('|');
+
+function armMetrics(runs) {
+  const correct = runs.filter((run) => run.correct === true).length;
+  const interval = (field) => bootstrapMeanInterval(
+    runs.map((run) => run[field]).filter((value) => numeric(value) !== null),
+    { seed: field }
+  );
+  return {
+    runs: runs.length,
+    correctness: proportionInterval(correct, runs.length),
+    uncachedInputTokens: interval('uncachedInputTokens'),
+    cachedInputTokens: interval('cachedInputTokens'),
+    outputTokens: interval('outputTokens'),
+    totalTokens: interval('totalTokens'),
+    toolCalls: interval('toolCalls'),
+    failedToolCalls: interval('failedToolCalls'),
+    latencyMs: interval('latencyMs'),
+    costUsd: interval('costUsd'),
+    injectedTokens: interval('injectedTokens'),
+    harmfulFindings: runs.reduce((sum, run) => sum + (numeric(run.harmfulFindings) || 0), 0),
+  };
+}
+
+function pairedEffects(runs, treatmentArm) {
+  const pairs = new Map();
+  for (const run of runs) {
+    if (!run.pairId || !['baseline', treatmentArm].includes(run.arm)) continue;
+    if (!pairs.has(run.pairId)) pairs.set(run.pairId, {});
+    pairs.get(run.pairId)[run.arm] = run;
+  }
+  const complete = [...pairs.values()].filter((pair) => pair.baseline && pair[treatmentArm]);
+  const delta = (field, lowerIsBetter = true) => bootstrapMeanInterval(
+    complete
+      .map((pair) => {
+        const baseline = numeric(pair.baseline[field]);
+        const treatment = numeric(pair[treatmentArm][field]);
+        if (baseline === null || treatment === null) return null;
+        return lowerIsBetter ? baseline - treatment : treatment - baseline;
+      })
+      .filter((value) => value !== null),
+    { seed: `${treatmentArm}:${field}` }
+  );
+  return {
+    arm: treatmentArm,
+    pairs: complete.length,
+    // Positive values always mean the treatment improved the metric.
+    totalTokensSaved: delta('totalTokens'),
+    uncachedInputTokensSaved: delta('uncachedInputTokens'),
+    toolCallsAvoided: delta('toolCalls'),
+    latencyMsSaved: delta('latencyMs'),
+    costUsdSaved: delta('costUsd'),
+    correctnessDelta: delta('correct', false),
+  };
+}
+
+function matchesFilters(event, filters) {
+  for (const field of ['client', 'clientVersion', 'model', 'modelVersion', 'taskId', 'arm']) {
+    if (filters[field] && String(event[field] || '') !== String(filters[field])) return false;
+  }
+  return true;
+}
+
+/**
+ * The dashboard-facing evidence console.  Deterministic fixture verification,
+ * live hook traces, and randomized model evals remain visibly distinct: only
+ * `eval-run` records with paired arms can produce a causal effect interval.
+ */
+export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
+  const evidence = readEvidence(dir).filter((event) => matchesFilters(event, filters));
+  const runs = evidence.filter((event) => event.kind === 'eval-run');
+  const injections = evidence.filter((event) => event.kind === 'inject');
+  const outcomes = evidence.filter((event) => event.kind === 'tool-outcome');
+  const feedback = evidence.filter((event) => event.kind === 'finding-feedback');
+
+  const byInjection = new Map(
+    outcomes.filter((event) => event.injectionId).map((event) => [event.injectionId, event])
+  );
+  const traced = injections
+    .slice()
+    .sort((a, b) => (b.at || 0) - (a.at || 0))
+    .slice(0, Math.max(1, Math.min(500, episodeLimit)))
+    .map((injection) => ({
+      injectionId: injection.injectionId,
+      episodeId: injection.episodeId || injection.sessionId || null,
+      at: injection.at,
+      arm: injection.arm || (injection.holdout ? 'holdout' : 'treated'),
+      client: injection.client || 'unknown',
+      clientVersion: injection.clientVersion || null,
+      model: injection.model || null,
+      taskId: injection.taskId || null,
+      surface: injection.surface || injection.trigger || 'file',
+      anchor: injection.anchor,
+      findingIds: injection.findingIds || [],
+      deliveredTokens: injection.deliveredTokens ?? injection.tokens ?? 0,
+      shadowTokens: injection.shadowTokens ?? injection.tokens ?? 0,
+      outcome: byInjection.get(injection.injectionId) || null,
+    }));
+
+  const grouped = new Map();
+  for (const run of runs) {
+    const key = cohortKey(run);
+    if (!grouped.has(key)) grouped.set(key, []);
+    grouped.get(key).push(run);
+  }
+
+  const minimumPairs = Math.max(2, Number(process.env.TOKEN_OPTIMIZER_EVAL_MIN_PAIRS) || 5);
+  const cohorts = [...grouped.entries()].map(([key, cohortRuns]) => {
+    const arms = Object.fromEntries(
+      ['baseline', 'optimizer', 'retrieval', 'full'].map((arm) => [
+        arm,
+        armMetrics(cohortRuns.filter((run) => run.arm === arm)),
+      ])
+    );
+    const effects = ['optimizer', 'retrieval', 'full'].map((arm) => pairedEffects(cohortRuns, arm));
+    const enough = effects.some((effect) => effect.pairs >= minimumPairs);
+    return {
+      key,
+      client: cohortRuns[0]?.client || 'unknown',
+      clientVersion: cohortRuns[0]?.clientVersion || null,
+      model: cohortRuns[0]?.model || null,
+      modelVersion: cohortRuns[0]?.modelVersion || null,
+      taskId: cohortRuns[0]?.taskId || null,
+      arms,
+      effects,
+      evidenceStatus: enough
+        ? 'causal estimate available'
+        : `insufficient paired runs (need ${minimumPairs})`,
+    };
+  });
+
+  const joined = injections.filter((injection) =>
+    byInjection.has(injection.injectionId)
+  ).length;
+  const harmful = feedback.filter((event) => event.rating === 'harmful').length;
+  return {
+    schemaVersion: 2,
+    generatedAt: new Date().toISOString(),
+    filters,
+    summary: {
+      liveInjections: injections.length,
+      joinedOutcomes: joined,
+      causalJoinCoverage: injections.length ? joined / injections.length : null,
+      evalRuns: runs.length,
+      cohorts: cohorts.length,
+      harmfulFeedback: harmful,
+      harmRate: feedback.length ? harmful / feedback.length : null,
+      evidenceStatus: cohorts.some((cohort) => cohort.evidenceStatus === 'causal estimate available')
+        ? 'causal estimates available'
+        : 'insufficient randomized evidence',
+    },
+    cohorts,
+    episodes: traced,
+    methodology: {
+      intervals: 'deterministic percentile bootstrap (95%); Wilson interval for correctness',
+      causalRule: 'only matched eval-run pairs compare an arm with baseline',
+      minimumPairs,
+      deterministicChecksAreCausalProof: false,
+    },
+  };
 }

--- a/integrations/windsurf/hooks/lib/recording.mjs
+++ b/integrations/windsurf/hooks/lib/recording.mjs
@@ -159,6 +159,9 @@ export function semanticHarvestPrompt({
     + ' If this work produced a durable, non-obvious conclusion -- a failed approach and why, '
     + 'a decision and its rejected alternative, or a command that finally worked -- call '
     + 'wiki_write now with a real file anchor. Do not delegate this to another model or an '
-    + 'external harvester. If there is no such conclusion, do not invent one; finish normally.'
+    + 'external harvester. Include: the concrete evidence, when the finding applies, a calibrated '
+    + 'confidenceLabel (verified/probable/speculative), its project/organization/global scope, '
+    + 'and anything that would invalidate it. If there is no such conclusion, do not invent one; '
+    + 'finish normally.'
   );
 }

--- a/integrations/windsurf/hooks/lib/utility.mjs
+++ b/integrations/windsurf/hooks/lib/utility.mjs
@@ -1,0 +1,135 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/utility.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Evidence-aware retrieval economics.
+ *
+ * Relevance alone is not enough: a true finding can still cost more context
+ * than it saves.  Every candidate receives a conservative expected-benefit
+ * estimate, its delivery cost and risk are subtracted, and harmful findings
+ * are quarantined from automatic delivery while remaining visible for audit.
+ */
+
+import { readEvidence } from './metrics.mjs';
+
+const DAY = 86_400_000;
+const ORIGIN_WEIGHT = { human: 1.2, agent: 1.08, harvested: 1 };
+
+const envNumber = (name, fallback) => {
+  const value = Number(process.env[name]);
+  return Number.isFinite(value) && value >= 0 ? value : fallback;
+};
+
+export const retrievalPolicy = () => ({
+  baseBenefitTokens: envNumber('TOKEN_OPTIMIZER_EXPECTED_BENEFIT_TOKENS', 400),
+  minimumNetUtility: envNumber('TOKEN_OPTIMIZER_MIN_EXPECTED_UTILITY', 20),
+  cooldownMs: envNumber('TOKEN_OPTIMIZER_INJECTION_COOLDOWN_MS', 60_000),
+  quarantineHarmCount: Math.max(1, envNumber('TOKEN_OPTIMIZER_QUARANTINE_HARM_COUNT', 2)),
+});
+
+function feedbackFor(events, key) {
+  return events.filter((event) =>
+    event.kind === 'finding-feedback'
+    && (event.findingId === key || (event.findingIds || []).includes(key))
+  );
+}
+
+function outcomesFor(events, key) {
+  return events.filter((event) =>
+    event.kind === 'tool-outcome' && (event.findingIds || []).includes(key)
+  );
+}
+
+function deliveredRecently(events, key, episodeId, now, cooldownMs) {
+  if (!episodeId || cooldownMs <= 0) return false;
+  return events.some((event) =>
+    event.kind === 'inject'
+    && event.episodeId === episodeId
+    && (event.findingIds || []).includes(key)
+    && !event.holdout
+    && now - (event.at || 0) < cooldownMs
+  );
+}
+
+/**
+ * Returns eligible candidates in utility order plus every rejection reason.
+ * `costFor` is supplied by inject.mjs so the gate prices the exact rendered
+ * text rather than a second approximation that could drift.
+ */
+export function assessFindings(
+  dir,
+  findings,
+  {
+    relevanceFor = () => 1,
+    costFor = () => 0,
+    episodeId = null,
+    now = Date.now(),
+    policy = retrievalPolicy(),
+  } = {}
+) {
+  const events = readEvidence(dir);
+  const eligible = [];
+  const rejected = [];
+
+  for (const finding of findings) {
+    const key = finding.key;
+    const feedback = feedbackFor(events, key);
+    const outcomes = outcomesFor(events, key);
+    const helpful = feedback.filter((event) => event.rating === 'helpful').length;
+    const neutral = feedback.filter((event) => event.rating === 'neutral').length;
+    const harmful = feedback.filter((event) => event.rating === 'harmful').length;
+    const successfulUses = outcomes.filter((event) => event.success === true).length;
+    const failedUses = outcomes.filter((event) => event.success === false).length;
+
+    if (harmful >= policy.quarantineHarmCount && harmful >= helpful + neutral) {
+      rejected.push({ key, reason: 'quarantined-harm', helpful, neutral, harmful });
+      continue;
+    }
+    if (deliveredRecently(events, key, episodeId, now, policy.cooldownMs)) {
+      rejected.push({ key, reason: 'cooldown' });
+      continue;
+    }
+
+    const confidence = Number.isFinite(finding.confidence) ? finding.confidence : 0.5;
+    const relevance = Math.max(0, Math.min(1, Number(relevanceFor(finding)) || 0));
+    const ageDays = Math.max(0, (now - (finding.at || now)) / DAY);
+    const recency = finding.pinned ? 1 : Math.pow(0.5, ageDays / 90);
+    const provenance = ORIGIN_WEIGHT[finding.origin] || 1;
+    // Outcome evidence moves the estimate gradually. Explicit harmful feedback
+    // is handled above; a failed command alone is not labelled harmful because
+    // the model may have ignored correct advice.
+    const observed = successfulUses + failedUses;
+    const successFactor = observed
+      ? 0.75 + 0.5 * (successfulUses / observed)
+      : 1;
+    const feedbackFactor = Math.max(0.25, 1 + helpful * 0.12 - harmful * 0.35);
+    const expectedBenefit =
+      policy.baseBenefitTokens * confidence * relevance * recency * provenance * successFactor * feedbackFactor;
+    const deliveryCost = Math.max(0, Number(costFor(finding)) || 0);
+    const riskPenalty =
+      (finding.stale ? 160 : 0)
+      + (finding.confidenceLabel === 'speculative' ? 100 : 0)
+      + harmful * 100;
+    const netUtility = expectedBenefit - deliveryCost - riskPenalty;
+
+    const assessed = {
+      finding,
+      expectedBenefit,
+      deliveryCost,
+      riskPenalty,
+      netUtility,
+      helpful,
+      neutral,
+      harmful,
+      successfulUses,
+      failedUses,
+    };
+    if (netUtility < policy.minimumNetUtility) {
+      rejected.push({ key, reason: 'negative-expected-value', ...assessed, finding: undefined });
+      continue;
+    }
+    eligible.push(assessed);
+  }
+
+  eligible.sort((a, b) => b.netUtility - a.netUtility);
+  return { eligible, rejected };
+}

--- a/integrations/windsurf/hooks/lib/utility.mjs
+++ b/integrations/windsurf/hooks/lib/utility.mjs
@@ -64,6 +64,7 @@ export function assessFindings(
     episodeId = null,
     now = Date.now(),
     policy = retrievalPolicy(),
+    bypassCooldown = false,
   } = {}
 ) {
   const events = readEvidence(dir);
@@ -84,7 +85,7 @@ export function assessFindings(
       rejected.push({ key, reason: 'quarantined-harm', helpful, neutral, harmful });
       continue;
     }
-    if (deliveredRecently(events, key, episodeId, now, policy.cooldownMs)) {
+    if (!bypassCooldown && deliveredRecently(events, key, episodeId, now, policy.cooldownMs)) {
       rejected.push({ key, reason: 'cooldown' });
       continue;
     }

--- a/integrations/windsurf/hooks/lib/wire.mjs
+++ b/integrations/windsurf/hooks/lib/wire.mjs
@@ -28,7 +28,7 @@ export const MARKER = 'token-optimizer';
 /** The events we wire, and which hook file serves each. */
 export const WIRING = [
   { event: 'SessionStart', file: 'session-start.mjs', matcher: null },
-  { event: 'PreToolUse', file: 'pretooluse-router.mjs', matcher: 'Read|Grep|Glob|Edit|MultiEdit|Write|Bash' },
+  { event: 'PreToolUse', file: 'pretooluse-router.mjs', matcher: 'Read|Grep|Glob|Edit|MultiEdit|Write|Bash|PowerShell' },
   { event: 'PreCompact', file: 'precompact-optimize.mjs', matcher: null },
 ];
 

--- a/integrations/windsurf/token-optimizer.md
+++ b/integrations/windsurf/token-optimizer.md
@@ -25,6 +25,10 @@ LIVE GRAPH — THE ACTIVE MODEL DOES THE SEMANTIC HARVEST:
   command that finally worked.
 - Anchor every claim to a real file path or path#symbol. Never invent a claim
   merely to populate the graph, and do not delegate harvesting to another model.
+- Include the concrete evidence, when it applies, confidenceLabel
+  (verified/probable/speculative), scope (project/organization/global), and any
+  condition that would invalidate it. Use project scope unless transfer is
+  genuinely justified.
 - Before finishing substantive work, reflect once and write any still-unrecorded
   conclusion while you hold the reasoning. This is what makes the lesson
   available across sessions and projects instead of losing it to compaction.

--- a/integrations/zed/AGENTS.md
+++ b/integrations/zed/AGENTS.md
@@ -25,6 +25,10 @@ LIVE GRAPH — THE ACTIVE MODEL DOES THE SEMANTIC HARVEST:
   command that finally worked.
 - Anchor every claim to a real file path or path#symbol. Never invent a claim
   merely to populate the graph, and do not delegate harvesting to another model.
+- Include the concrete evidence, when it applies, confidenceLabel
+  (verified/probable/speculative), scope (project/organization/global), and any
+  condition that would invalidate it. Use project scope unless transfer is
+  genuinely justified.
 - Before finishing substantive work, reflect once and write any still-unrecorded
   conclusion while you hold the reasoning. This is what makes the lesson
   available across sessions and projects instead of losing it to compaction.

--- a/package.json
+++ b/package.json
@@ -59,7 +59,10 @@
     "verify:harvest": "node scripts/verify-harvest-api.mjs",
     "verify:live-graph": "node scripts/verify-live-graph-flow.mjs",
     "verify:clients": "node scripts/verify-client-configs.mjs",
-    "verify:all": "npm run sync:hooks:check && npm run verify:clients && npm run verify:harvest && npm run verify:live-graph && npm run verify:ui && npm run verify:interactions",
+    "verify:certification": "node scripts/certify-clients.mjs --no-version-check",
+    "eval:evidence": "node scripts/run-evidence-eval.mjs",
+    "eval:evidence:plan": "node scripts/run-evidence-eval.mjs --dry-run",
+    "verify:all": "npm run sync:hooks:check && npm run verify:clients && npm run verify:certification && npm run verify:harvest && npm run verify:live-graph && npm run verify:ui && npm run verify:interactions",
     "verify:interactions": "node scripts/verify-wiki-interactions.mjs",
     "explore:wiki": "node scripts/explore-wiki.mjs"
   },

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -12,7 +12,7 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "Read|Grep|Glob|Edit|MultiEdit|Write|Bash",
+        "matcher": "Read|Grep|Glob|Edit|MultiEdit|Write|Bash|PowerShell",
         "hooks": [
           {
             "type": "command",
@@ -33,7 +33,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Edit|MultiEdit|Write|Bash|mcp__.*__(?:smart_edit|smart_write)",
+        "matcher": "Edit|MultiEdit|Write|Bash|PowerShell|mcp__.*__(?:smart_edit|smart_write)",
         "hooks": [
           {
             "type": "command",

--- a/plugin/hooks/lib/adapter.mjs
+++ b/plugin/hooks/lib/adapter.mjs
@@ -31,7 +31,9 @@ import {
   readCostBytes,
   touchedFiles,
 } from './decide.mjs';
-import { recordRead, fingerprint } from './metrics.mjs';
+import {
+  recordRead, fingerprint, recordToolOutcome, recordEpisodeOutcome,
+} from './metrics.mjs';
 import {
   contentHash,
   harvest,
@@ -57,6 +59,8 @@ import { isFsSafePath } from './paths.mjs';
 import {
   isSubstantive, recordingNudge, semanticHarvestPrompt,
 } from './recording.mjs';
+import { nativeClientProfiles } from './capabilities.mjs';
+import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 
 /**
  * Per-client capability.
@@ -65,41 +69,7 @@ import {
  * it true where the client has no pre-execution veto would make the product
  * claim enforcement it cannot deliver.
  */
-export const CLIENTS = {
-  'claude-code': { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  codex: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  cline: {
-    canDeny: true,
-    contextStyle: 'cline',
-    denyStyle: 'cline',
-    stopDecision: 'block',
-  },
-  copilot: {
-    canDeny: true,
-    contextStyle: 'top-level',
-    denyStyle: 'top-level-permission',
-    stopDecision: 'block',
-  },
-  cursor: {
-    canDeny: true,
-    contextStyle: 'cursor',
-    denyStyle: 'cursor',
-    stopStyle: 'followup',
-    stopDecision: 'block',
-  },
-  // Gemini's BeforeTool and AfterAgent decisions are top-level. Treating it
-  // like Codex produced well-formed JSON that Gemini ignored.
-  gemini: { canDeny: true, denyStyle: 'top-level', stopDecision: 'deny' },
-  kilo: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  opencode: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  qwen: { canDeny: true, denyStyle: 'permission', stopDecision: 'block' },
-  windsurf: {
-    canDeny: true,
-    contextStyle: 'silent',
-    denyStyle: 'exit-2',
-    stopDecision: 'block',
-  },
-};
+export const CLIENTS = nativeClientProfiles();
 
 /** Never synchronously hash an unbounded build artifact on a hook path. */
 const HARVEST_MAX_BYTES =
@@ -135,6 +105,24 @@ export function mutationSucceeded(clientName, raw) {
   // or are called by our in-process bridge only from its successful after hook.
   return new Set(['claude-code', 'qwen', 'opencode', 'kilo', 'windsurf'])
     .has(clientName);
+}
+
+/** Conservative success classification for any completed tool call. */
+export function toolSucceeded(raw) {
+  if (raw?.error || raw?.tool_response?.error || raw?.toolResponse?.error)
+    return false;
+  if (raw?.postToolUse?.success === false || raw?.success === false) return false;
+  const status =
+    raw?.tool_response?.status ?? raw?.toolResponse?.status ??
+    raw?.tool_result?.status ?? raw?.toolResult?.status;
+  if (status !== undefined) {
+    if (/^(?:error|failed|failure|cancelled|canceled|denied)$/i.test(String(status))) return false;
+    if (/^(?:ok|success|succeeded|complete|completed)$/i.test(String(status))) return true;
+  }
+  // A post-tool lifecycle event is evidence that the call completed, but not
+  // that its output proved the task.  `success` here is deliberately scoped to
+  // the tool call; task correctness comes only from an eval grader.
+  return true;
 }
 
 function contextOutput(client, eventName, additionalContext) {
@@ -253,8 +241,10 @@ refused.
 
 Worth recording: a decision and why the alternative was rejected, a failure and
 what actually caused it, a command that turned out to be the one that works.
-Not worth recording: what the code plainly says. Prefer the thing someone had to
-work out, because that exists nowhere in the source tree.${projectBriefing()}`;
+Not worth recording: what the code plainly says. Every wiki_write must include
+the concrete evidence, when it applies, a calibrated confidence label, its
+scope, and what would invalidate it. Prefer the thing someone had to work out,
+because that exists nowhere in the source tree.${projectBriefing()}`;
 }
 
 /**
@@ -315,7 +305,7 @@ function projectBriefing() {
  * metrics. It never called forTouch/forCommand, so four advertised clients
  * accumulated a graph that their active model could not receive.
  */
-function observeAndInject(payload, state) {
+function observeAndInject(payload, state, episode, features) {
   const touched = touchedFiles(payload);
   const dirFor = (path) => wikiDir(projectRootFor(path, payload.cwd));
 
@@ -344,45 +334,51 @@ function observeAndInject(payload, state) {
   state.injected = state.injected || [];
   const alreadyInjected = new Set(state.injected);
 
-  for (const { path } of touched) {
-    const dir = dirFor(path);
-    const note = forTouch(dir, load(dir), path, {
-      sessionId: payload.session_id,
-      alreadyInjected,
-    });
-    if (note) parts.push(note);
-  }
+  if (features.retrieval) {
+    for (const { path } of touched) {
+      const dir = dirFor(path);
+      const note = forTouch(dir, load(dir), path, {
+        sessionId: payload.session_id,
+        alreadyInjected,
+        episode,
+      });
+      if (note) parts.push(note);
+    }
 
-  const command = payload.tool_input?.command;
-  if (command) {
-    const root = commandProjectRoot(payload, payload.cwd);
-    const dir = wikiDir(root);
-    const local = forCommand(dir, load(dir), command, {
-      sessionId: payload.session_id,
-      alreadyInjected,
-    });
-    if (local) parts.push(local);
+    const command = payload.tool_input?.command;
+    if (command) {
+      const root = commandProjectRoot(payload, payload.cwd);
+      const dir = wikiDir(root);
+      const local = forCommand(dir, load(dir), command, {
+        sessionId: payload.session_id,
+        alreadyInjected,
+        episode,
+      });
+      if (local) parts.push(local);
 
-    const shared = forSharedCommand(dir, command, {
-      sessionId: payload.session_id,
-      alreadyInjected,
-      projectRoot: root,
-    });
-    if (shared) parts.push(shared);
+      const shared = forSharedCommand(dir, command, {
+        sessionId: payload.session_id,
+        alreadyInjected,
+        projectRoot: root,
+        episode,
+      });
+      if (shared) parts.push(shared);
 
-    const crossed = noteActClasses(state, command);
-    const repeated = forRepeatedAct(dir, command, crossed, {
-      sessionId: payload.session_id,
-      projectRoot: root,
-    });
-    if (repeated) parts.push(repeated);
+      const crossed = noteActClasses(state, command);
+      const repeated = forRepeatedAct(dir, command, crossed, {
+        sessionId: payload.session_id,
+        projectRoot: root,
+        episode,
+      });
+      if (repeated) parts.push(repeated);
+    }
   }
   state.injected = [...alreadyInjected];
 
   // Structural capture is evidence about what was touched, not a semantic
   // conclusion. It is therefore safe to automate for every client and leaves
   // the active model responsible for wiki_write at completion.
-  for (const { path, size } of touched) {
+  if (features.capture) for (const { path, size } of touched) {
     try {
       if (isArchived(path) || size > HARVEST_MAX_BYTES || !isFsSafePath(path))
         continue;
@@ -420,7 +416,10 @@ export async function run(clientName, event) {
 
   if (mode() === MODE_OFF) process.exit(0);
 
+  const features = featuresForArm();
+
   if (event === 'session-start') {
+    if (!features.routing && !features.retrieval && !features.harvest) process.exit(0);
     const output = contextOutput(client, eventName, policyText(client.canDeny));
     if (output) emit(output);
     process.exit(0);
@@ -437,10 +436,22 @@ export async function run(clientName, event) {
     const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? 'default';
     const agentScope = raw.transcript_path ?? raw.transcriptPath ?? null;
     const state = loadState(sessionId, agentScope);
+    const episode = episodeMeta({ client: clientName, raw });
+    try {
+      const cwd = raw.cwd || raw.working_directory || process.cwd();
+      const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+      recordEpisodeOutcome(dir, {
+        ...episode,
+        status: 'completed',
+        ...usageFrom(raw),
+      });
+    } catch {
+      // Evidence is best effort and must never stop a session from finishing.
+    }
     const alreadyHarvested =
       Number(state.edits || 0) > 0 &&
       Number(state.harvestedEdits || 0) >= Number(state.edits || 0);
-    const prompt = semanticHarvestPrompt({
+    const prompt = features.harvest ? semanticHarvestPrompt({
       edits: state.edits,
       files: state.editedFiles,
       model: raw.model,
@@ -449,7 +460,7 @@ export async function run(clientName, event) {
         raw.stopHookActive === true ||
         alreadyHarvested ||
         (clientName === 'cursor' && Number(raw.loop_count || 0) > 0),
-    });
+    }) : null;
     if (prompt) {
       state.harvestedEdits = Number(state.edits || 0);
       saveState(sessionId, state, agentScope);
@@ -466,6 +477,7 @@ export async function run(clientName, event) {
     process.exit(0);
   const payload = normalizePayload(normalizeClientPayload(clientName, event, raw));
   if (!payload.tool_name) process.exit(0);
+  const episode = episodeMeta({ client: clientName, raw, payload });
 
   // THE AGENT, not just the session -- the same scope the Claude Code router
   // applies. Subagents inherit the parent's session id, so keying state on the
@@ -506,17 +518,41 @@ export async function run(clientName, event) {
       const anchor = state.editedFiles[0]
         || join(payload.cwd || process.cwd(), '__recording__');
       const dir = wikiDir(projectRootFor(anchor, payload.cwd));
-      recordingContext = recordingNudge(dir, {
+      recordingContext = features.harvest ? recordingNudge(dir, {
         state,
         edits: state.edits,
         files: state.editedFiles,
-      });
+      }) : null;
       if (recordingContext) state.recordingNudged = true;
     } catch {
       // Recording pressure is an optimization and must never cost a tool call.
     }
   }
-  const verdict = decide(payload, state);
+  if (event === 'post-tool') {
+    try {
+      const command = payload.tool_input?.command;
+      const touched = touchedFiles(payload);
+      const anchor = command
+        ? String(command).slice(0, 120)
+        : touched[0]?.path || payload.tool_input?.file_path || '';
+      const root = command
+        ? commandProjectRoot(payload, payload.cwd)
+        : projectRootFor(anchor || join(payload.cwd || process.cwd(), '__tool__'), payload.cwd);
+      recordToolOutcome(wikiDir(root), {
+        ...episode,
+        surface: command ? 'command' : 'file',
+        anchor,
+        toolName: payload.tool_name,
+        success: toolSucceeded(raw),
+        durationMs: Number(raw.duration_ms ?? raw.durationMs ?? raw.elapsed_ms ?? raw.elapsedMs) || null,
+        ...usageFrom(raw),
+      });
+    } catch {
+      // Causal tracing is fail-open like every other hook optimization.
+    }
+  }
+
+  const verdict = features.routing ? decide(payload, state) : null;
   const repeat = verdict && event === 'pre-tool'
     ? alreadyDenied(state, verdict.key)
     : false;
@@ -571,7 +607,7 @@ export async function run(clientName, event) {
   remember(payload, state);
   let graphContext = null;
   try {
-    graphContext = observeAndInject(payload, state);
+    graphContext = observeAndInject(payload, state, episode, features);
   } catch {
     // Delivery is an optimization. Fail open.
   }

--- a/plugin/hooks/lib/capabilities.mjs
+++ b/plugin/hooks/lib/capabilities.mjs
@@ -1,0 +1,130 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/capabilities.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * The product's honest cross-client capability contract.
+ *
+ * A client is listed at the strongest surface its public lifecycle protocol can
+ * actually support.  This registry is consumed by the adapter, certification
+ * tooling, and evidence reports so a rules-only integration can never be
+ * presented as equivalent to a native stop-continuation integration.
+ */
+
+export const CAPABILITY_TIERS = Object.freeze({
+  CONTINUATION: 'lifecycle-continuation',
+  OBSERVATION: 'native-observation',
+  RULES: 'mcp-rules',
+});
+
+const native = (profile) => ({
+  structuralCapture: 'native',
+  findingDelivery: 'native',
+  routing: 'native-veto',
+  ...profile,
+});
+
+export const CLIENT_CAPABILITIES = Object.freeze({
+  'claude-code': native({
+    name: 'Claude Code', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-continuation', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  codex: native({
+    name: 'Codex', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-continuation', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  copilot: native({
+    name: 'GitHub Copilot CLI', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'agent-stop-continuation', canDeny: true,
+    contextStyle: 'top-level', denyStyle: 'top-level-permission', stopDecision: 'block',
+  }),
+  gemini: native({
+    name: 'Gemini CLI', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'after-agent-retry', canDeny: true,
+    denyStyle: 'top-level', stopDecision: 'deny',
+  }),
+  qwen: native({
+    name: 'Qwen Code', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-continuation', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  cursor: native({
+    name: 'Cursor', tier: CAPABILITY_TIERS.CONTINUATION,
+    semanticHarvest: 'stop-followup', canDeny: true,
+    contextStyle: 'cursor', denyStyle: 'cursor', stopStyle: 'followup', stopDecision: 'block',
+  }),
+  cline: native({
+    name: 'Cline', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    contextStyle: 'cline', denyStyle: 'cline', stopDecision: 'block',
+  }),
+  opencode: native({
+    name: 'OpenCode', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  kilo: native({
+    name: 'Kilo', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    denyStyle: 'permission', stopDecision: 'block',
+  }),
+  windsurf: native({
+    name: 'Windsurf', tier: CAPABILITY_TIERS.OBSERVATION,
+    semanticHarvest: 'active-model-rule', canDeny: true,
+    contextStyle: 'silent', denyStyle: 'exit-2', stopDecision: 'block',
+  }),
+  roo: {
+    name: 'Roo Code', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  zed: {
+    name: 'Zed', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  amp: {
+    name: 'Amp', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  continue: {
+    name: 'Continue', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  crush: {
+    name: 'Crush', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+  droid: {
+    name: 'Droid (Factory)', tier: CAPABILITY_TIERS.RULES, routing: 'rules',
+    structuralCapture: 'mcp-visible-only', findingDelivery: 'explicit-mcp',
+    semanticHarvest: 'active-model-rule', canDeny: false,
+  },
+});
+
+export function capabilityFor(client) {
+  return CLIENT_CAPABILITIES[String(client || '').toLowerCase()] || null;
+}
+
+export function nativeClientProfiles() {
+  return Object.fromEntries(
+    Object.entries(CLIENT_CAPABILITIES)
+      .filter(([, profile]) => profile.structuralCapture === 'native')
+      .map(([key, profile]) => [key, { ...profile }])
+  );
+}
+
+export function capabilitySummary() {
+  return Object.entries(CLIENT_CAPABILITIES).map(([client, profile]) => ({
+    client,
+    name: profile.name,
+    tier: profile.tier,
+    routing: profile.routing,
+    structuralCapture: profile.structuralCapture,
+    findingDelivery: profile.findingDelivery,
+    semanticHarvest: profile.semanticHarvest,
+  }));
+}

--- a/plugin/hooks/lib/decide.mjs
+++ b/plugin/hooks/lib/decide.mjs
@@ -513,6 +513,8 @@ const TOOL_ALIASES = new Map(
     create_file: 'Write',
 
     bash: 'Bash',
+    powershell: 'Bash',
+    pwsh: 'Bash',
     shell: 'Bash',
     run_command: 'Bash',
     execute_command: 'Bash',

--- a/plugin/hooks/lib/experiment.mjs
+++ b/plugin/hooks/lib/experiment.mjs
@@ -1,0 +1,82 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/experiment.mjs. Regenerate with `npm run sync:hooks`.
+/** Explicit, reproducible feature arms and causal episode identity. */
+
+export const EXPERIMENT_ARMS = Object.freeze([
+  'baseline',
+  'optimizer',
+  'retrieval',
+  'full',
+]);
+
+const FEATURES = Object.freeze({
+  baseline: Object.freeze({ routing: false, retrieval: false, capture: false, harvest: false }),
+  optimizer: Object.freeze({ routing: true, retrieval: false, capture: false, harvest: false }),
+  retrieval: Object.freeze({ routing: true, retrieval: true, capture: true, harvest: false }),
+  full: Object.freeze({ routing: true, retrieval: true, capture: true, harvest: true }),
+});
+
+export function experimentArm(env = process.env) {
+  const requested = String(env.TOKEN_OPTIMIZER_EXPERIMENT_ARM || '').trim().toLowerCase();
+  return EXPERIMENT_ARMS.includes(requested) ? requested : 'full';
+}
+
+export function featuresForArm(arm = experimentArm()) {
+  return FEATURES[arm] || FEATURES.full;
+}
+
+const first = (...values) => values.find((value) => value !== undefined && value !== null && value !== '');
+
+/**
+ * Normalises identifiers exposed under different names by lifecycle clients.
+ * Environment overrides let the live evaluation harness pin a pair/task id
+ * without asking each CLI to support experiment-specific payload fields.
+ */
+export function episodeMeta({ client, raw = {}, payload = {}, env = process.env } = {}) {
+  const sessionId = String(first(
+    payload.session_id, raw.session_id, raw.sessionId, raw.conversation_id,
+    raw.conversationId, raw.taskId, raw.task_id, raw.trajectory_id, 'default'
+  ));
+  const episodeId = String(first(
+    env.TOKEN_OPTIMIZER_EPISODE_ID, raw.episode_id, raw.episodeId, sessionId
+  ));
+  const toolCallId = first(
+    raw.tool_use_id, raw.toolUseId, raw.tool_call_id, raw.toolCallId,
+    raw.call_id, raw.callId, raw.postToolUse?.toolUseId, raw.preToolUse?.toolUseId
+  );
+  const model = first(payload.model, raw.model?.slug, raw.model, raw.model_name, env.TOKEN_OPTIMIZER_MODEL);
+  const clientVersion = first(
+    raw.client_version, raw.clientVersion, raw.version, env.TOKEN_OPTIMIZER_CLIENT_VERSION
+  );
+  const modelVersion = first(raw.model_version, raw.modelVersion, env.TOKEN_OPTIMIZER_MODEL_VERSION);
+
+  return {
+    schemaVersion: 2,
+    episodeId,
+    sessionId,
+    turnId: first(raw.turn_id, raw.turnId, raw.message_id, raw.messageId) ?? null,
+    toolCallId: toolCallId == null ? null : String(toolCallId),
+    taskId: first(env.TOKEN_OPTIMIZER_TASK_ID, raw.task_id, raw.taskId) ?? null,
+    pairId: first(env.TOKEN_OPTIMIZER_PAIR_ID, raw.pair_id, raw.pairId) ?? null,
+    arm: experimentArm(env),
+    client: String(client || first(raw.client, raw.client_name, 'unknown')),
+    clientVersion: clientVersion == null ? null : String(clientVersion),
+    model: model == null ? null : String(model),
+    modelVersion: modelVersion == null ? null : String(modelVersion),
+  };
+}
+
+export function usageFrom(raw = {}) {
+  const usage = raw.usage || raw.token_usage || raw.tokenUsage || raw.metrics?.usage || {};
+  const number = (...values) => {
+    const value = first(...values);
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+  };
+  return {
+    uncachedInputTokens: number(usage.uncached_input_tokens, usage.uncachedInputTokens),
+    cachedInputTokens: number(usage.cached_input_tokens, usage.cachedInputTokens, usage.cache_read_input_tokens),
+    outputTokens: number(usage.output_tokens, usage.outputTokens),
+    totalTokens: number(usage.total_tokens, usage.totalTokens, raw.tokens_used, raw.tokensUsed),
+  };
+}

--- a/plugin/hooks/lib/harvest-write.mjs
+++ b/plugin/hooks/lib/harvest-write.mjs
@@ -96,8 +96,13 @@ function promoteToShared(finding, { projectRoot, sessionId, provenance, key }) {
           key: `shared-${key}`,
           claim: finding.claim,
           confidence: finding.confidence,
+          confidenceLabel: finding.confidenceLabel,
           type: finding.type,
           trigger: typeof finding.trigger === 'string' && finding.trigger ? finding.trigger : undefined,
+          applicability: finding.applicability,
+          evidence: finding.evidence,
+          invalidators: Array.isArray(finding.invalidators) ? finding.invalidators : [],
+          scope: finding.scope || 'global',
           origin: provenance,
           quote: typeof finding.quote === 'string' && finding.quote.trim() ? finding.quote : undefined,
           // WHERE IT WAS LEARNED, carried so the reader can discount it. A lesson
@@ -351,6 +356,26 @@ export function writeHarvested(
     // anything, so it is dropped rather than kept as unfalsifiable.
     if (!resolved.length) continue;
 
+    // Exact semantic duplicates collapse to the existing active record.  The
+    // normalisation intentionally ignores punctuation/formatting noise but not
+    // meaning-bearing words; near-duplicates that need judgement remain visible
+    // to curation rather than being silently merged by a fuzzy heuristic.
+    const fingerprint = claimFingerprint(finding.claim);
+    const currentGraph = load(dir);
+    const duplicate = [...currentGraph.nodes.values()].find((node) =>
+      node.kind === 'finding'
+      && !node.retired
+      && node.type === finding.type
+      && claimFingerprint(node.claim) === fingerprint
+      && resolved.every((target) => currentGraph.edges.some((edge) =>
+        edge.from === node.id && edge.edge === 'derived_from' && edge.to === target
+      ))
+    );
+    if (duplicate) {
+      written.push(duplicate.key);
+      continue;
+    }
+
     // Date.now() plus an index is not unique across CONCURRENT detached
     // workers: two Stop hooks finishing in the same millisecond produce the
     // same key, and putNode keeps the last write for an id -- so one session's
@@ -371,6 +396,7 @@ export function writeHarvested(
         key,
         claim: finding.claim,
         confidence: finding.confidence,
+        confidenceLabel: finding.confidenceLabel,
         type: finding.type,
         // WHEN this finding is relevant, not just what it is about. Anchors
         // answer "which file", which is the wrong question for a claim about
@@ -380,6 +406,16 @@ export function writeHarvested(
         trigger: typeof finding.trigger === 'string' && finding.trigger
           ? finding.trigger
           : undefined,
+        applicability: typeof finding.applicability === 'string'
+          ? finding.applicability
+          : undefined,
+        evidence: typeof finding.evidence === 'string'
+          ? finding.evidence
+          : undefined,
+        invalidators: Array.isArray(finding.invalidators)
+          ? finding.invalidators
+          : [],
+        scope: finding.scope || 'project',
         origin: provenance,
         // THE EVIDENCE TRAVELS WITH THE CLAIM. Without it a human-origin
         // finding asserts its own provenance and nothing can check it.
@@ -398,7 +434,11 @@ export function writeHarvested(
     // record of what happened here; the shared tier is a copy for the lessons
     // that are not about here. Skipped when the two are the same directory,
     // which is the suite's usual arrangement.
-    if (id && !isSharedDir(dir)) {
+    if (
+      id
+      && !isSharedDir(dir)
+      && (finding.scope === undefined || finding.scope === 'organization' || finding.scope === 'global')
+    ) {
       promoteToShared(finding, { projectRoot, sessionId, provenance, key });
     }
   }

--- a/plugin/hooks/lib/harvest.mjs
+++ b/plugin/hooks/lib/harvest.mjs
@@ -201,7 +201,11 @@ const PROMPT = `Extract durable findings from this coding session for a project 
 Return ONLY a JSON array. Each element:
 {"type": "finding|decision|failure|command|map",
  "claim": "one sentence, specific and checkable",
- "confidence": 0.0-1.0,
+ "evidence": "the concrete observation, command result, or rejected approach that proved it",
+ "applicability": "the condition under which a future model should use it",
+ "confidenceLabel": "verified|probable|speculative",
+ "scope": "project|organization|global",
+ "invalidators": ["what change would require this to be checked again"],
  "anchors": ["absolute/file/path" or "absolute/file/path#symbolName"]}
 
 RULES:
@@ -211,7 +215,9 @@ RULES:
 - Prefer "failure" and "decision" entries. What was TRIED AND REJECTED, and WHY,
   is the most valuable thing here because it exists nowhere in the source tree.
 - Do not restate what the code plainly says. Record what someone had to work out.
-- confidence reflects how well established the claim is, not how important.
+- verified requires direct evidence; probable means strong but incomplete evidence;
+  speculative is a hypothesis and must be labelled as such.
+- Use project scope unless the lesson is genuinely independent of this repository.
 - If nothing durable was learned, return [].`;
 
 /**
@@ -232,8 +238,29 @@ export function validate(raw, { knownFiles = null } = {}) {
     if (!FINDING_TYPES.includes(item.type)) continue;
     if (typeof item.claim !== 'string' || item.claim.trim().length < 8) continue;
 
-    const confidence = Number(item.confidence);
-    if (!Number.isFinite(confidence) || confidence <= 0 || confidence > 1) continue;
+    const evidence = typeof item.evidence === 'string' ? item.evidence.trim() : '';
+    const applicability = typeof item.applicability === 'string' ? item.applicability.trim() : '';
+    if (evidence.length < 8 || applicability.length < 8) continue;
+
+    const confidenceLabel = ['verified', 'probable', 'speculative'].includes(item.confidenceLabel)
+      ? item.confidenceLabel
+      : null;
+    if (!confidenceLabel) continue;
+    const defaults = { verified: 0.95, probable: 0.75, speculative: 0.45 };
+    const supplied = Number(item.confidence);
+    if (
+      item.confidence !== undefined
+      && (!Number.isFinite(supplied) || supplied <= 0 || supplied > 1)
+    ) continue;
+    const confidence = item.confidence === undefined
+      ? defaults[confidenceLabel]
+      : supplied;
+    const scope = ['project', 'organization', 'global'].includes(item.scope)
+      ? item.scope
+      : 'project';
+    const invalidators = Array.isArray(item.invalidators)
+      ? item.invalidators.filter((value) => typeof value === 'string' && value.trim()).slice(0, 10)
+      : [];
 
     let anchors = Array.isArray(item.anchors) ? item.anchors.filter((a) => typeof a === 'string' && a) : [];
     // A model asked for file paths will sometimes invent them. When the caller
@@ -241,7 +268,18 @@ export function validate(raw, { knownFiles = null } = {}) {
     if (knownFiles) anchors = anchors.filter((a) => knownFiles.has(a.split('#')[0]));
     if (!anchors.length) continue;
 
-    accepted.push({ type: item.type, claim: item.claim.trim(), confidence, anchors });
+    accepted.push({
+      type: item.type,
+      claim: item.claim.trim(),
+      evidence,
+      applicability,
+      confidence,
+      confidenceLabel,
+      scope,
+      invalidators,
+      anchors,
+      trigger: typeof item.trigger === 'string' ? item.trigger : undefined,
+    });
   }
   return accepted;
 }

--- a/plugin/hooks/lib/inject.mjs
+++ b/plugin/hooks/lib/inject.mjs
@@ -30,6 +30,7 @@ import { inHoldout, record, indexBudget } from './metrics.mjs';
 import { canonicalPath, resolvableCandidates } from './paths.mjs';
 import { annotatedSkeleton } from './skeleton.mjs';
 import { substitutionBudget } from './metrics.mjs';
+import { assessFindings } from './utility.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
@@ -150,7 +151,7 @@ export function forTouch(
   dir,
   graph,
   rawPath,
-  { budget = touchBudget(), sessionId, alreadyInjected = new Set() } = {}
+  { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
   // Canonical, so a touch finds findings anchored under any other spelling.
   const filePath = canonicalPath(rawPath);
@@ -169,16 +170,36 @@ export function forTouch(
   // variance drops out. A session-pinned arm would destroy that.
   const holdout = inHoldout(filePath);
   const served = serve(graph, candidates);
-  const { kept, spent } = fit(served, budget);
+  const assessed = assessFindings(dir, served, {
+    episodeId: episode.episodeId || sessionId,
+    relevanceFor: () => 1,
+    costFor: (finding) => estimate(render(finding)),
+  });
+  if (assessed.rejected.length) {
+    record(dir, {
+      kind: 'retrieval-decision', ...episode, sessionId,
+      surface: 'file', anchor: filePath,
+      rejected: assessed.rejected.map(({ key, reason }) => ({ key, reason })),
+    });
+    for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
+  }
+  const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
+  if (!kept.length) return null;
 
   record(dir, {
     kind: 'inject',
+    ...episode,
     // The surface whose saving CAN be measured: reads of this anchor afterwards.
     surface: 'file',
     anchor: filePath,
     holdout,
     tokens: holdout ? 0 : spent,
-    count: kept.length,
+    deliveredTokens: holdout ? 0 : spent,
+    shadowTokens: spent,
+    count: holdout ? 0 : kept.length,
+    candidateCount: kept.length,
+    findingIds: holdout ? [] : kept.map((finding) => finding.key),
+    shadowFindingIds: kept.map((finding) => finding.key),
     stale: kept.some((f) => f.stale),
     sessionId,
   });
@@ -297,7 +318,7 @@ export function forCommand(
   dir,
   graph,
   command,
-  { budget = touchBudget(), sessionId, alreadyInjected = new Set() } = {}
+  { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
   if (!command) return null;
 
@@ -335,7 +356,20 @@ export function forCommand(
   const considered = candidates.slice(0, MAX_COMMAND_CANDIDATES);
 
   const served = serve(graph, considered);
-  const { kept, spent } = fit(served, budget);
+  const assessed = assessFindings(dir, served, {
+    episodeId: episode.episodeId || sessionId,
+    relevanceFor: (finding) => explicit(finding) ? 1 : 0.6,
+    costFor: (finding) => estimate(render(finding)),
+  });
+  if (assessed.rejected.length) {
+    record(dir, {
+      kind: 'retrieval-decision', ...episode, sessionId,
+      surface: 'command', anchor: String(command).slice(0, 120),
+      rejected: assessed.rejected.map(({ key: findingKey, reason }) => ({ key: findingKey, reason })),
+    });
+    for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
+  }
+  const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
   if (!kept.length) return null;
 
   // THE COMMAND PATH TAKES PART IN THE HOLDOUT TOO.
@@ -353,6 +387,7 @@ export function forCommand(
 
   record(dir, {
     kind: 'inject',
+    ...episode,
     trigger: 'command',
     // The surface the report needs to keep these OUT of the file-read balance:
     // a command has no anchor that read events can be joined to.
@@ -360,7 +395,12 @@ export function forCommand(
     anchor: String(command).slice(0, 120),
     holdout,
     tokens: holdout ? 0 : spent,
+    deliveredTokens: holdout ? 0 : spent,
+    shadowTokens: spent,
     count: holdout ? 0 : kept.length,
+    candidateCount: kept.length,
+    findingIds: holdout ? [] : kept.map((finding) => finding.key),
+    shadowFindingIds: kept.map((finding) => finding.key),
     stale: kept.some((f) => f.stale),
     sessionId,
   });
@@ -509,7 +549,7 @@ export function forRepeatedAct(
   projectDir,
   command,
   crossedClasses,
-  { sessionId = null, projectRoot = null } = {}
+  { sessionId = null, projectRoot = null, episode = {} } = {}
 ) {
   if (!crossedClasses || !crossedClasses.size) return null;
 
@@ -527,14 +567,33 @@ export function forRepeatedAct(
       if (![...crossedClasses].some((c) => claimClasses.has(c))) continue;
 
       const cls = [...crossedClasses].find((c) => claimClasses.has(c));
+      const assessed = assessFindings(projectDir, [node], {
+        episodeId: episode.episodeId || sessionId,
+        relevanceFor: () => 1,
+        costFor: (finding) => estimate(render(finding)),
+      });
+      if (!assessed.eligible.length) {
+        record(projectDir, {
+          kind: 'retrieval-decision', ...episode, sessionId,
+          surface: 'shared', anchor: String(command).slice(0, 120),
+          rejected: assessed.rejected.map(({ key, reason }) => ({ key, reason })),
+        });
+        continue;
+      }
       record(projectDir, {
         kind: 'inject',
+        ...episode,
         trigger: 'repeat',
         surface: 'shared',
         anchor: String(command).slice(0, 120),
         holdout: false,
         tokens: estimate(node.claim),
+        deliveredTokens: estimate(node.claim),
+        shadowTokens: estimate(node.claim),
         count: 1,
+        candidateCount: 1,
+        findingIds: [node.key],
+        shadowFindingIds: [node.key],
         stale: false,
         sessionId,
       });
@@ -585,7 +644,10 @@ function appliesCrossProject(finding, command) {
 export function forSharedCommand(
   projectDir,
   command,
-  { budget = sharedBudget(), sessionId = null, alreadyInjected = new Set(), projectRoot = null } = {}
+  {
+    budget = sharedBudget(), sessionId = null, alreadyInjected = new Set(),
+    projectRoot = null, episode = {},
+  } = {}
 ) {
   if (!command) return null;
 
@@ -622,7 +684,21 @@ export function forSharedCommand(
     // No serve() here: these types are not content-dependent, so there is no
     // anchor to re-read and nothing to diff. serve() would spend a file read per
     // finding to answer a question that does not apply to them.
-    const { kept, spent } = fit(candidates.slice(0, MAX_SHARED), budget);
+    const considered = candidates.slice(0, MAX_SHARED);
+    const assessed = assessFindings(projectDir, considered, {
+      episodeId: episode.episodeId || sessionId,
+      relevanceFor: (finding) => explicit(finding) ? 0.8 : 0.5,
+      costFor: (finding) => estimate(render(finding)),
+    });
+    if (assessed.rejected.length) {
+      record(projectDir, {
+        kind: 'retrieval-decision', ...episode, sessionId,
+        surface: 'shared', anchor: String(command).slice(0, 120),
+        rejected: assessed.rejected.map(({ key, reason }) => ({ key, reason })),
+      });
+      for (const rejected of assessed.rejected) alreadyInjected.add(rejected.key);
+    }
+    const { kept, spent } = fit(assessed.eligible.map((item) => item.finding), budget);
     if (!kept.length) return null;
 
     // THE SAME ARM AS THE LOCAL PATH, KEYED THE SAME WAY.
@@ -644,6 +720,7 @@ export function forSharedCommand(
 
     record(projectDir, {
       kind: 'inject',
+      ...episode,
       trigger: 'command',
       // ITS OWN SURFACE. The balance sheet joins `file` injections to later read
       // events; a shared lesson has no anchor in this project to join to, and
@@ -653,7 +730,12 @@ export function forSharedCommand(
       anchor: String(command).slice(0, 120),
       holdout,
       tokens: holdout ? 0 : spent,
+      deliveredTokens: holdout ? 0 : spent,
+      shadowTokens: spent,
       count: holdout ? 0 : kept.length,
+      candidateCount: kept.length,
+      findingIds: holdout ? [] : kept.map((finding) => finding.key),
+      shadowFindingIds: kept.map((finding) => finding.key),
       stale: false,
       sessionId,
     });

--- a/plugin/hooks/lib/inject.mjs
+++ b/plugin/hooks/lib/inject.mjs
@@ -571,6 +571,10 @@ export function forRepeatedAct(
         episodeId: episode.episodeId || sessionId,
         relevanceFor: () => 1,
         costFor: (finding) => estimate(render(finding)),
+        // This surface exists specifically to re-surface a lesson once the
+        // session crosses the repeat threshold. Ordinary retrieval remains
+        // cooldown-protected; harm quarantine and utility gating still apply.
+        bypassCooldown: true,
       });
       if (!assessed.eligible.length) {
         record(projectDir, {

--- a/plugin/hooks/lib/metrics.mjs
+++ b/plugin/hooks/lib/metrics.mjs
@@ -1022,6 +1022,7 @@ function armMetrics(runs) {
     runs: runs.length,
     correctness: proportionInterval(correct, runs.length),
     uncachedInputTokens: interval('uncachedInputTokens'),
+    cacheCreationInputTokens: interval('cacheCreationInputTokens'),
     cachedInputTokens: interval('cachedInputTokens'),
     outputTokens: interval('outputTokens'),
     totalTokens: interval('totalTokens'),
@@ -1034,31 +1035,37 @@ function armMetrics(runs) {
   };
 }
 
-function pairedEffects(runs, treatmentArm) {
+function pairedEffects(runs, controlArm, treatmentArm, contrastType = 'incremental') {
   const pairs = new Map();
   for (const run of runs) {
-    if (!run.pairId || !['baseline', treatmentArm].includes(run.arm)) continue;
+    if (!run.pairId || ![controlArm, treatmentArm].includes(run.arm)) continue;
     if (!pairs.has(run.pairId)) pairs.set(run.pairId, {});
     pairs.get(run.pairId)[run.arm] = run;
   }
-  const complete = [...pairs.values()].filter((pair) => pair.baseline && pair[treatmentArm]);
+  const complete = [...pairs.values()].filter((pair) => pair[controlArm] && pair[treatmentArm]);
   const delta = (field, lowerIsBetter = true) => bootstrapMeanInterval(
     complete
       .map((pair) => {
-        const baseline = numeric(pair.baseline[field]);
+        const baseline = numeric(pair[controlArm][field]);
         const treatment = numeric(pair[treatmentArm][field]);
         if (baseline === null || treatment === null) return null;
         return lowerIsBetter ? baseline - treatment : treatment - baseline;
       })
       .filter((value) => value !== null),
-    { seed: `${treatmentArm}:${field}` }
+    { seed: `${controlArm}:${treatmentArm}:${field}` }
   );
   return {
     arm: treatmentArm,
+    controlArm,
+    comparison: `${treatmentArm} vs ${controlArm}`,
+    contrastType,
     pairs: complete.length,
     // Positive values always mean the treatment improved the metric.
     totalTokensSaved: delta('totalTokens'),
     uncachedInputTokensSaved: delta('uncachedInputTokens'),
+    cacheCreationInputTokensSaved: delta('cacheCreationInputTokens'),
+    cachedInputTokensSaved: delta('cachedInputTokens'),
+    outputTokensSaved: delta('outputTokens'),
     toolCallsAvoided: delta('toolCalls'),
     latencyMsSaved: delta('latencyMs'),
     costUsdSaved: delta('costUsd'),
@@ -1124,8 +1131,13 @@ export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
         armMetrics(cohortRuns.filter((run) => run.arm === arm)),
       ])
     );
-    const effects = ['optimizer', 'retrieval', 'full'].map((arm) => pairedEffects(cohortRuns, arm));
-    const enough = effects.some((effect) => effect.pairs >= minimumPairs);
+    const effects = [
+      pairedEffects(cohortRuns, 'baseline', 'optimizer'),
+      pairedEffects(cohortRuns, 'optimizer', 'retrieval'),
+      pairedEffects(cohortRuns, 'retrieval', 'full'),
+      pairedEffects(cohortRuns, 'baseline', 'full', 'total-system'),
+    ];
+    const enough = effects.every((effect) => effect.pairs >= minimumPairs);
     return {
       key,
       client: cohortRuns[0]?.client || 'unknown',
@@ -1165,7 +1177,8 @@ export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
     episodes: traced,
     methodology: {
       intervals: 'deterministic percentile bootstrap (95%); Wilson interval for correctness',
-      causalRule: 'only matched eval-run pairs compare an arm with baseline',
+      causalRule:
+        'matched pairs estimate optimizer vs baseline, retrieval vs optimizer, full vs retrieval, and full vs baseline',
       minimumPairs,
       deterministicChecksAreCausalProof: false,
     },

--- a/plugin/hooks/lib/metrics.mjs
+++ b/plugin/hooks/lib/metrics.mjs
@@ -61,6 +61,7 @@ const metricsPath = (dir) => join(dir, 'metrics.jsonl');
  * on it drops BOTH arms proportionally instead of starving the rare one.
  */
 const balancePath = (dir) => join(dir, 'balance.jsonl');
+const evidencePath = (dir) => join(dir, 'evidence.jsonl');
 
 /** Kinds the net balance is computed from, and which therefore must survive. */
 /**
@@ -83,6 +84,24 @@ export const BALANCE_KINDS = new Set([
   // aged out before it was written and the backstop was structurally unable to fire, reporting
   // "only N/10 refreshes observed" for the life of the project.
   'keepwarm',
+]);
+
+/**
+ * Causal records have their own bounded log.  Tool outcomes are much rarer
+ * than read/capture telemetry but more frequent than balance records; mixing
+ * them into either window would eventually evict the evidence needed to join
+ * an injection to its result.
+ */
+export const EVIDENCE_KINDS = new Set([
+  'inject',
+  'harvest',
+  'tool-outcome',
+  'episode-outcome',
+  'eval-run',
+  'finding-feedback',
+  'retrieval-decision',
+  'mcp-client',
+  'mcp-tool',
 ]);
 
 /**
@@ -198,15 +217,30 @@ export function record(dir, event) {
     // single millisecond collapsed to ONE, so a graph with ample data reported
     // 'insufficient data (2 treated, 1 holdout)'. Real events were being
     // discarded by the deduplicator, silently.
-    const line =
-      JSON.stringify({ id: nextId(), ...event, at: event.at ?? Date.now() }) + '\n';
+    const id = event.id || nextId();
+    const complete = {
+      schemaVersion: event.schemaVersion || 2,
+      id,
+      ...event,
+      // An injection id is first-class rather than an inference from the log
+      // record id.  Exporters may rewrite record ids while preserving causal
+      // identity, and downstream tool outcomes refer to this value explicitly.
+      ...(event.kind === 'inject'
+        ? { injectionId: event.injectionId || id }
+        : {}),
+      at: event.at ?? Date.now(),
+    };
+    const line = JSON.stringify(complete) + '\n';
     appendFileSync(metricsPath(dir), line);
     // Balance-critical records go to their own log as well, so the windows on
     // the firehose can never starve the measurement. Written SECOND: a torn
     // write here costs a duplicate the reader dedupes, not a lost event.
     if (BALANCE_KINDS.has(event.kind)) appendFileSync(balancePath(dir), line);
+    if (EVIDENCE_KINDS.has(event.kind)) appendFileSync(evidencePath(dir), line);
+    return complete;
   } catch {
     // Metrics must never break a tool call.
+    return null;
   }
 }
 
@@ -402,6 +436,92 @@ export function readBalance(dir) {
     out.push(e);
   }
   return out;
+}
+
+/** Every causal evidence record inside the byte cap, deduplicated by id. */
+export function readEvidence(dir) {
+  const path = evidencePath(dir);
+  if (!existsSync(path)) return [];
+
+  let text = '';
+  try {
+    const { size } = statSync(path);
+    if (size <= MAX_BYTES) {
+      text = readFileSync(path, 'utf8');
+    } else {
+      const fd = openSync(path, 'r');
+      try {
+        const buffer = Buffer.allocUnsafe(MAX_BYTES);
+        const read = readSync(fd, buffer, 0, MAX_BYTES, size - MAX_BYTES);
+        text = buffer.subarray(0, read).toString('utf8');
+      } finally {
+        closeSync(fd);
+      }
+      text = text.slice(text.indexOf('\n') + 1);
+    }
+  } catch {
+    return [];
+  }
+
+  const seen = new Set();
+  const out = [];
+  for (const line of text.split('\n')) {
+    if (!line) continue;
+    try {
+      const event = JSON.parse(line);
+      if (!EVIDENCE_KINDS.has(event.kind)) continue;
+      const id = event.id || JSON.stringify(event);
+      if (seen.has(id)) continue;
+      seen.add(id);
+      out.push(event);
+    } catch {
+      // A concurrently appended final line may be torn.  It costs one record,
+      // never the user's tool call or the rest of the evidence report.
+    }
+  }
+  return out;
+}
+
+/**
+ * Joins a post-tool result to the most recent matching injection.  The exact
+ * tool-call id wins; clients that omit it fall back to episode + surface +
+ * anchor, in timestamp order, and the report states the weaker join method.
+ */
+export function recordToolOutcome(dir, outcome) {
+  const evidence = readEvidence(dir);
+  const anchor = String(outcome.anchor || '').slice(0, 120);
+  const candidates = evidence
+    .filter((event) => event.kind === 'inject' && event.episodeId === outcome.episodeId)
+    .filter((event) => {
+      if (outcome.toolCallId && event.toolCallId)
+        return String(event.toolCallId) === String(outcome.toolCallId);
+      return event.surface === outcome.surface && String(event.anchor || '').slice(0, 120) === anchor;
+    })
+    .sort((a, b) => (b.at || 0) - (a.at || 0));
+  const injection = candidates[0] || null;
+  const joinMethod = injection
+    ? (outcome.toolCallId && injection.toolCallId ? 'tool-call-id' : 'episode-anchor')
+    : 'none';
+
+  return record(dir, {
+    kind: 'tool-outcome',
+    ...outcome,
+    anchor,
+    injectionId: injection?.injectionId || null,
+    findingIds: injection?.findingIds || [],
+    joinMethod,
+  });
+}
+
+export function recordEpisodeOutcome(dir, outcome) {
+  return record(dir, { kind: 'episode-outcome', ...outcome });
+}
+
+export function recordFindingFeedback(dir, feedback) {
+  const rating = ['helpful', 'neutral', 'harmful'].includes(feedback?.rating)
+    ? feedback.rating
+    : 'neutral';
+  return record(dir, { kind: 'finding-feedback', ...feedback, rating });
 }
 
 /**
@@ -813,4 +933,241 @@ export function indexBudget(dir, { floor = 150, base = 300, ceiling = 1200 } = {
   // 0% hit rate falls to the floor; ~50% and above reaches the ceiling.
   const scaled = Math.round(floor + (ceiling - floor) * Math.min(1, hitRate * 2));
   return Math.max(floor, Math.min(ceiling, scaled));
+}
+
+/* ----------------------------------------------------------------------
+ * Episode-level causal evidence
+ * ------------------------------------------------------------------- */
+
+const numeric = (value) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const average = (values) => {
+  const finite = values.map(numeric).filter((value) => value !== null);
+  return finite.length
+    ? finite.reduce((sum, value) => sum + value, 0) / finite.length
+    : null;
+};
+
+/** Deterministic PRNG so regenerating a report does not move its interval. */
+function seededRandom(seedText) {
+  let seed = 2166136261;
+  for (const char of String(seedText)) {
+    seed ^= char.charCodeAt(0);
+    seed = Math.imul(seed, 16777619);
+  }
+  return () => {
+    seed += 0x6d2b79f5;
+    let value = seed;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Percentile bootstrap interval for a mean, paired delta, or other scalar. */
+export function bootstrapMeanInterval(values, { samples = 1000, seed = 'token-optimizer' } = {}) {
+  const finite = values.map(numeric).filter((value) => value !== null);
+  if (!finite.length) return { mean: null, low: null, high: null, n: 0 };
+  if (finite.length === 1) {
+    return { mean: finite[0], low: finite[0], high: finite[0], n: 1 };
+  }
+
+  const random = seededRandom(`${seed}:${finite.join(',')}`);
+  const means = [];
+  for (let sample = 0; sample < samples; sample++) {
+    let total = 0;
+    for (let index = 0; index < finite.length; index++) {
+      total += finite[Math.floor(random() * finite.length)];
+    }
+    means.push(total / finite.length);
+  }
+  means.sort((a, b) => a - b);
+  return {
+    mean: average(finite),
+    low: means[Math.floor(means.length * 0.025)],
+    high: means[Math.min(means.length - 1, Math.floor(means.length * 0.975))],
+    n: finite.length,
+  };
+}
+
+/** Wilson interval keeps small correctness samples honest and inside 0..1. */
+export function proportionInterval(successes, total, z = 1.96) {
+  if (!total) return { rate: null, low: null, high: null, n: 0 };
+  const rate = successes / total;
+  const denominator = 1 + (z * z) / total;
+  const centre = (rate + (z * z) / (2 * total)) / denominator;
+  const radius =
+    (z / denominator) * Math.sqrt((rate * (1 - rate)) / total + (z * z) / (4 * total * total));
+  return { rate, low: Math.max(0, centre - radius), high: Math.min(1, centre + radius), n: total };
+}
+
+const cohortKey = (run) => [
+  run.client || 'unknown',
+  run.clientVersion || 'unknown',
+  run.model || 'unknown',
+  run.modelVersion || 'unknown',
+  run.taskId || 'unknown',
+].join('|');
+
+function armMetrics(runs) {
+  const correct = runs.filter((run) => run.correct === true).length;
+  const interval = (field) => bootstrapMeanInterval(
+    runs.map((run) => run[field]).filter((value) => numeric(value) !== null),
+    { seed: field }
+  );
+  return {
+    runs: runs.length,
+    correctness: proportionInterval(correct, runs.length),
+    uncachedInputTokens: interval('uncachedInputTokens'),
+    cachedInputTokens: interval('cachedInputTokens'),
+    outputTokens: interval('outputTokens'),
+    totalTokens: interval('totalTokens'),
+    toolCalls: interval('toolCalls'),
+    failedToolCalls: interval('failedToolCalls'),
+    latencyMs: interval('latencyMs'),
+    costUsd: interval('costUsd'),
+    injectedTokens: interval('injectedTokens'),
+    harmfulFindings: runs.reduce((sum, run) => sum + (numeric(run.harmfulFindings) || 0), 0),
+  };
+}
+
+function pairedEffects(runs, treatmentArm) {
+  const pairs = new Map();
+  for (const run of runs) {
+    if (!run.pairId || !['baseline', treatmentArm].includes(run.arm)) continue;
+    if (!pairs.has(run.pairId)) pairs.set(run.pairId, {});
+    pairs.get(run.pairId)[run.arm] = run;
+  }
+  const complete = [...pairs.values()].filter((pair) => pair.baseline && pair[treatmentArm]);
+  const delta = (field, lowerIsBetter = true) => bootstrapMeanInterval(
+    complete
+      .map((pair) => {
+        const baseline = numeric(pair.baseline[field]);
+        const treatment = numeric(pair[treatmentArm][field]);
+        if (baseline === null || treatment === null) return null;
+        return lowerIsBetter ? baseline - treatment : treatment - baseline;
+      })
+      .filter((value) => value !== null),
+    { seed: `${treatmentArm}:${field}` }
+  );
+  return {
+    arm: treatmentArm,
+    pairs: complete.length,
+    // Positive values always mean the treatment improved the metric.
+    totalTokensSaved: delta('totalTokens'),
+    uncachedInputTokensSaved: delta('uncachedInputTokens'),
+    toolCallsAvoided: delta('toolCalls'),
+    latencyMsSaved: delta('latencyMs'),
+    costUsdSaved: delta('costUsd'),
+    correctnessDelta: delta('correct', false),
+  };
+}
+
+function matchesFilters(event, filters) {
+  for (const field of ['client', 'clientVersion', 'model', 'modelVersion', 'taskId', 'arm']) {
+    if (filters[field] && String(event[field] || '') !== String(filters[field])) return false;
+  }
+  return true;
+}
+
+/**
+ * The dashboard-facing evidence console.  Deterministic fixture verification,
+ * live hook traces, and randomized model evals remain visibly distinct: only
+ * `eval-run` records with paired arms can produce a causal effect interval.
+ */
+export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
+  const evidence = readEvidence(dir).filter((event) => matchesFilters(event, filters));
+  const runs = evidence.filter((event) => event.kind === 'eval-run');
+  const injections = evidence.filter((event) => event.kind === 'inject');
+  const outcomes = evidence.filter((event) => event.kind === 'tool-outcome');
+  const feedback = evidence.filter((event) => event.kind === 'finding-feedback');
+
+  const byInjection = new Map(
+    outcomes.filter((event) => event.injectionId).map((event) => [event.injectionId, event])
+  );
+  const traced = injections
+    .slice()
+    .sort((a, b) => (b.at || 0) - (a.at || 0))
+    .slice(0, Math.max(1, Math.min(500, episodeLimit)))
+    .map((injection) => ({
+      injectionId: injection.injectionId,
+      episodeId: injection.episodeId || injection.sessionId || null,
+      at: injection.at,
+      arm: injection.arm || (injection.holdout ? 'holdout' : 'treated'),
+      client: injection.client || 'unknown',
+      clientVersion: injection.clientVersion || null,
+      model: injection.model || null,
+      taskId: injection.taskId || null,
+      surface: injection.surface || injection.trigger || 'file',
+      anchor: injection.anchor,
+      findingIds: injection.findingIds || [],
+      deliveredTokens: injection.deliveredTokens ?? injection.tokens ?? 0,
+      shadowTokens: injection.shadowTokens ?? injection.tokens ?? 0,
+      outcome: byInjection.get(injection.injectionId) || null,
+    }));
+
+  const grouped = new Map();
+  for (const run of runs) {
+    const key = cohortKey(run);
+    if (!grouped.has(key)) grouped.set(key, []);
+    grouped.get(key).push(run);
+  }
+
+  const minimumPairs = Math.max(2, Number(process.env.TOKEN_OPTIMIZER_EVAL_MIN_PAIRS) || 5);
+  const cohorts = [...grouped.entries()].map(([key, cohortRuns]) => {
+    const arms = Object.fromEntries(
+      ['baseline', 'optimizer', 'retrieval', 'full'].map((arm) => [
+        arm,
+        armMetrics(cohortRuns.filter((run) => run.arm === arm)),
+      ])
+    );
+    const effects = ['optimizer', 'retrieval', 'full'].map((arm) => pairedEffects(cohortRuns, arm));
+    const enough = effects.some((effect) => effect.pairs >= minimumPairs);
+    return {
+      key,
+      client: cohortRuns[0]?.client || 'unknown',
+      clientVersion: cohortRuns[0]?.clientVersion || null,
+      model: cohortRuns[0]?.model || null,
+      modelVersion: cohortRuns[0]?.modelVersion || null,
+      taskId: cohortRuns[0]?.taskId || null,
+      arms,
+      effects,
+      evidenceStatus: enough
+        ? 'causal estimate available'
+        : `insufficient paired runs (need ${minimumPairs})`,
+    };
+  });
+
+  const joined = injections.filter((injection) =>
+    byInjection.has(injection.injectionId)
+  ).length;
+  const harmful = feedback.filter((event) => event.rating === 'harmful').length;
+  return {
+    schemaVersion: 2,
+    generatedAt: new Date().toISOString(),
+    filters,
+    summary: {
+      liveInjections: injections.length,
+      joinedOutcomes: joined,
+      causalJoinCoverage: injections.length ? joined / injections.length : null,
+      evalRuns: runs.length,
+      cohorts: cohorts.length,
+      harmfulFeedback: harmful,
+      harmRate: feedback.length ? harmful / feedback.length : null,
+      evidenceStatus: cohorts.some((cohort) => cohort.evidenceStatus === 'causal estimate available')
+        ? 'causal estimates available'
+        : 'insufficient randomized evidence',
+    },
+    cohorts,
+    episodes: traced,
+    methodology: {
+      intervals: 'deterministic percentile bootstrap (95%); Wilson interval for correctness',
+      causalRule: 'only matched eval-run pairs compare an arm with baseline',
+      minimumPairs,
+      deterministicChecksAreCausalProof: false,
+    },
+  };
 }

--- a/plugin/hooks/lib/recording.mjs
+++ b/plugin/hooks/lib/recording.mjs
@@ -159,6 +159,9 @@ export function semanticHarvestPrompt({
     + ' If this work produced a durable, non-obvious conclusion -- a failed approach and why, '
     + 'a decision and its rejected alternative, or a command that finally worked -- call '
     + 'wiki_write now with a real file anchor. Do not delegate this to another model or an '
-    + 'external harvester. If there is no such conclusion, do not invent one; finish normally.'
+    + 'external harvester. Include: the concrete evidence, when the finding applies, a calibrated '
+    + 'confidenceLabel (verified/probable/speculative), its project/organization/global scope, '
+    + 'and anything that would invalidate it. If there is no such conclusion, do not invent one; '
+    + 'finish normally.'
   );
 }

--- a/plugin/hooks/lib/utility.mjs
+++ b/plugin/hooks/lib/utility.mjs
@@ -1,0 +1,135 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/utility.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Evidence-aware retrieval economics.
+ *
+ * Relevance alone is not enough: a true finding can still cost more context
+ * than it saves.  Every candidate receives a conservative expected-benefit
+ * estimate, its delivery cost and risk are subtracted, and harmful findings
+ * are quarantined from automatic delivery while remaining visible for audit.
+ */
+
+import { readEvidence } from './metrics.mjs';
+
+const DAY = 86_400_000;
+const ORIGIN_WEIGHT = { human: 1.2, agent: 1.08, harvested: 1 };
+
+const envNumber = (name, fallback) => {
+  const value = Number(process.env[name]);
+  return Number.isFinite(value) && value >= 0 ? value : fallback;
+};
+
+export const retrievalPolicy = () => ({
+  baseBenefitTokens: envNumber('TOKEN_OPTIMIZER_EXPECTED_BENEFIT_TOKENS', 400),
+  minimumNetUtility: envNumber('TOKEN_OPTIMIZER_MIN_EXPECTED_UTILITY', 20),
+  cooldownMs: envNumber('TOKEN_OPTIMIZER_INJECTION_COOLDOWN_MS', 60_000),
+  quarantineHarmCount: Math.max(1, envNumber('TOKEN_OPTIMIZER_QUARANTINE_HARM_COUNT', 2)),
+});
+
+function feedbackFor(events, key) {
+  return events.filter((event) =>
+    event.kind === 'finding-feedback'
+    && (event.findingId === key || (event.findingIds || []).includes(key))
+  );
+}
+
+function outcomesFor(events, key) {
+  return events.filter((event) =>
+    event.kind === 'tool-outcome' && (event.findingIds || []).includes(key)
+  );
+}
+
+function deliveredRecently(events, key, episodeId, now, cooldownMs) {
+  if (!episodeId || cooldownMs <= 0) return false;
+  return events.some((event) =>
+    event.kind === 'inject'
+    && event.episodeId === episodeId
+    && (event.findingIds || []).includes(key)
+    && !event.holdout
+    && now - (event.at || 0) < cooldownMs
+  );
+}
+
+/**
+ * Returns eligible candidates in utility order plus every rejection reason.
+ * `costFor` is supplied by inject.mjs so the gate prices the exact rendered
+ * text rather than a second approximation that could drift.
+ */
+export function assessFindings(
+  dir,
+  findings,
+  {
+    relevanceFor = () => 1,
+    costFor = () => 0,
+    episodeId = null,
+    now = Date.now(),
+    policy = retrievalPolicy(),
+  } = {}
+) {
+  const events = readEvidence(dir);
+  const eligible = [];
+  const rejected = [];
+
+  for (const finding of findings) {
+    const key = finding.key;
+    const feedback = feedbackFor(events, key);
+    const outcomes = outcomesFor(events, key);
+    const helpful = feedback.filter((event) => event.rating === 'helpful').length;
+    const neutral = feedback.filter((event) => event.rating === 'neutral').length;
+    const harmful = feedback.filter((event) => event.rating === 'harmful').length;
+    const successfulUses = outcomes.filter((event) => event.success === true).length;
+    const failedUses = outcomes.filter((event) => event.success === false).length;
+
+    if (harmful >= policy.quarantineHarmCount && harmful >= helpful + neutral) {
+      rejected.push({ key, reason: 'quarantined-harm', helpful, neutral, harmful });
+      continue;
+    }
+    if (deliveredRecently(events, key, episodeId, now, policy.cooldownMs)) {
+      rejected.push({ key, reason: 'cooldown' });
+      continue;
+    }
+
+    const confidence = Number.isFinite(finding.confidence) ? finding.confidence : 0.5;
+    const relevance = Math.max(0, Math.min(1, Number(relevanceFor(finding)) || 0));
+    const ageDays = Math.max(0, (now - (finding.at || now)) / DAY);
+    const recency = finding.pinned ? 1 : Math.pow(0.5, ageDays / 90);
+    const provenance = ORIGIN_WEIGHT[finding.origin] || 1;
+    // Outcome evidence moves the estimate gradually. Explicit harmful feedback
+    // is handled above; a failed command alone is not labelled harmful because
+    // the model may have ignored correct advice.
+    const observed = successfulUses + failedUses;
+    const successFactor = observed
+      ? 0.75 + 0.5 * (successfulUses / observed)
+      : 1;
+    const feedbackFactor = Math.max(0.25, 1 + helpful * 0.12 - harmful * 0.35);
+    const expectedBenefit =
+      policy.baseBenefitTokens * confidence * relevance * recency * provenance * successFactor * feedbackFactor;
+    const deliveryCost = Math.max(0, Number(costFor(finding)) || 0);
+    const riskPenalty =
+      (finding.stale ? 160 : 0)
+      + (finding.confidenceLabel === 'speculative' ? 100 : 0)
+      + harmful * 100;
+    const netUtility = expectedBenefit - deliveryCost - riskPenalty;
+
+    const assessed = {
+      finding,
+      expectedBenefit,
+      deliveryCost,
+      riskPenalty,
+      netUtility,
+      helpful,
+      neutral,
+      harmful,
+      successfulUses,
+      failedUses,
+    };
+    if (netUtility < policy.minimumNetUtility) {
+      rejected.push({ key, reason: 'negative-expected-value', ...assessed, finding: undefined });
+      continue;
+    }
+    eligible.push(assessed);
+  }
+
+  eligible.sort((a, b) => b.netUtility - a.netUtility);
+  return { eligible, rejected };
+}

--- a/plugin/hooks/lib/utility.mjs
+++ b/plugin/hooks/lib/utility.mjs
@@ -64,6 +64,7 @@ export function assessFindings(
     episodeId = null,
     now = Date.now(),
     policy = retrievalPolicy(),
+    bypassCooldown = false,
   } = {}
 ) {
   const events = readEvidence(dir);
@@ -84,7 +85,7 @@ export function assessFindings(
       rejected.push({ key, reason: 'quarantined-harm', helpful, neutral, harmful });
       continue;
     }
-    if (deliveredRecently(events, key, episodeId, now, policy.cooldownMs)) {
+    if (!bypassCooldown && deliveredRecently(events, key, episodeId, now, policy.cooldownMs)) {
       rejected.push({ key, reason: 'cooldown' });
       continue;
     }

--- a/plugin/hooks/lib/wire.mjs
+++ b/plugin/hooks/lib/wire.mjs
@@ -28,7 +28,7 @@ export const MARKER = 'token-optimizer';
 /** The events we wire, and which hook file serves each. */
 export const WIRING = [
   { event: 'SessionStart', file: 'session-start.mjs', matcher: null },
-  { event: 'PreToolUse', file: 'pretooluse-router.mjs', matcher: 'Read|Grep|Glob|Edit|MultiEdit|Write|Bash' },
+  { event: 'PreToolUse', file: 'pretooluse-router.mjs', matcher: 'Read|Grep|Glob|Edit|MultiEdit|Write|Bash|PowerShell' },
   { event: 'PreCompact', file: 'precompact-optimize.mjs', matcher: null },
 ];
 

--- a/plugin/hooks/pretooluse-router.mjs
+++ b/plugin/hooks/pretooluse-router.mjs
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env node
+#!/usr/bin/env node
 /**
  * Claude Code PreToolUse adapter.
  *
@@ -54,6 +54,7 @@ import { indexFile } from './lib/staleness.mjs';
 import { isArchived } from './lib/transcript.mjs';
 import { isFsSafePath } from './lib/paths.mjs';
 import { readFileSync } from 'node:fs';
+import { episodeMeta, featuresForArm } from './lib/experiment.mjs';
 
 /**
  * Largest file the hook will read to index. Above this the touch is still
@@ -75,6 +76,8 @@ try {
   // identically to every other client's adapter on the same underlying call.
   const payload = normalizePayload(raw);
   if (!payload.tool_name) allow();
+  const features = featuresForArm();
+  const episode = episodeMeta({ client: 'claude-code', raw });
 
   // The AGENT, not just the session. Subagents inherit the parent's session id,
   // so keying state on the session alone made one agent's reads silence another's
@@ -83,7 +86,7 @@ try {
   // scope, which is right for the main session's own calls.
   const agentScope = payload.transcript_path || null;
   const state = loadState(payload.session_id, agentScope);
-  const verdict = decide(payload, state);
+  const verdict = features.routing ? decide(payload, state) : null;
 
   if (!verdict) {
     // Allowed calls are what BUILD the re-read index -- this is the only place
@@ -171,7 +174,7 @@ try {
     // is anchored to a file nobody opens at the moment they run the command,
     // so file-touch injection alone could never deliver it -- and did not.
     let context = null;
-    try {
+    if (features.retrieval) try {
       // Once per session, per finding. Repeating advice on every call is how a
       // real signal becomes wallpaper, and an ignored injection still costs its
       // tokens every time.
@@ -186,6 +189,7 @@ try {
         const note = forTouch(dir, load(dir), path, {
           sessionId: payload.session_id,
           alreadyInjected,
+          episode,
         });
         if (note) parts.push(note);
       }
@@ -201,6 +205,7 @@ try {
         const note = forCommand(dir, load(dir), command, {
           sessionId: payload.session_id,
           alreadyInjected,
+          episode,
         });
         if (note) parts.push(note);
 
@@ -221,6 +226,7 @@ try {
           sessionId: payload.session_id,
           alreadyInjected,
           projectRoot: root,
+          episode,
         });
         if (shared) parts.push(shared);
 
@@ -236,6 +242,7 @@ try {
         const repeat = forRepeatedAct(dir, command, crossed, {
           sessionId: payload.session_id,
           projectRoot: root,
+          episode,
         });
         if (repeat) parts.push(repeat);
       }
@@ -266,7 +273,7 @@ try {
     // Timing and specificity are what is available -- fired after the work exists, naming the
     // files, exactly once.
     try {
-      if (isSubstantive(payload.tool_name)) {
+      if (features.harvest && isSubstantive(payload.tool_name)) {
         state.edits = (state.edits || 0) + 1;
         const edited = payload.tool_input?.file_path;
         if (edited) state.editedFiles = [edited, ...(state.editedFiles || [])].slice(0, 20);
@@ -315,7 +322,7 @@ ${nudge}` : nudge;
     // refusal, consolidation, re-derivation detection) fed by a producer that
     // never ran. Structural only: it records what demonstrably happened and
     // makes no claims.
-    for (const { path, size } of touched) {
+    if (features.capture) for (const { path, size } of touched) {
       try {
         // NEVER THE TRANSCRIPT ARCHIVE.
         //

--- a/plugin/skills/token-optimization/SKILL.md
+++ b/plugin/skills/token-optimization/SKILL.md
@@ -49,7 +49,9 @@ tool call itself.
 
 - Call **`wiki_write`** when you establish a durable, non-obvious conclusion:
   a failed approach and why, a decision and its rejected alternative, or a
-  command that finally worked. Anchor it to a real file or `path#symbol`.
+  command that finally worked. Anchor it to a real file or `path#symbol`, and
+  include its concrete evidence, applicability, calibrated `confidenceLabel`,
+  scope, and invalidators.
 - Perform this semantic harvest yourself while you still hold the reasoning.
   Do not delegate it to another model, and do not invent a finding merely to
   populate the graph.

--- a/scripts/certify-clients.mjs
+++ b/scripts/certify-clients.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/** Structured, capability-tiered certification for every supported CLI. */
+
+import { existsSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  CLIENT_CAPABILITIES, CAPABILITY_TIERS,
+} from '../hooks-core/capabilities.mjs';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+const PACKAGED_SURFACES = {
+  'claude-code': ['plugin/hooks/hooks.json', 'plugin/hooks/pretooluse-router.mjs', 'plugin/hooks/stop.mjs'],
+  codex: ['integrations/codex/hooks/hooks.json', 'integrations/codex/hooks/pre-tool.mjs', 'integrations/codex/hooks/stop.mjs'],
+  copilot: ['integrations/copilot/.github/hooks/token-optimizer.json', 'integrations/copilot/.github/hooks/pre-tool.mjs'],
+  gemini: ['integrations/gemini/hooks/hooks.json', 'integrations/gemini/hooks/pre-tool.mjs', 'integrations/gemini/hooks/stop.mjs'],
+  qwen: ['integrations/qwen/hooks/hooks.json', 'integrations/qwen/hooks/pre-tool.mjs', 'integrations/qwen/hooks/stop.mjs'],
+  cursor: ['integrations/cursor/hooks.json', 'integrations/cursor/hooks/pre-tool.mjs', 'integrations/cursor/hooks/stop.mjs'],
+  cline: ['integrations/cline/hooks/PreToolUse', 'integrations/cline/hooks/PostToolUse', 'integrations/cline/token-optimizer.md'],
+  opencode: ['integrations/opencode/.opencode/plugins/token-optimizer.js', 'integrations/opencode/hooks/pre-tool.mjs'],
+  kilo: ['integrations/kilo/.kilo/plugin/token-optimizer.js', 'integrations/kilo/hooks/pre-tool.mjs'],
+  windsurf: ['integrations/windsurf/hooks.json', 'integrations/windsurf/hooks/pre-tool.mjs'],
+  roo: ['integrations/roo/mcp.json', 'integrations/roo/token-optimizer.md'],
+  zed: ['integrations/zed/settings.json', 'integrations/zed/AGENTS.md'],
+  amp: ['integrations/amp/settings.json', 'integrations/amp/AGENTS.md'],
+  continue: ['integrations/continue/config.yaml', 'integrations/continue/token-optimizer.md'],
+  crush: ['integrations/crush/crush.json', 'integrations/crush/AGENTS.md'],
+  droid: ['integrations/droid/mcp.json', 'integrations/droid/AGENTS.md'],
+};
+
+const BINARIES = {
+  'claude-code': 'claude', codex: 'codex', copilot: 'copilot', gemini: 'gemini',
+  qwen: 'qwen', cursor: 'cursor-agent', cline: 'cline', opencode: 'opencode',
+  kilo: 'kilo', windsurf: 'windsurf', roo: 'roo', zed: 'zed', amp: 'amp',
+  continue: 'cn', crush: 'crush', droid: 'droid',
+};
+
+function versionOf(binary) {
+  try {
+    const result = spawnSync(binary, ['--version'], {
+      encoding: 'utf8', timeout: 10_000, windowsHide: true, shell: false,
+    });
+    if (result.error || result.status !== 0) return null;
+    return `${result.stdout || result.stderr}`.trim().split('\n')[0].slice(0, 300) || null;
+  } catch {
+    return null;
+  }
+}
+
+export function certificationReport({ detectVersions = true } = {}) {
+  const clients = Object.entries(CLIENT_CAPABILITIES).map(([client, capability]) => {
+    const files = PACKAGED_SURFACES[client] || [];
+    const missing = files.filter((relative) => !existsSync(join(ROOT, relative)));
+    const version = detectVersions ? versionOf(BINARIES[client]) : null;
+    const protocolCertified = files.length > 0 && missing.length === 0;
+    return {
+      client,
+      name: capability.name,
+      tier: capability.tier,
+      promisedCapture: capability.structuralCapture,
+      semanticHarvest: capability.semanticHarvest,
+      protocolCertified,
+      checkedFiles: files,
+      missing,
+      installedVersion: version,
+      liveStatus: !detectVersions
+        ? 'version detection not requested'
+        : version
+          ? 'installed version detected; run the live evidence suite for causal certification'
+          : 'protocol-only; exact CLI not detected on this machine',
+      continuationGuaranteed: capability.tier === CAPABILITY_TIERS.CONTINUATION,
+    };
+  });
+  return {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    protocolPassed: clients.filter((client) => client.protocolCertified).length,
+    total: clients.length,
+    liveVersionsDetected: clients.filter((client) => client.installedVersion).length,
+    clients,
+    note: 'Protocol certification proves packaged wiring. Only randomized live eval runs prove model effectiveness.',
+  };
+}
+
+const args = process.argv.slice(2);
+const report = certificationReport({ detectVersions: !args.includes('--no-version-check') });
+if (args.includes('--json')) {
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+} else {
+  for (const client of report.clients) {
+    const protocol = client.protocolCertified ? 'PASS' : 'FAIL';
+    const live = client.installedVersion || (args.includes('--no-version-check') ? 'version not checked' : 'not installed');
+    process.stdout.write(`${protocol} ${client.name} [${client.tier}] — ${live}\n`);
+    if (client.missing.length) process.stdout.write(`  missing: ${client.missing.join(', ')}\n`);
+  }
+  process.stdout.write(`${report.protocolPassed}/${report.total} protocol certifications passed; ${report.liveVersionsDetected} exact CLI versions detected\n`);
+}
+
+const requireLiveArg = args.indexOf('--require-live');
+const requiredLive = requireLiveArg >= 0
+  ? new Set(String(args[requireLiveArg + 1] || '').split(',').filter(Boolean))
+  : new Set();
+const missingRequiredLive = report.clients.filter((client) =>
+  requiredLive.has(client.client) && !client.installedVersion
+);
+if (report.protocolPassed !== report.total || missingRequiredLive.length) process.exit(1);

--- a/scripts/generate-client-configs.mjs
+++ b/scripts/generate-client-configs.mjs
@@ -18,6 +18,7 @@ import { mkdirSync, readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { contentMatches, readIfExists, writeIfChanged } from './lib/text.mjs';
+import { capabilityFor, CAPABILITY_TIERS } from '../hooks-core/capabilities.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -124,6 +125,15 @@ const CLIENTS = [
     docs: 'https://docs.factory.ai/cli/configuration/mcp', verified: 'mcpServers key confirmed; the CLI reads ~/.factory/mcp.json' },
 ];
 
+for (const client of CLIENTS) {
+  const capability = capabilityFor(client.key);
+  if (!capability) throw new Error(`missing capability registry entry for ${client.key}`);
+  const registrySaysNative = capability.tier !== CAPABILITY_TIERS.RULES;
+  if (Boolean(client.nativeHooks) !== registrySaysNative) {
+    throw new Error(`capability drift for ${client.key}: generator and registry disagree`);
+  }
+}
+
 /** The policy, written once. */
 function rules(client) {
   const enforcement = client.nativeHooks
@@ -154,6 +164,10 @@ LIVE GRAPH — THE ACTIVE MODEL DOES THE SEMANTIC HARVEST:
   command that finally worked.
 - Anchor every claim to a real file path or path#symbol. Never invent a claim
   merely to populate the graph, and do not delegate harvesting to another model.
+- Include the concrete evidence, when it applies, confidenceLabel
+  (verified/probable/speculative), scope (project/organization/global), and any
+  condition that would invalidate it. Use project scope unless transfer is
+  genuinely justified.
 - Before finishing substantive work, reflect once and write any still-unrecorded
   conclusion while you hold the reasoning. This is what makes the lesson
   available across sessions and projects instead of losing it to compaction.

--- a/scripts/run-evidence-eval.mjs
+++ b/scripts/run-evidence-eval.mjs
@@ -11,7 +11,7 @@
 import {
   appendFileSync, cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync,
 } from 'node:fs';
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { dirname, isAbsolute, join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -23,6 +23,16 @@ import { writeHarvested } from '../hooks-core/harvest-write.mjs';
 import { ORIGIN_AGENT } from '../hooks-core/curate.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const gitResult = spawnSync('git', ['rev-parse', 'HEAD'], {
+  cwd: ROOT, encoding: 'utf8', windowsHide: true,
+});
+const statusResult = spawnSync('git', ['status', '--porcelain'], {
+  cwd: ROOT, encoding: 'utf8', windowsHide: true,
+});
+const GIT_PROVENANCE = {
+  commit: gitResult.status === 0 ? gitResult.stdout.trim() : null,
+  dirty: statusResult.status === 0 ? Boolean(statusResult.stdout.trim()) : null,
+};
 
 function parseArgs(argv) {
   const options = {
@@ -131,9 +141,14 @@ function walkNumbers(value, output = {}) {
 }
 
 export function parseUsage(text, profile = {}) {
+  const documents = [];
   const numbers = {};
   for (const line of String(text).split('\n')) {
-    try { Object.assign(numbers, walkNumbers(JSON.parse(line))); } catch { /* non-JSON output */ }
+    try {
+      const document = JSON.parse(line);
+      documents.push(document);
+      Object.assign(numbers, walkNumbers(document));
+    } catch { /* non-JSON output */ }
   }
   const from = (...keys) => {
     for (const key of keys) if (Number.isFinite(numbers[key])) return numbers[key];
@@ -145,17 +160,70 @@ export function parseUsage(text, profile = {}) {
     const value = Number(String(match?.[1] || '').replace(/,/g, ''));
     return Number.isFinite(value) ? value : null;
   };
+  const uncachedInputTokens = from(
+    'uncached_input_tokens', 'uncachedInputTokens', 'input_tokens', 'inputTokens'
+  );
+  const cacheCreationInputTokens = from(
+    'cache_creation_input_tokens', 'cacheCreationInputTokens'
+  );
+  const cachedInputTokens = from(
+    'cached_input_tokens', 'cachedInputTokens', 'cache_read_input_tokens', 'cacheReadInputTokens'
+  );
+  const outputTokens = from('output_tokens', 'outputTokens');
+  const reportedTotal = from('total_tokens', 'totalTokens', 'tokens_used', 'tokensUsed')
+    ?? regexNumber(profile.tokenPatterns?.total);
+  const dimensions = [
+    uncachedInputTokens, cacheCreationInputTokens, cachedInputTokens, outputTokens,
+  ];
+  const totalTokens = reportedTotal ?? (
+    dimensions.every((value) => value !== null)
+      ? dimensions.reduce((sum, value) => sum + value, 0)
+      : null
+  );
+
+  const toolUseIds = new Set();
+  let failedToolCalls = 0;
+  const visit = (value) => {
+    if (!value || typeof value !== 'object') return;
+    if (value.type === 'tool_use') toolUseIds.add(value.id || hash(JSON.stringify(value)));
+    if (value.type === 'tool_result' && value.is_error === true) failedToolCalls += 1;
+    for (const item of Object.values(value)) visit(item);
+  };
+  for (const document of documents) visit(document);
+  const isLifecycleStream = documents.some((document) =>
+    document?.type === 'system' && document?.subtype === 'init'
+  );
+
   return {
-    uncachedInputTokens: from('uncached_input_tokens', 'uncachedInputTokens'),
-    cachedInputTokens: from('cached_input_tokens', 'cachedInputTokens', 'cache_read_input_tokens'),
-    outputTokens: from('output_tokens', 'outputTokens'),
-    totalTokens: from('total_tokens', 'totalTokens', 'tokens_used', 'tokensUsed')
-      ?? regexNumber(profile.tokenPatterns?.total),
+    uncachedInputTokens,
+    cacheCreationInputTokens,
+    cachedInputTokens,
+    outputTokens,
+    totalTokens,
     costUsd: from('cost_usd', 'costUsd', 'total_cost_usd')
       ?? regexNumber(profile.tokenPatterns?.costUsd),
-    toolCalls: from('tool_calls', 'toolCalls') ?? regexNumber(profile.tokenPatterns?.toolCalls),
-    failedToolCalls: from('failed_tool_calls', 'failedToolCalls'),
+    toolCalls: from('tool_calls', 'toolCalls')
+      ?? regexNumber(profile.tokenPatterns?.toolCalls)
+      ?? (isLifecycleStream ? toolUseIds.size : null),
+    failedToolCalls: from('failed_tool_calls', 'failedToolCalls')
+      ?? (isLifecycleStream ? failedToolCalls : null),
   };
+}
+
+export function parseRunIdentity(text) {
+  for (const line of String(text).split('\n')) {
+    try {
+      const document = JSON.parse(line);
+      if (document?.type === 'system' && document?.subtype === 'init') {
+        return {
+          modelVersion: document.model || null,
+          clientVersion: document.claude_code_version || null,
+          sessionId: document.session_id || null,
+        };
+      }
+    } catch { /* non-JSON output */ }
+  }
+  return { modelVersion: null, clientVersion: null, sessionId: null };
 }
 
 async function grade(task, run, workspace, graphDir, evidenceEvents) {
@@ -268,8 +336,14 @@ async function main() {
   const runners = readJson(resolveFromRoot(options.runner));
   const profile = runners[options.client];
   if (!profile) throw new Error(`runner profile not found for ${options.client}`);
-  if (!Array.isArray(profile.armArgs?.baseline) || !profile.baselineIsolation) {
-    throw new Error('runner must declare baseline armArgs and baselineIsolation; an ordinary treated session is not a baseline');
+  if (
+    !Array.isArray(profile.armArgs?.baseline)
+    || !profile.baselineIsolation
+    || !profile.treatmentConfiguration
+  ) {
+    throw new Error(
+      'runner must declare baseline armArgs, baselineIsolation, and treatmentConfiguration'
+    );
   }
 
   const output = resolveFromRoot(options.output);
@@ -319,7 +393,29 @@ async function main() {
       env,
       timeoutMs: Number(profile.timeoutMs) || 600_000,
     });
+    const observedIdentity = parseRunIdentity(run.stdout);
     const localEvidence = readEvidence(isolatedGraph);
+    // Preserve causal joins after the disposable workspace is removed, but do
+    // not copy private fixture paths into the aggregate evidence graph.
+    for (const event of localEvidence) {
+      const { anchor, cwd, projectRoot, ...safeEvent } = event;
+      record(aggregateGraph, {
+        ...safeEvent,
+        anchor: anchor ? `sha256:${hash(anchor)}` : undefined,
+        cwdHash: cwd ? hash(cwd) : undefined,
+        projectRootHash: projectRoot ? hash(projectRoot) : undefined,
+        client: options.client,
+        clientVersion:
+          observedIdentity.clientVersion || profile.version || event.clientVersion || null,
+        model: context.model || event.model || null,
+        modelVersion:
+          observedIdentity.modelVersion || profile.modelVersion || event.modelVersion || null,
+        taskId: item.task.id,
+        pairId: item.pairId,
+        arm: item.arm,
+        evidenceSource: 'live-eval-trace',
+      });
+    }
     const grading = await grade(item.task, run, workspace, isolatedGraph, localEvidence);
     const usage = parseUsage(`${run.stdout}\n${run.stderr}`, profile);
     const result = {
@@ -334,10 +430,12 @@ async function main() {
       order: item.order,
       arm: item.arm,
       client: options.client,
-      clientVersion: profile.version || null,
+      clientVersion: observedIdentity.clientVersion || profile.version || null,
       model: context.model || null,
-      modelVersion: profile.modelVersion || null,
-      repoCommit: process.env.GITHUB_SHA || null,
+      modelVersion: observedIdentity.modelVersion || profile.modelVersion || null,
+      sessionId: observedIdentity.sessionId,
+      repoCommit: process.env.GITHUB_SHA || GIT_PROVENANCE.commit,
+      workingTreeDirty: GIT_PROVENANCE.dirty,
       promptHash: hash(item.task.prompt),
       fixtureHash: hash(JSON.stringify(item.task.seedFindings || []) + (item.task.fixture || '')),
       correct: grading.correct,

--- a/scripts/run-evidence-eval.mjs
+++ b/scripts/run-evidence-eval.mjs
@@ -1,0 +1,373 @@
+#!/usr/bin/env node
+/**
+ * Reproducible four-arm live-model evaluation runner.
+ *
+ * Runner profiles own the exact CLI flags because disabling all user config is
+ * client/version-specific.  The harness owns everything that must remain the
+ * same: task fixture, prompt, pair id, fresh graph/state, arm ordering, grading,
+ * raw artifact schema, and the aggregate evidence record consumed by the UI.
+ */
+
+import {
+  appendFileSync, cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync,
+} from 'node:fs';
+import { spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { EXPERIMENT_ARMS } from '../hooks-core/experiment.mjs';
+import { record, readEvidence } from '../hooks-core/metrics.mjs';
+import { wikiDir, load as loadGraph } from '../hooks-core/wiki.mjs';
+import { writeHarvested } from '../hooks-core/harvest-write.mjs';
+import { ORIGIN_AGENT } from '../hooks-core/curate.mjs';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+function parseArgs(argv) {
+  const options = {
+    suite: join(ROOT, 'evals', 'task-suite.json'),
+    repetitions: 1,
+    output: join(ROOT, '.token-optimizer', 'evals', `run-${Date.now()}.jsonl`),
+    graphDir: wikiDir(ROOT),
+    dryRun: false,
+    includeTranscript: false,
+    keepWorkspaces: false,
+  };
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+    if (arg === '--dry-run') options.dryRun = true;
+    else if (arg === '--include-transcript') options.includeTranscript = true;
+    else if (arg === '--keep-workspaces') options.keepWorkspaces = true;
+    else if (arg.startsWith('--')) {
+      const key = arg.slice(2).replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+      const value = argv[++index];
+      if (value === undefined) throw new Error(`${arg} requires a value`);
+      options[key] = value;
+    }
+  }
+  options.repetitions = Math.max(1, Number(options.repetitions) || 1);
+  return options;
+}
+
+const readJson = (path) => JSON.parse(readFileSync(path, 'utf8'));
+const hash = (value) => createHash('sha256').update(String(value)).digest('hex');
+const resolveFromRoot = (path) => isAbsolute(path) ? path : resolve(ROOT, path);
+
+/** Latin rotation: each arm occupies each order position before repeating. */
+export function evaluationSchedule(tasks, repetitions) {
+  const schedule = [];
+  for (const task of tasks) {
+    for (let repetition = 0; repetition < repetitions; repetition++) {
+      const offset = repetition % EXPERIMENT_ARMS.length;
+      const arms = EXPERIMENT_ARMS.map((_, index) =>
+        EXPERIMENT_ARMS[(index + offset) % EXPERIMENT_ARMS.length]
+      );
+      for (const [order, arm] of arms.entries()) {
+        schedule.push({ task, repetition, order, arm, pairId: `${task.id}-${repetition + 1}` });
+      }
+    }
+  }
+  return schedule;
+}
+
+function materialize(task) {
+  const workspace = mkdtempSync(join(tmpdir(), `token-optimizer-eval-${task.id}-`));
+  if (task.fixture) cpSync(resolveFromRoot(task.fixture), workspace, { recursive: true });
+  return workspace;
+}
+
+function replacePlaceholders(value, context) {
+  return String(value).replace(/\{(prompt|workspace|arm|taskId|pairId|model)\}/g, (_, key) =>
+    String(context[key] ?? '')
+  );
+}
+
+function execute(command, args, { cwd, env, timeoutMs }) {
+  return new Promise((resolvePromise) => {
+    const started = Date.now();
+    const child = spawn(command, args, {
+      cwd,
+      env,
+      shell: false,
+      windowsHide: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const stdout = [];
+    const stderr = [];
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill();
+    }, timeoutMs);
+    child.stdout.on('data', (chunk) => stdout.push(chunk));
+    child.stderr.on('data', (chunk) => stderr.push(chunk));
+    child.on('error', (error) => {
+      clearTimeout(timer);
+      resolvePromise({
+        exitCode: null, signal: null, timedOut, latencyMs: Date.now() - started,
+        stdout: Buffer.concat(stdout).toString('utf8'),
+        stderr: `${Buffer.concat(stderr).toString('utf8')}\n${error.message}`.trim(),
+      });
+    });
+    child.on('close', (exitCode, signal) => {
+      clearTimeout(timer);
+      resolvePromise({
+        exitCode, signal, timedOut, latencyMs: Date.now() - started,
+        stdout: Buffer.concat(stdout).toString('utf8'),
+        stderr: Buffer.concat(stderr).toString('utf8'),
+      });
+    });
+  });
+}
+
+function walkNumbers(value, output = {}) {
+  if (!value || typeof value !== 'object') return output;
+  for (const [key, item] of Object.entries(value)) {
+    if (typeof item === 'number') output[key] = item;
+    else if (item && typeof item === 'object') walkNumbers(item, output);
+  }
+  return output;
+}
+
+export function parseUsage(text, profile = {}) {
+  const numbers = {};
+  for (const line of String(text).split('\n')) {
+    try { Object.assign(numbers, walkNumbers(JSON.parse(line))); } catch { /* non-JSON output */ }
+  }
+  const from = (...keys) => {
+    for (const key of keys) if (Number.isFinite(numbers[key])) return numbers[key];
+    return null;
+  };
+  const regexNumber = (pattern) => {
+    if (!pattern) return null;
+    const match = String(text).match(new RegExp(pattern, 'im'));
+    const value = Number(String(match?.[1] || '').replace(/,/g, ''));
+    return Number.isFinite(value) ? value : null;
+  };
+  return {
+    uncachedInputTokens: from('uncached_input_tokens', 'uncachedInputTokens'),
+    cachedInputTokens: from('cached_input_tokens', 'cachedInputTokens', 'cache_read_input_tokens'),
+    outputTokens: from('output_tokens', 'outputTokens'),
+    totalTokens: from('total_tokens', 'totalTokens', 'tokens_used', 'tokensUsed')
+      ?? regexNumber(profile.tokenPatterns?.total),
+    costUsd: from('cost_usd', 'costUsd', 'total_cost_usd')
+      ?? regexNumber(profile.tokenPatterns?.costUsd),
+    toolCalls: from('tool_calls', 'toolCalls') ?? regexNumber(profile.tokenPatterns?.toolCalls),
+    failedToolCalls: from('failed_tool_calls', 'failedToolCalls'),
+  };
+}
+
+async function grade(task, run, workspace, graphDir, evidenceEvents) {
+  const combined = `${run.stdout}\n${run.stderr}`;
+  const grader = task.grader || {};
+  const required = (grader.responseIncludes || []).every((value) =>
+    combined.toLowerCase().includes(String(value).toLowerCase())
+  );
+  const forbidden = !(grader.responseExcludes || []).some((value) =>
+    combined.toLowerCase().includes(String(value).toLowerCase())
+  );
+  let commandResult = null;
+  if (grader.command) {
+    commandResult = await execute(
+      grader.command,
+      grader.args || [],
+      { cwd: workspace, env: { ...process.env, TOKEN_OPTIMIZER_EVAL_RESPONSE: run.stdout }, timeoutMs: 60_000 }
+    );
+  }
+  let graphFinding = null;
+  if (grader.graphFinding) {
+    const graph = loadGraph(graphDir);
+    graphFinding = [...graph.nodes.values()].some((node) =>
+      node.kind === 'finding'
+      && !node.retired
+      && node.origin === 'agent'
+      && typeof node.evidence === 'string'
+      && typeof node.applicability === 'string'
+      && ['verified', 'probable', 'speculative'].includes(node.confidenceLabel)
+    );
+  }
+  const deliveredTokens = evidenceEvents
+    .filter((event) => event.kind === 'inject')
+    .reduce((sum, event) => sum + (event.deliveredTokens || 0), 0);
+  const deliveryWithinLimit = grader.maxDeliveredTokens === undefined
+    || deliveredTokens <= Number(grader.maxDeliveredTokens);
+  return {
+    correct: run.exitCode === 0 && !run.timedOut && required && forbidden
+      && (!commandResult || commandResult.exitCode === 0)
+      && (graphFinding === null || graphFinding)
+      && deliveryWithinLimit,
+    checks: {
+      runnerExitedZero: run.exitCode === 0,
+      requiredResponse: required,
+      forbiddenResponseAbsent: forbidden,
+      commandGrader: commandResult ? commandResult.exitCode === 0 : null,
+      graphFinding,
+      deliveryWithinLimit,
+    },
+  };
+}
+
+function seedGraph(task, rootWorkspace, activeWorkspace, graphDir, sharedGraph) {
+  if (!Array.isArray(task.seedFindings)) return [];
+  const seedRoot = task.seedWorkspace
+    ? join(rootWorkspace, task.seedWorkspace)
+    : activeWorkspace;
+  const findings = task.seedFindings.map((finding) => ({
+    ...finding,
+    anchors: finding.anchors.map((anchor) => join(seedRoot, anchor)),
+  }));
+  const seedGraphDir = seedRoot === activeWorkspace
+    ? graphDir
+    : join(seedRoot, '.token-optimizer', 'wiki');
+  const previousShared = process.env.TOKEN_OPTIMIZER_SHARED_DIR;
+  process.env.TOKEN_OPTIMIZER_SHARED_DIR = sharedGraph;
+  try {
+    const keys = writeHarvested(seedGraphDir, findings, {
+      sessionId: 'seed-session',
+      origin: ORIGIN_AGENT,
+      projectRoot: seedRoot,
+    });
+    for (const feedback of task.seedFeedback || []) {
+      const findingId = keys[feedback.findingIndex || 0];
+      if (!findingId) continue;
+      record(graphDir, {
+        kind: 'finding-feedback',
+        findingId,
+        rating: feedback.rating,
+        reason: feedback.reason || 'pre-registered adversarial fixture',
+        episodeId: 'seed-session',
+      });
+    }
+    return keys;
+  } finally {
+    if (previousShared === undefined) delete process.env.TOKEN_OPTIMIZER_SHARED_DIR;
+    else process.env.TOKEN_OPTIMIZER_SHARED_DIR = previousShared;
+  }
+  return [];
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const suite = readJson(resolveFromRoot(options.suite));
+  let tasks = suite.tasks || [];
+  if (options.tasks) {
+    const selected = new Set(String(options.tasks).split(',').map((value) => value.trim()));
+    tasks = tasks.filter((task) => selected.has(task.id));
+  }
+  if (!tasks.length) throw new Error('no evaluation tasks selected');
+  const schedule = evaluationSchedule(tasks, options.repetitions);
+
+  if (options.dryRun) {
+    process.stdout.write(JSON.stringify({ suite: suite.name, runs: schedule.map(({ task, ...run }) => ({ taskId: task.id, ...run })) }, null, 2));
+    return;
+  }
+  if (!options.runner || !options.client) {
+    throw new Error('--runner and --client are required unless --dry-run is used');
+  }
+  const runners = readJson(resolveFromRoot(options.runner));
+  const profile = runners[options.client];
+  if (!profile) throw new Error(`runner profile not found for ${options.client}`);
+  if (!Array.isArray(profile.armArgs?.baseline) || !profile.baselineIsolation) {
+    throw new Error('runner must declare baseline armArgs and baselineIsolation; an ordinary treated session is not a baseline');
+  }
+
+  const output = resolveFromRoot(options.output);
+  mkdirSync(dirname(output), { recursive: true });
+  const aggregateGraph = resolveFromRoot(options.graphDir);
+  mkdirSync(aggregateGraph, { recursive: true });
+
+  for (const item of schedule) {
+    const rootWorkspace = materialize(item.task);
+    const workspace = item.task.workspace
+      ? join(rootWorkspace, item.task.workspace)
+      : rootWorkspace;
+    const isolatedGraph = join(workspace, '.token-optimizer', 'wiki');
+    const sharedGraph = join(rootWorkspace, '.token-optimizer', 'shared');
+    mkdirSync(isolatedGraph, { recursive: true });
+    seedGraph(item.task, rootWorkspace, workspace, isolatedGraph, sharedGraph);
+    for (const mutation of item.task.mutateAfterSeed || []) {
+      appendFileSync(join(rootWorkspace, mutation.path), mutation.append || '\n// changed after finding\n');
+    }
+    const context = {
+      prompt: item.task.prompt,
+      workspace,
+      arm: item.arm,
+      taskId: item.task.id,
+      pairId: item.pairId,
+      model: options.model || profile.model || '',
+    };
+    // Keep arm-level isolation switches ahead of the prompt. Several CLIs stop
+    // parsing options once their positional prompt begins.
+    const args = [...(profile.armArgs[item.arm] || []), ...(profile.args || [])]
+      .map((arg) => replacePlaceholders(arg, context));
+    const env = {
+      ...process.env,
+      ...(profile.env || {}),
+      TOKEN_OPTIMIZER_EXPERIMENT_ARM: item.arm,
+      TOKEN_OPTIMIZER_EPISODE_ID: `${item.pairId}-${item.arm}`,
+      TOKEN_OPTIMIZER_PAIR_ID: item.pairId,
+      TOKEN_OPTIMIZER_TASK_ID: item.task.id,
+      TOKEN_OPTIMIZER_MODEL: context.model,
+      TOKEN_OPTIMIZER_CLIENT_VERSION: profile.version || '',
+      TOKEN_OPTIMIZER_WIKI_DIR: isolatedGraph,
+      TOKEN_OPTIMIZER_SHARED_DIR: sharedGraph,
+      TOKEN_OPTIMIZER_STATE_DIR: join(workspace, '.token-optimizer', 'state'),
+    };
+    const run = await execute(profile.command, args, {
+      cwd: workspace,
+      env,
+      timeoutMs: Number(profile.timeoutMs) || 600_000,
+    });
+    const localEvidence = readEvidence(isolatedGraph);
+    const grading = await grade(item.task, run, workspace, isolatedGraph, localEvidence);
+    const usage = parseUsage(`${run.stdout}\n${run.stderr}`, profile);
+    const result = {
+      kind: 'eval-run',
+      schemaVersion: 2,
+      suite: suite.name,
+      suiteVersion: suite.version,
+      taskId: item.task.id,
+      taskFamily: item.task.family,
+      pairId: item.pairId,
+      repetition: item.repetition,
+      order: item.order,
+      arm: item.arm,
+      client: options.client,
+      clientVersion: profile.version || null,
+      model: context.model || null,
+      modelVersion: profile.modelVersion || null,
+      repoCommit: process.env.GITHUB_SHA || null,
+      promptHash: hash(item.task.prompt),
+      fixtureHash: hash(JSON.stringify(item.task.seedFindings || []) + (item.task.fixture || '')),
+      correct: grading.correct,
+      grader: grading.checks,
+      exitCode: run.exitCode,
+      timedOut: run.timedOut,
+      latencyMs: run.latencyMs,
+      ...usage,
+      injectedTokens: localEvidence
+        .filter((event) => event.kind === 'inject')
+        .reduce((sum, event) => sum + (event.deliveredTokens || 0), 0),
+      toolCalls: usage.toolCalls ?? localEvidence.filter((event) => ['tool-outcome', 'mcp-tool'].includes(event.kind)).length,
+      failedToolCalls: usage.failedToolCalls
+        ?? localEvidence.filter((event) => ['tool-outcome', 'mcp-tool'].includes(event.kind) && event.success === false).length,
+      harmfulFindings: localEvidence.filter((event) => event.kind === 'finding-feedback' && event.rating === 'harmful').length,
+      stdoutHash: hash(run.stdout),
+      stderrHash: hash(run.stderr),
+      ...(options.includeTranscript ? { stdout: run.stdout, stderr: run.stderr } : {}),
+    };
+    appendFileSync(output, `${JSON.stringify(result)}\n`);
+    record(aggregateGraph, result);
+    process.stdout.write(`${grading.correct ? 'PASS' : 'FAIL'} ${item.task.id} ${item.arm} (${run.latencyMs}ms)\n`);
+
+    if (!options.keepWorkspaces) rmSync(rootWorkspace, { recursive: true, force: true });
+  }
+  process.stdout.write(`Evidence artifact: ${output}\n`);
+}
+
+const isMain = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/scripts/verify-client-configs.mjs
+++ b/scripts/verify-client-configs.mjs
@@ -27,6 +27,7 @@
 import { readFileSync, existsSync, readdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { capabilityFor, CAPABILITY_TIERS } from '../hooks-core/capabilities.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const INTEGRATIONS = join(ROOT, 'integrations');
@@ -99,6 +100,12 @@ function parseJsonc(raw) {
 
 for (const [key, expected] of Object.entries(EXPECTED)) {
   const dir = join(INTEGRATIONS, key);
+  const capability = capabilityFor(key);
+  check(`${key}: capability registry entry exists`, Boolean(capability));
+  check(`${key}: registry tier matches packaged surface`, Boolean(capability)
+    && (expected.nativeHooks
+      ? capability.tier !== CAPABILITY_TIERS.RULES
+      : capability.tier === CAPABILITY_TIERS.RULES));
 
   if (!existsSync(dir)) {
     check(`${key}: integration exists`, false);

--- a/scripts/verify-harvest-api.mjs
+++ b/scripts/verify-harvest-api.mjs
@@ -76,7 +76,17 @@ try {
 
   /* ---- Responses a real model actually returns ------------------------ */
 
-  const finding = { type: 'failure', claim: 'the retry loop deadlocks on close', confidence: 0.8, anchors: ['/src/auth.ts'] };
+  const finding = {
+    type: 'failure',
+    claim: 'the retry loop deadlocks on close',
+    evidence: 'the close-path concurrency test timed out',
+    applicability: 'when changing retry shutdown behavior',
+    confidenceLabel: 'probable',
+    confidence: 0.8,
+    scope: 'project',
+    invalidators: ['retry ownership changes'],
+    anchors: ['/src/auth.ts'],
+  };
 
   handler = () => ({ status: 200, body: { content: [{ type: 'text', text: JSON.stringify([finding]) }] } });
   let out = await extract(DIGEST);
@@ -130,10 +140,10 @@ try {
   /* ---- The schema still gates what the model returns ------------------ */
 
   handler = () => ({ status: 200, body: { content: [{ type: 'text', text: JSON.stringify([
-    { type: 'finding', claim: 'no anchor on this one at all', confidence: 0.9, anchors: [] },
-    { type: 'musing', claim: 'wrong type entirely here', confidence: 0.9, anchors: ['/src/auth.ts'] },
-    { type: 'finding', claim: 'x', confidence: 0.9, anchors: ['/src/auth.ts'] },
-    { type: 'finding', claim: 'confidence out of range here', confidence: 9, anchors: ['/src/auth.ts'] },
+    { ...finding, claim: 'no anchor on this one at all', anchors: [] },
+    { ...finding, type: 'musing', claim: 'wrong type entirely here' },
+    { ...finding, claim: 'x' },
+    { ...finding, claim: 'confidence out of range here', confidence: 9 },
     finding,
   ]) }] } });
   const gated = validate(await extract(DIGEST));

--- a/scripts/verify-live-graph-flow.mjs
+++ b/scripts/verify-live-graph-flow.mjs
@@ -139,6 +139,17 @@ async function main() {
   const write = await wikiWrite({
     claim,
     anchors: [anchor],
+    evidence:
+      'The fixture package test script exits unless Jest is launched through the documented project command.',
+    applicability:
+      'Use when running the fixture verification suite from this project root.',
+    confidenceLabel: 'verified',
+    // This verifier intentionally exercises the explicit cross-project path.
+    // A normal project-specific finding remains project scoped by default.
+    scope: 'global',
+    invalidators: [
+      'The fixture package test script or its documented verification command changes.',
+    ],
     type: 'command',
     trigger: '\\bnpx\\s+jest\\b',
     confidence: 0.99,

--- a/scripts/verify-wiki-ui.mjs
+++ b/scripts/verify-wiki-ui.mjs
@@ -89,6 +89,18 @@ async function seed() {
   for (let i = 0; i < 25; i++) record(GRAPH, { kind: 'inject', holdout: false, tokens: 120, downstream: 300 });
   for (let i = 0; i < 8; i++) record(GRAPH, { kind: 'inject', holdout: true, tokens: 0, downstream: 2400 });
   record(GRAPH, { kind: 'harvest', tokens: 800 });
+  for (let pair = 1; pair <= 5; pair++) {
+    for (const [arm, totalTokens, toolCalls] of [
+      ['baseline', 1000, 10], ['optimizer', 900, 9],
+      ['retrieval', 750, 7], ['full', 600, 6],
+    ]) {
+      record(GRAPH, {
+        kind: 'eval-run', pairId: `ui-${pair}`, taskId: 'ui-recovery', arm,
+        client: 'codex', clientVersion: 'ui-fixture', model: 'fixture-model',
+        modelVersion: '1', correct: true, totalTokens, toolCalls, latencyMs: totalTokens,
+      });
+    }
+  }
 }
 
 async function waitForServer(attempts = 40) {
@@ -288,6 +300,19 @@ async function main() {
         check('audit surfaces the contradiction', /Contradicted/i.test(auditText || ''));
         check('audit surfaces low confidence', /Low confidence/i.test(auditText || ''));
         await page.screenshot({ path: join(SHOTS, 'audit.png'), fullPage: true });
+
+        // Evidence console: causal cohorts, live traces, and honest client tiers.
+        await page.click('.wiki-tab[data-tab="evidence"]');
+        await page.waitForSelector('#evidence-capabilities tbody tr', { timeout: 5000 });
+        const evidenceState = await page.getAttribute('#evidence-status', 'data-state');
+        check('evidence console distinguishes sufficient causal data', evidenceState === 'ok', evidenceState);
+        const cohortText = await page.textContent('#evidence-cohorts');
+        check('evidence renders matched effect intervals', /full/i.test(cohortText || '') && /400/.test(cohortText || ''));
+        const capabilityCount = await page.locator('#evidence-capabilities tbody tr').count();
+        check('evidence lists all supported client capabilities', capabilityCount === 16, String(capabilityCount));
+        const capabilityText = await page.textContent('#evidence-capabilities');
+        check('rules-only clients are labelled MCP-visible only', /mcp-visible-only/i.test(capabilityText || ''));
+        await page.screenshot({ path: join(SHOTS, 'evidence.png'), fullPage: true });
       } else {
         await page.screenshot({ path: join(SHOTS, 'narrow.png'), fullPage: true });
       }

--- a/src/dashboard/public/css/wiki.css
+++ b/src/dashboard/public/css/wiki.css
@@ -179,7 +179,9 @@
 }
 
 #wiki-search,
-#wiki-type {
+#wiki-type,
+.evidence-filters input,
+.evidence-filters select {
   width: 100%;
   background: var(--surface-2);
   border: 1px solid var(--line);
@@ -191,7 +193,9 @@
 }
 
 #wiki-search:focus,
-#wiki-type:focus {
+#wiki-type:focus,
+.evidence-filters input:focus,
+.evidence-filters select:focus {
   outline: 2px solid var(--saved);
   outline-offset: 1px;
   border-color: transparent;
@@ -420,6 +424,59 @@
 
 .wiki-figure {
   margin: 0;
+}
+
+/* ------------------------------------------------------------ evidence -- */
+
+.evidence-filters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.evidence-filters input,
+.evidence-filters select {
+  width: 100%;
+}
+
+.table-scroll {
+  overflow-x: auto;
+  margin: 10px 0 24px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+}
+
+.evidence-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12.5px;
+}
+
+.evidence-table th,
+.evidence-table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--line);
+  text-align: left;
+  vertical-align: top;
+}
+
+.evidence-table th {
+  color: var(--ink-3);
+  background: var(--surface-2);
+  font-size: 11px;
+  font-weight: 650;
+  white-space: nowrap;
+}
+
+.evidence-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.evidence-anchor {
+  max-width: 320px;
+  overflow-wrap: anywhere;
+  font-family: var(--mono);
 }
 
 /* -------------------------------------------------------------- drawer -- */

--- a/src/dashboard/public/js/wiki.js
+++ b/src/dashboard/public/js/wiki.js
@@ -187,7 +187,7 @@ async function loadEvidence() {
         <td>${escapeHtml(cohort.client)}<br><span class="wiki-muted">${escapeHtml(cohort.clientVersion || 'version unknown')}</span></td>
         <td>${escapeHtml(cohort.model || 'model unknown')}</td>
         <td>${escapeHtml(cohort.taskId || 'task unknown')}</td>
-        <td>${escapeHtml(effect.arm)}</td>
+        <td>${escapeHtml(effect.comparison || effect.arm)}</td>
         <td>${nf.format(effect.pairs)}</td>
         <td>${escapeHtml(formatInterval(effect.totalTokensSaved, ' tokens'))}</td>
         <td>${escapeHtml(formatInterval(effect.toolCallsAvoided, ' calls'))}</td>
@@ -196,7 +196,7 @@ async function loadEvidence() {
     }
   }
   el('evidence-cohorts').innerHTML = `
-    <thead><tr><th>Client</th><th>Model</th><th>Task</th><th>Arm</th><th>Pairs</th><th>Token effect (95% CI)</th><th>Call effect (95% CI)</th><th>Status</th></tr></thead>
+    <thead><tr><th>Client</th><th>Model</th><th>Task</th><th>Comparison</th><th>Pairs</th><th>Token effect (95% CI)</th><th>Call effect (95% CI)</th><th>Status</th></tr></thead>
     <tbody>${cohortRows.join('') || '<tr><td colspan="8">No randomized cohorts match these filters.</td></tr>'}</tbody>`;
 
   const episodeRows = (report.episodes || [])

--- a/src/dashboard/public/js/wiki.js
+++ b/src/dashboard/public/js/wiki.js
@@ -123,6 +123,112 @@ async function loadBalance() {
   }
 }
 
+/* ---- Causal evidence ------------------------------------------------ */
+
+function formatInterval(interval, suffix = '') {
+  if (!interval || interval.mean === null) return '—';
+  const mean = nf.format(Math.round(interval.mean * 100) / 100);
+  const low = nf.format(Math.round(interval.low * 100) / 100);
+  const high = nf.format(Math.round(interval.high * 100) / 100);
+  return `${mean}${suffix} [${low}, ${high}]`;
+}
+
+async function loadEvidence() {
+  const params = new URLSearchParams();
+  const values = {
+    client: el('evidence-client').value.trim(),
+    model: el('evidence-model').value.trim(),
+    taskId: el('evidence-task').value.trim(),
+    arm: el('evidence-arm').value,
+  };
+  for (const [key, value] of Object.entries(values))
+    if (value) params.set(key, value);
+
+  let report;
+  try {
+    report = await api(`/api/wiki/evidence?${params}`);
+  } catch {
+    el('evidence-status').textContent = 'Evidence report unavailable';
+    el('evidence-status').dataset.state = 'bad';
+    return;
+  }
+
+  const summary = report.summary;
+  const coverage =
+    summary.causalJoinCoverage === null
+      ? '—'
+      : `${Math.round(summary.causalJoinCoverage * 100)}%`;
+  el('evidence-summary').innerHTML = [
+    ['Randomized runs', nf.format(summary.evalRuns)],
+    ['Live injections', nf.format(summary.liveInjections)],
+    ['Outcome join coverage', coverage],
+    ['Harmful feedback', nf.format(summary.harmfulFeedback)],
+  ]
+    .map(
+      ([label, value]) => `
+    <div class="stat-card"><div class="stat-content">
+      <div class="stat-label">${escapeHtml(label)}</div>
+      <div class="stat-value wiki-figure">${escapeHtml(value)}</div>
+    </div></div>`
+    )
+    .join('');
+
+  const status = el('evidence-status');
+  status.textContent = summary.evidenceStatus;
+  status.dataset.state =
+    summary.evidenceStatus === 'causal estimates available'
+      ? 'ok'
+      : 'insufficient';
+
+  const cohortRows = [];
+  for (const cohort of report.cohorts || []) {
+    for (const effect of cohort.effects || []) {
+      cohortRows.push(`<tr>
+        <td>${escapeHtml(cohort.client)}<br><span class="wiki-muted">${escapeHtml(cohort.clientVersion || 'version unknown')}</span></td>
+        <td>${escapeHtml(cohort.model || 'model unknown')}</td>
+        <td>${escapeHtml(cohort.taskId || 'task unknown')}</td>
+        <td>${escapeHtml(effect.arm)}</td>
+        <td>${nf.format(effect.pairs)}</td>
+        <td>${escapeHtml(formatInterval(effect.totalTokensSaved, ' tokens'))}</td>
+        <td>${escapeHtml(formatInterval(effect.toolCallsAvoided, ' calls'))}</td>
+        <td>${escapeHtml(cohort.evidenceStatus)}</td>
+      </tr>`);
+    }
+  }
+  el('evidence-cohorts').innerHTML = `
+    <thead><tr><th>Client</th><th>Model</th><th>Task</th><th>Arm</th><th>Pairs</th><th>Token effect (95% CI)</th><th>Call effect (95% CI)</th><th>Status</th></tr></thead>
+    <tbody>${cohortRows.join('') || '<tr><td colspan="8">No randomized cohorts match these filters.</td></tr>'}</tbody>`;
+
+  const episodeRows = (report.episodes || [])
+    .map(
+      (trace) => `<tr>
+    <td>${escapeHtml(trace.client)}</td>
+    <td>${escapeHtml(trace.arm)}</td>
+    <td>${escapeHtml(trace.surface)}</td>
+    <td class="evidence-anchor">${escapeHtml(trace.anchor || '—')}</td>
+    <td>${nf.format(trace.deliveredTokens || 0)} / ${nf.format(trace.shadowTokens || 0)}</td>
+    <td>${trace.outcome ? `${trace.outcome.success ? '✓ success' : '✕ failed'} · ${escapeHtml(trace.outcome.joinMethod)}` : 'not joined'}</td>
+  </tr>`
+    )
+    .join('');
+  el('evidence-episodes').innerHTML = `
+    <thead><tr><th>Client</th><th>Arm</th><th>Surface</th><th>Anchor</th><th>Delivered / shadow</th><th>Outcome</th></tr></thead>
+    <tbody>${episodeRows || '<tr><td colspan="6">No live injection traces match these filters.</td></tr>'}</tbody>`;
+
+  const capabilityRows = (report.capabilities || [])
+    .map(
+      (client) => `<tr>
+    <td>${escapeHtml(client.name)}</td><td>${escapeHtml(client.tier)}</td>
+    <td>${escapeHtml(client.routing)}</td><td>${escapeHtml(client.structuralCapture)}</td>
+    <td>${escapeHtml(client.findingDelivery)}</td><td>${escapeHtml(client.semanticHarvest)}</td>
+  </tr>`
+    )
+    .join('');
+  el('evidence-capabilities').innerHTML = `
+    <thead><tr><th>Client</th><th>Tier</th><th>Routing</th><th>Capture</th><th>Delivery</th><th>Harvest</th></tr></thead>
+    <tbody>${capabilityRows}</tbody>`;
+}
+
 /* ---- Finding list ---------------------------------------------------- */
 
 function tagsFor(item) {
@@ -517,6 +623,11 @@ function showDetail(node) {
       <dt>Type</dt><dd>${escapeHtml(node.type || '—')}</dd>
       <dt>Origin</dt><dd>${node.origin === 'human' ? '✎ asserted by a person' : 'harvested from a session'}</dd>
       <dt>Confidence</dt><dd class="wiki-figure">${(node.confidence ?? 0.5).toFixed(2)}</dd>
+      <dt>Calibration</dt><dd>${escapeHtml(node.confidenceLabel || 'legacy/unlabelled')}</dd>
+      <dt>Scope</dt><dd>${escapeHtml(node.scope || 'project')}</dd>
+      <dt>Applies when</dt><dd>${escapeHtml(node.applicability || 'legacy finding: unspecified')}</dd>
+      <dt>Evidence</dt><dd>${escapeHtml(node.evidence || 'legacy finding: unspecified')}</dd>
+      <dt>Invalidated by</dt><dd>${escapeHtml((node.invalidators || []).join('; ') || 'anchor changes')}</dd>
       <dt>Status</dt><dd>${node.stale ? '⚠ stale' : 'current'}</dd>
     </dl>
     ${node.snapshot ? `<div class="wiki-diff">${escapeHtml(node.snapshot.slice(0, 2000))}</div>` : ''}
@@ -528,6 +639,8 @@ function showDetail(node) {
         <button class="btn btn-primary" id="detail-correct">Save correction</button>
         <button class="btn" id="detail-pin">${node.pinned ? 'Unpin' : 'Pin'}</button>
         <button class="btn" id="detail-retire">Retire</button>
+        <button class="btn" id="detail-helpful">Helpful</button>
+        <button class="btn" id="detail-harmful">Harmful</button>
       </div>
       <p class="wiki-muted">Corrections append: the original is retired and kept,
       so the record shows what changed and when.</p>`
@@ -561,6 +674,19 @@ function showDetail(node) {
   el('detail-retire').addEventListener('click', () =>
     curate({ action: 'retire' })
   );
+  const feedback = async (rating) => {
+    await api('/api/wiki/evidence/feedback', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-token-optimizer': 'dashboard',
+      },
+      body: JSON.stringify({ findingId: node.key, rating }),
+    });
+    await loadEvidence();
+  };
+  el('detail-helpful').addEventListener('click', () => feedback('helpful'));
+  el('detail-harmful').addEventListener('click', () => feedback('harmful'));
 }
 
 /**
@@ -677,6 +803,10 @@ el('wiki-search').addEventListener(
 );
 el('wiki-type').addEventListener('change', () => search());
 el('wiki-more-btn').addEventListener('click', () => search(true));
+for (const id of ['evidence-client', 'evidence-model', 'evidence-task']) {
+  el(id).addEventListener('input', debounce(loadEvidence, 250));
+}
+el('evidence-arm').addEventListener('change', loadEvidence);
 
 el('mode-focus').addEventListener('click', () => {
   setMode('focus');
@@ -694,8 +824,9 @@ document.querySelectorAll('.wiki-tab').forEach((tab) => {
       t.classList.toggle('is-active', t === tab);
       t.setAttribute('aria-selected', String(t === tab));
     });
-    el('tab-explore').hidden = tab.dataset.tab !== 'explore';
-    el('tab-audit').hidden = tab.dataset.tab !== 'audit';
+    document.querySelectorAll('.wiki-panel').forEach((panel) => {
+      panel.hidden = panel.id !== `tab-${tab.dataset.tab}`;
+    });
     // The drawer describes a selection made in the tab being left, so leaving it
     // open shows detail for something no longer on screen.
     setDetailOpen(false);
@@ -750,5 +881,5 @@ if (typeof ResizeObserver !== 'undefined') {
     el('graph-stats').textContent = 'Graph unavailable';
     return;
   }
-  await Promise.all([loadBalance(), search(), loadAudit()]);
+  await Promise.all([loadBalance(), search(), loadAudit(), loadEvidence()]);
 })();

--- a/src/dashboard/public/wiki.html
+++ b/src/dashboard/public/wiki.html
@@ -22,12 +22,12 @@
       <!-- Says, in words, what this page is for. Someone arriving here has no
            reason to know what a knowledge graph is or why they want one. -->
       <section class="intro">
-        <h1>Everything Claude has learned about this project</h1>
+        <h1>What your coding agents have learned and whether it helps</h1>
         <p>
-          Each file Claude reads gets remembered here &mdash; its structure, and
-          anything worked out about it. Next time, that memory is offered
-          instead of the whole file, which is where most of your savings come
-          from. This page is that memory, and you can correct it.
+          Native lifecycle clients capture the work they can observe; every
+          supported MCP client can deliberately read and write durable findings.
+          This page keeps the knowledge, its provenance, and the causal evidence
+          about whether delivering it improved later work.
         </p>
       </section>
 
@@ -54,6 +54,9 @@
         </button>
         <button class="wiki-tab" role="tab" aria-selected="false" data-tab="audit">
           Needs a look
+        </button>
+        <button class="wiki-tab" role="tab" aria-selected="false" data-tab="evidence">
+          Evidence
         </button>
       </nav>
 
@@ -124,6 +127,41 @@
             <span id="audit-count"></span>
           </p>
           <div id="audit-groups"></div>
+        </section>
+
+        <section id="tab-evidence" class="wiki-panel" role="tabpanel" hidden>
+          <p class="wiki-muted panel-intro">
+            Deterministic wiring checks, passive lifecycle traces, and randomized
+            model evaluations are kept separate. Only matched evaluation pairs
+            produce a causal effect interval.
+          </p>
+          <div class="evidence-filters">
+            <label><span class="ctl-label">Client</span><input id="evidence-client" placeholder="all clients" /></label>
+            <label><span class="ctl-label">Model</span><input id="evidence-model" placeholder="all models" /></label>
+            <label><span class="ctl-label">Task</span><input id="evidence-task" placeholder="all tasks" /></label>
+            <label>
+              <span class="ctl-label">Arm</span>
+              <select id="evidence-arm">
+                <option value="">all arms</option>
+                <option value="baseline">baseline</option>
+                <option value="optimizer">optimizer</option>
+                <option value="retrieval">retrieval</option>
+                <option value="full">full</option>
+              </select>
+            </label>
+          </div>
+          <div class="stats-grid" id="evidence-summary"></div>
+          <p class="verdict-line" id="evidence-status"></p>
+
+          <h2>Causal cohorts</h2>
+          <div class="table-scroll"><table class="evidence-table" id="evidence-cohorts"></table></div>
+
+          <h2>Recent injection traces</h2>
+          <div class="table-scroll"><table class="evidence-table" id="evidence-episodes"></table></div>
+
+          <h2>Client capability contract</h2>
+          <p class="wiki-muted">Rules/MCP-only clients are not labelled as native capture clients.</p>
+          <div class="table-scroll"><table class="evidence-table" id="evidence-capabilities"></table></div>
         </section>
       </main>
     </div>

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -15,6 +15,7 @@ import { modelRouting, ROUTING_TOOL } from './routing-tool.js';
 import { tokenAudit, AUDIT_TOOL } from './audit-tool.js';
 import { installDoctor, DOCTOR_TOOL } from './doctor-tool.js';
 import { fleetAudit, FLEET_TOOL } from './fleet-tool.js';
+import { McpEvidenceRecorder } from './mcp-evidence.js';
 import {
   wikiWrite,
   WIKI_WRITE_TOOL_DEFINITION,
@@ -589,6 +590,10 @@ const server = new Server(
     },
   }
 );
+const mcpEvidence = new McpEvidenceRecorder();
+server.oninitialized = () => {
+  mcpEvidence.clientInitialized(server.getClientVersion());
+};
 
 // Define tools
 /**
@@ -2921,6 +2926,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   // Best-effort: feed savings into analytics so the report/breakdown tools have
   // real data. Never blocks meaningfully or breaks the tool call.
   await recordToolAnalytics(analyticsManager, request.params.name, result);
+  mcpEvidence.toolOutcome(
+    request.params.name,
+    Date.now() - started,
+    !(result as { isError?: boolean } | null)?.isError
+  );
 
   // THE ONE PLACE EVERY TOOL RESULT PASSES THROUGH. Disclosing here rather than
   // per-tool is what keeps it a single policy instead of ninety. The elapsed

--- a/src/server/mcp-evidence.ts
+++ b/src/server/mcp-evidence.ts
@@ -1,0 +1,82 @@
+/** Best-effort MCP-native client and tool telemetry for rules-only clients. */
+
+import path from 'path';
+import { dirname } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const processEpisodeId =
+  process.env.TOKEN_OPTIMIZER_EPISODE_ID ??
+  `mcp-${process.pid}-${Date.now().toString(36)}`;
+
+interface EvidenceModules {
+  wiki: {
+    projectRootFor(filePath: string, fallback: string): string;
+    wikiDir(cwd: string): string;
+  };
+  metrics: {
+    record(dir: string, event: Record<string, unknown>): unknown;
+  };
+}
+
+export interface McpClientInfo {
+  name?: string;
+  version?: string;
+  title?: string;
+}
+
+let cached: Promise<EvidenceModules> | null = null;
+
+function coreUrl(name: string): string {
+  return pathToFileURL(path.join(here, '..', '..', 'hooks-core', name)).href;
+}
+
+async function modules(): Promise<EvidenceModules> {
+  if (!cached) {
+    cached = Promise.all([
+      import(coreUrl('wiki.mjs')),
+      import(coreUrl('metrics.mjs')),
+    ]).then(([wiki, metrics]) => ({ wiki, metrics }) as EvidenceModules);
+  }
+  return cached;
+}
+
+export class McpEvidenceRecorder {
+  private client: McpClientInfo | null = null;
+
+  private async record(event: Record<string, unknown>): Promise<void> {
+    try {
+      const loaded = await modules();
+      const cwd = process.cwd();
+      const root = loaded.wiki.projectRootFor(path.join(cwd, '__mcp__'), cwd);
+      loaded.metrics.record(loaded.wiki.wikiDir(root), {
+        schemaVersion: 2,
+        episodeId: processEpisodeId,
+        sessionId: processEpisodeId,
+        arm: process.env.TOKEN_OPTIMIZER_EXPERIMENT_ARM || 'full',
+        client: this.client?.name || 'unknown-mcp-client',
+        clientVersion: this.client?.version || null,
+        ...event,
+      });
+    } catch {
+      // Telemetry must never make an MCP client fail to initialize or call a tool.
+    }
+  }
+
+  clientInitialized(info?: McpClientInfo): void {
+    this.client = info || null;
+    void this.record({
+      kind: 'mcp-client',
+      clientTitle: info?.title || null,
+    });
+  }
+
+  toolOutcome(toolName: string, durationMs: number, success: boolean): void {
+    void this.record({
+      kind: 'mcp-tool',
+      toolName,
+      durationMs,
+      success,
+    });
+  }
+}

--- a/src/server/tool-profile.ts
+++ b/src/server/tool-profile.ts
@@ -20,6 +20,21 @@ export const CORE_TOOL_NAMES = [
 ] as const;
 
 export type ToolProfile = 'core' | 'full';
+export type ExperimentArm = 'baseline' | 'optimizer' | 'retrieval' | 'full';
+
+export function resolveExperimentArm(
+  value = process.env.TOKEN_OPTIMIZER_EXPERIMENT_ARM
+): ExperimentArm {
+  const arm = String(value || 'full')
+    .trim()
+    .toLowerCase();
+  if (['baseline', 'optimizer', 'retrieval', 'full'].includes(arm))
+    return arm as ExperimentArm;
+  throw new Error(
+    `Invalid TOKEN_OPTIMIZER_EXPERIMENT_ARM=${JSON.stringify(value)}. ` +
+      'Expected baseline, optimizer, retrieval, or full.'
+  );
+}
 
 export function resolveToolProfile(
   value = process.env.TOKEN_OPTIMIZER_TOOL_PROFILE
@@ -46,18 +61,30 @@ export function resolveToolProfile(
  */
 export function selectToolDefinitions<T extends { name: string }>(
   tools: readonly T[],
-  profile = resolveToolProfile()
+  profile = resolveToolProfile(),
+  arm = resolveExperimentArm()
 ): T[] {
-  if (profile === 'full') return [...tools];
-
   const core = new Set<string>(CORE_TOOL_NAMES);
-  const selected = tools.filter((tool) => core.has(tool.name));
+  const selected =
+    profile === 'full'
+      ? [...tools]
+      : tools.filter((tool) => core.has(tool.name));
   const selectedNames = new Set(selected.map((tool) => tool.name));
-  const missing = CORE_TOOL_NAMES.filter((name) => !selectedNames.has(name));
+  const missing =
+    profile === 'core'
+      ? CORE_TOOL_NAMES.filter((name) => !selectedNames.has(name))
+      : [];
 
   if (missing.length) {
     throw new Error(`Core MCP tool profile is missing: ${missing.join(', ')}`);
   }
 
+  if (arm === 'baseline') return [];
+  if (arm === 'optimizer')
+    return selected.filter(
+      (tool) => !['wiki_read', 'wiki_write'].includes(tool.name)
+    );
+  if (arm === 'retrieval')
+    return selected.filter((tool) => tool.name !== 'wiki_write');
   return selected;
 }

--- a/src/server/wiki-routes.ts
+++ b/src/server/wiki-routes.ts
@@ -32,6 +32,7 @@ interface GraphModules {
   curate: any;
   metrics: any;
   staleness: any;
+  capabilities: any;
 }
 
 let cached: GraphModules | null = null;
@@ -39,13 +40,14 @@ let cached: GraphModules | null = null;
 async function modules(): Promise<GraphModules | null> {
   if (cached) return cached;
   try {
-    const [wiki, curate, metrics, staleness] = await Promise.all([
+    const [wiki, curate, metrics, staleness, capabilities] = await Promise.all([
       import(coreUrl('wiki.mjs')),
       import(coreUrl('curate.mjs')),
       import(coreUrl('metrics.mjs')),
       import(coreUrl('staleness.mjs')),
+      import(coreUrl('capabilities.mjs')),
     ]);
-    cached = { wiki, curate, metrics, staleness };
+    cached = { wiki, curate, metrics, staleness, capabilities };
     return cached;
   } catch {
     return null;
@@ -164,6 +166,11 @@ function summarise(node: any) {
     claim: node.claim,
     type: node.type,
     confidence: node.confidence,
+    confidenceLabel: node.confidenceLabel,
+    evidence: node.evidence,
+    applicability: node.applicability,
+    scope: node.scope || 'project',
+    invalidators: Array.isArray(node.invalidators) ? node.invalidators : [],
     origin: node.origin || 'harvested',
     stale: Boolean(node.stale),
     pinned: Boolean(node.pinned),
@@ -379,6 +386,82 @@ export function registerWikiRoutes(app: Express): void {
       return res.status(500).json({ error: 'balance failed' });
     }
   });
+
+  /**
+   * Causal evidence, with cohort filters and honest capability tiers.  This is
+   * separate from /balance because randomized eval runs and passive file
+   * holdouts are different strengths of evidence and must not be blended.
+   */
+  app.get('/api/wiki/evidence', async (req: Request, res: Response) => {
+    const mods = await modules();
+    if (!mods) return res.status(503).json({ error: 'graph unavailable' });
+
+    const filters: Record<string, string> = {};
+    for (const key of [
+      'client',
+      'clientVersion',
+      'model',
+      'modelVersion',
+      'taskId',
+      'arm',
+    ]) {
+      const value = req.query[key];
+      if (typeof value === 'string' && value.trim())
+        filters[key] = value.trim().slice(0, 200);
+    }
+    const requestedLimit = Number(req.query.limit);
+    const episodeLimit = Number.isFinite(requestedLimit)
+      ? Math.max(1, Math.min(500, requestedLimit))
+      : 100;
+
+    try {
+      return res.json({
+        ...mods.metrics.evidenceReport(graphDir(req, mods.wiki), {
+          filters,
+          episodeLimit,
+        }),
+        capabilities: mods.capabilities.capabilitySummary(),
+      });
+    } catch {
+      return res.status(500).json({ error: 'evidence report failed' });
+    }
+  });
+
+  /** Human outcome feedback drives utility ranking and harmful-finding quarantine. */
+  app.post(
+    '/api/wiki/evidence/feedback',
+    async (req: Request, res: Response) => {
+      if (rejectsCrossSite(req, res)) return undefined;
+      const mods = await modules();
+      if (!mods) return res.status(503).json({ error: 'graph unavailable' });
+
+      const { findingId, rating, reason, episodeId, injectionId } =
+        req.body || {};
+      if (typeof findingId !== 'string' || !findingId.trim())
+        return res.status(400).json({ error: 'findingId required' });
+      if (!['helpful', 'neutral', 'harmful'].includes(rating))
+        return res
+          .status(400)
+          .json({ error: 'rating must be helpful, neutral, or harmful' });
+
+      const recorded = mods.metrics.recordFindingFeedback(
+        graphDir(req, mods.wiki),
+        {
+          findingId: findingId.trim().slice(0, 300),
+          rating,
+          reason:
+            typeof reason === 'string' ? reason.trim().slice(0, 1000) : null,
+          episodeId:
+            typeof episodeId === 'string' ? episodeId.slice(0, 300) : null,
+          injectionId:
+            typeof injectionId === 'string' ? injectionId.slice(0, 300) : null,
+        }
+      );
+      return recorded
+        ? res.json({ ok: true, id: recorded.id })
+        : res.status(500).json({ error: 'feedback write failed' });
+    }
+  );
 
   /** Markdown export -- the graph as reviewable, committable documentation. */
   app.get('/api/wiki/export', async (req: Request, res: Response) => {

--- a/src/tools/intelligence/wiki-write.ts
+++ b/src/tools/intelligence/wiki-write.ts
@@ -39,6 +39,10 @@ export interface WikiWriteOptions {
    * dropped and the finding is refused rather than stored unfalsifiable.
    */
   anchors: string[];
+  /** Concrete observation, command result, test, or user decision supporting the claim. */
+  evidence: string;
+  /** Human-readable condition under which a later model should use the claim. */
+  applicability: string;
   /** finding | decision | failure | command | map. */
   type?: string;
   /**
@@ -50,6 +54,12 @@ export interface WikiWriteOptions {
   trigger?: string;
   /** 0..1. Defaults to 0.9 — deliberate, but still a model's assertion. */
   confidence?: number;
+  /** Calibrated status; the numeric value is derived from this when omitted. */
+  confidenceLabel: 'verified' | 'probable' | 'speculative';
+  /** Project-only by default; broader scopes opt into cross-project delivery. */
+  scope?: 'project' | 'organization' | 'global';
+  /** Conditions that should cause a later reader to distrust or re-check it. */
+  invalidators?: string[];
   /** Recorded for provenance so a claim can be traced to the session. */
   sessionId?: string;
   /** Overrides the project the finding belongs to. Defaults to the anchor's repo. */
@@ -106,15 +116,74 @@ export async function wikiWrite(
     };
   }
 
+  const evidence = String(options?.evidence ?? '').trim();
+  if (evidence.length < 8) {
+    return {
+      success: false,
+      ...empty,
+      error:
+        'evidence is required: name the observation, test, command result, or user decision that proved the claim',
+    };
+  }
+
+  const applicability = String(options?.applicability ?? '').trim();
+  if (applicability.length < 8) {
+    return {
+      success: false,
+      ...empty,
+      error:
+        'applicability is required: state when a later model should use this finding',
+    };
+  }
+
   const type = FINDING_TYPES.includes(String(options?.type))
     ? String(options.type)
     : 'finding';
+  const confidenceLabel = ['verified', 'probable', 'speculative'].includes(
+    String(options?.confidenceLabel)
+  )
+    ? options.confidenceLabel
+    : null;
+  if (!confidenceLabel) {
+    return {
+      success: false,
+      ...empty,
+      error: 'confidenceLabel must be verified, probable, or speculative',
+    };
+  }
+  const confidenceDefaults = {
+    verified: 0.95,
+    probable: 0.75,
+    speculative: 0.45,
+  };
+  if (
+    options?.confidence !== undefined &&
+    (!Number.isFinite(options.confidence) ||
+      (options.confidence as number) <= 0 ||
+      (options.confidence as number) > 1)
+  ) {
+    return {
+      success: false,
+      ...empty,
+      error: 'confidence must be greater than 0 and at most 1 when supplied',
+    };
+  }
   const confidence =
     Number.isFinite(options?.confidence) &&
     (options!.confidence as number) > 0 &&
     (options!.confidence as number) <= 1
       ? (options!.confidence as number)
-      : 0.9;
+      : confidenceDefaults[confidenceLabel];
+  const scope = ['project', 'organization', 'global'].includes(
+    String(options?.scope)
+  )
+    ? options.scope
+    : 'project';
+  const invalidators = Array.isArray(options?.invalidators)
+    ? options.invalidators
+        .filter((item) => typeof item === 'string' && item.trim())
+        .slice(0, 10)
+    : [];
 
   try {
     const [wiki, harvestWrite, curate] = await Promise.all([
@@ -133,7 +202,20 @@ export async function wikiWrite(
 
     const keys: string[] = harvestWrite.writeHarvested(
       dir,
-      [{ type, claim, confidence, anchors, trigger: options.trigger }],
+      [
+        {
+          type,
+          claim,
+          confidence,
+          confidenceLabel,
+          anchors,
+          evidence,
+          applicability,
+          scope,
+          invalidators,
+          trigger: options.trigger,
+        },
+      ],
       {
         sessionId: options.sessionId ?? null,
         origin: curate.ORIGIN_AGENT,
@@ -202,6 +284,16 @@ export const WIKI_WRITE_TOOL_DEFINITION = {
         description:
           'Files the claim is about, as absolute paths, or "path#symbol" to anchor to one function.',
       },
+      evidence: {
+        type: 'string',
+        description:
+          'The concrete observation that supports the claim: a test result, command output, rejected approach, or explicit user decision.',
+      },
+      applicability: {
+        type: 'string',
+        description:
+          'When a future model should use this finding. Be specific enough to prevent unrelated injection.',
+      },
       type: {
         type: 'string',
         enum: FINDING_TYPES,
@@ -214,6 +306,24 @@ export const WIKI_WRITE_TOOL_DEFINITION = {
         type: 'number',
         description:
           '0..1, default 0.9. Lower it when the claim is plausible but unverified.',
+      },
+      confidenceLabel: {
+        type: 'string',
+        enum: ['verified', 'probable', 'speculative'],
+        description:
+          'verified = directly proved; probable = strong but incomplete evidence; speculative = a hypothesis that must be re-checked.',
+      },
+      scope: {
+        type: 'string',
+        enum: ['project', 'organization', 'global'],
+        description:
+          'Where the finding may be reused. project is safest; organization/global explicitly opt into cross-project delivery.',
+      },
+      invalidators: {
+        type: 'array',
+        items: { type: 'string' },
+        description:
+          'Versions, files, configuration, or assumptions whose change should force re-validation.',
       },
       sessionId: {
         type: 'string',
@@ -233,6 +343,12 @@ export const WIKI_WRITE_TOOL_DEFINITION = {
           'Optional. Defaults to the repository containing the first anchor.',
       },
     },
-    required: ['claim', 'anchors'],
+    required: [
+      'claim',
+      'anchors',
+      'evidence',
+      'applicability',
+      'confidenceLabel',
+    ],
   },
 };

--- a/tests/hooks/causal-evidence.test.mjs
+++ b/tests/hooks/causal-evidence.test.mjs
@@ -151,7 +151,21 @@ describe('paired evidence report', () => {
     expect(report.cohorts).toHaveLength(1);
     expect(report.summary.evidenceStatus).toBe('causal estimates available');
     expect(report.cohorts[0].arms.full.correctness.rate).toBe(1);
-    const full = report.cohorts[0].effects.find((effect) => effect.arm === 'full');
+    const optimizer = report.cohorts[0].effects.find((effect) =>
+      effect.arm === 'optimizer' && effect.controlArm === 'baseline'
+    );
+    const retrieval = report.cohorts[0].effects.find((effect) =>
+      effect.arm === 'retrieval' && effect.controlArm === 'optimizer'
+    );
+    const harvest = report.cohorts[0].effects.find((effect) =>
+      effect.arm === 'full' && effect.controlArm === 'retrieval'
+    );
+    const full = report.cohorts[0].effects.find((effect) =>
+      effect.arm === 'full' && effect.controlArm === 'baseline'
+    );
+    expect(optimizer.totalTokensSaved.mean).toBe(100);
+    expect(retrieval.totalTokensSaved.mean).toBe(150);
+    expect(harvest.totalTokensSaved.mean).toBe(150);
     expect(full.pairs).toBe(5);
     expect(full.totalTokensSaved.mean).toBe(400);
     expect(full.totalTokensSaved.low).toBeGreaterThan(0);

--- a/tests/hooks/causal-evidence.test.mjs
+++ b/tests/hooks/causal-evidence.test.mjs
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  evidenceReport,
+  readEvidence,
+  record,
+  recordFindingFeedback,
+  recordToolOutcome,
+} from '../../hooks-core/metrics.mjs';
+import { load, wikiDir } from '../../hooks-core/wiki.mjs';
+import { writeHarvested } from '../../hooks-core/harvest-write.mjs';
+import { ORIGIN_AGENT } from '../../hooks-core/curate.mjs';
+import { forCommand, forTouch } from '../../hooks-core/inject.mjs';
+
+let workspace;
+let dir;
+let anchor;
+const previous = {};
+
+beforeEach(() => {
+  workspace = mkdtempSync(join(tmpdir(), 'causal-evidence-'));
+  dir = wikiDir(workspace);
+  anchor = join(workspace, 'RUNBOOK.md');
+  writeFileSync(anchor, '# Runbook\nUse npm test.\n');
+  for (const key of [
+    'TOKEN_OPTIMIZER_HOLDOUT',
+    'TOKEN_OPTIMIZER_INJECTION_COOLDOWN_MS',
+    'TOKEN_OPTIMIZER_MIN_EXPECTED_UTILITY',
+  ]) previous[key] = process.env[key];
+  process.env.TOKEN_OPTIMIZER_HOLDOUT = '0';
+  process.env.TOKEN_OPTIMIZER_INJECTION_COOLDOWN_MS = '60000';
+  process.env.TOKEN_OPTIMIZER_MIN_EXPECTED_UTILITY = '0';
+});
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(previous)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  rmSync(workspace, { recursive: true, force: true });
+});
+
+function seed(type = 'command', trigger = 'bad-command') {
+  return writeHarvested(dir, [{
+    type,
+    claim: 'Use npm test instead of the unsupported direct probe.',
+    evidence: 'The package command passed and the direct probe exited one.',
+    applicability: 'When verification uses the unsupported direct probe.',
+    confidenceLabel: 'verified',
+    confidence: 0.98,
+    scope: 'project',
+    invalidators: ['package.json test script changes'],
+    trigger,
+    anchors: [anchor],
+  }], { sessionId: 'author', origin: ORIGIN_AGENT, projectRoot: workspace })[0];
+}
+
+describe('causal episode tracing', () => {
+  test('persists the semantic evidence contract and deduplicates an exact repeat', () => {
+    const key = seed();
+    const repeated = seed();
+    const node = [...load(dir).nodes.values()].find((item) => item.key === key);
+    expect(repeated).toBe(key);
+    expect(node).toMatchObject({
+      evidence: 'The package command passed and the direct probe exited one.',
+      applicability: 'When verification uses the unsupported direct probe.',
+      confidenceLabel: 'verified',
+      scope: 'project',
+      invalidators: ['package.json test script changes'],
+    });
+  });
+
+  test('joins a tool outcome to the exact injection id', () => {
+    const injection = record(dir, {
+      kind: 'inject', episodeId: 'episode-1', sessionId: 'session-1',
+      toolCallId: 'call-1', surface: 'command', anchor: 'bad-command',
+      findingIds: ['finding-1'], holdout: false, deliveredTokens: 20,
+    });
+    const outcome = recordToolOutcome(dir, {
+      episodeId: 'episode-1', sessionId: 'session-1', toolCallId: 'call-1',
+      surface: 'command', anchor: 'bad-command', success: true,
+    });
+
+    expect(outcome.injectionId).toBe(injection.injectionId);
+    expect(outcome.findingIds).toEqual(['finding-1']);
+    expect(outcome.joinMethod).toBe('tool-call-id');
+  });
+
+  test('holdouts retain shadow candidates without delivering them', () => {
+    const key = seed();
+    process.env.TOKEN_OPTIMIZER_HOLDOUT = '1';
+    const context = forCommand(dir, load(dir), 'bad-command', {
+      sessionId: 's1', episode: { episodeId: 'e1', arm: 'retrieval', client: 'codex' },
+    });
+    const injection = readEvidence(dir).find((event) => event.kind === 'inject');
+
+    expect(context).toBeNull();
+    expect(injection.deliveredTokens).toBe(0);
+    expect(injection.findingIds).toEqual([]);
+    expect(injection.shadowFindingIds).toEqual([key]);
+    expect(injection.shadowTokens).toBeGreaterThan(0);
+  });
+
+  test('harm feedback quarantines a finding and a cooldown backs up session state', () => {
+    const key = seed('finding', null);
+    const first = forTouch(dir, load(dir), anchor, {
+      sessionId: 's1', episode: { episodeId: 'e1', arm: 'full' },
+    });
+    expect(first).toMatch(/Known about/);
+
+    // A fresh in-memory gate simulates a concurrent hook process that did not
+    // inherit alreadyInjected; durable evidence still enforces the cooldown.
+    const second = forTouch(dir, load(dir), anchor, {
+      sessionId: 's1', alreadyInjected: new Set(), episode: { episodeId: 'e1', arm: 'full' },
+    });
+    expect(second).toBeNull();
+
+    recordFindingFeedback(dir, { findingId: key, rating: 'harmful', episodeId: 'review-1' });
+    recordFindingFeedback(dir, { findingId: key, rating: 'harmful', episodeId: 'review-2' });
+    const quarantined = forTouch(dir, load(dir), anchor, {
+      sessionId: 's2', episode: { episodeId: 'e2', arm: 'full' },
+    });
+    expect(quarantined).toBeNull();
+    const decisions = readEvidence(dir).filter((event) => event.kind === 'retrieval-decision');
+    expect(decisions.flatMap((event) => event.rejected).map((item) => item.reason))
+      .toEqual(expect.arrayContaining(['cooldown', 'quarantined-harm']));
+  });
+});
+
+describe('paired evidence report', () => {
+  test('keeps four arms separate and reports a bootstrap interval from matched pairs', () => {
+    for (let pair = 1; pair <= 5; pair++) {
+      for (const [arm, tokens, calls] of [
+        ['baseline', 1000 + pair, 10],
+        ['optimizer', 900 + pair, 9],
+        ['retrieval', 750 + pair, 7],
+        ['full', 600 + pair, 6],
+      ]) {
+        record(dir, {
+          kind: 'eval-run', taskId: 'recovery', pairId: `p${pair}`, arm,
+          client: 'codex', clientVersion: '1.0', model: 'model-a', modelVersion: '2026-08',
+          correct: true, totalTokens: tokens, toolCalls: calls, latencyMs: tokens,
+          uncachedInputTokens: tokens - 10, cachedInputTokens: 0, outputTokens: 10,
+        });
+      }
+    }
+
+    const report = evidenceReport(dir);
+    expect(report.cohorts).toHaveLength(1);
+    expect(report.summary.evidenceStatus).toBe('causal estimates available');
+    expect(report.cohorts[0].arms.full.correctness.rate).toBe(1);
+    const full = report.cohorts[0].effects.find((effect) => effect.arm === 'full');
+    expect(full.pairs).toBe(5);
+    expect(full.totalTokensSaved.mean).toBe(400);
+    expect(full.totalTokensSaved.low).toBeGreaterThan(0);
+    expect(report.methodology.deterministicChecksAreCausalProof).toBe(false);
+  });
+});

--- a/tests/hooks/clients.test.mjs
+++ b/tests/hooks/clients.test.mjs
@@ -51,6 +51,7 @@ describe('tool names normalize across clients', () => {
     ['find_files', 'Glob'], ['glob_file_search', 'Glob'],
     ['apply_patch', 'Edit'], ['search_replace', 'Edit'],
     ['write_file', 'Write'], ['run_terminal_cmd', 'Bash'],
+    ['PowerShell', 'Bash'], ['pwsh', 'Bash'],
   ])('%s -> %s', (alias, canonical) => {
     expect(normalizeTool(alias)).toBe(canonical);
   });

--- a/tests/hooks/evidence-harness.test.mjs
+++ b/tests/hooks/evidence-harness.test.mjs
@@ -1,5 +1,7 @@
 import { describe, expect, test } from '@jest/globals';
-import { evaluationSchedule, parseUsage } from '../../scripts/run-evidence-eval.mjs';
+import {
+  evaluationSchedule, parseRunIdentity, parseUsage,
+} from '../../scripts/run-evidence-eval.mjs';
 
 describe('live evidence harness', () => {
   test('counterbalances every four-arm pair', () => {
@@ -18,5 +20,20 @@ describe('live evidence harness', () => {
     expect(parseUsage('ordinary output')).toMatchObject({ totalTokens: null, costUsd: null, toolCalls: null });
     expect(parseUsage('{"usage":{"uncached_input_tokens":10,"cached_input_tokens":20,"output_tokens":4,"total_tokens":34}}'))
       .toMatchObject({ uncachedInputTokens: 10, cachedInputTokens: 20, outputTokens: 4, totalTokens: 34 });
+  });
+
+  test('reads Claude cache dimensions, exact identity, and tool calls from stream JSON', () => {
+    const stream = [
+      JSON.stringify({ type: 'system', subtype: 'init', model: 'claude-sonnet-5', claude_code_version: '2.1.225', session_id: 's1' }),
+      JSON.stringify({ type: 'assistant', message: { content: [{ type: 'tool_use', id: 'tool-1', name: 'Read' }] } }),
+      JSON.stringify({ type: 'result', total_cost_usd: 0.25, usage: { input_tokens: 2, cache_creation_input_tokens: 10, cache_read_input_tokens: 20, output_tokens: 4 } }),
+    ].join('\n');
+    expect(parseUsage(stream)).toMatchObject({
+      uncachedInputTokens: 2, cacheCreationInputTokens: 10, cachedInputTokens: 20,
+      outputTokens: 4, totalTokens: 36, toolCalls: 1, failedToolCalls: 0, costUsd: 0.25,
+    });
+    expect(parseRunIdentity(stream)).toEqual({
+      modelVersion: 'claude-sonnet-5', clientVersion: '2.1.225', sessionId: 's1',
+    });
   });
 });

--- a/tests/hooks/evidence-harness.test.mjs
+++ b/tests/hooks/evidence-harness.test.mjs
@@ -1,0 +1,22 @@
+import { describe, expect, test } from '@jest/globals';
+import { evaluationSchedule, parseUsage } from '../../scripts/run-evidence-eval.mjs';
+
+describe('live evidence harness', () => {
+  test('counterbalances every four-arm pair', () => {
+    const schedule = evaluationSchedule([{ id: 'task' }], 4);
+    expect(schedule).toHaveLength(16);
+    for (let repetition = 0; repetition < 4; repetition++) {
+      const run = schedule.filter((item) => item.repetition === repetition);
+      expect(new Set(run.map((item) => item.arm))).toEqual(
+        new Set(['baseline', 'optimizer', 'retrieval', 'full'])
+      );
+      expect(run[0].arm).toBe(['baseline', 'optimizer', 'retrieval', 'full'][repetition]);
+    }
+  });
+
+  test('keeps missing usage null and reads JSONL usage without inventing zeros', () => {
+    expect(parseUsage('ordinary output')).toMatchObject({ totalTokens: null, costUsd: null, toolCalls: null });
+    expect(parseUsage('{"usage":{"uncached_input_tokens":10,"cached_input_tokens":20,"output_tokens":4,"total_tokens":34}}'))
+      .toMatchObject({ uncachedInputTokens: 10, cachedInputTokens: 20, outputTokens: 4, totalTokens: 34 });
+  });
+});

--- a/tests/hooks/experiment-capabilities.test.mjs
+++ b/tests/hooks/experiment-capabilities.test.mjs
@@ -1,0 +1,39 @@
+import { describe, expect, test } from '@jest/globals';
+import {
+  CLIENT_CAPABILITIES, CAPABILITY_TIERS, capabilitySummary, nativeClientProfiles,
+} from '../../hooks-core/capabilities.mjs';
+import { EXPERIMENT_ARMS, featuresForArm, episodeMeta, usageFrom } from '../../hooks-core/experiment.mjs';
+
+describe('cross-client capability contract', () => {
+  test('names all sixteen clients and keeps rules-only promises bounded', () => {
+    expect(Object.keys(CLIENT_CAPABILITIES)).toHaveLength(16);
+    expect(Object.keys(nativeClientProfiles())).toHaveLength(10);
+    const rules = capabilitySummary().filter((client) => client.tier === CAPABILITY_TIERS.RULES);
+    expect(rules).toHaveLength(6);
+    expect(rules.every((client) => client.structuralCapture === 'mcp-visible-only')).toBe(true);
+  });
+});
+
+describe('experiment arms and metadata', () => {
+  test('isolates optimizer, retrieval, and semantic harvest contributions', () => {
+    expect(EXPERIMENT_ARMS).toEqual(['baseline', 'optimizer', 'retrieval', 'full']);
+    expect(featuresForArm('baseline')).toEqual({ routing: false, retrieval: false, capture: false, harvest: false });
+    expect(featuresForArm('optimizer')).toEqual({ routing: true, retrieval: false, capture: false, harvest: false });
+    expect(featuresForArm('retrieval')).toEqual({ routing: true, retrieval: true, capture: true, harvest: false });
+    expect(featuresForArm('full')).toEqual({ routing: true, retrieval: true, capture: true, harvest: true });
+  });
+
+  test('normalizes causal ids and token dimensions', () => {
+    const meta = episodeMeta({
+      client: 'codex',
+      raw: { session_id: 's1', turn_id: 't1', tool_use_id: 'c1', model: 'm1', client_version: 'v1' },
+      env: { TOKEN_OPTIMIZER_EXPERIMENT_ARM: 'retrieval', TOKEN_OPTIMIZER_PAIR_ID: 'p1' },
+    });
+    expect(meta).toMatchObject({
+      episodeId: 's1', sessionId: 's1', turnId: 't1', toolCallId: 'c1',
+      client: 'codex', clientVersion: 'v1', model: 'm1', arm: 'retrieval', pairId: 'p1',
+    });
+    expect(usageFrom({ usage: { uncached_input_tokens: 10, cached_input_tokens: 20, output_tokens: 3 } }))
+      .toEqual({ uncachedInputTokens: 10, cachedInputTokens: 20, outputTokens: 3, totalTokens: null });
+  });
+});

--- a/tests/hooks/injection.test.mjs
+++ b/tests/hooks/injection.test.mjs
@@ -66,16 +66,16 @@ describe('P3 harvest -- the schema keeps the graph honest', () => {
     // Models asked for paths will sometimes produce plausible fabrications.
     const known = new Set(['/real.ts']);
     const out = validate([
-      { type: 'finding', claim: 'real one here', confidence: 0.8, anchors: ['/real.ts'] },
-      { type: 'finding', claim: 'invented one here', confidence: 0.8, anchors: ['/imaginary.ts'] },
+      { type: 'finding', claim: 'real one here', evidence: 'a passing focused test', applicability: 'when changing the real module', confidenceLabel: 'probable', confidence: 0.8, scope: 'project', anchors: ['/real.ts'] },
+      { type: 'finding', claim: 'invented one here', evidence: 'an unsupported model guess', applicability: 'when changing an invented module', confidenceLabel: 'speculative', confidence: 0.8, scope: 'project', anchors: ['/imaginary.ts'] },
     ], { knownFiles: known });
     expect(out).toHaveLength(1);
     expect(out[0].claim).toBe('real one here');
   });
 
   test('a valid finding survives intact', () => {
-    const out = validate([{ type: 'failure', claim: 'retry loop deadlocks on close', confidence: 0.7, anchors: ['/a.ts#run'] }]);
-    expect(out).toEqual([{ type: 'failure', claim: 'retry loop deadlocks on close', confidence: 0.7, anchors: ['/a.ts#run'] }]);
+    const out = validate([{ type: 'failure', claim: 'retry loop deadlocks on close', evidence: 'the close-path concurrency test timed out', applicability: 'when changing the retry close path', confidenceLabel: 'probable', confidence: 0.7, scope: 'project', invalidators: ['retry ownership changes'], anchors: ['/a.ts#run'] }]);
+    expect(out).toEqual([{ type: 'failure', claim: 'retry loop deadlocks on close', evidence: 'the close-path concurrency test timed out', applicability: 'when changing the retry close path', confidenceLabel: 'probable', confidence: 0.7, scope: 'project', invalidators: ['retry ownership changes'], anchors: ['/a.ts#run'], trigger: undefined }]);
   });
 
   test('harvest is disabled without a key, rather than failing', () => {

--- a/tests/integration/client-hooks.test.ts
+++ b/tests/integration/client-hooks.test.ts
@@ -213,6 +213,14 @@ describe('native CLI hook integrations', () => {
     }
   });
 
+  it('observes Claude Code PowerShell calls on Windows', () => {
+    const manifest = JSON.parse(
+      readFileSync(join(repoRoot, 'plugin/hooks/hooks.json'), 'utf8')
+    );
+    expect(manifest.hooks.PreToolUse[0].matcher).toContain('PowerShell');
+    expect(manifest.hooks.PostToolUse[0].matcher).toContain('PowerShell');
+  });
+
   it('ships a Codex plugin MCP config that Codex can discover', () => {
     const config = JSON.parse(
       readFileSync(join(repoRoot, 'integrations/codex/plugin/.mcp.json'), 'utf8')

--- a/tests/integration/mcp-tool-profiles.test.ts
+++ b/tests/integration/mcp-tool-profiles.test.ts
@@ -15,7 +15,7 @@ interface ListedTool {
   inputSchema?: unknown;
 }
 
-function runServer(profile?: string, toolCall?: string) {
+function runServer(profile?: string, toolCall?: string, arm?: string) {
   const messages: object[] = [
     {
       jsonrpc: '2.0',
@@ -41,12 +41,14 @@ function runServer(profile?: string, toolCall?: string) {
 
   const env = {
     ...process.env,
-    TOKEN_OPTIMIZER_CACHE_DIR: join(fixture, profile || 'default', 'cache'),
-    TOKEN_OPTIMIZER_WIKI_DIR: join(fixture, profile || 'default', 'wiki'),
-    TOKEN_OPTIMIZER_STATE_DIR: join(fixture, profile || 'default', 'state'),
+    TOKEN_OPTIMIZER_CACHE_DIR: join(fixture, profile || 'default', arm || 'full', 'cache'),
+    TOKEN_OPTIMIZER_WIKI_DIR: join(fixture, profile || 'default', arm || 'full', 'wiki'),
+    TOKEN_OPTIMIZER_STATE_DIR: join(fixture, profile || 'default', arm || 'full', 'state'),
   };
   if (profile !== undefined) env.TOKEN_OPTIMIZER_TOOL_PROFILE = profile;
   else delete env.TOKEN_OPTIMIZER_TOOL_PROFILE;
+  if (arm !== undefined) env.TOKEN_OPTIMIZER_EXPERIMENT_ARM = arm;
+  else delete env.TOKEN_OPTIMIZER_EXPERIMENT_ARM;
 
   const result = spawnSync(process.execPath, [SERVER], {
     cwd: fixture,
@@ -115,5 +117,20 @@ describe('MCP tool profiles over the real stdio transport', () => {
     const result = runServer('everything');
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain('Invalid TOKEN_OPTIMIZER_TOOL_PROFILE');
+  });
+
+  it('isolates the four causal experiment arms at the server boundary', () => {
+    const names = (arm: string) => {
+      const result = runServer(undefined, undefined, arm);
+      expect(result.status).toBe(0);
+      return (result.responses.find((message) => message.id === 2)?.result
+        ?.tools as ListedTool[]).map((tool) => tool.name);
+    };
+
+    expect(names('baseline')).toEqual([]);
+    expect(names('optimizer')).not.toEqual(expect.arrayContaining(['wiki_read', 'wiki_write']));
+    expect(names('retrieval')).toContain('wiki_read');
+    expect(names('retrieval')).not.toContain('wiki_write');
+    expect(names('full')).toEqual(expect.arrayContaining(['wiki_read', 'wiki_write']));
   });
 });

--- a/tests/unit/wiki-write-contract.test.ts
+++ b/tests/unit/wiki-write-contract.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  WIKI_WRITE_TOOL_DEFINITION,
+  wikiWrite,
+} from '../../src/tools/intelligence/wiki-write.js';
+
+let workspace: string;
+let anchor: string;
+let priorWikiDir: string | undefined;
+
+beforeEach(() => {
+  workspace = mkdtempSync(join(tmpdir(), 'wiki-write-contract-'));
+  anchor = join(workspace, 'source.ts');
+  writeFileSync(anchor, 'export const value = 1;\n');
+  priorWikiDir = process.env.TOKEN_OPTIMIZER_WIKI_DIR;
+  process.env.TOKEN_OPTIMIZER_WIKI_DIR = join(workspace, 'graph');
+});
+
+afterEach(() => {
+  if (priorWikiDir === undefined) delete process.env.TOKEN_OPTIMIZER_WIKI_DIR;
+  else process.env.TOKEN_OPTIMIZER_WIKI_DIR = priorWikiDir;
+  rmSync(workspace, { recursive: true, force: true });
+});
+
+describe('active-model semantic finding contract', () => {
+  it('advertises every evidence and calibration field as required', () => {
+    expect(WIKI_WRITE_TOOL_DEFINITION.inputSchema.required).toEqual(
+      expect.arrayContaining([
+        'claim', 'anchors', 'evidence', 'applicability', 'confidenceLabel',
+      ])
+    );
+  });
+
+  it('rejects a plausible claim when the model supplies no evidence', async () => {
+    const result = await wikiWrite({
+      claim: 'The verifier requires the project runner.',
+      anchors: [anchor],
+      applicability: 'When running project verification.',
+      confidenceLabel: 'probable',
+      projectRoot: workspace,
+    } as never);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/evidence is required/i);
+  });
+
+});


### PR DESCRIPTION
## Evidence summary

This PR adds the causal measurement system and includes real model results. Evidence tiers are kept separate so a deterministic fixture cannot be mistaken for model improvement.

### A. Live four-arm cohort run on this PR

Client: Claude Code `2.1.225`. Observed model: `claude-sonnet-5`. Task: `command-recovery`. Five matched repetitions, 20 fresh sessions, Latin-rotated arm order. The first four repetitions put every arm in every order position; the fifth supplied the configured minimum fifth pair.

Baseline used `--setting-sources project`, a strict empty MCP configuration, and no plugin. Treated arms explicitly loaded only this checkout's plugin and built MCP server. Isolation smokes confirmed zero plugins/MCP in baseline, the local plugin/MCP in treated sessions, and an actual 24-token finding delivery. Transcripts were excluded.

#### Arm means

| Arm | Correct | Total tokens mean (95% bootstrap interval) | Tool calls | Latency | Cost | Finding tokens |
| --- | :---: | ---: | ---: | ---: | ---: | ---: |
| Baseline | 5/5 | 58,885 (58,537–59,214) | 4.8 | 16.390 s | $0.272727 | 0 |
| Optimizer | 5/5 | 59,898 (59,301–60,467) | 4.2 | 19.172 s | $0.269654 | 0 |
| Retrieval | 5/5 | 59,731 (59,367–60,308) | 3.4 | 17.839 s | $0.251858 | 24 |
| Full | 5/5 | 59,554 (59,114–60,235) | 3.2 | 16.798 s | $0.250657 | 24 |

#### Matched effects

Positive values mean the treatment improved the metric.

| Comparison | Tokens saved (95% interval) | Tool calls avoided | Latency saved | Cost saved | Correctness delta |
| --- | ---: | ---: | ---: | ---: | ---: |
| Optimizer vs baseline | -1,012 (-1,627 to -517) | 0.6 (-1.2 to 1.8) | -2.782 s (-5.631 to -0.739) | $0.003073 (-$0.023449 to $0.029596) | 0 |
| Retrieval vs optimizer | 167 (-761 to 1,166) | 0.8 (-2.0 to 4.2) | 1.334 s (-1.994 to 4.789) | $0.017795 (-$0.020217 to $0.057976) | 0 |
| Full vs retrieval | 177 (-14 to 424) | 0.2 (0.0 to 0.6) | 1.041 s (-0.613 to 2.322) | $0.001201 (-$0.012692 to $0.016090) | 0 |
| Full vs baseline | -668 (-1,205 to -230) | 1.6 (-0.2 to 3.2) | -0.408 s (-4.226 to 4.487) | $0.022070 ($0.000935 to $0.039046) | 0 |

What this establishes:

- All 20 sessions were correct; there is no measured correctness difference on this task.
- Retrieval/full delivered the seeded finding in all ten applicable runs and never in baseline/optimizer.
- Retrieval's incremental token, call, latency, and cost intervals cross zero; this cohort does not establish a retrieval benefit.
- Full used **668 more tokens than baseline**, with the token interval entirely on the worse side.
- Full cost about **$0.022 less** because Claude's cache pricing differs from raw token count.
- Tool-call direction favored full, but that interval crosses zero.

This meets the dashboard's five-pair display threshold. It is still one task, one client, and one model—not a powered cross-task or cross-client conclusion. The complete redacted ledger includes all 20 session IDs, per-run metrics, response hashes, isolation details, and artifact SHA-256: [Claude Sonnet 5 evidence report](https://github.com/ooples/token-optimizer-mcp/blob/agent/causal-evidence-and-client-effectiveness/evals/results/2026-08-09-claude-sonnet-5-command-recovery.md).

### B. Historical live-model evidence inherited from merged PR #300

The prior pilot used `gpt-5.6-sol` through Codex CLI `0.147.0`. Both arms used optimizer hooks; the treatment difference was graph retrieval, so this estimates **retrieval vs optimizer**, not full-system vs no-system.

| Pair | Retrieval tokens | Optimizer/holdout tokens | Paired tokens saved | Retrieval correct | Holdout correct |
| ---: | ---: | ---: | ---: | :---: | :---: |
| 1 | 12,250 | 26,672 | 14,422 | yes | yes |
| 2 | 13,306 | 16,464 | 3,158 | yes | yes |
| 3 | 8,250 | 13,797 | 5,547 | yes | yes |
| **Mean / total** | **11,269** | **18,978** | **7,709 (40.6%)** | **3/3** | **3/3** |

Observed paired savings ranged from 3,158 to 14,422 tokens. This is directional only: three pairs, one task, one client, and one model.

#### Historical negative control

| Arm | Tokens | Shell calls | Behavioral gain |
| --- | ---: | ---: | :---: |
| Retrieval | 12,903 | 3 | no |
| Holdout | 4,031 | 3 | baseline |

Retrieval was **8,872 tokens / 220.1% worse** with no call or behavioral improvement. This observed harm motivated expected-value gating, negative controls, cooldown, feedback, and quarantine.

#### Historical Codex context-window probe

| Configuration | First-turn input tokens | Delta from core |
| --- | ---: | ---: |
| Core 18-tool MCP profile | 14,227 | 0 |
| Full 98-tool MCP profile | 14,227 | 0 |
| Installed plugins disabled | 14,228 | +1 |
| User configuration ignored | 13,686 | -541 |

Core vs full differed by zero on that Codex probe, consistent with lazy schema exposure. This result is client-specific and is not generalized to Claude or tool-heavy sessions. Static catalog serialization fell from about 35,415 to 5,604 tokens (**84.2% smaller**), but that is not claimed as observed context reduction.

Full historical protocol and session IDs: [docs/LIVE_MODEL_EVALUATION.md](https://github.com/ooples/token-optimizer-mcp/blob/agent/causal-evidence-and-client-effectiveness/docs/LIVE_MODEL_EVALUATION.md).

### C. Production-path verification on this PR

`npm run verify:live-graph` exercised built `wiki_write`, production hooks, graph storage, cross-session retrieval, explicit cross-project retrieval, dashboard routes, and telemetry in an isolated graph:

| Measurement | Result |
| --- | ---: |
| Active-model findings written | 1, `origin: agent` |
| Later-session delivery | passed |
| Cross-project delivery with source provenance | passed |
| Dashboard graph-directory check | passed |
| Controlled injections / holdouts | 26 / 8 |
| Injection tokens | 2,532 |
| Harvest tokens | 500 |
| Controlled estimated tokens avoided | 47,000 |
| Controlled net balance | **+43,968 tokens** |

The +43,968 result verifies joins, balance calculation, and rendering; it is a deterministic controlled verifier, not model-effect evidence.

The UI fixture used five matched runs per arm and recovered its known 400-token full-vs-baseline contrast. It proves interval calculation and rendering, not model improvement.

### D. Evidence status

| Claim | Status |
| --- | --- |
| Packaged client wiring | **16/16 protocol-certified**: 6 lifecycle-continuation, 4 native-observation, 6 MCP-visible-only |
| Live active-model harvest and cross-session/cross-project retrieval | **observed** historically; production path reverified here |
| Retrieval can reduce tokens without lowering correctness | **directional for historical Codex**; not reproduced as a clear Claude effect in the current five-pair task |
| Retrieval can be harmful | **observed** in the historical negative control |
| Full system is better across clients/tasks | **not established**; current Claude task shows token overhead, equal correctness, and lower cost |

## Measurement fixes found by running the evidence

- Claude Code 2.1.225 used its Windows `PowerShell` tool, which the plugin did not match. The manifest and normalization now cover `PowerShell`/`pwsh`.
- The Claude-specific router now honors all four experiment feature gates and attaches episode identity to deliveries.
- Effects now estimate optimizer-vs-baseline, retrieval-vs-optimizer, full-vs-retrieval, and full-vs-baseline instead of conflating every arm with baseline.
- Claude cache-creation/read dimensions, exact model/client/session identity, stream tool calls, failures, cost, and total tokens are parsed directly.
- Runner profiles must document both baseline isolation and treated-branch configuration.
- Redacted local injection/outcome traces are copied into aggregate evidence before disposable workspaces are removed, preserving causal joins without raw paths.

## Eight completed implementation tasks

- [x] Schema-v2 causal episodes with stable injection IDs and exact/fallback outcome joins.
- [x] Counterbalanced `baseline` / `optimizer` / `retrieval` / `full` evaluation arms.
- [x] Correctness, token, tool-call, failure, latency, cost, harm, join-coverage, and 95% interval metrics.
- [x] Ten-task suite covering command recovery, repeated reads, search, cross-session/project reuse, staleness, harm, harvesting, a negative control, and compaction.
- [x] Expected-value retrieval, episode cooldown, and harmful-finding quarantine.
- [x] Active-model semantic contract: claim, anchors, evidence, applicability, confidence, scope, and invalidators.
- [x] Honest capability tiers and certification for all 16 supported clients.
- [x] Browser-tested evidence console with filters, component/total effects, intervals, traces, capability labels, and feedback.

## Validation

- Root Jest suite: **168 suites, 2,113 passed, 5 skipped**
- Current evidence-fix focused suite: **40/40 passed**
- Client packaging: **227/227 checks**
- Client protocol certification: **16/16**
- Harvest contract: **27/27 checks**
- Dashboard visual/evidence checks: **26/26**
- Dashboard interaction/security checks: **57/57**
- Build, hook-sync, formatting, package validation, and diff checks: passed

The description intentionally includes the unfavorable results. Neither the historical three-pair pilot nor this five-pair single-task cohort is promoted as proof that the system makes every model smarter or more token-efficient.
