### PR TITLE
fix(dashboard): repair wiki route and plugin activity status

### DIFF
--- a/integrations/cline/hooks/token-optimizer/lib/observability.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/observability.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 /**
  * Privacy-safe, cross-client lifecycle diagnostics.
  *

--- a/integrations/cline/hooks/token-optimizer/post-tool.mjs
+++ b/integrations/cline/hooks/token-optimizer/post-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/cline/hooks/token-optimizer/pre-tool.mjs
+++ b/integrations/cline/hooks/token-optimizer/pre-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/cline/hooks/token-optimizer/session-start.mjs
+++ b/integrations/cline/hooks/token-optimizer/session-start.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/codex/hooks/lib/observability.mjs
+++ b/integrations/codex/hooks/lib/observability.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 /**
  * Privacy-safe, cross-client lifecycle diagnostics.
  *

--- a/integrations/codex/hooks/post-tool.mjs
+++ b/integrations/codex/hooks/post-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/codex/hooks/pre-tool.mjs
+++ b/integrations/codex/hooks/pre-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/codex/hooks/session-start.mjs
+++ b/integrations/codex/hooks/session-start.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/codex/hooks/stop.mjs
+++ b/integrations/codex/hooks/stop.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/codex/plugin/hooks/lib/observability.mjs
+++ b/integrations/codex/plugin/hooks/lib/observability.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 /**
  * Privacy-safe, cross-client lifecycle diagnostics.
  *

--- a/integrations/codex/plugin/hooks/post-tool.mjs
+++ b/integrations/codex/plugin/hooks/post-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/codex/plugin/hooks/pre-tool.mjs
+++ b/integrations/codex/plugin/hooks/pre-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/codex/plugin/hooks/session-start.mjs
+++ b/integrations/codex/plugin/hooks/session-start.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/codex/plugin/hooks/stop.mjs
+++ b/integrations/codex/plugin/hooks/stop.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/copilot/.github/hooks/lib/observability.mjs
+++ b/integrations/copilot/.github/hooks/lib/observability.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 /**
  * Privacy-safe, cross-client lifecycle diagnostics.
  *

--- a/integrations/copilot/.github/hooks/post-tool.mjs
+++ b/integrations/copilot/.github/hooks/post-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/copilot/.github/hooks/pre-tool.mjs
+++ b/integrations/copilot/.github/hooks/pre-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/copilot/.github/hooks/session-start.mjs
+++ b/integrations/copilot/.github/hooks/session-start.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/copilot/.github/hooks/stop.mjs
+++ b/integrations/copilot/.github/hooks/stop.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/cursor/hooks/lib/observability.mjs
+++ b/integrations/cursor/hooks/lib/observability.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 /**
  * Privacy-safe, cross-client lifecycle diagnostics.
  *

--- a/integrations/cursor/hooks/post-tool.mjs
+++ b/integrations/cursor/hooks/post-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/cursor/hooks/pre-tool.mjs
+++ b/integrations/cursor/hooks/pre-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/cursor/hooks/session-start.mjs
+++ b/integrations/cursor/hooks/session-start.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/cursor/hooks/stop.mjs
+++ b/integrations/cursor/hooks/stop.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/gemini/hooks/lib/observability.mjs
+++ b/integrations/gemini/hooks/lib/observability.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 /**
  * Privacy-safe, cross-client lifecycle diagnostics.
  *

--- a/integrations/gemini/hooks/post-tool.mjs
+++ b/integrations/gemini/hooks/post-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/gemini/hooks/pre-tool.mjs
+++ b/integrations/gemini/hooks/pre-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/gemini/hooks/session-start.mjs
+++ b/integrations/gemini/hooks/session-start.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/gemini/hooks/stop.mjs
+++ b/integrations/gemini/hooks/stop.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/kilo/hooks/lib/observability.mjs
+++ b/integrations/kilo/hooks/lib/observability.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 /**
  * Privacy-safe, cross-client lifecycle diagnostics.
  *

--- a/integrations/kilo/hooks/post-tool.mjs
+++ b/integrations/kilo/hooks/post-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/kilo/hooks/pre-tool.mjs
+++ b/integrations/kilo/hooks/pre-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/kilo/hooks/session-start.mjs
+++ b/integrations/kilo/hooks/session-start.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/opencode/hooks/lib/observability.mjs
+++ b/integrations/opencode/hooks/lib/observability.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 /**
  * Privacy-safe, cross-client lifecycle diagnostics.
  *

--- a/integrations/opencode/hooks/post-tool.mjs
+++ b/integrations/opencode/hooks/post-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/opencode/hooks/pre-tool.mjs
+++ b/integrations/opencode/hooks/pre-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/opencode/hooks/session-start.mjs
+++ b/integrations/opencode/hooks/session-start.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/qwen/hooks/lib/observability.mjs
+++ b/integrations/qwen/hooks/lib/observability.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 /**
  * Privacy-safe, cross-client lifecycle diagnostics.
  *

--- a/integrations/qwen/hooks/post-tool.mjs
+++ b/integrations/qwen/hooks/post-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/qwen/hooks/pre-tool.mjs
+++ b/integrations/qwen/hooks/pre-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/qwen/hooks/session-start.mjs
+++ b/integrations/qwen/hooks/session-start.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/qwen/hooks/stop.mjs
+++ b/integrations/qwen/hooks/stop.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/windsurf/hooks/lib/observability.mjs
+++ b/integrations/windsurf/hooks/lib/observability.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 /**
  * Privacy-safe, cross-client lifecycle diagnostics.
  *

--- a/integrations/windsurf/hooks/post-tool.mjs
+++ b/integrations/windsurf/hooks/post-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/windsurf/hooks/pre-tool.mjs
+++ b/integrations/windsurf/hooks/pre-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/plugin/hooks/lib/observability.mjs
+++ b/plugin/hooks/lib/observability.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 /**
  * Privacy-safe, cross-client lifecycle diagnostics.
  *

--- a/plugin/hooks/post-tool.mjs
+++ b/plugin/hooks/post-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/plugin/hooks/stop.mjs
+++ b/plugin/hooks/stop.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/src/dashboard/public/js/dashboard.js
+++ b/src/dashboard/public/js/dashboard.js
@@ -848,10 +848,10 @@ function renderKpis(s) {
   if (!s) {
     host.innerHTML =
       '<div class="card empty-span"><div class="empty is-compact"><div class="mark">◔</div>' +
-      '<h3>No active session</h3>' +
-      '<p>These fill in while you are working in a supported coding agent. The savings above ' +
+      '<h3>No recent agent activity</h3>' +
+      '<p>These fill in from cross-client lifecycle telemetry while you are working in a supported coding agent. The savings above ' +
       'are kept per project, so they stay accurate between sessions.</p>' +
-      '<p class="next">Start a session, then refresh.</p></div></div>';
+      '<p class="next">Run an agent action, then refresh.</p></div></div>';
     return;
   }
 
@@ -869,7 +869,7 @@ function renderKpis(s) {
             tip: 'Pre-tool actions observed by the cross-client hook protocol during the last 24 hours.',
           },
           {
-            label: 'CLI clients active',
+            label: 'CLI clients observed',
             value: fmt(s.activeClients),
             tip: 'Distinct CLI clients that emitted lifecycle telemetry during the last 24 hours.',
           },

--- a/src/server/web-server.ts
+++ b/src/server/web-server.ts
@@ -32,7 +32,7 @@ import {
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-const app = express();
+export const app = express();
 // Configurable because 3100 is a popular port and a collision is silent: the
 // second server fails to bind while the FIRST one keeps answering, so anything
 // probing the port gets stale results from a process it did not start. The UI
@@ -60,10 +60,18 @@ const limiter = rateLimit({
 app.use(limiter);
 app.use(cors());
 app.use(express.json());
-app.use(express.static(path.join(__dirname, '..', 'dashboard', 'public')));
+const dashboardPublicDirectory = path.join(
+  __dirname,
+  '..',
+  'dashboard',
+  'public'
+);
+app.use(express.static(dashboardPublicDirectory));
 
-// Helper function to get hooks data path
-function getHooksDataPath(): string {
+// Compatibility storage used only by the legacy Claude hook/session APIs.
+// Current plugin activity is read from the cross-client diagnostic ledger by
+// /api/diagnostics/hooks; it must never depend on this install-specific path.
+function getLegacyClaudeHooksDataPath(): string {
   return path.join(os.homedir(), '.claude-global', 'hooks', 'data');
 }
 
@@ -86,7 +94,7 @@ export { isValidSessionId } from '../utils/session-id.js';
 function resolveSessionLogPath(sessionId: string): string | null {
   if (!isValidSessionId(sessionId)) return null;
 
-  const base = path.resolve(getHooksDataPath());
+  const base = path.resolve(getLegacyClaudeHooksDataPath());
 
   // THE PATH IS BUILT FROM A DIRECTORY ENTRY, NOT FROM THE REQUEST.
   //
@@ -222,11 +230,13 @@ function splitCsvRow(line: string): string[] {
   return cells;
 }
 
-// Helper function to get current session ID
+// Legacy compatibility for callers of /api/session-summary and
+// /api/session-events. The dashboard's current activity cards use the
+// cross-client diagnostic ledger instead.
 function getCurrentSessionId(): string | null {
   try {
     const sessionFilePath = path.join(
-      getHooksDataPath(),
+      getLegacyClaudeHooksDataPath(),
       'current-session.txt'
     );
     if (!fs.existsSync(sessionFilePath)) {
@@ -638,14 +648,17 @@ app.get('/api/health', (_req, res) => {
 registerWikiRoutes(app);
 registerUcrRoutes(app);
 
-// Serve the wiki graph browser.
+// Serve the wiki graph browser through the same static middleware that already
+// serves /wiki.html reliably in globally installed packages. Express sendFile
+// returned a false 404 for this alias on the reported macOS npm installation
+// even though the resolved file existed; redirecting keeps one serving path.
 app.get('/wiki', (_req, res) => {
-  res.sendFile(path.join(__dirname, '..', 'dashboard', 'public', 'wiki.html'));
+  res.redirect(302, '/wiki.html');
 });
 
 // Serve index.html for root route
 app.get('/', (_req, res) => {
-  res.sendFile(path.join(__dirname, '..', 'dashboard', 'public', 'index.html'));
+  res.sendFile(path.join(dashboardPublicDirectory, 'index.html'));
 });
 
 // Start server

--- a/tests/hooks/observability.test.mjs
+++ b/tests/hooks/observability.test.mjs
@@ -12,6 +12,9 @@ import {
 } from '../../hooks-core/observability.mjs';
 
 const ROOT = process.cwd();
+const PACKAGE_VERSION = JSON.parse(
+  readFileSync(join(ROOT, 'package.json'), 'utf8')
+).version;
 let workspace;
 let previous;
 
@@ -229,7 +232,7 @@ describe('cross-client hook observability', () => {
     const [event] = readEventsFrom(join(workspace, 'claude-logs'));
     expect(event).toMatchObject({
       schemaVersion: 2,
-      serviceVersion: '5.7.0',
+      serviceVersion: PACKAGE_VERSION,
       client: 'claude-code',
       hookEvent: 'pre-tool',
       outcome: 'timeout',
@@ -287,7 +290,7 @@ describe('cross-client hook observability', () => {
       expect(event).toMatchObject({
       schemaVersion: 2,
         service: 'token-optimizer',
-        serviceVersion: '5.7.0',
+        serviceVersion: PACKAGE_VERSION,
         client,
         hookEvent: 'pre-tool',
         outcome: 'success',

--- a/tests/unit/dashboard-web-server.test.ts
+++ b/tests/unit/dashboard-web-server.test.ts
@@ -1,0 +1,100 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+} from '@jest/globals';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { AddressInfo } from 'node:net';
+import type { Server } from 'node:http';
+import { app } from '../../src/server/web-server.js';
+
+let server: Server;
+let baseUrl: string;
+let temporaryDirectory: string | null = null;
+const originalLogDirectory = process.env.TOKEN_OPTIMIZER_LOG_DIR;
+
+beforeAll(async () => {
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, '127.0.0.1', () => {
+      const address = server.address() as AddressInfo;
+      baseUrl = `http://127.0.0.1:${address.port}`;
+      resolve();
+    });
+  });
+});
+
+afterEach(() => {
+  if (originalLogDirectory === undefined)
+    delete process.env.TOKEN_OPTIMIZER_LOG_DIR;
+  else process.env.TOKEN_OPTIMIZER_LOG_DIR = originalLogDirectory;
+
+  if (temporaryDirectory) {
+    rmSync(temporaryDirectory, { recursive: true, force: true });
+    temporaryDirectory = null;
+  }
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+describe('dashboard web routes', () => {
+  it('serves the extensionless wiki route through the working static asset path', async () => {
+    const alias = await fetch(`${baseUrl}/wiki`, { redirect: 'manual' });
+
+    expect(alias.status).toBe(302);
+    expect(alias.headers.get('location')).toBe('/wiki.html');
+
+    const page = await fetch(new URL(alias.headers.get('location')!, baseUrl));
+    expect(page.status).toBe(200);
+    expect(await page.text()).toContain(
+      '<title>What it knows &middot; Token Optimizer</title>'
+    );
+  });
+
+  it('reports Claude Code plugin activity from the cross-client ledger', async () => {
+    temporaryDirectory = mkdtempSync(
+      join(tmpdir(), 'token-optimizer-dashboard-')
+    );
+    const logDirectory = join(temporaryDirectory, 'logs');
+    mkdirSync(logDirectory);
+    process.env.TOKEN_OPTIMIZER_LOG_DIR = logDirectory;
+    writeFileSync(
+      join(logDirectory, 'hook-events-2026-08-25.jsonl'),
+      `${JSON.stringify({
+        schemaVersion: 2,
+        timestamp: new Date().toISOString(),
+        event: 'hook.completed',
+        invocationId: 'claude-plugin-invocation',
+        client: 'claude-code',
+        hookEvent: 'pre-tool',
+        toolName: 'Read',
+        outcome: 'success',
+        durationMs: 12,
+      })}\n`,
+      'utf8'
+    );
+
+    const response = await fetch(
+      `${baseUrl}/api/diagnostics/hooks?hours=1&limit=10`
+    );
+    const report = (await response.json()) as {
+      summary: {
+        available: boolean;
+        actions: number;
+        byClient: Record<string, { total: number }>;
+      };
+    };
+
+    expect(response.status).toBe(200);
+    expect(report.summary).toMatchObject({ available: true, actions: 1 });
+    expect(report.summary.byClient['claude-code']).toMatchObject({ total: 1 });
+  });
+});


### PR DESCRIPTION
## Outcome

The dashboard now opens the knowledge view from the extensionless `/wiki` navigation link in globally installed packages, and the activity cards explicitly use cross-client lifecycle telemetry rather than presenting the legacy Claude session marker as the current source.

## Changes

- Redirect `/wiki` to the proven static `/wiki.html` asset path instead of calling the failing explicit `sendFile` alias.
- Export the Express app and add HTTP-level regressions for the redirect, shipped wiki asset, and Claude Code plugin activity ledger.
- Relabel the 24-hour activity cards accurately as recent/observed activity.
- Keep `~/.claude-global/hooks/data` isolated to legacy session-summary compatibility and document that boundary.
- Repair the 5.7.1 release baseline's generated hook-version drift; all generated changes are produced by `npm run sync:hooks` and only update `5.7.0` to `5.7.1`.
- Make observability assertions follow the package version so the next release bump cannot recreate that drift failure.

## Verification

- Full Jest: 209/209 suites passed; 2,444 passed, 5 skipped, 0 failed.
- Browser dashboard verification: 55/55 checks passed, including `/wiki` navigation and zero console/page errors.
- Build passed.
- Package validation passed with no warnings.
- Generated hook/config/pin sync passed.
- ESLint passed with 0 errors (existing warning baseline only).
- Prettier and `git diff --check` passed.

Fixes #311