### PR TITLE
fix: wiki_write refuses anchors with no VCS ancestor via wrong containment root

### DIFF
--- a/README.md
+++ b/README.md
@@ -710,6 +710,28 @@ TOKEN_OPTIMIZER_MODE=off      # disable the hooks entirely
 TOKEN_OPTIMIZER_LARGE_READ_BYTES=51200   # raise the "large file" threshold
 ```
 
+#### If enforcement never fires
+
+Symptom: the tools work fine when called directly, but native `Read`/`Grep`/`Edit`/`Bash`
+calls are never refused — the deny rate in `~/.token-optimizer/logs/hook-events-*.jsonl`
+sits near zero.
+
+Cause: `PreToolUse` only enforces once the hook can prove the MCP tools are registered
+in the current session. Claude Code's hook payload carries no tool-inventory field for
+it to check, so that proof never arrives on a stock install, and enforcement silently
+degrades to observation only.
+
+Fix: state the tool list explicitly via `settings.json`'s `env` key (any scope; takes
+effect for sessions started after the change):
+
+```json
+{
+  "env": {
+    "TOKEN_OPTIMIZER_MCP_CAPABILITIES": "smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write"
+  }
+}
+```
+
 #### MCP server only (not recommended)
 
 If you want the tools without the enforcement:

--- a/hooks-core/harvest-write.mjs
+++ b/hooks-core/harvest-write.mjs
@@ -23,11 +23,13 @@
 
 import {
   putNodeWithEdges, load, nodeId, sharedDir, isSharedDir, putNode, putEdge,
+  unrootedRoot,
 } from './wiki.mjs';
 import { indexFile } from './staleness.mjs';
 import { symbolKey } from './symbols.mjs';
 import { canonicalPath } from './paths.mjs';
 import { randomBytes } from 'node:crypto';
+import { homedir } from 'node:os';
 import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
 
 /**
@@ -322,7 +324,15 @@ function resolveAnchor(dir, anchor, projectRoot) {
   // that file into .token-optimizer and serve it back on the next touch. The
   // findings come from a model reading a transcript, so the paths are not
   // trusted input.
-  if (projectRoot && !withinProject(path, projectRoot)) return null;
+  //
+  // The unrooted bucket is a storage location, not a project: nothing on disk
+  // lives inside ~/.token-optimizer/unrooted, so using it as the containment
+  // root refused every anchor with no VCS ancestor -- dotfiles and machine-wide
+  // configs included. Home directory is the boundary that actually matches
+  // what an unrooted anchor looks like, and keeps the same protection.
+  const containmentRoot =
+    projectRoot === unrootedRoot() ? homedir() : projectRoot;
+  if (containmentRoot && !withinProject(path, containmentRoot)) return null;
 
   // Indexing creates the file node and its symbols with hashes and spans, which
   // is what makes the claim checkable later.

--- a/integrations/cline/hooks/token-optimizer/lib/harvest-write.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/harvest-write.mjs
@@ -25,11 +25,13 @@
 
 import {
   putNodeWithEdges, load, nodeId, sharedDir, isSharedDir, putNode, putEdge,
+  unrootedRoot,
 } from './wiki.mjs';
 import { indexFile } from './staleness.mjs';
 import { symbolKey } from './symbols.mjs';
 import { canonicalPath } from './paths.mjs';
 import { randomBytes } from 'node:crypto';
+import { homedir } from 'node:os';
 import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
 
 /**
@@ -324,7 +326,15 @@ function resolveAnchor(dir, anchor, projectRoot) {
   // that file into .token-optimizer and serve it back on the next touch. The
   // findings come from a model reading a transcript, so the paths are not
   // trusted input.
-  if (projectRoot && !withinProject(path, projectRoot)) return null;
+  //
+  // The unrooted bucket is a storage location, not a project: nothing on disk
+  // lives inside ~/.token-optimizer/unrooted, so using it as the containment
+  // root refused every anchor with no VCS ancestor -- dotfiles and machine-wide
+  // configs included. Home directory is the boundary that actually matches
+  // what an unrooted anchor looks like, and keeps the same protection.
+  const containmentRoot =
+    projectRoot === unrootedRoot() ? homedir() : projectRoot;
+  if (containmentRoot && !withinProject(path, containmentRoot)) return null;
 
   // Indexing creates the file node and its symbols with hashes and spans, which
   // is what makes the claim checkable later.

--- a/integrations/codex/hooks/lib/harvest-write.mjs
+++ b/integrations/codex/hooks/lib/harvest-write.mjs
@@ -25,11 +25,13 @@
 
 import {
   putNodeWithEdges, load, nodeId, sharedDir, isSharedDir, putNode, putEdge,
+  unrootedRoot,
 } from './wiki.mjs';
 import { indexFile } from './staleness.mjs';
 import { symbolKey } from './symbols.mjs';
 import { canonicalPath } from './paths.mjs';
 import { randomBytes } from 'node:crypto';
+import { homedir } from 'node:os';
 import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
 
 /**
@@ -324,7 +326,15 @@ function resolveAnchor(dir, anchor, projectRoot) {
   // that file into .token-optimizer and serve it back on the next touch. The
   // findings come from a model reading a transcript, so the paths are not
   // trusted input.
-  if (projectRoot && !withinProject(path, projectRoot)) return null;
+  //
+  // The unrooted bucket is a storage location, not a project: nothing on disk
+  // lives inside ~/.token-optimizer/unrooted, so using it as the containment
+  // root refused every anchor with no VCS ancestor -- dotfiles and machine-wide
+  // configs included. Home directory is the boundary that actually matches
+  // what an unrooted anchor looks like, and keeps the same protection.
+  const containmentRoot =
+    projectRoot === unrootedRoot() ? homedir() : projectRoot;
+  if (containmentRoot && !withinProject(path, containmentRoot)) return null;
 
   // Indexing creates the file node and its symbols with hashes and spans, which
   // is what makes the claim checkable later.

--- a/integrations/codex/plugin/hooks/lib/harvest-write.mjs
+++ b/integrations/codex/plugin/hooks/lib/harvest-write.mjs
@@ -25,11 +25,13 @@
 
 import {
   putNodeWithEdges, load, nodeId, sharedDir, isSharedDir, putNode, putEdge,
+  unrootedRoot,
 } from './wiki.mjs';
 import { indexFile } from './staleness.mjs';
 import { symbolKey } from './symbols.mjs';
 import { canonicalPath } from './paths.mjs';
 import { randomBytes } from 'node:crypto';
+import { homedir } from 'node:os';
 import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
 
 /**
@@ -324,7 +326,15 @@ function resolveAnchor(dir, anchor, projectRoot) {
   // that file into .token-optimizer and serve it back on the next touch. The
   // findings come from a model reading a transcript, so the paths are not
   // trusted input.
-  if (projectRoot && !withinProject(path, projectRoot)) return null;
+  //
+  // The unrooted bucket is a storage location, not a project: nothing on disk
+  // lives inside ~/.token-optimizer/unrooted, so using it as the containment
+  // root refused every anchor with no VCS ancestor -- dotfiles and machine-wide
+  // configs included. Home directory is the boundary that actually matches
+  // what an unrooted anchor looks like, and keeps the same protection.
+  const containmentRoot =
+    projectRoot === unrootedRoot() ? homedir() : projectRoot;
+  if (containmentRoot && !withinProject(path, containmentRoot)) return null;
 
   // Indexing creates the file node and its symbols with hashes and spans, which
   // is what makes the claim checkable later.

--- a/integrations/copilot/.github/hooks/lib/harvest-write.mjs
+++ b/integrations/copilot/.github/hooks/lib/harvest-write.mjs
@@ -25,11 +25,13 @@
 
 import {
   putNodeWithEdges, load, nodeId, sharedDir, isSharedDir, putNode, putEdge,
+  unrootedRoot,
 } from './wiki.mjs';
 import { indexFile } from './staleness.mjs';
 import { symbolKey } from './symbols.mjs';
 import { canonicalPath } from './paths.mjs';
 import { randomBytes } from 'node:crypto';
+import { homedir } from 'node:os';
 import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
 
 /**
@@ -324,7 +326,15 @@ function resolveAnchor(dir, anchor, projectRoot) {
   // that file into .token-optimizer and serve it back on the next touch. The
   // findings come from a model reading a transcript, so the paths are not
   // trusted input.
-  if (projectRoot && !withinProject(path, projectRoot)) return null;
+  //
+  // The unrooted bucket is a storage location, not a project: nothing on disk
+  // lives inside ~/.token-optimizer/unrooted, so using it as the containment
+  // root refused every anchor with no VCS ancestor -- dotfiles and machine-wide
+  // configs included. Home directory is the boundary that actually matches
+  // what an unrooted anchor looks like, and keeps the same protection.
+  const containmentRoot =
+    projectRoot === unrootedRoot() ? homedir() : projectRoot;
+  if (containmentRoot && !withinProject(path, containmentRoot)) return null;
 
   // Indexing creates the file node and its symbols with hashes and spans, which
   // is what makes the claim checkable later.

--- a/integrations/cursor/hooks/lib/harvest-write.mjs
+++ b/integrations/cursor/hooks/lib/harvest-write.mjs
@@ -25,11 +25,13 @@
 
 import {
   putNodeWithEdges, load, nodeId, sharedDir, isSharedDir, putNode, putEdge,
+  unrootedRoot,
 } from './wiki.mjs';
 import { indexFile } from './staleness.mjs';
 import { symbolKey } from './symbols.mjs';
 import { canonicalPath } from './paths.mjs';
 import { randomBytes } from 'node:crypto';
+import { homedir } from 'node:os';
 import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
 
 /**
@@ -324,7 +326,15 @@ function resolveAnchor(dir, anchor, projectRoot) {
   // that file into .token-optimizer and serve it back on the next touch. The
   // findings come from a model reading a transcript, so the paths are not
   // trusted input.
-  if (projectRoot && !withinProject(path, projectRoot)) return null;
+  //
+  // The unrooted bucket is a storage location, not a project: nothing on disk
+  // lives inside ~/.token-optimizer/unrooted, so using it as the containment
+  // root refused every anchor with no VCS ancestor -- dotfiles and machine-wide
+  // configs included. Home directory is the boundary that actually matches
+  // what an unrooted anchor looks like, and keeps the same protection.
+  const containmentRoot =
+    projectRoot === unrootedRoot() ? homedir() : projectRoot;
+  if (containmentRoot && !withinProject(path, containmentRoot)) return null;
 
   // Indexing creates the file node and its symbols with hashes and spans, which
   // is what makes the claim checkable later.

--- a/integrations/gemini/hooks/lib/harvest-write.mjs
+++ b/integrations/gemini/hooks/lib/harvest-write.mjs
@@ -25,11 +25,13 @@
 
 import {
   putNodeWithEdges, load, nodeId, sharedDir, isSharedDir, putNode, putEdge,
+  unrootedRoot,
 } from './wiki.mjs';
 import { indexFile } from './staleness.mjs';
 import { symbolKey } from './symbols.mjs';
 import { canonicalPath } from './paths.mjs';
 import { randomBytes } from 'node:crypto';
+import { homedir } from 'node:os';
 import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
 
 /**
@@ -324,7 +326,15 @@ function resolveAnchor(dir, anchor, projectRoot) {
   // that file into .token-optimizer and serve it back on the next touch. The
   // findings come from a model reading a transcript, so the paths are not
   // trusted input.
-  if (projectRoot && !withinProject(path, projectRoot)) return null;
+  //
+  // The unrooted bucket is a storage location, not a project: nothing on disk
+  // lives inside ~/.token-optimizer/unrooted, so using it as the containment
+  // root refused every anchor with no VCS ancestor -- dotfiles and machine-wide
+  // configs included. Home directory is the boundary that actually matches
+  // what an unrooted anchor looks like, and keeps the same protection.
+  const containmentRoot =
+    projectRoot === unrootedRoot() ? homedir() : projectRoot;
+  if (containmentRoot && !withinProject(path, containmentRoot)) return null;
 
   // Indexing creates the file node and its symbols with hashes and spans, which
   // is what makes the claim checkable later.

--- a/integrations/kilo/hooks/lib/harvest-write.mjs
+++ b/integrations/kilo/hooks/lib/harvest-write.mjs
@@ -25,11 +25,13 @@
 
 import {
   putNodeWithEdges, load, nodeId, sharedDir, isSharedDir, putNode, putEdge,
+  unrootedRoot,
 } from './wiki.mjs';
 import { indexFile } from './staleness.mjs';
 import { symbolKey } from './symbols.mjs';
 import { canonicalPath } from './paths.mjs';
 import { randomBytes } from 'node:crypto';
+import { homedir } from 'node:os';
 import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
 
 /**
@@ -324,7 +326,15 @@ function resolveAnchor(dir, anchor, projectRoot) {
   // that file into .token-optimizer and serve it back on the next touch. The
   // findings come from a model reading a transcript, so the paths are not
   // trusted input.
-  if (projectRoot && !withinProject(path, projectRoot)) return null;
+  //
+  // The unrooted bucket is a storage location, not a project: nothing on disk
+  // lives inside ~/.token-optimizer/unrooted, so using it as the containment
+  // root refused every anchor with no VCS ancestor -- dotfiles and machine-wide
+  // configs included. Home directory is the boundary that actually matches
+  // what an unrooted anchor looks like, and keeps the same protection.
+  const containmentRoot =
+    projectRoot === unrootedRoot() ? homedir() : projectRoot;
+  if (containmentRoot && !withinProject(path, containmentRoot)) return null;
 
   // Indexing creates the file node and its symbols with hashes and spans, which
   // is what makes the claim checkable later.

--- a/integrations/opencode/hooks/lib/harvest-write.mjs
+++ b/integrations/opencode/hooks/lib/harvest-write.mjs
@@ -25,11 +25,13 @@
 
 import {
   putNodeWithEdges, load, nodeId, sharedDir, isSharedDir, putNode, putEdge,
+  unrootedRoot,
 } from './wiki.mjs';
 import { indexFile } from './staleness.mjs';
 import { symbolKey } from './symbols.mjs';
 import { canonicalPath } from './paths.mjs';
 import { randomBytes } from 'node:crypto';
+import { homedir } from 'node:os';
 import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
 
 /**
@@ -324,7 +326,15 @@ function resolveAnchor(dir, anchor, projectRoot) {
   // that file into .token-optimizer and serve it back on the next touch. The
   // findings come from a model reading a transcript, so the paths are not
   // trusted input.
-  if (projectRoot && !withinProject(path, projectRoot)) return null;
+  //
+  // The unrooted bucket is a storage location, not a project: nothing on disk
+  // lives inside ~/.token-optimizer/unrooted, so using it as the containment
+  // root refused every anchor with no VCS ancestor -- dotfiles and machine-wide
+  // configs included. Home directory is the boundary that actually matches
+  // what an unrooted anchor looks like, and keeps the same protection.
+  const containmentRoot =
+    projectRoot === unrootedRoot() ? homedir() : projectRoot;
+  if (containmentRoot && !withinProject(path, containmentRoot)) return null;
 
   // Indexing creates the file node and its symbols with hashes and spans, which
   // is what makes the claim checkable later.

--- a/integrations/qwen/hooks/lib/harvest-write.mjs
+++ b/integrations/qwen/hooks/lib/harvest-write.mjs
@@ -25,11 +25,13 @@
 
 import {
   putNodeWithEdges, load, nodeId, sharedDir, isSharedDir, putNode, putEdge,
+  unrootedRoot,
 } from './wiki.mjs';
 import { indexFile } from './staleness.mjs';
 import { symbolKey } from './symbols.mjs';
 import { canonicalPath } from './paths.mjs';
 import { randomBytes } from 'node:crypto';
+import { homedir } from 'node:os';
 import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
 
 /**
@@ -324,7 +326,15 @@ function resolveAnchor(dir, anchor, projectRoot) {
   // that file into .token-optimizer and serve it back on the next touch. The
   // findings come from a model reading a transcript, so the paths are not
   // trusted input.
-  if (projectRoot && !withinProject(path, projectRoot)) return null;
+  //
+  // The unrooted bucket is a storage location, not a project: nothing on disk
+  // lives inside ~/.token-optimizer/unrooted, so using it as the containment
+  // root refused every anchor with no VCS ancestor -- dotfiles and machine-wide
+  // configs included. Home directory is the boundary that actually matches
+  // what an unrooted anchor looks like, and keeps the same protection.
+  const containmentRoot =
+    projectRoot === unrootedRoot() ? homedir() : projectRoot;
+  if (containmentRoot && !withinProject(path, containmentRoot)) return null;
 
   // Indexing creates the file node and its symbols with hashes and spans, which
   // is what makes the claim checkable later.

--- a/integrations/windsurf/hooks/lib/harvest-write.mjs
+++ b/integrations/windsurf/hooks/lib/harvest-write.mjs
@@ -25,11 +25,13 @@
 
 import {
   putNodeWithEdges, load, nodeId, sharedDir, isSharedDir, putNode, putEdge,
+  unrootedRoot,
 } from './wiki.mjs';
 import { indexFile } from './staleness.mjs';
 import { symbolKey } from './symbols.mjs';
 import { canonicalPath } from './paths.mjs';
 import { randomBytes } from 'node:crypto';
+import { homedir } from 'node:os';
 import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
 
 /**
@@ -324,7 +326,15 @@ function resolveAnchor(dir, anchor, projectRoot) {
   // that file into .token-optimizer and serve it back on the next touch. The
   // findings come from a model reading a transcript, so the paths are not
   // trusted input.
-  if (projectRoot && !withinProject(path, projectRoot)) return null;
+  //
+  // The unrooted bucket is a storage location, not a project: nothing on disk
+  // lives inside ~/.token-optimizer/unrooted, so using it as the containment
+  // root refused every anchor with no VCS ancestor -- dotfiles and machine-wide
+  // configs included. Home directory is the boundary that actually matches
+  // what an unrooted anchor looks like, and keeps the same protection.
+  const containmentRoot =
+    projectRoot === unrootedRoot() ? homedir() : projectRoot;
+  if (containmentRoot && !withinProject(path, containmentRoot)) return null;
 
   // Indexing creates the file node and its symbols with hashes and spans, which
   // is what makes the claim checkable later.

--- a/plugin/hooks/lib/harvest-write.mjs
+++ b/plugin/hooks/lib/harvest-write.mjs
@@ -25,11 +25,13 @@
 
 import {
   putNodeWithEdges, load, nodeId, sharedDir, isSharedDir, putNode, putEdge,
+  unrootedRoot,
 } from './wiki.mjs';
 import { indexFile } from './staleness.mjs';
 import { symbolKey } from './symbols.mjs';
 import { canonicalPath } from './paths.mjs';
 import { randomBytes } from 'node:crypto';
+import { homedir } from 'node:os';
 import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
 
 /**
@@ -324,7 +326,15 @@ function resolveAnchor(dir, anchor, projectRoot) {
   // that file into .token-optimizer and serve it back on the next touch. The
   // findings come from a model reading a transcript, so the paths are not
   // trusted input.
-  if (projectRoot && !withinProject(path, projectRoot)) return null;
+  //
+  // The unrooted bucket is a storage location, not a project: nothing on disk
+  // lives inside ~/.token-optimizer/unrooted, so using it as the containment
+  // root refused every anchor with no VCS ancestor -- dotfiles and machine-wide
+  // configs included. Home directory is the boundary that actually matches
+  // what an unrooted anchor looks like, and keeps the same protection.
+  const containmentRoot =
+    projectRoot === unrootedRoot() ? homedir() : projectRoot;
+  if (containmentRoot && !withinProject(path, containmentRoot)) return null;
 
   // Indexing creates the file node and its symbols with hashes and spans, which
   // is what makes the claim checkable later.

--- a/tests/hooks/wiki-write-unrooted-anchor.test.mjs
+++ b/tests/hooks/wiki-write-unrooted-anchor.test.mjs
@@ -1,0 +1,73 @@
+/**
+ * Regression for wiki_write refusing anchors with no VCS ancestor.
+ *
+ * projectRootFor() falls back to unrootedRoot() -- a storage bucket, not a
+ * real directory anything lives inside -- when no .git/.hg/.svn marker
+ * exists above the anchor. resolveAnchor() used to pass that same bucket
+ * straight into the containment check, so no anchor outside a repo could
+ * ever resolve, not because the file was missing but because nothing on
+ * disk sits inside the bucket path it was compared against. Home directory
+ * is the boundary that actually matches what an unrooted anchor looks like.
+ */
+import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir, homedir } from 'os';
+
+import { wikiDir, projectRootFor, unrootedRoot } from '../../hooks-core/wiki.mjs';
+import { writeHarvested } from '../../hooks-core/harvest-write.mjs';
+import { ORIGIN_AGENT } from '../../hooks-core/curate.mjs';
+
+let priorUnrootedDir, unrootedDir, homeWorkspace, outsideWorkspace;
+
+beforeEach(() => {
+  priorUnrootedDir = process.env.TOKEN_OPTIMIZER_UNROOTED_DIR;
+  unrootedDir = mkdtempSync(join(tmpdir(), 'wiki-write-unrooted-'));
+  process.env.TOKEN_OPTIMIZER_UNROOTED_DIR = unrootedDir;
+});
+
+afterEach(() => {
+  if (priorUnrootedDir === undefined) delete process.env.TOKEN_OPTIMIZER_UNROOTED_DIR;
+  else process.env.TOKEN_OPTIMIZER_UNROOTED_DIR = priorUnrootedDir;
+  for (const d of [unrootedDir, homeWorkspace, outsideWorkspace]) {
+    if (d) try { rmSync(d, { recursive: true, force: true }); } catch { /* windows lock */ }
+  }
+  homeWorkspace = undefined;
+  outsideWorkspace = undefined;
+});
+
+describe('anchors with no VCS ancestor', () => {
+  test('one under the home directory resolves', () => {
+    homeWorkspace = mkdtempSync(join(homedir(), '.token-optimizer-harvest-test-'));
+    const anchor = join(homeWorkspace, 'config.json');
+    writeFileSync(anchor, '{}\n');
+
+    const project = projectRootFor(anchor, process.cwd());
+    expect(project).toBe(unrootedRoot());
+
+    const keys = writeHarvested(
+      wikiDir(project),
+      [{ type: 'finding', claim: 'A home config file with no VCS ancestor is anchorable.',
+         confidence: 0.9, anchors: [anchor] }],
+      { sessionId: null, origin: ORIGIN_AGENT, projectRoot: project }
+    );
+    expect(keys.length).toBe(1);
+  });
+
+  test('one outside the home directory still stays refused', () => {
+    outsideWorkspace = mkdtempSync(join(tmpdir(), 'wiki-write-outside-home-'));
+    const anchor = join(outsideWorkspace, 'secret.txt');
+    writeFileSync(anchor, 'not under home\n');
+
+    const project = projectRootFor(anchor, process.cwd());
+    expect(project).toBe(unrootedRoot());
+
+    const keys = writeHarvested(
+      wikiDir(project),
+      [{ type: 'finding', claim: 'A file with no VCS ancestor and outside home stays refused.',
+         confidence: 0.9, anchors: [anchor] }],
+      { sessionId: null, origin: ORIGIN_AGENT, projectRoot: project }
+    );
+    expect(keys.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Description
`wiki_write` refuses any anchor with no VCS ancestor (dotfiles, machine-wide configs) with a misleading "no anchor resolved to a file on disk" error, even when the file exists. `resolveAnchor()`'s containment check compares the anchor against `unrootedRoot()`, a storage bucket nothing on disk actually lives inside, so the prefix test always fails. Fixed by using `homedir()` as the containment boundary for that case only — same protection, correct boundary. Also documents the `TOKEN_OPTIMIZER_MCP_CAPABILITIES` escape hatch in the Claude Code README section, since enforcement silently stays near-inert without it (Claude Code's hook payload carries no tool-inventory field for the registration proof).

## Type of Change
- [x] 🐛 Bug fix
- [x] 📝 Documentation update
- [x] ✅ Test update

## Changes Made
- `resolveAnchor()`: use `homedir()` as containment root when `projectRoot` is the unrooted bucket
- Regression tests in `tests/hooks/wiki-write-unrooted-anchor.test.mjs`
- README: note on `TOKEN_OPTIMIZER_MCP_CAPABILITIES` for Claude Code

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed
- [x] All tests passing locally

## Commit Message Convention
- [x] Commit messages follow conventional commits format