### PR TITLE
Fix 5.7 live capture observability and dashboard evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,9 +183,55 @@ a page. A mature graph holds thousands of nodes, and shipping it wholesale would
 make every page load a multi-megabyte download for a view that shows twenty
 things.
 
+The default **All known projects** scope combines captured graphs through an
+opaque machine-local project registry; filesystem paths never reach the
+browser. Lifecycle hooks register repositories as they are used. To backfill
+existing local checkouts without reading their source files, run the bounded
+discovery command against one or more explicit roots:
+
+```bash
+npm run projects:discover -- /absolute/path/to/repos /absolute/path/to/worktrees
+```
+
+Coverage distinguishes repositories with graph data from known repositories
+whose capture has not started. The balance cards are backed by persisted events:
+**Memory deliveries** counts graph context actually supplied to an agent,
+**Kept back for comparison** counts randomized control touches, and **Cost of
+remembering** combines delivered-context tokens with measured semantic-write
+payload cost. **Reading avoided** stays “Not enough comparisons” until at least
+20 deliveries and 5 holdouts exist; the dashboard does not manufacture a
+savings estimate from missing data.
+
 See [the causal evidence protocol](docs/EVIDENCE_PROTOCOL.md), the
 [cross-client capability contract](docs/CLIENT_SUPPORT.md), and the
 [live evaluation suite](evals/README.md).
+
+### Cross-client lifecycle diagnostics
+
+Every native hook writes the same bounded JSONL lifecycle record, including
+Claude Code's custom router and compaction paths. Records carry the client and
+plugin versions, event, hashed session/turn correlation, latency, outcome,
+input/output byte counts, and response key shape. They deliberately retain no
+prompt, command, tool output, file content, or raw working-directory path. The
+fields include OpenTelemetry log severity and resource semantics so the local
+files can be collected without inventing a second schema.
+
+```bash
+npm run diagnostics                         # last 24 hours, summary-first JSON
+npm run diagnostics -- --hours 72 --output hook-summary.json
+npm run diagnostics -- --include-events --limit 100 --output hook-report.json
+```
+
+Raw event rows are opt-in and capped at 1,000. The default report contains aggregate health and
+at most twenty recent failures/timeouts, keeping routine troubleshooting output small enough for
+CLI and model context windows.
+
+The dashboard's **Capture health** panel shows runs, failures, timeouts and
+p50/p95 latency by client. Logs rotate at 5 MiB, retain at most 40 files for 14
+days, and live under `.token-optimizer/logs` when a state directory is set (or
+`~/.token-optimizer/logs` otherwise). `TOKEN_OPTIMIZER_LOG_DIR`,
+`TOKEN_OPTIMIZER_LOG_MAX_BYTES`, `TOKEN_OPTIMIZER_LOG_MAX_FILES`, and
+`TOKEN_OPTIMIZER_LOG_RETENTION_DAYS` override those operational defaults.
 
 ---
 

--- a/docs/CLIENT_SUPPORT.md
+++ b/docs/CLIENT_SUPPORT.md
@@ -49,6 +49,15 @@ each client executes hooks from a directory it controls (`~/.codex/hooks`, the
 Gemini extension path, the Claude Code plugin root) and no shared location
 resolves across all of them. `sync:hooks:check` is what keeps vendoring honest.
 
+All native lifecycle paths also import the same privacy-safe observability core.
+Each invocation produces one correlated completion event whether it succeeds,
+skips unusable input, times out, or fails open after an exception. The version
+stamped into vendored hooks comes from `package.json` during `sync:hooks`, so a
+mixed installation is visible in diagnostics instead of looking like a product
+logic failure. Claude Code's custom SessionStart, PreToolUse, and PreCompact
+paths are explicitly instrumented rather than being mistaken for generated
+adapter entries.
+
 ## How these were verified
 
 Every config shape was checked against the client's own published documentation,
@@ -89,6 +98,10 @@ needs the complete 102-tool specialist catalog. Use the four-operation
 | `TOKEN_OPTIMIZER_MODE`                  | `enforce` | `advise` = never refuse; `off` = disable |
 | `TOKEN_OPTIMIZER_LARGE_READ_BYTES`      | `25600`   | Size at which a read stops being cheap   |
 | `TOKEN_OPTIMIZER_PRECOMPACT_TIMEOUT_MS` | `8000`    | Cap on pre-compaction work               |
+| `TOKEN_OPTIMIZER_LOG_DIR`               | state logs | Structured lifecycle JSONL directory     |
+| `TOKEN_OPTIMIZER_LOG_MAX_BYTES`         | `5242880` | Rotate an active lifecycle log at size   |
+| `TOKEN_OPTIMIZER_LOG_RETENTION_DAYS`    | `14`      | Maximum lifecycle log age                |
+| `TOKEN_OPTIMIZER_LOG_MAX_FILES`         | `40`      | Maximum retained lifecycle log files     |
 
 An unrecognised `TOKEN_OPTIMIZER_MODE` falls back to `enforce`, so a typo cannot
 quietly turn the product off.

--- a/hooks-core/adapter.mjs
+++ b/hooks-core/adapter.mjs
@@ -25,6 +25,7 @@ import {
   MODE_OFF,
   MODE_ADVISE,
   largeFileBytes,
+  readPayloadResult,
   withEscape,
 } from './policy.mjs';
 import {
@@ -81,6 +82,8 @@ import {
 } from './capabilities.mjs';
 import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 import { evaluateUcrGuards } from './ucr-guard.mjs';
+import { beginHookInvocation, noteHookOutput } from './observability.mjs';
+import { registerProject } from './projects.mjs';
 
 /**
  * Per-client capability.
@@ -126,7 +129,14 @@ export function mutationSucceeded(clientName, raw) {
 
   // These lifecycle contracts fire this event only after a successful tool,
   // or are called by our in-process bridge only from its successful after hook.
-  return new Set(['claude-code', 'qwen', 'opencode', 'kilo', 'windsurf']).has(
+  return new Set([
+    'claude-code',
+    'codex',
+    'qwen',
+    'opencode',
+    'kilo',
+    'windsurf',
+  ]).has(
     clientName
   );
 }
@@ -239,37 +249,9 @@ export function sessionTaskContext(raw = {}) {
 }
 
 function emit(object) {
-  process.stdout.write(JSON.stringify(object));
-}
-
-/**
- * Bounded stdin read. See policy.readPayload for why the ceiling matters: the
- * entry points fail open on a THROW, but a host that opens the pipe and never
- * closes it produces no throw -- just a hook that waits forever with the user's
- * tool call stuck behind it.
- */
-async function readStdin({ timeoutMs = 5000 } = {}) {
-  const raw = await new Promise((resolve) => {
-    const chunks = [];
-    const timer = setTimeout(() => resolve(null), timeoutMs);
-    process.stdin.setEncoding('utf8');
-    process.stdin.on('data', (chunk) => chunks.push(chunk));
-    process.stdin.on('end', () => {
-      clearTimeout(timer);
-      resolve(chunks.join(''));
-    });
-    process.stdin.on('error', () => {
-      clearTimeout(timer);
-      resolve(null);
-    });
-  });
-
-  if (raw === null) return null;
-  try {
-    return JSON.parse(raw);
-  } catch {
-    return null;
-  }
+  const serialized = JSON.stringify(object);
+  noteHookOutput(object, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
 }
 
 /** The session-start notice, shared verbatim so no client drifts its own copy. */
@@ -500,6 +482,17 @@ function observeAndInject(payload, state, episode, features) {
  * @param {'session-start'|'pre-tool'|'post-tool'|'stop'} event
  */
 export async function run(clientName, event) {
+  const invocation = beginHookInvocation(clientName, event);
+  try {
+    await runHook(clientName, event, invocation);
+    invocation.succeed();
+  } catch (error) {
+    // The optimizer must fail open, but the failure is now reconstructable.
+    invocation.fail(error);
+  }
+}
+
+async function runHook(clientName, event, invocation) {
   const client = CLIENTS[clientName] || CLIENTS['claude-code'];
   const eventName =
     event === 'session-start'
@@ -527,7 +520,10 @@ export async function run(clientName, event) {
     // full pre-tool timeout would turn optional context into a five-second
     // startup tax; lifecycle payloads are tiny and arrive immediately when
     // the host supplies one.
-    const raw = (await readStdin({ timeoutMs: 250 })) || {};
+    const input = await readPayloadResult({ timeoutMs: 250 });
+    const raw = input.payload || {};
+    invocation.bind(raw, null, input.bytes);
+    if (input.status !== 'ok') invocation.noteInput(input.status, input.bytes);
     const toolEvidence = optimizerToolEvidence(raw);
     const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id;
     if (sessionId && toolEvidence.proven) {
@@ -538,10 +534,12 @@ export async function run(clientName, event) {
     const parts = [
       policyText(client.canDeny, toolEvidence.names, toolEvidence.proven),
     ];
+    const cwd = raw.cwd || raw.working_directory || process.cwd();
+    const root = projectRootFor(join(cwd, '__session__'), cwd);
+    registerProject({ root, graphDir: wikiDir(root), client: clientName });
     if (features.retrieval) {
       try {
-        const cwd = raw.cwd || raw.working_directory || process.cwd();
-        const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+        const dir = wikiDir(root);
         // SessionStart needs hashes and claims, not stored file bodies. Parsing
         // the snapshot sidecar here would make startup scale with repository
         // history even though this compact index never renders a diff.
@@ -567,14 +565,20 @@ export async function run(clientName, event) {
     process.exit(0);
   }
 
-  const raw = await readStdin();
+  const input = await readPayloadResult();
+  const raw = input.payload;
   if (!raw) {
+    invocation.noteInput(input.status, input.bytes);
     // Stop requires JSON on stdout even when it has nothing to add.
     if (event === 'stop') emit({});
     process.exit(0);
   }
 
   if (event === 'stop') {
+    // Stop has no normalized tool payload, but it is still a fully formed hook
+    // invocation. Bind its lifecycle identifiers so successful completions do
+    // not look like an input reader that never ran in cross-client telemetry.
+    invocation.bind(raw, null, input.bytes);
     const sessionId =
       raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? 'default';
     const agentScope = raw.transcript_path ?? raw.transcriptPath ?? null;
@@ -630,6 +634,7 @@ export async function run(clientName, event) {
   const payload = normalizePayload(
     normalizeClientPayload(clientName, event, raw)
   );
+  invocation.bind(raw, payload, input.bytes);
   if (!payload.tool_name) process.exit(0);
   const episode = episodeMeta({ client: clientName, raw, payload });
 

--- a/hooks-core/metrics.mjs
+++ b/hooks-core/metrics.mjs
@@ -736,10 +736,7 @@ function canonicalKeyish(p) {
  * arms, multiplied by treated touches. Reporting it as a measured fact would be
  * the same overclaiming this project criticises competitors for.
  */
-export function report(dir) {
-  const events = readAll(dir);
-  // Injections and harvests come from the log that cannot be starved.
-  const balance = readBalance(dir);
+function buildReport(events, balance) {
 
   // COMMAND INJECTIONS ARE COUNTED SEPARATELY, not mixed into the balance.
   //
@@ -841,6 +838,15 @@ export function report(dir) {
   const sufficient = treated.length >= 20 && withheld.length >= 5;
 
   return {
+    memoryDeliveries: allInjections.filter((event) => !event.holdout).length,
+    memoryHoldouts: allInjections.filter((event) => event.holdout).length,
+    deliveryTokens: allInjections
+      .filter((event) => !event.holdout)
+      .reduce(
+        (sum, event) =>
+          sum + (event.deliveredTokens ?? event.tokens ?? 0),
+        0
+      ),
     injections: treated.length,
     sessionStartInjections: sessionStartInjections.length,
     sessionStartInjectedTokens: sessionStartInjections.reduce(
@@ -862,6 +868,27 @@ export function report(dir) {
         ? 'the graph is saving more than it costs'
         : 'the graph is NOT yet paying for itself',
   };
+}
+
+export function report(dir) {
+  return buildReport(readAll(dir), readBalance(dir));
+}
+
+/**
+ * One statistically valid machine/project-group report.
+ *
+ * Summing per-project verdicts is wrong: five projects with four treated reads
+ * each do not individually meet the threshold, but together they are twenty
+ * observations. Pooling the underlying events preserves the randomized arms
+ * and computes the means once over the selected population.
+ */
+export function reportMany(dirs) {
+  const unique = [...new Set((dirs || []).map((dir) => String(dir)))];
+  const report = buildReport(
+    unique.flatMap((dir) => readAll(dir)),
+    unique.flatMap((dir) => readBalance(dir))
+  );
+  return { ...report, projects: unique.length };
 }
 
 /**

--- a/hooks-core/metrics.mjs
+++ b/hooks-core/metrics.mjs
@@ -1295,8 +1295,8 @@ function concurrencySummary(runs) {
  * live hook traces, and randomized model evals remain visibly distinct: only
  * `eval-run` records with paired arms can produce a causal effect interval.
  */
-export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
-  const evidence = readEvidence(dir).filter((event) => matchesFilters(event, filters));
+function buildEvidenceReport(evidence, { filters = {}, episodeLimit = 100 } = {}) {
+  evidence = evidence.filter((event) => matchesFilters(event, filters));
   const runs = evidence.filter((event) => event.kind === 'eval-run');
   const handoffRuns = evidence.filter((event) => event.kind === 'handoff-run');
   const concurrencyRuns = evidence.filter((event) => event.kind === 'concurrency-run');
@@ -1400,6 +1400,47 @@ export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
       minimumPairs,
       handoffMinimumPairs: handoffMinimumPairs(),
       deterministicChecksAreCausalProof: false,
+    },
+  };
+}
+
+export function evidenceReport(dir, options = {}) {
+  const events = readEvidence(dir);
+  const report = buildEvidenceReport(events, options);
+  const hasMatchingEvidence = events.some((event) =>
+    matchesFilters(event, options.filters || {})
+  );
+  return {
+    ...report,
+    sourceCoverage: {
+      projects: 1,
+      projectsWithEvidence: hasMatchingEvidence ? 1 : 0,
+      projectsWithoutEvidence: hasMatchingEvidence ? 0 : 1,
+    },
+  };
+}
+
+/**
+ * Pools evidence across registered projects before computing cohorts.
+ *
+ * A cohort split across two worktrees is still one experiment. Summing already
+ * aggregated reports would lose pairing and produce invalid confidence
+ * intervals, so this combines the append-only source events first and runs the
+ * estimator exactly once.
+ */
+export function evidenceReportMany(dirs, options = {}) {
+  const unique = [...new Set((dirs || []).map((dir) => String(dir)))];
+  const sources = unique.map((dir) => readEvidence(dir));
+  const report = buildEvidenceReport(sources.flat(), options);
+  const projectsWithEvidence = sources.filter((events) =>
+    events.some((event) => matchesFilters(event, options.filters || {}))
+  ).length;
+  return {
+    ...report,
+    sourceCoverage: {
+      projects: unique.length,
+      projectsWithEvidence,
+      projectsWithoutEvidence: unique.length - projectsWithEvidence,
     },
   };
 }

--- a/hooks-core/observability.mjs
+++ b/hooks-core/observability.mjs
@@ -1,0 +1,397 @@
+/**
+ * Privacy-safe, cross-client lifecycle diagnostics.
+ *
+ * Hook processes are intentionally fail-open, but fail-open must not mean
+ * fail-silent. Every client writes the same bounded JSONL schema so failures
+ * can be correlated without storing prompts, commands, tool output, or file
+ * contents.
+ */
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmdirSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { createHash, randomUUID } from 'node:crypto';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export const HOOK_LOG_SCHEMA_VERSION = 1;
+const DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
+const DEFAULT_RETENTION_DAYS = 14;
+const DEFAULT_MAX_FILES = 40;
+const DEFAULT_DEADLINE_MS = 4200;
+const MAX_ERROR_CHARS = 4000;
+const MAX_DIMENSION_CHARS = 160;
+let activeInvocation = null;
+
+function positiveInteger(name, fallback) {
+  const value = Number(process.env[name]);
+  return Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+export function hookLogDirectory() {
+  if (process.env.TOKEN_OPTIMIZER_LOG_DIR)
+    return process.env.TOKEN_OPTIMIZER_LOG_DIR;
+  const stateRoot =
+    process.env.TOKEN_OPTIMIZER_STATE_DIR ||
+    join(homedir(), '.token-optimizer');
+  return join(stateRoot, 'logs');
+}
+
+function hash(value, length = 16) {
+  if (!value) return null;
+  return createHash('sha256').update(String(value)).digest('hex').slice(0, length);
+}
+
+function sanitize(text) {
+  if (text === undefined || text === null) return null;
+  let value = String(text);
+  const home = homedir().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  if (home) value = value.replace(new RegExp(home, 'gi'), '<home>');
+  value = value
+    .replace(/\b(?:sk-[A-Za-z0-9_-]{12,}|gh[opusr]_[A-Za-z0-9]{12,})\b/g, '[REDACTED]')
+    .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi, '$1[REDACTED]')
+    .replace(/\b(password|secret|token|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi, '$1=[REDACTED]');
+  return value.slice(0, MAX_ERROR_CHARS);
+}
+
+function errorFields(error) {
+  if (!error) return null;
+  return {
+    type: sanitize(error.name || error.constructor?.name || 'Error'),
+    message: sanitize(error.message || error),
+    stack: sanitize(error.stack),
+  };
+}
+
+function dimension(value) {
+  const sanitized = sanitize(value);
+  return sanitized === null ? null : sanitized.slice(0, MAX_DIMENSION_CHARS);
+}
+
+function severity(level) {
+  if (level === 'error') return { severityText: 'ERROR', severityNumber: 17 };
+  if (level === 'warn') return { severityText: 'WARN', severityNumber: 13 };
+  return { severityText: 'INFO', severityNumber: 9 };
+}
+
+function activeLogPath(now = new Date()) {
+  const date = now.toISOString().slice(0, 10);
+  return join(hookLogDirectory(), `hook-events-${date}.jsonl`);
+}
+
+function rotateIfNeeded(path) {
+  try {
+    if (!existsSync(path)) return;
+    const maxBytes = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_BYTES', DEFAULT_MAX_BYTES);
+    if (statSync(path).size < maxBytes) return;
+
+    const lock = join(hookLogDirectory(), '.rotate.lock');
+    try {
+      mkdirSync(lock);
+    } catch {
+      return;
+    }
+    try {
+      if (existsSync(path) && statSync(path).size >= maxBytes) {
+        // Multiple hook processes (or several writes in one millisecond) must
+        // never select the same rotation target and overwrite an earlier file.
+        const rotated = path.replace(
+          /\.jsonl$/,
+          `-${Date.now()}-${process.pid}-${randomUUID()}.jsonl`
+        );
+        renameSync(path, rotated);
+      }
+    } finally {
+      // Non-recursive removal of the one fixed-name lock directory only.
+      try { rmdirSync(lock); } catch { /* best effort */ }
+    }
+  } catch {
+    // Diagnostics must never become the reason a lifecycle hook fails.
+  }
+}
+
+function pruneIfDue(now = new Date()) {
+  try {
+    const dir = hookLogDirectory();
+    const marker = join(dir, '.last-prune');
+    if (existsSync(marker) && now.getTime() - statSync(marker).mtimeMs < 60 * 60 * 1000)
+      return;
+    writeFileSync(marker, now.toISOString(), { flag: 'w' });
+
+    const retentionMs =
+      positiveInteger('TOKEN_OPTIMIZER_LOG_RETENTION_DAYS', DEFAULT_RETENTION_DAYS) *
+      24 * 60 * 60 * 1000;
+    const maxFiles = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_FILES', DEFAULT_MAX_FILES);
+    const files = readdirSync(dir)
+      .filter((name) => /^hook-events-.*\.jsonl$/.test(name))
+      .map((name) => {
+        const path = join(dir, name);
+        return { path, mtimeMs: statSync(path).mtimeMs };
+      })
+      .sort((a, b) => b.mtimeMs - a.mtimeMs);
+    for (let i = 0; i < files.length; i++) {
+      if (i >= maxFiles || now.getTime() - files[i].mtimeMs > retentionMs)
+        unlinkSync(files[i].path);
+    }
+  } catch {
+    // Retention is best effort and cannot affect the host tool call.
+  }
+}
+
+export function writeHookEvent(event) {
+  try {
+    const now = new Date();
+    const dir = hookLogDirectory();
+    mkdirSync(dir, { recursive: true });
+    const path = activeLogPath(now);
+    rotateIfNeeded(path);
+    const record = {
+      schemaVersion: HOOK_LOG_SCHEMA_VERSION,
+      timestamp: now.toISOString(),
+      service: 'token-optimizer',
+      serviceVersion:
+        process.env.TOKEN_OPTIMIZER_VERSION ||
+        process.env.npm_package_version ||
+        'unknown',
+      ...severity(event.level),
+      body: event.event || 'hook.event',
+      ...event,
+    };
+    record.resource = {
+      'service.name': record.service,
+      'service.version': record.serviceVersion,
+      'host.arch': process.arch,
+      'os.type': process.platform,
+      'process.runtime.name': 'node',
+      'process.runtime.version': process.version,
+    };
+    appendFileSync(path, `${JSON.stringify(record)}\n`, { encoding: 'utf8' });
+    pruneIfDue(now);
+    return path;
+  } catch {
+    return null;
+  }
+}
+
+export function beginHookInvocation(client, event, options = {}) {
+  const started = Date.now();
+  const invocationId = randomUUID();
+  let ended = false;
+  let outcome = 'success';
+  let reason = 'completed';
+  let error = null;
+  const dimensions = {
+    sessionIdHash: null,
+    turnIdHash: null,
+    toolUseIdHash: null,
+    toolName: null,
+    clientVersion: null,
+    model: null,
+    cwdHash: null,
+    payloadBytes: null,
+    outputBytes: 0,
+    outputShape: [],
+    inputStatus: 'pending',
+  };
+  const spanId = hash(invocationId, 16);
+  let traceId = hash(invocationId, 32);
+
+  let deadline;
+  const finish = (nextOutcome = outcome, nextReason = reason, nextError = error) => {
+    if (ended) return;
+    ended = true;
+    if (deadline) clearTimeout(deadline);
+    process.removeListener('exit', onExit);
+    writeHookEvent({
+      level: nextOutcome === 'failure' || nextOutcome === 'timeout' ? 'error' : 'info',
+      event: 'hook.completed',
+      outcome: nextOutcome,
+      reason: nextReason,
+      durationMs: Date.now() - started,
+      invocationId,
+      traceId,
+      spanId,
+      client,
+      hookEvent: event,
+      processId: process.pid,
+      ...dimensions,
+      error: errorFields(nextError),
+    });
+  };
+  const onExit = () => finish();
+  process.once('exit', onExit);
+
+  deadline = setTimeout(() => {
+    outcome = 'timeout';
+    reason = 'internal_deadline_exceeded';
+    finish(outcome, reason);
+    // Beat the host's five-second timeout and fail open deterministically.
+    process.exit(0);
+  }, options.deadlineMs ?? positiveInteger('TOKEN_OPTIMIZER_HOOK_DEADLINE_MS', DEFAULT_DEADLINE_MS));
+  deadline.unref();
+
+  const invocation = {
+    invocationId,
+    bind(raw = {}, payload = null, payloadBytes = null) {
+      const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? null;
+      dimensions.sessionIdHash = hash(sessionId);
+      dimensions.turnIdHash = hash(raw.turn_id ?? raw.turnId ?? null);
+      dimensions.toolUseIdHash = hash(raw.tool_use_id ?? raw.toolUseId ?? null);
+      dimensions.toolName = payload?.tool_name ?? raw.tool_name ?? raw.toolName ?? null;
+      dimensions.clientVersion = dimension(raw.client_version ?? raw.clientVersion ?? null);
+      dimensions.model = dimension(raw.model ?? raw.model_name ?? raw.modelName ?? null);
+      dimensions.cwdHash = hash(raw.cwd ?? raw.working_directory ?? process.cwd());
+      dimensions.payloadBytes = payloadBytes;
+      dimensions.inputStatus = 'ok';
+      if (sessionId) traceId = hash(sessionId, 32);
+    },
+    noteInput(status, payloadBytes = null) {
+      dimensions.inputStatus = status;
+      dimensions.payloadBytes = payloadBytes;
+      if (status === 'timeout') {
+        outcome = 'timeout';
+        reason = 'stdin_timeout';
+      } else if (status !== 'ok') {
+        outcome = 'skipped';
+        reason = status;
+      }
+    },
+    skip(nextReason) {
+      outcome = 'skipped';
+      reason = nextReason;
+    },
+    noteOutput(output, outputBytes = null) {
+      dimensions.outputBytes = outputBytes ?? Buffer.byteLength(JSON.stringify(output), 'utf8');
+      if (!output || typeof output !== 'object' || Array.isArray(output)) {
+        dimensions.outputShape = [];
+        return;
+      }
+      const shape = Object.keys(output).sort();
+      const hookSpecific = output.hookSpecificOutput;
+      if (hookSpecific && typeof hookSpecific === 'object' && !Array.isArray(hookSpecific)) {
+        for (const key of Object.keys(hookSpecific).sort()) shape.push(`hookSpecificOutput.${key}`);
+      }
+      dimensions.outputShape = shape;
+    },
+    fail(nextError, nextReason = 'unhandled_exception') {
+      outcome = 'failure';
+      reason = nextReason;
+      error = nextError;
+      finish(outcome, reason, error);
+    },
+    succeed(nextReason = 'completed') {
+      outcome = 'success';
+      reason = nextReason;
+      finish(outcome, reason);
+    },
+  };
+  activeInvocation = invocation;
+  return invocation;
+}
+
+/** Records response metadata without retaining response content. */
+export function noteHookOutput(output, outputBytes = null) {
+  activeInvocation?.noteOutput(output, outputBytes);
+}
+
+export function recordHookBootstrapFailure(client, event, error) {
+  writeHookEvent({
+    level: 'error',
+    event: 'hook.completed',
+    outcome: 'failure',
+    reason: 'bootstrap_import_failure',
+    durationMs: 0,
+    invocationId: randomUUID(),
+    client,
+    hookEvent: event,
+    processId: process.pid,
+    error: errorFields(error),
+  });
+}
+
+export function readHookEvents({ limit = 200, sinceMs = 24 * 60 * 60 * 1000 } = {}) {
+  try {
+    const dir = hookLogDirectory();
+    if (!existsSync(dir)) return [];
+    const cutoff = Date.now() - Math.max(0, sinceMs);
+    const files = readdirSync(dir)
+      .filter((name) => /^hook-events-.*\.jsonl$/.test(name))
+      .map((name) => join(dir, name))
+      .sort()
+      .reverse();
+    const events = [];
+    for (const file of files) {
+      const lines = readFileSync(file, 'utf8').split(/\r?\n/).filter(Boolean).reverse();
+      for (const line of lines) {
+        try {
+          const event = JSON.parse(line);
+          if (Date.parse(event.timestamp) < cutoff) continue;
+          events.push(event);
+          if (events.length >= limit) return events;
+        } catch {
+          // A partially written final line must not hide the rest of the log.
+        }
+      }
+    }
+    return events;
+  } catch {
+    return [];
+  }
+}
+
+export function hookHealthSummary(options = {}) {
+  const sinceMs = options.sinceMs ?? 24 * 60 * 60 * 1000;
+  const events = readHookEvents({ limit: options.limit || 5000, sinceMs });
+  const durations = events
+    .map((event) => Number(event.durationMs))
+    .filter(Number.isFinite)
+    .sort((a, b) => a - b);
+  const failures = events.filter((event) => event.outcome === 'failure');
+  const timeouts = events.filter((event) => event.outcome === 'timeout');
+  const skipped = events.filter((event) => event.outcome === 'skipped');
+  const successes = events.filter((event) => event.outcome === 'success');
+  const byClient = {};
+  for (const event of events) {
+    const key = event.client || 'unknown';
+    const current = byClient[key] || { total: 0, failures: 0, timeouts: 0, skipped: 0 };
+    current.total++;
+    if (event.outcome === 'failure') current.failures++;
+    if (event.outcome === 'timeout') current.timeouts++;
+    if (event.outcome === 'skipped') current.skipped++;
+    byClient[key] = current;
+  }
+  const percentile = (p) =>
+    durations.length
+      ? durations[Math.min(durations.length - 1, Math.floor(durations.length * p))]
+      : null;
+  const summary = {
+    schemaVersion: HOOK_LOG_SCHEMA_VERSION,
+    available: events.length > 0,
+    windowHours: sinceMs / 3_600_000,
+    total: events.length,
+    failures: failures.length,
+    timeouts: timeouts.length,
+    skipped: skipped.length,
+    successRate: events.length ? successes.length / events.length : null,
+    p50DurationMs: percentile(0.5),
+    p95DurationMs: percentile(0.95),
+    byClient,
+    recentFailures: [...failures, ...timeouts]
+      .sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp))
+      .slice(0, 20),
+  };
+  // Absolute paths are useful to a local doctor, but they do not belong in a
+  // diagnostics export that may be attached to a public issue.
+  if (options.includeLogDirectory === true)
+    summary.logDirectory = hookLogDirectory();
+  return summary;
+}

--- a/hooks-core/policy.mjs
+++ b/hooks-core/policy.mjs
@@ -46,6 +46,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { createHash } from 'node:crypto';
 import { isFsSafePath } from './paths.mjs';
+import { noteHookOutput } from './observability.mjs';
 
 /** Enforcement modes, least to most permissive. */
 export const MODE_ENFORCE = 'enforce';
@@ -651,14 +652,15 @@ export function allow() {
  */
 export function allowWithContext(context) {
   if (context) {
-    process.stdout.write(
-      JSON.stringify({
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-          additionalContext: withEscape(context),
-        },
-      })
-    );
+    const output = {
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        additionalContext: withEscape(context),
+      },
+    };
+    const serialized = JSON.stringify(output);
+    noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+    process.stdout.write(serialized);
   }
   process.exit(0);
 }
@@ -671,15 +673,16 @@ export function allowWithContext(context) {
  * says "use the optimized tool" gets met with a retry of the same call.
  */
 export function deny(reason) {
-  process.stdout.write(
-    JSON.stringify({
-      hookSpecificOutput: {
-        hookEventName: 'PreToolUse',
-        permissionDecision: 'deny',
-        permissionDecisionReason: withEscape(reason),
-      },
-    })
-  );
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+      permissionDecisionReason: withEscape(reason),
+    },
+  };
+  const serialized = JSON.stringify(output);
+  noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
   process.exit(0);
 }
 
@@ -704,14 +707,15 @@ export function withEscape(reason) {
 
 /** Lets the call through, attaching a note the model sees. */
 export function advise(context) {
-  process.stdout.write(
-    JSON.stringify({
-      hookSpecificOutput: {
-        hookEventName: 'PreToolUse',
-        additionalContext: context,
-      },
-    })
-  );
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      additionalContext: context,
+    },
+  };
+  const serialized = JSON.stringify(output);
+  noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
   process.exit(0);
 }
 
@@ -739,26 +743,34 @@ export function enforce(reason, deniedBefore) {
  * than an absent one, so the wait has a ceiling and expiring it is treated
  * exactly like unusable input.
  */
-export async function readPayload({
-  timeoutMs = 5000,
+export async function readPayloadResult({
+  timeoutMs = 1500,
   maxBytes = 8_000_000,
 } = {}) {
   const chunks = [];
   let size = 0;
+  let inputStatus = 'pending';
 
   const raw = await new Promise((resolve) => {
     const onData = (chunk) => {
-      size += chunk.length;
+      size += Buffer.byteLength(chunk, 'utf8');
       // A payload this large is not a tool call; refusing to buffer it
       // unboundedly keeps a hook from becoming a memory problem.
       if (size > maxBytes) {
+        inputStatus = 'too_large';
         finish(null);
         return;
       }
       chunks.push(chunk);
     };
-    const onEnd = () => finish(chunks.join(''));
-    const onError = () => finish(null);
+    const onEnd = () => {
+      inputStatus = 'received';
+      finish(chunks.join(''));
+    };
+    const onError = () => {
+      inputStatus = 'input_error';
+      finish(null);
+    };
 
     // Listeners are REMOVED on every exit path. Leaving them attached after the
     // timeout wins means a late chunk keeps growing a buffer nobody will read,
@@ -772,17 +784,21 @@ export async function readPayload({
       resolve(value);
     }
 
-    const timer = setTimeout(() => finish(null), timeoutMs);
+    const timer = setTimeout(() => {
+      inputStatus = 'timeout';
+      finish(null);
+    }, timeoutMs);
     process.stdin.setEncoding('utf8');
     process.stdin.on('data', onData);
     process.stdin.on('end', onEnd);
     process.stdin.on('error', onError);
   });
 
-  if (raw === null) return null;
+  if (raw === null) return { payload: null, status: inputStatus, bytes: size };
+  if (!raw.trim()) return { payload: null, status: 'empty_input', bytes: size };
   try {
-    return JSON.parse(raw);
+    return { payload: JSON.parse(raw), status: 'ok', bytes: size };
   } catch {
-    return null;
+    return { payload: null, status: 'invalid_json', bytes: size };
   }
 }

--- a/hooks-core/projects.mjs
+++ b/hooks-core/projects.mjs
@@ -1,0 +1,212 @@
+/**
+ * Machine-local index of project graph stores.
+ *
+ * A graph is deliberately stored with the project whose files it describes.
+ * That isolation is important for retrieval, but it also means a dashboard
+ * cannot honestly describe machine-wide capture unless it knows which stores
+ * exist. This registry is that missing directory. It is written by lifecycle
+ * hooks and can be backfilled by the explicit discovery command.
+ *
+ * The browser never receives `root` or `graphDir`. Routes resolve an opaque
+ * project id through this server-owned file, so restoring cross-project views
+ * does not restore the old arbitrary-path query vulnerability.
+ */
+
+import {
+  appendFileSync,
+  chmodSync,
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+} from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+import { createHash } from 'node:crypto';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
+
+export const PROJECT_REGISTRY_VERSION = 1;
+
+export function projectRegistryPath() {
+  return (
+    process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY ||
+    join(homedir(), '.token-optimizer', 'projects.jsonl')
+  );
+}
+
+export function projectIdFor(root) {
+  return `project-${createHash('sha256')
+    .update(canonicalPath(root))
+    .digest('hex')
+    .slice(0, 16)}`;
+}
+
+function displayName(root) {
+  return basename(root) || 'Unnamed project';
+}
+
+function acquire(path) {
+  const lockPath = `${path}.lock`;
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+  } catch {
+    return null;
+  }
+
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      closeSync(openSync(lockPath, 'wx', 0o600));
+      return lockPath;
+    } catch {
+      try {
+        if (Date.now() - statSync(lockPath).mtimeMs > 5000) unlinkSync(lockPath);
+      } catch {
+        // The holder may have released it between open and stat; retry.
+      }
+    }
+  }
+  return null;
+}
+
+function release(lockPath) {
+  if (!lockPath) return;
+  try {
+    unlinkSync(lockPath);
+  } catch {
+    // A killed process or cleanup race must not fail the hook.
+  }
+}
+
+/**
+ * Folds the append-only registry into one current entry per canonical project.
+ * Malformed, stale-schema, and unsafe records are ignored rather than trusted.
+ */
+export function registeredProjects() {
+  const path = projectRegistryPath();
+  const projects = new Map();
+  if (!existsSync(path)) return [];
+
+  try {
+    for (const line of readFileSync(path, 'utf8').split('\n')) {
+      if (!line) continue;
+      let record;
+      try {
+        record = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (
+        record.v !== PROJECT_REGISTRY_VERSION ||
+        !isFsSafePath(record.root) ||
+        !isFsSafePath(record.graphDir)
+      ) {
+        continue;
+      }
+      const root = canonicalPath(record.root);
+      const graphDir = canonicalPath(record.graphDir);
+      // Append-only history can outlive a deleted worktree (especially a
+      // short-lived test or CI checkout). A source that no longer exists
+      // cannot be captured, and presenting it as a current coverage gap makes
+      // the dashboard steadily less truthful over time.
+      if (!existsSync(root)) continue;
+      // A broad discovery root may contain hundreds of dormant worktrees. They
+      // are not capture coverage until a hook has observed them or a graph
+      // exists; listing all of them turns the selector into filesystem noise.
+      if (
+        record.client === 'discovery' &&
+        !existsSync(join(graphDir, 'graph.jsonl'))
+      ) {
+        continue;
+      }
+      const id = projectIdFor(root);
+      if (record.id !== id) continue;
+
+      const previous = projects.get(id);
+      projects.set(id, {
+        id,
+        name: String(record.name || displayName(root)).slice(0, 160),
+        root,
+        graphDir,
+        firstSeenAt: previous?.firstSeenAt || record.at || 0,
+        lastSeenAt: Math.max(previous?.lastSeenAt || 0, Number(record.at) || 0),
+        clients: [
+          ...new Set([
+            ...(previous?.clients || []),
+            ...(typeof record.client === 'string' && record.client
+              ? [record.client.slice(0, 80)]
+              : []),
+          ]),
+        ].sort(),
+      });
+    }
+  } catch {
+    return [];
+  }
+
+  return [...projects.values()].sort(
+    (a, b) => b.lastSeenAt - a.lastSeenAt || a.name.localeCompare(b.name)
+  );
+}
+
+/** Registers one VCS project without ever making a hook fail closed. */
+export function registerProject({ root, graphDir, client = 'unknown', name } = {}) {
+  if (!isFsSafePath(root) || !isFsSafePath(graphDir)) return null;
+  try {
+    const canonicalRoot = canonicalPath(root);
+    const canonicalGraphDir = canonicalPath(graphDir);
+    const isRepository = ['.git', '.hg', '.svn'].some((marker) =>
+      existsSync(join(canonicalRoot, marker))
+    );
+    if (!isRepository) return null;
+    const id = projectIdFor(canonicalRoot);
+    const now = Date.now();
+    const recent = registeredProjects().find(
+      (project) =>
+        project.id === id &&
+        project.graphDir === canonicalGraphDir &&
+        project.clients.includes(client) &&
+        now - project.lastSeenAt < 60 * 60 * 1000
+    );
+    if (recent) return recent;
+
+    const path = projectRegistryPath();
+    const lockPath = acquire(path);
+    if (!lockPath) return null;
+    try {
+      appendFileSync(
+        path,
+        `${JSON.stringify({
+          v: PROJECT_REGISTRY_VERSION,
+          id,
+          name: String(name || displayName(canonicalRoot)).slice(0, 160),
+          root: canonicalRoot,
+          graphDir: canonicalGraphDir,
+          client: String(client || 'unknown').slice(0, 80),
+          at: now,
+        })}\n`,
+        { mode: 0o600 }
+      );
+      try {
+        chmodSync(path, 0o600);
+      } catch {
+        // Windows and some filesystems do not expose POSIX modes.
+      }
+    } finally {
+      release(lockPath);
+    }
+    return {
+      id,
+      name: String(name || displayName(canonicalRoot)).slice(0, 160),
+      root: canonicalRoot,
+      graphDir: canonicalGraphDir,
+      firstSeenAt: now,
+      lastSeenAt: now,
+      clients: [String(client || 'unknown').slice(0, 80)],
+    };
+  } catch {
+    return null;
+  }
+}

--- a/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
@@ -27,6 +27,7 @@ import {
   MODE_OFF,
   MODE_ADVISE,
   largeFileBytes,
+  readPayloadResult,
   withEscape,
 } from './policy.mjs';
 import {
@@ -83,6 +84,8 @@ import {
 } from './capabilities.mjs';
 import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 import { evaluateUcrGuards } from './ucr-guard.mjs';
+import { beginHookInvocation, noteHookOutput } from './observability.mjs';
+import { registerProject } from './projects.mjs';
 
 /**
  * Per-client capability.
@@ -128,7 +131,14 @@ export function mutationSucceeded(clientName, raw) {
 
   // These lifecycle contracts fire this event only after a successful tool,
   // or are called by our in-process bridge only from its successful after hook.
-  return new Set(['claude-code', 'qwen', 'opencode', 'kilo', 'windsurf']).has(
+  return new Set([
+    'claude-code',
+    'codex',
+    'qwen',
+    'opencode',
+    'kilo',
+    'windsurf',
+  ]).has(
     clientName
   );
 }
@@ -241,37 +251,9 @@ export function sessionTaskContext(raw = {}) {
 }
 
 function emit(object) {
-  process.stdout.write(JSON.stringify(object));
-}
-
-/**
- * Bounded stdin read. See policy.readPayload for why the ceiling matters: the
- * entry points fail open on a THROW, but a host that opens the pipe and never
- * closes it produces no throw -- just a hook that waits forever with the user's
- * tool call stuck behind it.
- */
-async function readStdin({ timeoutMs = 5000 } = {}) {
-  const raw = await new Promise((resolve) => {
-    const chunks = [];
-    const timer = setTimeout(() => resolve(null), timeoutMs);
-    process.stdin.setEncoding('utf8');
-    process.stdin.on('data', (chunk) => chunks.push(chunk));
-    process.stdin.on('end', () => {
-      clearTimeout(timer);
-      resolve(chunks.join(''));
-    });
-    process.stdin.on('error', () => {
-      clearTimeout(timer);
-      resolve(null);
-    });
-  });
-
-  if (raw === null) return null;
-  try {
-    return JSON.parse(raw);
-  } catch {
-    return null;
-  }
+  const serialized = JSON.stringify(object);
+  noteHookOutput(object, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
 }
 
 /** The session-start notice, shared verbatim so no client drifts its own copy. */
@@ -502,6 +484,17 @@ function observeAndInject(payload, state, episode, features) {
  * @param {'session-start'|'pre-tool'|'post-tool'|'stop'} event
  */
 export async function run(clientName, event) {
+  const invocation = beginHookInvocation(clientName, event);
+  try {
+    await runHook(clientName, event, invocation);
+    invocation.succeed();
+  } catch (error) {
+    // The optimizer must fail open, but the failure is now reconstructable.
+    invocation.fail(error);
+  }
+}
+
+async function runHook(clientName, event, invocation) {
   const client = CLIENTS[clientName] || CLIENTS['claude-code'];
   const eventName =
     event === 'session-start'
@@ -529,7 +522,10 @@ export async function run(clientName, event) {
     // full pre-tool timeout would turn optional context into a five-second
     // startup tax; lifecycle payloads are tiny and arrive immediately when
     // the host supplies one.
-    const raw = (await readStdin({ timeoutMs: 250 })) || {};
+    const input = await readPayloadResult({ timeoutMs: 250 });
+    const raw = input.payload || {};
+    invocation.bind(raw, null, input.bytes);
+    if (input.status !== 'ok') invocation.noteInput(input.status, input.bytes);
     const toolEvidence = optimizerToolEvidence(raw);
     const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id;
     if (sessionId && toolEvidence.proven) {
@@ -540,10 +536,12 @@ export async function run(clientName, event) {
     const parts = [
       policyText(client.canDeny, toolEvidence.names, toolEvidence.proven),
     ];
+    const cwd = raw.cwd || raw.working_directory || process.cwd();
+    const root = projectRootFor(join(cwd, '__session__'), cwd);
+    registerProject({ root, graphDir: wikiDir(root), client: clientName });
     if (features.retrieval) {
       try {
-        const cwd = raw.cwd || raw.working_directory || process.cwd();
-        const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+        const dir = wikiDir(root);
         // SessionStart needs hashes and claims, not stored file bodies. Parsing
         // the snapshot sidecar here would make startup scale with repository
         // history even though this compact index never renders a diff.
@@ -569,14 +567,20 @@ export async function run(clientName, event) {
     process.exit(0);
   }
 
-  const raw = await readStdin();
+  const input = await readPayloadResult();
+  const raw = input.payload;
   if (!raw) {
+    invocation.noteInput(input.status, input.bytes);
     // Stop requires JSON on stdout even when it has nothing to add.
     if (event === 'stop') emit({});
     process.exit(0);
   }
 
   if (event === 'stop') {
+    // Stop has no normalized tool payload, but it is still a fully formed hook
+    // invocation. Bind its lifecycle identifiers so successful completions do
+    // not look like an input reader that never ran in cross-client telemetry.
+    invocation.bind(raw, null, input.bytes);
     const sessionId =
       raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? 'default';
     const agentScope = raw.transcript_path ?? raw.transcriptPath ?? null;
@@ -632,6 +636,7 @@ export async function run(clientName, event) {
   const payload = normalizePayload(
     normalizeClientPayload(clientName, event, raw)
   );
+  invocation.bind(raw, payload, input.bytes);
   if (!payload.tool_name) process.exit(0);
   const episode = episodeMeta({ client: clientName, raw, payload });
 

--- a/integrations/cline/hooks/token-optimizer/lib/metrics.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/metrics.mjs
@@ -1297,8 +1297,8 @@ function concurrencySummary(runs) {
  * live hook traces, and randomized model evals remain visibly distinct: only
  * `eval-run` records with paired arms can produce a causal effect interval.
  */
-export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
-  const evidence = readEvidence(dir).filter((event) => matchesFilters(event, filters));
+function buildEvidenceReport(evidence, { filters = {}, episodeLimit = 100 } = {}) {
+  evidence = evidence.filter((event) => matchesFilters(event, filters));
   const runs = evidence.filter((event) => event.kind === 'eval-run');
   const handoffRuns = evidence.filter((event) => event.kind === 'handoff-run');
   const concurrencyRuns = evidence.filter((event) => event.kind === 'concurrency-run');
@@ -1402,6 +1402,47 @@ export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
       minimumPairs,
       handoffMinimumPairs: handoffMinimumPairs(),
       deterministicChecksAreCausalProof: false,
+    },
+  };
+}
+
+export function evidenceReport(dir, options = {}) {
+  const events = readEvidence(dir);
+  const report = buildEvidenceReport(events, options);
+  const hasMatchingEvidence = events.some((event) =>
+    matchesFilters(event, options.filters || {})
+  );
+  return {
+    ...report,
+    sourceCoverage: {
+      projects: 1,
+      projectsWithEvidence: hasMatchingEvidence ? 1 : 0,
+      projectsWithoutEvidence: hasMatchingEvidence ? 0 : 1,
+    },
+  };
+}
+
+/**
+ * Pools evidence across registered projects before computing cohorts.
+ *
+ * A cohort split across two worktrees is still one experiment. Summing already
+ * aggregated reports would lose pairing and produce invalid confidence
+ * intervals, so this combines the append-only source events first and runs the
+ * estimator exactly once.
+ */
+export function evidenceReportMany(dirs, options = {}) {
+  const unique = [...new Set((dirs || []).map((dir) => String(dir)))];
+  const sources = unique.map((dir) => readEvidence(dir));
+  const report = buildEvidenceReport(sources.flat(), options);
+  const projectsWithEvidence = sources.filter((events) =>
+    events.some((event) => matchesFilters(event, options.filters || {}))
+  ).length;
+  return {
+    ...report,
+    sourceCoverage: {
+      projects: unique.length,
+      projectsWithEvidence,
+      projectsWithoutEvidence: unique.length - projectsWithEvidence,
     },
   };
 }

--- a/integrations/cline/hooks/token-optimizer/lib/metrics.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/metrics.mjs
@@ -738,10 +738,7 @@ function canonicalKeyish(p) {
  * arms, multiplied by treated touches. Reporting it as a measured fact would be
  * the same overclaiming this project criticises competitors for.
  */
-export function report(dir) {
-  const events = readAll(dir);
-  // Injections and harvests come from the log that cannot be starved.
-  const balance = readBalance(dir);
+function buildReport(events, balance) {
 
   // COMMAND INJECTIONS ARE COUNTED SEPARATELY, not mixed into the balance.
   //
@@ -843,6 +840,15 @@ export function report(dir) {
   const sufficient = treated.length >= 20 && withheld.length >= 5;
 
   return {
+    memoryDeliveries: allInjections.filter((event) => !event.holdout).length,
+    memoryHoldouts: allInjections.filter((event) => event.holdout).length,
+    deliveryTokens: allInjections
+      .filter((event) => !event.holdout)
+      .reduce(
+        (sum, event) =>
+          sum + (event.deliveredTokens ?? event.tokens ?? 0),
+        0
+      ),
     injections: treated.length,
     sessionStartInjections: sessionStartInjections.length,
     sessionStartInjectedTokens: sessionStartInjections.reduce(
@@ -864,6 +870,27 @@ export function report(dir) {
         ? 'the graph is saving more than it costs'
         : 'the graph is NOT yet paying for itself',
   };
+}
+
+export function report(dir) {
+  return buildReport(readAll(dir), readBalance(dir));
+}
+
+/**
+ * One statistically valid machine/project-group report.
+ *
+ * Summing per-project verdicts is wrong: five projects with four treated reads
+ * each do not individually meet the threshold, but together they are twenty
+ * observations. Pooling the underlying events preserves the randomized arms
+ * and computes the means once over the selected population.
+ */
+export function reportMany(dirs) {
+  const unique = [...new Set((dirs || []).map((dir) => String(dir)))];
+  const report = buildReport(
+    unique.flatMap((dir) => readAll(dir)),
+    unique.flatMap((dir) => readBalance(dir))
+  );
+  return { ...report, projects: unique.length };
 }
 
 /**

--- a/integrations/cline/hooks/token-optimizer/lib/observability.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/observability.mjs
@@ -1,0 +1,400 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+/**
+ * Privacy-safe, cross-client lifecycle diagnostics.
+ *
+ * Hook processes are intentionally fail-open, but fail-open must not mean
+ * fail-silent. Every client writes the same bounded JSONL schema so failures
+ * can be correlated without storing prompts, commands, tool output, or file
+ * contents.
+ */
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmdirSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { createHash, randomUUID } from 'node:crypto';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export const HOOK_LOG_SCHEMA_VERSION = 1;
+const DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
+const DEFAULT_RETENTION_DAYS = 14;
+const DEFAULT_MAX_FILES = 40;
+const DEFAULT_DEADLINE_MS = 4200;
+const MAX_ERROR_CHARS = 4000;
+const MAX_DIMENSION_CHARS = 160;
+let activeInvocation = null;
+
+function positiveInteger(name, fallback) {
+  const value = Number(process.env[name]);
+  return Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+export function hookLogDirectory() {
+  if (process.env.TOKEN_OPTIMIZER_LOG_DIR)
+    return process.env.TOKEN_OPTIMIZER_LOG_DIR;
+  const stateRoot =
+    process.env.TOKEN_OPTIMIZER_STATE_DIR ||
+    join(homedir(), '.token-optimizer');
+  return join(stateRoot, 'logs');
+}
+
+function hash(value, length = 16) {
+  if (!value) return null;
+  return createHash('sha256').update(String(value)).digest('hex').slice(0, length);
+}
+
+function sanitize(text) {
+  if (text === undefined || text === null) return null;
+  let value = String(text);
+  const home = homedir().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  if (home) value = value.replace(new RegExp(home, 'gi'), '<home>');
+  value = value
+    .replace(/\b(?:sk-[A-Za-z0-9_-]{12,}|gh[opusr]_[A-Za-z0-9]{12,})\b/g, '[REDACTED]')
+    .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi, '$1[REDACTED]')
+    .replace(/\b(password|secret|token|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi, '$1=[REDACTED]');
+  return value.slice(0, MAX_ERROR_CHARS);
+}
+
+function errorFields(error) {
+  if (!error) return null;
+  return {
+    type: sanitize(error.name || error.constructor?.name || 'Error'),
+    message: sanitize(error.message || error),
+    stack: sanitize(error.stack),
+  };
+}
+
+function dimension(value) {
+  const sanitized = sanitize(value);
+  return sanitized === null ? null : sanitized.slice(0, MAX_DIMENSION_CHARS);
+}
+
+function severity(level) {
+  if (level === 'error') return { severityText: 'ERROR', severityNumber: 17 };
+  if (level === 'warn') return { severityText: 'WARN', severityNumber: 13 };
+  return { severityText: 'INFO', severityNumber: 9 };
+}
+
+function activeLogPath(now = new Date()) {
+  const date = now.toISOString().slice(0, 10);
+  return join(hookLogDirectory(), `hook-events-${date}.jsonl`);
+}
+
+function rotateIfNeeded(path) {
+  try {
+    if (!existsSync(path)) return;
+    const maxBytes = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_BYTES', DEFAULT_MAX_BYTES);
+    if (statSync(path).size < maxBytes) return;
+
+    const lock = join(hookLogDirectory(), '.rotate.lock');
+    try {
+      mkdirSync(lock);
+    } catch {
+      return;
+    }
+    try {
+      if (existsSync(path) && statSync(path).size >= maxBytes) {
+        // Multiple hook processes (or several writes in one millisecond) must
+        // never select the same rotation target and overwrite an earlier file.
+        const rotated = path.replace(
+          /\.jsonl$/,
+          `-${Date.now()}-${process.pid}-${randomUUID()}.jsonl`
+        );
+        renameSync(path, rotated);
+      }
+    } finally {
+      // Non-recursive removal of the one fixed-name lock directory only.
+      try { rmdirSync(lock); } catch { /* best effort */ }
+    }
+  } catch {
+    // Diagnostics must never become the reason a lifecycle hook fails.
+  }
+}
+
+function pruneIfDue(now = new Date()) {
+  try {
+    const dir = hookLogDirectory();
+    const marker = join(dir, '.last-prune');
+    if (existsSync(marker) && now.getTime() - statSync(marker).mtimeMs < 60 * 60 * 1000)
+      return;
+    writeFileSync(marker, now.toISOString(), { flag: 'w' });
+
+    const retentionMs =
+      positiveInteger('TOKEN_OPTIMIZER_LOG_RETENTION_DAYS', DEFAULT_RETENTION_DAYS) *
+      24 * 60 * 60 * 1000;
+    const maxFiles = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_FILES', DEFAULT_MAX_FILES);
+    const files = readdirSync(dir)
+      .filter((name) => /^hook-events-.*\.jsonl$/.test(name))
+      .map((name) => {
+        const path = join(dir, name);
+        return { path, mtimeMs: statSync(path).mtimeMs };
+      })
+      .sort((a, b) => b.mtimeMs - a.mtimeMs);
+    for (let i = 0; i < files.length; i++) {
+      if (i >= maxFiles || now.getTime() - files[i].mtimeMs > retentionMs)
+        unlinkSync(files[i].path);
+    }
+  } catch {
+    // Retention is best effort and cannot affect the host tool call.
+  }
+}
+
+export function writeHookEvent(event) {
+  try {
+    const now = new Date();
+    const dir = hookLogDirectory();
+    mkdirSync(dir, { recursive: true });
+    const path = activeLogPath(now);
+    rotateIfNeeded(path);
+    const record = {
+      schemaVersion: HOOK_LOG_SCHEMA_VERSION,
+      timestamp: now.toISOString(),
+      service: 'token-optimizer',
+      serviceVersion:
+        process.env.TOKEN_OPTIMIZER_VERSION ||
+        process.env.npm_package_version ||
+        'unknown',
+      ...severity(event.level),
+      body: event.event || 'hook.event',
+      ...event,
+    };
+    record.resource = {
+      'service.name': record.service,
+      'service.version': record.serviceVersion,
+      'host.arch': process.arch,
+      'os.type': process.platform,
+      'process.runtime.name': 'node',
+      'process.runtime.version': process.version,
+    };
+    appendFileSync(path, `${JSON.stringify(record)}\n`, { encoding: 'utf8' });
+    pruneIfDue(now);
+    return path;
+  } catch {
+    return null;
+  }
+}
+
+export function beginHookInvocation(client, event, options = {}) {
+  const started = Date.now();
+  const invocationId = randomUUID();
+  let ended = false;
+  let outcome = 'success';
+  let reason = 'completed';
+  let error = null;
+  const dimensions = {
+    sessionIdHash: null,
+    turnIdHash: null,
+    toolUseIdHash: null,
+    toolName: null,
+    clientVersion: null,
+    model: null,
+    cwdHash: null,
+    payloadBytes: null,
+    outputBytes: 0,
+    outputShape: [],
+    inputStatus: 'pending',
+  };
+  const spanId = hash(invocationId, 16);
+  let traceId = hash(invocationId, 32);
+
+  let deadline;
+  const finish = (nextOutcome = outcome, nextReason = reason, nextError = error) => {
+    if (ended) return;
+    ended = true;
+    if (deadline) clearTimeout(deadline);
+    process.removeListener('exit', onExit);
+    writeHookEvent({
+      level: nextOutcome === 'failure' || nextOutcome === 'timeout' ? 'error' : 'info',
+      event: 'hook.completed',
+      outcome: nextOutcome,
+      reason: nextReason,
+      durationMs: Date.now() - started,
+      invocationId,
+      traceId,
+      spanId,
+      client,
+      hookEvent: event,
+      processId: process.pid,
+      ...dimensions,
+      error: errorFields(nextError),
+    });
+  };
+  const onExit = () => finish();
+  process.once('exit', onExit);
+
+  deadline = setTimeout(() => {
+    outcome = 'timeout';
+    reason = 'internal_deadline_exceeded';
+    finish(outcome, reason);
+    // Beat the host's five-second timeout and fail open deterministically.
+    process.exit(0);
+  }, options.deadlineMs ?? positiveInteger('TOKEN_OPTIMIZER_HOOK_DEADLINE_MS', DEFAULT_DEADLINE_MS));
+  deadline.unref();
+
+  const invocation = {
+    invocationId,
+    bind(raw = {}, payload = null, payloadBytes = null) {
+      const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? null;
+      dimensions.sessionIdHash = hash(sessionId);
+      dimensions.turnIdHash = hash(raw.turn_id ?? raw.turnId ?? null);
+      dimensions.toolUseIdHash = hash(raw.tool_use_id ?? raw.toolUseId ?? null);
+      dimensions.toolName = payload?.tool_name ?? raw.tool_name ?? raw.toolName ?? null;
+      dimensions.clientVersion = dimension(raw.client_version ?? raw.clientVersion ?? null);
+      dimensions.model = dimension(raw.model ?? raw.model_name ?? raw.modelName ?? null);
+      dimensions.cwdHash = hash(raw.cwd ?? raw.working_directory ?? process.cwd());
+      dimensions.payloadBytes = payloadBytes;
+      dimensions.inputStatus = 'ok';
+      if (sessionId) traceId = hash(sessionId, 32);
+    },
+    noteInput(status, payloadBytes = null) {
+      dimensions.inputStatus = status;
+      dimensions.payloadBytes = payloadBytes;
+      if (status === 'timeout') {
+        outcome = 'timeout';
+        reason = 'stdin_timeout';
+      } else if (status !== 'ok') {
+        outcome = 'skipped';
+        reason = status;
+      }
+    },
+    skip(nextReason) {
+      outcome = 'skipped';
+      reason = nextReason;
+    },
+    noteOutput(output, outputBytes = null) {
+      dimensions.outputBytes = outputBytes ?? Buffer.byteLength(JSON.stringify(output), 'utf8');
+      if (!output || typeof output !== 'object' || Array.isArray(output)) {
+        dimensions.outputShape = [];
+        return;
+      }
+      const shape = Object.keys(output).sort();
+      const hookSpecific = output.hookSpecificOutput;
+      if (hookSpecific && typeof hookSpecific === 'object' && !Array.isArray(hookSpecific)) {
+        for (const key of Object.keys(hookSpecific).sort()) shape.push(`hookSpecificOutput.${key}`);
+      }
+      dimensions.outputShape = shape;
+    },
+    fail(nextError, nextReason = 'unhandled_exception') {
+      outcome = 'failure';
+      reason = nextReason;
+      error = nextError;
+      finish(outcome, reason, error);
+    },
+    succeed(nextReason = 'completed') {
+      outcome = 'success';
+      reason = nextReason;
+      finish(outcome, reason);
+    },
+  };
+  activeInvocation = invocation;
+  return invocation;
+}
+
+/** Records response metadata without retaining response content. */
+export function noteHookOutput(output, outputBytes = null) {
+  activeInvocation?.noteOutput(output, outputBytes);
+}
+
+export function recordHookBootstrapFailure(client, event, error) {
+  writeHookEvent({
+    level: 'error',
+    event: 'hook.completed',
+    outcome: 'failure',
+    reason: 'bootstrap_import_failure',
+    durationMs: 0,
+    invocationId: randomUUID(),
+    client,
+    hookEvent: event,
+    processId: process.pid,
+    error: errorFields(error),
+  });
+}
+
+export function readHookEvents({ limit = 200, sinceMs = 24 * 60 * 60 * 1000 } = {}) {
+  try {
+    const dir = hookLogDirectory();
+    if (!existsSync(dir)) return [];
+    const cutoff = Date.now() - Math.max(0, sinceMs);
+    const files = readdirSync(dir)
+      .filter((name) => /^hook-events-.*\.jsonl$/.test(name))
+      .map((name) => join(dir, name))
+      .sort()
+      .reverse();
+    const events = [];
+    for (const file of files) {
+      const lines = readFileSync(file, 'utf8').split(/\r?\n/).filter(Boolean).reverse();
+      for (const line of lines) {
+        try {
+          const event = JSON.parse(line);
+          if (Date.parse(event.timestamp) < cutoff) continue;
+          events.push(event);
+          if (events.length >= limit) return events;
+        } catch {
+          // A partially written final line must not hide the rest of the log.
+        }
+      }
+    }
+    return events;
+  } catch {
+    return [];
+  }
+}
+
+export function hookHealthSummary(options = {}) {
+  const sinceMs = options.sinceMs ?? 24 * 60 * 60 * 1000;
+  const events = readHookEvents({ limit: options.limit || 5000, sinceMs });
+  const durations = events
+    .map((event) => Number(event.durationMs))
+    .filter(Number.isFinite)
+    .sort((a, b) => a - b);
+  const failures = events.filter((event) => event.outcome === 'failure');
+  const timeouts = events.filter((event) => event.outcome === 'timeout');
+  const skipped = events.filter((event) => event.outcome === 'skipped');
+  const successes = events.filter((event) => event.outcome === 'success');
+  const byClient = {};
+  for (const event of events) {
+    const key = event.client || 'unknown';
+    const current = byClient[key] || { total: 0, failures: 0, timeouts: 0, skipped: 0 };
+    current.total++;
+    if (event.outcome === 'failure') current.failures++;
+    if (event.outcome === 'timeout') current.timeouts++;
+    if (event.outcome === 'skipped') current.skipped++;
+    byClient[key] = current;
+  }
+  const percentile = (p) =>
+    durations.length
+      ? durations[Math.min(durations.length - 1, Math.floor(durations.length * p))]
+      : null;
+  const summary = {
+    schemaVersion: HOOK_LOG_SCHEMA_VERSION,
+    available: events.length > 0,
+    windowHours: sinceMs / 3_600_000,
+    total: events.length,
+    failures: failures.length,
+    timeouts: timeouts.length,
+    skipped: skipped.length,
+    successRate: events.length ? successes.length / events.length : null,
+    p50DurationMs: percentile(0.5),
+    p95DurationMs: percentile(0.95),
+    byClient,
+    recentFailures: [...failures, ...timeouts]
+      .sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp))
+      .slice(0, 20),
+  };
+  // Absolute paths are useful to a local doctor, but they do not belong in a
+  // diagnostics export that may be attached to a public issue.
+  if (options.includeLogDirectory === true)
+    summary.logDirectory = hookLogDirectory();
+  return summary;
+}

--- a/integrations/cline/hooks/token-optimizer/lib/policy.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/policy.mjs
@@ -48,6 +48,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { createHash } from 'node:crypto';
 import { isFsSafePath } from './paths.mjs';
+import { noteHookOutput } from './observability.mjs';
 
 /** Enforcement modes, least to most permissive. */
 export const MODE_ENFORCE = 'enforce';
@@ -653,14 +654,15 @@ export function allow() {
  */
 export function allowWithContext(context) {
   if (context) {
-    process.stdout.write(
-      JSON.stringify({
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-          additionalContext: withEscape(context),
-        },
-      })
-    );
+    const output = {
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        additionalContext: withEscape(context),
+      },
+    };
+    const serialized = JSON.stringify(output);
+    noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+    process.stdout.write(serialized);
   }
   process.exit(0);
 }
@@ -673,15 +675,16 @@ export function allowWithContext(context) {
  * says "use the optimized tool" gets met with a retry of the same call.
  */
 export function deny(reason) {
-  process.stdout.write(
-    JSON.stringify({
-      hookSpecificOutput: {
-        hookEventName: 'PreToolUse',
-        permissionDecision: 'deny',
-        permissionDecisionReason: withEscape(reason),
-      },
-    })
-  );
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+      permissionDecisionReason: withEscape(reason),
+    },
+  };
+  const serialized = JSON.stringify(output);
+  noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
   process.exit(0);
 }
 
@@ -706,14 +709,15 @@ export function withEscape(reason) {
 
 /** Lets the call through, attaching a note the model sees. */
 export function advise(context) {
-  process.stdout.write(
-    JSON.stringify({
-      hookSpecificOutput: {
-        hookEventName: 'PreToolUse',
-        additionalContext: context,
-      },
-    })
-  );
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      additionalContext: context,
+    },
+  };
+  const serialized = JSON.stringify(output);
+  noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
   process.exit(0);
 }
 
@@ -741,26 +745,34 @@ export function enforce(reason, deniedBefore) {
  * than an absent one, so the wait has a ceiling and expiring it is treated
  * exactly like unusable input.
  */
-export async function readPayload({
-  timeoutMs = 5000,
+export async function readPayloadResult({
+  timeoutMs = 1500,
   maxBytes = 8_000_000,
 } = {}) {
   const chunks = [];
   let size = 0;
+  let inputStatus = 'pending';
 
   const raw = await new Promise((resolve) => {
     const onData = (chunk) => {
-      size += chunk.length;
+      size += Buffer.byteLength(chunk, 'utf8');
       // A payload this large is not a tool call; refusing to buffer it
       // unboundedly keeps a hook from becoming a memory problem.
       if (size > maxBytes) {
+        inputStatus = 'too_large';
         finish(null);
         return;
       }
       chunks.push(chunk);
     };
-    const onEnd = () => finish(chunks.join(''));
-    const onError = () => finish(null);
+    const onEnd = () => {
+      inputStatus = 'received';
+      finish(chunks.join(''));
+    };
+    const onError = () => {
+      inputStatus = 'input_error';
+      finish(null);
+    };
 
     // Listeners are REMOVED on every exit path. Leaving them attached after the
     // timeout wins means a late chunk keeps growing a buffer nobody will read,
@@ -774,17 +786,21 @@ export async function readPayload({
       resolve(value);
     }
 
-    const timer = setTimeout(() => finish(null), timeoutMs);
+    const timer = setTimeout(() => {
+      inputStatus = 'timeout';
+      finish(null);
+    }, timeoutMs);
     process.stdin.setEncoding('utf8');
     process.stdin.on('data', onData);
     process.stdin.on('end', onEnd);
     process.stdin.on('error', onError);
   });
 
-  if (raw === null) return null;
+  if (raw === null) return { payload: null, status: inputStatus, bytes: size };
+  if (!raw.trim()) return { payload: null, status: 'empty_input', bytes: size };
   try {
-    return JSON.parse(raw);
+    return { payload: JSON.parse(raw), status: 'ok', bytes: size };
   } catch {
-    return null;
+    return { payload: null, status: 'invalid_json', bytes: size };
   }
 }

--- a/integrations/cline/hooks/token-optimizer/lib/projects.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/projects.mjs
@@ -1,0 +1,214 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/projects.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Machine-local index of project graph stores.
+ *
+ * A graph is deliberately stored with the project whose files it describes.
+ * That isolation is important for retrieval, but it also means a dashboard
+ * cannot honestly describe machine-wide capture unless it knows which stores
+ * exist. This registry is that missing directory. It is written by lifecycle
+ * hooks and can be backfilled by the explicit discovery command.
+ *
+ * The browser never receives `root` or `graphDir`. Routes resolve an opaque
+ * project id through this server-owned file, so restoring cross-project views
+ * does not restore the old arbitrary-path query vulnerability.
+ */
+
+import {
+  appendFileSync,
+  chmodSync,
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+} from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+import { createHash } from 'node:crypto';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
+
+export const PROJECT_REGISTRY_VERSION = 1;
+
+export function projectRegistryPath() {
+  return (
+    process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY ||
+    join(homedir(), '.token-optimizer', 'projects.jsonl')
+  );
+}
+
+export function projectIdFor(root) {
+  return `project-${createHash('sha256')
+    .update(canonicalPath(root))
+    .digest('hex')
+    .slice(0, 16)}`;
+}
+
+function displayName(root) {
+  return basename(root) || 'Unnamed project';
+}
+
+function acquire(path) {
+  const lockPath = `${path}.lock`;
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+  } catch {
+    return null;
+  }
+
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      closeSync(openSync(lockPath, 'wx', 0o600));
+      return lockPath;
+    } catch {
+      try {
+        if (Date.now() - statSync(lockPath).mtimeMs > 5000) unlinkSync(lockPath);
+      } catch {
+        // The holder may have released it between open and stat; retry.
+      }
+    }
+  }
+  return null;
+}
+
+function release(lockPath) {
+  if (!lockPath) return;
+  try {
+    unlinkSync(lockPath);
+  } catch {
+    // A killed process or cleanup race must not fail the hook.
+  }
+}
+
+/**
+ * Folds the append-only registry into one current entry per canonical project.
+ * Malformed, stale-schema, and unsafe records are ignored rather than trusted.
+ */
+export function registeredProjects() {
+  const path = projectRegistryPath();
+  const projects = new Map();
+  if (!existsSync(path)) return [];
+
+  try {
+    for (const line of readFileSync(path, 'utf8').split('\n')) {
+      if (!line) continue;
+      let record;
+      try {
+        record = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (
+        record.v !== PROJECT_REGISTRY_VERSION ||
+        !isFsSafePath(record.root) ||
+        !isFsSafePath(record.graphDir)
+      ) {
+        continue;
+      }
+      const root = canonicalPath(record.root);
+      const graphDir = canonicalPath(record.graphDir);
+      // Append-only history can outlive a deleted worktree (especially a
+      // short-lived test or CI checkout). A source that no longer exists
+      // cannot be captured, and presenting it as a current coverage gap makes
+      // the dashboard steadily less truthful over time.
+      if (!existsSync(root)) continue;
+      // A broad discovery root may contain hundreds of dormant worktrees. They
+      // are not capture coverage until a hook has observed them or a graph
+      // exists; listing all of them turns the selector into filesystem noise.
+      if (
+        record.client === 'discovery' &&
+        !existsSync(join(graphDir, 'graph.jsonl'))
+      ) {
+        continue;
+      }
+      const id = projectIdFor(root);
+      if (record.id !== id) continue;
+
+      const previous = projects.get(id);
+      projects.set(id, {
+        id,
+        name: String(record.name || displayName(root)).slice(0, 160),
+        root,
+        graphDir,
+        firstSeenAt: previous?.firstSeenAt || record.at || 0,
+        lastSeenAt: Math.max(previous?.lastSeenAt || 0, Number(record.at) || 0),
+        clients: [
+          ...new Set([
+            ...(previous?.clients || []),
+            ...(typeof record.client === 'string' && record.client
+              ? [record.client.slice(0, 80)]
+              : []),
+          ]),
+        ].sort(),
+      });
+    }
+  } catch {
+    return [];
+  }
+
+  return [...projects.values()].sort(
+    (a, b) => b.lastSeenAt - a.lastSeenAt || a.name.localeCompare(b.name)
+  );
+}
+
+/** Registers one VCS project without ever making a hook fail closed. */
+export function registerProject({ root, graphDir, client = 'unknown', name } = {}) {
+  if (!isFsSafePath(root) || !isFsSafePath(graphDir)) return null;
+  try {
+    const canonicalRoot = canonicalPath(root);
+    const canonicalGraphDir = canonicalPath(graphDir);
+    const isRepository = ['.git', '.hg', '.svn'].some((marker) =>
+      existsSync(join(canonicalRoot, marker))
+    );
+    if (!isRepository) return null;
+    const id = projectIdFor(canonicalRoot);
+    const now = Date.now();
+    const recent = registeredProjects().find(
+      (project) =>
+        project.id === id &&
+        project.graphDir === canonicalGraphDir &&
+        project.clients.includes(client) &&
+        now - project.lastSeenAt < 60 * 60 * 1000
+    );
+    if (recent) return recent;
+
+    const path = projectRegistryPath();
+    const lockPath = acquire(path);
+    if (!lockPath) return null;
+    try {
+      appendFileSync(
+        path,
+        `${JSON.stringify({
+          v: PROJECT_REGISTRY_VERSION,
+          id,
+          name: String(name || displayName(canonicalRoot)).slice(0, 160),
+          root: canonicalRoot,
+          graphDir: canonicalGraphDir,
+          client: String(client || 'unknown').slice(0, 80),
+          at: now,
+        })}\n`,
+        { mode: 0o600 }
+      );
+      try {
+        chmodSync(path, 0o600);
+      } catch {
+        // Windows and some filesystems do not expose POSIX modes.
+      }
+    } finally {
+      release(lockPath);
+    }
+    return {
+      id,
+      name: String(name || displayName(canonicalRoot)).slice(0, 160),
+      root: canonicalRoot,
+      graphDir: canonicalGraphDir,
+      firstSeenAt: now,
+      lastSeenAt: now,
+      clients: [String(client || 'unknown').slice(0, 80)],
+    };
+  } catch {
+    return null;
+  }
+}

--- a/integrations/cline/hooks/token-optimizer/post-tool.mjs
+++ b/integrations/cline/hooks/token-optimizer/post-tool.mjs
@@ -2,7 +2,17 @@
 // GENERATED FILE -- do not edit. Regenerate with `npm run sync:hooks`.
 // Client entry point: names the client and event; all policy lives in the
 // shared core so no client can drift its own thresholds or guidance.
-import { run } from './lib/adapter.mjs';
-
 // Fail open: a defect in the optimizer must never cost the user a tool call.
-run('cline', 'post-tool').catch(() => process.exit(0));
+// Bootstrap failures are still recorded so fail-open does not become fail-silent.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+try {
+  const { run } = await import('./lib/adapter.mjs');
+  await run('cline', 'post-tool');
+} catch (error) {
+  try {
+    const { recordHookBootstrapFailure } = await import('./lib/observability.mjs');
+    recordHookBootstrapFailure('cline', 'post-tool', error);
+  } catch {
+    // A logger bootstrap failure is the only condition that remains silent.
+  }
+}

--- a/integrations/cline/hooks/token-optimizer/pre-tool.mjs
+++ b/integrations/cline/hooks/token-optimizer/pre-tool.mjs
@@ -2,7 +2,17 @@
 // GENERATED FILE -- do not edit. Regenerate with `npm run sync:hooks`.
 // Client entry point: names the client and event; all policy lives in the
 // shared core so no client can drift its own thresholds or guidance.
-import { run } from './lib/adapter.mjs';
-
 // Fail open: a defect in the optimizer must never cost the user a tool call.
-run('cline', 'pre-tool').catch(() => process.exit(0));
+// Bootstrap failures are still recorded so fail-open does not become fail-silent.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+try {
+  const { run } = await import('./lib/adapter.mjs');
+  await run('cline', 'pre-tool');
+} catch (error) {
+  try {
+    const { recordHookBootstrapFailure } = await import('./lib/observability.mjs');
+    recordHookBootstrapFailure('cline', 'pre-tool', error);
+  } catch {
+    // A logger bootstrap failure is the only condition that remains silent.
+  }
+}

--- a/integrations/cline/hooks/token-optimizer/session-start.mjs
+++ b/integrations/cline/hooks/token-optimizer/session-start.mjs
@@ -2,7 +2,17 @@
 // GENERATED FILE -- do not edit. Regenerate with `npm run sync:hooks`.
 // Client entry point: names the client and event; all policy lives in the
 // shared core so no client can drift its own thresholds or guidance.
-import { run } from './lib/adapter.mjs';
-
 // Fail open: a defect in the optimizer must never cost the user a tool call.
-run('cline', 'session-start').catch(() => process.exit(0));
+// Bootstrap failures are still recorded so fail-open does not become fail-silent.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+try {
+  const { run } = await import('./lib/adapter.mjs');
+  await run('cline', 'session-start');
+} catch (error) {
+  try {
+    const { recordHookBootstrapFailure } = await import('./lib/observability.mjs');
+    recordHookBootstrapFailure('cline', 'session-start', error);
+  } catch {
+    // A logger bootstrap failure is the only condition that remains silent.
+  }
+}

--- a/integrations/codex/hooks/lib/adapter.mjs
+++ b/integrations/codex/hooks/lib/adapter.mjs
@@ -27,6 +27,7 @@ import {
   MODE_OFF,
   MODE_ADVISE,
   largeFileBytes,
+  readPayloadResult,
   withEscape,
 } from './policy.mjs';
 import {
@@ -83,6 +84,8 @@ import {
 } from './capabilities.mjs';
 import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 import { evaluateUcrGuards } from './ucr-guard.mjs';
+import { beginHookInvocation, noteHookOutput } from './observability.mjs';
+import { registerProject } from './projects.mjs';
 
 /**
  * Per-client capability.
@@ -128,7 +131,14 @@ export function mutationSucceeded(clientName, raw) {
 
   // These lifecycle contracts fire this event only after a successful tool,
   // or are called by our in-process bridge only from its successful after hook.
-  return new Set(['claude-code', 'qwen', 'opencode', 'kilo', 'windsurf']).has(
+  return new Set([
+    'claude-code',
+    'codex',
+    'qwen',
+    'opencode',
+    'kilo',
+    'windsurf',
+  ]).has(
     clientName
   );
 }
@@ -241,37 +251,9 @@ export function sessionTaskContext(raw = {}) {
 }
 
 function emit(object) {
-  process.stdout.write(JSON.stringify(object));
-}
-
-/**
- * Bounded stdin read. See policy.readPayload for why the ceiling matters: the
- * entry points fail open on a THROW, but a host that opens the pipe and never
- * closes it produces no throw -- just a hook that waits forever with the user's
- * tool call stuck behind it.
- */
-async function readStdin({ timeoutMs = 5000 } = {}) {
-  const raw = await new Promise((resolve) => {
-    const chunks = [];
-    const timer = setTimeout(() => resolve(null), timeoutMs);
-    process.stdin.setEncoding('utf8');
-    process.stdin.on('data', (chunk) => chunks.push(chunk));
-    process.stdin.on('end', () => {
-      clearTimeout(timer);
-      resolve(chunks.join(''));
-    });
-    process.stdin.on('error', () => {
-      clearTimeout(timer);
-      resolve(null);
-    });
-  });
-
-  if (raw === null) return null;
-  try {
-    return JSON.parse(raw);
-  } catch {
-    return null;
-  }
+  const serialized = JSON.stringify(object);
+  noteHookOutput(object, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
 }
 
 /** The session-start notice, shared verbatim so no client drifts its own copy. */
@@ -502,6 +484,17 @@ function observeAndInject(payload, state, episode, features) {
  * @param {'session-start'|'pre-tool'|'post-tool'|'stop'} event
  */
 export async function run(clientName, event) {
+  const invocation = beginHookInvocation(clientName, event);
+  try {
+    await runHook(clientName, event, invocation);
+    invocation.succeed();
+  } catch (error) {
+    // The optimizer must fail open, but the failure is now reconstructable.
+    invocation.fail(error);
+  }
+}
+
+async function runHook(clientName, event, invocation) {
   const client = CLIENTS[clientName] || CLIENTS['claude-code'];
   const eventName =
     event === 'session-start'
@@ -529,7 +522,10 @@ export async function run(clientName, event) {
     // full pre-tool timeout would turn optional context into a five-second
     // startup tax; lifecycle payloads are tiny and arrive immediately when
     // the host supplies one.
-    const raw = (await readStdin({ timeoutMs: 250 })) || {};
+    const input = await readPayloadResult({ timeoutMs: 250 });
+    const raw = input.payload || {};
+    invocation.bind(raw, null, input.bytes);
+    if (input.status !== 'ok') invocation.noteInput(input.status, input.bytes);
     const toolEvidence = optimizerToolEvidence(raw);
     const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id;
     if (sessionId && toolEvidence.proven) {
@@ -540,10 +536,12 @@ export async function run(clientName, event) {
     const parts = [
       policyText(client.canDeny, toolEvidence.names, toolEvidence.proven),
     ];
+    const cwd = raw.cwd || raw.working_directory || process.cwd();
+    const root = projectRootFor(join(cwd, '__session__'), cwd);
+    registerProject({ root, graphDir: wikiDir(root), client: clientName });
     if (features.retrieval) {
       try {
-        const cwd = raw.cwd || raw.working_directory || process.cwd();
-        const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+        const dir = wikiDir(root);
         // SessionStart needs hashes and claims, not stored file bodies. Parsing
         // the snapshot sidecar here would make startup scale with repository
         // history even though this compact index never renders a diff.
@@ -569,14 +567,20 @@ export async function run(clientName, event) {
     process.exit(0);
   }
 
-  const raw = await readStdin();
+  const input = await readPayloadResult();
+  const raw = input.payload;
   if (!raw) {
+    invocation.noteInput(input.status, input.bytes);
     // Stop requires JSON on stdout even when it has nothing to add.
     if (event === 'stop') emit({});
     process.exit(0);
   }
 
   if (event === 'stop') {
+    // Stop has no normalized tool payload, but it is still a fully formed hook
+    // invocation. Bind its lifecycle identifiers so successful completions do
+    // not look like an input reader that never ran in cross-client telemetry.
+    invocation.bind(raw, null, input.bytes);
     const sessionId =
       raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? 'default';
     const agentScope = raw.transcript_path ?? raw.transcriptPath ?? null;
@@ -632,6 +636,7 @@ export async function run(clientName, event) {
   const payload = normalizePayload(
     normalizeClientPayload(clientName, event, raw)
   );
+  invocation.bind(raw, payload, input.bytes);
   if (!payload.tool_name) process.exit(0);
   const episode = episodeMeta({ client: clientName, raw, payload });
 

--- a/integrations/codex/hooks/lib/metrics.mjs
+++ b/integrations/codex/hooks/lib/metrics.mjs
@@ -1297,8 +1297,8 @@ function concurrencySummary(runs) {
  * live hook traces, and randomized model evals remain visibly distinct: only
  * `eval-run` records with paired arms can produce a causal effect interval.
  */
-export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
-  const evidence = readEvidence(dir).filter((event) => matchesFilters(event, filters));
+function buildEvidenceReport(evidence, { filters = {}, episodeLimit = 100 } = {}) {
+  evidence = evidence.filter((event) => matchesFilters(event, filters));
   const runs = evidence.filter((event) => event.kind === 'eval-run');
   const handoffRuns = evidence.filter((event) => event.kind === 'handoff-run');
   const concurrencyRuns = evidence.filter((event) => event.kind === 'concurrency-run');
@@ -1402,6 +1402,47 @@ export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
       minimumPairs,
       handoffMinimumPairs: handoffMinimumPairs(),
       deterministicChecksAreCausalProof: false,
+    },
+  };
+}
+
+export function evidenceReport(dir, options = {}) {
+  const events = readEvidence(dir);
+  const report = buildEvidenceReport(events, options);
+  const hasMatchingEvidence = events.some((event) =>
+    matchesFilters(event, options.filters || {})
+  );
+  return {
+    ...report,
+    sourceCoverage: {
+      projects: 1,
+      projectsWithEvidence: hasMatchingEvidence ? 1 : 0,
+      projectsWithoutEvidence: hasMatchingEvidence ? 0 : 1,
+    },
+  };
+}
+
+/**
+ * Pools evidence across registered projects before computing cohorts.
+ *
+ * A cohort split across two worktrees is still one experiment. Summing already
+ * aggregated reports would lose pairing and produce invalid confidence
+ * intervals, so this combines the append-only source events first and runs the
+ * estimator exactly once.
+ */
+export function evidenceReportMany(dirs, options = {}) {
+  const unique = [...new Set((dirs || []).map((dir) => String(dir)))];
+  const sources = unique.map((dir) => readEvidence(dir));
+  const report = buildEvidenceReport(sources.flat(), options);
+  const projectsWithEvidence = sources.filter((events) =>
+    events.some((event) => matchesFilters(event, options.filters || {}))
+  ).length;
+  return {
+    ...report,
+    sourceCoverage: {
+      projects: unique.length,
+      projectsWithEvidence,
+      projectsWithoutEvidence: unique.length - projectsWithEvidence,
     },
   };
 }

--- a/integrations/codex/hooks/lib/metrics.mjs
+++ b/integrations/codex/hooks/lib/metrics.mjs
@@ -738,10 +738,7 @@ function canonicalKeyish(p) {
  * arms, multiplied by treated touches. Reporting it as a measured fact would be
  * the same overclaiming this project criticises competitors for.
  */
-export function report(dir) {
-  const events = readAll(dir);
-  // Injections and harvests come from the log that cannot be starved.
-  const balance = readBalance(dir);
+function buildReport(events, balance) {
 
   // COMMAND INJECTIONS ARE COUNTED SEPARATELY, not mixed into the balance.
   //
@@ -843,6 +840,15 @@ export function report(dir) {
   const sufficient = treated.length >= 20 && withheld.length >= 5;
 
   return {
+    memoryDeliveries: allInjections.filter((event) => !event.holdout).length,
+    memoryHoldouts: allInjections.filter((event) => event.holdout).length,
+    deliveryTokens: allInjections
+      .filter((event) => !event.holdout)
+      .reduce(
+        (sum, event) =>
+          sum + (event.deliveredTokens ?? event.tokens ?? 0),
+        0
+      ),
     injections: treated.length,
     sessionStartInjections: sessionStartInjections.length,
     sessionStartInjectedTokens: sessionStartInjections.reduce(
@@ -864,6 +870,27 @@ export function report(dir) {
         ? 'the graph is saving more than it costs'
         : 'the graph is NOT yet paying for itself',
   };
+}
+
+export function report(dir) {
+  return buildReport(readAll(dir), readBalance(dir));
+}
+
+/**
+ * One statistically valid machine/project-group report.
+ *
+ * Summing per-project verdicts is wrong: five projects with four treated reads
+ * each do not individually meet the threshold, but together they are twenty
+ * observations. Pooling the underlying events preserves the randomized arms
+ * and computes the means once over the selected population.
+ */
+export function reportMany(dirs) {
+  const unique = [...new Set((dirs || []).map((dir) => String(dir)))];
+  const report = buildReport(
+    unique.flatMap((dir) => readAll(dir)),
+    unique.flatMap((dir) => readBalance(dir))
+  );
+  return { ...report, projects: unique.length };
 }
 
 /**

--- a/integrations/codex/hooks/lib/observability.mjs
+++ b/integrations/codex/hooks/lib/observability.mjs
@@ -1,0 +1,400 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+/**
+ * Privacy-safe, cross-client lifecycle diagnostics.
+ *
+ * Hook processes are intentionally fail-open, but fail-open must not mean
+ * fail-silent. Every client writes the same bounded JSONL schema so failures
+ * can be correlated without storing prompts, commands, tool output, or file
+ * contents.
+ */
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmdirSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { createHash, randomUUID } from 'node:crypto';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export const HOOK_LOG_SCHEMA_VERSION = 1;
+const DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
+const DEFAULT_RETENTION_DAYS = 14;
+const DEFAULT_MAX_FILES = 40;
+const DEFAULT_DEADLINE_MS = 4200;
+const MAX_ERROR_CHARS = 4000;
+const MAX_DIMENSION_CHARS = 160;
+let activeInvocation = null;
+
+function positiveInteger(name, fallback) {
+  const value = Number(process.env[name]);
+  return Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+export function hookLogDirectory() {
+  if (process.env.TOKEN_OPTIMIZER_LOG_DIR)
+    return process.env.TOKEN_OPTIMIZER_LOG_DIR;
+  const stateRoot =
+    process.env.TOKEN_OPTIMIZER_STATE_DIR ||
+    join(homedir(), '.token-optimizer');
+  return join(stateRoot, 'logs');
+}
+
+function hash(value, length = 16) {
+  if (!value) return null;
+  return createHash('sha256').update(String(value)).digest('hex').slice(0, length);
+}
+
+function sanitize(text) {
+  if (text === undefined || text === null) return null;
+  let value = String(text);
+  const home = homedir().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  if (home) value = value.replace(new RegExp(home, 'gi'), '<home>');
+  value = value
+    .replace(/\b(?:sk-[A-Za-z0-9_-]{12,}|gh[opusr]_[A-Za-z0-9]{12,})\b/g, '[REDACTED]')
+    .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi, '$1[REDACTED]')
+    .replace(/\b(password|secret|token|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi, '$1=[REDACTED]');
+  return value.slice(0, MAX_ERROR_CHARS);
+}
+
+function errorFields(error) {
+  if (!error) return null;
+  return {
+    type: sanitize(error.name || error.constructor?.name || 'Error'),
+    message: sanitize(error.message || error),
+    stack: sanitize(error.stack),
+  };
+}
+
+function dimension(value) {
+  const sanitized = sanitize(value);
+  return sanitized === null ? null : sanitized.slice(0, MAX_DIMENSION_CHARS);
+}
+
+function severity(level) {
+  if (level === 'error') return { severityText: 'ERROR', severityNumber: 17 };
+  if (level === 'warn') return { severityText: 'WARN', severityNumber: 13 };
+  return { severityText: 'INFO', severityNumber: 9 };
+}
+
+function activeLogPath(now = new Date()) {
+  const date = now.toISOString().slice(0, 10);
+  return join(hookLogDirectory(), `hook-events-${date}.jsonl`);
+}
+
+function rotateIfNeeded(path) {
+  try {
+    if (!existsSync(path)) return;
+    const maxBytes = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_BYTES', DEFAULT_MAX_BYTES);
+    if (statSync(path).size < maxBytes) return;
+
+    const lock = join(hookLogDirectory(), '.rotate.lock');
+    try {
+      mkdirSync(lock);
+    } catch {
+      return;
+    }
+    try {
+      if (existsSync(path) && statSync(path).size >= maxBytes) {
+        // Multiple hook processes (or several writes in one millisecond) must
+        // never select the same rotation target and overwrite an earlier file.
+        const rotated = path.replace(
+          /\.jsonl$/,
+          `-${Date.now()}-${process.pid}-${randomUUID()}.jsonl`
+        );
+        renameSync(path, rotated);
+      }
+    } finally {
+      // Non-recursive removal of the one fixed-name lock directory only.
+      try { rmdirSync(lock); } catch { /* best effort */ }
+    }
+  } catch {
+    // Diagnostics must never become the reason a lifecycle hook fails.
+  }
+}
+
+function pruneIfDue(now = new Date()) {
+  try {
+    const dir = hookLogDirectory();
+    const marker = join(dir, '.last-prune');
+    if (existsSync(marker) && now.getTime() - statSync(marker).mtimeMs < 60 * 60 * 1000)
+      return;
+    writeFileSync(marker, now.toISOString(), { flag: 'w' });
+
+    const retentionMs =
+      positiveInteger('TOKEN_OPTIMIZER_LOG_RETENTION_DAYS', DEFAULT_RETENTION_DAYS) *
+      24 * 60 * 60 * 1000;
+    const maxFiles = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_FILES', DEFAULT_MAX_FILES);
+    const files = readdirSync(dir)
+      .filter((name) => /^hook-events-.*\.jsonl$/.test(name))
+      .map((name) => {
+        const path = join(dir, name);
+        return { path, mtimeMs: statSync(path).mtimeMs };
+      })
+      .sort((a, b) => b.mtimeMs - a.mtimeMs);
+    for (let i = 0; i < files.length; i++) {
+      if (i >= maxFiles || now.getTime() - files[i].mtimeMs > retentionMs)
+        unlinkSync(files[i].path);
+    }
+  } catch {
+    // Retention is best effort and cannot affect the host tool call.
+  }
+}
+
+export function writeHookEvent(event) {
+  try {
+    const now = new Date();
+    const dir = hookLogDirectory();
+    mkdirSync(dir, { recursive: true });
+    const path = activeLogPath(now);
+    rotateIfNeeded(path);
+    const record = {
+      schemaVersion: HOOK_LOG_SCHEMA_VERSION,
+      timestamp: now.toISOString(),
+      service: 'token-optimizer',
+      serviceVersion:
+        process.env.TOKEN_OPTIMIZER_VERSION ||
+        process.env.npm_package_version ||
+        'unknown',
+      ...severity(event.level),
+      body: event.event || 'hook.event',
+      ...event,
+    };
+    record.resource = {
+      'service.name': record.service,
+      'service.version': record.serviceVersion,
+      'host.arch': process.arch,
+      'os.type': process.platform,
+      'process.runtime.name': 'node',
+      'process.runtime.version': process.version,
+    };
+    appendFileSync(path, `${JSON.stringify(record)}\n`, { encoding: 'utf8' });
+    pruneIfDue(now);
+    return path;
+  } catch {
+    return null;
+  }
+}
+
+export function beginHookInvocation(client, event, options = {}) {
+  const started = Date.now();
+  const invocationId = randomUUID();
+  let ended = false;
+  let outcome = 'success';
+  let reason = 'completed';
+  let error = null;
+  const dimensions = {
+    sessionIdHash: null,
+    turnIdHash: null,
+    toolUseIdHash: null,
+    toolName: null,
+    clientVersion: null,
+    model: null,
+    cwdHash: null,
+    payloadBytes: null,
+    outputBytes: 0,
+    outputShape: [],
+    inputStatus: 'pending',
+  };
+  const spanId = hash(invocationId, 16);
+  let traceId = hash(invocationId, 32);
+
+  let deadline;
+  const finish = (nextOutcome = outcome, nextReason = reason, nextError = error) => {
+    if (ended) return;
+    ended = true;
+    if (deadline) clearTimeout(deadline);
+    process.removeListener('exit', onExit);
+    writeHookEvent({
+      level: nextOutcome === 'failure' || nextOutcome === 'timeout' ? 'error' : 'info',
+      event: 'hook.completed',
+      outcome: nextOutcome,
+      reason: nextReason,
+      durationMs: Date.now() - started,
+      invocationId,
+      traceId,
+      spanId,
+      client,
+      hookEvent: event,
+      processId: process.pid,
+      ...dimensions,
+      error: errorFields(nextError),
+    });
+  };
+  const onExit = () => finish();
+  process.once('exit', onExit);
+
+  deadline = setTimeout(() => {
+    outcome = 'timeout';
+    reason = 'internal_deadline_exceeded';
+    finish(outcome, reason);
+    // Beat the host's five-second timeout and fail open deterministically.
+    process.exit(0);
+  }, options.deadlineMs ?? positiveInteger('TOKEN_OPTIMIZER_HOOK_DEADLINE_MS', DEFAULT_DEADLINE_MS));
+  deadline.unref();
+
+  const invocation = {
+    invocationId,
+    bind(raw = {}, payload = null, payloadBytes = null) {
+      const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? null;
+      dimensions.sessionIdHash = hash(sessionId);
+      dimensions.turnIdHash = hash(raw.turn_id ?? raw.turnId ?? null);
+      dimensions.toolUseIdHash = hash(raw.tool_use_id ?? raw.toolUseId ?? null);
+      dimensions.toolName = payload?.tool_name ?? raw.tool_name ?? raw.toolName ?? null;
+      dimensions.clientVersion = dimension(raw.client_version ?? raw.clientVersion ?? null);
+      dimensions.model = dimension(raw.model ?? raw.model_name ?? raw.modelName ?? null);
+      dimensions.cwdHash = hash(raw.cwd ?? raw.working_directory ?? process.cwd());
+      dimensions.payloadBytes = payloadBytes;
+      dimensions.inputStatus = 'ok';
+      if (sessionId) traceId = hash(sessionId, 32);
+    },
+    noteInput(status, payloadBytes = null) {
+      dimensions.inputStatus = status;
+      dimensions.payloadBytes = payloadBytes;
+      if (status === 'timeout') {
+        outcome = 'timeout';
+        reason = 'stdin_timeout';
+      } else if (status !== 'ok') {
+        outcome = 'skipped';
+        reason = status;
+      }
+    },
+    skip(nextReason) {
+      outcome = 'skipped';
+      reason = nextReason;
+    },
+    noteOutput(output, outputBytes = null) {
+      dimensions.outputBytes = outputBytes ?? Buffer.byteLength(JSON.stringify(output), 'utf8');
+      if (!output || typeof output !== 'object' || Array.isArray(output)) {
+        dimensions.outputShape = [];
+        return;
+      }
+      const shape = Object.keys(output).sort();
+      const hookSpecific = output.hookSpecificOutput;
+      if (hookSpecific && typeof hookSpecific === 'object' && !Array.isArray(hookSpecific)) {
+        for (const key of Object.keys(hookSpecific).sort()) shape.push(`hookSpecificOutput.${key}`);
+      }
+      dimensions.outputShape = shape;
+    },
+    fail(nextError, nextReason = 'unhandled_exception') {
+      outcome = 'failure';
+      reason = nextReason;
+      error = nextError;
+      finish(outcome, reason, error);
+    },
+    succeed(nextReason = 'completed') {
+      outcome = 'success';
+      reason = nextReason;
+      finish(outcome, reason);
+    },
+  };
+  activeInvocation = invocation;
+  return invocation;
+}
+
+/** Records response metadata without retaining response content. */
+export function noteHookOutput(output, outputBytes = null) {
+  activeInvocation?.noteOutput(output, outputBytes);
+}
+
+export function recordHookBootstrapFailure(client, event, error) {
+  writeHookEvent({
+    level: 'error',
+    event: 'hook.completed',
+    outcome: 'failure',
+    reason: 'bootstrap_import_failure',
+    durationMs: 0,
+    invocationId: randomUUID(),
+    client,
+    hookEvent: event,
+    processId: process.pid,
+    error: errorFields(error),
+  });
+}
+
+export function readHookEvents({ limit = 200, sinceMs = 24 * 60 * 60 * 1000 } = {}) {
+  try {
+    const dir = hookLogDirectory();
+    if (!existsSync(dir)) return [];
+    const cutoff = Date.now() - Math.max(0, sinceMs);
+    const files = readdirSync(dir)
+      .filter((name) => /^hook-events-.*\.jsonl$/.test(name))
+      .map((name) => join(dir, name))
+      .sort()
+      .reverse();
+    const events = [];
+    for (const file of files) {
+      const lines = readFileSync(file, 'utf8').split(/\r?\n/).filter(Boolean).reverse();
+      for (const line of lines) {
+        try {
+          const event = JSON.parse(line);
+          if (Date.parse(event.timestamp) < cutoff) continue;
+          events.push(event);
+          if (events.length >= limit) return events;
+        } catch {
+          // A partially written final line must not hide the rest of the log.
+        }
+      }
+    }
+    return events;
+  } catch {
+    return [];
+  }
+}
+
+export function hookHealthSummary(options = {}) {
+  const sinceMs = options.sinceMs ?? 24 * 60 * 60 * 1000;
+  const events = readHookEvents({ limit: options.limit || 5000, sinceMs });
+  const durations = events
+    .map((event) => Number(event.durationMs))
+    .filter(Number.isFinite)
+    .sort((a, b) => a - b);
+  const failures = events.filter((event) => event.outcome === 'failure');
+  const timeouts = events.filter((event) => event.outcome === 'timeout');
+  const skipped = events.filter((event) => event.outcome === 'skipped');
+  const successes = events.filter((event) => event.outcome === 'success');
+  const byClient = {};
+  for (const event of events) {
+    const key = event.client || 'unknown';
+    const current = byClient[key] || { total: 0, failures: 0, timeouts: 0, skipped: 0 };
+    current.total++;
+    if (event.outcome === 'failure') current.failures++;
+    if (event.outcome === 'timeout') current.timeouts++;
+    if (event.outcome === 'skipped') current.skipped++;
+    byClient[key] = current;
+  }
+  const percentile = (p) =>
+    durations.length
+      ? durations[Math.min(durations.length - 1, Math.floor(durations.length * p))]
+      : null;
+  const summary = {
+    schemaVersion: HOOK_LOG_SCHEMA_VERSION,
+    available: events.length > 0,
+    windowHours: sinceMs / 3_600_000,
+    total: events.length,
+    failures: failures.length,
+    timeouts: timeouts.length,
+    skipped: skipped.length,
+    successRate: events.length ? successes.length / events.length : null,
+    p50DurationMs: percentile(0.5),
+    p95DurationMs: percentile(0.95),
+    byClient,
+    recentFailures: [...failures, ...timeouts]
+      .sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp))
+      .slice(0, 20),
+  };
+  // Absolute paths are useful to a local doctor, but they do not belong in a
+  // diagnostics export that may be attached to a public issue.
+  if (options.includeLogDirectory === true)
+    summary.logDirectory = hookLogDirectory();
+  return summary;
+}

--- a/integrations/codex/hooks/lib/policy.mjs
+++ b/integrations/codex/hooks/lib/policy.mjs
@@ -48,6 +48,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { createHash } from 'node:crypto';
 import { isFsSafePath } from './paths.mjs';
+import { noteHookOutput } from './observability.mjs';
 
 /** Enforcement modes, least to most permissive. */
 export const MODE_ENFORCE = 'enforce';
@@ -653,14 +654,15 @@ export function allow() {
  */
 export function allowWithContext(context) {
   if (context) {
-    process.stdout.write(
-      JSON.stringify({
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-          additionalContext: withEscape(context),
-        },
-      })
-    );
+    const output = {
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        additionalContext: withEscape(context),
+      },
+    };
+    const serialized = JSON.stringify(output);
+    noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+    process.stdout.write(serialized);
   }
   process.exit(0);
 }
@@ -673,15 +675,16 @@ export function allowWithContext(context) {
  * says "use the optimized tool" gets met with a retry of the same call.
  */
 export function deny(reason) {
-  process.stdout.write(
-    JSON.stringify({
-      hookSpecificOutput: {
-        hookEventName: 'PreToolUse',
-        permissionDecision: 'deny',
-        permissionDecisionReason: withEscape(reason),
-      },
-    })
-  );
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+      permissionDecisionReason: withEscape(reason),
+    },
+  };
+  const serialized = JSON.stringify(output);
+  noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
   process.exit(0);
 }
 
@@ -706,14 +709,15 @@ export function withEscape(reason) {
 
 /** Lets the call through, attaching a note the model sees. */
 export function advise(context) {
-  process.stdout.write(
-    JSON.stringify({
-      hookSpecificOutput: {
-        hookEventName: 'PreToolUse',
-        additionalContext: context,
-      },
-    })
-  );
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      additionalContext: context,
+    },
+  };
+  const serialized = JSON.stringify(output);
+  noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
   process.exit(0);
 }
 
@@ -741,26 +745,34 @@ export function enforce(reason, deniedBefore) {
  * than an absent one, so the wait has a ceiling and expiring it is treated
  * exactly like unusable input.
  */
-export async function readPayload({
-  timeoutMs = 5000,
+export async function readPayloadResult({
+  timeoutMs = 1500,
   maxBytes = 8_000_000,
 } = {}) {
   const chunks = [];
   let size = 0;
+  let inputStatus = 'pending';
 
   const raw = await new Promise((resolve) => {
     const onData = (chunk) => {
-      size += chunk.length;
+      size += Buffer.byteLength(chunk, 'utf8');
       // A payload this large is not a tool call; refusing to buffer it
       // unboundedly keeps a hook from becoming a memory problem.
       if (size > maxBytes) {
+        inputStatus = 'too_large';
         finish(null);
         return;
       }
       chunks.push(chunk);
     };
-    const onEnd = () => finish(chunks.join(''));
-    const onError = () => finish(null);
+    const onEnd = () => {
+      inputStatus = 'received';
+      finish(chunks.join(''));
+    };
+    const onError = () => {
+      inputStatus = 'input_error';
+      finish(null);
+    };
 
     // Listeners are REMOVED on every exit path. Leaving them attached after the
     // timeout wins means a late chunk keeps growing a buffer nobody will read,
@@ -774,17 +786,21 @@ export async function readPayload({
       resolve(value);
     }
 
-    const timer = setTimeout(() => finish(null), timeoutMs);
+    const timer = setTimeout(() => {
+      inputStatus = 'timeout';
+      finish(null);
+    }, timeoutMs);
     process.stdin.setEncoding('utf8');
     process.stdin.on('data', onData);
     process.stdin.on('end', onEnd);
     process.stdin.on('error', onError);
   });
 
-  if (raw === null) return null;
+  if (raw === null) return { payload: null, status: inputStatus, bytes: size };
+  if (!raw.trim()) return { payload: null, status: 'empty_input', bytes: size };
   try {
-    return JSON.parse(raw);
+    return { payload: JSON.parse(raw), status: 'ok', bytes: size };
   } catch {
-    return null;
+    return { payload: null, status: 'invalid_json', bytes: size };
   }
 }

--- a/integrations/codex/hooks/lib/projects.mjs
+++ b/integrations/codex/hooks/lib/projects.mjs
@@ -1,0 +1,214 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/projects.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Machine-local index of project graph stores.
+ *
+ * A graph is deliberately stored with the project whose files it describes.
+ * That isolation is important for retrieval, but it also means a dashboard
+ * cannot honestly describe machine-wide capture unless it knows which stores
+ * exist. This registry is that missing directory. It is written by lifecycle
+ * hooks and can be backfilled by the explicit discovery command.
+ *
+ * The browser never receives `root` or `graphDir`. Routes resolve an opaque
+ * project id through this server-owned file, so restoring cross-project views
+ * does not restore the old arbitrary-path query vulnerability.
+ */
+
+import {
+  appendFileSync,
+  chmodSync,
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+} from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+import { createHash } from 'node:crypto';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
+
+export const PROJECT_REGISTRY_VERSION = 1;
+
+export function projectRegistryPath() {
+  return (
+    process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY ||
+    join(homedir(), '.token-optimizer', 'projects.jsonl')
+  );
+}
+
+export function projectIdFor(root) {
+  return `project-${createHash('sha256')
+    .update(canonicalPath(root))
+    .digest('hex')
+    .slice(0, 16)}`;
+}
+
+function displayName(root) {
+  return basename(root) || 'Unnamed project';
+}
+
+function acquire(path) {
+  const lockPath = `${path}.lock`;
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+  } catch {
+    return null;
+  }
+
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      closeSync(openSync(lockPath, 'wx', 0o600));
+      return lockPath;
+    } catch {
+      try {
+        if (Date.now() - statSync(lockPath).mtimeMs > 5000) unlinkSync(lockPath);
+      } catch {
+        // The holder may have released it between open and stat; retry.
+      }
+    }
+  }
+  return null;
+}
+
+function release(lockPath) {
+  if (!lockPath) return;
+  try {
+    unlinkSync(lockPath);
+  } catch {
+    // A killed process or cleanup race must not fail the hook.
+  }
+}
+
+/**
+ * Folds the append-only registry into one current entry per canonical project.
+ * Malformed, stale-schema, and unsafe records are ignored rather than trusted.
+ */
+export function registeredProjects() {
+  const path = projectRegistryPath();
+  const projects = new Map();
+  if (!existsSync(path)) return [];
+
+  try {
+    for (const line of readFileSync(path, 'utf8').split('\n')) {
+      if (!line) continue;
+      let record;
+      try {
+        record = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (
+        record.v !== PROJECT_REGISTRY_VERSION ||
+        !isFsSafePath(record.root) ||
+        !isFsSafePath(record.graphDir)
+      ) {
+        continue;
+      }
+      const root = canonicalPath(record.root);
+      const graphDir = canonicalPath(record.graphDir);
+      // Append-only history can outlive a deleted worktree (especially a
+      // short-lived test or CI checkout). A source that no longer exists
+      // cannot be captured, and presenting it as a current coverage gap makes
+      // the dashboard steadily less truthful over time.
+      if (!existsSync(root)) continue;
+      // A broad discovery root may contain hundreds of dormant worktrees. They
+      // are not capture coverage until a hook has observed them or a graph
+      // exists; listing all of them turns the selector into filesystem noise.
+      if (
+        record.client === 'discovery' &&
+        !existsSync(join(graphDir, 'graph.jsonl'))
+      ) {
+        continue;
+      }
+      const id = projectIdFor(root);
+      if (record.id !== id) continue;
+
+      const previous = projects.get(id);
+      projects.set(id, {
+        id,
+        name: String(record.name || displayName(root)).slice(0, 160),
+        root,
+        graphDir,
+        firstSeenAt: previous?.firstSeenAt || record.at || 0,
+        lastSeenAt: Math.max(previous?.lastSeenAt || 0, Number(record.at) || 0),
+        clients: [
+          ...new Set([
+            ...(previous?.clients || []),
+            ...(typeof record.client === 'string' && record.client
+              ? [record.client.slice(0, 80)]
+              : []),
+          ]),
+        ].sort(),
+      });
+    }
+  } catch {
+    return [];
+  }
+
+  return [...projects.values()].sort(
+    (a, b) => b.lastSeenAt - a.lastSeenAt || a.name.localeCompare(b.name)
+  );
+}
+
+/** Registers one VCS project without ever making a hook fail closed. */
+export function registerProject({ root, graphDir, client = 'unknown', name } = {}) {
+  if (!isFsSafePath(root) || !isFsSafePath(graphDir)) return null;
+  try {
+    const canonicalRoot = canonicalPath(root);
+    const canonicalGraphDir = canonicalPath(graphDir);
+    const isRepository = ['.git', '.hg', '.svn'].some((marker) =>
+      existsSync(join(canonicalRoot, marker))
+    );
+    if (!isRepository) return null;
+    const id = projectIdFor(canonicalRoot);
+    const now = Date.now();
+    const recent = registeredProjects().find(
+      (project) =>
+        project.id === id &&
+        project.graphDir === canonicalGraphDir &&
+        project.clients.includes(client) &&
+        now - project.lastSeenAt < 60 * 60 * 1000
+    );
+    if (recent) return recent;
+
+    const path = projectRegistryPath();
+    const lockPath = acquire(path);
+    if (!lockPath) return null;
+    try {
+      appendFileSync(
+        path,
+        `${JSON.stringify({
+          v: PROJECT_REGISTRY_VERSION,
+          id,
+          name: String(name || displayName(canonicalRoot)).slice(0, 160),
+          root: canonicalRoot,
+          graphDir: canonicalGraphDir,
+          client: String(client || 'unknown').slice(0, 80),
+          at: now,
+        })}\n`,
+        { mode: 0o600 }
+      );
+      try {
+        chmodSync(path, 0o600);
+      } catch {
+        // Windows and some filesystems do not expose POSIX modes.
+      }
+    } finally {
+      release(lockPath);
+    }
+    return {
+      id,
+      name: String(name || displayName(canonicalRoot)).slice(0, 160),
+      root: canonicalRoot,
+      graphDir: canonicalGraphDir,
+      firstSeenAt: now,
+      lastSeenAt: now,
+      clients: [String(client || 'unknown').slice(0, 80)],
+    };
+  } catch {
+    return null;
+  }
+}

--- a/integrations/codex/hooks/post-tool.mjs
+++ b/integrations/codex/hooks/post-tool.mjs
@@ -2,7 +2,17 @@
 // GENERATED FILE -- do not edit. Regenerate with `npm run sync:hooks`.
 // Client entry point: names the client and event; all policy lives in the
 // shared core so no client can drift its own thresholds or guidance.
-import { run } from './lib/adapter.mjs';
-
 // Fail open: a defect in the optimizer must never cost the user a tool call.
-run('codex', 'post-tool').catch(() => process.exit(0));
+// Bootstrap failures are still recorded so fail-open does not become fail-silent.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+try {
+  const { run } = await import('./lib/adapter.mjs');
+  await run('codex', 'post-tool');
+} catch (error) {
+  try {
+    const { recordHookBootstrapFailure } = await import('./lib/observability.mjs');
+    recordHookBootstrapFailure('codex', 'post-tool', error);
+  } catch {
+    // A logger bootstrap failure is the only condition that remains silent.
+  }
+}

--- a/integrations/codex/hooks/pre-tool.mjs
+++ b/integrations/codex/hooks/pre-tool.mjs
@@ -2,7 +2,17 @@
 // GENERATED FILE -- do not edit. Regenerate with `npm run sync:hooks`.
 // Client entry point: names the client and event; all policy lives in the
 // shared core so no client can drift its own thresholds or guidance.
-import { run } from './lib/adapter.mjs';
-
 // Fail open: a defect in the optimizer must never cost the user a tool call.
-run('codex', 'pre-tool').catch(() => process.exit(0));
+// Bootstrap failures are still recorded so fail-open does not become fail-silent.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+try {
+  const { run } = await import('./lib/adapter.mjs');
+  await run('codex', 'pre-tool');
+} catch (error) {
+  try {
+    const { recordHookBootstrapFailure } = await import('./lib/observability.mjs');
+    recordHookBootstrapFailure('codex', 'pre-tool', error);
+  } catch {
+    // A logger bootstrap failure is the only condition that remains silent.
+  }
+}

--- a/integrations/codex/hooks/session-start.mjs
+++ b/integrations/codex/hooks/session-start.mjs
@@ -2,7 +2,17 @@
 // GENERATED FILE -- do not edit. Regenerate with `npm run sync:hooks`.
 // Client entry point: names the client and event; all policy lives in the
 // shared core so no client can drift its own thresholds or guidance.
-import { run } from './lib/adapter.mjs';
-
 // Fail open: a defect in the optimizer must never cost the user a tool call.
-run('codex', 'session-start').catch(() => process.exit(0));
+// Bootstrap failures are still recorded so fail-open does not become fail-silent.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+try {
+  const { run } = await import('./lib/adapter.mjs');
+  await run('codex', 'session-start');
+} catch (error) {
+  try {
+    const { recordHookBootstrapFailure } = await import('./lib/observability.mjs');
+    recordHookBootstrapFailure('codex', 'session-start', error);
+  } catch {
+    // A logger bootstrap failure is the only condition that remains silent.
+  }
+}

--- a/integrations/codex/hooks/stop.mjs
+++ b/integrations/codex/hooks/stop.mjs
@@ -2,7 +2,17 @@
 // GENERATED FILE -- do not edit. Regenerate with `npm run sync:hooks`.
 // Client entry point: names the client and event; all policy lives in the
 // shared core so no client can drift its own thresholds or guidance.
-import { run } from './lib/adapter.mjs';
-
 // Fail open: a defect in the optimizer must never cost the user a tool call.
-run('codex', 'stop').catch(() => process.exit(0));
+// Bootstrap failures are still recorded so fail-open does not become fail-silent.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+try {
+  const { run } = await import('./lib/adapter.mjs');
+  await run('codex', 'stop');
+} catch (error) {
+  try {
+    const { recordHookBootstrapFailure } = await import('./lib/observability.mjs');
+    recordHookBootstrapFailure('codex', 'stop', error);
+  } catch {
+    // A logger bootstrap failure is the only condition that remains silent.
+  }
+}

--- a/integrations/codex/plugin/hooks/lib/adapter.mjs
+++ b/integrations/codex/plugin/hooks/lib/adapter.mjs
@@ -27,6 +27,7 @@ import {
   MODE_OFF,
   MODE_ADVISE,
   largeFileBytes,
+  readPayloadResult,
   withEscape,
 } from './policy.mjs';
 import {
@@ -83,6 +84,8 @@ import {
 } from './capabilities.mjs';
 import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 import { evaluateUcrGuards } from './ucr-guard.mjs';
+import { beginHookInvocation, noteHookOutput } from './observability.mjs';
+import { registerProject } from './projects.mjs';
 
 /**
  * Per-client capability.
@@ -128,7 +131,14 @@ export function mutationSucceeded(clientName, raw) {
 
   // These lifecycle contracts fire this event only after a successful tool,
   // or are called by our in-process bridge only from its successful after hook.
-  return new Set(['claude-code', 'qwen', 'opencode', 'kilo', 'windsurf']).has(
+  return new Set([
+    'claude-code',
+    'codex',
+    'qwen',
+    'opencode',
+    'kilo',
+    'windsurf',
+  ]).has(
     clientName
   );
 }
@@ -241,37 +251,9 @@ export function sessionTaskContext(raw = {}) {
 }
 
 function emit(object) {
-  process.stdout.write(JSON.stringify(object));
-}
-
-/**
- * Bounded stdin read. See policy.readPayload for why the ceiling matters: the
- * entry points fail open on a THROW, but a host that opens the pipe and never
- * closes it produces no throw -- just a hook that waits forever with the user's
- * tool call stuck behind it.
- */
-async function readStdin({ timeoutMs = 5000 } = {}) {
-  const raw = await new Promise((resolve) => {
-    const chunks = [];
-    const timer = setTimeout(() => resolve(null), timeoutMs);
-    process.stdin.setEncoding('utf8');
-    process.stdin.on('data', (chunk) => chunks.push(chunk));
-    process.stdin.on('end', () => {
-      clearTimeout(timer);
-      resolve(chunks.join(''));
-    });
-    process.stdin.on('error', () => {
-      clearTimeout(timer);
-      resolve(null);
-    });
-  });
-
-  if (raw === null) return null;
-  try {
-    return JSON.parse(raw);
-  } catch {
-    return null;
-  }
+  const serialized = JSON.stringify(object);
+  noteHookOutput(object, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
 }
 
 /** The session-start notice, shared verbatim so no client drifts its own copy. */
@@ -502,6 +484,17 @@ function observeAndInject(payload, state, episode, features) {
  * @param {'session-start'|'pre-tool'|'post-tool'|'stop'} event
  */
 export async function run(clientName, event) {
+  const invocation = beginHookInvocation(clientName, event);
+  try {
+    await runHook(clientName, event, invocation);
+    invocation.succeed();
+  } catch (error) {
+    // The optimizer must fail open, but the failure is now reconstructable.
+    invocation.fail(error);
+  }
+}
+
+async function runHook(clientName, event, invocation) {
   const client = CLIENTS[clientName] || CLIENTS['claude-code'];
   const eventName =
     event === 'session-start'
@@ -529,7 +522,10 @@ export async function run(clientName, event) {
     // full pre-tool timeout would turn optional context into a five-second
     // startup tax; lifecycle payloads are tiny and arrive immediately when
     // the host supplies one.
-    const raw = (await readStdin({ timeoutMs: 250 })) || {};
+    const input = await readPayloadResult({ timeoutMs: 250 });
+    const raw = input.payload || {};
+    invocation.bind(raw, null, input.bytes);
+    if (input.status !== 'ok') invocation.noteInput(input.status, input.bytes);
     const toolEvidence = optimizerToolEvidence(raw);
     const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id;
     if (sessionId && toolEvidence.proven) {
@@ -540,10 +536,12 @@ export async function run(clientName, event) {
     const parts = [
       policyText(client.canDeny, toolEvidence.names, toolEvidence.proven),
     ];
+    const cwd = raw.cwd || raw.working_directory || process.cwd();
+    const root = projectRootFor(join(cwd, '__session__'), cwd);
+    registerProject({ root, graphDir: wikiDir(root), client: clientName });
     if (features.retrieval) {
       try {
-        const cwd = raw.cwd || raw.working_directory || process.cwd();
-        const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+        const dir = wikiDir(root);
         // SessionStart needs hashes and claims, not stored file bodies. Parsing
         // the snapshot sidecar here would make startup scale with repository
         // history even though this compact index never renders a diff.
@@ -569,14 +567,20 @@ export async function run(clientName, event) {
     process.exit(0);
   }
 
-  const raw = await readStdin();
+  const input = await readPayloadResult();
+  const raw = input.payload;
   if (!raw) {
+    invocation.noteInput(input.status, input.bytes);
     // Stop requires JSON on stdout even when it has nothing to add.
     if (event === 'stop') emit({});
     process.exit(0);
   }
 
   if (event === 'stop') {
+    // Stop has no normalized tool payload, but it is still a fully formed hook
+    // invocation. Bind its lifecycle identifiers so successful completions do
+    // not look like an input reader that never ran in cross-client telemetry.
+    invocation.bind(raw, null, input.bytes);
     const sessionId =
       raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? 'default';
     const agentScope = raw.transcript_path ?? raw.transcriptPath ?? null;
@@ -632,6 +636,7 @@ export async function run(clientName, event) {
   const payload = normalizePayload(
     normalizeClientPayload(clientName, event, raw)
   );
+  invocation.bind(raw, payload, input.bytes);
   if (!payload.tool_name) process.exit(0);
   const episode = episodeMeta({ client: clientName, raw, payload });
 

--- a/integrations/codex/plugin/hooks/lib/metrics.mjs
+++ b/integrations/codex/plugin/hooks/lib/metrics.mjs
@@ -1297,8 +1297,8 @@ function concurrencySummary(runs) {
  * live hook traces, and randomized model evals remain visibly distinct: only
  * `eval-run` records with paired arms can produce a causal effect interval.
  */
-export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
-  const evidence = readEvidence(dir).filter((event) => matchesFilters(event, filters));
+function buildEvidenceReport(evidence, { filters = {}, episodeLimit = 100 } = {}) {
+  evidence = evidence.filter((event) => matchesFilters(event, filters));
   const runs = evidence.filter((event) => event.kind === 'eval-run');
   const handoffRuns = evidence.filter((event) => event.kind === 'handoff-run');
   const concurrencyRuns = evidence.filter((event) => event.kind === 'concurrency-run');
@@ -1402,6 +1402,47 @@ export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
       minimumPairs,
       handoffMinimumPairs: handoffMinimumPairs(),
       deterministicChecksAreCausalProof: false,
+    },
+  };
+}
+
+export function evidenceReport(dir, options = {}) {
+  const events = readEvidence(dir);
+  const report = buildEvidenceReport(events, options);
+  const hasMatchingEvidence = events.some((event) =>
+    matchesFilters(event, options.filters || {})
+  );
+  return {
+    ...report,
+    sourceCoverage: {
+      projects: 1,
+      projectsWithEvidence: hasMatchingEvidence ? 1 : 0,
+      projectsWithoutEvidence: hasMatchingEvidence ? 0 : 1,
+    },
+  };
+}
+
+/**
+ * Pools evidence across registered projects before computing cohorts.
+ *
+ * A cohort split across two worktrees is still one experiment. Summing already
+ * aggregated reports would lose pairing and produce invalid confidence
+ * intervals, so this combines the append-only source events first and runs the
+ * estimator exactly once.
+ */
+export function evidenceReportMany(dirs, options = {}) {
+  const unique = [...new Set((dirs || []).map((dir) => String(dir)))];
+  const sources = unique.map((dir) => readEvidence(dir));
+  const report = buildEvidenceReport(sources.flat(), options);
+  const projectsWithEvidence = sources.filter((events) =>
+    events.some((event) => matchesFilters(event, options.filters || {}))
+  ).length;
+  return {
+    ...report,
+    sourceCoverage: {
+      projects: unique.length,
+      projectsWithEvidence,
+      projectsWithoutEvidence: unique.length - projectsWithEvidence,
     },
   };
 }

--- a/integrations/codex/plugin/hooks/lib/metrics.mjs
+++ b/integrations/codex/plugin/hooks/lib/metrics.mjs
@@ -738,10 +738,7 @@ function canonicalKeyish(p) {
  * arms, multiplied by treated touches. Reporting it as a measured fact would be
  * the same overclaiming this project criticises competitors for.
  */
-export function report(dir) {
-  const events = readAll(dir);
-  // Injections and harvests come from the log that cannot be starved.
-  const balance = readBalance(dir);
+function buildReport(events, balance) {
 
   // COMMAND INJECTIONS ARE COUNTED SEPARATELY, not mixed into the balance.
   //
@@ -843,6 +840,15 @@ export function report(dir) {
   const sufficient = treated.length >= 20 && withheld.length >= 5;
 
   return {
+    memoryDeliveries: allInjections.filter((event) => !event.holdout).length,
+    memoryHoldouts: allInjections.filter((event) => event.holdout).length,
+    deliveryTokens: allInjections
+      .filter((event) => !event.holdout)
+      .reduce(
+        (sum, event) =>
+          sum + (event.deliveredTokens ?? event.tokens ?? 0),
+        0
+      ),
     injections: treated.length,
     sessionStartInjections: sessionStartInjections.length,
     sessionStartInjectedTokens: sessionStartInjections.reduce(
@@ -864,6 +870,27 @@ export function report(dir) {
         ? 'the graph is saving more than it costs'
         : 'the graph is NOT yet paying for itself',
   };
+}
+
+export function report(dir) {
+  return buildReport(readAll(dir), readBalance(dir));
+}
+
+/**
+ * One statistically valid machine/project-group report.
+ *
+ * Summing per-project verdicts is wrong: five projects with four treated reads
+ * each do not individually meet the threshold, but together they are twenty
+ * observations. Pooling the underlying events preserves the randomized arms
+ * and computes the means once over the selected population.
+ */
+export function reportMany(dirs) {
+  const unique = [...new Set((dirs || []).map((dir) => String(dir)))];
+  const report = buildReport(
+    unique.flatMap((dir) => readAll(dir)),
+    unique.flatMap((dir) => readBalance(dir))
+  );
+  return { ...report, projects: unique.length };
 }
 
 /**

--- a/integrations/codex/plugin/hooks/lib/observability.mjs
+++ b/integrations/codex/plugin/hooks/lib/observability.mjs
@@ -1,0 +1,400 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+/**
+ * Privacy-safe, cross-client lifecycle diagnostics.
+ *
+ * Hook processes are intentionally fail-open, but fail-open must not mean
+ * fail-silent. Every client writes the same bounded JSONL schema so failures
+ * can be correlated without storing prompts, commands, tool output, or file
+ * contents.
+ */
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmdirSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { createHash, randomUUID } from 'node:crypto';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export const HOOK_LOG_SCHEMA_VERSION = 1;
+const DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
+const DEFAULT_RETENTION_DAYS = 14;
+const DEFAULT_MAX_FILES = 40;
+const DEFAULT_DEADLINE_MS = 4200;
+const MAX_ERROR_CHARS = 4000;
+const MAX_DIMENSION_CHARS = 160;
+let activeInvocation = null;
+
+function positiveInteger(name, fallback) {
+  const value = Number(process.env[name]);
+  return Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+export function hookLogDirectory() {
+  if (process.env.TOKEN_OPTIMIZER_LOG_DIR)
+    return process.env.TOKEN_OPTIMIZER_LOG_DIR;
+  const stateRoot =
+    process.env.TOKEN_OPTIMIZER_STATE_DIR ||
+    join(homedir(), '.token-optimizer');
+  return join(stateRoot, 'logs');
+}
+
+function hash(value, length = 16) {
+  if (!value) return null;
+  return createHash('sha256').update(String(value)).digest('hex').slice(0, length);
+}
+
+function sanitize(text) {
+  if (text === undefined || text === null) return null;
+  let value = String(text);
+  const home = homedir().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  if (home) value = value.replace(new RegExp(home, 'gi'), '<home>');
+  value = value
+    .replace(/\b(?:sk-[A-Za-z0-9_-]{12,}|gh[opusr]_[A-Za-z0-9]{12,})\b/g, '[REDACTED]')
+    .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi, '$1[REDACTED]')
+    .replace(/\b(password|secret|token|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi, '$1=[REDACTED]');
+  return value.slice(0, MAX_ERROR_CHARS);
+}
+
+function errorFields(error) {
+  if (!error) return null;
+  return {
+    type: sanitize(error.name || error.constructor?.name || 'Error'),
+    message: sanitize(error.message || error),
+    stack: sanitize(error.stack),
+  };
+}
+
+function dimension(value) {
+  const sanitized = sanitize(value);
+  return sanitized === null ? null : sanitized.slice(0, MAX_DIMENSION_CHARS);
+}
+
+function severity(level) {
+  if (level === 'error') return { severityText: 'ERROR', severityNumber: 17 };
+  if (level === 'warn') return { severityText: 'WARN', severityNumber: 13 };
+  return { severityText: 'INFO', severityNumber: 9 };
+}
+
+function activeLogPath(now = new Date()) {
+  const date = now.toISOString().slice(0, 10);
+  return join(hookLogDirectory(), `hook-events-${date}.jsonl`);
+}
+
+function rotateIfNeeded(path) {
+  try {
+    if (!existsSync(path)) return;
+    const maxBytes = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_BYTES', DEFAULT_MAX_BYTES);
+    if (statSync(path).size < maxBytes) return;
+
+    const lock = join(hookLogDirectory(), '.rotate.lock');
+    try {
+      mkdirSync(lock);
+    } catch {
+      return;
+    }
+    try {
+      if (existsSync(path) && statSync(path).size >= maxBytes) {
+        // Multiple hook processes (or several writes in one millisecond) must
+        // never select the same rotation target and overwrite an earlier file.
+        const rotated = path.replace(
+          /\.jsonl$/,
+          `-${Date.now()}-${process.pid}-${randomUUID()}.jsonl`
+        );
+        renameSync(path, rotated);
+      }
+    } finally {
+      // Non-recursive removal of the one fixed-name lock directory only.
+      try { rmdirSync(lock); } catch { /* best effort */ }
+    }
+  } catch {
+    // Diagnostics must never become the reason a lifecycle hook fails.
+  }
+}
+
+function pruneIfDue(now = new Date()) {
+  try {
+    const dir = hookLogDirectory();
+    const marker = join(dir, '.last-prune');
+    if (existsSync(marker) && now.getTime() - statSync(marker).mtimeMs < 60 * 60 * 1000)
+      return;
+    writeFileSync(marker, now.toISOString(), { flag: 'w' });
+
+    const retentionMs =
+      positiveInteger('TOKEN_OPTIMIZER_LOG_RETENTION_DAYS', DEFAULT_RETENTION_DAYS) *
+      24 * 60 * 60 * 1000;
+    const maxFiles = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_FILES', DEFAULT_MAX_FILES);
+    const files = readdirSync(dir)
+      .filter((name) => /^hook-events-.*\.jsonl$/.test(name))
+      .map((name) => {
+        const path = join(dir, name);
+        return { path, mtimeMs: statSync(path).mtimeMs };
+      })
+      .sort((a, b) => b.mtimeMs - a.mtimeMs);
+    for (let i = 0; i < files.length; i++) {
+      if (i >= maxFiles || now.getTime() - files[i].mtimeMs > retentionMs)
+        unlinkSync(files[i].path);
+    }
+  } catch {
+    // Retention is best effort and cannot affect the host tool call.
+  }
+}
+
+export function writeHookEvent(event) {
+  try {
+    const now = new Date();
+    const dir = hookLogDirectory();
+    mkdirSync(dir, { recursive: true });
+    const path = activeLogPath(now);
+    rotateIfNeeded(path);
+    const record = {
+      schemaVersion: HOOK_LOG_SCHEMA_VERSION,
+      timestamp: now.toISOString(),
+      service: 'token-optimizer',
+      serviceVersion:
+        process.env.TOKEN_OPTIMIZER_VERSION ||
+        process.env.npm_package_version ||
+        'unknown',
+      ...severity(event.level),
+      body: event.event || 'hook.event',
+      ...event,
+    };
+    record.resource = {
+      'service.name': record.service,
+      'service.version': record.serviceVersion,
+      'host.arch': process.arch,
+      'os.type': process.platform,
+      'process.runtime.name': 'node',
+      'process.runtime.version': process.version,
+    };
+    appendFileSync(path, `${JSON.stringify(record)}\n`, { encoding: 'utf8' });
+    pruneIfDue(now);
+    return path;
+  } catch {
+    return null;
+  }
+}
+
+export function beginHookInvocation(client, event, options = {}) {
+  const started = Date.now();
+  const invocationId = randomUUID();
+  let ended = false;
+  let outcome = 'success';
+  let reason = 'completed';
+  let error = null;
+  const dimensions = {
+    sessionIdHash: null,
+    turnIdHash: null,
+    toolUseIdHash: null,
+    toolName: null,
+    clientVersion: null,
+    model: null,
+    cwdHash: null,
+    payloadBytes: null,
+    outputBytes: 0,
+    outputShape: [],
+    inputStatus: 'pending',
+  };
+  const spanId = hash(invocationId, 16);
+  let traceId = hash(invocationId, 32);
+
+  let deadline;
+  const finish = (nextOutcome = outcome, nextReason = reason, nextError = error) => {
+    if (ended) return;
+    ended = true;
+    if (deadline) clearTimeout(deadline);
+    process.removeListener('exit', onExit);
+    writeHookEvent({
+      level: nextOutcome === 'failure' || nextOutcome === 'timeout' ? 'error' : 'info',
+      event: 'hook.completed',
+      outcome: nextOutcome,
+      reason: nextReason,
+      durationMs: Date.now() - started,
+      invocationId,
+      traceId,
+      spanId,
+      client,
+      hookEvent: event,
+      processId: process.pid,
+      ...dimensions,
+      error: errorFields(nextError),
+    });
+  };
+  const onExit = () => finish();
+  process.once('exit', onExit);
+
+  deadline = setTimeout(() => {
+    outcome = 'timeout';
+    reason = 'internal_deadline_exceeded';
+    finish(outcome, reason);
+    // Beat the host's five-second timeout and fail open deterministically.
+    process.exit(0);
+  }, options.deadlineMs ?? positiveInteger('TOKEN_OPTIMIZER_HOOK_DEADLINE_MS', DEFAULT_DEADLINE_MS));
+  deadline.unref();
+
+  const invocation = {
+    invocationId,
+    bind(raw = {}, payload = null, payloadBytes = null) {
+      const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? null;
+      dimensions.sessionIdHash = hash(sessionId);
+      dimensions.turnIdHash = hash(raw.turn_id ?? raw.turnId ?? null);
+      dimensions.toolUseIdHash = hash(raw.tool_use_id ?? raw.toolUseId ?? null);
+      dimensions.toolName = payload?.tool_name ?? raw.tool_name ?? raw.toolName ?? null;
+      dimensions.clientVersion = dimension(raw.client_version ?? raw.clientVersion ?? null);
+      dimensions.model = dimension(raw.model ?? raw.model_name ?? raw.modelName ?? null);
+      dimensions.cwdHash = hash(raw.cwd ?? raw.working_directory ?? process.cwd());
+      dimensions.payloadBytes = payloadBytes;
+      dimensions.inputStatus = 'ok';
+      if (sessionId) traceId = hash(sessionId, 32);
+    },
+    noteInput(status, payloadBytes = null) {
+      dimensions.inputStatus = status;
+      dimensions.payloadBytes = payloadBytes;
+      if (status === 'timeout') {
+        outcome = 'timeout';
+        reason = 'stdin_timeout';
+      } else if (status !== 'ok') {
+        outcome = 'skipped';
+        reason = status;
+      }
+    },
+    skip(nextReason) {
+      outcome = 'skipped';
+      reason = nextReason;
+    },
+    noteOutput(output, outputBytes = null) {
+      dimensions.outputBytes = outputBytes ?? Buffer.byteLength(JSON.stringify(output), 'utf8');
+      if (!output || typeof output !== 'object' || Array.isArray(output)) {
+        dimensions.outputShape = [];
+        return;
+      }
+      const shape = Object.keys(output).sort();
+      const hookSpecific = output.hookSpecificOutput;
+      if (hookSpecific && typeof hookSpecific === 'object' && !Array.isArray(hookSpecific)) {
+        for (const key of Object.keys(hookSpecific).sort()) shape.push(`hookSpecificOutput.${key}`);
+      }
+      dimensions.outputShape = shape;
+    },
+    fail(nextError, nextReason = 'unhandled_exception') {
+      outcome = 'failure';
+      reason = nextReason;
+      error = nextError;
+      finish(outcome, reason, error);
+    },
+    succeed(nextReason = 'completed') {
+      outcome = 'success';
+      reason = nextReason;
+      finish(outcome, reason);
+    },
+  };
+  activeInvocation = invocation;
+  return invocation;
+}
+
+/** Records response metadata without retaining response content. */
+export function noteHookOutput(output, outputBytes = null) {
+  activeInvocation?.noteOutput(output, outputBytes);
+}
+
+export function recordHookBootstrapFailure(client, event, error) {
+  writeHookEvent({
+    level: 'error',
+    event: 'hook.completed',
+    outcome: 'failure',
+    reason: 'bootstrap_import_failure',
+    durationMs: 0,
+    invocationId: randomUUID(),
+    client,
+    hookEvent: event,
+    processId: process.pid,
+    error: errorFields(error),
+  });
+}
+
+export function readHookEvents({ limit = 200, sinceMs = 24 * 60 * 60 * 1000 } = {}) {
+  try {
+    const dir = hookLogDirectory();
+    if (!existsSync(dir)) return [];
+    const cutoff = Date.now() - Math.max(0, sinceMs);
+    const files = readdirSync(dir)
+      .filter((name) => /^hook-events-.*\.jsonl$/.test(name))
+      .map((name) => join(dir, name))
+      .sort()
+      .reverse();
+    const events = [];
+    for (const file of files) {
+      const lines = readFileSync(file, 'utf8').split(/\r?\n/).filter(Boolean).reverse();
+      for (const line of lines) {
+        try {
+          const event = JSON.parse(line);
+          if (Date.parse(event.timestamp) < cutoff) continue;
+          events.push(event);
+          if (events.length >= limit) return events;
+        } catch {
+          // A partially written final line must not hide the rest of the log.
+        }
+      }
+    }
+    return events;
+  } catch {
+    return [];
+  }
+}
+
+export function hookHealthSummary(options = {}) {
+  const sinceMs = options.sinceMs ?? 24 * 60 * 60 * 1000;
+  const events = readHookEvents({ limit: options.limit || 5000, sinceMs });
+  const durations = events
+    .map((event) => Number(event.durationMs))
+    .filter(Number.isFinite)
+    .sort((a, b) => a - b);
+  const failures = events.filter((event) => event.outcome === 'failure');
+  const timeouts = events.filter((event) => event.outcome === 'timeout');
+  const skipped = events.filter((event) => event.outcome === 'skipped');
+  const successes = events.filter((event) => event.outcome === 'success');
+  const byClient = {};
+  for (const event of events) {
+    const key = event.client || 'unknown';
+    const current = byClient[key] || { total: 0, failures: 0, timeouts: 0, skipped: 0 };
+    current.total++;
+    if (event.outcome === 'failure') current.failures++;
+    if (event.outcome === 'timeout') current.timeouts++;
+    if (event.outcome === 'skipped') current.skipped++;
+    byClient[key] = current;
+  }
+  const percentile = (p) =>
+    durations.length
+      ? durations[Math.min(durations.length - 1, Math.floor(durations.length * p))]
+      : null;
+  const summary = {
+    schemaVersion: HOOK_LOG_SCHEMA_VERSION,
+    available: events.length > 0,
+    windowHours: sinceMs / 3_600_000,
+    total: events.length,
+    failures: failures.length,
+    timeouts: timeouts.length,
+    skipped: skipped.length,
+    successRate: events.length ? successes.length / events.length : null,
+    p50DurationMs: percentile(0.5),
+    p95DurationMs: percentile(0.95),
+    byClient,
+    recentFailures: [...failures, ...timeouts]
+      .sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp))
+      .slice(0, 20),
+  };
+  // Absolute paths are useful to a local doctor, but they do not belong in a
+  // diagnostics export that may be attached to a public issue.
+  if (options.includeLogDirectory === true)
+    summary.logDirectory = hookLogDirectory();
+  return summary;
+}

--- a/integrations/codex/plugin/hooks/lib/policy.mjs
+++ b/integrations/codex/plugin/hooks/lib/policy.mjs
@@ -48,6 +48,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { createHash } from 'node:crypto';
 import { isFsSafePath } from './paths.mjs';
+import { noteHookOutput } from './observability.mjs';
 
 /** Enforcement modes, least to most permissive. */
 export const MODE_ENFORCE = 'enforce';
@@ -653,14 +654,15 @@ export function allow() {
  */
 export function allowWithContext(context) {
   if (context) {
-    process.stdout.write(
-      JSON.stringify({
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-          additionalContext: withEscape(context),
-        },
-      })
-    );
+    const output = {
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        additionalContext: withEscape(context),
+      },
+    };
+    const serialized = JSON.stringify(output);
+    noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+    process.stdout.write(serialized);
   }
   process.exit(0);
 }
@@ -673,15 +675,16 @@ export function allowWithContext(context) {
  * says "use the optimized tool" gets met with a retry of the same call.
  */
 export function deny(reason) {
-  process.stdout.write(
-    JSON.stringify({
-      hookSpecificOutput: {
-        hookEventName: 'PreToolUse',
-        permissionDecision: 'deny',
-        permissionDecisionReason: withEscape(reason),
-      },
-    })
-  );
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+      permissionDecisionReason: withEscape(reason),
+    },
+  };
+  const serialized = JSON.stringify(output);
+  noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
   process.exit(0);
 }
 
@@ -706,14 +709,15 @@ export function withEscape(reason) {
 
 /** Lets the call through, attaching a note the model sees. */
 export function advise(context) {
-  process.stdout.write(
-    JSON.stringify({
-      hookSpecificOutput: {
-        hookEventName: 'PreToolUse',
-        additionalContext: context,
-      },
-    })
-  );
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      additionalContext: context,
+    },
+  };
+  const serialized = JSON.stringify(output);
+  noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
   process.exit(0);
 }
 
@@ -741,26 +745,34 @@ export function enforce(reason, deniedBefore) {
  * than an absent one, so the wait has a ceiling and expiring it is treated
  * exactly like unusable input.
  */
-export async function readPayload({
-  timeoutMs = 5000,
+export async function readPayloadResult({
+  timeoutMs = 1500,
   maxBytes = 8_000_000,
 } = {}) {
   const chunks = [];
   let size = 0;
+  let inputStatus = 'pending';
 
   const raw = await new Promise((resolve) => {
     const onData = (chunk) => {
-      size += chunk.length;
+      size += Buffer.byteLength(chunk, 'utf8');
       // A payload this large is not a tool call; refusing to buffer it
       // unboundedly keeps a hook from becoming a memory problem.
       if (size > maxBytes) {
+        inputStatus = 'too_large';
         finish(null);
         return;
       }
       chunks.push(chunk);
     };
-    const onEnd = () => finish(chunks.join(''));
-    const onError = () => finish(null);
+    const onEnd = () => {
+      inputStatus = 'received';
+      finish(chunks.join(''));
+    };
+    const onError = () => {
+      inputStatus = 'input_error';
+      finish(null);
+    };
 
     // Listeners are REMOVED on every exit path. Leaving them attached after the
     // timeout wins means a late chunk keeps growing a buffer nobody will read,
@@ -774,17 +786,21 @@ export async function readPayload({
       resolve(value);
     }
 
-    const timer = setTimeout(() => finish(null), timeoutMs);
+    const timer = setTimeout(() => {
+      inputStatus = 'timeout';
+      finish(null);
+    }, timeoutMs);
     process.stdin.setEncoding('utf8');
     process.stdin.on('data', onData);
     process.stdin.on('end', onEnd);
     process.stdin.on('error', onError);
   });
 
-  if (raw === null) return null;
+  if (raw === null) return { payload: null, status: inputStatus, bytes: size };
+  if (!raw.trim()) return { payload: null, status: 'empty_input', bytes: size };
   try {
-    return JSON.parse(raw);
+    return { payload: JSON.parse(raw), status: 'ok', bytes: size };
   } catch {
-    return null;
+    return { payload: null, status: 'invalid_json', bytes: size };
   }
 }

--- a/integrations/codex/plugin/hooks/lib/projects.mjs
+++ b/integrations/codex/plugin/hooks/lib/projects.mjs
@@ -1,0 +1,214 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/projects.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Machine-local index of project graph stores.
+ *
+ * A graph is deliberately stored with the project whose files it describes.
+ * That isolation is important for retrieval, but it also means a dashboard
+ * cannot honestly describe machine-wide capture unless it knows which stores
+ * exist. This registry is that missing directory. It is written by lifecycle
+ * hooks and can be backfilled by the explicit discovery command.
+ *
+ * The browser never receives `root` or `graphDir`. Routes resolve an opaque
+ * project id through this server-owned file, so restoring cross-project views
+ * does not restore the old arbitrary-path query vulnerability.
+ */
+
+import {
+  appendFileSync,
+  chmodSync,
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+} from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+import { createHash } from 'node:crypto';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
+
+export const PROJECT_REGISTRY_VERSION = 1;
+
+export function projectRegistryPath() {
+  return (
+    process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY ||
+    join(homedir(), '.token-optimizer', 'projects.jsonl')
+  );
+}
+
+export function projectIdFor(root) {
+  return `project-${createHash('sha256')
+    .update(canonicalPath(root))
+    .digest('hex')
+    .slice(0, 16)}`;
+}
+
+function displayName(root) {
+  return basename(root) || 'Unnamed project';
+}
+
+function acquire(path) {
+  const lockPath = `${path}.lock`;
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+  } catch {
+    return null;
+  }
+
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      closeSync(openSync(lockPath, 'wx', 0o600));
+      return lockPath;
+    } catch {
+      try {
+        if (Date.now() - statSync(lockPath).mtimeMs > 5000) unlinkSync(lockPath);
+      } catch {
+        // The holder may have released it between open and stat; retry.
+      }
+    }
+  }
+  return null;
+}
+
+function release(lockPath) {
+  if (!lockPath) return;
+  try {
+    unlinkSync(lockPath);
+  } catch {
+    // A killed process or cleanup race must not fail the hook.
+  }
+}
+
+/**
+ * Folds the append-only registry into one current entry per canonical project.
+ * Malformed, stale-schema, and unsafe records are ignored rather than trusted.
+ */
+export function registeredProjects() {
+  const path = projectRegistryPath();
+  const projects = new Map();
+  if (!existsSync(path)) return [];
+
+  try {
+    for (const line of readFileSync(path, 'utf8').split('\n')) {
+      if (!line) continue;
+      let record;
+      try {
+        record = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (
+        record.v !== PROJECT_REGISTRY_VERSION ||
+        !isFsSafePath(record.root) ||
+        !isFsSafePath(record.graphDir)
+      ) {
+        continue;
+      }
+      const root = canonicalPath(record.root);
+      const graphDir = canonicalPath(record.graphDir);
+      // Append-only history can outlive a deleted worktree (especially a
+      // short-lived test or CI checkout). A source that no longer exists
+      // cannot be captured, and presenting it as a current coverage gap makes
+      // the dashboard steadily less truthful over time.
+      if (!existsSync(root)) continue;
+      // A broad discovery root may contain hundreds of dormant worktrees. They
+      // are not capture coverage until a hook has observed them or a graph
+      // exists; listing all of them turns the selector into filesystem noise.
+      if (
+        record.client === 'discovery' &&
+        !existsSync(join(graphDir, 'graph.jsonl'))
+      ) {
+        continue;
+      }
+      const id = projectIdFor(root);
+      if (record.id !== id) continue;
+
+      const previous = projects.get(id);
+      projects.set(id, {
+        id,
+        name: String(record.name || displayName(root)).slice(0, 160),
+        root,
+        graphDir,
+        firstSeenAt: previous?.firstSeenAt || record.at || 0,
+        lastSeenAt: Math.max(previous?.lastSeenAt || 0, Number(record.at) || 0),
+        clients: [
+          ...new Set([
+            ...(previous?.clients || []),
+            ...(typeof record.client === 'string' && record.client
+              ? [record.client.slice(0, 80)]
+              : []),
+          ]),
+        ].sort(),
+      });
+    }
+  } catch {
+    return [];
+  }
+
+  return [...projects.values()].sort(
+    (a, b) => b.lastSeenAt - a.lastSeenAt || a.name.localeCompare(b.name)
+  );
+}
+
+/** Registers one VCS project without ever making a hook fail closed. */
+export function registerProject({ root, graphDir, client = 'unknown', name } = {}) {
+  if (!isFsSafePath(root) || !isFsSafePath(graphDir)) return null;
+  try {
+    const canonicalRoot = canonicalPath(root);
+    const canonicalGraphDir = canonicalPath(graphDir);
+    const isRepository = ['.git', '.hg', '.svn'].some((marker) =>
+      existsSync(join(canonicalRoot, marker))
+    );
+    if (!isRepository) return null;
+    const id = projectIdFor(canonicalRoot);
+    const now = Date.now();
+    const recent = registeredProjects().find(
+      (project) =>
+        project.id === id &&
+        project.graphDir === canonicalGraphDir &&
+        project.clients.includes(client) &&
+        now - project.lastSeenAt < 60 * 60 * 1000
+    );
+    if (recent) return recent;
+
+    const path = projectRegistryPath();
+    const lockPath = acquire(path);
+    if (!lockPath) return null;
+    try {
+      appendFileSync(
+        path,
+        `${JSON.stringify({
+          v: PROJECT_REGISTRY_VERSION,
+          id,
+          name: String(name || displayName(canonicalRoot)).slice(0, 160),
+          root: canonicalRoot,
+          graphDir: canonicalGraphDir,
+          client: String(client || 'unknown').slice(0, 80),
+          at: now,
+        })}\n`,
+        { mode: 0o600 }
+      );
+      try {
+        chmodSync(path, 0o600);
+      } catch {
+        // Windows and some filesystems do not expose POSIX modes.
+      }
+    } finally {
+      release(lockPath);
+    }
+    return {
+      id,
+      name: String(name || displayName(canonicalRoot)).slice(0, 160),
+      root: canonicalRoot,
+      graphDir: canonicalGraphDir,
+      firstSeenAt: now,
+      lastSeenAt: now,
+      clients: [String(client || 'unknown').slice(0, 80)],
+    };
+  } catch {
+    return null;
+  }
+}

--- a/integrations/codex/plugin/hooks/post-tool.mjs
+++ b/integrations/codex/plugin/hooks/post-tool.mjs
@@ -2,7 +2,17 @@
 // GENERATED FILE -- do not edit. Regenerate with `npm run sync:hooks`.
 // Client entry point: names the client and event; all policy lives in the
 // shared core so no client can drift its own thresholds or guidance.
-import { run } from './lib/adapter.mjs';
-
 // Fail open: a defect in the optimizer must never cost the user a tool call.
-run('codex', 'post-tool').catch(() => process.exit(0));
+// Bootstrap failures are still recorded so fail-open does not become fail-silent.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+try {
+  const { run } = await import('./lib/adapter.mjs');
+  await run('codex', 'post-tool');
+} catch (error) {
+  try {
+    const { recordHookBootstrapFailure } = await import('./lib/observability.mjs');
+    recordHookBootstrapFailure('codex', 'post-tool', error);
+  } catch {
+    // A logger bootstrap failure is the only condition that remains silent.
+  }
+}

--- a/integrations/codex/plugin/hooks/pre-tool.mjs
+++ b/integrations/codex/plugin/hooks/pre-tool.mjs
@@ -2,7 +2,17 @@
 // GENERATED FILE -- do not edit. Regenerate with `npm run sync:hooks`.
 // Client entry point: names the client and event; all policy lives in the
 // shared core so no client can drift its own thresholds or guidance.
-import { run } from './lib/adapter.mjs';
-
 // Fail open: a defect in the optimizer must never cost the user a tool call.
-run('codex', 'pre-tool').catch(() => process.exit(0));
+// Bootstrap failures are still recorded so fail-open does not become fail-silent.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+try {
+  const { run } = await import('./lib/adapter.mjs');
+  await run('codex', 'pre-tool');
+} catch (error) {
+  try {
+    const { recordHookBootstrapFailure } = await import('./lib/observability.mjs');
+    recordHookBootstrapFailure('codex', 'pre-tool', error);
+  } catch {
+    // A logger bootstrap failure is the only condition that remains silent.
+  }
+}

--- a/integrations/codex/plugin/hooks/session-start.mjs
+++ b/integrations/codex/plugin/hooks/session-start.mjs
@@ -2,7 +2,17 @@
 // GENERATED FILE -- do not edit. Regenerate with `npm run sync:hooks`.
 // Client entry point: names the client and event; all policy lives in the
 // shared core so no client can drift its own thresholds or guidance.
-import { run } from './lib/adapter.mjs';
-
 // Fail open: a defect in the optimizer must never cost the user a tool call.
-run('codex', 'session-start').catch(() => process.exit(0));
+// Bootstrap failures are still recorded so fail-open does not become fail-silent.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+try {
+  const { run } = await import('./lib/adapter.mjs');
+  await run('codex', 'session-start');
+} catch (error) {
+  try {
+    const { recordHookBootstrapFailure } = await import('./lib/observability.mjs');
+    recordHookBootstrapFailure('codex', 'session-start', error);
+  } catch {
+    // A logger bootstrap failure is the only condition that remains silent.
+  }
+}

--- a/integrations/codex/plugin/hooks/stop.mjs
+++ b/integrations/codex/plugin/hooks/stop.mjs
@@ -2,7 +2,17 @@
 // GENERATED FILE -- do not edit. Regenerate with `npm run sync:hooks`.
 // Client entry point: names the client and event; all policy lives in the
 // shared core so no client can drift its own thresholds or guidance.
-import { run } from './lib/adapter.mjs';
-
 // Fail open: a defect in the optimizer must never cost the user a tool call.
-run('codex', 'stop').catch(() => process.exit(0));
+// Bootstrap failures are still recorded so fail-open does not become fail-silent.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+try {
+  const { run } = await import('./lib/adapter.mjs');
+  await run('codex', 'stop');
+} catch (error) {
+  try {
+    const { recordHookBootstrapFailure } = await import('./lib/observability.mjs');
+    recordHookBootstrapFailure('codex', 'stop', error);
+  } catch {
+    // A logger bootstrap failure is the only condition that remains silent.
+  }
+}

--- a/integrations/copilot/.github/hooks/lib/adapter.mjs
+++ b/integrations/copilot/.github/hooks/lib/adapter.mjs
@@ -27,6 +27,7 @@ import {
   MODE_OFF,
   MODE_ADVISE,
   largeFileBytes,
+  readPayloadResult,
   withEscape,
 } from './policy.mjs';
 import {
@@ -83,6 +84,8 @@ import {
 } from './capabilities.mjs';
 import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 import { evaluateUcrGuards } from './ucr-guard.mjs';
+import { beginHookInvocation, noteHookOutput } from './observability.mjs';
+import { registerProject } from './projects.mjs';
 
 /**
  * Per-client capability.
@@ -128,7 +131,14 @@ export function mutationSucceeded(clientName, raw) {
 
   // These lifecycle contracts fire this event only after a successful tool,
   // or are called by our in-process bridge only from its successful after hook.
-  return new Set(['claude-code', 'qwen', 'opencode', 'kilo', 'windsurf']).has(
+  return new Set([
+    'claude-code',
+    'codex',
+    'qwen',
+    'opencode',
+    'kilo',
+    'windsurf',
+  ]).has(
     clientName
   );
 }
@@ -241,37 +251,9 @@ export function sessionTaskContext(raw = {}) {
 }
 
 function emit(object) {
-  process.stdout.write(JSON.stringify(object));
-}
-
-/**
- * Bounded stdin read. See policy.readPayload for why the ceiling matters: the
- * entry points fail open on a THROW, but a host that opens the pipe and never
- * closes it produces no throw -- just a hook that waits forever with the user's
- * tool call stuck behind it.
- */
-async function readStdin({ timeoutMs = 5000 } = {}) {
-  const raw = await new Promise((resolve) => {
-    const chunks = [];
-    const timer = setTimeout(() => resolve(null), timeoutMs);
-    process.stdin.setEncoding('utf8');
-    process.stdin.on('data', (chunk) => chunks.push(chunk));
-    process.stdin.on('end', () => {
-      clearTimeout(timer);
-      resolve(chunks.join(''));
-    });
-    process.stdin.on('error', () => {
-      clearTimeout(timer);
-      resolve(null);
-    });
-  });
-
-  if (raw === null) return null;
-  try {
-    return JSON.parse(raw);
-  } catch {
-    return null;
-  }
+  const serialized = JSON.stringify(object);
+  noteHookOutput(object, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
 }
 
 /** The session-start notice, shared verbatim so no client drifts its own copy. */
@@ -502,6 +484,17 @@ function observeAndInject(payload, state, episode, features) {
  * @param {'session-start'|'pre-tool'|'post-tool'|'stop'} event
  */
 export async function run(clientName, event) {
+  const invocation = beginHookInvocation(clientName, event);
+  try {
+    await runHook(clientName, event, invocation);
+    invocation.succeed();
+  } catch (error) {
+    // The optimizer must fail open, but the failure is now reconstructable.
+    invocation.fail(error);
+  }
+}
+
+async function runHook(clientName, event, invocation) {
   const client = CLIENTS[clientName] || CLIENTS['claude-code'];
   const eventName =
     event === 'session-start'
@@ -529,7 +522,10 @@ export async function run(clientName, event) {
     // full pre-tool timeout would turn optional context into a five-second
     // startup tax; lifecycle payloads are tiny and arrive immediately when
     // the host supplies one.
-    const raw = (await readStdin({ timeoutMs: 250 })) || {};
+    const input = await readPayloadResult({ timeoutMs: 250 });
+    const raw = input.payload || {};
+    invocation.bind(raw, null, input.bytes);
+    if (input.status !== 'ok') invocation.noteInput(input.status, input.bytes);
     const toolEvidence = optimizerToolEvidence(raw);
     const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id;
     if (sessionId && toolEvidence.proven) {
@@ -540,10 +536,12 @@ export async function run(clientName, event) {
     const parts = [
       policyText(client.canDeny, toolEvidence.names, toolEvidence.proven),
     ];
+    const cwd = raw.cwd || raw.working_directory || process.cwd();
+    const root = projectRootFor(join(cwd, '__session__'), cwd);
+    registerProject({ root, graphDir: wikiDir(root), client: clientName });
     if (features.retrieval) {
       try {
-        const cwd = raw.cwd || raw.working_directory || process.cwd();
-        const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+        const dir = wikiDir(root);
         // SessionStart needs hashes and claims, not stored file bodies. Parsing
         // the snapshot sidecar here would make startup scale with repository
         // history even though this compact index never renders a diff.
@@ -569,14 +567,20 @@ export async function run(clientName, event) {
     process.exit(0);
   }
 
-  const raw = await readStdin();
+  const input = await readPayloadResult();
+  const raw = input.payload;
   if (!raw) {
+    invocation.noteInput(input.status, input.bytes);
     // Stop requires JSON on stdout even when it has nothing to add.
     if (event === 'stop') emit({});
     process.exit(0);
   }
 
   if (event === 'stop') {
+    // Stop has no normalized tool payload, but it is still a fully formed hook
+    // invocation. Bind its lifecycle identifiers so successful completions do
+    // not look like an input reader that never ran in cross-client telemetry.
+    invocation.bind(raw, null, input.bytes);
     const sessionId =
       raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? 'default';
     const agentScope = raw.transcript_path ?? raw.transcriptPath ?? null;
@@ -632,6 +636,7 @@ export async function run(clientName, event) {
   const payload = normalizePayload(
     normalizeClientPayload(clientName, event, raw)
   );
+  invocation.bind(raw, payload, input.bytes);
   if (!payload.tool_name) process.exit(0);
   const episode = episodeMeta({ client: clientName, raw, payload });
 

--- a/integrations/copilot/.github/hooks/lib/metrics.mjs
+++ b/integrations/copilot/.github/hooks/lib/metrics.mjs
@@ -1297,8 +1297,8 @@ function concurrencySummary(runs) {
  * live hook traces, and randomized model evals remain visibly distinct: only
  * `eval-run` records with paired arms can produce a causal effect interval.
  */
-export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
-  const evidence = readEvidence(dir).filter((event) => matchesFilters(event, filters));
+function buildEvidenceReport(evidence, { filters = {}, episodeLimit = 100 } = {}) {
+  evidence = evidence.filter((event) => matchesFilters(event, filters));
   const runs = evidence.filter((event) => event.kind === 'eval-run');
   const handoffRuns = evidence.filter((event) => event.kind === 'handoff-run');
   const concurrencyRuns = evidence.filter((event) => event.kind === 'concurrency-run');
@@ -1402,6 +1402,47 @@ export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
       minimumPairs,
       handoffMinimumPairs: handoffMinimumPairs(),
       deterministicChecksAreCausalProof: false,
+    },
+  };
+}
+
+export function evidenceReport(dir, options = {}) {
+  const events = readEvidence(dir);
+  const report = buildEvidenceReport(events, options);
+  const hasMatchingEvidence = events.some((event) =>
+    matchesFilters(event, options.filters || {})
+  );
+  return {
+    ...report,
+    sourceCoverage: {
+      projects: 1,
+      projectsWithEvidence: hasMatchingEvidence ? 1 : 0,
+      projectsWithoutEvidence: hasMatchingEvidence ? 0 : 1,
+    },
+  };
+}
+
+/**
+ * Pools evidence across registered projects before computing cohorts.
+ *
+ * A cohort split across two worktrees is still one experiment. Summing already
+ * aggregated reports would lose pairing and produce invalid confidence
+ * intervals, so this combines the append-only source events first and runs the
+ * estimator exactly once.
+ */
+export function evidenceReportMany(dirs, options = {}) {
+  const unique = [...new Set((dirs || []).map((dir) => String(dir)))];
+  const sources = unique.map((dir) => readEvidence(dir));
+  const report = buildEvidenceReport(sources.flat(), options);
+  const projectsWithEvidence = sources.filter((events) =>
+    events.some((event) => matchesFilters(event, options.filters || {}))
+  ).length;
+  return {
+    ...report,
+    sourceCoverage: {
+      projects: unique.length,
+      projectsWithEvidence,
+      projectsWithoutEvidence: unique.length - projectsWithEvidence,
     },
   };
 }

--- a/integrations/copilot/.github/hooks/lib/metrics.mjs
+++ b/integrations/copilot/.github/hooks/lib/metrics.mjs
@@ -738,10 +738,7 @@ function canonicalKeyish(p) {
  * arms, multiplied by treated touches. Reporting it as a measured fact would be
  * the same overclaiming this project criticises competitors for.
  */
-export function report(dir) {
-  const events = readAll(dir);
-  // Injections and harvests come from the log that cannot be starved.
-  const balance = readBalance(dir);
+function buildReport(events, balance) {
 
   // COMMAND INJECTIONS ARE COUNTED SEPARATELY, not mixed into the balance.
   //
@@ -843,6 +840,15 @@ export function report(dir) {
   const sufficient = treated.length >= 20 && withheld.length >= 5;
 
   return {
+    memoryDeliveries: allInjections.filter((event) => !event.holdout).length,
+    memoryHoldouts: allInjections.filter((event) => event.holdout).length,
+    deliveryTokens: allInjections
+      .filter((event) => !event.holdout)
+      .reduce(
+        (sum, event) =>
+          sum + (event.deliveredTokens ?? event.tokens ?? 0),
+        0
+      ),
     injections: treated.length,
     sessionStartInjections: sessionStartInjections.length,
     sessionStartInjectedTokens: sessionStartInjections.reduce(
@@ -864,6 +870,27 @@ export function report(dir) {
         ? 'the graph is saving more than it costs'
         : 'the graph is NOT yet paying for itself',
   };
+}
+
+export function report(dir) {
+  return buildReport(readAll(dir), readBalance(dir));
+}
+
+/**
+ * One statistically valid machine/project-group report.
+ *
+ * Summing per-project verdicts is wrong: five projects with four treated reads
+ * each do not individually meet the threshold, but together they are twenty
+ * observations. Pooling the underlying events preserves the randomized arms
+ * and computes the means once over the selected population.
+ */
+export function reportMany(dirs) {
+  const unique = [...new Set((dirs || []).map((dir) => String(dir)))];
+  const report = buildReport(
+    unique.flatMap((dir) => readAll(dir)),
+    unique.flatMap((dir) => readBalance(dir))
+  );
+  return { ...report, projects: unique.length };
 }
 
 /**

--- a/integrations/copilot/.github/hooks/lib/observability.mjs
+++ b/integrations/copilot/.github/hooks/lib/observability.mjs
@@ -1,0 +1,400 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+/**
+ * Privacy-safe, cross-client lifecycle diagnostics.
+ *
+ * Hook processes are intentionally fail-open, but fail-open must not mean
+ * fail-silent. Every client writes the same bounded JSONL schema so failures
+ * can be correlated without storing prompts, commands, tool output, or file
+ * contents.
+ */
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmdirSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { createHash, randomUUID } from 'node:crypto';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export const HOOK_LOG_SCHEMA_VERSION = 1;
+const DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
+const DEFAULT_RETENTION_DAYS = 14;
+const DEFAULT_MAX_FILES = 40;
+const DEFAULT_DEADLINE_MS = 4200;
+const MAX_ERROR_CHARS = 4000;
+const MAX_DIMENSION_CHARS = 160;
+let activeInvocation = null;
+
+function positiveInteger(name, fallback) {
+  const value = Number(process.env[name]);
+  return Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+export function hookLogDirectory() {
+  if (process.env.TOKEN_OPTIMIZER_LOG_DIR)
+    return process.env.TOKEN_OPTIMIZER_LOG_DIR;
+  const stateRoot =
+    process.env.TOKEN_OPTIMIZER_STATE_DIR ||
+    join(homedir(), '.token-optimizer');
+  return join(stateRoot, 'logs');
+}
+
+function hash(value, length = 16) {
+  if (!value) return null;
+  return createHash('sha256').update(String(value)).digest('hex').slice(0, length);
+}
+
+function sanitize(text) {
+  if (text === undefined || text === null) return null;
+  let value = String(text);
+  const home = homedir().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  if (home) value = value.replace(new RegExp(home, 'gi'), '<home>');
+  value = value
+    .replace(/\b(?:sk-[A-Za-z0-9_-]{12,}|gh[opusr]_[A-Za-z0-9]{12,})\b/g, '[REDACTED]')
+    .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi, '$1[REDACTED]')
+    .replace(/\b(password|secret|token|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi, '$1=[REDACTED]');
+  return value.slice(0, MAX_ERROR_CHARS);
+}
+
+function errorFields(error) {
+  if (!error) return null;
+  return {
+    type: sanitize(error.name || error.constructor?.name || 'Error'),
+    message: sanitize(error.message || error),
+    stack: sanitize(error.stack),
+  };
+}
+
+function dimension(value) {
+  const sanitized = sanitize(value);
+  return sanitized === null ? null : sanitized.slice(0, MAX_DIMENSION_CHARS);
+}
+
+function severity(level) {
+  if (level === 'error') return { severityText: 'ERROR', severityNumber: 17 };
+  if (level === 'warn') return { severityText: 'WARN', severityNumber: 13 };
+  return { severityText: 'INFO', severityNumber: 9 };
+}
+
+function activeLogPath(now = new Date()) {
+  const date = now.toISOString().slice(0, 10);
+  return join(hookLogDirectory(), `hook-events-${date}.jsonl`);
+}
+
+function rotateIfNeeded(path) {
+  try {
+    if (!existsSync(path)) return;
+    const maxBytes = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_BYTES', DEFAULT_MAX_BYTES);
+    if (statSync(path).size < maxBytes) return;
+
+    const lock = join(hookLogDirectory(), '.rotate.lock');
+    try {
+      mkdirSync(lock);
+    } catch {
+      return;
+    }
+    try {
+      if (existsSync(path) && statSync(path).size >= maxBytes) {
+        // Multiple hook processes (or several writes in one millisecond) must
+        // never select the same rotation target and overwrite an earlier file.
+        const rotated = path.replace(
+          /\.jsonl$/,
+          `-${Date.now()}-${process.pid}-${randomUUID()}.jsonl`
+        );
+        renameSync(path, rotated);
+      }
+    } finally {
+      // Non-recursive removal of the one fixed-name lock directory only.
+      try { rmdirSync(lock); } catch { /* best effort */ }
+    }
+  } catch {
+    // Diagnostics must never become the reason a lifecycle hook fails.
+  }
+}
+
+function pruneIfDue(now = new Date()) {
+  try {
+    const dir = hookLogDirectory();
+    const marker = join(dir, '.last-prune');
+    if (existsSync(marker) && now.getTime() - statSync(marker).mtimeMs < 60 * 60 * 1000)
+      return;
+    writeFileSync(marker, now.toISOString(), { flag: 'w' });
+
+    const retentionMs =
+      positiveInteger('TOKEN_OPTIMIZER_LOG_RETENTION_DAYS', DEFAULT_RETENTION_DAYS) *
+      24 * 60 * 60 * 1000;
+    const maxFiles = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_FILES', DEFAULT_MAX_FILES);
+    const files = readdirSync(dir)
+      .filter((name) => /^hook-events-.*\.jsonl$/.test(name))
+      .map((name) => {
+        const path = join(dir, name);
+        return { path, mtimeMs: statSync(path).mtimeMs };
+      })
+      .sort((a, b) => b.mtimeMs - a.mtimeMs);
+    for (let i = 0; i < files.length; i++) {
+      if (i >= maxFiles || now.getTime() - files[i].mtimeMs > retentionMs)
+        unlinkSync(files[i].path);
+    }
+  } catch {
+    // Retention is best effort and cannot affect the host tool call.
+  }
+}
+
+export function writeHookEvent(event) {
+  try {
+    const now = new Date();
+    const dir = hookLogDirectory();
+    mkdirSync(dir, { recursive: true });
+    const path = activeLogPath(now);
+    rotateIfNeeded(path);
+    const record = {
+      schemaVersion: HOOK_LOG_SCHEMA_VERSION,
+      timestamp: now.toISOString(),
+      service: 'token-optimizer',
+      serviceVersion:
+        process.env.TOKEN_OPTIMIZER_VERSION ||
+        process.env.npm_package_version ||
+        'unknown',
+      ...severity(event.level),
+      body: event.event || 'hook.event',
+      ...event,
+    };
+    record.resource = {
+      'service.name': record.service,
+      'service.version': record.serviceVersion,
+      'host.arch': process.arch,
+      'os.type': process.platform,
+      'process.runtime.name': 'node',
+      'process.runtime.version': process.version,
+    };
+    appendFileSync(path, `${JSON.stringify(record)}\n`, { encoding: 'utf8' });
+    pruneIfDue(now);
+    return path;
+  } catch {
+    return null;
+  }
+}
+
+export function beginHookInvocation(client, event, options = {}) {
+  const started = Date.now();
+  const invocationId = randomUUID();
+  let ended = false;
+  let outcome = 'success';
+  let reason = 'completed';
+  let error = null;
+  const dimensions = {
+    sessionIdHash: null,
+    turnIdHash: null,
+    toolUseIdHash: null,
+    toolName: null,
+    clientVersion: null,
+    model: null,
+    cwdHash: null,
+    payloadBytes: null,
+    outputBytes: 0,
+    outputShape: [],
+    inputStatus: 'pending',
+  };
+  const spanId = hash(invocationId, 16);
+  let traceId = hash(invocationId, 32);
+
+  let deadline;
+  const finish = (nextOutcome = outcome, nextReason = reason, nextError = error) => {
+    if (ended) return;
+    ended = true;
+    if (deadline) clearTimeout(deadline);
+    process.removeListener('exit', onExit);
+    writeHookEvent({
+      level: nextOutcome === 'failure' || nextOutcome === 'timeout' ? 'error' : 'info',
+      event: 'hook.completed',
+      outcome: nextOutcome,
+      reason: nextReason,
+      durationMs: Date.now() - started,
+      invocationId,
+      traceId,
+      spanId,
+      client,
+      hookEvent: event,
+      processId: process.pid,
+      ...dimensions,
+      error: errorFields(nextError),
+    });
+  };
+  const onExit = () => finish();
+  process.once('exit', onExit);
+
+  deadline = setTimeout(() => {
+    outcome = 'timeout';
+    reason = 'internal_deadline_exceeded';
+    finish(outcome, reason);
+    // Beat the host's five-second timeout and fail open deterministically.
+    process.exit(0);
+  }, options.deadlineMs ?? positiveInteger('TOKEN_OPTIMIZER_HOOK_DEADLINE_MS', DEFAULT_DEADLINE_MS));
+  deadline.unref();
+
+  const invocation = {
+    invocationId,
+    bind(raw = {}, payload = null, payloadBytes = null) {
+      const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? null;
+      dimensions.sessionIdHash = hash(sessionId);
+      dimensions.turnIdHash = hash(raw.turn_id ?? raw.turnId ?? null);
+      dimensions.toolUseIdHash = hash(raw.tool_use_id ?? raw.toolUseId ?? null);
+      dimensions.toolName = payload?.tool_name ?? raw.tool_name ?? raw.toolName ?? null;
+      dimensions.clientVersion = dimension(raw.client_version ?? raw.clientVersion ?? null);
+      dimensions.model = dimension(raw.model ?? raw.model_name ?? raw.modelName ?? null);
+      dimensions.cwdHash = hash(raw.cwd ?? raw.working_directory ?? process.cwd());
+      dimensions.payloadBytes = payloadBytes;
+      dimensions.inputStatus = 'ok';
+      if (sessionId) traceId = hash(sessionId, 32);
+    },
+    noteInput(status, payloadBytes = null) {
+      dimensions.inputStatus = status;
+      dimensions.payloadBytes = payloadBytes;
+      if (status === 'timeout') {
+        outcome = 'timeout';
+        reason = 'stdin_timeout';
+      } else if (status !== 'ok') {
+        outcome = 'skipped';
+        reason = status;
+      }
+    },
+    skip(nextReason) {
+      outcome = 'skipped';
+      reason = nextReason;
+    },
+    noteOutput(output, outputBytes = null) {
+      dimensions.outputBytes = outputBytes ?? Buffer.byteLength(JSON.stringify(output), 'utf8');
+      if (!output || typeof output !== 'object' || Array.isArray(output)) {
+        dimensions.outputShape = [];
+        return;
+      }
+      const shape = Object.keys(output).sort();
+      const hookSpecific = output.hookSpecificOutput;
+      if (hookSpecific && typeof hookSpecific === 'object' && !Array.isArray(hookSpecific)) {
+        for (const key of Object.keys(hookSpecific).sort()) shape.push(`hookSpecificOutput.${key}`);
+      }
+      dimensions.outputShape = shape;
+    },
+    fail(nextError, nextReason = 'unhandled_exception') {
+      outcome = 'failure';
+      reason = nextReason;
+      error = nextError;
+      finish(outcome, reason, error);
+    },
+    succeed(nextReason = 'completed') {
+      outcome = 'success';
+      reason = nextReason;
+      finish(outcome, reason);
+    },
+  };
+  activeInvocation = invocation;
+  return invocation;
+}
+
+/** Records response metadata without retaining response content. */
+export function noteHookOutput(output, outputBytes = null) {
+  activeInvocation?.noteOutput(output, outputBytes);
+}
+
+export function recordHookBootstrapFailure(client, event, error) {
+  writeHookEvent({
+    level: 'error',
+    event: 'hook.completed',
+    outcome: 'failure',
+    reason: 'bootstrap_import_failure',
+    durationMs: 0,
+    invocationId: randomUUID(),
+    client,
+    hookEvent: event,
+    processId: process.pid,
+    error: errorFields(error),
+  });
+}
+
+export function readHookEvents({ limit = 200, sinceMs = 24 * 60 * 60 * 1000 } = {}) {
+  try {
+    const dir = hookLogDirectory();
+    if (!existsSync(dir)) return [];
+    const cutoff = Date.now() - Math.max(0, sinceMs);
+    const files = readdirSync(dir)
+      .filter((name) => /^hook-events-.*\.jsonl$/.test(name))
+      .map((name) => join(dir, name))
+      .sort()
+      .reverse();
+    const events = [];
+    for (const file of files) {
+      const lines = readFileSync(file, 'utf8').split(/\r?\n/).filter(Boolean).reverse();
+      for (const line of lines) {
+        try {
+          const event = JSON.parse(line);
+          if (Date.parse(event.timestamp) < cutoff) continue;
+          events.push(event);
+          if (events.length >= limit) return events;
+        } catch {
+          // A partially written final line must not hide the rest of the log.
+        }
+      }
+    }
+    return events;
+  } catch {
+    return [];
+  }
+}
+
+export function hookHealthSummary(options = {}) {
+  const sinceMs = options.sinceMs ?? 24 * 60 * 60 * 1000;
+  const events = readHookEvents({ limit: options.limit || 5000, sinceMs });
+  const durations = events
+    .map((event) => Number(event.durationMs))
+    .filter(Number.isFinite)
+    .sort((a, b) => a - b);
+  const failures = events.filter((event) => event.outcome === 'failure');
+  const timeouts = events.filter((event) => event.outcome === 'timeout');
+  const skipped = events.filter((event) => event.outcome === 'skipped');
+  const successes = events.filter((event) => event.outcome === 'success');
+  const byClient = {};
+  for (const event of events) {
+    const key = event.client || 'unknown';
+    const current = byClient[key] || { total: 0, failures: 0, timeouts: 0, skipped: 0 };
+    current.total++;
+    if (event.outcome === 'failure') current.failures++;
+    if (event.outcome === 'timeout') current.timeouts++;
+    if (event.outcome === 'skipped') current.skipped++;
+    byClient[key] = current;
+  }
+  const percentile = (p) =>
+    durations.length
+      ? durations[Math.min(durations.length - 1, Math.floor(durations.length * p))]
+      : null;
+  const summary = {
+    schemaVersion: HOOK_LOG_SCHEMA_VERSION,
+    available: events.length > 0,
+    windowHours: sinceMs / 3_600_000,
+    total: events.length,
+    failures: failures.length,
+    timeouts: timeouts.length,
+    skipped: skipped.length,
+    successRate: events.length ? successes.length / events.length : null,
+    p50DurationMs: percentile(0.5),
+    p95DurationMs: percentile(0.95),
+    byClient,
+    recentFailures: [...failures, ...timeouts]
+      .sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp))
+      .slice(0, 20),
+  };
+  // Absolute paths are useful to a local doctor, but they do not belong in a
+  // diagnostics export that may be attached to a public issue.
+  if (options.includeLogDirectory === true)
+    summary.logDirectory = hookLogDirectory();
+  return summary;
+}

--- a/integrations/copilot/.github/hooks/lib/policy.mjs
+++ b/integrations/copilot/.github/hooks/lib/policy.mjs
@@ -48,6 +48,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { createHash } from 'node:crypto';
 import { isFsSafePath } from './paths.mjs';
+import { noteHookOutput } from './observability.mjs';
 
 /** Enforcement modes, least to most permissive. */
 export const MODE_ENFORCE = 'enforce';
@@ -653,14 +654,15 @@ export function allow() {
  */
 export function allowWithContext(context) {
   if (context) {
-    process.stdout.write(
-      JSON.stringify({
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-          additionalContext: withEscape(context),
-        },
-      })
-    );
+    const output = {
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        additionalContext: withEscape(context),
+      },
+    };
+    const serialized = JSON.stringify(output);
+    noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+    process.stdout.write(serialized);
   }
   process.exit(0);
 }
@@ -673,15 +675,16 @@ export function allowWithContext(context) {
  * says "use the optimized tool" gets met with a retry of the same call.
  */
 export function deny(reason) {
-  process.stdout.write(
-    JSON.stringify({
-      hookSpecificOutput: {
-        hookEventName: 'PreToolUse',
-        permissionDecision: 'deny',
-        permissionDecisionReason: withEscape(reason),
-      },
-    })
-  );
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+      permissionDecisionReason: withEscape(reason),
+    },
+  };
+  const serialized = JSON.stringify(output);
+  noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
   process.exit(0);
 }
 
@@ -706,14 +709,15 @@ export function withEscape(reason) {
 
 /** Lets the call through, attaching a note the model sees. */
 export function advise(context) {
-  process.stdout.write(
-    JSON.stringify({
-      hookSpecificOutput: {
-        hookEventName: 'PreToolUse',
-        additionalContext: context,
-      },
-    })
-  );
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      additionalContext: context,
+    },
+  };
+  const serialized = JSON.stringify(output);
+  noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
   process.exit(0);
 }
 
@@ -741,26 +745,34 @@ export function enforce(reason, deniedBefore) {
  * than an absent one, so the wait has a ceiling and expiring it is treated
  * exactly like unusable input.
  */
-export async function readPayload({
-  timeoutMs = 5000,
+export async function readPayloadResult({
+  timeoutMs = 1500,
   maxBytes = 8_000_000,
 } = {}) {
   const chunks = [];
   let size = 0;
+  let inputStatus = 'pending';
 
   const raw = await new Promise((resolve) => {
     const onData = (chunk) => {
-      size += chunk.length;
+      size += Buffer.byteLength(chunk, 'utf8');
       // A payload this large is not a tool call; refusing to buffer it
       // unboundedly keeps a hook from becoming a memory problem.
       if (size > maxBytes) {
+        inputStatus = 'too_large';
         finish(null);
         return;
       }
       chunks.push(chunk);
     };
-    const onEnd = () => finish(chunks.join(''));
-    const onError = () => finish(null);
+    const onEnd = () => {
+      inputStatus = 'received';
+      finish(chunks.join(''));
+    };
+    const onError = () => {
+      inputStatus = 'input_error';
+      finish(null);
+    };
 
     // Listeners are REMOVED on every exit path. Leaving them attached after the
     // timeout wins means a late chunk keeps growing a buffer nobody will read,
@@ -774,17 +786,21 @@ export async function readPayload({
       resolve(value);
     }
 
-    const timer = setTimeout(() => finish(null), timeoutMs);
+    const timer = setTimeout(() => {
+      inputStatus = 'timeout';
+      finish(null);
+    }, timeoutMs);
     process.stdin.setEncoding('utf8');
     process.stdin.on('data', onData);
     process.stdin.on('end', onEnd);
     process.stdin.on('error', onError);
   });
 
-  if (raw === null) return null;
+  if (raw === null) return { payload: null, status: inputStatus, bytes: size };
+  if (!raw.trim()) return { payload: null, status: 'empty_input', bytes: size };
   try {
-    return JSON.parse(raw);
+    return { payload: JSON.parse(raw), status: 'ok', bytes: size };
   } catch {
-    return null;
+    return { payload: null, status: 'invalid_json', bytes: size };
   }
 }

--- a/integrations/copilot/.github/hooks/lib/projects.mjs
+++ b/integrations/copilot/.github/hooks/lib/projects.mjs
@@ -1,0 +1,214 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/projects.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Machine-local index of project graph stores.
+ *
+ * A graph is deliberately stored with the project whose files it describes.
+ * That isolation is important for retrieval, but it also means a dashboard
+ * cannot honestly describe machine-wide capture unless it knows which stores
+ * exist. This registry is that missing directory. It is written by lifecycle
+ * hooks and can be backfilled by the explicit discovery command.
+ *
+ * The browser never receives `root` or `graphDir`. Routes resolve an opaque
+ * project id through this server-owned file, so restoring cross-project views
+ * does not restore the old arbitrary-path query vulnerability.
+ */
+
+import {
+  appendFileSync,
+  chmodSync,
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+} from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+import { createHash } from 'node:crypto';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
+
+export const PROJECT_REGISTRY_VERSION = 1;
+
+export function projectRegistryPath() {
+  return (
+    process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY ||
+    join(homedir(), '.token-optimizer', 'projects.jsonl')
+  );
+}
+
+export function projectIdFor(root) {
+  return `project-${createHash('sha256')
+    .update(canonicalPath(root))
+    .digest('hex')
+    .slice(0, 16)}`;
+}
+
+function displayName(root) {
+  return basename(root) || 'Unnamed project';
+}
+
+function acquire(path) {
+  const lockPath = `${path}.lock`;
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+  } catch {
+    return null;
+  }
+
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      closeSync(openSync(lockPath, 'wx', 0o600));
+      return lockPath;
+    } catch {
+      try {
+        if (Date.now() - statSync(lockPath).mtimeMs > 5000) unlinkSync(lockPath);
+      } catch {
+        // The holder may have released it between open and stat; retry.
+      }
+    }
+  }
+  return null;
+}
+
+function release(lockPath) {
+  if (!lockPath) return;
+  try {
+    unlinkSync(lockPath);
+  } catch {
+    // A killed process or cleanup race must not fail the hook.
+  }
+}
+
+/**
+ * Folds the append-only registry into one current entry per canonical project.
+ * Malformed, stale-schema, and unsafe records are ignored rather than trusted.
+ */
+export function registeredProjects() {
+  const path = projectRegistryPath();
+  const projects = new Map();
+  if (!existsSync(path)) return [];
+
+  try {
+    for (const line of readFileSync(path, 'utf8').split('\n')) {
+      if (!line) continue;
+      let record;
+      try {
+        record = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (
+        record.v !== PROJECT_REGISTRY_VERSION ||
+        !isFsSafePath(record.root) ||
+        !isFsSafePath(record.graphDir)
+      ) {
+        continue;
+      }
+      const root = canonicalPath(record.root);
+      const graphDir = canonicalPath(record.graphDir);
+      // Append-only history can outlive a deleted worktree (especially a
+      // short-lived test or CI checkout). A source that no longer exists
+      // cannot be captured, and presenting it as a current coverage gap makes
+      // the dashboard steadily less truthful over time.
+      if (!existsSync(root)) continue;
+      // A broad discovery root may contain hundreds of dormant worktrees. They
+      // are not capture coverage until a hook has observed them or a graph
+      // exists; listing all of them turns the selector into filesystem noise.
+      if (
+        record.client === 'discovery' &&
+        !existsSync(join(graphDir, 'graph.jsonl'))
+      ) {
+        continue;
+      }
+      const id = projectIdFor(root);
+      if (record.id !== id) continue;
+
+      const previous = projects.get(id);
+      projects.set(id, {
+        id,
+        name: String(record.name || displayName(root)).slice(0, 160),
+        root,
+        graphDir,
+        firstSeenAt: previous?.firstSeenAt || record.at || 0,
+        lastSeenAt: Math.max(previous?.lastSeenAt || 0, Number(record.at) || 0),
+        clients: [
+          ...new Set([
+            ...(previous?.clients || []),
+            ...(typeof record.client === 'string' && record.client
+              ? [record.client.slice(0, 80)]
+              : []),
+          ]),
+        ].sort(),
+      });
+    }
+  } catch {
+    return [];
+  }
+
+  return [...projects.values()].sort(
+    (a, b) => b.lastSeenAt - a.lastSeenAt || a.name.localeCompare(b.name)
+  );
+}
+
+/** Registers one VCS project without ever making a hook fail closed. */
+export function registerProject({ root, graphDir, client = 'unknown', name } = {}) {
+  if (!isFsSafePath(root) || !isFsSafePath(graphDir)) return null;
+  try {
+    const canonicalRoot = canonicalPath(root);
+    const canonicalGraphDir = canonicalPath(graphDir);
+    const isRepository = ['.git', '.hg', '.svn'].some((marker) =>
+      existsSync(join(canonicalRoot, marker))
+    );
+    if (!isRepository) return null;
+    const id = projectIdFor(canonicalRoot);
+    const now = Date.now();
+    const recent = registeredProjects().find(
+      (project) =>
+        project.id === id &&
+        project.graphDir === canonicalGraphDir &&
+        project.clients.includes(client) &&
+        now - project.lastSeenAt < 60 * 60 * 1000
+    );
+    if (recent) return recent;
+
+    const path = projectRegistryPath();
+    const lockPath = acquire(path);
+    if (!lockPath) return null;
+    try {
+      appendFileSync(
+        path,
+        `${JSON.stringify({
+          v: PROJECT_REGISTRY_VERSION,
+          id,
+          name: String(name || displayName(canonicalRoot)).slice(0, 160),
+          root: canonicalRoot,
+          graphDir: canonicalGraphDir,
+          client: String(client || 'unknown').slice(0, 80),
+          at: now,
+        })}\n`,
+        { mode: 0o600 }
+      );
+      try {
+        chmodSync(path, 0o600);
+      } catch {
+        // Windows and some filesystems do not expose POSIX modes.
+      }
+    } finally {
+      release(lockPath);
+    }
+    return {
+      id,
+      name: String(name || displayName(canonicalRoot)).slice(0, 160),
+      root: canonicalRoot,
+      graphDir: canonicalGraphDir,
+      firstSeenAt: now,
+      lastSeenAt: now,
+      clients: [String(client || 'unknown').slice(0, 80)],
+    };
+  } catch {
+    return null;
+  }
+}

--- a/integrations/copilot/.github/hooks/post-tool.mjs
+++ b/integrations/copilot/.github/hooks/post-tool.mjs
@@ -2,7 +2,17 @@
 // GENERATED FILE -- do not edit. Regenerate with `npm run sync:hooks`.
 // Client entry point: names the client and event; all policy lives in the
 // shared core so no client can drift its own thresholds or guidance.
-import { run } from './lib/adapter.mjs';
-
 // Fail open: a defect in the optimizer must never cost the user a tool call.
-run('copilot', 'post-tool').catch(() => process.exit(0));
+// Bootstrap failures are still recorded so fail-open does not become fail-silent.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+try {
+  const { run } = await import('./lib/adapter.mjs');
+  await run('copilot', 'post-tool');
+} catch (error) {
+  try {
+    const { recordHookBootstrapFailure } = await import('./lib/observability.mjs');
+    recordHookBootstrapFailure('copilot', 'post-tool', error);
+  } catch {
+    // A logger bootstrap failure is the only condition that remains silent.
+  }
+}

--- a/integrations/copilot/.github/hooks/pre-tool.mjs
+++ b/integrations/copilot/.github/hooks/pre-tool.mjs
@@ -2,7 +2,17 @@
 // GENERATED FILE -- do not edit. Regenerate with `npm run sync:hooks`.
 // Client entry point: names the client and event; all policy lives in the
 // shared core so no client can drift its own thresholds or guidance.
-import { run } from './lib/adapter.mjs';
-
 // Fail open: a defect in the optimizer must never cost the user a tool call.
-run('copilot', 'pre-tool').catch(() => process.exit(0));
+// Bootstrap failures are still recorded so fail-open does not become fail-silent.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+try {
+  const { run } = await import('./lib/adapter.mjs');
+  await run('copilot', 'pre-tool');
+} catch (error) {
+  try {
+    const { recordHookBootstrapFailure } = await import('./lib/observability.mjs');
+    recordHookBootstrapFailure('copilot', 'pre-tool', error);
+  } catch {
+    // A logger bootstrap failure is the only condition that remains silent.
+  }
+}

--- a/integrations/copilot/.github/hooks/session-start.mjs
+++ b/integrations/copilot/.github/hooks/session-start.mjs
@@ -2,7 +2,17 @@
 // GENERATED FILE -- do not edit. Regenerate with `npm run sync:hooks`.
 // Client entry point: names the client and event; all policy lives in the
 // shared core so no client can drift its own thresholds or guidance.
-import { run } from './lib/adapter.mjs';
-
 // Fail open: a defect in the optimizer must never cost the user a tool call.
-run('copilot', 'session-start').catch(() => process.exit(0));
+// Bootstrap failures are still recorded so fail-open does not become fail-silent.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+try {
+  const { run } = await import('./lib/adapter.mjs');
+  await run('copilot', 'session-start');
+} catch (error) {
+  try {
+    const { recordHookBootstrapFailure } = await import('./lib/observability.mjs');
+    recordHookBootstrapFailure('copilot', 'session-start', error);
+  } catch {
+    // A logger bootstrap failure is the only condition that remains silent.
+  }
+}

--- a/integrations/copilot/.github/hooks/stop.mjs
+++ b/integrations/copilot/.github/hooks/stop.mjs
@@ -2,7 +2,17 @@
 // GENERATED FILE -- do not edit. Regenerate with `npm run sync:hooks`.
 // Client entry point: names the client and event; all policy lives in the
 // shared core so no client can drift its own thresholds or guidance.
-import { run } from './lib/adapter.mjs';
-
 // Fail open: a defect in the optimizer must never cost the user a tool call.
-run('copilot', 'stop').catch(() => process.exit(0));
+// Bootstrap failures are still recorded so fail-open does not become fail-silent.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+try {
+  const { run } = await import('./lib/adapter.mjs');
+  await run('copilot', 'stop');
+} catch (error) {
+  try {
+    const { recordHookBootstrapFailure } = await import('./lib/observability.mjs');
+    recordHookBootstrapFailure('copilot', 'stop', error);
+  } catch {
+    // A logger bootstrap failure is the only condition that remains silent.
+  }
+}

--- a/integrations/cursor/hooks/lib/adapter.mjs
+++ b/integrations/cursor/hooks/lib/adapter.mjs
@@ -27,6 +27,7 @@ import {
   MODE_OFF,
   MODE_ADVISE,
   largeFileBytes,
+  readPayloadResult,
   withEscape,
 } from './policy.mjs';
 import {
@@ -83,6 +84,8 @@ import {
 } from './capabilities.mjs';
 import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 import { evaluateUcrGuards } from './ucr-guard.mjs';
+import { beginHookInvocation, noteHookOutput } from './observability.mjs';
+import { registerProject } from './projects.mjs';
 
 /**
  * Per-client capability.
@@ -128,7 +131,14 @@ export function mutationSucceeded(clientName, raw) {
 
   // These lifecycle contracts fire this event only after a successful tool,
   // or are called by our in-process bridge only from its successful after hook.
-  return new Set(['claude-code', 'qwen', 'opencode', 'kilo', 'windsurf']).has(
+  return new Set([
+    'claude-code',
+    'codex',
+    'qwen',
+    'opencode',
+    'kilo',
+    'windsurf',
+  ]).has(
     clientName
   );
 }
@@ -241,37 +251,9 @@ export function sessionTaskContext(raw = {}) {
 }
 
 function emit(object) {
-  process.stdout.write(JSON.stringify(object));
-}
-
-/**
- * Bounded stdin read. See policy.readPayload for why the ceiling matters: the
- * entry points fail open on a THROW, but a host that opens the pipe and never
- * closes it produces no throw -- just a hook that waits forever with the user's
- * tool call stuck behind it.
- */
-async function readStdin({ timeoutMs = 5000 } = {}) {
-  const raw = await new Promise((resolve) => {
-    const chunks = [];
-    const timer = setTimeout(() => resolve(null), timeoutMs);
-    process.stdin.setEncoding('utf8');
-    process.stdin.on('data', (chunk) => chunks.push(chunk));
-    process.stdin.on('end', () => {
-      clearTimeout(timer);
-      resolve(chunks.join(''));
-    });
-    process.stdin.on('error', () => {
-      clearTimeout(timer);
-      resolve(null);
-    });
-  });
-
-  if (raw === null) return null;
-  try {
-    return JSON.parse(raw);
-  } catch {
-    return null;
-  }
+  const serialized = JSON.stringify(object);
+  noteHookOutput(object, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
 }
 
 /** The session-start notice, shared verbatim so no client drifts its own copy. */
@@ -502,6 +484,17 @@ function observeAndInject(payload, state, episode, features) {
  * @param {'session-start'|'pre-tool'|'post-tool'|'stop'} event
  */
 export async function run(clientName, event) {
+  const invocation = beginHookInvocation(clientName, event);
+  try {
+    await runHook(clientName, event, invocation);
+    invocation.succeed();
+  } catch (error) {
+    // The optimizer must fail open, but the failure is now reconstructable.
+    invocation.fail(error);
+  }
+}
+
+async function runHook(clientName, event, invocation) {
   const client = CLIENTS[clientName] || CLIENTS['claude-code'];
   const eventName =
     event === 'session-start'
@@ -529,7 +522,10 @@ export async function run(clientName, event) {
     // full pre-tool timeout would turn optional context into a five-second
     // startup tax; lifecycle payloads are tiny and arrive immediately when
     // the host supplies one.
-    const raw = (await readStdin({ timeoutMs: 250 })) || {};
+    const input = await readPayloadResult({ timeoutMs: 250 });
+    const raw = input.payload || {};
+    invocation.bind(raw, null, input.bytes);
+    if (input.status !== 'ok') invocation.noteInput(input.status, input.bytes);
     const toolEvidence = optimizerToolEvidence(raw);
     const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id;
     if (sessionId && toolEvidence.proven) {
@@ -540,10 +536,12 @@ export async function run(clientName, event) {
     const parts = [
       policyText(client.canDeny, toolEvidence.names, toolEvidence.proven),
     ];
+    const cwd = raw.cwd || raw.working_directory || process.cwd();
+    const root = projectRootFor(join(cwd, '__session__'), cwd);
+    registerProject({ root, graphDir: wikiDir(root), client: clientName });
     if (features.retrieval) {
       try {
-        const cwd = raw.cwd || raw.working_directory || process.cwd();
-        const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+        const dir = wikiDir(root);
         // SessionStart needs hashes and claims, not stored file bodies. Parsing
         // the snapshot sidecar here would make startup scale with repository
         // history even though this compact index never renders a diff.
@@ -569,14 +567,20 @@ export async function run(clientName, event) {
     process.exit(0);
   }
 
-  const raw = await readStdin();
+  const input = await readPayloadResult();
+  const raw = input.payload;
   if (!raw) {
+    invocation.noteInput(input.status, input.bytes);
     // Stop requires JSON on stdout even when it has nothing to add.
     if (event === 'stop') emit({});
     process.exit(0);
   }
 
   if (event === 'stop') {
+    // Stop has no normalized tool payload, but it is still a fully formed hook
+    // invocation. Bind its lifecycle identifiers so successful completions do
+    // not look like an input reader that never ran in cross-client telemetry.
+    invocation.bind(raw, null, input.bytes);
     const sessionId =
       raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? 'default';
     const agentScope = raw.transcript_path ?? raw.transcriptPath ?? null;
@@ -632,6 +636,7 @@ export async function run(clientName, event) {
   const payload = normalizePayload(
     normalizeClientPayload(clientName, event, raw)
   );
+  invocation.bind(raw, payload, input.bytes);
   if (!payload.tool_name) process.exit(0);
   const episode = episodeMeta({ client: clientName, raw, payload });
 

--- a/integrations/cursor/hooks/lib/metrics.mjs
+++ b/integrations/cursor/hooks/lib/metrics.mjs
@@ -1297,8 +1297,8 @@ function concurrencySummary(runs) {
  * live hook traces, and randomized model evals remain visibly distinct: only
  * `eval-run` records with paired arms can produce a causal effect interval.
  */
-export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
-  const evidence = readEvidence(dir).filter((event) => matchesFilters(event, filters));
+function buildEvidenceReport(evidence, { filters = {}, episodeLimit = 100 } = {}) {
+  evidence = evidence.filter((event) => matchesFilters(event, filters));
   const runs = evidence.filter((event) => event.kind === 'eval-run');
   const handoffRuns = evidence.filter((event) => event.kind === 'handoff-run');
   const concurrencyRuns = evidence.filter((event) => event.kind === 'concurrency-run');
@@ -1402,6 +1402,47 @@ export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
       minimumPairs,
       handoffMinimumPairs: handoffMinimumPairs(),
       deterministicChecksAreCausalProof: false,
+    },
+  };
+}
+
+export function evidenceReport(dir, options = {}) {
+  const events = readEvidence(dir);
+  const report = buildEvidenceReport(events, options);
+  const hasMatchingEvidence = events.some((event) =>
+    matchesFilters(event, options.filters || {})
+  );
+  return {
+    ...report,
+    sourceCoverage: {
+      projects: 1,
+      projectsWithEvidence: hasMatchingEvidence ? 1 : 0,
+      projectsWithoutEvidence: hasMatchingEvidence ? 0 : 1,
+    },
+  };
+}
+
+/**
+ * Pools evidence across registered projects before computing cohorts.
+ *
+ * A cohort split across two worktrees is still one experiment. Summing already
+ * aggregated reports would lose pairing and produce invalid confidence
+ * intervals, so this combines the append-only source events first and runs the
+ * estimator exactly once.
+ */
+export function evidenceReportMany(dirs, options = {}) {
+  const unique = [...new Set((dirs || []).map((dir) => String(dir)))];
+  const sources = unique.map((dir) => readEvidence(dir));
+  const report = buildEvidenceReport(sources.flat(), options);
+  const projectsWithEvidence = sources.filter((events) =>
+    events.some((event) => matchesFilters(event, options.filters || {}))
+  ).length;
+  return {
+    ...report,
+    sourceCoverage: {
+      projects: unique.length,
+      projectsWithEvidence,
+      projectsWithoutEvidence: unique.length - projectsWithEvidence,
     },
   };
 }

--- a/integrations/cursor/hooks/lib/metrics.mjs
+++ b/integrations/cursor/hooks/lib/metrics.mjs
@@ -738,10 +738,7 @@ function canonicalKeyish(p) {
  * arms, multiplied by treated touches. Reporting it as a measured fact would be
  * the same overclaiming this project criticises competitors for.
  */
-export function report(dir) {
-  const events = readAll(dir);
-  // Injections and harvests come from the log that cannot be starved.
-  const balance = readBalance(dir);
+function buildReport(events, balance) {
 
   // COMMAND INJECTIONS ARE COUNTED SEPARATELY, not mixed into the balance.
   //
@@ -843,6 +840,15 @@ export function report(dir) {
   const sufficient = treated.length >= 20 && withheld.length >= 5;
 
   return {
+    memoryDeliveries: allInjections.filter((event) => !event.holdout).length,
+    memoryHoldouts: allInjections.filter((event) => event.holdout).length,
+    deliveryTokens: allInjections
+      .filter((event) => !event.holdout)
+      .reduce(
+        (sum, event) =>
+          sum + (event.deliveredTokens ?? event.tokens ?? 0),
+        0
+      ),
     injections: treated.length,
     sessionStartInjections: sessionStartInjections.length,
     sessionStartInjectedTokens: sessionStartInjections.reduce(
@@ -864,6 +870,27 @@ export function report(dir) {
         ? 'the graph is saving more than it costs'
         : 'the graph is NOT yet paying for itself',
   };
+}
+
+export function report(dir) {
+  return buildReport(readAll(dir), readBalance(dir));
+}
+
+/**
+ * One statistically valid machine/project-group report.
+ *
+ * Summing per-project verdicts is wrong: five projects with four treated reads
+ * each do not individually meet the threshold, but together they are twenty
+ * observations. Pooling the underlying events preserves the randomized arms
+ * and computes the means once over the selected population.
+ */
+export function reportMany(dirs) {
+  const unique = [...new Set((dirs || []).map((dir) => String(dir)))];
+  const report = buildReport(
+    unique.flatMap((dir) => readAll(dir)),
+    unique.flatMap((dir) => readBalance(dir))
+  );
+  return { ...report, projects: unique.length };
 }
 
 /**

--- a/integrations/cursor/hooks/lib/observability.mjs
+++ b/integrations/cursor/hooks/lib/observability.mjs
@@ -1,0 +1,400 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+/**
+ * Privacy-safe, cross-client lifecycle diagnostics.
+ *
+ * Hook processes are intentionally fail-open, but fail-open must not mean
+ * fail-silent. Every client writes the same bounded JSONL schema so failures
+ * can be correlated without storing prompts, commands, tool output, or file
+ * contents.
+ */
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmdirSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { createHash, randomUUID } from 'node:crypto';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export const HOOK_LOG_SCHEMA_VERSION = 1;
+const DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
+const DEFAULT_RETENTION_DAYS = 14;
+const DEFAULT_MAX_FILES = 40;
+const DEFAULT_DEADLINE_MS = 4200;
+const MAX_ERROR_CHARS = 4000;
+const MAX_DIMENSION_CHARS = 160;
+let activeInvocation = null;
+
+function positiveInteger(name, fallback) {
+  const value = Number(process.env[name]);
+  return Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+export function hookLogDirectory() {
+  if (process.env.TOKEN_OPTIMIZER_LOG_DIR)
+    return process.env.TOKEN_OPTIMIZER_LOG_DIR;
+  const stateRoot =
+    process.env.TOKEN_OPTIMIZER_STATE_DIR ||
+    join(homedir(), '.token-optimizer');
+  return join(stateRoot, 'logs');
+}
+
+function hash(value, length = 16) {
+  if (!value) return null;
+  return createHash('sha256').update(String(value)).digest('hex').slice(0, length);
+}
+
+function sanitize(text) {
+  if (text === undefined || text === null) return null;
+  let value = String(text);
+  const home = homedir().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  if (home) value = value.replace(new RegExp(home, 'gi'), '<home>');
+  value = value
+    .replace(/\b(?:sk-[A-Za-z0-9_-]{12,}|gh[opusr]_[A-Za-z0-9]{12,})\b/g, '[REDACTED]')
+    .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi, '$1[REDACTED]')
+    .replace(/\b(password|secret|token|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi, '$1=[REDACTED]');
+  return value.slice(0, MAX_ERROR_CHARS);
+}
+
+function errorFields(error) {
+  if (!error) return null;
+  return {
+    type: sanitize(error.name || error.constructor?.name || 'Error'),
+    message: sanitize(error.message || error),
+    stack: sanitize(error.stack),
+  };
+}
+
+function dimension(value) {
+  const sanitized = sanitize(value);
+  return sanitized === null ? null : sanitized.slice(0, MAX_DIMENSION_CHARS);
+}
+
+function severity(level) {
+  if (level === 'error') return { severityText: 'ERROR', severityNumber: 17 };
+  if (level === 'warn') return { severityText: 'WARN', severityNumber: 13 };
+  return { severityText: 'INFO', severityNumber: 9 };
+}
+
+function activeLogPath(now = new Date()) {
+  const date = now.toISOString().slice(0, 10);
+  return join(hookLogDirectory(), `hook-events-${date}.jsonl`);
+}
+
+function rotateIfNeeded(path) {
+  try {
+    if (!existsSync(path)) return;
+    const maxBytes = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_BYTES', DEFAULT_MAX_BYTES);
+    if (statSync(path).size < maxBytes) return;
+
+    const lock = join(hookLogDirectory(), '.rotate.lock');
+    try {
+      mkdirSync(lock);
+    } catch {
+      return;
+    }
+    try {
+      if (existsSync(path) && statSync(path).size >= maxBytes) {
+        // Multiple hook processes (or several writes in one millisecond) must
+        // never select the same rotation target and overwrite an earlier file.
+        const rotated = path.replace(
+          /\.jsonl$/,
+          `-${Date.now()}-${process.pid}-${randomUUID()}.jsonl`
+        );
+        renameSync(path, rotated);
+      }
+    } finally {
+      // Non-recursive removal of the one fixed-name lock directory only.
+      try { rmdirSync(lock); } catch { /* best effort */ }
+    }
+  } catch {
+    // Diagnostics must never become the reason a lifecycle hook fails.
+  }
+}
+
+function pruneIfDue(now = new Date()) {
+  try {
+    const dir = hookLogDirectory();
+    const marker = join(dir, '.last-prune');
+    if (existsSync(marker) && now.getTime() - statSync(marker).mtimeMs < 60 * 60 * 1000)
+      return;
+    writeFileSync(marker, now.toISOString(), { flag: 'w' });
+
+    const retentionMs =
+      positiveInteger('TOKEN_OPTIMIZER_LOG_RETENTION_DAYS', DEFAULT_RETENTION_DAYS) *
+      24 * 60 * 60 * 1000;
+    const maxFiles = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_FILES', DEFAULT_MAX_FILES);
+    const files = readdirSync(dir)
+      .filter((name) => /^hook-events-.*\.jsonl$/.test(name))
+      .map((name) => {
+        const path = join(dir, name);
+        return { path, mtimeMs: statSync(path).mtimeMs };
+      })
+      .sort((a, b) => b.mtimeMs - a.mtimeMs);
+    for (let i = 0; i < files.length; i++) {
+      if (i >= maxFiles || now.getTime() - files[i].mtimeMs > retentionMs)
+        unlinkSync(files[i].path);
+    }
+  } catch {
+    // Retention is best effort and cannot affect the host tool call.
+  }
+}
+
+export function writeHookEvent(event) {
+  try {
+    const now = new Date();
+    const dir = hookLogDirectory();
+    mkdirSync(dir, { recursive: true });
+    const path = activeLogPath(now);
+    rotateIfNeeded(path);
+    const record = {
+      schemaVersion: HOOK_LOG_SCHEMA_VERSION,
+      timestamp: now.toISOString(),
+      service: 'token-optimizer',
+      serviceVersion:
+        process.env.TOKEN_OPTIMIZER_VERSION ||
+        process.env.npm_package_version ||
+        'unknown',
+      ...severity(event.level),
+      body: event.event || 'hook.event',
+      ...event,
+    };
+    record.resource = {
+      'service.name': record.service,
+      'service.version': record.serviceVersion,
+      'host.arch': process.arch,
+      'os.type': process.platform,
+      'process.runtime.name': 'node',
+      'process.runtime.version': process.version,
+    };
+    appendFileSync(path, `${JSON.stringify(record)}\n`, { encoding: 'utf8' });
+    pruneIfDue(now);
+    return path;
+  } catch {
+    return null;
+  }
+}
+
+export function beginHookInvocation(client, event, options = {}) {
+  const started = Date.now();
+  const invocationId = randomUUID();
+  let ended = false;
+  let outcome = 'success';
+  let reason = 'completed';
+  let error = null;
+  const dimensions = {
+    sessionIdHash: null,
+    turnIdHash: null,
+    toolUseIdHash: null,
+    toolName: null,
+    clientVersion: null,
+    model: null,
+    cwdHash: null,
+    payloadBytes: null,
+    outputBytes: 0,
+    outputShape: [],
+    inputStatus: 'pending',
+  };
+  const spanId = hash(invocationId, 16);
+  let traceId = hash(invocationId, 32);
+
+  let deadline;
+  const finish = (nextOutcome = outcome, nextReason = reason, nextError = error) => {
+    if (ended) return;
+    ended = true;
+    if (deadline) clearTimeout(deadline);
+    process.removeListener('exit', onExit);
+    writeHookEvent({
+      level: nextOutcome === 'failure' || nextOutcome === 'timeout' ? 'error' : 'info',
+      event: 'hook.completed',
+      outcome: nextOutcome,
+      reason: nextReason,
+      durationMs: Date.now() - started,
+      invocationId,
+      traceId,
+      spanId,
+      client,
+      hookEvent: event,
+      processId: process.pid,
+      ...dimensions,
+      error: errorFields(nextError),
+    });
+  };
+  const onExit = () => finish();
+  process.once('exit', onExit);
+
+  deadline = setTimeout(() => {
+    outcome = 'timeout';
+    reason = 'internal_deadline_exceeded';
+    finish(outcome, reason);
+    // Beat the host's five-second timeout and fail open deterministically.
+    process.exit(0);
+  }, options.deadlineMs ?? positiveInteger('TOKEN_OPTIMIZER_HOOK_DEADLINE_MS', DEFAULT_DEADLINE_MS));
+  deadline.unref();
+
+  const invocation = {
+    invocationId,
+    bind(raw = {}, payload = null, payloadBytes = null) {
+      const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? null;
+      dimensions.sessionIdHash = hash(sessionId);
+      dimensions.turnIdHash = hash(raw.turn_id ?? raw.turnId ?? null);
+      dimensions.toolUseIdHash = hash(raw.tool_use_id ?? raw.toolUseId ?? null);
+      dimensions.toolName = payload?.tool_name ?? raw.tool_name ?? raw.toolName ?? null;
+      dimensions.clientVersion = dimension(raw.client_version ?? raw.clientVersion ?? null);
+      dimensions.model = dimension(raw.model ?? raw.model_name ?? raw.modelName ?? null);
+      dimensions.cwdHash = hash(raw.cwd ?? raw.working_directory ?? process.cwd());
+      dimensions.payloadBytes = payloadBytes;
+      dimensions.inputStatus = 'ok';
+      if (sessionId) traceId = hash(sessionId, 32);
+    },
+    noteInput(status, payloadBytes = null) {
+      dimensions.inputStatus = status;
+      dimensions.payloadBytes = payloadBytes;
+      if (status === 'timeout') {
+        outcome = 'timeout';
+        reason = 'stdin_timeout';
+      } else if (status !== 'ok') {
+        outcome = 'skipped';
+        reason = status;
+      }
+    },
+    skip(nextReason) {
+      outcome = 'skipped';
+      reason = nextReason;
+    },
+    noteOutput(output, outputBytes = null) {
+      dimensions.outputBytes = outputBytes ?? Buffer.byteLength(JSON.stringify(output), 'utf8');
+      if (!output || typeof output !== 'object' || Array.isArray(output)) {
+        dimensions.outputShape = [];
+        return;
+      }
+      const shape = Object.keys(output).sort();
+      const hookSpecific = output.hookSpecificOutput;
+      if (hookSpecific && typeof hookSpecific === 'object' && !Array.isArray(hookSpecific)) {
+        for (const key of Object.keys(hookSpecific).sort()) shape.push(`hookSpecificOutput.${key}`);
+      }
+      dimensions.outputShape = shape;
+    },
+    fail(nextError, nextReason = 'unhandled_exception') {
+      outcome = 'failure';
+      reason = nextReason;
+      error = nextError;
+      finish(outcome, reason, error);
+    },
+    succeed(nextReason = 'completed') {
+      outcome = 'success';
+      reason = nextReason;
+      finish(outcome, reason);
+    },
+  };
+  activeInvocation = invocation;
+  return invocation;
+}
+
+/** Records response metadata without retaining response content. */
+export function noteHookOutput(output, outputBytes = null) {
+  activeInvocation?.noteOutput(output, outputBytes);
+}
+
+export function recordHookBootstrapFailure(client, event, error) {
+  writeHookEvent({
+    level: 'error',
+    event: 'hook.completed',
+    outcome: 'failure',
+    reason: 'bootstrap_import_failure',
+    durationMs: 0,
+    invocationId: randomUUID(),
+    client,
+    hookEvent: event,
+    processId: process.pid,
+    error: errorFields(error),
+  });
+}
+
+export function readHookEvents({ limit = 200, sinceMs = 24 * 60 * 60 * 1000 } = {}) {
+  try {
+    const dir = hookLogDirectory();
+    if (!existsSync(dir)) return [];
+    const cutoff = Date.now() - Math.max(0, sinceMs);
+    const files = readdirSync(dir)
+      .filter((name) => /^hook-events-.*\.jsonl$/.test(name))
+      .map((name) => join(dir, name))
+      .sort()
+      .reverse();
+    const events = [];
+    for (const file of files) {
+      const lines = readFileSync(file, 'utf8').split(/\r?\n/).filter(Boolean).reverse();
+      for (const line of lines) {
+        try {
+          const event = JSON.parse(line);
+          if (Date.parse(event.timestamp) < cutoff) continue;
+          events.push(event);
+          if (events.length >= limit) return events;
+        } catch {
+          // A partially written final line must not hide the rest of the log.
+        }
+      }
+    }
+    return events;
+  } catch {
+    return [];
+  }
+}
+
+export function hookHealthSummary(options = {}) {
+  const sinceMs = options.sinceMs ?? 24 * 60 * 60 * 1000;
+  const events = readHookEvents({ limit: options.limit || 5000, sinceMs });
+  const durations = events
+    .map((event) => Number(event.durationMs))
+    .filter(Number.isFinite)
+    .sort((a, b) => a - b);
+  const failures = events.filter((event) => event.outcome === 'failure');
+  const timeouts = events.filter((event) => event.outcome === 'timeout');
+  const skipped = events.filter((event) => event.outcome === 'skipped');
+  const successes = events.filter((event) => event.outcome === 'success');
+  const byClient = {};
+  for (const event of events) {
+    const key = event.client || 'unknown';
+    const current = byClient[key] || { total: 0, failures: 0, timeouts: 0, skipped: 0 };
+    current.total++;
+    if (event.outcome === 'failure') current.failures++;
+    if (event.outcome === 'timeout') current.timeouts++;
+    if (event.outcome === 'skipped') current.skipped++;
+    byClient[key] = current;
+  }
+  const percentile = (p) =>
+    durations.length
+      ? durations[Math.min(durations.length - 1, Math.floor(durations.length * p))]
+      : null;
+  const summary = {
+    schemaVersion: HOOK_LOG_SCHEMA_VERSION,
+    available: events.length > 0,
+    windowHours: sinceMs / 3_600_000,
+    total: events.length,
+    failures: failures.length,
+    timeouts: timeouts.length,
+    skipped: skipped.length,
+    successRate: events.length ? successes.length / events.length : null,
+    p50DurationMs: percentile(0.5),
+    p95DurationMs: percentile(0.95),
+    byClient,
+    recentFailures: [...failures, ...timeouts]
+      .sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp))
+      .slice(0, 20),
+  };
+  // Absolute paths are useful to a local doctor, but they do not belong in a
+  // diagnostics export that may be attached to a public issue.
+  if (options.includeLogDirectory === true)
+    summary.logDirectory = hookLogDirectory();
+  return summary;
+}

--- a/integrations/cursor/hooks/lib/policy.mjs
+++ b/integrations/cursor/hooks/lib/policy.mjs
@@ -48,6 +48,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { createHash } from 'node:crypto';
 import { isFsSafePath } from './paths.mjs';
+import { noteHookOutput } from './observability.mjs';
 
 /** Enforcement modes, least to most permissive. */
 export const MODE_ENFORCE = 'enforce';
@@ -653,14 +654,15 @@ export function allow() {
  */
 export function allowWithContext(context) {
   if (context) {
-    process.stdout.write(
-      JSON.stringify({
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-          additionalContext: withEscape(context),
-        },
-      })
-    );
+    const output = {
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        additionalContext: withEscape(context),
+      },
+    };
+    const serialized = JSON.stringify(output);
+    noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+    process.stdout.write(serialized);
   }
   process.exit(0);
 }
@@ -673,15 +675,16 @@ export function allowWithContext(context) {
  * says "use the optimized tool" gets met with a retry of the same call.
  */
 export function deny(reason) {
-  process.stdout.write(
-    JSON.stringify({
-      hookSpecificOutput: {
-        hookEventName: 'PreToolUse',
-        permissionDecision: 'deny',
-        permissionDecisionReason: withEscape(reason),
-      },
-    })
-  );
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+      permissionDecisionReason: withEscape(reason),
+    },
+  };
+  const serialized = JSON.stringify(output);
+  noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
   process.exit(0);
 }
 
@@ -706,14 +709,15 @@ export function withEscape(reason) {
 
 /** Lets the call through, attaching a note the model sees. */
 export function advise(context) {
-  process.stdout.write(
-    JSON.stringify({
-      hookSpecificOutput: {
-        hookEventName: 'PreToolUse',
-        additionalContext: context,
-      },
-    })
-  );
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      additionalContext: context,
+    },
+  };
+  const serialized = JSON.stringify(output);
+  noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
   process.exit(0);
 }
 
@@ -741,26 +745,34 @@ export function enforce(reason, deniedBefore) {
  * than an absent one, so the wait has a ceiling and expiring it is treated
  * exactly like unusable input.
  */
-export async function readPayload({
-  timeoutMs = 5000,
+export async function readPayloadResult({
+  timeoutMs = 1500,
   maxBytes = 8_000_000,
 } = {}) {
   const chunks = [];
   let size = 0;
+  let inputStatus = 'pending';
 
   const raw = await new Promise((resolve) => {
     const onData = (chunk) => {
-      size += chunk.length;
+      size += Buffer.byteLength(chunk, 'utf8');
       // A payload this large is not a tool call; refusing to buffer it
       // unboundedly keeps a hook from becoming a memory problem.
       if (size > maxBytes) {
+        inputStatus = 'too_large';
         finish(null);
         return;
       }
       chunks.push(chunk);
     };
-    const onEnd = () => finish(chunks.join(''));
-    const onError = () => finish(null);
+    const onEnd = () => {
+      inputStatus = 'received';
+      finish(chunks.join(''));
+    };
+    const onError = () => {
+      inputStatus = 'input_error';
+      finish(null);
+    };
 
     // Listeners are REMOVED on every exit path. Leaving them attached after the
     // timeout wins means a late chunk keeps growing a buffer nobody will read,
@@ -774,17 +786,21 @@ export async function readPayload({
       resolve(value);
     }
 
-    const timer = setTimeout(() => finish(null), timeoutMs);
+    const timer = setTimeout(() => {
+      inputStatus = 'timeout';
+      finish(null);
+    }, timeoutMs);
     process.stdin.setEncoding('utf8');
     process.stdin.on('data', onData);
     process.stdin.on('end', onEnd);
     process.stdin.on('error', onError);
   });
 
-  if (raw === null) return null;
+  if (raw === null) return { payload: null, status: inputStatus, bytes: size };
+  if (!raw.trim()) return { payload: null, status: 'empty_input', bytes: size };
   try {
-    return JSON.parse(raw);
+    return { payload: JSON.parse(raw), status: 'ok', bytes: size };
   } catch {
-    return null;
+    return { payload: null, status: 'invalid_json', bytes: size };
   }
 }

--- a/integrations/cursor/hooks/lib/projects.mjs
+++ b/integrations/cursor/hooks/lib/projects.mjs
@@ -1,0 +1,214 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/projects.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Machine-local index of project graph stores.
+ *
+ * A graph is deliberately stored with the project whose files it describes.
+ * That isolation is important for retrieval, but it also means a dashboard
+ * cannot honestly describe machine-wide capture unless it knows which stores
+ * exist. This registry is that missing directory. It is written by lifecycle
+ * hooks and can be backfilled by the explicit discovery command.
+ *
+ * The browser never receives `root` or `graphDir`. Routes resolve an opaque
+ * project id through this server-owned file, so restoring cross-project views
+ * does not restore the old arbitrary-path query vulnerability.
+ */
+
+import {
+  appendFileSync,
+  chmodSync,
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+} from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+import { createHash } from 'node:crypto';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
+
+export const PROJECT_REGISTRY_VERSION = 1;
+
+export function projectRegistryPath() {
+  return (
+    process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY ||
+    join(homedir(), '.token-optimizer', 'projects.jsonl')
+  );
+}
+
+export function projectIdFor(root) {
+  return `project-${createHash('sha256')
+    .update(canonicalPath(root))
+    .digest('hex')
+    .slice(0, 16)}`;
+}
+
+function displayName(root) {
+  return basename(root) || 'Unnamed project';
+}
+
+function acquire(path) {
+  const lockPath = `${path}.lock`;
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+  } catch {
+    return null;
+  }
+
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      closeSync(openSync(lockPath, 'wx', 0o600));
+      return lockPath;
+    } catch {
+      try {
+        if (Date.now() - statSync(lockPath).mtimeMs > 5000) unlinkSync(lockPath);
+      } catch {
+        // The holder may have released it between open and stat; retry.
+      }
+    }
+  }
+  return null;
+}
+
+function release(lockPath) {
+  if (!lockPath) return;
+  try {
+    unlinkSync(lockPath);
+  } catch {
+    // A killed process or cleanup race must not fail the hook.
+  }
+}
+
+/**
+ * Folds the append-only registry into one current entry per canonical project.
+ * Malformed, stale-schema, and unsafe records are ignored rather than trusted.
+ */
+export function registeredProjects() {
+  const path = projectRegistryPath();
+  const projects = new Map();
+  if (!existsSync(path)) return [];
+
+  try {
+    for (const line of readFileSync(path, 'utf8').split('\n')) {
+      if (!line) continue;
+      let record;
+      try {
+        record = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (
+        record.v !== PROJECT_REGISTRY_VERSION ||
+        !isFsSafePath(record.root) ||
+        !isFsSafePath(record.graphDir)
+      ) {
+        continue;
+      }
+      const root = canonicalPath(record.root);
+      const graphDir = canonicalPath(record.graphDir);
+      // Append-only history can outlive a deleted worktree (especially a
+      // short-lived test or CI checkout). A source that no longer exists
+      // cannot be captured, and presenting it as a current coverage gap makes
+      // the dashboard steadily less truthful over time.
+      if (!existsSync(root)) continue;
+      // A broad discovery root may contain hundreds of dormant worktrees. They
+      // are not capture coverage until a hook has observed them or a graph
+      // exists; listing all of them turns the selector into filesystem noise.
+      if (
+        record.client === 'discovery' &&
+        !existsSync(join(graphDir, 'graph.jsonl'))
+      ) {
+        continue;
+      }
+      const id = projectIdFor(root);
+      if (record.id !== id) continue;
+
+      const previous = projects.get(id);
+      projects.set(id, {
+        id,
+        name: String(record.name || displayName(root)).slice(0, 160),
+        root,
+        graphDir,
+        firstSeenAt: previous?.firstSeenAt || record.at || 0,
+        lastSeenAt: Math.max(previous?.lastSeenAt || 0, Number(record.at) || 0),
+        clients: [
+          ...new Set([
+            ...(previous?.clients || []),
+            ...(typeof record.client === 'string' && record.client
+              ? [record.client.slice(0, 80)]
+              : []),
+          ]),
+        ].sort(),
+      });
+    }
+  } catch {
+    return [];
+  }
+
+  return [...projects.values()].sort(
+    (a, b) => b.lastSeenAt - a.lastSeenAt || a.name.localeCompare(b.name)
+  );
+}
+
+/** Registers one VCS project without ever making a hook fail closed. */
+export function registerProject({ root, graphDir, client = 'unknown', name } = {}) {
+  if (!isFsSafePath(root) || !isFsSafePath(graphDir)) return null;
+  try {
+    const canonicalRoot = canonicalPath(root);
+    const canonicalGraphDir = canonicalPath(graphDir);
+    const isRepository = ['.git', '.hg', '.svn'].some((marker) =>
+      existsSync(join(canonicalRoot, marker))
+    );
+    if (!isRepository) return null;
+    const id = projectIdFor(canonicalRoot);
+    const now = Date.now();
+    const recent = registeredProjects().find(
+      (project) =>
+        project.id === id &&
+        project.graphDir === canonicalGraphDir &&
+        project.clients.includes(client) &&
+        now - project.lastSeenAt < 60 * 60 * 1000
+    );
+    if (recent) return recent;
+
+    const path = projectRegistryPath();
+    const lockPath = acquire(path);
+    if (!lockPath) return null;
+    try {
+      appendFileSync(
+        path,
+        `${JSON.stringify({
+          v: PROJECT_REGISTRY_VERSION,
+          id,
+          name: String(name || displayName(canonicalRoot)).slice(0, 160),
+          root: canonicalRoot,
+          graphDir: canonicalGraphDir,
+          client: String(client || 'unknown').slice(0, 80),
+          at: now,
+        })}\n`,
+        { mode: 0o600 }
+      );
+      try {
+        chmodSync(path, 0o600);
+      } catch {
+        // Windows and some filesystems do not expose POSIX modes.
+      }
+    } finally {
+      release(lockPath);
+    }
+    return {
+      id,
+      name: String(name || displayName(canonicalRoot)).slice(0, 160),
+      root: canonicalRoot,
+      graphDir: canonicalGraphDir,
+      firstSeenAt: now,
+      lastSeenAt: now,
+      clients: [String(client || 'unknown').slice(0, 80)],
+    };
+  } catch {
+    return null;
+  }
+}

--- a/integrations/cursor/hooks/post-tool.mjs
+++ b/integrations/cursor/hooks/post-tool.mjs
@@ -2,7 +2,17 @@
 // GENERATED FILE -- do not edit. Regenerate with `npm run sync:hooks`.
 // Client entry point: names the client and event; all policy lives in the
 // shared core so no client can drift its own thresholds or guidance.
-import { run } from './lib/adapter.mjs';
-
 // Fail open: a defect in the optimizer must never cost the user a tool call.
-run('cursor', 'post-tool').catch(() => process.exit(0));
+// Bootstrap failures are still recorded so fail-open does not become fail-silent.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+try {
+  const { run } = await import('./lib/adapter.mjs');
+  await run('cursor', 'post-tool');
+} catch (error) {
+  try {
+    const { recordHookBootstrapFailure } = await import('./lib/observability.mjs');
+    recordHookBootstrapFailure('cursor', 'post-tool', error);
+  } catch {
+    // A logger bootstrap failure is the only condition that remains silent.
+  }
+}

--- a/integrations/cursor/hooks/pre-tool.mjs
+++ b/integrations/cursor/hooks/pre-tool.mjs
@@ -2,7 +2,17 @@
 // GENERATED FILE -- do not edit. Regenerate with `npm run sync:hooks`.
 // Client entry point: names the client and event; all policy lives in the
 // shared core so no client can drift its own thresholds or guidance.
-import { run } from './lib/adapter.mjs';
-
 // Fail open: a defect in the optimizer must never cost the user a tool call.
-run('cursor', 'pre-tool').catch(() => process.exit(0));
+// Bootstrap failures are still recorded so fail-open does not become fail-silent.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+try {
+  const { run } = await import('./lib/adapter.mjs');
+  await run('cursor', 'pre-tool');
+} catch (error) {
+  try {
+    const { recordHookBootstrapFailure } = await import('./lib/observability.mjs');
+    recordHookBootstrapFailure('cursor', 'pre-tool', error);
+  } catch {
+    // A logger bootstrap failure is the only condition that remains silent.
+  }
+}

--- a/integrations/cursor/hooks/session-start.mjs
+++ b/integrations/cursor/hooks/session-start.mjs
@@ -2,7 +2,17 @@
 // GENERATED FILE -- do not edit. Regenerate with `npm run sync:hooks`.
 // Client entry point: names the client and event; all policy lives in the
 // shared core so no client can drift its own thresholds or guidance.
-import { run } from './lib/adapter.mjs';
-
 // Fail open: a defect in the optimizer must never cost the user a tool call.
-run('cursor', 'session-start').catch(() => process.exit(0));
+// Bootstrap failures are still recorded so fail-open does not become fail-silent.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+try {
+  const { run } = await import('./lib/adapter.mjs');
+  await run('cursor', 'session-start');
+} catch (error) {
+  try {
+    const { recordHookBootstrapFailure } = await import('./lib/observability.mjs');
+    recordHookBootstrapFailure('cursor', 'session-start', error);
+  } catch {
+    // A logger bootstrap failure is the only condition that remains silent.
+  }
+}

--- a/integrations/cursor/hooks/stop.mjs
+++ b/integrations/cursor/hooks/stop.mjs
@@ -2,7 +2,17 @@
 // GENERATED FILE -- do not edit. Regenerate with `npm run sync:hooks`.
 // Client entry point: names the client and event; all policy lives in the
 // shared core so no client can drift its own thresholds or guidance.
-import { run } from './lib/adapter.mjs';
-
 // Fail open: a defect in the optimizer must never cost the user a tool call.
-run('cursor', 'stop').catch(() => process.exit(0));
+// Bootstrap failures are still recorded so fail-open does not become fail-silent.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+try {
+  const { run } = await import('./lib/adapter.mjs');
+  await run('cursor', 'stop');
+} catch (error) {
+  try {
+    const { recordHookBootstrapFailure } = await import('./lib/observability.mjs');
+    recordHookBootstrapFailure('cursor', 'stop', error);
+  } catch {
+    // A logger bootstrap failure is the only condition that remains silent.
+  }
+}

--- a/integrations/gemini/hooks/lib/adapter.mjs
+++ b/integrations/gemini/hooks/lib/adapter.mjs
@@ -27,6 +27,7 @@ import {
   MODE_OFF,
   MODE_ADVISE,
   largeFileBytes,
+  readPayloadResult,
   withEscape,
 } from './policy.mjs';
 import {
@@ -83,6 +84,8 @@ import {
 } from './capabilities.mjs';
 import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 import { evaluateUcrGuards } from './ucr-guard.mjs';
+import { beginHookInvocation, noteHookOutput } from './observability.mjs';
+import { registerProject } from './projects.mjs';
 
 /**
  * Per-client capability.
@@ -128,7 +131,14 @@ export function mutationSucceeded(clientName, raw) {
 
   // These lifecycle contracts fire this event only after a successful tool,
   // or are called by our in-process bridge only from its successful after hook.
-  return new Set(['claude-code', 'qwen', 'opencode', 'kilo', 'windsurf']).has(
+  return new Set([
+    'claude-code',
+    'codex',
+    'qwen',
+    'opencode',
+    'kilo',
+    'windsurf',
+  ]).has(
     clientName
   );
 }
@@ -241,37 +251,9 @@ export function sessionTaskContext(raw = {}) {
 }
 
 function emit(object) {
-  process.stdout.write(JSON.stringify(object));
-}
-
-/**
- * Bounded stdin read. See policy.readPayload for why the ceiling matters: the
- * entry points fail open on a THROW, but a host that opens the pipe and never
- * closes it produces no throw -- just a hook that waits forever with the user's
- * tool call stuck behind it.
- */
-async function readStdin({ timeoutMs = 5000 } = {}) {
-  const raw = await new Promise((resolve) => {
-    const chunks = [];
-    const timer = setTimeout(() => resolve(null), timeoutMs);
-    process.stdin.setEncoding('utf8');
-    process.stdin.on('data', (chunk) => chunks.push(chunk));
-    process.stdin.on('end', () => {
-      clearTimeout(timer);
-      resolve(chunks.join(''));
-    });
-    process.stdin.on('error', () => {
-      clearTimeout(timer);
-      resolve(null);
-    });
-  });
-
-  if (raw === null) return null;
-  try {
-    return JSON.parse(raw);
-  } catch {
-    return null;
-  }
+  const serialized = JSON.stringify(object);
+  noteHookOutput(object, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
 }
 
 /** The session-start notice, shared verbatim so no client drifts its own copy. */
@@ -502,6 +484,17 @@ function observeAndInject(payload, state, episode, features) {
  * @param {'session-start'|'pre-tool'|'post-tool'|'stop'} event
  */
 export async function run(clientName, event) {
+  const invocation = beginHookInvocation(clientName, event);
+  try {
+    await runHook(clientName, event, invocation);
+    invocation.succeed();
+  } catch (error) {
+    // The optimizer must fail open, but the failure is now reconstructable.
+    invocation.fail(error);
+  }
+}
+
+async function runHook(clientName, event, invocation) {
   const client = CLIENTS[clientName] || CLIENTS['claude-code'];
   const eventName =
     event === 'session-start'
@@ -529,7 +522,10 @@ export async function run(clientName, event) {
     // full pre-tool timeout would turn optional context into a five-second
     // startup tax; lifecycle payloads are tiny and arrive immediately when
     // the host supplies one.
-    const raw = (await readStdin({ timeoutMs: 250 })) || {};
+    const input = await readPayloadResult({ timeoutMs: 250 });
+    const raw = input.payload || {};
+    invocation.bind(raw, null, input.bytes);
+    if (input.status !== 'ok') invocation.noteInput(input.status, input.bytes);
     const toolEvidence = optimizerToolEvidence(raw);
     const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id;
     if (sessionId && toolEvidence.proven) {
@@ -540,10 +536,12 @@ export async function run(clientName, event) {
     const parts = [
       policyText(client.canDeny, toolEvidence.names, toolEvidence.proven),
     ];
+    const cwd = raw.cwd || raw.working_directory || process.cwd();
+    const root = projectRootFor(join(cwd, '__session__'), cwd);
+    registerProject({ root, graphDir: wikiDir(root), client: clientName });
     if (features.retrieval) {
       try {
-        const cwd = raw.cwd || raw.working_directory || process.cwd();
-        const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+        const dir = wikiDir(root);
         // SessionStart needs hashes and claims, not stored file bodies. Parsing
         // the snapshot sidecar here would make startup scale with repository
         // history even though this compact index never renders a diff.
@@ -569,14 +567,20 @@ export async function run(clientName, event) {
     process.exit(0);
   }
 
-  const raw = await readStdin();
+  const input = await readPayloadResult();
+  const raw = input.payload;
   if (!raw) {
+    invocation.noteInput(input.status, input.bytes);
     // Stop requires JSON on stdout even when it has nothing to add.
     if (event === 'stop') emit({});
     process.exit(0);
   }
 
   if (event === 'stop') {
+    // Stop has no normalized tool payload, but it is still a fully formed hook
+    // invocation. Bind its lifecycle identifiers so successful completions do
+    // not look like an input reader that never ran in cross-client telemetry.
+    invocation.bind(raw, null, input.bytes);
     const sessionId =
       raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? 'default';
     const agentScope = raw.transcript_path ?? raw.transcriptPath ?? null;
@@ -632,6 +636,7 @@ export async function run(clientName, event) {
   const payload = normalizePayload(
     normalizeClientPayload(clientName, event, raw)
   );
+  invocation.bind(raw, payload, input.bytes);
   if (!payload.tool_name) process.exit(0);
   const episode = episodeMeta({ client: clientName, raw, payload });
 

--- a/integrations/gemini/hooks/lib/metrics.mjs
+++ b/integrations/gemini/hooks/lib/metrics.mjs
@@ -1297,8 +1297,8 @@ function concurrencySummary(runs) {
  * live hook traces, and randomized model evals remain visibly distinct: only
  * `eval-run` records with paired arms can produce a causal effect interval.
  */
-export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
-  const evidence = readEvidence(dir).filter((event) => matchesFilters(event, filters));
+function buildEvidenceReport(evidence, { filters = {}, episodeLimit = 100 } = {}) {
+  evidence = evidence.filter((event) => matchesFilters(event, filters));
   const runs = evidence.filter((event) => event.kind === 'eval-run');
   const handoffRuns = evidence.filter((event) => event.kind === 'handoff-run');
   const concurrencyRuns = evidence.filter((event) => event.kind === 'concurrency-run');
@@ -1402,6 +1402,47 @@ export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
       minimumPairs,
       handoffMinimumPairs: handoffMinimumPairs(),
       deterministicChecksAreCausalProof: false,
+    },
+  };
+}
+
+export function evidenceReport(dir, options = {}) {
+  const events = readEvidence(dir);
+  const report = buildEvidenceReport(events, options);
+  const hasMatchingEvidence = events.some((event) =>
+    matchesFilters(event, options.filters || {})
+  );
+  return {
+    ...report,
+    sourceCoverage: {
+      projects: 1,
+      projectsWithEvidence: hasMatchingEvidence ? 1 : 0,
+      projectsWithoutEvidence: hasMatchingEvidence ? 0 : 1,
+    },
+  };
+}
+
+/**
+ * Pools evidence across registered projects before computing cohorts.
+ *
+ * A cohort split across two worktrees is still one experiment. Summing already
+ * aggregated reports would lose pairing and produce invalid confidence
+ * intervals, so this combines the append-only source events first and runs the
+ * estimator exactly once.
+ */
+export function evidenceReportMany(dirs, options = {}) {
+  const unique = [...new Set((dirs || []).map((dir) => String(dir)))];
+  const sources = unique.map((dir) => readEvidence(dir));
+  const report = buildEvidenceReport(sources.flat(), options);
+  const projectsWithEvidence = sources.filter((events) =>
+    events.some((event) => matchesFilters(event, options.filters || {}))
+  ).length;
+  return {
+    ...report,
+    sourceCoverage: {
+      projects: unique.length,
+      projectsWithEvidence,
+      projectsWithoutEvidence: unique.length - projectsWithEvidence,
     },
   };
 }

--- a/integrations/gemini/hooks/lib/metrics.mjs
+++ b/integrations/gemini/hooks/lib/metrics.mjs
@@ -738,10 +738,7 @@ function canonicalKeyish(p) {
  * arms, multiplied by treated touches. Reporting it as a measured fact would be
  * the same overclaiming this project criticises competitors for.
  */
-export function report(dir) {
-  const events = readAll(dir);
-  // Injections and harvests come from the log that cannot be starved.
-  const balance = readBalance(dir);
+function buildReport(events, balance) {
 
   // COMMAND INJECTIONS ARE COUNTED SEPARATELY, not mixed into the balance.
   //
@@ -843,6 +840,15 @@ export function report(dir) {
   const sufficient = treated.length >= 20 && withheld.length >= 5;
 
   return {
+    memoryDeliveries: allInjections.filter((event) => !event.holdout).length,
+    memoryHoldouts: allInjections.filter((event) => event.holdout).length,
+    deliveryTokens: allInjections
+      .filter((event) => !event.holdout)
+      .reduce(
+        (sum, event) =>
+          sum + (event.deliveredTokens ?? event.tokens ?? 0),
+        0
+      ),
     injections: treated.length,
     sessionStartInjections: sessionStartInjections.length,
     sessionStartInjectedTokens: sessionStartInjections.reduce(
@@ -864,6 +870,27 @@ export function report(dir) {
         ? 'the graph is saving more than it costs'
         : 'the graph is NOT yet paying for itself',
   };
+}
+
+export function report(dir) {
+  return buildReport(readAll(dir), readBalance(dir));
+}
+
+/**
+ * One statistically valid machine/project-group report.
+ *
+ * Summing per-project verdicts is wrong: five projects with four treated reads
+ * each do not individually meet the threshold, but together they are twenty
+ * observations. Pooling the underlying events preserves the randomized arms
+ * and computes the means once over the selected population.
+ */
+export function reportMany(dirs) {
+  const unique = [...new Set((dirs || []).map((dir) => String(dir)))];
+  const report = buildReport(
+    unique.flatMap((dir) => readAll(dir)),
+    unique.flatMap((dir) => readBalance(dir))
+  );
+  return { ...report, projects: unique.length };
 }
 
 /**

--- a/integrations/gemini/hooks/lib/observability.mjs
+++ b/integrations/gemini/hooks/lib/observability.mjs
@@ -1,0 +1,400 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+/**
+ * Privacy-safe, cross-client lifecycle diagnostics.
+ *
+ * Hook processes are intentionally fail-open, but fail-open must not mean
+ * fail-silent. Every client writes the same bounded JSONL schema so failures
+ * can be correlated without storing prompts, commands, tool output, or file
+ * contents.
+ */
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmdirSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { createHash, randomUUID } from 'node:crypto';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export const HOOK_LOG_SCHEMA_VERSION = 1;
+const DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
+const DEFAULT_RETENTION_DAYS = 14;
+const DEFAULT_MAX_FILES = 40;
+const DEFAULT_DEADLINE_MS = 4200;
+const MAX_ERROR_CHARS = 4000;
+const MAX_DIMENSION_CHARS = 160;
+let activeInvocation = null;
+
+function positiveInteger(name, fallback) {
+  const value = Number(process.env[name]);
+  return Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+export function hookLogDirectory() {
+  if (process.env.TOKEN_OPTIMIZER_LOG_DIR)
+    return process.env.TOKEN_OPTIMIZER_LOG_DIR;
+  const stateRoot =
+    process.env.TOKEN_OPTIMIZER_STATE_DIR ||
+    join(homedir(), '.token-optimizer');
+  return join(stateRoot, 'logs');
+}
+
+function hash(value, length = 16) {
+  if (!value) return null;
+  return createHash('sha256').update(String(value)).digest('hex').slice(0, length);
+}
+
+function sanitize(text) {
+  if (text === undefined || text === null) return null;
+  let value = String(text);
+  const home = homedir().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  if (home) value = value.replace(new RegExp(home, 'gi'), '<home>');
+  value = value
+    .replace(/\b(?:sk-[A-Za-z0-9_-]{12,}|gh[opusr]_[A-Za-z0-9]{12,})\b/g, '[REDACTED]')
+    .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi, '$1[REDACTED]')
+    .replace(/\b(password|secret|token|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi, '$1=[REDACTED]');
+  return value.slice(0, MAX_ERROR_CHARS);
+}
+
+function errorFields(error) {
+  if (!error) return null;
+  return {
+    type: sanitize(error.name || error.constructor?.name || 'Error'),
+    message: sanitize(error.message || error),
+    stack: sanitize(error.stack),
+  };
+}
+
+function dimension(value) {
+  const sanitized = sanitize(value);
+  return sanitized === null ? null : sanitized.slice(0, MAX_DIMENSION_CHARS);
+}
+
+function severity(level) {
+  if (level === 'error') return { severityText: 'ERROR', severityNumber: 17 };
+  if (level === 'warn') return { severityText: 'WARN', severityNumber: 13 };
+  return { severityText: 'INFO', severityNumber: 9 };
+}
+
+function activeLogPath(now = new Date()) {
+  const date = now.toISOString().slice(0, 10);
+  return join(hookLogDirectory(), `hook-events-${date}.jsonl`);
+}
+
+function rotateIfNeeded(path) {
+  try {
+    if (!existsSync(path)) return;
+    const maxBytes = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_BYTES', DEFAULT_MAX_BYTES);
+    if (statSync(path).size < maxBytes) return;
+
+    const lock = join(hookLogDirectory(), '.rotate.lock');
+    try {
+      mkdirSync(lock);
+    } catch {
+      return;
+    }
+    try {
+      if (existsSync(path) && statSync(path).size >= maxBytes) {
+        // Multiple hook processes (or several writes in one millisecond) must
+        // never select the same rotation target and overwrite an earlier file.
+        const rotated = path.replace(
+          /\.jsonl$/,
+          `-${Date.now()}-${process.pid}-${randomUUID()}.jsonl`
+        );
+        renameSync(path, rotated);
+      }
+    } finally {
+      // Non-recursive removal of the one fixed-name lock directory only.
+      try { rmdirSync(lock); } catch { /* best effort */ }
+    }
+  } catch {
+    // Diagnostics must never become the reason a lifecycle hook fails.
+  }
+}
+
+function pruneIfDue(now = new Date()) {
+  try {
+    const dir = hookLogDirectory();
+    const marker = join(dir, '.last-prune');
+    if (existsSync(marker) && now.getTime() - statSync(marker).mtimeMs < 60 * 60 * 1000)
+      return;
+    writeFileSync(marker, now.toISOString(), { flag: 'w' });
+
+    const retentionMs =
+      positiveInteger('TOKEN_OPTIMIZER_LOG_RETENTION_DAYS', DEFAULT_RETENTION_DAYS) *
+      24 * 60 * 60 * 1000;
+    const maxFiles = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_FILES', DEFAULT_MAX_FILES);
+    const files = readdirSync(dir)
+      .filter((name) => /^hook-events-.*\.jsonl$/.test(name))
+      .map((name) => {
+        const path = join(dir, name);
+        return { path, mtimeMs: statSync(path).mtimeMs };
+      })
+      .sort((a, b) => b.mtimeMs - a.mtimeMs);
+    for (let i = 0; i < files.length; i++) {
+      if (i >= maxFiles || now.getTime() - files[i].mtimeMs > retentionMs)
+        unlinkSync(files[i].path);
+    }
+  } catch {
+    // Retention is best effort and cannot affect the host tool call.
+  }
+}
+
+export function writeHookEvent(event) {
+  try {
+    const now = new Date();
+    const dir = hookLogDirectory();
+    mkdirSync(dir, { recursive: true });
+    const path = activeLogPath(now);
+    rotateIfNeeded(path);
+    const record = {
+      schemaVersion: HOOK_LOG_SCHEMA_VERSION,
+      timestamp: now.toISOString(),
+      service: 'token-optimizer',
+      serviceVersion:
+        process.env.TOKEN_OPTIMIZER_VERSION ||
+        process.env.npm_package_version ||
+        'unknown',
+      ...severity(event.level),
+      body: event.event || 'hook.event',
+      ...event,
+    };
+    record.resource = {
+      'service.name': record.service,
+      'service.version': record.serviceVersion,
+      'host.arch': process.arch,
+      'os.type': process.platform,
+      'process.runtime.name': 'node',
+      'process.runtime.version': process.version,
+    };
+    appendFileSync(path, `${JSON.stringify(record)}\n`, { encoding: 'utf8' });
+    pruneIfDue(now);
+    return path;
+  } catch {
+    return null;
+  }
+}
+
+export function beginHookInvocation(client, event, options = {}) {
+  const started = Date.now();
+  const invocationId = randomUUID();
+  let ended = false;
+  let outcome = 'success';
+  let reason = 'completed';
+  let error = null;
+  const dimensions = {
+    sessionIdHash: null,
+    turnIdHash: null,
+    toolUseIdHash: null,
+    toolName: null,
+    clientVersion: null,
+    model: null,
+    cwdHash: null,
+    payloadBytes: null,
+    outputBytes: 0,
+    outputShape: [],
+    inputStatus: 'pending',
+  };
+  const spanId = hash(invocationId, 16);
+  let traceId = hash(invocationId, 32);
+
+  let deadline;
+  const finish = (nextOutcome = outcome, nextReason = reason, nextError = error) => {
+    if (ended) return;
+    ended = true;
+    if (deadline) clearTimeout(deadline);
+    process.removeListener('exit', onExit);
+    writeHookEvent({
+      level: nextOutcome === 'failure' || nextOutcome === 'timeout' ? 'error' : 'info',
+      event: 'hook.completed',
+      outcome: nextOutcome,
+      reason: nextReason,
+      durationMs: Date.now() - started,
+      invocationId,
+      traceId,
+      spanId,
+      client,
+      hookEvent: event,
+      processId: process.pid,
+      ...dimensions,
+      error: errorFields(nextError),
+    });
+  };
+  const onExit = () => finish();
+  process.once('exit', onExit);
+
+  deadline = setTimeout(() => {
+    outcome = 'timeout';
+    reason = 'internal_deadline_exceeded';
+    finish(outcome, reason);
+    // Beat the host's five-second timeout and fail open deterministically.
+    process.exit(0);
+  }, options.deadlineMs ?? positiveInteger('TOKEN_OPTIMIZER_HOOK_DEADLINE_MS', DEFAULT_DEADLINE_MS));
+  deadline.unref();
+
+  const invocation = {
+    invocationId,
+    bind(raw = {}, payload = null, payloadBytes = null) {
+      const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? null;
+      dimensions.sessionIdHash = hash(sessionId);
+      dimensions.turnIdHash = hash(raw.turn_id ?? raw.turnId ?? null);
+      dimensions.toolUseIdHash = hash(raw.tool_use_id ?? raw.toolUseId ?? null);
+      dimensions.toolName = payload?.tool_name ?? raw.tool_name ?? raw.toolName ?? null;
+      dimensions.clientVersion = dimension(raw.client_version ?? raw.clientVersion ?? null);
+      dimensions.model = dimension(raw.model ?? raw.model_name ?? raw.modelName ?? null);
+      dimensions.cwdHash = hash(raw.cwd ?? raw.working_directory ?? process.cwd());
+      dimensions.payloadBytes = payloadBytes;
+      dimensions.inputStatus = 'ok';
+      if (sessionId) traceId = hash(sessionId, 32);
+    },
+    noteInput(status, payloadBytes = null) {
+      dimensions.inputStatus = status;
+      dimensions.payloadBytes = payloadBytes;
+      if (status === 'timeout') {
+        outcome = 'timeout';
+        reason = 'stdin_timeout';
+      } else if (status !== 'ok') {
+        outcome = 'skipped';
+        reason = status;
+      }
+    },
+    skip(nextReason) {
+      outcome = 'skipped';
+      reason = nextReason;
+    },
+    noteOutput(output, outputBytes = null) {
+      dimensions.outputBytes = outputBytes ?? Buffer.byteLength(JSON.stringify(output), 'utf8');
+      if (!output || typeof output !== 'object' || Array.isArray(output)) {
+        dimensions.outputShape = [];
+        return;
+      }
+      const shape = Object.keys(output).sort();
+      const hookSpecific = output.hookSpecificOutput;
+      if (hookSpecific && typeof hookSpecific === 'object' && !Array.isArray(hookSpecific)) {
+        for (const key of Object.keys(hookSpecific).sort()) shape.push(`hookSpecificOutput.${key}`);
+      }
+      dimensions.outputShape = shape;
+    },
+    fail(nextError, nextReason = 'unhandled_exception') {
+      outcome = 'failure';
+      reason = nextReason;
+      error = nextError;
+      finish(outcome, reason, error);
+    },
+    succeed(nextReason = 'completed') {
+      outcome = 'success';
+      reason = nextReason;
+      finish(outcome, reason);
+    },
+  };
+  activeInvocation = invocation;
+  return invocation;
+}
+
+/** Records response metadata without retaining response content. */
+export function noteHookOutput(output, outputBytes = null) {
+  activeInvocation?.noteOutput(output, outputBytes);
+}
+
+export function recordHookBootstrapFailure(client, event, error) {
+  writeHookEvent({
+    level: 'error',
+    event: 'hook.completed',
+    outcome: 'failure',
+    reason: 'bootstrap_import_failure',
+    durationMs: 0,
+    invocationId: randomUUID(),
+    client,
+    hookEvent: event,
+    processId: process.pid,
+    error: errorFields(error),
+  });
+}
+
+export function readHookEvents({ limit = 200, sinceMs = 24 * 60 * 60 * 1000 } = {}) {
+  try {
+    const dir = hookLogDirectory();
+    if (!existsSync(dir)) return [];
+    const cutoff = Date.now() - Math.max(0, sinceMs);
+    const files = readdirSync(dir)
+      .filter((name) => /^hook-events-.*\.jsonl$/.test(name))
+      .map((name) => join(dir, name))
+      .sort()
+      .reverse();
+    const events = [];
+    for (const file of files) {
+      const lines = readFileSync(file, 'utf8').split(/\r?\n/).filter(Boolean).reverse();
+      for (const line of lines) {
+        try {
+          const event = JSON.parse(line);
+          if (Date.parse(event.timestamp) < cutoff) continue;
+          events.push(event);
+          if (events.length >= limit) return events;
+        } catch {
+          // A partially written final line must not hide the rest of the log.
+        }
+      }
+    }
+    return events;
+  } catch {
+    return [];
+  }
+}
+
+export function hookHealthSummary(options = {}) {
+  const sinceMs = options.sinceMs ?? 24 * 60 * 60 * 1000;
+  const events = readHookEvents({ limit: options.limit || 5000, sinceMs });
+  const durations = events
+    .map((event) => Number(event.durationMs))
+    .filter(Number.isFinite)
+    .sort((a, b) => a - b);
+  const failures = events.filter((event) => event.outcome === 'failure');
+  const timeouts = events.filter((event) => event.outcome === 'timeout');
+  const skipped = events.filter((event) => event.outcome === 'skipped');
+  const successes = events.filter((event) => event.outcome === 'success');
+  const byClient = {};
+  for (const event of events) {
+    const key = event.client || 'unknown';
+    const current = byClient[key] || { total: 0, failures: 0, timeouts: 0, skipped: 0 };
+    current.total++;
+    if (event.outcome === 'failure') current.failures++;
+    if (event.outcome === 'timeout') current.timeouts++;
+    if (event.outcome === 'skipped') current.skipped++;
+    byClient[key] = current;
+  }
+  const percentile = (p) =>
+    durations.length
+      ? durations[Math.min(durations.length - 1, Math.floor(durations.length * p))]
+      : null;
+  const summary = {
+    schemaVersion: HOOK_LOG_SCHEMA_VERSION,
+    available: events.length > 0,
+    windowHours: sinceMs / 3_600_000,
+    total: events.length,
+    failures: failures.length,
+    timeouts: timeouts.length,
+    skipped: skipped.length,
+    successRate: events.length ? successes.length / events.length : null,
+    p50DurationMs: percentile(0.5),
+    p95DurationMs: percentile(0.95),
+    byClient,
+    recentFailures: [...failures, ...timeouts]
+      .sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp))
+      .slice(0, 20),
+  };
+  // Absolute paths are useful to a local doctor, but they do not belong in a
+  // diagnostics export that may be attached to a public issue.
+  if (options.includeLogDirectory === true)
+    summary.logDirectory = hookLogDirectory();
+  return summary;
+}

--- a/integrations/gemini/hooks/lib/policy.mjs
+++ b/integrations/gemini/hooks/lib/policy.mjs
@@ -48,6 +48,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { createHash } from 'node:crypto';
 import { isFsSafePath } from './paths.mjs';
+import { noteHookOutput } from './observability.mjs';
 
 /** Enforcement modes, least to most permissive. */
 export const MODE_ENFORCE = 'enforce';
@@ -653,14 +654,15 @@ export function allow() {
  */
 export function allowWithContext(context) {
   if (context) {
-    process.stdout.write(
-      JSON.stringify({
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-          additionalContext: withEscape(context),
-        },
-      })
-    );
+    const output = {
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        additionalContext: withEscape(context),
+      },
+    };
+    const serialized = JSON.stringify(output);
+    noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+    process.stdout.write(serialized);
   }
   process.exit(0);
 }
@@ -673,15 +675,16 @@ export function allowWithContext(context) {
  * says "use the optimized tool" gets met with a retry of the same call.
  */
 export function deny(reason) {
-  process.stdout.write(
-    JSON.stringify({
-      hookSpecificOutput: {
-        hookEventName: 'PreToolUse',
-        permissionDecision: 'deny',
-        permissionDecisionReason: withEscape(reason),
-      },
-    })
-  );
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+      permissionDecisionReason: withEscape(reason),
+    },
+  };
+  const serialized = JSON.stringify(output);
+  noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
   process.exit(0);
 }
 
@@ -706,14 +709,15 @@ export function withEscape(reason) {
 
 /** Lets the call through, attaching a note the model sees. */
 export function advise(context) {
-  process.stdout.write(
-    JSON.stringify({
-      hookSpecificOutput: {
-        hookEventName: 'PreToolUse',
-        additionalContext: context,
-      },
-    })
-  );
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      additionalContext: context,
+    },
+  };
+  const serialized = JSON.stringify(output);
+  noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
   process.exit(0);
 }
 
@@ -741,26 +745,34 @@ export function enforce(reason, deniedBefore) {
  * than an absent one, so the wait has a ceiling and expiring it is treated
  * exactly like unusable input.
  */
-export async function readPayload({
-  timeoutMs = 5000,
+export async function readPayloadResult({
+  timeoutMs = 1500,
   maxBytes = 8_000_000,
 } = {}) {
   const chunks = [];
   let size = 0;
+  let inputStatus = 'pending';
 
   const raw = await new Promise((resolve) => {
     const onData = (chunk) => {
-      size += chunk.length;
+      size += Buffer.byteLength(chunk, 'utf8');
       // A payload this large is not a tool call; refusing to buffer it
       // unboundedly keeps a hook from becoming a memory problem.
       if (size > maxBytes) {
+        inputStatus = 'too_large';
         finish(null);
         return;
       }
       chunks.push(chunk);
     };
-    const onEnd = () => finish(chunks.join(''));
-    const onError = () => finish(null);
+    const onEnd = () => {
+      inputStatus = 'received';
+      finish(chunks.join(''));
+    };
+    const onError = () => {
+      inputStatus = 'input_error';
+      finish(null);
+    };
 
     // Listeners are REMOVED on every exit path. Leaving them attached after the
     // timeout wins means a late chunk keeps growing a buffer nobody will read,
@@ -774,17 +786,21 @@ export async function readPayload({
       resolve(value);
     }
 
-    const timer = setTimeout(() => finish(null), timeoutMs);
+    const timer = setTimeout(() => {
+      inputStatus = 'timeout';
+      finish(null);
+    }, timeoutMs);
     process.stdin.setEncoding('utf8');
     process.stdin.on('data', onData);
     process.stdin.on('end', onEnd);
     process.stdin.on('error', onError);
   });
 
-  if (raw === null) return null;
+  if (raw === null) return { payload: null, status: inputStatus, bytes: size };
+  if (!raw.trim()) return { payload: null, status: 'empty_input', bytes: size };
   try {
-    return JSON.parse(raw);
+    return { payload: JSON.parse(raw), status: 'ok', bytes: size };
   } catch {
-    return null;
+    return { payload: null, status: 'invalid_json', bytes: size };
   }
 }

--- a/integrations/gemini/hooks/lib/projects.mjs
+++ b/integrations/gemini/hooks/lib/projects.mjs
@@ -1,0 +1,214 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/projects.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Machine-local index of project graph stores.
+ *
+ * A graph is deliberately stored with the project whose files it describes.
+ * That isolation is important for retrieval, but it also means a dashboard
+ * cannot honestly describe machine-wide capture unless it knows which stores
+ * exist. This registry is that missing directory. It is written by lifecycle
+ * hooks and can be backfilled by the explicit discovery command.
+ *
+ * The browser never receives `root` or `graphDir`. Routes resolve an opaque
+ * project id through this server-owned file, so restoring cross-project views
+ * does not restore the old arbitrary-path query vulnerability.
+ */
+
+import {
+  appendFileSync,
+  chmodSync,
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+} from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+import { createHash } from 'node:crypto';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
+
+export const PROJECT_REGISTRY_VERSION = 1;
+
+export function projectRegistryPath() {
+  return (
+    process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY ||
+    join(homedir(), '.token-optimizer', 'projects.jsonl')
+  );
+}
+
+export function projectIdFor(root) {
+  return `project-${createHash('sha256')
+    .update(canonicalPath(root))
+    .digest('hex')
+    .slice(0, 16)}`;
+}
+
+function displayName(root) {
+  return basename(root) || 'Unnamed project';
+}
+
+function acquire(path) {
+  const lockPath = `${path}.lock`;
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+  } catch {
+    return null;
+  }
+
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      closeSync(openSync(lockPath, 'wx', 0o600));
+      return lockPath;
+    } catch {
+      try {
+        if (Date.now() - statSync(lockPath).mtimeMs > 5000) unlinkSync(lockPath);
+      } catch {
+        // The holder may have released it between open and stat; retry.
+      }
+    }
+  }
+  return null;
+}
+
+function release(lockPath) {
+  if (!lockPath) return;
+  try {
+    unlinkSync(lockPath);
+  } catch {
+    // A killed process or cleanup race must not fail the hook.
+  }
+}
+
+/**
+ * Folds the append-only registry into one current entry per canonical project.
+ * Malformed, stale-schema, and unsafe records are ignored rather than trusted.
+ */
+export function registeredProjects() {
+  const path = projectRegistryPath();
+  const projects = new Map();
+  if (!existsSync(path)) return [];
+
+  try {
+    for (const line of readFileSync(path, 'utf8').split('\n')) {
+      if (!line) continue;
+      let record;
+      try {
+        record = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (
+        record.v !== PROJECT_REGISTRY_VERSION ||
+        !isFsSafePath(record.root) ||
+        !isFsSafePath(record.graphDir)
+      ) {
+        continue;
+      }
+      const root = canonicalPath(record.root);
+      const graphDir = canonicalPath(record.graphDir);
+      // Append-only history can outlive a deleted worktree (especially a
+      // short-lived test or CI checkout). A source that no longer exists
+      // cannot be captured, and presenting it as a current coverage gap makes
+      // the dashboard steadily less truthful over time.
+      if (!existsSync(root)) continue;
+      // A broad discovery root may contain hundreds of dormant worktrees. They
+      // are not capture coverage until a hook has observed them or a graph
+      // exists; listing all of them turns the selector into filesystem noise.
+      if (
+        record.client === 'discovery' &&
+        !existsSync(join(graphDir, 'graph.jsonl'))
+      ) {
+        continue;
+      }
+      const id = projectIdFor(root);
+      if (record.id !== id) continue;
+
+      const previous = projects.get(id);
+      projects.set(id, {
+        id,
+        name: String(record.name || displayName(root)).slice(0, 160),
+        root,
+        graphDir,
+        firstSeenAt: previous?.firstSeenAt || record.at || 0,
+        lastSeenAt: Math.max(previous?.lastSeenAt || 0, Number(record.at) || 0),
+        clients: [
+          ...new Set([
+            ...(previous?.clients || []),
+            ...(typeof record.client === 'string' && record.client
+              ? [record.client.slice(0, 80)]
+              : []),
+          ]),
+        ].sort(),
+      });
+    }
+  } catch {
+    return [];
+  }
+
+  return [...projects.values()].sort(
+    (a, b) => b.lastSeenAt - a.lastSeenAt || a.name.localeCompare(b.name)
+  );
+}
+
+/** Registers one VCS project without ever making a hook fail closed. */
+export function registerProject({ root, graphDir, client = 'unknown', name } = {}) {
+  if (!isFsSafePath(root) || !isFsSafePath(graphDir)) return null;
+  try {
+    const canonicalRoot = canonicalPath(root);
+    const canonicalGraphDir = canonicalPath(graphDir);
+    const isRepository = ['.git', '.hg', '.svn'].some((marker) =>
+      existsSync(join(canonicalRoot, marker))
+    );
+    if (!isRepository) return null;
+    const id = projectIdFor(canonicalRoot);
+    const now = Date.now();
+    const recent = registeredProjects().find(
+      (project) =>
+        project.id === id &&
+        project.graphDir === canonicalGraphDir &&
+        project.clients.includes(client) &&
+        now - project.lastSeenAt < 60 * 60 * 1000
+    );
+    if (recent) return recent;
+
+    const path = projectRegistryPath();
+    const lockPath = acquire(path);
+    if (!lockPath) return null;
+    try {
+      appendFileSync(
+        path,
+        `${JSON.stringify({
+          v: PROJECT_REGISTRY_VERSION,
+          id,
+          name: String(name || displayName(canonicalRoot)).slice(0, 160),
+          root: canonicalRoot,
+          graphDir: canonicalGraphDir,
+          client: String(client || 'unknown').slice(0, 80),
+          at: now,
+        })}\n`,
+        { mode: 0o600 }
+      );
+      try {
+        chmodSync(path, 0o600);
+      } catch {
+        // Windows and some filesystems do not expose POSIX modes.
+      }
+    } finally {
+      release(lockPath);
+    }
+    return {
+      id,
+      name: String(name || displayName(canonicalRoot)).slice(0, 160),
+      root: canonicalRoot,
+      graphDir: canonicalGraphDir,
+      firstSeenAt: now,
+      lastSeenAt: now,
+      clients: [String(client || 'unknown').slice(0, 80)],
+    };
+  } catch {
+    return null;
+  }
+}

--- a/integrations/gemini/hooks/post-tool.mjs
+++ b/integrations/gemini/hooks/post-tool.mjs
@@ -2,7 +2,17 @@
 // GENERATED FILE -- do not edit. Regenerate with `npm run sync:hooks`.
 // Client entry point: names the client and event; all policy lives in the
 // shared core so no client can drift its own thresholds or guidance.
-import { run } from './lib/adapter.mjs';
-
 // Fail open: a defect in the optimizer must never cost the user a tool call.
-run('gemini', 'post-tool').catch(() => process.exit(0));
+// Bootstrap failures are still recorded so fail-open does not become fail-silent.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+try {
+  const { run } = await import('./lib/adapter.mjs');
+  await run('gemini', 'post-tool');
+} catch (error) {
+  try {
+    const { recordHookBootstrapFailure } = await import('./lib/observability.mjs');
+    recordHookBootstrapFailure('gemini', 'post-tool', error);
+  } catch {
+    // A logger bootstrap failure is the only condition that remains silent.
+  }
+}

--- a/integrations/gemini/hooks/pre-tool.mjs
+++ b/integrations/gemini/hooks/pre-tool.mjs
@@ -2,7 +2,17 @@
 // GENERATED FILE -- do not edit. Regenerate with `npm run sync:hooks`.
 // Client entry point: names the client and event; all policy lives in the
 // shared core so no client can drift its own thresholds or guidance.
-import { run } from './lib/adapter.mjs';
-
 // Fail open: a defect in the optimizer must never cost the user a tool call.
-run('gemini', 'pre-tool').catch(() => process.exit(0));
+// Bootstrap failures are still recorded so fail-open does not become fail-silent.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+try {
+  const { run } = await import('./lib/adapter.mjs');
+  await run('gemini', 'pre-tool');
+} catch (error) {
+  try {
+    const { recordHookBootstrapFailure } = await import('./lib/observability.mjs');
+    recordHookBootstrapFailure('gemini', 'pre-tool', error);
+  } catch {
+    // A logger bootstrap failure is the only condition that remains silent.
+  }
+}

--- a/integrations/gemini/hooks/session-start.mjs
+++ b/integrations/gemini/hooks/session-start.mjs
@@ -2,7 +2,17 @@
 // GENERATED FILE -- do not edit. Regenerate with `npm run sync:hooks`.
 // Client entry point: names the client and event; all policy lives in the
 // shared core so no client can drift its own thresholds or guidance.
-import { run } from './lib/adapter.mjs';
-
 // Fail open: a defect in the optimizer must never cost the user a tool call.
-run('gemini', 'session-start').catch(() => process.exit(0));
+// Bootstrap failures are still recorded so fail-open does not become fail-silent.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+try {
+  const { run } = await import('./lib/adapter.mjs');
+  await run('gemini', 'session-start');
+} catch (error) {
+  try {
+    const { recordHookBootstrapFailure } = await import('./lib/observability.mjs');
+    recordHookBootstrapFailure('gemini', 'session-start', error);
+  } catch {
+    // A logger bootstrap failure is the only condition that remains silent.
+  }
+}

--- a/integrations/gemini/hooks/stop.mjs
+++ b/integrations/gemini/hooks/stop.mjs
@@ -2,7 +2,17 @@
 // GENERATED FILE -- do not edit. Regenerate with `npm run sync:hooks`.
 // Client entry point: names the client and event; all policy lives in the
 // shared core so no client can drift its own thresholds or guidance.
-import { run } from './lib/adapter.mjs';
-
 // Fail open: a defect in the optimizer must never cost the user a tool call.
-run('gemini', 'stop').catch(() => process.exit(0));
+// Bootstrap failures are still recorded so fail-open does not become fail-silent.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+try {
+  const { run } = await import('./lib/adapter.mjs');
+  await run('gemini', 'stop');
+} catch (error) {
+  try {
+    const { recordHookBootstrapFailure } = await import('./lib/observability.mjs');
+    recordHookBootstrapFailure('gemini', 'stop', error);
+  } catch {
+    // A logger bootstrap failure is the only condition that remains silent.
+  }
+}

--- a/integrations/kilo/hooks/lib/adapter.mjs
+++ b/integrations/kilo/hooks/lib/adapter.mjs
@@ -27,6 +27,7 @@ import {
   MODE_OFF,
   MODE_ADVISE,
   largeFileBytes,
+  readPayloadResult,
   withEscape,
 } from './policy.mjs';
 import {
@@ -83,6 +84,8 @@ import {
 } from './capabilities.mjs';
 import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 import { evaluateUcrGuards } from './ucr-guard.mjs';
+import { beginHookInvocation, noteHookOutput } from './observability.mjs';
+import { registerProject } from './projects.mjs';
 
 /**
  * Per-client capability.
@@ -128,7 +131,14 @@ export function mutationSucceeded(clientName, raw) {
 
   // These lifecycle contracts fire this event only after a successful tool,
   // or are called by our in-process bridge only from its successful after hook.
-  return new Set(['claude-code', 'qwen', 'opencode', 'kilo', 'windsurf']).has(
+  return new Set([
+    'claude-code',
+    'codex',
+    'qwen',
+    'opencode',
+    'kilo',
+    'windsurf',
+  ]).has(
     clientName
   );
 }
@@ -241,37 +251,9 @@ export function sessionTaskContext(raw = {}) {
 }
 
 function emit(object) {
-  process.stdout.write(JSON.stringify(object));
-}
-
-/**
- * Bounded stdin read. See policy.readPayload for why the ceiling matters: the
- * entry points fail open on a THROW, but a host that opens the pipe and never
- * closes it produces no throw -- just a hook that waits forever with the user's
- * tool call stuck behind it.
- */
-async function readStdin({ timeoutMs = 5000 } = {}) {
-  const raw = await new Promise((resolve) => {
-    const chunks = [];
-    const timer = setTimeout(() => resolve(null), timeoutMs);
-    process.stdin.setEncoding('utf8');
-    process.stdin.on('data', (chunk) => chunks.push(chunk));
-    process.stdin.on('end', () => {
-      clearTimeout(timer);
-      resolve(chunks.join(''));
-    });
-    process.stdin.on('error', () => {
-      clearTimeout(timer);
-      resolve(null);
-    });
-  });
-
-  if (raw === null) return null;
-  try {
-    return JSON.parse(raw);
-  } catch {
-    return null;
-  }
+  const serialized = JSON.stringify(object);
+  noteHookOutput(object, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
 }
 
 /** The session-start notice, shared verbatim so no client drifts its own copy. */
@@ -502,6 +484,17 @@ function observeAndInject(payload, state, episode, features) {
  * @param {'session-start'|'pre-tool'|'post-tool'|'stop'} event
  */
 export async function run(clientName, event) {
+  const invocation = beginHookInvocation(clientName, event);
+  try {
+    await runHook(clientName, event, invocation);
+    invocation.succeed();
+  } catch (error) {
+    // The optimizer must fail open, but the failure is now reconstructable.
+    invocation.fail(error);
+  }
+}
+
+async function runHook(clientName, event, invocation) {
   const client = CLIENTS[clientName] || CLIENTS['claude-code'];
   const eventName =
     event === 'session-start'
@@ -529,7 +522,10 @@ export async function run(clientName, event) {
     // full pre-tool timeout would turn optional context into a five-second
     // startup tax; lifecycle payloads are tiny and arrive immediately when
     // the host supplies one.
-    const raw = (await readStdin({ timeoutMs: 250 })) || {};
+    const input = await readPayloadResult({ timeoutMs: 250 });
+    const raw = input.payload || {};
+    invocation.bind(raw, null, input.bytes);
+    if (input.status !== 'ok') invocation.noteInput(input.status, input.bytes);
     const toolEvidence = optimizerToolEvidence(raw);
     const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id;
     if (sessionId && toolEvidence.proven) {
@@ -540,10 +536,12 @@ export async function run(clientName, event) {
     const parts = [
       policyText(client.canDeny, toolEvidence.names, toolEvidence.proven),
     ];
+    const cwd = raw.cwd || raw.working_directory || process.cwd();
+    const root = projectRootFor(join(cwd, '__session__'), cwd);
+    registerProject({ root, graphDir: wikiDir(root), client: clientName });
     if (features.retrieval) {
       try {
-        const cwd = raw.cwd || raw.working_directory || process.cwd();
-        const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+        const dir = wikiDir(root);
         // SessionStart needs hashes and claims, not stored file bodies. Parsing
         // the snapshot sidecar here would make startup scale with repository
         // history even though this compact index never renders a diff.
@@ -569,14 +567,20 @@ export async function run(clientName, event) {
     process.exit(0);
   }
 
-  const raw = await readStdin();
+  const input = await readPayloadResult();
+  const raw = input.payload;
   if (!raw) {
+    invocation.noteInput(input.status, input.bytes);
     // Stop requires JSON on stdout even when it has nothing to add.
     if (event === 'stop') emit({});
     process.exit(0);
   }
 
   if (event === 'stop') {
+    // Stop has no normalized tool payload, but it is still a fully formed hook
+    // invocation. Bind its lifecycle identifiers so successful completions do
+    // not look like an input reader that never ran in cross-client telemetry.
+    invocation.bind(raw, null, input.bytes);
     const sessionId =
       raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? 'default';
     const agentScope = raw.transcript_path ?? raw.transcriptPath ?? null;
@@ -632,6 +636,7 @@ export async function run(clientName, event) {
   const payload = normalizePayload(
     normalizeClientPayload(clientName, event, raw)
   );
+  invocation.bind(raw, payload, input.bytes);
   if (!payload.tool_name) process.exit(0);
   const episode = episodeMeta({ client: clientName, raw, payload });
 

--- a/integrations/kilo/hooks/lib/metrics.mjs
+++ b/integrations/kilo/hooks/lib/metrics.mjs
@@ -1297,8 +1297,8 @@ function concurrencySummary(runs) {
  * live hook traces, and randomized model evals remain visibly distinct: only
  * `eval-run` records with paired arms can produce a causal effect interval.
  */
-export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
-  const evidence = readEvidence(dir).filter((event) => matchesFilters(event, filters));
+function buildEvidenceReport(evidence, { filters = {}, episodeLimit = 100 } = {}) {
+  evidence = evidence.filter((event) => matchesFilters(event, filters));
   const runs = evidence.filter((event) => event.kind === 'eval-run');
   const handoffRuns = evidence.filter((event) => event.kind === 'handoff-run');
   const concurrencyRuns = evidence.filter((event) => event.kind === 'concurrency-run');
@@ -1402,6 +1402,47 @@ export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
       minimumPairs,
       handoffMinimumPairs: handoffMinimumPairs(),
       deterministicChecksAreCausalProof: false,
+    },
+  };
+}
+
+export function evidenceReport(dir, options = {}) {
+  const events = readEvidence(dir);
+  const report = buildEvidenceReport(events, options);
+  const hasMatchingEvidence = events.some((event) =>
+    matchesFilters(event, options.filters || {})
+  );
+  return {
+    ...report,
+    sourceCoverage: {
+      projects: 1,
+      projectsWithEvidence: hasMatchingEvidence ? 1 : 0,
+      projectsWithoutEvidence: hasMatchingEvidence ? 0 : 1,
+    },
+  };
+}
+
+/**
+ * Pools evidence across registered projects before computing cohorts.
+ *
+ * A cohort split across two worktrees is still one experiment. Summing already
+ * aggregated reports would lose pairing and produce invalid confidence
+ * intervals, so this combines the append-only source events first and runs the
+ * estimator exactly once.
+ */
+export function evidenceReportMany(dirs, options = {}) {
+  const unique = [...new Set((dirs || []).map((dir) => String(dir)))];
+  const sources = unique.map((dir) => readEvidence(dir));
+  const report = buildEvidenceReport(sources.flat(), options);
+  const projectsWithEvidence = sources.filter((events) =>
+    events.some((event) => matchesFilters(event, options.filters || {}))
+  ).length;
+  return {
+    ...report,
+    sourceCoverage: {
+      projects: unique.length,
+      projectsWithEvidence,
+      projectsWithoutEvidence: unique.length - projectsWithEvidence,
     },
   };
 }

--- a/integrations/kilo/hooks/lib/metrics.mjs
+++ b/integrations/kilo/hooks/lib/metrics.mjs
@@ -738,10 +738,7 @@ function canonicalKeyish(p) {
  * arms, multiplied by treated touches. Reporting it as a measured fact would be
  * the same overclaiming this project criticises competitors for.
  */
-export function report(dir) {
-  const events = readAll(dir);
-  // Injections and harvests come from the log that cannot be starved.
-  const balance = readBalance(dir);
+function buildReport(events, balance) {
 
   // COMMAND INJECTIONS ARE COUNTED SEPARATELY, not mixed into the balance.
   //
@@ -843,6 +840,15 @@ export function report(dir) {
   const sufficient = treated.length >= 20 && withheld.length >= 5;
 
   return {
+    memoryDeliveries: allInjections.filter((event) => !event.holdout).length,
+    memoryHoldouts: allInjections.filter((event) => event.holdout).length,
+    deliveryTokens: allInjections
+      .filter((event) => !event.holdout)
+      .reduce(
+        (sum, event) =>
+          sum + (event.deliveredTokens ?? event.tokens ?? 0),
+        0
+      ),
     injections: treated.length,
     sessionStartInjections: sessionStartInjections.length,
     sessionStartInjectedTokens: sessionStartInjections.reduce(
@@ -864,6 +870,27 @@ export function report(dir) {
         ? 'the graph is saving more than it costs'
         : 'the graph is NOT yet paying for itself',
   };
+}
+
+export function report(dir) {
+  return buildReport(readAll(dir), readBalance(dir));
+}
+
+/**
+ * One statistically valid machine/project-group report.
+ *
+ * Summing per-project verdicts is wrong: five projects with four treated reads
+ * each do not individually meet the threshold, but together they are twenty
+ * observations. Pooling the underlying events preserves the randomized arms
+ * and computes the means once over the selected population.
+ */
+export function reportMany(dirs) {
+  const unique = [...new Set((dirs || []).map((dir) => String(dir)))];
+  const report = buildReport(
+    unique.flatMap((dir) => readAll(dir)),
+    unique.flatMap((dir) => readBalance(dir))
+  );
+  return { ...report, projects: unique.length };
 }
 
 /**

--- a/integrations/kilo/hooks/lib/observability.mjs
+++ b/integrations/kilo/hooks/lib/observability.mjs
@@ -1,0 +1,400 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+/**
+ * Privacy-safe, cross-client lifecycle diagnostics.
+ *
+ * Hook processes are intentionally fail-open, but fail-open must not mean
+ * fail-silent. Every client writes the same bounded JSONL schema so failures
+ * can be correlated without storing prompts, commands, tool output, or file
+ * contents.
+ */
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmdirSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { createHash, randomUUID } from 'node:crypto';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export const HOOK_LOG_SCHEMA_VERSION = 1;
+const DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
+const DEFAULT_RETENTION_DAYS = 14;
+const DEFAULT_MAX_FILES = 40;
+const DEFAULT_DEADLINE_MS = 4200;
+const MAX_ERROR_CHARS = 4000;
+const MAX_DIMENSION_CHARS = 160;
+let activeInvocation = null;
+
+function positiveInteger(name, fallback) {
+  const value = Number(process.env[name]);
+  return Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+export function hookLogDirectory() {
+  if (process.env.TOKEN_OPTIMIZER_LOG_DIR)
+    return process.env.TOKEN_OPTIMIZER_LOG_DIR;
+  const stateRoot =
+    process.env.TOKEN_OPTIMIZER_STATE_DIR ||
+    join(homedir(), '.token-optimizer');
+  return join(stateRoot, 'logs');
+}
+
+function hash(value, length = 16) {
+  if (!value) return null;
+  return createHash('sha256').update(String(value)).digest('hex').slice(0, length);
+}
+
+function sanitize(text) {
+  if (text === undefined || text === null) return null;
+  let value = String(text);
+  const home = homedir().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  if (home) value = value.replace(new RegExp(home, 'gi'), '<home>');
+  value = value
+    .replace(/\b(?:sk-[A-Za-z0-9_-]{12,}|gh[opusr]_[A-Za-z0-9]{12,})\b/g, '[REDACTED]')
+    .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi, '$1[REDACTED]')
+    .replace(/\b(password|secret|token|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi, '$1=[REDACTED]');
+  return value.slice(0, MAX_ERROR_CHARS);
+}
+
+function errorFields(error) {
+  if (!error) return null;
+  return {
+    type: sanitize(error.name || error.constructor?.name || 'Error'),
+    message: sanitize(error.message || error),
+    stack: sanitize(error.stack),
+  };
+}
+
+function dimension(value) {
+  const sanitized = sanitize(value);
+  return sanitized === null ? null : sanitized.slice(0, MAX_DIMENSION_CHARS);
+}
+
+function severity(level) {
+  if (level === 'error') return { severityText: 'ERROR', severityNumber: 17 };
+  if (level === 'warn') return { severityText: 'WARN', severityNumber: 13 };
+  return { severityText: 'INFO', severityNumber: 9 };
+}
+
+function activeLogPath(now = new Date()) {
+  const date = now.toISOString().slice(0, 10);
+  return join(hookLogDirectory(), `hook-events-${date}.jsonl`);
+}
+
+function rotateIfNeeded(path) {
+  try {
+    if (!existsSync(path)) return;
+    const maxBytes = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_BYTES', DEFAULT_MAX_BYTES);
+    if (statSync(path).size < maxBytes) return;
+
+    const lock = join(hookLogDirectory(), '.rotate.lock');
+    try {
+      mkdirSync(lock);
+    } catch {
+      return;
+    }
+    try {
+      if (existsSync(path) && statSync(path).size >= maxBytes) {
+        // Multiple hook processes (or several writes in one millisecond) must
+        // never select the same rotation target and overwrite an earlier file.
+        const rotated = path.replace(
+          /\.jsonl$/,
+          `-${Date.now()}-${process.pid}-${randomUUID()}.jsonl`
+        );
+        renameSync(path, rotated);
+      }
+    } finally {
+      // Non-recursive removal of the one fixed-name lock directory only.
+      try { rmdirSync(lock); } catch { /* best effort */ }
+    }
+  } catch {
+    // Diagnostics must never become the reason a lifecycle hook fails.
+  }
+}
+
+function pruneIfDue(now = new Date()) {
+  try {
+    const dir = hookLogDirectory();
+    const marker = join(dir, '.last-prune');
+    if (existsSync(marker) && now.getTime() - statSync(marker).mtimeMs < 60 * 60 * 1000)
+      return;
+    writeFileSync(marker, now.toISOString(), { flag: 'w' });
+
+    const retentionMs =
+      positiveInteger('TOKEN_OPTIMIZER_LOG_RETENTION_DAYS', DEFAULT_RETENTION_DAYS) *
+      24 * 60 * 60 * 1000;
+    const maxFiles = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_FILES', DEFAULT_MAX_FILES);
+    const files = readdirSync(dir)
+      .filter((name) => /^hook-events-.*\.jsonl$/.test(name))
+      .map((name) => {
+        const path = join(dir, name);
+        return { path, mtimeMs: statSync(path).mtimeMs };
+      })
+      .sort((a, b) => b.mtimeMs - a.mtimeMs);
+    for (let i = 0; i < files.length; i++) {
+      if (i >= maxFiles || now.getTime() - files[i].mtimeMs > retentionMs)
+        unlinkSync(files[i].path);
+    }
+  } catch {
+    // Retention is best effort and cannot affect the host tool call.
+  }
+}
+
+export function writeHookEvent(event) {
+  try {
+    const now = new Date();
+    const dir = hookLogDirectory();
+    mkdirSync(dir, { recursive: true });
+    const path = activeLogPath(now);
+    rotateIfNeeded(path);
+    const record = {
+      schemaVersion: HOOK_LOG_SCHEMA_VERSION,
+      timestamp: now.toISOString(),
+      service: 'token-optimizer',
+      serviceVersion:
+        process.env.TOKEN_OPTIMIZER_VERSION ||
+        process.env.npm_package_version ||
+        'unknown',
+      ...severity(event.level),
+      body: event.event || 'hook.event',
+      ...event,
+    };
+    record.resource = {
+      'service.name': record.service,
+      'service.version': record.serviceVersion,
+      'host.arch': process.arch,
+      'os.type': process.platform,
+      'process.runtime.name': 'node',
+      'process.runtime.version': process.version,
+    };
+    appendFileSync(path, `${JSON.stringify(record)}\n`, { encoding: 'utf8' });
+    pruneIfDue(now);
+    return path;
+  } catch {
+    return null;
+  }
+}
+
+export function beginHookInvocation(client, event, options = {}) {
+  const started = Date.now();
+  const invocationId = randomUUID();
+  let ended = false;
+  let outcome = 'success';
+  let reason = 'completed';
+  let error = null;
+  const dimensions = {
+    sessionIdHash: null,
+    turnIdHash: null,
+    toolUseIdHash: null,
+    toolName: null,
+    clientVersion: null,
+    model: null,
+    cwdHash: null,
+    payloadBytes: null,
+    outputBytes: 0,
+    outputShape: [],
+    inputStatus: 'pending',
+  };
+  const spanId = hash(invocationId, 16);
+  let traceId = hash(invocationId, 32);
+
+  let deadline;
+  const finish = (nextOutcome = outcome, nextReason = reason, nextError = error) => {
+    if (ended) return;
+    ended = true;
+    if (deadline) clearTimeout(deadline);
+    process.removeListener('exit', onExit);
+    writeHookEvent({
+      level: nextOutcome === 'failure' || nextOutcome === 'timeout' ? 'error' : 'info',
+      event: 'hook.completed',
+      outcome: nextOutcome,
+      reason: nextReason,
+      durationMs: Date.now() - started,
+      invocationId,
+      traceId,
+      spanId,
+      client,
+      hookEvent: event,
+      processId: process.pid,
+      ...dimensions,
+      error: errorFields(nextError),
+    });
+  };
+  const onExit = () => finish();
+  process.once('exit', onExit);
+
+  deadline = setTimeout(() => {
+    outcome = 'timeout';
+    reason = 'internal_deadline_exceeded';
+    finish(outcome, reason);
+    // Beat the host's five-second timeout and fail open deterministically.
+    process.exit(0);
+  }, options.deadlineMs ?? positiveInteger('TOKEN_OPTIMIZER_HOOK_DEADLINE_MS', DEFAULT_DEADLINE_MS));
+  deadline.unref();
+
+  const invocation = {
+    invocationId,
+    bind(raw = {}, payload = null, payloadBytes = null) {
+      const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? null;
+      dimensions.sessionIdHash = hash(sessionId);
+      dimensions.turnIdHash = hash(raw.turn_id ?? raw.turnId ?? null);
+      dimensions.toolUseIdHash = hash(raw.tool_use_id ?? raw.toolUseId ?? null);
+      dimensions.toolName = payload?.tool_name ?? raw.tool_name ?? raw.toolName ?? null;
+      dimensions.clientVersion = dimension(raw.client_version ?? raw.clientVersion ?? null);
+      dimensions.model = dimension(raw.model ?? raw.model_name ?? raw.modelName ?? null);
+      dimensions.cwdHash = hash(raw.cwd ?? raw.working_directory ?? process.cwd());
+      dimensions.payloadBytes = payloadBytes;
+      dimensions.inputStatus = 'ok';
+      if (sessionId) traceId = hash(sessionId, 32);
+    },
+    noteInput(status, payloadBytes = null) {
+      dimensions.inputStatus = status;
+      dimensions.payloadBytes = payloadBytes;
+      if (status === 'timeout') {
+        outcome = 'timeout';
+        reason = 'stdin_timeout';
+      } else if (status !== 'ok') {
+        outcome = 'skipped';
+        reason = status;
+      }
+    },
+    skip(nextReason) {
+      outcome = 'skipped';
+      reason = nextReason;
+    },
+    noteOutput(output, outputBytes = null) {
+      dimensions.outputBytes = outputBytes ?? Buffer.byteLength(JSON.stringify(output), 'utf8');
+      if (!output || typeof output !== 'object' || Array.isArray(output)) {
+        dimensions.outputShape = [];
+        return;
+      }
+      const shape = Object.keys(output).sort();
+      const hookSpecific = output.hookSpecificOutput;
+      if (hookSpecific && typeof hookSpecific === 'object' && !Array.isArray(hookSpecific)) {
+        for (const key of Object.keys(hookSpecific).sort()) shape.push(`hookSpecificOutput.${key}`);
+      }
+      dimensions.outputShape = shape;
+    },
+    fail(nextError, nextReason = 'unhandled_exception') {
+      outcome = 'failure';
+      reason = nextReason;
+      error = nextError;
+      finish(outcome, reason, error);
+    },
+    succeed(nextReason = 'completed') {
+      outcome = 'success';
+      reason = nextReason;
+      finish(outcome, reason);
+    },
+  };
+  activeInvocation = invocation;
+  return invocation;
+}
+
+/** Records response metadata without retaining response content. */
+export function noteHookOutput(output, outputBytes = null) {
+  activeInvocation?.noteOutput(output, outputBytes);
+}
+
+export function recordHookBootstrapFailure(client, event, error) {
+  writeHookEvent({
+    level: 'error',
+    event: 'hook.completed',
+    outcome: 'failure',
+    reason: 'bootstrap_import_failure',
+    durationMs: 0,
+    invocationId: randomUUID(),
+    client,
+    hookEvent: event,
+    processId: process.pid,
+    error: errorFields(error),
+  });
+}
+
+export function readHookEvents({ limit = 200, sinceMs = 24 * 60 * 60 * 1000 } = {}) {
+  try {
+    const dir = hookLogDirectory();
+    if (!existsSync(dir)) return [];
+    const cutoff = Date.now() - Math.max(0, sinceMs);
+    const files = readdirSync(dir)
+      .filter((name) => /^hook-events-.*\.jsonl$/.test(name))
+      .map((name) => join(dir, name))
+      .sort()
+      .reverse();
+    const events = [];
+    for (const file of files) {
+      const lines = readFileSync(file, 'utf8').split(/\r?\n/).filter(Boolean).reverse();
+      for (const line of lines) {
+        try {
+          const event = JSON.parse(line);
+          if (Date.parse(event.timestamp) < cutoff) continue;
+          events.push(event);
+          if (events.length >= limit) return events;
+        } catch {
+          // A partially written final line must not hide the rest of the log.
+        }
+      }
+    }
+    return events;
+  } catch {
+    return [];
+  }
+}
+
+export function hookHealthSummary(options = {}) {
+  const sinceMs = options.sinceMs ?? 24 * 60 * 60 * 1000;
+  const events = readHookEvents({ limit: options.limit || 5000, sinceMs });
+  const durations = events
+    .map((event) => Number(event.durationMs))
+    .filter(Number.isFinite)
+    .sort((a, b) => a - b);
+  const failures = events.filter((event) => event.outcome === 'failure');
+  const timeouts = events.filter((event) => event.outcome === 'timeout');
+  const skipped = events.filter((event) => event.outcome === 'skipped');
+  const successes = events.filter((event) => event.outcome === 'success');
+  const byClient = {};
+  for (const event of events) {
+    const key = event.client || 'unknown';
+    const current = byClient[key] || { total: 0, failures: 0, timeouts: 0, skipped: 0 };
+    current.total++;
+    if (event.outcome === 'failure') current.failures++;
+    if (event.outcome === 'timeout') current.timeouts++;
+    if (event.outcome === 'skipped') current.skipped++;
+    byClient[key] = current;
+  }
+  const percentile = (p) =>
+    durations.length
+      ? durations[Math.min(durations.length - 1, Math.floor(durations.length * p))]
+      : null;
+  const summary = {
+    schemaVersion: HOOK_LOG_SCHEMA_VERSION,
+    available: events.length > 0,
+    windowHours: sinceMs / 3_600_000,
+    total: events.length,
+    failures: failures.length,
+    timeouts: timeouts.length,
+    skipped: skipped.length,
+    successRate: events.length ? successes.length / events.length : null,
+    p50DurationMs: percentile(0.5),
+    p95DurationMs: percentile(0.95),
+    byClient,
+    recentFailures: [...failures, ...timeouts]
+      .sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp))
+      .slice(0, 20),
+  };
+  // Absolute paths are useful to a local doctor, but they do not belong in a
+  // diagnostics export that may be attached to a public issue.
+  if (options.includeLogDirectory === true)
+    summary.logDirectory = hookLogDirectory();
+  return summary;
+}

--- a/integrations/kilo/hooks/lib/policy.mjs
+++ b/integrations/kilo/hooks/lib/policy.mjs
@@ -48,6 +48,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { createHash } from 'node:crypto';
 import { isFsSafePath } from './paths.mjs';
+import { noteHookOutput } from './observability.mjs';
 
 /** Enforcement modes, least to most permissive. */
 export const MODE_ENFORCE = 'enforce';
@@ -653,14 +654,15 @@ export function allow() {
  */
 export function allowWithContext(context) {
   if (context) {
-    process.stdout.write(
-      JSON.stringify({
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-          additionalContext: withEscape(context),
-        },
-      })
-    );
+    const output = {
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        additionalContext: withEscape(context),
+      },
+    };
+    const serialized = JSON.stringify(output);
+    noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+    process.stdout.write(serialized);
   }
   process.exit(0);
 }
@@ -673,15 +675,16 @@ export function allowWithContext(context) {
  * says "use the optimized tool" gets met with a retry of the same call.
  */
 export function deny(reason) {
-  process.stdout.write(
-    JSON.stringify({
-      hookSpecificOutput: {
-        hookEventName: 'PreToolUse',
-        permissionDecision: 'deny',
-        permissionDecisionReason: withEscape(reason),
-      },
-    })
-  );
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+      permissionDecisionReason: withEscape(reason),
+    },
+  };
+  const serialized = JSON.stringify(output);
+  noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
   process.exit(0);
 }
 
@@ -706,14 +709,15 @@ export function withEscape(reason) {
 
 /** Lets the call through, attaching a note the model sees. */
 export function advise(context) {
-  process.stdout.write(
-    JSON.stringify({
-      hookSpecificOutput: {
-        hookEventName: 'PreToolUse',
-        additionalContext: context,
-      },
-    })
-  );
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      additionalContext: context,
+    },
+  };
+  const serialized = JSON.stringify(output);
+  noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
   process.exit(0);
 }
 
@@ -741,26 +745,34 @@ export function enforce(reason, deniedBefore) {
  * than an absent one, so the wait has a ceiling and expiring it is treated
  * exactly like unusable input.
  */
-export async function readPayload({
-  timeoutMs = 5000,
+export async function readPayloadResult({
+  timeoutMs = 1500,
   maxBytes = 8_000_000,
 } = {}) {
   const chunks = [];
   let size = 0;
+  let inputStatus = 'pending';
 
   const raw = await new Promise((resolve) => {
     const onData = (chunk) => {
-      size += chunk.length;
+      size += Buffer.byteLength(chunk, 'utf8');
       // A payload this large is not a tool call; refusing to buffer it
       // unboundedly keeps a hook from becoming a memory problem.
       if (size > maxBytes) {
+        inputStatus = 'too_large';
         finish(null);
         return;
       }
       chunks.push(chunk);
     };
-    const onEnd = () => finish(chunks.join(''));
-    const onError = () => finish(null);
+    const onEnd = () => {
+      inputStatus = 'received';
+      finish(chunks.join(''));
+    };
+    const onError = () => {
+      inputStatus = 'input_error';
+      finish(null);
+    };
 
     // Listeners are REMOVED on every exit path. Leaving them attached after the
     // timeout wins means a late chunk keeps growing a buffer nobody will read,
@@ -774,17 +786,21 @@ export async function readPayload({
       resolve(value);
     }
 
-    const timer = setTimeout(() => finish(null), timeoutMs);
+    const timer = setTimeout(() => {
+      inputStatus = 'timeout';
+      finish(null);
+    }, timeoutMs);
     process.stdin.setEncoding('utf8');
     process.stdin.on('data', onData);
     process.stdin.on('end', onEnd);
     process.stdin.on('error', onError);
   });
 
-  if (raw === null) return null;
+  if (raw === null) return { payload: null, status: inputStatus, bytes: size };
+  if (!raw.trim()) return { payload: null, status: 'empty_input', bytes: size };
   try {
-    return JSON.parse(raw);
+    return { payload: JSON.parse(raw), status: 'ok', bytes: size };
   } catch {
-    return null;
+    return { payload: null, status: 'invalid_json', bytes: size };
   }
 }

--- a/integrations/kilo/hooks/lib/projects.mjs
+++ b/integrations/kilo/hooks/lib/projects.mjs
@@ -1,0 +1,214 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/projects.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Machine-local index of project graph stores.
+ *
+ * A graph is deliberately stored with the project whose files it describes.
+ * That isolation is important for retrieval, but it also means a dashboard
+ * cannot honestly describe machine-wide capture unless it knows which stores
+ * exist. This registry is that missing directory. It is written by lifecycle
+ * hooks and can be backfilled by the explicit discovery command.
+ *
+ * The browser never receives `root` or `graphDir`. Routes resolve an opaque
+ * project id through this server-owned file, so restoring cross-project views
+ * does not restore the old arbitrary-path query vulnerability.
+ */
+
+import {
+  appendFileSync,
+  chmodSync,
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+} from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+import { createHash } from 'node:crypto';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
+
+export const PROJECT_REGISTRY_VERSION = 1;
+
+export function projectRegistryPath() {
+  return (
+    process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY ||
+    join(homedir(), '.token-optimizer', 'projects.jsonl')
+  );
+}
+
+export function projectIdFor(root) {
+  return `project-${createHash('sha256')
+    .update(canonicalPath(root))
+    .digest('hex')
+    .slice(0, 16)}`;
+}
+
+function displayName(root) {
+  return basename(root) || 'Unnamed project';
+}
+
+function acquire(path) {
+  const lockPath = `${path}.lock`;
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+  } catch {
+    return null;
+  }
+
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      closeSync(openSync(lockPath, 'wx', 0o600));
+      return lockPath;
+    } catch {
+      try {
+        if (Date.now() - statSync(lockPath).mtimeMs > 5000) unlinkSync(lockPath);
+      } catch {
+        // The holder may have released it between open and stat; retry.
+      }
+    }
+  }
+  return null;
+}
+
+function release(lockPath) {
+  if (!lockPath) return;
+  try {
+    unlinkSync(lockPath);
+  } catch {
+    // A killed process or cleanup race must not fail the hook.
+  }
+}
+
+/**
+ * Folds the append-only registry into one current entry per canonical project.
+ * Malformed, stale-schema, and unsafe records are ignored rather than trusted.
+ */
+export function registeredProjects() {
+  const path = projectRegistryPath();
+  const projects = new Map();
+  if (!existsSync(path)) return [];
+
+  try {
+    for (const line of readFileSync(path, 'utf8').split('\n')) {
+      if (!line) continue;
+      let record;
+      try {
+        record = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (
+        record.v !== PROJECT_REGISTRY_VERSION ||
+        !isFsSafePath(record.root) ||
+        !isFsSafePath(record.graphDir)
+      ) {
+        continue;
+      }
+      const root = canonicalPath(record.root);
+      const graphDir = canonicalPath(record.graphDir);
+      // Append-only history can outlive a deleted worktree (especially a
+      // short-lived test or CI checkout). A source that no longer exists
+      // cannot be captured, and presenting it as a current coverage gap makes
+      // the dashboard steadily less truthful over time.
+      if (!existsSync(root)) continue;
+      // A broad discovery root may contain hundreds of dormant worktrees. They
+      // are not capture coverage until a hook has observed them or a graph
+      // exists; listing all of them turns the selector into filesystem noise.
+      if (
+        record.client === 'discovery' &&
+        !existsSync(join(graphDir, 'graph.jsonl'))
+      ) {
+        continue;
+      }
+      const id = projectIdFor(root);
+      if (record.id !== id) continue;
+
+      const previous = projects.get(id);
+      projects.set(id, {
+        id,
+        name: String(record.name || displayName(root)).slice(0, 160),
+        root,
+        graphDir,
+        firstSeenAt: previous?.firstSeenAt || record.at || 0,
+        lastSeenAt: Math.max(previous?.lastSeenAt || 0, Number(record.at) || 0),
+        clients: [
+          ...new Set([
+            ...(previous?.clients || []),
+            ...(typeof record.client === 'string' && record.client
+              ? [record.client.slice(0, 80)]
+              : []),
+          ]),
+        ].sort(),
+      });
+    }
+  } catch {
+    return [];
+  }
+
+  return [...projects.values()].sort(
+    (a, b) => b.lastSeenAt - a.lastSeenAt || a.name.localeCompare(b.name)
+  );
+}
+
+/** Registers one VCS project without ever making a hook fail closed. */
+export function registerProject({ root, graphDir, client = 'unknown', name } = {}) {
+  if (!isFsSafePath(root) || !isFsSafePath(graphDir)) return null;
+  try {
+    const canonicalRoot = canonicalPath(root);
+    const canonicalGraphDir = canonicalPath(graphDir);
+    const isRepository = ['.git', '.hg', '.svn'].some((marker) =>
+      existsSync(join(canonicalRoot, marker))
+    );
+    if (!isRepository) return null;
+    const id = projectIdFor(canonicalRoot);
+    const now = Date.now();
+    const recent = registeredProjects().find(
+      (project) =>
+        project.id === id &&
+        project.graphDir === canonicalGraphDir &&
+        project.clients.includes(client) &&
+        now - project.lastSeenAt < 60 * 60 * 1000
+    );
+    if (recent) return recent;
+
+    const path = projectRegistryPath();
+    const lockPath = acquire(path);
+    if (!lockPath) return null;
+    try {
+      appendFileSync(
+        path,
+        `${JSON.stringify({
+          v: PROJECT_REGISTRY_VERSION,
+          id,
+          name: String(name || displayName(canonicalRoot)).slice(0, 160),
+          root: canonicalRoot,
+          graphDir: canonicalGraphDir,
+          client: String(client || 'unknown').slice(0, 80),
+          at: now,
+        })}\n`,
+        { mode: 0o600 }
+      );
+      try {
+        chmodSync(path, 0o600);
+      } catch {
+        // Windows and some filesystems do not expose POSIX modes.
+      }
+    } finally {
+      release(lockPath);
+    }
+    return {
+      id,
+      name: String(name || displayName(canonicalRoot)).slice(0, 160),
+      root: canonicalRoot,
+      graphDir: canonicalGraphDir,
+      firstSeenAt: now,
+      lastSeenAt: now,
+      clients: [String(client || 'unknown').slice(0, 80)],
+    };
+  } catch {
+    return null;
+  }
+}

--- a/integrations/kilo/hooks/post-tool.mjs
+++ b/integrations/kilo/hooks/post-tool.mjs
@@ -2,7 +2,17 @@
 // GENERATED FILE -- do not edit. Regenerate with `npm run sync:hooks`.
 // Client entry point: names the client and event; all policy lives in the
 // shared core so no client can drift its own thresholds or guidance.
-import { run } from './lib/adapter.mjs';
-
 // Fail open: a defect in the optimizer must never cost the user a tool call.
-run('kilo', 'post-tool').catch(() => process.exit(0));
+// Bootstrap failures are still recorded so fail-open does not become fail-silent.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+try {
+  const { run } = await import('./lib/adapter.mjs');
+  await run('kilo', 'post-tool');
+} catch (error) {
+  try {
+    const { recordHookBootstrapFailure } = await import('./lib/observability.mjs');
+    recordHookBootstrapFailure('kilo', 'post-tool', error);
+  } catch {
+    // A logger bootstrap failure is the only condition that remains silent.
+  }
+}

--- a/integrations/kilo/hooks/pre-tool.mjs
+++ b/integrations/kilo/hooks/pre-tool.mjs
@@ -2,7 +2,17 @@
 // GENERATED FILE -- do not edit. Regenerate with `npm run sync:hooks`.
 // Client entry point: names the client and event; all policy lives in the
 // shared core so no client can drift its own thresholds or guidance.
-import { run } from './lib/adapter.mjs';
-
 // Fail open: a defect in the optimizer must never cost the user a tool call.
-run('kilo', 'pre-tool').catch(() => process.exit(0));
+// Bootstrap failures are still recorded so fail-open does not become fail-silent.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+try {
+  const { run } = await import('./lib/adapter.mjs');
+  await run('kilo', 'pre-tool');
+} catch (error) {
+  try {
+    const { recordHookBootstrapFailure } = await import('./lib/observability.mjs');
+    recordHookBootstrapFailure('kilo', 'pre-tool', error);
+  } catch {
+    // A logger bootstrap failure is the only condition that remains silent.
+  }
+}

--- a/integrations/kilo/hooks/session-start.mjs
+++ b/integrations/kilo/hooks/session-start.mjs
@@ -2,7 +2,17 @@
 // GENERATED FILE -- do not edit. Regenerate with `npm run sync:hooks`.
 // Client entry point: names the client and event; all policy lives in the
 // shared core so no client can drift its own thresholds or guidance.
-import { run } from './lib/adapter.mjs';
-
 // Fail open: a defect in the optimizer must never cost the user a tool call.
-run('kilo', 'session-start').catch(() => process.exit(0));
+// Bootstrap failures are still recorded so fail-open does not become fail-silent.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+try {
+  const { run } = await import('./lib/adapter.mjs');
+  await run('kilo', 'session-start');
+} catch (error) {
+  try {
+    const { recordHookBootstrapFailure } = await import('./lib/observability.mjs');
+    recordHookBootstrapFailure('kilo', 'session-start', error);
+  } catch {
+    // A logger bootstrap failure is the only condition that remains silent.
+  }
+}

--- a/integrations/opencode/hooks/lib/adapter.mjs
+++ b/integrations/opencode/hooks/lib/adapter.mjs
@@ -27,6 +27,7 @@ import {
   MODE_OFF,
   MODE_ADVISE,
   largeFileBytes,
+  readPayloadResult,
   withEscape,
 } from './policy.mjs';
 import {
@@ -83,6 +84,8 @@ import {
 } from './capabilities.mjs';
 import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 import { evaluateUcrGuards } from './ucr-guard.mjs';
+import { beginHookInvocation, noteHookOutput } from './observability.mjs';
+import { registerProject } from './projects.mjs';
 
 /**
  * Per-client capability.
@@ -128,7 +131,14 @@ export function mutationSucceeded(clientName, raw) {
 
   // These lifecycle contracts fire this event only after a successful tool,
   // or are called by our in-process bridge only from its successful after hook.
-  return new Set(['claude-code', 'qwen', 'opencode', 'kilo', 'windsurf']).has(
+  return new Set([
+    'claude-code',
+    'codex',
+    'qwen',
+    'opencode',
+    'kilo',
+    'windsurf',
+  ]).has(
     clientName
   );
 }
@@ -241,37 +251,9 @@ export function sessionTaskContext(raw = {}) {
 }
 
 function emit(object) {
-  process.stdout.write(JSON.stringify(object));
-}
-
-/**
- * Bounded stdin read. See policy.readPayload for why the ceiling matters: the
- * entry points fail open on a THROW, but a host that opens the pipe and never
- * closes it produces no throw -- just a hook that waits forever with the user's
- * tool call stuck behind it.
- */
-async function readStdin({ timeoutMs = 5000 } = {}) {
-  const raw = await new Promise((resolve) => {
-    const chunks = [];
-    const timer = setTimeout(() => resolve(null), timeoutMs);
-    process.stdin.setEncoding('utf8');
-    process.stdin.on('data', (chunk) => chunks.push(chunk));
-    process.stdin.on('end', () => {
-      clearTimeout(timer);
-      resolve(chunks.join(''));
-    });
-    process.stdin.on('error', () => {
-      clearTimeout(timer);
-      resolve(null);
-    });
-  });
-
-  if (raw === null) return null;
-  try {
-    return JSON.parse(raw);
-  } catch {
-    return null;
-  }
+  const serialized = JSON.stringify(object);
+  noteHookOutput(object, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
 }
 
 /** The session-start notice, shared verbatim so no client drifts its own copy. */
@@ -502,6 +484,17 @@ function observeAndInject(payload, state, episode, features) {
  * @param {'session-start'|'pre-tool'|'post-tool'|'stop'} event
  */
 export async function run(clientName, event) {
+  const invocation = beginHookInvocation(clientName, event);
+  try {
+    await runHook(clientName, event, invocation);
+    invocation.succeed();
+  } catch (error) {
+    // The optimizer must fail open, but the failure is now reconstructable.
+    invocation.fail(error);
+  }
+}
+
+async function runHook(clientName, event, invocation) {
   const client = CLIENTS[clientName] || CLIENTS['claude-code'];
   const eventName =
     event === 'session-start'
@@ -529,7 +522,10 @@ export async function run(clientName, event) {
     // full pre-tool timeout would turn optional context into a five-second
     // startup tax; lifecycle payloads are tiny and arrive immediately when
     // the host supplies one.
-    const raw = (await readStdin({ timeoutMs: 250 })) || {};
+    const input = await readPayloadResult({ timeoutMs: 250 });
+    const raw = input.payload || {};
+    invocation.bind(raw, null, input.bytes);
+    if (input.status !== 'ok') invocation.noteInput(input.status, input.bytes);
     const toolEvidence = optimizerToolEvidence(raw);
     const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id;
     if (sessionId && toolEvidence.proven) {
@@ -540,10 +536,12 @@ export async function run(clientName, event) {
     const parts = [
       policyText(client.canDeny, toolEvidence.names, toolEvidence.proven),
     ];
+    const cwd = raw.cwd || raw.working_directory || process.cwd();
+    const root = projectRootFor(join(cwd, '__session__'), cwd);
+    registerProject({ root, graphDir: wikiDir(root), client: clientName });
     if (features.retrieval) {
       try {
-        const cwd = raw.cwd || raw.working_directory || process.cwd();
-        const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+        const dir = wikiDir(root);
         // SessionStart needs hashes and claims, not stored file bodies. Parsing
         // the snapshot sidecar here would make startup scale with repository
         // history even though this compact index never renders a diff.
@@ -569,14 +567,20 @@ export async function run(clientName, event) {
     process.exit(0);
   }
 
-  const raw = await readStdin();
+  const input = await readPayloadResult();
+  const raw = input.payload;
   if (!raw) {
+    invocation.noteInput(input.status, input.bytes);
     // Stop requires JSON on stdout even when it has nothing to add.
     if (event === 'stop') emit({});
     process.exit(0);
   }
 
   if (event === 'stop') {
+    // Stop has no normalized tool payload, but it is still a fully formed hook
+    // invocation. Bind its lifecycle identifiers so successful completions do
+    // not look like an input reader that never ran in cross-client telemetry.
+    invocation.bind(raw, null, input.bytes);
     const sessionId =
       raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? 'default';
     const agentScope = raw.transcript_path ?? raw.transcriptPath ?? null;
@@ -632,6 +636,7 @@ export async function run(clientName, event) {
   const payload = normalizePayload(
     normalizeClientPayload(clientName, event, raw)
   );
+  invocation.bind(raw, payload, input.bytes);
   if (!payload.tool_name) process.exit(0);
   const episode = episodeMeta({ client: clientName, raw, payload });
 

--- a/integrations/opencode/hooks/lib/metrics.mjs
+++ b/integrations/opencode/hooks/lib/metrics.mjs
@@ -1297,8 +1297,8 @@ function concurrencySummary(runs) {
  * live hook traces, and randomized model evals remain visibly distinct: only
  * `eval-run` records with paired arms can produce a causal effect interval.
  */
-export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
-  const evidence = readEvidence(dir).filter((event) => matchesFilters(event, filters));
+function buildEvidenceReport(evidence, { filters = {}, episodeLimit = 100 } = {}) {
+  evidence = evidence.filter((event) => matchesFilters(event, filters));
   const runs = evidence.filter((event) => event.kind === 'eval-run');
   const handoffRuns = evidence.filter((event) => event.kind === 'handoff-run');
   const concurrencyRuns = evidence.filter((event) => event.kind === 'concurrency-run');
@@ -1402,6 +1402,47 @@ export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
       minimumPairs,
       handoffMinimumPairs: handoffMinimumPairs(),
       deterministicChecksAreCausalProof: false,
+    },
+  };
+}
+
+export function evidenceReport(dir, options = {}) {
+  const events = readEvidence(dir);
+  const report = buildEvidenceReport(events, options);
+  const hasMatchingEvidence = events.some((event) =>
+    matchesFilters(event, options.filters || {})
+  );
+  return {
+    ...report,
+    sourceCoverage: {
+      projects: 1,
+      projectsWithEvidence: hasMatchingEvidence ? 1 : 0,
+      projectsWithoutEvidence: hasMatchingEvidence ? 0 : 1,
+    },
+  };
+}
+
+/**
+ * Pools evidence across registered projects before computing cohorts.
+ *
+ * A cohort split across two worktrees is still one experiment. Summing already
+ * aggregated reports would lose pairing and produce invalid confidence
+ * intervals, so this combines the append-only source events first and runs the
+ * estimator exactly once.
+ */
+export function evidenceReportMany(dirs, options = {}) {
+  const unique = [...new Set((dirs || []).map((dir) => String(dir)))];
+  const sources = unique.map((dir) => readEvidence(dir));
+  const report = buildEvidenceReport(sources.flat(), options);
+  const projectsWithEvidence = sources.filter((events) =>
+    events.some((event) => matchesFilters(event, options.filters || {}))
+  ).length;
+  return {
+    ...report,
+    sourceCoverage: {
+      projects: unique.length,
+      projectsWithEvidence,
+      projectsWithoutEvidence: unique.length - projectsWithEvidence,
     },
   };
 }

--- a/integrations/opencode/hooks/lib/metrics.mjs
+++ b/integrations/opencode/hooks/lib/metrics.mjs
@@ -738,10 +738,7 @@ function canonicalKeyish(p) {
  * arms, multiplied by treated touches. Reporting it as a measured fact would be
  * the same overclaiming this project criticises competitors for.
  */
-export function report(dir) {
-  const events = readAll(dir);
-  // Injections and harvests come from the log that cannot be starved.
-  const balance = readBalance(dir);
+function buildReport(events, balance) {
 
   // COMMAND INJECTIONS ARE COUNTED SEPARATELY, not mixed into the balance.
   //
@@ -843,6 +840,15 @@ export function report(dir) {
   const sufficient = treated.length >= 20 && withheld.length >= 5;
 
   return {
+    memoryDeliveries: allInjections.filter((event) => !event.holdout).length,
+    memoryHoldouts: allInjections.filter((event) => event.holdout).length,
+    deliveryTokens: allInjections
+      .filter((event) => !event.holdout)
+      .reduce(
+        (sum, event) =>
+          sum + (event.deliveredTokens ?? event.tokens ?? 0),
+        0
+      ),
     injections: treated.length,
     sessionStartInjections: sessionStartInjections.length,
     sessionStartInjectedTokens: sessionStartInjections.reduce(
@@ -864,6 +870,27 @@ export function report(dir) {
         ? 'the graph is saving more than it costs'
         : 'the graph is NOT yet paying for itself',
   };
+}
+
+export function report(dir) {
+  return buildReport(readAll(dir), readBalance(dir));
+}
+
+/**
+ * One statistically valid machine/project-group report.
+ *
+ * Summing per-project verdicts is wrong: five projects with four treated reads
+ * each do not individually meet the threshold, but together they are twenty
+ * observations. Pooling the underlying events preserves the randomized arms
+ * and computes the means once over the selected population.
+ */
+export function reportMany(dirs) {
+  const unique = [...new Set((dirs || []).map((dir) => String(dir)))];
+  const report = buildReport(
+    unique.flatMap((dir) => readAll(dir)),
+    unique.flatMap((dir) => readBalance(dir))
+  );
+  return { ...report, projects: unique.length };
 }
 
 /**

--- a/integrations/opencode/hooks/lib/observability.mjs
+++ b/integrations/opencode/hooks/lib/observability.mjs
@@ -1,0 +1,400 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+/**
+ * Privacy-safe, cross-client lifecycle diagnostics.
+ *
+ * Hook processes are intentionally fail-open, but fail-open must not mean
+ * fail-silent. Every client writes the same bounded JSONL schema so failures
+ * can be correlated without storing prompts, commands, tool output, or file
+ * contents.
+ */
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmdirSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { createHash, randomUUID } from 'node:crypto';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export const HOOK_LOG_SCHEMA_VERSION = 1;
+const DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
+const DEFAULT_RETENTION_DAYS = 14;
+const DEFAULT_MAX_FILES = 40;
+const DEFAULT_DEADLINE_MS = 4200;
+const MAX_ERROR_CHARS = 4000;
+const MAX_DIMENSION_CHARS = 160;
+let activeInvocation = null;
+
+function positiveInteger(name, fallback) {
+  const value = Number(process.env[name]);
+  return Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+export function hookLogDirectory() {
+  if (process.env.TOKEN_OPTIMIZER_LOG_DIR)
+    return process.env.TOKEN_OPTIMIZER_LOG_DIR;
+  const stateRoot =
+    process.env.TOKEN_OPTIMIZER_STATE_DIR ||
+    join(homedir(), '.token-optimizer');
+  return join(stateRoot, 'logs');
+}
+
+function hash(value, length = 16) {
+  if (!value) return null;
+  return createHash('sha256').update(String(value)).digest('hex').slice(0, length);
+}
+
+function sanitize(text) {
+  if (text === undefined || text === null) return null;
+  let value = String(text);
+  const home = homedir().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  if (home) value = value.replace(new RegExp(home, 'gi'), '<home>');
+  value = value
+    .replace(/\b(?:sk-[A-Za-z0-9_-]{12,}|gh[opusr]_[A-Za-z0-9]{12,})\b/g, '[REDACTED]')
+    .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi, '$1[REDACTED]')
+    .replace(/\b(password|secret|token|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi, '$1=[REDACTED]');
+  return value.slice(0, MAX_ERROR_CHARS);
+}
+
+function errorFields(error) {
+  if (!error) return null;
+  return {
+    type: sanitize(error.name || error.constructor?.name || 'Error'),
+    message: sanitize(error.message || error),
+    stack: sanitize(error.stack),
+  };
+}
+
+function dimension(value) {
+  const sanitized = sanitize(value);
+  return sanitized === null ? null : sanitized.slice(0, MAX_DIMENSION_CHARS);
+}
+
+function severity(level) {
+  if (level === 'error') return { severityText: 'ERROR', severityNumber: 17 };
+  if (level === 'warn') return { severityText: 'WARN', severityNumber: 13 };
+  return { severityText: 'INFO', severityNumber: 9 };
+}
+
+function activeLogPath(now = new Date()) {
+  const date = now.toISOString().slice(0, 10);
+  return join(hookLogDirectory(), `hook-events-${date}.jsonl`);
+}
+
+function rotateIfNeeded(path) {
+  try {
+    if (!existsSync(path)) return;
+    const maxBytes = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_BYTES', DEFAULT_MAX_BYTES);
+    if (statSync(path).size < maxBytes) return;
+
+    const lock = join(hookLogDirectory(), '.rotate.lock');
+    try {
+      mkdirSync(lock);
+    } catch {
+      return;
+    }
+    try {
+      if (existsSync(path) && statSync(path).size >= maxBytes) {
+        // Multiple hook processes (or several writes in one millisecond) must
+        // never select the same rotation target and overwrite an earlier file.
+        const rotated = path.replace(
+          /\.jsonl$/,
+          `-${Date.now()}-${process.pid}-${randomUUID()}.jsonl`
+        );
+        renameSync(path, rotated);
+      }
+    } finally {
+      // Non-recursive removal of the one fixed-name lock directory only.
+      try { rmdirSync(lock); } catch { /* best effort */ }
+    }
+  } catch {
+    // Diagnostics must never become the reason a lifecycle hook fails.
+  }
+}
+
+function pruneIfDue(now = new Date()) {
+  try {
+    const dir = hookLogDirectory();
+    const marker = join(dir, '.last-prune');
+    if (existsSync(marker) && now.getTime() - statSync(marker).mtimeMs < 60 * 60 * 1000)
+      return;
+    writeFileSync(marker, now.toISOString(), { flag: 'w' });
+
+    const retentionMs =
+      positiveInteger('TOKEN_OPTIMIZER_LOG_RETENTION_DAYS', DEFAULT_RETENTION_DAYS) *
+      24 * 60 * 60 * 1000;
+    const maxFiles = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_FILES', DEFAULT_MAX_FILES);
+    const files = readdirSync(dir)
+      .filter((name) => /^hook-events-.*\.jsonl$/.test(name))
+      .map((name) => {
+        const path = join(dir, name);
+        return { path, mtimeMs: statSync(path).mtimeMs };
+      })
+      .sort((a, b) => b.mtimeMs - a.mtimeMs);
+    for (let i = 0; i < files.length; i++) {
+      if (i >= maxFiles || now.getTime() - files[i].mtimeMs > retentionMs)
+        unlinkSync(files[i].path);
+    }
+  } catch {
+    // Retention is best effort and cannot affect the host tool call.
+  }
+}
+
+export function writeHookEvent(event) {
+  try {
+    const now = new Date();
+    const dir = hookLogDirectory();
+    mkdirSync(dir, { recursive: true });
+    const path = activeLogPath(now);
+    rotateIfNeeded(path);
+    const record = {
+      schemaVersion: HOOK_LOG_SCHEMA_VERSION,
+      timestamp: now.toISOString(),
+      service: 'token-optimizer',
+      serviceVersion:
+        process.env.TOKEN_OPTIMIZER_VERSION ||
+        process.env.npm_package_version ||
+        'unknown',
+      ...severity(event.level),
+      body: event.event || 'hook.event',
+      ...event,
+    };
+    record.resource = {
+      'service.name': record.service,
+      'service.version': record.serviceVersion,
+      'host.arch': process.arch,
+      'os.type': process.platform,
+      'process.runtime.name': 'node',
+      'process.runtime.version': process.version,
+    };
+    appendFileSync(path, `${JSON.stringify(record)}\n`, { encoding: 'utf8' });
+    pruneIfDue(now);
+    return path;
+  } catch {
+    return null;
+  }
+}
+
+export function beginHookInvocation(client, event, options = {}) {
+  const started = Date.now();
+  const invocationId = randomUUID();
+  let ended = false;
+  let outcome = 'success';
+  let reason = 'completed';
+  let error = null;
+  const dimensions = {
+    sessionIdHash: null,
+    turnIdHash: null,
+    toolUseIdHash: null,
+    toolName: null,
+    clientVersion: null,
+    model: null,
+    cwdHash: null,
+    payloadBytes: null,
+    outputBytes: 0,
+    outputShape: [],
+    inputStatus: 'pending',
+  };
+  const spanId = hash(invocationId, 16);
+  let traceId = hash(invocationId, 32);
+
+  let deadline;
+  const finish = (nextOutcome = outcome, nextReason = reason, nextError = error) => {
+    if (ended) return;
+    ended = true;
+    if (deadline) clearTimeout(deadline);
+    process.removeListener('exit', onExit);
+    writeHookEvent({
+      level: nextOutcome === 'failure' || nextOutcome === 'timeout' ? 'error' : 'info',
+      event: 'hook.completed',
+      outcome: nextOutcome,
+      reason: nextReason,
+      durationMs: Date.now() - started,
+      invocationId,
+      traceId,
+      spanId,
+      client,
+      hookEvent: event,
+      processId: process.pid,
+      ...dimensions,
+      error: errorFields(nextError),
+    });
+  };
+  const onExit = () => finish();
+  process.once('exit', onExit);
+
+  deadline = setTimeout(() => {
+    outcome = 'timeout';
+    reason = 'internal_deadline_exceeded';
+    finish(outcome, reason);
+    // Beat the host's five-second timeout and fail open deterministically.
+    process.exit(0);
+  }, options.deadlineMs ?? positiveInteger('TOKEN_OPTIMIZER_HOOK_DEADLINE_MS', DEFAULT_DEADLINE_MS));
+  deadline.unref();
+
+  const invocation = {
+    invocationId,
+    bind(raw = {}, payload = null, payloadBytes = null) {
+      const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? null;
+      dimensions.sessionIdHash = hash(sessionId);
+      dimensions.turnIdHash = hash(raw.turn_id ?? raw.turnId ?? null);
+      dimensions.toolUseIdHash = hash(raw.tool_use_id ?? raw.toolUseId ?? null);
+      dimensions.toolName = payload?.tool_name ?? raw.tool_name ?? raw.toolName ?? null;
+      dimensions.clientVersion = dimension(raw.client_version ?? raw.clientVersion ?? null);
+      dimensions.model = dimension(raw.model ?? raw.model_name ?? raw.modelName ?? null);
+      dimensions.cwdHash = hash(raw.cwd ?? raw.working_directory ?? process.cwd());
+      dimensions.payloadBytes = payloadBytes;
+      dimensions.inputStatus = 'ok';
+      if (sessionId) traceId = hash(sessionId, 32);
+    },
+    noteInput(status, payloadBytes = null) {
+      dimensions.inputStatus = status;
+      dimensions.payloadBytes = payloadBytes;
+      if (status === 'timeout') {
+        outcome = 'timeout';
+        reason = 'stdin_timeout';
+      } else if (status !== 'ok') {
+        outcome = 'skipped';
+        reason = status;
+      }
+    },
+    skip(nextReason) {
+      outcome = 'skipped';
+      reason = nextReason;
+    },
+    noteOutput(output, outputBytes = null) {
+      dimensions.outputBytes = outputBytes ?? Buffer.byteLength(JSON.stringify(output), 'utf8');
+      if (!output || typeof output !== 'object' || Array.isArray(output)) {
+        dimensions.outputShape = [];
+        return;
+      }
+      const shape = Object.keys(output).sort();
+      const hookSpecific = output.hookSpecificOutput;
+      if (hookSpecific && typeof hookSpecific === 'object' && !Array.isArray(hookSpecific)) {
+        for (const key of Object.keys(hookSpecific).sort()) shape.push(`hookSpecificOutput.${key}`);
+      }
+      dimensions.outputShape = shape;
+    },
+    fail(nextError, nextReason = 'unhandled_exception') {
+      outcome = 'failure';
+      reason = nextReason;
+      error = nextError;
+      finish(outcome, reason, error);
+    },
+    succeed(nextReason = 'completed') {
+      outcome = 'success';
+      reason = nextReason;
+      finish(outcome, reason);
+    },
+  };
+  activeInvocation = invocation;
+  return invocation;
+}
+
+/** Records response metadata without retaining response content. */
+export function noteHookOutput(output, outputBytes = null) {
+  activeInvocation?.noteOutput(output, outputBytes);
+}
+
+export function recordHookBootstrapFailure(client, event, error) {
+  writeHookEvent({
+    level: 'error',
+    event: 'hook.completed',
+    outcome: 'failure',
+    reason: 'bootstrap_import_failure',
+    durationMs: 0,
+    invocationId: randomUUID(),
+    client,
+    hookEvent: event,
+    processId: process.pid,
+    error: errorFields(error),
+  });
+}
+
+export function readHookEvents({ limit = 200, sinceMs = 24 * 60 * 60 * 1000 } = {}) {
+  try {
+    const dir = hookLogDirectory();
+    if (!existsSync(dir)) return [];
+    const cutoff = Date.now() - Math.max(0, sinceMs);
+    const files = readdirSync(dir)
+      .filter((name) => /^hook-events-.*\.jsonl$/.test(name))
+      .map((name) => join(dir, name))
+      .sort()
+      .reverse();
+    const events = [];
+    for (const file of files) {
+      const lines = readFileSync(file, 'utf8').split(/\r?\n/).filter(Boolean).reverse();
+      for (const line of lines) {
+        try {
+          const event = JSON.parse(line);
+          if (Date.parse(event.timestamp) < cutoff) continue;
+          events.push(event);
+          if (events.length >= limit) return events;
+        } catch {
+          // A partially written final line must not hide the rest of the log.
+        }
+      }
+    }
+    return events;
+  } catch {
+    return [];
+  }
+}
+
+export function hookHealthSummary(options = {}) {
+  const sinceMs = options.sinceMs ?? 24 * 60 * 60 * 1000;
+  const events = readHookEvents({ limit: options.limit || 5000, sinceMs });
+  const durations = events
+    .map((event) => Number(event.durationMs))
+    .filter(Number.isFinite)
+    .sort((a, b) => a - b);
+  const failures = events.filter((event) => event.outcome === 'failure');
+  const timeouts = events.filter((event) => event.outcome === 'timeout');
+  const skipped = events.filter((event) => event.outcome === 'skipped');
+  const successes = events.filter((event) => event.outcome === 'success');
+  const byClient = {};
+  for (const event of events) {
+    const key = event.client || 'unknown';
+    const current = byClient[key] || { total: 0, failures: 0, timeouts: 0, skipped: 0 };
+    current.total++;
+    if (event.outcome === 'failure') current.failures++;
+    if (event.outcome === 'timeout') current.timeouts++;
+    if (event.outcome === 'skipped') current.skipped++;
+    byClient[key] = current;
+  }
+  const percentile = (p) =>
+    durations.length
+      ? durations[Math.min(durations.length - 1, Math.floor(durations.length * p))]
+      : null;
+  const summary = {
+    schemaVersion: HOOK_LOG_SCHEMA_VERSION,
+    available: events.length > 0,
+    windowHours: sinceMs / 3_600_000,
+    total: events.length,
+    failures: failures.length,
+    timeouts: timeouts.length,
+    skipped: skipped.length,
+    successRate: events.length ? successes.length / events.length : null,
+    p50DurationMs: percentile(0.5),
+    p95DurationMs: percentile(0.95),
+    byClient,
+    recentFailures: [...failures, ...timeouts]
+      .sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp))
+      .slice(0, 20),
+  };
+  // Absolute paths are useful to a local doctor, but they do not belong in a
+  // diagnostics export that may be attached to a public issue.
+  if (options.includeLogDirectory === true)
+    summary.logDirectory = hookLogDirectory();
+  return summary;
+}

--- a/integrations/opencode/hooks/lib/policy.mjs
+++ b/integrations/opencode/hooks/lib/policy.mjs
@@ -48,6 +48,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { createHash } from 'node:crypto';
 import { isFsSafePath } from './paths.mjs';
+import { noteHookOutput } from './observability.mjs';
 
 /** Enforcement modes, least to most permissive. */
 export const MODE_ENFORCE = 'enforce';
@@ -653,14 +654,15 @@ export function allow() {
  */
 export function allowWithContext(context) {
   if (context) {
-    process.stdout.write(
-      JSON.stringify({
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-          additionalContext: withEscape(context),
-        },
-      })
-    );
+    const output = {
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        additionalContext: withEscape(context),
+      },
+    };
+    const serialized = JSON.stringify(output);
+    noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+    process.stdout.write(serialized);
   }
   process.exit(0);
 }
@@ -673,15 +675,16 @@ export function allowWithContext(context) {
  * says "use the optimized tool" gets met with a retry of the same call.
  */
 export function deny(reason) {
-  process.stdout.write(
-    JSON.stringify({
-      hookSpecificOutput: {
-        hookEventName: 'PreToolUse',
-        permissionDecision: 'deny',
-        permissionDecisionReason: withEscape(reason),
-      },
-    })
-  );
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+      permissionDecisionReason: withEscape(reason),
+    },
+  };
+  const serialized = JSON.stringify(output);
+  noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
   process.exit(0);
 }
 
@@ -706,14 +709,15 @@ export function withEscape(reason) {
 
 /** Lets the call through, attaching a note the model sees. */
 export function advise(context) {
-  process.stdout.write(
-    JSON.stringify({
-      hookSpecificOutput: {
-        hookEventName: 'PreToolUse',
-        additionalContext: context,
-      },
-    })
-  );
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      additionalContext: context,
+    },
+  };
+  const serialized = JSON.stringify(output);
+  noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
   process.exit(0);
 }
 
@@ -741,26 +745,34 @@ export function enforce(reason, deniedBefore) {
  * than an absent one, so the wait has a ceiling and expiring it is treated
  * exactly like unusable input.
  */
-export async function readPayload({
-  timeoutMs = 5000,
+export async function readPayloadResult({
+  timeoutMs = 1500,
   maxBytes = 8_000_000,
 } = {}) {
   const chunks = [];
   let size = 0;
+  let inputStatus = 'pending';
 
   const raw = await new Promise((resolve) => {
     const onData = (chunk) => {
-      size += chunk.length;
+      size += Buffer.byteLength(chunk, 'utf8');
       // A payload this large is not a tool call; refusing to buffer it
       // unboundedly keeps a hook from becoming a memory problem.
       if (size > maxBytes) {
+        inputStatus = 'too_large';
         finish(null);
         return;
       }
       chunks.push(chunk);
     };
-    const onEnd = () => finish(chunks.join(''));
-    const onError = () => finish(null);
+    const onEnd = () => {
+      inputStatus = 'received';
+      finish(chunks.join(''));
+    };
+    const onError = () => {
+      inputStatus = 'input_error';
+      finish(null);
+    };
 
     // Listeners are REMOVED on every exit path. Leaving them attached after the
     // timeout wins means a late chunk keeps growing a buffer nobody will read,
@@ -774,17 +786,21 @@ export async function readPayload({
       resolve(value);
     }
 
-    const timer = setTimeout(() => finish(null), timeoutMs);
+    const timer = setTimeout(() => {
+      inputStatus = 'timeout';
+      finish(null);
+    }, timeoutMs);
     process.stdin.setEncoding('utf8');
     process.stdin.on('data', onData);
     process.stdin.on('end', onEnd);
     process.stdin.on('error', onError);
   });
 
-  if (raw === null) return null;
+  if (raw === null) return { payload: null, status: inputStatus, bytes: size };
+  if (!raw.trim()) return { payload: null, status: 'empty_input', bytes: size };
   try {
-    return JSON.parse(raw);
+    return { payload: JSON.parse(raw), status: 'ok', bytes: size };
   } catch {
-    return null;
+    return { payload: null, status: 'invalid_json', bytes: size };
   }
 }

--- a/integrations/opencode/hooks/lib/projects.mjs
+++ b/integrations/opencode/hooks/lib/projects.mjs
@@ -1,0 +1,214 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/projects.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Machine-local index of project graph stores.
+ *
+ * A graph is deliberately stored with the project whose files it describes.
+ * That isolation is important for retrieval, but it also means a dashboard
+ * cannot honestly describe machine-wide capture unless it knows which stores
+ * exist. This registry is that missing directory. It is written by lifecycle
+ * hooks and can be backfilled by the explicit discovery command.
+ *
+ * The browser never receives `root` or `graphDir`. Routes resolve an opaque
+ * project id through this server-owned file, so restoring cross-project views
+ * does not restore the old arbitrary-path query vulnerability.
+ */
+
+import {
+  appendFileSync,
+  chmodSync,
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+} from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+import { createHash } from 'node:crypto';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
+
+export const PROJECT_REGISTRY_VERSION = 1;
+
+export function projectRegistryPath() {
+  return (
+    process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY ||
+    join(homedir(), '.token-optimizer', 'projects.jsonl')
+  );
+}
+
+export function projectIdFor(root) {
+  return `project-${createHash('sha256')
+    .update(canonicalPath(root))
+    .digest('hex')
+    .slice(0, 16)}`;
+}
+
+function displayName(root) {
+  return basename(root) || 'Unnamed project';
+}
+
+function acquire(path) {
+  const lockPath = `${path}.lock`;
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+  } catch {
+    return null;
+  }
+
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      closeSync(openSync(lockPath, 'wx', 0o600));
+      return lockPath;
+    } catch {
+      try {
+        if (Date.now() - statSync(lockPath).mtimeMs > 5000) unlinkSync(lockPath);
+      } catch {
+        // The holder may have released it between open and stat; retry.
+      }
+    }
+  }
+  return null;
+}
+
+function release(lockPath) {
+  if (!lockPath) return;
+  try {
+    unlinkSync(lockPath);
+  } catch {
+    // A killed process or cleanup race must not fail the hook.
+  }
+}
+
+/**
+ * Folds the append-only registry into one current entry per canonical project.
+ * Malformed, stale-schema, and unsafe records are ignored rather than trusted.
+ */
+export function registeredProjects() {
+  const path = projectRegistryPath();
+  const projects = new Map();
+  if (!existsSync(path)) return [];
+
+  try {
+    for (const line of readFileSync(path, 'utf8').split('\n')) {
+      if (!line) continue;
+      let record;
+      try {
+        record = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (
+        record.v !== PROJECT_REGISTRY_VERSION ||
+        !isFsSafePath(record.root) ||
+        !isFsSafePath(record.graphDir)
+      ) {
+        continue;
+      }
+      const root = canonicalPath(record.root);
+      const graphDir = canonicalPath(record.graphDir);
+      // Append-only history can outlive a deleted worktree (especially a
+      // short-lived test or CI checkout). A source that no longer exists
+      // cannot be captured, and presenting it as a current coverage gap makes
+      // the dashboard steadily less truthful over time.
+      if (!existsSync(root)) continue;
+      // A broad discovery root may contain hundreds of dormant worktrees. They
+      // are not capture coverage until a hook has observed them or a graph
+      // exists; listing all of them turns the selector into filesystem noise.
+      if (
+        record.client === 'discovery' &&
+        !existsSync(join(graphDir, 'graph.jsonl'))
+      ) {
+        continue;
+      }
+      const id = projectIdFor(root);
+      if (record.id !== id) continue;
+
+      const previous = projects.get(id);
+      projects.set(id, {
+        id,
+        name: String(record.name || displayName(root)).slice(0, 160),
+        root,
+        graphDir,
+        firstSeenAt: previous?.firstSeenAt || record.at || 0,
+        lastSeenAt: Math.max(previous?.lastSeenAt || 0, Number(record.at) || 0),
+        clients: [
+          ...new Set([
+            ...(previous?.clients || []),
+            ...(typeof record.client === 'string' && record.client
+              ? [record.client.slice(0, 80)]
+              : []),
+          ]),
+        ].sort(),
+      });
+    }
+  } catch {
+    return [];
+  }
+
+  return [...projects.values()].sort(
+    (a, b) => b.lastSeenAt - a.lastSeenAt || a.name.localeCompare(b.name)
+  );
+}
+
+/** Registers one VCS project without ever making a hook fail closed. */
+export function registerProject({ root, graphDir, client = 'unknown', name } = {}) {
+  if (!isFsSafePath(root) || !isFsSafePath(graphDir)) return null;
+  try {
+    const canonicalRoot = canonicalPath(root);
+    const canonicalGraphDir = canonicalPath(graphDir);
+    const isRepository = ['.git', '.hg', '.svn'].some((marker) =>
+      existsSync(join(canonicalRoot, marker))
+    );
+    if (!isRepository) return null;
+    const id = projectIdFor(canonicalRoot);
+    const now = Date.now();
+    const recent = registeredProjects().find(
+      (project) =>
+        project.id === id &&
+        project.graphDir === canonicalGraphDir &&
+        project.clients.includes(client) &&
+        now - project.lastSeenAt < 60 * 60 * 1000
+    );
+    if (recent) return recent;
+
+    const path = projectRegistryPath();
+    const lockPath = acquire(path);
+    if (!lockPath) return null;
+    try {
+      appendFileSync(
+        path,
+        `${JSON.stringify({
+          v: PROJECT_REGISTRY_VERSION,
+          id,
+          name: String(name || displayName(canonicalRoot)).slice(0, 160),
+          root: canonicalRoot,
+          graphDir: canonicalGraphDir,
+          client: String(client || 'unknown').slice(0, 80),
+          at: now,
+        })}\n`,
+        { mode: 0o600 }
+      );
+      try {
+        chmodSync(path, 0o600);
+      } catch {
+        // Windows and some filesystems do not expose POSIX modes.
+      }
+    } finally {
+      release(lockPath);
+    }
+    return {
+      id,
+      name: String(name || displayName(canonicalRoot)).slice(0, 160),
+      root: canonicalRoot,
+      graphDir: canonicalGraphDir,
+      firstSeenAt: now,
+      lastSeenAt: now,
+      clients: [String(client || 'unknown').slice(0, 80)],
+    };
+  } catch {
+    return null;
+  }
+}

--- a/integrations/opencode/hooks/post-tool.mjs
+++ b/integrations/opencode/hooks/post-tool.mjs
@@ -2,7 +2,17 @@
 // GENERATED FILE -- do not edit. Regenerate with `npm run sync:hooks`.
 // Client entry point: names the client and event; all policy lives in the
 // shared core so no client can drift its own thresholds or guidance.
-import { run } from './lib/adapter.mjs';
-
 // Fail open: a defect in the optimizer must never cost the user a tool call.
-run('opencode', 'post-tool').catch(() => process.exit(0));
+// Bootstrap failures are still recorded so fail-open does not become fail-silent.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+try {
+  const { run } = await import('./lib/adapter.mjs');
+  await run('opencode', 'post-tool');
+} catch (error) {
+  try {
+    const { recordHookBootstrapFailure } = await import('./lib/observability.mjs');
+    recordHookBootstrapFailure('opencode', 'post-tool', error);
+  } catch {
+    // A logger bootstrap failure is the only condition that remains silent.
+  }
+}

--- a/integrations/opencode/hooks/pre-tool.mjs
+++ b/integrations/opencode/hooks/pre-tool.mjs
@@ -2,7 +2,17 @@
 // GENERATED FILE -- do not edit. Regenerate with `npm run sync:hooks`.
 // Client entry point: names the client and event; all policy lives in the
 // shared core so no client can drift its own thresholds or guidance.
-import { run } from './lib/adapter.mjs';
-
 // Fail open: a defect in the optimizer must never cost the user a tool call.
-run('opencode', 'pre-tool').catch(() => process.exit(0));
+// Bootstrap failures are still recorded so fail-open does not become fail-silent.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+try {
+  const { run } = await import('./lib/adapter.mjs');
+  await run('opencode', 'pre-tool');
+} catch (error) {
+  try {
+    const { recordHookBootstrapFailure } = await import('./lib/observability.mjs');
+    recordHookBootstrapFailure('opencode', 'pre-tool', error);
+  } catch {
+    // A logger bootstrap failure is the only condition that remains silent.
+  }
+}

--- a/integrations/opencode/hooks/session-start.mjs
+++ b/integrations/opencode/hooks/session-start.mjs
@@ -2,7 +2,17 @@
 // GENERATED FILE -- do not edit. Regenerate with `npm run sync:hooks`.
 // Client entry point: names the client and event; all policy lives in the
 // shared core so no client can drift its own thresholds or guidance.
-import { run } from './lib/adapter.mjs';
-
 // Fail open: a defect in the optimizer must never cost the user a tool call.
-run('opencode', 'session-start').catch(() => process.exit(0));
+// Bootstrap failures are still recorded so fail-open does not become fail-silent.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+try {
+  const { run } = await import('./lib/adapter.mjs');
+  await run('opencode', 'session-start');
+} catch (error) {
+  try {
+    const { recordHookBootstrapFailure } = await import('./lib/observability.mjs');
+    recordHookBootstrapFailure('opencode', 'session-start', error);
+  } catch {
+    // A logger bootstrap failure is the only condition that remains silent.
+  }
+}

--- a/integrations/qwen/hooks/lib/adapter.mjs
+++ b/integrations/qwen/hooks/lib/adapter.mjs
@@ -27,6 +27,7 @@ import {
   MODE_OFF,
   MODE_ADVISE,
   largeFileBytes,
+  readPayloadResult,
   withEscape,
 } from './policy.mjs';
 import {
@@ -83,6 +84,8 @@ import {
 } from './capabilities.mjs';
 import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 import { evaluateUcrGuards } from './ucr-guard.mjs';
+import { beginHookInvocation, noteHookOutput } from './observability.mjs';
+import { registerProject } from './projects.mjs';
 
 /**
  * Per-client capability.
@@ -128,7 +131,14 @@ export function mutationSucceeded(clientName, raw) {
 
   // These lifecycle contracts fire this event only after a successful tool,
   // or are called by our in-process bridge only from its successful after hook.
-  return new Set(['claude-code', 'qwen', 'opencode', 'kilo', 'windsurf']).has(
+  return new Set([
+    'claude-code',
+    'codex',
+    'qwen',
+    'opencode',
+    'kilo',
+    'windsurf',
+  ]).has(
     clientName
   );
 }
@@ -241,37 +251,9 @@ export function sessionTaskContext(raw = {}) {
 }
 
 function emit(object) {
-  process.stdout.write(JSON.stringify(object));
-}
-
-/**
- * Bounded stdin read. See policy.readPayload for why the ceiling matters: the
- * entry points fail open on a THROW, but a host that opens the pipe and never
- * closes it produces no throw -- just a hook that waits forever with the user's
- * tool call stuck behind it.
- */
-async function readStdin({ timeoutMs = 5000 } = {}) {
-  const raw = await new Promise((resolve) => {
-    const chunks = [];
-    const timer = setTimeout(() => resolve(null), timeoutMs);
-    process.stdin.setEncoding('utf8');
-    process.stdin.on('data', (chunk) => chunks.push(chunk));
-    process.stdin.on('end', () => {
-      clearTimeout(timer);
-      resolve(chunks.join(''));
-    });
-    process.stdin.on('error', () => {
-      clearTimeout(timer);
-      resolve(null);
-    });
-  });
-
-  if (raw === null) return null;
-  try {
-    return JSON.parse(raw);
-  } catch {
-    return null;
-  }
+  const serialized = JSON.stringify(object);
+  noteHookOutput(object, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
 }
 
 /** The session-start notice, shared verbatim so no client drifts its own copy. */
@@ -502,6 +484,17 @@ function observeAndInject(payload, state, episode, features) {
  * @param {'session-start'|'pre-tool'|'post-tool'|'stop'} event
  */
 export async function run(clientName, event) {
+  const invocation = beginHookInvocation(clientName, event);
+  try {
+    await runHook(clientName, event, invocation);
+    invocation.succeed();
+  } catch (error) {
+    // The optimizer must fail open, but the failure is now reconstructable.
+    invocation.fail(error);
+  }
+}
+
+async function runHook(clientName, event, invocation) {
   const client = CLIENTS[clientName] || CLIENTS['claude-code'];
   const eventName =
     event === 'session-start'
@@ -529,7 +522,10 @@ export async function run(clientName, event) {
     // full pre-tool timeout would turn optional context into a five-second
     // startup tax; lifecycle payloads are tiny and arrive immediately when
     // the host supplies one.
-    const raw = (await readStdin({ timeoutMs: 250 })) || {};
+    const input = await readPayloadResult({ timeoutMs: 250 });
+    const raw = input.payload || {};
+    invocation.bind(raw, null, input.bytes);
+    if (input.status !== 'ok') invocation.noteInput(input.status, input.bytes);
     const toolEvidence = optimizerToolEvidence(raw);
     const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id;
     if (sessionId && toolEvidence.proven) {
@@ -540,10 +536,12 @@ export async function run(clientName, event) {
     const parts = [
       policyText(client.canDeny, toolEvidence.names, toolEvidence.proven),
     ];
+    const cwd = raw.cwd || raw.working_directory || process.cwd();
+    const root = projectRootFor(join(cwd, '__session__'), cwd);
+    registerProject({ root, graphDir: wikiDir(root), client: clientName });
     if (features.retrieval) {
       try {
-        const cwd = raw.cwd || raw.working_directory || process.cwd();
-        const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+        const dir = wikiDir(root);
         // SessionStart needs hashes and claims, not stored file bodies. Parsing
         // the snapshot sidecar here would make startup scale with repository
         // history even though this compact index never renders a diff.
@@ -569,14 +567,20 @@ export async function run(clientName, event) {
     process.exit(0);
   }
 
-  const raw = await readStdin();
+  const input = await readPayloadResult();
+  const raw = input.payload;
   if (!raw) {
+    invocation.noteInput(input.status, input.bytes);
     // Stop requires JSON on stdout even when it has nothing to add.
     if (event === 'stop') emit({});
     process.exit(0);
   }
 
   if (event === 'stop') {
+    // Stop has no normalized tool payload, but it is still a fully formed hook
+    // invocation. Bind its lifecycle identifiers so successful completions do
+    // not look like an input reader that never ran in cross-client telemetry.
+    invocation.bind(raw, null, input.bytes);
     const sessionId =
       raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? 'default';
     const agentScope = raw.transcript_path ?? raw.transcriptPath ?? null;
@@ -632,6 +636,7 @@ export async function run(clientName, event) {
   const payload = normalizePayload(
     normalizeClientPayload(clientName, event, raw)
   );
+  invocation.bind(raw, payload, input.bytes);
   if (!payload.tool_name) process.exit(0);
   const episode = episodeMeta({ client: clientName, raw, payload });
 

--- a/integrations/qwen/hooks/lib/metrics.mjs
+++ b/integrations/qwen/hooks/lib/metrics.mjs
@@ -1297,8 +1297,8 @@ function concurrencySummary(runs) {
  * live hook traces, and randomized model evals remain visibly distinct: only
  * `eval-run` records with paired arms can produce a causal effect interval.
  */
-export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
-  const evidence = readEvidence(dir).filter((event) => matchesFilters(event, filters));
+function buildEvidenceReport(evidence, { filters = {}, episodeLimit = 100 } = {}) {
+  evidence = evidence.filter((event) => matchesFilters(event, filters));
   const runs = evidence.filter((event) => event.kind === 'eval-run');
   const handoffRuns = evidence.filter((event) => event.kind === 'handoff-run');
   const concurrencyRuns = evidence.filter((event) => event.kind === 'concurrency-run');
@@ -1402,6 +1402,47 @@ export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
       minimumPairs,
       handoffMinimumPairs: handoffMinimumPairs(),
       deterministicChecksAreCausalProof: false,
+    },
+  };
+}
+
+export function evidenceReport(dir, options = {}) {
+  const events = readEvidence(dir);
+  const report = buildEvidenceReport(events, options);
+  const hasMatchingEvidence = events.some((event) =>
+    matchesFilters(event, options.filters || {})
+  );
+  return {
+    ...report,
+    sourceCoverage: {
+      projects: 1,
+      projectsWithEvidence: hasMatchingEvidence ? 1 : 0,
+      projectsWithoutEvidence: hasMatchingEvidence ? 0 : 1,
+    },
+  };
+}
+
+/**
+ * Pools evidence across registered projects before computing cohorts.
+ *
+ * A cohort split across two worktrees is still one experiment. Summing already
+ * aggregated reports would lose pairing and produce invalid confidence
+ * intervals, so this combines the append-only source events first and runs the
+ * estimator exactly once.
+ */
+export function evidenceReportMany(dirs, options = {}) {
+  const unique = [...new Set((dirs || []).map((dir) => String(dir)))];
+  const sources = unique.map((dir) => readEvidence(dir));
+  const report = buildEvidenceReport(sources.flat(), options);
+  const projectsWithEvidence = sources.filter((events) =>
+    events.some((event) => matchesFilters(event, options.filters || {}))
+  ).length;
+  return {
+    ...report,
+    sourceCoverage: {
+      projects: unique.length,
+      projectsWithEvidence,
+      projectsWithoutEvidence: unique.length - projectsWithEvidence,
     },
   };
 }

--- a/integrations/qwen/hooks/lib/metrics.mjs
+++ b/integrations/qwen/hooks/lib/metrics.mjs
@@ -738,10 +738,7 @@ function canonicalKeyish(p) {
  * arms, multiplied by treated touches. Reporting it as a measured fact would be
  * the same overclaiming this project criticises competitors for.
  */
-export function report(dir) {
-  const events = readAll(dir);
-  // Injections and harvests come from the log that cannot be starved.
-  const balance = readBalance(dir);
+function buildReport(events, balance) {
 
   // COMMAND INJECTIONS ARE COUNTED SEPARATELY, not mixed into the balance.
   //
@@ -843,6 +840,15 @@ export function report(dir) {
   const sufficient = treated.length >= 20 && withheld.length >= 5;
 
   return {
+    memoryDeliveries: allInjections.filter((event) => !event.holdout).length,
+    memoryHoldouts: allInjections.filter((event) => event.holdout).length,
+    deliveryTokens: allInjections
+      .filter((event) => !event.holdout)
+      .reduce(
+        (sum, event) =>
+          sum + (event.deliveredTokens ?? event.tokens ?? 0),
+        0
+      ),
     injections: treated.length,
     sessionStartInjections: sessionStartInjections.length,
     sessionStartInjectedTokens: sessionStartInjections.reduce(
@@ -864,6 +870,27 @@ export function report(dir) {
         ? 'the graph is saving more than it costs'
         : 'the graph is NOT yet paying for itself',
   };
+}
+
+export function report(dir) {
+  return buildReport(readAll(dir), readBalance(dir));
+}
+
+/**
+ * One statistically valid machine/project-group report.
+ *
+ * Summing per-project verdicts is wrong: five projects with four treated reads
+ * each do not individually meet the threshold, but together they are twenty
+ * observations. Pooling the underlying events preserves the randomized arms
+ * and computes the means once over the selected population.
+ */
+export function reportMany(dirs) {
+  const unique = [...new Set((dirs || []).map((dir) => String(dir)))];
+  const report = buildReport(
+    unique.flatMap((dir) => readAll(dir)),
+    unique.flatMap((dir) => readBalance(dir))
+  );
+  return { ...report, projects: unique.length };
 }
 
 /**

--- a/integrations/qwen/hooks/lib/observability.mjs
+++ b/integrations/qwen/hooks/lib/observability.mjs
@@ -1,0 +1,400 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+/**
+ * Privacy-safe, cross-client lifecycle diagnostics.
+ *
+ * Hook processes are intentionally fail-open, but fail-open must not mean
+ * fail-silent. Every client writes the same bounded JSONL schema so failures
+ * can be correlated without storing prompts, commands, tool output, or file
+ * contents.
+ */
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmdirSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { createHash, randomUUID } from 'node:crypto';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export const HOOK_LOG_SCHEMA_VERSION = 1;
+const DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
+const DEFAULT_RETENTION_DAYS = 14;
+const DEFAULT_MAX_FILES = 40;
+const DEFAULT_DEADLINE_MS = 4200;
+const MAX_ERROR_CHARS = 4000;
+const MAX_DIMENSION_CHARS = 160;
+let activeInvocation = null;
+
+function positiveInteger(name, fallback) {
+  const value = Number(process.env[name]);
+  return Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+export function hookLogDirectory() {
+  if (process.env.TOKEN_OPTIMIZER_LOG_DIR)
+    return process.env.TOKEN_OPTIMIZER_LOG_DIR;
+  const stateRoot =
+    process.env.TOKEN_OPTIMIZER_STATE_DIR ||
+    join(homedir(), '.token-optimizer');
+  return join(stateRoot, 'logs');
+}
+
+function hash(value, length = 16) {
+  if (!value) return null;
+  return createHash('sha256').update(String(value)).digest('hex').slice(0, length);
+}
+
+function sanitize(text) {
+  if (text === undefined || text === null) return null;
+  let value = String(text);
+  const home = homedir().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  if (home) value = value.replace(new RegExp(home, 'gi'), '<home>');
+  value = value
+    .replace(/\b(?:sk-[A-Za-z0-9_-]{12,}|gh[opusr]_[A-Za-z0-9]{12,})\b/g, '[REDACTED]')
+    .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi, '$1[REDACTED]')
+    .replace(/\b(password|secret|token|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi, '$1=[REDACTED]');
+  return value.slice(0, MAX_ERROR_CHARS);
+}
+
+function errorFields(error) {
+  if (!error) return null;
+  return {
+    type: sanitize(error.name || error.constructor?.name || 'Error'),
+    message: sanitize(error.message || error),
+    stack: sanitize(error.stack),
+  };
+}
+
+function dimension(value) {
+  const sanitized = sanitize(value);
+  return sanitized === null ? null : sanitized.slice(0, MAX_DIMENSION_CHARS);
+}
+
+function severity(level) {
+  if (level === 'error') return { severityText: 'ERROR', severityNumber: 17 };
+  if (level === 'warn') return { severityText: 'WARN', severityNumber: 13 };
+  return { severityText: 'INFO', severityNumber: 9 };
+}
+
+function activeLogPath(now = new Date()) {
+  const date = now.toISOString().slice(0, 10);
+  return join(hookLogDirectory(), `hook-events-${date}.jsonl`);
+}
+
+function rotateIfNeeded(path) {
+  try {
+    if (!existsSync(path)) return;
+    const maxBytes = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_BYTES', DEFAULT_MAX_BYTES);
+    if (statSync(path).size < maxBytes) return;
+
+    const lock = join(hookLogDirectory(), '.rotate.lock');
+    try {
+      mkdirSync(lock);
+    } catch {
+      return;
+    }
+    try {
+      if (existsSync(path) && statSync(path).size >= maxBytes) {
+        // Multiple hook processes (or several writes in one millisecond) must
+        // never select the same rotation target and overwrite an earlier file.
+        const rotated = path.replace(
+          /\.jsonl$/,
+          `-${Date.now()}-${process.pid}-${randomUUID()}.jsonl`
+        );
+        renameSync(path, rotated);
+      }
+    } finally {
+      // Non-recursive removal of the one fixed-name lock directory only.
+      try { rmdirSync(lock); } catch { /* best effort */ }
+    }
+  } catch {
+    // Diagnostics must never become the reason a lifecycle hook fails.
+  }
+}
+
+function pruneIfDue(now = new Date()) {
+  try {
+    const dir = hookLogDirectory();
+    const marker = join(dir, '.last-prune');
+    if (existsSync(marker) && now.getTime() - statSync(marker).mtimeMs < 60 * 60 * 1000)
+      return;
+    writeFileSync(marker, now.toISOString(), { flag: 'w' });
+
+    const retentionMs =
+      positiveInteger('TOKEN_OPTIMIZER_LOG_RETENTION_DAYS', DEFAULT_RETENTION_DAYS) *
+      24 * 60 * 60 * 1000;
+    const maxFiles = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_FILES', DEFAULT_MAX_FILES);
+    const files = readdirSync(dir)
+      .filter((name) => /^hook-events-.*\.jsonl$/.test(name))
+      .map((name) => {
+        const path = join(dir, name);
+        return { path, mtimeMs: statSync(path).mtimeMs };
+      })
+      .sort((a, b) => b.mtimeMs - a.mtimeMs);
+    for (let i = 0; i < files.length; i++) {
+      if (i >= maxFiles || now.getTime() - files[i].mtimeMs > retentionMs)
+        unlinkSync(files[i].path);
+    }
+  } catch {
+    // Retention is best effort and cannot affect the host tool call.
+  }
+}
+
+export function writeHookEvent(event) {
+  try {
+    const now = new Date();
+    const dir = hookLogDirectory();
+    mkdirSync(dir, { recursive: true });
+    const path = activeLogPath(now);
+    rotateIfNeeded(path);
+    const record = {
+      schemaVersion: HOOK_LOG_SCHEMA_VERSION,
+      timestamp: now.toISOString(),
+      service: 'token-optimizer',
+      serviceVersion:
+        process.env.TOKEN_OPTIMIZER_VERSION ||
+        process.env.npm_package_version ||
+        'unknown',
+      ...severity(event.level),
+      body: event.event || 'hook.event',
+      ...event,
+    };
+    record.resource = {
+      'service.name': record.service,
+      'service.version': record.serviceVersion,
+      'host.arch': process.arch,
+      'os.type': process.platform,
+      'process.runtime.name': 'node',
+      'process.runtime.version': process.version,
+    };
+    appendFileSync(path, `${JSON.stringify(record)}\n`, { encoding: 'utf8' });
+    pruneIfDue(now);
+    return path;
+  } catch {
+    return null;
+  }
+}
+
+export function beginHookInvocation(client, event, options = {}) {
+  const started = Date.now();
+  const invocationId = randomUUID();
+  let ended = false;
+  let outcome = 'success';
+  let reason = 'completed';
+  let error = null;
+  const dimensions = {
+    sessionIdHash: null,
+    turnIdHash: null,
+    toolUseIdHash: null,
+    toolName: null,
+    clientVersion: null,
+    model: null,
+    cwdHash: null,
+    payloadBytes: null,
+    outputBytes: 0,
+    outputShape: [],
+    inputStatus: 'pending',
+  };
+  const spanId = hash(invocationId, 16);
+  let traceId = hash(invocationId, 32);
+
+  let deadline;
+  const finish = (nextOutcome = outcome, nextReason = reason, nextError = error) => {
+    if (ended) return;
+    ended = true;
+    if (deadline) clearTimeout(deadline);
+    process.removeListener('exit', onExit);
+    writeHookEvent({
+      level: nextOutcome === 'failure' || nextOutcome === 'timeout' ? 'error' : 'info',
+      event: 'hook.completed',
+      outcome: nextOutcome,
+      reason: nextReason,
+      durationMs: Date.now() - started,
+      invocationId,
+      traceId,
+      spanId,
+      client,
+      hookEvent: event,
+      processId: process.pid,
+      ...dimensions,
+      error: errorFields(nextError),
+    });
+  };
+  const onExit = () => finish();
+  process.once('exit', onExit);
+
+  deadline = setTimeout(() => {
+    outcome = 'timeout';
+    reason = 'internal_deadline_exceeded';
+    finish(outcome, reason);
+    // Beat the host's five-second timeout and fail open deterministically.
+    process.exit(0);
+  }, options.deadlineMs ?? positiveInteger('TOKEN_OPTIMIZER_HOOK_DEADLINE_MS', DEFAULT_DEADLINE_MS));
+  deadline.unref();
+
+  const invocation = {
+    invocationId,
+    bind(raw = {}, payload = null, payloadBytes = null) {
+      const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? null;
+      dimensions.sessionIdHash = hash(sessionId);
+      dimensions.turnIdHash = hash(raw.turn_id ?? raw.turnId ?? null);
+      dimensions.toolUseIdHash = hash(raw.tool_use_id ?? raw.toolUseId ?? null);
+      dimensions.toolName = payload?.tool_name ?? raw.tool_name ?? raw.toolName ?? null;
+      dimensions.clientVersion = dimension(raw.client_version ?? raw.clientVersion ?? null);
+      dimensions.model = dimension(raw.model ?? raw.model_name ?? raw.modelName ?? null);
+      dimensions.cwdHash = hash(raw.cwd ?? raw.working_directory ?? process.cwd());
+      dimensions.payloadBytes = payloadBytes;
+      dimensions.inputStatus = 'ok';
+      if (sessionId) traceId = hash(sessionId, 32);
+    },
+    noteInput(status, payloadBytes = null) {
+      dimensions.inputStatus = status;
+      dimensions.payloadBytes = payloadBytes;
+      if (status === 'timeout') {
+        outcome = 'timeout';
+        reason = 'stdin_timeout';
+      } else if (status !== 'ok') {
+        outcome = 'skipped';
+        reason = status;
+      }
+    },
+    skip(nextReason) {
+      outcome = 'skipped';
+      reason = nextReason;
+    },
+    noteOutput(output, outputBytes = null) {
+      dimensions.outputBytes = outputBytes ?? Buffer.byteLength(JSON.stringify(output), 'utf8');
+      if (!output || typeof output !== 'object' || Array.isArray(output)) {
+        dimensions.outputShape = [];
+        return;
+      }
+      const shape = Object.keys(output).sort();
+      const hookSpecific = output.hookSpecificOutput;
+      if (hookSpecific && typeof hookSpecific === 'object' && !Array.isArray(hookSpecific)) {
+        for (const key of Object.keys(hookSpecific).sort()) shape.push(`hookSpecificOutput.${key}`);
+      }
+      dimensions.outputShape = shape;
+    },
+    fail(nextError, nextReason = 'unhandled_exception') {
+      outcome = 'failure';
+      reason = nextReason;
+      error = nextError;
+      finish(outcome, reason, error);
+    },
+    succeed(nextReason = 'completed') {
+      outcome = 'success';
+      reason = nextReason;
+      finish(outcome, reason);
+    },
+  };
+  activeInvocation = invocation;
+  return invocation;
+}
+
+/** Records response metadata without retaining response content. */
+export function noteHookOutput(output, outputBytes = null) {
+  activeInvocation?.noteOutput(output, outputBytes);
+}
+
+export function recordHookBootstrapFailure(client, event, error) {
+  writeHookEvent({
+    level: 'error',
+    event: 'hook.completed',
+    outcome: 'failure',
+    reason: 'bootstrap_import_failure',
+    durationMs: 0,
+    invocationId: randomUUID(),
+    client,
+    hookEvent: event,
+    processId: process.pid,
+    error: errorFields(error),
+  });
+}
+
+export function readHookEvents({ limit = 200, sinceMs = 24 * 60 * 60 * 1000 } = {}) {
+  try {
+    const dir = hookLogDirectory();
+    if (!existsSync(dir)) return [];
+    const cutoff = Date.now() - Math.max(0, sinceMs);
+    const files = readdirSync(dir)
+      .filter((name) => /^hook-events-.*\.jsonl$/.test(name))
+      .map((name) => join(dir, name))
+      .sort()
+      .reverse();
+    const events = [];
+    for (const file of files) {
+      const lines = readFileSync(file, 'utf8').split(/\r?\n/).filter(Boolean).reverse();
+      for (const line of lines) {
+        try {
+          const event = JSON.parse(line);
+          if (Date.parse(event.timestamp) < cutoff) continue;
+          events.push(event);
+          if (events.length >= limit) return events;
+        } catch {
+          // A partially written final line must not hide the rest of the log.
+        }
+      }
+    }
+    return events;
+  } catch {
+    return [];
+  }
+}
+
+export function hookHealthSummary(options = {}) {
+  const sinceMs = options.sinceMs ?? 24 * 60 * 60 * 1000;
+  const events = readHookEvents({ limit: options.limit || 5000, sinceMs });
+  const durations = events
+    .map((event) => Number(event.durationMs))
+    .filter(Number.isFinite)
+    .sort((a, b) => a - b);
+  const failures = events.filter((event) => event.outcome === 'failure');
+  const timeouts = events.filter((event) => event.outcome === 'timeout');
+  const skipped = events.filter((event) => event.outcome === 'skipped');
+  const successes = events.filter((event) => event.outcome === 'success');
+  const byClient = {};
+  for (const event of events) {
+    const key = event.client || 'unknown';
+    const current = byClient[key] || { total: 0, failures: 0, timeouts: 0, skipped: 0 };
+    current.total++;
+    if (event.outcome === 'failure') current.failures++;
+    if (event.outcome === 'timeout') current.timeouts++;
+    if (event.outcome === 'skipped') current.skipped++;
+    byClient[key] = current;
+  }
+  const percentile = (p) =>
+    durations.length
+      ? durations[Math.min(durations.length - 1, Math.floor(durations.length * p))]
+      : null;
+  const summary = {
+    schemaVersion: HOOK_LOG_SCHEMA_VERSION,
+    available: events.length > 0,
+    windowHours: sinceMs / 3_600_000,
+    total: events.length,
+    failures: failures.length,
+    timeouts: timeouts.length,
+    skipped: skipped.length,
+    successRate: events.length ? successes.length / events.length : null,
+    p50DurationMs: percentile(0.5),
+    p95DurationMs: percentile(0.95),
+    byClient,
+    recentFailures: [...failures, ...timeouts]
+      .sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp))
+      .slice(0, 20),
+  };
+  // Absolute paths are useful to a local doctor, but they do not belong in a
+  // diagnostics export that may be attached to a public issue.
+  if (options.includeLogDirectory === true)
+    summary.logDirectory = hookLogDirectory();
+  return summary;
+}

--- a/integrations/qwen/hooks/lib/policy.mjs
+++ b/integrations/qwen/hooks/lib/policy.mjs
@@ -48,6 +48,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { createHash } from 'node:crypto';
 import { isFsSafePath } from './paths.mjs';
+import { noteHookOutput } from './observability.mjs';
 
 /** Enforcement modes, least to most permissive. */
 export const MODE_ENFORCE = 'enforce';
@@ -653,14 +654,15 @@ export function allow() {
  */
 export function allowWithContext(context) {
   if (context) {
-    process.stdout.write(
-      JSON.stringify({
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-          additionalContext: withEscape(context),
-        },
-      })
-    );
+    const output = {
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        additionalContext: withEscape(context),
+      },
+    };
+    const serialized = JSON.stringify(output);
+    noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+    process.stdout.write(serialized);
   }
   process.exit(0);
 }
@@ -673,15 +675,16 @@ export function allowWithContext(context) {
  * says "use the optimized tool" gets met with a retry of the same call.
  */
 export function deny(reason) {
-  process.stdout.write(
-    JSON.stringify({
-      hookSpecificOutput: {
-        hookEventName: 'PreToolUse',
-        permissionDecision: 'deny',
-        permissionDecisionReason: withEscape(reason),
-      },
-    })
-  );
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+      permissionDecisionReason: withEscape(reason),
+    },
+  };
+  const serialized = JSON.stringify(output);
+  noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
   process.exit(0);
 }
 
@@ -706,14 +709,15 @@ export function withEscape(reason) {
 
 /** Lets the call through, attaching a note the model sees. */
 export function advise(context) {
-  process.stdout.write(
-    JSON.stringify({
-      hookSpecificOutput: {
-        hookEventName: 'PreToolUse',
-        additionalContext: context,
-      },
-    })
-  );
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      additionalContext: context,
+    },
+  };
+  const serialized = JSON.stringify(output);
+  noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
   process.exit(0);
 }
 
@@ -741,26 +745,34 @@ export function enforce(reason, deniedBefore) {
  * than an absent one, so the wait has a ceiling and expiring it is treated
  * exactly like unusable input.
  */
-export async function readPayload({
-  timeoutMs = 5000,
+export async function readPayloadResult({
+  timeoutMs = 1500,
   maxBytes = 8_000_000,
 } = {}) {
   const chunks = [];
   let size = 0;
+  let inputStatus = 'pending';
 
   const raw = await new Promise((resolve) => {
     const onData = (chunk) => {
-      size += chunk.length;
+      size += Buffer.byteLength(chunk, 'utf8');
       // A payload this large is not a tool call; refusing to buffer it
       // unboundedly keeps a hook from becoming a memory problem.
       if (size > maxBytes) {
+        inputStatus = 'too_large';
         finish(null);
         return;
       }
       chunks.push(chunk);
     };
-    const onEnd = () => finish(chunks.join(''));
-    const onError = () => finish(null);
+    const onEnd = () => {
+      inputStatus = 'received';
+      finish(chunks.join(''));
+    };
+    const onError = () => {
+      inputStatus = 'input_error';
+      finish(null);
+    };
 
     // Listeners are REMOVED on every exit path. Leaving them attached after the
     // timeout wins means a late chunk keeps growing a buffer nobody will read,
@@ -774,17 +786,21 @@ export async function readPayload({
       resolve(value);
     }
 
-    const timer = setTimeout(() => finish(null), timeoutMs);
+    const timer = setTimeout(() => {
+      inputStatus = 'timeout';
+      finish(null);
+    }, timeoutMs);
     process.stdin.setEncoding('utf8');
     process.stdin.on('data', onData);
     process.stdin.on('end', onEnd);
     process.stdin.on('error', onError);
   });
 
-  if (raw === null) return null;
+  if (raw === null) return { payload: null, status: inputStatus, bytes: size };
+  if (!raw.trim()) return { payload: null, status: 'empty_input', bytes: size };
   try {
-    return JSON.parse(raw);
+    return { payload: JSON.parse(raw), status: 'ok', bytes: size };
   } catch {
-    return null;
+    return { payload: null, status: 'invalid_json', bytes: size };
   }
 }

--- a/integrations/qwen/hooks/lib/projects.mjs
+++ b/integrations/qwen/hooks/lib/projects.mjs
@@ -1,0 +1,214 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/projects.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Machine-local index of project graph stores.
+ *
+ * A graph is deliberately stored with the project whose files it describes.
+ * That isolation is important for retrieval, but it also means a dashboard
+ * cannot honestly describe machine-wide capture unless it knows which stores
+ * exist. This registry is that missing directory. It is written by lifecycle
+ * hooks and can be backfilled by the explicit discovery command.
+ *
+ * The browser never receives `root` or `graphDir`. Routes resolve an opaque
+ * project id through this server-owned file, so restoring cross-project views
+ * does not restore the old arbitrary-path query vulnerability.
+ */
+
+import {
+  appendFileSync,
+  chmodSync,
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+} from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+import { createHash } from 'node:crypto';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
+
+export const PROJECT_REGISTRY_VERSION = 1;
+
+export function projectRegistryPath() {
+  return (
+    process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY ||
+    join(homedir(), '.token-optimizer', 'projects.jsonl')
+  );
+}
+
+export function projectIdFor(root) {
+  return `project-${createHash('sha256')
+    .update(canonicalPath(root))
+    .digest('hex')
+    .slice(0, 16)}`;
+}
+
+function displayName(root) {
+  return basename(root) || 'Unnamed project';
+}
+
+function acquire(path) {
+  const lockPath = `${path}.lock`;
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+  } catch {
+    return null;
+  }
+
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      closeSync(openSync(lockPath, 'wx', 0o600));
+      return lockPath;
+    } catch {
+      try {
+        if (Date.now() - statSync(lockPath).mtimeMs > 5000) unlinkSync(lockPath);
+      } catch {
+        // The holder may have released it between open and stat; retry.
+      }
+    }
+  }
+  return null;
+}
+
+function release(lockPath) {
+  if (!lockPath) return;
+  try {
+    unlinkSync(lockPath);
+  } catch {
+    // A killed process or cleanup race must not fail the hook.
+  }
+}
+
+/**
+ * Folds the append-only registry into one current entry per canonical project.
+ * Malformed, stale-schema, and unsafe records are ignored rather than trusted.
+ */
+export function registeredProjects() {
+  const path = projectRegistryPath();
+  const projects = new Map();
+  if (!existsSync(path)) return [];
+
+  try {
+    for (const line of readFileSync(path, 'utf8').split('\n')) {
+      if (!line) continue;
+      let record;
+      try {
+        record = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (
+        record.v !== PROJECT_REGISTRY_VERSION ||
+        !isFsSafePath(record.root) ||
+        !isFsSafePath(record.graphDir)
+      ) {
+        continue;
+      }
+      const root = canonicalPath(record.root);
+      const graphDir = canonicalPath(record.graphDir);
+      // Append-only history can outlive a deleted worktree (especially a
+      // short-lived test or CI checkout). A source that no longer exists
+      // cannot be captured, and presenting it as a current coverage gap makes
+      // the dashboard steadily less truthful over time.
+      if (!existsSync(root)) continue;
+      // A broad discovery root may contain hundreds of dormant worktrees. They
+      // are not capture coverage until a hook has observed them or a graph
+      // exists; listing all of them turns the selector into filesystem noise.
+      if (
+        record.client === 'discovery' &&
+        !existsSync(join(graphDir, 'graph.jsonl'))
+      ) {
+        continue;
+      }
+      const id = projectIdFor(root);
+      if (record.id !== id) continue;
+
+      const previous = projects.get(id);
+      projects.set(id, {
+        id,
+        name: String(record.name || displayName(root)).slice(0, 160),
+        root,
+        graphDir,
+        firstSeenAt: previous?.firstSeenAt || record.at || 0,
+        lastSeenAt: Math.max(previous?.lastSeenAt || 0, Number(record.at) || 0),
+        clients: [
+          ...new Set([
+            ...(previous?.clients || []),
+            ...(typeof record.client === 'string' && record.client
+              ? [record.client.slice(0, 80)]
+              : []),
+          ]),
+        ].sort(),
+      });
+    }
+  } catch {
+    return [];
+  }
+
+  return [...projects.values()].sort(
+    (a, b) => b.lastSeenAt - a.lastSeenAt || a.name.localeCompare(b.name)
+  );
+}
+
+/** Registers one VCS project without ever making a hook fail closed. */
+export function registerProject({ root, graphDir, client = 'unknown', name } = {}) {
+  if (!isFsSafePath(root) || !isFsSafePath(graphDir)) return null;
+  try {
+    const canonicalRoot = canonicalPath(root);
+    const canonicalGraphDir = canonicalPath(graphDir);
+    const isRepository = ['.git', '.hg', '.svn'].some((marker) =>
+      existsSync(join(canonicalRoot, marker))
+    );
+    if (!isRepository) return null;
+    const id = projectIdFor(canonicalRoot);
+    const now = Date.now();
+    const recent = registeredProjects().find(
+      (project) =>
+        project.id === id &&
+        project.graphDir === canonicalGraphDir &&
+        project.clients.includes(client) &&
+        now - project.lastSeenAt < 60 * 60 * 1000
+    );
+    if (recent) return recent;
+
+    const path = projectRegistryPath();
+    const lockPath = acquire(path);
+    if (!lockPath) return null;
+    try {
+      appendFileSync(
+        path,
+        `${JSON.stringify({
+          v: PROJECT_REGISTRY_VERSION,
+          id,
+          name: String(name || displayName(canonicalRoot)).slice(0, 160),
+          root: canonicalRoot,
+          graphDir: canonicalGraphDir,
+          client: String(client || 'unknown').slice(0, 80),
+          at: now,
+        })}\n`,
+        { mode: 0o600 }
+      );
+      try {
+        chmodSync(path, 0o600);
+      } catch {
+        // Windows and some filesystems do not expose POSIX modes.
+      }
+    } finally {
+      release(lockPath);
+    }
+    return {
+      id,
+      name: String(name || displayName(canonicalRoot)).slice(0, 160),
+      root: canonicalRoot,
+      graphDir: canonicalGraphDir,
+      firstSeenAt: now,
+      lastSeenAt: now,
+      clients: [String(client || 'unknown').slice(0, 80)],
+    };
+  } catch {
+    return null;
+  }
+}

--- a/integrations/qwen/hooks/post-tool.mjs
+++ b/integrations/qwen/hooks/post-tool.mjs
@@ -2,7 +2,17 @@
 // GENERATED FILE -- do not edit. Regenerate with `npm run sync:hooks`.
 // Client entry point: names the client and event; all policy lives in the
 // shared core so no client can drift its own thresholds or guidance.
-import { run } from './lib/adapter.mjs';
-
 // Fail open: a defect in the optimizer must never cost the user a tool call.
-run('qwen', 'post-tool').catch(() => process.exit(0));
+// Bootstrap failures are still recorded so fail-open does not become fail-silent.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+try {
+  const { run } = await import('./lib/adapter.mjs');
+  await run('qwen', 'post-tool');
+} catch (error) {
+  try {
+    const { recordHookBootstrapFailure } = await import('./lib/observability.mjs');
+    recordHookBootstrapFailure('qwen', 'post-tool', error);
+  } catch {
+    // A logger bootstrap failure is the only condition that remains silent.
+  }
+}

--- a/integrations/qwen/hooks/pre-tool.mjs
+++ b/integrations/qwen/hooks/pre-tool.mjs
@@ -2,7 +2,17 @@
 // GENERATED FILE -- do not edit. Regenerate with `npm run sync:hooks`.
 // Client entry point: names the client and event; all policy lives in the
 // shared core so no client can drift its own thresholds or guidance.
-import { run } from './lib/adapter.mjs';
-
 // Fail open: a defect in the optimizer must never cost the user a tool call.
-run('qwen', 'pre-tool').catch(() => process.exit(0));
+// Bootstrap failures are still recorded so fail-open does not become fail-silent.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+try {
+  const { run } = await import('./lib/adapter.mjs');
+  await run('qwen', 'pre-tool');
+} catch (error) {
+  try {
+    const { recordHookBootstrapFailure } = await import('./lib/observability.mjs');
+    recordHookBootstrapFailure('qwen', 'pre-tool', error);
+  } catch {
+    // A logger bootstrap failure is the only condition that remains silent.
+  }
+}

--- a/integrations/qwen/hooks/session-start.mjs
+++ b/integrations/qwen/hooks/session-start.mjs
@@ -2,7 +2,17 @@
 // GENERATED FILE -- do not edit. Regenerate with `npm run sync:hooks`.
 // Client entry point: names the client and event; all policy lives in the
 // shared core so no client can drift its own thresholds or guidance.
-import { run } from './lib/adapter.mjs';
-
 // Fail open: a defect in the optimizer must never cost the user a tool call.
-run('qwen', 'session-start').catch(() => process.exit(0));
+// Bootstrap failures are still recorded so fail-open does not become fail-silent.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+try {
+  const { run } = await import('./lib/adapter.mjs');
+  await run('qwen', 'session-start');
+} catch (error) {
+  try {
+    const { recordHookBootstrapFailure } = await import('./lib/observability.mjs');
+    recordHookBootstrapFailure('qwen', 'session-start', error);
+  } catch {
+    // A logger bootstrap failure is the only condition that remains silent.
+  }
+}

--- a/integrations/qwen/hooks/stop.mjs
+++ b/integrations/qwen/hooks/stop.mjs
@@ -2,7 +2,17 @@
 // GENERATED FILE -- do not edit. Regenerate with `npm run sync:hooks`.
 // Client entry point: names the client and event; all policy lives in the
 // shared core so no client can drift its own thresholds or guidance.
-import { run } from './lib/adapter.mjs';
-
 // Fail open: a defect in the optimizer must never cost the user a tool call.
-run('qwen', 'stop').catch(() => process.exit(0));
+// Bootstrap failures are still recorded so fail-open does not become fail-silent.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+try {
+  const { run } = await import('./lib/adapter.mjs');
+  await run('qwen', 'stop');
+} catch (error) {
+  try {
+    const { recordHookBootstrapFailure } = await import('./lib/observability.mjs');
+    recordHookBootstrapFailure('qwen', 'stop', error);
+  } catch {
+    // A logger bootstrap failure is the only condition that remains silent.
+  }
+}

--- a/integrations/windsurf/hooks/lib/adapter.mjs
+++ b/integrations/windsurf/hooks/lib/adapter.mjs
@@ -27,6 +27,7 @@ import {
   MODE_OFF,
   MODE_ADVISE,
   largeFileBytes,
+  readPayloadResult,
   withEscape,
 } from './policy.mjs';
 import {
@@ -83,6 +84,8 @@ import {
 } from './capabilities.mjs';
 import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 import { evaluateUcrGuards } from './ucr-guard.mjs';
+import { beginHookInvocation, noteHookOutput } from './observability.mjs';
+import { registerProject } from './projects.mjs';
 
 /**
  * Per-client capability.
@@ -128,7 +131,14 @@ export function mutationSucceeded(clientName, raw) {
 
   // These lifecycle contracts fire this event only after a successful tool,
   // or are called by our in-process bridge only from its successful after hook.
-  return new Set(['claude-code', 'qwen', 'opencode', 'kilo', 'windsurf']).has(
+  return new Set([
+    'claude-code',
+    'codex',
+    'qwen',
+    'opencode',
+    'kilo',
+    'windsurf',
+  ]).has(
     clientName
   );
 }
@@ -241,37 +251,9 @@ export function sessionTaskContext(raw = {}) {
 }
 
 function emit(object) {
-  process.stdout.write(JSON.stringify(object));
-}
-
-/**
- * Bounded stdin read. See policy.readPayload for why the ceiling matters: the
- * entry points fail open on a THROW, but a host that opens the pipe and never
- * closes it produces no throw -- just a hook that waits forever with the user's
- * tool call stuck behind it.
- */
-async function readStdin({ timeoutMs = 5000 } = {}) {
-  const raw = await new Promise((resolve) => {
-    const chunks = [];
-    const timer = setTimeout(() => resolve(null), timeoutMs);
-    process.stdin.setEncoding('utf8');
-    process.stdin.on('data', (chunk) => chunks.push(chunk));
-    process.stdin.on('end', () => {
-      clearTimeout(timer);
-      resolve(chunks.join(''));
-    });
-    process.stdin.on('error', () => {
-      clearTimeout(timer);
-      resolve(null);
-    });
-  });
-
-  if (raw === null) return null;
-  try {
-    return JSON.parse(raw);
-  } catch {
-    return null;
-  }
+  const serialized = JSON.stringify(object);
+  noteHookOutput(object, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
 }
 
 /** The session-start notice, shared verbatim so no client drifts its own copy. */
@@ -502,6 +484,17 @@ function observeAndInject(payload, state, episode, features) {
  * @param {'session-start'|'pre-tool'|'post-tool'|'stop'} event
  */
 export async function run(clientName, event) {
+  const invocation = beginHookInvocation(clientName, event);
+  try {
+    await runHook(clientName, event, invocation);
+    invocation.succeed();
+  } catch (error) {
+    // The optimizer must fail open, but the failure is now reconstructable.
+    invocation.fail(error);
+  }
+}
+
+async function runHook(clientName, event, invocation) {
   const client = CLIENTS[clientName] || CLIENTS['claude-code'];
   const eventName =
     event === 'session-start'
@@ -529,7 +522,10 @@ export async function run(clientName, event) {
     // full pre-tool timeout would turn optional context into a five-second
     // startup tax; lifecycle payloads are tiny and arrive immediately when
     // the host supplies one.
-    const raw = (await readStdin({ timeoutMs: 250 })) || {};
+    const input = await readPayloadResult({ timeoutMs: 250 });
+    const raw = input.payload || {};
+    invocation.bind(raw, null, input.bytes);
+    if (input.status !== 'ok') invocation.noteInput(input.status, input.bytes);
     const toolEvidence = optimizerToolEvidence(raw);
     const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id;
     if (sessionId && toolEvidence.proven) {
@@ -540,10 +536,12 @@ export async function run(clientName, event) {
     const parts = [
       policyText(client.canDeny, toolEvidence.names, toolEvidence.proven),
     ];
+    const cwd = raw.cwd || raw.working_directory || process.cwd();
+    const root = projectRootFor(join(cwd, '__session__'), cwd);
+    registerProject({ root, graphDir: wikiDir(root), client: clientName });
     if (features.retrieval) {
       try {
-        const cwd = raw.cwd || raw.working_directory || process.cwd();
-        const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+        const dir = wikiDir(root);
         // SessionStart needs hashes and claims, not stored file bodies. Parsing
         // the snapshot sidecar here would make startup scale with repository
         // history even though this compact index never renders a diff.
@@ -569,14 +567,20 @@ export async function run(clientName, event) {
     process.exit(0);
   }
 
-  const raw = await readStdin();
+  const input = await readPayloadResult();
+  const raw = input.payload;
   if (!raw) {
+    invocation.noteInput(input.status, input.bytes);
     // Stop requires JSON on stdout even when it has nothing to add.
     if (event === 'stop') emit({});
     process.exit(0);
   }
 
   if (event === 'stop') {
+    // Stop has no normalized tool payload, but it is still a fully formed hook
+    // invocation. Bind its lifecycle identifiers so successful completions do
+    // not look like an input reader that never ran in cross-client telemetry.
+    invocation.bind(raw, null, input.bytes);
     const sessionId =
       raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? 'default';
     const agentScope = raw.transcript_path ?? raw.transcriptPath ?? null;
@@ -632,6 +636,7 @@ export async function run(clientName, event) {
   const payload = normalizePayload(
     normalizeClientPayload(clientName, event, raw)
   );
+  invocation.bind(raw, payload, input.bytes);
   if (!payload.tool_name) process.exit(0);
   const episode = episodeMeta({ client: clientName, raw, payload });
 

--- a/integrations/windsurf/hooks/lib/metrics.mjs
+++ b/integrations/windsurf/hooks/lib/metrics.mjs
@@ -1297,8 +1297,8 @@ function concurrencySummary(runs) {
  * live hook traces, and randomized model evals remain visibly distinct: only
  * `eval-run` records with paired arms can produce a causal effect interval.
  */
-export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
-  const evidence = readEvidence(dir).filter((event) => matchesFilters(event, filters));
+function buildEvidenceReport(evidence, { filters = {}, episodeLimit = 100 } = {}) {
+  evidence = evidence.filter((event) => matchesFilters(event, filters));
   const runs = evidence.filter((event) => event.kind === 'eval-run');
   const handoffRuns = evidence.filter((event) => event.kind === 'handoff-run');
   const concurrencyRuns = evidence.filter((event) => event.kind === 'concurrency-run');
@@ -1402,6 +1402,47 @@ export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
       minimumPairs,
       handoffMinimumPairs: handoffMinimumPairs(),
       deterministicChecksAreCausalProof: false,
+    },
+  };
+}
+
+export function evidenceReport(dir, options = {}) {
+  const events = readEvidence(dir);
+  const report = buildEvidenceReport(events, options);
+  const hasMatchingEvidence = events.some((event) =>
+    matchesFilters(event, options.filters || {})
+  );
+  return {
+    ...report,
+    sourceCoverage: {
+      projects: 1,
+      projectsWithEvidence: hasMatchingEvidence ? 1 : 0,
+      projectsWithoutEvidence: hasMatchingEvidence ? 0 : 1,
+    },
+  };
+}
+
+/**
+ * Pools evidence across registered projects before computing cohorts.
+ *
+ * A cohort split across two worktrees is still one experiment. Summing already
+ * aggregated reports would lose pairing and produce invalid confidence
+ * intervals, so this combines the append-only source events first and runs the
+ * estimator exactly once.
+ */
+export function evidenceReportMany(dirs, options = {}) {
+  const unique = [...new Set((dirs || []).map((dir) => String(dir)))];
+  const sources = unique.map((dir) => readEvidence(dir));
+  const report = buildEvidenceReport(sources.flat(), options);
+  const projectsWithEvidence = sources.filter((events) =>
+    events.some((event) => matchesFilters(event, options.filters || {}))
+  ).length;
+  return {
+    ...report,
+    sourceCoverage: {
+      projects: unique.length,
+      projectsWithEvidence,
+      projectsWithoutEvidence: unique.length - projectsWithEvidence,
     },
   };
 }

--- a/integrations/windsurf/hooks/lib/metrics.mjs
+++ b/integrations/windsurf/hooks/lib/metrics.mjs
@@ -738,10 +738,7 @@ function canonicalKeyish(p) {
  * arms, multiplied by treated touches. Reporting it as a measured fact would be
  * the same overclaiming this project criticises competitors for.
  */
-export function report(dir) {
-  const events = readAll(dir);
-  // Injections and harvests come from the log that cannot be starved.
-  const balance = readBalance(dir);
+function buildReport(events, balance) {
 
   // COMMAND INJECTIONS ARE COUNTED SEPARATELY, not mixed into the balance.
   //
@@ -843,6 +840,15 @@ export function report(dir) {
   const sufficient = treated.length >= 20 && withheld.length >= 5;
 
   return {
+    memoryDeliveries: allInjections.filter((event) => !event.holdout).length,
+    memoryHoldouts: allInjections.filter((event) => event.holdout).length,
+    deliveryTokens: allInjections
+      .filter((event) => !event.holdout)
+      .reduce(
+        (sum, event) =>
+          sum + (event.deliveredTokens ?? event.tokens ?? 0),
+        0
+      ),
     injections: treated.length,
     sessionStartInjections: sessionStartInjections.length,
     sessionStartInjectedTokens: sessionStartInjections.reduce(
@@ -864,6 +870,27 @@ export function report(dir) {
         ? 'the graph is saving more than it costs'
         : 'the graph is NOT yet paying for itself',
   };
+}
+
+export function report(dir) {
+  return buildReport(readAll(dir), readBalance(dir));
+}
+
+/**
+ * One statistically valid machine/project-group report.
+ *
+ * Summing per-project verdicts is wrong: five projects with four treated reads
+ * each do not individually meet the threshold, but together they are twenty
+ * observations. Pooling the underlying events preserves the randomized arms
+ * and computes the means once over the selected population.
+ */
+export function reportMany(dirs) {
+  const unique = [...new Set((dirs || []).map((dir) => String(dir)))];
+  const report = buildReport(
+    unique.flatMap((dir) => readAll(dir)),
+    unique.flatMap((dir) => readBalance(dir))
+  );
+  return { ...report, projects: unique.length };
 }
 
 /**

--- a/integrations/windsurf/hooks/lib/observability.mjs
+++ b/integrations/windsurf/hooks/lib/observability.mjs
@@ -1,0 +1,400 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+/**
+ * Privacy-safe, cross-client lifecycle diagnostics.
+ *
+ * Hook processes are intentionally fail-open, but fail-open must not mean
+ * fail-silent. Every client writes the same bounded JSONL schema so failures
+ * can be correlated without storing prompts, commands, tool output, or file
+ * contents.
+ */
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmdirSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { createHash, randomUUID } from 'node:crypto';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export const HOOK_LOG_SCHEMA_VERSION = 1;
+const DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
+const DEFAULT_RETENTION_DAYS = 14;
+const DEFAULT_MAX_FILES = 40;
+const DEFAULT_DEADLINE_MS = 4200;
+const MAX_ERROR_CHARS = 4000;
+const MAX_DIMENSION_CHARS = 160;
+let activeInvocation = null;
+
+function positiveInteger(name, fallback) {
+  const value = Number(process.env[name]);
+  return Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+export function hookLogDirectory() {
+  if (process.env.TOKEN_OPTIMIZER_LOG_DIR)
+    return process.env.TOKEN_OPTIMIZER_LOG_DIR;
+  const stateRoot =
+    process.env.TOKEN_OPTIMIZER_STATE_DIR ||
+    join(homedir(), '.token-optimizer');
+  return join(stateRoot, 'logs');
+}
+
+function hash(value, length = 16) {
+  if (!value) return null;
+  return createHash('sha256').update(String(value)).digest('hex').slice(0, length);
+}
+
+function sanitize(text) {
+  if (text === undefined || text === null) return null;
+  let value = String(text);
+  const home = homedir().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  if (home) value = value.replace(new RegExp(home, 'gi'), '<home>');
+  value = value
+    .replace(/\b(?:sk-[A-Za-z0-9_-]{12,}|gh[opusr]_[A-Za-z0-9]{12,})\b/g, '[REDACTED]')
+    .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi, '$1[REDACTED]')
+    .replace(/\b(password|secret|token|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi, '$1=[REDACTED]');
+  return value.slice(0, MAX_ERROR_CHARS);
+}
+
+function errorFields(error) {
+  if (!error) return null;
+  return {
+    type: sanitize(error.name || error.constructor?.name || 'Error'),
+    message: sanitize(error.message || error),
+    stack: sanitize(error.stack),
+  };
+}
+
+function dimension(value) {
+  const sanitized = sanitize(value);
+  return sanitized === null ? null : sanitized.slice(0, MAX_DIMENSION_CHARS);
+}
+
+function severity(level) {
+  if (level === 'error') return { severityText: 'ERROR', severityNumber: 17 };
+  if (level === 'warn') return { severityText: 'WARN', severityNumber: 13 };
+  return { severityText: 'INFO', severityNumber: 9 };
+}
+
+function activeLogPath(now = new Date()) {
+  const date = now.toISOString().slice(0, 10);
+  return join(hookLogDirectory(), `hook-events-${date}.jsonl`);
+}
+
+function rotateIfNeeded(path) {
+  try {
+    if (!existsSync(path)) return;
+    const maxBytes = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_BYTES', DEFAULT_MAX_BYTES);
+    if (statSync(path).size < maxBytes) return;
+
+    const lock = join(hookLogDirectory(), '.rotate.lock');
+    try {
+      mkdirSync(lock);
+    } catch {
+      return;
+    }
+    try {
+      if (existsSync(path) && statSync(path).size >= maxBytes) {
+        // Multiple hook processes (or several writes in one millisecond) must
+        // never select the same rotation target and overwrite an earlier file.
+        const rotated = path.replace(
+          /\.jsonl$/,
+          `-${Date.now()}-${process.pid}-${randomUUID()}.jsonl`
+        );
+        renameSync(path, rotated);
+      }
+    } finally {
+      // Non-recursive removal of the one fixed-name lock directory only.
+      try { rmdirSync(lock); } catch { /* best effort */ }
+    }
+  } catch {
+    // Diagnostics must never become the reason a lifecycle hook fails.
+  }
+}
+
+function pruneIfDue(now = new Date()) {
+  try {
+    const dir = hookLogDirectory();
+    const marker = join(dir, '.last-prune');
+    if (existsSync(marker) && now.getTime() - statSync(marker).mtimeMs < 60 * 60 * 1000)
+      return;
+    writeFileSync(marker, now.toISOString(), { flag: 'w' });
+
+    const retentionMs =
+      positiveInteger('TOKEN_OPTIMIZER_LOG_RETENTION_DAYS', DEFAULT_RETENTION_DAYS) *
+      24 * 60 * 60 * 1000;
+    const maxFiles = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_FILES', DEFAULT_MAX_FILES);
+    const files = readdirSync(dir)
+      .filter((name) => /^hook-events-.*\.jsonl$/.test(name))
+      .map((name) => {
+        const path = join(dir, name);
+        return { path, mtimeMs: statSync(path).mtimeMs };
+      })
+      .sort((a, b) => b.mtimeMs - a.mtimeMs);
+    for (let i = 0; i < files.length; i++) {
+      if (i >= maxFiles || now.getTime() - files[i].mtimeMs > retentionMs)
+        unlinkSync(files[i].path);
+    }
+  } catch {
+    // Retention is best effort and cannot affect the host tool call.
+  }
+}
+
+export function writeHookEvent(event) {
+  try {
+    const now = new Date();
+    const dir = hookLogDirectory();
+    mkdirSync(dir, { recursive: true });
+    const path = activeLogPath(now);
+    rotateIfNeeded(path);
+    const record = {
+      schemaVersion: HOOK_LOG_SCHEMA_VERSION,
+      timestamp: now.toISOString(),
+      service: 'token-optimizer',
+      serviceVersion:
+        process.env.TOKEN_OPTIMIZER_VERSION ||
+        process.env.npm_package_version ||
+        'unknown',
+      ...severity(event.level),
+      body: event.event || 'hook.event',
+      ...event,
+    };
+    record.resource = {
+      'service.name': record.service,
+      'service.version': record.serviceVersion,
+      'host.arch': process.arch,
+      'os.type': process.platform,
+      'process.runtime.name': 'node',
+      'process.runtime.version': process.version,
+    };
+    appendFileSync(path, `${JSON.stringify(record)}\n`, { encoding: 'utf8' });
+    pruneIfDue(now);
+    return path;
+  } catch {
+    return null;
+  }
+}
+
+export function beginHookInvocation(client, event, options = {}) {
+  const started = Date.now();
+  const invocationId = randomUUID();
+  let ended = false;
+  let outcome = 'success';
+  let reason = 'completed';
+  let error = null;
+  const dimensions = {
+    sessionIdHash: null,
+    turnIdHash: null,
+    toolUseIdHash: null,
+    toolName: null,
+    clientVersion: null,
+    model: null,
+    cwdHash: null,
+    payloadBytes: null,
+    outputBytes: 0,
+    outputShape: [],
+    inputStatus: 'pending',
+  };
+  const spanId = hash(invocationId, 16);
+  let traceId = hash(invocationId, 32);
+
+  let deadline;
+  const finish = (nextOutcome = outcome, nextReason = reason, nextError = error) => {
+    if (ended) return;
+    ended = true;
+    if (deadline) clearTimeout(deadline);
+    process.removeListener('exit', onExit);
+    writeHookEvent({
+      level: nextOutcome === 'failure' || nextOutcome === 'timeout' ? 'error' : 'info',
+      event: 'hook.completed',
+      outcome: nextOutcome,
+      reason: nextReason,
+      durationMs: Date.now() - started,
+      invocationId,
+      traceId,
+      spanId,
+      client,
+      hookEvent: event,
+      processId: process.pid,
+      ...dimensions,
+      error: errorFields(nextError),
+    });
+  };
+  const onExit = () => finish();
+  process.once('exit', onExit);
+
+  deadline = setTimeout(() => {
+    outcome = 'timeout';
+    reason = 'internal_deadline_exceeded';
+    finish(outcome, reason);
+    // Beat the host's five-second timeout and fail open deterministically.
+    process.exit(0);
+  }, options.deadlineMs ?? positiveInteger('TOKEN_OPTIMIZER_HOOK_DEADLINE_MS', DEFAULT_DEADLINE_MS));
+  deadline.unref();
+
+  const invocation = {
+    invocationId,
+    bind(raw = {}, payload = null, payloadBytes = null) {
+      const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? null;
+      dimensions.sessionIdHash = hash(sessionId);
+      dimensions.turnIdHash = hash(raw.turn_id ?? raw.turnId ?? null);
+      dimensions.toolUseIdHash = hash(raw.tool_use_id ?? raw.toolUseId ?? null);
+      dimensions.toolName = payload?.tool_name ?? raw.tool_name ?? raw.toolName ?? null;
+      dimensions.clientVersion = dimension(raw.client_version ?? raw.clientVersion ?? null);
+      dimensions.model = dimension(raw.model ?? raw.model_name ?? raw.modelName ?? null);
+      dimensions.cwdHash = hash(raw.cwd ?? raw.working_directory ?? process.cwd());
+      dimensions.payloadBytes = payloadBytes;
+      dimensions.inputStatus = 'ok';
+      if (sessionId) traceId = hash(sessionId, 32);
+    },
+    noteInput(status, payloadBytes = null) {
+      dimensions.inputStatus = status;
+      dimensions.payloadBytes = payloadBytes;
+      if (status === 'timeout') {
+        outcome = 'timeout';
+        reason = 'stdin_timeout';
+      } else if (status !== 'ok') {
+        outcome = 'skipped';
+        reason = status;
+      }
+    },
+    skip(nextReason) {
+      outcome = 'skipped';
+      reason = nextReason;
+    },
+    noteOutput(output, outputBytes = null) {
+      dimensions.outputBytes = outputBytes ?? Buffer.byteLength(JSON.stringify(output), 'utf8');
+      if (!output || typeof output !== 'object' || Array.isArray(output)) {
+        dimensions.outputShape = [];
+        return;
+      }
+      const shape = Object.keys(output).sort();
+      const hookSpecific = output.hookSpecificOutput;
+      if (hookSpecific && typeof hookSpecific === 'object' && !Array.isArray(hookSpecific)) {
+        for (const key of Object.keys(hookSpecific).sort()) shape.push(`hookSpecificOutput.${key}`);
+      }
+      dimensions.outputShape = shape;
+    },
+    fail(nextError, nextReason = 'unhandled_exception') {
+      outcome = 'failure';
+      reason = nextReason;
+      error = nextError;
+      finish(outcome, reason, error);
+    },
+    succeed(nextReason = 'completed') {
+      outcome = 'success';
+      reason = nextReason;
+      finish(outcome, reason);
+    },
+  };
+  activeInvocation = invocation;
+  return invocation;
+}
+
+/** Records response metadata without retaining response content. */
+export function noteHookOutput(output, outputBytes = null) {
+  activeInvocation?.noteOutput(output, outputBytes);
+}
+
+export function recordHookBootstrapFailure(client, event, error) {
+  writeHookEvent({
+    level: 'error',
+    event: 'hook.completed',
+    outcome: 'failure',
+    reason: 'bootstrap_import_failure',
+    durationMs: 0,
+    invocationId: randomUUID(),
+    client,
+    hookEvent: event,
+    processId: process.pid,
+    error: errorFields(error),
+  });
+}
+
+export function readHookEvents({ limit = 200, sinceMs = 24 * 60 * 60 * 1000 } = {}) {
+  try {
+    const dir = hookLogDirectory();
+    if (!existsSync(dir)) return [];
+    const cutoff = Date.now() - Math.max(0, sinceMs);
+    const files = readdirSync(dir)
+      .filter((name) => /^hook-events-.*\.jsonl$/.test(name))
+      .map((name) => join(dir, name))
+      .sort()
+      .reverse();
+    const events = [];
+    for (const file of files) {
+      const lines = readFileSync(file, 'utf8').split(/\r?\n/).filter(Boolean).reverse();
+      for (const line of lines) {
+        try {
+          const event = JSON.parse(line);
+          if (Date.parse(event.timestamp) < cutoff) continue;
+          events.push(event);
+          if (events.length >= limit) return events;
+        } catch {
+          // A partially written final line must not hide the rest of the log.
+        }
+      }
+    }
+    return events;
+  } catch {
+    return [];
+  }
+}
+
+export function hookHealthSummary(options = {}) {
+  const sinceMs = options.sinceMs ?? 24 * 60 * 60 * 1000;
+  const events = readHookEvents({ limit: options.limit || 5000, sinceMs });
+  const durations = events
+    .map((event) => Number(event.durationMs))
+    .filter(Number.isFinite)
+    .sort((a, b) => a - b);
+  const failures = events.filter((event) => event.outcome === 'failure');
+  const timeouts = events.filter((event) => event.outcome === 'timeout');
+  const skipped = events.filter((event) => event.outcome === 'skipped');
+  const successes = events.filter((event) => event.outcome === 'success');
+  const byClient = {};
+  for (const event of events) {
+    const key = event.client || 'unknown';
+    const current = byClient[key] || { total: 0, failures: 0, timeouts: 0, skipped: 0 };
+    current.total++;
+    if (event.outcome === 'failure') current.failures++;
+    if (event.outcome === 'timeout') current.timeouts++;
+    if (event.outcome === 'skipped') current.skipped++;
+    byClient[key] = current;
+  }
+  const percentile = (p) =>
+    durations.length
+      ? durations[Math.min(durations.length - 1, Math.floor(durations.length * p))]
+      : null;
+  const summary = {
+    schemaVersion: HOOK_LOG_SCHEMA_VERSION,
+    available: events.length > 0,
+    windowHours: sinceMs / 3_600_000,
+    total: events.length,
+    failures: failures.length,
+    timeouts: timeouts.length,
+    skipped: skipped.length,
+    successRate: events.length ? successes.length / events.length : null,
+    p50DurationMs: percentile(0.5),
+    p95DurationMs: percentile(0.95),
+    byClient,
+    recentFailures: [...failures, ...timeouts]
+      .sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp))
+      .slice(0, 20),
+  };
+  // Absolute paths are useful to a local doctor, but they do not belong in a
+  // diagnostics export that may be attached to a public issue.
+  if (options.includeLogDirectory === true)
+    summary.logDirectory = hookLogDirectory();
+  return summary;
+}

--- a/integrations/windsurf/hooks/lib/policy.mjs
+++ b/integrations/windsurf/hooks/lib/policy.mjs
@@ -48,6 +48,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { createHash } from 'node:crypto';
 import { isFsSafePath } from './paths.mjs';
+import { noteHookOutput } from './observability.mjs';
 
 /** Enforcement modes, least to most permissive. */
 export const MODE_ENFORCE = 'enforce';
@@ -653,14 +654,15 @@ export function allow() {
  */
 export function allowWithContext(context) {
   if (context) {
-    process.stdout.write(
-      JSON.stringify({
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-          additionalContext: withEscape(context),
-        },
-      })
-    );
+    const output = {
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        additionalContext: withEscape(context),
+      },
+    };
+    const serialized = JSON.stringify(output);
+    noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+    process.stdout.write(serialized);
   }
   process.exit(0);
 }
@@ -673,15 +675,16 @@ export function allowWithContext(context) {
  * says "use the optimized tool" gets met with a retry of the same call.
  */
 export function deny(reason) {
-  process.stdout.write(
-    JSON.stringify({
-      hookSpecificOutput: {
-        hookEventName: 'PreToolUse',
-        permissionDecision: 'deny',
-        permissionDecisionReason: withEscape(reason),
-      },
-    })
-  );
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+      permissionDecisionReason: withEscape(reason),
+    },
+  };
+  const serialized = JSON.stringify(output);
+  noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
   process.exit(0);
 }
 
@@ -706,14 +709,15 @@ export function withEscape(reason) {
 
 /** Lets the call through, attaching a note the model sees. */
 export function advise(context) {
-  process.stdout.write(
-    JSON.stringify({
-      hookSpecificOutput: {
-        hookEventName: 'PreToolUse',
-        additionalContext: context,
-      },
-    })
-  );
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      additionalContext: context,
+    },
+  };
+  const serialized = JSON.stringify(output);
+  noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
   process.exit(0);
 }
 
@@ -741,26 +745,34 @@ export function enforce(reason, deniedBefore) {
  * than an absent one, so the wait has a ceiling and expiring it is treated
  * exactly like unusable input.
  */
-export async function readPayload({
-  timeoutMs = 5000,
+export async function readPayloadResult({
+  timeoutMs = 1500,
   maxBytes = 8_000_000,
 } = {}) {
   const chunks = [];
   let size = 0;
+  let inputStatus = 'pending';
 
   const raw = await new Promise((resolve) => {
     const onData = (chunk) => {
-      size += chunk.length;
+      size += Buffer.byteLength(chunk, 'utf8');
       // A payload this large is not a tool call; refusing to buffer it
       // unboundedly keeps a hook from becoming a memory problem.
       if (size > maxBytes) {
+        inputStatus = 'too_large';
         finish(null);
         return;
       }
       chunks.push(chunk);
     };
-    const onEnd = () => finish(chunks.join(''));
-    const onError = () => finish(null);
+    const onEnd = () => {
+      inputStatus = 'received';
+      finish(chunks.join(''));
+    };
+    const onError = () => {
+      inputStatus = 'input_error';
+      finish(null);
+    };
 
     // Listeners are REMOVED on every exit path. Leaving them attached after the
     // timeout wins means a late chunk keeps growing a buffer nobody will read,
@@ -774,17 +786,21 @@ export async function readPayload({
       resolve(value);
     }
 
-    const timer = setTimeout(() => finish(null), timeoutMs);
+    const timer = setTimeout(() => {
+      inputStatus = 'timeout';
+      finish(null);
+    }, timeoutMs);
     process.stdin.setEncoding('utf8');
     process.stdin.on('data', onData);
     process.stdin.on('end', onEnd);
     process.stdin.on('error', onError);
   });
 
-  if (raw === null) return null;
+  if (raw === null) return { payload: null, status: inputStatus, bytes: size };
+  if (!raw.trim()) return { payload: null, status: 'empty_input', bytes: size };
   try {
-    return JSON.parse(raw);
+    return { payload: JSON.parse(raw), status: 'ok', bytes: size };
   } catch {
-    return null;
+    return { payload: null, status: 'invalid_json', bytes: size };
   }
 }

--- a/integrations/windsurf/hooks/lib/projects.mjs
+++ b/integrations/windsurf/hooks/lib/projects.mjs
@@ -1,0 +1,214 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/projects.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Machine-local index of project graph stores.
+ *
+ * A graph is deliberately stored with the project whose files it describes.
+ * That isolation is important for retrieval, but it also means a dashboard
+ * cannot honestly describe machine-wide capture unless it knows which stores
+ * exist. This registry is that missing directory. It is written by lifecycle
+ * hooks and can be backfilled by the explicit discovery command.
+ *
+ * The browser never receives `root` or `graphDir`. Routes resolve an opaque
+ * project id through this server-owned file, so restoring cross-project views
+ * does not restore the old arbitrary-path query vulnerability.
+ */
+
+import {
+  appendFileSync,
+  chmodSync,
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+} from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+import { createHash } from 'node:crypto';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
+
+export const PROJECT_REGISTRY_VERSION = 1;
+
+export function projectRegistryPath() {
+  return (
+    process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY ||
+    join(homedir(), '.token-optimizer', 'projects.jsonl')
+  );
+}
+
+export function projectIdFor(root) {
+  return `project-${createHash('sha256')
+    .update(canonicalPath(root))
+    .digest('hex')
+    .slice(0, 16)}`;
+}
+
+function displayName(root) {
+  return basename(root) || 'Unnamed project';
+}
+
+function acquire(path) {
+  const lockPath = `${path}.lock`;
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+  } catch {
+    return null;
+  }
+
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      closeSync(openSync(lockPath, 'wx', 0o600));
+      return lockPath;
+    } catch {
+      try {
+        if (Date.now() - statSync(lockPath).mtimeMs > 5000) unlinkSync(lockPath);
+      } catch {
+        // The holder may have released it between open and stat; retry.
+      }
+    }
+  }
+  return null;
+}
+
+function release(lockPath) {
+  if (!lockPath) return;
+  try {
+    unlinkSync(lockPath);
+  } catch {
+    // A killed process or cleanup race must not fail the hook.
+  }
+}
+
+/**
+ * Folds the append-only registry into one current entry per canonical project.
+ * Malformed, stale-schema, and unsafe records are ignored rather than trusted.
+ */
+export function registeredProjects() {
+  const path = projectRegistryPath();
+  const projects = new Map();
+  if (!existsSync(path)) return [];
+
+  try {
+    for (const line of readFileSync(path, 'utf8').split('\n')) {
+      if (!line) continue;
+      let record;
+      try {
+        record = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (
+        record.v !== PROJECT_REGISTRY_VERSION ||
+        !isFsSafePath(record.root) ||
+        !isFsSafePath(record.graphDir)
+      ) {
+        continue;
+      }
+      const root = canonicalPath(record.root);
+      const graphDir = canonicalPath(record.graphDir);
+      // Append-only history can outlive a deleted worktree (especially a
+      // short-lived test or CI checkout). A source that no longer exists
+      // cannot be captured, and presenting it as a current coverage gap makes
+      // the dashboard steadily less truthful over time.
+      if (!existsSync(root)) continue;
+      // A broad discovery root may contain hundreds of dormant worktrees. They
+      // are not capture coverage until a hook has observed them or a graph
+      // exists; listing all of them turns the selector into filesystem noise.
+      if (
+        record.client === 'discovery' &&
+        !existsSync(join(graphDir, 'graph.jsonl'))
+      ) {
+        continue;
+      }
+      const id = projectIdFor(root);
+      if (record.id !== id) continue;
+
+      const previous = projects.get(id);
+      projects.set(id, {
+        id,
+        name: String(record.name || displayName(root)).slice(0, 160),
+        root,
+        graphDir,
+        firstSeenAt: previous?.firstSeenAt || record.at || 0,
+        lastSeenAt: Math.max(previous?.lastSeenAt || 0, Number(record.at) || 0),
+        clients: [
+          ...new Set([
+            ...(previous?.clients || []),
+            ...(typeof record.client === 'string' && record.client
+              ? [record.client.slice(0, 80)]
+              : []),
+          ]),
+        ].sort(),
+      });
+    }
+  } catch {
+    return [];
+  }
+
+  return [...projects.values()].sort(
+    (a, b) => b.lastSeenAt - a.lastSeenAt || a.name.localeCompare(b.name)
+  );
+}
+
+/** Registers one VCS project without ever making a hook fail closed. */
+export function registerProject({ root, graphDir, client = 'unknown', name } = {}) {
+  if (!isFsSafePath(root) || !isFsSafePath(graphDir)) return null;
+  try {
+    const canonicalRoot = canonicalPath(root);
+    const canonicalGraphDir = canonicalPath(graphDir);
+    const isRepository = ['.git', '.hg', '.svn'].some((marker) =>
+      existsSync(join(canonicalRoot, marker))
+    );
+    if (!isRepository) return null;
+    const id = projectIdFor(canonicalRoot);
+    const now = Date.now();
+    const recent = registeredProjects().find(
+      (project) =>
+        project.id === id &&
+        project.graphDir === canonicalGraphDir &&
+        project.clients.includes(client) &&
+        now - project.lastSeenAt < 60 * 60 * 1000
+    );
+    if (recent) return recent;
+
+    const path = projectRegistryPath();
+    const lockPath = acquire(path);
+    if (!lockPath) return null;
+    try {
+      appendFileSync(
+        path,
+        `${JSON.stringify({
+          v: PROJECT_REGISTRY_VERSION,
+          id,
+          name: String(name || displayName(canonicalRoot)).slice(0, 160),
+          root: canonicalRoot,
+          graphDir: canonicalGraphDir,
+          client: String(client || 'unknown').slice(0, 80),
+          at: now,
+        })}\n`,
+        { mode: 0o600 }
+      );
+      try {
+        chmodSync(path, 0o600);
+      } catch {
+        // Windows and some filesystems do not expose POSIX modes.
+      }
+    } finally {
+      release(lockPath);
+    }
+    return {
+      id,
+      name: String(name || displayName(canonicalRoot)).slice(0, 160),
+      root: canonicalRoot,
+      graphDir: canonicalGraphDir,
+      firstSeenAt: now,
+      lastSeenAt: now,
+      clients: [String(client || 'unknown').slice(0, 80)],
+    };
+  } catch {
+    return null;
+  }
+}

--- a/integrations/windsurf/hooks/post-tool.mjs
+++ b/integrations/windsurf/hooks/post-tool.mjs
@@ -2,7 +2,17 @@
 // GENERATED FILE -- do not edit. Regenerate with `npm run sync:hooks`.
 // Client entry point: names the client and event; all policy lives in the
 // shared core so no client can drift its own thresholds or guidance.
-import { run } from './lib/adapter.mjs';
-
 // Fail open: a defect in the optimizer must never cost the user a tool call.
-run('windsurf', 'post-tool').catch(() => process.exit(0));
+// Bootstrap failures are still recorded so fail-open does not become fail-silent.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+try {
+  const { run } = await import('./lib/adapter.mjs');
+  await run('windsurf', 'post-tool');
+} catch (error) {
+  try {
+    const { recordHookBootstrapFailure } = await import('./lib/observability.mjs');
+    recordHookBootstrapFailure('windsurf', 'post-tool', error);
+  } catch {
+    // A logger bootstrap failure is the only condition that remains silent.
+  }
+}

--- a/integrations/windsurf/hooks/pre-tool.mjs
+++ b/integrations/windsurf/hooks/pre-tool.mjs
@@ -2,7 +2,17 @@
 // GENERATED FILE -- do not edit. Regenerate with `npm run sync:hooks`.
 // Client entry point: names the client and event; all policy lives in the
 // shared core so no client can drift its own thresholds or guidance.
-import { run } from './lib/adapter.mjs';
-
 // Fail open: a defect in the optimizer must never cost the user a tool call.
-run('windsurf', 'pre-tool').catch(() => process.exit(0));
+// Bootstrap failures are still recorded so fail-open does not become fail-silent.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+try {
+  const { run } = await import('./lib/adapter.mjs');
+  await run('windsurf', 'pre-tool');
+} catch (error) {
+  try {
+    const { recordHookBootstrapFailure } = await import('./lib/observability.mjs');
+    recordHookBootstrapFailure('windsurf', 'pre-tool', error);
+  } catch {
+    // A logger bootstrap failure is the only condition that remains silent.
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "token-optimizer-mcp": "./dist/server/index.js",
     "token-optimizer-daemon": "./dist/server/daemon.js",
     "token-optimizer-install": "./scripts/install-cli.mjs",
-    "token-optimizer-doctor": "./scripts/doctor.mjs"
+    "token-optimizer-doctor": "./scripts/doctor.mjs",
+    "token-optimizer-diagnostics": "./scripts/export-diagnostics.mjs"
   },
   "files": [
     "dist/**/*",
@@ -35,6 +36,8 @@
     "screenshots": "node scripts/capture-screenshots.mjs",
     "uninstall-hooks": "node scripts/uninstall.mjs",
     "doctor": "node scripts/doctor.mjs",
+    "diagnostics": "node scripts/export-diagnostics.mjs",
+    "projects:discover": "node scripts/discover-project-graphs.mjs",
     "build": "tsc && npm run copy:assets",
     "copy:assets": "node scripts/copy-assets.mjs",
     "start": "node dist/server/index.js",

--- a/plugin/hooks/lib/adapter.mjs
+++ b/plugin/hooks/lib/adapter.mjs
@@ -27,6 +27,7 @@ import {
   MODE_OFF,
   MODE_ADVISE,
   largeFileBytes,
+  readPayloadResult,
   withEscape,
 } from './policy.mjs';
 import {
@@ -83,6 +84,8 @@ import {
 } from './capabilities.mjs';
 import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 import { evaluateUcrGuards } from './ucr-guard.mjs';
+import { beginHookInvocation, noteHookOutput } from './observability.mjs';
+import { registerProject } from './projects.mjs';
 
 /**
  * Per-client capability.
@@ -128,7 +131,14 @@ export function mutationSucceeded(clientName, raw) {
 
   // These lifecycle contracts fire this event only after a successful tool,
   // or are called by our in-process bridge only from its successful after hook.
-  return new Set(['claude-code', 'qwen', 'opencode', 'kilo', 'windsurf']).has(
+  return new Set([
+    'claude-code',
+    'codex',
+    'qwen',
+    'opencode',
+    'kilo',
+    'windsurf',
+  ]).has(
     clientName
   );
 }
@@ -241,37 +251,9 @@ export function sessionTaskContext(raw = {}) {
 }
 
 function emit(object) {
-  process.stdout.write(JSON.stringify(object));
-}
-
-/**
- * Bounded stdin read. See policy.readPayload for why the ceiling matters: the
- * entry points fail open on a THROW, but a host that opens the pipe and never
- * closes it produces no throw -- just a hook that waits forever with the user's
- * tool call stuck behind it.
- */
-async function readStdin({ timeoutMs = 5000 } = {}) {
-  const raw = await new Promise((resolve) => {
-    const chunks = [];
-    const timer = setTimeout(() => resolve(null), timeoutMs);
-    process.stdin.setEncoding('utf8');
-    process.stdin.on('data', (chunk) => chunks.push(chunk));
-    process.stdin.on('end', () => {
-      clearTimeout(timer);
-      resolve(chunks.join(''));
-    });
-    process.stdin.on('error', () => {
-      clearTimeout(timer);
-      resolve(null);
-    });
-  });
-
-  if (raw === null) return null;
-  try {
-    return JSON.parse(raw);
-  } catch {
-    return null;
-  }
+  const serialized = JSON.stringify(object);
+  noteHookOutput(object, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
 }
 
 /** The session-start notice, shared verbatim so no client drifts its own copy. */
@@ -502,6 +484,17 @@ function observeAndInject(payload, state, episode, features) {
  * @param {'session-start'|'pre-tool'|'post-tool'|'stop'} event
  */
 export async function run(clientName, event) {
+  const invocation = beginHookInvocation(clientName, event);
+  try {
+    await runHook(clientName, event, invocation);
+    invocation.succeed();
+  } catch (error) {
+    // The optimizer must fail open, but the failure is now reconstructable.
+    invocation.fail(error);
+  }
+}
+
+async function runHook(clientName, event, invocation) {
   const client = CLIENTS[clientName] || CLIENTS['claude-code'];
   const eventName =
     event === 'session-start'
@@ -529,7 +522,10 @@ export async function run(clientName, event) {
     // full pre-tool timeout would turn optional context into a five-second
     // startup tax; lifecycle payloads are tiny and arrive immediately when
     // the host supplies one.
-    const raw = (await readStdin({ timeoutMs: 250 })) || {};
+    const input = await readPayloadResult({ timeoutMs: 250 });
+    const raw = input.payload || {};
+    invocation.bind(raw, null, input.bytes);
+    if (input.status !== 'ok') invocation.noteInput(input.status, input.bytes);
     const toolEvidence = optimizerToolEvidence(raw);
     const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id;
     if (sessionId && toolEvidence.proven) {
@@ -540,10 +536,12 @@ export async function run(clientName, event) {
     const parts = [
       policyText(client.canDeny, toolEvidence.names, toolEvidence.proven),
     ];
+    const cwd = raw.cwd || raw.working_directory || process.cwd();
+    const root = projectRootFor(join(cwd, '__session__'), cwd);
+    registerProject({ root, graphDir: wikiDir(root), client: clientName });
     if (features.retrieval) {
       try {
-        const cwd = raw.cwd || raw.working_directory || process.cwd();
-        const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
+        const dir = wikiDir(root);
         // SessionStart needs hashes and claims, not stored file bodies. Parsing
         // the snapshot sidecar here would make startup scale with repository
         // history even though this compact index never renders a diff.
@@ -569,14 +567,20 @@ export async function run(clientName, event) {
     process.exit(0);
   }
 
-  const raw = await readStdin();
+  const input = await readPayloadResult();
+  const raw = input.payload;
   if (!raw) {
+    invocation.noteInput(input.status, input.bytes);
     // Stop requires JSON on stdout even when it has nothing to add.
     if (event === 'stop') emit({});
     process.exit(0);
   }
 
   if (event === 'stop') {
+    // Stop has no normalized tool payload, but it is still a fully formed hook
+    // invocation. Bind its lifecycle identifiers so successful completions do
+    // not look like an input reader that never ran in cross-client telemetry.
+    invocation.bind(raw, null, input.bytes);
     const sessionId =
       raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? 'default';
     const agentScope = raw.transcript_path ?? raw.transcriptPath ?? null;
@@ -632,6 +636,7 @@ export async function run(clientName, event) {
   const payload = normalizePayload(
     normalizeClientPayload(clientName, event, raw)
   );
+  invocation.bind(raw, payload, input.bytes);
   if (!payload.tool_name) process.exit(0);
   const episode = episodeMeta({ client: clientName, raw, payload });
 

--- a/plugin/hooks/lib/metrics.mjs
+++ b/plugin/hooks/lib/metrics.mjs
@@ -1297,8 +1297,8 @@ function concurrencySummary(runs) {
  * live hook traces, and randomized model evals remain visibly distinct: only
  * `eval-run` records with paired arms can produce a causal effect interval.
  */
-export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
-  const evidence = readEvidence(dir).filter((event) => matchesFilters(event, filters));
+function buildEvidenceReport(evidence, { filters = {}, episodeLimit = 100 } = {}) {
+  evidence = evidence.filter((event) => matchesFilters(event, filters));
   const runs = evidence.filter((event) => event.kind === 'eval-run');
   const handoffRuns = evidence.filter((event) => event.kind === 'handoff-run');
   const concurrencyRuns = evidence.filter((event) => event.kind === 'concurrency-run');
@@ -1402,6 +1402,47 @@ export function evidenceReport(dir, { filters = {}, episodeLimit = 100 } = {}) {
       minimumPairs,
       handoffMinimumPairs: handoffMinimumPairs(),
       deterministicChecksAreCausalProof: false,
+    },
+  };
+}
+
+export function evidenceReport(dir, options = {}) {
+  const events = readEvidence(dir);
+  const report = buildEvidenceReport(events, options);
+  const hasMatchingEvidence = events.some((event) =>
+    matchesFilters(event, options.filters || {})
+  );
+  return {
+    ...report,
+    sourceCoverage: {
+      projects: 1,
+      projectsWithEvidence: hasMatchingEvidence ? 1 : 0,
+      projectsWithoutEvidence: hasMatchingEvidence ? 0 : 1,
+    },
+  };
+}
+
+/**
+ * Pools evidence across registered projects before computing cohorts.
+ *
+ * A cohort split across two worktrees is still one experiment. Summing already
+ * aggregated reports would lose pairing and produce invalid confidence
+ * intervals, so this combines the append-only source events first and runs the
+ * estimator exactly once.
+ */
+export function evidenceReportMany(dirs, options = {}) {
+  const unique = [...new Set((dirs || []).map((dir) => String(dir)))];
+  const sources = unique.map((dir) => readEvidence(dir));
+  const report = buildEvidenceReport(sources.flat(), options);
+  const projectsWithEvidence = sources.filter((events) =>
+    events.some((event) => matchesFilters(event, options.filters || {}))
+  ).length;
+  return {
+    ...report,
+    sourceCoverage: {
+      projects: unique.length,
+      projectsWithEvidence,
+      projectsWithoutEvidence: unique.length - projectsWithEvidence,
     },
   };
 }

--- a/plugin/hooks/lib/metrics.mjs
+++ b/plugin/hooks/lib/metrics.mjs
@@ -738,10 +738,7 @@ function canonicalKeyish(p) {
  * arms, multiplied by treated touches. Reporting it as a measured fact would be
  * the same overclaiming this project criticises competitors for.
  */
-export function report(dir) {
-  const events = readAll(dir);
-  // Injections and harvests come from the log that cannot be starved.
-  const balance = readBalance(dir);
+function buildReport(events, balance) {
 
   // COMMAND INJECTIONS ARE COUNTED SEPARATELY, not mixed into the balance.
   //
@@ -843,6 +840,15 @@ export function report(dir) {
   const sufficient = treated.length >= 20 && withheld.length >= 5;
 
   return {
+    memoryDeliveries: allInjections.filter((event) => !event.holdout).length,
+    memoryHoldouts: allInjections.filter((event) => event.holdout).length,
+    deliveryTokens: allInjections
+      .filter((event) => !event.holdout)
+      .reduce(
+        (sum, event) =>
+          sum + (event.deliveredTokens ?? event.tokens ?? 0),
+        0
+      ),
     injections: treated.length,
     sessionStartInjections: sessionStartInjections.length,
     sessionStartInjectedTokens: sessionStartInjections.reduce(
@@ -864,6 +870,27 @@ export function report(dir) {
         ? 'the graph is saving more than it costs'
         : 'the graph is NOT yet paying for itself',
   };
+}
+
+export function report(dir) {
+  return buildReport(readAll(dir), readBalance(dir));
+}
+
+/**
+ * One statistically valid machine/project-group report.
+ *
+ * Summing per-project verdicts is wrong: five projects with four treated reads
+ * each do not individually meet the threshold, but together they are twenty
+ * observations. Pooling the underlying events preserves the randomized arms
+ * and computes the means once over the selected population.
+ */
+export function reportMany(dirs) {
+  const unique = [...new Set((dirs || []).map((dir) => String(dir)))];
+  const report = buildReport(
+    unique.flatMap((dir) => readAll(dir)),
+    unique.flatMap((dir) => readBalance(dir))
+  );
+  return { ...report, projects: unique.length };
 }
 
 /**

--- a/plugin/hooks/lib/observability.mjs
+++ b/plugin/hooks/lib/observability.mjs
@@ -1,0 +1,400 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+/**
+ * Privacy-safe, cross-client lifecycle diagnostics.
+ *
+ * Hook processes are intentionally fail-open, but fail-open must not mean
+ * fail-silent. Every client writes the same bounded JSONL schema so failures
+ * can be correlated without storing prompts, commands, tool output, or file
+ * contents.
+ */
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmdirSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { createHash, randomUUID } from 'node:crypto';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export const HOOK_LOG_SCHEMA_VERSION = 1;
+const DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
+const DEFAULT_RETENTION_DAYS = 14;
+const DEFAULT_MAX_FILES = 40;
+const DEFAULT_DEADLINE_MS = 4200;
+const MAX_ERROR_CHARS = 4000;
+const MAX_DIMENSION_CHARS = 160;
+let activeInvocation = null;
+
+function positiveInteger(name, fallback) {
+  const value = Number(process.env[name]);
+  return Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+export function hookLogDirectory() {
+  if (process.env.TOKEN_OPTIMIZER_LOG_DIR)
+    return process.env.TOKEN_OPTIMIZER_LOG_DIR;
+  const stateRoot =
+    process.env.TOKEN_OPTIMIZER_STATE_DIR ||
+    join(homedir(), '.token-optimizer');
+  return join(stateRoot, 'logs');
+}
+
+function hash(value, length = 16) {
+  if (!value) return null;
+  return createHash('sha256').update(String(value)).digest('hex').slice(0, length);
+}
+
+function sanitize(text) {
+  if (text === undefined || text === null) return null;
+  let value = String(text);
+  const home = homedir().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  if (home) value = value.replace(new RegExp(home, 'gi'), '<home>');
+  value = value
+    .replace(/\b(?:sk-[A-Za-z0-9_-]{12,}|gh[opusr]_[A-Za-z0-9]{12,})\b/g, '[REDACTED]')
+    .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi, '$1[REDACTED]')
+    .replace(/\b(password|secret|token|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi, '$1=[REDACTED]');
+  return value.slice(0, MAX_ERROR_CHARS);
+}
+
+function errorFields(error) {
+  if (!error) return null;
+  return {
+    type: sanitize(error.name || error.constructor?.name || 'Error'),
+    message: sanitize(error.message || error),
+    stack: sanitize(error.stack),
+  };
+}
+
+function dimension(value) {
+  const sanitized = sanitize(value);
+  return sanitized === null ? null : sanitized.slice(0, MAX_DIMENSION_CHARS);
+}
+
+function severity(level) {
+  if (level === 'error') return { severityText: 'ERROR', severityNumber: 17 };
+  if (level === 'warn') return { severityText: 'WARN', severityNumber: 13 };
+  return { severityText: 'INFO', severityNumber: 9 };
+}
+
+function activeLogPath(now = new Date()) {
+  const date = now.toISOString().slice(0, 10);
+  return join(hookLogDirectory(), `hook-events-${date}.jsonl`);
+}
+
+function rotateIfNeeded(path) {
+  try {
+    if (!existsSync(path)) return;
+    const maxBytes = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_BYTES', DEFAULT_MAX_BYTES);
+    if (statSync(path).size < maxBytes) return;
+
+    const lock = join(hookLogDirectory(), '.rotate.lock');
+    try {
+      mkdirSync(lock);
+    } catch {
+      return;
+    }
+    try {
+      if (existsSync(path) && statSync(path).size >= maxBytes) {
+        // Multiple hook processes (or several writes in one millisecond) must
+        // never select the same rotation target and overwrite an earlier file.
+        const rotated = path.replace(
+          /\.jsonl$/,
+          `-${Date.now()}-${process.pid}-${randomUUID()}.jsonl`
+        );
+        renameSync(path, rotated);
+      }
+    } finally {
+      // Non-recursive removal of the one fixed-name lock directory only.
+      try { rmdirSync(lock); } catch { /* best effort */ }
+    }
+  } catch {
+    // Diagnostics must never become the reason a lifecycle hook fails.
+  }
+}
+
+function pruneIfDue(now = new Date()) {
+  try {
+    const dir = hookLogDirectory();
+    const marker = join(dir, '.last-prune');
+    if (existsSync(marker) && now.getTime() - statSync(marker).mtimeMs < 60 * 60 * 1000)
+      return;
+    writeFileSync(marker, now.toISOString(), { flag: 'w' });
+
+    const retentionMs =
+      positiveInteger('TOKEN_OPTIMIZER_LOG_RETENTION_DAYS', DEFAULT_RETENTION_DAYS) *
+      24 * 60 * 60 * 1000;
+    const maxFiles = positiveInteger('TOKEN_OPTIMIZER_LOG_MAX_FILES', DEFAULT_MAX_FILES);
+    const files = readdirSync(dir)
+      .filter((name) => /^hook-events-.*\.jsonl$/.test(name))
+      .map((name) => {
+        const path = join(dir, name);
+        return { path, mtimeMs: statSync(path).mtimeMs };
+      })
+      .sort((a, b) => b.mtimeMs - a.mtimeMs);
+    for (let i = 0; i < files.length; i++) {
+      if (i >= maxFiles || now.getTime() - files[i].mtimeMs > retentionMs)
+        unlinkSync(files[i].path);
+    }
+  } catch {
+    // Retention is best effort and cannot affect the host tool call.
+  }
+}
+
+export function writeHookEvent(event) {
+  try {
+    const now = new Date();
+    const dir = hookLogDirectory();
+    mkdirSync(dir, { recursive: true });
+    const path = activeLogPath(now);
+    rotateIfNeeded(path);
+    const record = {
+      schemaVersion: HOOK_LOG_SCHEMA_VERSION,
+      timestamp: now.toISOString(),
+      service: 'token-optimizer',
+      serviceVersion:
+        process.env.TOKEN_OPTIMIZER_VERSION ||
+        process.env.npm_package_version ||
+        'unknown',
+      ...severity(event.level),
+      body: event.event || 'hook.event',
+      ...event,
+    };
+    record.resource = {
+      'service.name': record.service,
+      'service.version': record.serviceVersion,
+      'host.arch': process.arch,
+      'os.type': process.platform,
+      'process.runtime.name': 'node',
+      'process.runtime.version': process.version,
+    };
+    appendFileSync(path, `${JSON.stringify(record)}\n`, { encoding: 'utf8' });
+    pruneIfDue(now);
+    return path;
+  } catch {
+    return null;
+  }
+}
+
+export function beginHookInvocation(client, event, options = {}) {
+  const started = Date.now();
+  const invocationId = randomUUID();
+  let ended = false;
+  let outcome = 'success';
+  let reason = 'completed';
+  let error = null;
+  const dimensions = {
+    sessionIdHash: null,
+    turnIdHash: null,
+    toolUseIdHash: null,
+    toolName: null,
+    clientVersion: null,
+    model: null,
+    cwdHash: null,
+    payloadBytes: null,
+    outputBytes: 0,
+    outputShape: [],
+    inputStatus: 'pending',
+  };
+  const spanId = hash(invocationId, 16);
+  let traceId = hash(invocationId, 32);
+
+  let deadline;
+  const finish = (nextOutcome = outcome, nextReason = reason, nextError = error) => {
+    if (ended) return;
+    ended = true;
+    if (deadline) clearTimeout(deadline);
+    process.removeListener('exit', onExit);
+    writeHookEvent({
+      level: nextOutcome === 'failure' || nextOutcome === 'timeout' ? 'error' : 'info',
+      event: 'hook.completed',
+      outcome: nextOutcome,
+      reason: nextReason,
+      durationMs: Date.now() - started,
+      invocationId,
+      traceId,
+      spanId,
+      client,
+      hookEvent: event,
+      processId: process.pid,
+      ...dimensions,
+      error: errorFields(nextError),
+    });
+  };
+  const onExit = () => finish();
+  process.once('exit', onExit);
+
+  deadline = setTimeout(() => {
+    outcome = 'timeout';
+    reason = 'internal_deadline_exceeded';
+    finish(outcome, reason);
+    // Beat the host's five-second timeout and fail open deterministically.
+    process.exit(0);
+  }, options.deadlineMs ?? positiveInteger('TOKEN_OPTIMIZER_HOOK_DEADLINE_MS', DEFAULT_DEADLINE_MS));
+  deadline.unref();
+
+  const invocation = {
+    invocationId,
+    bind(raw = {}, payload = null, payloadBytes = null) {
+      const sessionId = raw.session_id ?? raw.sessionId ?? raw.conversation_id ?? null;
+      dimensions.sessionIdHash = hash(sessionId);
+      dimensions.turnIdHash = hash(raw.turn_id ?? raw.turnId ?? null);
+      dimensions.toolUseIdHash = hash(raw.tool_use_id ?? raw.toolUseId ?? null);
+      dimensions.toolName = payload?.tool_name ?? raw.tool_name ?? raw.toolName ?? null;
+      dimensions.clientVersion = dimension(raw.client_version ?? raw.clientVersion ?? null);
+      dimensions.model = dimension(raw.model ?? raw.model_name ?? raw.modelName ?? null);
+      dimensions.cwdHash = hash(raw.cwd ?? raw.working_directory ?? process.cwd());
+      dimensions.payloadBytes = payloadBytes;
+      dimensions.inputStatus = 'ok';
+      if (sessionId) traceId = hash(sessionId, 32);
+    },
+    noteInput(status, payloadBytes = null) {
+      dimensions.inputStatus = status;
+      dimensions.payloadBytes = payloadBytes;
+      if (status === 'timeout') {
+        outcome = 'timeout';
+        reason = 'stdin_timeout';
+      } else if (status !== 'ok') {
+        outcome = 'skipped';
+        reason = status;
+      }
+    },
+    skip(nextReason) {
+      outcome = 'skipped';
+      reason = nextReason;
+    },
+    noteOutput(output, outputBytes = null) {
+      dimensions.outputBytes = outputBytes ?? Buffer.byteLength(JSON.stringify(output), 'utf8');
+      if (!output || typeof output !== 'object' || Array.isArray(output)) {
+        dimensions.outputShape = [];
+        return;
+      }
+      const shape = Object.keys(output).sort();
+      const hookSpecific = output.hookSpecificOutput;
+      if (hookSpecific && typeof hookSpecific === 'object' && !Array.isArray(hookSpecific)) {
+        for (const key of Object.keys(hookSpecific).sort()) shape.push(`hookSpecificOutput.${key}`);
+      }
+      dimensions.outputShape = shape;
+    },
+    fail(nextError, nextReason = 'unhandled_exception') {
+      outcome = 'failure';
+      reason = nextReason;
+      error = nextError;
+      finish(outcome, reason, error);
+    },
+    succeed(nextReason = 'completed') {
+      outcome = 'success';
+      reason = nextReason;
+      finish(outcome, reason);
+    },
+  };
+  activeInvocation = invocation;
+  return invocation;
+}
+
+/** Records response metadata without retaining response content. */
+export function noteHookOutput(output, outputBytes = null) {
+  activeInvocation?.noteOutput(output, outputBytes);
+}
+
+export function recordHookBootstrapFailure(client, event, error) {
+  writeHookEvent({
+    level: 'error',
+    event: 'hook.completed',
+    outcome: 'failure',
+    reason: 'bootstrap_import_failure',
+    durationMs: 0,
+    invocationId: randomUUID(),
+    client,
+    hookEvent: event,
+    processId: process.pid,
+    error: errorFields(error),
+  });
+}
+
+export function readHookEvents({ limit = 200, sinceMs = 24 * 60 * 60 * 1000 } = {}) {
+  try {
+    const dir = hookLogDirectory();
+    if (!existsSync(dir)) return [];
+    const cutoff = Date.now() - Math.max(0, sinceMs);
+    const files = readdirSync(dir)
+      .filter((name) => /^hook-events-.*\.jsonl$/.test(name))
+      .map((name) => join(dir, name))
+      .sort()
+      .reverse();
+    const events = [];
+    for (const file of files) {
+      const lines = readFileSync(file, 'utf8').split(/\r?\n/).filter(Boolean).reverse();
+      for (const line of lines) {
+        try {
+          const event = JSON.parse(line);
+          if (Date.parse(event.timestamp) < cutoff) continue;
+          events.push(event);
+          if (events.length >= limit) return events;
+        } catch {
+          // A partially written final line must not hide the rest of the log.
+        }
+      }
+    }
+    return events;
+  } catch {
+    return [];
+  }
+}
+
+export function hookHealthSummary(options = {}) {
+  const sinceMs = options.sinceMs ?? 24 * 60 * 60 * 1000;
+  const events = readHookEvents({ limit: options.limit || 5000, sinceMs });
+  const durations = events
+    .map((event) => Number(event.durationMs))
+    .filter(Number.isFinite)
+    .sort((a, b) => a - b);
+  const failures = events.filter((event) => event.outcome === 'failure');
+  const timeouts = events.filter((event) => event.outcome === 'timeout');
+  const skipped = events.filter((event) => event.outcome === 'skipped');
+  const successes = events.filter((event) => event.outcome === 'success');
+  const byClient = {};
+  for (const event of events) {
+    const key = event.client || 'unknown';
+    const current = byClient[key] || { total: 0, failures: 0, timeouts: 0, skipped: 0 };
+    current.total++;
+    if (event.outcome === 'failure') current.failures++;
+    if (event.outcome === 'timeout') current.timeouts++;
+    if (event.outcome === 'skipped') current.skipped++;
+    byClient[key] = current;
+  }
+  const percentile = (p) =>
+    durations.length
+      ? durations[Math.min(durations.length - 1, Math.floor(durations.length * p))]
+      : null;
+  const summary = {
+    schemaVersion: HOOK_LOG_SCHEMA_VERSION,
+    available: events.length > 0,
+    windowHours: sinceMs / 3_600_000,
+    total: events.length,
+    failures: failures.length,
+    timeouts: timeouts.length,
+    skipped: skipped.length,
+    successRate: events.length ? successes.length / events.length : null,
+    p50DurationMs: percentile(0.5),
+    p95DurationMs: percentile(0.95),
+    byClient,
+    recentFailures: [...failures, ...timeouts]
+      .sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp))
+      .slice(0, 20),
+  };
+  // Absolute paths are useful to a local doctor, but they do not belong in a
+  // diagnostics export that may be attached to a public issue.
+  if (options.includeLogDirectory === true)
+    summary.logDirectory = hookLogDirectory();
+  return summary;
+}

--- a/plugin/hooks/lib/policy.mjs
+++ b/plugin/hooks/lib/policy.mjs
@@ -48,6 +48,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { createHash } from 'node:crypto';
 import { isFsSafePath } from './paths.mjs';
+import { noteHookOutput } from './observability.mjs';
 
 /** Enforcement modes, least to most permissive. */
 export const MODE_ENFORCE = 'enforce';
@@ -653,14 +654,15 @@ export function allow() {
  */
 export function allowWithContext(context) {
   if (context) {
-    process.stdout.write(
-      JSON.stringify({
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-          additionalContext: withEscape(context),
-        },
-      })
-    );
+    const output = {
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        additionalContext: withEscape(context),
+      },
+    };
+    const serialized = JSON.stringify(output);
+    noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+    process.stdout.write(serialized);
   }
   process.exit(0);
 }
@@ -673,15 +675,16 @@ export function allowWithContext(context) {
  * says "use the optimized tool" gets met with a retry of the same call.
  */
 export function deny(reason) {
-  process.stdout.write(
-    JSON.stringify({
-      hookSpecificOutput: {
-        hookEventName: 'PreToolUse',
-        permissionDecision: 'deny',
-        permissionDecisionReason: withEscape(reason),
-      },
-    })
-  );
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+      permissionDecisionReason: withEscape(reason),
+    },
+  };
+  const serialized = JSON.stringify(output);
+  noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
   process.exit(0);
 }
 
@@ -706,14 +709,15 @@ export function withEscape(reason) {
 
 /** Lets the call through, attaching a note the model sees. */
 export function advise(context) {
-  process.stdout.write(
-    JSON.stringify({
-      hookSpecificOutput: {
-        hookEventName: 'PreToolUse',
-        additionalContext: context,
-      },
-    })
-  );
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      additionalContext: context,
+    },
+  };
+  const serialized = JSON.stringify(output);
+  noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
   process.exit(0);
 }
 
@@ -741,26 +745,34 @@ export function enforce(reason, deniedBefore) {
  * than an absent one, so the wait has a ceiling and expiring it is treated
  * exactly like unusable input.
  */
-export async function readPayload({
-  timeoutMs = 5000,
+export async function readPayloadResult({
+  timeoutMs = 1500,
   maxBytes = 8_000_000,
 } = {}) {
   const chunks = [];
   let size = 0;
+  let inputStatus = 'pending';
 
   const raw = await new Promise((resolve) => {
     const onData = (chunk) => {
-      size += chunk.length;
+      size += Buffer.byteLength(chunk, 'utf8');
       // A payload this large is not a tool call; refusing to buffer it
       // unboundedly keeps a hook from becoming a memory problem.
       if (size > maxBytes) {
+        inputStatus = 'too_large';
         finish(null);
         return;
       }
       chunks.push(chunk);
     };
-    const onEnd = () => finish(chunks.join(''));
-    const onError = () => finish(null);
+    const onEnd = () => {
+      inputStatus = 'received';
+      finish(chunks.join(''));
+    };
+    const onError = () => {
+      inputStatus = 'input_error';
+      finish(null);
+    };
 
     // Listeners are REMOVED on every exit path. Leaving them attached after the
     // timeout wins means a late chunk keeps growing a buffer nobody will read,
@@ -774,17 +786,21 @@ export async function readPayload({
       resolve(value);
     }
 
-    const timer = setTimeout(() => finish(null), timeoutMs);
+    const timer = setTimeout(() => {
+      inputStatus = 'timeout';
+      finish(null);
+    }, timeoutMs);
     process.stdin.setEncoding('utf8');
     process.stdin.on('data', onData);
     process.stdin.on('end', onEnd);
     process.stdin.on('error', onError);
   });
 
-  if (raw === null) return null;
+  if (raw === null) return { payload: null, status: inputStatus, bytes: size };
+  if (!raw.trim()) return { payload: null, status: 'empty_input', bytes: size };
   try {
-    return JSON.parse(raw);
+    return { payload: JSON.parse(raw), status: 'ok', bytes: size };
   } catch {
-    return null;
+    return { payload: null, status: 'invalid_json', bytes: size };
   }
 }

--- a/plugin/hooks/lib/projects.mjs
+++ b/plugin/hooks/lib/projects.mjs
@@ -1,0 +1,214 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/projects.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Machine-local index of project graph stores.
+ *
+ * A graph is deliberately stored with the project whose files it describes.
+ * That isolation is important for retrieval, but it also means a dashboard
+ * cannot honestly describe machine-wide capture unless it knows which stores
+ * exist. This registry is that missing directory. It is written by lifecycle
+ * hooks and can be backfilled by the explicit discovery command.
+ *
+ * The browser never receives `root` or `graphDir`. Routes resolve an opaque
+ * project id through this server-owned file, so restoring cross-project views
+ * does not restore the old arbitrary-path query vulnerability.
+ */
+
+import {
+  appendFileSync,
+  chmodSync,
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+} from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+import { createHash } from 'node:crypto';
+import { canonicalPath, isFsSafePath } from './paths.mjs';
+
+export const PROJECT_REGISTRY_VERSION = 1;
+
+export function projectRegistryPath() {
+  return (
+    process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY ||
+    join(homedir(), '.token-optimizer', 'projects.jsonl')
+  );
+}
+
+export function projectIdFor(root) {
+  return `project-${createHash('sha256')
+    .update(canonicalPath(root))
+    .digest('hex')
+    .slice(0, 16)}`;
+}
+
+function displayName(root) {
+  return basename(root) || 'Unnamed project';
+}
+
+function acquire(path) {
+  const lockPath = `${path}.lock`;
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+  } catch {
+    return null;
+  }
+
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      closeSync(openSync(lockPath, 'wx', 0o600));
+      return lockPath;
+    } catch {
+      try {
+        if (Date.now() - statSync(lockPath).mtimeMs > 5000) unlinkSync(lockPath);
+      } catch {
+        // The holder may have released it between open and stat; retry.
+      }
+    }
+  }
+  return null;
+}
+
+function release(lockPath) {
+  if (!lockPath) return;
+  try {
+    unlinkSync(lockPath);
+  } catch {
+    // A killed process or cleanup race must not fail the hook.
+  }
+}
+
+/**
+ * Folds the append-only registry into one current entry per canonical project.
+ * Malformed, stale-schema, and unsafe records are ignored rather than trusted.
+ */
+export function registeredProjects() {
+  const path = projectRegistryPath();
+  const projects = new Map();
+  if (!existsSync(path)) return [];
+
+  try {
+    for (const line of readFileSync(path, 'utf8').split('\n')) {
+      if (!line) continue;
+      let record;
+      try {
+        record = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (
+        record.v !== PROJECT_REGISTRY_VERSION ||
+        !isFsSafePath(record.root) ||
+        !isFsSafePath(record.graphDir)
+      ) {
+        continue;
+      }
+      const root = canonicalPath(record.root);
+      const graphDir = canonicalPath(record.graphDir);
+      // Append-only history can outlive a deleted worktree (especially a
+      // short-lived test or CI checkout). A source that no longer exists
+      // cannot be captured, and presenting it as a current coverage gap makes
+      // the dashboard steadily less truthful over time.
+      if (!existsSync(root)) continue;
+      // A broad discovery root may contain hundreds of dormant worktrees. They
+      // are not capture coverage until a hook has observed them or a graph
+      // exists; listing all of them turns the selector into filesystem noise.
+      if (
+        record.client === 'discovery' &&
+        !existsSync(join(graphDir, 'graph.jsonl'))
+      ) {
+        continue;
+      }
+      const id = projectIdFor(root);
+      if (record.id !== id) continue;
+
+      const previous = projects.get(id);
+      projects.set(id, {
+        id,
+        name: String(record.name || displayName(root)).slice(0, 160),
+        root,
+        graphDir,
+        firstSeenAt: previous?.firstSeenAt || record.at || 0,
+        lastSeenAt: Math.max(previous?.lastSeenAt || 0, Number(record.at) || 0),
+        clients: [
+          ...new Set([
+            ...(previous?.clients || []),
+            ...(typeof record.client === 'string' && record.client
+              ? [record.client.slice(0, 80)]
+              : []),
+          ]),
+        ].sort(),
+      });
+    }
+  } catch {
+    return [];
+  }
+
+  return [...projects.values()].sort(
+    (a, b) => b.lastSeenAt - a.lastSeenAt || a.name.localeCompare(b.name)
+  );
+}
+
+/** Registers one VCS project without ever making a hook fail closed. */
+export function registerProject({ root, graphDir, client = 'unknown', name } = {}) {
+  if (!isFsSafePath(root) || !isFsSafePath(graphDir)) return null;
+  try {
+    const canonicalRoot = canonicalPath(root);
+    const canonicalGraphDir = canonicalPath(graphDir);
+    const isRepository = ['.git', '.hg', '.svn'].some((marker) =>
+      existsSync(join(canonicalRoot, marker))
+    );
+    if (!isRepository) return null;
+    const id = projectIdFor(canonicalRoot);
+    const now = Date.now();
+    const recent = registeredProjects().find(
+      (project) =>
+        project.id === id &&
+        project.graphDir === canonicalGraphDir &&
+        project.clients.includes(client) &&
+        now - project.lastSeenAt < 60 * 60 * 1000
+    );
+    if (recent) return recent;
+
+    const path = projectRegistryPath();
+    const lockPath = acquire(path);
+    if (!lockPath) return null;
+    try {
+      appendFileSync(
+        path,
+        `${JSON.stringify({
+          v: PROJECT_REGISTRY_VERSION,
+          id,
+          name: String(name || displayName(canonicalRoot)).slice(0, 160),
+          root: canonicalRoot,
+          graphDir: canonicalGraphDir,
+          client: String(client || 'unknown').slice(0, 80),
+          at: now,
+        })}\n`,
+        { mode: 0o600 }
+      );
+      try {
+        chmodSync(path, 0o600);
+      } catch {
+        // Windows and some filesystems do not expose POSIX modes.
+      }
+    } finally {
+      release(lockPath);
+    }
+    return {
+      id,
+      name: String(name || displayName(canonicalRoot)).slice(0, 160),
+      root: canonicalRoot,
+      graphDir: canonicalGraphDir,
+      firstSeenAt: now,
+      lastSeenAt: now,
+      clients: [String(client || 'unknown').slice(0, 80)],
+    };
+  } catch {
+    return null;
+  }
+}

--- a/plugin/hooks/post-tool.mjs
+++ b/plugin/hooks/post-tool.mjs
@@ -2,7 +2,17 @@
 // GENERATED FILE -- do not edit. Regenerate with `npm run sync:hooks`.
 // Client entry point: names the client and event; all policy lives in the
 // shared core so no client can drift its own thresholds or guidance.
-import { run } from './lib/adapter.mjs';
-
 // Fail open: a defect in the optimizer must never cost the user a tool call.
-run('claude-code', 'post-tool').catch(() => process.exit(0));
+// Bootstrap failures are still recorded so fail-open does not become fail-silent.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+try {
+  const { run } = await import('./lib/adapter.mjs');
+  await run('claude-code', 'post-tool');
+} catch (error) {
+  try {
+    const { recordHookBootstrapFailure } = await import('./lib/observability.mjs');
+    recordHookBootstrapFailure('claude-code', 'post-tool', error);
+  } catch {
+    // A logger bootstrap failure is the only condition that remains silent.
+  }
+}

--- a/plugin/hooks/precompact-optimize.mjs
+++ b/plugin/hooks/precompact-optimize.mjs
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env node
+#!/usr/bin/env node
 /**
  * Claude Code PreCompact adapter -- optimize at the moment it matters most.
  *
@@ -21,16 +21,26 @@
 import { spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
-import { mode, MODE_OFF, loadState, clearSeen } from './lib/policy.mjs';
+import { mode, MODE_OFF, loadState, clearSeen, readPayloadResult } from './lib/policy.mjs';
 import { linkCoOccurrence } from './lib/inject.mjs';
 import { wikiDir, projectRootFor } from './lib/wiki.mjs';
 import { closeForecast } from './lib/surface.mjs';
 import { compactionNudge } from './lib/recording.mjs';
 import { optimizerToolsForHook } from './lib/capabilities.mjs';
+import { beginHookInvocation, noteHookOutput } from './lib/observability.mjs';
 
 /** Longest compaction may be delayed. Past this the work is abandoned. */
 const TIMEOUT_MS =
   Number(process.env.TOKEN_OPTIMIZER_PRECOMPACT_TIMEOUT_MS) || 8000;
+const invocation = beginHookInvocation('claude-code', 'pre-compact', {
+  deadlineMs: Math.max(4200, TIMEOUT_MS + 1000),
+});
+
+function emit(output) {
+  const serialized = JSON.stringify(output);
+  noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+  process.stdout.write(serialized);
+}
 
 function findWrapper() {
   // Plugin installs place the plugin under .../plugin; the wrapper, when
@@ -53,16 +63,13 @@ function findWrapper() {
 async function main() {
   if (mode() === MODE_OFF) return;
 
-  const chunks = [];
-  process.stdin.setEncoding('utf8');
-  for await (const chunk of process.stdin) chunks.push(chunk);
-
-  let payload;
-  try {
-    payload = JSON.parse(chunks.join(''));
-  } catch {
+  const input = await readPayloadResult();
+  const payload = input.payload;
+  if (!payload) {
+    invocation.noteInput(input.status, input.bytes);
     return;
   }
+  invocation.bind(payload, null, input.bytes);
 
   // STATE AND CO-OCCURRENCE BEFORE THE WRAPPER CHECK, deliberately.
   //
@@ -144,7 +151,7 @@ async function main() {
       ? compactionNudge(graphDir, { edits: state.edits || 0 })
       : null;
     if (nudge) {
-      process.stdout.write(JSON.stringify({ systemMessage: nudge }));
+      emit({ systemMessage: nudge });
     }
   } catch {
     // Never delay compaction for a reminder.
@@ -209,14 +216,13 @@ async function main() {
     });
   });
 
-  process.stdout.write(
-    JSON.stringify({
+  emit({
       systemMessage: `token-optimizer: compressed ${seenCount} tracked file operation(s) before compaction.`,
-    })
-  );
+    });
 }
 
 // Compaction must proceed whatever happens here.
 main()
-  .catch(() => {})
+  .then(() => invocation.succeed())
+  .catch((error) => invocation.fail(error))
   .finally(() => process.exit(0));

--- a/plugin/hooks/pretooluse-router.mjs
+++ b/plugin/hooks/pretooluse-router.mjs
@@ -12,7 +12,7 @@
  */
 
 import {
-  readPayload,
+  readPayloadResult,
   loadState,
   saveState,
   alreadyDenied,
@@ -60,6 +60,7 @@ import {
   rememberOptimizerTools,
 } from './lib/capabilities.mjs';
 import { evaluateUcrGuards } from './lib/ucr-guard.mjs';
+import { beginHookInvocation } from './lib/observability.mjs';
 
 /**
  * Largest file the hook will read to index. Above this the touch is still
@@ -68,18 +69,24 @@ import { evaluateUcrGuards } from './lib/ucr-guard.mjs';
  */
 const HARVEST_MAX_BYTES =
   Number(process.env.TOKEN_OPTIMIZER_HARVEST_MAX_BYTES) || 4_000_000;
+const invocation = beginHookInvocation('claude-code', 'pre-tool');
 
 // Wrapped whole. Any defect in this hook must cost the user nothing: an
 // exception here allows the call exactly as if the plugin were not installed.
 try {
   if (mode() === MODE_OFF) allow();
 
-  const raw = await readPayload();
-  if (!raw) allow();
+  const input = await readPayloadResult();
+  const raw = input.payload;
+  if (!raw) {
+    invocation.noteInput(input.status, input.bytes);
+    allow();
+  }
 
   // Normalized here rather than in the engine so this adapter behaves
   // identically to every other client's adapter on the same underlying call.
   const payload = normalizePayload(raw);
+  invocation.bind(raw, payload, input.bytes);
   if (!payload.tool_name) allow();
   const features = featuresForArm();
   const episode = episodeMeta({ client: 'claude-code', raw });
@@ -474,6 +481,7 @@ ${nudge}`
   // On a repeat this degrades to a note and lets the call through, which is
   // what bounds the blast radius when the MCP server is unavailable.
   enforce(reason, repeat);
-} catch {
+} catch (error) {
+  invocation.fail(error);
   allow();
 }

--- a/plugin/hooks/session-start.mjs
+++ b/plugin/hooks/session-start.mjs
@@ -21,7 +21,7 @@
 import {
   mode,
   MODE_OFF,
-  readPayload,
+  readPayloadResult,
   loadState,
   saveState,
 } from './lib/policy.mjs';
@@ -39,8 +39,9 @@ import {
 import { wikiDir, load, projectRootFor } from './lib/wiki.mjs';
 import { episodeMeta, featuresForArm } from './lib/experiment.mjs';
 import { join } from 'node:path';
+import { beginHookInvocation, noteHookOutput } from './lib/observability.mjs';
 
-if (mode() === MODE_OFF) process.exit(0);
+const invocation = beginHookInvocation('claude-code', 'session-start');
 
 /**
  * The restoration block, when this session is resuming from a compaction.
@@ -56,7 +57,7 @@ if (mode() === MODE_OFF) process.exit(0);
  * harness telling us exactly this case.
  */
 async function restoration(parsed) {
-  // `readPayload` returns the PARSED object, not the raw text. Parsing it again
+  // `readPayloadResult` returns the PARSED object, not the raw text. Parsing it again
   // throws on `[object Object]`, and the throw is swallowed by the catch below,
   // so the restoration block simply never appeared -- the failure mode a
   // fail-open hook is most likely to hide.
@@ -95,7 +96,12 @@ async function restoration(parsed) {
 // clients and silently skipped Claude Code, the one client most users are on.
 // Claude Code keeps its own entry point because its PreToolUse router does more
 // than the shared one; the standing notice is not a place it needs to differ.
-const payload = (await readPayload()) || {};
+async function main() {
+if (mode() === MODE_OFF) return;
+const input = await readPayloadResult({ timeoutMs: 250 });
+const payload = input.payload || {};
+if (input.payload) invocation.bind(payload, null, input.bytes);
+else invocation.noteInput(input.status, input.bytes);
 const features = featuresForArm();
 const toolEvidence = optimizerToolEvidence(payload);
 if (payload.session_id && toolEvidence.proven) {
@@ -147,11 +153,17 @@ try {
   // The policy notice must still arrive if anything above fails.
 }
 
-process.stdout.write(
-  JSON.stringify({
+const output = {
     hookSpecificOutput: {
       hookEventName: 'SessionStart',
       additionalContext: parts.join('\n\n'),
     },
-  })
-);
+  };
+const serialized = JSON.stringify(output);
+noteHookOutput(output, Buffer.byteLength(serialized, 'utf8'));
+process.stdout.write(serialized);
+}
+
+main()
+  .then(() => invocation.succeed())
+  .catch((error) => invocation.fail(error));

--- a/plugin/hooks/stop.mjs
+++ b/plugin/hooks/stop.mjs
@@ -2,7 +2,17 @@
 // GENERATED FILE -- do not edit. Regenerate with `npm run sync:hooks`.
 // Client entry point: names the client and event; all policy lives in the
 // shared core so no client can drift its own thresholds or guidance.
-import { run } from './lib/adapter.mjs';
-
 // Fail open: a defect in the optimizer must never cost the user a tool call.
-run('claude-code', 'stop').catch(() => process.exit(0));
+// Bootstrap failures are still recorded so fail-open does not become fail-silent.
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+try {
+  const { run } = await import('./lib/adapter.mjs');
+  await run('claude-code', 'stop');
+} catch (error) {
+  try {
+    const { recordHookBootstrapFailure } = await import('./lib/observability.mjs');
+    recordHookBootstrapFailure('claude-code', 'stop', error);
+  } catch {
+    // A logger bootstrap failure is the only condition that remains silent.
+  }
+}

--- a/scripts/assemble-ucr-evidence.mjs
+++ b/scripts/assemble-ucr-evidence.mjs
@@ -137,6 +137,10 @@ function readReport([name, filename, evidenceClass, requiredPass = true]) {
     reportHash,
     schemaVersion: report.schemaVersion,
     passed: report.passed === true,
+    qualificationStatus: report.qualification?.status || null,
+    qualificationPassed: report.qualification?.passed === true,
+    qualificationMaximumTokenOverhead:
+      report.qualification?.maximumObservedTokenOverhead ?? null,
     executedAt: report.executedAt || null,
     sourceTreeHash: report.sourceTreeHash || report.sourceHash || null,
     ledgerHash: ledgerVerification?.ledgerHash || null,

--- a/scripts/discover-project-graphs.mjs
+++ b/scripts/discover-project-graphs.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/**
+ * Explicitly backfills the machine project registry from known source roots.
+ *
+ * The dashboard never scans the filesystem on a web request. Operators choose
+ * the roots here; traversal is bounded and ignores dependency/build trees.
+ */
+
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import { basename, dirname, join, resolve } from 'node:path';
+import { registerProject, registeredProjects } from '../hooks-core/projects.mjs';
+
+const requestedRoots = process.argv.slice(2).map((root) => resolve(root));
+if (requestedRoots.length === 0) {
+  console.error('Usage: node scripts/discover-project-graphs.mjs <source-root> [...]');
+  process.exit(2);
+}
+
+const excluded = new Set([
+  '.git',
+  'node_modules',
+  'bin',
+  'obj',
+  'dist',
+  'coverage',
+  'artifacts',
+  'TestResults',
+]);
+const found = [];
+
+function visit(directory, depth = 0, explicitRepository = false) {
+  if (depth > 10) return;
+  let entries;
+  try {
+    entries = readdirSync(directory, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  const store = join(directory, '.token-optimizer', 'wiki', 'graph.jsonl');
+  const isRepository = existsSync(join(directory, '.git'));
+  if (existsSync(store) || explicitRepository) {
+    const graphDir = dirname(store);
+    const project = registerProject({
+      root: directory,
+      graphDir,
+      client: explicitRepository ? 'discovery-explicit' : 'discovery',
+      name: basename(directory),
+    });
+    if (project) {
+      found.push({
+        id: project.id,
+        name: project.name,
+        captured: existsSync(store),
+        bytes: existsSync(store) ? statSync(store).size : 0,
+      });
+    }
+    // A repository may contain nested worktrees, so traversal continues.
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory() || excluded.has(entry.name)) continue;
+    if (entry.name === '.token-optimizer') continue;
+    visit(join(directory, entry.name), depth + 1, false);
+  }
+}
+
+for (const root of requestedRoots)
+  visit(root, 0, existsSync(join(root, '.git')));
+
+const deduped = [...new Map(found.map((project) => [project.id, project])).values()];
+console.log(
+  JSON.stringify(
+    {
+      roots: requestedRoots,
+      discovered: deduped.length,
+      projects: deduped,
+      registryProjects: registeredProjects().length,
+    },
+    null,
+    2
+  )
+);

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -12,6 +12,7 @@ import { fileURLToPath } from 'node:url';
 import { tmpdir, homedir } from 'node:os';
 import { diagnose, renderDiagnosis } from '../hooks-core/doctor.mjs';
 import { wikiDir } from '../hooks-core/wiki.mjs';
+import { hookHealthSummary } from '../hooks-core/observability.mjs';
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -23,9 +24,29 @@ const result = diagnose({
 });
 
 console.log(renderDiagnosis(result));
+const hookHealth = hookHealthSummary({ includeLogDirectory: true });
+console.log('');
+console.log('Lifecycle diagnostics (last 24 hours):');
+if (hookHealth.total === 0) {
+  console.log(`  No hook runs recorded yet. Log directory: ${hookHealth.logDirectory}`);
+} else {
+  console.log(
+    `  ${hookHealth.total} runs; ${hookHealth.failures} failures; ` +
+    `${hookHealth.timeouts} timeouts; ${hookHealth.skipped} skipped; ` +
+    `p95 ${hookHealth.p95DurationMs ?? 'n/a'} ms.`
+  );
+  for (const [client, counts] of Object.entries(hookHealth.byClient)) {
+    console.log(
+      `  ${client}: ${counts.total} runs, ${counts.failures} failures, ` +
+      `${counts.timeouts} timeouts, ${counts.skipped || 0} skipped.`
+    );
+  }
+}
 console.log('');
 console.log('Verify the release itself with `npm audit signatures` (provenance attestation),');
 console.log('or `sha256sum -c CHECKSUMS.sha256` for an offline check.');
+console.log('Export a bounded summary with `npm run diagnostics -- --hours 24`.');
+console.log('Add `--include-events --limit 100` only when event-level evidence is required.');
 
 // A broken install should fail a script that asks whether it is broken.
 process.exit(result.healthy ? 0 : 1);

--- a/scripts/export-diagnostics.mjs
+++ b/scripts/export-diagnostics.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+/** Export privacy-safe cross-client lifecycle diagnostics as one JSON report. */
+
+import { writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  hookHealthSummary,
+  readHookEvents,
+} from '../hooks-core/observability.mjs';
+
+function valueAfter(flag) {
+  const index = process.argv.indexOf(flag);
+  return index >= 0 ? process.argv[index + 1] : null;
+}
+
+const hours = Math.min(24 * 30, Math.max(1, Number(valueAfter('--hours')) || 24));
+const includeEvents = process.argv.includes('--include-events');
+const limit = Math.min(1_000, Math.max(1, Number(valueAfter('--limit')) || 100));
+const output = valueAfter('--output');
+const sinceMs = hours * 60 * 60 * 1000;
+const report = {
+  generatedAt: new Date().toISOString(),
+  privacy:
+    'No prompts, commands, tool output, file contents, or raw working-directory paths are retained.',
+  scope: {
+    windowHours: hours,
+    eventPayloadIncluded: includeEvents,
+    ...(includeEvents ? { eventLimit: limit } : {}),
+  },
+  summary: hookHealthSummary({ sinceMs }),
+};
+if (includeEvents) report.events = readHookEvents({ sinceMs, limit });
+const json = `${JSON.stringify(report, null, 2)}\n`;
+
+if (output) {
+  const destination = resolve(output);
+  writeFileSync(destination, json, { encoding: 'utf8' });
+  console.log(destination);
+} else {
+  process.stdout.write(json);
+}

--- a/scripts/generate-client-entries.mjs
+++ b/scripts/generate-client-entries.mjs
@@ -10,11 +10,15 @@
  * drifted apart.
  */
 
+import { readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { contentMatches, readIfExists, writeIfChanged } from './lib/text.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const PACKAGE_VERSION = JSON.parse(
+  readFileSync(join(ROOT, 'package.json'), 'utf8')
+).version;
 
 /** [directory, client key, event, filename] */
 const ENTRIES = [
@@ -72,10 +76,20 @@ for (const [dir, client, event, name] of ENTRIES) {
 // GENERATED FILE -- do not edit. Regenerate with \`npm run sync:hooks\`.
 // Client entry point: names the client and event; all policy lives in the
 // shared core so no client can drift its own thresholds or guidance.
-import { run } from './lib/adapter.mjs';
-
 // Fail open: a defect in the optimizer must never cost the user a tool call.
-run('${client}', '${event}').catch(() => process.exit(0));
+// Bootstrap failures are still recorded so fail-open does not become fail-silent.
+process.env.TOKEN_OPTIMIZER_VERSION = '${PACKAGE_VERSION}';
+try {
+  const { run } = await import('./lib/adapter.mjs');
+  await run('${client}', '${event}');
+} catch (error) {
+  try {
+    const { recordHookBootstrapFailure } = await import('./lib/observability.mjs');
+    recordHookBootstrapFailure('${client}', '${event}', error);
+  } catch {
+    // A logger bootstrap failure is the only condition that remains silent.
+  }
+}
 `;
 
   if (check) {

--- a/scripts/run-ucr-full-study.mjs
+++ b/scripts/run-ucr-full-study.mjs
@@ -426,6 +426,24 @@ try {
       model: trial.consumerModel,
       modelVersion: result?.modelVersion || null,
       modelAttestations,
+      // Privacy-safe phase accounting retained in the signed row. Without it,
+      // a token regression only reported one opaque total and could not be
+      // attributed to producer capture, consumer reconstruction, cache-backed
+      // input, output, or extra action turns.
+      invocationAccounting: (result?.invocations || []).map(
+        (invocation) => ({
+          role: invocation.role,
+          transport: invocation.transport,
+          inputTokens: invocation.inputTokens,
+          cachedInputTokens: invocation.cachedInputTokens,
+          cacheCreationInputTokens: invocation.cacheCreationInputTokens,
+          effectiveInputTokens: invocation.effectiveInputTokens,
+          outputTokens: invocation.outputTokens,
+          totalTokens: invocation.totalTokens,
+          actionEvents: invocation.actionEvents,
+          latencyMs: invocation.latencyMs,
+        })
+      ),
       consumerMcpExposed: result?.consumerMcpExposed ?? null,
       actionAuditHash: sha256(result?.actionAudit || []),
       semanticEvidenceVerification:

--- a/scripts/sync-hook-core.mjs
+++ b/scripts/sync-hook-core.mjs
@@ -23,6 +23,9 @@ import { fileURLToPath } from 'node:url';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const SOURCE = join(ROOT, 'hooks-core');
+const PACKAGE_VERSION = JSON.parse(
+  readFileSync(join(ROOT, 'package.json'), 'utf8')
+).version;
 
 /** Every directory that must hold an identical copy of the core. */
 const TARGETS = [
@@ -44,7 +47,10 @@ const files = readdirSync(SOURCE).filter((f) => f.endsWith('.mjs'));
 
 const banner = (name) =>
   `// GENERATED FILE -- do not edit.\n` +
-  `// Source of truth: hooks-core/${name}. Regenerate with \`npm run sync:hooks\`.\n`;
+  `// Source of truth: hooks-core/${name}. Regenerate with \`npm run sync:hooks\`.\n` +
+  (name === 'observability.mjs'
+    ? `process.env.TOKEN_OPTIMIZER_VERSION = '${PACKAGE_VERSION}';\n`
+    : '');
 
 // The EOL-safe comparison this file used to carry locally now lives in
 // scripts/lib/text.mjs, because it was needed by the other two generators and

--- a/scripts/ucr-live-study-driver.mjs
+++ b/scripts/ucr-live-study-driver.mjs
@@ -303,7 +303,7 @@ function consumerContext(decision, tokenBudget) {
   const context = [
     'A host-verified pre-action continuity capsule is available.',
     decision.payload,
-    'Treat it as evidence, confirm it against the repository, and do not expose or invoke any MCP server.',
+    'Use it as the primary explanation of the prior failure. Inspect only the exact cited paths needed to implement and verify the correction; do not repeat broad discovery that the predecessor already completed. Do not expose or invoke any MCP server.',
   ].join('\n');
   const maximumCharacters = Math.max(0, Number(tokenBudget) || 0) * 4;
   if (!maximumCharacters || context.length <= maximumCharacters) return context;
@@ -427,6 +427,8 @@ try {
       cacheCreationInputTokens: producer.usage.cacheCreationInputTokens,
       effectiveInputTokens: producer.usage.effectiveInputTokens,
       outputTokens: producer.usage.outputTokens,
+      totalTokens: producer.usage.totalTokens,
+      actionEvents: producer.actionAudit.length,
       latencyMs: producer.endedAtMs - producer.startedAtMs,
       startedAtMs: producer.startedAtMs,
       endedAtMs: producer.endedAtMs,
@@ -449,6 +451,8 @@ try {
       cacheCreationInputTokens: consumer.usage.cacheCreationInputTokens,
       effectiveInputTokens: consumer.usage.effectiveInputTokens,
       outputTokens: consumer.usage.outputTokens,
+      totalTokens: consumer.usage.totalTokens,
+      actionEvents: consumer.actionAudit.length,
       latencyMs: consumer.endedAtMs - consumer.startedAtMs,
       startedAtMs: consumer.startedAtMs,
       endedAtMs: consumer.endedAtMs,

--- a/scripts/verify-live-dashboard.mjs
+++ b/scripts/verify-live-dashboard.mjs
@@ -116,6 +116,34 @@ try {
       element.__knowledgeGraph3d?.projectedNodes?.().length ?? null,
     selected: element.dataset.selected || null,
   }));
+  const detailVisible = await page.locator('#wiki-detail').isVisible();
+  await page.locator('.wiki-tab[data-tab="evidence"]').click();
+  await page.waitForFunction(
+    () => document.querySelectorAll('#evidence-summary .stat-card').length === 6
+  );
+  await page.waitForFunction(
+    () => document.querySelectorAll('#ucr-missing tbody tr').length > 0
+  );
+  const evidence = await page.evaluate(() => ({
+    summary: [...document.querySelectorAll('#evidence-summary .stat-card')].map(
+      (card) => ({
+        label: card.querySelector('.stat-label')?.textContent?.trim() || '',
+        value: card.querySelector('.stat-value')?.textContent?.trim() || '',
+      })
+    ),
+    status: document.querySelector('#evidence-status')?.textContent?.trim() || '',
+    ucrSummary: [...document.querySelectorAll('#ucr-summary .stat-card')].map(
+      (card) => ({
+        label: card.querySelector('.stat-label')?.textContent?.trim() || '',
+        value: card.querySelector('.stat-value')?.textContent?.trim() || '',
+      })
+    ),
+    missingMetrics: document.querySelectorAll('#ucr-missing tbody tr').length,
+  }));
+  await page.screenshot({
+    path: join(output, 'wiki-evidence.png'),
+    fullPage: true,
+  });
   const wiki = {
     listCount: await page.locator('#wiki-list li').count(),
     scopeOptions: await page.locator('#wiki-scope option').count(),
@@ -146,7 +174,8 @@ try {
     graph3d,
     cameraStability,
     afterSelect,
-    detailVisible: await page.locator('#wiki-detail').isVisible(),
+    evidence,
+    detailVisible,
     drawerOverlap: await page.evaluate(() => {
       const drawer = document.querySelector('#wiki-detail')?.getBoundingClientRect();
       if (!drawer) return null;
@@ -207,6 +236,18 @@ try {
     wiki.cameraStability.pitchSpread <= 0.0001 &&
     wiki.afterSelect.projected > 0 &&
     Boolean(wiki.afterSelect.selected) &&
+    wiki.evidence.summary.length === 6 &&
+    wiki.evidence.summary.every(({ value }) => value.length > 0 && value !== '—') &&
+    wiki.evidence.summary
+      .filter(({ label }) =>
+        ['Randomized runs', 'Handoff runs', 'Concurrency runs'].includes(label)
+      )
+      .every(({ value }) => value === 'Not run') &&
+    /selected projects have evidence events/i.test(wiki.evidence.status) &&
+    wiki.evidence.ucrSummary.some(
+      ({ label, value }) => label === 'UCR runtime events' && value === 'Not exercised'
+    ) &&
+    wiki.evidence.missingMetrics > 0 &&
     wiki.detailVisible &&
     wiki.drawerOverlap?.length === 0 &&
     errors.length === 0;

--- a/scripts/verify-live-dashboard.mjs
+++ b/scripts/verify-live-dashboard.mjs
@@ -22,6 +22,35 @@ page.on('requestfailed', (request) =>
   errors.push(`request:${request.url()}:${request.failure()?.errorText}`)
 );
 
+async function measureCameraStability(host) {
+  return host.evaluate(async (element) => {
+    const samples = [];
+    for (let index = 0; index < 12; index += 1) {
+      samples.push({
+        width: element.clientWidth,
+        height: element.clientHeight,
+        zoom: Number(element.dataset.zoom),
+        yaw: Number(element.dataset.yaw),
+        pitch: Number(element.dataset.pitch),
+      });
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    }
+    const spread = (key) => {
+      const values = samples.map((sample) => sample[key]);
+      return Math.max(...values) - Math.min(...values);
+    };
+    return {
+      first: samples[0],
+      last: samples.at(-1),
+      widthSpread: spread('width'),
+      heightSpread: spread('height'),
+      zoomSpread: spread('zoom'),
+      yawSpread: spread('yaw'),
+      pitchSpread: spread('pitch'),
+    };
+  });
+}
+
 try {
   await page.goto(base, { waitUntil: 'networkidle' });
   const overviewBody = await page.locator('body').innerText();
@@ -33,6 +62,14 @@ try {
       /which actions cost the most|what it has learned|agent activity/i.test(
         overviewBody
       ),
+    staleLegacySession: /november 2025|2025-11-02/i.test(overviewBody),
+    activityCards: await page.locator('#kpis .kpi').evaluateAll((cards) =>
+      cards.map((card) => ({
+        label: card.querySelector('.kpi-label')?.childNodes[0]?.textContent?.trim() || '',
+        value: card.querySelector('.kpi-value')?.textContent?.trim() || '',
+      }))
+    ),
+    cameraStability: await measureCameraStability(page.locator('#constellation')),
   };
   await page.screenshot({
     path: join(output, 'overview.png'),
@@ -41,6 +78,26 @@ try {
 
   await page.goto(`${base}/wiki`, { waitUntil: 'networkidle' });
   await page.waitForSelector('#wiki-list li');
+  await page.waitForFunction(
+    () => document.querySelectorAll('#hook-health-grid .stat-card').length === 6
+  );
+  const captureHealth = await page.evaluate(() => {
+    const values = [...document.querySelectorAll('#hook-health-grid .stat-card')]
+      .map((card) => ({
+        label: card.querySelector('.stat-label')?.textContent?.trim() || '',
+        value: card.querySelector('.stat-value')?.textContent?.trim() || '',
+      }));
+    return {
+      values,
+      status: document.querySelector('#hook-health-status')?.textContent?.trim() || '',
+      state: document.querySelector('#hook-health-status')?.dataset.state || '',
+      detail: document.querySelector('#hook-health-detail')?.textContent?.trim() || '',
+    };
+  });
+  await page.screenshot({
+    path: join(output, 'wiki-capture-health.png'),
+    fullPage: true,
+  });
   const host = page.locator('#wiki-graph-3d');
   const graph3d = await host.evaluate((element) => ({
     width: element.clientWidth,
@@ -49,6 +106,7 @@ try {
       element.__knowledgeGraph3d?.projectedNodes?.().length ?? null,
     selected: element.dataset.selected || null,
   }));
+  const cameraStability = await measureCameraStability(host);
   await page.locator('#mode-constellation').click();
   await page.waitForTimeout(800);
   await page.locator('#wiki-list li').first().click();
@@ -60,9 +118,53 @@ try {
   }));
   const wiki = {
     listCount: await page.locator('#wiki-list li').count(),
+    scopeOptions: await page.locator('#wiki-scope option').count(),
+    coverage: await page.locator('#wiki-coverage').innerText(),
+    graphStats: await page.locator('#graph-stats').innerText(),
+    aggregateCoverage: await page.evaluate(async () => {
+      const [status, inventory] = await Promise.all([
+        fetch('/api/wiki/status?scope=all').then((response) => response.json()),
+        fetch('/api/wiki/projects').then((response) => response.json()),
+      ]);
+      return {
+        nodes: status.nodes,
+        capturedProjects: status.capturedProjects,
+        largestProjectNodes: Math.max(
+          0,
+          ...inventory.projects.map((project) => project.nodes || 0)
+        ),
+        missingProjects: inventory.missing,
+      };
+    }),
+    balanceCards: await page.locator('#balance-grid .stat-card').evaluateAll((cards) =>
+      cards.map((card) => ({
+        label: card.querySelector('.stat-label')?.textContent?.trim() || '',
+        value: card.querySelector('.stat-value')?.textContent?.trim() || '',
+      }))
+    ),
+    captureHealth,
     graph3d,
+    cameraStability,
     afterSelect,
     detailVisible: await page.locator('#wiki-detail').isVisible(),
+    drawerOverlap: await page.evaluate(() => {
+      const drawer = document.querySelector('#wiki-detail')?.getBoundingClientRect();
+      if (!drawer) return null;
+      const selectors = [
+        '#hook-health-grid .stat-card',
+        '#balance-grid .stat-card',
+        '.wiki-tabs',
+        '.wiki-toolbar',
+      ];
+      return selectors.flatMap((selector) =>
+        [...document.querySelectorAll(selector)]
+          .filter((element) => {
+            const rect = element.getBoundingClientRect();
+            return rect.right > drawer.left && rect.left < drawer.right;
+          })
+          .map((element) => selector)
+      );
+    }),
   };
   await page.screenshot({
     path: join(output, 'wiki-3d.png'),
@@ -72,13 +174,41 @@ try {
   const passed =
     !overview.claudeHardcode &&
     overview.genericActivity &&
+    !overview.staleLegacySession &&
+    overview.activityCards.length === 4 &&
+    overview.activityCards.some(
+      ({ label, value }) => label === 'Lifecycle events' && Number(value.replaceAll(',', '')) > 0
+    ) &&
+    overview.cameraStability.widthSpread <= 1 &&
+    overview.cameraStability.heightSpread <= 1 &&
+    overview.cameraStability.zoomSpread <= 0.0001 &&
+    overview.cameraStability.yawSpread <= 0.0001 &&
+    overview.cameraStability.pitchSpread <= 0.0001 &&
     wiki.listCount > 0 &&
+    wiki.scopeOptions >= 3 &&
+    /contain graph data/i.test(wiki.coverage) &&
+    wiki.aggregateCoverage.capturedProjects >= 2 &&
+    wiki.aggregateCoverage.nodes > wiki.aggregateCoverage.largestProjectNodes &&
+    wiki.aggregateCoverage.missingProjects >= 1 &&
+    wiki.balanceCards.length === 4 &&
+    wiki.balanceCards.every(({ value }) => value.length > 0 && value !== '—') &&
+    wiki.captureHealth.values.length === 6 &&
+    wiki.captureHealth.values.some(
+      ({ label, value }) => label === 'Hook runs' && Number(value.replaceAll(',', '')) > 0
+    ) &&
+    wiki.captureHealth.state === 'ok' &&
     wiki.graph3d.width > 0 &&
     wiki.graph3d.height > 0 &&
     wiki.graph3d.projected > 0 &&
+    wiki.cameraStability.widthSpread <= 1 &&
+    wiki.cameraStability.heightSpread <= 1 &&
+    wiki.cameraStability.zoomSpread <= 0.0001 &&
+    wiki.cameraStability.yawSpread <= 0.0001 &&
+    wiki.cameraStability.pitchSpread <= 0.0001 &&
     wiki.afterSelect.projected > 0 &&
     Boolean(wiki.afterSelect.selected) &&
     wiki.detailVisible &&
+    wiki.drawerOverlap?.length === 0 &&
     errors.length === 0;
   process.stdout.write(
     `${JSON.stringify({ passed, base, overview, wiki, errors }, null, 2)}\n`

--- a/scripts/verify-live-graph-flow.mjs
+++ b/scripts/verify-live-graph-flow.mjs
@@ -30,6 +30,7 @@ const claim =
 
 const originalEnv = {
   shared: process.env.TOKEN_OPTIMIZER_SHARED_DIR,
+  registry: process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY,
   state: process.env.TOKEN_OPTIMIZER_STATE_DIR,
   holdout: process.env.TOKEN_OPTIMIZER_HOLDOUT,
 };
@@ -128,6 +129,7 @@ async function main() {
   writeFileSync(anchor, 'export const configuredRunner = "npm test";\n');
 
   process.env.TOKEN_OPTIMIZER_SHARED_DIR = shared;
+  process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY = join(temp, 'projects.jsonl');
   process.env.TOKEN_OPTIMIZER_STATE_DIR = state;
   process.env.TOKEN_OPTIMIZER_HOLDOUT = '0';
 
@@ -234,11 +236,11 @@ async function main() {
     });
     recordRead(wikiA, { anchor, sessionId, bytes: 8_000 });
   }
-  // Charge a conservative semantic-recording cost even though wiki_write does
-  // not call an external harvester, so the positive result is net of overhead.
-  record(wikiA, { kind: 'harvest', tokens: 500 });
-
   const directBalance = report(wikiA);
+  assert(
+    directBalance.harvestTokens > 0,
+    'successful production wiki_write did not record semantic persistence cost'
+  );
   assert(
     directBalance.sufficientData,
     `balance remained insufficient: ${directBalance.verdict}`
@@ -261,6 +263,7 @@ async function main() {
         ...process.env,
         PORT: String(port),
         TOKEN_OPTIMIZER_WIKI_DIR: wikiA,
+        TOKEN_OPTIMIZER_PROJECT_REGISTRY: join(temp, 'projects.jsonl'),
       },
     }
   );
@@ -285,7 +288,8 @@ async function main() {
   const dashboardFinding = search.items?.find((item) => item.claim === claim);
 
   assert(
-    status.dir === wikiA,
+    String(status.dir).replaceAll('\\', '/').toLowerCase() ===
+      String(wikiA).replaceAll('\\', '/').toLowerCase(),
     `dashboard served ${status.dir}, expected ${wikiA}`
   );
   assert(status.findings >= 1, 'dashboard did not count the harvested finding');
@@ -340,6 +344,7 @@ try {
 } finally {
   await stopDashboard();
   restoreEnv('TOKEN_OPTIMIZER_SHARED_DIR', originalEnv.shared);
+  restoreEnv('TOKEN_OPTIMIZER_PROJECT_REGISTRY', originalEnv.registry);
   restoreEnv('TOKEN_OPTIMIZER_STATE_DIR', originalEnv.state);
   restoreEnv('TOKEN_OPTIMIZER_HOLDOUT', originalEnv.holdout);
   try {

--- a/scripts/verify-wiki-interactions.mjs
+++ b/scripts/verify-wiki-interactions.mjs
@@ -23,6 +23,8 @@ import { fileURLToPath } from 'node:url';
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const GRAPH = mkdtempSync(join(tmpdir(), 'wiki-interactions-'));
 process.env.TOKEN_OPTIMIZER_WIKI_DIR = GRAPH;
+process.env.TOKEN_OPTIMIZER_SHARED_DIR = GRAPH;
+process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY = join(GRAPH, 'projects.jsonl');
 
 const PORT = 3600 + Math.floor(Math.random() * 300);
 const BASE = `http://localhost:${PORT}`;
@@ -494,6 +496,39 @@ async function main() {
     );
 
     /* ---- API robustness --------------------------------------------------- */
+
+    const inventoryResponse = await fetch(`${BASE}/api/wiki/projects`);
+    const inventoryText = await inventoryResponse.text();
+    const inventory = JSON.parse(inventoryText);
+    check(
+      'project inventory exposes opaque ids without filesystem paths',
+      inventoryResponse.ok &&
+        inventory.projects.length >= 1 &&
+        inventory.projects.every(
+          (project) =>
+            /^project-|^(current|shared)$/.test(project.id) &&
+            !('root' in project) &&
+            !('dir' in project) &&
+            !('graphDir' in project)
+        ) &&
+        !inventoryText.includes(GRAPH),
+      inventoryText.slice(0, 300)
+    );
+
+    const unknownScope = await fetch(
+      `${BASE}/api/wiki/status?scope=not-a-registered-project`
+    );
+    check(
+      'unknown opaque project scope is refused',
+      unknownScope.status === 400,
+      String(unknownScope.status)
+    );
+
+    check(
+      'knowledge scope selector reports capture coverage',
+      (await page.locator('#wiki-scope option').count()) >= 2 &&
+        (await page.locator('#wiki-coverage').innerText()).length > 0
+    );
 
     for (const [label, path] of [
       ['missing node', '/api/wiki/node/does-not-exist'],

--- a/scripts/verify-wiki-ui.mjs
+++ b/scripts/verify-wiki-ui.mjs
@@ -830,6 +830,17 @@ async function main() {
           ucrState === 'insufficient',
           ucrState
         );
+        const missingMetricRows = await page
+          .locator('#ucr-missing tbody tr')
+          .count();
+        const missingMetricText = await page.textContent('#ucr-missing');
+        check(
+          'UCR dashboard maps every missing metric to its evidence producer',
+          missingMetricRows > 0 &&
+            /effectiveness/i.test(missingMetricText || '') &&
+            /powered full study/i.test(missingMetricText || ''),
+          `${missingMetricRows} missing metrics`
+        );
         await page.screenshot({
           path: join(SHOTS, 'evidence.png'),
           fullPage: true,

--- a/scripts/verify-wiki-ui.mjs
+++ b/scripts/verify-wiki-ui.mjs
@@ -58,6 +58,8 @@ const BASE = `http://localhost:${PORT}`;
  */
 const GRAPH = mkdtempSync(join(tmpdir(), 'wiki-ui-graph-'));
 process.env.TOKEN_OPTIMIZER_WIKI_DIR = GRAPH;
+process.env.TOKEN_OPTIMIZER_SHARED_DIR = GRAPH;
+process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY = join(GRAPH, 'projects.jsonl');
 const UCR = mkdtempSync(join(tmpdir(), 'wiki-ui-ucr-'));
 process.env.TOKEN_OPTIMIZER_UCR_DIR = UCR;
 
@@ -855,6 +857,16 @@ async function main() {
     });
     overview.on('pageerror', (error) =>
       consoleErrors.push(`overview: ${error.message}`)
+    );
+    // Force the compatibility path so this fixture continues proving that a
+    // legacy client's object-shaped token totals render correctly. The live
+    // dashboard test separately proves the preferred cross-client diagnostics
+    // path and its explicit "not measured" states.
+    await overview.route('**/api/diagnostics/hooks*', (route) =>
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ summary: { available: false }, events: [] }),
+      })
     );
     await overview.route('**/api/session-summary*', (route) =>
       route.fulfill({

--- a/src/dashboard/public/css/wiki.css
+++ b/src/dashboard/public/css/wiki.css
@@ -198,6 +198,7 @@
 
 #wiki-search,
 #wiki-type,
+#wiki-scope,
 .evidence-filters input,
 .evidence-filters select {
   width: 100%;
@@ -212,11 +213,20 @@
 
 #wiki-search:focus,
 #wiki-type:focus,
+#wiki-scope:focus,
 .evidence-filters input:focus,
 .evidence-filters select:focus {
   outline: 2px solid var(--saved);
   outline-offset: 1px;
   border-color: transparent;
+}
+
+.ctl-scope {
+  min-width: 210px;
+}
+
+.wiki-coverage {
+  margin: -8px 0 16px;
 }
 
 .wiki-modes {
@@ -597,12 +607,13 @@ body.wiki-detail-open {
  * That is a usability bug, not a test artefact -- a real user with the panel
  * open cannot reach those rows either.
  *
- * Applied to `main` rather than the list pane because the toolbar is a sibling of
- * the list, not a child -- shifting only the list left the buttons underneath.
- * Margin rather than padding so backgrounds do not extend under the panel, and
- * the same `min()` as the panel's width so the two cannot disagree.
+ * Applied to the entire shell because capture-health and effectiveness evidence
+ * sit above `main`. Reserving space only for `main` left those cards underneath
+ * the drawer even though the graph itself remained reachable. Margin rather
+ * than padding keeps card backgrounds out from beneath the panel, and the same
+ * `min()` as the panel's width keeps the two from disagreeing.
  */
-body.wiki-detail-open main {
+body.wiki-detail-open .shell {
   margin-right: min(460px, 92vw);
 }
 

--- a/src/dashboard/public/index.html
+++ b/src/dashboard/public/index.html
@@ -96,7 +96,7 @@
             >
               ?
               <span class="tip tip-below tip-left" role="tooltip">
-                Files observed by supported coding agents are remembered here
+                Graph nodes observed by supported coding agents are remembered here
                 with their structure, discoveries, and provenance. Any supported
                 client can reuse that knowledge in a later session or project.
               </span>
@@ -115,7 +115,7 @@
       <section class="panels">
         <div class="card">
           <p class="card-title">
-            Where the context went
+            Observed activity by source
             <button
               class="explain"
               type="button"
@@ -123,35 +123,35 @@
             >
               ?
               <span class="tip" role="tooltip">
-                Which kinds of thing filled the workspace. Big slices are where
-                there is most left to win.
+                Lifecycle activity is grouped by CLI when cross-client telemetry
+                is available; older clients may report context categories instead.
               </span>
             </button>
           </p>
           <p class="card-sub">
-            Bigger slices are the best places to save more.
+            Cross-client observations are used instead of a single CLI's stale session file.
           </p>
           <div class="chart" id="category-chart"></div>
         </div>
 
         <div class="card">
           <p class="card-title">
-            Which actions cost the most
+            Which actions ran most
             <button
               class="explain"
               type="button"
-              aria-label="Which actions cost the most?"
+              aria-label="Which actions ran most?"
             >
               ?
               <span class="tip" role="tooltip">
-                Context used by each observed read, edit, search, command, or
-                connected tool. An action near the top every session is worth a
-                closer look.
+                Frequency of each observed read, edit, search, command, or
+                connected tool. Context cost is shown only when the client
+                actually reports it.
               </span>
             </button>
           </p>
           <p class="card-sub">
-            Ranked by how much of the workspace each one used.
+            Ranked by observed calls; no token amount is invented when a CLI omits it.
           </p>
           <div class="chart" id="server-chart"></div>
         </div>

--- a/src/dashboard/public/js/dashboard.js
+++ b/src/dashboard/public/js/dashboard.js
@@ -69,26 +69,68 @@ async function load() {
   // Every panel is independent: the graph is worth showing even when there is
   // no active session, and vice versa. One missing answer must not blank the
   // whole page.
-  const [summary, events, balance, status, constellation] = await Promise.all([
-    get('/session-summary'),
-    get('/session-events?limit=100'),
-    get('/wiki/balance'),
-    get('/wiki/status'),
-    get('/wiki/constellation?cap=90'),
+  const [diagnostics, balance, status, constellation] = await Promise.all([
+    get('/diagnostics/hooks?hours=24&limit=100'),
+    get('/wiki/balance?scope=all'),
+    get('/wiki/status?scope=all'),
+    get('/wiki/constellation?cap=90&scope=all'),
   ]);
+  let summary = { ok: false, body: null };
+  let events = { ok: false, body: null };
+  if (!diagnostics.ok || !diagnostics.body?.summary?.available) {
+    [summary, events] = await Promise.all([
+      get('/session-summary'),
+      get('/session-events?limit=100'),
+    ]);
+  }
 
   renderSavings(balance.body, status.body);
   renderVerdict(balance.body, status.body);
   renderGraph(constellation.body, status.body);
 
-  const session = summary.ok && summary.body?.success ? summary.body : null;
+  const session =
+    diagnostics.ok && diagnostics.body?.summary?.available
+      ? activityFromDiagnostics(diagnostics.body)
+      : summary.ok && summary.body?.success
+        ? summary.body
+        : null;
   renderKpis(session);
   renderCategories(session);
   renderServers(session);
-  renderTimeline(events.ok ? events.body?.events : null);
+  renderTimeline(
+    session?.activityMode === 'hooks'
+      ? session.events
+      : events.ok
+        ? events.body?.events
+        : null
+  );
   renderBreakdown(session);
 
   $('last-updated').textContent = new Date().toLocaleTimeString();
+}
+
+function activityFromDiagnostics(report) {
+  const events = report.events || [];
+  const actions = events.filter(
+    (event) => event.hookEvent === 'pre-tool' && event.toolName
+  );
+  const toolBreakdown = {};
+  for (const event of actions) {
+    const name = event.toolName || 'Unknown action';
+    toolBreakdown[name] ||= { count: 0, tokens: null };
+    toolBreakdown[name].count += 1;
+  }
+  return {
+    activityMode: 'hooks',
+    totalHooks: report.summary.total || 0,
+    totalTools: actions.length,
+    activeClients: Object.keys(report.summary.byClient || {}).length,
+    p95DurationMs: report.summary.p95DurationMs,
+    successRate: report.summary.successRate,
+    clients: report.summary.byClient || {},
+    toolBreakdown,
+    events,
+  };
 }
 
 /* ------------------------------------------------------------- the hero -- */
@@ -206,7 +248,7 @@ function renderGraph(constellation, status) {
     // files exist the honest message is that nothing has been CONCLUDED yet.
     host.innerHTML = remembered
       ? '<div class="empty is-compact"><div class="mark">◍</div>' +
-        `<h3>${fmt(remembered)} files remembered</h3>` +
+        `<h3>${fmt(remembered)} graph nodes remembered</h3>` +
         '<p>Nothing has been concluded about them yet. Findings appear here as ' +
         'your coding agents work out how the pieces fit together.</p></div>'
       : '<div class="empty is-compact"><div class="mark">◌</div>' +
@@ -233,7 +275,7 @@ function renderGraph(constellation, status) {
 
 function statRows(status) {
   const rows = [
-    ['files remembered', status?.nodes],
+    ['graph nodes', status?.nodes],
     ['connections', status?.edges],
     ['things discovered', status?.findings],
   ];
@@ -333,32 +375,59 @@ function renderKpis(s) {
     return;
   }
 
-  const cards = [
-    {
-      label: 'Context used',
-      value: compact(s.totalTokens),
-      tip:
-        'How much of the active agent’s limited workspace this session has taken up. ' +
-        'The smaller this is for the same work, the better.',
-    },
-    {
-      label: 'Messages exchanged',
-      value: fmt(s.totalTurns),
-      tip: 'How many back-and-forth turns you have had in this session.',
-    },
-    {
-      label: 'Actions taken',
-      value: fmt(s.totalTools),
-      tip:
-        'Reads, edits, searches and commands the active agent ran on your behalf. ' +
-        'Each one is a chance to save context.',
-    },
-    {
-      label: 'Session length',
-      value: s.duration || '—',
-      tip: 'How long this session has been going.',
-    },
-  ];
+  const cards =
+    s.activityMode === 'hooks'
+      ? [
+          {
+            label: 'Lifecycle events',
+            value: fmt(s.totalHooks),
+            tip: 'Hook executions observed across every installed CLI during the last 24 hours.',
+          },
+          {
+            label: 'Actions observed',
+            value: fmt(s.totalTools),
+            tip: 'Pre-tool actions observed by the cross-client hook protocol during the last 24 hours.',
+          },
+          {
+            label: 'CLI clients active',
+            value: fmt(s.activeClients),
+            tip: 'Distinct CLI clients that emitted lifecycle telemetry during the last 24 hours.',
+          },
+          {
+            label: 'Hook latency p95',
+            value:
+              s.p95DurationMs == null
+                ? 'Not measured'
+                : `${fmt(s.p95DurationMs)} ms`,
+            tip: 'Ninety-five percent of observed hook calls completed at or below this latency.',
+          },
+        ]
+      : [
+          {
+            label: 'Context used',
+            value: compact(s.totalTokens),
+            tip:
+              'How much of the active agent’s limited workspace this session has taken up. ' +
+              'The smaller this is for the same work, the better.',
+          },
+          {
+            label: 'Messages exchanged',
+            value: fmt(s.totalTurns),
+            tip: 'How many back-and-forth turns you have had in this session.',
+          },
+          {
+            label: 'Actions taken',
+            value: fmt(s.totalTools),
+            tip:
+              'Reads, edits, searches and commands the active agent ran on your behalf. ' +
+              'Each one is a chance to save context.',
+          },
+          {
+            label: 'Session length',
+            value: s.duration || '—',
+            tip: 'How long this session has been going.',
+          },
+        ];
 
   host.innerHTML = cards
     .map(
@@ -377,6 +446,18 @@ function renderKpis(s) {
 
 function renderCategories(s) {
   const host = $('category-chart');
+  if (s?.activityMode === 'hooks') {
+    const slices = Object.entries(s.clients).map(([client, values], index) => ({
+      label: client,
+      value: values.total || 0,
+      color: SERVER_COLORS[index % SERVER_COLORS.length],
+    }));
+    donut(host, slices, {
+      centerLabel: 'lifecycle events',
+      centerValue: compact(s.totalHooks),
+    });
+    return;
+  }
   if (!s?.tokensByCategory) {
     host.innerHTML = teach(
       'Nothing to break down yet',
@@ -397,6 +478,28 @@ function renderCategories(s) {
 
 function renderServers(s) {
   const host = $('server-chart');
+  if (s?.activityMode === 'hooks') {
+    const slices = toolRows(s)
+      .filter((row) => row.count > 0)
+      .map((row, index) => ({
+        label: row.name || row.tool,
+        value: row.count,
+        color: SERVER_COLORS[index % SERVER_COLORS.length],
+      }))
+      .sort((a, b) => b.value - a.value);
+    if (!slices.length) {
+      host.innerHTML = teach(
+        'No actions observed yet',
+        'Lifecycle hooks are healthy, but no pre-tool action is present in the selected 24-hour window.'
+      );
+      return;
+    }
+    donut(host, slices, {
+      centerLabel: 'actions observed',
+      centerValue: compact(slices.reduce((sum, item) => sum + item.value, 0)),
+    });
+    return;
+  }
   let entries = Object.entries(s?.tokensByServer || {}).filter(
     ([, v]) => (v?.tokens || v) > 0
   );
@@ -444,7 +547,7 @@ function renderTimeline(events) {
           <span class="ev-name">${escapeHtml(action.tool)}</span>
           <span class="ev-detail">${escapeHtml(action.detail)}</span>
         </span>
-        <span class="ev-meta num">${action.tokens ? `${compact(action.tokens)} context tokens` : 'no context recorded'}</span>
+        <span class="ev-meta num">${action.tokens ? `${compact(action.tokens)} context tokens` : action.costLabel}</span>
         <span class="ev-time">${e.timestamp ? new Date(e.timestamp).toLocaleTimeString() : ''}</span>
       </div>`;
     })
@@ -452,8 +555,15 @@ function renderTimeline(events) {
 }
 
 function describeEvent(event) {
+  const hookEvent = String(event.hookEvent || '').trim();
+  const client = String(event.client || '').trim();
   const tool = String(
-    event.toolName || event.name || event.tool || event.type || 'agent event'
+    event.toolName ||
+      event.name ||
+      event.tool ||
+      (hookEvent && `${client || 'agent'} ${hookEvent.replaceAll('-', ' ')}`) ||
+      event.type ||
+      'agent event'
   );
   const details = {
     Edit: 'Edited project content',
@@ -468,13 +578,19 @@ function describeEvent(event) {
     BashOutput: 'Inspected terminal output',
     KillShell: 'Stopped a background command',
   };
-  const eventType = String(event.type || 'agent event').replaceAll('_', ' ');
+  const eventType = String(hookEvent || event.type || 'agent event')
+    .replaceAll('_', ' ')
+    .replaceAll('-', ' ');
+  const tokens = Number(event.estimatedTokens ?? event.tokens ?? 0);
   return {
     tool,
     detail:
       details[tool] ||
       `${eventType.charAt(0).toUpperCase()}${eventType.slice(1)}`,
-    tokens: Number(event.estimatedTokens ?? event.tokens ?? 0),
+    tokens,
+    costLabel: hookEvent
+      ? 'token cost not reported by client'
+      : 'no context recorded',
   };
 }
 
@@ -497,7 +613,7 @@ function renderBreakdown(s) {
       <tr>
         <td>${escapeHtml(t.name || t.tool)}</td>
         <td class="right num">${fmt(t.count)}</td>
-        <td class="right num">${fmt(t.tokens)}</td>
+        <td class="right num">${t.tokens == null ? 'Not measured' : fmt(t.tokens)}</td>
       </tr>`
     )
     .join('');

--- a/src/dashboard/public/js/graph3d.js
+++ b/src/dashboard/public/js/graph3d.js
@@ -149,14 +149,21 @@ export function createKnowledgeGraph3D(host, initial, options = {}) {
   }
 
   function resize() {
-    const box = host.getBoundingClientRect();
     const ratio = Math.min(2, window.devicePixelRatio || 1);
-    width = Math.max(280, Math.round(box.width));
-    height = Math.max(options.compact ? 190 : 420, Math.round(box.height));
+    // Size the backing buffer from the host's CONTENT box. Using
+    // getBoundingClientRect() here included the host's two border pixels, then
+    // assigning that border-box size to the child canvas made the auto-sized
+    // host two pixels larger. ResizeObserver observed the growth and repeated
+    // it forever, which looked like a camera continuously zooming into the
+    // overview graph while the entire canvas expanded without bound.
+    width = Math.max(1, Math.round(host.clientWidth));
+    height = Math.max(1, Math.round(host.clientHeight));
     canvas.width = Math.round(width * ratio);
     canvas.height = Math.round(height * ratio);
-    canvas.style.width = `${width}px`;
-    canvas.style.height = `${height}px`;
+    // CSS owns the display size (100% x 100%). Setting pixel dimensions here
+    // would reintroduce the child -> auto-sized parent feedback loop.
+    canvas.style.removeProperty('width');
+    canvas.style.removeProperty('height');
     context.setTransform(ratio, 0, 0, ratio, 0, 0);
     draw();
   }

--- a/src/dashboard/public/js/wiki.js
+++ b/src/dashboard/public/js/wiki.js
@@ -47,6 +47,8 @@ const state = {
   offset: 0,
   selected: null,
   items: [],
+  scope: 'all',
+  projects: [],
 };
 let knowledgeGraph3d = null;
 
@@ -65,6 +67,12 @@ async function api(path, options) {
   return response.json();
 }
 
+function scoped(path) {
+  const url = new URL(path, window.location.origin);
+  url.searchParams.set('scope', state.scope);
+  return `${url.pathname}${url.search}`;
+}
+
 /* ---- Balance --------------------------------------------------------- */
 
 const nf = new Intl.NumberFormat();
@@ -79,7 +87,7 @@ const nf = new Intl.NumberFormat();
 async function loadBalance() {
   let balance;
   try {
-    balance = await api('/api/wiki/balance');
+    balance = await api(scoped('/api/wiki/balance'));
   } catch {
     return;
   }
@@ -88,13 +96,25 @@ async function loadBalance() {
   // what "injected" means. The words describe what happened, not what the code
   // calls it.
   const tiles = [
-    ['Times memory was used', nf.format(balance.injections)],
-    ['Kept back for comparison', nf.format(balance.holdouts)],
-    ['Cost of remembering', `${nf.format(balance.injectedTokens)} tokens`],
+    [
+      'Memory deliveries',
+      nf.format(balance.memoryDeliveries ?? balance.injections),
+    ],
+    [
+      'Kept back for comparison',
+      nf.format(balance.memoryHoldouts ?? balance.holdouts),
+    ],
+    [
+      'Cost of remembering',
+      `${nf.format(
+        Number(balance.deliveryTokens ?? balance.injectedTokens) +
+          Number(balance.harvestTokens || 0)
+      )} tokens`,
+    ],
     [
       'Reading avoided',
       balance.estimatedTokensAvoided === null
-        ? '—'
+        ? 'Not enough comparisons'
         : `${nf.format(balance.estimatedTokensAvoided)} tokens`,
     ],
   ];
@@ -123,6 +143,10 @@ async function loadBalance() {
     el('balance-method').textContent =
       `Measured against ${nf.format(balance.holdouts)} withheld control touches — not estimated. ` +
       `Net after injection and harvest cost: ${nf.format(balance.netTokens)} tokens.`;
+  } else {
+    el('balance-method').textContent =
+      `The graph has ${nf.format(balance.injections)} measured file deliveries and ${nf.format(balance.holdouts)} file holdouts; ` +
+      'the savings estimate unlocks at 20 and 5. Command and session-start deliveries are counted above but excluded from the file-read comparison because they have no valid downstream file-read join.';
   }
 }
 
@@ -475,6 +499,8 @@ async function loadUcr() {
 
 function tagsFor(item) {
   const tags = [];
+  if (state.scope === 'all' && item.projectName)
+    tags.push({ text: item.projectName, status: 'project' });
   if (item.type && item.type !== 'finding') tags.push({ text: item.type });
   if (item.origin === 'human') tags.push({ text: '✎ human', status: 'human' });
   if (item.pinned) tags.push({ text: '★ pinned', status: 'pinned' });
@@ -541,7 +567,7 @@ async function search(append = false) {
     offset: String(state.offset),
     limit: '50',
   });
-  const result = await api(`/api/wiki/search?${params}`);
+  const result = await api(scoped(`/api/wiki/search?${params}`));
 
   state.items = append ? state.items.concat(result.items) : result.items;
   state.offset += result.items.length;
@@ -668,7 +694,7 @@ async function renderFocus(nodeId) {
  * after it settles.
  */
 async function renderConstellation() {
-  const data = await api('/api/wiki/constellation?cap=150');
+  const data = await api(scoped('/api/wiki/constellation?cap=150'));
   const svg = el('wiki-graph');
   const host = el('wiki-graph-3d');
   svg.setAttribute('hidden', '');
@@ -677,7 +703,9 @@ async function renderConstellation() {
   const hint = el('graph-hint');
   hint.hidden = false;
   hint.textContent = data.nodes.length
-    ? 'Drag to orbit, scroll to zoom, and select a node to inspect its evidence and history.'
+    ? data.capped
+      ? `Showing the ${nf.format(data.renderedFindings)} highest-confidence findings from ${nf.format(data.projects)} sources; ${nf.format(data.findings)} findings are captured in this scope. Drag to orbit, scroll to zoom, and select a node to inspect it.`
+      : `Showing all ${nf.format(data.findings)} findings from ${nf.format(data.projects)} sources. Drag to orbit, scroll to zoom, and select a node to inspect it.`
     : 'The 3D knowledge map will appear as supported coding agents capture project findings.';
 
   if (knowledgeGraph3d) {
@@ -795,6 +823,7 @@ function showDetail(node) {
     <h3>${escapeHtml(node.claim || node.key)}</h3>
     <dl>
       <dt>Kind</dt><dd>${escapeHtml(node.kind)}</dd>
+      <dt>Project</dt><dd>${escapeHtml(node.projectName || 'Current project')}</dd>
       <dt>Type</dt><dd>${escapeHtml(node.type || '—')}</dd>
       <dt>Origin</dt><dd>${node.origin === 'human' ? '✎ asserted by a person' : 'harvested from a session'}</dd>
       <dt>Confidence</dt><dd class="wiki-figure">${(node.confidence ?? 0.5).toFixed(2)}</dd>
@@ -833,7 +862,11 @@ function showDetail(node) {
         'content-type': 'application/json',
         'x-token-optimizer': 'dashboard',
       },
-      body: JSON.stringify({ key: node.key, ...body }),
+      body: JSON.stringify({
+        key: node.key,
+        projectId: node.projectId,
+        ...body,
+      }),
     });
     setDetailOpen(false);
     await Promise.all([search(), loadAudit()]);
@@ -856,7 +889,11 @@ function showDetail(node) {
         'content-type': 'application/json',
         'x-token-optimizer': 'dashboard',
       },
-      body: JSON.stringify({ findingId: node.key, rating }),
+      body: JSON.stringify({
+        findingId: node.key,
+        projectId: node.projectId,
+        rating,
+      }),
     });
     await loadEvidence();
   };
@@ -928,7 +965,7 @@ const AUDIT_GROUPS = [
 async function loadAudit() {
   let audit;
   try {
-    audit = await api('/api/wiki/audit');
+    audit = await api(scoped('/api/wiki/audit'));
   } catch {
     return;
   }
@@ -959,6 +996,115 @@ async function loadAudit() {
     '<p class="wiki-muted">Nothing needs attention. The graph is healthy.</p>';
 }
 
+async function loadHookHealth() {
+  const grid = el('hook-health-grid');
+  const status = el('hook-health-status');
+  const detail = el('hook-health-detail');
+  try {
+    const report = await api('/api/diagnostics/hooks?hours=24&limit=20');
+    const summary = report.summary;
+    const success =
+      summary.successRate === null
+        ? '—'
+        : `${(summary.successRate * 100).toFixed(1)}%`;
+    grid.innerHTML = [
+      ['Hook runs', nf.format(summary.total)],
+      ['Success rate', success],
+      ['Failures', nf.format(summary.failures)],
+      ['Timeouts', nf.format(summary.timeouts)],
+      [
+        'p50 latency',
+        summary.p50DurationMs == null ? '—' : `${summary.p50DurationMs} ms`,
+      ],
+      [
+        'p95 latency',
+        summary.p95DurationMs == null ? '—' : `${summary.p95DurationMs} ms`,
+      ],
+    ]
+      .map(
+        ([label, value]) => `
+        <div class="stat-card"><div class="stat-content">
+          <div class="stat-label">${escapeHtml(label)}</div>
+          <div class="stat-value wiki-figure">${escapeHtml(value)}</div>
+        </div></div>`
+      )
+      .join('');
+
+    const unhealthy = summary.failures > 0 || summary.timeouts > 0;
+    status.textContent = !summary.available
+      ? 'No lifecycle telemetry has been captured yet.'
+      : unhealthy
+        ? `${summary.failures} failure(s) and ${summary.timeouts} timeout(s) need attention.`
+        : 'Lifecycle capture is healthy across the observed clients.';
+    status.dataset.state = !summary.available
+      ? 'insufficient'
+      : unhealthy
+        ? 'bad'
+        : 'ok';
+    const clients = Object.entries(summary.byClient || {})
+      .map(
+        ([name, value]) =>
+          `${name}: ${value.total} runs, ${value.failures} failures, ${value.timeouts} timeouts, ${value.skipped || 0} skipped`
+      )
+      .join(' · ');
+    detail.textContent =
+      clients ||
+      'Privacy-safe JSONL diagnostics retain no prompts, commands, or tool output.';
+  } catch {
+    grid.innerHTML = '';
+    status.textContent = 'Capture diagnostics unavailable.';
+    status.dataset.state = 'bad';
+    detail.textContent = '';
+  }
+}
+
+async function loadProjects() {
+  const inventory = await api('/api/wiki/projects');
+  state.projects = inventory.projects || [];
+  const select = el('wiki-scope');
+  select.innerHTML = [
+    `<option value="all">All known projects (${nf.format(inventory.captured)} captured)</option>`,
+    ...state.projects.map(
+      (project) =>
+        `<option value="${escapeHtml(project.id)}">${escapeHtml(project.name)}${project.current ? ' — current' : ''}${project.captured ? '' : ' — no capture yet'}</option>`
+    ),
+  ].join('');
+  select.value = state.scope;
+  const missing = state.projects.filter((project) => !project.captured);
+  el('wiki-coverage').textContent = missing.length
+    ? `${nf.format(inventory.captured)} of ${nf.format(state.projects.length)} known sources contain graph data. Missing capture: ${missing.map((project) => project.name).join(', ')}.`
+    : `${nf.format(inventory.captured)} known sources contain graph data; no registered source is missing its graph.`;
+}
+
+async function loadGraphStatus() {
+  const status = await api(scoped('/api/wiki/status'));
+  const scopeLabel =
+    state.scope === 'all'
+      ? `${nf.format(status.capturedProjects)} captured sources`
+      : state.projects.find((project) => project.id === state.scope)?.name ||
+        'current project';
+  el('graph-stats').textContent = status.available
+    ? `${nf.format(status.findings)} findings · ${nf.format(status.nodes)} nodes · ${nf.format(status.edges)} edges · ${scopeLabel}`
+    : 'No graph yet — it builds as you work';
+  return status;
+}
+
+async function changeScope() {
+  state.scope = el('wiki-scope').value;
+  state.selected = null;
+  setDetailOpen(false);
+  el('wiki-export').href =
+    `/api/wiki/export?scope=${encodeURIComponent(state.scope)}`;
+  const status = await loadGraphStatus();
+  if (!status.available) return;
+  await Promise.all([
+    loadBalance(),
+    search(),
+    renderConstellation(),
+    loadAudit(),
+  ]);
+}
+
 /* ---- Wiring ---------------------------------------------------------- */
 
 function debounce(fn, ms) {
@@ -983,6 +1129,7 @@ el('wiki-search').addEventListener(
   debounce(() => search(), 250)
 );
 el('wiki-type').addEventListener('change', () => search());
+el('wiki-scope').addEventListener('change', changeScope);
 el('wiki-more-btn').addEventListener('click', () => search(true));
 for (const id of ['evidence-client', 'evidence-model', 'evidence-task']) {
   el(id).addEventListener('input', debounce(loadEvidence, 250));
@@ -1052,11 +1199,10 @@ if (typeof ResizeObserver !== 'undefined') {
 }
 
 (async function init() {
+  await loadHookHealth();
   try {
-    const status = await api('/api/wiki/status');
-    el('graph-stats').textContent = status.available
-      ? `${status.findings} findings · ${status.nodes} nodes · ${status.edges} edges`
-      : 'No graph yet — it builds as you work';
+    await loadProjects();
+    const status = await loadGraphStatus();
     if (!status.available) return;
   } catch {
     el('graph-stats').textContent = 'Graph unavailable';

--- a/src/dashboard/public/js/wiki.js
+++ b/src/dashboard/public/js/wiki.js
@@ -85,10 +85,31 @@ const nf = new Intl.NumberFormat();
  * kind of confident-looking number this project exists to argue against.
  */
 async function loadBalance() {
+  const grid = el('balance-grid');
+  const verdict = el('balance-verdict');
+  const method = el('balance-method');
   let balance;
   try {
     balance = await api(scoped('/api/wiki/balance'));
   } catch {
+    grid.innerHTML = [
+      'Memory deliveries',
+      'Kept back for comparison',
+      'Cost of remembering',
+      'Reading avoided',
+    ]
+      .map(
+        (label) => `
+        <div class="stat-card"><div class="stat-content">
+          <div class="stat-label">${escapeHtml(label)}</div>
+          <div class="stat-value wiki-figure">Unavailable</div>
+        </div></div>`
+      )
+      .join('');
+    verdict.textContent = 'Balance telemetry could not be loaded.';
+    verdict.dataset.state = 'bad';
+    method.textContent =
+      'No saving or cost claim is shown until the event source is reachable.';
     return;
   }
 
@@ -119,7 +140,7 @@ async function loadBalance() {
     ],
   ];
 
-  el('balance-grid').innerHTML = tiles
+  grid.innerHTML = tiles
     .map(
       ([label, value]) => `
     <div class="stat-card">
@@ -131,7 +152,6 @@ async function loadBalance() {
     )
     .join('');
 
-  const verdict = el('balance-verdict');
   verdict.textContent = balance.verdict;
   verdict.dataset.state = !balance.sufficientData
     ? 'insufficient'
@@ -140,11 +160,11 @@ async function loadBalance() {
       : 'negative';
 
   if (balance.sufficientData) {
-    el('balance-method').textContent =
+    method.textContent =
       `Measured against ${nf.format(balance.holdouts)} withheld control touches — not estimated. ` +
       `Net after injection and harvest cost: ${nf.format(balance.netTokens)} tokens.`;
   } else {
-    el('balance-method').textContent =
+    method.textContent =
       `The graph has ${nf.format(balance.injections)} measured file deliveries and ${nf.format(balance.holdouts)} file holdouts; ` +
       'the savings estimate unlocks at 20 and 5. Command and session-start deliveries are counted above but excluded from the file-read comparison because they have no valid downstream file-read join.';
   }
@@ -162,6 +182,7 @@ function formatInterval(interval, suffix = '') {
 
 async function loadEvidence() {
   const params = new URLSearchParams();
+  params.set('scope', state.scope);
   const values = {
     client: el('evidence-client').value.trim(),
     model: el('evidence-model').value.trim(),
@@ -181,14 +202,16 @@ async function loadEvidence() {
   }
 
   const summary = report.summary;
+  const measuredCount = (value) =>
+    Number(value) > 0 ? nf.format(value) : 'Not run';
   const coverage =
     summary.causalJoinCoverage === null
-      ? '—'
+      ? 'Not measurable'
       : `${Math.round(summary.causalJoinCoverage * 100)}%`;
   el('evidence-summary').innerHTML = [
-    ['Randomized runs', nf.format(summary.evalRuns)],
-    ['Handoff runs', nf.format(summary.handoffRuns || 0)],
-    ['Concurrency runs', nf.format(summary.concurrencyRuns || 0)],
+    ['Randomized runs', measuredCount(summary.evalRuns)],
+    ['Handoff runs', measuredCount(summary.handoffRuns)],
+    ['Concurrency runs', measuredCount(summary.concurrencyRuns)],
     ['Live injections', nf.format(summary.liveInjections)],
     ['Outcome join coverage', coverage],
     ['Harmful feedback', nf.format(summary.harmfulFeedback)],
@@ -203,7 +226,10 @@ async function loadEvidence() {
     .join('');
 
   const status = el('evidence-status');
-  status.textContent = summary.evidenceStatus;
+  const sourceCoverage = report.sourceCoverage;
+  status.textContent = sourceCoverage
+    ? `${summary.evidenceStatus} · ${nf.format(sourceCoverage.projectsWithEvidence)} of ${nf.format(sourceCoverage.projects)} selected projects have evidence events`
+    : summary.evidenceStatus;
   status.dataset.state =
     summary.evidenceStatus === 'causal estimates available'
       ? 'ok'
@@ -305,8 +331,14 @@ async function loadUcr() {
   }
   el('ucr-summary').innerHTML = [
     ['Protocol', status.protocolVersion],
-    ['Canonical events', nf.format(status.events)],
-    ['Typed objects', nf.format(status.graph?.objects || 0)],
+    [
+      'UCR runtime events',
+      status.events ? nf.format(status.events) : 'Not exercised',
+    ],
+    [
+      'UCR typed objects',
+      status.graph?.objects ? nf.format(status.graph.objects) : 'Not exercised',
+    ],
     ['Certified clients', nf.format(status.certifiedClients)],
     [
       'Effectiveness verdict',
@@ -468,6 +500,30 @@ async function loadUcr() {
       : verdict === 'harmful'
         ? 'bad'
         : 'insufficient';
+  const missingMetrics = status.metricCoverage?.missing || [];
+  const producerFor = (evidenceClass) =>
+    ({
+      effectiveness: 'Powered full study',
+      superiority: 'Competitive study',
+      production: 'Signed production traffic study',
+      conformance: 'Adapter certification',
+      transport: 'Transport integrity study',
+    })[evidenceClass] || 'Unclassified producer';
+  el('ucr-missing').innerHTML = `
+    <thead><tr><th>Metric</th><th>Required evidence</th><th>Producer</th><th>Eligible ledgers</th></tr></thead>
+    <tbody>${
+      missingMetrics
+        .map(
+          (metric) => `<tr>
+          <td>${escapeHtml(metric.metric)}</td>
+          <td>${escapeHtml(metric.requiredEvidence)}</td>
+          <td>${escapeHtml(producerFor(metric.requiredEvidence))}</td>
+          <td>${nf.format(metric.eligibleLedgers || 0)}</td>
+        </tr>`
+        )
+        .join('') ||
+      '<tr><td colspan="4">Every release metric has an eligible evidence source.</td></tr>'
+    }</tbody>`;
   const tiers = status.evidenceIndex?.tiers || {};
   el('ucr-tiers').innerHTML = `
     <thead><tr><th>Tier</th><th>Status</th><th>Ledgers</th><th>Rows</th></tr></thead>
@@ -489,7 +545,15 @@ async function loadUcr() {
           <td>${escapeHtml(artifact.name)}</td>
           <td>${escapeHtml(artifact.evidenceClass)}</td>
           <td>${artifact.valid ? 'valid' : 'invalid'}</td>
-          <td>${artifact.passed ? 'passed' : 'negative / incomplete'}</td>
+          <td>${
+            artifact.passed
+              ? 'passed'
+              : artifact.qualificationPassed
+                ? `qualification passed (non-promotable${artifact.qualificationMaximumTokenOverhead == null ? '' : `; max token overhead ${(artifact.qualificationMaximumTokenOverhead * 100).toFixed(2)}%`})`
+                : artifact.qualificationStatus === 'failed'
+                  ? 'qualification failed'
+                  : 'negative / incomplete'
+          }</td>
         </tr>`
       )
       .join('')}</tbody>`;

--- a/src/dashboard/public/wiki.html
+++ b/src/dashboard/public/wiki.html
@@ -236,6 +236,15 @@
           </p>
           <div class="stats-grid" id="ucr-summary"></div>
           <p class="verdict-line" id="ucr-verdict"></p>
+          <h3>Missing evidence producers</h3>
+          <p class="wiki-muted">
+            A blank release metric is never treated as zero. This table names
+            the evidence class that must be produced before the metric can be
+            calculated.
+          </p>
+          <div class="table-scroll">
+            <table class="evidence-table" id="ucr-missing"></table>
+          </div>
           <h3>Evidence tiers</h3>
           <div class="table-scroll">
             <table class="evidence-table" id="ucr-tiers"></table>

--- a/src/dashboard/public/wiki.html
+++ b/src/dashboard/public/wiki.html
@@ -16,7 +16,7 @@
           <a href="/wiki" aria-current="page">What it knows</a>
         </nav>
         <div class="spacer"></div>
-        <a class="btn" href="/api/wiki/export">Export</a>
+        <a class="btn" id="wiki-export" href="/api/wiki/export?scope=all">Export</a>
       </header>
 
       <!-- Says, in words, what this page is for. Someone arriving here has no
@@ -29,6 +29,13 @@
           This page keeps the knowledge, its provenance, and the causal evidence
           about whether delivering it improved later work.
         </p>
+      </section>
+
+      <section class="wiki-balance" aria-labelledby="capture-health-heading">
+        <h2 id="capture-health-heading" class="card-title">Capture health</h2>
+        <div class="stats-grid" id="hook-health-grid"></div>
+        <p class="verdict-line" id="hook-health-status"></p>
+        <p class="method-line" id="hook-health-detail"></p>
       </section>
 
       <section class="wiki-balance">
@@ -82,6 +89,12 @@
       <main>
         <section id="tab-explore" class="wiki-panel" role="tabpanel">
           <div class="wiki-controls">
+            <label class="ctl-scope">
+              <span class="ctl-label">Knowledge scope</span>
+              <select id="wiki-scope" aria-describedby="wiki-coverage">
+                <option value="all">All known projects</option>
+              </select>
+            </label>
             <label class="ctl-search">
               <span class="ctl-label">Search what it knows</span>
               <input
@@ -118,6 +131,7 @@
               </button>
             </div>
           </div>
+          <p class="wiki-muted wiki-coverage" id="wiki-coverage"></p>
 
           <div class="wiki-split">
             <div class="wiki-list-pane">

--- a/src/server/hook-diagnostics.ts
+++ b/src/server/hook-diagnostics.ts
@@ -1,0 +1,134 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+export interface HookDiagnosticEvent {
+  timestamp?: string;
+  client?: string;
+  hookEvent?: string;
+  outcome?: string;
+  reason?: string;
+  durationMs?: number;
+  [key: string]: unknown;
+}
+
+const MAX_FILES = 10;
+const MAX_BYTES_PER_FILE = 1024 * 1024;
+
+export function hookDiagnosticDirectory(): string {
+  if (process.env.TOKEN_OPTIMIZER_LOG_DIR)
+    return process.env.TOKEN_OPTIMIZER_LOG_DIR;
+  const stateRoot =
+    process.env.TOKEN_OPTIMIZER_STATE_DIR ||
+    path.join(os.homedir(), '.token-optimizer');
+  return path.join(stateRoot, 'logs');
+}
+
+function readTail(file: string): string {
+  const size = fs.statSync(file).size;
+  const length = Math.min(size, MAX_BYTES_PER_FILE);
+  const buffer = Buffer.alloc(length);
+  const descriptor = fs.openSync(file, 'r');
+  try {
+    fs.readSync(descriptor, buffer, 0, length, size - length);
+  } finally {
+    fs.closeSync(descriptor);
+  }
+  // A bounded tail may begin in the middle of a JSONL record. Dropping the
+  // first line is safer than presenting a parse error as a product failure.
+  const text = buffer.toString('utf8');
+  return size > length ? text.slice(text.indexOf('\n') + 1) : text;
+}
+
+export function readHookDiagnosticEvents(
+  limit = 200,
+  sinceMs = 24 * 60 * 60 * 1000
+): HookDiagnosticEvent[] {
+  try {
+    const directory = hookDiagnosticDirectory();
+    if (!fs.existsSync(directory)) return [];
+    const cutoff = Date.now() - Math.max(0, sinceMs);
+    const files = fs
+      .readdirSync(directory)
+      .filter((name) => /^hook-events-.*\.jsonl$/.test(name))
+      .map((name) => path.join(directory, name))
+      .sort()
+      .reverse()
+      .slice(0, MAX_FILES);
+    const events: HookDiagnosticEvent[] = [];
+    for (const file of files) {
+      const lines = readTail(file).split(/\r?\n/).filter(Boolean).reverse();
+      for (const line of lines) {
+        try {
+          const event = JSON.parse(line) as HookDiagnosticEvent;
+          if (event.timestamp && Date.parse(event.timestamp) < cutoff) continue;
+          events.push(event);
+          if (events.length >= limit) return events;
+        } catch {
+          // Concurrent append or a corrupt line cannot hide healthy records.
+        }
+      }
+    }
+    return events;
+  } catch {
+    return [];
+  }
+}
+
+export function summarizeHookDiagnostics(
+  sinceMs = 24 * 60 * 60 * 1000
+): Record<string, unknown> {
+  const events = readHookDiagnosticEvents(5000, sinceMs);
+  const failures = events.filter((event) => event.outcome === 'failure');
+  const timeouts = events.filter((event) => event.outcome === 'timeout');
+  const skipped = events.filter((event) => event.outcome === 'skipped');
+  const successes = events.filter((event) => event.outcome === 'success');
+  const durations = events
+    .map((event) => Number(event.durationMs))
+    .filter(Number.isFinite)
+    .sort((a, b) => a - b);
+  const byClient: Record<
+    string,
+    { total: number; failures: number; timeouts: number; skipped: number }
+  > = {};
+  for (const event of events) {
+    const key = event.client || 'unknown';
+    const current = byClient[key] || {
+      total: 0,
+      failures: 0,
+      timeouts: 0,
+      skipped: 0,
+    };
+    current.total++;
+    if (event.outcome === 'failure') current.failures++;
+    if (event.outcome === 'timeout') current.timeouts++;
+    if (event.outcome === 'skipped') current.skipped++;
+    byClient[key] = current;
+  }
+  const percentile = (fraction: number): number | null =>
+    durations.length
+      ? durations[
+          Math.min(
+            durations.length - 1,
+            Math.floor(durations.length * fraction)
+          )
+        ]
+      : null;
+  return {
+    available: events.length > 0,
+    windowHours: sinceMs / 3_600_000,
+    total: events.length,
+    failures: failures.length,
+    timeouts: timeouts.length,
+    skipped: skipped.length,
+    successRate: events.length ? successes.length / events.length : null,
+    p50DurationMs: percentile(0.5),
+    p95DurationMs: percentile(0.95),
+    byClient,
+    recentFailures: events
+      .filter(
+        (event) => event.outcome === 'failure' || event.outcome === 'timeout'
+      )
+      .slice(0, 20),
+  };
+}

--- a/src/server/mcp-evidence.ts
+++ b/src/server/mcp-evidence.ts
@@ -17,6 +17,9 @@ interface EvidenceModules {
   metrics: {
     record(dir: string, event: Record<string, unknown>): unknown;
   };
+  projects: {
+    registerProject(options: Record<string, unknown>): unknown;
+  };
 }
 
 export interface McpClientInfo {
@@ -36,7 +39,11 @@ async function modules(): Promise<EvidenceModules> {
     cached = Promise.all([
       import(coreUrl('wiki.mjs')),
       import(coreUrl('metrics.mjs')),
-    ]).then(([wiki, metrics]) => ({ wiki, metrics }) as EvidenceModules);
+      import(coreUrl('projects.mjs')),
+    ]).then(
+      ([wiki, metrics, projects]) =>
+        ({ wiki, metrics, projects }) as EvidenceModules
+    );
   }
   return cached;
 }
@@ -49,7 +56,13 @@ export class McpEvidenceRecorder {
       const loaded = await modules();
       const cwd = process.cwd();
       const root = loaded.wiki.projectRootFor(path.join(cwd, '__mcp__'), cwd);
-      loaded.metrics.record(loaded.wiki.wikiDir(root), {
+      const dir = loaded.wiki.wikiDir(root);
+      loaded.projects.registerProject({
+        root,
+        graphDir: dir,
+        client: this.client?.name || 'unknown-mcp-client',
+      });
+      loaded.metrics.record(dir, {
         schemaVersion: 2,
         episodeId: processEpisodeId,
         sessionId: processEpisodeId,

--- a/src/server/ucr-routes.ts
+++ b/src/server/ucr-routes.ts
@@ -101,6 +101,23 @@ export function registerUcrRoutes(app: Express): void {
       const replay = store.read();
       const graph = ucr.rebuildGraph(replay.events);
       const evidence = releaseEvidence(ucr);
+      const metricSources = evidence.evidenceIndex?.derived?.sources || {};
+      const metrics = evidence.metrics || {};
+      const metricNames = [
+        ...new Set([...Object.keys(metricSources), ...Object.keys(metrics)]),
+      ];
+      const metricCoverage = metricNames.map((metric) => {
+        const value = metrics[metric];
+        return {
+          metric,
+          measured: value !== null && value !== undefined,
+          value,
+          requiredEvidence:
+            metricSources[metric]?.requiredClass || 'unclassified',
+          eligibleLedgers:
+            metricSources[metric]?.eligibleLedgerHashes?.length || 0,
+        };
+      });
       return res.json({
         available: true,
         protocolVersion: ucr.UCR_PROTOCOL_VERSION,
@@ -120,6 +137,11 @@ export function registerUcrRoutes(app: Express): void {
           evidence.evidenceIndex?.tieredVerdict ||
           ucr.tieredReleaseVerdict(evidence.metrics || {}),
         metrics: evidence.metrics,
+        metricCoverage: {
+          total: metricCoverage.length,
+          measured: metricCoverage.filter((metric) => metric.measured).length,
+          missing: metricCoverage.filter((metric) => !metric.measured),
+        },
         deterministicEvidence: evidence.deterministic
           ? {
               checksPassed:
@@ -152,6 +174,10 @@ export function registerUcrRoutes(app: Express): void {
                   evidenceClass: artifact.evidenceClass,
                   valid: artifact.valid,
                   passed: artifact.passed,
+                  qualificationStatus: artifact.qualificationStatus,
+                  qualificationPassed: artifact.qualificationPassed,
+                  qualificationMaximumTokenOverhead:
+                    artifact.qualificationMaximumTokenOverhead,
                   reportHash: artifact.reportHash,
                 })
               ),

--- a/src/server/web-server.ts
+++ b/src/server/web-server.ts
@@ -15,6 +15,10 @@ import { fileURLToPath } from 'url';
 import { dirname } from 'path';
 import { registerWikiRoutes } from './wiki-routes.js';
 import { registerUcrRoutes } from './ucr-routes.js';
+import {
+  readHookDiagnosticEvents,
+  summarizeHookDiagnostics,
+} from './hook-diagnostics.js';
 import { isValidSessionId } from '../utils/session-id.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -224,7 +228,16 @@ function getCurrentSessionId(): string | null {
       .readFileSync(sessionFilePath, 'utf-8')
       .replace(BOM_REGEX, '');
     const sessionData = JSON.parse(sessionContent);
-    return sessionData.sessionId;
+    const sessionId = sessionData.sessionId;
+    if (!isValidSessionId(sessionId)) return null;
+    const log = resolveSessionLogPath(sessionId);
+    if (!log) return null;
+    // The legacy Claude hook wrote a "current" pointer and never cleared it.
+    // On this machine it made a November 2025 CSV appear as the live August
+    // 2026 session. A stale pointer is historical data, not an active session.
+    if (Date.now() - fs.statSync(log).mtimeMs > 24 * 60 * 60 * 1000)
+      return null;
+    return sessionId;
   } catch (error) {
     console.error('Error getting current session ID:', error);
     return null;
@@ -554,11 +567,22 @@ app.get('/api/session-events', (req, res) => {
  * GET /api/health
  * Health check endpoint
  */
+app.get('/api/diagnostics/hooks', (req, res) => {
+  const hours = Math.min(24 * 30, Math.max(1, Number(req.query.hours) || 24));
+  const limit = Math.min(500, Math.max(1, Number(req.query.limit) || 100));
+  const sinceMs = hours * 60 * 60 * 1000;
+  res.json({
+    summary: summarizeHookDiagnostics(sinceMs),
+    events: readHookDiagnosticEvents(limit, sinceMs),
+  });
+});
+
 app.get('/api/health', (_req, res) => {
   res.json({
     status: 'ok',
     timestamp: new Date().toISOString(),
     port: PORT,
+    hookDiagnostics: summarizeHookDiagnostics(),
   });
 });
 

--- a/src/server/wiki-routes.ts
+++ b/src/server/wiki-routes.ts
@@ -33,6 +33,7 @@ interface GraphModules {
   metrics: any;
   staleness: any;
   capabilities: any;
+  projects: any;
 }
 
 let cached: GraphModules | null = null;
@@ -40,14 +41,16 @@ let cached: GraphModules | null = null;
 async function modules(): Promise<GraphModules | null> {
   if (cached) return cached;
   try {
-    const [wiki, curate, metrics, staleness, capabilities] = await Promise.all([
-      import(coreUrl('wiki.mjs')),
-      import(coreUrl('curate.mjs')),
-      import(coreUrl('metrics.mjs')),
-      import(coreUrl('staleness.mjs')),
-      import(coreUrl('capabilities.mjs')),
-    ]);
-    cached = { wiki, curate, metrics, staleness, capabilities };
+    const [wiki, curate, metrics, staleness, capabilities, projects] =
+      await Promise.all([
+        import(coreUrl('wiki.mjs')),
+        import(coreUrl('curate.mjs')),
+        import(coreUrl('metrics.mjs')),
+        import(coreUrl('staleness.mjs')),
+        import(coreUrl('capabilities.mjs')),
+        import(coreUrl('projects.mjs')),
+      ]);
+    cached = { wiki, curate, metrics, staleness, capabilities, projects };
     return cached;
   } catch {
     return null;
@@ -65,12 +68,145 @@ async function modules(): Promise<GraphModules | null> {
  * location. With no auth on a localhost server, any page open in the user's
  * browser could drive it.
  *
- * The dashboard serves exactly one project: the one it was started in. An
- * operator who wants a different graph sets TOKEN_OPTIMIZER_WIKI_DIR, which is
- * a deliberate act on the server side rather than a request parameter.
+ * Cross-project access is restored through an opaque, server-owned registry.
+ * A request may choose a registry id, but it can never supply a filesystem path.
  */
 function graphDir(_req: Request, wiki: any): string {
   return wiki.wikiDir(process.cwd());
+}
+
+interface GraphSource {
+  id: string;
+  name: string;
+  dir: string;
+  current: boolean;
+  shared: boolean;
+  clients: string[];
+  lastSeenAt: number;
+}
+
+function pathKey(value: string): string {
+  return path.resolve(value).replaceAll('\\', '/').toLowerCase();
+}
+
+function inferredProjectName(dir: string): string {
+  const parent = path.dirname(dir);
+  return path.basename(parent) === '.token-optimizer'
+    ? path.basename(path.dirname(parent))
+    : path.basename(process.cwd());
+}
+
+function graphSources(mods: GraphModules): GraphSource[] {
+  const currentDir = graphDir({} as Request, mods.wiki);
+  const registered = mods.projects.registeredProjects();
+  const currentMatch = registered.find(
+    (project: any) => pathKey(project.graphDir) === pathKey(currentDir)
+  );
+  const current: GraphSource = currentMatch
+    ? {
+        id: currentMatch.id,
+        name: currentMatch.name,
+        dir: currentMatch.graphDir,
+        current: true,
+        shared: false,
+        clients: currentMatch.clients || [],
+        lastSeenAt: currentMatch.lastSeenAt || 0,
+      }
+    : {
+        id: 'current',
+        name: inferredProjectName(currentDir) || 'Current project',
+        dir: currentDir,
+        current: true,
+        shared: false,
+        clients: [],
+        lastSeenAt: 0,
+      };
+
+  const candidates: GraphSource[] = [
+    current,
+    ...registered.map((project: any) => ({
+      id: project.id,
+      name: project.name,
+      dir: project.graphDir,
+      current: pathKey(project.graphDir) === pathKey(currentDir),
+      shared: false,
+      clients: project.clients || [],
+      lastSeenAt: project.lastSeenAt || 0,
+    })),
+    {
+      id: 'shared',
+      name: 'Shared lessons',
+      dir: mods.wiki.sharedDir(),
+      current: pathKey(mods.wiki.sharedDir()) === pathKey(currentDir),
+      shared: true,
+      clients: [],
+      lastSeenAt: 0,
+    },
+  ];
+
+  // A worktree can be rediscovered through overlapping roots. The graph store,
+  // not the spelling of the path used to find it, is the unique source.
+  const byDirectory = new Map<string, GraphSource>();
+  for (const source of candidates) {
+    const key = pathKey(source.dir);
+    const previous = byDirectory.get(key);
+    if (!previous || source.current || source.lastSeenAt > previous.lastSeenAt)
+      byDirectory.set(key, source);
+  }
+  return [...byDirectory.values()].sort(
+    (a, b) =>
+      Number(b.current) - Number(a.current) ||
+      Number(a.shared) - Number(b.shared) ||
+      b.lastSeenAt - a.lastSeenAt ||
+      a.name.localeCompare(b.name)
+  );
+}
+
+class ScopeError extends Error {}
+
+function sourcesFor(req: Request, mods: GraphModules): GraphSource[] {
+  const sources = graphSources(mods);
+  const scope = String(req.query.scope || 'current');
+  if (scope === 'all') return sources;
+  if (scope === 'current')
+    return sources.filter((source) => source.current).slice(0, 1);
+  const source = sources.find((candidate) => candidate.id === scope);
+  if (!source) throw new ScopeError('unknown project scope');
+  return [source];
+}
+
+function sourceById(id: string, mods: GraphModules): GraphSource | null {
+  return graphSources(mods).find((source) => source.id === id) || null;
+}
+
+function selectedSource(req: Request, mods: GraphModules): GraphSource {
+  const requested = String(
+    (req.body && req.body.projectId) || req.query.scope || 'current'
+  );
+  if (requested === 'all') {
+    const current = graphSources(mods).find((source) => source.current);
+    if (current) return current;
+    throw new ScopeError('current project unavailable');
+  }
+  if (requested === 'current') {
+    const current = graphSources(mods).find((source) => source.current);
+    if (current) return current;
+  }
+  const source = sourceById(requested, mods);
+  if (!source) throw new ScopeError('unknown project scope');
+  return source;
+}
+
+function qualifiedId(source: GraphSource, nodeId: string): string {
+  return `${source.id}~${nodeId}`;
+}
+
+function splitQualifiedId(
+  value: string
+): { sourceId: string; nodeId: string } | null {
+  const split = value.indexOf('~');
+  if (split < 1) return null;
+  return { sourceId: value.slice(0, split), nodeId: value.slice(split + 1) };
 }
 
 /**
@@ -113,7 +249,7 @@ interface CachedGraph {
   graph: any;
 }
 
-let graphCache: CachedGraph | null = null;
+const graphCache = new Map<string, CachedGraph>();
 
 /**
  * Loads the graph, reusing the parse when the log has not changed.
@@ -139,15 +275,14 @@ function loadGraph(dir: string, wiki: any): any {
   }
 
   if (
-    graphCache &&
-    graphCache.mtimeMs === stamp.mtimeMs &&
-    graphCache.size === stamp.size
+    graphCache.get(pathKey(dir))?.mtimeMs === stamp.mtimeMs &&
+    graphCache.get(pathKey(dir))?.size === stamp.size
   ) {
-    return graphCache.graph;
+    return graphCache.get(pathKey(dir))!.graph;
   }
 
   const graph = wiki.load(dir);
-  graphCache = { ...stamp, graph };
+  graphCache.set(pathKey(dir), { ...stamp, graph });
   return graph;
 }
 
@@ -158,9 +293,11 @@ function loadGraph(dir: string, wiki: any): any {
  * characters and the list views never render it. Detail views fetch it
  * explicitly.
  */
-function summarise(node: any) {
+function summarise(node: any, source?: GraphSource) {
   return {
-    id: node.id,
+    id: source ? qualifiedId(source, node.id) : node.id,
+    projectId: source?.id,
+    projectName: source?.name,
     kind: node.kind,
     key: node.key,
     claim: node.claim,
@@ -184,6 +321,36 @@ function summarise(node: any) {
 }
 
 export function registerWikiRoutes(app: Express): void {
+  /** Safe project inventory. Filesystem paths intentionally stay server-side. */
+  app.get('/api/wiki/projects', async (_req: Request, res: Response) => {
+    const mods = await modules();
+    if (!mods) return res.status(503).json({ error: 'graph unavailable' });
+    try {
+      const projects = graphSources(mods).map((source) => {
+        const graph = loadGraph(source.dir, mods.wiki);
+        return {
+          id: source.id,
+          name: source.name,
+          current: source.current,
+          shared: source.shared,
+          clients: source.clients,
+          lastSeenAt: source.lastSeenAt || null,
+          captured: graph.nodes.size > 0,
+          nodes: graph.nodes.size,
+          edges: graph.edges.length,
+          findings: mods.curate.activeFindings(graph).length,
+        };
+      });
+      return res.json({
+        projects,
+        captured: projects.filter((project) => project.captured).length,
+        missing: projects.filter((project) => !project.captured).length,
+      });
+    } catch {
+      return res.status(500).json({ error: 'project inventory failed' });
+    }
+  });
+
   /** Is there a graph at all? Lets the UI hide the section rather than error. */
   app.get('/api/wiki/status', async (req: Request, res: Response) => {
     const mods = await modules();
@@ -191,16 +358,33 @@ export function registerWikiRoutes(app: Express): void {
       return res.json({ available: false, reason: 'graph modules not found' });
 
     try {
-      const graph = loadGraph(graphDir(req, mods.wiki), mods.wiki);
-      const findings = mods.curate.activeFindings(graph);
+      const sources = sourcesFor(req, mods);
+      const reports = sources.map((source) => {
+        const graph = loadGraph(source.dir, mods.wiki);
+        return {
+          source,
+          nodes: graph.nodes.size,
+          edges: graph.edges.length,
+          findings: mods.curate.activeFindings(graph).length,
+        };
+      });
       return res.json({
         available: true,
-        nodes: graph.nodes.size,
-        edges: graph.edges.length,
-        findings: findings.length,
-        dir: graphDir(req, mods.wiki),
+        nodes: reports.reduce((sum, report) => sum + report.nodes, 0),
+        edges: reports.reduce((sum, report) => sum + report.edges, 0),
+        findings: reports.reduce((sum, report) => sum + report.findings, 0),
+        projects: reports.length,
+        capturedProjects: reports.filter((report) => report.nodes > 0).length,
+        scope: String(req.query.scope || 'current'),
+        // Kept for current-scope compatibility with diagnostics. Aggregate
+        // responses never disclose the source directories.
+        ...(String(req.query.scope || 'current') === 'current'
+          ? { dir: reports[0]?.source.dir || graphDir(req, mods.wiki) }
+          : {}),
       });
-    } catch {
+    } catch (error) {
+      if (error instanceof ScopeError)
+        return res.status(400).json({ error: error.message });
       return res.json({ available: false, reason: 'graph unreadable' });
     }
   });
@@ -216,42 +400,56 @@ export function registerWikiRoutes(app: Express): void {
     const offset = Math.max(0, Number(req.query.offset) || 0);
 
     try {
-      const graph = loadGraph(graphDir(req, mods.wiki), mods.wiki);
-      let findings = mods.curate.activeFindings(graph);
+      let findings = sourcesFor(req, mods).flatMap((source) => {
+        const graph = loadGraph(source.dir, mods.wiki);
+        return mods.curate
+          .activeFindings(graph)
+          .map((node: any) => ({ node, source }));
+      });
 
       // Lexical filter, per the design's traversal-plus-lexical retrieval --
       // there is no embedding index to consult and deliberately so.
       if (query) {
         findings = findings.filter(
-          (f: any) =>
-            String(f.claim || '')
+          (entry: any) =>
+            String(entry.node.claim || '')
               .toLowerCase()
               .includes(query) ||
-            String(f.key || '')
+            String(entry.node.key || '')
               .toLowerCase()
               .includes(query)
         );
       }
       if (kind)
-        findings = findings.filter((f: any) => (f.type || 'finding') === kind);
+        findings = findings.filter(
+          (entry: any) => (entry.node.type || 'finding') === kind
+        );
 
       findings.sort((a: any, b: any) => {
-        const weight = (f: any) =>
-          (f.confidence ?? 0.5) *
-          // originWeight, not a human-only ternary: the `: 1` branch ranked an
-          // agent finding level with a post-hoc harvested guess, so this sort
-          // and findingsFor disagreed about provenance.
-          mods.curate.originWeight(f.origin) *
-          (f.pinned ? 2 : 1);
+        const weight = (entry: any) => {
+          const f = entry.node;
+          return (
+            (f.confidence ?? 0.5) *
+            // originWeight, not a human-only ternary: the `: 1` branch ranked an
+            // agent finding level with a post-hoc harvested guess, so this sort
+            // and findingsFor disagreed about provenance.
+            mods.curate.originWeight(f.origin) *
+            (f.pinned ? 2 : 1)
+          );
+        };
         return weight(b) - weight(a);
       });
 
       return res.json({
         total: findings.length,
         offset,
-        items: findings.slice(offset, offset + limit).map(summarise),
+        items: findings
+          .slice(offset, offset + limit)
+          .map((entry: any) => summarise(entry.node, entry.source)),
       });
-    } catch {
+    } catch (error) {
+      if (error instanceof ScopeError)
+        return res.status(400).json({ error: error.message });
       return res.status(500).json({ error: 'search failed' });
     }
   });
@@ -265,8 +463,19 @@ export function registerWikiRoutes(app: Express): void {
     if (!mods) return res.status(503).json({ error: 'graph unavailable' });
 
     try {
-      const graph = loadGraph(graphDir(req, mods.wiki), mods.wiki);
-      const node = graph.nodes.get(req.params.id);
+      const qualified = splitQualifiedId(req.params.id);
+      let source: GraphSource | null;
+      let nodeId: string;
+      if (qualified) {
+        source = sourceById(qualified.sourceId, mods);
+        nodeId = qualified.nodeId;
+      } else {
+        source = sourcesFor(req, mods)[0] || null;
+        nodeId = req.params.id;
+      }
+      if (!source) return res.status(404).json({ error: 'no such project' });
+      const graph = loadGraph(source.dir, mods.wiki);
+      const node = graph.nodes.get(nodeId);
       if (!node) return res.status(404).json({ error: 'no such node' });
 
       const cap = Math.min(120, Number(req.query.cap) || 40);
@@ -278,25 +487,27 @@ export function registerWikiRoutes(app: Express): void {
       for (const edge of edges) {
         const otherId = edge.from === node.id ? edge.to : edge.from;
         const other = graph.nodes.get(otherId);
-        if (other) neighbours.set(otherId, summarise(other));
+        if (other) neighbours.set(otherId, summarise(other, source));
       }
 
       // Provenance: which task established this, and from what. "Why do you
       // believe this?" is the question a knowledge graph has to answer.
       return res.json({
         node: {
-          ...summarise(node),
+          ...summarise(node, source),
           snapshot: node.snapshot ? node.snapshot.slice(0, 4000) : undefined,
         },
         edges: edges.map((e: any) => ({
-          from: e.from,
-          to: e.to,
+          from: qualifiedId(source, e.from),
+          to: qualifiedId(source, e.to),
           edge: e.edge,
         })),
         neighbours: [...neighbours.values()],
         truncated: edges.length === cap,
       });
-    } catch {
+    } catch (error) {
+      if (error instanceof ScopeError)
+        return res.status(400).json({ error: error.message });
       return res.status(500).json({ error: 'node lookup failed' });
     }
   });
@@ -314,31 +525,67 @@ export function registerWikiRoutes(app: Express): void {
 
     const cap = Math.min(300, Number(req.query.cap) || 150);
     try {
-      const graph = loadGraph(graphDir(req, mods.wiki), mods.wiki);
-      const findings = mods.curate
-        .activeFindings(graph)
-        .sort((a: any, b: any) => (b.confidence ?? 0) - (a.confidence ?? 0))
+      const sources = sourcesFor(req, mods);
+      const graphs = new Map(
+        sources.map((source) => [source.id, loadGraph(source.dir, mods.wiki)])
+      );
+      const allFindings = sources.flatMap((source) =>
+        mods.curate
+          .activeFindings(graphs.get(source.id))
+          .map((node: any) => ({ node, source }))
+      );
+      const findings = allFindings
+        .sort(
+          (a: any, b: any) =>
+            (b.node.confidence ?? 0) - (a.node.confidence ?? 0)
+        )
         .slice(0, cap);
 
-      const keep = new Set(findings.map((f: any) => f.id));
+      const keep = new Map<string, Set<string>>();
+      for (const { node, source } of findings) {
+        if (!keep.has(source.id)) keep.set(source.id, new Set());
+        keep.get(source.id)!.add(node.id);
+      }
       // Pull in the anchors those findings hang from, so the picture shows
       // structure rather than a cloud of disconnected points.
-      for (const edge of graph.edges) {
-        if (edge.edge === 'derived_from' && keep.has(edge.from))
-          keep.add(edge.to);
+      for (const source of sources) {
+        const sourceKeep = keep.get(source.id);
+        if (!sourceKeep) continue;
+        for (const edge of graphs.get(source.id).edges) {
+          if (edge.edge === 'derived_from' && sourceKeep.has(edge.from))
+            sourceKeep.add(edge.to);
+        }
       }
 
       return res.json({
-        nodes: [...keep]
-          .map((id) => graph.nodes.get(id))
-          .filter(Boolean)
-          .map(summarise),
-        edges: graph.edges
-          .filter((e: any) => keep.has(e.from) && keep.has(e.to))
-          .map((e: any) => ({ from: e.from, to: e.to, edge: e.edge })),
-        capped: findings.length === cap,
+        nodes: sources.flatMap((source) =>
+          [...(keep.get(source.id) || [])]
+            .map((id) => graphs.get(source.id).nodes.get(id))
+            .filter(Boolean)
+            .map((node) => summarise(node, source))
+        ),
+        edges: sources.flatMap((source) => {
+          const sourceKeep = keep.get(source.id) || new Set();
+          return graphs
+            .get(source.id)
+            .edges.filter(
+              (edge: any) =>
+                sourceKeep.has(edge.from) && sourceKeep.has(edge.to)
+            )
+            .map((edge: any) => ({
+              from: qualifiedId(source, edge.from),
+              to: qualifiedId(source, edge.to),
+              edge: edge.edge,
+            }));
+        }),
+        projects: sources.length,
+        findings: allFindings.length,
+        renderedFindings: findings.length,
+        capped: allFindings.length > cap,
       });
-    } catch {
+    } catch (error) {
+      if (error instanceof ScopeError)
+        return res.status(400).json({ error: error.message });
       return res.status(500).json({ error: 'constellation failed' });
     }
   });
@@ -349,21 +596,32 @@ export function registerWikiRoutes(app: Express): void {
     if (!mods) return res.status(503).json({ error: 'graph unavailable' });
 
     try {
-      const result = mods.curate.audit(
-        loadGraph(graphDir(req, mods.wiki), mods.wiki)
-      );
+      const results = sourcesFor(req, mods).map((source) => ({
+        source,
+        result: mods.curate.audit(loadGraph(source.dir, mods.wiki)),
+      }));
+      const collect = (key: string) =>
+        results.flatMap(({ source, result }) =>
+          result[key].map((node: any) => summarise(node, source))
+        );
+      const contradicted = collect('contradicted');
+      const orphaned = collect('orphaned');
+      const lowConfidence = collect('lowConfidence');
+      const stale = collect('stale');
       return res.json({
-        contradicted: result.contradicted.map(summarise),
-        orphaned: result.orphaned.map(summarise),
-        lowConfidence: result.lowConfidence.map(summarise),
-        stale: result.stale.map(summarise),
+        contradicted,
+        orphaned,
+        lowConfidence,
+        stale,
         total:
-          result.contradicted.length +
-          result.orphaned.length +
-          result.lowConfidence.length +
-          result.stale.length,
+          contradicted.length +
+          orphaned.length +
+          lowConfidence.length +
+          stale.length,
       });
-    } catch {
+    } catch (error) {
+      if (error instanceof ScopeError)
+        return res.status(400).json({ error: error.message });
       return res.status(500).json({ error: 'audit failed' });
     }
   });
@@ -381,8 +639,17 @@ export function registerWikiRoutes(app: Express): void {
     if (!mods) return res.status(503).json({ error: 'graph unavailable' });
 
     try {
-      return res.json(mods.metrics.report(graphDir(req, mods.wiki)));
-    } catch {
+      const selected = sourcesFor(req, mods);
+      return res.json(
+        selected.length > 1
+          ? mods.metrics.reportMany(selected.map((source) => source.dir))
+          : mods.metrics.report(
+              selected[0]?.dir || selectedSource(req, mods).dir
+            )
+      );
+    } catch (error) {
+      if (error instanceof ScopeError)
+        return res.status(400).json({ error: error.message });
       return res.status(500).json({ error: 'balance failed' });
     }
   });
@@ -416,13 +683,15 @@ export function registerWikiRoutes(app: Express): void {
 
     try {
       return res.json({
-        ...mods.metrics.evidenceReport(graphDir(req, mods.wiki), {
+        ...mods.metrics.evidenceReport(selectedSource(req, mods).dir, {
           filters,
           episodeLimit,
         }),
         capabilities: mods.capabilities.capabilitySummary(),
       });
-    } catch {
+    } catch (error) {
+      if (error instanceof ScopeError)
+        return res.status(400).json({ error: error.message });
       return res.status(500).json({ error: 'evidence report failed' });
     }
   });
@@ -445,7 +714,7 @@ export function registerWikiRoutes(app: Express): void {
           .json({ error: 'rating must be helpful, neutral, or harmful' });
 
       const recorded = mods.metrics.recordFindingFeedback(
-        graphDir(req, mods.wiki),
+        selectedSource(req, mods).dir,
         {
           findingId: findingId.trim().slice(0, 300),
           rating,
@@ -469,11 +738,19 @@ export function registerWikiRoutes(app: Express): void {
     if (!mods) return res.status(503).json({ error: 'graph unavailable' });
 
     try {
-      const markdown = mods.curate.exportMarkdown(
-        loadGraph(graphDir(req, mods.wiki), mods.wiki)
-      );
+      const sources = sourcesFor(req, mods);
+      const markdown = sources
+        .map(
+          (source) =>
+            `# ${source.name}\n\n${mods.curate.exportMarkdown(
+              loadGraph(source.dir, mods.wiki)
+            )}`
+        )
+        .join('\n\n---\n\n');
       return res.type('text/markdown').send(markdown);
-    } catch {
+    } catch (error) {
+      if (error instanceof ScopeError)
+        return res.status(400).json({ error: error.message });
       return res.status(500).json({ error: 'export failed' });
     }
   });
@@ -489,11 +766,18 @@ export function registerWikiRoutes(app: Express): void {
     if (!mods) return res.status(503).json({ error: 'graph unavailable' });
 
     const { action, key, claim, anchors, confidence, pinned } = req.body || {};
-    const dir = graphDir(req, mods.wiki);
+    let dir: string;
+    try {
+      dir = selectedSource(req, mods).dir;
+    } catch (error) {
+      if (error instanceof ScopeError)
+        return res.status(400).json({ error: error.message });
+      throw error;
+    }
     // Any curation appends to the log, so the cached parse is stale the moment
     // it succeeds. Dropping it here is cheaper and more obviously correct than
     // trying to patch the cached graph in place.
-    graphCache = null;
+    graphCache.delete(pathKey(dir));
 
     try {
       switch (action) {

--- a/src/server/wiki-routes.ts
+++ b/src/server/wiki-routes.ts
@@ -682,11 +682,26 @@ export function registerWikiRoutes(app: Express): void {
       : 100;
 
     try {
+      const selected = sourcesFor(req, mods);
+      const evidence =
+        selected.length > 1
+          ? mods.metrics.evidenceReportMany(
+              selected.map((source) => source.dir),
+              {
+                filters,
+                episodeLimit,
+              }
+            )
+          : mods.metrics.evidenceReport(
+              selected[0]?.dir || selectedSource(req, mods).dir,
+              {
+                filters,
+                episodeLimit,
+              }
+            );
       return res.json({
-        ...mods.metrics.evidenceReport(selectedSource(req, mods).dir, {
-          filters,
-          episodeLimit,
-        }),
+        ...evidence,
+        scope: String(req.query.scope || 'current'),
         capabilities: mods.capabilities.capabilitySummary(),
       });
     } catch (error) {

--- a/src/tools/intelligence/wiki-write.ts
+++ b/src/tools/intelligence/wiki-write.ts
@@ -186,10 +186,12 @@ export async function wikiWrite(
     : [];
 
   try {
-    const [wiki, harvestWrite, curate] = await Promise.all([
+    const [wiki, harvestWrite, curate, metrics, projects] = await Promise.all([
       import(coreUrl('wiki.mjs')),
       import(coreUrl('harvest-write.mjs')),
       import(coreUrl('curate.mjs')),
+      import(coreUrl('metrics.mjs')),
+      import(coreUrl('projects.mjs')),
     ]);
 
     // The finding belongs to the project the ANCHOR is in, not to wherever the
@@ -199,6 +201,7 @@ export async function wikiWrite(
       options.projectRoot ??
       wiki.projectRootFor(anchors[0].split('#')[0], process.cwd());
     const dir = wiki.wikiDir(project);
+    projects.registerProject({ root: project, graphDir: dir, client: 'mcp' });
 
     const keys: string[] = harvestWrite.writeHarvested(
       dir,
@@ -239,6 +242,34 @@ export async function wikiWrite(
         : wiki.nodeId('file', wiki.canonicalKey('file', file));
       return !graph.nodes.has(id);
     });
+
+    if (keys.length) {
+      // This is the marginal context used to persist the conclusion: the model
+      // emits these tool arguments specifically so later models need not derive
+      // them again. It was previously written by fixture seeders only, making
+      // "cost of remembering" permanently under-report real use.
+      const payloadTokens = Math.ceil(
+        Buffer.byteLength(
+          JSON.stringify({
+            claim,
+            anchors,
+            evidence,
+            applicability,
+            type,
+            trigger: options.trigger,
+            invalidators,
+          }),
+          'utf8'
+        ) / 4
+      );
+      metrics.record(dir, {
+        kind: 'harvest',
+        tokens: payloadTokens,
+        findings: keys.length,
+        origin: curate.ORIGIN_AGENT,
+        sessionId: options.sessionId ?? null,
+      });
+    }
 
     return {
       success: keys.length > 0,

--- a/tests/hooks/causal-evidence.test.mjs
+++ b/tests/hooks/causal-evidence.test.mjs
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
   evidenceReport,
+  evidenceReportMany,
   readEvidence,
   record,
   recordFindingFeedback,
@@ -130,6 +131,39 @@ describe('causal episode tracing', () => {
 });
 
 describe('paired evidence report', () => {
+  test('pools raw events across project graphs before estimating cohorts', () => {
+    const secondWorkspace = mkdtempSync(join(tmpdir(), 'causal-evidence-second-'));
+    const secondDir = wikiDir(secondWorkspace);
+    try {
+      for (let pair = 1; pair <= 5; pair++) {
+        record(dir, {
+          kind: 'eval-run', taskId: 'cross-project', pairId: `p${pair}`,
+          arm: 'baseline', client: 'codex', model: 'model-a', correct: true,
+          totalTokens: 1000, toolCalls: 10,
+        });
+        record(secondDir, {
+          kind: 'eval-run', taskId: 'cross-project', pairId: `p${pair}`,
+          arm: 'full', client: 'codex', model: 'model-a', correct: true,
+          totalTokens: 600, toolCalls: 6,
+        });
+      }
+
+      const report = evidenceReportMany([dir, secondDir]);
+      const full = report.cohorts[0].effects.find((effect) =>
+        effect.arm === 'full' && effect.controlArm === 'baseline'
+      );
+      expect(full.pairs).toBe(5);
+      expect(full.totalTokensSaved.mean).toBe(400);
+      expect(report.sourceCoverage).toEqual({
+        projects: 2,
+        projectsWithEvidence: 2,
+        projectsWithoutEvidence: 0,
+      });
+    } finally {
+      rmSync(secondWorkspace, { recursive: true, force: true });
+    }
+  });
+
   test('keeps four arms separate and reports a bootstrap interval from matched pairs', () => {
     for (let pair = 1; pair <= 5; pair++) {
       for (const [arm, tokens, calls] of [

--- a/tests/hooks/codex-semantic-harvest.test.mjs
+++ b/tests/hooks/codex-semantic-harvest.test.mjs
@@ -55,7 +55,9 @@ function editPayload(sessionId, file) {
     tool_input: {
       command: `*** Begin Patch\n*** Update File: ${file}\n@@\n-old\n+new\n*** End Patch`,
     },
-    tool_response: { status: 'completed' },
+    // Codex documents tool_response as an opaque tool-specific value. It does
+    // not guarantee a synthetic status field for a successful apply_patch.
+    tool_response: { output: 'Done!' },
   };
 }
 

--- a/tests/hooks/observability.test.mjs
+++ b/tests/hooks/observability.test.mjs
@@ -1,0 +1,341 @@
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals';
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir, homedir } from 'node:os';
+import { join } from 'node:path';
+import { spawn, spawnSync } from 'node:child_process';
+import {
+  beginHookInvocation,
+  hookHealthSummary,
+  readHookEvents,
+  recordHookBootstrapFailure,
+  writeHookEvent,
+} from '../../hooks-core/observability.mjs';
+
+const ROOT = process.cwd();
+let workspace;
+let previous;
+
+beforeEach(() => {
+  workspace = mkdtempSync(join(tmpdir(), 'token-optimizer-observability-'));
+  previous = {
+    logDir: process.env.TOKEN_OPTIMIZER_LOG_DIR,
+    maxBytes: process.env.TOKEN_OPTIMIZER_LOG_MAX_BYTES,
+  };
+  process.env.TOKEN_OPTIMIZER_LOG_DIR = join(workspace, 'logs');
+  process.env.TOKEN_OPTIMIZER_VERSION = 'test-version';
+});
+
+afterEach(() => {
+  if (previous.logDir === undefined) delete process.env.TOKEN_OPTIMIZER_LOG_DIR;
+  else process.env.TOKEN_OPTIMIZER_LOG_DIR = previous.logDir;
+  if (previous.maxBytes === undefined) delete process.env.TOKEN_OPTIMIZER_LOG_MAX_BYTES;
+  else process.env.TOKEN_OPTIMIZER_LOG_MAX_BYTES = previous.maxBytes;
+  delete process.env.TOKEN_OPTIMIZER_VERSION;
+  rmSync(workspace, { recursive: true, force: true });
+});
+
+describe('cross-client hook observability', () => {
+  test('writes one correlated, privacy-safe completion event', () => {
+    const invocation = beginHookInvocation('codex', 'post-tool');
+    invocation.bind(
+      {
+        session_id: 'session-1',
+        turn_id: 'turn-1',
+        tool_use_id: 'tool-1',
+        tool_name: 'apply_patch',
+        cwd: workspace,
+        tool_input: { command: 'secret source content that must not be logged' },
+      },
+      { tool_name: 'apply_patch' },
+      321
+    );
+    invocation.noteOutput({
+      hookSpecificOutput: {
+        hookEventName: 'PostToolUse',
+        additionalContext: 'private response text',
+      },
+    });
+    invocation.succeed('captured');
+
+    const events = readHookEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      schemaVersion: 1,
+      service: 'token-optimizer',
+      serviceVersion: 'test-version',
+      event: 'hook.completed',
+      outcome: 'success',
+      reason: 'captured',
+      client: 'codex',
+      hookEvent: 'post-tool',
+      toolName: 'apply_patch',
+      payloadBytes: 321,
+      severityText: 'INFO',
+      severityNumber: 9,
+      body: 'hook.completed',
+      outputShape: [
+        'hookSpecificOutput',
+        'hookSpecificOutput.additionalContext',
+        'hookSpecificOutput.hookEventName',
+      ],
+    });
+    expect(events[0].cwdHash).toMatch(/^[a-f0-9]{16}$/);
+    expect(events[0].sessionIdHash).toMatch(/^[a-f0-9]{16}$/);
+    expect(events[0].turnIdHash).toMatch(/^[a-f0-9]{16}$/);
+    expect(events[0].toolUseIdHash).toMatch(/^[a-f0-9]{16}$/);
+    expect(events[0].traceId).toMatch(/^[a-f0-9]{32}$/);
+    expect(events[0].spanId).toMatch(/^[a-f0-9]{16}$/);
+    expect(events[0].resource).toMatchObject({
+      'service.name': 'token-optimizer',
+      'service.version': 'test-version',
+      'process.runtime.name': 'node',
+    });
+    expect(JSON.stringify(events[0])).not.toContain('secret source content');
+    expect(JSON.stringify(events[0])).not.toContain('private response text');
+    expect(JSON.stringify(events[0])).not.toContain('session-1');
+    expect(events[0]).not.toHaveProperty('tool_input');
+  });
+
+  test('records bootstrap failures with secrets and home paths redacted', () => {
+    recordHookBootstrapFailure(
+      'gemini',
+      'pre-tool',
+      new Error(`${homedir()} password=hunter2 ghp_12345678901234567890`)
+    );
+
+    const [event] = readHookEvents();
+    expect(event.outcome).toBe('failure');
+    expect(event.reason).toBe('bootstrap_import_failure');
+    expect(event.error.message).toContain('<home>');
+    expect(event.error.message).not.toContain('hunter2');
+    expect(event.error.message).not.toContain('ghp_12345678901234567890');
+  });
+
+  test('rotates bounded JSONL files and aggregates health by client', () => {
+    process.env.TOKEN_OPTIMIZER_LOG_MAX_BYTES = '1';
+    writeHookEvent({ client: 'codex', outcome: 'success', durationMs: 10 });
+    writeHookEvent({ client: 'codex', outcome: 'failure', durationMs: 20 });
+    writeHookEvent({ client: 'claude-code', outcome: 'timeout', durationMs: 30 });
+
+    const files = readdirSync(process.env.TOKEN_OPTIMIZER_LOG_DIR).filter((name) =>
+      name.endsWith('.jsonl')
+    );
+    expect(files.length).toBeGreaterThan(1);
+    const health = hookHealthSummary();
+    expect(health.total).toBe(3);
+    expect(health.failures).toBe(1);
+    expect(health.timeouts).toBe(1);
+    expect(health.byClient.codex).toMatchObject({ total: 2, failures: 1 });
+    expect(health.byClient['claude-code']).toMatchObject({ total: 1, timeouts: 1 });
+    expect(health).not.toHaveProperty('logDirectory');
+    expect(hookHealthSummary({ includeLogDirectory: true }).logDirectory).toBe(
+      process.env.TOKEN_OPTIMIZER_LOG_DIR
+    );
+  });
+
+  test('fails open before the host timeout when stdin never closes', async () => {
+    const started = Date.now();
+    const child = spawn(
+      process.execPath,
+      [join(ROOT, 'integrations', 'codex', 'plugin', 'hooks', 'pre-tool.mjs')],
+      {
+        cwd: workspace,
+        env: {
+          ...process.env,
+          TOKEN_OPTIMIZER_LOG_DIR: join(workspace, 'timeout-logs'),
+          TOKEN_OPTIMIZER_HOOK_DEADLINE_MS: '3000',
+        },
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }
+    );
+
+    const result = await new Promise((resolve, reject) => {
+      child.once('error', reject);
+      child.once('exit', (code) => resolve({ code, elapsed: Date.now() - started }));
+    });
+    expect(result.code).toBe(0);
+    expect(result.elapsed).toBeLessThan(2500);
+
+    const file = readdirSync(join(workspace, 'timeout-logs')).find((name) =>
+      name.endsWith('.jsonl')
+    );
+    const event = JSON.parse(
+      readFileSync(join(workspace, 'timeout-logs', file), 'utf8').trim()
+    );
+    expect(event.outcome).toBe('timeout');
+    expect(event.reason).toBe('stdin_timeout');
+    expect(event.inputStatus).toBe('timeout');
+  });
+
+  test('covers Claude Code custom hooks with the same bounded schema', async () => {
+    const child = spawn(
+      process.execPath,
+      [join(ROOT, 'plugin', 'hooks', 'pretooluse-router.mjs')],
+      {
+        cwd: workspace,
+        env: {
+          ...process.env,
+          TOKEN_OPTIMIZER_LOG_DIR: join(workspace, 'claude-logs'),
+        },
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }
+    );
+
+    const result = await new Promise((resolve, reject) => {
+      child.once('error', reject);
+      child.once('exit', (code) => resolve({ code }));
+    });
+    expect(result.code).toBe(0);
+
+    const [event] = readEventsFrom(join(workspace, 'claude-logs'));
+    expect(event).toMatchObject({
+      schemaVersion: 1,
+      serviceVersion: '5.7.0',
+      client: 'claude-code',
+      hookEvent: 'pre-tool',
+      outcome: 'timeout',
+      reason: 'stdin_timeout',
+      inputStatus: 'timeout',
+    });
+  });
+
+  test('every generated CLI adapter emits the same successful diagnostic schema', async () => {
+    const adapters = [
+      ['codex', ['integrations', 'codex', 'plugin', 'hooks', 'pre-tool.mjs']],
+      ['gemini', ['integrations', 'gemini', 'hooks', 'pre-tool.mjs']],
+      ['qwen', ['integrations', 'qwen', 'hooks', 'pre-tool.mjs']],
+      ['opencode', ['integrations', 'opencode', 'hooks', 'pre-tool.mjs']],
+      ['copilot', ['integrations', 'copilot', '.github', 'hooks', 'pre-tool.mjs']],
+      ['cline', ['integrations', 'cline', 'hooks', 'token-optimizer', 'pre-tool.mjs']],
+      ['cursor', ['integrations', 'cursor', 'hooks', 'pre-tool.mjs']],
+      ['windsurf', ['integrations', 'windsurf', 'hooks', 'pre-tool.mjs']],
+      ['kilo', ['integrations', 'kilo', 'hooks', 'pre-tool.mjs']],
+    ];
+
+    const results = await Promise.all(
+      adapters.map(async ([client, entryParts]) => {
+        const logDirectory = join(workspace, `${client}-logs`);
+        const child = spawn(process.execPath, [join(ROOT, ...entryParts)], {
+          cwd: workspace,
+          env: {
+            ...process.env,
+            TOKEN_OPTIMIZER_LOG_DIR: logDirectory,
+          },
+          stdio: ['pipe', 'pipe', 'pipe'],
+        });
+        child.stdin.end(
+          JSON.stringify({
+            session_id: `${client}-session`,
+            turn_id: `${client}-turn`,
+            tool_use_id: `${client}-tool-use`,
+            cwd: workspace,
+            tool_name: 'Read',
+            tool_input: { file_path: join(workspace, 'probe.txt') },
+          })
+        );
+
+        const exitCode = await new Promise((resolve, reject) => {
+          child.once('error', reject);
+          child.once('exit', resolve);
+        });
+        return { client, exitCode, event: readEventsFrom(logDirectory)[0] };
+      })
+    );
+
+    expect(results.map(({ client }) => client)).toEqual(adapters.map(([client]) => client));
+    for (const { client, exitCode, event } of results) {
+      expect(exitCode).toBe(0);
+      expect(event).toMatchObject({
+        schemaVersion: 1,
+        service: 'token-optimizer',
+        serviceVersion: '5.7.0',
+        client,
+        hookEvent: 'pre-tool',
+        outcome: 'success',
+        inputStatus: 'ok',
+      });
+      expect(event.sessionIdHash).toMatch(/^[a-f0-9]{16}$/);
+      expect(event.traceId).toMatch(/^[a-f0-9]{32}$/);
+      expect(event.spanId).toMatch(/^[a-f0-9]{16}$/);
+    }
+  });
+
+  test('records a successful Stop payload as consumed instead of pending', async () => {
+    const logDirectory = join(workspace, 'stop-logs');
+    const child = spawn(
+      process.execPath,
+      [join(ROOT, 'integrations', 'codex', 'plugin', 'hooks', 'stop.mjs')],
+      {
+        cwd: workspace,
+        env: {
+          ...process.env,
+          TOKEN_OPTIMIZER_LOG_DIR: logDirectory,
+        },
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }
+    );
+    child.stdin.end(
+      JSON.stringify({
+        session_id: 'stop-session',
+        turn_id: 'stop-turn',
+        cwd: workspace,
+        stop_hook_active: false,
+      })
+    );
+
+    const result = await new Promise((resolve, reject) => {
+      child.once('error', reject);
+      child.once('exit', (code) => resolve({ code }));
+    });
+    expect(result.code).toBe(0);
+
+    const [event] = readEventsFrom(logDirectory);
+    expect(event).toMatchObject({
+      client: 'codex',
+      hookEvent: 'stop',
+      outcome: 'success',
+      inputStatus: 'ok',
+    });
+    expect(event.sessionIdHash).toMatch(/^[a-f0-9]{16}$/);
+    expect(event.turnIdHash).toMatch(/^[a-f0-9]{16}$/);
+  });
+
+  test('diagnostics export is summary-first and event rows are bounded opt-in', () => {
+    writeHookEvent({ client: 'codex', outcome: 'success', durationMs: 10 });
+    writeHookEvent({ client: 'gemini', outcome: 'success', durationMs: 20 });
+
+    const summaryRun = spawnSync(process.execPath, [join(ROOT, 'scripts', 'export-diagnostics.mjs')], {
+      cwd: workspace,
+      env: process.env,
+      encoding: 'utf8',
+    });
+    expect(summaryRun.status).toBe(0);
+    const summary = JSON.parse(summaryRun.stdout);
+    expect(summary.scope).toEqual({ windowHours: 24, eventPayloadIncluded: false });
+    expect(summary.summary.total).toBe(2);
+    expect(summary).not.toHaveProperty('events');
+
+    const eventRun = spawnSync(
+      process.execPath,
+      [join(ROOT, 'scripts', 'export-diagnostics.mjs'), '--include-events', '--limit', '1'],
+      { cwd: workspace, env: process.env, encoding: 'utf8' }
+    );
+    expect(eventRun.status).toBe(0);
+    const eventReport = JSON.parse(eventRun.stdout);
+    expect(eventReport.scope).toEqual({
+      windowHours: 24,
+      eventPayloadIncluded: true,
+      eventLimit: 1,
+    });
+    expect(eventReport.summary.total).toBe(2);
+    expect(eventReport.events).toHaveLength(1);
+  });
+});
+
+function readEventsFrom(directory) {
+  const file = readdirSync(directory).find((name) => name.endsWith('.jsonl'));
+  return readFileSync(join(directory, file), 'utf8')
+    .trim()
+    .split(/\r?\n/)
+    .map((line) => JSON.parse(line));
+}

--- a/tests/hooks/project-registry.test.mjs
+++ b/tests/hooks/project-registry.test.mjs
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  projectIdFor,
+  registerProject,
+  registeredProjects,
+} from '../../hooks-core/projects.mjs';
+
+let workspace;
+let priorRegistry;
+
+beforeEach(() => {
+  workspace = mkdtempSync(join(tmpdir(), 'project-registry-'));
+  priorRegistry = process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY;
+  process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY = join(workspace, 'projects.jsonl');
+});
+
+afterEach(() => {
+  if (priorRegistry === undefined)
+    delete process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY;
+  else process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY = priorRegistry;
+  rmSync(workspace, { recursive: true, force: true });
+});
+
+describe('machine project graph registry', () => {
+  it('deduplicates one repository while retaining observed client coverage', () => {
+    const root = join(workspace, 'repo');
+    const graphDir = join(root, '.token-optimizer', 'wiki');
+    mkdirSync(join(root, '.git'), { recursive: true });
+
+    registerProject({ root, graphDir, client: 'codex' });
+    registerProject({ root, graphDir, client: 'claude-code' });
+
+    const projects = registeredProjects();
+    expect(projects).toHaveLength(1);
+    expect(projects[0].id).toBe(projectIdFor(root));
+    expect(projects[0].clients).toEqual(['claude-code', 'codex']);
+  });
+
+  it('does not turn arbitrary unrooted hook payloads into dashboard sources', () => {
+    const root = join(workspace, 'not-a-repository');
+    mkdirSync(root, { recursive: true });
+    expect(
+      registerProject({
+        root,
+        graphDir: join(root, '.token-optimizer', 'wiki'),
+        client: 'codex',
+      })
+    ).toBeNull();
+    expect(registeredProjects()).toEqual([]);
+  });
+});

--- a/tests/hooks/semantic-harvest-clients.test.mjs
+++ b/tests/hooks/semantic-harvest-clients.test.mjs
@@ -12,7 +12,9 @@ const CLIENTS = [
     name: 'Codex',
     root: 'integrations/codex/hooks',
     decision: 'block',
-    result: { tool_response: { status: 'completed' } },
+    // Match Codex's documented opaque tool response rather than inventing a
+    // lifecycle status field that the host does not promise.
+    result: { tool_response: { output: 'Done!' } },
   },
   {
     name: 'Copilot',

--- a/tests/hooks/standing-rules.test.mjs
+++ b/tests/hooks/standing-rules.test.mjs
@@ -167,7 +167,13 @@ describe('through the real SessionStart hook', () => {
       input: '{}',
       encoding: 'utf8',
       timeout: 30_000,
-      env: { ...process.env, TOKEN_OPTIMIZER_WIKI_DIR: graphDir, TOKEN_OPTIMIZER_SHARED_DIR: graphDir, CLAUDE_PROJECT_DIR: project },
+      env: {
+        ...process.env,
+        TOKEN_OPTIMIZER_WIKI_DIR: graphDir,
+        TOKEN_OPTIMIZER_SHARED_DIR: graphDir,
+        TOKEN_OPTIMIZER_PROJECT_REGISTRY: join(project, 'projects.jsonl'),
+        CLAUDE_PROJECT_DIR: project,
+      },
     });
 
     const ctx = JSON.parse(r.stdout || '{}')?.hookSpecificOutput?.additionalContext || '';
@@ -194,6 +200,7 @@ describe('through the real SessionStart hook', () => {
           ...process.env,
           TOKEN_OPTIMIZER_WIKI_DIR: graphDir,
           TOKEN_OPTIMIZER_SHARED_DIR: graphDir,
+          TOKEN_OPTIMIZER_PROJECT_REGISTRY: join(project, 'projects.jsonl'),
           CLAUDE_PROJECT_DIR: project,
         },
       });

--- a/tests/ucr/live-study-driver.test.mjs
+++ b/tests/ucr/live-study-driver.test.mjs
@@ -101,6 +101,7 @@ describe('live study driver protocol helpers', () => {
       cachedInputTokens: 55000,
       cacheCreationInputTokens: 700,
       effectiveInputTokens: 55702,
+      totalTokens: 55714,
     });
     expect(
       parseLiveCliTelemetry('codex', sample).usage.effectiveInputTokens

--- a/tests/unit/generators-are-eol-insensitive.test.ts
+++ b/tests/unit/generators-are-eol-insensitive.test.ts
@@ -196,6 +196,10 @@ describe('a generator run against a CRLF working tree', () => {
       join(process.cwd(), 'scripts', 'lib', 'text.mjs'),
       join(root, 'scripts', 'lib', 'text.mjs')
     );
+    // Generated hook entries stamp the package version into lifecycle telemetry,
+    // making package.json an explicit generator input alongside the script and
+    // its EOL-safe text helper.
+    copyFileSync(join(process.cwd(), 'package.json'), join(root, 'package.json'));
     return root;
   }
 

--- a/ucr/live-study-driver.mjs
+++ b/ucr/live-study-driver.mjs
@@ -182,11 +182,6 @@ export function parseLiveCliTelemetry(client, stdout) {
     'totalTokens',
     'totalTokenCount',
   ]);
-  const totalTokens =
-    reportedTotal ??
-    (inputTokens !== null && outputTokens !== null
-      ? inputTokens + outputTokens
-      : null);
   // Claude reports newly read and newly created cache tokens outside
   // input_tokens. Codex and Gemini include their cached subset in the prompt
   // total, so adding it there would double-count reconstruction context.
@@ -194,6 +189,15 @@ export function parseLiveCliTelemetry(client, stdout) {
     client === 'claude-code' && inputTokens !== null
       ? inputTokens + (cachedInputTokens || 0) + (cacheCreationInputTokens || 0)
       : inputTokens;
+  // Compare the logical context each arm consumed, regardless of whether the
+  // provider billed it as a cache read, cache creation, or uncached input.
+  // Using input_tokens + output_tokens for Claude silently dropped most of the
+  // context from the qualification gate whenever prompt caching was active.
+  const totalTokens =
+    reportedTotal ??
+    (effectiveInputTokens !== null && outputTokens !== null
+      ? effectiveInputTokens + outputTokens
+      : null);
   const toolEvents = [];
   for (const object of objects)
     visit(object, (value) => {


### PR DESCRIPTION
## What changed

- added bounded, rotated, privacy-safe structured hook logs for every generated native client integration
- added hook health diagnostics, support export, and dashboard capture-health reporting
- fixed fail-open behavior for malformed/oversized hook input and Codex post-tool success envelopes
- fixed the 3D graph ResizeObserver feedback loop that continuously enlarged the canvas
- added an opaque machine-local project registry and bounded project graph discovery
- made the dashboard aggregate all captured projects by default while keeping filesystem paths server-side
- wired activity, memory deliveries, holdouts, delivery cost, and semantic-write cost to persisted production events
- replaced the stale Claude-specific overview fallback with cross-client lifecycle diagnostics
- added live Playwright coverage for camera stability, multi-project aggregation, coverage gaps, real metrics, and browser errors

## Root causes

The 5.7 hook surface lacked a shared operational telemetry contract, so failures were both hard to reproduce and inconsistently classified. The dashboard then compounded that gap: it preferred a stale Claude-only session pointer, queried only one graph directory, and had no production event for semantic persistence cost. The 3D graph sized its child canvas from the host border box; that child size enlarged the host and retriggered `ResizeObserver`, creating an unbounded zoom/growth loop.

## Live evidence from this machine

The dashboard is running against the real local AiDotNet graph plus the machine registry, not a seeded UI fixture:

| Measure | Observed |
| --- | ---: |
| Known sources | 9 |
| Sources with graph data | 7 |
| Explicit missing capture | 2 (`HarmonicEngine`, `mcp-console-automation`) |
| Aggregate graph | 1,854 nodes / 5,406 edges / 54 findings |
| Largest individual graph | 862 nodes |
| Memory deliveries | 47 |
| Withheld comparisons | 4 |
| Measured delivery + persistence cost | 6,966 tokens |
| Hook runs in current 24h window | 8 |
| Hook success | 100% |
| Hook failures / timeouts | 0 / 0 |
| Hook p50 / p95 | 26 ms / 103 ms |
| Overview camera spread across 12 samples | 0 px / 0 zoom |
| Knowledge camera spread across 12 samples | 0 px / 0 zoom |

The live graph contains more than twice the nodes of the largest individual project, proving that the default view is actually aggregating sources. The live registry currently has lifecycle events from Codex only; cross-client behavior is covered by the deterministic client suite, not mislabelled as live multi-client evidence.

`Reading avoided` intentionally renders **Not enough comparisons** because the live store has 4 holdouts and the frozen minimum is 5 (with at least 20 deliveries). The dashboard no longer renders a blank or fabricates a savings number.

## Validation

- `npm run build`
- `npm test` — 194 suites passed; 2,303 tests passed; 5 skipped
- `npm run verify:all`
  - 237/237 generated client/config checks
  - 16/16 client protocol certifications
  - 27/27 harvest contract checks
  - 29/29 deterministic UCR checks
  - live graph flow passed with real production `wiki_write` accounting
  - 49/49 browser UI checks
  - 63/63 browser interaction/security checks
- targeted registry regression — 12/12 tests
- production dashboard Playwright verification — passed with zero page/console errors
- `npm run sync:hooks:check`
- `git diff --check`

## Honest release status

This fixes the operational and dashboard defects and makes missing evidence visible. It does not change the UCR replacement verdict: the repository's qualification gate still reports insufficient live-model evidence, including token non-inferiority failures in the existing study artifacts. That claim remains gated on the full study rather than deterministic conformance.

<!-- live-evidence-round-20260811 -->
### Dashboard evidence wiring and live qualification (2026-08-11)

- Live browser capture: **570 lifecycle events** across **6 CLI clients**, **0 hook failures**, **0 hook timeouts**, and **100 ms p95** hook latency. The 98.8% lifecycle success rate includes 7 explicitly skipped events rather than hiding them as failures.
- Live graph: **1,860 nodes**, **5,454 edges**, and **54 findings**. Project capture is **7/9**; `mcp-console-automation` and `HarmonicEngine` are now reported as missing coverage rather than disappearing from the UI.
- Balance evidence: **47 deliveries**, **4 holdouts**, and **6,966 delivered tokens**. The current file-read cohort is explicitly marked insufficient at 15 deliveries / 2 holdouts against the 20 / 5 minimum.
- Evidence joins: **34 injections**, **13 joined outcomes (38.2%)**, with evidence-bearing events in **3/9 projects**. Randomized, handoff, and concurrency studies are shown as **Not run**, not blank or zero.
- Release evidence coverage: **8/37 metrics measured** and **29/37 missing**. Every missing metric is mapped to its required evidence producer in the dashboard.
- Signed bounded Codex-to-Claude qualification: both arms completed correctly, runtime context arrived before the first consumer action, consumer actions fell **20 to 13 (-35%)**, and end-to-end latency fell **193,482 ms to 67,238 ms (-65.25%)**. Logical tokens increased **74,570 to 76,240 (+2.24%)**, so this is a qualification pass within the 5% regression guardrail, **not a token-savings claim**. Integrity ledger SHA-256: `3f64ede7e7ed0ef909dab3e9114901c5c5f4ffeb263498fb4a8ac7b341b2ba1c`.
- The frozen powered design remains unexecuted: **54,054 trials / 113,022 provider calls** across 11 families, 7 arms, 3 models, and 9 handoff directions. The dashboard and PR do not claim full effectiveness or competitive replacement evidence before that study runs.
- Verification: all **16 protocol certifications**, **29 deterministic UCR checks**, **50 dashboard checks**, **63 interaction checks**, **27 harvesting checks**, and **237 client configuration checks** passed. The full Jest inventory passed after rebuilding the server artifact: **194 suites**, **2,304 tests passed**, **5 skipped**. The isolated live graph flow recorded 26 deliveries, 8 holdouts, 2,682 overhead tokens, 47,000 avoided tokens, and **44,318 net avoided tokens**.
<!-- /live-evidence-round-20260811 -->
