### PR TITLE
fix(wiki): connect the knowledge graph's declared capabilities (#204, part 1 of 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,10 @@ The overview answers the questions a token optimizer should answer first:
    new agent re-derives work, call `wiki_read` for the project or the files it is
    about to touch. Native clients can also deliver matching knowledge
    automatically.
+   Use `wiki_query` to read the graph directly — one finding by key, a ranked
+   BM25 search over claims, a node with its neighbours, or the graph's own audit
+   — which is how a subagent that never sees the SessionStart briefing reaches
+   what previous sessions established.
 4. Open `http://localhost:3100`. Use **Overview** for combined accounting and
    **What it knows** for capture health, graph exploration, audits, and causal
    evidence.

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -1,6 +1,11 @@
 # Token Optimizer MCP - Complete Tool Reference
 
-This document provides comprehensive documentation for all 61 tools available in the Token Optimizer MCP server.
+This document documents 62 tools of the Token Optimizer MCP server. It is not
+the complete advertised set: the server also exposes tools that are not covered
+here, including `wiki_read`, `wiki_write`, `expand`, `waste_audit`, `cache_audit`,
+`model_routing`, `token_audit`, `install_doctor`, `fleet_audit` and
+`get_optimization_report`. The authoritative list of what a given profile
+advertises is `CORE_TOOL_NAMES` in `src/server/tool-profile.ts`.
 
 ## Table of Contents
 
@@ -11,6 +16,7 @@ This document provides comprehensive documentation for all 61 tools available in
 - [Advanced Caching](#advanced-caching) (10 tools)
 - [Monitoring & Dashboards](#monitoring--dashboards) (7 tools)
 - [System Operations](#system-operations) (6 tools)
+- [Project Knowledge Graph](#project-knowledge-graph) (1 tool)
 
 ---
 
@@ -1563,6 +1569,78 @@ optimize_session({
   sessionId: 'session-123',
   min_token_threshold: 100,
 });
+```
+
+---
+
+## Project Knowledge Graph
+
+### wiki_query
+
+Read the project's knowledge graph — the findings, decisions and dead ends the
+graph has accumulated (see [WIKI_GRAPH.md](./WIKI_GRAPH.md)). This is the escape
+hatch from the per-touch injection budget: anything the budget dropped is still
+reachable here.
+
+**Not for anchored retrieval.** To ask what is known about a particular file or
+symbol, use `wiki_read`, which does exactly that and is the tool the enforcement
+layer points at. `wiki_query` deliberately has no `anchor` operation.
+
+**What it can return depends on what the graph holds.** A default install builds
+the *structural* graph (files, symbols, tasks). Findings accrue only where the
+semantic harvest or a local model endpoint is configured, so on a fresh install
+`search` and `overview` can legitimately return nothing.
+
+**Parameters:**
+
+- `operation` (string, required) - One of `get`, `search`, `node`, `audit`, `balance`, `overview`
+- `key` (string, optional) - Finding key, for `operation: 'get'`
+- `query` (string, optional) - Search terms, for `operation: 'search'`
+- `type` (string, optional) - Restrict a search to one finding type: `finding`, `decision`, `failure`, `command`, `map`, `feedback`
+- `nodeId` (string, optional) - Node id, for `operation: 'node'`. Ids have the form `<kind>:<16 hex chars>`; take one from the `id` of a finding or node already returned
+- `limit` (number, optional) - Max rows returned (default: 20, capped at 100). Applies to `search` and to `node`'s neighbour list; `audit`, `balance` and `overview` ignore it
+- `graphDir` (string, optional) - Explicit graph directory. Normally omitted
+- `projectRoot` (string, optional) - Explicit project root. Normally omitted
+- `sessionId` (string, optional) - Recorded with the query event, so hit rate can be attributed to a session
+
+**Notes:**
+
+- `search` ranks with BM25 (`hooks-core/lexical.mjs`), the same primitive the
+  dashboard's `/api/wiki/search` uses. Query terms of 3+ characters also match by
+  prefix (`custom` finds `customer`), but **infix does not match** (`tomer` does
+  not find `customer`). A query that tokenizes to nothing falls through to the
+  unranked pool ordered by confidence x origin x pinned.
+- `get` and `search` serve findings through the staleness path, so a stale
+  finding arrives marked and, where the evidence survives, with the diff that
+  invalidated it.
+- Responses never carry file snapshots: every response is walked and snapshot
+  fields are stripped at the boundary.
+- Every call records a `query` metrics event, which is what earns the
+  session-start index its token allowance.
+
+**Example:**
+
+```typescript
+// get - one finding by key, served with any staleness marking
+wiki_query({ operation: 'get', key: 'auth-token-refresh-race' });
+
+// search - BM25-ranked findings matching terms, optionally one type only
+wiki_query({ operation: 'search', query: 'skip lib check', limit: 10 });
+wiki_query({ operation: 'search', query: 'retry backoff', type: 'failure' });
+
+// node - a node and its immediate neighbours. Node ids are
+// `<kind>:<16 hex chars>`, e.g. from the `id` of a finding returned above.
+wiki_query({ operation: 'node', nodeId: 'file:3f2a91c04b7d1e88' });
+
+// audit - findings needing attention (returns the whole audit; `limit` does
+// not apply to this operation)
+wiki_query({ operation: 'audit' });
+
+// balance - what the graph has cost and saved
+wiki_query({ operation: 'balance' });
+
+// overview - node counts, densest anchors, stale and total findings
+wiki_query({ operation: 'overview' });
 ```
 
 ---

--- a/docs/WIKI_GRAPH.md
+++ b/docs/WIKI_GRAPH.md
@@ -231,6 +231,9 @@ rather than rendering an empty diff as though nothing had changed.
 
 **Diffs are bounded three ways** — lines (40), characters per line (200), and
 total UTF-8 bytes (4,000) — and every truncation is announced in the output. The
+line bound covers the whole body, elision markers included, so the output is at
+most 40 lines plus one final notice when the byte cap dropped lines: 41 in the
+worst case, which is what the test asserts. The
 byte bound is not redundant with the line bound: with only the line cap in
 force, two 200,000-character single-line inputs produced 2 lines and 400,005
 bytes, and that output goes straight into model context

--- a/docs/WIKI_GRAPH.md
+++ b/docs/WIKI_GRAPH.md
@@ -64,11 +64,27 @@ differently:
 ### Edges
 
 `derived_from` (finding → file/symbol), `contains` (file → symbol), `imports`,
-`calls`, `supersedes`, `contradicts`, `answers`.
+`calls`, `supersedes`, `contradicts`, `answers`, and `related` — a weak,
+behaviour-derived edge between files worked on together, which is what gives
+traversal-only retrieval a semantic neighbourhood without an embedding model.
 
 `contradicts` is an edge rather than an overwrite on purpose: when a belief
 changes, the graph should record *that it changed and why*, not silently present
-the new one as if it had always been true.
+the new one as if it had always been true. It is written, and it is disclosed:
+a served finding that something disputes carries `contradicted: true` and, when
+the other end resolves to a node, `contradictedBy` naming its key
+(`hooks-core/staleness.mjs`, `disputeOf`). Dispute is tracked separately from
+staleness — a finding can be disputed without being stale, and stale without
+being disputed.
+
+`answers` links a finding back to the task that produced it. Its attribution is
+deliberately narrow: absent an explicit task id, the target is derived by
+session-scoped traversal that requires the task to have touched *every* one of
+the finding's anchors, and only when an authoritative session id is present.
+**It does not fire on a default install.** `wiki_write` never supplies an
+authoritative session id, so the model-invoked path never produces the edge; the
+only producer today is the harvest worker, which runs only when the semantic
+harvest is enabled (`hooks-core/harvest-write.mjs`).
 
 ## Harvest — structural free, semantic at boundaries
 
@@ -87,10 +103,48 @@ Model-invoked `wiki_write` exists for the agent to record something deliberately
 but nothing depends on it. The lesson of the enforcement redesign is that
 anything opt-in does not happen.
 
+**What a default install actually produces is the structural graph.** The
+semantic pass needs a model to call: it is off with no credential
+(`off:no-key`), runs against a local endpoint if one is configured, and is
+disabled outright by `TOKEN_OPTIMIZER_HARVEST=0` or `TOKEN_OPTIMIZER_MODE=off`
+(`hooks-core/harvest.mjs`, `harvestMode`). So findings — and everything that
+depends on them, including the `answers` edge and the hit-rate numbers below —
+accrue only where the harvest or a local model endpoint is in play. Nothing
+below should be read as describing verdicts that accrue on their own.
+
 ## Retrieval — traversal and lexical, no embeddings
 
-Retrieval is graph traversal plus BM25/keyword for fuzzy lookup. **No embedding
-model, no vector index.**
+Retrieval is graph traversal plus BM25 for fuzzy lookup. **No embedding model,
+no vector index.**
+
+BM25 is implemented in [`hooks-core/lexical.mjs`](../hooks-core/lexical.mjs) and
+is shared by both surfaces that search findings: the `wiki_query` tool's `search`
+operation and the dashboard's `/api/wiki/search` route. It replaced a substring
+`includes()` filter, which could not rank — and ranking is the whole value under
+a token budget, because the budget otherwise keeps whatever happened to match
+rather than what matched best.
+
+Three properties of that matching are worth stating exactly, because "lexical
+search" is easy to read as more than it is:
+
+- **Compound identifiers are split.** The tokenizer emits each alphanumeric run
+  whole *and* its camelCase / letter-digit parts, so `skipLibCheck` also yields
+  `skip`, `lib`, `check`, and `TS2345` also yields `ts`, `2345`.
+- **Query terms of three or more characters also match by prefix**, at a flat
+  sub-1.0 term-frequency credit so a prefix hit can never outscore an exact one.
+  `custom` finds `customer`; `skip` finds `skipLibCheck`.
+- **Infix does not match.** `tomer` does not find `customer`. That is a real
+  recall gap against the old substring filter, accepted rather than papered
+  over.
+
+A query that tokenizes to nothing — empty, whitespace, or punctuation only —
+does not return nothing. Both surfaces fall through to the unranked pool ordered
+by `confidence x origin weight x pinned`, so a blank search box and an omitted
+`query` argument both mean "no filter".
+
+One consequence to expect on the dashboard: `total` counts BM25-scored matches,
+and `rank` omits findings no query term matched at all, so it can be smaller
+than the count a substring filter would have reported for the same query.
 
 That is a deliberate trade. Embeddings would add semantic recall for findings
 with no structural path to the current work — and would reintroduce exactly the
@@ -111,17 +165,92 @@ what exists and can ask for it.
 and injects the findings anchored to it. The model receives what it previously
 spent 20k tokens deriving, for ~150 — *and never had to know to ask*.
 
-**A hard token budget per touch** (default ~500), ranked by `confidence x
-recency`, with everything else reachable through `wiki_query`. This bound is not
-a detail: without it, the most heavily-worked files accumulate the most findings
-and become the most expensive to touch, and the optimizer becomes its own token
+**A hard token budget per touch** (default 500 tokens,
+`TOKEN_OPTIMIZER_TOUCH_BUDGET`), ranked by `confidence x recency`, with
+everything else reachable through `wiki_query`. This bound is not a detail:
+without it, the most heavily-worked files accumulate the most findings and
+become the most expensive to touch, and the optimizer becomes its own token
 problem.
+
+### `wiki_query` — the escape hatch, and it exists
+
+`wiki_query` is what makes "everything else reachable" true. It is advertised in
+the core tool profile, dispatched, and argument-validated, and it has **six**
+operations:
+
+| Operation | Returns |
+|---|---|
+| `get` | one finding by key, served through the staleness path |
+| `search` | findings matching terms, BM25-ranked |
+| `node` | a node and its immediate neighbours |
+| `audit` | findings needing attention |
+| `balance` | what the graph has cost and saved |
+| `overview` | node counts, densest anchors, stale and total findings |
+
+There is deliberately **no `anchor` operation**. `wiki_read` already owns
+anchored retrieval — "what does the graph know about this file" — and two tools
+offering the same operation costs the model tokens deciding between them.
+
+Every call records a `kind: 'query'` metrics event, which is the numerator
+`indexBudget` needs to earn the session index its allowance. That does not by
+itself demonstrate the metric: `sessionIndex` returns `null` when it has nothing
+to list, so on a graph with no findings the denominator is zero too. The budget
+cannot be shown moving until findings exist.
 
 ## Staleness — flag and serve, with the diff
 
 When a file or symbol node's content hash changes, findings `derived_from` it
 become **stale**. Stale findings are **served, marked, and accompanied by the
 diff that invalidated them**.
+
+**How a change is noticed.** There are two paths, and the distinction matters
+because one of them is the only thing that works for edits the agent made
+itself:
+
+1. **Queued at write, applied at the next graph read.** The post-tool hook
+   already holds the write's evidence, so it appends one record to a pending
+   queue and exits (`hooks-core/pending.mjs`, `queueInvalidation`); it does not
+   load the graph, because loading a megabyte of JSONL on the return path of
+   every write is the cost this shape exists to avoid. The next graph read —
+   `forTouch`, `forCommand`, `sessionIndex`, `standingRules` — drains the queue
+   **before serving anything** (`hooks-core/inject.mjs`, `withPendingApplied`).
+2. **Lazy comparison at serve time**, which compares the anchor's stored hash
+   against disk and so still covers changes the hooks never observed.
+
+Path 1 is not an optimisation of path 2. The lazy check cannot see the session's
+own writes at all: `indexFile` re-points a file node's stored hash at the bytes
+just read, so by the next retrieval the anchor already agrees with disk and a
+finding derived from the old content is served clean. Lazy catches what we never
+saw; only the queue catches what we did.
+
+**Two grades of evidence.** A queued record carrying both sides of the write
+yields a symbol-precise diff. A record carrying only a path — a whole-file write,
+or content past the snapshot cap — yields a hash comparison with no diff. In
+that case the served finding says so (`stale` with `staleEvidence: false`)
+rather than rendering an empty diff as though nothing had changed.
+
+**Diffs are bounded three ways** — lines (40), characters per line (200), and
+total UTF-8 bytes (4,000) — and every truncation is announced in the output. The
+byte bound is not redundant with the line bound: with only the line cap in
+force, two 200,000-character single-line inputs produced 2 lines and 400,005
+bytes, and that output goes straight into model context
+(`hooks-core/staleness.mjs`, `diffLines`).
+
+**A separate, narrower check: `derivationCheck`.** A finding may record the
+anchor hashes that were in force when it was claimed, together with the file
+operations that matched it. `derivationCheck` compares those hashes against the
+anchor node's **last-indexed hash — not against disk** — which is why the served
+finding carries `derivationCheckedAgainst: 'index'` rather than leaving a
+consumer to infer it from a field name. It catches the case node-level staleness
+cannot: a file changed, then re-indexed by some later unrelated write, so `stale`
+reports fresh while the bytes this claim was derived from are gone. The disk
+comparison is already owned by `stale`; this is complementary, not a second
+opinion on the same question.
+
+The derivation record also marks its own incompleteness (`operationsComplete`,
+`operationsScope`). The join is file-scoped: command, build and test outcomes
+are permanently unjoinable against a file-path anchor, and the record says so
+rather than implying it captured them.
 
 Not deleted, and not withheld. Re-verifying a conclusion against a known diff is
 dramatically cheaper than re-deriving it from nothing, and that saving is the
@@ -141,6 +270,19 @@ and automatically committing them puts unreviewed analysis into git history.
 
 An append-only JSONL log plus a derived index, so concurrent sessions cannot
 corrupt it and the whole graph can be rebuilt from the log.
+
+Records are version-stamped. `load()` accepts a *range* of schema versions
+(`SUPPORTED_VERSIONS`) and upcasts in memory; nothing on disk is rewritten, and a
+record's own `v` is carried rather than restamped. `GRAPH_VERSION` is still `1`
+because no record shape has changed. A future bump must add its upcast step
+**and** its `SUPPORTED_VERSIONS` entry in the same change, or older logs stop
+loading (`hooks-core/wiki.mjs`).
+
+The core is vendored rather than imported: `scripts/sync-hook-core.mjs` copies
+`hooks-core/` into **eleven** client integration directories, so counting the
+source there are twelve copies of each module — twelve `inject.mjs` files carry
+the injected text. `npm run sync:hooks:check` fails the build if any copy has
+drifted.
 
 ## Browsing
 

--- a/docs/superpowers/plans/2026-08-25-wiki-graph-plan-1-retrieval-and-wiring.md
+++ b/docs/superpowers/plans/2026-08-25-wiki-graph-plan-1-retrieval-and-wiring.md
@@ -1508,3 +1508,171 @@ Measured, not asserted — run against a real project graph after one working se
 | Eager invalidation live | `grep -rn "queueInvalidation" hooks-core/adapter.mjs` | a call, not a comment |
 | Allowlist shrunk | `grep -c "^  \['" tests/hooks/reachability.test.mjs` | 9 (from 11) |
 | No drift | `npm run sync:hooks:check` | clean |
+
+---
+
+## Task 11: Nothing clears a stale flag
+
+**Added mid-plan.** Task 4 turned eager invalidation from dead code into a live
+mechanism. Nothing in the codebase ever clears a `stale` flag, so every finding on
+an edited file now becomes permanently stale and the graph degrades toward
+all-stale. That was harmless while the mechanism never fired; it is a rot path now.
+
+**Files:**
+- Modify: `hooks-core/staleness.mjs`, `hooks-core/curate.mjs`
+- Test: `tests/hooks/stale-clearing.test.mjs` **(new)**
+
+**Interfaces:**
+- Consumes: `putNode`, `load` (`wiki.mjs`); `checkAnchor` (`staleness.mjs`).
+- Produces:
+  - `clearStale(dir, key) => boolean` — rewrites the finding without `stale`, `staleReason` or `diff`
+  - `reverify(dir, key) => 'cleared' | 'still-stale' | 'unknown'` — clears the flag when the evidence for it is gone
+
+**The mechanics, already established — do not re-derive them.** `putNode` does NOT
+merge: it writes a full record from what the caller passes, and `load` replaces the
+node wholesale, last write wins. The stale write at `staleness.mjs:629` spreads
+`...finding` and adds `stale: true`, `staleReason` and `diff`. So clearing is
+writing the node back with those three fields destructured away — no deletion
+primitive is needed, and the append-only rule is respected.
+
+- [ ] **Step 1: Write the failing tests**
+
+```javascript
+// tests/hooks/stale-clearing.test.mjs
+it('clears the flag when the anchor returns to its recorded content', () => {
+  // A revert, or a change elsewhere in the file that leaves the anchored symbol
+  // untouched. The finding was never actually invalidated by this edit.
+  writeFileSync(file, ORIGINAL);
+  indexFile(dir, file, ORIGINAL);
+  const key = seedFinding(dir, file);
+  markStale(dir, file, ORIGINAL, CHANGED);
+  expect(findingByKey(dir, key).stale).toBe(true);
+
+  writeFileSync(file, ORIGINAL);            // reverted
+  expect(reverify(dir, key)).toBe('cleared');
+  const after = findingByKey(dir, key);
+  expect(after.stale).toBeFalsy();
+  expect(after.diff).toBeFalsy();
+  expect(after.staleReason).toBeFalsy();
+});
+
+it('leaves the flag set when the content genuinely still differs', () => {
+  // reverify must not be a way to launder a stale finding back to fresh.
+  writeFileSync(file, CHANGED);
+  expect(reverify(dir, key)).toBe('still-stale');
+  expect(findingByKey(dir, key).stale).toBe(true);
+});
+
+it('does not let a correction inherit its predecessor stale flag', () => {
+  // curate.correct spreads the original node, which carries stale: true, so a
+  // correction would be born stale -- asserting the fix, not the current bug.
+  markStale(dir, file, ORIGINAL, CHANGED);
+  const corrected = correct(dir, { key, claim: 're-derived against the new code' });
+  expect(findingByKey(dir, corrected).stale).toBeFalsy();
+});
+
+it('preserves every other field when clearing', () => {
+  // The clear path rewrites the whole node, so a dropped claim or confidence
+  // would be silent data loss.
+  const before = findingByKey(dir, key);
+  clearStale(dir, key);
+  const after = findingByKey(dir, key);
+  expect(after.claim).toBe(before.claim);
+  expect(after.confidence).toBe(before.confidence);
+  expect(after.origin).toBe(before.origin);
+});
+```
+
+- [ ] **Step 2: Run to verify they fail** — `npm test -- tests/hooks/stale-clearing.test.mjs`
+
+- [ ] **Step 3: Implement `clearStale` and `reverify`**
+
+`clearStale` destructures `stale`, `staleReason` and `diff` off the node and calls
+`putNode` with the remainder. `reverify` compares every anchor against disk via
+`checkAnchor`: if all match the hashes recorded at claim time, clear; otherwise
+report `still-stale` and change nothing.
+
+**`reverify` must not be a laundering route.** It clears only on evidence that the
+content matches what the claim was made against. A finding whose anchor genuinely
+changed stays stale until someone re-records the claim against the new content.
+
+- [ ] **Step 4: Fix the correction-inherits-stale bug** in `curate.mjs`, where
+`correct()` spreads the original node (see the comment at `curate.mjs:125` — the
+correction inherits anchors, and currently the flag too).
+
+- [ ] **Step 5: Run the suite** — `npm test -- tests/hooks` and `npm run sync:hooks:check`
+
+- [ ] **Step 6: Commit** with a message stating that nothing ever cleared one, that
+it was harmless while eager invalidation was dead code, and that `reverify` clears
+only on evidence so it is not a laundering route.
+
+---
+
+## Task 12: The post-tool matcher advertises tools the normaliser discards
+
+**Added mid-plan.** `plugin/hooks/hooks.json`'s PostToolUse matcher explicitly lists
+`mcp__.*__(?:smart_edit|smart_write)`, but `normalizeTool` (`decide.mjs:547`)
+returns a name only for seven built-ins or a `TOOL_ALIASES` hit, so an MCP-prefixed
+name maps to `null` and `runHook` exits before any logic runs. `NotebookEdit` is
+dropped the same way. The consequence: when enforcement successfully redirects an
+edit to the project's OWN tool, the post-tool accounting for that edit is discarded
+— staleness, mutation accounting and harvest pressure all blind, on the exact path
+the optimizer pushes the model toward.
+
+This is the same declared-but-not-wired shape as the rest of this plan: a matcher
+advertising coverage a normaliser drops.
+
+**Files:**
+- Modify: `hooks-core/decide.mjs`
+- Test: `tests/hooks/tool-normalisation.test.mjs` **(new)**
+
+**Interfaces:**
+- Produces: `normalizeTool` resolves MCP-prefixed names by their trailing segment; `TOOL_ALIASES` gains the `smart_*` family and `notebookedit`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```javascript
+it('resolves an MCP-prefixed tool name by its trailing segment', () => {
+  expect(normalizeTool('mcp__plugin_token-optimizer_token-optimizer__smart_edit')).toBe('Edit');
+  expect(normalizeTool('mcp__whatever__smart_write')).toBe('Write');
+  expect(normalizeTool('NotebookEdit')).toBe('Edit');
+});
+
+it('still returns null for a tool it genuinely does not know', () => {
+  // The permissive direction matters: an unknown tool must stay unknown rather
+  // than being coerced into a built-in that changes a routing verdict.
+  expect(normalizeTool('mcp__vendor__deploy_to_prod')).toBeNull();
+});
+
+it('does not make the router redirect a tool that is already the replacement', () => {
+  // THE LOOP HAZARD. smart_edit normalising to Edit must not cause the router to
+  // deny smart_edit and redirect it to smart_edit.
+  const verdict = decide(payloadFor('mcp__x__smart_edit', { file_path: file }), state);
+  expect(verdict.deny).toBeFalsy();
+});
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+- [ ] **Step 3: Implement.** Strip an `mcp__<server>__` prefix before the alias
+lookup, and add `smart_edit`, `smart_write`, `smart_read`, `smart_grep`,
+`smart_glob` and `notebookedit`.
+
+- [ ] **Step 4: Prove the routing verdicts did not regress — this is the whole risk.**
+
+The reason this was not folded into Task 4 is that it changes what the router
+decides, for all eleven clients. So measure it rather than assert it:
+
+```bash
+npm test -- tests/hooks/enforcement.test.mjs tests/hooks/clients.test.mjs tests/hooks/routing.test.mjs tests/hooks/policy-asks-for-findings.test.mjs
+```
+
+Report, per client, whether any verdict changed. A changed verdict is not
+automatically wrong — but it must be named and justified, not discovered later.
+If any `smart_*` call now gets denied, that is the loop hazard and it blocks.
+
+- [ ] **Step 5: Full suite and sync check**
+
+- [ ] **Step 6: Commit** with a message stating that the matcher advertised names
+the normaliser mapped to null, so the optimizer was blind to its own preferred
+tools on the path enforcement pushes the model toward.

--- a/docs/superpowers/plans/2026-08-25-wiki-graph-plan-1-retrieval-and-wiring.md
+++ b/docs/superpowers/plans/2026-08-25-wiki-graph-plan-1-retrieval-and-wiring.md
@@ -1,0 +1,1499 @@
+# Wiki Graph Plan 1 — Retrieval and Wiring
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the graph readable and its declared wiring live — ship `wiki_query`, real BM25, and connect the five capabilities that are declared, tested, and called by nothing.
+
+**Architecture:** All graph logic lives in `hooks-core/*.mjs` and is vendored into seven client copies by `npm run sync:hooks`; never edit a copy. MCP tools in `src/tools/**` reach hooks-core through dynamic `import(coreUrl('x.mjs'))`, following `src/tools/intelligence/wiki-write.ts`. Retrieval is traversal plus lexical, no embeddings.
+
+**Tech Stack:** Node 22 ESM (`.mjs`) for hooks-core, TypeScript for `src/`, Jest (`tests/hooks/*.test.mjs`, `tests/unit/*.test.ts`), Express for the dashboard.
+
+**Spec:** `docs/superpowers/specs/2026-08-25-wiki-graph-gap-closure-design.md`
+
+## Global Constraints
+
+- **Never edit a vendored copy.** Edit `hooks-core/<file>.mjs`, then run `npm run sync:hooks`. CI runs `npm run sync:hooks:check`.
+- **Fail open.** A defect in the optimizer must never cost the user a tool call. Every hook path wraps its work in try/catch and exits 0.
+- **No `GRAPH_VERSION` bump.** It stays at `1`. New record fields must be optional and read with a default.
+- **Append-only.** Never mutate a graph record in place; `putNode`/`putEdge`/`putNodeWithEdges` only.
+- **Anchor discipline.** A finding whose anchors do not resolve is refused, never stored. Index anchors with `indexFile` before creating the finding.
+- **Declare every MCP option.** An option missing from `inputSchema` is silently dropped at dispatch. The schema-completeness ratchet enforces this.
+- **No null-forgiving `!`** in TypeScript. Use real narrowing.
+- **Enums/closed sets** never typed as bare `string` where the values form a closed set.
+- **Branch:** `feat/close-wiki-graph-gaps`. Never commit to `master`.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `hooks-core/lexical.mjs` **(new)** | BM25 scoring and ranking over findings. Pure, no I/O, no deps. |
+| `src/tools/intelligence/wiki-query.ts` **(new)** | The `wiki_query` MCP tool: seven read operations over the graph. |
+| `src/validation/tool-schemas.ts` | Add `WikiQuerySchema`; register in the schema map. |
+| `src/server/index.ts` | Dispatch `case 'wiki_query'`. |
+| `src/server/wiki-routes.ts` | `/api/wiki/search` switches from substring to BM25. |
+| `hooks-core/staleness.mjs` | Add `applyPending`; `invalidateOnWrite` gains a caller. |
+| `hooks-core/pending.mjs` **(new)** | The pending-invalidation queue written by post-tool, drained at next read. |
+| `hooks-core/adapter.mjs` | post-tool records a pending invalidation; pre-tool drains it before serving. |
+| `hooks-core/curate.mjs` | `contradict()` writes the `contradicts` edge; confidence gating. |
+| `hooks-core/harvest-write.mjs` | Writes the `answers` edge from finding to task. |
+| `hooks-core/inject.mjs` | Block assembly routed through `cacheOrdered`. |
+| `hooks-core/keepwarm.mjs` | `kind:'lessons'` reader (resolves the dead writer). |
+| `tests/hooks/lexical.test.mjs` **(new)** | BM25 ranking behaviour. |
+| `tests/hooks/wiki-query-tool.test.mjs` **(new)** | Tool reachable through dispatch; `query` event recorded. |
+| `tests/hooks/pending-invalidation.test.mjs` **(new)** | A write marks findings stale through the hook chain. |
+| `tests/hooks/contradicts.test.mjs` **(new)** | Contradiction recorded as an edge; confidence not promoted. |
+
+**Task order is dependency order.** Task 2 needs Task 1. Task 4 needs Task 3.
+
+---
+
+## Task 1: BM25 in hooks-core
+
+**Files:**
+- Create: `hooks-core/lexical.mjs`
+- Test: `tests/hooks/lexical.test.mjs`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `tokenize(text: string) => string[]`
+  - `rank(query: string, findings: Array<{key, claim}>, opts?: {limit?: number, k1?: number, b?: number}) => Array<{finding, score}>` — descending by score, zero-score entries omitted.
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+// tests/hooks/lexical.test.mjs
+import { describe, it, expect } from '@jest/globals';
+import { tokenize, rank } from '../../hooks-core/lexical.mjs';
+
+const FINDINGS = [
+  { key: 'a', claim: 'the retry backoff is capped at thirty seconds' },
+  { key: 'b', claim: 'retry retry retry' },
+  { key: 'c', claim: 'the parser rejects a trailing comma' },
+];
+
+describe('lexical', () => {
+  it('splits on non-word characters and lowercases', () => {
+    expect(tokenize('Retry-Backoff, capped!')).toEqual(['retry', 'backoff', 'capped']);
+  });
+
+  it('ranks a specific match above a repetitive one', () => {
+    // This is the whole reason BM25 replaces substring matching: 'b' contains
+    // the term more often, 'a' is the better answer. Saturation must win.
+    const ranked = rank('retry backoff', FINDINGS);
+    expect(ranked[0].finding.key).toBe('a');
+  });
+
+  it('omits findings with no matching term rather than scoring them zero', () => {
+    const keys = rank('retry backoff', FINDINGS).map((r) => r.finding.key);
+    expect(keys).not.toContain('c');
+  });
+
+  it('respects limit', () => {
+    expect(rank('retry', FINDINGS, { limit: 1 })).toHaveLength(1);
+  });
+
+  it('returns nothing for an empty query rather than everything', () => {
+    expect(rank('   ', FINDINGS)).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest tests/hooks/lexical.test.mjs`
+Expected: FAIL — `Cannot find module '../../hooks-core/lexical.mjs'`
+
+- [ ] **Step 3: Write the implementation**
+
+```javascript
+// hooks-core/lexical.mjs
+/**
+ * BM25 over findings. Pure, dependency-free, deterministic.
+ *
+ * WHY THIS REPLACES `includes()`. The dashboard filtered findings by substring,
+ * which cannot RANK -- and every consumer of retrieval here is under a hard
+ * token budget, so the budget kept whatever happened to match rather than what
+ * matched best. Ranking is the whole value at a budget.
+ *
+ * WHY BM25 AND NOT EMBEDDINGS. Deliberate, per docs/WIKI_GRAPH.md: deterministic,
+ * instant, explainable, and it cannot drift or need a rebuild. The known cost is
+ * recall on findings with no lexical overlap; Plan 2's recall probe measures that
+ * rather than assuming it away.
+ */
+
+/** Non-word split, lowercased. Short tokens are kept: `fs`, `id`, `os` matter here. */
+export function tokenize(text) {
+  return String(text || '')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+}
+
+/**
+ * Classic BM25. `k1` controls term-frequency saturation, `b` length normalisation.
+ * Defaults are the standard ones and are exposed so the recall probe can sweep them.
+ */
+export function rank(query, findings, { limit = 20, k1 = 1.2, b = 0.75 } = {}) {
+  const terms = tokenize(query);
+  if (!terms.length || !Array.isArray(findings) || !findings.length) return [];
+
+  // A finding's searchable text is its claim AND its key: the key is how the
+  // session index refers to it, so a model quoting a key must find it.
+  const docs = findings.map((finding) => ({
+    finding,
+    tokens: tokenize(`${finding.key || ''} ${finding.claim || ''}`),
+  }));
+
+  const avgLen = docs.reduce((sum, d) => sum + d.tokens.length, 0) / docs.length;
+  const N = docs.length;
+
+  const docFreq = new Map();
+  for (const { tokens } of docs) {
+    for (const term of new Set(tokens)) {
+      docFreq.set(term, (docFreq.get(term) || 0) + 1);
+    }
+  }
+
+  const scored = [];
+  for (const { finding, tokens } of docs) {
+    const counts = new Map();
+    for (const token of tokens) counts.set(token, (counts.get(token) || 0) + 1);
+
+    let score = 0;
+    for (const term of terms) {
+      const tf = counts.get(term);
+      if (!tf) continue;
+      const df = docFreq.get(term) || 0;
+      // Standard BM25 IDF, floored at zero so a term present in every document
+      // contributes nothing rather than a negative score.
+      const idf = Math.max(0, Math.log(1 + (N - df + 0.5) / (df + 0.5)));
+      const norm = tf + k1 * (1 - b + (b * tokens.length) / (avgLen || 1));
+      score += idf * ((tf * (k1 + 1)) / (norm || 1));
+    }
+
+    // Zero means no term matched. Omitted rather than returned, so a caller
+    // under a token budget never spends it on an irrelevant finding.
+    if (score > 0) scored.push({ finding, score });
+  }
+
+  return scored.sort((a, b2) => b2.score - a.score).slice(0, limit);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx jest tests/hooks/lexical.test.mjs`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Sync the vendored copies**
+
+Run: `npm run sync:hooks`
+Expected: `lexical.mjs` written into all seven target directories.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add hooks-core/lexical.mjs tests/hooks/lexical.test.mjs plugin/hooks/lib/lexical.mjs integrations
+git commit -m "feat(wiki): BM25 ranking for findings, replacing substring matching
+
+WIKI_GRAPH.md has claimed traversal-plus-BM25 since it was written; retrieval
+was a substring includes() filter. Substring cannot rank, and every consumer
+is under a hard token budget, so the budget kept whatever matched rather than
+what matched best."
+```
+
+---
+
+## Task 2: The `wiki_query` MCP tool
+
+**Files:**
+- Create: `src/tools/intelligence/wiki-query.ts`
+- Modify: `src/validation/tool-schemas.ts`, `src/server/index.ts`
+- Test: `tests/hooks/wiki-query-tool.test.mjs`
+
+**Interfaces:**
+- Consumes: `rank()` from Task 1; `wiki.mjs` (`load`, `wikiDir`, `projectRootFor`, `findingsFor`, `nodeId`), `curate.mjs` (`activeFindings`, `audit`), `metrics.mjs` (`record`, `report`), `staleness.mjs` (`serve`), `projects.mjs` (`registerProject`).
+- Produces:
+  - `WIKI_QUERY_TOOL_DEFINITION` — MCP tool definition object
+  - `wikiQuery(options: WikiQueryOptions) => Promise<WikiQueryResult>`
+  - `WikiQueryOperation` — enum, **not** a bare string union of magic strings
+
+**Why this task matters:** `wiki_query` is named in injected prompt text in seven shipped copies and in `docs/WIKI_GRAPH.md`, and it does not exist. The SessionStart index tells the model to call a tool that is not there, and the hard per-touch budget has no escape hatch. Recording a `query` event also resurrects `indexBudget`, which is currently pinned to its 150-token floor for every project once five index injections have occurred.
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+// tests/hooks/wiki-query-tool.test.mjs
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { putNodeWithEdges, load, nodeId, wikiDir } from '../../hooks-core/wiki.mjs';
+import { readAll } from '../../hooks-core/metrics.mjs';
+import { wikiQuery } from '../../dist/tools/intelligence/wiki-query.js';
+
+let dir;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'wq-'));
+  putNodeWithEdges(dir, { kind: 'file', key: join(dir, 'auth.ts'), hash: 'abc' });
+  putNodeWithEdges(
+    dir,
+    { kind: 'finding', key: 'retry-cap', claim: 'the retry backoff is capped at thirty seconds', confidence: 0.9 },
+    [{ edge: 'derived_from', to: nodeId('file', join(dir, 'auth.ts')) }]
+  );
+});
+
+describe('wiki_query', () => {
+  it('returns a finding by key', async () => {
+    const result = await wikiQuery({ operation: 'get', key: 'retry-cap', graphDir: dir });
+    expect(result.finding.claim).toContain('thirty seconds');
+  });
+
+  it('finds a finding by search term', async () => {
+    const result = await wikiQuery({ operation: 'search', query: 'retry backoff', graphDir: dir });
+    expect(result.findings.map((f) => f.key)).toContain('retry-cap');
+  });
+
+  it('traverses from a file anchor to its findings', async () => {
+    const result = await wikiQuery({ operation: 'anchor', anchor: join(dir, 'auth.ts'), graphDir: dir });
+    expect(result.findings.map((f) => f.key)).toContain('retry-cap');
+  });
+
+  it('records a query event, which is what earns the session index its budget', async () => {
+    await wikiQuery({ operation: 'get', key: 'retry-cap', graphDir: dir });
+    const events = readAll(dir).filter((e) => e.kind === 'query');
+    expect(events).toHaveLength(1);
+    expect(events[0].operation).toBe('get');
+  });
+
+  it('reports a missing key rather than throwing', async () => {
+    const result = await wikiQuery({ operation: 'get', key: 'nope', graphDir: dir });
+    expect(result.found).toBe(false);
+  });
+});
+
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run build && npx jest tests/hooks/wiki-query-tool.test.mjs`
+Expected: FAIL — cannot find `dist/tools/intelligence/wiki-query.js`
+
+- [ ] **Step 3: Write the tool**
+
+```typescript
+// src/tools/intelligence/wiki-query.ts
+/**
+ * wiki_query — reading the graph, which nothing could do.
+ *
+ * The SessionStart index has told the model to "call wiki_query with a key for
+ * detail" in seven shipped copies of the injected text since injection landed.
+ * The tool did not exist. So the design's escape hatch for the hard per-touch
+ * budget -- "everything else reachable through wiki_query" -- was not reachable
+ * at all, and anything the 500-token cap dropped was simply gone.
+ *
+ * IT ALSO FIXES A DEAD METRIC. `indexBudget` earns the session index its token
+ * allowance from `queries / listed`, and nothing in the product had ever written
+ * a `query` event -- only the test suite. So the ratio was 0 for every project
+ * on earth, and the budget ratcheted to its floor and stayed there. Recording
+ * the event here is the numerator.
+ */
+
+import path from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { dirname } from 'path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+function coreUrl(name: string): string {
+  return pathToFileURL(path.join(here, '..', '..', '..', 'hooks-core', name)).href;
+}
+
+/** Closed set, so a typo cannot compile. */
+export enum WikiQueryOperation {
+  Get = 'get',
+  Search = 'search',
+  Anchor = 'anchor',
+  Node = 'node',
+  Audit = 'audit',
+  Balance = 'balance',
+  Overview = 'overview',
+}
+
+export interface WikiQueryOptions {
+  operation: WikiQueryOperation | `${WikiQueryOperation}`;
+  /** `get`: the finding key. */
+  key?: string;
+  /** `search`: the search terms. */
+  query?: string;
+  /** `search`: restrict to one finding type. */
+  type?: string;
+  /** `anchor`: a file path or `file#symbol`. */
+  anchor?: string;
+  /** `node`: a node id. */
+  nodeId?: string;
+  /** Max rows returned. Default 20, capped at 100. */
+  limit?: number;
+  /** Explicit graph directory. Tests use it; callers normally omit it. */
+  graphDir?: string;
+  /** Explicit project root, when the caller knows better than inference. */
+  projectRoot?: string;
+  /** Recorded with the query event so hit rate can be attributed to a session. */
+  sessionId?: string;
+}
+
+export interface WikiQueryResult {
+  operation: string;
+  found: boolean;
+  finding?: unknown;
+  findings?: unknown[];
+  node?: unknown;
+  neighbours?: unknown[];
+  audit?: unknown;
+  balance?: unknown;
+  overview?: unknown;
+  note?: string;
+}
+
+export const WIKI_QUERY_TOOL_DEFINITION = {
+  name: 'wiki_query',
+  description:
+    "Read the project's knowledge graph: fetch a finding by key, search findings, list what is known about a file or symbol, inspect a node, or get the graph's audit, token balance and overall shape. Use this when the session index mentions a finding you want in full, or before re-deriving something about a file you are about to work on.",
+  inputSchema: {
+    type: 'object',
+    properties: {
+      operation: {
+        type: 'string',
+        enum: ['get', 'search', 'anchor', 'node', 'audit', 'balance', 'overview'],
+        description:
+          "get = one finding by key. search = findings matching terms. anchor = everything known about a file or 'file#symbol'. node = a node and its neighbours. audit = findings needing attention. balance = what the graph has cost and saved. overview = the graph's shape.",
+      },
+      key: { type: 'string', description: 'Finding key, for operation=get.' },
+      query: { type: 'string', description: 'Search terms, for operation=search.' },
+      type: {
+        type: 'string',
+        enum: ['finding', 'decision', 'failure', 'command', 'map', 'feedback'],
+        description: 'Restrict search to one finding type.',
+      },
+      anchor: { type: 'string', description: "File path or 'file#symbol', for operation=anchor." },
+      nodeId: { type: 'string', description: 'Node id, for operation=node.' },
+      limit: { type: 'number', description: 'Max rows. Default 20, capped at 100.' },
+      graphDir: { type: 'string', description: 'Explicit graph directory. Normally omitted.' },
+      projectRoot: { type: 'string', description: 'Explicit project root. Normally omitted.' },
+      sessionId: { type: 'string', description: 'Session id, recorded with the query event.' },
+    },
+    required: ['operation'],
+  },
+} as const;
+
+/** Trimmed shape for a finding, so a response cannot carry a snapshot. */
+function summariseFinding(node: Record<string, unknown>): Record<string, unknown> {
+  return {
+    key: node.key,
+    claim: node.claim,
+    type: node.type ?? 'finding',
+    confidence: node.confidence,
+    origin: node.origin,
+    pinned: node.pinned ?? false,
+    stale: node.stale ?? false,
+    at: node.at,
+  };
+}
+
+export async function wikiQuery(options: WikiQueryOptions): Promise<WikiQueryResult> {
+  const operation = String(options?.operation ?? '');
+  const limit = Math.min(100, Math.max(1, Number(options?.limit) || 20));
+
+  const [wiki, curate, metrics, staleness, lexical, projects] = await Promise.all([
+    import(coreUrl('wiki.mjs')),
+    import(coreUrl('curate.mjs')),
+    import(coreUrl('metrics.mjs')),
+    import(coreUrl('staleness.mjs')),
+    import(coreUrl('lexical.mjs')),
+    import(coreUrl('projects.mjs')),
+  ]);
+
+  // The graph belongs to the project the ANCHOR is in, not to wherever the
+  // session happens to be running -- the same rule wiki_write follows.
+  const inferredRoot =
+    options.projectRoot ??
+    (options.anchor
+      ? wiki.projectRootFor(String(options.anchor).split('#')[0], process.cwd())
+      : process.cwd());
+  const dir = options.graphDir ?? wiki.wikiDir(inferredRoot);
+  if (!options.graphDir) {
+    projects.registerProject({ root: inferredRoot, graphDir: dir, client: 'mcp' });
+  }
+
+  // Recorded BEFORE the work, so a query that then fails still counts as the
+  // model having asked. The metric is about the index leading somewhere, not
+  // about whether the answer existed.
+  metrics.record(dir, {
+    kind: 'query',
+    operation,
+    key: options.key ?? options.anchor ?? null,
+    sessionId: options.sessionId ?? null,
+  });
+
+  const graph = wiki.load(dir);
+
+  if (operation === WikiQueryOperation.Get) {
+    const all = curate.activeFindings(graph);
+    const match = all.find((f: Record<string, unknown>) => f.key === options.key);
+    if (!match) return { operation, found: false, note: 'no finding with that key' };
+    // Served through `serve` so a stale finding arrives WITH the diff that
+    // invalidated it. A stale finding served bare is worse than no graph.
+    const [served] = staleness.serve(graph, [match]);
+    return { operation, found: true, finding: served };
+  }
+
+  if (operation === WikiQueryOperation.Search) {
+    let pool = curate.activeFindings(graph);
+    if (options.type) {
+      pool = pool.filter((f: Record<string, unknown>) => (f.type ?? 'finding') === options.type);
+    }
+    const ranked = lexical.rank(String(options.query ?? ''), pool, { limit });
+    const served = staleness.serve(graph, ranked.map((r: { finding: unknown }) => r.finding));
+    return { operation, found: served.length > 0, findings: served };
+  }
+
+  if (operation === WikiQueryOperation.Anchor) {
+    const anchor = String(options.anchor ?? '');
+    const id = anchor.includes('#')
+      ? wiki.nodeId('symbol', anchor)
+      : wiki.nodeId('file', anchor);
+    const found = wiki.findingsFor(graph, id, { limit });
+    const served = staleness.serve(graph, found);
+    return { operation, found: served.length > 0, findings: served };
+  }
+
+  if (operation === WikiQueryOperation.Node) {
+    const node = graph.nodes.get(String(options.nodeId ?? ''));
+    if (!node) return { operation, found: false, note: 'no such node' };
+    const edges = graph.edges
+      .filter((e: { from: string; to: string }) => e.from === node.id || e.to === node.id)
+      .slice(0, limit);
+    const neighbours = edges
+      .map((e: { from: string; to: string }) =>
+        graph.nodes.get(e.from === node.id ? e.to : e.from)
+      )
+      .filter(Boolean);
+    return { operation, found: true, node, neighbours };
+  }
+
+  if (operation === WikiQueryOperation.Audit) {
+    return { operation, found: true, audit: curate.audit(graph) };
+  }
+
+  if (operation === WikiQueryOperation.Balance) {
+    return { operation, found: true, balance: metrics.report(dir) };
+  }
+
+  if (operation === WikiQueryOperation.Overview) {
+    const counts: Record<string, number> = {};
+    for (const node of graph.nodes.values()) {
+      counts[node.kind] = (counts[node.kind] || 0) + 1;
+    }
+    // Densest anchors: the files carrying the most findings. This is the part a
+    // constellation of coordinates could never tell a model.
+    const perAnchor = new Map<string, number>();
+    for (const edge of graph.edges) {
+      if (edge.edge !== 'derived_from') continue;
+      const target = graph.nodes.get(edge.to);
+      if (target) perAnchor.set(target.key, (perAnchor.get(target.key) || 0) + 1);
+    }
+    const densest = [...perAnchor.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 10)
+      .map(([key, findings]) => ({ key, findings }));
+    const findings = curate.activeFindings(graph);
+    return {
+      operation,
+      found: true,
+      overview: {
+        counts,
+        densest,
+        stale: findings.filter((f: Record<string, unknown>) => f.stale).length,
+        total: findings.length,
+      },
+    };
+  }
+
+  return { operation, found: false, note: `unknown operation: ${operation}` };
+}
+```
+
+- [ ] **Step 4: Add the schema**
+
+In `src/validation/tool-schemas.ts`, beside the existing `WikiWriteSchema`:
+
+```typescript
+// wiki_query: reading the knowledge graph. EVERY option must be declared --
+// an option missing here is spread into the handler and silently dropped.
+export const WikiQuerySchema = z.object({
+  operation: z.enum(['get', 'search', 'anchor', 'node', 'audit', 'balance', 'overview']),
+  key: z.string().optional(),
+  query: z.string().optional(),
+  type: z.enum(['finding', 'decision', 'failure', 'command', 'map', 'feedback']).optional(),
+  anchor: z.string().optional(),
+  nodeId: z.string().optional(),
+  limit: z.number().int().positive().max(100).optional(),
+  graphDir: z.string().optional(),
+  projectRoot: z.string().optional(),
+  sessionId: z.string().optional(),
+});
+```
+
+And in the schema map beside `wiki_write: WikiWriteSchema,`:
+
+```typescript
+  wiki_query: WikiQuerySchema,
+```
+
+- [ ] **Step 5: Dispatch it**
+
+In `src/server/index.ts`, add the import beside `wikiWrite`:
+
+```typescript
+import { wikiQuery, WIKI_QUERY_TOOL_DEFINITION } from '../tools/intelligence/wiki-query.js';
+```
+
+And beside `case 'wiki_write':`:
+
+```typescript
+      case 'wiki_query': {
+        const result = await wikiQuery(args as never);
+        return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+      }
+```
+
+Register `WIKI_QUERY_TOOL_DEFINITION` wherever `WIKI_WRITE_TOOL_DEFINITION` is listed in the tool inventory.
+
+- [ ] **Step 6: Declare it in the bundled capability list**
+
+`wiki_query` must appear in `TOKEN_OPTIMIZER_MCP_CAPABILITIES`, which is generated. Edit the generator, not the entries:
+
+```bash
+grep -rn "TOKEN_OPTIMIZER_MCP_CAPABILITIES" scripts/generate-client-entries.mjs
+```
+
+Add `wiki_query` to that list, then `npm run sync:hooks`.
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `npm run build && npx jest tests/hooks/wiki-query-tool.test.mjs`
+Expected: PASS (5 tests)
+
+- [ ] **Step 8: Verify the schema ratchet still passes**
+
+Run: `npx jest tests/hooks/ucr-guard.test.mjs tests/unit --silent`
+Expected: PASS. If the schema-completeness ratchet fails, an option is missing from `inputSchema` — add it rather than allowlisting it.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/tools/intelligence/wiki-query.ts src/validation/tool-schemas.ts src/server/index.ts scripts/generate-client-entries.mjs tests/hooks/wiki-query-tool.test.mjs plugin integrations
+git commit -m "feat(wiki): wiki_query, the tool the injected text already promised
+
+The SessionStart index has told the model to 'call wiki_query with a key for
+detail' in seven shipped copies since injection landed, and the tool did not
+exist -- so the hard per-touch budget had no escape hatch and anything it
+dropped was unreachable.
+
+It also resurrects indexBudget. That budget earns the session index its
+allowance from queries/listed, and nothing in the product had ever written a
+query event -- only the test suite. The ratio was 0 everywhere, so the budget
+sat at its 150-token floor for every project on earth."
+```
+
+---
+
+## Task 3: Dashboard search uses BM25
+
+**Files:**
+- Modify: `src/server/wiki-routes.ts` (the `/api/wiki/search` handler)
+- Test: `tests/unit/wiki-routes-search.test.ts` **(new)**
+
+**Interfaces:**
+- Consumes: `rank()` from Task 1.
+- Produces: no new exports; `/api/wiki/search` response shape is unchanged (`{ total, offset, items }`).
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/unit/wiki-routes-search.test.ts
+import { describe, it, expect } from '@jest/globals';
+import { pathToFileURL } from 'url';
+import path from 'path';
+
+const lexical = await import(
+  pathToFileURL(path.join(process.cwd(), 'hooks-core', 'lexical.mjs')).href
+);
+
+describe('/api/wiki/search ranking', () => {
+  it('ranks a specific claim above a repetitive one', () => {
+    const findings = [
+      { key: 'a', claim: 'the retry backoff is capped at thirty seconds' },
+      { key: 'b', claim: 'retry retry retry' },
+    ];
+    const ranked = lexical.rank('retry backoff', findings);
+    expect(ranked[0].finding.key).toBe('a');
+  });
+});
+```
+
+- [ ] **Step 2: Run it to confirm the ranking primitive is available**
+
+Run: `npx jest tests/unit/wiki-routes-search.test.ts`
+Expected: PASS (Task 1 supplies `rank`). This test guards the property the route must preserve.
+
+- [ ] **Step 3: Replace the substring filter**
+
+In `src/server/wiki-routes.ts`, add `lexical` to the `modules()` import list, then replace the `if (query) { findings = findings.filter(...) }` block with:
+
+```typescript
+      // Lexical retrieval per the design -- now actually ranked. The previous
+      // substring filter could not order results, so the caller kept whatever
+      // matched rather than what matched best.
+      if (query) {
+        findings = mods.lexical
+          .rank(query, findings, { limit: offset + limit })
+          .map((row: { finding: unknown }) => row.finding);
+      } else {
+        findings.sort((a: any, b: any) => {
+          const weight = (f: any) =>
+            (f.confidence ?? 0.5) *
+            (f.origin === 'human' ? mods.curate.HUMAN_WEIGHT : 1) *
+            (f.pinned ? 2 : 1);
+          return weight(b) - weight(a);
+        });
+      }
+```
+
+Note the sort now applies only to the unfiltered case: when a query is present, BM25 relevance decides the order.
+
+- [ ] **Step 4: Run the dashboard tests**
+
+Run: `npm run build && npx jest tests/unit/wiki-routes-search.test.ts tests/unit/dashboard-web-server.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/server/wiki-routes.ts tests/unit/wiki-routes-search.test.ts
+git commit -m "fix(dashboard): rank wiki search by BM25 instead of substring"
+```
+
+---
+
+## Task 4: Wire `invalidateOnWrite` through the post-tool path
+
+**Files:**
+- Create: `hooks-core/pending.mjs`
+- Modify: `hooks-core/adapter.mjs` (post-tool branch; pre-tool serve path)
+- Modify: `tests/hooks/reachability.test.mjs` (remove the `invalidateOnWrite` allowlist entry)
+- Test: `tests/hooks/pending-invalidation.test.mjs`
+
+**Interfaces:**
+- Consumes: `invalidateOnWrite(dir, graph, rawPath, beforeText, afterText)` from `staleness.mjs`.
+- Produces:
+  - `queueInvalidation(dir, { path, before, after, at })` — appends one pending record
+  - `drainInvalidations(dir, graph) => number` — applies and clears; returns findings marked
+
+**Why:** `staleness.mjs`'s header describes two invalidation paths and says eager exists because lazy "would silently serve stale findings as fresh whenever a change came from outside the agent." `invalidateOnWrite` has **1 raw reference and 0 code references** — the reference is a comment in `pretooluse-router.mjs:153`. Staleness is lazy-only in production.
+
+The hook does **not** load the graph. It queues; the next graph read drains. Correctness is unchanged because the property that matters is that a stale finding is never *served* fresh, and serve time is where that is enforced.
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+// tests/hooks/pending-invalidation.test.mjs
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { putNodeWithEdges, load, nodeId } from '../../hooks-core/wiki.mjs';
+import { indexFile } from '../../hooks-core/staleness.mjs';
+import { queueInvalidation, drainInvalidations } from '../../hooks-core/pending.mjs';
+
+let dir, file;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'pend-'));
+  file = join(dir, 'auth.ts');
+  writeFileSync(file, 'export function f() { return 1; }');
+  indexFile(dir, file, 'export function f() { return 1; }');
+  putNodeWithEdges(
+    dir,
+    { kind: 'finding', key: 'f-returns-one', claim: 'f returns 1', confidence: 0.9 },
+    [{ edge: 'derived_from', to: nodeId('file', file) }]
+  );
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+describe('pending invalidation', () => {
+  it('marks a finding stale when a queued write is drained', () => {
+    queueInvalidation(dir, {
+      path: file,
+      before: 'export function f() { return 1; }',
+      after: 'export function f() { return 2; }',
+      at: 1,
+    });
+
+    const marked = drainInvalidations(dir, load(dir));
+    expect(marked).toBeGreaterThan(0);
+
+    const finding = [...load(dir).nodes.values()].find((n) => n.key === 'f-returns-one');
+    expect(finding.stale).toBe(true);
+  });
+
+  it('is idempotent -- draining twice does not re-apply', () => {
+    queueInvalidation(dir, { path: file, before: 'a', after: 'b', at: 1 });
+    drainInvalidations(dir, load(dir));
+    expect(drainInvalidations(dir, load(dir))).toBe(0);
+  });
+
+  it('never throws on a malformed record, because it runs on a hook path', () => {
+    queueInvalidation(dir, { path: null, before: null, after: null, at: 1 });
+    expect(() => drainInvalidations(dir, load(dir))).not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest tests/hooks/pending-invalidation.test.mjs`
+Expected: FAIL — cannot find `hooks-core/pending.mjs`
+
+- [ ] **Step 3: Write `pending.mjs`**
+
+```javascript
+// hooks-core/pending.mjs
+/**
+ * The eager-invalidation queue.
+ *
+ * WHY A QUEUE AND NOT A DIRECT CALL. `invalidateOnWrite` needs the graph, and
+ * the graph is a megabyte of JSONL. Loading it inside the post-tool hook would
+ * put that read on the return path of every write. So the hook, which already
+ * holds the before and after text, appends one record here and exits; the next
+ * graph read -- the pre-tool injection path, which loads the graph anyway --
+ * drains it before serving anything.
+ *
+ * The guarantee is unchanged. What must never happen is SERVING a stale finding
+ * as fresh, and serve time is where that is enforced.
+ */
+
+import { appendFileSync, readFileSync, existsSync, mkdirSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import { invalidateOnWrite } from './staleness.mjs';
+
+const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
+
+/** Appends one pending write. Never throws: a hook path must not fail. */
+export function queueInvalidation(dir, { path, before, after, at }) {
+  try {
+    mkdirSync(dir, { recursive: true });
+    appendFileSync(
+      queuePath(dir),
+      `${JSON.stringify({ path, before, after, at: at ?? Date.now() })}\n`,
+      'utf8'
+    );
+  } catch {
+    // A queue we cannot write degrades to the lazy path, which still catches
+    // the change at the next retrieval. Silence is correct here.
+  }
+}
+
+/**
+ * Applies every queued invalidation and clears the queue.
+ *
+ * Returns the number of findings marked, so a caller can log it and the test
+ * can assert idempotence. Clearing AFTER applying, and unconditionally, because
+ * a record that cannot be applied must not be retried forever.
+ */
+export function drainInvalidations(dir, graph) {
+  let records;
+  try {
+    if (!existsSync(queuePath(dir))) return 0;
+    records = readFileSync(queuePath(dir), 'utf8')
+      .split('\n')
+      .filter((line) => line.trim())
+      .map((line) => {
+        try {
+          return JSON.parse(line);
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch {
+    return 0;
+  }
+
+  let marked = 0;
+  for (const record of records) {
+    if (!record.path) continue;
+    try {
+      const result = invalidateOnWrite(dir, graph, record.path, record.before, record.after);
+      marked += Array.isArray(result) ? result.length : Number(result) || 0;
+    } catch {
+      // One bad record must not stop the rest.
+    }
+  }
+
+  try {
+    unlinkSync(queuePath(dir));
+  } catch {
+    // Already gone, or held. The next drain will retry.
+  }
+
+  return marked;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx jest tests/hooks/pending-invalidation.test.mjs`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Call it from the hook path**
+
+In `hooks-core/adapter.mjs`, in the `event === 'post-tool'` branch, after the existing bookkeeping, queue the invalidation using the before/after text the write already provides:
+
+```javascript
+  // EAGER INVALIDATION, finally connected. `invalidateOnWrite` has existed and
+  // been tested since staleness landed, and its only reference in shipped code
+  // was a COMMENT -- so the path the module's own header calls load-bearing has
+  // never run. Queued rather than applied, so no graph load lands here.
+  try {
+    const { queueInvalidation } = await import('./pending.mjs');
+    queueInvalidation(dir, { path: writtenPath, before: beforeText, after: afterText });
+  } catch {
+    /* never let bookkeeping break a completed call */
+  }
+```
+
+And in the pre-tool path, immediately after the graph is loaded and **before** anything is served:
+
+```javascript
+  // Drain BEFORE serving. This is the whole point: a write the hook observed
+  // must not be served as fresh on the next touch.
+  try {
+    const { drainInvalidations } = await import('./pending.mjs');
+    drainInvalidations(dir, graph);
+  } catch {
+    /* lazy staleness still covers this */
+  }
+```
+
+- [ ] **Step 6: Remove the allowlist entry**
+
+In `tests/hooks/reachability.test.mjs`, delete the line:
+
+```javascript
+  ['invalidateOnWrite', 'UNWIRED: the eager staleness path; invalidation currently happens only lazily, on the next touch.'],
+```
+
+- [ ] **Step 7: Verify the detector now passes without the entry**
+
+Run: `npx jest tests/hooks/reachability.test.mjs tests/hooks/staleness.test.mjs tests/hooks/stale-before-reindex.test.mjs`
+Expected: PASS. If reachability fails, `invalidateOnWrite` is still only referenced from `pending.mjs` — confirm `pending.mjs` itself has a caller in `adapter.mjs`.
+
+- [ ] **Step 8: Sync and commit**
+
+```bash
+npm run sync:hooks
+git add hooks-core/pending.mjs hooks-core/adapter.mjs tests/hooks/pending-invalidation.test.mjs tests/hooks/reachability.test.mjs plugin integrations
+git commit -m "fix(staleness): connect eager invalidation, which was prose only
+
+staleness.mjs documents two invalidation paths and says eager exists because
+lazy 'would silently serve stale findings as fresh whenever a change came from
+outside the agent'. invalidateOnWrite had 1 raw reference and 0 code
+references: the reference was a comment. Staleness was lazy-only in production.
+
+Queued at post-tool and drained at the next graph read, so no graph load lands
+on the return path of a write. The guarantee is unchanged -- what must never
+happen is SERVING a stale finding as fresh."
+```
+
+---
+
+## Task 5: Write the `contradicts` edge, and gate confidence on it
+
+**Files:**
+- Modify: `hooks-core/curate.mjs`
+- Test: `tests/hooks/contradicts.test.mjs`
+
+**Interfaces:**
+- Consumes: `putEdge`, `nodeId`, `load` from `wiki.mjs`.
+- Produces:
+  - `contradict(dir, { key, byKey, reason }) => boolean` — records that `byKey` disagrees with `key`
+  - `hasOutstandingContradiction(graph, key) => boolean` — used to gate confidence promotion
+
+**Why:** `EDGE_KINDS` declares `contradicts`, `WIKI_GRAPH.md` gives it a paragraph as the design's departure from RAG ("when a belief changes, the graph should record THAT it changed and why"), and `curate.mjs:264` now *reads* it. Nothing writes it. It is simultaneously an unwritten edge kind and a reader with no producer.
+
+It is also the guard against Plan 2's Layer 2 rewarding falsehoods: that metric measures read suppression, and a confidently wrong finding suppresses reads better than a hedged true one.
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+// tests/hooks/contradicts.test.mjs
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { putNodeWithEdges, load, nodeId } from '../../hooks-core/wiki.mjs';
+import { contradict, hasOutstandingContradiction } from '../../hooks-core/curate.mjs';
+
+let dir;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'contra-'));
+  putNodeWithEdges(dir, { kind: 'finding', key: 'old', claim: 'f returns 1', confidence: 0.9 });
+  putNodeWithEdges(dir, { kind: 'finding', key: 'new', claim: 'f returns 2', confidence: 0.9 });
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+describe('contradicts', () => {
+  it('records a disagreement as an edge rather than an overwrite', () => {
+    expect(contradict(dir, { key: 'old', byKey: 'new', reason: 're-derived' })).toBe(true);
+
+    const graph = load(dir);
+    const edge = graph.edges.find((e) => e.edge === 'contradicts');
+    expect(edge).toBeDefined();
+    expect(edge.from).toBe(nodeId('finding', 'new'));
+    expect(edge.to).toBe(nodeId('finding', 'old'));
+  });
+
+  it('leaves the contradicted finding present, not retired', () => {
+    contradict(dir, { key: 'old', byKey: 'new', reason: 're-derived' });
+    const old = [...load(dir).nodes.values()].find((n) => n.key === 'old');
+    expect(old.retired).toBeFalsy();
+  });
+
+  it('reports an outstanding contradiction, which blocks confidence promotion', () => {
+    contradict(dir, { key: 'old', byKey: 'new', reason: 're-derived' });
+    const graph = load(dir);
+    expect(hasOutstandingContradiction(graph, 'old')).toBe(true);
+    expect(hasOutstandingContradiction(graph, 'new')).toBe(false);
+  });
+
+  it('refuses a contradiction against a key that does not exist', () => {
+    expect(contradict(dir, { key: 'nope', byKey: 'new', reason: 'x' })).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest tests/hooks/contradicts.test.mjs`
+Expected: FAIL — `contradict is not a function`
+
+- [ ] **Step 3: Implement in `curate.mjs`**
+
+```javascript
+/**
+ * Records that one finding disagrees with another.
+ *
+ * AN EDGE, NOT AN OVERWRITE -- the design is explicit about why: "when a belief
+ * changes, the graph should record THAT it changed and why, not quietly present
+ * the new one as though it had always been true." `contradicts` has been in
+ * EDGE_KINDS since the schema existed and was written by nothing, while
+ * `audit()` already READ it.
+ *
+ * The contradicted finding is deliberately NOT retired. A reader needs to see
+ * both claims and the disagreement between them; retiring one silently picks a
+ * winner, which is the overwrite this edge exists to avoid.
+ */
+export function contradict(dir, { key, byKey, reason }) {
+  const graph = load(dir);
+  const target = [...graph.nodes.values()].find((n) => n.kind === 'finding' && n.key === key);
+  const source = [...graph.nodes.values()].find((n) => n.kind === 'finding' && n.key === byKey);
+  // Both ends must exist, or the edge is unresolvable and the disagreement is
+  // recorded against nothing -- the same un-invalidatable shape anchors prevent.
+  if (!target || !source) return false;
+
+  putEdge(dir, source.id, 'contradicts', target.id);
+  putNode(dir, {
+    kind: 'finding',
+    key,
+    contradictedAt: Date.now(),
+    contradictionReason: String(reason || '').slice(0, 400),
+  });
+  return true;
+}
+
+/**
+ * Whether anything currently disagrees with this finding.
+ *
+ * Gates confidence promotion. Plan 2's per-finding utility measures whether a
+ * finding SUPPRESSES READS, and a confidently wrong finding suppresses reads
+ * better than a hedged true one -- so utility must never raise confidence on
+ * its own, and this is the check that stops it.
+ */
+export function hasOutstandingContradiction(graph, key) {
+  const node = [...graph.nodes.values()].find((n) => n.kind === 'finding' && n.key === key);
+  if (!node) return false;
+  return graph.edges.some((e) => e.edge === 'contradicts' && e.to === node.id);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx jest tests/hooks/contradicts.test.mjs`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Sync and commit**
+
+```bash
+npm run sync:hooks
+git add hooks-core/curate.mjs tests/hooks/contradicts.test.mjs plugin integrations
+git commit -m "feat(wiki): write the contradicts edge, declared since the schema existed
+
+EDGE_KINDS declared it, WIKI_GRAPH.md gives it a paragraph as the design's
+departure from RAG, and curate.mjs:264 already read it. Nothing wrote it.
+
+hasOutstandingContradiction gates confidence promotion, because per-finding
+utility measures read suppression and a confidently wrong finding suppresses
+reads better than a hedged true one."
+```
+
+---
+
+## Task 6: Write the `answers` edge
+
+**Files:**
+- Modify: `hooks-core/harvest-write.mjs`
+- Test: `tests/hooks/contradicts.test.mjs` (add a describe block — same subsystem, same file)
+
+**Interfaces:**
+- Consumes: `putEdge`, `nodeId` from `wiki.mjs`.
+- Produces: no new export; `writeHarvested` gains an `answers` edge from each finding to the task that produced it, when a `taskId` is supplied.
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+// append to tests/hooks/contradicts.test.mjs
+describe('answers', () => {
+  it('links a finding to the task that produced it', () => {
+    const dir2 = mkdtempSync(join(tmpdir(), 'ans-'));
+    const file = join(dir2, 'x.ts');
+    writeFileSync(file, 'export const x = 1;');
+    indexFile(dir2, file, 'export const x = 1;');
+    putNodeWithEdges(dir2, { kind: 'task', key: 'task-1', prompt: 'why is x 1' });
+
+    writeHarvested(
+      dir2,
+      [{ type: 'finding', claim: 'x is 1 by default', anchors: [file], confidence: 0.8 }],
+      { sessionId: 's1', taskId: 'task-1', projectRoot: dir2 }
+    );
+
+    const graph = load(dir2);
+    const edge = graph.edges.find((e) => e.edge === 'answers');
+    expect(edge).toBeDefined();
+    expect(edge.to).toBe(nodeId('task', 'task-1'));
+    rmSync(dir2, { recursive: true, force: true });
+  });
+});
+```
+
+Add these imports at the top of the file: `writeFileSync` from `node:fs`, `indexFile` from `../../hooks-core/staleness.mjs`, `writeHarvested` from `../../hooks-core/harvest-write.mjs`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest tests/hooks/contradicts.test.mjs -t answers`
+Expected: FAIL — `edge` is undefined
+
+- [ ] **Step 3: Add the edge in `writeHarvested`**
+
+Where the finding's edge list is assembled beside its `derived_from` anchors:
+
+```javascript
+    // `answers` closes the loop back to the task that produced the finding, so
+    // provenance can be traversed rather than inferred: "which session
+    // established this, and from what". Declared in EDGE_KINDS and written by
+    // nothing until now.
+    if (options.taskId) {
+      edges.push({ edge: 'answers', to: nodeId('task', options.taskId) });
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx jest tests/hooks/contradicts.test.mjs`
+Expected: PASS
+
+- [ ] **Step 5: Sync and commit**
+
+```bash
+npm run sync:hooks
+git add hooks-core/harvest-write.mjs tests/hooks/contradicts.test.mjs plugin integrations
+git commit -m "feat(wiki): write the answers edge from finding to task
+
+The last declared edge kind with no write site. Provenance is now traversable
+rather than inferred."
+```
+
+---
+
+## Task 7: Resolve the `lessons` dead writer
+
+**Files:**
+- Modify: `hooks-core/keepwarm.mjs` **or** `plugin/hooks/harvest-worker.mjs` (see step 1)
+- Test: `tests/hooks/lessons.test.mjs`
+
+**Interfaces:**
+- Consumes: `readAll` from `metrics.mjs`.
+- Produces: `lessonStats(dir) => { count: number, recent: Array<{claim, at}> }` if wired; otherwise the writer is removed.
+
+**Why:** `harvest-worker.mjs:113` writes `kind: 'lessons'`. Nothing reads it. That is the inverse of the `query` defect and the same class as the already-fixed `tokensFullFile`.
+
+- [ ] **Step 1: Determine which resolution applies**
+
+Run:
+```bash
+grep -rn "kind: 'lessons'" hooks-core plugin/hooks --include=*.mjs
+grep -rn "'lessons'" hooks-core/lessons.mjs | head -20
+```
+
+If `lessons.mjs` has a consumer that *should* be reading these events, wire it (step 2). If the event duplicates what `lessons.mjs` already derives from another source, delete the write (step 3). **Record which you chose and why in the commit message** — this is the decision the next reader will want.
+
+- [ ] **Step 2 (if wiring): add the reader**
+
+```javascript
+/**
+ * What the harvest recorded as lessons, for the audit surface.
+ *
+ * The `lessons` event was written by harvest-worker and read by nothing --
+ * the inverse of the `query` defect, and the same shape as `tokensFullFile`
+ * before it. A produced-and-never-consumed event is not telemetry.
+ */
+export function lessonStats(dir) {
+  const events = readAll(dir).filter((e) => e.kind === 'lessons');
+  return {
+    count: events.length,
+    recent: events.slice(-10).map((e) => ({ claim: e.claim ?? null, at: e.at ?? null })),
+  };
+}
+```
+
+Then call it from the audit render so it reaches a human.
+
+- [ ] **Step 3 (if deleting): remove the write**
+
+Delete the `record(dir, { kind: 'lessons', ... })` call in `plugin/hooks/harvest-worker.mjs` and any now-unused locals.
+
+- [ ] **Step 4: Test whichever path you took**
+
+If wired:
+```javascript
+it('reports lessons the harvest recorded', () => {
+  record(dir, { kind: 'lessons', claim: 'prefer smart_read' });
+  expect(lessonStats(dir).count).toBe(1);
+});
+```
+If deleted:
+```javascript
+it('writes no event kind that nothing reads', () => {
+  const written = readAll(dir).map((e) => e.kind);
+  expect(written).not.toContain('lessons');
+});
+```
+
+Run: `npx jest tests/hooks/lessons.test.mjs`
+Expected: PASS
+
+- [ ] **Step 5: Sync and commit**
+
+```bash
+npm run sync:hooks
+git add hooks-core plugin tests/hooks/lessons.test.mjs integrations
+git commit -m "fix(harvest): resolve the lessons event, which nothing read
+
+Written by harvest-worker.mjs:113 and consumed by nothing -- the inverse of
+the query defect and the same shape as tokensFullFile before it."
+```
+
+---
+
+## Task 8: Wire `cacheOrdered` into injection assembly
+
+**Files:**
+- Modify: `hooks-core/inject.mjs`
+- Modify: `tests/hooks/reachability.test.mjs` (remove the `cacheOrdered` allowlist entry)
+- Test: `tests/hooks/cache.test.mjs` (add a describe block)
+
+**Interfaces:**
+- Consumes: `cacheOrdered(items)` from `cache.mjs`.
+- Produces: no new export. Injected blocks are emitted stable-first, volatile-last.
+
+**Why:** `cacheOrdered` assembles injections so a changed line invalidates only the tail of the prompt cache. Prompt-cache economics already ships; this is the ordering that makes it bite. It has zero call sites.
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+// append to tests/hooks/cache.test.mjs
+import { cacheOrdered } from '../../hooks-core/cache.mjs';
+
+describe('cache ordering is applied to injection', () => {
+  it('puts stable blocks before volatile ones', () => {
+    const ordered = cacheOrdered([
+      { id: 'findings', volatility: 'high', text: 'a' },
+      { id: 'standing', volatility: 'low', text: 'b' },
+    ]);
+    expect(ordered.map((o) => o.id)).toEqual(['standing', 'findings']);
+  });
+});
+```
+
+Confirm the parameter shape `cacheOrdered` actually expects before writing the assertion:
+
+```bash
+sed -n '430,470p' hooks-core/cache.mjs
+```
+
+Adjust the test to the real shape — do not change `cacheOrdered` to fit a guessed one.
+
+- [ ] **Step 2: Run test to verify it fails or reveals the real shape**
+
+Run: `npx jest tests/hooks/cache.test.mjs -t "cache ordering"`
+Expected: FAIL, and the failure names the real contract.
+
+- [ ] **Step 3: Route assembly through it**
+
+In `hooks-core/inject.mjs`, where the injected blocks are concatenated for a session, collect them as items with their volatility and emit `cacheOrdered(items)`:
+
+```javascript
+  // CACHE ORDER, stable first. A later session re-emitting the same block with
+  // one changed line invalidates the prompt cache from that line onward, so the
+  // parts that rarely change belong at the top and the freshest at the bottom.
+  // `cacheOrdered` has existed for exactly this and had no caller.
+  const blocks = cacheOrdered([
+    { id: 'standing', volatility: 'low', text: standingBlock },
+    { id: 'index', volatility: 'medium', text: indexBlock },
+    { id: 'findings', volatility: 'high', text: findingsBlock },
+  ].filter((b) => b.text));
+```
+
+- [ ] **Step 4: Run the injection suite**
+
+Run: `npx jest tests/hooks/injection.test.mjs tests/hooks/injection-e2e.test.mjs tests/hooks/cache.test.mjs tests/hooks/standing-rules.test.mjs`
+Expected: PASS. Injection tests assert on emitted text; if ordering assertions fail, update them to the new order and note in the commit that the order changed deliberately.
+
+- [ ] **Step 5: Remove the allowlist entry and verify**
+
+Delete `['cacheOrdered', ...]` from `tests/hooks/reachability.test.mjs`, then:
+
+Run: `npx jest tests/hooks/reachability.test.mjs`
+Expected: PASS
+
+- [ ] **Step 6: Sync and commit**
+
+```bash
+npm run sync:hooks
+git add hooks-core/inject.mjs tests/hooks/cache.test.mjs tests/hooks/reachability.test.mjs plugin integrations
+git commit -m "perf(inject): assemble injections in cache order, stable first
+
+cacheOrdered confines prompt-cache invalidation to the tail of our injected
+blocks and had zero call sites. Prompt-cache economics already ships; this is
+the ordering that makes it bite."
+```
+
+---
+
+## Task 9: Documentation and the full suite
+
+**Files:**
+- Modify: `docs/WIKI_GRAPH.md`
+- Modify: `docs/TOOLS.md`
+
+- [ ] **Step 1: Correct `WIKI_GRAPH.md`**
+
+Three statements to change:
+1. Retrieval: BM25 is now true rather than aspirational — say it is implemented in `hooks-core/lexical.mjs` and shared with the dashboard.
+2. Invalidation: describe the real mechanism — queued at post-tool, drained at the next graph read, with lazy comparison still covering changes the hooks never observed.
+3. `wiki_query` exists; state its seven operations.
+
+- [ ] **Step 2: Document `wiki_query` in `docs/TOOLS.md`** beside `wiki_write`, with one example per operation.
+
+- [ ] **Step 3: Run the whole suite and the sync check**
+
+Run: `npm run build && npx jest && npm run sync:hooks:check`
+Expected: PASS, PASS, no drift.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/WIKI_GRAPH.md docs/TOOLS.md
+git commit -m "docs(wiki): describe wiki_query, real BM25, and the actual invalidation path"
+```
+
+---
+
+## Task 10: The schema safety net (independent — may run first)
+
+**Files:**
+- Modify: `hooks-core/wiki.mjs` (`load`, `compactIfWasteful`, the header comment)
+- Test: `tests/hooks/schema-compat.test.mjs` **(new)**
+
+**Interfaces:**
+- Produces:
+  - `SUPPORTED_VERSIONS: number[]` — the range `load` accepts
+  - `upcast(record) => record` — pure, per-version step; identity for the current version
+
+**Why, and why the bump is deliberately NOT taken:** `load()` skips any record whose `v !== GRAPH_VERSION` (`wiki.mjs:640`), justified by a header comment saying "nothing has been released". It ships on npm as v5.7.0, so that comment is false and load-bearing: a future bump would silently zero every existing user graph. Worse, `compactIfWasteful` carries the **same filter**, so a bump would also **drop v1 records while compacting** — a second route to the same data loss.
+
+Nothing in this work changes a graph record's shape (utility lives in metrics, `contradicts`/`answers` use the existing edge record, extractor fields are additive), so `GRAPH_VERSION` **stays at 1**. This task builds the net for the first change that does need it.
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+// tests/hooks/schema-compat.test.mjs
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { load, SUPPORTED_VERSIONS, upcast, GRAPH_VERSION } from '../../hooks-core/wiki.mjs';
+
+let dir;
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'schema-')); });
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+describe('schema compatibility', () => {
+  it('loads a v1 log with every node intact -- the regression that would have caught silent zeroing', () => {
+    writeFileSync(
+      join(dir, 'graph.jsonl'),
+      [
+        JSON.stringify({ t: 'n', v: 1, id: 'file:aaa', kind: 'file', key: '/x/a.ts', at: 1 }),
+        JSON.stringify({ t: 'n', v: 1, id: 'finding:bbb', kind: 'finding', key: 'k1', claim: 'c', at: 2 }),
+        JSON.stringify({ t: 'e', v: 1, from: 'finding:bbb', edge: 'derived_from', to: 'file:aaa', at: 3 }),
+      ].join('\n') + '\n'
+    );
+    const graph = load(dir);
+    expect(graph.nodes.size).toBe(2);
+    expect(graph.edges).toHaveLength(1);
+  });
+
+  it('still skips a record from a FUTURE version, because ignoring the future is safe', () => {
+    writeFileSync(
+      join(dir, 'graph.jsonl'),
+      JSON.stringify({ t: 'n', v: 9999, id: 'file:zzz', kind: 'file', key: '/x/z.ts', at: 1 }) + '\n'
+    );
+    expect(load(dir).nodes.size).toBe(0);
+  });
+
+  it('does not bump the version, because no record shape changed in this work', () => {
+    expect(GRAPH_VERSION).toBe(1);
+    expect(SUPPORTED_VERSIONS).toContain(1);
+  });
+
+  it('upcast is identity for a current-version record', () => {
+    const record = { t: 'n', v: GRAPH_VERSION, id: 'x', kind: 'file', key: '/a', at: 1 };
+    expect(upcast(record)).toEqual(record);
+  });
+
+  it('compaction preserves records of every supported version', () => {
+    // The second data-loss route: compactIfWasteful carries the same version
+    // filter as load, so a bump would drop old records while compacting.
+    writeFileSync(
+      join(dir, 'graph.jsonl'),
+      Array.from({ length: 50 }, (_, i) =>
+        JSON.stringify({ t: 'n', v: 1, id: `file:${i}`, kind: 'file', key: `/x/${i}.ts`, at: i })
+      ).join('\n') + '\n'
+    );
+    const before = load(dir).nodes.size;
+    load(dir, { snapshots: true });   // triggers the compaction path
+    expect(load(dir).nodes.size).toBe(before);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx jest tests/hooks/schema-compat.test.mjs`
+Expected: FAIL — `SUPPORTED_VERSIONS` and `upcast` are not exported.
+
+- [ ] **Step 3: Implement the range reader and upcaster**
+
+```javascript
+/**
+ * Versions this reader accepts, oldest first.
+ *
+ * A RANGE, NOT AN EQUALITY. The equality check this replaces would have
+ * discarded every existing graph the moment anyone bumped the version -- and the
+ * header once justified that with "nothing has been released", which stopped
+ * being true at v5.7.0 on npm.
+ *
+ * Nothing on disk is ever rewritten to migrate: `upcast` runs in memory during
+ * the fold, so there is no migration pass to fail halfway and no race with the
+ * concurrent sessions this store is designed for. A mixed-version log is safe
+ * precisely because the original records are never mutated, and the existing
+ * compaction retires old ones naturally as it rewrites snapshots.
+ */
+export const SUPPORTED_VERSIONS = [1];
+
+/**
+ * Brings one record up to the current version. Pure, and one step per version.
+ *
+ * Identity today because GRAPH_VERSION is 1 and no shape has changed. It exists
+ * now so the first change that DOES need it has somewhere to go other than an
+ * equality check that silently deletes user data.
+ */
+export function upcast(record) {
+  return record;
+}
+
+/** True when this reader can interpret the record at all. */
+function readable(record) {
+  const version = record.v ?? 0;
+  // Forward-incompatible records are skipped: a v-from-the-future was written by
+  // a newer client and we cannot know its shape. Ignoring the future is safe;
+  // ignoring the past is data loss.
+  return SUPPORTED_VERSIONS.includes(version);
+}
+```
+
+Replace **both** version checks — in `load` (around line 640) and in `compactIfWasteful` (around line 346) — with `if (!readable(record)) continue;` followed by `record = upcast(record);`.
+
+- [ ] **Step 4: Correct the false header comment**
+
+The block above `GRAPH_VERSION` claims "nothing has been released" and uses that to justify having no migration path. Replace that justification: the package ships on npm, the reader now accepts a range, and a bump is taken only when a record shape actually changes.
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `npx jest tests/hooks/schema-compat.test.mjs tests/hooks/graph-compaction.test.mjs tests/hooks/concurrency.test.mjs`
+Expected: PASS
+
+- [ ] **Step 6: Sync and commit**
+
+```bash
+npm run sync:hooks
+git add hooks-core/wiki.mjs tests/hooks/schema-compat.test.mjs plugin integrations
+git commit -m "fix(wiki): accept a version range, so a future bump cannot zero a graph
+
+load() skipped any record whose v != GRAPH_VERSION, justified by a header
+comment saying nothing had been released. It ships on npm as 5.7.0. A bump
+would have silently discarded every existing graph -- and compactIfWasteful
+carries the same filter, so it would also drop old records while compacting.
+
+Read-time upcasting, nothing rewritten on disk: no migration pass to fail
+halfway and no race with concurrent sessions. GRAPH_VERSION deliberately stays
+at 1, because no record shape changed here."
+```
+
+---
+
+## Definition of done for Plan 1
+
+Measured, not asserted — run against a real project graph after one working session:
+
+| Check | Command | Expected |
+|---|---|---|
+| `query` events exist | `grep -c '"kind":"query"' .token-optimizer/wiki/metrics.jsonl` | > 0 |
+| `contradicts` writable | `npx jest tests/hooks/contradicts.test.mjs` | PASS |
+| No dead edge kinds | every member of `EDGE_KINDS` has a write site | true |
+| Eager invalidation live | `grep -rn "queueInvalidation" hooks-core/adapter.mjs` | a call, not a comment |
+| Allowlist shrunk | `grep -c "^  \['" tests/hooks/reachability.test.mjs` | 9 (from 11) |
+| No drift | `npm run sync:hooks:check` | clean |

--- a/docs/superpowers/plans/2026-08-25-wiki-graph-plan-1-retrieval-and-wiring.md
+++ b/docs/superpowers/plans/2026-08-25-wiki-graph-plan-1-retrieval-and-wiring.md
@@ -1239,27 +1239,37 @@ import { cacheOrdered } from '../../hooks-core/cache.mjs';
 
 describe('cache ordering is applied to injection', () => {
   it('puts stable blocks before volatile ones', () => {
+    // VERIFIED CONTRACT (hooks-core/cache.mjs:430): `volatility` is a NUMBER,
+    // sorted ascending so lower is more stable, falling back to `fresh ? 1 : 0`.
+    // An earlier draft of this plan used 'high'/'low' strings, which subtract to
+    // NaN -- the sort would have been a no-op and the test would have passed by
+    // accident on insertion order.
     const ordered = cacheOrdered([
-      { id: 'findings', volatility: 'high', text: 'a' },
-      { id: 'standing', volatility: 'low', text: 'b' },
+      { id: 'findings', volatility: 2, text: 'a' },
+      { id: 'standing', volatility: 0, text: 'b' },
     ]);
     expect(ordered.map((o) => o.id)).toEqual(['standing', 'findings']);
   });
 });
 ```
 
-Confirm the parameter shape `cacheOrdered` actually expects before writing the assertion:
+The contract is already verified, so no guessing is required:
 
-```bash
-sed -n '430,470p' hooks-core/cache.mjs
+```javascript
+export function cacheOrdered(items) {
+  return [...items].sort((a, b) => {
+    const stability = (item) => item.volatility ?? (item.fresh ? 1 : 0);
+    return stability(a) - stability(b);
+  });
+}
 ```
 
-Adjust the test to the real shape — do not change `cacheOrdered` to fit a guessed one.
-
-- [ ] **Step 2: Run test to verify it fails or reveals the real shape**
+- [ ] **Step 2: Run test to verify it fails**
 
 Run: `npx jest tests/hooks/cache.test.mjs -t "cache ordering"`
-Expected: FAIL, and the failure names the real contract.
+Expected: PASS for the helper itself (it already sorts correctly) — the point of
+this task is that **nothing calls it**. The failing assertion is the reachability
+one in Step 5; treat that as the red test for this task.
 
 - [ ] **Step 3: Route assembly through it**
 
@@ -1270,10 +1280,11 @@ In `hooks-core/inject.mjs`, where the injected blocks are concatenated for a ses
   // one changed line invalidates the prompt cache from that line onward, so the
   // parts that rarely change belong at the top and the freshest at the bottom.
   // `cacheOrdered` has existed for exactly this and had no caller.
+  // Numeric volatility, ascending: standing rules change least, findings most.
   const blocks = cacheOrdered([
-    { id: 'standing', volatility: 'low', text: standingBlock },
-    { id: 'index', volatility: 'medium', text: indexBlock },
-    { id: 'findings', volatility: 'high', text: findingsBlock },
+    { id: 'standing', volatility: 0, text: standingBlock },
+    { id: 'index', volatility: 1, text: indexBlock },
+    { id: 'findings', volatility: 2, text: findingsBlock },
   ].filter((b) => b.text));
 ```
 

--- a/docs/superpowers/plans/2026-08-25-wiki-graph-plan-1-retrieval-and-wiring.md
+++ b/docs/superpowers/plans/2026-08-25-wiki-graph-plan-1-retrieval-and-wiring.md
@@ -4,7 +4,7 @@
 
 **Goal:** Make the graph readable and its declared wiring live — ship `wiki_query`, real BM25, and connect the five capabilities that are declared, tested, and called by nothing.
 
-**Architecture:** All graph logic lives in `hooks-core/*.mjs` and is vendored into seven client copies by `npm run sync:hooks`; never edit a copy. MCP tools in `src/tools/**` reach hooks-core through dynamic `import(coreUrl('x.mjs'))`, following `src/tools/intelligence/wiki-write.ts`. Retrieval is traversal plus lexical, no embeddings.
+**Architecture:** All graph logic lives in `hooks-core/*.mjs` and is vendored into eleven client copies by `npm run sync:hooks`; never edit a copy. MCP tools in `src/tools/**` reach hooks-core through dynamic `import(coreUrl('x.mjs'))`, following `src/tools/intelligence/wiki-write.ts`. Retrieval is traversal plus lexical, no embeddings.
 
 **Tech Stack:** Node 22 ESM (`.mjs`) for hooks-core, TypeScript for `src/`, Jest (`tests/hooks/*.test.mjs`, `tests/unit/*.test.ts`), Express for the dashboard.
 
@@ -221,7 +221,7 @@ what matched best."
   - `wikiQuery(options: WikiQueryOptions) => Promise<WikiQueryResult>`
   - `WikiQueryOperation` — enum, **not** a bare string union of magic strings
 
-**Why this task matters:** `wiki_query` is named in injected prompt text in seven shipped copies and in `docs/WIKI_GRAPH.md`, and it does not exist. The SessionStart index tells the model to call a tool that is not there, and the hard per-touch budget has no escape hatch. Recording a `query` event also resurrects `indexBudget`, which is currently pinned to its 150-token floor for every project once five index injections have occurred.
+**Why this task matters:** `wiki_query` is named in injected prompt text in twelve shipped copies and in `docs/WIKI_GRAPH.md`, and it does not exist. The SessionStart index tells the model to call a tool that is not there, and the hard per-touch budget has no escape hatch. Recording a `query` event also resurrects `indexBudget`, which is currently pinned to its 150-token floor for every project once five index injections have occurred.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -291,7 +291,7 @@ Expected: FAIL — cannot find `dist/tools/intelligence/wiki-query.js`
  * wiki_query — reading the graph, which nothing could do.
  *
  * The SessionStart index has told the model to "call wiki_query with a key for
- * detail" in seven shipped copies of the injected text since injection landed.
+ * detail" in twelve shipped copies of the injected text since injection landed.
  * The tool did not exist. So the design's escape hatch for the hard per-touch
  * budget -- "everything else reachable through wiki_query" -- was not reachable
  * at all, and anything the 500-token cap dropped was simply gone.
@@ -600,7 +600,7 @@ git add src/tools/intelligence/wiki-query.ts src/validation/tool-schemas.ts src/
 git commit -m "feat(wiki): wiki_query, the tool the injected text already promised
 
 The SessionStart index has told the model to 'call wiki_query with a key for
-detail' in seven shipped copies since injection landed, and the tool did not
+detail' in twelve shipped copies since injection landed, and the tool did not
 exist -- so the hard per-touch budget had no escape hatch and anything it
 dropped was unreachable.
 

--- a/docs/superpowers/plans/2026-08-25-wiki-graph-plan-2-production-and-measurement.md
+++ b/docs/superpowers/plans/2026-08-25-wiki-graph-plan-2-production-and-measurement.md
@@ -1,0 +1,914 @@
+# Wiki Graph Plan 2 — Production and Measurement
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a default install produce findings without a model call, and measure per-finding value causally rather than by guessing whether a retrieval was "used".
+
+**Architecture:** Extraction runs at `Stop`, derives findings from data the hooks already hold (exit codes, test transitions, corrections, churn), passes them through budgeted selection, and stores them with the same anchor discipline as every other writer. Measurement is two layers: a cheap explicit-reference label, and a per-finding leave-one-out holdout whose effect is shrunk by empirical Bayes and published under FDR control. The two are deliberately independent so calibrating one against the other is not circular.
+
+**Tech Stack:** Node 22 ESM for hooks-core, TypeScript for `src/`, Jest.
+
+**Spec:** `docs/superpowers/specs/2026-08-25-wiki-graph-gap-closure-design.md`
+
+**Depends on:** Plan 1 (the `query` event supplies Layer 1's numerator; `contradict`/`hasOutstandingContradiction` gate confidence).
+
+## Global Constraints
+
+- **Never edit a vendored copy.** Edit `hooks-core/`, run `npm run sync:hooks`.
+- **Fail open.** Extraction and measurement must never break a tool call or a session end.
+- **No model call in `derive.mjs`.** Nothing leaves the machine. That is what makes it safe on by default.
+- **Redaction is mandatory** on any text derived from captured output, before storage.
+- **No `GRAPH_VERSION` bump.** Per-finding utility lives in metrics, never in graph nodes.
+- **Confidence is never raised by utility.** Promotion requires `!hasOutstandingContradiction`.
+- **No dollar figure on an estimated saving.** Currency appears only on measured-counterfactual lines, sourced from `pricing.mjs`.
+- **Anchor discipline.** `indexFile` first; refuse unanchorable findings.
+- **Branch:** `feat/close-wiki-graph-gaps`.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `hooks-core/redact.mjs` **(new)** | Secret-pattern redaction and capping for any derived claim text. |
+| `hooks-core/derive.mjs` **(new)** | The four zero-cost extractors. No model, no network. |
+| `hooks-core/adapter.mjs` | post-tool records exit code and truncated output; Stop runs `derive`. |
+| `hooks-core/consolidate.mjs` | `selectForConsolidation` gains its caller; `contentAnchor` is deleted. |
+| `hooks-core/usage.mjs` **(new)** | Layer 1: explicit-reference classification per injection. |
+| `hooks-core/loo.mjs` **(new)** | Layer 2: leave-one-out arms, empirical Bayes, BH-FDR, ε-exploration. |
+| `hooks-core/metrics.mjs` | Report gains Layer 1, Layer 2, the calibration verdict, `consolidationRatio`. |
+| `hooks-core/keepwarm.mjs` | `recordRefresh`/`recordRefreshOutcome` wired; decision reads observed hit rate. |
+| `hooks-core/recall.mjs` **(new)** | Held-out retrieval probe. |
+| `hooks-core/inject.mjs` | Consults `loo.mjs` for which finding to withhold; ε-exploration. |
+| `src/tools/analytics/get-optimization-report.ts` | Routes `balanceSheet()`; pricing via `pricing.mjs`. |
+
+---
+
+## Task 1: Redaction, before anything derives a claim
+
+**Files:** Create `hooks-core/redact.mjs`; Test `tests/hooks/redact.test.mjs`
+
+**Interfaces:**
+- Produces: `redact(text: string, { max?: number }) => string`
+
+**Why first:** every later task in this plan writes claim text derived from captured command output. Claims are injected into context *and* exported to markdown, so a secret in stderr becomes a secret in two more places. This must exist before the first extractor.
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+// tests/hooks/redact.test.mjs
+import { describe, it, expect } from '@jest/globals';
+import { redact } from '../../hooks-core/redact.mjs';
+
+describe('redact', () => {
+  it('removes bearer tokens', () => {
+    expect(redact('failed: Authorization: Bearer sk-abc123def456ghi789')).not.toContain('sk-abc123');
+  });
+  it('removes assignments that look like secrets', () => {
+    expect(redact('AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG')).not.toContain('wJalrXUtnFEMI');
+  });
+  it('removes connection strings with credentials', () => {
+    expect(redact('postgres://user:hunter2@db:5432/x')).not.toContain('hunter2');
+  });
+  it('keeps ordinary error text intact', () => {
+    const text = 'TS2345: Argument of type string is not assignable to number';
+    expect(redact(text)).toBe(text);
+  });
+  it('caps length', () => {
+    expect(redact('x'.repeat(5000), { max: 400 }).length).toBeLessThanOrEqual(400);
+  });
+  it('never throws on non-string input', () => {
+    expect(() => redact(null)).not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx jest tests/hooks/redact.test.mjs` → FAIL, module not found.
+
+- [ ] **Step 3: Implement**
+
+```javascript
+// hooks-core/redact.mjs
+/**
+ * Redaction for anything derived from captured output.
+ *
+ * WHY THIS IS MANDATORY RATHER THAN PRUDENT. derive.mjs builds claims out of
+ * command stderr. A claim is INJECTED into model context and EXPORTED to
+ * markdown, so a secret that reaches a claim reaches two more places than the
+ * terminal it came from. Pattern matching is imperfect and that is stated in the
+ * spec, but "imperfect" beats "absent" by a wide margin here.
+ */
+
+const PATTERNS = [
+  // Bearer / API-key shaped tokens.
+  [/\b(bearer\s+)[A-Za-z0-9._~+/-]{12,}/gi, '$1[redacted]'],
+  [/\b(sk|pk|ghp|gho|github_pat|xox[baprs])[-_][A-Za-z0-9._-]{10,}/gi, '[redacted]'],
+  // KEY=value where the key name suggests a secret.
+  [/\b([A-Z0-9_]*(?:SECRET|TOKEN|PASSWORD|PASSWD|APIKEY|API_KEY|PRIVATE_KEY|CREDENTIAL)[A-Z0-9_]*)\s*[=:]\s*\S+/g, '$1=[redacted]'],
+  // Credentials inside a URL.
+  [/\b([a-z][a-z0-9+.-]*:\/\/[^\s:/@]+):[^\s@]+@/gi, '$1:[redacted]@'],
+  // PEM blocks.
+  [/-----BEGIN[^-]*PRIVATE KEY-----[\s\S]*?-----END[^-]*PRIVATE KEY-----/g, '[redacted key]'],
+];
+
+export function redact(text, { max = 400 } = {}) {
+  let out = String(text ?? '');
+  for (const [pattern, replacement] of PATTERNS) out = out.replace(pattern, replacement);
+  return out.length > max ? `${out.slice(0, Math.max(0, max - 1))}…` : out;
+}
+```
+
+- [ ] **Step 4: Run to verify it passes** → `npx jest tests/hooks/redact.test.mjs` → PASS (6)
+- [ ] **Step 5: Commit**
+
+```bash
+npm run sync:hooks
+git add hooks-core/redact.mjs tests/hooks/redact.test.mjs plugin integrations
+git commit -m "feat(derive): mandatory redaction for claims derived from captured output"
+```
+
+---
+
+## Task 2: Capture exit codes and output at post-tool
+
+**Files:** Modify `hooks-core/adapter.mjs`; Test `tests/hooks/capture-results.test.mjs` **(new)**
+
+**Interfaces:**
+- Produces: a `kind: 'result'` event per observed command: `{ kind: 'result', command, exit, output, at, sessionId }` where `output` is redacted and capped at 4 KB.
+
+**Why:** `WIKI_GRAPH.md` and #204 both list "commands run and their exit codes, tests and their results" as free structural harvest. Nothing records them — `buildDigest` takes command text from `tool_use` and deliberately skips `tool_result`. The extractors in Task 3 have no data source until this exists.
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+// tests/hooks/capture-results.test.mjs
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readAll } from '../../hooks-core/metrics.mjs';
+import { recordResult } from '../../hooks-core/adapter.mjs';
+
+let dir;
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'res-')); });
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+describe('result capture', () => {
+  it('records the command, its exit code and its output', () => {
+    recordResult(dir, { command: 'npm test', exit: 1, output: 'FAIL x.test.ts', sessionId: 's' });
+    const [event] = readAll(dir).filter((e) => e.kind === 'result');
+    expect(event.exit).toBe(1);
+    expect(event.command).toBe('npm test');
+    expect(event.output).toContain('FAIL');
+  });
+
+  it('redacts secrets out of captured output', () => {
+    recordResult(dir, { command: 'deploy', exit: 1, output: 'API_TOKEN=abcdef123456 failed' });
+    const [event] = readAll(dir).filter((e) => e.kind === 'result');
+    expect(event.output).not.toContain('abcdef123456');
+  });
+
+  it('caps output so a huge log is never stored whole', () => {
+    recordResult(dir, { command: 'build', exit: 0, output: 'x'.repeat(100_000) });
+    const [event] = readAll(dir).filter((e) => e.kind === 'result');
+    expect(event.output.length).toBeLessThanOrEqual(4096);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails** → `recordResult is not a function`
+
+- [ ] **Step 3: Implement `recordResult` in `adapter.mjs` and call it from the post-tool branch**
+
+```javascript
+/**
+ * Records one observed command result.
+ *
+ * The structural layer promised "commands run and their exit codes, tests and
+ * their results" and recorded none of them: buildDigest reads command TEXT from
+ * tool_use and deliberately skips tool_result. derive.mjs cannot detect a
+ * failed-then-succeeded pair without this.
+ *
+ * Capped at 4 KB and redacted at the boundary, so a 10 MB test log never lands
+ * in the log and a secret in stderr never becomes a stored claim.
+ */
+export function recordResult(dir, { command, exit, output, sessionId } = {}) {
+  try {
+    record(dir, {
+      kind: 'result',
+      command: String(command ?? '').slice(0, 400),
+      exit: Number.isInteger(exit) ? exit : null,
+      output: redact(String(output ?? ''), { max: 4096 }),
+      sessionId: sessionId ?? null,
+    });
+  } catch {
+    /* bookkeeping must never break a completed call */
+  }
+}
+```
+
+Import `redact` from `./redact.mjs` and call `recordResult` in the `event === 'post-tool'` branch, reading exit code and output from the client's post-tool payload. **Client payload shapes differ** — `adapter.mjs:332` already normalises `raw.postToolUse`; extend that normaliser rather than reading raw fields at the call site.
+
+- [ ] **Step 4: Run to verify it passes** → PASS (3)
+- [ ] **Step 5: Commit**
+
+```bash
+npm run sync:hooks
+git add hooks-core/adapter.mjs tests/hooks/capture-results.test.mjs plugin integrations
+git commit -m "feat(capture): record command exit codes and output, promised since P1
+
+WIKI_GRAPH.md lists exit codes and test results as free structural harvest.
+Nothing recorded them, so the extractors had no data source."
+```
+
+---
+
+## Task 3: The four extractors
+
+**Files:** Create `hooks-core/derive.mjs`; Test `tests/hooks/derive.test.mjs`
+
+**Interfaces:**
+- Consumes: `readAll` (`metrics.mjs`), `redact`, `selectForConsolidation` (`consolidate.mjs`), `writeHarvested` (`harvest-write.mjs`), `rereadWaste` (`metrics.mjs`).
+- Produces: `derive(dir, { sessionId, transcriptPath, projectRoot }) => { candidates: Array, written: string[] }`
+- Confidence caps, exported for the test: `CONFIDENCE = { command: 0.9, test: 0.85, correction: 0.6, churn: 0.4 }`
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+// tests/hooks/derive.test.mjs
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { record } from '../../hooks-core/metrics.mjs';
+import { indexFile } from '../../hooks-core/staleness.mjs';
+import { load } from '../../hooks-core/wiki.mjs';
+import { derive, CONFIDENCE } from '../../hooks-core/derive.mjs';
+
+let dir, file;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'der-'));
+  file = join(dir, 'a.ts');
+  writeFileSync(file, 'export const a = 1;');
+  indexFile(dir, file, 'export const a = 1;');
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+describe('derive', () => {
+  it('turns a failed-then-succeeded command into a command and a failure finding', () => {
+    record(dir, { kind: 'result', command: 'npm run build', exit: 1, output: 'TS2345 error' });
+    record(dir, { kind: 'result', command: 'npm run build -- --skipLibCheck', exit: 0, output: 'ok' });
+
+    const { candidates } = derive(dir, { sessionId: 's', projectRoot: dir });
+    const types = candidates.map((c) => c.type);
+    expect(types).toContain('command');
+    expect(types).toContain('failure');
+  });
+
+  it('caps confidence per detector so a heuristic cannot outrank an exit code', () => {
+    expect(CONFIDENCE.command).toBeGreaterThan(CONFIDENCE.correction);
+    expect(CONFIDENCE.correction).toBeGreaterThan(CONFIDENCE.churn);
+  });
+
+  it('redacts secrets out of a derived claim', () => {
+    record(dir, { kind: 'result', command: 'deploy', exit: 1, output: 'API_TOKEN=abcdef123456' });
+    record(dir, { kind: 'result', command: 'deploy --retry', exit: 0, output: 'ok' });
+    const { candidates } = derive(dir, { sessionId: 's', projectRoot: dir });
+    expect(JSON.stringify(candidates)).not.toContain('abcdef123456');
+  });
+
+  it('writes nothing when there is nothing to derive', () => {
+    expect(derive(dir, { sessionId: 's', projectRoot: dir }).candidates).toEqual([]);
+  });
+
+  it('never throws, because it runs at session end', () => {
+    record(dir, { kind: 'result', command: null, exit: null, output: null });
+    expect(() => derive(dir, { sessionId: 's', projectRoot: dir })).not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails** → module not found
+
+- [ ] **Step 3: Implement `derive.mjs`**
+
+```javascript
+// hooks-core/derive.mjs
+/**
+ * Findings from data we already hold, with no model call.
+ *
+ * WHY THIS EXISTS. The semantic harvest is opt-in for good reasons -- it spends
+ * money and sends a digest off the machine -- so a default install produced a
+ * structural skeleton and no verdicts. Measured on this repository over three
+ * weeks: 1,446 symbol nodes, 468 file nodes, 45 task nodes, ONE finding. The
+ * product thesis is "retrieve verdicts, not evidence" and there were no verdicts.
+ *
+ * Everything here is derived from exit codes, test transitions, corrections and
+ * churn -- all already recorded, all local. Nothing leaves the machine, so there
+ * is nothing to consent to and this is on by default.
+ *
+ * PRECISION IS CAPPED, NOT CLAIMED. "Failed then succeeded" does not prove the
+ * second command fixed the first. Each detector carries a confidence ceiling and
+ * Plan 2's per-finding utility prunes what turns out not to help.
+ */
+
+import { readAll, rereadWaste } from './metrics.mjs';
+import { redact } from './redact.mjs';
+
+/** Ceilings, ordered by how much the evidence actually supports. */
+export const CONFIDENCE = { command: 0.9, test: 0.85, correction: 0.6, churn: 0.4 };
+
+const TEST_COMMAND = /\b(test|jest|vitest|pytest|mocha|dotnet\s+test|go\s+test|cargo\s+test)\b/i;
+
+/** Commands are "the same attempt" when their first two words match. */
+function attemptKey(command) {
+  return String(command || '').trim().split(/\s+/).slice(0, 2).join(' ').toLowerCase();
+}
+
+export function derive(dir, { sessionId, projectRoot } = {}) {
+  let events;
+  try {
+    events = readAll(dir);
+  } catch {
+    return { candidates: [], written: [] };
+  }
+
+  const results = events.filter((e) => e.kind === 'result' && e.command);
+  const candidates = [];
+
+  // ---- 1 & 2: a failed attempt followed by a succeeding one -------------
+  // Grouped by attempt key and ordered, so `npm run build` failing and then
+  // `npm run build -- --skipLibCheck` succeeding is one story rather than two
+  // unrelated events.
+  const byAttempt = new Map();
+  for (const event of results) {
+    const key = attemptKey(event.command);
+    if (!byAttempt.has(key)) byAttempt.set(key, []);
+    byAttempt.get(key).push(event);
+  }
+
+  for (const [, run] of byAttempt) {
+    const failed = run.find((e) => Number.isInteger(e.exit) && e.exit !== 0);
+    if (!failed) continue;
+    const fixed = run.find((e) => e.exit === 0 && (e.at ?? 0) > (failed.at ?? 0));
+    if (!fixed) continue;
+
+    const isTest = TEST_COMMAND.test(fixed.command);
+    const cap = isTest ? CONFIDENCE.test : CONFIDENCE.command;
+
+    candidates.push({
+      type: 'command',
+      claim: redact(`\`${fixed.command}\` works where \`${failed.command}\` failed`),
+      confidence: cap,
+      anchors: [projectRoot],
+      evidence: redact(`exit ${failed.exit} then exit 0`),
+      derivedBy: isTest ? 'test-transition' : 'command-transition',
+      at: fixed.at ?? Date.now(),
+    });
+
+    candidates.push({
+      type: 'failure',
+      claim: redact(`\`${failed.command}\` fails: ${String(failed.output || '').split('\n')[0]}`),
+      confidence: cap,
+      anchors: [projectRoot],
+      evidence: redact(String(failed.output || '')),
+      derivedBy: isTest ? 'test-transition' : 'command-transition',
+      at: failed.at ?? Date.now(),
+    });
+  }
+
+  // ---- 3: user corrections -------------------------------------------------
+  // A `feedback` finding, the one type whose source is a person saying the agent
+  // was wrong. Heuristic, hence the lowest cap but one.
+  for (const event of events) {
+    if (event.kind !== 'correction' || !event.text) continue;
+    candidates.push({
+      type: 'feedback',
+      claim: redact(String(event.text)),
+      confidence: CONFIDENCE.correction,
+      anchors: event.files?.length ? event.files : [projectRoot],
+      evidence: 'user correction observed in session',
+      derivedBy: 'correction',
+      at: event.at ?? Date.now(),
+    });
+  }
+
+  // ---- 4: re-read churn ---------------------------------------------------
+  // Describes our own behaviour rather than the code, so it gets the lowest cap
+  // and will be starved by the injection budget's confidence ranking unless it
+  // earns its place through measured utility.
+  try {
+    const waste = rereadWaste(dir, { events });
+    for (const row of waste?.worst?.slice(0, 3) ?? []) {
+      candidates.push({
+        type: 'map',
+        claim: `${row.anchor} is a recurring reference point in this project`,
+        confidence: CONFIDENCE.churn,
+        anchors: [row.anchor],
+        evidence: `re-read ${row.rereads ?? 0} times`,
+        derivedBy: 'churn',
+        at: Date.now(),
+      });
+    }
+  } catch {
+    // rereadWaste has its own log window; a failure here costs one detector.
+  }
+
+  return { candidates, written: [] };
+}
+```
+
+Verify `rereadWaste`'s real return shape before relying on `worst`:
+
+```bash
+sed -n '451,505p' hooks-core/metrics.mjs
+```
+
+Adjust the churn detector to the real shape rather than changing `rereadWaste`.
+
+- [ ] **Step 4: Run to verify it passes** → PASS (5)
+- [ ] **Step 5: Commit**
+
+```bash
+npm run sync:hooks
+git add hooks-core/derive.mjs tests/hooks/derive.test.mjs plugin integrations
+git commit -m "feat(derive): four zero-cost extractors, so a default install produces findings
+
+This repository's own graph held 1,446 symbol nodes and ONE finding after three
+weeks, because the only path to a verdict was an opt-in model call. These four
+derive findings from exit codes, test transitions, corrections and churn --
+locally, with no model and nothing leaving the machine."
+```
+
+---
+
+## Task 4: Wire `selectForConsolidation`, delete `contentAnchor`
+
+**Files:** Modify `hooks-core/derive.mjs`, `hooks-core/consolidate.mjs`, `tests/hooks/reachability.test.mjs`, `tests/hooks/consolidate.test.mjs`
+
+**Interfaces:**
+- Consumes: `selectForConsolidation(graph, candidates, { budget })`.
+- Produces: `derive()` now returns `written: string[]` — the keys actually stored.
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+// append to tests/hooks/derive.test.mjs
+it('passes candidates through budgeted selection before writing', () => {
+  for (let i = 0; i < 40; i++) {
+    record(dir, { kind: 'result', command: `cmd${i} a`, exit: 1, output: 'x', at: i });
+    record(dir, { kind: 'result', command: `cmd${i} a --fix`, exit: 0, output: 'ok', at: i + 1000 });
+  }
+  const { candidates, written } = derive(dir, { sessionId: 's', projectRoot: dir });
+  // Selection is under a token budget, so not everything derived is stored.
+  expect(written.length).toBeGreaterThan(0);
+  expect(written.length).toBeLessThan(candidates.length);
+});
+```
+
+- [ ] **Step 2: Run to verify it fails** → `written` is empty
+
+- [ ] **Step 3: Wire selection and storage into `derive()`**
+
+```javascript
+  // BUDGETED SELECTION, not everything derived. selectForConsolidation exists
+  // for exactly this and had no caller: it keeps failures and decisions on a
+  // floor regardless of score, which encodes the design's judgement that dead
+  // ends are the highest-value kind.
+  const { selectForConsolidation } = await import('./consolidate.mjs');
+  const { writeHarvested } = await import('./harvest-write.mjs');
+  const { load } = await import('./wiki.mjs');
+
+  const graph = load(dir);
+  const chosen = selectForConsolidation(graph, candidates, { budget: 4000 });
+  const written = writeHarvested(dir, chosen, {
+    sessionId,
+    origin: ORIGIN_HARVESTED,
+    projectRoot,
+  });
+  return { candidates, written };
+```
+
+`derive` becomes `async` — update its callers and the tests to `await`.
+
+- [ ] **Step 4: Delete `contentAnchor`**
+
+Remove `export function contentAnchor` from `hooks-core/consolidate.mjs` and its allowlist entry. Then open the follow-up issue so the idea is not lost:
+
+```bash
+gh issue create --title "Content-addressed anchors: a finding about a vendored file should appear in every repo holding it" --body "$(cat <<'EOF'
+`contentAnchor` was implemented in `hooks-core/consolidate.mjs` and never wired,
+then deleted in the #204 gap-closure work rather than left dormant.
+
+The idea is worth keeping. From its docblock:
+
+> A vendored library file is the same file in every repository that holds it,
+> whatever path each gives it. Anchoring to content as well as path means a
+> finding about it appears in all of them with no promotion step and no path
+> mapping -- reach a per-session checkpoint cannot have even in principle.
+> The PATH anchor still drives staleness within a repo; this is additive.
+
+Deleted rather than wired because it introduces a second anchor identity, and
+anchor identity is the one place in this codebase that has already caused silent
+node-splitting (Windows path canonicalisation). It also interacts with
+`fleet.mjs` cross-project transfer. That deserves its own design pass.
+
+Recoverable from git history: see the deletion commit on `feat/close-wiki-graph-gaps`.
+EOF
+)"
+```
+
+- [ ] **Step 5: Run tests** → `npx jest tests/hooks/derive.test.mjs tests/hooks/consolidate.test.mjs tests/hooks/reachability.test.mjs` → PASS
+- [ ] **Step 6: Commit**
+
+```bash
+npm run sync:hooks
+git add hooks-core tests plugin integrations
+git commit -m "feat(derive): budgeted selection before storage; delete contentAnchor
+
+selectForConsolidation had no caller, so nothing bounded what entered the
+graph -- risk 2 (bloat) unaddressed. contentAnchor is deleted rather than left
+dormant, with the idea preserved in a follow-up issue."
+```
+
+---
+
+## Task 5: Run `derive` at Stop, and the other three cold-graph measures
+
+**Files:** Modify `hooks-core/adapter.mjs`, `hooks-core/standing.mjs`, `hooks-core/doctor.mjs`, `docs/WIKI_GRAPH.md`, `README.md`; Test `tests/hooks/derive.test.mjs`
+
+- [ ] **Step 1: Call `derive` from the Stop branch of `adapter.mjs`**, alongside the existing harvest, wrapped so a failure is silent.
+- [ ] **Step 2: Add the standing rule** nudging `wiki_write`, inside the existing standing budget in `standing.mjs`. Keep it to one line of guidance; the budget is 400 tokens for roughly a dozen rules.
+- [ ] **Step 3: Surface the local endpoint.** In `doctor.mjs` and the SessionStart summary, when `harvestMode()` returns `'local'`, say so plainly: `local model found — semantic harvest is on, free and private`. When it returns `'off:not-opted-in'`, say what turning it on would buy and what it would send.
+- [ ] **Step 4: State the default honestly** in `README.md` and `docs/WIKI_GRAPH.md`: a default install derives findings locally from exit codes, tests, corrections and churn; the model-based semantic harvest additionally requires `TOKEN_OPTIMIZER_HARVEST=1` or a local endpoint.
+- [ ] **Step 5: Test the Stop path end to end**
+
+```javascript
+it('derives findings when the session ends, through the Stop path', async () => {
+  record(dir, { kind: 'result', command: 'npm run build', exit: 1, output: 'TS2345' });
+  record(dir, { kind: 'result', command: 'npm run build -- --fix', exit: 0, output: 'ok' });
+  await runStop(dir, { sessionId: 's', projectRoot: dir });   // real Stop entry, not derive() directly
+  const findings = [...load(dir).nodes.values()].filter((n) => n.kind === 'finding');
+  expect(findings.length).toBeGreaterThan(0);
+});
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+npm run sync:hooks
+git add hooks-core docs README.md tests plugin integrations
+git commit -m "feat(derive): run at Stop; surface local harvest; state the default honestly"
+```
+
+---
+
+## Task 6: Layer 1 — explicit-reference classification
+
+**Files:** Create `hooks-core/usage.mjs`; Test `tests/hooks/usage.test.mjs`
+
+**Interfaces:**
+- Consumes: `readAll`, `readBalance` from `metrics.mjs`. Depends on Plan 1's `query` event.
+- Produces:
+  - `classify(dir) => Array<{ findingKey, sessionId, label: 'referenced'|'not-referenced'|'unknown' }>`
+  - `referenceRate(dir) => { referenced: number, denominator: number, rate: number|null }`
+
+**Why Layer 1 uses references and not read-suppression:** read-suppression is Layer 2's estimand. Using it in both would make the calibration loop compare two spellings of one quantity — a strong correlation that means nothing. `unknown` is excluded from the denominator rather than counted as a miss.
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+// tests/hooks/usage.test.mjs
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { record } from '../../hooks-core/metrics.mjs';
+import { classify, referenceRate } from '../../hooks-core/usage.mjs';
+
+let dir;
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'usage-')); });
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+describe('Layer 1', () => {
+  it('labels an injection referenced when a later query names the finding', () => {
+    record(dir, { kind: 'inject', anchor: 'a.ts', findingKeys: ['k1'], sessionId: 's', at: 1 });
+    record(dir, { kind: 'query', operation: 'get', key: 'k1', sessionId: 's', at: 2 });
+    expect(classify(dir).find((r) => r.findingKey === 'k1').label).toBe('referenced');
+  });
+
+  it('does not count a query that preceded the injection', () => {
+    record(dir, { kind: 'query', operation: 'get', key: 'k1', sessionId: 's', at: 1 });
+    record(dir, { kind: 'inject', anchor: 'a.ts', findingKeys: ['k1'], sessionId: 's', at: 2 });
+    expect(classify(dir).find((r) => r.findingKey === 'k1').label).not.toBe('referenced');
+  });
+
+  it('excludes unknown from the denominator instead of scoring it a miss', () => {
+    record(dir, { kind: 'inject', anchor: 'a.ts', findingKeys: ['k1'], sessionId: 's', at: 1 });
+    record(dir, { kind: 'query', operation: 'get', key: 'k1', sessionId: 's', at: 2 });
+    record(dir, { kind: 'inject', anchor: 'b.ts', findingKeys: ['k2'], sessionId: 's2', at: 3 });
+    const rate = referenceRate(dir);
+    expect(rate.denominator).toBeLessThan(classify(dir).length);
+  });
+
+  it('returns a null rate rather than 0 when there is no evidence', () => {
+    expect(referenceRate(dir).rate).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails** → module not found
+- [ ] **Step 3: Implement `usage.mjs`.** Join `inject` events to later `query`/`expand` events on `(sessionId, findingKey)` with `at` ordering. A session with no subsequent tool activity yields `unknown`.
+- [ ] **Step 4: Run to verify it passes** → PASS (4)
+- [ ] **Step 5: Ensure `inject` records `findingKeys`.** If it does not, add it in `inject.mjs` — Layer 1 cannot attribute without it.
+- [ ] **Step 6: Commit**
+
+```bash
+npm run sync:hooks
+git add hooks-core/usage.mjs hooks-core/inject.mjs tests/hooks/usage.test.mjs plugin integrations
+git commit -m "feat(metrics): Layer 1, explicit-reference classification
+
+Deliberately independent of read-suppression: that is Layer 2's estimand, and
+using it in both would make the calibration loop compare two spellings of one
+quantity. unknown is excluded from the denominator, never counted as a miss."
+```
+
+---
+
+## Task 7: Layer 2 — per-finding leave-one-out
+
+**Files:** Create `hooks-core/loo.mjs`; Modify `hooks-core/inject.mjs`; Test `tests/hooks/loo.test.mjs`
+
+**Interfaces:**
+- Produces:
+  - `withheldFor(findingKeys, sessionId, graph, dir) => string|null` — which single finding to withhold, or null
+  - `effects(dir) => Array<{ findingKey, served, withheld, raw, shrunk, published: boolean }>`
+  - `LOO_ENABLED() => boolean` — false when `TOKEN_OPTIMIZER_LOO=off`
+- Constants: `MIN_PRIOR_INJECTIONS = 4`, `MIN_SERVED = 6`, `MIN_WITHHELD = 3`, `FDR_Q = 0.10`, `EPSILON = 0.10`
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+// tests/hooks/loo.test.mjs
+import { describe, it, expect } from '@jest/globals';
+import { withheldFor, effects, MIN_PRIOR_INJECTIONS } from '../../hooks-core/loo.mjs';
+
+describe('Layer 2 guards', () => {
+  it('never withholds a pinned or human-origin finding', () => {
+    const graph = { nodes: new Map([['f1', { key: 'k1', pinned: true, origin: 'harvested' }]]) };
+    expect(withheldFor(['k1'], 's', graph, null)).toBeNull();
+  });
+
+  it('withholds at most one finding per touch', () => {
+    const chosen = withheldFor(['k1', 'k2', 'k3'], 's', graphWith(['k1', 'k2', 'k3']), dirWithHistory());
+    expect(typeof chosen === 'string' || chosen === null).toBe(true);
+  });
+
+  it('is stable for a session, so an arm cannot flip mid-session', () => {
+    const a = withheldFor(['k1', 'k2'], 'sess', graphWith(['k1', 'k2']), dirWithHistory());
+    const b = withheldFor(['k1', 'k2'], 'sess', graphWith(['k1', 'k2']), dirWithHistory());
+    expect(a).toBe(b);
+  });
+
+  it('does not enter a finding into the experiment before enough prior injections', () => {
+    expect(MIN_PRIOR_INJECTIONS).toBeGreaterThanOrEqual(4);
+  });
+
+  it('publishes no verdict below the observation floor', () => {
+    const rows = effects(dirWithFewObservations());
+    expect(rows.every((r) => r.published === false)).toBe(true);
+  });
+
+  it('shrinks a low-observation effect toward the population mean', () => {
+    const rows = effects(dirWithMixedObservations());
+    const low = rows.find((r) => r.served + r.withheld < 10);
+    expect(Math.abs(low.shrunk)).toBeLessThan(Math.abs(low.raw));
+  });
+
+  it('is disabled by the kill switch', () => {
+    process.env.TOKEN_OPTIMIZER_LOO = 'off';
+    expect(withheldFor(['k1'], 's', graphWith(['k1']), dirWithHistory())).toBeNull();
+    delete process.env.TOKEN_OPTIMIZER_LOO;
+  });
+});
+```
+
+Write the `graphWith` / `dirWithHistory` / `dirWithFewObservations` / `dirWithMixedObservations` helpers at the top of the file as real fixture builders using `record()` — not mocks.
+
+- [ ] **Step 2: Run to verify it fails** → module not found
+- [ ] **Step 3: Implement `loo.mjs`** with:
+  - arm from `hash(findingKey + sessionId)`, stable for the session;
+  - guards: skip `pinned` and `origin === 'human'`; require `MIN_PRIOR_INJECTIONS`; return at most one key;
+  - `effects()`: per-key mean downstream read cost served vs withheld, shrunk by empirical Bayes `(n·observed + k·prior) / (n + k)` toward the population mean;
+  - Benjamini–Hochberg at `FDR_Q = 0.10` deciding `published`;
+  - `ε = 0.10` of injections ignore the utility ranking so a low-scored finding still accrues observations;
+  - the serving-policy version recorded with each observation.
+- [ ] **Step 4: Run to verify it passes** → PASS (7)
+- [ ] **Step 5: Consult it from `inject.mjs`** when assembling a touch's finding set, withholding the returned key and recording `{ loo: findingKey }` on the inject event.
+- [ ] **Step 6: Commit**
+
+```bash
+npm run sync:hooks
+git add hooks-core/loo.mjs hooks-core/inject.mjs tests/hooks/loo.test.mjs plugin integrations
+git commit -m "feat(metrics): Layer 2, per-finding causal utility by leave-one-out
+
+Nobody in this space measures per-item value causally in production -- the
+state of the art is offline eval sets. Guarded: never pinned or human-origin,
+never more than one withheld per touch, four prior injections before entry,
+empirical-Bayes shrinkage, BH-FDR at q=0.10, and 10% exploration so a low score
+cannot become self-fulfilling."
+```
+
+---
+
+## Task 8: Calibration, report routing, pricing, `consolidationRatio`
+
+**Files:** Modify `hooks-core/metrics.mjs`, `src/tools/analytics/get-optimization-report.ts`; Test `tests/hooks/calibration-loop.test.mjs` **(new)**, `tests/unit/optimization-report.test.ts` **(new)**
+
+**Interfaces:**
+- Produces: `calibration(dir) => { gap: number|null, verdict: string, publishable: boolean }`; `balanceSheet()` gains `layer1`, `layer2`, `calibration`, `consolidation`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```javascript
+// tests/hooks/calibration-loop.test.mjs
+it('refuses to publish Layer 1 when its label does not predict Layer 2', () => {
+  const dir = dirWhereReferencedFindingsShowNoEffect();
+  const result = calibration(dir);
+  expect(result.publishable).toBe(false);
+  expect(result.verdict).toMatch(/does not predict|uncalibrated/i);
+});
+
+it('publishes when referenced findings show a larger causal effect', () => {
+  const dir = dirWhereReferencedFindingsShowEffect();
+  expect(calibration(dir).publishable).toBe(true);
+});
+```
+
+```typescript
+// tests/unit/optimization-report.test.ts
+it('shows the graph balance sheet', async () => {
+  const report = await getOptimizationReport({});
+  expect(report.data.graph).toBeDefined();
+});
+
+it('puts a dollar figure only on measured lines', async () => {
+  const report = await getOptimizationReport({});
+  expect(report.formatted).toContain('estimate');
+  // The estimated-savings line must carry no currency symbol.
+  const estimatedLine = report.formatted.split('\n').find((l) => /estimat/i.test(l));
+  expect(estimatedLine).not.toMatch(/\$/);
+});
+```
+
+- [ ] **Step 2: Run to verify they fail**
+- [ ] **Step 3: Implement `calibration()`** comparing mean Layer-2 effect for `referenced` versus `unknown` findings, returning `publishable: false` with a stated reason when the gap is not positive with enough data.
+- [ ] **Step 4: Add `layer1`, `layer2`, `calibration` and `consolidation` (from `consolidationRatio`, labelled an estimate) to `balanceSheet()`.**
+- [ ] **Step 5: Route `balanceSheet()` into `get-optimization-report.ts`,** replace `approxCost`'s hardcoded `$3/1M` with `pricing.mjs`, and emit currency only on measured-counterfactual lines.
+- [ ] **Step 6: Consume `hasOutstandingContradiction` — the gate, not just the predicate**
+
+Plan 1 Task 5 produces `hasOutstandingContradiction`. Without this step it would be an exported predicate that nothing calls — a fresh instance of the exact defect class this work exists to close, and the census in Plan 3 would catch it.
+
+Wherever measured utility influences a finding's standing, consult it first:
+
+```javascript
+/**
+ * Utility RANKS a finding. It must never raise its confidence.
+ *
+ * Layer 2 measures whether a finding suppresses reads, and a confidently WRONG
+ * finding suppresses reads better than a hedged true one -- so utility alone
+ * optimises directly against risk 1, "wrong findings are worse than none".
+ * A finding with an outstanding contradiction is ranked on its measured utility
+ * like any other, and is never promoted on the strength of it.
+ */
+function mayPromote(graph, key) {
+  return !hasOutstandingContradiction(graph, key);
+}
+```
+
+Add the test that proves the gate bites:
+
+```javascript
+it('does not promote confidence for a finding that something contradicts', () => {
+  contradict(dir, { key: 'suppressor', byKey: 'rebuttal', reason: 're-derived differently' });
+  const before = findingByKey(dir, 'suppressor').confidence;
+  applyUtility(dir, { key: 'suppressor', effect: 5000 });   // a large measured win
+  expect(findingByKey(dir, 'suppressor').confidence).toBe(before);
+});
+```
+
+- [ ] **Step 7: Remove the `consolidationRatio` allowlist entry.**
+- [ ] **Step 8: Run** `npm run build && npx jest tests/hooks/calibration-loop.test.mjs tests/unit/optimization-report.test.ts tests/hooks/reachability.test.mjs` → PASS
+- [ ] **Step 9: Commit**
+
+```bash
+npm run sync:hooks
+git add hooks-core/metrics.mjs src/tools/analytics/get-optimization-report.ts tests plugin integrations
+git commit -m "feat(metrics): calibration loop, balance sheet in the report, pricing from the table
+
+The report hardcoded \$3/1M and priced estimated savings, contradicting the
+project's own rule that no unmeasured saving gets a price. Currency now appears
+only on measured-counterfactual lines.
+
+consolidationRatio is wired: cost-to-derive against cost-to-carry, labelled an
+estimate, which is the most legible statement of what the graph is for."
+```
+
+---
+
+## Task 9: Close the keep-warm loop
+
+**Files:** Modify `hooks-core/keepwarm.mjs`, `hooks-core/adapter.mjs`, `tests/hooks/reachability.test.mjs`; Test `tests/hooks/keepwarm.test.mjs`
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+it('lets an observed hit rate change the keep-warm decision', () => {
+  const cold = mkdtempSync(join(tmpdir(), 'kw-'));
+  for (let i = 0; i < 10; i++) {
+    recordRefresh(cold, { tier: '5m', prefixTokens: 20000, expectedValue: 1 });
+    recordRefreshOutcome(cold, { tier: '5m', prefixTokens: 20000, hit: false });
+  }
+  // Ten refreshes that never bought a read must not keep recommending refresh.
+  expect(keepWarmDecision(cold, { tier: '5m', prefixTokens: 20000 }).refresh).toBe(false);
+});
+```
+
+- [ ] **Step 2: Run to verify it fails** — the decision ignores outcomes today.
+- [ ] **Step 3: Call `recordRefresh` where a refresh is issued and `recordRefreshOutcome` when the next turn arrives before expiry or does not.** The turn-arrival signal comes from the Stop/pre-tool boundary; if no signal is available for a tier, record nothing rather than guessing `hit: false`.
+- [ ] **Step 4: Have `keepWarmDecision` read the observed hit rate,** falling back to expected value when observations are below a floor.
+- [ ] **Step 5: Remove both allowlist entries.**
+- [ ] **Step 6: Run** `npx jest tests/hooks/keepwarm.test.mjs tests/hooks/reachability.test.mjs` → PASS
+- [ ] **Step 7: Commit**
+
+```bash
+npm run sync:hooks
+git add hooks-core tests plugin integrations
+git commit -m "feat(keepwarm): close the loop -- refreshes now learn whether they paid off
+
+keepWarmDecision spent money on refreshes and could never check whether one
+bought a read, because both recording halves had no call site."
+```
+
+---
+
+## Task 10: The recall probe
+
+**Files:** Create `hooks-core/recall.mjs`; Test `tests/hooks/recall.test.mjs`
+
+**Interfaces:**
+- Produces: `recallProbe(dir, { limit }) => { probed: number, retrieved: number, rate: number|null, misses: Array<{key, reason}> }`
+
+**Why:** `WIKI_GRAPH.md` says embeddings get added "if measurement shows real recall loss". Nothing measures recall, so the no-embeddings stance is unfalsifiable. For each finding, hide it and ask whether traversal plus BM25 would surface it from its own originating context.
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+it('retrieves a finding from its own anchor', () => {
+  // A finding anchored to a file must be reachable from that file, or traversal
+  // is broken rather than merely lossy.
+  expect(recallProbe(dir).rate).toBe(1);
+});
+
+it('reports a finding reachable by neither traversal nor lexical as a miss', () => {
+  putNodeWithEdges(dir, { kind: 'finding', key: 'orphan', claim: 'zqx unrelated' });
+  const result = recallProbe(dir);
+  expect(result.misses.map((m) => m.key)).toContain('orphan');
+});
+
+it('returns a null rate rather than 1 on an empty graph', () => {
+  expect(recallProbe(emptyDir).rate).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+- [ ] **Step 3: Implement.** For each active finding: take its anchors, run `findingsFor` from each; if absent, run `lexical.rank` using the finding's own claim terms against the rest; record a hit if either surfaces it, a miss with a reason otherwise.
+- [ ] **Step 4: Run to verify it passes**
+- [ ] **Step 5: Report it** alongside the balance sheet, labelled as an offline probe over the current graph.
+- [ ] **Step 6: Commit**
+
+```bash
+npm run sync:hooks
+git add hooks-core/recall.mjs tests/hooks/recall.test.mjs plugin integrations
+git commit -m "test(wiki): recall probe, making the no-embeddings stance falsifiable
+
+The design says embeddings get added if measurement shows recall loss, and
+nothing measured recall. Now it does."
+```
+
+---
+
+## Definition of done for Plan 2
+
+| Check | Command | Expected |
+|---|---|---|
+| Findings on a default install | one session, then count `kind:"finding"` in `graph.jsonl` | > 0 without `TOKEN_OPTIMIZER_HARVEST` |
+| Result events recorded | `grep -c '"kind":"result"' .token-optimizer/wiki/metrics.jsonl` | > 0 |
+| Layer 1 has a denominator | `referenceRate(dir).denominator` | > 0 after a session using `wiki_query` |
+| Layer 2 refuses early verdicts | `effects(dir).every(r => !r.published)` on a young graph | true |
+| Calibration refuses when uncalibrated | `calibration(dir).publishable` | false, with a stated reason |
+| No price on an estimate | the estimated line in `get_optimization_report` | no `$` |
+| Recall measured | `recallProbe(dir).rate` | a number, or null with a reason |
+| Allowlist shrunk | `grep -c "^  \['" tests/hooks/reachability.test.mjs` | 4 (from 9) |

--- a/docs/superpowers/plans/2026-08-25-wiki-graph-plan-2-production-and-measurement.md
+++ b/docs/superpowers/plans/2026-08-25-wiki-graph-plan-2-production-and-measurement.md
@@ -131,14 +131,29 @@ git commit -m "feat(derive): mandatory redaction for claims derived from capture
 
 ---
 
-## Task 2: Capture exit codes and output at post-tool
+## Task 2: Extend `tool-outcome` with output and exit code
 
 **Files:** Modify `hooks-core/adapter.mjs`; Test `tests/hooks/capture-results.test.mjs` **(new)**
 
-**Interfaces:**
-- Produces: a `kind: 'result'` event per observed command: `{ kind: 'result', command, exit, output, at, sessionId }` where `output` is redacted and capped at 4 KB.
+**VERIFIED CONTRACT — this task is far smaller than first planned.** The
+post-tool branch of `adapter.mjs` (~line 855) already computes the command, the
+touched files, the anchor and the project root, and calls
+`recordToolOutcome(wikiDir(root), { ...episode, surface, anchor, toolName,
+success: toolSucceeded(raw), durationMs, ...usageFrom(raw) })`.
+`recordToolOutcome` (`metrics.mjs:505`) writes `kind: 'tool-outcome'` and — the
+part that matters most — **already joins the outcome back to its injection**,
+recording `injectionId`, `findingIds` and a `joinMethod` of `tool-call-id`,
+`episode-anchor` or `none`. This repository holds **234 live `tool-outcome`
+events**, so the pipeline runs.
 
-**Why:** `WIKI_GRAPH.md` and #204 both list "commands run and their exit codes, tests and their results" as free structural harvest. Nothing records them — `buildDigest` takes command text from `tool_use` and deliberately skips `tool_result`. The extractors in Task 3 have no data source until this exists.
+There is therefore **no new event kind**. Add two *optional* fields to what
+post-tool already passes: `output` (redacted per Task 1, capped at 4 KB) and
+`exit` (the numeric code where a client supplies one, `null` otherwise).
+
+**Interfaces:**
+- Produces: `kind: 'tool-outcome'` gains optional `output` and `exit`. Additive only, so no `GRAPH_VERSION` question.
+
+**Why:** `toolSucceeded(raw)` returns a **boolean**, normalised across clients from error and status fields. A boolean cannot distinguish a compile error from a test failure from a denied permission, and the failure findings that carry the most value need the text. The exit code is opportunistic — many clients never report one.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -148,79 +163,98 @@ import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { readAll } from '../../hooks-core/metrics.mjs';
-import { recordResult } from '../../hooks-core/adapter.mjs';
+import { readAll, recordToolOutcome } from '../../hooks-core/metrics.mjs';
 
 let dir;
 beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'res-')); });
 afterEach(() => rmSync(dir, { recursive: true, force: true }));
 
-describe('result capture', () => {
-  it('records the command, its exit code and its output', () => {
-    recordResult(dir, { command: 'npm test', exit: 1, output: 'FAIL x.test.ts', sessionId: 's' });
-    const [event] = readAll(dir).filter((e) => e.kind === 'result');
-    expect(event.exit).toBe(1);
-    expect(event.command).toBe('npm test');
-    expect(event.output).toContain('FAIL');
+const outcome = (extra) => recordToolOutcome(dir, {
+  surface: 'command', anchor: 'npm test', toolName: 'Bash', success: false, ...extra,
+});
+const latest = () => readAll(dir).filter((e) => e.kind === 'tool-outcome').pop();
+
+describe('tool-outcome carries output and exit', () => {
+  it('records the output and the exit code alongside success', () => {
+    outcome({ output: 'FAIL x.test.ts', exit: 1 });
+    expect(latest().success).toBe(false);
+    expect(latest().exit).toBe(1);
+    expect(latest().output).toContain('FAIL');
   });
 
   it('redacts secrets out of captured output', () => {
-    recordResult(dir, { command: 'deploy', exit: 1, output: 'API_TOKEN=abcdef123456 failed' });
-    const [event] = readAll(dir).filter((e) => e.kind === 'result');
-    expect(event.output).not.toContain('abcdef123456');
+    outcome({ output: 'API_TOKEN=abcdef123456 failed', exit: 1 });
+    expect(latest().output).not.toContain('abcdef123456');
   });
 
   it('caps output so a huge log is never stored whole', () => {
-    recordResult(dir, { command: 'build', exit: 0, output: 'x'.repeat(100_000) });
-    const [event] = readAll(dir).filter((e) => e.kind === 'result');
-    expect(event.output.length).toBeLessThanOrEqual(4096);
+    outcome({ output: 'x'.repeat(100000), exit: 0 });
+    expect(latest().output.length).toBeLessThanOrEqual(4096);
+  });
+
+  it('leaves exit null when the client reports no code, rather than guessing 0', () => {
+    outcome({ output: 'denied' });
+    expect(latest().exit).toBeNull();
+  });
+
+  it('does not disturb the injection join the pipeline already performs', () => {
+    outcome({ output: 'x', exit: 1 });
+    expect(latest().joinMethod).toBeDefined();
   });
 });
 ```
 
-- [ ] **Step 2: Run to verify it fails** → `recordResult is not a function`
+- [ ] **Step 2: Run to verify it fails** → `event.exit` and `event.output` are `undefined`
 
-- [ ] **Step 3: Implement `recordResult` in `adapter.mjs` and call it from the post-tool branch**
+- [ ] **Step 3: Normalise the two fields in `metrics.mjs`, and pass them from `adapter.mjs`**
+
+In `recordToolOutcome`, normalise at the boundary so no caller can store raw text:
 
 ```javascript
-/**
- * Records one observed command result.
- *
- * The structural layer promised "commands run and their exit codes, tests and
- * their results" and recorded none of them: buildDigest reads command TEXT from
- * tool_use and deliberately skips tool_result. derive.mjs cannot detect a
- * failed-then-succeeded pair without this.
- *
- * Capped at 4 KB and redacted at the boundary, so a 10 MB test log never lands
- * in the log and a secret in stderr never becomes a stored claim.
- */
-export function recordResult(dir, { command, exit, output, sessionId } = {}) {
-  try {
-    record(dir, {
-      kind: 'result',
-      command: String(command ?? '').slice(0, 400),
-      exit: Number.isInteger(exit) ? exit : null,
-      output: redact(String(output ?? ''), { max: 4096 }),
-      sessionId: sessionId ?? null,
-    });
-  } catch {
-    /* bookkeeping must never break a completed call */
-  }
-}
+  // REDACTED AND CAPPED HERE, not at the call site. A claim built from this text
+  // is injected into model context AND exported to markdown, so the boundary is
+  // the only place that can guarantee it.
+  const output = outcome.output === undefined
+    ? undefined
+    : redact(String(outcome.output), { max: 4096 });
+  // Null rather than 0 when nothing is reported: most clients supply no numeric
+  // code, and defaulting to 0 would claim every unreported call succeeded.
+  const exit = Number.isInteger(outcome.exit) ? outcome.exit : null;
 ```
 
-Import `redact` from `./redact.mjs` and call `recordResult` in the `event === 'post-tool'` branch, reading exit code and output from the client's post-tool payload. **Client payload shapes differ** — `adapter.mjs:332` already normalises `raw.postToolUse`; extend that normaliser rather than reading raw fields at the call site.
+Include both in the recorded event and import `redact` from `./redact.mjs`.
+
+In `adapter.mjs`'s post-tool branch, add two fields to the **existing**
+`recordToolOutcome` call — do not add a second call:
+
+```javascript
+        output: outputFrom(raw),
+        exit: exitFrom(raw),
+```
+
+`outputFrom` and `exitFrom` belong beside `toolSucceeded` (`adapter.mjs:145`),
+which is where per-client response shapes are already normalised — the same
+`raw.tool_response` / `raw.toolResponse` / `raw.tool_result` / `raw.postToolUse`
+family it reads today. Do not read raw fields at the call site; that is precisely
+what `toolSucceeded` exists to prevent.
+
 
 - [ ] **Step 4: Run to verify it passes** → PASS (3)
 - [ ] **Step 5: Commit**
 
 ```bash
 npm run sync:hooks
-git add hooks-core/adapter.mjs tests/hooks/capture-results.test.mjs plugin integrations
-git commit -m "feat(capture): record command exit codes and output, promised since P1
+git add hooks-core/adapter.mjs hooks-core/metrics.mjs tests/hooks/capture-results.test.mjs plugin integrations
+git commit -m "feat(capture): carry output and exit code on tool-outcome
 
-WIKI_GRAPH.md lists exit codes and test results as free structural harvest.
-Nothing recorded them, so the extractors had no data source."
+Only a success boolean was recorded, which cannot distinguish a compile error
+from a test failure from a denied permission.
+
+Extends the existing tool-outcome event rather than adding a parallel kind:
+that pipeline already runs (234 live events in this repo) and already joins
+each outcome to its injection, so a second event describing the same thing
+would have duplicated the join and given the overloaded kind field a fifth
+meaning."
 ```
 
 ---
@@ -258,8 +292,10 @@ afterEach(() => rmSync(dir, { recursive: true, force: true }));
 
 describe('derive', () => {
   it('turns a failed-then-succeeded command into a command and a failure finding', () => {
-    record(dir, { kind: 'result', command: 'npm run build', exit: 1, output: 'TS2345 error' });
-    record(dir, { kind: 'result', command: 'npm run build -- --skipLibCheck', exit: 0, output: 'ok' });
+    // VERIFIED: the event kind is 'tool-outcome' with a `success` boolean, and
+    // optional `output`/`exit` added in Task 2. There is no 'result' kind.
+    record(dir, { kind: 'tool-outcome', surface: 'command', anchor: 'npm run build', success: false, output: 'TS2345 error', exit: 1, at: 1 });
+    record(dir, { kind: 'tool-outcome', surface: 'command', anchor: 'npm run build -- --skipLibCheck', success: true, output: 'ok', exit: 0, at: 2 });
 
     const { candidates } = derive(dir, { sessionId: 's', projectRoot: dir });
     const types = candidates.map((c) => c.type);
@@ -273,8 +309,8 @@ describe('derive', () => {
   });
 
   it('redacts secrets out of a derived claim', () => {
-    record(dir, { kind: 'result', command: 'deploy', exit: 1, output: 'API_TOKEN=abcdef123456' });
-    record(dir, { kind: 'result', command: 'deploy --retry', exit: 0, output: 'ok' });
+    record(dir, { kind: 'tool-outcome', surface: 'command', anchor: 'deploy', success: false, output: 'API_TOKEN=abcdef123456', at: 1 });
+    record(dir, { kind: 'tool-outcome', surface: 'command', anchor: 'deploy --retry', success: true, output: 'ok', at: 2 });
     const { candidates } = derive(dir, { sessionId: 's', projectRoot: dir });
     expect(JSON.stringify(candidates)).not.toContain('abcdef123456');
   });
@@ -284,7 +320,7 @@ describe('derive', () => {
   });
 
   it('never throws, because it runs at session end', () => {
-    record(dir, { kind: 'result', command: null, exit: null, output: null });
+    record(dir, { kind: 'tool-outcome', surface: 'command', anchor: null, success: null, output: null, at: 1 });
     expect(() => derive(dir, { sessionId: 's', projectRoot: dir })).not.toThrow();
   });
 });
@@ -314,7 +350,7 @@ describe('derive', () => {
  * Plan 2's per-finding utility prunes what turns out not to help.
  */
 
-import { readAll, rereadWaste } from './metrics.mjs';
+import { readAll, rereadsByAnchor } from './metrics.mjs';
 import { redact } from './redact.mjs';
 
 /** Ceilings, ordered by how much the evidence actually supports. */
@@ -335,7 +371,12 @@ export function derive(dir, { sessionId, projectRoot } = {}) {
     return { candidates: [], written: [] };
   }
 
-  const results = events.filter((e) => e.kind === 'result' && e.command);
+  // 'tool-outcome' with surface 'command'. The anchor holds the command text --
+  // adapter.mjs sets `anchor` to the command for a command surface, which is why
+  // there is no separate `command` field to read.
+  const results = events
+    .filter((e) => e.kind === 'tool-outcome' && e.surface === 'command' && e.anchor)
+    .map((e) => ({ ...e, command: e.anchor, failed: e.success === false || (Number.isInteger(e.exit) && e.exit !== 0) }));
   const candidates = [];
 
   // ---- 1 & 2: a failed attempt followed by a succeeding one -------------
@@ -350,9 +391,11 @@ export function derive(dir, { sessionId, projectRoot } = {}) {
   }
 
   for (const [, run] of byAttempt) {
-    const failed = run.find((e) => Number.isInteger(e.exit) && e.exit !== 0);
+    // `failed` uses the success boolean first and the exit code only as a
+    // refinement, because most clients never report a numeric code.
+    const failed = run.find((e) => e.failed);
     if (!failed) continue;
-    const fixed = run.find((e) => e.exit === 0 && (e.at ?? 0) > (failed.at ?? 0));
+    const fixed = run.find((e) => !e.failed && (e.at ?? 0) > (failed.at ?? 0));
     if (!fixed) continue;
 
     const isTest = TEST_COMMAND.test(fixed.command);
@@ -363,7 +406,7 @@ export function derive(dir, { sessionId, projectRoot } = {}) {
       claim: redact(`\`${fixed.command}\` works where \`${failed.command}\` failed`),
       confidence: cap,
       anchors: [projectRoot],
-      evidence: redact(`exit ${failed.exit} then exit 0`),
+      evidence: redact(`failed${Number.isInteger(failed.exit) ? ` (exit ${failed.exit})` : ''} then succeeded`),
       derivedBy: isTest ? 'test-transition' : 'command-transition',
       at: fixed.at ?? Date.now(),
     });
@@ -399,34 +442,37 @@ export function derive(dir, { sessionId, projectRoot } = {}) {
   // Describes our own behaviour rather than the code, so it gets the lowest cap
   // and will be starved by the injection budget's confidence ranking unless it
   // earns its place through measured utility.
+  // VERIFIED: rereadWaste returns a single AGGREGATE -- { repeats, wasteful,
+  // wastefulTokens, legitimate, legitimateTokens, undecidable,
+  // undecidableTokens, coverage } -- with no per-anchor rows. An earlier draft
+  // of this plan iterated `waste.worst`, which does not exist, so the detector
+  // would have produced nothing silently inside this try/catch.
+  //
+  // Both consumers now share `rereadsByAnchor` (Task 3b) rather than each
+  // implementing "what counts as a wasteful re-read".
   try {
-    const waste = rereadWaste(dir, { events });
-    for (const row of waste?.worst?.slice(0, 3) ?? []) {
+    for (const row of rereadsByAnchor(events).slice(0, 3)) {
+      if (!row.anchor || row.repeats < 2) continue;
       candidates.push({
         type: 'map',
         claim: `${row.anchor} is a recurring reference point in this project`,
         confidence: CONFIDENCE.churn,
         anchors: [row.anchor],
-        evidence: `re-read ${row.rereads ?? 0} times`,
+        evidence: `re-read ${row.repeats} times, ${row.wasteful} without changing`,
         derivedBy: 'churn',
         at: Date.now(),
       });
     }
   } catch {
-    // rereadWaste has its own log window; a failure here costs one detector.
+    // A failure here costs one detector, never the session.
   }
 
   return { candidates, written: [] };
 }
 ```
 
-Verify `rereadWaste`'s real return shape before relying on `worst`:
-
-```bash
-sed -n '451,505p' hooks-core/metrics.mjs
-```
-
-Adjust the churn detector to the real shape rather than changing `rereadWaste`.
+No verification step is needed — `rereadWaste`'s shape is recorded above, and
+Task 3b supplies the per-anchor helper this detector consumes.
 
 - [ ] **Step 4: Run to verify it passes** → PASS (5)
 - [ ] **Step 5: Commit**
@@ -440,6 +486,67 @@ This repository's own graph held 1,446 symbol nodes and ONE finding after three
 weeks, because the only path to a verdict was an opt-in model call. These four
 derive findings from exit codes, test transitions, corrections and churn --
 locally, with no model and nothing leaving the machine."
+```
+
+---
+
+## Task 3b: `rereadsByAnchor` — one implementation, two consumers
+
+**Files:** Modify `hooks-core/metrics.mjs`; Test `tests/hooks/reread-waste.test.mjs`
+
+**Interfaces:**
+- Produces: `rereadsByAnchor(events) => Array<{ anchor, repeats, wasteful, tokens }>`, descending by `wasteful` then `repeats`.
+- `rereadWaste` keeps **every existing field unchanged** and gains `worst: rereadsByAnchor(events).slice(0, 10)`.
+
+**Why:** the churn detector needs per-anchor rows and `rereadWaste` returns only an aggregate. Implementing the grouping a second time inside `derive.mjs` would put two definitions of "what counts as a wasteful re-read" in the codebase, free to drift — the exact divergence `npm run sync:hooks` exists to prevent elsewhere. So the grouping moves into one shared function that both consume.
+
+The existing aggregate fields must not change: `balanceSheet` reads them, and `worst` is purely additive.
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+it('groups re-reads by anchor, worst first', () => {
+  const events = [
+    { kind: 'read', anchor: 'a.ts', fp: 'x', tokens: 100, at: 1 },
+    { kind: 'read', anchor: 'a.ts', fp: 'x', tokens: 100, at: 2 },
+    { kind: 'read', anchor: 'a.ts', fp: 'x', tokens: 100, at: 3 },
+    { kind: 'read', anchor: 'b.ts', fp: 'y', tokens: 50, at: 4 },
+    { kind: 'read', anchor: 'b.ts', fp: 'z', tokens: 50, at: 5 },
+  ];
+  const rows = rereadsByAnchor(events);
+  expect(rows[0].anchor).toBe('a.ts');
+  // Two repeats with an unchanged fingerprint are wasteful; b.ts changed, so it is not.
+  expect(rows[0].wasteful).toBe(2);
+  expect(rows.find((r) => r.anchor === 'b.ts').wasteful).toBe(0);
+});
+
+it('leaves every existing rereadWaste field untouched', () => {
+  const before = rereadWaste(dir, { events, includeFixtures: true });
+  expect(before).toHaveProperty('repeats');
+  expect(before).toHaveProperty('wastefulTokens');
+  expect(before).toHaveProperty('coverage');
+  expect(Array.isArray(before.worst)).toBe(true);
+});
+```
+
+- [ ] **Step 2: Run to verify it fails** → `rereadsByAnchor is not a function`
+
+- [ ] **Step 3: Extract the grouping**
+
+Lift the per-anchor loop already inside `rereadWaste` into `rereadsByAnchor`, have `rereadWaste` call it and fold its rows into the existing counters, then append `worst`. The judgement of wasteful-versus-legitimate (`prev.fp === cur.fp`) moves with it and must not be reimplemented.
+
+- [ ] **Step 4: Run to verify it passes** → `npx jest tests/hooks/reread-waste.test.mjs`
+
+- [ ] **Step 5: Commit**
+
+```bash
+npm run sync:hooks
+git add hooks-core/metrics.mjs tests/hooks/reread-waste.test.mjs plugin integrations
+git commit -m "refactor(metrics): share re-read grouping between rereadWaste and derive
+
+The churn detector needs per-anchor rows; rereadWaste returned only an
+aggregate. One shared helper rather than two definitions of what counts as a
+wasteful re-read. Existing aggregate fields are unchanged -- worst is additive."
 ```
 
 ---
@@ -569,13 +676,27 @@ git commit -m "feat(derive): run at Stop; surface local harvest; state the defau
 
 **Files:** Create `hooks-core/usage.mjs`; Test `tests/hooks/usage.test.mjs`
 
-**Interfaces:**
-- Consumes: `readAll`, `readBalance` from `metrics.mjs`. Depends on Plan 1's `query` event.
-- Produces:
-  - `classify(dir) => Array<{ findingKey, sessionId, label: 'referenced'|'not-referenced'|'unknown' }>`
-  - `referenceRate(dir) => { referenced: number, denominator: number, rate: number|null }`
+**VERIFIED CONTRACT — do not invent a join.** `inject` events already record
+`findingIds` (the finding keys) at five call sites in `inject.mjs`, and
+`recordToolOutcome` already joins each outcome back to its injection, recording
+`injectionId`, `findingIds` and a `joinMethod` of `tool-call-id`,
+`episode-anchor` or `none`. That join prefers an exact `tool-call-id` match,
+which is strictly better evidence than the `(sessionId, findingKey)`
+approximation an earlier draft of this plan proposed — and it already reports
+`joinMethod: 'none'` when it cannot attribute, so unattributable observations can
+be excluded honestly instead of silently mis-joined.
 
-**Why Layer 1 uses references and not read-suppression:** read-suppression is Layer 2's estimand. Using it in both would make the calibration loop compare two spellings of one quantity — a strong correlation that means nothing. `unknown` is excluded from the denominator rather than counted as a miss.
+**So Layer 1 requires no change to `inject.mjs` at all.** It reads
+`kind: 'tool-outcome'` events, uses their `findingIds`, and drops rows whose
+`joinMethod` is `none`.
+
+**Interfaces:**
+- Consumes: `readAll` from `metrics.mjs`; `tool-outcome` events with `findingIds`, `injectionId`, `joinMethod`. Depends on Plan 1's `query` event for the numerator.
+- Produces:
+  - `classify(dir) => Array<{ findingKey, injectionId, label: 'referenced'|'not-referenced'|'unknown' }>`
+  - `referenceRate(dir) => { referenced: number, denominator: number, rate: number|null, unattributable: number }`
+
+**Why Layer 1 uses references and not read-suppression:** read-suppression is Layer 2's estimand. Using it in both would make the calibration loop compare two spellings of one quantity — a strong correlation that means nothing. `unknown` is excluded from the denominator rather than counted as a miss, and `unattributable` is reported separately rather than folded into either.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -620,19 +741,24 @@ describe('Layer 1', () => {
 ```
 
 - [ ] **Step 2: Run to verify it fails** → module not found
-- [ ] **Step 3: Implement `usage.mjs`.** Join `inject` events to later `query`/`expand` events on `(sessionId, findingKey)` with `at` ordering. A session with no subsequent tool activity yields `unknown`.
+- [ ] **Step 3: Implement `usage.mjs`.** For each `tool-outcome` with `joinMethod !== 'none'`, take its `findingIds` and look for a later `query` or `expand` event naming one of them, ordered by `at`. A session with no subsequent tool activity yields `unknown`; a `joinMethod` of `none` increments `unattributable` and enters neither arm.
 - [ ] **Step 4: Run to verify it passes** → PASS (4)
-- [ ] **Step 5: Ensure `inject` records `findingKeys`.** If it does not, add it in `inject.mjs` — Layer 1 cannot attribute without it.
+- [ ] **Step 5: Measure how much of the join is usable.** Run against this repository's 234 live `tool-outcome` events and report the share with `joinMethod: 'none'`. If most cannot attribute, say so in the report rather than publishing a rate computed from a handful of rows — the same discipline `sufficientData` already applies.
 - [ ] **Step 6: Commit**
 
 ```bash
 npm run sync:hooks
-git add hooks-core/usage.mjs hooks-core/inject.mjs tests/hooks/usage.test.mjs plugin integrations
+git add hooks-core/usage.mjs tests/hooks/usage.test.mjs plugin integrations
 git commit -m "feat(metrics): Layer 1, explicit-reference classification
 
 Deliberately independent of read-suppression: that is Layer 2's estimand, and
 using it in both would make the calibration loop compare two spellings of one
-quantity. unknown is excluded from the denominator, never counted as a miss."
+quantity. unknown is excluded from the denominator, never counted as a miss.
+
+Built on the injection-to-outcome join recordToolOutcome already performs --
+which prefers an exact tool-call-id match and already reports when it cannot
+attribute -- rather than a weaker (sessionId, findingKey) join of its own. No
+change to inject.mjs was needed: it has recorded findingIds all along."
 ```
 
 ---
@@ -698,7 +824,7 @@ describe('Layer 2 guards', () => {
 Write the `graphWith` / `dirWithHistory` / `dirWithFewObservations` / `dirWithMixedObservations` helpers at the top of the file as real fixture builders using `record()` — not mocks.
 
 - [ ] **Step 2: Run to verify it fails** → module not found
-- [ ] **Step 3: Implement `loo.mjs`** with:
+- [ ] **Step 3: Implement `loo.mjs`**, reading downstream cost through the same `tool-outcome` join Layer 1 uses (never a fresh `(sessionId, findingKey)` join), with:
   - arm from `hash(findingKey + sessionId)`, stable for the session;
   - guards: skip `pinned` and `origin === 'human'`; require `MIN_PRIOR_INJECTIONS`; return at most one key;
   - `effects()`: per-key mean downstream read cost served vs withheld, shrunk by empirical Bayes `(n·observed + k·prior) / (n + k)` toward the population mean;

--- a/docs/superpowers/plans/2026-08-25-wiki-graph-plan-3-detector-and-allowlist.md
+++ b/docs/superpowers/plans/2026-08-25-wiki-graph-plan-3-detector-and-allowlist.md
@@ -1,0 +1,587 @@
+# Wiki Graph Plan 3 — The Detector and Its Allowlist
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the defect class rather than its instances — fix the two holes in the existing reachability detector, extend it to the three sub-classes it cannot see, and empty its allowlist to zero backlog entries.
+
+**Architecture:** `tests/hooks/reachability.test.mjs` already exists and is the right idea; it fails in two specific ways. This plan makes its scan comment-aware, extends declaration collection beyond `export function`, adds producer/consumer censuses for event kinds, edge kinds and tool names, and resolves the remaining allowlist entries by wiring or deleting each.
+
+**Tech Stack:** Node 22 ESM, Jest. No new dependencies — the detector reads source text.
+
+**Spec:** `docs/superpowers/specs/2026-08-25-wiki-graph-gap-closure-design.md`
+
+**Depends on:** Plans 1 and 2 remove seven allowlist entries as a side effect of wiring their subsystems. This plan removes the remainder and makes the guard airtight. **Run it last**, or its first task will fail on work the other plans have not done yet.
+
+## Global Constraints
+
+- **The detector must be wrong only in the permissive direction.** A check that fails CI on working code gets deleted within a week — `reachability.test.mjs` says so itself, and it is right.
+- **Every allowlist entry needs a reason.** By the end of this plan the only entry is `policyText`.
+- **Never edit a vendored copy.** `hooks-core/` then `npm run sync:hooks`.
+- **Branch:** `feat/close-wiki-graph-gaps`.
+
+---
+
+## Why this plan exists
+
+Round 1 built this detector. It found ~21 instances of correct-but-unreachable code, four were wired, and sixteen were moved to an allowlist labelled `TRIAGE BACKLOG` — in a file whose own documentation says *"If the reason is 'we might use it later', the honest action is to delete the function and write it again when that day comes."*
+
+The disease is not blindness. **An accurate written description of a defect felt like resolution.** Two mechanical holes let it stick:
+
+| Hole | Evidence |
+|---|---|
+| `usedInShippedCode` bare-word-matches **raw text**, so a comment counts as a call site | `invalidateOnWrite`: 1 raw reference, 0 code references. The reference is prose at `pretooluse-router.mjs:153`. Remove the allowlist entry and the test still passes. |
+| Only `export function` is collected — 38 exported consts are invisible | `contradicts` and `answers` sat in `EDGE_KINDS` with zero write sites |
+
+And three sub-classes are outside its model entirely: readers with no producer (`kind:'query'`), producers with no reader (`kind:'lessons'`), and referents with no target (`wiki_query`, named in seven shipped copies of injected prompt text).
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `tests/hooks/reachability.test.mjs` | Comment-aware scan; const declarations; the allowlist. |
+| `tests/hooks/census.test.mjs` **(new)** | Event-kind, edge-kind and tool-name producer/consumer censuses. |
+| `scripts/wiki-census.mjs` **(new)** | Runnable census for the acceptance criteria — live state, not CI state. |
+| `hooks-core/standing.mjs` | `renderStanding` gains a caller. |
+| `hooks-core/audit.mjs` | Renders the standing panel. |
+| `hooks-core/doctor.mjs` | Reports manifest coverage via `manifestSize`. |
+
+---
+
+## Task 1: Make the scan comment-aware
+
+**Files:** Modify `tests/hooks/reachability.test.mjs`
+
+**Interfaces:**
+- Produces: `stripComments(text: string) => string` (module-local); `usedInShippedCode` consumes stripped text.
+
+- [ ] **Step 1: Write the failing test**
+
+Add this to `reachability.test.mjs`. It asserts the hole directly, using a name that is genuinely prose-only, so it fails before the fix and passes after.
+
+```javascript
+describe('the scan does not mistake prose for a call site', () => {
+  it('ignores a name that appears only in a comment', () => {
+    const text = [
+      '// A write the hook observes is invalidated eagerly by `someOrphanFn`, so',
+      'export function other() { return 1; }',
+    ].join('\n');
+    expect(stripComments(text)).not.toContain('someOrphanFn');
+  });
+
+  it('ignores a name inside a block comment', () => {
+    expect(stripComments('/* calls someOrphanFn */ const x = 1;')).not.toContain('someOrphanFn');
+  });
+
+  it('keeps real code intact, including a URL that contains a double slash', () => {
+    const code = "const url = 'https://example.com/x'; realCall();";
+    const stripped = stripComments(code);
+    expect(stripped).toContain('realCall');
+    expect(stripped).toContain('example.com');
+  });
+});
+```
+
+The third case is the trap: a naïve `indexOf('//')` truncates at the `//` in `https://`, which would silently blind the scan to everything after any URL in a file. **`stripComments` must not do that.**
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx jest tests/hooks/reachability.test.mjs -t "prose"`
+Expected: FAIL — `stripComments is not defined`
+
+- [ ] **Step 3: Implement `stripComments`**
+
+```javascript
+/**
+ * Removes comments and string literals before the usage scan.
+ *
+ * THIS IS THE HOLE THAT MADE THE ALLOWLIST NECESSARY. `usedInShippedCode`
+ * matched raw file text, so DOCUMENTING a dead function marked it live:
+ * `invalidateOnWrite` had exactly one reference in shipped code and it was a
+ * comment. Measured before this fix: 1 raw reference, 0 code references.
+ *
+ * Written as a small scanner rather than regexes because the naive line-comment
+ * regex truncates at the `//` inside `https://`, which would blind the scan to
+ * everything after any URL -- a silent permissive failure, which is exactly the
+ * kind this guard exists to prevent.
+ */
+function stripComments(text) {
+  const source = String(text);
+  let out = '';
+  let i = 0;
+  const n = source.length;
+
+  while (i < n) {
+    const c = source[i];
+    const next = source[i + 1];
+
+    // Line comment: only when not preceded by a colon (the `https://` case is
+    // handled by string skipping below, but a bare scheme in code is not).
+    if (c === '/' && next === '/') {
+      while (i < n && source[i] !== '\n') i += 1;
+      continue;
+    }
+    if (c === '/' && next === '*') {
+      i += 2;
+      while (i < n && !(source[i] === '*' && source[i + 1] === '/')) i += 1;
+      i += 2;
+      continue;
+    }
+    // String and template literals are skipped whole: a name inside a string is
+    // not a call. Template literals may nest `${}`, but a name there is code, so
+    // template contents are preserved rather than dropped.
+    if (c === '"' || c === "'") {
+      const quote = c;
+      i += 1;
+      while (i < n && source[i] !== quote) {
+        if (source[i] === '\\') i += 1;
+        i += 1;
+      }
+      i += 1;
+      out += ' ';
+      continue;
+    }
+    if (c === '`') {
+      i += 1;
+      while (i < n && source[i] !== '`') {
+        if (source[i] === '\\') { i += 2; continue; }
+        // Preserve interpolations -- they contain real code.
+        if (source[i] === '$' && source[i + 1] === '{') {
+          let depth = 1;
+          out += ' ';
+          i += 2;
+          while (i < n && depth > 0) {
+            if (source[i] === '{') depth += 1;
+            if (source[i] === '}') depth -= 1;
+            if (depth > 0) out += source[i];
+            i += 1;
+          }
+          continue;
+        }
+        i += 1;
+      }
+      i += 1;
+      out += ' ';
+      continue;
+    }
+    out += c;
+    i += 1;
+  }
+  return out;
+}
+```
+
+Then change `usedInShippedCode` to scan stripped text:
+
+```javascript
+// Stripped ONCE per file, not per name -- this runs over 256 files times ~250
+// exported names, and re-stripping per name made the suite visibly slower.
+const strippedUsages = usages.map(({ file, text }) => ({ file, text: stripComments(text) }));
+```
+
+and have `usedInShippedCode` read `strippedUsages`.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npx jest tests/hooks/reachability.test.mjs`
+Expected: the three new tests PASS. **The orphan assertions may now fail with new names** — that is the hole closing. Record the list; Task 5 resolves it.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/hooks/reachability.test.mjs
+git commit -m "test(reachability): stop counting comments as call sites
+
+usedInShippedCode matched raw text, so documenting a dead function marked it
+live -- invalidateOnWrite had 1 raw reference and 0 code references, the
+reference being prose. This is the hole that made the allowlist necessary."
+```
+
+---
+
+## Task 2: Collect exported consts, not just functions
+
+**Files:** Modify `tests/hooks/reachability.test.mjs`
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+it('collects exported consts, which were invisible to the scan', () => {
+  const names = exportedNames().map((e) => e.name);
+  // EDGE_KINDS is an exported const in hooks-core/wiki.mjs. If the collector
+  // only sees `export function`, 38 declarations go unchecked -- which is where
+  // contradicts and answers hid with zero write sites.
+  expect(names).toContain('EDGE_KINDS');
+});
+```
+
+- [ ] **Step 2: Run to verify it fails** → `EDGE_KINDS` absent
+
+- [ ] **Step 3: Rename `exportedFunctions` to `exportedNames` and add the const pattern**
+
+```javascript
+/** Every `export function` / `export async function` / `export const` in the live path. */
+function exportedNames() {
+  const found = [];
+  for (const { file, text } of declarations) {
+    const code = stripComments(text);
+    for (const re of [
+      /export\s+(?:async\s+)?function\s+([A-Za-z_$][\w$]*)/g,
+      /export\s+const\s+([A-Za-z_$][\w$]*)/g,
+    ]) {
+      let m;
+      while ((m = re.exec(code)) !== null) found.push({ name: m[1], file });
+    }
+  }
+  return found;
+}
+```
+
+Update the declaration-subtraction in `usedInShippedCode` to discount `export const NAME` as well as `export function NAME`, or a const referenced nowhere else will look used by its own declaration.
+
+- [ ] **Step 4: Run** → the new test passes; expect additional orphans reported.
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/hooks/reachability.test.mjs
+git commit -m "test(reachability): check exported consts too -- 38 were invisible"
+```
+
+---
+
+## Task 3: Producer/consumer censuses
+
+**Files:** Create `tests/hooks/census.test.mjs`
+
+**Interfaces:**
+- Produces (module-local): `eventKinds()`, `edgeKinds()`, `toolNamesInInjectedText()`
+
+**Note on false positives:** `kind` is used in at least three unrelated namespaces — event kinds, node kinds (`file`/`symbol`/`task`/`finding`), symbol kinds (`function`/`class`/`variable`), standing-entry kinds (`skill`/`agent`), and a token-type parameter in `pricing.mjs`. A census that conflates them reports confident nonsense. Restrict extraction to `record(` / `recordRead(` call sites for producers and to `metrics.mjs` consumers for readers, and keep an explicit non-event allowlist.
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+// tests/hooks/census.test.mjs
+import { describe, it, expect } from '@jest/globals';
+
+describe('event kinds', () => {
+  it('has no kind that is read but never written', () => {
+    const { written, read } = eventKinds();
+    const orphanReaders = [...read].filter((k) => !written.has(k));
+    // `query` was read by indexBudget and written only by the test suite, so
+    // the ratio was 0 for every project and the budget sat at its floor.
+    expect(orphanReaders).toEqual([]);
+  });
+
+  it('has no kind that is written but never read', () => {
+    const { written, read } = eventKinds();
+    const orphanWriters = [...written].filter((k) => !read.has(k));
+    // `lessons` was written by harvest-worker.mjs:113 and read by nothing.
+    expect(orphanWriters).toEqual([]);
+  });
+});
+
+describe('edge kinds', () => {
+  it('has a write site for every declared edge kind', () => {
+    const { declared, written } = edgeKinds();
+    expect([...declared].filter((k) => !written.has(k))).toEqual([]);
+  });
+});
+
+describe('tool names in injected text', () => {
+  it('names no tool that does not exist', () => {
+    // The SessionStart index told the model to call wiki_query for a year.
+    expect(toolNamesInInjectedText().missing).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx jest tests/hooks/census.test.mjs`
+Expected: FAIL on any sub-class Plans 1 and 2 have not yet closed. If all four pass immediately, verify the extractors actually find something — add an assertion that `written.size > 5` so a broken census cannot report a clean bill of health.
+
+- [ ] **Step 3: Implement the three censuses**
+
+```javascript
+/** Event kinds, restricted to record()/recordRead() call sites and metrics readers. */
+function eventKinds() {
+  // NOT an event kind. `kind` is overloaded across four namespaces in this
+  // codebase and conflating them produces confident nonsense -- verified by
+  // getting it wrong once: `output` is a token-type in pricing.mjs, `skill` and
+  // `agent` are standing-context entry types, `file`/`symbol`/`task`/`finding`
+  // are node kinds.
+  const NOT_EVENTS = new Set([
+    'file', 'symbol', 'task', 'finding',
+    'function', 'class', 'variable', 'expression', 'reexport',
+    'skill', 'agent', 'output', 'ours', 'yours',
+  ]);
+
+  const written = new Set();
+  for (const { text } of declarations) {
+    const code = stripComments(text);
+    // Two-line window after a record( call, which is how these are written.
+    const re = /record(?:Read)?\(\s*[A-Za-z_$][\w$]*\s*,\s*\{[^}]{0,200}?kind:\s*'([a-z_]+)'/g;
+    let m;
+    while ((m = re.exec(code)) !== null) {
+      if (!NOT_EVENTS.has(m[1])) written.add(m[1]);
+    }
+  }
+
+  const read = new Set();
+  for (const { file, text } of declarations) {
+    if (!/metrics\.mjs$/.test(file)) continue;
+    const code = stripComments(text);
+    const re = /kind\s*[=!]==\s*'([a-z_]+)'/g;
+    let m;
+    while ((m = re.exec(code)) !== null) {
+      if (!NOT_EVENTS.has(m[1])) read.add(m[1]);
+    }
+  }
+
+  return { written, read };
+}
+
+/** Declared edge kinds against actual putEdge / putNodeWithEdges write sites. */
+function edgeKinds() {
+  const wiki = declarations.find(({ file }) => /hooks-core[\\/]wiki\.mjs$/.test(file));
+  const block = /export const EDGE_KINDS = \[([\s\S]*?)\]/.exec(stripComments(wiki.text));
+  const declared = new Set([...block[1].matchAll(/'([a-z_]+)'/g)].map((m) => m[1]));
+
+  const written = new Set();
+  for (const { text } of declarations) {
+    const code = stripComments(text);
+    for (const m of code.matchAll(/putEdge\([^,]+,\s*'([a-z_]+)'/g)) written.add(m[1]);
+    for (const m of code.matchAll(/edge:\s*'([a-z_]+)'/g)) written.add(m[1]);
+  }
+  return { declared, written };
+}
+
+/** Tool names appearing in injected prompt text, checked against the registry. */
+function toolNamesInInjectedText() {
+  const registry = new Set();
+  for (const { file, text } of usages) {
+    if (!/tool-schemas\.ts$/.test(file)) continue;
+    for (const m of stripComments(text).matchAll(/^\s{2}([a-z_]+):\s*\w+Schema,/gm)) {
+      registry.add(m[1]);
+    }
+  }
+
+  const mentioned = new Set();
+  for (const { file, text } of declarations) {
+    // Injected text lives in template literals, which stripComments preserves
+    // only for interpolations -- so scan the RAW text here and accept that a
+    // tool name in a comment counts. Over-reporting is the safe direction for
+    // this particular check: a name in a comment that does not exist is still
+    // worth knowing about.
+    if (!/inject\.mjs$|policy\.mjs$|adapter\.mjs$/.test(file)) continue;
+    for (const m of text.matchAll(/\b(smart_[a-z_]+|wiki_[a-z_]+|optimize_session|get_optimization_report)\b/g)) {
+      mentioned.add(m[1]);
+    }
+  }
+
+  return { mentioned, registry, missing: [...mentioned].filter((t) => !registry.has(t)) };
+}
+```
+
+- [ ] **Step 4: Run to verify it passes** (after Plans 1 and 2)
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/hooks/census.test.mjs
+git commit -m "test(census): catch the three sub-classes the reachability scan cannot see
+
+Readers with no producer (kind:'query'), producers with no reader
+(kind:'lessons'), and referents with no target (wiki_query in seven shipped
+copies of injected text). The overloaded `kind` field is namespaced explicitly,
+because conflating the four namespaces produced confident nonsense on the first
+attempt."
+```
+
+---
+
+## Task 4: Wire `renderStanding` and `manifestSize`
+
+**Files:** Modify `hooks-core/audit.mjs`, `hooks-core/doctor.mjs`, `tests/hooks/reachability.test.mjs`; Test `tests/hooks/standing.test.mjs`, `tests/hooks/doctor.test.mjs`
+
+**Why:** `auditStanding` and `verdictFor` are both reachable, so something already computes which CLAUDE.md rules and skills are stale or never used, and throws the result away. Skills/memory health is one of the gaps #203 claimed closed, which is hard to defend while the report cannot be seen.
+
+- [ ] **Step 1: Write the failing tests**
+
+```javascript
+// tests/hooks/standing.test.mjs
+it('includes the standing-context panel in the audit output', () => {
+  const output = renderAudit(auditFixture());
+  expect(output).toMatch(/standing context|never used|stale instruction/i);
+});
+```
+
+```javascript
+// tests/hooks/doctor.test.mjs
+it('reports what the installation manifest covers', () => {
+  expect(diagnose().some((row) => /manifest/i.test(row.label))).toBe(true);
+});
+```
+
+- [ ] **Step 2: Run to verify they fail**
+- [ ] **Step 3: Call `renderStanding` from `audit.mjs`** where the other panels are assembled, and `manifestSize` from `doctor.mjs` in the installation section.
+- [ ] **Step 4: Remove both allowlist entries.**
+- [ ] **Step 5: Run** `npx jest tests/hooks/standing.test.mjs tests/hooks/doctor.test.mjs tests/hooks/audit.test.mjs tests/hooks/reachability.test.mjs` → PASS
+- [ ] **Step 6: Commit**
+
+```bash
+npm run sync:hooks
+git add hooks-core/audit.mjs hooks-core/doctor.mjs tests plugin integrations
+git commit -m "feat(audit): surface the standing-context report and manifest coverage
+
+auditStanding computed which rules are stale or never used and nothing showed
+it. Skills and memory health is a gap #203 claimed closed."
+```
+
+---
+
+## Task 5: Empty the allowlist
+
+**Files:** Modify `tests/hooks/reachability.test.mjs`
+
+- [ ] **Step 1: Remove the stale `forTouch` entry**
+
+It has 2 real call sites (verified by probe), so the entry is dead weight that would mask a regression.
+
+- [ ] **Step 2: Confirm the remaining entries are gone**
+
+By this point Plans 1 and 2 plus Task 4 have resolved: `invalidateOnWrite`, `cacheOrdered`, `selectForConsolidation`, `consolidationRatio`, `contentAnchor` (deleted), `recordRefresh`, `recordRefreshOutcome`, `renderStanding`, `manifestSize`.
+
+Run: `grep -c "^  \['" tests/hooks/reachability.test.mjs`
+Expected: `1` — only `policyText`.
+
+- [ ] **Step 3: Add the ratchet that stops the list growing back**
+
+```javascript
+it('keeps the allowlist at zero backlog entries', () => {
+  // The list is not a backlog. Round 1 built this detector, it found ~21
+  // unreachable capabilities, four were wired and sixteen were parked here with
+  // accurate descriptions -- and an accurate description of a defect felt like
+  // resolution. Every entry now must be genuine public API, and there is
+  // exactly one.
+  const backlog = [...ALLOWED.entries()].filter(([, reason]) => !/^PUBLIC API/.test(reason));
+  expect(backlog).toEqual([]);
+});
+```
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `npm run build && npx jest && npm run sync:hooks:check`
+Expected: PASS, PASS, clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/hooks/reachability.test.mjs
+git commit -m "test(reachability): empty the allowlist, and refuse a new backlog entry
+
+Sixteen capabilities were parked here with accurate descriptions of what was
+wrong with them. That is how round 1 ended: an honest note where a wire or a
+deletion belonged. Entries must now be genuine public API, and there is one."
+```
+
+---
+
+## Task 6: The census script — acceptance measured, not asserted
+
+**Files:** Create `scripts/wiki-census.mjs`; Modify `package.json`
+
+**Why:** every one of the ten instances passed CI. A green suite is not evidence that the graph is alive; the live logs are. This script is what the spec's acceptance criteria are checked against, and it can be re-run any time to see whether the graph is still working.
+
+- [ ] **Step 1: Write the script**
+
+```javascript
+#!/usr/bin/env node
+/**
+ * What the graph is actually doing, on this machine, right now.
+ *
+ * NOT A TEST. Every instance of the wiring defect this work closed passed CI --
+ * the detector that found them is a test, but the evidence that a capability is
+ * ALIVE is that its events exist in a real log. This prints that.
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const dir = process.argv[2] || join(process.cwd(), '.token-optimizer', 'wiki');
+const count = (file, pattern) => {
+  const path = join(dir, file);
+  if (!existsSync(path)) return 0;
+  return (readFileSync(path, 'utf8').match(pattern) || []).length;
+};
+
+const rows = [
+  ['findings in graph', count('graph.jsonl', /"kind":"finding"/g)],
+  ['query events', count('metrics.jsonl', /"kind":"query"/g)],
+  ['index events', count('metrics.jsonl', /"kind":"index"/g)],
+  ['result events', count('metrics.jsonl', /"kind":"result"/g)],
+  ['inject events', count('metrics.jsonl', /"kind":"inject"/g)],
+  ['contradicts edges', count('graph.jsonl', /"edge":"contradicts"/g)],
+  ['answers edges', count('graph.jsonl', /"edge":"answers"/g)],
+];
+
+console.log(`\nwiki census -- ${dir}\n`);
+for (const [label, value] of rows) {
+  const flag = value === 0 ? '  <-- DEAD' : '';
+  console.log(`  ${String(value).padStart(7)}  ${label}${flag}`);
+}
+console.log('\nA zero on any row means that capability is declared and not running.\n');
+```
+
+- [ ] **Step 2: Add the script to `package.json`**
+
+```json
+    "wiki:census": "node scripts/wiki-census.mjs",
+```
+
+- [ ] **Step 3: Run it**
+
+Run: `npm run wiki:census`
+Expected: it prints. Before this work: findings 1, query 0, index 0, result 0, contradicts 0, answers 0. After a working session with all three plans landed, every row should be non-zero.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/wiki-census.mjs package.json
+git commit -m "chore(wiki): census script -- acceptance measured from live logs, not CI
+
+Every instance of the wiring defect passed CI. A green suite is not evidence
+that a capability runs; events in a real log are."
+```
+
+---
+
+## Task 7: Close out the documentation and the issues
+
+- [ ] **Step 1: Update `docs/WIKI_GRAPH.md`** — hit rate defined as Layer 1 calibrated against Layer 2, with the interference, power and selection limitations stated rather than implied.
+- [ ] **Step 2: Add the status column to `docs/COMPETITIVE_GAPS.md`**, and correct the stale concession: the doc still says our delta-on-re-read "requires the model to reissue the call against `smart_read`", which zero-turn substitution made untrue.
+- [ ] **Step 3: Tick #204's phases with census output**, not assertions. Note explicitly which parts of the design were **changed** rather than implemented: hit rate was redefined, `contentAnchor` was deleted with a follow-up issue, and `GRAPH_VERSION` was deliberately not bumped.
+- [ ] **Step 4: Open the PR**
+
+```bash
+npm run validate:pr && npm run pr:create
+```
+
+Never `gh pr create` directly — it bypasses the validation pipeline.
+
+- [ ] **Step 5: Commit any doc fixes the validation surfaces**
+
+---
+
+## Definition of done for Plan 3
+
+| Check | Command | Expected |
+|---|---|---|
+| Prose is not a call site | `npx jest tests/hooks/reachability.test.mjs -t prose` | PASS |
+| Consts are checked | `EDGE_KINDS` appears in `exportedNames()` | true |
+| No dead event kinds | `npx jest tests/hooks/census.test.mjs` | PASS |
+| No dead edge kinds | same | PASS |
+| No dangling tool names | same | PASS |
+| Allowlist has no backlog | `grep -c "^  \['" tests/hooks/reachability.test.mjs` | 1 (`policyText`) |
+| Census runs | `npm run wiki:census` | every row non-zero after a session |
+| Full suite green | `npm run build && npx jest && npm run sync:hooks:check` | PASS |

--- a/docs/superpowers/plans/2026-08-25-wiki-graph-plan-3-detector-and-allowlist.md
+++ b/docs/superpowers/plans/2026-08-25-wiki-graph-plan-3-detector-and-allowlist.md
@@ -39,6 +39,22 @@ imported and never called and the guard passes it. Proven by mutation: dropping 
 the import too made it fail. So Task 1 must discount import and export specifier
 occurrences as well as comments and strings — "imported" is not "called".
 
+**A FOURTH HOLE, and a FIFTH, found while executing Plan 1.**
+
+*Fourth:* the scan checks EXPORTS, so an unread RECORD FIELD is invisible to it.
+`contradictionReason` -- up to 400 characters of human explanation -- was written on
+every `contradict` call with the guard green throughout, and read by nothing. Plan 3
+needs a written-fields-versus-read-fields census, or this class stays undetectable.
+
+*Fifth (test hygiene, not reachability):* several entry points consult the stratified
+holdout (`forTouch`, `forCommand`, `forSharedCommand`, `substitutionFor`), so a test
+asserting on their output must pin `TOKEN_OPTIMIZER_HOLDOUT` or it fails
+intermittently when the anchor lands in the withheld arm. The convention is
+copy-pasted per suite in three different variants and nothing enforces it -- one
+newly-added test on this branch omitted it and produced exactly that flake. A guard
+asserting that every suite calling a holdout-consulting entry point pins the arm
+would close it.
+
 And three sub-classes are outside its model entirely: readers with no producer (`kind:'query'`), producers with no reader (`kind:'lessons'`), and referents with no target (`wiki_query`, named in twelve shipped copies of injected prompt text).
 
 ---

--- a/docs/superpowers/plans/2026-08-25-wiki-graph-plan-3-detector-and-allowlist.md
+++ b/docs/superpowers/plans/2026-08-25-wiki-graph-plan-3-detector-and-allowlist.md
@@ -32,7 +32,7 @@ The disease is not blindness. **An accurate written description of a defect felt
 | `usedInShippedCode` bare-word-matches **raw text**, so a comment counts as a call site | `invalidateOnWrite`: 1 raw reference, 0 code references. The reference is prose at `pretooluse-router.mjs:153`. Remove the allowlist entry and the test still passes. |
 | Only `export function` is collected — 38 exported consts are invisible | `contradicts` and `answers` sat in `EDGE_KINDS` with zero write sites |
 
-And three sub-classes are outside its model entirely: readers with no producer (`kind:'query'`), producers with no reader (`kind:'lessons'`), and referents with no target (`wiki_query`, named in seven shipped copies of injected prompt text).
+And three sub-classes are outside its model entirely: readers with no producer (`kind:'query'`), producers with no reader (`kind:'lessons'`), and referents with no target (`wiki_query`, named in twelve shipped copies of injected prompt text).
 
 ---
 

--- a/docs/superpowers/plans/2026-08-25-wiki-graph-plan-3-detector-and-allowlist.md
+++ b/docs/superpowers/plans/2026-08-25-wiki-graph-plan-3-detector-and-allowlist.md
@@ -32,6 +32,13 @@ The disease is not blindness. **An accurate written description of a defect felt
 | `usedInShippedCode` bare-word-matches **raw text**, so a comment counts as a call site | `invalidateOnWrite`: 1 raw reference, 0 code references. The reference is prose at `pretooluse-router.mjs:153`. Remove the allowlist entry and the test still passes. |
 | Only `export function` is collected — 38 exported consts are invisible | `contradicts` and `answers` sat in `EDGE_KINDS` with zero write sites |
 
+**A THIRD HOLE, found during Plan 1 Task 8.** `usedInShippedCode` word-matches over
+stripped code, so an `import { name }` specifier counts as a use. A function can be
+imported and never called and the guard passes it. Proven by mutation: dropping the
+`cacheOrdered` CALL while keeping its import left reachability green; only dropping
+the import too made it fail. So Task 1 must discount import and export specifier
+occurrences as well as comments and strings — "imported" is not "called".
+
 And three sub-classes are outside its model entirely: readers with no producer (`kind:'query'`), producers with no reader (`kind:'lessons'`), and referents with no target (`wiki_query`, named in twelve shipped copies of injected prompt text).
 
 ---

--- a/docs/superpowers/specs/2026-08-25-wiki-graph-gap-closure-design.md
+++ b/docs/superpowers/specs/2026-08-25-wiki-graph-gap-closure-design.md
@@ -1,7 +1,7 @@
-# Closing the wiki-graph gaps (#204, #311)
+# Closing the wiki-graph gaps (#204)
 
 **Date:** 2026-08-25
-**Issues:** #204 (living wiki graph), #311 (dashboard `/wiki` 404 + session widget)
+**Issues:** #204 (living wiki graph). #311 was in scope at authoring time and is now closed by #313.
 **Branch:** `feat/close-wiki-graph-gaps`
 
 ---
@@ -37,13 +37,26 @@ The important part is that **round 1 already built the detector.**
 cannot see it. It found ~21 instances. Four were wired. **Sixteen were moved to
 an allowlist labelled "TRIAGE BACKLOG".**
 
+> **Revised 2026-08-25 against HEAD `d6fcc24`.** The audit behind this spec ran
+> against `315e620`; master has since advanced by 21,705 insertions across 115
+> files, so every claim was re-verified. Three things changed: **#311 is fully
+> closed by #313** (Component H is dropped); the **`PostToolUse` hook now
+> exists** (`plugin/hooks/post-tool.mjs`, handled in `adapter.mjs`), reducing
+> Component B to the two things still missing; and the **calibration loop was
+> wired**, removing four allowlist entries. The list now holds 11 entries, of
+> which **9 are real backlog** — `forTouch` is stale (2 live call sites) and
+> `policyText` is genuine public API. Everything else was re-confirmed open, and
+> one got worse: `contradicts` is now *read* by `curate.mjs:264` while still
+> written by nothing, making it a reader-with-no-producer as well as an unwritten
+> edge kind.
+
 That allowlist's own documentation says: *"If the reason is 'we might use it
 later', the honest action is to delete the function and write it again when that
-day comes."* It then violates that rule sixteen times.
+day comes."* It violated that rule sixteen times at authoring; nine entries remain.
 
 So the disease is not blindness. It is that **an accurate written description of
 a defect felt like resolution.** Any fix that closes three instances and leaves
-thirteen parked reproduces round 1 exactly.
+the rest parked reproduces round 1 exactly.
 
 ### 1.2 Two structural holes in the existing detector
 
@@ -89,7 +102,7 @@ now has 2 real call sites, so a regression there would be masked.
 | 10 | The reachability detector's two holes are fixed and its allowlist is emptied to zero backlog entries |
 | 11 | `contradicts` is wired, and confidence promotion requires no outstanding contradiction |
 | 12 | Held-out retrieval probe measures recall; no embedding baseline |
-| 13 | #311 both bugs fixed here |
+| 13 | ~~#311 both bugs fixed here~~ — superseded: closed by #313 |
 | 14 | One PR, ordered commits |
 
 ---
@@ -138,7 +151,23 @@ option declared, or the argument is silently dropped.
 
 ## 5. Component B — Capture
 
-### `plugin/hooks/posttooluse-capture.mjs` (new)
+### The hook already exists — two things are missing
+
+**Revised.** `plugin/hooks/post-tool.mjs` ships with matcher
+`Edit|MultiEdit|Write|Bash|PowerShell|mcp__.*__(?:smart_edit|smart_write)` and is
+handled in `adapter.mjs`, which is materially the design below. So this component
+is no longer "add a hook". What remains:
+
+1. **Wire `invalidateOnWrite` into the existing post-tool path.** It is still
+   prose-only (1 raw reference, 0 code references, verified by probe) and still
+   allowlisted, so staleness is lazy-only in production.
+2. **Capture exit codes and test results**, which `derive.mjs` (§6) needs and
+   which nothing records today — `buildDigest` takes command text from
+   `tool_use` and deliberately skips `tool_result`.
+
+The original design, retained because the reasoning still governs both items:
+
+### ~~`plugin/hooks/posttooluse-capture.mjs` (new)~~
 
 `hooks.json` gains `PostToolUse` with matcher
 `Bash|Edit|Write|MultiEdit|NotebookEdit`. Read, Grep, Glob and every MCP tool
@@ -360,7 +389,20 @@ alone.
 
 ---
 
-## 11. Component H — Dashboard (#311)
+## 11. Component H — Dashboard (#311) — **CLOSED, not in scope**
+
+**Superseded by #313** (merged 2026-08-25T15:29:48Z), verified at HEAD:
+
+- Bug 1: `/wiki` now `res.redirect(302, '/wiki.html')` at `web-server.ts:655`,
+  served by the `express.static` path that always worked, with
+  `tests/unit/dashboard-web-server.test.ts` asserting the 302 and the 200.
+- Bug 2: the `.claude-global` path is now `getLegacyClaudeHooksDataPath()`,
+  explicitly marked compatibility-only, with current activity read from the
+  cross-client diagnostic ledger via `/api/diagnostics/hooks`.
+
+No work remains here. The original analysis follows for the record.
+
+### ~~Original plan~~
 
 **Bug 1** — `/wiki` 404s. The reporter confirmed the file exists and
 `express.static` serves it at `/wiki.html`, so this is a `res.sendFile`
@@ -424,9 +466,9 @@ After the PR merges and one working session on this repository:
 | `kind:'index'` events > 0 | 0 |
 | declared edge kinds with zero write sites | 2 (`contradicts`, `answers`) |
 | findings on a default install (no harvest opt-in) > 0 | 1 total, ever |
-| reachability allowlist backlog entries | 16 |
+| reachability allowlist backlog entries | 9 (11 listed; `forTouch` stale, `policyText` legitimate) |
 | dead event kinds (read-no-writer or writer-no-reader) | 2 |
-| `/wiki` returns 200 | 404 |
+| `/wiki` returns 200 | ~~404~~ closed by #313 |
 | `get_optimization_report` shows the graph balance | absent |
 
 A census script reports these, so the state is checkable at any time rather than
@@ -436,7 +478,20 @@ re-derived by audit.
 
 ## 15. Delivery
 
-One PR on `feat/close-wiki-graph-gaps`, closing #204 and #311. Ordered commits:
+One PR on `feat/close-wiki-graph-gaps`, closing #204. (#311 needs nothing — #313
+closed it.) The work is split across **three plan documents** so each produces
+working, testable software on its own, all landing on the one branch:
+
+- **Plan 1 — Retrieval and wiring:** `lexical.mjs` BM25, `wiki_query`, the `query`
+  event, `invalidateOnWrite` wired, `contradicts` and `answers` written, `lessons`
+  resolved.
+- **Plan 2 — Production and measurement:** `derive.mjs` extractors, the
+  cold-graph measures, Layer 1, Layer 2, calibration, report routing, pricing,
+  recall probe. Depends on Plan 1 for the query signal.
+- **Plan 3 — The detector and its allowlist:** comment stripping, the four
+  declaration classes, and the nine wire-or-delete decisions.
+
+Ordered commits:
 
 1. Schema safety net (range reader, upcast, compaction fix, regression test)
 2. Detector fixes (comment stripping, four declaration classes)
@@ -447,7 +502,7 @@ One PR on `feat/close-wiki-graph-gaps`, closing #204 and #311. Ordered commits:
 7. Measurement (Layer 1, Layer 2, calibration, report routing, pricing)
 8. Recall probe
 9. Allowlist emptied
-10. Dashboard (#311)
+10. ~~Dashboard (#311)~~ -- closed by #313, nothing to do
 11. Docs, issue updates, census script
 
 Honest note: this is a large diff spanning MCP tools, hooks, metrics, docs and
@@ -479,5 +534,5 @@ dashboard. The commit order is what keeps it reviewable.
   substitution shipped.
 - `HOOKS-PERFORMANCE-OPTIMIZATION.md` — the capture hook's budget.
 - `#204` — phases ticked with evidence from the census, not assertions.
-- `#311` — closed.
+- `#311` — already closed by #313; nothing to do.
 - `#201` — out of scope; handled by the doc status pass, then closed as answered.

--- a/docs/superpowers/specs/2026-08-25-wiki-graph-gap-closure-design.md
+++ b/docs/superpowers/specs/2026-08-25-wiki-graph-gap-closure-design.md
@@ -1,0 +1,483 @@
+# Closing the wiki-graph gaps (#204, #311)
+
+**Date:** 2026-08-25
+**Issues:** #204 (living wiki graph), #311 (dashboard `/wiki` 404 + session widget)
+**Branch:** `feat/close-wiki-graph-gaps`
+
+---
+
+## 1. Context: what is actually wrong
+
+All six phases of #204 have real implementations. P1 (`wiki.mjs`, 735 lines), P2
+(`staleness.mjs`, 525), P3 (`harvest.mjs` + `harvest-write.mjs`), P4
+(`inject.mjs`, 669), P5 (`metrics.mjs`), P6 (`wiki-routes.ts` + dashboard). Two
+of them exceed the design: staleness gained a lazy path the doc never asked for,
+and injection gained zero-turn substitution.
+
+And on this repository's own graph, accumulated 2026-08-04 to 2026-08-25:
+
+```
+graph.jsonl    1446 symbol   468 file   45 task   1 finding
+metrics.jsonl   857 read   5 substitute   2 inject   0 index   0 query
+```
+
+One finding. The product thesis — *retrieve verdicts, not evidence* — has
+approximately one verdict to retrieve.
+
+### 1.1 Root cause
+
+Not "unbuilt". The repeating defect is **capabilities that are declared,
+documented, tested, and then not connected to anything that runs.** Ten verified
+instances, four already fixed (`downstream`, `harvest-write` unimported,
+`HUMAN_WEIGHT` unconsumed, `tokensFullFile` unread).
+
+The important part is that **round 1 already built the detector.**
+`tests/hooks/reachability.test.mjs` exists, is explicit that this defect
+"occurred twice", and correctly identifies why unit tests and mutation testing
+cannot see it. It found ~21 instances. Four were wired. **Sixteen were moved to
+an allowlist labelled "TRIAGE BACKLOG".**
+
+That allowlist's own documentation says: *"If the reason is 'we might use it
+later', the honest action is to delete the function and write it again when that
+day comes."* It then violates that rule sixteen times.
+
+So the disease is not blindness. It is that **an accurate written description of
+a defect felt like resolution.** Any fix that closes three instances and leaves
+thirteen parked reproduces round 1 exactly.
+
+### 1.2 Two structural holes in the existing detector
+
+| Hole | Evidence |
+|---|---|
+| Comments count as call sites — `usedInShippedCode` bare-word-matches raw text | `invalidateOnWrite`: **1 raw ref, 0 code refs.** Removing it from the allowlist leaves the test passing, because `pretooluse-router.mjs:153` mentions it in prose. Verified by probe. |
+| Only `export function` is scanned — 38 exported consts are invisible | `contradicts` and `answers` are declared in `EDGE_KINDS` with **zero write sites**. `contradicts` gets a full paragraph in `WIKI_GRAPH.md` as the design's departure from RAG. |
+
+The detector also cannot see three whole sub-classes: readers with no producer
+(`kind:'query'`), producers with no reader (`kind:'lessons'`, written at
+`harvest-worker.mjs:113`), and referents with no target (`wiki_query`, named in
+seven shipped copies of injected prompt text).
+
+The allowlist has also already rotted: `forTouch` is listed as pending-wiring but
+now has 2 real call sites, so a regression there would be masked.
+
+---
+
+## 2. Non-goals
+
+- No embeddings or vector index. The stance stays, but §7 makes it falsifiable.
+- No reranking model. Retrieval mechanics stay deliberately below state of the art.
+- No change to the semantic harvest's opt-in default. Privacy and billing consent
+  is correct as it stands; §6 makes a default install productive without it.
+- No `GRAPH_VERSION` bump (§8).
+- Issue #201 is out of scope here and is handled separately (doc status pass, then close).
+
+---
+
+## 3. Decisions
+
+| # | Decision |
+|---|---|
+| 1 | `wiki_query` ships as the union: `get`, `search`, `anchor`, `node`, `audit`, `balance`, `overview` — `overview` is textual graph shape, not layout coordinates |
+| 2 | Real BM25 in `hooks-core/lexical.mjs`, consumed by both `wiki_query` and `/api/wiki/search` |
+| 3 | Hit rate = Layer 1 (explicit reference) calibrated against Layer 2 (per-finding causal effect) |
+| 4 | Layer 2 on by default, guarded, with an env kill switch |
+| 5 | All four cold-graph measures ship |
+| 6 | Four local extractors, no model call, redaction mandatory |
+| 7 | Dollars only on measured-counterfactual lines, sourced from `pricing.mjs` |
+| 8 | Upcaster and range reader built; `GRAPH_VERSION` stays at 1 |
+| 9 | `PostToolUse` scoped to write/exec tools, capture-only, invalidation applied at next graph read |
+| 10 | The reachability detector's two holes are fixed and its allowlist is emptied to zero backlog entries |
+| 11 | `contradicts` is wired, and confidence promotion requires no outstanding contradiction |
+| 12 | Held-out retrieval probe measures recall; no embedding baseline |
+| 13 | #311 both bugs fixed here |
+| 14 | One PR, ordered commits |
+
+---
+
+## 4. Component A — Retrieval
+
+### `hooks-core/lexical.mjs` (new)
+
+Pure BM25 over finding `claim` and `key`. No dependency. Exports
+`score(query, docs)` and `rank(query, findings, { limit })`.
+
+Why it matters beyond doc-honesty: substring matching cannot rank, so a
+budget-capped retrieval currently keeps whatever happened to match rather than
+what matched best. `/api/wiki/search` switches to it, removing the divergence
+between what the dashboard does and what the doc claims.
+
+Ranking prior: BM25 relevance is combined with the per-finding utility from
+Component E where a verdict exists. Implicit relevance feedback from a *causal*
+signal is the one retrieval advantage available to us that a search engine
+cannot replicate.
+
+### `src/tools/intelligence/wiki-query.ts` (new)
+
+Follows `wiki-write.ts`. Registered in `src/server/index.ts`; schema in
+`src/validation/tool-schemas.ts`.
+
+| Operation | Returns |
+|---|---|
+| `get` | finding by key: claim, confidence, origin, anchors, staleness + invalidating diff, provenance |
+| `search` | BM25-ranked active findings, optional `type` filter |
+| `anchor` | findings reachable from a file/symbol via `findingsFor` |
+| `node` | node plus bounded neighbourhood |
+| `audit` | `curate.audit` output |
+| `balance` | `metrics.report` output |
+| `overview` | counts by kind, densest anchors, most-stale clusters — text |
+
+Every call records `record(dir, { kind: 'query', operation, key })` against the
+project resolved by `projectRootFor`, not the session cwd. That single line
+resurrects `indexBudget`, which is currently pinned at its 150-token floor for
+every project on earth once five index injections have occurred.
+
+Constraint: the tool must satisfy the existing schema-completeness ratchet. Every
+option declared, or the argument is silently dropped.
+
+---
+
+## 5. Component B — Capture
+
+### `plugin/hooks/posttooluse-capture.mjs` (new)
+
+`hooks.json` gains `PostToolUse` with matcher
+`Bash|Edit|Write|MultiEdit|NotebookEdit`. Read, Grep, Glob and every MCP tool
+never invoke it.
+
+The hook appends **one** bounded record and exits: exit code, stdout/stderr
+truncated to 4 KB, before/after content hashes, anchor, timestamp. No parsing, no
+diffing, no graph load. Fail-open on any throw.
+
+### Pending invalidation, applied at next read
+
+`invalidateOnWrite` is revived — but not called inside the write hook, because
+that would load a 1 MB graph on the return path of every write. Instead the
+capture record carries the invalidation intent, and the next graph read (the
+`PreToolUse` injection path, which already loads the graph) applies pending
+invalidations before serving.
+
+Correctness is unchanged: the property that matters is that a stale finding is
+never *served* as fresh, and serve time is where that is enforced. This is
+strictly fewer graph loads than eager-as-documented, with the same guarantee.
+
+`WIKI_GRAPH.md` is corrected to describe this: PostToolUse on writes and
+commands, results derived at Stop, invalidation applied at next read.
+
+Performance budget, measured not asserted, recorded in
+`HOOKS-PERFORMANCE-OPTIMIZATION.md`: **zero** added cost on read-path calls (the
+matcher means the hook does not run), and **p95 under 50 ms** for the capture hook
+itself on write/exec calls. Measured by median-of-9 across multiple process
+launches, not a single shot — timing on these machines has roughly 4× run-to-run
+variance.
+
+---
+
+## 6. Component C — Production (making a default install produce findings)
+
+### `hooks-core/derive.mjs` (new) — run at Stop, no model call
+
+| Detector | Anchor | Confidence cap |
+|---|---|---|
+| Command failed then succeeded | command + project | 0.90 |
+| Test/build red → green | files edited between | 0.85 |
+| User correction detected | files in scope | 0.60 |
+| Re-read churn | the file | 0.40 |
+
+All four route through `harvest-write.mjs`'s anchor discipline — `indexFile`
+first, refuse anything whose anchors do not resolve — and are stamped
+`ORIGIN_HARVESTED`, never `ORIGIN_HUMAN`.
+
+**Redaction is mandatory, not optional.** Captured stderr can contain secrets,
+and finding claims are both injected into context and exported to markdown. Claim
+text is capped and passed through secret-pattern redaction before storage.
+
+Precision caveat, stated because it is real: "failed then succeeded" does not
+prove the second command fixed the first. Confidence caps plus Component E's
+utility pruning are what keep low-precision derivations from accumulating.
+
+### The other three measures
+
+- Standing rule nudging `wiki_write`, inside the existing standing budget.
+- `localEndpoint()` detection surfaced loudly in `doctor` and at SessionStart
+  ("local model found — harvest is on, free and private").
+- README, `WIKI_GRAPH.md` and #204 state plainly that a default install without a
+  local model ships the structural skeleton, and that verdicts require
+  `TOKEN_OPTIMIZER_HARVEST` or a local endpoint.
+
+---
+
+## 7. Component D — Correctness, distinct from usefulness
+
+Component E measures whether a finding *suppresses reads*. A confidently wrong
+finding suppresses reads better than a hedged true one, so utility alone
+optimises directly against risk 1 ("wrong findings are worse than none").
+
+So:
+
+- **`contradicts` is wired.** When a session re-derives against an anchor and
+  reaches a conclusion that disagrees with a served finding, the disagreement is
+  recorded as a `contradicts` edge rather than an overwrite — which is what the
+  schema declared and nothing ever wrote.
+- **`answers` is wired** (finding → task), closing the other dead edge kind.
+- **Confidence promotion requires no outstanding contradiction.** Measured utility
+  ranks a finding; it never raises its confidence.
+
+This also closes an accidental competitive gap: contradiction modelling is
+something Graphiti-class systems do and we declared but never did.
+
+---
+
+## 8. Component E — Measurement
+
+### Layer 1 — explicit reference (independent signal)
+
+For each injection, classify from logged events only:
+
+- `referenced` — a subsequent `wiki_query` or `expand` names that finding
+- `not-referenced` — no such call
+- `unknown` — the session ended immediately; **excluded from the denominator**
+
+Layer 1 deliberately does **not** use read-suppression. Read-suppression is
+Layer 2's estimand, and using it in both would make the calibration loop
+circular — it would report a strong correlation between two spellings of the same
+quantity and mean nothing.
+
+### Layer 2 — per-finding causal effect
+
+Leave-one-out: for a finding `f`, arm decided by `hash(f.key + sessionId)`, stable
+for the session. Effect = mean downstream read cost when `f` was withheld minus
+when `f` was served.
+
+Guards:
+
+- Never withhold `pinned` or `ORIGIN_HUMAN` findings. A person asserted it;
+  withholding it to run an experiment overrides an explicit human decision. These
+  are always served and simply carry no causal score.
+- A finding enters the experiment only after **4 ordinary injections**, mirroring
+  the threshold `substitutionBudget` already uses before it trusts an arm.
+- At most one finding withheld per touch — with two, the effect cannot be
+  attributed to either, and the user's worst case stays "one finding missing from
+  a served set".
+- On by default; `TOKEN_OPTIMIZER_LOO=off` disables it.
+
+Statistics:
+
+- **Empirical Bayes shrinkage** toward the population mean, so a two-observation
+  finding cannot post a wild score.
+- **FDR control** (Benjamini–Hochberg, **q = 0.10**) on published per-finding
+  verdicts, because hundreds of findings tested individually produce false
+  discoveries. A verdict is published only when it survives BH adjustment **and**
+  has at least 6 served and 3 withheld observations; otherwise the finding is
+  reported as "no verdict" rather than given a number.
+- **ε-exploration at 10%** — matching the existing holdout fraction — where
+  injections ignore the utility ranking, so a finding ranked down still accrues
+  observations. Without this, utility feeds ranking feeds injection frequency
+  feeds observations, and a low score becomes self-fulfilling.
+- **Serving-policy version** logged with each observation, so effects are never
+  pooled across policy changes.
+
+### Stated limitations (these go in the report, not just this doc)
+
+1. **Interference.** Withholding `f` can still expose `f`'s information because the
+   model reads the file. The estimand is therefore *marginal contribution under
+   the current serving policy*, not "the value of `f`". Reported as such.
+2. **Power.** Most findings will never see enough injections for a verdict.
+   Empirical Bayes handles this correctly by declining to give one; the report
+   says how many findings have no verdict rather than implying coverage.
+3. **Selection.** The population effect is estimated on non-pinned,
+   non-human-origin findings and does not extrapolate to the excluded ones.
+4. Arm sizes are reported, so small-sample imbalance is visible.
+
+### Calibration loop
+
+Does Layer 1's `referenced` label predict Layer 2's causal effect? If referenced
+findings show no better effect than `unknown` ones, the report says the label is
+theatre instead of publishing it — the same discipline `forecast.mjs` already
+applies to predictions.
+
+### Reporting
+
+`balanceSheet()` routes into `get_optimization_report`. `approxCost`'s hardcoded
+`$3/1M` is replaced by `pricing.mjs`, and a dollar figure appears **only** on
+measured-counterfactual lines. Estimated lines show tokens, labelled as
+estimates, with no currency.
+
+---
+
+## 9. Component F — Recall, so "no embeddings" is falsifiable
+
+`WIKI_GRAPH.md` says embeddings get added "if measurement shows real recall
+loss". Nothing measures recall, which makes the stance unfalsifiable.
+
+Held-out retrieval probe: for each finding, hide it and ask whether traversal
+plus BM25 would surface it from its own originating context. Offline,
+deterministic, no model call, no embedding dependency. Reported alongside the
+balance sheet so the decision stays honest as the graph grows.
+
+---
+
+## 10. Component G — The detector and its allowlist
+
+### Fix both holes in `tests/hooks/reachability.test.mjs`
+
+1. **Strip comments and string literals before matching.** This is the change that
+   would have caught `invalidateOnWrite` without an allowlist entry.
+2. **Extend beyond `export function`** to four declaration classes:
+   - exported consts (38 currently invisible)
+   - event kinds — every `kind` read must have a product writer and vice versa
+   - edge kinds — every member of `EDGE_KINDS` must have a write site
+   - tool names appearing in injected prompt text must exist in the registry
+
+Sub-class coverage after the fix:
+
+| Sub-class | Example | Covered by |
+|---|---|---|
+| export with no product caller | `invalidateOnWrite` | comment-stripped scan |
+| reader with no producer | `kind:'query'` | event-kind census |
+| producer with no reader | `kind:'lessons'` | event-kind census |
+| declared const never used | `contradicts`, `answers` | const + edge-kind census |
+| referent with no target | `wiki_query` | tool-name census |
+
+### Empty the allowlist
+
+All 16 entries get one of two outcomes — wired to a real call site, or deleted.
+Nothing stays parked. The allowlist ends at zero backlog entries plus the one
+genuine public API (`policyText`).
+
+Expected shape of that work, from the verified 0-reference census:
+
+- **Wire:** the calibration loop (`logForecast`, `observeOutcome`, `forecastPanel`,
+  `worthSurfacing`) needs an entry point; keep-warm needs its outcome half
+  (`recordRefresh`, `recordRefreshOutcome`) called or it can never learn;
+  `invalidateOnWrite` is wired by Component B.
+- **Decide per item:** consolidation (`selectForConsolidation`,
+  `consolidationRatio`, `contentAnchor`), `cacheOrdered`, `renderStanding`,
+  `auditFindings`, `manifestSize`. Several are likely deletions.
+- **Remove the stale entry:** `forTouch` has 2 real call sites.
+
+Judgement calls here are brought to the user individually rather than decided
+alone.
+
+---
+
+## 11. Component H — Dashboard (#311)
+
+**Bug 1** — `/wiki` 404s. The reporter confirmed the file exists and
+`express.static` serves it at `/wiki.html`, so this is a `res.sendFile`
+root/absolute-path problem, not a missing asset. Diagnosed rather than guessed.
+Regression test fetches `/wiki` and asserts 200.
+
+**Bug 2** — the session widget's hardcoded `~/.claude-global/hooks/data` becomes
+the same per-project `.token-optimizer` resolution the hooks use.
+
+---
+
+## 12. Schema compatibility
+
+Nothing in this work changes a graph record's shape: utility lives in metrics,
+`contradicts`/`answers` use the existing edge record, extractor fields are
+additive. So `GRAPH_VERSION` stays at **1**.
+
+Built anyway, as the safety net for the first change that does need it:
+
+- Version-**range** reader in `load()`, plus a pure per-step `upcast()`.
+- **The compaction fix.** `wiki.mjs:346` carries the same
+  `v !== GRAPH_VERSION` filter, so a future bump would silently **drop** v1
+  records while compacting — a second route to the same data loss. The upcaster is
+  wired there too.
+- Forward-incompatible records (a v3 from a newer client) are still skipped:
+  ignoring the future is safe, ignoring the past is data loss.
+- Regression test: a v1 log loads with every node intact.
+- The header comment claiming "nothing has been released" is corrected. It ships
+  on npm.
+
+---
+
+## 13. Testing
+
+TDD: failing test first for each behaviour. Beyond unit coverage, each resurrected
+capability gets a test that drives the **product path**, not the function:
+
+- `wiki_query` callable through the server dispatch, not just the module
+- a `query` event present in the log after a `wiki_query` call
+- a write marking findings stale via the hook chain, not via a direct
+  `invalidateOnWrite` call
+- a `contradicts` edge present after a disagreeing re-derivation
+- BM25 ranking asserted to order better than substring on a fixture
+
+`npm run sync:hooks` after every `hooks-core` change; CI's `sync:hooks:check`
+enforces the seven vendored copies. `tests/hooks/injection.test.mjs:145` becomes a
+real assertion instead of one that locks in a dangling reference.
+
+---
+
+## 14. Acceptance criteria
+
+Deliberately **live-census based, not CI-green based**, because every one of the
+ten instances passed CI and was caught by live measurement or code reading.
+
+After the PR merges and one working session on this repository:
+
+| Criterion | Today |
+|---|---|
+| `kind:'query'` events > 0 | 0 |
+| `kind:'index'` events > 0 | 0 |
+| declared edge kinds with zero write sites | 2 (`contradicts`, `answers`) |
+| findings on a default install (no harvest opt-in) > 0 | 1 total, ever |
+| reachability allowlist backlog entries | 16 |
+| dead event kinds (read-no-writer or writer-no-reader) | 2 |
+| `/wiki` returns 200 | 404 |
+| `get_optimization_report` shows the graph balance | absent |
+
+A census script reports these, so the state is checkable at any time rather than
+re-derived by audit.
+
+---
+
+## 15. Delivery
+
+One PR on `feat/close-wiki-graph-gaps`, closing #204 and #311. Ordered commits:
+
+1. Schema safety net (range reader, upcast, compaction fix, regression test)
+2. Detector fixes (comment stripping, four declaration classes)
+3. Capture (PostToolUse, pending invalidation, `invalidateOnWrite` wired)
+4. Retrieval (`lexical.mjs`, `wiki_query`, `query` event)
+5. Production (`derive.mjs`, standing rule, endpoint surfacing)
+6. Correctness (`contradicts`, `answers`, confidence gating)
+7. Measurement (Layer 1, Layer 2, calibration, report routing, pricing)
+8. Recall probe
+9. Allowlist emptied
+10. Dashboard (#311)
+11. Docs, issue updates, census script
+
+Honest note: this is a large diff spanning MCP tools, hooks, metrics, docs and
+dashboard. The commit order is what keeps it reviewable.
+
+---
+
+## 16. Risks
+
+| Risk | Mitigation | Residual |
+|---|---|---|
+| Emptying the allowlist expands scope unpredictably | Each entry is wire-or-delete, judgement calls surfaced individually | Real. Some entries may be larger than they look |
+| Extractor noise floods the injection budget | Confidence caps, utility pruning, ε-exploration | Low-precision derivations still compete initially |
+| Layer 2 degrades a real turn | Three guards; worst case is one finding missing from a served set | Accepted deliberately |
+| Secrets in captured stderr reaching findings | Mandatory redaction and caps before storage | Pattern-based redaction is imperfect |
+| PostToolUse latency | Scoped matcher, capture-only, measured budget | One process spawn per write/exec call |
+| Utility rewards persuasive falsehoods | `contradicts` wired, confidence never promoted by utility | Detection depends on a re-derivation happening |
+| Large single PR | Ordered commits | Review quality risk is real |
+
+---
+
+## 17. Docs and issues
+
+- `WIKI_GRAPH.md` — BM25 now true; hit rate redefined to what is measured;
+  PostToolUse and apply-at-next-read described; default-install honesty; recall
+  probe named.
+- `COMPETITIVE_GAPS.md` — per-gap status column; the stale concession about
+  requiring the model to reissue against `smart_read` corrected, since zero-turn
+  substitution shipped.
+- `HOOKS-PERFORMANCE-OPTIMIZATION.md` — the capture hook's budget.
+- `#204` — phases ticked with evidence from the census, not assertions.
+- `#311` — closed.
+- `#201` — out of scope; handled by the doc status pass, then closed as answered.

--- a/docs/superpowers/specs/2026-08-25-wiki-graph-gap-closure-design.md
+++ b/docs/superpowers/specs/2026-08-25-wiki-graph-gap-closure-design.md
@@ -68,7 +68,7 @@ the rest parked reproduces round 1 exactly.
 The detector also cannot see three whole sub-classes: readers with no producer
 (`kind:'query'`), producers with no reader (`kind:'lessons'`, written at
 `harvest-worker.mjs:113`), and referents with no target (`wiki_query`, named in
-seven shipped copies of injected prompt text).
+twelve shipped copies of injected prompt text).
 
 The allowlist has also already rotted: `forTouch` is listed as pending-wiring but
 now has 2 real call sites, so a regression there would be masked.
@@ -448,7 +448,7 @@ capability gets a test that drives the **product path**, not the function:
 - BM25 ranking asserted to order better than substring on a fixture
 
 `npm run sync:hooks` after every `hooks-core` change; CI's `sync:hooks:check`
-enforces the seven vendored copies. `tests/hooks/injection.test.mjs:145` becomes a
+enforces the eleven vendored copies. `tests/hooks/injection.test.mjs:145` becomes a
 real assertion instead of one that locks in a dangling reference.
 
 ---

--- a/hooks-core/adapter.mjs
+++ b/hooks-core/adapter.mjs
@@ -66,7 +66,7 @@ import {
   standingRules,
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
-import { observedWrite, queueInvalidation } from './pending.mjs';
+import { observedWrites, queueInvalidation } from './pending.mjs';
 import { isArchived } from './transcript.mjs';
 import { isFsSafePath } from './paths.mjs';
 import {
@@ -896,8 +896,7 @@ async function runHook(clientName, event, invocation) {
     // avoid. The next graph read drains it before serving anything.
     try {
       if (mutationSucceeded(clientName, raw)) {
-        const evidence = observedWrite(payload, raw);
-        if (evidence) {
+        for (const evidence of observedWrites(payload, raw)) {
           // THE SAME DIRECTORY THE GRAPH ITSELF USES. `observeAndInject` keys
           // every write on `wikiDir(projectRootFor(path, payload.cwd))`, and a
           // queue written anywhere else is a queue nothing ever drains.

--- a/hooks-core/adapter.mjs
+++ b/hooks-core/adapter.mjs
@@ -66,6 +66,7 @@ import {
   standingRules,
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
+import { observedWrite, queueInvalidation } from './pending.mjs';
 import { isArchived } from './transcript.mjs';
 import { isFsSafePath } from './paths.mjs';
 import {
@@ -879,6 +880,35 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Causal tracing is fail-open like every other hook optimization.
+    }
+
+    // EAGER INVALIDATION, finally connected. `invalidateOnWrite` has existed,
+    // been tested and been described in staleness.mjs's own header since
+    // staleness landed, and its only reference in shipped code was a COMMENT in
+    // the PreToolUse router -- so the path that header calls load-bearing had
+    // never run once in production. It matters most for exactly this event: the
+    // lazy check compares the anchor's stored hash against disk, and the
+    // capture below re-points that hash at the bytes this write just produced,
+    // so a write the session performed ITSELF is invisible to lazy staleness.
+    //
+    // QUEUED, NOT APPLIED. Applying needs the graph, and loading a megabyte of
+    // JSONL on the return path of every write is what this shape exists to
+    // avoid. The next graph read drains it before serving anything.
+    try {
+      if (mutationSucceeded(clientName, raw)) {
+        const evidence = observedWrite(payload, raw);
+        if (evidence) {
+          // THE SAME DIRECTORY THE GRAPH ITSELF USES. `observeAndInject` keys
+          // every write on `wikiDir(projectRootFor(path, payload.cwd))`, and a
+          // queue written anywhere else is a queue nothing ever drains.
+          queueInvalidation(
+            wikiDir(projectRootFor(evidence.path, payload.cwd)),
+            evidence
+          );
+        }
+      }
+    } catch {
+      // Bookkeeping for a call that already completed. Never let it cost one.
     }
   }
 

--- a/hooks-core/adapter.mjs
+++ b/hooks-core/adapter.mjs
@@ -62,6 +62,7 @@ import {
   forTouch,
   noteActClasses,
   relevantFindingIdsForContext,
+  sessionContext,
   sessionIndex,
   standingRules,
 } from './inject.mjs';
@@ -688,8 +689,23 @@ async function runHook(clientName, event, invocation) {
       rememberOptimizerTools(state, toolEvidence);
       saveState(sessionId, state);
     }
-    const parts = [
-      policyText(client.canDeny, toolEvidence.names, toolEvidence.proven),
+    // ASSEMBLED IN CACHE ORDER, not in whatever order this function happens to
+    // discover the blocks. Everything emitted here sits near the FRONT of the
+    // prompt prefix, and a prefix cache invalidates from the first differing
+    // byte onward -- so the block that changes most often has to sit LAST, or it
+    // re-prices every block behind it on every session. `sessionContext` sorts
+    // by the declared volatility; inject.mjs records how each number was
+    // assigned and why.
+    const blocks = [
+      {
+        id: 'policy',
+        volatility: 0,
+        text: policyText(
+          client.canDeny,
+          toolEvidence.names,
+          toolEvidence.proven
+        ),
+      },
     ];
     const cwd = raw.cwd || raw.working_directory || process.cwd();
     const root = projectRootFor(join(cwd, '__session__'), cwd);
@@ -703,7 +719,7 @@ async function runHook(clientName, event, invocation) {
         const graph = load(dir);
         const episode = episodeMeta({ client: clientName, raw });
         const rules = standingRules(dir, graph, { episode });
-        if (rules) parts.push(rules);
+        if (rules) blocks.push({ id: 'standing', volatility: 1, text: rules });
         const relevantFindingIds = relevantFindingIdsForContext(
           graph,
           sessionTaskContext(raw)
@@ -712,12 +728,12 @@ async function runHook(clientName, event, invocation) {
           episode,
           relevantFindingIds,
         });
-        if (index) parts.push(index);
+        if (index) blocks.push({ id: 'index', volatility: 2, text: index });
       } catch {
         // Retrieval is optional context; the policy must still reach the model.
       }
     }
-    const output = contextOutput(client, eventName, parts.join('\n\n'));
+    const output = contextOutput(client, eventName, sessionContext(blocks));
     if (output) emit(output);
     process.exit(0);
   }

--- a/hooks-core/capabilities.mjs
+++ b/hooks-core/capabilities.mjs
@@ -36,6 +36,10 @@ export const HOOK_MCP_TOOLS = Object.freeze([
   'optimize_session',
   'get_optimization_report',
   'wiki_write',
+  // The read side of the graph. The session index tells the model to "call
+  // wiki_query with a key for detail", so the hook needs positive evidence that
+  // the name it is advertising is actually registered in this host.
+  'wiki_query',
 ]);
 
 const HOOK_MCP_TOOL_SET = new Set(HOOK_MCP_TOOLS);

--- a/hooks-core/curate.mjs
+++ b/hooks-core/curate.mjs
@@ -122,7 +122,17 @@ export function correct(
   const replacementKey = `${key}-c${Date.now().toString(36)}`;
 
   const edges = [{ edge: 'supersedes', to: originalId }];
-  // The correction inherits the original's anchors, so it can go stale too.
+  // The correction inherits the original's anchors, so it can go stale too --
+  // but it inherits NOTHING ELSE, and that is deliberate rather than incidental.
+  // The node written below is built field by field from `existing` instead of
+  // spreading it, which is what keeps the staleness fields (`stale`,
+  // `staleReason`, `diff`) off the successor: a correction is re-derived
+  // against the current code by definition, so being born carrying its
+  // predecessor's invalidation would discount it the moment it existed --
+  // `disclose.mjs` skips a stale finding outright and `utility.mjs` penalises
+  // one by 160. Any future edit here that reaches for `...existing` to pick up
+  // one more field re-introduces that, since `putNode` writes what it is handed
+  // wholesale; `tests/hooks/stale-clearing.test.mjs` is the guard.
   for (const edge of graph.edges) {
     if (edge.edge === 'derived_from' && edge.from === originalId) {
       edges.push({ edge: 'derived_from', to: edge.to });
@@ -242,13 +252,38 @@ export function contradict(dir, { key, byKey, reason }) {
  * It also matches `audit()`, the reader that has always been here: it puts both
  * `from` and `to` in its `contradicted` bucket, because "until one looks, BOTH
  * are being served".
+ *
+ * A RETIRED COUNTERPART DOES NOT COUNT, and that sentence quoted just above is
+ * the reason. This read edges ONLY, so retiring one end of a contradiction left
+ * the survivor gated against confidence promotion forever and served with a
+ * DISPUTED note naming a key `serve` refuses to hand anybody -- `serve`,
+ * `activeFindings`, `findingsFor` and `sessionIndex` all drop a retired
+ * finding. A retired claim is served to NOBODY, so "BOTH are being served" is
+ * false and the premise of the gate is gone: only one claim is in play, and
+ * there is nothing left to choose between. Retiring one end IS the person
+ * looking that this gate was waiting for -- so the edge counts as open only
+ * while NEITHER end is retired, answered the same way from both directions.
+ *
+ * AN UNRESOLVABLE END STILL COUNTS. An edge whose other side names no node
+ * proves nothing about whether that claim was withdrawn, and the conservative
+ * reading -- still disputed -- is the one that cannot promote a claim nobody
+ * adjudicated.
  */
 export function hasOutstandingContradiction(graph, key) {
   const node = findingByKey(graph, key);
-  if (!node) return false;
-  return graph.edges.some(
-    (e) => e.edge === 'contradicts' && (e.to === node.id || e.from === node.id)
-  );
+  // A withdrawn claim is not in a dispute either: a dispute needs two claims in
+  // play, and this one has been taken out of play. Without this the RETIRED end
+  // still reported an open disagreement, which is the same defect from the other
+  // side -- and the answer has to agree from both directions, since the gate is
+  // symmetric on purpose.
+  if (!node || node.retired) return false;
+  return graph.edges.some((e) => {
+    if (e.edge !== 'contradicts') return false;
+    const otherId = e.from === node.id ? e.to : e.to === node.id ? e.from : null;
+    if (!otherId) return false;
+    const other = graph.nodes.get(otherId);
+    return !other || !other.retired;
+  });
 }
 
 /**
@@ -332,11 +367,24 @@ export function audit(graph) {
       .map((e) => e.from)
   );
 
+  // THE SAME DEFINITION OF AN OPEN DISPUTE as hasOutstandingContradiction, and
+  // it has to be: that function's own comment claims it "matches audit()", and
+  // two rankings that disagree about what needs a human is worse than one that
+  // is wrong. A retired counterpart is a resolved dispute -- the retired claim
+  // is served to nobody -- so the survivor is not one of two claims in play and
+  // does not belong in the bucket of things needing a person to look.
+  //
+  // One pass, not a call per finding: this is a dashboard read over the whole
+  // graph, and the obvious rewrite is O(findings x edges).
   const contradicted = new Set();
   for (const edge of graph.edges) {
     if (edge.edge !== 'contradicts') continue;
-    contradicted.add(edge.from);
-    contradicted.add(edge.to);
+    const from = graph.nodes.get(edge.from);
+    const to = graph.nodes.get(edge.to);
+    // An end that resolves to nothing cannot be shown retired, so it still
+    // counts against the other end.
+    if (!to || !to.retired) contradicted.add(edge.from);
+    if (!from || !from.retired) contradicted.add(edge.to);
   }
 
   return {

--- a/hooks-core/curate.mjs
+++ b/hooks-core/curate.mjs
@@ -20,7 +20,7 @@
  */
 
 import { randomBytes } from 'node:crypto';
-import { putNode, putNodeWithEdges, load, nodeId } from './wiki.mjs';
+import { putNode, putEdge, putNodeWithEdges, load, nodeId } from './wiki.mjs';
 import { indexFile } from './staleness.mjs';
 import { symbolKey } from './symbols.mjs';
 import { canonicalPath } from './paths.mjs';
@@ -176,6 +176,79 @@ export function retire(dir, key) {
   if (!existing) return false;
   putNode(dir, { ...existing, kind: 'finding', key, retired: true });
   return true;
+}
+
+/**
+ * Records that one finding disagrees with another.
+ *
+ * AN EDGE, NOT AN OVERWRITE -- the design is explicit about why: "when a belief
+ * changes, the graph should record THAT it changed and why, not quietly present
+ * the new one as though it had always been true." `contradicts` has been in
+ * EDGE_KINDS since the schema existed and was written by nothing, while
+ * `audit()` already READ it.
+ *
+ * The contradicted finding is deliberately NOT retired, and its claim is
+ * deliberately preserved. A reader needs to see both claims and the
+ * disagreement between them; retiring one silently picks a winner, and putNode
+ * does not merge -- it writes the whole record from what it is handed, so
+ * annotating the target without spreading it back in would blank the very claim
+ * this edge exists to keep visible. That is the overwrite by another name.
+ *
+ * THE EDGE IS WRITTEN FIRST, and the order is the guarantee. These are two
+ * appends and `append` fails open, so either can be the one that lands. Edge
+ * without annotation is a complete, readable disagreement missing only its
+ * reason. Annotation without edge is a finding that says "something contradicts
+ * me" with no contradictor -- a claim of proof with no proof, and invisible to
+ * `audit()` and to `hasOutstandingContradiction`, both of which read the edge.
+ */
+export function contradict(dir, { key, byKey, reason }) {
+  const graph = load(dir);
+  const target = findingByKey(graph, key);
+  const source = findingByKey(graph, byKey);
+  // Both ends must exist, or the edge is unresolvable and the disagreement is
+  // recorded against nothing -- the same un-invalidatable shape anchors prevent.
+  if (!target || !source) return false;
+  // A finding cannot disagree with itself. The self-edge resolves, so the guard
+  // above waves it through, and the result is a node permanently blocked from
+  // confidence promotion by a dispute no person can ever resolve: there is no
+  // second claim to choose between.
+  if (target.id === source.id) return false;
+
+  putEdge(dir, source.id, 'contradicts', target.id);
+  putNode(dir, {
+    ...target,
+    kind: 'finding',
+    key,
+    contradictedAt: Date.now(),
+    contradictionReason: String(reason || '').slice(0, 400),
+  });
+  return true;
+}
+
+/**
+ * Whether anything currently disagrees with this finding.
+ *
+ * Gates confidence promotion. Plan 2's per-finding utility measures whether a
+ * finding SUPPRESSES READS, and a confidently wrong finding suppresses reads
+ * better than a hedged true one -- so utility must never raise confidence on
+ * its own, and this is the check that stops it.
+ *
+ * SYMMETRIC, deliberately: BOTH ends of a `contradicts` edge are outstanding
+ * until a person resolves the disagreement. The named hazard in the design is
+ * presenting "the new one as though it had always been true", so gating only
+ * the older claim would leave the newer one -- which is just as likely to be
+ * the wrong one, since nothing here adjudicates -- free to be promoted on
+ * measured utility alone. That is the exact failure this gate exists to stop.
+ * It also matches `audit()`, the reader that has always been here: it puts both
+ * `from` and `to` in its `contradicted` bucket, because "until one looks, BOTH
+ * are being served".
+ */
+export function hasOutstandingContradiction(graph, key) {
+  const node = findingByKey(graph, key);
+  if (!node) return false;
+  return graph.edges.some(
+    (e) => e.edge === 'contradicts' && (e.to === node.id || e.from === node.id)
+  );
 }
 
 /**

--- a/hooks-core/curate.mjs
+++ b/hooks-core/curate.mjs
@@ -68,6 +68,38 @@ export function originWeight(origin) {
   return 1;
 }
 
+/**
+ * The claim-time anchor hashes, for a finding being written right now.
+ *
+ * THE CHECKABLE HALF OF PROVENANCE, and until now only `harvest-write.mjs`
+ * wrote it -- so the asymmetry ran exactly the wrong way. `reverify` and the
+ * automatic clear in `serve` both compare disk against these frozen hashes, and
+ * a finding without them can never have a stale flag cleared by anything. That
+ * meant HUMAN-asserted findings, the ones somebody deliberately created or
+ * corrected, were the only ones condemned to stay stale forever once marked,
+ * while machine-harvested claims could recover. The hashes are simply the anchor
+ * nodes' hashes at this moment, and every writer has them in hand.
+ *
+ * DELIBERATELY NOT THE WHOLE RECORD `derivationFor` BUILDS. That one joins the
+ * evidence log to find FILE-surface operations behind the claim; curation
+ * performs no such join, so `operations` is empty and `operationsComplete` says
+ * so. An empty list declared incomplete is honest -- "nothing recorded here, and
+ * do not read that as nothing happened" -- where an empty list declared complete
+ * would assert a fact nobody established.
+ *
+ * An anchor with no stored hash contributes no entry, and a finding whose
+ * anchors all lack one gets a record with no hashes -- which `claimTimeVerdict`
+ * reads as `unknown` and refuses to clear on, which is the correct reading.
+ */
+function claimTimeDerivation(graph, resolved) {
+  const anchors = {};
+  for (const id of resolved) {
+    const node = graph.nodes.get(id);
+    if (node && typeof node.hash === 'string') anchors[id] = node.hash;
+  }
+  return { at: Date.now(), anchors, operations: [], operationsComplete: false };
+}
+
 function findingByKey(graph, key) {
   return graph.nodes.get(nodeId('finding', key)) || null;
 }
@@ -122,6 +154,11 @@ export function correct(
   const replacementKey = `${key}-c${Date.now().toString(36)}`;
 
   const edges = [{ edge: 'supersedes', to: originalId }];
+  // Collected alongside the edges so the correction carries its own claim-time
+  // hashes: it is a NEW claim, re-derived against whatever the code says now, so
+  // its evidence is the anchors' current state -- not the predecessor's, which is
+  // precisely what went stale.
+  const inherited = [];
   // The correction inherits the original's anchors, so it can go stale too --
   // but it inherits NOTHING ELSE, and that is deliberate rather than incidental.
   // The node written below is built field by field from `existing` instead of
@@ -136,6 +173,7 @@ export function correct(
   for (const edge of graph.edges) {
     if (edge.edge === 'derived_from' && edge.from === originalId) {
       edges.push({ edge: 'derived_from', to: edge.to });
+      inherited.push(edge.to);
     }
   }
 
@@ -169,6 +207,11 @@ export function correct(
       // branches, and an unrecognised value already degrades to the neutral
       // ranking weight rather than doing damage.
       origin: typeof origin === 'string' && origin ? origin : ORIGIN_HUMAN,
+      // Without this a correction could never have a stale flag cleared: both
+      // clearing paths compare disk against these hashes, and a finding with
+      // none is `unknown` forever. A hand-written correction being the least
+      // recoverable record in the graph was the wrong way round.
+      derivation: claimTimeDerivation(graph, inherited),
     },
     edges
   );
@@ -337,7 +380,18 @@ export function create(dir, { claim, anchors, type = 'finding', confidence = 0.9
   // path. No process death required; one transient EBUSY is enough.
   const id = putNodeWithEdges(
     dir,
-    { kind: 'finding', key, claim, confidence, type, origin: ORIGIN_HUMAN },
+    {
+      kind: 'finding',
+      key,
+      claim,
+      confidence,
+      type,
+      origin: ORIGIN_HUMAN,
+      // Read AFTER the indexFile loop above, so the hashes are the ones the
+      // person's claim was actually made against rather than whatever the graph
+      // held before this call touched it.
+      derivation: claimTimeDerivation(loadGraph(dir), resolved),
+    },
     resolved.map((target) => ({ edge: 'derived_from', to: target }))
   );
   if (!id) return null;

--- a/hooks-core/decide.mjs
+++ b/hooks-core/decide.mjs
@@ -540,19 +540,92 @@ const TOOL_ALIASES = new Map(
     run_shell_command: 'Bash',
     run_terminal_cmd: 'Bash',
     terminal: 'Bash',
+
+    // THIS PROJECT'S OWN TOOLS, which the table did not list for as long as it
+    // existed. `plugin/hooks/hooks.json`'s PostToolUse matcher named
+    // `mcp__.*__(?:smart_edit|smart_write)` and Codex's AfterTool matcher named
+    // the bare `smart_edit|smart_write`, so both hooks fired -- and then
+    // `normalizeTool` returned null and the hook exited before a single line of
+    // accounting ran. Staleness, mutation counting and harvest pressure were all
+    // blind on exactly the path enforcement pushes the model toward, which is the
+    // worst place to be blind: the more effective the routing, the less the
+    // optimizer saw.
+    //
+    // These names are the CANONICAL operation, not a licence to redirect. A call
+    // that is already the replacement is excluded from routing by
+    // `isReplacementTool` below.
+    smart_read: 'Read',
+    smart_grep: 'Grep',
+    smart_glob: 'Glob',
+    smart_edit: 'Edit',
+    smart_write: 'Write',
+
+    // Claude Code's notebook editor. Same shape of gap: a real mutation of a
+    // real file on disk that arrived as null and so never reached
+    // `pending.mjs`'s MUTATING set, leaving every notebook write invisible to
+    // invalidation.
+    notebookedit: 'Edit',
+    notebook_edit: 'Edit',
   })
 );
 
-/** Maps a client's tool name onto the canonical one, or null if unhandled. */
+/**
+ * The optimizer's own replacement tools, by canonical trailing segment.
+ *
+ * Kept separate from the alias table because the two answer different questions.
+ * The table answers "what operation is this", which post-tool accounting needs.
+ * This set answers "is this call ALREADY the thing we would have recommended",
+ * which routing needs -- and conflating them is the loop hazard: `smart_edit`
+ * resolves to `Edit`, the Edit branch recommends `smart_edit`, and the model is
+ * told to call the tool it just called.
+ */
+const REPLACEMENT_TOOLS = new Set([
+  'smart_read',
+  'smart_grep',
+  'smart_glob',
+  'smart_edit',
+  'smart_write',
+]);
+
+/**
+ * The tool name with an `mcp__<server>__` prefix removed, if it had one.
+ *
+ * Server segments contain underscores freely (`plugin_token-optimizer_token-optimizer`)
+ * and so do tool names (`smart_edit`), so the split is taken at the LAST `__`
+ * after the `mcp__` sentinel. Both halves must be non-empty: `mcp__edit` names
+ * no server and is not a name any host emits, and treating it as `edit` would
+ * coerce an unrecognised string into a built-in.
+ */
+function withoutMcpPrefix(name) {
+  const match = /^mcp__(.+)__(.+)$/.exec(name);
+  return match ? match[2] : name;
+}
+
+/** Whether this call IS one of the optimizer's replacements, however spelled. */
+export function isReplacementTool(name) {
+  if (!name) return false;
+  return REPLACEMENT_TOOLS.has(withoutMcpPrefix(String(name)).toLowerCase());
+}
+
+/**
+ * Maps a client's tool name onto the canonical one, or null if unhandled.
+ *
+ * PERMISSIVE IN ONE DIRECTION ONLY. An MCP-prefixed name is resolved by its
+ * trailing segment, but only against the same table every other client is held
+ * to -- so `mcp__vendor__deploy_to_prod` stays null. Coercing an unrecognised
+ * MCP tool into a built-in would change a routing verdict for a tool nobody has
+ * considered, which is a far worse failure than not accounting for it.
+ */
 export function normalizeTool(name) {
   if (!name) return null;
+  const candidate = withoutMcpPrefix(String(name));
   if (
     ['Read', 'Grep', 'Glob', 'Edit', 'MultiEdit', 'Write', 'Bash'].includes(
-      name
+      candidate
     )
   )
-    return name;
-  return TOOL_ALIASES.get(String(name).toLowerCase()) || null;
+    return candidate;
+  return TOOL_ALIASES.get(candidate.toLowerCase()) || null;
 }
 
 /**
@@ -612,6 +685,13 @@ export function normalizePayload(raw) {
     transcript_path: raw.transcript_path ?? raw.transcriptPath ?? null,
     cwd,
     tool_name: normalizeTool(raw.tool_name ?? raw.toolName ?? raw.tool),
+    // WHETHER THIS CALL IS ALREADY THE REPLACEMENT, carried alongside the
+    // canonical name rather than inferred from it -- because it cannot be
+    // inferred from it. `smart_edit` and `Edit` both normalise to `Edit`, and
+    // routing has to treat them as opposites while accounting treats them as
+    // the same. Absent by default (`false`), so a payload assembled by hand in
+    // a test or by a caller that predates this field is a normal built-in call.
+    replacement: isReplacementTool(raw.tool_name ?? raw.toolName ?? raw.tool),
     tool_input: {
       ...input,
       // CANONICALISED HERE, once. Every consumer downstream -- the `seen` map
@@ -671,6 +751,19 @@ function replacementAvailable(availableTools, name) {
 }
 
 export function decide(payload, state, availableTools = undefined) {
+  // THE LOOP HAZARD, and the reason this guard is at the top rather than inside
+  // any one branch. Resolving `smart_edit` to `Edit` is what makes post-tool
+  // accounting work; it must not also make the Edit branch answer a smart_edit
+  // call with "call smart_edit instead". This is not theoretical on a matcher
+  // level either: Qwen's PreToolUse matcher is the unanchored regex
+  // `edit|write_file|run_shell_command`, and `edit` matches inside
+  // `mcp__x__smart_edit`, so that client really does hand the router calls to
+  // its own replacements.
+  //
+  // A tool that IS the replacement is never routed. There is nothing better to
+  // recommend, and every branch below would recommend itself.
+  if (payload.replacement) return null;
+
   const tool = payload.tool_name;
   const input = payload.tool_input || {};
   const threshold = largeFileBytes();
@@ -871,6 +964,12 @@ export function remember(payload, state) {
  */
 export function readCostBytes(payload) {
   if (payload.tool_name !== 'Read') return 0;
+  // A REPLACEMENT DID NOT SPEND THE WHOLE FILE. `smart_read` normalises to
+  // `Read` so the graph sees the touch, but it returns a diff -- charging the
+  // full file size here would feed the holdout comparison a cost that was never
+  // paid, on the arm the optimizer is trying to show is cheaper. Better to
+  // record nothing than to record a number in the wrong direction.
+  if (payload.replacement) return 0;
   const path = payload.tool_input?.file_path;
   if (!path || isBinaryPath(path)) return 0;
   const size = fileSize(path);

--- a/hooks-core/disclose.mjs
+++ b/hooks-core/disclose.mjs
@@ -292,6 +292,11 @@ export function verdictFor(graph, { anchors = [], question, minConfidence = 0.7 
     const id = nodeId('file', canonicalPath(anchor));
     if (!graph.nodes.has(id)) continue;
 
+    // READ-ONLY serve: no `dir` is threaded here, so this cannot clear a stale
+    // flag whose evidence is gone. That is deliberate -- this function takes a
+    // graph, not the directory it came from, and widening its signature to give
+    // an analysis path a write capability buys nothing: the injection path runs
+    // on every tool call and clears the same findings.
     const findings = serve(graph, findingsFor(graph, id, { limit: 4 }));
     for (const finding of findings) {
       if (finding.stale) continue;

--- a/hooks-core/harvest-write.mjs
+++ b/hooks-core/harvest-write.mjs
@@ -450,11 +450,13 @@ function resolveAnchor(dir, anchor, projectRoot) {
  * `linkCoOccurrence()` (wiki.mjs, inject.mjs) both key a task node by
  * `sessionId`, always, so there is exactly ONE task node for "the current
  * session" and it is `nodeId('task', sessionId)`. Restricting to that ONE
- * node structurally eliminates cases 1 and 2 -- a prior or concurrent
- * session's task has a DIFFERENT sessionId and therefore a different node
- * id, so it is never even looked at, regardless of timing. No caller can
- * supply a wrong sessionId and get someone ELSE's task; they can only fail
- * to get a match.
+ * node structurally eliminates cases 1 and 2 PROVIDED the identity itself is
+ * trustworthy: an UNRELATED sessionId (typo'd, invented, or simply absent)
+ * cannot resolve to someone else's task, because a different key is a
+ * different node id, full stop, regardless of timing. That is NOT the same
+ * guarantee as "no caller can get someone else's task" -- see the note on
+ * `authoritativeSessionId` below for the residual this leaves when the
+ * identity is real but comes from an untrusted caller.
  *
  * COVERAGE, NOT OVERLAP, fixes case 3: the session's task must have a
  * `derived_from` edge to EVERY one of this finding's anchors, not merely one.
@@ -470,17 +472,41 @@ function resolveAnchor(dir, anchor, projectRoot) {
  * or without a timestamp on that edge -- there is no ranking left for a
  * missing timestamp to lose.
  *
- * `sessionId` absent means there is no identity to scope by, which means no
- * candidate -- not "fall back to guessing". Absence is the correct answer
- * when the graph cannot support attribution.
+ * NO IDENTITY MEANS NO CANDIDATE -- not "fall back to guessing". Absence is
+ * the correct answer when the graph cannot support attribution.
+ *
+ * ROUND 4: THE IDENTITY ITSELF MUST BE AUTHORITATIVE, not merely present.
+ * Scoping to `nodeId('task', sessionId)` only refuses an UNRELATED session;
+ * it does nothing against a FOREIGN BUT REAL one. `wiki_write`'s `sessionId`
+ * is a plain MCP tool argument the calling model supplies, unverified -- a
+ * model that names some OTHER, prior session whose task genuinely covered
+ * these anchors gets an `answers` edge to that stale task, because coverage
+ * cannot tell "this session" from "a session that really did touch these
+ * files, named by a string nothing cross-checked". Session id is not
+ * evidence unless the CALLER'S OWN CHANNEL is trustworthy, which is true of
+ * `plugin/hooks/harvest-worker.mjs` (Claude Code's own hook payload) and not
+ * true of a tool-call argument. So this parameter is named for what it must
+ * be, `authoritativeSessionId`, and every caller is a promise: pass this only
+ * when you did not just read it out of untrusted input. `wiki_write` passes
+ * NONE, which means its calls never traverse -- see `writeHarvested`'s own
+ * comment at the call site for what that costs and why it is accepted rather
+ * than worked around.
+ *
+ * COVERAGE IS CHECKED AGAINST RESOLVED ANCHORS, not the caller's original
+ * list. `writeHarvested` already drops any anchor `resolveAnchor` could not
+ * resolve before this function ever runs, so "every anchor" here means every
+ * anchor that survived that filter -- self-consistent with the
+ * `derived_from` edges the same resolved list produces, but worth stating:
+ * an anchor that failed to resolve cannot raise or lower the bar for the
+ * anchors that did.
  */
-function taskForAnchors(graph, anchorIds, sessionId) {
-  if (!sessionId || !anchorIds || !anchorIds.length) return null;
-  const taskTarget = nodeId('task', sessionId);
+function taskForAnchors(graph, resolvedAnchorIds, authoritativeSessionId) {
+  if (!authoritativeSessionId || !resolvedAnchorIds || !resolvedAnchorIds.length) return null;
+  const taskTarget = nodeId('task', authoritativeSessionId);
   const task = graph.nodes.get(taskTarget);
   if (!task || task.kind !== 'task') return null;
 
-  for (const anchor of anchorIds) {
+  for (const anchor of resolvedAnchorIds) {
     const covered = graph.edges.some((edge) =>
       edge.edge === 'derived_from' && edge.from === taskTarget && edge.to === anchor
     );
@@ -602,7 +628,19 @@ function derivationFor(graph, resolvedAnchors, evidence, evidenceIncomplete, anc
 export function writeHarvested(
   dir,
   findings,
-  { sessionId = null, origin = ORIGIN_HARVESTED, projectRoot = null, taskId = null } = {}
+  {
+    sessionId = null,
+    origin = ORIGIN_HARVESTED,
+    projectRoot = null,
+    taskId = null,
+    // Distinct from `sessionId`, which is stored on every finding for
+    // provenance/display regardless of trust. This one gates the `answers`
+    // traversal fallback specifically, and every caller passing it is
+    // asserting the identity came from a channel it does not control --
+    // Claude Code's own hook payload, not a tool-call argument a model
+    // typed. See `taskForAnchors`'s comment for the attack this closes.
+    authoritativeSessionId = null,
+  } = {}
 ) {
   if (!Array.isArray(findings) || !findings.length) return [];
 
@@ -700,16 +738,29 @@ export function writeHarvested(
     // An explicit `taskId` is authoritative when a caller supplies one --
     // it OVERRIDES traversal rather than merely seeding it, so a caller that
     // knows better is never second-guessed by inference. Absent one, the task
-    // is DERIVED from the graph itself: `taskForAnchors` finds the CURRENT
-    // session's task (scoped by `sessionId`, the same identity this write
-    // already carries for provenance) and requires it to have touched EVERY
-    // one of this finding's anchors, not merely one -- see that function's
-    // own comment for the four attacks this closes. Either way, held to the
-    // same discipline as the anchors above: a target that does not resolve to
-    // an existing task node produces no edge rather than a dangling one.
+    // is DERIVED from the graph itself, but ONLY when `authoritativeSessionId`
+    // is present: `taskForAnchors` scopes to that exact session's task and
+    // requires it to have touched EVERY one of this finding's anchors, not
+    // merely one -- see that function's own comment for why the identity
+    // itself must be trustworthy, not merely present.
+    //
+    // THE CONSEQUENCE, STATED PLAINLY: `wiki_write` never supplies
+    // `authoritativeSessionId` (its `sessionId` is a model-typed MCP
+    // argument nothing cross-checks), so its calls never traverse and
+    // `answers` never fires on that path. `plugin/hooks/harvest-worker.mjs`
+    // does supply it (Claude Code's own hook payload), so `answers` fires
+    // there -- opt-in gated. `answers` therefore does NOT fire on a default
+    // install today. Recovering default liveness needs an authoritative
+    // identity on a default-install path, which is what Plan 2's
+    // `hooks-core/derive.mjs` (running in the Stop hook, where the session id
+    // is real) is for -- not a weaker check here.
+    //
+    // Either way, held to the same discipline as the anchors above: a target
+    // that does not resolve to an existing task node produces no edge rather
+    // than a dangling one.
     const answersTarget = taskId
       ? nodeId('task', taskId)
-      : taskForAnchors(currentGraph, resolved, sessionId);
+      : taskForAnchors(currentGraph, resolved, authoritativeSessionId);
     if (answersTarget && currentGraph.nodes.has(answersTarget)) {
       edges.push({ edge: 'answers', to: answersTarget });
     }

--- a/hooks-core/harvest-write.mjs
+++ b/hooks-core/harvest-write.mjs
@@ -434,7 +434,7 @@ function resolveAnchor(dir, anchor, projectRoot) {
 export function writeHarvested(
   dir,
   findings,
-  { sessionId = null, origin = ORIGIN_HARVESTED, projectRoot = null } = {}
+  { sessionId = null, origin = ORIGIN_HARVESTED, projectRoot = null, taskId = null } = {}
 ) {
   if (!Array.isArray(findings) || !findings.length) return [];
 
@@ -514,6 +514,21 @@ export function writeHarvested(
     // collision vanishingly unlikely while keeping the timestamp readable.
     const provenance = provenanceFor(finding);
     const key = `${prefixFor(provenance)}-${Date.now().toString(36)}-${written.length}-${randomBytes(4).toString("hex")}`;
+
+    const edges = resolved.map((target) => ({ edge: 'derived_from', to: target }));
+    // `answers` closes the loop back to the task that produced the finding, so
+    // provenance can be traversed rather than inferred: "which session
+    // established this, and from what". Declared in EDGE_KINDS and written by
+    // nothing until now. Held to the same discipline as the anchors above: a
+    // taskId that does not resolve to an existing task node produces no edge
+    // rather than a dangling one.
+    if (taskId) {
+      const taskTarget = nodeId('task', taskId);
+      if (currentGraph.nodes.has(taskTarget)) {
+        edges.push({ edge: 'answers', to: taskTarget });
+      }
+    }
+
     // ONE APPEND for the finding and every anchor it resolved. This runs in a
     // detached worker, so "the process survives to finish the loop" is not a
     // safe assumption: a node written without its edges is an active finding
@@ -555,7 +570,7 @@ export function writeHarvested(
           : undefined,
         sessionId,
       },
-      resolved.map((target) => ({ edge: 'derived_from', to: target }))
+      edges
     );
     // A failed write returns null. Reporting the key anyway would tell the
     // caller a claim was stored that no later session can retrieve.

--- a/hooks-core/harvest-write.mjs
+++ b/hooks-core/harvest-write.mjs
@@ -32,6 +32,7 @@ import { randomBytes } from 'node:crypto';
 import { realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
+import { readEvidence } from './metrics.mjs';
 
 /**
  * The types that may cross a project boundary.
@@ -426,6 +427,121 @@ function resolveAnchor(dir, anchor, projectRoot) {
 }
 
 /**
+ * Which task actually produced this finding, when nothing said so directly.
+ *
+ * Session id was the only signal `answers` had, and a session id is exactly
+ * what a caller may not have (`wiki_write`'s `sessionId` is optional and
+ * nothing populates it today; the detached harvest worker's is gated behind
+ * an opt-in). But the graph does not need to be TOLD which task this is: the
+ * structural harvest already writes `task -[derived_from]-> file` for every
+ * tool call, unconditionally, on every install. So the task is DERIVABLE --
+ * it is whichever task node has a `derived_from` edge to one of the SAME
+ * anchors this finding resolved to.
+ *
+ * "Most recent task, full stop" was rejected on purpose: a task that never
+ * touched these files could still be the newest node in the graph (a
+ * different file, a different concern, in a later session), and attaching
+ * provenance to it would be a WRONG edge, not a missing one -- worse than no
+ * edge, because a reader trusts it. So candidates are filtered to tasks that
+ * touched at least one of these anchors FIRST, and only ties among THOSE are
+ * broken by recency.
+ *
+ * The tie-break is the edge's own `at`, not the task node's `at`. A task that
+ * touched this file once, long ago, and then stayed active on unrelated files
+ * for hours has a late node timestamp that says nothing about this anchor;
+ * the edge timestamp says exactly when THIS task touched THIS anchor, which
+ * is the question being asked. Among tasks sharing an anchor, the one whose
+ * most recent touch to any shared anchor is latest wins -- recency of the
+ * relevant work, not recency of the task in general.
+ */
+function taskForAnchors(graph, anchorIds) {
+  if (!anchorIds || !anchorIds.length) return null;
+  const anchors = new Set(anchorIds);
+  let best = null;
+  for (const edge of graph.edges) {
+    if (edge.edge !== 'derived_from' || !anchors.has(edge.to)) continue;
+    const from = graph.nodes.get(edge.from);
+    // `derived_from` is also how a FINDING cites its own anchors, so without
+    // this a finding that already cited the same file would be mistaken for
+    // the task that produced it.
+    if (!from || from.kind !== 'task') continue;
+    const at = Number(edge.at) || 0;
+    if (!best || at > best.at) best = { taskId: edge.from, at };
+  }
+  return best ? best.taskId : null;
+}
+
+/**
+ * A file path the way `recordToolOutcome` (metrics.mjs) already truncates and
+ * stores it on a `tool-outcome` event's `anchor` field, so a derivation record
+ * can join against that log without a second, divergent notion of "the same
+ * anchor".
+ */
+function anchorLabel(rawAnchor) {
+  const path = String(rawAnchor).split('#')[0];
+  return canonicalPath(path).slice(0, 120);
+}
+
+/** How many recorded operations a single finding's derivation may cite. */
+const MAX_DERIVATION_OPERATIONS = 5;
+
+/**
+ * The checkable half of provenance: not just where a finding came from, but
+ * whether that derivation still holds.
+ *
+ * Citation-style provenance (a session or task id) answers "where". It never
+ * answers "does this still apply" -- that is what staleness already computes,
+ * by comparing an anchor's STORED hash against disk. This record is what lets
+ * that comparison be reconstructed for a specific claim rather than only for
+ * the anchor in general: the hash each anchor carried at the moment this
+ * finding was derived from it, plus what evidence exists that any work
+ * actually happened against it.
+ *
+ * DELIBERATELY NOT DUPLICATING THE EDGES. `derived_from` already records
+ * WHICH anchors this finding cites; restating that here would be a second,
+ * driftable copy of the same fact. What is new here, and only here, is the
+ * HASH each anchor carried at claim time -- edges carry no such thing.
+ *
+ * DELIBERATELY NOT A REPLAY LOG. Recording enough to mechanically re-run a
+ * derivation is a separate subsystem with real storage cost. This stores only
+ * what the evidence log already has: `tool-outcome` events matching these
+ * anchors, each reduced to the fields that were actually captured. An event
+ * that carries no exit code or output contributes none -- nothing here is
+ * invented to fill a shape the pipeline does not evidence yet. If a future
+ * capture pass adds `exit`/`output` to those events, this starts carrying them
+ * with no change to this function.
+ */
+function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
+  const anchorHashes = {};
+  for (const id of resolvedAnchors) {
+    const node = graph.nodes.get(id);
+    if (node && typeof node.hash === 'string') anchorHashes[id] = node.hash;
+  }
+
+  const labels = new Set((anchorSpecs || []).map(anchorLabel));
+  const operations = evidence
+    .filter((event) => event.kind === 'tool-outcome' && labels.has(event.anchor))
+    .sort((a, b) => (Number(b.at) || 0) - (Number(a.at) || 0))
+    .slice(0, MAX_DERIVATION_OPERATIONS)
+    .map((event) => {
+      const op = {};
+      if (typeof event.toolName === 'string' && event.toolName)
+        op.tool = event.toolName.slice(0, 60);
+      if (typeof event.success === 'boolean') op.success = event.success;
+      if (typeof event.at === 'number') op.at = event.at;
+      // Forward-compatible, not fabricated: neither field exists on a
+      // `tool-outcome` event in this pipeline today, so every operation
+      // omits them until a capture pass actually evidences one.
+      if (typeof event.exit === 'number') op.exit = event.exit;
+      if (typeof event.output === 'string' && event.output)
+        op.output = event.output.slice(0, 200);
+      return op;
+    });
+
+  return { at: Date.now(), anchors: anchorHashes, operations };
+}
+
+/**
  * Writes validated findings, returning the keys actually stored.
  *
  * `findings` is the output of `harvest.validate()`, so type/claim/confidence
@@ -465,6 +581,11 @@ export function writeHarvested(
       : batch;
   const prefixFor = (p) =>
     p === ORIGIN_AGENT ? 'agent' : p === ORIGIN_HUMAN ? 'human' : 'harvested';
+
+  // Read once: every finding in this batch shares the same evidence log, and
+  // it can hold thousands of lines, so re-reading it per finding would turn a
+  // batch of N findings into N passes over the same bytes.
+  const evidence = readEvidence(dir);
 
   const written = [];
   for (const finding of findings) {
@@ -519,14 +640,21 @@ export function writeHarvested(
     // `answers` closes the loop back to the task that produced the finding, so
     // provenance can be traversed rather than inferred: "which session
     // established this, and from what". Declared in EDGE_KINDS and written by
-    // nothing until now. Held to the same discipline as the anchors above: a
-    // taskId that does not resolve to an existing task node produces no edge
-    // rather than a dangling one.
-    if (taskId) {
-      const taskTarget = nodeId('task', taskId);
-      if (currentGraph.nodes.has(taskTarget)) {
-        edges.push({ edge: 'answers', to: taskTarget });
-      }
+    // nothing until now.
+    //
+    // An explicit `taskId` is authoritative when a caller supplies one --
+    // it OVERRIDES traversal rather than merely seeding it, so a caller that
+    // knows better is never second-guessed by inference. Absent one, the task
+    // is DERIVED from the graph itself: `taskForAnchors` finds the task that
+    // actually touched these anchors, which needs no session id from anyone.
+    // Either way, held to the same discipline as the anchors above: a target
+    // that does not resolve to an existing task node produces no edge rather
+    // than a dangling one.
+    const answersTarget = taskId
+      ? nodeId('task', taskId)
+      : taskForAnchors(currentGraph, resolved);
+    if (answersTarget && currentGraph.nodes.has(answersTarget)) {
+      edges.push({ edge: 'answers', to: answersTarget });
     }
 
     // ONE APPEND for the finding and every anchor it resolved. This runs in a
@@ -569,6 +697,15 @@ export function writeHarvested(
           ? finding.quote
           : undefined,
         sessionId,
+        // THE CHECKABLE HALF OF PROVENANCE. Citation-style (this `sessionId`,
+        // the `answers` edge above) says WHERE a claim came from; it never
+        // says whether that derivation still applies. `derivationFor` reaches
+        // through `wiki_query`'s `node`/`get`/`search` operations only (those
+        // return a finding's stored fields wholesale) -- never through
+        // `render()`/`renderSessionIndex()` in inject.mjs or `wiki_read`'s
+        // `toFinding()` projection, neither of which reads this field, so it
+        // is not part of the automatic per-touch injection `fit()` prices.
+        derivation: derivationFor(currentGraph, resolved, evidence, finding.anchors || []),
       },
       edges
     );

--- a/hooks-core/harvest-write.mjs
+++ b/hooks-core/harvest-write.mjs
@@ -32,7 +32,7 @@ import { randomBytes } from 'node:crypto';
 import { realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
-import { readEvidence } from './metrics.mjs';
+import { readEvidence, evidenceTruncated } from './metrics.mjs';
 
 /**
  * The types that may cross a project boundary.
@@ -429,53 +429,84 @@ function resolveAnchor(dir, anchor, projectRoot) {
 /**
  * Which task actually produced this finding, when nothing said so directly.
  *
- * Session id was the only signal `answers` had, and a session id is exactly
- * what a caller may not have (`wiki_write`'s `sessionId` is optional and
- * nothing populates it today; the detached harvest worker's is gated behind
- * an opt-in). But the graph does not need to be TOLD which task this is: the
- * structural harvest already writes `task -[derived_from]-> file` for every
- * tool call, unconditionally, on every install. So the task is DERIVABLE --
- * it is whichever task node has a `derived_from` edge to one of the SAME
- * anchors this finding resolved to.
+ * ROUND 2's version scanned the WHOLE graph for any task sharing any anchor,
+ * broken by recency. An adversarial review constructed four cases where that
+ * attributes a finding to the WRONG task:
  *
- * "Most recent task, full stop" was rejected on purpose: a task that never
- * touched these files could still be the newest node in the graph (a
- * different file, a different concern, in a later session), and attaching
- * provenance to it would be a WRONG edge, not a missing one -- worse than no
- * edge, because a reader trusts it. So candidates are filtered to tasks that
- * touched at least one of these anchors FIRST, and only ties among THOSE are
- * broken by recency.
+ *   1. STALE PRIOR SESSION -- a session that reasons from injected memory and
+ *      writes a finding about `foo.ts` without touching it this session gets
+ *      attributed to whatever task last touched `foo.ts`, possibly days old,
+ *      possibly someone else's work.
+ *   2. CONCURRENT SESSION -- two windows on one repository; the other
+ *      session's task wins if its touch is a millisecond later.
+ *   3. OVERLAP, NOT COVERAGE -- a finding anchored to [a, b]; a task that
+ *      touched only `b` could still win over one that touched both.
+ *   4. THE TIE-BREAK CONTRADICTED ITS OWN COMMENT -- `Number(edge.at) || 0`
+ *      with strict `>` means the FIRST edge in log order wins on a tie,
+ *      which is the OLDER task, not "more recently" as documented.
  *
- * The tie-break is the edge's own `at`, not the task node's `at`. A task that
- * touched this file once, long ago, and then stayed active on unrelated files
- * for hours has a late node timestamp that says nothing about this anchor;
- * the edge timestamp says exactly when THIS task touched THIS anchor, which
- * is the question being asked. Among tasks sharing an anchor, the one whose
- * most recent touch to any shared anchor is latest wins -- recency of the
- * relevant work, not recency of the task in general.
+ * THE FIX IS NARROWER THAN A BETTER RANKING: SCOPE, THEN REQUIRE COVERAGE.
+ * A task only ever belongs to the session that created it -- `harvest()` and
+ * `linkCoOccurrence()` (wiki.mjs, inject.mjs) both key a task node by
+ * `sessionId`, always, so there is exactly ONE task node for "the current
+ * session" and it is `nodeId('task', sessionId)`. Restricting to that ONE
+ * node structurally eliminates cases 1 and 2 -- a prior or concurrent
+ * session's task has a DIFFERENT sessionId and therefore a different node
+ * id, so it is never even looked at, regardless of timing. No caller can
+ * supply a wrong sessionId and get someone ELSE's task; they can only fail
+ * to get a match.
+ *
+ * COVERAGE, NOT OVERLAP, fixes case 3: the session's task must have a
+ * `derived_from` edge to EVERY one of this finding's anchors, not merely one.
+ * A partial touch is not attribution.
+ *
+ * With the candidate set reduced to at most one node, there is nothing left
+ * to break a tie between -- case 4's comparator is not "fixed", it is
+ * deleted, because the scenario it was written for (two DIFFERENT tasks both
+ * legitimately eligible) cannot occur under this scoping: two task nodes can
+ * never share a key, and only the current session's key is ever considered.
+ * An edge's `at` therefore plays NO role here: presence of a `derived_from`
+ * edge from the session's task to an anchor is what "touched it" means, with
+ * or without a timestamp on that edge -- there is no ranking left for a
+ * missing timestamp to lose.
+ *
+ * `sessionId` absent means there is no identity to scope by, which means no
+ * candidate -- not "fall back to guessing". Absence is the correct answer
+ * when the graph cannot support attribution.
  */
-function taskForAnchors(graph, anchorIds) {
-  if (!anchorIds || !anchorIds.length) return null;
-  const anchors = new Set(anchorIds);
-  let best = null;
-  for (const edge of graph.edges) {
-    if (edge.edge !== 'derived_from' || !anchors.has(edge.to)) continue;
-    const from = graph.nodes.get(edge.from);
-    // `derived_from` is also how a FINDING cites its own anchors, so without
-    // this a finding that already cited the same file would be mistaken for
-    // the task that produced it.
-    if (!from || from.kind !== 'task') continue;
-    const at = Number(edge.at) || 0;
-    if (!best || at > best.at) best = { taskId: edge.from, at };
+function taskForAnchors(graph, anchorIds, sessionId) {
+  if (!sessionId || !anchorIds || !anchorIds.length) return null;
+  const taskTarget = nodeId('task', sessionId);
+  const task = graph.nodes.get(taskTarget);
+  if (!task || task.kind !== 'task') return null;
+
+  for (const anchor of anchorIds) {
+    const covered = graph.edges.some((edge) =>
+      edge.edge === 'derived_from' && edge.from === taskTarget && edge.to === anchor
+    );
+    // ONE missing anchor refuses the whole attribution. A finding cited three
+    // files; this session's task touched two of them -- that is evidence the
+    // task did SOME related work, not evidence it produced THIS finding.
+    if (!covered) return null;
   }
-  return best ? best.taskId : null;
+  return taskTarget;
 }
 
 /**
  * A file path the way `recordToolOutcome` (metrics.mjs) already truncates and
- * stores it on a `tool-outcome` event's `anchor` field, so a derivation record
- * can join against that log without a second, divergent notion of "the same
- * anchor".
+ * stores it on a FILE-surface `tool-outcome` event's `anchor` field, so a
+ * derivation record can join against that log without a second, divergent
+ * notion of "the same anchor".
+ *
+ * COMMAND-surface events are DECLARED OUT OF SCOPE, not silently missed:
+ * `adapter.mjs` stores the COMMAND TEXT in `anchor` for those
+ * (`String(command).slice(0, 120)`), so a build or test run can never share
+ * an anchor string with a canonical file path -- there is no join key in
+ * common, and inventing a command-to-file heuristic (which files did a given
+ * `npm test` invocation cover?) is not something this record can answer
+ * honestly. `operationsScope` on the returned record says so explicitly,
+ * rather than letting an empty `operations` array look like "no build or
+ * test ever ran" when the truth is "this join cannot see it".
  */
 function anchorLabel(rawAnchor) {
   const path = String(rawAnchor).split('#')[0];
@@ -495,7 +526,8 @@ const MAX_DERIVATION_OPERATIONS = 5;
  * that comparison be reconstructed for a specific claim rather than only for
  * the anchor in general: the hash each anchor carried at the moment this
  * finding was derived from it, plus what evidence exists that any work
- * actually happened against it.
+ * actually happened against it. `derivationCheck` (staleness.mjs) is the
+ * reader that actually performs that comparison at serve time.
  *
  * DELIBERATELY NOT DUPLICATING THE EDGES. `derived_from` already records
  * WHICH anchors this finding cites; restating that here would be a second,
@@ -504,14 +536,23 @@ const MAX_DERIVATION_OPERATIONS = 5;
  *
  * DELIBERATELY NOT A REPLAY LOG. Recording enough to mechanically re-run a
  * derivation is a separate subsystem with real storage cost. This stores only
- * what the evidence log already has: `tool-outcome` events matching these
- * anchors, each reduced to the fields that were actually captured. An event
- * that carries no exit code or output contributes none -- nothing here is
- * invented to fill a shape the pipeline does not evidence yet. If a future
- * capture pass adds `exit`/`output` to those events, this starts carrying them
- * with no change to this function.
+ * what the evidence log already has: FILE-surface `tool-outcome` events
+ * matching these anchors, each reduced to the fields that were actually
+ * captured. An event that carries no exit code or output contributes none --
+ * nothing here is invented to fill a shape the pipeline does not evidence
+ * yet. If a future capture pass adds `exit`/`output` to those events, this
+ * starts carrying them with no change to this function.
+ *
+ * INCOMPLETENESS IS MARKED, NOT IMPLIED. An empty `operations` array is
+ * genuinely ambiguous on its own -- it is the same shape whether nothing
+ * happened, or something happened but fell outside what this join can see.
+ * `operationsComplete` distinguishes them: false when the evidence log itself
+ * may have dropped older matches (`evidenceIncomplete`, from
+ * `metrics.evidenceTruncated`) OR when more matches existed than the cap
+ * kept. A reader can then tell "no operations happened" from "operations
+ * existed but are not recorded here" instead of guessing.
  */
-function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
+function derivationFor(graph, resolvedAnchors, evidence, evidenceIncomplete, anchorSpecs) {
   const anchorHashes = {};
   for (const id of resolvedAnchors) {
     const node = graph.nodes.get(id);
@@ -519,8 +560,10 @@ function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
   }
 
   const labels = new Set((anchorSpecs || []).map(anchorLabel));
-  const operations = evidence
-    .filter((event) => event.kind === 'tool-outcome' && labels.has(event.anchor))
+  const matching = evidence.filter(
+    (event) => event.kind === 'tool-outcome' && labels.has(event.anchor)
+  );
+  const operations = [...matching]
     .sort((a, b) => (Number(b.at) || 0) - (Number(a.at) || 0))
     .slice(0, MAX_DERIVATION_OPERATIONS)
     .map((event) => {
@@ -538,7 +581,16 @@ function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
       return op;
     });
 
-  return { at: Date.now(), anchors: anchorHashes, operations };
+  return {
+    at: Date.now(),
+    anchors: anchorHashes,
+    operations,
+    // FILE touches only -- see `anchorLabel`. Declared here, in the record
+    // itself, not only in this function's comment, so a reader who never
+    // opens this source file still learns builds and test runs are excluded.
+    operationsScope: 'file',
+    operationsComplete: !evidenceIncomplete && matching.length <= operations.length,
+  };
 }
 
 /**
@@ -586,6 +638,9 @@ export function writeHarvested(
   // it can hold thousands of lines, so re-reading it per finding would turn a
   // batch of N findings into N passes over the same bytes.
   const evidence = readEvidence(dir);
+  // Cheap: one stat call, checked once per batch rather than once per
+  // finding's derivation record.
+  const evidenceIncomplete = evidenceTruncated(dir);
 
   const written = [];
   for (const finding of findings) {
@@ -645,14 +700,16 @@ export function writeHarvested(
     // An explicit `taskId` is authoritative when a caller supplies one --
     // it OVERRIDES traversal rather than merely seeding it, so a caller that
     // knows better is never second-guessed by inference. Absent one, the task
-    // is DERIVED from the graph itself: `taskForAnchors` finds the task that
-    // actually touched these anchors, which needs no session id from anyone.
-    // Either way, held to the same discipline as the anchors above: a target
-    // that does not resolve to an existing task node produces no edge rather
-    // than a dangling one.
+    // is DERIVED from the graph itself: `taskForAnchors` finds the CURRENT
+    // session's task (scoped by `sessionId`, the same identity this write
+    // already carries for provenance) and requires it to have touched EVERY
+    // one of this finding's anchors, not merely one -- see that function's
+    // own comment for the four attacks this closes. Either way, held to the
+    // same discipline as the anchors above: a target that does not resolve to
+    // an existing task node produces no edge rather than a dangling one.
     const answersTarget = taskId
       ? nodeId('task', taskId)
-      : taskForAnchors(currentGraph, resolved);
+      : taskForAnchors(currentGraph, resolved, sessionId);
     if (answersTarget && currentGraph.nodes.has(answersTarget)) {
       edges.push({ edge: 'answers', to: answersTarget });
     }
@@ -705,7 +762,7 @@ export function writeHarvested(
         // `render()`/`renderSessionIndex()` in inject.mjs or `wiki_read`'s
         // `toFinding()` projection, neither of which reads this field, so it
         // is not part of the automatic per-touch injection `fit()` prices.
-        derivation: derivationFor(currentGraph, resolved, evidence, finding.anchors || []),
+        derivation: derivationFor(currentGraph, resolved, evidence, evidenceIncomplete, finding.anchors || []),
       },
       edges
     );

--- a/hooks-core/inject.mjs
+++ b/hooks-core/inject.mjs
@@ -120,8 +120,29 @@ function fit(findings, budget) {
   return { kept, spent };
 }
 
+/**
+ * Discloses an open disagreement, on the same line as the claim it is about.
+ *
+ * BOTH HALVES, like the stale renderer below: the strong form names the other
+ * finding so the reader can fetch it, and the form without a key says only what
+ * is actually known. `serve` is what establishes the dispute; this only phrases
+ * it, and it phrases it in one short line because `fit` prices `render` against
+ * the injection budget -- a disagreement is worth a pointer, not both claims in
+ * full.
+ *
+ * NO DISMISSAL VOCABULARY, for the reason measured on the stale wording: an
+ * instruction to discount suppressed findings that were correct. This states
+ * that another claim exists and where to find it, and lets the reader decide.
+ */
+function disputeNote(finding) {
+  if (!finding.contradicted) return '';
+  return finding.contradictedBy
+    ? `\n  DISPUTED by ${finding.contradictedBy} -- wiki_query that key for the other claim`
+    : '\n  DISPUTED by another finding in this graph';
+}
+
 function render(finding) {
-  const head = `- [${finding.type || 'finding'}] ${finding.claim}`;
+  const head = `- [${finding.type || 'finding'}] ${finding.claim}${disputeNote(finding)}`;
   if (!finding.stale) return head;
 
   // A stale finding NEVER renders as though it were current. But the strength
@@ -995,7 +1016,15 @@ function renderSessionIndex(total, findings) {
       : finding.stale
         ? ' [possibly stale; verify before use]'
         : '';
-    return `- ${finding.key}${freshness}: ${finding.claim.slice(0, 90)}`;
+    // The session index is the first thing a session reads, so a disputed
+    // finding must not be listed there as settled either. Compressed to a
+    // marker and a key, matching the freshness markers beside it.
+    const dispute = finding.contradicted
+      ? finding.contradictedBy
+        ? ` [DISPUTED by ${finding.contradictedBy}]`
+        : ' [DISPUTED]'
+      : '';
+    return `- ${finding.key}${freshness}${dispute}: ${finding.claim.slice(0, 90)}`;
   });
   return `# Project wiki (${total} findings, ${findings.length} listed)
 

--- a/hooks-core/inject.mjs
+++ b/hooks-core/inject.mjs
@@ -141,6 +141,40 @@ function render(finding) {
 }
 
 /**
+ * Graph directories where a drain has already marked something in THIS process.
+ *
+ * THE SECOND CALLER IS WHY THIS EXISTS. SessionStart calls `standingRules` and
+ * then `sessionIndex` with the SAME graph object it loaded once. Without this,
+ * the first call drains, marks, and re-reads privately -- and the second call
+ * finds an empty queue, marks nothing, and therefore serves from the caller's
+ * pre-drain copy, advertising as current the very finding the first call had
+ * just marked. Draining is idempotent; its EFFECT on a caller's parsed graph is
+ * not, so what is remembered here is "a re-read is owed", nothing else.
+ *
+ * ONLY THE POSITIVE CASE IS REMEMBERED, and that is a correctness decision
+ * rather than a tuning one. Remembering "nothing was queued" would mean a queue
+ * arriving LATER in the same process is silently skipped and deferred to some
+ * future session. That cannot happen today, because `queueInvalidation` runs in
+ * the post-tool branch before any injection -- but that is an unguarded
+ * ordering dependency, and it stops being true the moment someone adds a call
+ * site. A repeated empty drain costs one `existsSync` on a file that is not
+ * there, which is a price worth paying to not have an invariant that depends on
+ * nobody reordering anything.
+ *
+ * KEYED CANONICALLY. Two spellings of one directory -- a trailing separator, a
+ * `..` segment, a lower-cased drive letter -- would otherwise be two entries,
+ * which reintroduces exactly the pre-drain-copy bug above. This is the same
+ * defect shape Task 2 on this branch shipped for real, where a tool resolved its
+ * graph from a raw cwd while the hooks resolved theirs through `projectRootFor`
+ * and the two halves of a metric landed in different directories. Path identity
+ * is why `canonicalKey` lives inside `nodeId` rather than at its call sites.
+ *
+ * A hook process handles one lifecycle event, so this set holds one or two
+ * entries and dies with the process.
+ */
+const drainedDirs = new Set();
+
+/**
  * Applies anything the post-tool hook queued, BEFORE anything is served.
  *
  * THIS IS WHERE EAGER STALENESS LANDS. `invalidateOnWrite` needs a graph, and
@@ -155,28 +189,14 @@ function render(finding) {
  * prevent. A second load costs a parse, and it is paid once per observed write
  * rather than once per tool call -- when nothing is queued this is one stat.
  */
-/**
- * Per process, per graph directory: did the drain change anything?
- *
- * THE SECOND CALLER IS WHY THIS EXISTS. SessionStart calls `standingRules` and
- * then `sessionIndex` with the SAME graph object it loaded once. Without this
- * memo the first call drains, marks, and re-reads privately -- and the second
- * call finds an empty queue, marks nothing, and therefore serves from the
- * caller's pre-drain copy, advertising as current the very finding the first
- * call had just marked. Draining is not idempotent from the caller's point of
- * view; remembering the ANSWER is what makes it so.
- *
- * A hook process handles one lifecycle event, so this map holds one or two
- * entries and dies with the process.
- */
-const drainedDirs = new Map();
-
 function withPendingApplied(dir, graph) {
   try {
-    if (drainedDirs.has(dir)) return drainedDirs.get(dir) ? load(dir) : graph;
-    const marked = drainInvalidations(dir, graph) > 0;
-    drainedDirs.set(dir, marked);
-    return marked ? load(dir) : graph;
+    const key = canonicalPath(dir);
+    // The drain runs EVERY time. It is one stat when there is nothing to do,
+    // and running it unconditionally is what keeps the memo from encoding an
+    // assumption about which hook branch ran first.
+    if (drainInvalidations(dir, graph) > 0) drainedDirs.add(key);
+    return drainedDirs.has(key) ? load(dir) : graph;
   } catch {
     // The lazy path still covers everything this would have caught early, and
     // a hook must never fail because bookkeeping did.

--- a/hooks-core/inject.mjs
+++ b/hooks-core/inject.mjs
@@ -274,7 +274,10 @@ export function forTouch(
   // others, so the comparison becomes within-file and the dominant source of
   // variance drops out. A session-pinned arm would destroy that.
   const holdout = inHoldout(filePath);
-  const served = serve(graph, candidates);
+  // `dir` so an eager flag whose evidence is gone is cleared here rather than
+  // waiting for somebody to open the dashboard. Same evidence test as the manual
+  // path -- see `serve`.
+  const served = serve(graph, candidates, { dir });
   const assessed = assessFindings(dir, served, {
     episodeId: episode.episodeId || sessionId,
     relevanceFor: () => 1,
@@ -461,7 +464,7 @@ export function forCommand(
   // only thing an uncapped list buys is the I/O.
   const considered = candidates.slice(0, MAX_COMMAND_CANDIDATES);
 
-  const served = serve(graph, considered);
+  const served = serve(graph, considered, { dir });
   const assessed = assessFindings(dir, served, {
     episodeId: episode.episodeId || sessionId,
     relevanceFor: (finding) => explicit(finding) ? 1 : 0.6,
@@ -988,7 +991,7 @@ export function sessionIndex(dir, graph, { episode = {}, relevantFindingIds = []
   // `serve` is the only path allowed to hand a finding to a model. In
   // particular, activating this previously-unwired index must not create a new
   // path that labels an invalidated content claim as current.
-  const served = serve(graph, selected);
+  const served = serve(graph, selected, { dir });
   if (!served.length) return null;
   // A stale marker is longer than the fresh preview used for candidate
   // selection. Trim from the lowest-ranked end until the ACTUAL message fits.

--- a/hooks-core/inject.mjs
+++ b/hooks-core/inject.mjs
@@ -155,9 +155,28 @@ function render(finding) {
  * prevent. A second load costs a parse, and it is paid once per observed write
  * rather than once per tool call -- when nothing is queued this is one stat.
  */
+/**
+ * Per process, per graph directory: did the drain change anything?
+ *
+ * THE SECOND CALLER IS WHY THIS EXISTS. SessionStart calls `standingRules` and
+ * then `sessionIndex` with the SAME graph object it loaded once. Without this
+ * memo the first call drains, marks, and re-reads privately -- and the second
+ * call finds an empty queue, marks nothing, and therefore serves from the
+ * caller's pre-drain copy, advertising as current the very finding the first
+ * call had just marked. Draining is not idempotent from the caller's point of
+ * view; remembering the ANSWER is what makes it so.
+ *
+ * A hook process handles one lifecycle event, so this map holds one or two
+ * entries and dies with the process.
+ */
+const drainedDirs = new Map();
+
 function withPendingApplied(dir, graph) {
   try {
-    return drainInvalidations(dir, graph) > 0 ? load(dir) : graph;
+    if (drainedDirs.has(dir)) return drainedDirs.get(dir) ? load(dir) : graph;
+    const marked = drainInvalidations(dir, graph) > 0;
+    drainedDirs.set(dir, marked);
+    return marked ? load(dir) : graph;
   } catch {
     // The lazy path still covers everything this would have caught early, and
     // a hook must never fail because bookkeeping did.
@@ -860,6 +879,12 @@ export function relevantFindingIdsForContext(graph, context, { limit = 8 } = {})
  * shrinks toward the floor. See metrics.indexBudget.
  */
 export function sessionIndex(dir, graph, { episode = {}, relevantFindingIds = [] } = {}) {
+  // DRAINED HERE TOO, and this is the worst place to be wrong. The session index
+  // is the FIRST thing a session sees and it arrives with no other context to
+  // correct it, so advertising a finding the graph already knows is stale is a
+  // false claim made at maximum leverage. The graph is loaded either way, so the
+  // only cost is the stat that finds no queue.
+  graph = withPendingApplied(dir, graph);
   const budget = indexBudget(dir);
   const relevant = new Set(relevantFindingIds);
   // Some SessionStart payloads have no task signal. Fail closed for situational
@@ -986,6 +1011,9 @@ ${lines.join('\n')}`;
  * is wallpaper, and the model stops reading the thing it always sees.
  */
 export function standingRules(dir, graph, { budget = standingBudget(), episode = {} } = {}) {
+  // Same reason as sessionIndex: always-on text, delivered before the first
+  // tool call, with nothing following it that could qualify what it said.
+  graph = withPendingApplied(dir, graph);
   const rules = [...graph.nodes.values()].filter(
     (n) =>
       n.kind === 'finding' &&

--- a/hooks-core/inject.mjs
+++ b/hooks-core/inject.mjs
@@ -154,9 +154,9 @@ function disputeNote(finding) {
 function derivationNote(finding) {
   if (finding.derivationHolds !== false) return '';
   const changed = Array.isArray(finding.derivationChanged) ? finding.derivationChanged : [];
-  return changed.length
-    ? `\n  DERIVATION CHANGED -- ${changed.join(', ')} no longer match what this claim was derived from`
-    : '\n  DERIVATION CHANGED since this claim was recorded';
+  if (!changed.length) return '\n  DERIVATION CHANGED since this claim was recorded';
+  const verb = changed.length === 1 ? 'no longer matches' : 'no longer match';
+  return `\n  DERIVATION CHANGED -- ${changed.join(', ')} ${verb} what this claim was derived from`;
 }
 
 function render(finding) {

--- a/hooks-core/inject.mjs
+++ b/hooks-core/inject.mjs
@@ -137,9 +137,26 @@ function fit(findings, budget) {
  */
 function disputeNote(finding) {
   if (!finding.contradicted) return '';
-  return finding.contradictedBy
+  const head = finding.contradictedBy
     ? `\n  DISPUTED by ${finding.contradictedBy} -- wiki_query that key for the other claim`
     : '\n  DISPUTED by another finding in this graph';
+  // THE REASON A PERSON TYPED, rendered here because this is the fullest of the
+  // three dispute surfaces and the only one with room for a sentence. `contradict`
+  // has always stored up to 400 characters of human explanation and, until this
+  // line, nothing read it: the pointer told a reader where to look and withheld
+  // the one thing that would tell them whether looking was worth a tool call.
+  //
+  // TRUNCATED AT 140, because `fit` prices this string against the injection
+  // budget and a 400-character paragraph beside a one-line claim inverts the
+  // proportions. The compressed surfaces -- the session index and restore.mjs's
+  // "Likely next" list -- deliberately keep marker-and-key only; they are one
+  // line per finding by design, and `wiki_query` returns the reason in full.
+  if (typeof finding.contradictionReason !== 'string' || !finding.contradictionReason.trim()) {
+    return head;
+  }
+  const reason = finding.contradictionReason.trim();
+  const shown = reason.length > 140 ? `${reason.slice(0, 140)}...` : reason;
+  return `${head}\n  Reason given: ${shown}`;
 }
 
 /**

--- a/hooks-core/inject.mjs
+++ b/hooks-core/inject.mjs
@@ -31,6 +31,7 @@ import { annotatedSkeleton } from './skeleton.mjs';
 import { substitutionBudget } from './metrics.mjs';
 import { assessFindings } from './utility.mjs';
 import { quarantineSharedSource } from './harvest-write.mjs';
+import { cacheOrdered } from './cache.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
@@ -1150,6 +1151,53 @@ export function standingRules(dir, graph, { budget = standingBudget(), episode =
   // which is worse than saying there are more: a model that knows the list is
   // truncated can ask, one that does not will assume it is complete.
   return `${HEADING}${lines.join('\n')}${truncated}`;
+}
+
+/**
+ * SessionStart context, assembled in cache order: stable first, volatile last.
+ *
+ * WHY THE ORDER IS A CORRECTNESS PROPERTY AND NOT A STYLE CHOICE. Everything
+ * here lands near the FRONT of the prompt prefix, and a prefix cache is
+ * invalidated from the first differing byte onward. A block whose text changes
+ * between sessions therefore prices everything positioned after it: put the
+ * freshest block first and the whole remainder of the prefix is re-written
+ * every session; put it last and the invalidation is confined to its own tail.
+ * cache.mjs measures exactly this cost in the user's files -- this is the same
+ * discipline applied to our own output, which is the half nobody else has to
+ * think about because nobody else writes into the prefix.
+ *
+ * `cacheOrdered` existed for precisely this and had no caller, so the order was
+ * whatever order the call sites happened to push in. It was accidentally right;
+ * it is now enforced, which is the difference that matters the next time a
+ * block is added.
+ *
+ * VOLATILITY IS ASSIGNED FROM HOW OFTEN THE TEXT ACTUALLY DIFFERS BETWEEN
+ * SESSIONS, not from how important the block is:
+ *
+ *   0  policy -- the optimization notice and project briefing. Deliberately
+ *      cache-safe by construction: the routing facts are number-free and the
+ *      briefing passes through `stableText`, which DROPS any line that would
+ *      vary. It changes when the tool inventory or configuration changes.
+ *   1  standing -- pinned facts and human-verified corrections, rendered in
+ *      full. Changes only when a person pins, retires or corrects something.
+ *   2  index -- the bounded wiki index, selected per session from the task
+ *      text, and carrying [STALE]/[DISPUTED] markers that flip as the code
+ *      moves. Different on most sessions.
+ *   3  restoration -- present only when resuming from a compaction, and derived
+ *      from the anchors of the session that was just discarded. Never twice the
+ *      same.
+ *
+ * A block with no text is dropped rather than joined, so an absent block cannot
+ * open the assembly with a blank line.
+ */
+export function sessionContext(blocks) {
+  return cacheOrdered(
+    (Array.isArray(blocks) ? blocks : []).filter(
+      (block) => block && typeof block.text === 'string' && block.text.trim()
+    )
+  )
+    .map((block) => block.text)
+    .join('\n\n');
 }
 
 /**

--- a/hooks-core/inject.mjs
+++ b/hooks-core/inject.mjs
@@ -141,8 +141,26 @@ function disputeNote(finding) {
     : '\n  DISPUTED by another finding in this graph';
 }
 
+/**
+ * Discloses `derivationCheck`'s verdict (staleness.mjs) -- distinct from
+ * `disputeNote` (another finding disagrees) and from the STALE block below
+ * (the anchor NODE's current hash does not match disk). This is about
+ * whether the bytes THIS claim was actually derived from are still the bytes
+ * an anchor holds; see `derivationCheck`'s comment for the case that catches
+ * that the other two can miss. Silent when it holds -- the common case pays
+ * nothing -- and silent when it was never checked at all (an older finding
+ * with no `derivation` record).
+ */
+function derivationNote(finding) {
+  if (finding.derivationHolds !== false) return '';
+  const changed = Array.isArray(finding.derivationChanged) ? finding.derivationChanged : [];
+  return changed.length
+    ? `\n  DERIVATION CHANGED -- ${changed.join(', ')} no longer match what this claim was derived from`
+    : '\n  DERIVATION CHANGED since this claim was recorded';
+}
+
 function render(finding) {
-  const head = `- [${finding.type || 'finding'}] ${finding.claim}${disputeNote(finding)}`;
+  const head = `- [${finding.type || 'finding'}] ${finding.claim}${disputeNote(finding)}${derivationNote(finding)}`;
   if (!finding.stale) return head;
 
   // A stale finding NEVER renders as though it were current. But the strength

--- a/hooks-core/inject.mjs
+++ b/hooks-core/inject.mjs
@@ -24,6 +24,7 @@ import {
 } from './wiki.mjs';
 import { basename } from 'node:path';
 import { serve, diffLines } from './staleness.mjs';
+import { drainInvalidations } from './pending.mjs';
 import { inHoldout, record, indexBudget } from './metrics.mjs';
 import { canonicalPath, resolvableCandidates } from './paths.mjs';
 import { annotatedSkeleton } from './skeleton.mjs';
@@ -140,6 +141,31 @@ function render(finding) {
 }
 
 /**
+ * Applies anything the post-tool hook queued, BEFORE anything is served.
+ *
+ * THIS IS WHERE EAGER STALENESS LANDS. `invalidateOnWrite` needs a graph, and
+ * loading one on the return path of every write is what pending.mjs exists to
+ * avoid -- so the hook queues and the next graph read applies. These two
+ * functions are that read: they already hold a freshly loaded graph, and they
+ * are the last thing to run before a finding reaches a model.
+ *
+ * RE-READ ONLY WHEN SOMETHING WAS ACTUALLY MARKED. The drain writes the stale
+ * flag to disk; it cannot mutate the caller's already-parsed graph, so serving
+ * from that copy would deliver the very "stale finding as fresh" this exists to
+ * prevent. A second load costs a parse, and it is paid once per observed write
+ * rather than once per tool call -- when nothing is queued this is one stat.
+ */
+function withPendingApplied(dir, graph) {
+  try {
+    return drainInvalidations(dir, graph) > 0 ? load(dir) : graph;
+  } catch {
+    // The lazy path still covers everything this would have caught early, and
+    // a hook must never fail because bookkeeping did.
+    return graph;
+  }
+}
+
+/**
  * What the model sees when it touches a file.
  *
  * Returns null when there is nothing to say, or when this touch fell into the
@@ -152,6 +178,7 @@ export function forTouch(
   rawPath,
   { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
+  graph = withPendingApplied(dir, graph);
   // Canonical, so a touch finds findings anchored under any other spelling.
   const filePath = canonicalPath(rawPath);
   const anchorId = nodeId('file', filePath);
@@ -320,6 +347,7 @@ export function forCommand(
   { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
   if (!command) return null;
+  graph = withPendingApplied(dir, graph);
 
   const candidates = [];
   for (const node of graph.nodes.values()) {

--- a/hooks-core/lexical.mjs
+++ b/hooks-core/lexical.mjs
@@ -63,6 +63,43 @@ export function tokenize(text) {
 }
 
 /**
+ * Effective term-frequency credit for a document that has NO exact token
+ * match for a query term but DOES have a token that starts with it (e.g.
+ * query `custom` against a document containing `customer`). Deliberately
+ * less than one exact occurrence (`1`), and it is a flat credit rather than
+ * one that grows with the number of prefix-matching tokens in the document,
+ * so a prefix hit can never outscore an exact hit of the same term:
+ *
+ *   BM25's per-term contribution is `idf * tf * (k1 + 1) / (tf + K)`, where
+ *   `K = k1 * (1 - b + b * L / avgL)` depends only on document length, not
+ *   on which term or how it matched. As a function of `tf` alone, with `K`
+ *   fixed, `f(tf) = tf / (tf + K)` is non-decreasing for every `tf >= 0` and
+ *   `k1 >= 0` (its derivative `K / (tf + K)^2` is never negative). So for
+ *   ANY document length, and any number of prefix-only occurrences, using
+ *   `PREFIX_TF < 1` in place of `tf` scores no higher than an actual exact
+ *   occurrence (`tf = 1`) would in that same document -- there is no
+ *   PREFIX_TF-independent way to accumulate more evidence than one real hit
+ *   by matching only a prefix. This is also why the count of prefix matches
+ *   is otherwise irrelevant here: it never feeds back into the score.
+ *
+ * PREFIX MATCHING IS NOT SUBSTRING MATCHING. It restores recall for a
+ * fragment typed at the START of a word -- `custom` now finds `customer` --
+ * which is the common case (a user typing the first few letters of a term
+ * they remember). It does NOT restore the old `.includes()` filter's ability
+ * to find a term in the MIDDLE of a word: a query for `tomer` still will not
+ * find `customer`. That recall gap is accepted, not silently reintroduced.
+ */
+const PREFIX_TF = 0.5;
+
+/**
+ * Below this length, a query term is not eligible for prefix matching: a
+ * one- or two-character prefix (`a`, `re`) is a substring of a large
+ * fraction of any real vocabulary, so it would match nearly every document
+ * and IDF alone would not discount it enough to keep the results relevant.
+ */
+const PREFIX_MIN_TERM_LENGTH = 3;
+
+/**
  * Classic BM25. `k1` controls term-frequency saturation, `b` length normalisation.
  * Defaults are the standard ones and are exposed so the recall probe can sweep them.
  */
@@ -94,7 +131,21 @@ export function rank(query, findings, { limit = 20, k1 = 1.2, b = 0.75 } = {}) {
 
     let score = 0;
     for (const term of terms) {
-      const tf = counts.get(term);
+      let tf = counts.get(term) || 0;
+
+      // No exact occurrence: fall back to a prefix match, which is weaker
+      // evidence and so credited at a flat PREFIX_TF rather than a real
+      // count (see PREFIX_TF's comment for why that ordering is safe). Only
+      // considered when nothing already matched exactly and the term is
+      // long enough that "starts with" is a meaningful signal.
+      if (tf === 0 && term.length >= PREFIX_MIN_TERM_LENGTH) {
+        for (const token of counts.keys()) {
+          if (token !== term && token.startsWith(term)) {
+            tf = PREFIX_TF;
+            break;
+          }
+        }
+      }
       if (!tf) continue;
       const df = docFreq.get(term) || 0;
       // Smoothed BM25 idf: log(1 + (N - df + 0.5) / (df + 0.5)). Unlike the

--- a/hooks-core/lexical.mjs
+++ b/hooks-core/lexical.mjs
@@ -1,0 +1,71 @@
+/**
+ * BM25 over findings. Pure, dependency-free, deterministic.
+ *
+ * WHY THIS REPLACES `includes()`. The dashboard filtered findings by substring,
+ * which cannot RANK -- and every consumer of retrieval here is under a hard
+ * token budget, so the budget kept whatever happened to match rather than what
+ * matched best. Ranking is the whole value at a budget.
+ *
+ * WHY BM25 AND NOT EMBEDDINGS. Deliberate, per docs/WIKI_GRAPH.md: deterministic,
+ * instant, explainable, and it cannot drift or need a rebuild. The known cost is
+ * recall on findings with no lexical overlap; Plan 2's recall probe measures that
+ * rather than assuming it away.
+ */
+
+/** Non-word split, lowercased. Short tokens are kept: `fs`, `id`, `os` matter here. */
+export function tokenize(text) {
+  return String(text || '')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+}
+
+/**
+ * Classic BM25. `k1` controls term-frequency saturation, `b` length normalisation.
+ * Defaults are the standard ones and are exposed so the recall probe can sweep them.
+ */
+export function rank(query, findings, { limit = 20, k1 = 1.2, b = 0.75 } = {}) {
+  const terms = tokenize(query);
+  if (!terms.length || !Array.isArray(findings) || !findings.length) return [];
+
+  // A finding's searchable text is its claim AND its key: the key is how the
+  // session index refers to it, so a model quoting a key must find it.
+  const docs = findings.map((finding) => ({
+    finding,
+    tokens: tokenize(`${finding.key || ''} ${finding.claim || ''}`),
+  }));
+
+  const avgLen = docs.reduce((sum, d) => sum + d.tokens.length, 0) / docs.length;
+  const N = docs.length;
+
+  const docFreq = new Map();
+  for (const { tokens } of docs) {
+    for (const term of new Set(tokens)) {
+      docFreq.set(term, (docFreq.get(term) || 0) + 1);
+    }
+  }
+
+  const scored = [];
+  for (const { finding, tokens } of docs) {
+    const counts = new Map();
+    for (const token of tokens) counts.set(token, (counts.get(token) || 0) + 1);
+
+    let score = 0;
+    for (const term of terms) {
+      const tf = counts.get(term);
+      if (!tf) continue;
+      const df = docFreq.get(term) || 0;
+      // Standard BM25 IDF, floored at zero so a term present in every document
+      // contributes nothing rather than a negative score.
+      const idf = Math.max(0, Math.log(1 + (N - df + 0.5) / (df + 0.5)));
+      const norm = tf + k1 * (1 - b + (b * tokens.length) / (avgLen || 1));
+      score += idf * ((tf * (k1 + 1)) / (norm || 1));
+    }
+
+    // Zero means no term matched. Omitted rather than returned, so a caller
+    // under a token budget never spends it on an irrelevant finding.
+    if (score > 0) scored.push({ finding, score });
+  }
+
+  return scored.sort((a, b2) => b2.score - a.score).slice(0, limit);
+}

--- a/hooks-core/lexical.mjs
+++ b/hooks-core/lexical.mjs
@@ -12,12 +12,54 @@
  * rather than assuming it away.
  */
 
-/** Non-word split, lowercased. Short tokens are kept: `fs`, `id`, `os` matter here. */
-export function tokenize(text) {
-  return String(text || '')
-    .toLowerCase()
-    .split(/[^a-z0-9]+/)
+/**
+ * Splits an identifier's alphanumeric run into its camelCase / letter-digit
+ * parts, e.g. `skipLibCheck` -> ['skip', 'Lib', 'Check'], `TS2345` ->
+ * ['TS', '2345']. Returns a single-element array when there is no internal
+ * boundary (e.g. `retry` -> ['retry']) so callers can skip emitting a
+ * redundant duplicate of the whole token.
+ */
+function splitIdentifierParts(word) {
+  return word
+    .replace(/([a-z])([A-Z])/g, '$1\0$2')
+    .replace(/([A-Za-z])([0-9])/g, '$1\0$2')
+    .replace(/([0-9])([A-Za-z])/g, '$1\0$2')
+    .split('\0')
     .filter(Boolean);
+}
+
+/**
+ * Non-word split, lowercased. Short tokens are kept: `fs`, `id`, `os` matter
+ * here.
+ *
+ * Emits sub-tokens for compound identifiers, in addition to the whole token.
+ * Delimited identifiers (`smart_read`, `wiki.mjs`, the flag in
+ * `--skipLibCheck`) already round-trip fine: the delimiter splits them, and
+ * because query and claim pass through this same function, a query typed
+ * with the same delimiters matches. The silent gap was CONCATENATED
+ * identifiers with no delimiter at all -- `skipLibCheck` collapsed to the
+ * single token `skiplibcheck`, so a query for "skip lib check" (or "TS 2345"
+ * against `TS2345`) never intersected it. No error, just an absent result --
+ * and findings are about code, where run-together identifiers are the
+ * common case. So every alphanumeric run keeps its whole-token form (a query
+ * for the concatenated form still matches) and ALSO contributes its
+ * camelCase / letter-digit parts (a query for the separated form now
+ * matches too). A lone incidental character -- e.g. the `c` split out of a
+ * Windows path `C:\Users\...` -- needs no special-casing: it is a real
+ * token like any other, and BM25's IDF already discounts a term that shows
+ * up in nearly every finding.
+ */
+export function tokenize(text) {
+  const words = String(text || '').match(/[A-Za-z0-9]+/g) || [];
+  const tokens = [];
+  for (const word of words) {
+    tokens.push(word.toLowerCase());
+    const parts = splitIdentifierParts(word);
+    if (parts.length > 1) {
+      for (const part of parts) tokens.push(part.toLowerCase());
+    }
+  }
+  return tokens;
 }
 
 /**
@@ -55,9 +97,15 @@ export function rank(query, findings, { limit = 20, k1 = 1.2, b = 0.75 } = {}) {
       const tf = counts.get(term);
       if (!tf) continue;
       const df = docFreq.get(term) || 0;
-      // Standard BM25 IDF, floored at zero so a term present in every document
-      // contributes nothing rather than a negative score.
-      const idf = Math.max(0, Math.log(1 + (N - df + 0.5) / (df + 0.5)));
+      // Smoothed BM25 idf: log(1 + (N - df + 0.5) / (df + 0.5)). Unlike the
+      // classic unsmoothed idf (log((N - df + 0.5) / (df + 0.5))), which goes
+      // negative once a term appears in most documents, this smoothed form
+      // is strictly positive for every df in [1, N]: even at df === N the
+      // ratio inside the log is (N + 1) / (N + 0.5), which is always
+      // strictly greater than 1, so log(1 + that) is always > 0. No floor
+      // is needed here, and none is applied -- there is no negative case
+      // for this formula to guard against.
+      const idf = Math.log(1 + (N - df + 0.5) / (df + 0.5));
       const norm = tf + k1 * (1 - b + (b * tokens.length) / (avgLen || 1));
       score += idf * ((tf * (k1 + 1)) / (norm || 1));
     }

--- a/hooks-core/metrics.mjs
+++ b/hooks-core/metrics.mjs
@@ -453,6 +453,23 @@ export function readBalance(dir) {
   return out;
 }
 
+/**
+ * True when `readEvidence` could not have read the whole log -- the file
+ * exceeds the byte cap, so anything written before the tail it kept is
+ * silently absent from what it returned. A caller that builds a per-claim
+ * record from `readEvidence` (the wiki graph's derivation record) needs this
+ * to say "operations existed but are not recorded here" rather than let an
+ * empty result read as "nothing happened".
+ */
+export function evidenceTruncated(dir) {
+  const path = evidencePath(dir);
+  try {
+    return statSync(path).size > MAX_BYTES;
+  } catch {
+    return false;
+  }
+}
+
 /** Every causal evidence record inside the byte cap, deduplicated by id. */
 export function readEvidence(dir) {
   const path = evidencePath(dir);

--- a/hooks-core/pending.mjs
+++ b/hooks-core/pending.mjs
@@ -1,0 +1,309 @@
+/**
+ * The eager-invalidation queue: the missing half of staleness.mjs's header.
+ *
+ * That header describes TWO invalidation paths and says eager exists because
+ * lazy "would silently serve stale findings as fresh whenever a change came
+ * from outside the agent". `invalidateOnWrite` had been written, tested and
+ * documented -- and its only reference in shipped code was a COMMENT in the
+ * PreToolUse router. Staleness was lazy-only in production, and the router's
+ * own comment ("a write the hook observes is invalidated eagerly by
+ * `invalidateOnWrite`") described something that never happened.
+ *
+ * WHY THAT MATTERS MORE THAN IT SOUNDS. The lazy check compares the anchor's
+ * stored hash against disk -- and both the router and the adapter call
+ * `indexFile` on every file they observe, which re-points that hash at the new
+ * bytes. So for a write the session performed ITSELF, the lazy check is
+ * self-defeating: by the next retrieval the anchor already agrees with disk and
+ * the finding derived from the old content is served clean. Lazy catches the
+ * changes we never saw; only eager catches the ones we did.
+ *
+ * WHY A QUEUE AND NOT A DIRECT CALL. `invalidateOnWrite` needs the graph, and
+ * the graph is a megabyte of JSONL. Loading it on the return path of every
+ * write is the cost this shape exists to avoid. So the post-tool hook, which
+ * already holds the write's evidence, appends one record here and exits; the
+ * next graph read -- `forTouch`/`forCommand`, which load the graph anyway --
+ * drains it BEFORE serving anything.
+ *
+ * The guarantee is unchanged. What must never happen is SERVING a stale finding
+ * as fresh, and serve time is where that is enforced.
+ */
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { invalidateOnWrite } from './staleness.mjs';
+import { canonicalPath, isFsSafePath, resolvableCandidates } from './paths.mjs';
+
+const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
+
+/**
+ * Largest before/after side kept in a queue record.
+ *
+ * Matched to the graph's own snapshot limit for the same reason it has one: past
+ * this size the text is a bundle, a lockfile or a generated asset, and copying
+ * it into a queue file would mirror the repository into the graph directory one
+ * write at a time. Past the cap the write is simply not queued -- the lazy path
+ * still governs it, which is exactly the status quo for that file.
+ */
+const MAX_SIDE_CHARS = 262_144;
+
+/**
+ * Largest queue file appended to.
+ *
+ * A queue only grows while nothing drains it, which means the retrieval feature
+ * is off or every read has failed. Neither is a reason to keep writing: bounded
+ * here so a long unattended session cannot turn one directory into a log of
+ * every file it touched.
+ */
+const MAX_QUEUE_BYTES = 8 * 1024 * 1024;
+
+/** The tool payload fields that name the file a mutation landed on. */
+function writtenPath(payload, raw) {
+  const input = payload?.tool_input || {};
+  const response = raw?.tool_response || raw?.toolResponse || {};
+  for (const candidate of [
+    input.file_path,
+    input.path,
+    input.notebook_path,
+    response.filePath,
+    response.file_path,
+  ]) {
+    if (typeof candidate === 'string' && candidate.trim()) return candidate;
+  }
+  return null;
+}
+
+/** First string among several possible spellings of the same field. */
+function firstString(...values) {
+  for (const value of values) if (typeof value === 'string') return value;
+  return null;
+}
+
+/**
+ * The text before the write, reconstructed from a completed edit.
+ *
+ * PREFERENCE ORDER IS ABOUT EXACTNESS, not convenience. Claude Code's Edit
+ * response carries the whole pre-edit file (`originalFile`), which needs no
+ * reasoning at all. Failing that, an edit is a known substitution, so reverting
+ * `new_string` back to `old_string` in the post-write text reproduces the
+ * before side exactly -- but only when the substitution is unambiguous, which
+ * is why a `new_string` that now appears more than once is refused rather than
+ * guessed at.
+ *
+ * NULL MEANS "DO NOT QUEUE", and that is deliberate. An unknown before side
+ * could be passed as '' -- and `invalidateOnWrite` would then see every symbol
+ * in the file as changed and mark every finding anchored anywhere in it, which
+ * is the exact over-marking its own comments call worse than the file-level
+ * staleness symbols were introduced to avoid. A missed eager invalidation costs
+ * what today already costs; a wrong one permanently discounts correct findings.
+ */
+function beforeText(payload, raw, after) {
+  const input = payload?.tool_input || {};
+  const response = raw?.tool_response || raw?.toolResponse || {};
+
+  const original = firstString(
+    response.originalFile,
+    response.original_file,
+    response.originalContent,
+    response.original_content
+  );
+  if (original !== null) return original;
+
+  // MultiEdit applies its edits in order, so reverting walks them backwards.
+  const edits = Array.isArray(input.edits) ? input.edits : null;
+  if (edits) {
+    let text = after;
+    for (const edit of [...edits].reverse()) {
+      const reverted = revert(text, edit);
+      if (reverted === null) return null;
+      text = reverted;
+    }
+    return text;
+  }
+
+  return revert(after, input);
+}
+
+/** Undoes one old->new substitution, or null when it cannot be done exactly. */
+function revert(text, edit) {
+  const oldString = firstString(edit?.old_string, edit?.oldString);
+  const newString = firstString(edit?.new_string, edit?.newString);
+  if (oldString === null || newString === null || newString === '') return null;
+
+  const all = edit?.replace_all === true || edit?.replaceAll === true;
+  if (all) return text.split(newString).join(oldString);
+
+  const at = text.indexOf(newString);
+  if (at < 0) return null;
+  // Ambiguous: more than one candidate for the occurrence that was written, and
+  // reverting the wrong one fabricates a before side that never existed.
+  if (text.indexOf(newString, at + newString.length) >= 0) return null;
+  return text.slice(0, at) + oldString + text.slice(at + newString.length);
+}
+
+/** The post-write text, read from disk because that is what the write produced. */
+function afterText(path) {
+  if (!isFsSafePath(path)) return null;
+  for (const candidate of resolvableCandidates(path)) {
+    try {
+      if (statSync(candidate).size > MAX_SIDE_CHARS) return null;
+      return readFileSync(candidate, 'utf8');
+    } catch {
+      // Wrong spelling, or gone again already. Try the next one.
+    }
+  }
+  return null;
+}
+
+/**
+ * Does this payload carry enough to reconstruct a before side at all?
+ *
+ * Named tool lists were the alternative and were rejected: every client calls
+ * its editor something different (`Edit`, `replace`, `write_to_file`,
+ * `apply_patch`), and a list would silently exclude the ones nobody thought of
+ * while still charging a file read for every Read that matched by accident.
+ * Asking about the EVIDENCE instead covers any client that carries an edit in
+ * one of these shapes and costs nothing on the calls that do not.
+ */
+function hasEditEvidence(payload, raw) {
+  const input = payload?.tool_input || {};
+  const response = raw?.tool_response || raw?.toolResponse || {};
+  if (
+    firstString(
+      response.originalFile,
+      response.original_file,
+      response.originalContent,
+      response.original_content
+    ) !== null
+  )
+    return true;
+  if (Array.isArray(input.edits) && input.edits.length > 0) return true;
+  return firstString(input.old_string, input.oldString) !== null;
+}
+
+/**
+ * The evidence a completed mutation left behind, or null when there is none.
+ *
+ * Separate from `queueInvalidation` so the caller can be a hook branch that
+ * knows nothing about diffs, and so the reconstruction above is testable
+ * without a filesystem queue.
+ */
+export function observedWrite(payload, raw) {
+  // CHEAP CHECK FIRST, because this runs after every tool call on every client.
+  // Reading the file is the expensive part, and there is no point paying for it
+  // on a Read, a Bash or a write whose before side cannot be reconstructed.
+  if (!hasEditEvidence(payload, raw)) return null;
+
+  const path = writtenPath(payload, raw);
+  if (!path) return null;
+
+  const after = afterText(path);
+  if (after === null || after.length > MAX_SIDE_CHARS) return null;
+
+  const before = beforeText(payload, raw, after);
+  if (before === null || before.length > MAX_SIDE_CHARS) return null;
+  // Nothing changed: a formatter no-op, or a write of identical bytes. Queuing
+  // it would mark findings stale against an empty diff.
+  if (before === after) return null;
+
+  return { path, before, after };
+}
+
+/**
+ * Appends one pending write.
+ *
+ * NEVER THROWS. This runs on a hook's return path, and a queue that cannot be
+ * written degrades to the lazy path rather than costing the user a tool call.
+ */
+export function queueInvalidation(dir, { path, before, after, at } = {}) {
+  try {
+    if (typeof path !== 'string' || !path.trim()) return false;
+    if (typeof before !== 'string' || typeof after !== 'string') return false;
+    if (before.length > MAX_SIDE_CHARS || after.length > MAX_SIDE_CHARS)
+      return false;
+
+    const file = queuePath(dir);
+    try {
+      if (statSync(file).size > MAX_QUEUE_BYTES) return false;
+    } catch {
+      // No queue yet, which is the normal case.
+    }
+
+    mkdirSync(dir, { recursive: true });
+    appendFileSync(
+      file,
+      `${JSON.stringify({ path: canonicalPath(path), before, after, at: at ?? Date.now() })}\n`,
+      'utf8'
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Applies every queued invalidation and clears the queue.
+ *
+ * Returns the number of findings marked, so the caller knows whether its
+ * in-memory graph is now behind the file on disk and needs re-reading.
+ *
+ * CLEARED AFTER APPLYING AND UNCONDITIONALLY: a record that cannot be applied
+ * must not be retried on every tool call for the rest of the session, and the
+ * cost of dropping one is a single missed eager mark that the lazy path still
+ * has a chance at.
+ */
+export function drainInvalidations(dir, graph) {
+  let records;
+  try {
+    const file = queuePath(dir);
+    if (!existsSync(file)) return 0;
+    records = readFileSync(file, 'utf8')
+      .split('\n')
+      .filter((line) => line.trim())
+      .map((line) => {
+        try {
+          return JSON.parse(line);
+        } catch {
+          // A torn append costs one record, not the queue.
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch {
+    return 0;
+  }
+
+  let marked = 0;
+  for (const record of records) {
+    if (!record || typeof record.path !== 'string' || !record.path) continue;
+    if (typeof record.before !== 'string' || typeof record.after !== 'string')
+      continue;
+    try {
+      const result = invalidateOnWrite(
+        dir,
+        graph,
+        record.path,
+        record.before,
+        record.after
+      );
+      marked += Array.isArray(result) ? result.length : 0;
+    } catch {
+      // One bad record must not stop the rest, and must not stop the tool call.
+    }
+  }
+
+  try {
+    rmSync(queuePath(dir), { force: true });
+  } catch {
+    // Held open by a concurrent hook. The next drain re-applies these records,
+    // which is safe: marking an already-marked finding is idempotent.
+  }
+
+  return marked;
+}

--- a/hooks-core/pending.mjs
+++ b/hooks-core/pending.mjs
@@ -33,6 +33,7 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  renameSync,
   rmSync,
   statSync,
 } from 'node:fs';
@@ -41,6 +42,15 @@ import { invalidateChangedAnchors, invalidateOnWrite } from './staleness.mjs';
 import { canonicalPath, isFsSafePath, resolvableCandidates } from './paths.mjs';
 
 const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
+/**
+ * Where a drain moves the queue before reading it.
+ *
+ * PER PROCESS, not one shared name: two hooks draining the same graph directory
+ * at once would otherwise race for the same claim file, and the loser would
+ * either clobber the winner's records or delete them mid-read. A pid makes the
+ * claim private to the drainer that won the rename.
+ */
+const claimPath = (dir) => join(dir, `pending-invalidation.claim.${process.pid}.jsonl`);
 
 /**
  * Largest before/after side kept in a queue record.
@@ -317,17 +327,47 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
  * Returns the number of findings marked, so the caller knows whether its
  * in-memory graph is now behind the file on disk and needs re-reading.
  *
- * CLEARED AFTER APPLYING AND UNCONDITIONALLY: a record that cannot be applied
- * must not be retried on every tool call for the rest of the session, and the
- * cost of dropping one is a single missed eager mark that the lazy path still
- * has a chance at.
+ * CLAIMED BY RENAME, THEN READ, THEN DELETED -- and the order is the whole
+ * point. This used to read the queue and then `rmSync` the same path, so a
+ * post-tool hook appending between the read and the unlink had its record
+ * deleted having never been read. Parallel tool calls in one assistant turn are
+ * the ordinary way that happens, not an exotic race. `renameSync` makes the
+ * claim atomic: whatever the drainer took is exactly what it deletes, and a
+ * record appended a microsecond later lands on a fresh queue that the next drain
+ * will find.
+ *
+ * A LOST RECORD IS A PERMANENTLY MISSED INVALIDATION, which is why this is worth
+ * a rename. The comment here used to price it as "a single missed eager mark that
+ * the lazy path still has a chance at", and that premise is false: this module's
+ * own header states it. The lazy path compares the anchor's stored hash against
+ * disk, and `indexFile` re-points that hash at the bytes the session just wrote,
+ * so for the session's OWN writes lazy is structurally blind rather than merely
+ * late. Nothing else was ever going to catch a dropped record.
+ *
+ * A RECORD THAT CANNOT BE APPLIED IS STILL DROPPED, deliberately and
+ * unconditionally: retrying a permanently unapplicable record on every tool call
+ * for the rest of the session costs more than it can ever recover, and the claim
+ * file is deleted whether the loop marked anything or threw.
+ *
+ * FAIL-OPEN THROUGHOUT. A rename that loses a race, or fails for any other
+ * reason, returns 0 and leaves the queue for the next drain; it never throws
+ * into a hook.
  */
 export function drainInvalidations(dir, graph) {
   let records;
+  let claim;
   try {
     const file = queuePath(dir);
     if (!existsSync(file)) return 0;
-    records = readFileSync(file, 'utf8')
+    claim = claimPath(dir);
+    // A LEFTOVER CLAIM FROM A KILLED DRAIN IS OVERWRITTEN, not merged: rename
+    // onto an existing path replaces it. The pid in the name means the only way
+    // to hit that is this same pid having died mid-drain, whose records were
+    // already being applied when it went -- and re-applying is idempotent, so
+    // losing them is the cheaper of the two errors. Not doing the rename at all
+    // would strand the live queue forever.
+    renameSync(file, claim);
+    records = readFileSync(claim, 'utf8')
       .split('\n')
       .filter((line) => line.trim())
       .map((line) => {
@@ -340,6 +380,18 @@ export function drainInvalidations(dir, graph) {
       })
       .filter(Boolean);
   } catch {
+    // The rename lost a race, or the claim could not be read. Nothing is deleted
+    // unread and the hook proceeds. If the claim was taken and then could not be
+    // read, it is put back under the queue name so the next drain still sees it:
+    // a claim file nobody looks at again is the same lost record this rename
+    // exists to prevent.
+    try {
+      if (claim && existsSync(claim) && !existsSync(queuePath(dir))) {
+        renameSync(claim, queuePath(dir));
+      }
+    } catch {
+      // Best effort only. A hook must not fail because bookkeeping did.
+    }
     return 0;
   }
 
@@ -363,10 +415,13 @@ export function drainInvalidations(dir, graph) {
   }
 
   try {
-    rmSync(queuePath(dir), { force: true });
+    // THE CLAIM, NOT THE QUEUE. Deleting `queuePath` here is what dropped a
+    // concurrently appended record; this path holds exactly the bytes that were
+    // just read, so nothing unread can be inside it.
+    rmSync(claim, { force: true });
   } catch {
-    // Held open by a concurrent hook. The next drain re-applies these records,
-    // which is safe: marking an already-marked finding is idempotent.
+    // Held open by something else. The claim is not read again -- the next drain
+    // looks at the queue -- so this costs a stray file, never a record.
   }
 
   return marked;

--- a/hooks-core/pending.mjs
+++ b/hooks-core/pending.mjs
@@ -197,10 +197,11 @@ function hasEditEvidence(payload, raw) {
  * before this module is reached at all. So matching here is both complete for
  * every client the adapter serves and impossible to spell wrong.
  *
- * `NotebookEdit` is absent because `normalizeTool` maps it to null, and the MCP
- * `smart_edit`/`smart_write` tools are absent for the same reason. Both are gaps
- * in that alias table rather than in this file, and widening it changes routing
- * verdicts for every client -- so they are reported, not papered over here.
+ * `NotebookEdit` and the MCP `smart_edit`/`smart_write` tools were absent for as
+ * long as `normalizeTool` mapped them to null. That was a gap in the alias table
+ * rather than in this file, and it has since been closed there: all three now
+ * arrive as `Edit` or `Write` and are matched by the set below without it having
+ * to learn a fourth name.
  */
 const MUTATING = new Set(['Edit', 'MultiEdit', 'Write']);
 

--- a/hooks-core/pending.mjs
+++ b/hooks-core/pending.mjs
@@ -37,7 +37,7 @@ import {
   statSync,
 } from 'node:fs';
 import { join } from 'node:path';
-import { invalidateOnWrite } from './staleness.mjs';
+import { invalidateChangedAnchors, invalidateOnWrite } from './staleness.mjs';
 import { canonicalPath, isFsSafePath, resolvableCandidates } from './paths.mjs';
 
 const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
@@ -188,31 +188,85 @@ function hasEditEvidence(payload, raw) {
 }
 
 /**
- * The evidence a completed mutation left behind, or null when there is none.
+ * Canonical tool names that mean bytes on disk changed.
  *
- * Separate from `queueInvalidation` so the caller can be a hook branch that
- * knows nothing about diffs, and so the reconstruction above is testable
- * without a filesystem queue.
+ * THE NORMALISED SET, not any client's own vocabulary. `normalizePayload` has
+ * already mapped `replace`, `write_file`, `apply_patch`, `str_replace`,
+ * `search_replace` and the rest onto these three through decide.mjs's alias
+ * table -- and a tool that table cannot map arrives as null and exits the hook
+ * before this module is reached at all. So matching here is both complete for
+ * every client the adapter serves and impossible to spell wrong.
+ *
+ * `NotebookEdit` is absent because `normalizeTool` maps it to null, and the MCP
+ * `smart_edit`/`smart_write` tools are absent for the same reason. Both are gaps
+ * in that alias table rather than in this file, and widening it changes routing
+ * verdicts for every client -- so they are reported, not papered over here.
  */
-export function observedWrite(payload, raw) {
-  // CHEAP CHECK FIRST, because this runs after every tool call on every client.
-  // Reading the file is the expensive part, and there is no point paying for it
-  // on a Read, a Bash or a write whose before side cannot be reconstructed.
-  if (!hasEditEvidence(payload, raw)) return null;
+const MUTATING = new Set(['Edit', 'MultiEdit', 'Write']);
+
+/** Files an apply_patch-style program declares it is about to change. */
+function patchTargets(payload) {
+  const command = payload?.tool_input?.command;
+  if (typeof command !== 'string') return [];
+  const out = [];
+  for (const match of command.matchAll(
+    /^\*\*\* (?:Add|Update|Delete) File:\s*(.+)$/gm
+  )) {
+    const candidate = match[1].trim().replace(/^['"]|['"]$/g, '');
+    // Bounded: one patch naming a thousand files must not append a thousand
+    // queue records on a hook path.
+    if (candidate && out.length < 20) out.push(candidate);
+  }
+  return out;
+}
+
+/**
+ * Everything a completed mutation left behind that is worth queueing.
+ *
+ * TWO GRADES OF EVIDENCE, and the distinction is the point:
+ *
+ *   { path, before, after }  a reconstructable edit. The drain builds a real
+ *                            diff and marks only the symbols that moved.
+ *   { path }                 a whole-file write, or a patch program. No before
+ *                            side exists anywhere in the payload, so the drain
+ *                            compares stored hashes against disk instead.
+ *
+ * The second grade is what closes the biggest hole. A whole-file write is the
+ * commonest write shape there is, and before it was added those writes fell
+ * through to a lazy path that CANNOT see the session's own writes at all --
+ * `indexFile` refreshes the anchor before the lazy check ever looks at it. They
+ * were uncovered, not degraded.
+ *
+ * Returns an array, because one apply_patch program changes several files.
+ */
+export function observedWrites(payload, raw) {
+  if (!MUTATING.has(String(payload?.tool_name || ''))) return [];
 
   const path = writtenPath(payload, raw);
-  if (!path) return null;
+  if (path) {
+    // The expensive branch is guarded: reading the file only pays off when the
+    // payload can actually yield a before side.
+    if (hasEditEvidence(payload, raw)) {
+      const after = afterText(path);
+      if (after !== null && after.length <= MAX_SIDE_CHARS) {
+        const before = beforeText(payload, raw, after);
+        // Identical bytes: a formatter no-op, or a rewrite of the same content.
+        // Nothing changed, so nothing is stale.
+        if (before === after) return [];
+        if (before !== null && before.length <= MAX_SIDE_CHARS)
+          return [{ path, before, after }];
+      }
+    }
+    // Hash grade. Deliberately NOT `{ path, before: '', after }`: an empty
+    // before side makes every symbol in the file look changed, and the eager
+    // mark is a stored flag no later check ever clears.
+    return [{ path }];
+  }
 
-  const after = afterText(path);
-  if (after === null || after.length > MAX_SIDE_CHARS) return null;
-
-  const before = beforeText(payload, raw, after);
-  if (before === null || before.length > MAX_SIDE_CHARS) return null;
-  // Nothing changed: a formatter no-op, or a write of identical bytes. Queuing
-  // it would mark findings stale against an empty diff.
-  if (before === after) return null;
-
-  return { path, before, after };
+  // Codex and code-mode clients carry the whole patch as program text with no
+  // file_path field at all, which is why this recorded nothing for them. The
+  // hash grade needs only the path, so the patch headers are enough.
+  return patchTargets(payload).map((target) => ({ path: target }));
 }
 
 /**
@@ -224,9 +278,14 @@ export function observedWrite(payload, raw) {
 export function queueInvalidation(dir, { path, before, after, at } = {}) {
   try {
     if (typeof path !== 'string' || !path.trim()) return false;
-    if (typeof before !== 'string' || typeof after !== 'string') return false;
-    if (before.length > MAX_SIDE_CHARS || after.length > MAX_SIDE_CHARS)
-      return false;
+    // BOTH SIDES OR NEITHER. A record carrying only one of them cannot produce
+    // a diff and must not pretend to, so it is written as a path-only record
+    // and the drain resolves it by comparing hashes.
+    const diffable =
+      typeof before === 'string' &&
+      typeof after === 'string' &&
+      before.length <= MAX_SIDE_CHARS &&
+      after.length <= MAX_SIDE_CHARS;
 
     const file = queuePath(dir);
     try {
@@ -238,7 +297,11 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
     mkdirSync(dir, { recursive: true });
     appendFileSync(
       file,
-      `${JSON.stringify({ path: canonicalPath(path), before, after, at: at ?? Date.now() })}\n`,
+      `${JSON.stringify({
+        path: canonicalPath(path),
+        ...(diffable ? { before, after } : {}),
+        at: at ?? Date.now(),
+      })}\n`,
       'utf8'
     );
     return true;
@@ -282,16 +345,16 @@ export function drainInvalidations(dir, graph) {
   let marked = 0;
   for (const record of records) {
     if (!record || typeof record.path !== 'string' || !record.path) continue;
-    if (typeof record.before !== 'string' || typeof record.after !== 'string')
-      continue;
+    const diffable =
+      typeof record.before === 'string' && typeof record.after === 'string';
     try {
-      const result = invalidateOnWrite(
-        dir,
-        graph,
-        record.path,
-        record.before,
-        record.after
-      );
+      // TWO GRADES, ONE QUEUE. A record carrying both sides gets a real diff and
+      // symbol-precise marking; one carrying only a path gets the hash
+      // comparison -- the same comparison the lazy path makes, and one that is
+      // only meaningful HERE, before `indexFile` refreshes the anchor.
+      const result = diffable
+        ? invalidateOnWrite(dir, graph, record.path, record.before, record.after)
+        : invalidateChangedAnchors(dir, graph, record.path);
       marked += Array.isArray(result) ? result.length : 0;
     } catch {
       // One bad record must not stop the rest, and must not stop the tool call.

--- a/hooks-core/restore.mjs
+++ b/hooks-core/restore.mjs
@@ -140,7 +140,7 @@ export function restorationPlan(dir, graph, context = {}) {
     for (const id of predicted) {
       const node = graph.nodes.get(id);
       if (!node) continue;
-      const findings = serve(graph, findingsFor(graph, id, { limit: 2 }));
+      const findings = serve(graph, findingsFor(graph, id, { limit: 2 }), { dir });
       for (const finding of findings) {
         // `! STALE` only where a diff actually exists to back it; see the
         // renderer in inject.mjs for the measurement behind this.

--- a/hooks-core/restore.mjs
+++ b/hooks-core/restore.mjs
@@ -156,7 +156,16 @@ export function restorationPlan(dir, graph, context = {}) {
             ? '! STALE '
             : '~ '
           : '';
-        lines.push(`${node.key}: ${mark}${finding.claim}`);
+        // A DISPUTE DISCLOSED ELSEWHERE AND SILENT HERE reads as "the dispute
+        // went away". `serve` already attached the fields; the only question is
+        // the wording, and this list is the most compressed surface in the
+        // system, so it gets the marker and the key and nothing else.
+        const disputed = finding.contradicted
+          ? finding.contradictedBy
+            ? ` (disputed by ${finding.contradictedBy})`
+            : ' (disputed)'
+          : '';
+        lines.push(`${node.key}: ${mark}${finding.claim}${disputed}`);
       }
     }
     section('Likely next', lines, total * split.forward);

--- a/hooks-core/skeleton.mjs
+++ b/hooks-core/skeleton.mjs
@@ -124,6 +124,11 @@ export function annotatedSkeleton(graph, rawPath, source, { budget = 1200, git =
 
   // Findings anchored to this file or the symbols inside it, served through the
   // one function that enforces the stale-plus-diff rule.
+  // READ-ONLY serve: no `dir` is threaded here, so this cannot clear a stale
+  // flag whose evidence is gone. That is deliberate -- this function takes a
+  // graph, not the directory it came from, and widening its signature to give
+  // an analysis path a write capability buys nothing: the injection path runs
+  // on every tool call and clears the same findings.
   const served = serve(graph, findingsFor(graph, nodeId('file', path), { limit: 40 }));
 
   // Index findings by the symbol they anchor to, so each one sits beside the

--- a/hooks-core/staleness.mjs
+++ b/hooks-core/staleness.mjs
@@ -51,7 +51,7 @@
 import { readFileSync, statSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { dirname, join } from 'node:path';
-import { putNode, putEdge, contentHash, nodeId } from './wiki.mjs';
+import { putNode, putEdge, contentHash, nodeId, load } from './wiki.mjs';
 import { hasOutstandingContradiction } from './curate.mjs';
 import { extractSymbols, spanText, symbolKey, extractImports } from './symbols.mjs';
 import { canonicalPath, resolvableCandidates, isFsSafePath } from './paths.mjs';
@@ -486,7 +486,16 @@ function disputeOf(graph, finding) {
     // An edge end that resolves to nothing names nothing. The dispute is still
     // disclosed -- the gate above already established it -- but without a key
     // the reader cannot be pointed anywhere, and inventing one would be worse.
-    if (other && typeof other.key === 'string' && !keys.includes(other.key)) keys.push(other.key);
+    //
+    // A RETIRED END IS NOT NAMED EITHER, for a sharper reason: the disclosure
+    // tells the reader to `wiki_query` that key, and `serve` refuses to return
+    // a retired finding at all. Naming it points them at a claim they cannot
+    // fetch. `hasOutstandingContradiction` above already declines to open the
+    // gate when EVERY disputant is retired; this is the same rule applied to
+    // each name, so a live disputant is still reported alongside a withdrawn one.
+    if (other && !other.retired && typeof other.key === 'string' && !keys.includes(other.key)) {
+      keys.push(other.key);
+    }
   }
 
   return { contradicted: true, ...(keys.length ? { contradictedBy: keys.join(', ') } : {}) };
@@ -868,6 +877,151 @@ export function invalidateChangedAnchors(dir, graph, rawPath) {
   // retrieval re-reports a change that has already been accounted for.
   if (source !== null) indexFile(dir, path, source);
   return marked;
+}
+
+/**
+ * The current content hash of an anchor, read from disk.
+ *
+ * DELIBERATELY NOT `checkAnchor`, and the difference is the whole of this
+ * clearing rule. `checkAnchor` compares disk against the anchor NODE's stored
+ * hash, and both eager paths call `indexFile` immediately after marking --
+ * which re-points that hash at the very bytes that caused the mark. So
+ * `checkAnchor` answers "fresh" for exactly the finding it just marked stale,
+ * and a clearing rule built on it would clear every flag it was handed,
+ * unconditionally. This returns a bare hash instead, so the caller can compare
+ * it against the FROZEN claim-time hash rather than against a value the marking
+ * path itself moved.
+ *
+ * Returns null when no content can be read at all -- a deleted file, or a
+ * symbol that no longer exists. A caller must treat that as "changed", never as
+ * "unknown": a claim about content that is gone certainly does not match the
+ * content it was made against.
+ */
+function anchorHashNow(anchor) {
+  const path = anchor.kind === 'symbol' ? anchor.file : anchor.key;
+  let source;
+  try {
+    source = readAnySpelling(path);
+  } catch {
+    return null;
+  }
+  if (anchor.kind !== 'symbol') return hash(source);
+
+  // By NAME, like checkAnchor: line numbers shift whenever anything above is
+  // edited, and re-locating by line would report a symbol as moved when only an
+  // unrelated insert happened above it.
+  const current = extractSymbols(path, source).find((s) => s.name === anchor.name);
+  if (!current) return null;
+  return hash(spanText(source, current));
+}
+
+/**
+ * Removes the staleness fields from a finding. Returns whether one was found.
+ *
+ * THE WHOLE NODE IS REWRITTEN, because `putNode` does not merge: it writes a
+ * full record from what it is handed and `load` replaces the node wholesale.
+ * Writing `{ kind, key, stale: false }` would blank the claim, the confidence
+ * and the provenance -- an overwrite by another name, and the same trap
+ * `contradict` documents. So the fields are destructured AWAY and everything
+ * else is spread back: no deletion primitive is needed, and the append-only rule
+ * is respected.
+ *
+ * `staleEvidence` is stripped as well, even though no writer stores it. It is
+ * added by `serve` to the object it hands out, so anything that ever writes a
+ * served finding back would carry it in -- at which point a cleared finding
+ * would still be advertising the quality of the evidence for a flag it no longer
+ * has.
+ *
+ * A PRIMITIVE, NOT A ROUTE. Nothing outside this module calls it: the only
+ * shipping caller is `reverify` below, which establishes the evidence first.
+ * Exposing it to a hook, a tool argument or an HTTP action would be a way to
+ * turn a stale finding fresh on request, which is exactly what must not exist.
+ */
+export function clearStale(dir, key) {
+  const node = load(dir).nodes.get(nodeId('finding', key));
+  if (!node || node.kind !== 'finding') return false;
+  const { stale, staleReason, diff, staleEvidence, ...rest } = node;
+  // Nothing to clear is a success, not a write: an unconditional putNode here
+  // would append a duplicate record to the log on every no-op call.
+  if (stale === undefined && staleReason === undefined
+    && diff === undefined && staleEvidence === undefined) return true;
+  putNode(dir, { ...rest, kind: 'finding', key: node.key });
+  return true;
+}
+
+/**
+ * Clears a stale flag when, and only when, the evidence for it is gone.
+ *
+ * WHY THIS HAS TO EXIST. Nothing in this codebase ever cleared a `stale` flag.
+ * That was harmless while eager invalidation was dead code; it fires now, so
+ * every finding on an edited file becomes permanently stale -- and permanently
+ * discounted, since `disclose.mjs` skips a stale finding outright and
+ * `utility.mjs` penalises one by 160. The graph degrades toward all-stale, and
+ * the eager path is over-eager on top of that: `invalidateOnWrite` marks every
+ * finding anchored to a FILE node on any observed write to that file, whether or
+ * not the bytes moved.
+ *
+ * WHAT COUNTS AS EVIDENCE, AND WHY IT IS NOT NEGOTIABLE. The only trustworthy
+ * record of what a claim was made against is `derivation.anchors` -- the hash
+ * each anchor carried at the moment the finding was written, frozen into the
+ * finding itself by `harvest-write.mjs`. Disk is re-hashed here and compared
+ * against that. If every anchor matches, the content IS what the claim was
+ * derived from: a revert, or a write that never moved the anchored bytes. The
+ * flag comes off. Anything else leaves it exactly as it was.
+ *
+ * IT IS NOT A LAUNDERING ROUTE, and that is a property of the comparison rather
+ * than of who is allowed to call it. A caller cannot make a finding fresh by
+ * asking; they can only make it fresh by putting the content back. There is no
+ * argument, no force flag and no second path -- and `clearStale` above, the one
+ * function that clears without checking, has no caller but this one.
+ *
+ * NO RECORD MEANS UNKNOWN, NEVER CLEAR. A finding with no `derivation.anchors`
+ * -- every one written before that record existed, and every hand-curated one --
+ * has nothing to compare disk against. That is an absence of evidence, and
+ * resolving it to "clear it" would hand back the laundering route through the
+ * side door. It reports `unknown` and changes nothing; re-recording the claim
+ * against the current code (`curate.correct`) is the way forward for those.
+ *
+ * DELIBERATELY NOT AUTOMATIC. This reads every anchor off disk, so running it on
+ * the serve path would put N file reads inside injection -- and, worse, it would
+ * silently un-mark findings nobody asked about. Staleness is disclosed to a
+ * reader who then decides; clearing is an explicit act.
+ */
+export function reverify(dir, key) {
+  const graph = load(dir);
+  const finding = graph.nodes.get(nodeId('finding', key));
+  if (!finding || finding.kind !== 'finding') return 'unknown';
+  // Idempotent: the postcondition -- no stale flag on this finding -- already
+  // holds, and reporting anything else would make a caller retry forever.
+  if (!finding.stale) return 'cleared';
+
+  const recorded = finding.derivation && finding.derivation.anchors;
+  if (!recorded || typeof recorded !== 'object') return 'unknown';
+
+  const anchorIds = new Set(
+    graph.edges
+      .filter((e) => e.edge === 'derived_from' && e.from === finding.id)
+      .map((e) => e.to)
+  );
+  // An unanchored finding cannot be checked against anything, which is the
+  // un-invalidatable shape the anchor discipline exists to refuse. It is equally
+  // un-VERIFIABLE, so it is reported as such rather than cleared.
+  if (!anchorIds.size) return 'unknown';
+
+  for (const id of anchorIds) {
+    const expected = recorded[id];
+    const node = graph.nodes.get(id);
+    // An anchor this finding never recorded a hash for, or one that no longer
+    // resolves to a node: nothing to compare, so nothing is concluded.
+    if (typeof expected !== 'string' || !expected || !node) return 'unknown';
+    if (node.kind !== 'file' && node.kind !== 'symbol') return 'unknown';
+    // null means the content is gone -- deleted file, vanished symbol. That is a
+    // difference, not an absence of evidence.
+    if (anchorHashNow(node) !== expected) return 'still-stale';
+  }
+
+  clearStale(dir, key);
+  return 'cleared';
 }
 
 export { contentHash };

--- a/hooks-core/staleness.mjs
+++ b/hooks-core/staleness.mjs
@@ -572,8 +572,20 @@ function derivationCheck(graph, finding) {
  * This is the only function that should ever hand a finding to a model, because
  * it is the one that enforces the rule: a stale finding leaves here carrying
  * `stale: true` AND a diff, or it does not leave at all.
+ *
+ * AND IT CLEARS A STORED FLAG WHOSE EVIDENCE IS GONE, when given a `dir` to
+ * write to. Clearing used to be reachable only by a person pressing Re-verify in
+ * the dashboard, which left the rot path fully open on every install where
+ * nobody opens the dashboard -- and that is most of them. The evidence test is
+ * what makes clearing safe, and it does not care who triggered it: the same
+ * `claimTimeVerdict` runs here as in `reverify`, so this cannot clear anything
+ * the button would not.
+ *
+ * `dir` IS OPTIONAL, AND OMITTING IT MAKES THIS READ-ONLY. Several callers hold
+ * a graph without the directory it came from, and a serve that silently did
+ * nothing would be worse than one that plainly cannot write.
  */
-export function serve(graph, findings) {
+export function serve(graph, findings, { dir = null } = {}) {
   const served = [];
 
   // RETIRED FINDINGS STOP HERE, unconditionally.
@@ -601,8 +613,42 @@ export function serve(graph, findings) {
       continue;
     }
 
+    // AUTOMATIC CLEARING, on the same evidence the manual path demands.
+    //
+    // ONLY THE STORED FLAG IS TOUCHED. The lazy loop below is left to run
+    // exactly as before and can independently mark this finding stale again on
+    // its own comparison -- disk against the anchor NODE's hash -- which answers
+    // a different question and is not this function's to overrule. Eager and
+    // lazy stay two mechanisms, as the module header insists.
+    //
+    // AND THE FIELDS GO WITH THE FLAG. `putNode` does not merge and neither does
+    // this spread: serving `{ ...finding, stale: false }` would hand back a
+    // finding that reads fresh while still carrying `staleReason` and `diff`
+    // from the record -- stale and fresh at once, which is worse than either.
+    // So the cleared record, not the stored one, is what the rest of this
+    // iteration reads and spreads.
+    //
+    // BOUNDED, and the bound is the point: this runs only for a finding whose
+    // flag is already STORED, only when a `derivation` record exists to check
+    // against, and it reads each of that finding's anchors at most once. A
+    // finding that is not flagged pays nothing. The lazy loop below already
+    // reads every anchor of every content-dependent finding served, so the worst
+    // case is twice the anchor reads on the already-stale subset alone.
+    //
+    // NOT ON THE NON-CONTENT-DEPENDENT EARLY RETURN ABOVE, deliberately. Both
+    // eager paths refuse to flag those types at all, so a flag there can only
+    // come from an older graph -- and reading anchors for a type whose truth
+    // does not depend on them is exactly the cost `CONTENT_DEPENDENT` exists to
+    // avoid.
+    let record = finding;
+    if (dir && finding.stale && claimTimeVerdict(graph, finding) === 'match') {
+      clearStale(dir, finding.key, { graph });
+      const { stale: _s, staleReason: _r, diff: _d, staleEvidence: _e, ...cleared } = finding;
+      record = cleared;
+    }
+
     const anchors = graph.edges
-      .filter((e) => e.edge === 'derived_from' && e.from === finding.id)
+      .filter((e) => e.edge === 'derived_from' && e.from === record.id)
       .map((e) => graph.nodes.get(e.to))
       .filter(Boolean);
 
@@ -627,10 +673,10 @@ export function serve(graph, findings) {
     // A finding already marked stale eagerly, whose diff was captured at write
     // time, keeps that diff -- the eager path saw the change we can no longer
     // reconstruct from disk alone.
-    if (!stale && finding.stale) {
+    if (!stale && record.stale) {
       stale = true;
-      diff = finding.diff || '';
-      reason = finding.staleReason || 'marked stale when the change was observed';
+      diff = record.diff || '';
+      reason = record.staleReason || 'marked stale when the change was observed';
     }
 
     if (stale && !diff) {
@@ -679,13 +725,19 @@ export function serve(graph, findings) {
     }
 
     served.push({
-      ...finding,
+      ...record,
       stale,
       ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
+      // BOTH OTHER DISCLOSURES SURVIVE A MID-SERVE CLEAR. `dispute` was computed
+      // above the content-dependence branch and is applied here untouched, and
+      // the derivation verdict is recomputed from the record -- which still
+      // carries its `derivation`, since clearing removes only the staleness
+      // fields. A finding whose flag was just cleared is still disclosed as
+      // disputed, and still reports whether its derivation holds.
       ...dispute,
       // Independent of `stale` above: see `derivationCheck`'s own comment for
       // the case it catches that node-level staleness can miss.
-      ...derivationCheck(graph, finding),
+      ...derivationCheck(graph, record),
     });
   }
   return served;
@@ -937,8 +989,21 @@ function anchorHashNow(anchor) {
  * Exposing it to a hook, a tool argument or an HTTP action would be a way to
  * turn a stale finding fresh on request, which is exactly what must not exist.
  */
-export function clearStale(dir, key) {
-  const node = load(dir).nodes.get(nodeId('finding', key));
+export function clearStale(dir, key, { graph = null } = {}) {
+  // A CALLER THAT ALREADY HOLDS THE GRAPH PASSES IT, and this is not
+  // micro-optimisation: `load` re-parses the entire append-only log, so clearing
+  // inside `serve`'s loop re-read and re-folded the whole graph once PER cleared
+  // finding. Measured on 40 findings all stale and all revertible -- the shape a
+  // mass revert produces -- that was 185 ms against 25 ms, a 7x regression on
+  // the injection path, all of it graph loading rather than the hashing this
+  // feature is actually for. With the graph passed through it is back in line.
+  //
+  // No new race: this store is last-write-wins with no compare-and-set anywhere,
+  // and every other caller that spreads a node back -- `pin`, `retire`,
+  // `contradict`, `correct` -- writes from a graph it loaded earlier too. Both
+  // callers here already DECIDED on this snapshot, so re-reading it purely for
+  // the write narrowed no window that was ever closed.
+  const node = (graph || load(dir)).nodes.get(nodeId('finding', key));
   if (!node || node.kind !== 'finding') return false;
   const { stale, staleReason, diff, staleEvidence, ...rest } = node;
   // Nothing to clear is a success, not a write: an unconditional putNode here
@@ -987,14 +1052,33 @@ export function clearStale(dir, key) {
  * silently un-mark findings nobody asked about. Staleness is disclosed to a
  * reader who then decides; clearing is an explicit act.
  */
-export function reverify(dir, key) {
-  const graph = load(dir);
-  const finding = graph.nodes.get(nodeId('finding', key));
-  if (!finding || finding.kind !== 'finding') return 'unknown';
-  // Idempotent: the postcondition -- no stale flag on this finding -- already
-  // holds, and reporting anything else would make a caller retry forever.
-  if (!finding.stale) return 'cleared';
-
+/**
+ * THE ONE EVIDENCE TEST. Does this finding's anchored content still hash to what
+ * the claim was actually made against?
+ *
+ * `'match'` -- every anchor on disk re-hashes to the value frozen into this
+ * finding's own `derivation.anchors` at claim time. The content IS what the
+ * claim was derived from: a revert, or a write that never moved the anchored
+ * bytes.
+ * `'differs'` -- at least one anchor does not, INCLUDING an anchor whose content
+ * is gone. Deleted is a difference, not a missing measurement.
+ * `'unknown'` -- there is nothing to compare: no `derivation.anchors`, no
+ * anchors, an anchor with no recorded hash, or one that no longer resolves.
+ *
+ * SHARED BY BOTH CLEARING PATHS ON PURPOSE, and that sharing is the guarantee
+ * rather than a convenience. `reverify` (a person pressing Re-verify) and
+ * `serve` (automatic, on every retrieval) call THIS function and nothing else,
+ * so the automatic path cannot clear anything the button would not, and neither
+ * can drift from the other. Two copies of this comparison would be two policies,
+ * and the weaker one would win wherever it ran more often -- which is the
+ * automatic one.
+ *
+ * NOT `checkAnchor`, for the reason `anchorHashNow` above spells out: that
+ * compares disk against the anchor NODE's stored hash, which both eager paths
+ * re-point at the very bytes that caused the mark, so it answers "fresh" for
+ * exactly the finding it just marked stale.
+ */
+function claimTimeVerdict(graph, finding) {
   const recorded = finding.derivation && finding.derivation.anchors;
   if (!recorded || typeof recorded !== 'object') return 'unknown';
 
@@ -1017,10 +1101,23 @@ export function reverify(dir, key) {
     if (node.kind !== 'file' && node.kind !== 'symbol') return 'unknown';
     // null means the content is gone -- deleted file, vanished symbol. That is a
     // difference, not an absence of evidence.
-    if (anchorHashNow(node) !== expected) return 'still-stale';
+    if (anchorHashNow(node) !== expected) return 'differs';
   }
+  return 'match';
+}
 
-  clearStale(dir, key);
+export function reverify(dir, key) {
+  const graph = load(dir);
+  const finding = graph.nodes.get(nodeId('finding', key));
+  if (!finding || finding.kind !== 'finding') return 'unknown';
+  // Idempotent: the postcondition -- no stale flag on this finding -- already
+  // holds, and reporting anything else would make a caller retry forever.
+  if (!finding.stale) return 'cleared';
+
+  const verdict = claimTimeVerdict(graph, finding);
+  if (verdict === 'unknown') return 'unknown';
+  if (verdict === 'differs') return 'still-stale';
+  clearStale(dir, key, { graph });
   return 'cleared';
 }
 

--- a/hooks-core/staleness.mjs
+++ b/hooks-core/staleness.mjs
@@ -493,6 +493,54 @@ function disputeOf(graph, finding) {
 }
 
 /**
+ * Whether THIS finding's own claim-time evidence still matches its anchors --
+ * the reader `harvest-write.mjs`'s `derivation` record was written for.
+ * Nothing consumed that record until now: a grep for it found only the writer
+ * and its own tests, which made "checkable rather than merely attributed" a
+ * claim with no code behind it.
+ *
+ * DISTINCT FROM `stale`/`checkAnchor`, DELIBERATELY, not a duplicate of it.
+ * `checkAnchor` compares disk against the anchor NODE's CURRENT stored hash,
+ * which is refreshed by `indexFile` every time ANYTHING touches that file --
+ * so it answers "has this file changed since the last time anyone indexed
+ * it", not "has it changed since THIS finding was derived from it". Those
+ * differ in a real case: file F changes, and a LATER, unrelated write
+ * (another finding, another session) re-indexes F, updating the node's
+ * stored hash to match the new content again. `checkAnchor` now reports
+ * "fresh" -- disk matches the node's current hash -- while this finding's own
+ * frozen `derivation.anchors[id]` snapshot, taken when IT was written, no
+ * longer matches. The bytes this claim was actually derived from are gone,
+ * and `stale` alone would never say so.
+ *
+ * Returns `{}` when there is nothing to check (no `derivation.anchors`
+ * recorded -- true of every finding written before this existed), so a
+ * caller can tell "not checked" from "checked and holds" by whether
+ * `derivationHolds` is present at all.
+ */
+function derivationCheck(graph, finding) {
+  const recorded = finding.derivation && finding.derivation.anchors;
+  if (!recorded || typeof recorded !== 'object') return {};
+  const ids = Object.keys(recorded);
+  if (!ids.length) return {};
+
+  const changed = [];
+  for (const id of ids) {
+    const node = graph.nodes.get(id);
+    const currentHash = node && typeof node.hash === 'string' ? node.hash : null;
+    // An anchor that no longer resolves at all cannot be confirmed either --
+    // treated the same as a changed hash, never as "still holds" by default.
+    if (currentHash === null || currentHash !== recorded[id]) {
+      changed.push(node && typeof node.key === 'string' ? node.key : id);
+    }
+  }
+
+  if (!changed.length) return { derivationHolds: true };
+  // Bounded: a finding with many anchors should not spend unbounded budget
+  // naming every one that moved.
+  return { derivationHolds: false, derivationChanged: changed.slice(0, 5) };
+}
+
+/**
  * Prepares findings for delivery, verifying each one lazily against disk.
  *
  * This is the only function that should ever hand a finding to a model, because
@@ -609,6 +657,9 @@ export function serve(graph, findings) {
       stale,
       ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
       ...dispute,
+      // Independent of `stale` above: see `derivationCheck`'s own comment for
+      // the case it catches that node-level staleness can miss.
+      ...derivationCheck(graph, finding),
     });
   }
   return served;

--- a/hooks-core/staleness.mjs
+++ b/hooks-core/staleness.mjs
@@ -516,6 +516,21 @@ function disputeOf(graph, finding) {
  * recorded -- true of every finding written before this existed), so a
  * caller can tell "not checked" from "checked and holds" by whether
  * `derivationHolds` is present at all.
+ *
+ * `derivationHolds: true` MEANS "MATCHES THE ANCHOR NODE'S LAST-INDEXED
+ * HASH", NOT "MATCHES DISK RIGHT NOW" -- and that distinction is stored in
+ * `derivationCheckedAgainst: 'index'` rather than left for a `wiki_query`
+ * consumer to infer from a field name alone. Two ways to close this gap were
+ * considered: recompute a live hash from disk here, or document precisely
+ * what is actually compared. `stale` (via `checkAnchor`, above) ALREADY owns
+ * the disk comparison -- re-reading the same file a second time on the same
+ * serve path, for the same anchor, from a second mechanism, is worse than
+ * one honest name. So: documented, not duplicated. A file changed on disk
+ * but never re-indexed by anything is still caught, correctly, by `stale`;
+ * `derivationHolds` answers a narrower, complementary question -- whether
+ * the LAST INDEXED state agrees with what this specific finding recorded --
+ * which is exactly the re-indexed-by-something-else case above that `stale`
+ * cannot see.
  */
 function derivationCheck(graph, finding) {
   const recorded = finding.derivation && finding.derivation.anchors;
@@ -534,10 +549,12 @@ function derivationCheck(graph, finding) {
     }
   }
 
-  if (!changed.length) return { derivationHolds: true };
+  // Declared on BOTH branches, not only the ambiguous one: a consumer should
+  // not have to already know the answer to know what was checked.
+  if (!changed.length) return { derivationHolds: true, derivationCheckedAgainst: 'index' };
   // Bounded: a finding with many anchors should not spend unbounded budget
   // naming every one that moved.
-  return { derivationHolds: false, derivationChanged: changed.slice(0, 5) };
+  return { derivationHolds: false, derivationChanged: changed.slice(0, 5), derivationCheckedAgainst: 'index' };
 }
 
 /**

--- a/hooks-core/staleness.mjs
+++ b/hooks-core/staleness.mjs
@@ -52,6 +52,7 @@ import { readFileSync, statSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { dirname, join } from 'node:path';
 import { putNode, putEdge, contentHash, nodeId } from './wiki.mjs';
+import { hasOutstandingContradiction } from './curate.mjs';
 import { extractSymbols, spanText, symbolKey, extractImports } from './symbols.mjs';
 import { canonicalPath, resolvableCandidates, isFsSafePath } from './paths.mjs';
 
@@ -452,6 +453,46 @@ export function diffLines(
 const CONTENT_DEPENDENT = new Set(['finding', 'map']);
 
 /**
+ * What, if anything, currently disagrees with this finding.
+ *
+ * DISCLOSED AT SERVE TIME, because that is the only moment the disagreement can
+ * do any good. `WIKI_GRAPH.md`'s whole argument for making `contradicts` an edge
+ * rather than an overwrite is that a reader "sees both claims and the
+ * disagreement between them" -- so handing a finding to a model while something
+ * in the graph disputes it, without saying so, throws away the reason the edge
+ * was recorded instead of an overwrite.
+ *
+ * `hasOutstandingContradiction` is the gate: it is the one definition of "an
+ * open dispute", shared with the confidence-promotion gate, so the two can never
+ * disagree about what counts. The loop only NAMES the other side, and it names a
+ * key rather than quoting a claim because the reader can call `wiki_query` with
+ * a key -- and because the injection path pays for every character it renders.
+ *
+ * SEPARATE FROM STALENESS on purpose. A finding can be disputed without being
+ * stale (nothing touched its anchor; another finding simply says otherwise) and
+ * stale without being disputed, so this adds its own fields rather than
+ * borrowing the stale ones, and the renderer discloses each on its own terms.
+ */
+function disputeOf(graph, finding) {
+  if (!hasOutstandingContradiction(graph, finding.key)) return {};
+
+  const keys = [];
+  for (const edge of graph.edges) {
+    if (edge.edge !== 'contradicts') continue;
+    const otherId =
+      edge.from === finding.id ? edge.to : edge.to === finding.id ? edge.from : null;
+    if (!otherId) continue;
+    const other = graph.nodes.get(otherId);
+    // An edge end that resolves to nothing names nothing. The dispute is still
+    // disclosed -- the gate above already established it -- but without a key
+    // the reader cannot be pointed anywhere, and inventing one would be worse.
+    if (other && typeof other.key === 'string' && !keys.includes(other.key)) keys.push(other.key);
+  }
+
+  return { contradicted: true, ...(keys.length ? { contradictedBy: keys.join(', ') } : {}) };
+}
+
+/**
  * Prepares findings for delivery, verifying each one lazily against disk.
  *
  * This is the only function that should ever hand a finding to a model, because
@@ -472,10 +513,17 @@ export function serve(graph, findings) {
   // quickly.
 
   for (const finding of findings.filter((f) => !f.retired)) {
+    // A DISPUTE TRAVELS WITH EVERY TYPE, which is why it is computed before the
+    // content-dependence branch below. A `command` or `rule` finding cannot be
+    // invalidated by an anchor's contents, but another finding can still
+    // disagree with it, and this early return is the path that would have
+    // quietly dropped that.
+    const dispute = disputeOf(graph, finding);
+
     // A claim that does not depend on the anchor's contents cannot be
     // invalidated by them. It is served as-is rather than discounted.
     if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) {
-      served.push({ ...finding });
+      served.push({ ...finding, ...dispute });
       continue;
     }
 
@@ -560,6 +608,7 @@ export function serve(graph, findings) {
       ...finding,
       stale,
       ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
+      ...dispute,
     });
   }
   return served;

--- a/hooks-core/staleness.mjs
+++ b/hooks-core/staleness.mjs
@@ -366,6 +366,12 @@ const DIFF_MAX_BYTES = () => {
  * line, and total bytes. Every truncation is announced in the output, because a
  * silently shortened diff is worse than a visibly shortened one -- a reader who
  * cannot tell content was elided believes they saw the whole change.
+ *
+ * `maxLines` BOUNDS THE BODY, MARKERS INCLUDED: at most `maxLines` lines of
+ * removed lines, added lines and "... N more" elision markers between them, plus
+ * at most one final notice when the byte cap dropped lines -- so `maxLines + 1`
+ * lines in total, and no more. That last line is outside the budget on purpose,
+ * for the reason stated where it is pushed.
  */
 export function diffLines(
   before,
@@ -416,10 +422,24 @@ export function diffLines(
     bytes += size;
   };
 
-  for (const line of removed.slice(0, maxLines / 2)) push('- ' + line);
-  if (removed.length > maxLines / 2) push(`  ... ${removed.length - maxLines / 2} more removed`);
-  for (const line of added.slice(0, maxLines / 2)) push('+ ' + line);
-  if (added.length > maxLines / 2) push(`  ... ${added.length - maxLines / 2} more added`);
+  // THE ELISION MARKER IS PAID FOR OUT OF THE SIDE'S OWN QUOTA, so `maxLines`
+  // bounds the whole body rather than only the content in it. It did not: at the
+  // default 40 the body could reach 42 lines -- 20 removed, 20 added and two
+  // "... N more" markers -- and the out-of-budget notice below made 43, against
+  // a documented bound of 40 and a test asserting 41. Three numbers, no two the
+  // same. A side that has to elide now shows one fewer content line and spends
+  // that line on saying so, which is the trade a reader wants anyway: knowing
+  // that 300 lines were cut matters more than the 20th of the 20 shown.
+  const half = Math.floor(maxLines / 2);
+  const emit = (lines, prefix, label) => {
+    const elides = lines.length > half;
+    const shown = elides ? Math.max(0, half - 1) : half;
+    for (const line of lines.slice(0, shown)) push(prefix + line);
+    if (elides) push(`  ... ${lines.length - shown} more ${label}`);
+  };
+
+  emit(removed, '- ', 'removed');
+  emit(added, '+ ', 'added');
 
   // Announced OUTSIDE the budget, deliberately: the one line a reader most
   // needs is the one saying the rest is missing, and dropping it to stay under
@@ -477,6 +497,15 @@ function disputeOf(graph, finding) {
   if (!hasOutstandingContradiction(graph, finding.key)) return {};
 
   const keys = [];
+  // AND THE REASON A PERSON TYPED, which had no reader anywhere. `contradict`
+  // stores `contradictionReason` -- up to 400 characters of human explanation --
+  // on the CONTRADICTED end only, and nothing outside its own test ever read it:
+  // this disclosure named the other key and stopped, `audit` counts ends, and the
+  // dashboard detail view renders neither. So the one field on the edge that says
+  // WHY was written on every contradiction and seen by nobody. It is collected
+  // from whichever end holds it, so both sides of a dispute disclose the same
+  // reason rather than only the claim that lost.
+  let reason = typeof finding.contradictionReason === 'string' ? finding.contradictionReason : '';
   for (const edge of graph.edges) {
     if (edge.edge !== 'contradicts') continue;
     const otherId =
@@ -495,10 +524,30 @@ function disputeOf(graph, finding) {
     // each name, so a live disputant is still reported alongside a withdrawn one.
     if (other && !other.retired && typeof other.key === 'string' && !keys.includes(other.key)) {
       keys.push(other.key);
+      // A RETIRED END'S REASON IS NOT BORROWED EITHER, which is why this sits
+      // inside the same guard as the key: `hasOutstandingContradiction` can be
+      // open on one live disputant while another is withdrawn, and quoting the
+      // withdrawn one's explanation would attribute the live dispute to a claim
+      // the reader cannot fetch.
+      if (!reason && typeof other.contradictionReason === 'string') {
+        reason = other.contradictionReason;
+      }
     }
   }
 
-  return { contradicted: true, ...(keys.length ? { contradictedBy: keys.join(', ') } : {}) };
+  return {
+    contradicted: true,
+    ...(keys.length ? { contradictedBy: keys.join(', ') } : {}),
+    // Trimmed here rather than at the renderer: an empty string is not a reason,
+    // and a consumer checking `if (reason)` should not have to trim first.
+    //
+    // SET UNCONDITIONALLY, INCLUDING TO `undefined`. `serve` spreads the stored
+    // record before this object, so omitting the key would let a whitespace-only
+    // stored reason through untouched and make the served value differ from the
+    // one this function decided on. The disclosure is authoritative or it is not
+    // a disclosure.
+    contradictionReason: reason.trim() || undefined,
+  };
 }
 
 /**
@@ -578,8 +627,15 @@ function derivationCheck(graph, finding) {
  * the dashboard, which left the rot path fully open on every install where
  * nobody opens the dashboard -- and that is most of them. The evidence test is
  * what makes clearing safe, and it does not care who triggered it: the same
- * `claimTimeVerdict` runs here as in `reverify`, so this cannot clear anything
+ * `claimTimeEvidence` runs here as in `reverify`, so this cannot clear anything
  * the button would not.
+ *
+ * A CLEAR ALSO RE-INDEXES THE ANCHORS IT VERIFIED. The three disclosures this
+ * function emits -- `stale`, `derivationHolds`, and the dispute -- are computed
+ * from three different comparisons, and clearing the flag without moving the
+ * anchor's stored hash made the first two contradict the clear on the revert
+ * path. `reindexVerifiedAnchors` explains the reproduction and why re-pointing
+ * the index is the fix rather than suppressing the disclosures.
  *
  * `dir` IS OPTIONAL, AND OMITTING IT MAKES THIS READ-ONLY. Several callers hold
  * a graph without the directory it came from, and a serve that silently did
@@ -615,11 +671,17 @@ export function serve(graph, findings, { dir = null } = {}) {
 
     // AUTOMATIC CLEARING, on the same evidence the manual path demands.
     //
-    // ONLY THE STORED FLAG IS TOUCHED. The lazy loop below is left to run
-    // exactly as before and can independently mark this finding stale again on
-    // its own comparison -- disk against the anchor NODE's hash -- which answers
-    // a different question and is not this function's to overrule. Eager and
-    // lazy stay two mechanisms, as the module header insists.
+    // THE FLAG AND THE INDEX MOVE TOGETHER. Clearing the flag alone made this
+    // function contradict itself on the revert path: the lazy loop below
+    // compares disk against the anchor NODE's hash, which the eager path
+    // re-pointed at the post-edit bytes, so a reverted file read as `stale:
+    // true, staleReason: 'file changed'` and `derivationHolds: false` inside the
+    // very object whose flag had just been cleared for matching its claim-time
+    // content. `reindexVerifiedAnchors` writes the verified bytes' hash back to
+    // the anchor, so all three disclosures are finally reading the same content
+    // and cannot disagree. Eager and lazy stay two mechanisms, as the module
+    // header insists -- what changed is that the index no longer holds a hash
+    // that matches no version of the file that exists.
     //
     // AND THE FIELDS GO WITH THE FLAG. `putNode` does not merge and neither does
     // this spread: serving `{ ...finding, stale: false }` would hand back a
@@ -628,12 +690,37 @@ export function serve(graph, findings, { dir = null } = {}) {
     // So the cleared record, not the stored one, is what the rest of this
     // iteration reads and spreads.
     //
-    // BOUNDED, and the bound is the point: this runs only for a finding whose
-    // flag is already STORED, only when a `derivation` record exists to check
-    // against, and it reads each of that finding's anchors at most once. A
-    // finding that is not flagged pays nothing. The lazy loop below already
+    // BOUNDED PER CALL, and the bound is the point: this runs only for a finding
+    // whose flag is already STORED, only when a `derivation` record exists to
+    // check against, and it reads each of that finding's anchors at most once.
+    // A finding that is not flagged pays nothing. The lazy loop below already
     // reads every anchor of every content-dependent finding served, so the worst
     // case is twice the anchor reads on the already-stale subset alone.
+    //
+    // AND THE PER-SESSION SHAPE, stated because the per-call bound alone reads
+    // as cheaper than it is. Measured on a synthetic 40-stale-finding graph, the
+    // serve path went 158 ms -> 217 ms (+37%), and for a GENUINELY stale finding
+    // that cost recurs on every call for the whole session: the verdict is
+    // `'differs'` forever, nothing is cleared, and the reads are repaid with
+    // nothing. What keeps it survivable in practice is not this bound but two
+    // others -- `findingsFor`'s result limit and inject.mjs's `alreadyInjected`
+    // gate, which together put it near 40 ms on the first touch of a hot file
+    // and zero on the touches after.
+    //
+    // THE REVERT CASE PAYS ONCE, AND THAT IS MEASURED, not argued. Same 40
+    // findings, all revertible, medians of 9 across three process launches: the
+    // read-only serve is 23-29 ms, the first clearing serve is 141-173 ms (the
+    // anchor reads plus one node append per cleared finding AND per re-pointed
+    // anchor), and the SECOND clearing serve is 21-28 ms -- back to the
+    // read-only baseline, because the flag is off and the index agrees, so this
+    // gate no longer fires. What the re-index changed is not that cost -- the
+    // gate stopped firing once the flag came off before, too -- but that every
+    // serve after the clear used to re-derive `stale: true` and
+    // `derivationHolds: false` from an index nobody had moved. The extra ~120 ms
+    // buys silence that is actually correct.
+    // On the genuinely-stale set the recurring cost is
+    // real and unchanged in kind: 26-45 ms read-only against 53-105 ms with
+    // clearing on, every call, clearing nothing.
     //
     // NOT ON THE NON-CONTENT-DEPENDENT EARLY RETURN ABOVE, deliberately. Both
     // eager paths refuse to flag those types at all, so a flag there can only
@@ -641,10 +728,14 @@ export function serve(graph, findings, { dir = null } = {}) {
     // does not depend on them is exactly the cost `CONTENT_DEPENDENT` exists to
     // avoid.
     let record = finding;
-    if (dir && finding.stale && claimTimeVerdict(graph, finding) === 'match') {
-      clearStale(dir, finding.key, { graph });
-      const { stale: _s, staleReason: _r, diff: _d, staleEvidence: _e, ...cleared } = finding;
-      record = cleared;
+    if (dir && finding.stale) {
+      const evidence = claimTimeEvidence(graph, finding);
+      if (evidence.verdict === 'match') {
+        reindexVerifiedAnchors(dir, graph, evidence.contents);
+        clearStale(dir, finding.key, { graph });
+        const { stale: _s, staleReason: _r, diff: _d, staleEvidence: _e, ...cleared } = finding;
+        record = cleared;
+      }
     }
 
     const anchors = graph.edges
@@ -734,6 +825,14 @@ export function serve(graph, findings, { dir = null } = {}) {
       // carries its `derivation`, since clearing removes only the staleness
       // fields. A finding whose flag was just cleared is still disclosed as
       // disputed, and still reports whether its derivation holds.
+      //
+      // AND THEY NO LONGER CONTRADICT THE CLEAR. Surviving is not the same as
+      // agreeing: for a whole serve this returned `stale: true, staleReason:
+      // 'file changed'` and `derivationHolds: false` on a finding it had just
+      // cleared, because the clear was decided against disk while these two read
+      // the anchor node's hash, and the eager path had moved it. All three now
+      // read the same content because the clear re-points the anchor; see
+      // `reindexVerifiedAnchors`.
       ...dispute,
       // Independent of `stale` above: see `derivationCheck`'s own comment for
       // the case it catches that node-level staleness can miss.
@@ -932,6 +1031,34 @@ export function invalidateChangedAnchors(dir, graph, rawPath) {
 }
 
 /**
+ * The current content of an anchor, read from disk: the whole file for a file
+ * anchor, the located span for a symbol one. Null when nothing can be read.
+ *
+ * SPLIT OUT FROM `anchorHashNow` SO THE BYTES SURVIVE THE COMPARISON. The
+ * clearing path hashes this to reach a verdict and, on `'match'`, re-indexes the
+ * anchor from the same bytes -- see `reindexVerifiedAnchors`. Returning only a
+ * hash forced a second read of a file that had just been read, for content
+ * already known to be identical.
+ */
+function anchorContentNow(anchor) {
+  const path = anchor.kind === 'symbol' ? anchor.file : anchor.key;
+  let source;
+  try {
+    source = readAnySpelling(path);
+  } catch {
+    return null;
+  }
+  if (anchor.kind !== 'symbol') return source;
+
+  // By NAME, like checkAnchor: line numbers shift whenever anything above is
+  // edited, and re-locating by line would report a symbol as moved when only an
+  // unrelated insert happened above it.
+  const current = extractSymbols(path, source).find((s) => s.name === anchor.name);
+  if (!current) return null;
+  return spanText(source, current);
+}
+
+/**
  * The current content hash of an anchor, read from disk.
  *
  * DELIBERATELY NOT `checkAnchor`, and the difference is the whole of this
@@ -950,21 +1077,8 @@ export function invalidateChangedAnchors(dir, graph, rawPath) {
  * content it was made against.
  */
 function anchorHashNow(anchor) {
-  const path = anchor.kind === 'symbol' ? anchor.file : anchor.key;
-  let source;
-  try {
-    source = readAnySpelling(path);
-  } catch {
-    return null;
-  }
-  if (anchor.kind !== 'symbol') return hash(source);
-
-  // By NAME, like checkAnchor: line numbers shift whenever anything above is
-  // edited, and re-locating by line would report a symbol as moved when only an
-  // unrelated insert happened above it.
-  const current = extractSymbols(path, source).find((s) => s.name === anchor.name);
-  if (!current) return null;
-  return hash(spanText(source, current));
+  const content = anchorContentNow(anchor);
+  return content === null ? null : hash(content);
 }
 
 /**
@@ -1003,21 +1117,51 @@ export function clearStale(dir, key, { graph = null } = {}) {
   // `contradict`, `correct` -- writes from a graph it loaded earlier too. Both
   // callers here already DECIDED on this snapshot, so re-reading it purely for
   // the write narrowed no window that was ever closed.
-  const node = (graph || load(dir)).nodes.get(nodeId('finding', key));
+  const id = nodeId('finding', key);
+  const node = (graph || load(dir)).nodes.get(id);
   if (!node || node.kind !== 'finding') return false;
   const { stale, staleReason, diff, staleEvidence, ...rest } = node;
   // Nothing to clear is a success, not a write: an unconditional putNode here
   // would append a duplicate record to the log on every no-op call.
   if (stale === undefined && staleReason === undefined
     && diff === undefined && staleEvidence === undefined) return true;
-  putNode(dir, { ...rest, kind: 'finding', key: node.key });
+  const cleared = { ...rest, kind: 'finding', key: node.key };
+  putNode(dir, cleared);
+  // AND THE CALLER'S GRAPH IS UPDATED, because the guard above reads THAT graph,
+  // not disk. Without this, a second `serve` on the same in-memory graph object
+  // -- two touched files anchored to one finding, or a lifecycle branch that
+  // serves twice from a graph it loaded once, as SessionStart does -- still saw
+  // `stale: true`, re-ran the evidence test, and appended a byte-identical clear
+  // record. The store is append-only, so that is permanent log growth for no
+  // change in state, and the "nothing to clear is a success, not a write"
+  // guarantee directly above was only true of the first call.
+  if (graph) graph.nodes.set(id, { ...cleared, id });
   return true;
 }
 
 /**
- * Clears a stale flag when, and only when, the evidence for it is gone.
+ * THE ONE EVIDENCE TEST, plus the bytes it read. Does this finding's anchored
+ * content still hash to what the claim was actually made against?
  *
- * WHY THIS HAS TO EXIST. Nothing in this codebase ever cleared a `stale` flag.
+ * `verdict` is one of:
+ *   `'match'`   -- every anchor on disk re-hashes to the value frozen into this
+ *                  finding's own `derivation.anchors` at claim time. The content
+ *                  IS what the claim was derived from: a revert, or a write that
+ *                  never moved the anchored bytes.
+ *   `'differs'` -- at least one anchor does not, INCLUDING an anchor whose
+ *                  content is gone. Deleted is a difference, not a missing
+ *                  measurement.
+ *   `'unknown'` -- there is nothing to compare: no `derivation.anchors`, no
+ *                  anchors, an anchor with no recorded hash, or one that no
+ *                  longer resolves.
+ *
+ * `contents` carries the disk bytes read to reach a `'match'`, keyed by anchor
+ * id, so the caller can re-index those anchors without reading them again. It is
+ * empty for the other two verdicts, which read no further than the first
+ * disagreement.
+ *
+ * WHY CLEARING HAS TO EXIST AT ALL. Nothing in this codebase ever cleared a
+ * `stale` flag.
  * That was harmless while eager invalidation was dead code; it fires now, so
  * every finding on an edited file becomes permanently stale -- and permanently
  * discounted, since `disclose.mjs` skips a stale finding outright and
@@ -1047,24 +1191,6 @@ export function clearStale(dir, key, { graph = null } = {}) {
  * side door. It reports `unknown` and changes nothing; re-recording the claim
  * against the current code (`curate.correct`) is the way forward for those.
  *
- * DELIBERATELY NOT AUTOMATIC. This reads every anchor off disk, so running it on
- * the serve path would put N file reads inside injection -- and, worse, it would
- * silently un-mark findings nobody asked about. Staleness is disclosed to a
- * reader who then decides; clearing is an explicit act.
- */
-/**
- * THE ONE EVIDENCE TEST. Does this finding's anchored content still hash to what
- * the claim was actually made against?
- *
- * `'match'` -- every anchor on disk re-hashes to the value frozen into this
- * finding's own `derivation.anchors` at claim time. The content IS what the
- * claim was derived from: a revert, or a write that never moved the anchored
- * bytes.
- * `'differs'` -- at least one anchor does not, INCLUDING an anchor whose content
- * is gone. Deleted is a difference, not a missing measurement.
- * `'unknown'` -- there is nothing to compare: no `derivation.anchors`, no
- * anchors, an anchor with no recorded hash, or one that no longer resolves.
- *
  * SHARED BY BOTH CLEARING PATHS ON PURPOSE, and that sharing is the guarantee
  * rather than a convenience. `reverify` (a person pressing Re-verify) and
  * `serve` (automatic, on every retrieval) call THIS function and nothing else,
@@ -1078,9 +1204,10 @@ export function clearStale(dir, key, { graph = null } = {}) {
  * re-point at the very bytes that caused the mark, so it answers "fresh" for
  * exactly the finding it just marked stale.
  */
-function claimTimeVerdict(graph, finding) {
+function claimTimeEvidence(graph, finding) {
+  const none = { verdict: 'unknown', contents: new Map() };
   const recorded = finding.derivation && finding.derivation.anchors;
-  if (!recorded || typeof recorded !== 'object') return 'unknown';
+  if (!recorded || typeof recorded !== 'object') return none;
 
   const anchorIds = new Set(
     graph.edges
@@ -1090,22 +1217,122 @@ function claimTimeVerdict(graph, finding) {
   // An unanchored finding cannot be checked against anything, which is the
   // un-invalidatable shape the anchor discipline exists to refuse. It is equally
   // un-VERIFIABLE, so it is reported as such rather than cleared.
-  if (!anchorIds.size) return 'unknown';
+  if (!anchorIds.size) return none;
 
+  const contents = new Map();
   for (const id of anchorIds) {
     const expected = recorded[id];
     const node = graph.nodes.get(id);
     // An anchor this finding never recorded a hash for, or one that no longer
     // resolves to a node: nothing to compare, so nothing is concluded.
-    if (typeof expected !== 'string' || !expected || !node) return 'unknown';
-    if (node.kind !== 'file' && node.kind !== 'symbol') return 'unknown';
+    if (typeof expected !== 'string' || !expected || !node) return none;
+    if (node.kind !== 'file' && node.kind !== 'symbol') return none;
     // null means the content is gone -- deleted file, vanished symbol. That is a
     // difference, not an absence of evidence.
-    if (anchorHashNow(node) !== expected) return 'differs';
+    const content = anchorContentNow(node);
+    if (content === null || hash(content) !== expected) {
+      return { verdict: 'differs', contents: new Map() };
+    }
+    contents.set(id, content);
   }
-  return 'match';
+  return { verdict: 'match', contents };
 }
 
+/** The verdict alone, for callers that do not re-index. */
+function claimTimeVerdict(graph, finding) {
+  return claimTimeEvidence(graph, finding).verdict;
+}
+
+/**
+ * Re-points every verified anchor at the content the evidence test just read.
+ *
+ * WHY A CLEAR IS NOT ENOUGH ON ITS OWN, reproduced end to end: index a file at
+ * H1, write a finding whose `derivation.anchors` records H1, edit and re-index so
+ * the node holds H2, let the eager path mark the finding, then REVERT the edit on
+ * disk. `claimTimeVerdict` now says `'match'` -- disk is H1, which is exactly
+ * what the claim was derived from -- and the flag comes off. But the node still
+ * holds H2, so the same `serve` call went on to emit `stale: true` with
+ * `staleReason: 'file changed'` from the lazy loop (disk H1 against node H2) and
+ * `derivationHolds: false` from `derivationCheck` (index H2 against claim H1).
+ * The model was shown DERIVATION CHANGED and STALE at the exact moment this
+ * module's own evidence test had concluded the derivation holds -- on every
+ * serve, until something unrelated happened to re-index the anchor.
+ *
+ * THE FIX IS TO MOVE THE INDEX, NOT TO SILENCE THE DISCLOSURES. Suppressing the
+ * lazy check and the derivation verdict for a cleared finding would leave the
+ * graph holding a hash that matches no version of the file that exists, so every
+ * OTHER finding on that anchor keeps reading stale, and the next reader has to be
+ * told which disclosures to disbelieve. The node hash is simply out of date, the
+ * bytes are already in hand from the comparison that just succeeded, and writing
+ * them makes all three disclosures agree because they are finally reading the
+ * same content.
+ *
+ * COSTS NO READ. `contents` comes from `claimTimeEvidence`, which read each
+ * anchor to reach `'match'`. The write is one node record per anchor whose hash
+ * actually moved, and it happens once per revert rather than once per serve: with
+ * the index re-pointed, the flag stays off and the gate in `serve` does not fire
+ * again.
+ *
+ * THE IN-MEMORY GRAPH IS UPDATED TOO, because the caller is mid-serve and is
+ * about to read these same nodes through the lazy loop and `derivationCheck`.
+ * Writing only to disk would fix the next process and leave this one contradicting
+ * itself, which is the whole defect.
+ *
+ * Line numbers are deliberately left alone on a symbol anchor: `checkAnchor` and
+ * `anchorContentNow` both re-locate by NAME, so a stored line is informational,
+ * and the body being byte-identical is what was just established.
+ */
+function reindexVerifiedAnchors(dir, graph, contents) {
+  for (const [id, content] of contents) {
+    const node = graph.nodes.get(id);
+    if (!node) continue;
+    const nextHash = hash(content);
+    // Already agrees: no record, no write. The common case once a revert has
+    // been accounted for.
+    if (node.hash === nextHash) continue;
+    const limit = node.kind === 'symbol' ? symbolSnapshotLimit() : snapshotLimit();
+    // Same bound as `indexFile`: past the cap the hash still drives staleness and
+    // only the reconstructed diff degrades.
+    const snapshot = content.length <= limit ? content : undefined;
+    const { hash: _h, snapshot: _s, ...rest } = node;
+    try {
+      putNode(dir, { ...rest, kind: node.kind, key: node.key, hash: nextHash, snapshot });
+    } catch {
+      // Fail open: a graph that could not be written is a disclosure that stays
+      // as it was, never a broken tool call. The in-memory copy is left alone to
+      // match, so this serve keeps agreeing with the store.
+      continue;
+    }
+    graph.nodes.set(id, { ...node, hash: nextHash, ...(snapshot ? { snapshot } : {}) });
+  }
+}
+
+/**
+ * Clears a stale flag on behalf of a person who asked for it -- the dashboard's
+ * Re-verify action -- and reports what the evidence said.
+ *
+ * `'cleared'` when the flag is gone (including when it was already gone, so a
+ * caller polling this does not retry forever), `'still-stale'` when the anchored
+ * content genuinely differs from what the claim was made against, `'unknown'`
+ * when there is nothing to compare and therefore nothing to conclude.
+ *
+ * NO LONGER THE ONLY CLEARING PATH, and the docblock that used to sit here said
+ * the opposite: that automatic clearing was refused because it would put N file
+ * reads inside injection and "silently un-mark findings nobody asked about".
+ * `serve` now does exactly that, on the same evidence, for the reason its own
+ * comment gives -- the manual path was reachable only where somebody opens the
+ * dashboard, which is almost nowhere, so the rot path stayed open on most
+ * installs. What survives of that objection is the cost, which `serve` bounds
+ * and states.
+ *
+ * WHAT THIS STILL ADDS over the automatic path: it loads the graph itself, so a
+ * caller holding nothing but a key and a directory can act; it reports the
+ * verdict rather than folding it into a served record; and it runs on demand
+ * rather than only when the finding happens to be retrieved. It re-indexes the
+ * verified anchors for the same reason `serve` does -- otherwise the button
+ * clears the flag and the very next retrieval re-derives a contradiction from a
+ * node hash nobody moved.
+ */
 export function reverify(dir, key) {
   const graph = load(dir);
   const finding = graph.nodes.get(nodeId('finding', key));
@@ -1114,9 +1341,10 @@ export function reverify(dir, key) {
   // holds, and reporting anything else would make a caller retry forever.
   if (!finding.stale) return 'cleared';
 
-  const verdict = claimTimeVerdict(graph, finding);
+  const { verdict, contents } = claimTimeEvidence(graph, finding);
   if (verdict === 'unknown') return 'unknown';
   if (verdict === 'differs') return 'still-stale';
+  reindexVerifiedAnchors(dir, graph, contents);
   clearStale(dir, key, { graph });
   return 'cleared';
 }

--- a/hooks-core/staleness.mjs
+++ b/hooks-core/staleness.mjs
@@ -29,6 +29,23 @@
  * Eager alone would silently serve stale findings as fresh whenever a change
  * came from outside the agent, which is the single failure mode the design
  * calls worse than no graph.
+ *
+ * AND LAZY ALONE IS BLIND TO THE AGENT'S OWN WRITES -- not degraded, BLIND.
+ * `indexFile` re-points an anchor's stored hash at the bytes it was just handed,
+ * and it is called on every file either hook observes: pretooluse-router.mjs
+ * (two call sites) and adapter.mjs (one). The lazy check then compares that
+ * refreshed hash against the same disk it came from and finds them equal. So
+ * for a file the session edited ITSELF, the lazy path cannot detect the change
+ * at all, and the finding derived from the pre-edit content is served CLEAN.
+ *
+ * Which means that until the eager path was connected, staleness for a file the
+ * agent edited did not work AT ALL: eager was dead code and lazy was defeated
+ * by re-indexing. Every account of this defect, including the one in this
+ * module's own git history, called it "lazy-only, therefore degraded". It was
+ * not degraded. `stale-before-reindex.test.mjs` states in its header that this
+ * case is covered by `invalidateOnWrite`, and `invalidateOnWrite` had never run
+ * once in production. The two paths are not redundant and never were: each is
+ * the ONLY cover for a whole class of change.
  */
 
 import { readFileSync, statSync } from 'node:fs';
@@ -620,6 +637,119 @@ export function invalidateOnWrite(dir, graph, rawPath, beforeText, afterText) {
   // Re-index so the anchors carry the new hashes; otherwise the lazy path would
   // report the same change again on every future retrieval.
   indexFile(dir, path, afterText);
+  return marked;
+}
+
+/**
+ * The eager path for a write with NO before/after pair: compare stored hashes
+ * against disk, and mark what actually moved.
+ *
+ * WHY THIS EXISTS AS A SECOND SHAPE. A whole-file `Write` replaces the file, so
+ * the payload carries the after side and nothing at all of the before -- and a
+ * whole-file write is the commonest write shape there is. `invalidateOnWrite`
+ * cannot serve it: passing '' as the before side makes every symbol in the file
+ * look changed, marks every finding anchored anywhere in it, and the eager mark
+ * is a stored flag no later check ever clears. False-stale is expensive and
+ * permanent, so it is not an acceptable price for coverage.
+ *
+ * But the hash comparison is available, and it is exactly the comparison the
+ * lazy path makes. The difference is WHEN: this runs at the top of injection,
+ * before `indexFile` refreshes the anchor, so the stored hash is still the
+ * pre-write one and the comparison is meaningful. That is the whole trick --
+ * lazy is not wrong, it is merely too late.
+ *
+ * SYMBOL-LEVEL, and from ONE read. Re-locating each symbol by name and
+ * comparing its own span hash is what keeps this from degenerating into
+ * file-level marking: editing one function must not stale a finding about
+ * another, which is the property symbol nodes exist to provide.
+ *
+ * WEAKER EVIDENCE, STATED AS SUCH. There is no before text, so no diff can be
+ * built -- the finding is marked with the two hashes and `serve` reports the
+ * evidence gap through `staleEvidence: false`, which the renderer turns into
+ * "no diff could be rebuilt" rather than promising a diff and showing nothing.
+ * A stale finding with weak evidence is far better than one served as fresh,
+ * but the reader has to be able to tell which one they are holding.
+ */
+export function invalidateChangedAnchors(dir, graph, rawPath) {
+  const path = canonicalPath(rawPath);
+  const marked = [];
+
+  // ONE read for the file and every symbol in it. checkAnchor would have been
+  // the obvious reuse and it reads per anchor, which on a file with fifty
+  // symbols is fifty-one reads of the same bytes on a hook path.
+  let source = null;
+  try {
+    source = readAnySpelling(path);
+  } catch {
+    // Deleted, or unreadable from this checkout. Handled below as a change,
+    // because a finding about a file that is no longer there is exactly the
+    // kind that must not be served as fresh.
+  }
+
+  const changed = [];
+  const fileNode = graph.nodes.get(nodeId('file', path));
+  const fileDigest = source === null ? null : hash(source);
+  if (fileNode && fileDigest !== fileNode.hash) {
+    changed.push({ node: fileNode, from: fileNode.hash, to: fileDigest });
+  }
+
+  const current = new Map(
+    source === null
+      ? []
+      : extractSymbols(path, source).map((s) => [s.name, hash(spanText(source, s))])
+  );
+  for (const node of graph.nodes.values()) {
+    if (node.kind !== 'symbol' || node.file !== path) continue;
+    const digest = current.has(node.name) ? current.get(node.name) : null;
+    if (digest !== node.hash) changed.push({ node, from: node.hash, to: digest });
+  }
+
+  if (changed.length) {
+    // Indexed once by target, for the reason invalidateOnWrite indexes: the
+    // nested alternative is O(nodes x edges) inside a hook.
+    const byTarget = new Map();
+    for (const edge of graph.edges) {
+      if (edge.edge !== 'derived_from') continue;
+      if (!byTarget.has(edge.to)) byTarget.set(edge.to, []);
+      byTarget.get(edge.to).push(edge);
+    }
+
+    for (const { node, from, to } of changed) {
+      for (const edge of byTarget.get(node.id) || []) {
+        const finding = graph.nodes.get(edge.from);
+        if (!finding || finding.kind !== 'finding') continue;
+        // The same type gate serve() applies, for the same reason it is applied
+        // in invalidateOnWrite: the flag is STORED, and disclose.mjs skips a
+        // stale finding while utility.mjs penalises one by 160.
+        if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) continue;
+        // ALREADY MARKED IS LEFT ALONE. Whatever marked it first had a diff or
+        // a more specific reason; overwriting that with a hash pair trades real
+        // evidence for less.
+        if (finding.stale) continue;
+
+        putNode(dir, {
+          ...finding,
+          kind: 'finding',
+          key: finding.key,
+          stale: true,
+          staleReason:
+            to === null
+              ? `the ${node.kind} it depends on is no longer present (was ${from})`
+              : `content hash changed during this session (${from} -> ${to}), observed without a before/after pair`,
+          // EXPLICITLY EMPTY, not absent. serve() reports `staleEvidence` from
+          // whether a diff survived, and the renderer says "no diff could be
+          // rebuilt" -- so the reader can tell "changed, diff unknown" from
+          // "changed, here is what changed".
+          diff: '',
+        });
+        marked.push(finding.key);
+      }
+    }
+  }
+
+  // Re-index for the same reason the diff path does: otherwise every future
+  // retrieval re-reports a change that has already been accounted for.
+  if (source !== null) indexFile(dir, path, source);
   return marked;
 }
 

--- a/hooks-core/staleness.mjs
+++ b/hooks-core/staleness.mjs
@@ -15,7 +15,13 @@
  * TWO INVALIDATION PATHS, and each covers what the other cannot see:
  *
  *   EAGER  -- our PostToolUse hook saw a write, so the finding is marked at the
- *             moment it went stale, with the exact before/after in hand.
+ *             moment it went stale, with the exact before/after in hand. The
+ *             hook does not call `invalidateOnWrite` directly: it queues the
+ *             evidence through pending.mjs, and the next graph read -- which
+ *             loads the graph anyway -- applies it before serving anything.
+ *             That path is also the only one that catches a write the SESSION
+ *             made, because the lazy check below compares the stored hash
+ *             against disk and `indexFile` has already refreshed it.
  *   LAZY   -- at retrieval, the anchor's stored hash is compared against disk.
  *             This is what catches `git pull`, another editor, a teammate, or a
  *             build step: every change our hooks never observed.
@@ -289,14 +295,69 @@ export function checkAnchor(anchor) {
 }
 
 /**
+ * Characters kept from any single diff line.
+ *
+ * A LINE CAP IS NOT A SIZE CAP, and the gap was measured: with only `maxLines`
+ * in force, `diffLines('X'.repeat(200000), 'Y'.repeat(200000))` returned 2 lines
+ * and 400,005 bytes. Minified bundles, generated sources and single-line JSON
+ * all have that shape, and this output goes STRAIGHT INTO MODEL CONTEXT from
+ * inject.mjs's zero-turn refusal -- so a line bound alone let one pathological
+ * file spend hundreds of thousands of tokens.
+ *
+ * 200 characters is chosen because it is past the width at which a line is read
+ * as a line by anybody, human or model: a hand-written source line is under
+ * ~120 columns, so the cap cannot truncate a diff a reader was going to use,
+ * while the cases it does truncate are ones where the interesting change is not
+ * legible from the raw text anyway.
+ */
+const DIFF_MAX_LINE_CHARS = () => {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_DIFF_MAX_LINE_CHARS);
+  return Number.isFinite(raw) && raw > 0 ? raw : 200;
+};
+
+/**
+ * Total UTF-8 bytes of diff body.
+ *
+ * 4,000 bytes is roughly 1,000 tokens. It is deliberately larger than the
+ * per-file injection budget (`TOKEN_OPTIMIZER_TOUCH_BUDGET`, 500 tokens) and
+ * far smaller than a file, because the two consumers want different things: the
+ * injection surface fits the diff inside its own budget and drops it if it does
+ * not fit, while the zero-turn refusal is replacing a whole file read and can
+ * afford more. One cap that neither consumer has to think about is worth more
+ * than two tuned ones.
+ *
+ * WHAT IT COSTS, PLAINLY: a legitimately large diff now arrives truncated, so a
+ * model looking at a 300-line refactor sees the head of it and a count of what
+ * was elided rather than the whole change. That is the correct direction to
+ * fail -- the alternative was a bounded-looking function that could emit 400 KB.
+ */
+const DIFF_MAX_BYTES = () => {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_DIFF_MAX_BYTES);
+  return Number.isFinite(raw) && raw > 0 ? raw : 4_000;
+};
+
+/**
  * A compact line diff.
  *
  * Deliberately not a full unified diff with hunks and context: the consumer is
  * a model deciding whether an existing conclusion still holds, and for that the
  * changed lines are the signal. Output is capped because an unbounded diff
  * injected alongside a finding would spend more tokens than re-deriving it.
+ *
+ * BOUNDED IN THREE WAYS, and each one is load-bearing: lines, characters per
+ * line, and total bytes. Every truncation is announced in the output, because a
+ * silently shortened diff is worse than a visibly shortened one -- a reader who
+ * cannot tell content was elided believes they saw the whole change.
  */
-export function diffLines(before, after, { maxLines = 40 } = {}) {
+export function diffLines(
+  before,
+  after,
+  {
+    maxLines = 40,
+    maxLineChars = DIFF_MAX_LINE_CHARS(),
+    maxBytes = DIFF_MAX_BYTES(),
+  } = {}
+) {
   const a = String(before).split('\n');
   const b = String(after).split('\n');
 
@@ -312,33 +373,44 @@ export function diffLines(before, after, { maxLines = 40 } = {}) {
   const added = b.slice(head, b.length - tail);
 
   const out = [];
-  for (const line of removed.slice(0, maxLines / 2)) out.push('- ' + line);
-  if (removed.length > maxLines / 2) out.push(`  ... ${removed.length - maxLines / 2} more removed`);
-  for (const line of added.slice(0, maxLines / 2)) out.push('+ ' + line);
-  if (added.length > maxLines / 2) out.push(`  ... ${added.length - maxLines / 2} more added`);
+  let bytes = 0;
+  let dropped = 0;
+
+  // Per line first, so ONE enormous line cannot consume the whole budget and
+  // leave every other changed line unrepresented.
+  const clamp = (line) => {
+    const text = String(line);
+    if (text.length <= maxLineChars) return text;
+    return `${text.slice(0, maxLineChars)} [+${text.length - maxLineChars} chars cut]`;
+  };
+
+  // Bytes, not characters: the cap exists to bound what is sent, and a
+  // multi-byte source file would otherwise pass a character check while
+  // emitting several times the budget.
+  const push = (line) => {
+    const text = clamp(line);
+    const size = Buffer.byteLength(text, 'utf8') + 1;
+    if (bytes + size > maxBytes) {
+      dropped++;
+      return;
+    }
+    out.push(text);
+    bytes += size;
+  };
+
+  for (const line of removed.slice(0, maxLines / 2)) push('- ' + line);
+  if (removed.length > maxLines / 2) push(`  ... ${removed.length - maxLines / 2} more removed`);
+  for (const line of added.slice(0, maxLines / 2)) push('+ ' + line);
+  if (added.length > maxLines / 2) push(`  ... ${added.length - maxLines / 2} more added`);
+
+  // Announced OUTSIDE the budget, deliberately: the one line a reader most
+  // needs is the one saying the rest is missing, and dropping it to stay under
+  // a self-imposed cap would hand back a diff that lies about being complete.
+  if (dropped) out.push(`  ... ${dropped} more changed line(s) cut at the size limit`);
 
   return out.join('\n');
 }
 
-/**
- * Prepares findings for delivery, verifying each one lazily against disk.
- *
- * This is the only function that should ever hand a finding to a model, because
- * it is the one that enforces the rule: a stale finding leaves here carrying
- * `stale: true` AND a diff, or it does not leave at all.
- */
-export function serve(graph, findings) {
-  const served = [];
-
-  // RETIRED FINDINGS STOP HERE, unconditionally.
-  //
-  // findingsFor and sessionIndex already filter them, so this is redundant on
-  // every current path -- deliberately. This function's own contract is that it
-  // is the only thing that hands a finding to a model, which makes it the right
-  // place for the guarantee to live: a future caller that reaches into the
-  // graph directly cannot accidentally serve a claim a human explicitly
-  // withdrew. A withheld claim reappearing is not a bug anyone would notice
-  // quickly.
 /**
  * Types whose truth is a claim ABOUT the anchor's contents.
  *
@@ -361,6 +433,26 @@ export function serve(graph, findings) {
  * to ignore -- taking the rare true positive with it.
  */
 const CONTENT_DEPENDENT = new Set(['finding', 'map']);
+
+/**
+ * Prepares findings for delivery, verifying each one lazily against disk.
+ *
+ * This is the only function that should ever hand a finding to a model, because
+ * it is the one that enforces the rule: a stale finding leaves here carrying
+ * `stale: true` AND a diff, or it does not leave at all.
+ */
+export function serve(graph, findings) {
+  const served = [];
+
+  // RETIRED FINDINGS STOP HERE, unconditionally.
+  //
+  // findingsFor and sessionIndex already filter them, so this is redundant on
+  // every current path -- deliberately. This function's own contract is that it
+  // is the only thing that hands a finding to a model, which makes it the right
+  // place for the guarantee to live: a future caller that reaches into the
+  // graph directly cannot accidentally serve a claim a human explicitly
+  // withdrew. A withheld claim reappearing is not a bug anyone would notice
+  // quickly.
 
   for (const finding of findings.filter((f) => !f.retired)) {
     // A claim that does not depend on the anchor's contents cannot be
@@ -503,6 +595,15 @@ export function invalidateOnWrite(dir, graph, rawPath, beforeText, afterText) {
     for (const edge of byTarget.get(node.id) || []) {
       const finding = graph.nodes.get(edge.from);
       if (!finding || finding.kind !== 'finding') continue;
+      // THE SAME TYPE GATE `serve` APPLIES, and it has to be here too now that
+      // this path actually runs. `serve` ignores a stale flag on a type whose
+      // truth is not a claim about the anchor's contents -- but the flag is
+      // STORED, and disclose.mjs skips a stale finding outright while
+      // utility.mjs penalises one by 160. So writing it onto a `failure` or a
+      // `command` would suppress that claim everywhere except the one reader
+      // that knows to ignore it, which is exactly the harm measured in the
+      // comment on CONTENT_DEPENDENT above.
+      if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) continue;
 
       putNode(dir, {
         ...finding,

--- a/hooks-core/waste.mjs
+++ b/hooks-core/waste.mjs
@@ -149,6 +149,11 @@ function reDerivation(events, graph) {
       const id = nodeId('file', canonicalPath(row.anchor));
       if (!graph.nodes.has(id)) continue;
 
+      // READ-ONLY serve: no `dir` is threaded here, so this cannot clear a stale
+      // flag whose evidence is gone. That is deliberate -- this function takes a
+      // graph, not the directory it came from, and widening its signature to give
+      // an analysis path a write capability buys nothing: the injection path runs
+      // on every tool call and clears the same findings.
       const findings = serve(graph, findingsFor(graph, id, { limit: 3 }))
         .filter((f) => !f.stale && (f.confidence ?? 0) >= 0.7);
       if (!findings.length) continue;

--- a/hooks-core/wiki.mjs
+++ b/hooks-core/wiki.mjs
@@ -773,7 +773,17 @@ function readSnapshots(dir) {
           unreadable.push(line);
           continue;
         }
+        // A RECORD WITH NO `id` IS KEPT VERBATIM, NOT DROPPED SILENTLY. It
+        // cannot be attributed to a node, so it is useless to `load` -- but this
+        // used to put it in neither bucket, and `compactIfWasteful` rebuilds the
+        // sidecar from `records` plus `unreadable`, so a line in neither was
+        // deleted permanently by the next compaction. That is the same shape as
+        // the Critical this reader's version check already fixed, and the same
+        // asymmetry: for the compactor, "ignore" and "destroy" are one operation.
+        // Unreachable today because every writer sets `id`; a reader is not the
+        // right place to rely on that.
         if (rec.id) out.push(upcast(rec));
+        else unreadable.push(line);
       } catch {
         // A torn line costs one snapshot -- and it is NOT preserved, because a
         // half-written line is not a record from another version, it is

--- a/hooks-core/wiki.mjs
+++ b/hooks-core/wiki.mjs
@@ -62,18 +62,37 @@ export const SUPPORTED_VERSIONS = [1];
  * Identity today because GRAPH_VERSION is 1 and no shape has changed. It exists
  * now so the first change that DOES need it has somewhere to go other than an
  * equality check that silently deletes user data.
+ *
+ * CONTRACT for the first non-identity step:
+ *  - It must be IDEMPOTENT. `upcast(upcast(r))` must equal `upcast(r)`, because
+ *    compaction upcasts a record to key it and `load` upcasts the same record
+ *    again on every subsequent read. A step that is not idempotent applies twice
+ *    to anything compaction has touched.
+ *  - It must NOT be relied on to restamp `v`. Nothing in this file writes an
+ *    upcast record back to disk under a version it did not come from; the
+ *    version stamp on disk is always the one that wrote the bytes. See the
+ *    per-branch comments in `compactIfWasteful`.
  */
 export function upcast(record) {
   return record;
 }
 
-/** True when this reader can interpret the record at all. */
-function readable(record) {
+/**
+ * True when this reader can interpret the record at all.
+ *
+ * `versions` is a PARAMETER so the range semantics are testable independently of
+ * today's constants. With `SUPPORTED_VERSIONS = [1]` and `GRAPH_VERSION = 1` a
+ * range check and the old equality check are extensionally identical, so a test
+ * pinned to the live constants cannot tell them apart -- and cannot fail if
+ * someone reverts this to an equality. Exercised against `[1, 2]`, it can.
+ */
+export function readable(record, versions = SUPPORTED_VERSIONS) {
   const version = record.v ?? 0;
   // Forward-incompatible records are skipped: a v-from-the-future was written by
-  // a newer client and we cannot know its shape. Ignoring the future is safe;
-  // ignoring the past is data loss.
-  return SUPPORTED_VERSIONS.includes(version);
+  // a newer client and we cannot know its shape. Ignoring the future is safe for
+  // a READER -- but see `compactIfWasteful`, where "ignore" would mean "delete",
+  // because compaction rewrites the files it reads.
+  return versions.includes(version);
 }
 
 /** Node kinds. `file` and `symbol` are first-class so staleness can propagate. */
@@ -432,9 +451,20 @@ function compactIfWasteful(dir) {
     const nodes = new Map();
     const edges = new Map();
     const snaps = new Map();
-    for (const rec of readSnapshots(dir)) {
+    // KEPT VERBATIM THROUGH THE REBUILD, exactly as the main log keeps what it
+    // cannot parse. These lines are not evictable by the snapshot budget below
+    // because their size cannot be attributed to an id we understand -- and
+    // preserving bytes we may not need is strictly better than deleting bytes a
+    // newer client does. They stop accumulating as soon as the client that
+    // wrote them compacts, since it can read and dedupe them.
+    const sidecar = readSnapshots(dir);
+    const rawSnaps = sidecar.unreadable;
+    for (const rec of sidecar.records) {
       if (typeof rec.snapshot === 'string' && rec.snapshot) {
-        snaps.set(rec.id, { at: rec.at || 0, snapshot: rec.snapshot });
+        // `v` IS CARRIED, not restamped. Writing GRAPH_VERSION over a record
+        // from another version mislabels bytes this reader did not produce, and
+        // the label is the only thing a future reader has to go on.
+        snaps.set(rec.id, { at: rec.at || 0, snapshot: rec.snapshot, v: rec.v ?? GRAPH_VERSION });
       }
     }
     for (const line of readFileSync(path, 'utf8').split('\n')) {
@@ -456,27 +486,40 @@ function compactIfWasteful(dir) {
         edges.set('raw:' + edges.size, line);
         continue;
       }
-      // Upcast IN MEMORY only, to key and classify the record. What gets written
-      // back below is the ORIGINAL `line`: compaction reclaims superseded
-      // records, it does not migrate surviving ones, so the on-disk version is
-      // whatever wrote it and `load` upcasts it again on every read.
-      record = upcast(record);
-      if (record.t === 'n') {
+      // TWO OBJECTS, ON PURPOSE. `record` is exactly what the bytes on disk say;
+      // `view` is the in-memory current-shape reading of it, used only to KEY and
+      // CLASSIFY. Nothing derived from `view` is ever serialized, because
+      // compaction reclaims superseded records -- it does not migrate surviving
+      // ones -- so every version stamp it writes is the one that wrote the bytes.
+      //
+      // An earlier revision of this comment claimed "the ORIGINAL line is written
+      // back" for the whole block. That was FALSE for the inline-snapshot branch,
+      // which re-serializes. It re-serialized the upcast object while carrying
+      // the old `v`, so the first non-identity `upcast` would have written
+      // new-shape bytes under an old label and every later `load` would have
+      // upcast them a second time. Hence: strip from `record`, never from `view`.
+      const view = upcast(record);
+      if (view.t === 'n') {
         // MIGRATION. Graphs written before snapshots were split still carry
         // them inline, and those are exactly the graphs that are slow. Moving
         // them out here means one compaction fixes an existing install.
+        //
+        // THE ONLY RE-SERIALIZING BRANCH in this loop. It writes the original
+        // record minus its snapshot, so the surviving bytes keep their own shape
+        // and their own `v`, and the snapshot moved to the sidecar carries the
+        // same `v` as the node it came out of.
         if (typeof record.snapshot === 'string' && record.snapshot) {
           const { snapshot, ...rest } = record;
-          nodes.set(record.id, JSON.stringify(rest));
-          snaps.set(record.id, { at: record.at || 0, snapshot });
+          nodes.set(view.id, JSON.stringify(rest));
+          snaps.set(view.id, { at: record.at || 0, snapshot, v: record.v ?? GRAPH_VERSION });
         } else {
-          nodes.set(record.id, line);
+          nodes.set(view.id, line);
         }
-      } else if (record.t === 's') {
+      } else if (view.t === 's') {
         if (typeof record.snapshot === 'string' && record.snapshot) {
-          snaps.set(record.id, { at: record.at || 0, snapshot: record.snapshot });
+          snaps.set(view.id, { at: record.at || 0, snapshot: record.snapshot, v: record.v ?? GRAPH_VERSION });
         }
-      } else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
+      } else if (view.t === 'e') edges.set(`${view.from}|${view.edge}|${view.to}`, line);
       else edges.set('raw:' + edges.size, line);
     }
 
@@ -539,10 +582,20 @@ function compactIfWasteful(dir) {
     renameSync(tmp, path);
     // The surviving snapshots are rewritten to their own file, which is also
     // what migrates a graph that still had them inline.
-    const snapOut =
-      [...keep.entries()]
-        .map(([id, v]) => JSON.stringify({ t: 's', v: GRAPH_VERSION, id, snapshot: v.snapshot, at: v.at }))
-        .join('\n') + (keep.size ? '\n' : '');
+    //
+    // UNREADABLE LINES FIRST AND VERBATIM. This rebuild replaces the file, so
+    // anything omitted here is deleted permanently -- which made the missing
+    // counterpart to the main log's `raw:` bucket a real data-loss path, not a
+    // theoretical one. Each survivor also keeps ITS OWN `v` rather than being
+    // restamped to GRAPH_VERSION, so no record is relabelled as something this
+    // reader wrote.
+    const snapLines = [
+      ...rawSnaps,
+      ...[...keep.entries()].map(([id, s]) =>
+        JSON.stringify({ t: 's', v: s.v ?? GRAPH_VERSION, id, snapshot: s.snapshot, at: s.at })
+      ),
+    ];
+    const snapOut = snapLines.join('\n') + (snapLines.length ? '\n' : '');
     const snapTmp = snapshotsPath(dir) + '.compact';
     writeFileSync(snapTmp, snapOut, { mode: 0o600 });
     renameSync(snapTmp, snapshotsPath(dir));
@@ -687,9 +740,26 @@ function appendSnapshot(dir, record) {
   }
 }
 
-/** Every snapshot record, latest wins. Read only when a caller asks. */
+/**
+ * Every snapshot record, latest wins. Read only when a caller asks.
+ *
+ * `unreadable` collects the RAW LINES this reader rejected, and it is the reason
+ * this function reports them at all rather than just dropping them. `load` has
+ * no use for them -- a reader that cannot interpret a record must ignore it --
+ * but `compactIfWasteful` REBUILDS this file from what it read, so for the
+ * compactor "ignore" and "delete permanently" are the same operation. The main
+ * log already keeps what it cannot parse (the `raw:` bucket); the sidecar had no
+ * equivalent, which made it the one asymmetric, destructive path in an otherwise
+ * append-only store.
+ *
+ * This is not hypothetical here: hooks-core is vendored into eleven client
+ * directories that update independently, so a stale client compacting a graph a
+ * newer client has already written to is the expected steady state, not an edge
+ * case.
+ */
 function readSnapshots(dir) {
-  const out = [];
+  /** @type {object[]} */ const out = [];
+  /** @type {string[]} */ const unreadable = [];
   try {
     for (const line of readFileSync(snapshotsPath(dir), 'utf8').split('\n')) {
       if (!line) continue;
@@ -697,19 +767,23 @@ function readSnapshots(dir) {
         const rec = JSON.parse(line);
         // THE SAME RANGE AS THE MAIN LOG, deliberately. An equality check here
         // was the quietest of the three: a bump would have made every stored
-        // snapshot unreadable, and the very next compaction -- which rebuilds
-        // this file from what it could read -- would have deleted them for
-        // good. That is the one place in this store where a read filter turns
-        // into a permanent write.
-        if (readable(rec) && rec.id) out.push(upcast(rec));
+        // snapshot unreadable, and the very next compaction would have deleted
+        // them for good.
+        if (!readable(rec)) {
+          unreadable.push(line);
+          continue;
+        }
+        if (rec.id) out.push(upcast(rec));
       } catch {
-        /* a torn line costs one snapshot */
+        // A torn line costs one snapshot -- and it is NOT preserved, because a
+        // half-written line is not a record from another version, it is
+        // garbage. Distinguishing the two is the whole point of parsing first.
       }
     }
   } catch {
     /* no sidecar yet */
   }
-  return out;
+  return { records: out, unreadable };
 }
 
 /**
@@ -775,7 +849,9 @@ export function load(dir, { snapshots = false } = {}) {
   // Re-attached after the sweep, so a snapshot record may appear before or
   // after the node it belongs to.
   if (pending) {
-    for (const rec of readSnapshots(dir)) pending.set(rec.id, rec.snapshot);
+    // A reader has no use for the lines it could not interpret; only the
+    // compactor does, because only the compactor rewrites the file.
+    for (const rec of readSnapshots(dir).records) pending.set(rec.id, rec.snapshot);
     for (const [id, snapshot] of pending) {
       const node = nodes.get(id);
       if (node) nodes.set(id, { ...node, snapshot });

--- a/hooks-core/wiki.mjs
+++ b/hooks-core/wiki.mjs
@@ -26,17 +26,55 @@ import { canonicalPath, isFsSafePath } from './paths.mjs';
 /**
  * Schema version stamped on every record.
  *
- * There is exactly ONE version and no migration code, because nothing has been
- * released: a graph written by an older commit of an unreleased branch is a
- * development artifact, not user data, and carrying migration paths for it costs
- * real complexity to protect something nobody has. A record from any other
- * version is skipped rather than interpreted, so a stale dev graph degrades to
- * "rebuilds from use" instead of silently mixing incompatible identities.
+ * THIS PACKAGE IS RELEASED. It ships on npm, so every graph on disk is user
+ * data. An earlier version of this comment claimed nothing had been released
+ * and used that to justify having no migration path at all -- and the reader
+ * below compared for EQUALITY, so the first bump would have discarded every
+ * existing graph in silence. That justification is gone and so is the equality:
+ * `SUPPORTED_VERSIONS` is the range this reader accepts, and `upcast` is where a
+ * shape change is absorbed in memory.
  *
- * When this does ship, a bump here is where migration would be added -- with
- * users to protect, that trade reverses.
+ * A bump here is taken only when a record's SHAPE actually changes, and it comes
+ * with a new `upcast` step and an entry in `SUPPORTED_VERSIONS` in the same
+ * change. Adding a field that older readers can ignore is not a shape change.
  */
 export const GRAPH_VERSION = 1;
+
+/**
+ * Versions this reader accepts, oldest first.
+ *
+ * A RANGE, NOT AN EQUALITY. The equality check this replaces would have
+ * discarded every existing graph the moment anyone bumped the version -- and the
+ * header once justified that with "nothing has been released", which stopped
+ * being true at v5.7.0 on npm.
+ *
+ * Nothing on disk is ever rewritten to migrate: `upcast` runs in memory during
+ * the fold, so there is no migration pass to fail halfway and no race with the
+ * concurrent sessions this store is designed for. A mixed-version log is safe
+ * precisely because the original records are never mutated, and the existing
+ * compaction retires old ones naturally as it rewrites snapshots.
+ */
+export const SUPPORTED_VERSIONS = [1];
+
+/**
+ * Brings one record up to the current version. Pure, and one step per version.
+ *
+ * Identity today because GRAPH_VERSION is 1 and no shape has changed. It exists
+ * now so the first change that DOES need it has somewhere to go other than an
+ * equality check that silently deletes user data.
+ */
+export function upcast(record) {
+  return record;
+}
+
+/** True when this reader can interpret the record at all. */
+function readable(record) {
+  const version = record.v ?? 0;
+  // Forward-incompatible records are skipped: a v-from-the-future was written by
+  // a newer client and we cannot know its shape. Ignoring the future is safe;
+  // ignoring the past is data loss.
+  return SUPPORTED_VERSIONS.includes(version);
+}
 
 /** Node kinds. `file` and `symbol` are first-class so staleness can propagate. */
 export const NODE_KINDS = ['file', 'symbol', 'task', 'finding'];
@@ -407,13 +445,22 @@ function compactIfWasteful(dir) {
       } catch {
         continue;
       }
-      // A record from another schema is KEPT VERBATIM rather than reinterpreted.
-      // load() skips it, but discarding it here would make compaction a silent
-      // migration that deletes data a future version might understand.
-      if ((record.v ?? 0) !== GRAPH_VERSION) {
+      // A record this reader cannot interpret is KEPT VERBATIM rather than
+      // reinterpreted. load() skips it, but discarding it here would make
+      // compaction a silent migration that deletes data a future version might
+      // understand. THE RANGE MATTERS HERE TOO: with an equality check, a bump
+      // would have parked every existing v1 record in `raw`, undeduplicated, so
+      // compaction would stop reclaiming anything and inline snapshots would
+      // never migrate out -- the same loss by a second route.
+      if (!readable(record)) {
         edges.set('raw:' + edges.size, line);
         continue;
       }
+      // Upcast IN MEMORY only, to key and classify the record. What gets written
+      // back below is the ORIGINAL `line`: compaction reclaims superseded
+      // records, it does not migrate surviving ones, so the on-disk version is
+      // whatever wrote it and `load` upcasts it again on every read.
+      record = upcast(record);
       if (record.t === 'n') {
         // MIGRATION. Graphs written before snapshots were split still carry
         // them inline, and those are exactly the graphs that are slow. Moving
@@ -648,7 +695,13 @@ function readSnapshots(dir) {
       if (!line) continue;
       try {
         const rec = JSON.parse(line);
-        if ((rec.v ?? 0) === GRAPH_VERSION && rec.id) out.push(rec);
+        // THE SAME RANGE AS THE MAIN LOG, deliberately. An equality check here
+        // was the quietest of the three: a bump would have made every stored
+        // snapshot unreadable, and the very next compaction -- which rebuilds
+        // this file from what it could read -- would have deleted them for
+        // good. That is the one place in this store where a read filter turns
+        // into a permanent write.
+        if (readable(rec) && rec.id) out.push(upcast(rec));
       } catch {
         /* a torn line costs one snapshot */
       }
@@ -689,7 +742,12 @@ export function load(dir, { snapshots = false } = {}) {
       if (!snapshots) continue;
       try {
         const rec = JSON.parse(line);
-        if ((rec.v ?? 0) === GRAPH_VERSION) pending.set(rec.id, rec.snapshot);
+        // Inline snapshots from an older graph: same range, same reason. These
+        // are precisely the records most likely to predate a bump.
+        if (readable(rec)) {
+          const snap = upcast(rec);
+          pending.set(snap.id, snap.snapshot);
+        }
       } catch {
         /* a torn line costs one snapshot, not the graph */
       }
@@ -701,10 +759,14 @@ export function load(dir, { snapshots = false } = {}) {
     } catch {
       continue;
     }
-    // A record from another schema is skipped, not interpreted: its ids and
-    // hashes were derived differently, so honouring it produces confident
-    // nonsense rather than a visible error.
-    if ((record.v ?? 0) !== GRAPH_VERSION) continue;
+    // A record this reader cannot interpret is skipped, not guessed at: a
+    // version from the FUTURE derived its ids and hashes in a way we do not
+    // know, so honouring it produces confident nonsense rather than a visible
+    // error. A record from the PAST is upcast, never skipped -- skipping it is
+    // data loss, and this comparison used to be an equality, which made the
+    // first version bump a silent delete of every graph on disk.
+    if (!readable(record)) continue;
+    record = upcast(record);
     if (record.t === 'n') nodes.set(record.id, record);
     else if (record.t === 'e') edges.push(record);
   }

--- a/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
@@ -68,6 +68,7 @@ import {
   standingRules,
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
+import { observedWrite, queueInvalidation } from './pending.mjs';
 import { isArchived } from './transcript.mjs';
 import { isFsSafePath } from './paths.mjs';
 import {
@@ -881,6 +882,35 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Causal tracing is fail-open like every other hook optimization.
+    }
+
+    // EAGER INVALIDATION, finally connected. `invalidateOnWrite` has existed,
+    // been tested and been described in staleness.mjs's own header since
+    // staleness landed, and its only reference in shipped code was a COMMENT in
+    // the PreToolUse router -- so the path that header calls load-bearing had
+    // never run once in production. It matters most for exactly this event: the
+    // lazy check compares the anchor's stored hash against disk, and the
+    // capture below re-points that hash at the bytes this write just produced,
+    // so a write the session performed ITSELF is invisible to lazy staleness.
+    //
+    // QUEUED, NOT APPLIED. Applying needs the graph, and loading a megabyte of
+    // JSONL on the return path of every write is what this shape exists to
+    // avoid. The next graph read drains it before serving anything.
+    try {
+      if (mutationSucceeded(clientName, raw)) {
+        const evidence = observedWrite(payload, raw);
+        if (evidence) {
+          // THE SAME DIRECTORY THE GRAPH ITSELF USES. `observeAndInject` keys
+          // every write on `wikiDir(projectRootFor(path, payload.cwd))`, and a
+          // queue written anywhere else is a queue nothing ever drains.
+          queueInvalidation(
+            wikiDir(projectRootFor(evidence.path, payload.cwd)),
+            evidence
+          );
+        }
+      }
+    } catch {
+      // Bookkeeping for a call that already completed. Never let it cost one.
     }
   }
 

--- a/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
@@ -64,6 +64,7 @@ import {
   forTouch,
   noteActClasses,
   relevantFindingIdsForContext,
+  sessionContext,
   sessionIndex,
   standingRules,
 } from './inject.mjs';
@@ -690,8 +691,23 @@ async function runHook(clientName, event, invocation) {
       rememberOptimizerTools(state, toolEvidence);
       saveState(sessionId, state);
     }
-    const parts = [
-      policyText(client.canDeny, toolEvidence.names, toolEvidence.proven),
+    // ASSEMBLED IN CACHE ORDER, not in whatever order this function happens to
+    // discover the blocks. Everything emitted here sits near the FRONT of the
+    // prompt prefix, and a prefix cache invalidates from the first differing
+    // byte onward -- so the block that changes most often has to sit LAST, or it
+    // re-prices every block behind it on every session. `sessionContext` sorts
+    // by the declared volatility; inject.mjs records how each number was
+    // assigned and why.
+    const blocks = [
+      {
+        id: 'policy',
+        volatility: 0,
+        text: policyText(
+          client.canDeny,
+          toolEvidence.names,
+          toolEvidence.proven
+        ),
+      },
     ];
     const cwd = raw.cwd || raw.working_directory || process.cwd();
     const root = projectRootFor(join(cwd, '__session__'), cwd);
@@ -705,7 +721,7 @@ async function runHook(clientName, event, invocation) {
         const graph = load(dir);
         const episode = episodeMeta({ client: clientName, raw });
         const rules = standingRules(dir, graph, { episode });
-        if (rules) parts.push(rules);
+        if (rules) blocks.push({ id: 'standing', volatility: 1, text: rules });
         const relevantFindingIds = relevantFindingIdsForContext(
           graph,
           sessionTaskContext(raw)
@@ -714,12 +730,12 @@ async function runHook(clientName, event, invocation) {
           episode,
           relevantFindingIds,
         });
-        if (index) parts.push(index);
+        if (index) blocks.push({ id: 'index', volatility: 2, text: index });
       } catch {
         // Retrieval is optional context; the policy must still reach the model.
       }
     }
-    const output = contextOutput(client, eventName, parts.join('\n\n'));
+    const output = contextOutput(client, eventName, sessionContext(blocks));
     if (output) emit(output);
     process.exit(0);
   }

--- a/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
@@ -68,7 +68,7 @@ import {
   standingRules,
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
-import { observedWrite, queueInvalidation } from './pending.mjs';
+import { observedWrites, queueInvalidation } from './pending.mjs';
 import { isArchived } from './transcript.mjs';
 import { isFsSafePath } from './paths.mjs';
 import {
@@ -898,8 +898,7 @@ async function runHook(clientName, event, invocation) {
     // avoid. The next graph read drains it before serving anything.
     try {
       if (mutationSucceeded(clientName, raw)) {
-        const evidence = observedWrite(payload, raw);
-        if (evidence) {
+        for (const evidence of observedWrites(payload, raw)) {
           // THE SAME DIRECTORY THE GRAPH ITSELF USES. `observeAndInject` keys
           // every write on `wikiDir(projectRootFor(path, payload.cwd))`, and a
           // queue written anywhere else is a queue nothing ever drains.

--- a/integrations/cline/hooks/token-optimizer/lib/capabilities.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/capabilities.mjs
@@ -38,6 +38,10 @@ export const HOOK_MCP_TOOLS = Object.freeze([
   'optimize_session',
   'get_optimization_report',
   'wiki_write',
+  // The read side of the graph. The session index tells the model to "call
+  // wiki_query with a key for detail", so the hook needs positive evidence that
+  // the name it is advertising is actually registered in this host.
+  'wiki_query',
 ]);
 
 const HOOK_MCP_TOOL_SET = new Set(HOOK_MCP_TOOLS);

--- a/integrations/cline/hooks/token-optimizer/lib/curate.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/curate.mjs
@@ -22,7 +22,7 @@
  */
 
 import { randomBytes } from 'node:crypto';
-import { putNode, putNodeWithEdges, load, nodeId } from './wiki.mjs';
+import { putNode, putEdge, putNodeWithEdges, load, nodeId } from './wiki.mjs';
 import { indexFile } from './staleness.mjs';
 import { symbolKey } from './symbols.mjs';
 import { canonicalPath } from './paths.mjs';
@@ -178,6 +178,79 @@ export function retire(dir, key) {
   if (!existing) return false;
   putNode(dir, { ...existing, kind: 'finding', key, retired: true });
   return true;
+}
+
+/**
+ * Records that one finding disagrees with another.
+ *
+ * AN EDGE, NOT AN OVERWRITE -- the design is explicit about why: "when a belief
+ * changes, the graph should record THAT it changed and why, not quietly present
+ * the new one as though it had always been true." `contradicts` has been in
+ * EDGE_KINDS since the schema existed and was written by nothing, while
+ * `audit()` already READ it.
+ *
+ * The contradicted finding is deliberately NOT retired, and its claim is
+ * deliberately preserved. A reader needs to see both claims and the
+ * disagreement between them; retiring one silently picks a winner, and putNode
+ * does not merge -- it writes the whole record from what it is handed, so
+ * annotating the target without spreading it back in would blank the very claim
+ * this edge exists to keep visible. That is the overwrite by another name.
+ *
+ * THE EDGE IS WRITTEN FIRST, and the order is the guarantee. These are two
+ * appends and `append` fails open, so either can be the one that lands. Edge
+ * without annotation is a complete, readable disagreement missing only its
+ * reason. Annotation without edge is a finding that says "something contradicts
+ * me" with no contradictor -- a claim of proof with no proof, and invisible to
+ * `audit()` and to `hasOutstandingContradiction`, both of which read the edge.
+ */
+export function contradict(dir, { key, byKey, reason }) {
+  const graph = load(dir);
+  const target = findingByKey(graph, key);
+  const source = findingByKey(graph, byKey);
+  // Both ends must exist, or the edge is unresolvable and the disagreement is
+  // recorded against nothing -- the same un-invalidatable shape anchors prevent.
+  if (!target || !source) return false;
+  // A finding cannot disagree with itself. The self-edge resolves, so the guard
+  // above waves it through, and the result is a node permanently blocked from
+  // confidence promotion by a dispute no person can ever resolve: there is no
+  // second claim to choose between.
+  if (target.id === source.id) return false;
+
+  putEdge(dir, source.id, 'contradicts', target.id);
+  putNode(dir, {
+    ...target,
+    kind: 'finding',
+    key,
+    contradictedAt: Date.now(),
+    contradictionReason: String(reason || '').slice(0, 400),
+  });
+  return true;
+}
+
+/**
+ * Whether anything currently disagrees with this finding.
+ *
+ * Gates confidence promotion. Plan 2's per-finding utility measures whether a
+ * finding SUPPRESSES READS, and a confidently wrong finding suppresses reads
+ * better than a hedged true one -- so utility must never raise confidence on
+ * its own, and this is the check that stops it.
+ *
+ * SYMMETRIC, deliberately: BOTH ends of a `contradicts` edge are outstanding
+ * until a person resolves the disagreement. The named hazard in the design is
+ * presenting "the new one as though it had always been true", so gating only
+ * the older claim would leave the newer one -- which is just as likely to be
+ * the wrong one, since nothing here adjudicates -- free to be promoted on
+ * measured utility alone. That is the exact failure this gate exists to stop.
+ * It also matches `audit()`, the reader that has always been here: it puts both
+ * `from` and `to` in its `contradicted` bucket, because "until one looks, BOTH
+ * are being served".
+ */
+export function hasOutstandingContradiction(graph, key) {
+  const node = findingByKey(graph, key);
+  if (!node) return false;
+  return graph.edges.some(
+    (e) => e.edge === 'contradicts' && (e.to === node.id || e.from === node.id)
+  );
 }
 
 /**

--- a/integrations/cline/hooks/token-optimizer/lib/curate.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/curate.mjs
@@ -124,7 +124,17 @@ export function correct(
   const replacementKey = `${key}-c${Date.now().toString(36)}`;
 
   const edges = [{ edge: 'supersedes', to: originalId }];
-  // The correction inherits the original's anchors, so it can go stale too.
+  // The correction inherits the original's anchors, so it can go stale too --
+  // but it inherits NOTHING ELSE, and that is deliberate rather than incidental.
+  // The node written below is built field by field from `existing` instead of
+  // spreading it, which is what keeps the staleness fields (`stale`,
+  // `staleReason`, `diff`) off the successor: a correction is re-derived
+  // against the current code by definition, so being born carrying its
+  // predecessor's invalidation would discount it the moment it existed --
+  // `disclose.mjs` skips a stale finding outright and `utility.mjs` penalises
+  // one by 160. Any future edit here that reaches for `...existing` to pick up
+  // one more field re-introduces that, since `putNode` writes what it is handed
+  // wholesale; `tests/hooks/stale-clearing.test.mjs` is the guard.
   for (const edge of graph.edges) {
     if (edge.edge === 'derived_from' && edge.from === originalId) {
       edges.push({ edge: 'derived_from', to: edge.to });
@@ -244,13 +254,38 @@ export function contradict(dir, { key, byKey, reason }) {
  * It also matches `audit()`, the reader that has always been here: it puts both
  * `from` and `to` in its `contradicted` bucket, because "until one looks, BOTH
  * are being served".
+ *
+ * A RETIRED COUNTERPART DOES NOT COUNT, and that sentence quoted just above is
+ * the reason. This read edges ONLY, so retiring one end of a contradiction left
+ * the survivor gated against confidence promotion forever and served with a
+ * DISPUTED note naming a key `serve` refuses to hand anybody -- `serve`,
+ * `activeFindings`, `findingsFor` and `sessionIndex` all drop a retired
+ * finding. A retired claim is served to NOBODY, so "BOTH are being served" is
+ * false and the premise of the gate is gone: only one claim is in play, and
+ * there is nothing left to choose between. Retiring one end IS the person
+ * looking that this gate was waiting for -- so the edge counts as open only
+ * while NEITHER end is retired, answered the same way from both directions.
+ *
+ * AN UNRESOLVABLE END STILL COUNTS. An edge whose other side names no node
+ * proves nothing about whether that claim was withdrawn, and the conservative
+ * reading -- still disputed -- is the one that cannot promote a claim nobody
+ * adjudicated.
  */
 export function hasOutstandingContradiction(graph, key) {
   const node = findingByKey(graph, key);
-  if (!node) return false;
-  return graph.edges.some(
-    (e) => e.edge === 'contradicts' && (e.to === node.id || e.from === node.id)
-  );
+  // A withdrawn claim is not in a dispute either: a dispute needs two claims in
+  // play, and this one has been taken out of play. Without this the RETIRED end
+  // still reported an open disagreement, which is the same defect from the other
+  // side -- and the answer has to agree from both directions, since the gate is
+  // symmetric on purpose.
+  if (!node || node.retired) return false;
+  return graph.edges.some((e) => {
+    if (e.edge !== 'contradicts') return false;
+    const otherId = e.from === node.id ? e.to : e.to === node.id ? e.from : null;
+    if (!otherId) return false;
+    const other = graph.nodes.get(otherId);
+    return !other || !other.retired;
+  });
 }
 
 /**
@@ -334,11 +369,24 @@ export function audit(graph) {
       .map((e) => e.from)
   );
 
+  // THE SAME DEFINITION OF AN OPEN DISPUTE as hasOutstandingContradiction, and
+  // it has to be: that function's own comment claims it "matches audit()", and
+  // two rankings that disagree about what needs a human is worse than one that
+  // is wrong. A retired counterpart is a resolved dispute -- the retired claim
+  // is served to nobody -- so the survivor is not one of two claims in play and
+  // does not belong in the bucket of things needing a person to look.
+  //
+  // One pass, not a call per finding: this is a dashboard read over the whole
+  // graph, and the obvious rewrite is O(findings x edges).
   const contradicted = new Set();
   for (const edge of graph.edges) {
     if (edge.edge !== 'contradicts') continue;
-    contradicted.add(edge.from);
-    contradicted.add(edge.to);
+    const from = graph.nodes.get(edge.from);
+    const to = graph.nodes.get(edge.to);
+    // An end that resolves to nothing cannot be shown retired, so it still
+    // counts against the other end.
+    if (!to || !to.retired) contradicted.add(edge.from);
+    if (!from || !from.retired) contradicted.add(edge.to);
   }
 
   return {

--- a/integrations/cline/hooks/token-optimizer/lib/curate.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/curate.mjs
@@ -70,6 +70,38 @@ export function originWeight(origin) {
   return 1;
 }
 
+/**
+ * The claim-time anchor hashes, for a finding being written right now.
+ *
+ * THE CHECKABLE HALF OF PROVENANCE, and until now only `harvest-write.mjs`
+ * wrote it -- so the asymmetry ran exactly the wrong way. `reverify` and the
+ * automatic clear in `serve` both compare disk against these frozen hashes, and
+ * a finding without them can never have a stale flag cleared by anything. That
+ * meant HUMAN-asserted findings, the ones somebody deliberately created or
+ * corrected, were the only ones condemned to stay stale forever once marked,
+ * while machine-harvested claims could recover. The hashes are simply the anchor
+ * nodes' hashes at this moment, and every writer has them in hand.
+ *
+ * DELIBERATELY NOT THE WHOLE RECORD `derivationFor` BUILDS. That one joins the
+ * evidence log to find FILE-surface operations behind the claim; curation
+ * performs no such join, so `operations` is empty and `operationsComplete` says
+ * so. An empty list declared incomplete is honest -- "nothing recorded here, and
+ * do not read that as nothing happened" -- where an empty list declared complete
+ * would assert a fact nobody established.
+ *
+ * An anchor with no stored hash contributes no entry, and a finding whose
+ * anchors all lack one gets a record with no hashes -- which `claimTimeVerdict`
+ * reads as `unknown` and refuses to clear on, which is the correct reading.
+ */
+function claimTimeDerivation(graph, resolved) {
+  const anchors = {};
+  for (const id of resolved) {
+    const node = graph.nodes.get(id);
+    if (node && typeof node.hash === 'string') anchors[id] = node.hash;
+  }
+  return { at: Date.now(), anchors, operations: [], operationsComplete: false };
+}
+
 function findingByKey(graph, key) {
   return graph.nodes.get(nodeId('finding', key)) || null;
 }
@@ -124,6 +156,11 @@ export function correct(
   const replacementKey = `${key}-c${Date.now().toString(36)}`;
 
   const edges = [{ edge: 'supersedes', to: originalId }];
+  // Collected alongside the edges so the correction carries its own claim-time
+  // hashes: it is a NEW claim, re-derived against whatever the code says now, so
+  // its evidence is the anchors' current state -- not the predecessor's, which is
+  // precisely what went stale.
+  const inherited = [];
   // The correction inherits the original's anchors, so it can go stale too --
   // but it inherits NOTHING ELSE, and that is deliberate rather than incidental.
   // The node written below is built field by field from `existing` instead of
@@ -138,6 +175,7 @@ export function correct(
   for (const edge of graph.edges) {
     if (edge.edge === 'derived_from' && edge.from === originalId) {
       edges.push({ edge: 'derived_from', to: edge.to });
+      inherited.push(edge.to);
     }
   }
 
@@ -171,6 +209,11 @@ export function correct(
       // branches, and an unrecognised value already degrades to the neutral
       // ranking weight rather than doing damage.
       origin: typeof origin === 'string' && origin ? origin : ORIGIN_HUMAN,
+      // Without this a correction could never have a stale flag cleared: both
+      // clearing paths compare disk against these hashes, and a finding with
+      // none is `unknown` forever. A hand-written correction being the least
+      // recoverable record in the graph was the wrong way round.
+      derivation: claimTimeDerivation(graph, inherited),
     },
     edges
   );
@@ -339,7 +382,18 @@ export function create(dir, { claim, anchors, type = 'finding', confidence = 0.9
   // path. No process death required; one transient EBUSY is enough.
   const id = putNodeWithEdges(
     dir,
-    { kind: 'finding', key, claim, confidence, type, origin: ORIGIN_HUMAN },
+    {
+      kind: 'finding',
+      key,
+      claim,
+      confidence,
+      type,
+      origin: ORIGIN_HUMAN,
+      // Read AFTER the indexFile loop above, so the hashes are the ones the
+      // person's claim was actually made against rather than whatever the graph
+      // held before this call touched it.
+      derivation: claimTimeDerivation(loadGraph(dir), resolved),
+    },
     resolved.map((target) => ({ edge: 'derived_from', to: target }))
   );
   if (!id) return null;

--- a/integrations/cline/hooks/token-optimizer/lib/decide.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/decide.mjs
@@ -542,19 +542,92 @@ const TOOL_ALIASES = new Map(
     run_shell_command: 'Bash',
     run_terminal_cmd: 'Bash',
     terminal: 'Bash',
+
+    // THIS PROJECT'S OWN TOOLS, which the table did not list for as long as it
+    // existed. `plugin/hooks/hooks.json`'s PostToolUse matcher named
+    // `mcp__.*__(?:smart_edit|smart_write)` and Codex's AfterTool matcher named
+    // the bare `smart_edit|smart_write`, so both hooks fired -- and then
+    // `normalizeTool` returned null and the hook exited before a single line of
+    // accounting ran. Staleness, mutation counting and harvest pressure were all
+    // blind on exactly the path enforcement pushes the model toward, which is the
+    // worst place to be blind: the more effective the routing, the less the
+    // optimizer saw.
+    //
+    // These names are the CANONICAL operation, not a licence to redirect. A call
+    // that is already the replacement is excluded from routing by
+    // `isReplacementTool` below.
+    smart_read: 'Read',
+    smart_grep: 'Grep',
+    smart_glob: 'Glob',
+    smart_edit: 'Edit',
+    smart_write: 'Write',
+
+    // Claude Code's notebook editor. Same shape of gap: a real mutation of a
+    // real file on disk that arrived as null and so never reached
+    // `pending.mjs`'s MUTATING set, leaving every notebook write invisible to
+    // invalidation.
+    notebookedit: 'Edit',
+    notebook_edit: 'Edit',
   })
 );
 
-/** Maps a client's tool name onto the canonical one, or null if unhandled. */
+/**
+ * The optimizer's own replacement tools, by canonical trailing segment.
+ *
+ * Kept separate from the alias table because the two answer different questions.
+ * The table answers "what operation is this", which post-tool accounting needs.
+ * This set answers "is this call ALREADY the thing we would have recommended",
+ * which routing needs -- and conflating them is the loop hazard: `smart_edit`
+ * resolves to `Edit`, the Edit branch recommends `smart_edit`, and the model is
+ * told to call the tool it just called.
+ */
+const REPLACEMENT_TOOLS = new Set([
+  'smart_read',
+  'smart_grep',
+  'smart_glob',
+  'smart_edit',
+  'smart_write',
+]);
+
+/**
+ * The tool name with an `mcp__<server>__` prefix removed, if it had one.
+ *
+ * Server segments contain underscores freely (`plugin_token-optimizer_token-optimizer`)
+ * and so do tool names (`smart_edit`), so the split is taken at the LAST `__`
+ * after the `mcp__` sentinel. Both halves must be non-empty: `mcp__edit` names
+ * no server and is not a name any host emits, and treating it as `edit` would
+ * coerce an unrecognised string into a built-in.
+ */
+function withoutMcpPrefix(name) {
+  const match = /^mcp__(.+)__(.+)$/.exec(name);
+  return match ? match[2] : name;
+}
+
+/** Whether this call IS one of the optimizer's replacements, however spelled. */
+export function isReplacementTool(name) {
+  if (!name) return false;
+  return REPLACEMENT_TOOLS.has(withoutMcpPrefix(String(name)).toLowerCase());
+}
+
+/**
+ * Maps a client's tool name onto the canonical one, or null if unhandled.
+ *
+ * PERMISSIVE IN ONE DIRECTION ONLY. An MCP-prefixed name is resolved by its
+ * trailing segment, but only against the same table every other client is held
+ * to -- so `mcp__vendor__deploy_to_prod` stays null. Coercing an unrecognised
+ * MCP tool into a built-in would change a routing verdict for a tool nobody has
+ * considered, which is a far worse failure than not accounting for it.
+ */
 export function normalizeTool(name) {
   if (!name) return null;
+  const candidate = withoutMcpPrefix(String(name));
   if (
     ['Read', 'Grep', 'Glob', 'Edit', 'MultiEdit', 'Write', 'Bash'].includes(
-      name
+      candidate
     )
   )
-    return name;
-  return TOOL_ALIASES.get(String(name).toLowerCase()) || null;
+    return candidate;
+  return TOOL_ALIASES.get(candidate.toLowerCase()) || null;
 }
 
 /**
@@ -614,6 +687,13 @@ export function normalizePayload(raw) {
     transcript_path: raw.transcript_path ?? raw.transcriptPath ?? null,
     cwd,
     tool_name: normalizeTool(raw.tool_name ?? raw.toolName ?? raw.tool),
+    // WHETHER THIS CALL IS ALREADY THE REPLACEMENT, carried alongside the
+    // canonical name rather than inferred from it -- because it cannot be
+    // inferred from it. `smart_edit` and `Edit` both normalise to `Edit`, and
+    // routing has to treat them as opposites while accounting treats them as
+    // the same. Absent by default (`false`), so a payload assembled by hand in
+    // a test or by a caller that predates this field is a normal built-in call.
+    replacement: isReplacementTool(raw.tool_name ?? raw.toolName ?? raw.tool),
     tool_input: {
       ...input,
       // CANONICALISED HERE, once. Every consumer downstream -- the `seen` map
@@ -673,6 +753,19 @@ function replacementAvailable(availableTools, name) {
 }
 
 export function decide(payload, state, availableTools = undefined) {
+  // THE LOOP HAZARD, and the reason this guard is at the top rather than inside
+  // any one branch. Resolving `smart_edit` to `Edit` is what makes post-tool
+  // accounting work; it must not also make the Edit branch answer a smart_edit
+  // call with "call smart_edit instead". This is not theoretical on a matcher
+  // level either: Qwen's PreToolUse matcher is the unanchored regex
+  // `edit|write_file|run_shell_command`, and `edit` matches inside
+  // `mcp__x__smart_edit`, so that client really does hand the router calls to
+  // its own replacements.
+  //
+  // A tool that IS the replacement is never routed. There is nothing better to
+  // recommend, and every branch below would recommend itself.
+  if (payload.replacement) return null;
+
   const tool = payload.tool_name;
   const input = payload.tool_input || {};
   const threshold = largeFileBytes();
@@ -873,6 +966,12 @@ export function remember(payload, state) {
  */
 export function readCostBytes(payload) {
   if (payload.tool_name !== 'Read') return 0;
+  // A REPLACEMENT DID NOT SPEND THE WHOLE FILE. `smart_read` normalises to
+  // `Read` so the graph sees the touch, but it returns a diff -- charging the
+  // full file size here would feed the holdout comparison a cost that was never
+  // paid, on the arm the optimizer is trying to show is cheaper. Better to
+  // record nothing than to record a number in the wrong direction.
+  if (payload.replacement) return 0;
   const path = payload.tool_input?.file_path;
   if (!path || isBinaryPath(path)) return 0;
   const size = fileSize(path);

--- a/integrations/cline/hooks/token-optimizer/lib/disclose.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/disclose.mjs
@@ -294,6 +294,11 @@ export function verdictFor(graph, { anchors = [], question, minConfidence = 0.7 
     const id = nodeId('file', canonicalPath(anchor));
     if (!graph.nodes.has(id)) continue;
 
+    // READ-ONLY serve: no `dir` is threaded here, so this cannot clear a stale
+    // flag whose evidence is gone. That is deliberate -- this function takes a
+    // graph, not the directory it came from, and widening its signature to give
+    // an analysis path a write capability buys nothing: the injection path runs
+    // on every tool call and clears the same findings.
     const findings = serve(graph, findingsFor(graph, id, { limit: 4 }));
     for (const finding of findings) {
       if (finding.stale) continue;

--- a/integrations/cline/hooks/token-optimizer/lib/harvest-write.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/harvest-write.mjs
@@ -34,7 +34,7 @@ import { randomBytes } from 'node:crypto';
 import { realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
-import { readEvidence } from './metrics.mjs';
+import { readEvidence, evidenceTruncated } from './metrics.mjs';
 
 /**
  * The types that may cross a project boundary.
@@ -431,53 +431,84 @@ function resolveAnchor(dir, anchor, projectRoot) {
 /**
  * Which task actually produced this finding, when nothing said so directly.
  *
- * Session id was the only signal `answers` had, and a session id is exactly
- * what a caller may not have (`wiki_write`'s `sessionId` is optional and
- * nothing populates it today; the detached harvest worker's is gated behind
- * an opt-in). But the graph does not need to be TOLD which task this is: the
- * structural harvest already writes `task -[derived_from]-> file` for every
- * tool call, unconditionally, on every install. So the task is DERIVABLE --
- * it is whichever task node has a `derived_from` edge to one of the SAME
- * anchors this finding resolved to.
+ * ROUND 2's version scanned the WHOLE graph for any task sharing any anchor,
+ * broken by recency. An adversarial review constructed four cases where that
+ * attributes a finding to the WRONG task:
  *
- * "Most recent task, full stop" was rejected on purpose: a task that never
- * touched these files could still be the newest node in the graph (a
- * different file, a different concern, in a later session), and attaching
- * provenance to it would be a WRONG edge, not a missing one -- worse than no
- * edge, because a reader trusts it. So candidates are filtered to tasks that
- * touched at least one of these anchors FIRST, and only ties among THOSE are
- * broken by recency.
+ *   1. STALE PRIOR SESSION -- a session that reasons from injected memory and
+ *      writes a finding about `foo.ts` without touching it this session gets
+ *      attributed to whatever task last touched `foo.ts`, possibly days old,
+ *      possibly someone else's work.
+ *   2. CONCURRENT SESSION -- two windows on one repository; the other
+ *      session's task wins if its touch is a millisecond later.
+ *   3. OVERLAP, NOT COVERAGE -- a finding anchored to [a, b]; a task that
+ *      touched only `b` could still win over one that touched both.
+ *   4. THE TIE-BREAK CONTRADICTED ITS OWN COMMENT -- `Number(edge.at) || 0`
+ *      with strict `>` means the FIRST edge in log order wins on a tie,
+ *      which is the OLDER task, not "more recently" as documented.
  *
- * The tie-break is the edge's own `at`, not the task node's `at`. A task that
- * touched this file once, long ago, and then stayed active on unrelated files
- * for hours has a late node timestamp that says nothing about this anchor;
- * the edge timestamp says exactly when THIS task touched THIS anchor, which
- * is the question being asked. Among tasks sharing an anchor, the one whose
- * most recent touch to any shared anchor is latest wins -- recency of the
- * relevant work, not recency of the task in general.
+ * THE FIX IS NARROWER THAN A BETTER RANKING: SCOPE, THEN REQUIRE COVERAGE.
+ * A task only ever belongs to the session that created it -- `harvest()` and
+ * `linkCoOccurrence()` (wiki.mjs, inject.mjs) both key a task node by
+ * `sessionId`, always, so there is exactly ONE task node for "the current
+ * session" and it is `nodeId('task', sessionId)`. Restricting to that ONE
+ * node structurally eliminates cases 1 and 2 -- a prior or concurrent
+ * session's task has a DIFFERENT sessionId and therefore a different node
+ * id, so it is never even looked at, regardless of timing. No caller can
+ * supply a wrong sessionId and get someone ELSE's task; they can only fail
+ * to get a match.
+ *
+ * COVERAGE, NOT OVERLAP, fixes case 3: the session's task must have a
+ * `derived_from` edge to EVERY one of this finding's anchors, not merely one.
+ * A partial touch is not attribution.
+ *
+ * With the candidate set reduced to at most one node, there is nothing left
+ * to break a tie between -- case 4's comparator is not "fixed", it is
+ * deleted, because the scenario it was written for (two DIFFERENT tasks both
+ * legitimately eligible) cannot occur under this scoping: two task nodes can
+ * never share a key, and only the current session's key is ever considered.
+ * An edge's `at` therefore plays NO role here: presence of a `derived_from`
+ * edge from the session's task to an anchor is what "touched it" means, with
+ * or without a timestamp on that edge -- there is no ranking left for a
+ * missing timestamp to lose.
+ *
+ * `sessionId` absent means there is no identity to scope by, which means no
+ * candidate -- not "fall back to guessing". Absence is the correct answer
+ * when the graph cannot support attribution.
  */
-function taskForAnchors(graph, anchorIds) {
-  if (!anchorIds || !anchorIds.length) return null;
-  const anchors = new Set(anchorIds);
-  let best = null;
-  for (const edge of graph.edges) {
-    if (edge.edge !== 'derived_from' || !anchors.has(edge.to)) continue;
-    const from = graph.nodes.get(edge.from);
-    // `derived_from` is also how a FINDING cites its own anchors, so without
-    // this a finding that already cited the same file would be mistaken for
-    // the task that produced it.
-    if (!from || from.kind !== 'task') continue;
-    const at = Number(edge.at) || 0;
-    if (!best || at > best.at) best = { taskId: edge.from, at };
+function taskForAnchors(graph, anchorIds, sessionId) {
+  if (!sessionId || !anchorIds || !anchorIds.length) return null;
+  const taskTarget = nodeId('task', sessionId);
+  const task = graph.nodes.get(taskTarget);
+  if (!task || task.kind !== 'task') return null;
+
+  for (const anchor of anchorIds) {
+    const covered = graph.edges.some((edge) =>
+      edge.edge === 'derived_from' && edge.from === taskTarget && edge.to === anchor
+    );
+    // ONE missing anchor refuses the whole attribution. A finding cited three
+    // files; this session's task touched two of them -- that is evidence the
+    // task did SOME related work, not evidence it produced THIS finding.
+    if (!covered) return null;
   }
-  return best ? best.taskId : null;
+  return taskTarget;
 }
 
 /**
  * A file path the way `recordToolOutcome` (metrics.mjs) already truncates and
- * stores it on a `tool-outcome` event's `anchor` field, so a derivation record
- * can join against that log without a second, divergent notion of "the same
- * anchor".
+ * stores it on a FILE-surface `tool-outcome` event's `anchor` field, so a
+ * derivation record can join against that log without a second, divergent
+ * notion of "the same anchor".
+ *
+ * COMMAND-surface events are DECLARED OUT OF SCOPE, not silently missed:
+ * `adapter.mjs` stores the COMMAND TEXT in `anchor` for those
+ * (`String(command).slice(0, 120)`), so a build or test run can never share
+ * an anchor string with a canonical file path -- there is no join key in
+ * common, and inventing a command-to-file heuristic (which files did a given
+ * `npm test` invocation cover?) is not something this record can answer
+ * honestly. `operationsScope` on the returned record says so explicitly,
+ * rather than letting an empty `operations` array look like "no build or
+ * test ever ran" when the truth is "this join cannot see it".
  */
 function anchorLabel(rawAnchor) {
   const path = String(rawAnchor).split('#')[0];
@@ -497,7 +528,8 @@ const MAX_DERIVATION_OPERATIONS = 5;
  * that comparison be reconstructed for a specific claim rather than only for
  * the anchor in general: the hash each anchor carried at the moment this
  * finding was derived from it, plus what evidence exists that any work
- * actually happened against it.
+ * actually happened against it. `derivationCheck` (staleness.mjs) is the
+ * reader that actually performs that comparison at serve time.
  *
  * DELIBERATELY NOT DUPLICATING THE EDGES. `derived_from` already records
  * WHICH anchors this finding cites; restating that here would be a second,
@@ -506,14 +538,23 @@ const MAX_DERIVATION_OPERATIONS = 5;
  *
  * DELIBERATELY NOT A REPLAY LOG. Recording enough to mechanically re-run a
  * derivation is a separate subsystem with real storage cost. This stores only
- * what the evidence log already has: `tool-outcome` events matching these
- * anchors, each reduced to the fields that were actually captured. An event
- * that carries no exit code or output contributes none -- nothing here is
- * invented to fill a shape the pipeline does not evidence yet. If a future
- * capture pass adds `exit`/`output` to those events, this starts carrying them
- * with no change to this function.
+ * what the evidence log already has: FILE-surface `tool-outcome` events
+ * matching these anchors, each reduced to the fields that were actually
+ * captured. An event that carries no exit code or output contributes none --
+ * nothing here is invented to fill a shape the pipeline does not evidence
+ * yet. If a future capture pass adds `exit`/`output` to those events, this
+ * starts carrying them with no change to this function.
+ *
+ * INCOMPLETENESS IS MARKED, NOT IMPLIED. An empty `operations` array is
+ * genuinely ambiguous on its own -- it is the same shape whether nothing
+ * happened, or something happened but fell outside what this join can see.
+ * `operationsComplete` distinguishes them: false when the evidence log itself
+ * may have dropped older matches (`evidenceIncomplete`, from
+ * `metrics.evidenceTruncated`) OR when more matches existed than the cap
+ * kept. A reader can then tell "no operations happened" from "operations
+ * existed but are not recorded here" instead of guessing.
  */
-function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
+function derivationFor(graph, resolvedAnchors, evidence, evidenceIncomplete, anchorSpecs) {
   const anchorHashes = {};
   for (const id of resolvedAnchors) {
     const node = graph.nodes.get(id);
@@ -521,8 +562,10 @@ function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
   }
 
   const labels = new Set((anchorSpecs || []).map(anchorLabel));
-  const operations = evidence
-    .filter((event) => event.kind === 'tool-outcome' && labels.has(event.anchor))
+  const matching = evidence.filter(
+    (event) => event.kind === 'tool-outcome' && labels.has(event.anchor)
+  );
+  const operations = [...matching]
     .sort((a, b) => (Number(b.at) || 0) - (Number(a.at) || 0))
     .slice(0, MAX_DERIVATION_OPERATIONS)
     .map((event) => {
@@ -540,7 +583,16 @@ function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
       return op;
     });
 
-  return { at: Date.now(), anchors: anchorHashes, operations };
+  return {
+    at: Date.now(),
+    anchors: anchorHashes,
+    operations,
+    // FILE touches only -- see `anchorLabel`. Declared here, in the record
+    // itself, not only in this function's comment, so a reader who never
+    // opens this source file still learns builds and test runs are excluded.
+    operationsScope: 'file',
+    operationsComplete: !evidenceIncomplete && matching.length <= operations.length,
+  };
 }
 
 /**
@@ -588,6 +640,9 @@ export function writeHarvested(
   // it can hold thousands of lines, so re-reading it per finding would turn a
   // batch of N findings into N passes over the same bytes.
   const evidence = readEvidence(dir);
+  // Cheap: one stat call, checked once per batch rather than once per
+  // finding's derivation record.
+  const evidenceIncomplete = evidenceTruncated(dir);
 
   const written = [];
   for (const finding of findings) {
@@ -647,14 +702,16 @@ export function writeHarvested(
     // An explicit `taskId` is authoritative when a caller supplies one --
     // it OVERRIDES traversal rather than merely seeding it, so a caller that
     // knows better is never second-guessed by inference. Absent one, the task
-    // is DERIVED from the graph itself: `taskForAnchors` finds the task that
-    // actually touched these anchors, which needs no session id from anyone.
-    // Either way, held to the same discipline as the anchors above: a target
-    // that does not resolve to an existing task node produces no edge rather
-    // than a dangling one.
+    // is DERIVED from the graph itself: `taskForAnchors` finds the CURRENT
+    // session's task (scoped by `sessionId`, the same identity this write
+    // already carries for provenance) and requires it to have touched EVERY
+    // one of this finding's anchors, not merely one -- see that function's
+    // own comment for the four attacks this closes. Either way, held to the
+    // same discipline as the anchors above: a target that does not resolve to
+    // an existing task node produces no edge rather than a dangling one.
     const answersTarget = taskId
       ? nodeId('task', taskId)
-      : taskForAnchors(currentGraph, resolved);
+      : taskForAnchors(currentGraph, resolved, sessionId);
     if (answersTarget && currentGraph.nodes.has(answersTarget)) {
       edges.push({ edge: 'answers', to: answersTarget });
     }
@@ -707,7 +764,7 @@ export function writeHarvested(
         // `render()`/`renderSessionIndex()` in inject.mjs or `wiki_read`'s
         // `toFinding()` projection, neither of which reads this field, so it
         // is not part of the automatic per-touch injection `fit()` prices.
-        derivation: derivationFor(currentGraph, resolved, evidence, finding.anchors || []),
+        derivation: derivationFor(currentGraph, resolved, evidence, evidenceIncomplete, finding.anchors || []),
       },
       edges
     );

--- a/integrations/cline/hooks/token-optimizer/lib/harvest-write.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/harvest-write.mjs
@@ -452,11 +452,13 @@ function resolveAnchor(dir, anchor, projectRoot) {
  * `linkCoOccurrence()` (wiki.mjs, inject.mjs) both key a task node by
  * `sessionId`, always, so there is exactly ONE task node for "the current
  * session" and it is `nodeId('task', sessionId)`. Restricting to that ONE
- * node structurally eliminates cases 1 and 2 -- a prior or concurrent
- * session's task has a DIFFERENT sessionId and therefore a different node
- * id, so it is never even looked at, regardless of timing. No caller can
- * supply a wrong sessionId and get someone ELSE's task; they can only fail
- * to get a match.
+ * node structurally eliminates cases 1 and 2 PROVIDED the identity itself is
+ * trustworthy: an UNRELATED sessionId (typo'd, invented, or simply absent)
+ * cannot resolve to someone else's task, because a different key is a
+ * different node id, full stop, regardless of timing. That is NOT the same
+ * guarantee as "no caller can get someone else's task" -- see the note on
+ * `authoritativeSessionId` below for the residual this leaves when the
+ * identity is real but comes from an untrusted caller.
  *
  * COVERAGE, NOT OVERLAP, fixes case 3: the session's task must have a
  * `derived_from` edge to EVERY one of this finding's anchors, not merely one.
@@ -472,17 +474,41 @@ function resolveAnchor(dir, anchor, projectRoot) {
  * or without a timestamp on that edge -- there is no ranking left for a
  * missing timestamp to lose.
  *
- * `sessionId` absent means there is no identity to scope by, which means no
- * candidate -- not "fall back to guessing". Absence is the correct answer
- * when the graph cannot support attribution.
+ * NO IDENTITY MEANS NO CANDIDATE -- not "fall back to guessing". Absence is
+ * the correct answer when the graph cannot support attribution.
+ *
+ * ROUND 4: THE IDENTITY ITSELF MUST BE AUTHORITATIVE, not merely present.
+ * Scoping to `nodeId('task', sessionId)` only refuses an UNRELATED session;
+ * it does nothing against a FOREIGN BUT REAL one. `wiki_write`'s `sessionId`
+ * is a plain MCP tool argument the calling model supplies, unverified -- a
+ * model that names some OTHER, prior session whose task genuinely covered
+ * these anchors gets an `answers` edge to that stale task, because coverage
+ * cannot tell "this session" from "a session that really did touch these
+ * files, named by a string nothing cross-checked". Session id is not
+ * evidence unless the CALLER'S OWN CHANNEL is trustworthy, which is true of
+ * `plugin/hooks/harvest-worker.mjs` (Claude Code's own hook payload) and not
+ * true of a tool-call argument. So this parameter is named for what it must
+ * be, `authoritativeSessionId`, and every caller is a promise: pass this only
+ * when you did not just read it out of untrusted input. `wiki_write` passes
+ * NONE, which means its calls never traverse -- see `writeHarvested`'s own
+ * comment at the call site for what that costs and why it is accepted rather
+ * than worked around.
+ *
+ * COVERAGE IS CHECKED AGAINST RESOLVED ANCHORS, not the caller's original
+ * list. `writeHarvested` already drops any anchor `resolveAnchor` could not
+ * resolve before this function ever runs, so "every anchor" here means every
+ * anchor that survived that filter -- self-consistent with the
+ * `derived_from` edges the same resolved list produces, but worth stating:
+ * an anchor that failed to resolve cannot raise or lower the bar for the
+ * anchors that did.
  */
-function taskForAnchors(graph, anchorIds, sessionId) {
-  if (!sessionId || !anchorIds || !anchorIds.length) return null;
-  const taskTarget = nodeId('task', sessionId);
+function taskForAnchors(graph, resolvedAnchorIds, authoritativeSessionId) {
+  if (!authoritativeSessionId || !resolvedAnchorIds || !resolvedAnchorIds.length) return null;
+  const taskTarget = nodeId('task', authoritativeSessionId);
   const task = graph.nodes.get(taskTarget);
   if (!task || task.kind !== 'task') return null;
 
-  for (const anchor of anchorIds) {
+  for (const anchor of resolvedAnchorIds) {
     const covered = graph.edges.some((edge) =>
       edge.edge === 'derived_from' && edge.from === taskTarget && edge.to === anchor
     );
@@ -604,7 +630,19 @@ function derivationFor(graph, resolvedAnchors, evidence, evidenceIncomplete, anc
 export function writeHarvested(
   dir,
   findings,
-  { sessionId = null, origin = ORIGIN_HARVESTED, projectRoot = null, taskId = null } = {}
+  {
+    sessionId = null,
+    origin = ORIGIN_HARVESTED,
+    projectRoot = null,
+    taskId = null,
+    // Distinct from `sessionId`, which is stored on every finding for
+    // provenance/display regardless of trust. This one gates the `answers`
+    // traversal fallback specifically, and every caller passing it is
+    // asserting the identity came from a channel it does not control --
+    // Claude Code's own hook payload, not a tool-call argument a model
+    // typed. See `taskForAnchors`'s comment for the attack this closes.
+    authoritativeSessionId = null,
+  } = {}
 ) {
   if (!Array.isArray(findings) || !findings.length) return [];
 
@@ -702,16 +740,29 @@ export function writeHarvested(
     // An explicit `taskId` is authoritative when a caller supplies one --
     // it OVERRIDES traversal rather than merely seeding it, so a caller that
     // knows better is never second-guessed by inference. Absent one, the task
-    // is DERIVED from the graph itself: `taskForAnchors` finds the CURRENT
-    // session's task (scoped by `sessionId`, the same identity this write
-    // already carries for provenance) and requires it to have touched EVERY
-    // one of this finding's anchors, not merely one -- see that function's
-    // own comment for the four attacks this closes. Either way, held to the
-    // same discipline as the anchors above: a target that does not resolve to
-    // an existing task node produces no edge rather than a dangling one.
+    // is DERIVED from the graph itself, but ONLY when `authoritativeSessionId`
+    // is present: `taskForAnchors` scopes to that exact session's task and
+    // requires it to have touched EVERY one of this finding's anchors, not
+    // merely one -- see that function's own comment for why the identity
+    // itself must be trustworthy, not merely present.
+    //
+    // THE CONSEQUENCE, STATED PLAINLY: `wiki_write` never supplies
+    // `authoritativeSessionId` (its `sessionId` is a model-typed MCP
+    // argument nothing cross-checks), so its calls never traverse and
+    // `answers` never fires on that path. `plugin/hooks/harvest-worker.mjs`
+    // does supply it (Claude Code's own hook payload), so `answers` fires
+    // there -- opt-in gated. `answers` therefore does NOT fire on a default
+    // install today. Recovering default liveness needs an authoritative
+    // identity on a default-install path, which is what Plan 2's
+    // `hooks-core/derive.mjs` (running in the Stop hook, where the session id
+    // is real) is for -- not a weaker check here.
+    //
+    // Either way, held to the same discipline as the anchors above: a target
+    // that does not resolve to an existing task node produces no edge rather
+    // than a dangling one.
     const answersTarget = taskId
       ? nodeId('task', taskId)
-      : taskForAnchors(currentGraph, resolved, sessionId);
+      : taskForAnchors(currentGraph, resolved, authoritativeSessionId);
     if (answersTarget && currentGraph.nodes.has(answersTarget)) {
       edges.push({ edge: 'answers', to: answersTarget });
     }

--- a/integrations/cline/hooks/token-optimizer/lib/harvest-write.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/harvest-write.mjs
@@ -436,7 +436,7 @@ function resolveAnchor(dir, anchor, projectRoot) {
 export function writeHarvested(
   dir,
   findings,
-  { sessionId = null, origin = ORIGIN_HARVESTED, projectRoot = null } = {}
+  { sessionId = null, origin = ORIGIN_HARVESTED, projectRoot = null, taskId = null } = {}
 ) {
   if (!Array.isArray(findings) || !findings.length) return [];
 
@@ -516,6 +516,21 @@ export function writeHarvested(
     // collision vanishingly unlikely while keeping the timestamp readable.
     const provenance = provenanceFor(finding);
     const key = `${prefixFor(provenance)}-${Date.now().toString(36)}-${written.length}-${randomBytes(4).toString("hex")}`;
+
+    const edges = resolved.map((target) => ({ edge: 'derived_from', to: target }));
+    // `answers` closes the loop back to the task that produced the finding, so
+    // provenance can be traversed rather than inferred: "which session
+    // established this, and from what". Declared in EDGE_KINDS and written by
+    // nothing until now. Held to the same discipline as the anchors above: a
+    // taskId that does not resolve to an existing task node produces no edge
+    // rather than a dangling one.
+    if (taskId) {
+      const taskTarget = nodeId('task', taskId);
+      if (currentGraph.nodes.has(taskTarget)) {
+        edges.push({ edge: 'answers', to: taskTarget });
+      }
+    }
+
     // ONE APPEND for the finding and every anchor it resolved. This runs in a
     // detached worker, so "the process survives to finish the loop" is not a
     // safe assumption: a node written without its edges is an active finding
@@ -557,7 +572,7 @@ export function writeHarvested(
           : undefined,
         sessionId,
       },
-      resolved.map((target) => ({ edge: 'derived_from', to: target }))
+      edges
     );
     // A failed write returns null. Reporting the key anyway would tell the
     // caller a claim was stored that no later session can retrieve.

--- a/integrations/cline/hooks/token-optimizer/lib/harvest-write.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/harvest-write.mjs
@@ -34,6 +34,7 @@ import { randomBytes } from 'node:crypto';
 import { realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
+import { readEvidence } from './metrics.mjs';
 
 /**
  * The types that may cross a project boundary.
@@ -428,6 +429,121 @@ function resolveAnchor(dir, anchor, projectRoot) {
 }
 
 /**
+ * Which task actually produced this finding, when nothing said so directly.
+ *
+ * Session id was the only signal `answers` had, and a session id is exactly
+ * what a caller may not have (`wiki_write`'s `sessionId` is optional and
+ * nothing populates it today; the detached harvest worker's is gated behind
+ * an opt-in). But the graph does not need to be TOLD which task this is: the
+ * structural harvest already writes `task -[derived_from]-> file` for every
+ * tool call, unconditionally, on every install. So the task is DERIVABLE --
+ * it is whichever task node has a `derived_from` edge to one of the SAME
+ * anchors this finding resolved to.
+ *
+ * "Most recent task, full stop" was rejected on purpose: a task that never
+ * touched these files could still be the newest node in the graph (a
+ * different file, a different concern, in a later session), and attaching
+ * provenance to it would be a WRONG edge, not a missing one -- worse than no
+ * edge, because a reader trusts it. So candidates are filtered to tasks that
+ * touched at least one of these anchors FIRST, and only ties among THOSE are
+ * broken by recency.
+ *
+ * The tie-break is the edge's own `at`, not the task node's `at`. A task that
+ * touched this file once, long ago, and then stayed active on unrelated files
+ * for hours has a late node timestamp that says nothing about this anchor;
+ * the edge timestamp says exactly when THIS task touched THIS anchor, which
+ * is the question being asked. Among tasks sharing an anchor, the one whose
+ * most recent touch to any shared anchor is latest wins -- recency of the
+ * relevant work, not recency of the task in general.
+ */
+function taskForAnchors(graph, anchorIds) {
+  if (!anchorIds || !anchorIds.length) return null;
+  const anchors = new Set(anchorIds);
+  let best = null;
+  for (const edge of graph.edges) {
+    if (edge.edge !== 'derived_from' || !anchors.has(edge.to)) continue;
+    const from = graph.nodes.get(edge.from);
+    // `derived_from` is also how a FINDING cites its own anchors, so without
+    // this a finding that already cited the same file would be mistaken for
+    // the task that produced it.
+    if (!from || from.kind !== 'task') continue;
+    const at = Number(edge.at) || 0;
+    if (!best || at > best.at) best = { taskId: edge.from, at };
+  }
+  return best ? best.taskId : null;
+}
+
+/**
+ * A file path the way `recordToolOutcome` (metrics.mjs) already truncates and
+ * stores it on a `tool-outcome` event's `anchor` field, so a derivation record
+ * can join against that log without a second, divergent notion of "the same
+ * anchor".
+ */
+function anchorLabel(rawAnchor) {
+  const path = String(rawAnchor).split('#')[0];
+  return canonicalPath(path).slice(0, 120);
+}
+
+/** How many recorded operations a single finding's derivation may cite. */
+const MAX_DERIVATION_OPERATIONS = 5;
+
+/**
+ * The checkable half of provenance: not just where a finding came from, but
+ * whether that derivation still holds.
+ *
+ * Citation-style provenance (a session or task id) answers "where". It never
+ * answers "does this still apply" -- that is what staleness already computes,
+ * by comparing an anchor's STORED hash against disk. This record is what lets
+ * that comparison be reconstructed for a specific claim rather than only for
+ * the anchor in general: the hash each anchor carried at the moment this
+ * finding was derived from it, plus what evidence exists that any work
+ * actually happened against it.
+ *
+ * DELIBERATELY NOT DUPLICATING THE EDGES. `derived_from` already records
+ * WHICH anchors this finding cites; restating that here would be a second,
+ * driftable copy of the same fact. What is new here, and only here, is the
+ * HASH each anchor carried at claim time -- edges carry no such thing.
+ *
+ * DELIBERATELY NOT A REPLAY LOG. Recording enough to mechanically re-run a
+ * derivation is a separate subsystem with real storage cost. This stores only
+ * what the evidence log already has: `tool-outcome` events matching these
+ * anchors, each reduced to the fields that were actually captured. An event
+ * that carries no exit code or output contributes none -- nothing here is
+ * invented to fill a shape the pipeline does not evidence yet. If a future
+ * capture pass adds `exit`/`output` to those events, this starts carrying them
+ * with no change to this function.
+ */
+function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
+  const anchorHashes = {};
+  for (const id of resolvedAnchors) {
+    const node = graph.nodes.get(id);
+    if (node && typeof node.hash === 'string') anchorHashes[id] = node.hash;
+  }
+
+  const labels = new Set((anchorSpecs || []).map(anchorLabel));
+  const operations = evidence
+    .filter((event) => event.kind === 'tool-outcome' && labels.has(event.anchor))
+    .sort((a, b) => (Number(b.at) || 0) - (Number(a.at) || 0))
+    .slice(0, MAX_DERIVATION_OPERATIONS)
+    .map((event) => {
+      const op = {};
+      if (typeof event.toolName === 'string' && event.toolName)
+        op.tool = event.toolName.slice(0, 60);
+      if (typeof event.success === 'boolean') op.success = event.success;
+      if (typeof event.at === 'number') op.at = event.at;
+      // Forward-compatible, not fabricated: neither field exists on a
+      // `tool-outcome` event in this pipeline today, so every operation
+      // omits them until a capture pass actually evidences one.
+      if (typeof event.exit === 'number') op.exit = event.exit;
+      if (typeof event.output === 'string' && event.output)
+        op.output = event.output.slice(0, 200);
+      return op;
+    });
+
+  return { at: Date.now(), anchors: anchorHashes, operations };
+}
+
+/**
  * Writes validated findings, returning the keys actually stored.
  *
  * `findings` is the output of `harvest.validate()`, so type/claim/confidence
@@ -467,6 +583,11 @@ export function writeHarvested(
       : batch;
   const prefixFor = (p) =>
     p === ORIGIN_AGENT ? 'agent' : p === ORIGIN_HUMAN ? 'human' : 'harvested';
+
+  // Read once: every finding in this batch shares the same evidence log, and
+  // it can hold thousands of lines, so re-reading it per finding would turn a
+  // batch of N findings into N passes over the same bytes.
+  const evidence = readEvidence(dir);
 
   const written = [];
   for (const finding of findings) {
@@ -521,14 +642,21 @@ export function writeHarvested(
     // `answers` closes the loop back to the task that produced the finding, so
     // provenance can be traversed rather than inferred: "which session
     // established this, and from what". Declared in EDGE_KINDS and written by
-    // nothing until now. Held to the same discipline as the anchors above: a
-    // taskId that does not resolve to an existing task node produces no edge
-    // rather than a dangling one.
-    if (taskId) {
-      const taskTarget = nodeId('task', taskId);
-      if (currentGraph.nodes.has(taskTarget)) {
-        edges.push({ edge: 'answers', to: taskTarget });
-      }
+    // nothing until now.
+    //
+    // An explicit `taskId` is authoritative when a caller supplies one --
+    // it OVERRIDES traversal rather than merely seeding it, so a caller that
+    // knows better is never second-guessed by inference. Absent one, the task
+    // is DERIVED from the graph itself: `taskForAnchors` finds the task that
+    // actually touched these anchors, which needs no session id from anyone.
+    // Either way, held to the same discipline as the anchors above: a target
+    // that does not resolve to an existing task node produces no edge rather
+    // than a dangling one.
+    const answersTarget = taskId
+      ? nodeId('task', taskId)
+      : taskForAnchors(currentGraph, resolved);
+    if (answersTarget && currentGraph.nodes.has(answersTarget)) {
+      edges.push({ edge: 'answers', to: answersTarget });
     }
 
     // ONE APPEND for the finding and every anchor it resolved. This runs in a
@@ -571,6 +699,15 @@ export function writeHarvested(
           ? finding.quote
           : undefined,
         sessionId,
+        // THE CHECKABLE HALF OF PROVENANCE. Citation-style (this `sessionId`,
+        // the `answers` edge above) says WHERE a claim came from; it never
+        // says whether that derivation still applies. `derivationFor` reaches
+        // through `wiki_query`'s `node`/`get`/`search` operations only (those
+        // return a finding's stored fields wholesale) -- never through
+        // `render()`/`renderSessionIndex()` in inject.mjs or `wiki_read`'s
+        // `toFinding()` projection, neither of which reads this field, so it
+        // is not part of the automatic per-touch injection `fit()` prices.
+        derivation: derivationFor(currentGraph, resolved, evidence, finding.anchors || []),
       },
       edges
     );

--- a/integrations/cline/hooks/token-optimizer/lib/inject.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/inject.mjs
@@ -26,6 +26,7 @@ import {
 } from './wiki.mjs';
 import { basename } from 'node:path';
 import { serve, diffLines } from './staleness.mjs';
+import { drainInvalidations } from './pending.mjs';
 import { inHoldout, record, indexBudget } from './metrics.mjs';
 import { canonicalPath, resolvableCandidates } from './paths.mjs';
 import { annotatedSkeleton } from './skeleton.mjs';
@@ -142,6 +143,31 @@ function render(finding) {
 }
 
 /**
+ * Applies anything the post-tool hook queued, BEFORE anything is served.
+ *
+ * THIS IS WHERE EAGER STALENESS LANDS. `invalidateOnWrite` needs a graph, and
+ * loading one on the return path of every write is what pending.mjs exists to
+ * avoid -- so the hook queues and the next graph read applies. These two
+ * functions are that read: they already hold a freshly loaded graph, and they
+ * are the last thing to run before a finding reaches a model.
+ *
+ * RE-READ ONLY WHEN SOMETHING WAS ACTUALLY MARKED. The drain writes the stale
+ * flag to disk; it cannot mutate the caller's already-parsed graph, so serving
+ * from that copy would deliver the very "stale finding as fresh" this exists to
+ * prevent. A second load costs a parse, and it is paid once per observed write
+ * rather than once per tool call -- when nothing is queued this is one stat.
+ */
+function withPendingApplied(dir, graph) {
+  try {
+    return drainInvalidations(dir, graph) > 0 ? load(dir) : graph;
+  } catch {
+    // The lazy path still covers everything this would have caught early, and
+    // a hook must never fail because bookkeeping did.
+    return graph;
+  }
+}
+
+/**
  * What the model sees when it touches a file.
  *
  * Returns null when there is nothing to say, or when this touch fell into the
@@ -154,6 +180,7 @@ export function forTouch(
   rawPath,
   { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
+  graph = withPendingApplied(dir, graph);
   // Canonical, so a touch finds findings anchored under any other spelling.
   const filePath = canonicalPath(rawPath);
   const anchorId = nodeId('file', filePath);
@@ -322,6 +349,7 @@ export function forCommand(
   { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
   if (!command) return null;
+  graph = withPendingApplied(dir, graph);
 
   const candidates = [];
   for (const node of graph.nodes.values()) {

--- a/integrations/cline/hooks/token-optimizer/lib/inject.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/inject.mjs
@@ -33,6 +33,7 @@ import { annotatedSkeleton } from './skeleton.mjs';
 import { substitutionBudget } from './metrics.mjs';
 import { assessFindings } from './utility.mjs';
 import { quarantineSharedSource } from './harvest-write.mjs';
+import { cacheOrdered } from './cache.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
@@ -1152,6 +1153,53 @@ export function standingRules(dir, graph, { budget = standingBudget(), episode =
   // which is worse than saying there are more: a model that knows the list is
   // truncated can ask, one that does not will assume it is complete.
   return `${HEADING}${lines.join('\n')}${truncated}`;
+}
+
+/**
+ * SessionStart context, assembled in cache order: stable first, volatile last.
+ *
+ * WHY THE ORDER IS A CORRECTNESS PROPERTY AND NOT A STYLE CHOICE. Everything
+ * here lands near the FRONT of the prompt prefix, and a prefix cache is
+ * invalidated from the first differing byte onward. A block whose text changes
+ * between sessions therefore prices everything positioned after it: put the
+ * freshest block first and the whole remainder of the prefix is re-written
+ * every session; put it last and the invalidation is confined to its own tail.
+ * cache.mjs measures exactly this cost in the user's files -- this is the same
+ * discipline applied to our own output, which is the half nobody else has to
+ * think about because nobody else writes into the prefix.
+ *
+ * `cacheOrdered` existed for precisely this and had no caller, so the order was
+ * whatever order the call sites happened to push in. It was accidentally right;
+ * it is now enforced, which is the difference that matters the next time a
+ * block is added.
+ *
+ * VOLATILITY IS ASSIGNED FROM HOW OFTEN THE TEXT ACTUALLY DIFFERS BETWEEN
+ * SESSIONS, not from how important the block is:
+ *
+ *   0  policy -- the optimization notice and project briefing. Deliberately
+ *      cache-safe by construction: the routing facts are number-free and the
+ *      briefing passes through `stableText`, which DROPS any line that would
+ *      vary. It changes when the tool inventory or configuration changes.
+ *   1  standing -- pinned facts and human-verified corrections, rendered in
+ *      full. Changes only when a person pins, retires or corrects something.
+ *   2  index -- the bounded wiki index, selected per session from the task
+ *      text, and carrying [STALE]/[DISPUTED] markers that flip as the code
+ *      moves. Different on most sessions.
+ *   3  restoration -- present only when resuming from a compaction, and derived
+ *      from the anchors of the session that was just discarded. Never twice the
+ *      same.
+ *
+ * A block with no text is dropped rather than joined, so an absent block cannot
+ * open the assembly with a blank line.
+ */
+export function sessionContext(blocks) {
+  return cacheOrdered(
+    (Array.isArray(blocks) ? blocks : []).filter(
+      (block) => block && typeof block.text === 'string' && block.text.trim()
+    )
+  )
+    .map((block) => block.text)
+    .join('\n\n');
 }
 
 /**

--- a/integrations/cline/hooks/token-optimizer/lib/inject.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/inject.mjs
@@ -122,8 +122,29 @@ function fit(findings, budget) {
   return { kept, spent };
 }
 
+/**
+ * Discloses an open disagreement, on the same line as the claim it is about.
+ *
+ * BOTH HALVES, like the stale renderer below: the strong form names the other
+ * finding so the reader can fetch it, and the form without a key says only what
+ * is actually known. `serve` is what establishes the dispute; this only phrases
+ * it, and it phrases it in one short line because `fit` prices `render` against
+ * the injection budget -- a disagreement is worth a pointer, not both claims in
+ * full.
+ *
+ * NO DISMISSAL VOCABULARY, for the reason measured on the stale wording: an
+ * instruction to discount suppressed findings that were correct. This states
+ * that another claim exists and where to find it, and lets the reader decide.
+ */
+function disputeNote(finding) {
+  if (!finding.contradicted) return '';
+  return finding.contradictedBy
+    ? `\n  DISPUTED by ${finding.contradictedBy} -- wiki_query that key for the other claim`
+    : '\n  DISPUTED by another finding in this graph';
+}
+
 function render(finding) {
-  const head = `- [${finding.type || 'finding'}] ${finding.claim}`;
+  const head = `- [${finding.type || 'finding'}] ${finding.claim}${disputeNote(finding)}`;
   if (!finding.stale) return head;
 
   // A stale finding NEVER renders as though it were current. But the strength
@@ -997,7 +1018,15 @@ function renderSessionIndex(total, findings) {
       : finding.stale
         ? ' [possibly stale; verify before use]'
         : '';
-    return `- ${finding.key}${freshness}: ${finding.claim.slice(0, 90)}`;
+    // The session index is the first thing a session reads, so a disputed
+    // finding must not be listed there as settled either. Compressed to a
+    // marker and a key, matching the freshness markers beside it.
+    const dispute = finding.contradicted
+      ? finding.contradictedBy
+        ? ` [DISPUTED by ${finding.contradictedBy}]`
+        : ' [DISPUTED]'
+      : '';
+    return `- ${finding.key}${freshness}${dispute}: ${finding.claim.slice(0, 90)}`;
   });
   return `# Project wiki (${total} findings, ${findings.length} listed)
 

--- a/integrations/cline/hooks/token-optimizer/lib/inject.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/inject.mjs
@@ -139,9 +139,26 @@ function fit(findings, budget) {
  */
 function disputeNote(finding) {
   if (!finding.contradicted) return '';
-  return finding.contradictedBy
+  const head = finding.contradictedBy
     ? `\n  DISPUTED by ${finding.contradictedBy} -- wiki_query that key for the other claim`
     : '\n  DISPUTED by another finding in this graph';
+  // THE REASON A PERSON TYPED, rendered here because this is the fullest of the
+  // three dispute surfaces and the only one with room for a sentence. `contradict`
+  // has always stored up to 400 characters of human explanation and, until this
+  // line, nothing read it: the pointer told a reader where to look and withheld
+  // the one thing that would tell them whether looking was worth a tool call.
+  //
+  // TRUNCATED AT 140, because `fit` prices this string against the injection
+  // budget and a 400-character paragraph beside a one-line claim inverts the
+  // proportions. The compressed surfaces -- the session index and restore.mjs's
+  // "Likely next" list -- deliberately keep marker-and-key only; they are one
+  // line per finding by design, and `wiki_query` returns the reason in full.
+  if (typeof finding.contradictionReason !== 'string' || !finding.contradictionReason.trim()) {
+    return head;
+  }
+  const reason = finding.contradictionReason.trim();
+  const shown = reason.length > 140 ? `${reason.slice(0, 140)}...` : reason;
+  return `${head}\n  Reason given: ${shown}`;
 }
 
 /**

--- a/integrations/cline/hooks/token-optimizer/lib/inject.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/inject.mjs
@@ -276,7 +276,10 @@ export function forTouch(
   // others, so the comparison becomes within-file and the dominant source of
   // variance drops out. A session-pinned arm would destroy that.
   const holdout = inHoldout(filePath);
-  const served = serve(graph, candidates);
+  // `dir` so an eager flag whose evidence is gone is cleared here rather than
+  // waiting for somebody to open the dashboard. Same evidence test as the manual
+  // path -- see `serve`.
+  const served = serve(graph, candidates, { dir });
   const assessed = assessFindings(dir, served, {
     episodeId: episode.episodeId || sessionId,
     relevanceFor: () => 1,
@@ -463,7 +466,7 @@ export function forCommand(
   // only thing an uncapped list buys is the I/O.
   const considered = candidates.slice(0, MAX_COMMAND_CANDIDATES);
 
-  const served = serve(graph, considered);
+  const served = serve(graph, considered, { dir });
   const assessed = assessFindings(dir, served, {
     episodeId: episode.episodeId || sessionId,
     relevanceFor: (finding) => explicit(finding) ? 1 : 0.6,
@@ -990,7 +993,7 @@ export function sessionIndex(dir, graph, { episode = {}, relevantFindingIds = []
   // `serve` is the only path allowed to hand a finding to a model. In
   // particular, activating this previously-unwired index must not create a new
   // path that labels an invalidated content claim as current.
-  const served = serve(graph, selected);
+  const served = serve(graph, selected, { dir });
   if (!served.length) return null;
   // A stale marker is longer than the fresh preview used for candidate
   // selection. Trim from the lowest-ranked end until the ACTUAL message fits.

--- a/integrations/cline/hooks/token-optimizer/lib/inject.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/inject.mjs
@@ -156,9 +156,9 @@ function disputeNote(finding) {
 function derivationNote(finding) {
   if (finding.derivationHolds !== false) return '';
   const changed = Array.isArray(finding.derivationChanged) ? finding.derivationChanged : [];
-  return changed.length
-    ? `\n  DERIVATION CHANGED -- ${changed.join(', ')} no longer match what this claim was derived from`
-    : '\n  DERIVATION CHANGED since this claim was recorded';
+  if (!changed.length) return '\n  DERIVATION CHANGED since this claim was recorded';
+  const verb = changed.length === 1 ? 'no longer matches' : 'no longer match';
+  return `\n  DERIVATION CHANGED -- ${changed.join(', ')} ${verb} what this claim was derived from`;
 }
 
 function render(finding) {

--- a/integrations/cline/hooks/token-optimizer/lib/inject.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/inject.mjs
@@ -143,8 +143,26 @@ function disputeNote(finding) {
     : '\n  DISPUTED by another finding in this graph';
 }
 
+/**
+ * Discloses `derivationCheck`'s verdict (staleness.mjs) -- distinct from
+ * `disputeNote` (another finding disagrees) and from the STALE block below
+ * (the anchor NODE's current hash does not match disk). This is about
+ * whether the bytes THIS claim was actually derived from are still the bytes
+ * an anchor holds; see `derivationCheck`'s comment for the case that catches
+ * that the other two can miss. Silent when it holds -- the common case pays
+ * nothing -- and silent when it was never checked at all (an older finding
+ * with no `derivation` record).
+ */
+function derivationNote(finding) {
+  if (finding.derivationHolds !== false) return '';
+  const changed = Array.isArray(finding.derivationChanged) ? finding.derivationChanged : [];
+  return changed.length
+    ? `\n  DERIVATION CHANGED -- ${changed.join(', ')} no longer match what this claim was derived from`
+    : '\n  DERIVATION CHANGED since this claim was recorded';
+}
+
 function render(finding) {
-  const head = `- [${finding.type || 'finding'}] ${finding.claim}${disputeNote(finding)}`;
+  const head = `- [${finding.type || 'finding'}] ${finding.claim}${disputeNote(finding)}${derivationNote(finding)}`;
   if (!finding.stale) return head;
 
   // A stale finding NEVER renders as though it were current. But the strength

--- a/integrations/cline/hooks/token-optimizer/lib/inject.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/inject.mjs
@@ -157,9 +157,28 @@ function render(finding) {
  * prevent. A second load costs a parse, and it is paid once per observed write
  * rather than once per tool call -- when nothing is queued this is one stat.
  */
+/**
+ * Per process, per graph directory: did the drain change anything?
+ *
+ * THE SECOND CALLER IS WHY THIS EXISTS. SessionStart calls `standingRules` and
+ * then `sessionIndex` with the SAME graph object it loaded once. Without this
+ * memo the first call drains, marks, and re-reads privately -- and the second
+ * call finds an empty queue, marks nothing, and therefore serves from the
+ * caller's pre-drain copy, advertising as current the very finding the first
+ * call had just marked. Draining is not idempotent from the caller's point of
+ * view; remembering the ANSWER is what makes it so.
+ *
+ * A hook process handles one lifecycle event, so this map holds one or two
+ * entries and dies with the process.
+ */
+const drainedDirs = new Map();
+
 function withPendingApplied(dir, graph) {
   try {
-    return drainInvalidations(dir, graph) > 0 ? load(dir) : graph;
+    if (drainedDirs.has(dir)) return drainedDirs.get(dir) ? load(dir) : graph;
+    const marked = drainInvalidations(dir, graph) > 0;
+    drainedDirs.set(dir, marked);
+    return marked ? load(dir) : graph;
   } catch {
     // The lazy path still covers everything this would have caught early, and
     // a hook must never fail because bookkeeping did.
@@ -862,6 +881,12 @@ export function relevantFindingIdsForContext(graph, context, { limit = 8 } = {})
  * shrinks toward the floor. See metrics.indexBudget.
  */
 export function sessionIndex(dir, graph, { episode = {}, relevantFindingIds = [] } = {}) {
+  // DRAINED HERE TOO, and this is the worst place to be wrong. The session index
+  // is the FIRST thing a session sees and it arrives with no other context to
+  // correct it, so advertising a finding the graph already knows is stale is a
+  // false claim made at maximum leverage. The graph is loaded either way, so the
+  // only cost is the stat that finds no queue.
+  graph = withPendingApplied(dir, graph);
   const budget = indexBudget(dir);
   const relevant = new Set(relevantFindingIds);
   // Some SessionStart payloads have no task signal. Fail closed for situational
@@ -988,6 +1013,9 @@ ${lines.join('\n')}`;
  * is wallpaper, and the model stops reading the thing it always sees.
  */
 export function standingRules(dir, graph, { budget = standingBudget(), episode = {} } = {}) {
+  // Same reason as sessionIndex: always-on text, delivered before the first
+  // tool call, with nothing following it that could qualify what it said.
+  graph = withPendingApplied(dir, graph);
   const rules = [...graph.nodes.values()].filter(
     (n) =>
       n.kind === 'finding' &&

--- a/integrations/cline/hooks/token-optimizer/lib/inject.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/inject.mjs
@@ -143,6 +143,40 @@ function render(finding) {
 }
 
 /**
+ * Graph directories where a drain has already marked something in THIS process.
+ *
+ * THE SECOND CALLER IS WHY THIS EXISTS. SessionStart calls `standingRules` and
+ * then `sessionIndex` with the SAME graph object it loaded once. Without this,
+ * the first call drains, marks, and re-reads privately -- and the second call
+ * finds an empty queue, marks nothing, and therefore serves from the caller's
+ * pre-drain copy, advertising as current the very finding the first call had
+ * just marked. Draining is idempotent; its EFFECT on a caller's parsed graph is
+ * not, so what is remembered here is "a re-read is owed", nothing else.
+ *
+ * ONLY THE POSITIVE CASE IS REMEMBERED, and that is a correctness decision
+ * rather than a tuning one. Remembering "nothing was queued" would mean a queue
+ * arriving LATER in the same process is silently skipped and deferred to some
+ * future session. That cannot happen today, because `queueInvalidation` runs in
+ * the post-tool branch before any injection -- but that is an unguarded
+ * ordering dependency, and it stops being true the moment someone adds a call
+ * site. A repeated empty drain costs one `existsSync` on a file that is not
+ * there, which is a price worth paying to not have an invariant that depends on
+ * nobody reordering anything.
+ *
+ * KEYED CANONICALLY. Two spellings of one directory -- a trailing separator, a
+ * `..` segment, a lower-cased drive letter -- would otherwise be two entries,
+ * which reintroduces exactly the pre-drain-copy bug above. This is the same
+ * defect shape Task 2 on this branch shipped for real, where a tool resolved its
+ * graph from a raw cwd while the hooks resolved theirs through `projectRootFor`
+ * and the two halves of a metric landed in different directories. Path identity
+ * is why `canonicalKey` lives inside `nodeId` rather than at its call sites.
+ *
+ * A hook process handles one lifecycle event, so this set holds one or two
+ * entries and dies with the process.
+ */
+const drainedDirs = new Set();
+
+/**
  * Applies anything the post-tool hook queued, BEFORE anything is served.
  *
  * THIS IS WHERE EAGER STALENESS LANDS. `invalidateOnWrite` needs a graph, and
@@ -157,28 +191,14 @@ function render(finding) {
  * prevent. A second load costs a parse, and it is paid once per observed write
  * rather than once per tool call -- when nothing is queued this is one stat.
  */
-/**
- * Per process, per graph directory: did the drain change anything?
- *
- * THE SECOND CALLER IS WHY THIS EXISTS. SessionStart calls `standingRules` and
- * then `sessionIndex` with the SAME graph object it loaded once. Without this
- * memo the first call drains, marks, and re-reads privately -- and the second
- * call finds an empty queue, marks nothing, and therefore serves from the
- * caller's pre-drain copy, advertising as current the very finding the first
- * call had just marked. Draining is not idempotent from the caller's point of
- * view; remembering the ANSWER is what makes it so.
- *
- * A hook process handles one lifecycle event, so this map holds one or two
- * entries and dies with the process.
- */
-const drainedDirs = new Map();
-
 function withPendingApplied(dir, graph) {
   try {
-    if (drainedDirs.has(dir)) return drainedDirs.get(dir) ? load(dir) : graph;
-    const marked = drainInvalidations(dir, graph) > 0;
-    drainedDirs.set(dir, marked);
-    return marked ? load(dir) : graph;
+    const key = canonicalPath(dir);
+    // The drain runs EVERY time. It is one stat when there is nothing to do,
+    // and running it unconditionally is what keeps the memo from encoding an
+    // assumption about which hook branch ran first.
+    if (drainInvalidations(dir, graph) > 0) drainedDirs.add(key);
+    return drainedDirs.has(key) ? load(dir) : graph;
   } catch {
     // The lazy path still covers everything this would have caught early, and
     // a hook must never fail because bookkeeping did.

--- a/integrations/cline/hooks/token-optimizer/lib/lexical.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/lexical.mjs
@@ -1,0 +1,73 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/lexical.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * BM25 over findings. Pure, dependency-free, deterministic.
+ *
+ * WHY THIS REPLACES `includes()`. The dashboard filtered findings by substring,
+ * which cannot RANK -- and every consumer of retrieval here is under a hard
+ * token budget, so the budget kept whatever happened to match rather than what
+ * matched best. Ranking is the whole value at a budget.
+ *
+ * WHY BM25 AND NOT EMBEDDINGS. Deliberate, per docs/WIKI_GRAPH.md: deterministic,
+ * instant, explainable, and it cannot drift or need a rebuild. The known cost is
+ * recall on findings with no lexical overlap; Plan 2's recall probe measures that
+ * rather than assuming it away.
+ */
+
+/** Non-word split, lowercased. Short tokens are kept: `fs`, `id`, `os` matter here. */
+export function tokenize(text) {
+  return String(text || '')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+}
+
+/**
+ * Classic BM25. `k1` controls term-frequency saturation, `b` length normalisation.
+ * Defaults are the standard ones and are exposed so the recall probe can sweep them.
+ */
+export function rank(query, findings, { limit = 20, k1 = 1.2, b = 0.75 } = {}) {
+  const terms = tokenize(query);
+  if (!terms.length || !Array.isArray(findings) || !findings.length) return [];
+
+  // A finding's searchable text is its claim AND its key: the key is how the
+  // session index refers to it, so a model quoting a key must find it.
+  const docs = findings.map((finding) => ({
+    finding,
+    tokens: tokenize(`${finding.key || ''} ${finding.claim || ''}`),
+  }));
+
+  const avgLen = docs.reduce((sum, d) => sum + d.tokens.length, 0) / docs.length;
+  const N = docs.length;
+
+  const docFreq = new Map();
+  for (const { tokens } of docs) {
+    for (const term of new Set(tokens)) {
+      docFreq.set(term, (docFreq.get(term) || 0) + 1);
+    }
+  }
+
+  const scored = [];
+  for (const { finding, tokens } of docs) {
+    const counts = new Map();
+    for (const token of tokens) counts.set(token, (counts.get(token) || 0) + 1);
+
+    let score = 0;
+    for (const term of terms) {
+      const tf = counts.get(term);
+      if (!tf) continue;
+      const df = docFreq.get(term) || 0;
+      // Standard BM25 IDF, floored at zero so a term present in every document
+      // contributes nothing rather than a negative score.
+      const idf = Math.max(0, Math.log(1 + (N - df + 0.5) / (df + 0.5)));
+      const norm = tf + k1 * (1 - b + (b * tokens.length) / (avgLen || 1));
+      score += idf * ((tf * (k1 + 1)) / (norm || 1));
+    }
+
+    // Zero means no term matched. Omitted rather than returned, so a caller
+    // under a token budget never spends it on an irrelevant finding.
+    if (score > 0) scored.push({ finding, score });
+  }
+
+  return scored.sort((a, b2) => b2.score - a.score).slice(0, limit);
+}

--- a/integrations/cline/hooks/token-optimizer/lib/lexical.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/lexical.mjs
@@ -14,12 +14,54 @@
  * rather than assuming it away.
  */
 
-/** Non-word split, lowercased. Short tokens are kept: `fs`, `id`, `os` matter here. */
-export function tokenize(text) {
-  return String(text || '')
-    .toLowerCase()
-    .split(/[^a-z0-9]+/)
+/**
+ * Splits an identifier's alphanumeric run into its camelCase / letter-digit
+ * parts, e.g. `skipLibCheck` -> ['skip', 'Lib', 'Check'], `TS2345` ->
+ * ['TS', '2345']. Returns a single-element array when there is no internal
+ * boundary (e.g. `retry` -> ['retry']) so callers can skip emitting a
+ * redundant duplicate of the whole token.
+ */
+function splitIdentifierParts(word) {
+  return word
+    .replace(/([a-z])([A-Z])/g, '$1\0$2')
+    .replace(/([A-Za-z])([0-9])/g, '$1\0$2')
+    .replace(/([0-9])([A-Za-z])/g, '$1\0$2')
+    .split('\0')
     .filter(Boolean);
+}
+
+/**
+ * Non-word split, lowercased. Short tokens are kept: `fs`, `id`, `os` matter
+ * here.
+ *
+ * Emits sub-tokens for compound identifiers, in addition to the whole token.
+ * Delimited identifiers (`smart_read`, `wiki.mjs`, the flag in
+ * `--skipLibCheck`) already round-trip fine: the delimiter splits them, and
+ * because query and claim pass through this same function, a query typed
+ * with the same delimiters matches. The silent gap was CONCATENATED
+ * identifiers with no delimiter at all -- `skipLibCheck` collapsed to the
+ * single token `skiplibcheck`, so a query for "skip lib check" (or "TS 2345"
+ * against `TS2345`) never intersected it. No error, just an absent result --
+ * and findings are about code, where run-together identifiers are the
+ * common case. So every alphanumeric run keeps its whole-token form (a query
+ * for the concatenated form still matches) and ALSO contributes its
+ * camelCase / letter-digit parts (a query for the separated form now
+ * matches too). A lone incidental character -- e.g. the `c` split out of a
+ * Windows path `C:\Users\...` -- needs no special-casing: it is a real
+ * token like any other, and BM25's IDF already discounts a term that shows
+ * up in nearly every finding.
+ */
+export function tokenize(text) {
+  const words = String(text || '').match(/[A-Za-z0-9]+/g) || [];
+  const tokens = [];
+  for (const word of words) {
+    tokens.push(word.toLowerCase());
+    const parts = splitIdentifierParts(word);
+    if (parts.length > 1) {
+      for (const part of parts) tokens.push(part.toLowerCase());
+    }
+  }
+  return tokens;
 }
 
 /**
@@ -57,9 +99,15 @@ export function rank(query, findings, { limit = 20, k1 = 1.2, b = 0.75 } = {}) {
       const tf = counts.get(term);
       if (!tf) continue;
       const df = docFreq.get(term) || 0;
-      // Standard BM25 IDF, floored at zero so a term present in every document
-      // contributes nothing rather than a negative score.
-      const idf = Math.max(0, Math.log(1 + (N - df + 0.5) / (df + 0.5)));
+      // Smoothed BM25 idf: log(1 + (N - df + 0.5) / (df + 0.5)). Unlike the
+      // classic unsmoothed idf (log((N - df + 0.5) / (df + 0.5))), which goes
+      // negative once a term appears in most documents, this smoothed form
+      // is strictly positive for every df in [1, N]: even at df === N the
+      // ratio inside the log is (N + 1) / (N + 0.5), which is always
+      // strictly greater than 1, so log(1 + that) is always > 0. No floor
+      // is needed here, and none is applied -- there is no negative case
+      // for this formula to guard against.
+      const idf = Math.log(1 + (N - df + 0.5) / (df + 0.5));
       const norm = tf + k1 * (1 - b + (b * tokens.length) / (avgLen || 1));
       score += idf * ((tf * (k1 + 1)) / (norm || 1));
     }

--- a/integrations/cline/hooks/token-optimizer/lib/lexical.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/lexical.mjs
@@ -65,6 +65,43 @@ export function tokenize(text) {
 }
 
 /**
+ * Effective term-frequency credit for a document that has NO exact token
+ * match for a query term but DOES have a token that starts with it (e.g.
+ * query `custom` against a document containing `customer`). Deliberately
+ * less than one exact occurrence (`1`), and it is a flat credit rather than
+ * one that grows with the number of prefix-matching tokens in the document,
+ * so a prefix hit can never outscore an exact hit of the same term:
+ *
+ *   BM25's per-term contribution is `idf * tf * (k1 + 1) / (tf + K)`, where
+ *   `K = k1 * (1 - b + b * L / avgL)` depends only on document length, not
+ *   on which term or how it matched. As a function of `tf` alone, with `K`
+ *   fixed, `f(tf) = tf / (tf + K)` is non-decreasing for every `tf >= 0` and
+ *   `k1 >= 0` (its derivative `K / (tf + K)^2` is never negative). So for
+ *   ANY document length, and any number of prefix-only occurrences, using
+ *   `PREFIX_TF < 1` in place of `tf` scores no higher than an actual exact
+ *   occurrence (`tf = 1`) would in that same document -- there is no
+ *   PREFIX_TF-independent way to accumulate more evidence than one real hit
+ *   by matching only a prefix. This is also why the count of prefix matches
+ *   is otherwise irrelevant here: it never feeds back into the score.
+ *
+ * PREFIX MATCHING IS NOT SUBSTRING MATCHING. It restores recall for a
+ * fragment typed at the START of a word -- `custom` now finds `customer` --
+ * which is the common case (a user typing the first few letters of a term
+ * they remember). It does NOT restore the old `.includes()` filter's ability
+ * to find a term in the MIDDLE of a word: a query for `tomer` still will not
+ * find `customer`. That recall gap is accepted, not silently reintroduced.
+ */
+const PREFIX_TF = 0.5;
+
+/**
+ * Below this length, a query term is not eligible for prefix matching: a
+ * one- or two-character prefix (`a`, `re`) is a substring of a large
+ * fraction of any real vocabulary, so it would match nearly every document
+ * and IDF alone would not discount it enough to keep the results relevant.
+ */
+const PREFIX_MIN_TERM_LENGTH = 3;
+
+/**
  * Classic BM25. `k1` controls term-frequency saturation, `b` length normalisation.
  * Defaults are the standard ones and are exposed so the recall probe can sweep them.
  */
@@ -96,7 +133,21 @@ export function rank(query, findings, { limit = 20, k1 = 1.2, b = 0.75 } = {}) {
 
     let score = 0;
     for (const term of terms) {
-      const tf = counts.get(term);
+      let tf = counts.get(term) || 0;
+
+      // No exact occurrence: fall back to a prefix match, which is weaker
+      // evidence and so credited at a flat PREFIX_TF rather than a real
+      // count (see PREFIX_TF's comment for why that ordering is safe). Only
+      // considered when nothing already matched exactly and the term is
+      // long enough that "starts with" is a meaningful signal.
+      if (tf === 0 && term.length >= PREFIX_MIN_TERM_LENGTH) {
+        for (const token of counts.keys()) {
+          if (token !== term && token.startsWith(term)) {
+            tf = PREFIX_TF;
+            break;
+          }
+        }
+      }
       if (!tf) continue;
       const df = docFreq.get(term) || 0;
       // Smoothed BM25 idf: log(1 + (N - df + 0.5) / (df + 0.5)). Unlike the

--- a/integrations/cline/hooks/token-optimizer/lib/metrics.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/metrics.mjs
@@ -455,6 +455,23 @@ export function readBalance(dir) {
   return out;
 }
 
+/**
+ * True when `readEvidence` could not have read the whole log -- the file
+ * exceeds the byte cap, so anything written before the tail it kept is
+ * silently absent from what it returned. A caller that builds a per-claim
+ * record from `readEvidence` (the wiki graph's derivation record) needs this
+ * to say "operations existed but are not recorded here" rather than let an
+ * empty result read as "nothing happened".
+ */
+export function evidenceTruncated(dir) {
+  const path = evidencePath(dir);
+  try {
+    return statSync(path).size > MAX_BYTES;
+  } catch {
+    return false;
+  }
+}
+
 /** Every causal evidence record inside the byte cap, deduplicated by id. */
 export function readEvidence(dir) {
   const path = evidencePath(dir);

--- a/integrations/cline/hooks/token-optimizer/lib/observability.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/observability.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 /**
  * Privacy-safe, cross-client lifecycle diagnostics.
  *

--- a/integrations/cline/hooks/token-optimizer/lib/pending.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/pending.mjs
@@ -39,7 +39,7 @@ import {
   statSync,
 } from 'node:fs';
 import { join } from 'node:path';
-import { invalidateOnWrite } from './staleness.mjs';
+import { invalidateChangedAnchors, invalidateOnWrite } from './staleness.mjs';
 import { canonicalPath, isFsSafePath, resolvableCandidates } from './paths.mjs';
 
 const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
@@ -190,31 +190,85 @@ function hasEditEvidence(payload, raw) {
 }
 
 /**
- * The evidence a completed mutation left behind, or null when there is none.
+ * Canonical tool names that mean bytes on disk changed.
  *
- * Separate from `queueInvalidation` so the caller can be a hook branch that
- * knows nothing about diffs, and so the reconstruction above is testable
- * without a filesystem queue.
+ * THE NORMALISED SET, not any client's own vocabulary. `normalizePayload` has
+ * already mapped `replace`, `write_file`, `apply_patch`, `str_replace`,
+ * `search_replace` and the rest onto these three through decide.mjs's alias
+ * table -- and a tool that table cannot map arrives as null and exits the hook
+ * before this module is reached at all. So matching here is both complete for
+ * every client the adapter serves and impossible to spell wrong.
+ *
+ * `NotebookEdit` is absent because `normalizeTool` maps it to null, and the MCP
+ * `smart_edit`/`smart_write` tools are absent for the same reason. Both are gaps
+ * in that alias table rather than in this file, and widening it changes routing
+ * verdicts for every client -- so they are reported, not papered over here.
  */
-export function observedWrite(payload, raw) {
-  // CHEAP CHECK FIRST, because this runs after every tool call on every client.
-  // Reading the file is the expensive part, and there is no point paying for it
-  // on a Read, a Bash or a write whose before side cannot be reconstructed.
-  if (!hasEditEvidence(payload, raw)) return null;
+const MUTATING = new Set(['Edit', 'MultiEdit', 'Write']);
+
+/** Files an apply_patch-style program declares it is about to change. */
+function patchTargets(payload) {
+  const command = payload?.tool_input?.command;
+  if (typeof command !== 'string') return [];
+  const out = [];
+  for (const match of command.matchAll(
+    /^\*\*\* (?:Add|Update|Delete) File:\s*(.+)$/gm
+  )) {
+    const candidate = match[1].trim().replace(/^['"]|['"]$/g, '');
+    // Bounded: one patch naming a thousand files must not append a thousand
+    // queue records on a hook path.
+    if (candidate && out.length < 20) out.push(candidate);
+  }
+  return out;
+}
+
+/**
+ * Everything a completed mutation left behind that is worth queueing.
+ *
+ * TWO GRADES OF EVIDENCE, and the distinction is the point:
+ *
+ *   { path, before, after }  a reconstructable edit. The drain builds a real
+ *                            diff and marks only the symbols that moved.
+ *   { path }                 a whole-file write, or a patch program. No before
+ *                            side exists anywhere in the payload, so the drain
+ *                            compares stored hashes against disk instead.
+ *
+ * The second grade is what closes the biggest hole. A whole-file write is the
+ * commonest write shape there is, and before it was added those writes fell
+ * through to a lazy path that CANNOT see the session's own writes at all --
+ * `indexFile` refreshes the anchor before the lazy check ever looks at it. They
+ * were uncovered, not degraded.
+ *
+ * Returns an array, because one apply_patch program changes several files.
+ */
+export function observedWrites(payload, raw) {
+  if (!MUTATING.has(String(payload?.tool_name || ''))) return [];
 
   const path = writtenPath(payload, raw);
-  if (!path) return null;
+  if (path) {
+    // The expensive branch is guarded: reading the file only pays off when the
+    // payload can actually yield a before side.
+    if (hasEditEvidence(payload, raw)) {
+      const after = afterText(path);
+      if (after !== null && after.length <= MAX_SIDE_CHARS) {
+        const before = beforeText(payload, raw, after);
+        // Identical bytes: a formatter no-op, or a rewrite of the same content.
+        // Nothing changed, so nothing is stale.
+        if (before === after) return [];
+        if (before !== null && before.length <= MAX_SIDE_CHARS)
+          return [{ path, before, after }];
+      }
+    }
+    // Hash grade. Deliberately NOT `{ path, before: '', after }`: an empty
+    // before side makes every symbol in the file look changed, and the eager
+    // mark is a stored flag no later check ever clears.
+    return [{ path }];
+  }
 
-  const after = afterText(path);
-  if (after === null || after.length > MAX_SIDE_CHARS) return null;
-
-  const before = beforeText(payload, raw, after);
-  if (before === null || before.length > MAX_SIDE_CHARS) return null;
-  // Nothing changed: a formatter no-op, or a write of identical bytes. Queuing
-  // it would mark findings stale against an empty diff.
-  if (before === after) return null;
-
-  return { path, before, after };
+  // Codex and code-mode clients carry the whole patch as program text with no
+  // file_path field at all, which is why this recorded nothing for them. The
+  // hash grade needs only the path, so the patch headers are enough.
+  return patchTargets(payload).map((target) => ({ path: target }));
 }
 
 /**
@@ -226,9 +280,14 @@ export function observedWrite(payload, raw) {
 export function queueInvalidation(dir, { path, before, after, at } = {}) {
   try {
     if (typeof path !== 'string' || !path.trim()) return false;
-    if (typeof before !== 'string' || typeof after !== 'string') return false;
-    if (before.length > MAX_SIDE_CHARS || after.length > MAX_SIDE_CHARS)
-      return false;
+    // BOTH SIDES OR NEITHER. A record carrying only one of them cannot produce
+    // a diff and must not pretend to, so it is written as a path-only record
+    // and the drain resolves it by comparing hashes.
+    const diffable =
+      typeof before === 'string' &&
+      typeof after === 'string' &&
+      before.length <= MAX_SIDE_CHARS &&
+      after.length <= MAX_SIDE_CHARS;
 
     const file = queuePath(dir);
     try {
@@ -240,7 +299,11 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
     mkdirSync(dir, { recursive: true });
     appendFileSync(
       file,
-      `${JSON.stringify({ path: canonicalPath(path), before, after, at: at ?? Date.now() })}\n`,
+      `${JSON.stringify({
+        path: canonicalPath(path),
+        ...(diffable ? { before, after } : {}),
+        at: at ?? Date.now(),
+      })}\n`,
       'utf8'
     );
     return true;
@@ -284,16 +347,16 @@ export function drainInvalidations(dir, graph) {
   let marked = 0;
   for (const record of records) {
     if (!record || typeof record.path !== 'string' || !record.path) continue;
-    if (typeof record.before !== 'string' || typeof record.after !== 'string')
-      continue;
+    const diffable =
+      typeof record.before === 'string' && typeof record.after === 'string';
     try {
-      const result = invalidateOnWrite(
-        dir,
-        graph,
-        record.path,
-        record.before,
-        record.after
-      );
+      // TWO GRADES, ONE QUEUE. A record carrying both sides gets a real diff and
+      // symbol-precise marking; one carrying only a path gets the hash
+      // comparison -- the same comparison the lazy path makes, and one that is
+      // only meaningful HERE, before `indexFile` refreshes the anchor.
+      const result = diffable
+        ? invalidateOnWrite(dir, graph, record.path, record.before, record.after)
+        : invalidateChangedAnchors(dir, graph, record.path);
       marked += Array.isArray(result) ? result.length : 0;
     } catch {
       // One bad record must not stop the rest, and must not stop the tool call.

--- a/integrations/cline/hooks/token-optimizer/lib/pending.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/pending.mjs
@@ -1,0 +1,311 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/pending.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * The eager-invalidation queue: the missing half of staleness.mjs's header.
+ *
+ * That header describes TWO invalidation paths and says eager exists because
+ * lazy "would silently serve stale findings as fresh whenever a change came
+ * from outside the agent". `invalidateOnWrite` had been written, tested and
+ * documented -- and its only reference in shipped code was a COMMENT in the
+ * PreToolUse router. Staleness was lazy-only in production, and the router's
+ * own comment ("a write the hook observes is invalidated eagerly by
+ * `invalidateOnWrite`") described something that never happened.
+ *
+ * WHY THAT MATTERS MORE THAN IT SOUNDS. The lazy check compares the anchor's
+ * stored hash against disk -- and both the router and the adapter call
+ * `indexFile` on every file they observe, which re-points that hash at the new
+ * bytes. So for a write the session performed ITSELF, the lazy check is
+ * self-defeating: by the next retrieval the anchor already agrees with disk and
+ * the finding derived from the old content is served clean. Lazy catches the
+ * changes we never saw; only eager catches the ones we did.
+ *
+ * WHY A QUEUE AND NOT A DIRECT CALL. `invalidateOnWrite` needs the graph, and
+ * the graph is a megabyte of JSONL. Loading it on the return path of every
+ * write is the cost this shape exists to avoid. So the post-tool hook, which
+ * already holds the write's evidence, appends one record here and exits; the
+ * next graph read -- `forTouch`/`forCommand`, which load the graph anyway --
+ * drains it BEFORE serving anything.
+ *
+ * The guarantee is unchanged. What must never happen is SERVING a stale finding
+ * as fresh, and serve time is where that is enforced.
+ */
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { invalidateOnWrite } from './staleness.mjs';
+import { canonicalPath, isFsSafePath, resolvableCandidates } from './paths.mjs';
+
+const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
+
+/**
+ * Largest before/after side kept in a queue record.
+ *
+ * Matched to the graph's own snapshot limit for the same reason it has one: past
+ * this size the text is a bundle, a lockfile or a generated asset, and copying
+ * it into a queue file would mirror the repository into the graph directory one
+ * write at a time. Past the cap the write is simply not queued -- the lazy path
+ * still governs it, which is exactly the status quo for that file.
+ */
+const MAX_SIDE_CHARS = 262_144;
+
+/**
+ * Largest queue file appended to.
+ *
+ * A queue only grows while nothing drains it, which means the retrieval feature
+ * is off or every read has failed. Neither is a reason to keep writing: bounded
+ * here so a long unattended session cannot turn one directory into a log of
+ * every file it touched.
+ */
+const MAX_QUEUE_BYTES = 8 * 1024 * 1024;
+
+/** The tool payload fields that name the file a mutation landed on. */
+function writtenPath(payload, raw) {
+  const input = payload?.tool_input || {};
+  const response = raw?.tool_response || raw?.toolResponse || {};
+  for (const candidate of [
+    input.file_path,
+    input.path,
+    input.notebook_path,
+    response.filePath,
+    response.file_path,
+  ]) {
+    if (typeof candidate === 'string' && candidate.trim()) return candidate;
+  }
+  return null;
+}
+
+/** First string among several possible spellings of the same field. */
+function firstString(...values) {
+  for (const value of values) if (typeof value === 'string') return value;
+  return null;
+}
+
+/**
+ * The text before the write, reconstructed from a completed edit.
+ *
+ * PREFERENCE ORDER IS ABOUT EXACTNESS, not convenience. Claude Code's Edit
+ * response carries the whole pre-edit file (`originalFile`), which needs no
+ * reasoning at all. Failing that, an edit is a known substitution, so reverting
+ * `new_string` back to `old_string` in the post-write text reproduces the
+ * before side exactly -- but only when the substitution is unambiguous, which
+ * is why a `new_string` that now appears more than once is refused rather than
+ * guessed at.
+ *
+ * NULL MEANS "DO NOT QUEUE", and that is deliberate. An unknown before side
+ * could be passed as '' -- and `invalidateOnWrite` would then see every symbol
+ * in the file as changed and mark every finding anchored anywhere in it, which
+ * is the exact over-marking its own comments call worse than the file-level
+ * staleness symbols were introduced to avoid. A missed eager invalidation costs
+ * what today already costs; a wrong one permanently discounts correct findings.
+ */
+function beforeText(payload, raw, after) {
+  const input = payload?.tool_input || {};
+  const response = raw?.tool_response || raw?.toolResponse || {};
+
+  const original = firstString(
+    response.originalFile,
+    response.original_file,
+    response.originalContent,
+    response.original_content
+  );
+  if (original !== null) return original;
+
+  // MultiEdit applies its edits in order, so reverting walks them backwards.
+  const edits = Array.isArray(input.edits) ? input.edits : null;
+  if (edits) {
+    let text = after;
+    for (const edit of [...edits].reverse()) {
+      const reverted = revert(text, edit);
+      if (reverted === null) return null;
+      text = reverted;
+    }
+    return text;
+  }
+
+  return revert(after, input);
+}
+
+/** Undoes one old->new substitution, or null when it cannot be done exactly. */
+function revert(text, edit) {
+  const oldString = firstString(edit?.old_string, edit?.oldString);
+  const newString = firstString(edit?.new_string, edit?.newString);
+  if (oldString === null || newString === null || newString === '') return null;
+
+  const all = edit?.replace_all === true || edit?.replaceAll === true;
+  if (all) return text.split(newString).join(oldString);
+
+  const at = text.indexOf(newString);
+  if (at < 0) return null;
+  // Ambiguous: more than one candidate for the occurrence that was written, and
+  // reverting the wrong one fabricates a before side that never existed.
+  if (text.indexOf(newString, at + newString.length) >= 0) return null;
+  return text.slice(0, at) + oldString + text.slice(at + newString.length);
+}
+
+/** The post-write text, read from disk because that is what the write produced. */
+function afterText(path) {
+  if (!isFsSafePath(path)) return null;
+  for (const candidate of resolvableCandidates(path)) {
+    try {
+      if (statSync(candidate).size > MAX_SIDE_CHARS) return null;
+      return readFileSync(candidate, 'utf8');
+    } catch {
+      // Wrong spelling, or gone again already. Try the next one.
+    }
+  }
+  return null;
+}
+
+/**
+ * Does this payload carry enough to reconstruct a before side at all?
+ *
+ * Named tool lists were the alternative and were rejected: every client calls
+ * its editor something different (`Edit`, `replace`, `write_to_file`,
+ * `apply_patch`), and a list would silently exclude the ones nobody thought of
+ * while still charging a file read for every Read that matched by accident.
+ * Asking about the EVIDENCE instead covers any client that carries an edit in
+ * one of these shapes and costs nothing on the calls that do not.
+ */
+function hasEditEvidence(payload, raw) {
+  const input = payload?.tool_input || {};
+  const response = raw?.tool_response || raw?.toolResponse || {};
+  if (
+    firstString(
+      response.originalFile,
+      response.original_file,
+      response.originalContent,
+      response.original_content
+    ) !== null
+  )
+    return true;
+  if (Array.isArray(input.edits) && input.edits.length > 0) return true;
+  return firstString(input.old_string, input.oldString) !== null;
+}
+
+/**
+ * The evidence a completed mutation left behind, or null when there is none.
+ *
+ * Separate from `queueInvalidation` so the caller can be a hook branch that
+ * knows nothing about diffs, and so the reconstruction above is testable
+ * without a filesystem queue.
+ */
+export function observedWrite(payload, raw) {
+  // CHEAP CHECK FIRST, because this runs after every tool call on every client.
+  // Reading the file is the expensive part, and there is no point paying for it
+  // on a Read, a Bash or a write whose before side cannot be reconstructed.
+  if (!hasEditEvidence(payload, raw)) return null;
+
+  const path = writtenPath(payload, raw);
+  if (!path) return null;
+
+  const after = afterText(path);
+  if (after === null || after.length > MAX_SIDE_CHARS) return null;
+
+  const before = beforeText(payload, raw, after);
+  if (before === null || before.length > MAX_SIDE_CHARS) return null;
+  // Nothing changed: a formatter no-op, or a write of identical bytes. Queuing
+  // it would mark findings stale against an empty diff.
+  if (before === after) return null;
+
+  return { path, before, after };
+}
+
+/**
+ * Appends one pending write.
+ *
+ * NEVER THROWS. This runs on a hook's return path, and a queue that cannot be
+ * written degrades to the lazy path rather than costing the user a tool call.
+ */
+export function queueInvalidation(dir, { path, before, after, at } = {}) {
+  try {
+    if (typeof path !== 'string' || !path.trim()) return false;
+    if (typeof before !== 'string' || typeof after !== 'string') return false;
+    if (before.length > MAX_SIDE_CHARS || after.length > MAX_SIDE_CHARS)
+      return false;
+
+    const file = queuePath(dir);
+    try {
+      if (statSync(file).size > MAX_QUEUE_BYTES) return false;
+    } catch {
+      // No queue yet, which is the normal case.
+    }
+
+    mkdirSync(dir, { recursive: true });
+    appendFileSync(
+      file,
+      `${JSON.stringify({ path: canonicalPath(path), before, after, at: at ?? Date.now() })}\n`,
+      'utf8'
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Applies every queued invalidation and clears the queue.
+ *
+ * Returns the number of findings marked, so the caller knows whether its
+ * in-memory graph is now behind the file on disk and needs re-reading.
+ *
+ * CLEARED AFTER APPLYING AND UNCONDITIONALLY: a record that cannot be applied
+ * must not be retried on every tool call for the rest of the session, and the
+ * cost of dropping one is a single missed eager mark that the lazy path still
+ * has a chance at.
+ */
+export function drainInvalidations(dir, graph) {
+  let records;
+  try {
+    const file = queuePath(dir);
+    if (!existsSync(file)) return 0;
+    records = readFileSync(file, 'utf8')
+      .split('\n')
+      .filter((line) => line.trim())
+      .map((line) => {
+        try {
+          return JSON.parse(line);
+        } catch {
+          // A torn append costs one record, not the queue.
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch {
+    return 0;
+  }
+
+  let marked = 0;
+  for (const record of records) {
+    if (!record || typeof record.path !== 'string' || !record.path) continue;
+    if (typeof record.before !== 'string' || typeof record.after !== 'string')
+      continue;
+    try {
+      const result = invalidateOnWrite(
+        dir,
+        graph,
+        record.path,
+        record.before,
+        record.after
+      );
+      marked += Array.isArray(result) ? result.length : 0;
+    } catch {
+      // One bad record must not stop the rest, and must not stop the tool call.
+    }
+  }
+
+  try {
+    rmSync(queuePath(dir), { force: true });
+  } catch {
+    // Held open by a concurrent hook. The next drain re-applies these records,
+    // which is safe: marking an already-marked finding is idempotent.
+  }
+
+  return marked;
+}

--- a/integrations/cline/hooks/token-optimizer/lib/pending.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/pending.mjs
@@ -199,10 +199,11 @@ function hasEditEvidence(payload, raw) {
  * before this module is reached at all. So matching here is both complete for
  * every client the adapter serves and impossible to spell wrong.
  *
- * `NotebookEdit` is absent because `normalizeTool` maps it to null, and the MCP
- * `smart_edit`/`smart_write` tools are absent for the same reason. Both are gaps
- * in that alias table rather than in this file, and widening it changes routing
- * verdicts for every client -- so they are reported, not papered over here.
+ * `NotebookEdit` and the MCP `smart_edit`/`smart_write` tools were absent for as
+ * long as `normalizeTool` mapped them to null. That was a gap in the alias table
+ * rather than in this file, and it has since been closed there: all three now
+ * arrive as `Edit` or `Write` and are matched by the set below without it having
+ * to learn a fourth name.
  */
 const MUTATING = new Set(['Edit', 'MultiEdit', 'Write']);
 

--- a/integrations/cline/hooks/token-optimizer/lib/pending.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/pending.mjs
@@ -35,6 +35,7 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  renameSync,
   rmSync,
   statSync,
 } from 'node:fs';
@@ -43,6 +44,15 @@ import { invalidateChangedAnchors, invalidateOnWrite } from './staleness.mjs';
 import { canonicalPath, isFsSafePath, resolvableCandidates } from './paths.mjs';
 
 const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
+/**
+ * Where a drain moves the queue before reading it.
+ *
+ * PER PROCESS, not one shared name: two hooks draining the same graph directory
+ * at once would otherwise race for the same claim file, and the loser would
+ * either clobber the winner's records or delete them mid-read. A pid makes the
+ * claim private to the drainer that won the rename.
+ */
+const claimPath = (dir) => join(dir, `pending-invalidation.claim.${process.pid}.jsonl`);
 
 /**
  * Largest before/after side kept in a queue record.
@@ -319,17 +329,47 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
  * Returns the number of findings marked, so the caller knows whether its
  * in-memory graph is now behind the file on disk and needs re-reading.
  *
- * CLEARED AFTER APPLYING AND UNCONDITIONALLY: a record that cannot be applied
- * must not be retried on every tool call for the rest of the session, and the
- * cost of dropping one is a single missed eager mark that the lazy path still
- * has a chance at.
+ * CLAIMED BY RENAME, THEN READ, THEN DELETED -- and the order is the whole
+ * point. This used to read the queue and then `rmSync` the same path, so a
+ * post-tool hook appending between the read and the unlink had its record
+ * deleted having never been read. Parallel tool calls in one assistant turn are
+ * the ordinary way that happens, not an exotic race. `renameSync` makes the
+ * claim atomic: whatever the drainer took is exactly what it deletes, and a
+ * record appended a microsecond later lands on a fresh queue that the next drain
+ * will find.
+ *
+ * A LOST RECORD IS A PERMANENTLY MISSED INVALIDATION, which is why this is worth
+ * a rename. The comment here used to price it as "a single missed eager mark that
+ * the lazy path still has a chance at", and that premise is false: this module's
+ * own header states it. The lazy path compares the anchor's stored hash against
+ * disk, and `indexFile` re-points that hash at the bytes the session just wrote,
+ * so for the session's OWN writes lazy is structurally blind rather than merely
+ * late. Nothing else was ever going to catch a dropped record.
+ *
+ * A RECORD THAT CANNOT BE APPLIED IS STILL DROPPED, deliberately and
+ * unconditionally: retrying a permanently unapplicable record on every tool call
+ * for the rest of the session costs more than it can ever recover, and the claim
+ * file is deleted whether the loop marked anything or threw.
+ *
+ * FAIL-OPEN THROUGHOUT. A rename that loses a race, or fails for any other
+ * reason, returns 0 and leaves the queue for the next drain; it never throws
+ * into a hook.
  */
 export function drainInvalidations(dir, graph) {
   let records;
+  let claim;
   try {
     const file = queuePath(dir);
     if (!existsSync(file)) return 0;
-    records = readFileSync(file, 'utf8')
+    claim = claimPath(dir);
+    // A LEFTOVER CLAIM FROM A KILLED DRAIN IS OVERWRITTEN, not merged: rename
+    // onto an existing path replaces it. The pid in the name means the only way
+    // to hit that is this same pid having died mid-drain, whose records were
+    // already being applied when it went -- and re-applying is idempotent, so
+    // losing them is the cheaper of the two errors. Not doing the rename at all
+    // would strand the live queue forever.
+    renameSync(file, claim);
+    records = readFileSync(claim, 'utf8')
       .split('\n')
       .filter((line) => line.trim())
       .map((line) => {
@@ -342,6 +382,18 @@ export function drainInvalidations(dir, graph) {
       })
       .filter(Boolean);
   } catch {
+    // The rename lost a race, or the claim could not be read. Nothing is deleted
+    // unread and the hook proceeds. If the claim was taken and then could not be
+    // read, it is put back under the queue name so the next drain still sees it:
+    // a claim file nobody looks at again is the same lost record this rename
+    // exists to prevent.
+    try {
+      if (claim && existsSync(claim) && !existsSync(queuePath(dir))) {
+        renameSync(claim, queuePath(dir));
+      }
+    } catch {
+      // Best effort only. A hook must not fail because bookkeeping did.
+    }
     return 0;
   }
 
@@ -365,10 +417,13 @@ export function drainInvalidations(dir, graph) {
   }
 
   try {
-    rmSync(queuePath(dir), { force: true });
+    // THE CLAIM, NOT THE QUEUE. Deleting `queuePath` here is what dropped a
+    // concurrently appended record; this path holds exactly the bytes that were
+    // just read, so nothing unread can be inside it.
+    rmSync(claim, { force: true });
   } catch {
-    // Held open by a concurrent hook. The next drain re-applies these records,
-    // which is safe: marking an already-marked finding is idempotent.
+    // Held open by something else. The claim is not read again -- the next drain
+    // looks at the queue -- so this costs a stray file, never a record.
   }
 
   return marked;

--- a/integrations/cline/hooks/token-optimizer/lib/restore.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/restore.mjs
@@ -142,7 +142,7 @@ export function restorationPlan(dir, graph, context = {}) {
     for (const id of predicted) {
       const node = graph.nodes.get(id);
       if (!node) continue;
-      const findings = serve(graph, findingsFor(graph, id, { limit: 2 }));
+      const findings = serve(graph, findingsFor(graph, id, { limit: 2 }), { dir });
       for (const finding of findings) {
         // `! STALE` only where a diff actually exists to back it; see the
         // renderer in inject.mjs for the measurement behind this.

--- a/integrations/cline/hooks/token-optimizer/lib/restore.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/restore.mjs
@@ -158,7 +158,16 @@ export function restorationPlan(dir, graph, context = {}) {
             ? '! STALE '
             : '~ '
           : '';
-        lines.push(`${node.key}: ${mark}${finding.claim}`);
+        // A DISPUTE DISCLOSED ELSEWHERE AND SILENT HERE reads as "the dispute
+        // went away". `serve` already attached the fields; the only question is
+        // the wording, and this list is the most compressed surface in the
+        // system, so it gets the marker and the key and nothing else.
+        const disputed = finding.contradicted
+          ? finding.contradictedBy
+            ? ` (disputed by ${finding.contradictedBy})`
+            : ' (disputed)'
+          : '';
+        lines.push(`${node.key}: ${mark}${finding.claim}${disputed}`);
       }
     }
     section('Likely next', lines, total * split.forward);

--- a/integrations/cline/hooks/token-optimizer/lib/skeleton.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/skeleton.mjs
@@ -126,6 +126,11 @@ export function annotatedSkeleton(graph, rawPath, source, { budget = 1200, git =
 
   // Findings anchored to this file or the symbols inside it, served through the
   // one function that enforces the stale-plus-diff rule.
+  // READ-ONLY serve: no `dir` is threaded here, so this cannot clear a stale
+  // flag whose evidence is gone. That is deliberate -- this function takes a
+  // graph, not the directory it came from, and widening its signature to give
+  // an analysis path a write capability buys nothing: the injection path runs
+  // on every tool call and clears the same findings.
   const served = serve(graph, findingsFor(graph, nodeId('file', path), { limit: 40 }));
 
   // Index findings by the symbol they anchor to, so each one sits beside the

--- a/integrations/cline/hooks/token-optimizer/lib/staleness.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/staleness.mjs
@@ -31,6 +31,23 @@
  * Eager alone would silently serve stale findings as fresh whenever a change
  * came from outside the agent, which is the single failure mode the design
  * calls worse than no graph.
+ *
+ * AND LAZY ALONE IS BLIND TO THE AGENT'S OWN WRITES -- not degraded, BLIND.
+ * `indexFile` re-points an anchor's stored hash at the bytes it was just handed,
+ * and it is called on every file either hook observes: pretooluse-router.mjs
+ * (two call sites) and adapter.mjs (one). The lazy check then compares that
+ * refreshed hash against the same disk it came from and finds them equal. So
+ * for a file the session edited ITSELF, the lazy path cannot detect the change
+ * at all, and the finding derived from the pre-edit content is served CLEAN.
+ *
+ * Which means that until the eager path was connected, staleness for a file the
+ * agent edited did not work AT ALL: eager was dead code and lazy was defeated
+ * by re-indexing. Every account of this defect, including the one in this
+ * module's own git history, called it "lazy-only, therefore degraded". It was
+ * not degraded. `stale-before-reindex.test.mjs` states in its header that this
+ * case is covered by `invalidateOnWrite`, and `invalidateOnWrite` had never run
+ * once in production. The two paths are not redundant and never were: each is
+ * the ONLY cover for a whole class of change.
  */
 
 import { readFileSync, statSync } from 'node:fs';
@@ -622,6 +639,119 @@ export function invalidateOnWrite(dir, graph, rawPath, beforeText, afterText) {
   // Re-index so the anchors carry the new hashes; otherwise the lazy path would
   // report the same change again on every future retrieval.
   indexFile(dir, path, afterText);
+  return marked;
+}
+
+/**
+ * The eager path for a write with NO before/after pair: compare stored hashes
+ * against disk, and mark what actually moved.
+ *
+ * WHY THIS EXISTS AS A SECOND SHAPE. A whole-file `Write` replaces the file, so
+ * the payload carries the after side and nothing at all of the before -- and a
+ * whole-file write is the commonest write shape there is. `invalidateOnWrite`
+ * cannot serve it: passing '' as the before side makes every symbol in the file
+ * look changed, marks every finding anchored anywhere in it, and the eager mark
+ * is a stored flag no later check ever clears. False-stale is expensive and
+ * permanent, so it is not an acceptable price for coverage.
+ *
+ * But the hash comparison is available, and it is exactly the comparison the
+ * lazy path makes. The difference is WHEN: this runs at the top of injection,
+ * before `indexFile` refreshes the anchor, so the stored hash is still the
+ * pre-write one and the comparison is meaningful. That is the whole trick --
+ * lazy is not wrong, it is merely too late.
+ *
+ * SYMBOL-LEVEL, and from ONE read. Re-locating each symbol by name and
+ * comparing its own span hash is what keeps this from degenerating into
+ * file-level marking: editing one function must not stale a finding about
+ * another, which is the property symbol nodes exist to provide.
+ *
+ * WEAKER EVIDENCE, STATED AS SUCH. There is no before text, so no diff can be
+ * built -- the finding is marked with the two hashes and `serve` reports the
+ * evidence gap through `staleEvidence: false`, which the renderer turns into
+ * "no diff could be rebuilt" rather than promising a diff and showing nothing.
+ * A stale finding with weak evidence is far better than one served as fresh,
+ * but the reader has to be able to tell which one they are holding.
+ */
+export function invalidateChangedAnchors(dir, graph, rawPath) {
+  const path = canonicalPath(rawPath);
+  const marked = [];
+
+  // ONE read for the file and every symbol in it. checkAnchor would have been
+  // the obvious reuse and it reads per anchor, which on a file with fifty
+  // symbols is fifty-one reads of the same bytes on a hook path.
+  let source = null;
+  try {
+    source = readAnySpelling(path);
+  } catch {
+    // Deleted, or unreadable from this checkout. Handled below as a change,
+    // because a finding about a file that is no longer there is exactly the
+    // kind that must not be served as fresh.
+  }
+
+  const changed = [];
+  const fileNode = graph.nodes.get(nodeId('file', path));
+  const fileDigest = source === null ? null : hash(source);
+  if (fileNode && fileDigest !== fileNode.hash) {
+    changed.push({ node: fileNode, from: fileNode.hash, to: fileDigest });
+  }
+
+  const current = new Map(
+    source === null
+      ? []
+      : extractSymbols(path, source).map((s) => [s.name, hash(spanText(source, s))])
+  );
+  for (const node of graph.nodes.values()) {
+    if (node.kind !== 'symbol' || node.file !== path) continue;
+    const digest = current.has(node.name) ? current.get(node.name) : null;
+    if (digest !== node.hash) changed.push({ node, from: node.hash, to: digest });
+  }
+
+  if (changed.length) {
+    // Indexed once by target, for the reason invalidateOnWrite indexes: the
+    // nested alternative is O(nodes x edges) inside a hook.
+    const byTarget = new Map();
+    for (const edge of graph.edges) {
+      if (edge.edge !== 'derived_from') continue;
+      if (!byTarget.has(edge.to)) byTarget.set(edge.to, []);
+      byTarget.get(edge.to).push(edge);
+    }
+
+    for (const { node, from, to } of changed) {
+      for (const edge of byTarget.get(node.id) || []) {
+        const finding = graph.nodes.get(edge.from);
+        if (!finding || finding.kind !== 'finding') continue;
+        // The same type gate serve() applies, for the same reason it is applied
+        // in invalidateOnWrite: the flag is STORED, and disclose.mjs skips a
+        // stale finding while utility.mjs penalises one by 160.
+        if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) continue;
+        // ALREADY MARKED IS LEFT ALONE. Whatever marked it first had a diff or
+        // a more specific reason; overwriting that with a hash pair trades real
+        // evidence for less.
+        if (finding.stale) continue;
+
+        putNode(dir, {
+          ...finding,
+          kind: 'finding',
+          key: finding.key,
+          stale: true,
+          staleReason:
+            to === null
+              ? `the ${node.kind} it depends on is no longer present (was ${from})`
+              : `content hash changed during this session (${from} -> ${to}), observed without a before/after pair`,
+          // EXPLICITLY EMPTY, not absent. serve() reports `staleEvidence` from
+          // whether a diff survived, and the renderer says "no diff could be
+          // rebuilt" -- so the reader can tell "changed, diff unknown" from
+          // "changed, here is what changed".
+          diff: '',
+        });
+        marked.push(finding.key);
+      }
+    }
+  }
+
+  // Re-index for the same reason the diff path does: otherwise every future
+  // retrieval re-reports a change that has already been accounted for.
+  if (source !== null) indexFile(dir, path, source);
   return marked;
 }
 

--- a/integrations/cline/hooks/token-optimizer/lib/staleness.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/staleness.mjs
@@ -574,8 +574,20 @@ function derivationCheck(graph, finding) {
  * This is the only function that should ever hand a finding to a model, because
  * it is the one that enforces the rule: a stale finding leaves here carrying
  * `stale: true` AND a diff, or it does not leave at all.
+ *
+ * AND IT CLEARS A STORED FLAG WHOSE EVIDENCE IS GONE, when given a `dir` to
+ * write to. Clearing used to be reachable only by a person pressing Re-verify in
+ * the dashboard, which left the rot path fully open on every install where
+ * nobody opens the dashboard -- and that is most of them. The evidence test is
+ * what makes clearing safe, and it does not care who triggered it: the same
+ * `claimTimeVerdict` runs here as in `reverify`, so this cannot clear anything
+ * the button would not.
+ *
+ * `dir` IS OPTIONAL, AND OMITTING IT MAKES THIS READ-ONLY. Several callers hold
+ * a graph without the directory it came from, and a serve that silently did
+ * nothing would be worse than one that plainly cannot write.
  */
-export function serve(graph, findings) {
+export function serve(graph, findings, { dir = null } = {}) {
   const served = [];
 
   // RETIRED FINDINGS STOP HERE, unconditionally.
@@ -603,8 +615,42 @@ export function serve(graph, findings) {
       continue;
     }
 
+    // AUTOMATIC CLEARING, on the same evidence the manual path demands.
+    //
+    // ONLY THE STORED FLAG IS TOUCHED. The lazy loop below is left to run
+    // exactly as before and can independently mark this finding stale again on
+    // its own comparison -- disk against the anchor NODE's hash -- which answers
+    // a different question and is not this function's to overrule. Eager and
+    // lazy stay two mechanisms, as the module header insists.
+    //
+    // AND THE FIELDS GO WITH THE FLAG. `putNode` does not merge and neither does
+    // this spread: serving `{ ...finding, stale: false }` would hand back a
+    // finding that reads fresh while still carrying `staleReason` and `diff`
+    // from the record -- stale and fresh at once, which is worse than either.
+    // So the cleared record, not the stored one, is what the rest of this
+    // iteration reads and spreads.
+    //
+    // BOUNDED, and the bound is the point: this runs only for a finding whose
+    // flag is already STORED, only when a `derivation` record exists to check
+    // against, and it reads each of that finding's anchors at most once. A
+    // finding that is not flagged pays nothing. The lazy loop below already
+    // reads every anchor of every content-dependent finding served, so the worst
+    // case is twice the anchor reads on the already-stale subset alone.
+    //
+    // NOT ON THE NON-CONTENT-DEPENDENT EARLY RETURN ABOVE, deliberately. Both
+    // eager paths refuse to flag those types at all, so a flag there can only
+    // come from an older graph -- and reading anchors for a type whose truth
+    // does not depend on them is exactly the cost `CONTENT_DEPENDENT` exists to
+    // avoid.
+    let record = finding;
+    if (dir && finding.stale && claimTimeVerdict(graph, finding) === 'match') {
+      clearStale(dir, finding.key, { graph });
+      const { stale: _s, staleReason: _r, diff: _d, staleEvidence: _e, ...cleared } = finding;
+      record = cleared;
+    }
+
     const anchors = graph.edges
-      .filter((e) => e.edge === 'derived_from' && e.from === finding.id)
+      .filter((e) => e.edge === 'derived_from' && e.from === record.id)
       .map((e) => graph.nodes.get(e.to))
       .filter(Boolean);
 
@@ -629,10 +675,10 @@ export function serve(graph, findings) {
     // A finding already marked stale eagerly, whose diff was captured at write
     // time, keeps that diff -- the eager path saw the change we can no longer
     // reconstruct from disk alone.
-    if (!stale && finding.stale) {
+    if (!stale && record.stale) {
       stale = true;
-      diff = finding.diff || '';
-      reason = finding.staleReason || 'marked stale when the change was observed';
+      diff = record.diff || '';
+      reason = record.staleReason || 'marked stale when the change was observed';
     }
 
     if (stale && !diff) {
@@ -681,13 +727,19 @@ export function serve(graph, findings) {
     }
 
     served.push({
-      ...finding,
+      ...record,
       stale,
       ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
+      // BOTH OTHER DISCLOSURES SURVIVE A MID-SERVE CLEAR. `dispute` was computed
+      // above the content-dependence branch and is applied here untouched, and
+      // the derivation verdict is recomputed from the record -- which still
+      // carries its `derivation`, since clearing removes only the staleness
+      // fields. A finding whose flag was just cleared is still disclosed as
+      // disputed, and still reports whether its derivation holds.
       ...dispute,
       // Independent of `stale` above: see `derivationCheck`'s own comment for
       // the case it catches that node-level staleness can miss.
-      ...derivationCheck(graph, finding),
+      ...derivationCheck(graph, record),
     });
   }
   return served;
@@ -939,8 +991,21 @@ function anchorHashNow(anchor) {
  * Exposing it to a hook, a tool argument or an HTTP action would be a way to
  * turn a stale finding fresh on request, which is exactly what must not exist.
  */
-export function clearStale(dir, key) {
-  const node = load(dir).nodes.get(nodeId('finding', key));
+export function clearStale(dir, key, { graph = null } = {}) {
+  // A CALLER THAT ALREADY HOLDS THE GRAPH PASSES IT, and this is not
+  // micro-optimisation: `load` re-parses the entire append-only log, so clearing
+  // inside `serve`'s loop re-read and re-folded the whole graph once PER cleared
+  // finding. Measured on 40 findings all stale and all revertible -- the shape a
+  // mass revert produces -- that was 185 ms against 25 ms, a 7x regression on
+  // the injection path, all of it graph loading rather than the hashing this
+  // feature is actually for. With the graph passed through it is back in line.
+  //
+  // No new race: this store is last-write-wins with no compare-and-set anywhere,
+  // and every other caller that spreads a node back -- `pin`, `retire`,
+  // `contradict`, `correct` -- writes from a graph it loaded earlier too. Both
+  // callers here already DECIDED on this snapshot, so re-reading it purely for
+  // the write narrowed no window that was ever closed.
+  const node = (graph || load(dir)).nodes.get(nodeId('finding', key));
   if (!node || node.kind !== 'finding') return false;
   const { stale, staleReason, diff, staleEvidence, ...rest } = node;
   // Nothing to clear is a success, not a write: an unconditional putNode here
@@ -989,14 +1054,33 @@ export function clearStale(dir, key) {
  * silently un-mark findings nobody asked about. Staleness is disclosed to a
  * reader who then decides; clearing is an explicit act.
  */
-export function reverify(dir, key) {
-  const graph = load(dir);
-  const finding = graph.nodes.get(nodeId('finding', key));
-  if (!finding || finding.kind !== 'finding') return 'unknown';
-  // Idempotent: the postcondition -- no stale flag on this finding -- already
-  // holds, and reporting anything else would make a caller retry forever.
-  if (!finding.stale) return 'cleared';
-
+/**
+ * THE ONE EVIDENCE TEST. Does this finding's anchored content still hash to what
+ * the claim was actually made against?
+ *
+ * `'match'` -- every anchor on disk re-hashes to the value frozen into this
+ * finding's own `derivation.anchors` at claim time. The content IS what the
+ * claim was derived from: a revert, or a write that never moved the anchored
+ * bytes.
+ * `'differs'` -- at least one anchor does not, INCLUDING an anchor whose content
+ * is gone. Deleted is a difference, not a missing measurement.
+ * `'unknown'` -- there is nothing to compare: no `derivation.anchors`, no
+ * anchors, an anchor with no recorded hash, or one that no longer resolves.
+ *
+ * SHARED BY BOTH CLEARING PATHS ON PURPOSE, and that sharing is the guarantee
+ * rather than a convenience. `reverify` (a person pressing Re-verify) and
+ * `serve` (automatic, on every retrieval) call THIS function and nothing else,
+ * so the automatic path cannot clear anything the button would not, and neither
+ * can drift from the other. Two copies of this comparison would be two policies,
+ * and the weaker one would win wherever it ran more often -- which is the
+ * automatic one.
+ *
+ * NOT `checkAnchor`, for the reason `anchorHashNow` above spells out: that
+ * compares disk against the anchor NODE's stored hash, which both eager paths
+ * re-point at the very bytes that caused the mark, so it answers "fresh" for
+ * exactly the finding it just marked stale.
+ */
+function claimTimeVerdict(graph, finding) {
   const recorded = finding.derivation && finding.derivation.anchors;
   if (!recorded || typeof recorded !== 'object') return 'unknown';
 
@@ -1019,10 +1103,23 @@ export function reverify(dir, key) {
     if (node.kind !== 'file' && node.kind !== 'symbol') return 'unknown';
     // null means the content is gone -- deleted file, vanished symbol. That is a
     // difference, not an absence of evidence.
-    if (anchorHashNow(node) !== expected) return 'still-stale';
+    if (anchorHashNow(node) !== expected) return 'differs';
   }
+  return 'match';
+}
 
-  clearStale(dir, key);
+export function reverify(dir, key) {
+  const graph = load(dir);
+  const finding = graph.nodes.get(nodeId('finding', key));
+  if (!finding || finding.kind !== 'finding') return 'unknown';
+  // Idempotent: the postcondition -- no stale flag on this finding -- already
+  // holds, and reporting anything else would make a caller retry forever.
+  if (!finding.stale) return 'cleared';
+
+  const verdict = claimTimeVerdict(graph, finding);
+  if (verdict === 'unknown') return 'unknown';
+  if (verdict === 'differs') return 'still-stale';
+  clearStale(dir, key, { graph });
   return 'cleared';
 }
 

--- a/integrations/cline/hooks/token-optimizer/lib/staleness.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/staleness.mjs
@@ -53,7 +53,7 @@
 import { readFileSync, statSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { dirname, join } from 'node:path';
-import { putNode, putEdge, contentHash, nodeId } from './wiki.mjs';
+import { putNode, putEdge, contentHash, nodeId, load } from './wiki.mjs';
 import { hasOutstandingContradiction } from './curate.mjs';
 import { extractSymbols, spanText, symbolKey, extractImports } from './symbols.mjs';
 import { canonicalPath, resolvableCandidates, isFsSafePath } from './paths.mjs';
@@ -488,7 +488,16 @@ function disputeOf(graph, finding) {
     // An edge end that resolves to nothing names nothing. The dispute is still
     // disclosed -- the gate above already established it -- but without a key
     // the reader cannot be pointed anywhere, and inventing one would be worse.
-    if (other && typeof other.key === 'string' && !keys.includes(other.key)) keys.push(other.key);
+    //
+    // A RETIRED END IS NOT NAMED EITHER, for a sharper reason: the disclosure
+    // tells the reader to `wiki_query` that key, and `serve` refuses to return
+    // a retired finding at all. Naming it points them at a claim they cannot
+    // fetch. `hasOutstandingContradiction` above already declines to open the
+    // gate when EVERY disputant is retired; this is the same rule applied to
+    // each name, so a live disputant is still reported alongside a withdrawn one.
+    if (other && !other.retired && typeof other.key === 'string' && !keys.includes(other.key)) {
+      keys.push(other.key);
+    }
   }
 
   return { contradicted: true, ...(keys.length ? { contradictedBy: keys.join(', ') } : {}) };
@@ -870,6 +879,151 @@ export function invalidateChangedAnchors(dir, graph, rawPath) {
   // retrieval re-reports a change that has already been accounted for.
   if (source !== null) indexFile(dir, path, source);
   return marked;
+}
+
+/**
+ * The current content hash of an anchor, read from disk.
+ *
+ * DELIBERATELY NOT `checkAnchor`, and the difference is the whole of this
+ * clearing rule. `checkAnchor` compares disk against the anchor NODE's stored
+ * hash, and both eager paths call `indexFile` immediately after marking --
+ * which re-points that hash at the very bytes that caused the mark. So
+ * `checkAnchor` answers "fresh" for exactly the finding it just marked stale,
+ * and a clearing rule built on it would clear every flag it was handed,
+ * unconditionally. This returns a bare hash instead, so the caller can compare
+ * it against the FROZEN claim-time hash rather than against a value the marking
+ * path itself moved.
+ *
+ * Returns null when no content can be read at all -- a deleted file, or a
+ * symbol that no longer exists. A caller must treat that as "changed", never as
+ * "unknown": a claim about content that is gone certainly does not match the
+ * content it was made against.
+ */
+function anchorHashNow(anchor) {
+  const path = anchor.kind === 'symbol' ? anchor.file : anchor.key;
+  let source;
+  try {
+    source = readAnySpelling(path);
+  } catch {
+    return null;
+  }
+  if (anchor.kind !== 'symbol') return hash(source);
+
+  // By NAME, like checkAnchor: line numbers shift whenever anything above is
+  // edited, and re-locating by line would report a symbol as moved when only an
+  // unrelated insert happened above it.
+  const current = extractSymbols(path, source).find((s) => s.name === anchor.name);
+  if (!current) return null;
+  return hash(spanText(source, current));
+}
+
+/**
+ * Removes the staleness fields from a finding. Returns whether one was found.
+ *
+ * THE WHOLE NODE IS REWRITTEN, because `putNode` does not merge: it writes a
+ * full record from what it is handed and `load` replaces the node wholesale.
+ * Writing `{ kind, key, stale: false }` would blank the claim, the confidence
+ * and the provenance -- an overwrite by another name, and the same trap
+ * `contradict` documents. So the fields are destructured AWAY and everything
+ * else is spread back: no deletion primitive is needed, and the append-only rule
+ * is respected.
+ *
+ * `staleEvidence` is stripped as well, even though no writer stores it. It is
+ * added by `serve` to the object it hands out, so anything that ever writes a
+ * served finding back would carry it in -- at which point a cleared finding
+ * would still be advertising the quality of the evidence for a flag it no longer
+ * has.
+ *
+ * A PRIMITIVE, NOT A ROUTE. Nothing outside this module calls it: the only
+ * shipping caller is `reverify` below, which establishes the evidence first.
+ * Exposing it to a hook, a tool argument or an HTTP action would be a way to
+ * turn a stale finding fresh on request, which is exactly what must not exist.
+ */
+export function clearStale(dir, key) {
+  const node = load(dir).nodes.get(nodeId('finding', key));
+  if (!node || node.kind !== 'finding') return false;
+  const { stale, staleReason, diff, staleEvidence, ...rest } = node;
+  // Nothing to clear is a success, not a write: an unconditional putNode here
+  // would append a duplicate record to the log on every no-op call.
+  if (stale === undefined && staleReason === undefined
+    && diff === undefined && staleEvidence === undefined) return true;
+  putNode(dir, { ...rest, kind: 'finding', key: node.key });
+  return true;
+}
+
+/**
+ * Clears a stale flag when, and only when, the evidence for it is gone.
+ *
+ * WHY THIS HAS TO EXIST. Nothing in this codebase ever cleared a `stale` flag.
+ * That was harmless while eager invalidation was dead code; it fires now, so
+ * every finding on an edited file becomes permanently stale -- and permanently
+ * discounted, since `disclose.mjs` skips a stale finding outright and
+ * `utility.mjs` penalises one by 160. The graph degrades toward all-stale, and
+ * the eager path is over-eager on top of that: `invalidateOnWrite` marks every
+ * finding anchored to a FILE node on any observed write to that file, whether or
+ * not the bytes moved.
+ *
+ * WHAT COUNTS AS EVIDENCE, AND WHY IT IS NOT NEGOTIABLE. The only trustworthy
+ * record of what a claim was made against is `derivation.anchors` -- the hash
+ * each anchor carried at the moment the finding was written, frozen into the
+ * finding itself by `harvest-write.mjs`. Disk is re-hashed here and compared
+ * against that. If every anchor matches, the content IS what the claim was
+ * derived from: a revert, or a write that never moved the anchored bytes. The
+ * flag comes off. Anything else leaves it exactly as it was.
+ *
+ * IT IS NOT A LAUNDERING ROUTE, and that is a property of the comparison rather
+ * than of who is allowed to call it. A caller cannot make a finding fresh by
+ * asking; they can only make it fresh by putting the content back. There is no
+ * argument, no force flag and no second path -- and `clearStale` above, the one
+ * function that clears without checking, has no caller but this one.
+ *
+ * NO RECORD MEANS UNKNOWN, NEVER CLEAR. A finding with no `derivation.anchors`
+ * -- every one written before that record existed, and every hand-curated one --
+ * has nothing to compare disk against. That is an absence of evidence, and
+ * resolving it to "clear it" would hand back the laundering route through the
+ * side door. It reports `unknown` and changes nothing; re-recording the claim
+ * against the current code (`curate.correct`) is the way forward for those.
+ *
+ * DELIBERATELY NOT AUTOMATIC. This reads every anchor off disk, so running it on
+ * the serve path would put N file reads inside injection -- and, worse, it would
+ * silently un-mark findings nobody asked about. Staleness is disclosed to a
+ * reader who then decides; clearing is an explicit act.
+ */
+export function reverify(dir, key) {
+  const graph = load(dir);
+  const finding = graph.nodes.get(nodeId('finding', key));
+  if (!finding || finding.kind !== 'finding') return 'unknown';
+  // Idempotent: the postcondition -- no stale flag on this finding -- already
+  // holds, and reporting anything else would make a caller retry forever.
+  if (!finding.stale) return 'cleared';
+
+  const recorded = finding.derivation && finding.derivation.anchors;
+  if (!recorded || typeof recorded !== 'object') return 'unknown';
+
+  const anchorIds = new Set(
+    graph.edges
+      .filter((e) => e.edge === 'derived_from' && e.from === finding.id)
+      .map((e) => e.to)
+  );
+  // An unanchored finding cannot be checked against anything, which is the
+  // un-invalidatable shape the anchor discipline exists to refuse. It is equally
+  // un-VERIFIABLE, so it is reported as such rather than cleared.
+  if (!anchorIds.size) return 'unknown';
+
+  for (const id of anchorIds) {
+    const expected = recorded[id];
+    const node = graph.nodes.get(id);
+    // An anchor this finding never recorded a hash for, or one that no longer
+    // resolves to a node: nothing to compare, so nothing is concluded.
+    if (typeof expected !== 'string' || !expected || !node) return 'unknown';
+    if (node.kind !== 'file' && node.kind !== 'symbol') return 'unknown';
+    // null means the content is gone -- deleted file, vanished symbol. That is a
+    // difference, not an absence of evidence.
+    if (anchorHashNow(node) !== expected) return 'still-stale';
+  }
+
+  clearStale(dir, key);
+  return 'cleared';
 }
 
 export { contentHash };

--- a/integrations/cline/hooks/token-optimizer/lib/staleness.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/staleness.mjs
@@ -368,6 +368,12 @@ const DIFF_MAX_BYTES = () => {
  * line, and total bytes. Every truncation is announced in the output, because a
  * silently shortened diff is worse than a visibly shortened one -- a reader who
  * cannot tell content was elided believes they saw the whole change.
+ *
+ * `maxLines` BOUNDS THE BODY, MARKERS INCLUDED: at most `maxLines` lines of
+ * removed lines, added lines and "... N more" elision markers between them, plus
+ * at most one final notice when the byte cap dropped lines -- so `maxLines + 1`
+ * lines in total, and no more. That last line is outside the budget on purpose,
+ * for the reason stated where it is pushed.
  */
 export function diffLines(
   before,
@@ -418,10 +424,24 @@ export function diffLines(
     bytes += size;
   };
 
-  for (const line of removed.slice(0, maxLines / 2)) push('- ' + line);
-  if (removed.length > maxLines / 2) push(`  ... ${removed.length - maxLines / 2} more removed`);
-  for (const line of added.slice(0, maxLines / 2)) push('+ ' + line);
-  if (added.length > maxLines / 2) push(`  ... ${added.length - maxLines / 2} more added`);
+  // THE ELISION MARKER IS PAID FOR OUT OF THE SIDE'S OWN QUOTA, so `maxLines`
+  // bounds the whole body rather than only the content in it. It did not: at the
+  // default 40 the body could reach 42 lines -- 20 removed, 20 added and two
+  // "... N more" markers -- and the out-of-budget notice below made 43, against
+  // a documented bound of 40 and a test asserting 41. Three numbers, no two the
+  // same. A side that has to elide now shows one fewer content line and spends
+  // that line on saying so, which is the trade a reader wants anyway: knowing
+  // that 300 lines were cut matters more than the 20th of the 20 shown.
+  const half = Math.floor(maxLines / 2);
+  const emit = (lines, prefix, label) => {
+    const elides = lines.length > half;
+    const shown = elides ? Math.max(0, half - 1) : half;
+    for (const line of lines.slice(0, shown)) push(prefix + line);
+    if (elides) push(`  ... ${lines.length - shown} more ${label}`);
+  };
+
+  emit(removed, '- ', 'removed');
+  emit(added, '+ ', 'added');
 
   // Announced OUTSIDE the budget, deliberately: the one line a reader most
   // needs is the one saying the rest is missing, and dropping it to stay under
@@ -479,6 +499,15 @@ function disputeOf(graph, finding) {
   if (!hasOutstandingContradiction(graph, finding.key)) return {};
 
   const keys = [];
+  // AND THE REASON A PERSON TYPED, which had no reader anywhere. `contradict`
+  // stores `contradictionReason` -- up to 400 characters of human explanation --
+  // on the CONTRADICTED end only, and nothing outside its own test ever read it:
+  // this disclosure named the other key and stopped, `audit` counts ends, and the
+  // dashboard detail view renders neither. So the one field on the edge that says
+  // WHY was written on every contradiction and seen by nobody. It is collected
+  // from whichever end holds it, so both sides of a dispute disclose the same
+  // reason rather than only the claim that lost.
+  let reason = typeof finding.contradictionReason === 'string' ? finding.contradictionReason : '';
   for (const edge of graph.edges) {
     if (edge.edge !== 'contradicts') continue;
     const otherId =
@@ -497,10 +526,30 @@ function disputeOf(graph, finding) {
     // each name, so a live disputant is still reported alongside a withdrawn one.
     if (other && !other.retired && typeof other.key === 'string' && !keys.includes(other.key)) {
       keys.push(other.key);
+      // A RETIRED END'S REASON IS NOT BORROWED EITHER, which is why this sits
+      // inside the same guard as the key: `hasOutstandingContradiction` can be
+      // open on one live disputant while another is withdrawn, and quoting the
+      // withdrawn one's explanation would attribute the live dispute to a claim
+      // the reader cannot fetch.
+      if (!reason && typeof other.contradictionReason === 'string') {
+        reason = other.contradictionReason;
+      }
     }
   }
 
-  return { contradicted: true, ...(keys.length ? { contradictedBy: keys.join(', ') } : {}) };
+  return {
+    contradicted: true,
+    ...(keys.length ? { contradictedBy: keys.join(', ') } : {}),
+    // Trimmed here rather than at the renderer: an empty string is not a reason,
+    // and a consumer checking `if (reason)` should not have to trim first.
+    //
+    // SET UNCONDITIONALLY, INCLUDING TO `undefined`. `serve` spreads the stored
+    // record before this object, so omitting the key would let a whitespace-only
+    // stored reason through untouched and make the served value differ from the
+    // one this function decided on. The disclosure is authoritative or it is not
+    // a disclosure.
+    contradictionReason: reason.trim() || undefined,
+  };
 }
 
 /**
@@ -580,8 +629,15 @@ function derivationCheck(graph, finding) {
  * the dashboard, which left the rot path fully open on every install where
  * nobody opens the dashboard -- and that is most of them. The evidence test is
  * what makes clearing safe, and it does not care who triggered it: the same
- * `claimTimeVerdict` runs here as in `reverify`, so this cannot clear anything
+ * `claimTimeEvidence` runs here as in `reverify`, so this cannot clear anything
  * the button would not.
+ *
+ * A CLEAR ALSO RE-INDEXES THE ANCHORS IT VERIFIED. The three disclosures this
+ * function emits -- `stale`, `derivationHolds`, and the dispute -- are computed
+ * from three different comparisons, and clearing the flag without moving the
+ * anchor's stored hash made the first two contradict the clear on the revert
+ * path. `reindexVerifiedAnchors` explains the reproduction and why re-pointing
+ * the index is the fix rather than suppressing the disclosures.
  *
  * `dir` IS OPTIONAL, AND OMITTING IT MAKES THIS READ-ONLY. Several callers hold
  * a graph without the directory it came from, and a serve that silently did
@@ -617,11 +673,17 @@ export function serve(graph, findings, { dir = null } = {}) {
 
     // AUTOMATIC CLEARING, on the same evidence the manual path demands.
     //
-    // ONLY THE STORED FLAG IS TOUCHED. The lazy loop below is left to run
-    // exactly as before and can independently mark this finding stale again on
-    // its own comparison -- disk against the anchor NODE's hash -- which answers
-    // a different question and is not this function's to overrule. Eager and
-    // lazy stay two mechanisms, as the module header insists.
+    // THE FLAG AND THE INDEX MOVE TOGETHER. Clearing the flag alone made this
+    // function contradict itself on the revert path: the lazy loop below
+    // compares disk against the anchor NODE's hash, which the eager path
+    // re-pointed at the post-edit bytes, so a reverted file read as `stale:
+    // true, staleReason: 'file changed'` and `derivationHolds: false` inside the
+    // very object whose flag had just been cleared for matching its claim-time
+    // content. `reindexVerifiedAnchors` writes the verified bytes' hash back to
+    // the anchor, so all three disclosures are finally reading the same content
+    // and cannot disagree. Eager and lazy stay two mechanisms, as the module
+    // header insists -- what changed is that the index no longer holds a hash
+    // that matches no version of the file that exists.
     //
     // AND THE FIELDS GO WITH THE FLAG. `putNode` does not merge and neither does
     // this spread: serving `{ ...finding, stale: false }` would hand back a
@@ -630,12 +692,37 @@ export function serve(graph, findings, { dir = null } = {}) {
     // So the cleared record, not the stored one, is what the rest of this
     // iteration reads and spreads.
     //
-    // BOUNDED, and the bound is the point: this runs only for a finding whose
-    // flag is already STORED, only when a `derivation` record exists to check
-    // against, and it reads each of that finding's anchors at most once. A
-    // finding that is not flagged pays nothing. The lazy loop below already
+    // BOUNDED PER CALL, and the bound is the point: this runs only for a finding
+    // whose flag is already STORED, only when a `derivation` record exists to
+    // check against, and it reads each of that finding's anchors at most once.
+    // A finding that is not flagged pays nothing. The lazy loop below already
     // reads every anchor of every content-dependent finding served, so the worst
     // case is twice the anchor reads on the already-stale subset alone.
+    //
+    // AND THE PER-SESSION SHAPE, stated because the per-call bound alone reads
+    // as cheaper than it is. Measured on a synthetic 40-stale-finding graph, the
+    // serve path went 158 ms -> 217 ms (+37%), and for a GENUINELY stale finding
+    // that cost recurs on every call for the whole session: the verdict is
+    // `'differs'` forever, nothing is cleared, and the reads are repaid with
+    // nothing. What keeps it survivable in practice is not this bound but two
+    // others -- `findingsFor`'s result limit and inject.mjs's `alreadyInjected`
+    // gate, which together put it near 40 ms on the first touch of a hot file
+    // and zero on the touches after.
+    //
+    // THE REVERT CASE PAYS ONCE, AND THAT IS MEASURED, not argued. Same 40
+    // findings, all revertible, medians of 9 across three process launches: the
+    // read-only serve is 23-29 ms, the first clearing serve is 141-173 ms (the
+    // anchor reads plus one node append per cleared finding AND per re-pointed
+    // anchor), and the SECOND clearing serve is 21-28 ms -- back to the
+    // read-only baseline, because the flag is off and the index agrees, so this
+    // gate no longer fires. What the re-index changed is not that cost -- the
+    // gate stopped firing once the flag came off before, too -- but that every
+    // serve after the clear used to re-derive `stale: true` and
+    // `derivationHolds: false` from an index nobody had moved. The extra ~120 ms
+    // buys silence that is actually correct.
+    // On the genuinely-stale set the recurring cost is
+    // real and unchanged in kind: 26-45 ms read-only against 53-105 ms with
+    // clearing on, every call, clearing nothing.
     //
     // NOT ON THE NON-CONTENT-DEPENDENT EARLY RETURN ABOVE, deliberately. Both
     // eager paths refuse to flag those types at all, so a flag there can only
@@ -643,10 +730,14 @@ export function serve(graph, findings, { dir = null } = {}) {
     // does not depend on them is exactly the cost `CONTENT_DEPENDENT` exists to
     // avoid.
     let record = finding;
-    if (dir && finding.stale && claimTimeVerdict(graph, finding) === 'match') {
-      clearStale(dir, finding.key, { graph });
-      const { stale: _s, staleReason: _r, diff: _d, staleEvidence: _e, ...cleared } = finding;
-      record = cleared;
+    if (dir && finding.stale) {
+      const evidence = claimTimeEvidence(graph, finding);
+      if (evidence.verdict === 'match') {
+        reindexVerifiedAnchors(dir, graph, evidence.contents);
+        clearStale(dir, finding.key, { graph });
+        const { stale: _s, staleReason: _r, diff: _d, staleEvidence: _e, ...cleared } = finding;
+        record = cleared;
+      }
     }
 
     const anchors = graph.edges
@@ -736,6 +827,14 @@ export function serve(graph, findings, { dir = null } = {}) {
       // carries its `derivation`, since clearing removes only the staleness
       // fields. A finding whose flag was just cleared is still disclosed as
       // disputed, and still reports whether its derivation holds.
+      //
+      // AND THEY NO LONGER CONTRADICT THE CLEAR. Surviving is not the same as
+      // agreeing: for a whole serve this returned `stale: true, staleReason:
+      // 'file changed'` and `derivationHolds: false` on a finding it had just
+      // cleared, because the clear was decided against disk while these two read
+      // the anchor node's hash, and the eager path had moved it. All three now
+      // read the same content because the clear re-points the anchor; see
+      // `reindexVerifiedAnchors`.
       ...dispute,
       // Independent of `stale` above: see `derivationCheck`'s own comment for
       // the case it catches that node-level staleness can miss.
@@ -934,6 +1033,34 @@ export function invalidateChangedAnchors(dir, graph, rawPath) {
 }
 
 /**
+ * The current content of an anchor, read from disk: the whole file for a file
+ * anchor, the located span for a symbol one. Null when nothing can be read.
+ *
+ * SPLIT OUT FROM `anchorHashNow` SO THE BYTES SURVIVE THE COMPARISON. The
+ * clearing path hashes this to reach a verdict and, on `'match'`, re-indexes the
+ * anchor from the same bytes -- see `reindexVerifiedAnchors`. Returning only a
+ * hash forced a second read of a file that had just been read, for content
+ * already known to be identical.
+ */
+function anchorContentNow(anchor) {
+  const path = anchor.kind === 'symbol' ? anchor.file : anchor.key;
+  let source;
+  try {
+    source = readAnySpelling(path);
+  } catch {
+    return null;
+  }
+  if (anchor.kind !== 'symbol') return source;
+
+  // By NAME, like checkAnchor: line numbers shift whenever anything above is
+  // edited, and re-locating by line would report a symbol as moved when only an
+  // unrelated insert happened above it.
+  const current = extractSymbols(path, source).find((s) => s.name === anchor.name);
+  if (!current) return null;
+  return spanText(source, current);
+}
+
+/**
  * The current content hash of an anchor, read from disk.
  *
  * DELIBERATELY NOT `checkAnchor`, and the difference is the whole of this
@@ -952,21 +1079,8 @@ export function invalidateChangedAnchors(dir, graph, rawPath) {
  * content it was made against.
  */
 function anchorHashNow(anchor) {
-  const path = anchor.kind === 'symbol' ? anchor.file : anchor.key;
-  let source;
-  try {
-    source = readAnySpelling(path);
-  } catch {
-    return null;
-  }
-  if (anchor.kind !== 'symbol') return hash(source);
-
-  // By NAME, like checkAnchor: line numbers shift whenever anything above is
-  // edited, and re-locating by line would report a symbol as moved when only an
-  // unrelated insert happened above it.
-  const current = extractSymbols(path, source).find((s) => s.name === anchor.name);
-  if (!current) return null;
-  return hash(spanText(source, current));
+  const content = anchorContentNow(anchor);
+  return content === null ? null : hash(content);
 }
 
 /**
@@ -1005,21 +1119,51 @@ export function clearStale(dir, key, { graph = null } = {}) {
   // `contradict`, `correct` -- writes from a graph it loaded earlier too. Both
   // callers here already DECIDED on this snapshot, so re-reading it purely for
   // the write narrowed no window that was ever closed.
-  const node = (graph || load(dir)).nodes.get(nodeId('finding', key));
+  const id = nodeId('finding', key);
+  const node = (graph || load(dir)).nodes.get(id);
   if (!node || node.kind !== 'finding') return false;
   const { stale, staleReason, diff, staleEvidence, ...rest } = node;
   // Nothing to clear is a success, not a write: an unconditional putNode here
   // would append a duplicate record to the log on every no-op call.
   if (stale === undefined && staleReason === undefined
     && diff === undefined && staleEvidence === undefined) return true;
-  putNode(dir, { ...rest, kind: 'finding', key: node.key });
+  const cleared = { ...rest, kind: 'finding', key: node.key };
+  putNode(dir, cleared);
+  // AND THE CALLER'S GRAPH IS UPDATED, because the guard above reads THAT graph,
+  // not disk. Without this, a second `serve` on the same in-memory graph object
+  // -- two touched files anchored to one finding, or a lifecycle branch that
+  // serves twice from a graph it loaded once, as SessionStart does -- still saw
+  // `stale: true`, re-ran the evidence test, and appended a byte-identical clear
+  // record. The store is append-only, so that is permanent log growth for no
+  // change in state, and the "nothing to clear is a success, not a write"
+  // guarantee directly above was only true of the first call.
+  if (graph) graph.nodes.set(id, { ...cleared, id });
   return true;
 }
 
 /**
- * Clears a stale flag when, and only when, the evidence for it is gone.
+ * THE ONE EVIDENCE TEST, plus the bytes it read. Does this finding's anchored
+ * content still hash to what the claim was actually made against?
  *
- * WHY THIS HAS TO EXIST. Nothing in this codebase ever cleared a `stale` flag.
+ * `verdict` is one of:
+ *   `'match'`   -- every anchor on disk re-hashes to the value frozen into this
+ *                  finding's own `derivation.anchors` at claim time. The content
+ *                  IS what the claim was derived from: a revert, or a write that
+ *                  never moved the anchored bytes.
+ *   `'differs'` -- at least one anchor does not, INCLUDING an anchor whose
+ *                  content is gone. Deleted is a difference, not a missing
+ *                  measurement.
+ *   `'unknown'` -- there is nothing to compare: no `derivation.anchors`, no
+ *                  anchors, an anchor with no recorded hash, or one that no
+ *                  longer resolves.
+ *
+ * `contents` carries the disk bytes read to reach a `'match'`, keyed by anchor
+ * id, so the caller can re-index those anchors without reading them again. It is
+ * empty for the other two verdicts, which read no further than the first
+ * disagreement.
+ *
+ * WHY CLEARING HAS TO EXIST AT ALL. Nothing in this codebase ever cleared a
+ * `stale` flag.
  * That was harmless while eager invalidation was dead code; it fires now, so
  * every finding on an edited file becomes permanently stale -- and permanently
  * discounted, since `disclose.mjs` skips a stale finding outright and
@@ -1049,24 +1193,6 @@ export function clearStale(dir, key, { graph = null } = {}) {
  * side door. It reports `unknown` and changes nothing; re-recording the claim
  * against the current code (`curate.correct`) is the way forward for those.
  *
- * DELIBERATELY NOT AUTOMATIC. This reads every anchor off disk, so running it on
- * the serve path would put N file reads inside injection -- and, worse, it would
- * silently un-mark findings nobody asked about. Staleness is disclosed to a
- * reader who then decides; clearing is an explicit act.
- */
-/**
- * THE ONE EVIDENCE TEST. Does this finding's anchored content still hash to what
- * the claim was actually made against?
- *
- * `'match'` -- every anchor on disk re-hashes to the value frozen into this
- * finding's own `derivation.anchors` at claim time. The content IS what the
- * claim was derived from: a revert, or a write that never moved the anchored
- * bytes.
- * `'differs'` -- at least one anchor does not, INCLUDING an anchor whose content
- * is gone. Deleted is a difference, not a missing measurement.
- * `'unknown'` -- there is nothing to compare: no `derivation.anchors`, no
- * anchors, an anchor with no recorded hash, or one that no longer resolves.
- *
  * SHARED BY BOTH CLEARING PATHS ON PURPOSE, and that sharing is the guarantee
  * rather than a convenience. `reverify` (a person pressing Re-verify) and
  * `serve` (automatic, on every retrieval) call THIS function and nothing else,
@@ -1080,9 +1206,10 @@ export function clearStale(dir, key, { graph = null } = {}) {
  * re-point at the very bytes that caused the mark, so it answers "fresh" for
  * exactly the finding it just marked stale.
  */
-function claimTimeVerdict(graph, finding) {
+function claimTimeEvidence(graph, finding) {
+  const none = { verdict: 'unknown', contents: new Map() };
   const recorded = finding.derivation && finding.derivation.anchors;
-  if (!recorded || typeof recorded !== 'object') return 'unknown';
+  if (!recorded || typeof recorded !== 'object') return none;
 
   const anchorIds = new Set(
     graph.edges
@@ -1092,22 +1219,122 @@ function claimTimeVerdict(graph, finding) {
   // An unanchored finding cannot be checked against anything, which is the
   // un-invalidatable shape the anchor discipline exists to refuse. It is equally
   // un-VERIFIABLE, so it is reported as such rather than cleared.
-  if (!anchorIds.size) return 'unknown';
+  if (!anchorIds.size) return none;
 
+  const contents = new Map();
   for (const id of anchorIds) {
     const expected = recorded[id];
     const node = graph.nodes.get(id);
     // An anchor this finding never recorded a hash for, or one that no longer
     // resolves to a node: nothing to compare, so nothing is concluded.
-    if (typeof expected !== 'string' || !expected || !node) return 'unknown';
-    if (node.kind !== 'file' && node.kind !== 'symbol') return 'unknown';
+    if (typeof expected !== 'string' || !expected || !node) return none;
+    if (node.kind !== 'file' && node.kind !== 'symbol') return none;
     // null means the content is gone -- deleted file, vanished symbol. That is a
     // difference, not an absence of evidence.
-    if (anchorHashNow(node) !== expected) return 'differs';
+    const content = anchorContentNow(node);
+    if (content === null || hash(content) !== expected) {
+      return { verdict: 'differs', contents: new Map() };
+    }
+    contents.set(id, content);
   }
-  return 'match';
+  return { verdict: 'match', contents };
 }
 
+/** The verdict alone, for callers that do not re-index. */
+function claimTimeVerdict(graph, finding) {
+  return claimTimeEvidence(graph, finding).verdict;
+}
+
+/**
+ * Re-points every verified anchor at the content the evidence test just read.
+ *
+ * WHY A CLEAR IS NOT ENOUGH ON ITS OWN, reproduced end to end: index a file at
+ * H1, write a finding whose `derivation.anchors` records H1, edit and re-index so
+ * the node holds H2, let the eager path mark the finding, then REVERT the edit on
+ * disk. `claimTimeVerdict` now says `'match'` -- disk is H1, which is exactly
+ * what the claim was derived from -- and the flag comes off. But the node still
+ * holds H2, so the same `serve` call went on to emit `stale: true` with
+ * `staleReason: 'file changed'` from the lazy loop (disk H1 against node H2) and
+ * `derivationHolds: false` from `derivationCheck` (index H2 against claim H1).
+ * The model was shown DERIVATION CHANGED and STALE at the exact moment this
+ * module's own evidence test had concluded the derivation holds -- on every
+ * serve, until something unrelated happened to re-index the anchor.
+ *
+ * THE FIX IS TO MOVE THE INDEX, NOT TO SILENCE THE DISCLOSURES. Suppressing the
+ * lazy check and the derivation verdict for a cleared finding would leave the
+ * graph holding a hash that matches no version of the file that exists, so every
+ * OTHER finding on that anchor keeps reading stale, and the next reader has to be
+ * told which disclosures to disbelieve. The node hash is simply out of date, the
+ * bytes are already in hand from the comparison that just succeeded, and writing
+ * them makes all three disclosures agree because they are finally reading the
+ * same content.
+ *
+ * COSTS NO READ. `contents` comes from `claimTimeEvidence`, which read each
+ * anchor to reach `'match'`. The write is one node record per anchor whose hash
+ * actually moved, and it happens once per revert rather than once per serve: with
+ * the index re-pointed, the flag stays off and the gate in `serve` does not fire
+ * again.
+ *
+ * THE IN-MEMORY GRAPH IS UPDATED TOO, because the caller is mid-serve and is
+ * about to read these same nodes through the lazy loop and `derivationCheck`.
+ * Writing only to disk would fix the next process and leave this one contradicting
+ * itself, which is the whole defect.
+ *
+ * Line numbers are deliberately left alone on a symbol anchor: `checkAnchor` and
+ * `anchorContentNow` both re-locate by NAME, so a stored line is informational,
+ * and the body being byte-identical is what was just established.
+ */
+function reindexVerifiedAnchors(dir, graph, contents) {
+  for (const [id, content] of contents) {
+    const node = graph.nodes.get(id);
+    if (!node) continue;
+    const nextHash = hash(content);
+    // Already agrees: no record, no write. The common case once a revert has
+    // been accounted for.
+    if (node.hash === nextHash) continue;
+    const limit = node.kind === 'symbol' ? symbolSnapshotLimit() : snapshotLimit();
+    // Same bound as `indexFile`: past the cap the hash still drives staleness and
+    // only the reconstructed diff degrades.
+    const snapshot = content.length <= limit ? content : undefined;
+    const { hash: _h, snapshot: _s, ...rest } = node;
+    try {
+      putNode(dir, { ...rest, kind: node.kind, key: node.key, hash: nextHash, snapshot });
+    } catch {
+      // Fail open: a graph that could not be written is a disclosure that stays
+      // as it was, never a broken tool call. The in-memory copy is left alone to
+      // match, so this serve keeps agreeing with the store.
+      continue;
+    }
+    graph.nodes.set(id, { ...node, hash: nextHash, ...(snapshot ? { snapshot } : {}) });
+  }
+}
+
+/**
+ * Clears a stale flag on behalf of a person who asked for it -- the dashboard's
+ * Re-verify action -- and reports what the evidence said.
+ *
+ * `'cleared'` when the flag is gone (including when it was already gone, so a
+ * caller polling this does not retry forever), `'still-stale'` when the anchored
+ * content genuinely differs from what the claim was made against, `'unknown'`
+ * when there is nothing to compare and therefore nothing to conclude.
+ *
+ * NO LONGER THE ONLY CLEARING PATH, and the docblock that used to sit here said
+ * the opposite: that automatic clearing was refused because it would put N file
+ * reads inside injection and "silently un-mark findings nobody asked about".
+ * `serve` now does exactly that, on the same evidence, for the reason its own
+ * comment gives -- the manual path was reachable only where somebody opens the
+ * dashboard, which is almost nowhere, so the rot path stayed open on most
+ * installs. What survives of that objection is the cost, which `serve` bounds
+ * and states.
+ *
+ * WHAT THIS STILL ADDS over the automatic path: it loads the graph itself, so a
+ * caller holding nothing but a key and a directory can act; it reports the
+ * verdict rather than folding it into a served record; and it runs on demand
+ * rather than only when the finding happens to be retrieved. It re-indexes the
+ * verified anchors for the same reason `serve` does -- otherwise the button
+ * clears the flag and the very next retrieval re-derives a contradiction from a
+ * node hash nobody moved.
+ */
 export function reverify(dir, key) {
   const graph = load(dir);
   const finding = graph.nodes.get(nodeId('finding', key));
@@ -1116,9 +1343,10 @@ export function reverify(dir, key) {
   // holds, and reporting anything else would make a caller retry forever.
   if (!finding.stale) return 'cleared';
 
-  const verdict = claimTimeVerdict(graph, finding);
+  const { verdict, contents } = claimTimeEvidence(graph, finding);
   if (verdict === 'unknown') return 'unknown';
   if (verdict === 'differs') return 'still-stale';
+  reindexVerifiedAnchors(dir, graph, contents);
   clearStale(dir, key, { graph });
   return 'cleared';
 }

--- a/integrations/cline/hooks/token-optimizer/lib/staleness.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/staleness.mjs
@@ -17,7 +17,13 @@
  * TWO INVALIDATION PATHS, and each covers what the other cannot see:
  *
  *   EAGER  -- our PostToolUse hook saw a write, so the finding is marked at the
- *             moment it went stale, with the exact before/after in hand.
+ *             moment it went stale, with the exact before/after in hand. The
+ *             hook does not call `invalidateOnWrite` directly: it queues the
+ *             evidence through pending.mjs, and the next graph read -- which
+ *             loads the graph anyway -- applies it before serving anything.
+ *             That path is also the only one that catches a write the SESSION
+ *             made, because the lazy check below compares the stored hash
+ *             against disk and `indexFile` has already refreshed it.
  *   LAZY   -- at retrieval, the anchor's stored hash is compared against disk.
  *             This is what catches `git pull`, another editor, a teammate, or a
  *             build step: every change our hooks never observed.
@@ -291,14 +297,69 @@ export function checkAnchor(anchor) {
 }
 
 /**
+ * Characters kept from any single diff line.
+ *
+ * A LINE CAP IS NOT A SIZE CAP, and the gap was measured: with only `maxLines`
+ * in force, `diffLines('X'.repeat(200000), 'Y'.repeat(200000))` returned 2 lines
+ * and 400,005 bytes. Minified bundles, generated sources and single-line JSON
+ * all have that shape, and this output goes STRAIGHT INTO MODEL CONTEXT from
+ * inject.mjs's zero-turn refusal -- so a line bound alone let one pathological
+ * file spend hundreds of thousands of tokens.
+ *
+ * 200 characters is chosen because it is past the width at which a line is read
+ * as a line by anybody, human or model: a hand-written source line is under
+ * ~120 columns, so the cap cannot truncate a diff a reader was going to use,
+ * while the cases it does truncate are ones where the interesting change is not
+ * legible from the raw text anyway.
+ */
+const DIFF_MAX_LINE_CHARS = () => {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_DIFF_MAX_LINE_CHARS);
+  return Number.isFinite(raw) && raw > 0 ? raw : 200;
+};
+
+/**
+ * Total UTF-8 bytes of diff body.
+ *
+ * 4,000 bytes is roughly 1,000 tokens. It is deliberately larger than the
+ * per-file injection budget (`TOKEN_OPTIMIZER_TOUCH_BUDGET`, 500 tokens) and
+ * far smaller than a file, because the two consumers want different things: the
+ * injection surface fits the diff inside its own budget and drops it if it does
+ * not fit, while the zero-turn refusal is replacing a whole file read and can
+ * afford more. One cap that neither consumer has to think about is worth more
+ * than two tuned ones.
+ *
+ * WHAT IT COSTS, PLAINLY: a legitimately large diff now arrives truncated, so a
+ * model looking at a 300-line refactor sees the head of it and a count of what
+ * was elided rather than the whole change. That is the correct direction to
+ * fail -- the alternative was a bounded-looking function that could emit 400 KB.
+ */
+const DIFF_MAX_BYTES = () => {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_DIFF_MAX_BYTES);
+  return Number.isFinite(raw) && raw > 0 ? raw : 4_000;
+};
+
+/**
  * A compact line diff.
  *
  * Deliberately not a full unified diff with hunks and context: the consumer is
  * a model deciding whether an existing conclusion still holds, and for that the
  * changed lines are the signal. Output is capped because an unbounded diff
  * injected alongside a finding would spend more tokens than re-deriving it.
+ *
+ * BOUNDED IN THREE WAYS, and each one is load-bearing: lines, characters per
+ * line, and total bytes. Every truncation is announced in the output, because a
+ * silently shortened diff is worse than a visibly shortened one -- a reader who
+ * cannot tell content was elided believes they saw the whole change.
  */
-export function diffLines(before, after, { maxLines = 40 } = {}) {
+export function diffLines(
+  before,
+  after,
+  {
+    maxLines = 40,
+    maxLineChars = DIFF_MAX_LINE_CHARS(),
+    maxBytes = DIFF_MAX_BYTES(),
+  } = {}
+) {
   const a = String(before).split('\n');
   const b = String(after).split('\n');
 
@@ -314,33 +375,44 @@ export function diffLines(before, after, { maxLines = 40 } = {}) {
   const added = b.slice(head, b.length - tail);
 
   const out = [];
-  for (const line of removed.slice(0, maxLines / 2)) out.push('- ' + line);
-  if (removed.length > maxLines / 2) out.push(`  ... ${removed.length - maxLines / 2} more removed`);
-  for (const line of added.slice(0, maxLines / 2)) out.push('+ ' + line);
-  if (added.length > maxLines / 2) out.push(`  ... ${added.length - maxLines / 2} more added`);
+  let bytes = 0;
+  let dropped = 0;
+
+  // Per line first, so ONE enormous line cannot consume the whole budget and
+  // leave every other changed line unrepresented.
+  const clamp = (line) => {
+    const text = String(line);
+    if (text.length <= maxLineChars) return text;
+    return `${text.slice(0, maxLineChars)} [+${text.length - maxLineChars} chars cut]`;
+  };
+
+  // Bytes, not characters: the cap exists to bound what is sent, and a
+  // multi-byte source file would otherwise pass a character check while
+  // emitting several times the budget.
+  const push = (line) => {
+    const text = clamp(line);
+    const size = Buffer.byteLength(text, 'utf8') + 1;
+    if (bytes + size > maxBytes) {
+      dropped++;
+      return;
+    }
+    out.push(text);
+    bytes += size;
+  };
+
+  for (const line of removed.slice(0, maxLines / 2)) push('- ' + line);
+  if (removed.length > maxLines / 2) push(`  ... ${removed.length - maxLines / 2} more removed`);
+  for (const line of added.slice(0, maxLines / 2)) push('+ ' + line);
+  if (added.length > maxLines / 2) push(`  ... ${added.length - maxLines / 2} more added`);
+
+  // Announced OUTSIDE the budget, deliberately: the one line a reader most
+  // needs is the one saying the rest is missing, and dropping it to stay under
+  // a self-imposed cap would hand back a diff that lies about being complete.
+  if (dropped) out.push(`  ... ${dropped} more changed line(s) cut at the size limit`);
 
   return out.join('\n');
 }
 
-/**
- * Prepares findings for delivery, verifying each one lazily against disk.
- *
- * This is the only function that should ever hand a finding to a model, because
- * it is the one that enforces the rule: a stale finding leaves here carrying
- * `stale: true` AND a diff, or it does not leave at all.
- */
-export function serve(graph, findings) {
-  const served = [];
-
-  // RETIRED FINDINGS STOP HERE, unconditionally.
-  //
-  // findingsFor and sessionIndex already filter them, so this is redundant on
-  // every current path -- deliberately. This function's own contract is that it
-  // is the only thing that hands a finding to a model, which makes it the right
-  // place for the guarantee to live: a future caller that reaches into the
-  // graph directly cannot accidentally serve a claim a human explicitly
-  // withdrew. A withheld claim reappearing is not a bug anyone would notice
-  // quickly.
 /**
  * Types whose truth is a claim ABOUT the anchor's contents.
  *
@@ -363,6 +435,26 @@ export function serve(graph, findings) {
  * to ignore -- taking the rare true positive with it.
  */
 const CONTENT_DEPENDENT = new Set(['finding', 'map']);
+
+/**
+ * Prepares findings for delivery, verifying each one lazily against disk.
+ *
+ * This is the only function that should ever hand a finding to a model, because
+ * it is the one that enforces the rule: a stale finding leaves here carrying
+ * `stale: true` AND a diff, or it does not leave at all.
+ */
+export function serve(graph, findings) {
+  const served = [];
+
+  // RETIRED FINDINGS STOP HERE, unconditionally.
+  //
+  // findingsFor and sessionIndex already filter them, so this is redundant on
+  // every current path -- deliberately. This function's own contract is that it
+  // is the only thing that hands a finding to a model, which makes it the right
+  // place for the guarantee to live: a future caller that reaches into the
+  // graph directly cannot accidentally serve a claim a human explicitly
+  // withdrew. A withheld claim reappearing is not a bug anyone would notice
+  // quickly.
 
   for (const finding of findings.filter((f) => !f.retired)) {
     // A claim that does not depend on the anchor's contents cannot be
@@ -505,6 +597,15 @@ export function invalidateOnWrite(dir, graph, rawPath, beforeText, afterText) {
     for (const edge of byTarget.get(node.id) || []) {
       const finding = graph.nodes.get(edge.from);
       if (!finding || finding.kind !== 'finding') continue;
+      // THE SAME TYPE GATE `serve` APPLIES, and it has to be here too now that
+      // this path actually runs. `serve` ignores a stale flag on a type whose
+      // truth is not a claim about the anchor's contents -- but the flag is
+      // STORED, and disclose.mjs skips a stale finding outright while
+      // utility.mjs penalises one by 160. So writing it onto a `failure` or a
+      // `command` would suppress that claim everywhere except the one reader
+      // that knows to ignore it, which is exactly the harm measured in the
+      // comment on CONTENT_DEPENDENT above.
+      if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) continue;
 
       putNode(dir, {
         ...finding,

--- a/integrations/cline/hooks/token-optimizer/lib/staleness.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/staleness.mjs
@@ -495,6 +495,54 @@ function disputeOf(graph, finding) {
 }
 
 /**
+ * Whether THIS finding's own claim-time evidence still matches its anchors --
+ * the reader `harvest-write.mjs`'s `derivation` record was written for.
+ * Nothing consumed that record until now: a grep for it found only the writer
+ * and its own tests, which made "checkable rather than merely attributed" a
+ * claim with no code behind it.
+ *
+ * DISTINCT FROM `stale`/`checkAnchor`, DELIBERATELY, not a duplicate of it.
+ * `checkAnchor` compares disk against the anchor NODE's CURRENT stored hash,
+ * which is refreshed by `indexFile` every time ANYTHING touches that file --
+ * so it answers "has this file changed since the last time anyone indexed
+ * it", not "has it changed since THIS finding was derived from it". Those
+ * differ in a real case: file F changes, and a LATER, unrelated write
+ * (another finding, another session) re-indexes F, updating the node's
+ * stored hash to match the new content again. `checkAnchor` now reports
+ * "fresh" -- disk matches the node's current hash -- while this finding's own
+ * frozen `derivation.anchors[id]` snapshot, taken when IT was written, no
+ * longer matches. The bytes this claim was actually derived from are gone,
+ * and `stale` alone would never say so.
+ *
+ * Returns `{}` when there is nothing to check (no `derivation.anchors`
+ * recorded -- true of every finding written before this existed), so a
+ * caller can tell "not checked" from "checked and holds" by whether
+ * `derivationHolds` is present at all.
+ */
+function derivationCheck(graph, finding) {
+  const recorded = finding.derivation && finding.derivation.anchors;
+  if (!recorded || typeof recorded !== 'object') return {};
+  const ids = Object.keys(recorded);
+  if (!ids.length) return {};
+
+  const changed = [];
+  for (const id of ids) {
+    const node = graph.nodes.get(id);
+    const currentHash = node && typeof node.hash === 'string' ? node.hash : null;
+    // An anchor that no longer resolves at all cannot be confirmed either --
+    // treated the same as a changed hash, never as "still holds" by default.
+    if (currentHash === null || currentHash !== recorded[id]) {
+      changed.push(node && typeof node.key === 'string' ? node.key : id);
+    }
+  }
+
+  if (!changed.length) return { derivationHolds: true };
+  // Bounded: a finding with many anchors should not spend unbounded budget
+  // naming every one that moved.
+  return { derivationHolds: false, derivationChanged: changed.slice(0, 5) };
+}
+
+/**
  * Prepares findings for delivery, verifying each one lazily against disk.
  *
  * This is the only function that should ever hand a finding to a model, because
@@ -611,6 +659,9 @@ export function serve(graph, findings) {
       stale,
       ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
       ...dispute,
+      // Independent of `stale` above: see `derivationCheck`'s own comment for
+      // the case it catches that node-level staleness can miss.
+      ...derivationCheck(graph, finding),
     });
   }
   return served;

--- a/integrations/cline/hooks/token-optimizer/lib/staleness.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/staleness.mjs
@@ -518,6 +518,21 @@ function disputeOf(graph, finding) {
  * recorded -- true of every finding written before this existed), so a
  * caller can tell "not checked" from "checked and holds" by whether
  * `derivationHolds` is present at all.
+ *
+ * `derivationHolds: true` MEANS "MATCHES THE ANCHOR NODE'S LAST-INDEXED
+ * HASH", NOT "MATCHES DISK RIGHT NOW" -- and that distinction is stored in
+ * `derivationCheckedAgainst: 'index'` rather than left for a `wiki_query`
+ * consumer to infer from a field name alone. Two ways to close this gap were
+ * considered: recompute a live hash from disk here, or document precisely
+ * what is actually compared. `stale` (via `checkAnchor`, above) ALREADY owns
+ * the disk comparison -- re-reading the same file a second time on the same
+ * serve path, for the same anchor, from a second mechanism, is worse than
+ * one honest name. So: documented, not duplicated. A file changed on disk
+ * but never re-indexed by anything is still caught, correctly, by `stale`;
+ * `derivationHolds` answers a narrower, complementary question -- whether
+ * the LAST INDEXED state agrees with what this specific finding recorded --
+ * which is exactly the re-indexed-by-something-else case above that `stale`
+ * cannot see.
  */
 function derivationCheck(graph, finding) {
   const recorded = finding.derivation && finding.derivation.anchors;
@@ -536,10 +551,12 @@ function derivationCheck(graph, finding) {
     }
   }
 
-  if (!changed.length) return { derivationHolds: true };
+  // Declared on BOTH branches, not only the ambiguous one: a consumer should
+  // not have to already know the answer to know what was checked.
+  if (!changed.length) return { derivationHolds: true, derivationCheckedAgainst: 'index' };
   // Bounded: a finding with many anchors should not spend unbounded budget
   // naming every one that moved.
-  return { derivationHolds: false, derivationChanged: changed.slice(0, 5) };
+  return { derivationHolds: false, derivationChanged: changed.slice(0, 5), derivationCheckedAgainst: 'index' };
 }
 
 /**

--- a/integrations/cline/hooks/token-optimizer/lib/staleness.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/staleness.mjs
@@ -54,6 +54,7 @@ import { readFileSync, statSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { dirname, join } from 'node:path';
 import { putNode, putEdge, contentHash, nodeId } from './wiki.mjs';
+import { hasOutstandingContradiction } from './curate.mjs';
 import { extractSymbols, spanText, symbolKey, extractImports } from './symbols.mjs';
 import { canonicalPath, resolvableCandidates, isFsSafePath } from './paths.mjs';
 
@@ -454,6 +455,46 @@ export function diffLines(
 const CONTENT_DEPENDENT = new Set(['finding', 'map']);
 
 /**
+ * What, if anything, currently disagrees with this finding.
+ *
+ * DISCLOSED AT SERVE TIME, because that is the only moment the disagreement can
+ * do any good. `WIKI_GRAPH.md`'s whole argument for making `contradicts` an edge
+ * rather than an overwrite is that a reader "sees both claims and the
+ * disagreement between them" -- so handing a finding to a model while something
+ * in the graph disputes it, without saying so, throws away the reason the edge
+ * was recorded instead of an overwrite.
+ *
+ * `hasOutstandingContradiction` is the gate: it is the one definition of "an
+ * open dispute", shared with the confidence-promotion gate, so the two can never
+ * disagree about what counts. The loop only NAMES the other side, and it names a
+ * key rather than quoting a claim because the reader can call `wiki_query` with
+ * a key -- and because the injection path pays for every character it renders.
+ *
+ * SEPARATE FROM STALENESS on purpose. A finding can be disputed without being
+ * stale (nothing touched its anchor; another finding simply says otherwise) and
+ * stale without being disputed, so this adds its own fields rather than
+ * borrowing the stale ones, and the renderer discloses each on its own terms.
+ */
+function disputeOf(graph, finding) {
+  if (!hasOutstandingContradiction(graph, finding.key)) return {};
+
+  const keys = [];
+  for (const edge of graph.edges) {
+    if (edge.edge !== 'contradicts') continue;
+    const otherId =
+      edge.from === finding.id ? edge.to : edge.to === finding.id ? edge.from : null;
+    if (!otherId) continue;
+    const other = graph.nodes.get(otherId);
+    // An edge end that resolves to nothing names nothing. The dispute is still
+    // disclosed -- the gate above already established it -- but without a key
+    // the reader cannot be pointed anywhere, and inventing one would be worse.
+    if (other && typeof other.key === 'string' && !keys.includes(other.key)) keys.push(other.key);
+  }
+
+  return { contradicted: true, ...(keys.length ? { contradictedBy: keys.join(', ') } : {}) };
+}
+
+/**
  * Prepares findings for delivery, verifying each one lazily against disk.
  *
  * This is the only function that should ever hand a finding to a model, because
@@ -474,10 +515,17 @@ export function serve(graph, findings) {
   // quickly.
 
   for (const finding of findings.filter((f) => !f.retired)) {
+    // A DISPUTE TRAVELS WITH EVERY TYPE, which is why it is computed before the
+    // content-dependence branch below. A `command` or `rule` finding cannot be
+    // invalidated by an anchor's contents, but another finding can still
+    // disagree with it, and this early return is the path that would have
+    // quietly dropped that.
+    const dispute = disputeOf(graph, finding);
+
     // A claim that does not depend on the anchor's contents cannot be
     // invalidated by them. It is served as-is rather than discounted.
     if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) {
-      served.push({ ...finding });
+      served.push({ ...finding, ...dispute });
       continue;
     }
 
@@ -562,6 +610,7 @@ export function serve(graph, findings) {
       ...finding,
       stale,
       ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
+      ...dispute,
     });
   }
   return served;

--- a/integrations/cline/hooks/token-optimizer/lib/waste.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/waste.mjs
@@ -151,6 +151,11 @@ function reDerivation(events, graph) {
       const id = nodeId('file', canonicalPath(row.anchor));
       if (!graph.nodes.has(id)) continue;
 
+      // READ-ONLY serve: no `dir` is threaded here, so this cannot clear a stale
+      // flag whose evidence is gone. That is deliberate -- this function takes a
+      // graph, not the directory it came from, and widening its signature to give
+      // an analysis path a write capability buys nothing: the injection path runs
+      // on every tool call and clears the same findings.
       const findings = serve(graph, findingsFor(graph, id, { limit: 3 }))
         .filter((f) => !f.stale && (f.confidence ?? 0) >= 0.7);
       if (!findings.length) continue;

--- a/integrations/cline/hooks/token-optimizer/lib/wiki.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/wiki.mjs
@@ -64,18 +64,37 @@ export const SUPPORTED_VERSIONS = [1];
  * Identity today because GRAPH_VERSION is 1 and no shape has changed. It exists
  * now so the first change that DOES need it has somewhere to go other than an
  * equality check that silently deletes user data.
+ *
+ * CONTRACT for the first non-identity step:
+ *  - It must be IDEMPOTENT. `upcast(upcast(r))` must equal `upcast(r)`, because
+ *    compaction upcasts a record to key it and `load` upcasts the same record
+ *    again on every subsequent read. A step that is not idempotent applies twice
+ *    to anything compaction has touched.
+ *  - It must NOT be relied on to restamp `v`. Nothing in this file writes an
+ *    upcast record back to disk under a version it did not come from; the
+ *    version stamp on disk is always the one that wrote the bytes. See the
+ *    per-branch comments in `compactIfWasteful`.
  */
 export function upcast(record) {
   return record;
 }
 
-/** True when this reader can interpret the record at all. */
-function readable(record) {
+/**
+ * True when this reader can interpret the record at all.
+ *
+ * `versions` is a PARAMETER so the range semantics are testable independently of
+ * today's constants. With `SUPPORTED_VERSIONS = [1]` and `GRAPH_VERSION = 1` a
+ * range check and the old equality check are extensionally identical, so a test
+ * pinned to the live constants cannot tell them apart -- and cannot fail if
+ * someone reverts this to an equality. Exercised against `[1, 2]`, it can.
+ */
+export function readable(record, versions = SUPPORTED_VERSIONS) {
   const version = record.v ?? 0;
   // Forward-incompatible records are skipped: a v-from-the-future was written by
-  // a newer client and we cannot know its shape. Ignoring the future is safe;
-  // ignoring the past is data loss.
-  return SUPPORTED_VERSIONS.includes(version);
+  // a newer client and we cannot know its shape. Ignoring the future is safe for
+  // a READER -- but see `compactIfWasteful`, where "ignore" would mean "delete",
+  // because compaction rewrites the files it reads.
+  return versions.includes(version);
 }
 
 /** Node kinds. `file` and `symbol` are first-class so staleness can propagate. */
@@ -434,9 +453,20 @@ function compactIfWasteful(dir) {
     const nodes = new Map();
     const edges = new Map();
     const snaps = new Map();
-    for (const rec of readSnapshots(dir)) {
+    // KEPT VERBATIM THROUGH THE REBUILD, exactly as the main log keeps what it
+    // cannot parse. These lines are not evictable by the snapshot budget below
+    // because their size cannot be attributed to an id we understand -- and
+    // preserving bytes we may not need is strictly better than deleting bytes a
+    // newer client does. They stop accumulating as soon as the client that
+    // wrote them compacts, since it can read and dedupe them.
+    const sidecar = readSnapshots(dir);
+    const rawSnaps = sidecar.unreadable;
+    for (const rec of sidecar.records) {
       if (typeof rec.snapshot === 'string' && rec.snapshot) {
-        snaps.set(rec.id, { at: rec.at || 0, snapshot: rec.snapshot });
+        // `v` IS CARRIED, not restamped. Writing GRAPH_VERSION over a record
+        // from another version mislabels bytes this reader did not produce, and
+        // the label is the only thing a future reader has to go on.
+        snaps.set(rec.id, { at: rec.at || 0, snapshot: rec.snapshot, v: rec.v ?? GRAPH_VERSION });
       }
     }
     for (const line of readFileSync(path, 'utf8').split('\n')) {
@@ -458,27 +488,40 @@ function compactIfWasteful(dir) {
         edges.set('raw:' + edges.size, line);
         continue;
       }
-      // Upcast IN MEMORY only, to key and classify the record. What gets written
-      // back below is the ORIGINAL `line`: compaction reclaims superseded
-      // records, it does not migrate surviving ones, so the on-disk version is
-      // whatever wrote it and `load` upcasts it again on every read.
-      record = upcast(record);
-      if (record.t === 'n') {
+      // TWO OBJECTS, ON PURPOSE. `record` is exactly what the bytes on disk say;
+      // `view` is the in-memory current-shape reading of it, used only to KEY and
+      // CLASSIFY. Nothing derived from `view` is ever serialized, because
+      // compaction reclaims superseded records -- it does not migrate surviving
+      // ones -- so every version stamp it writes is the one that wrote the bytes.
+      //
+      // An earlier revision of this comment claimed "the ORIGINAL line is written
+      // back" for the whole block. That was FALSE for the inline-snapshot branch,
+      // which re-serializes. It re-serialized the upcast object while carrying
+      // the old `v`, so the first non-identity `upcast` would have written
+      // new-shape bytes under an old label and every later `load` would have
+      // upcast them a second time. Hence: strip from `record`, never from `view`.
+      const view = upcast(record);
+      if (view.t === 'n') {
         // MIGRATION. Graphs written before snapshots were split still carry
         // them inline, and those are exactly the graphs that are slow. Moving
         // them out here means one compaction fixes an existing install.
+        //
+        // THE ONLY RE-SERIALIZING BRANCH in this loop. It writes the original
+        // record minus its snapshot, so the surviving bytes keep their own shape
+        // and their own `v`, and the snapshot moved to the sidecar carries the
+        // same `v` as the node it came out of.
         if (typeof record.snapshot === 'string' && record.snapshot) {
           const { snapshot, ...rest } = record;
-          nodes.set(record.id, JSON.stringify(rest));
-          snaps.set(record.id, { at: record.at || 0, snapshot });
+          nodes.set(view.id, JSON.stringify(rest));
+          snaps.set(view.id, { at: record.at || 0, snapshot, v: record.v ?? GRAPH_VERSION });
         } else {
-          nodes.set(record.id, line);
+          nodes.set(view.id, line);
         }
-      } else if (record.t === 's') {
+      } else if (view.t === 's') {
         if (typeof record.snapshot === 'string' && record.snapshot) {
-          snaps.set(record.id, { at: record.at || 0, snapshot: record.snapshot });
+          snaps.set(view.id, { at: record.at || 0, snapshot: record.snapshot, v: record.v ?? GRAPH_VERSION });
         }
-      } else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
+      } else if (view.t === 'e') edges.set(`${view.from}|${view.edge}|${view.to}`, line);
       else edges.set('raw:' + edges.size, line);
     }
 
@@ -541,10 +584,20 @@ function compactIfWasteful(dir) {
     renameSync(tmp, path);
     // The surviving snapshots are rewritten to their own file, which is also
     // what migrates a graph that still had them inline.
-    const snapOut =
-      [...keep.entries()]
-        .map(([id, v]) => JSON.stringify({ t: 's', v: GRAPH_VERSION, id, snapshot: v.snapshot, at: v.at }))
-        .join('\n') + (keep.size ? '\n' : '');
+    //
+    // UNREADABLE LINES FIRST AND VERBATIM. This rebuild replaces the file, so
+    // anything omitted here is deleted permanently -- which made the missing
+    // counterpart to the main log's `raw:` bucket a real data-loss path, not a
+    // theoretical one. Each survivor also keeps ITS OWN `v` rather than being
+    // restamped to GRAPH_VERSION, so no record is relabelled as something this
+    // reader wrote.
+    const snapLines = [
+      ...rawSnaps,
+      ...[...keep.entries()].map(([id, s]) =>
+        JSON.stringify({ t: 's', v: s.v ?? GRAPH_VERSION, id, snapshot: s.snapshot, at: s.at })
+      ),
+    ];
+    const snapOut = snapLines.join('\n') + (snapLines.length ? '\n' : '');
     const snapTmp = snapshotsPath(dir) + '.compact';
     writeFileSync(snapTmp, snapOut, { mode: 0o600 });
     renameSync(snapTmp, snapshotsPath(dir));
@@ -689,9 +742,26 @@ function appendSnapshot(dir, record) {
   }
 }
 
-/** Every snapshot record, latest wins. Read only when a caller asks. */
+/**
+ * Every snapshot record, latest wins. Read only when a caller asks.
+ *
+ * `unreadable` collects the RAW LINES this reader rejected, and it is the reason
+ * this function reports them at all rather than just dropping them. `load` has
+ * no use for them -- a reader that cannot interpret a record must ignore it --
+ * but `compactIfWasteful` REBUILDS this file from what it read, so for the
+ * compactor "ignore" and "delete permanently" are the same operation. The main
+ * log already keeps what it cannot parse (the `raw:` bucket); the sidecar had no
+ * equivalent, which made it the one asymmetric, destructive path in an otherwise
+ * append-only store.
+ *
+ * This is not hypothetical here: hooks-core is vendored into eleven client
+ * directories that update independently, so a stale client compacting a graph a
+ * newer client has already written to is the expected steady state, not an edge
+ * case.
+ */
 function readSnapshots(dir) {
-  const out = [];
+  /** @type {object[]} */ const out = [];
+  /** @type {string[]} */ const unreadable = [];
   try {
     for (const line of readFileSync(snapshotsPath(dir), 'utf8').split('\n')) {
       if (!line) continue;
@@ -699,19 +769,23 @@ function readSnapshots(dir) {
         const rec = JSON.parse(line);
         // THE SAME RANGE AS THE MAIN LOG, deliberately. An equality check here
         // was the quietest of the three: a bump would have made every stored
-        // snapshot unreadable, and the very next compaction -- which rebuilds
-        // this file from what it could read -- would have deleted them for
-        // good. That is the one place in this store where a read filter turns
-        // into a permanent write.
-        if (readable(rec) && rec.id) out.push(upcast(rec));
+        // snapshot unreadable, and the very next compaction would have deleted
+        // them for good.
+        if (!readable(rec)) {
+          unreadable.push(line);
+          continue;
+        }
+        if (rec.id) out.push(upcast(rec));
       } catch {
-        /* a torn line costs one snapshot */
+        // A torn line costs one snapshot -- and it is NOT preserved, because a
+        // half-written line is not a record from another version, it is
+        // garbage. Distinguishing the two is the whole point of parsing first.
       }
     }
   } catch {
     /* no sidecar yet */
   }
-  return out;
+  return { records: out, unreadable };
 }
 
 /**
@@ -777,7 +851,9 @@ export function load(dir, { snapshots = false } = {}) {
   // Re-attached after the sweep, so a snapshot record may appear before or
   // after the node it belongs to.
   if (pending) {
-    for (const rec of readSnapshots(dir)) pending.set(rec.id, rec.snapshot);
+    // A reader has no use for the lines it could not interpret; only the
+    // compactor does, because only the compactor rewrites the file.
+    for (const rec of readSnapshots(dir).records) pending.set(rec.id, rec.snapshot);
     for (const [id, snapshot] of pending) {
       const node = nodes.get(id);
       if (node) nodes.set(id, { ...node, snapshot });

--- a/integrations/cline/hooks/token-optimizer/lib/wiki.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/wiki.mjs
@@ -28,17 +28,55 @@ import { canonicalPath, isFsSafePath } from './paths.mjs';
 /**
  * Schema version stamped on every record.
  *
- * There is exactly ONE version and no migration code, because nothing has been
- * released: a graph written by an older commit of an unreleased branch is a
- * development artifact, not user data, and carrying migration paths for it costs
- * real complexity to protect something nobody has. A record from any other
- * version is skipped rather than interpreted, so a stale dev graph degrades to
- * "rebuilds from use" instead of silently mixing incompatible identities.
+ * THIS PACKAGE IS RELEASED. It ships on npm, so every graph on disk is user
+ * data. An earlier version of this comment claimed nothing had been released
+ * and used that to justify having no migration path at all -- and the reader
+ * below compared for EQUALITY, so the first bump would have discarded every
+ * existing graph in silence. That justification is gone and so is the equality:
+ * `SUPPORTED_VERSIONS` is the range this reader accepts, and `upcast` is where a
+ * shape change is absorbed in memory.
  *
- * When this does ship, a bump here is where migration would be added -- with
- * users to protect, that trade reverses.
+ * A bump here is taken only when a record's SHAPE actually changes, and it comes
+ * with a new `upcast` step and an entry in `SUPPORTED_VERSIONS` in the same
+ * change. Adding a field that older readers can ignore is not a shape change.
  */
 export const GRAPH_VERSION = 1;
+
+/**
+ * Versions this reader accepts, oldest first.
+ *
+ * A RANGE, NOT AN EQUALITY. The equality check this replaces would have
+ * discarded every existing graph the moment anyone bumped the version -- and the
+ * header once justified that with "nothing has been released", which stopped
+ * being true at v5.7.0 on npm.
+ *
+ * Nothing on disk is ever rewritten to migrate: `upcast` runs in memory during
+ * the fold, so there is no migration pass to fail halfway and no race with the
+ * concurrent sessions this store is designed for. A mixed-version log is safe
+ * precisely because the original records are never mutated, and the existing
+ * compaction retires old ones naturally as it rewrites snapshots.
+ */
+export const SUPPORTED_VERSIONS = [1];
+
+/**
+ * Brings one record up to the current version. Pure, and one step per version.
+ *
+ * Identity today because GRAPH_VERSION is 1 and no shape has changed. It exists
+ * now so the first change that DOES need it has somewhere to go other than an
+ * equality check that silently deletes user data.
+ */
+export function upcast(record) {
+  return record;
+}
+
+/** True when this reader can interpret the record at all. */
+function readable(record) {
+  const version = record.v ?? 0;
+  // Forward-incompatible records are skipped: a v-from-the-future was written by
+  // a newer client and we cannot know its shape. Ignoring the future is safe;
+  // ignoring the past is data loss.
+  return SUPPORTED_VERSIONS.includes(version);
+}
 
 /** Node kinds. `file` and `symbol` are first-class so staleness can propagate. */
 export const NODE_KINDS = ['file', 'symbol', 'task', 'finding'];
@@ -409,13 +447,22 @@ function compactIfWasteful(dir) {
       } catch {
         continue;
       }
-      // A record from another schema is KEPT VERBATIM rather than reinterpreted.
-      // load() skips it, but discarding it here would make compaction a silent
-      // migration that deletes data a future version might understand.
-      if ((record.v ?? 0) !== GRAPH_VERSION) {
+      // A record this reader cannot interpret is KEPT VERBATIM rather than
+      // reinterpreted. load() skips it, but discarding it here would make
+      // compaction a silent migration that deletes data a future version might
+      // understand. THE RANGE MATTERS HERE TOO: with an equality check, a bump
+      // would have parked every existing v1 record in `raw`, undeduplicated, so
+      // compaction would stop reclaiming anything and inline snapshots would
+      // never migrate out -- the same loss by a second route.
+      if (!readable(record)) {
         edges.set('raw:' + edges.size, line);
         continue;
       }
+      // Upcast IN MEMORY only, to key and classify the record. What gets written
+      // back below is the ORIGINAL `line`: compaction reclaims superseded
+      // records, it does not migrate surviving ones, so the on-disk version is
+      // whatever wrote it and `load` upcasts it again on every read.
+      record = upcast(record);
       if (record.t === 'n') {
         // MIGRATION. Graphs written before snapshots were split still carry
         // them inline, and those are exactly the graphs that are slow. Moving
@@ -650,7 +697,13 @@ function readSnapshots(dir) {
       if (!line) continue;
       try {
         const rec = JSON.parse(line);
-        if ((rec.v ?? 0) === GRAPH_VERSION && rec.id) out.push(rec);
+        // THE SAME RANGE AS THE MAIN LOG, deliberately. An equality check here
+        // was the quietest of the three: a bump would have made every stored
+        // snapshot unreadable, and the very next compaction -- which rebuilds
+        // this file from what it could read -- would have deleted them for
+        // good. That is the one place in this store where a read filter turns
+        // into a permanent write.
+        if (readable(rec) && rec.id) out.push(upcast(rec));
       } catch {
         /* a torn line costs one snapshot */
       }
@@ -691,7 +744,12 @@ export function load(dir, { snapshots = false } = {}) {
       if (!snapshots) continue;
       try {
         const rec = JSON.parse(line);
-        if ((rec.v ?? 0) === GRAPH_VERSION) pending.set(rec.id, rec.snapshot);
+        // Inline snapshots from an older graph: same range, same reason. These
+        // are precisely the records most likely to predate a bump.
+        if (readable(rec)) {
+          const snap = upcast(rec);
+          pending.set(snap.id, snap.snapshot);
+        }
       } catch {
         /* a torn line costs one snapshot, not the graph */
       }
@@ -703,10 +761,14 @@ export function load(dir, { snapshots = false } = {}) {
     } catch {
       continue;
     }
-    // A record from another schema is skipped, not interpreted: its ids and
-    // hashes were derived differently, so honouring it produces confident
-    // nonsense rather than a visible error.
-    if ((record.v ?? 0) !== GRAPH_VERSION) continue;
+    // A record this reader cannot interpret is skipped, not guessed at: a
+    // version from the FUTURE derived its ids and hashes in a way we do not
+    // know, so honouring it produces confident nonsense rather than a visible
+    // error. A record from the PAST is upcast, never skipped -- skipping it is
+    // data loss, and this comparison used to be an equality, which made the
+    // first version bump a silent delete of every graph on disk.
+    if (!readable(record)) continue;
+    record = upcast(record);
     if (record.t === 'n') nodes.set(record.id, record);
     else if (record.t === 'e') edges.push(record);
   }

--- a/integrations/cline/hooks/token-optimizer/lib/wiki.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/wiki.mjs
@@ -775,7 +775,17 @@ function readSnapshots(dir) {
           unreadable.push(line);
           continue;
         }
+        // A RECORD WITH NO `id` IS KEPT VERBATIM, NOT DROPPED SILENTLY. It
+        // cannot be attributed to a node, so it is useless to `load` -- but this
+        // used to put it in neither bucket, and `compactIfWasteful` rebuilds the
+        // sidecar from `records` plus `unreadable`, so a line in neither was
+        // deleted permanently by the next compaction. That is the same shape as
+        // the Critical this reader's version check already fixed, and the same
+        // asymmetry: for the compactor, "ignore" and "destroy" are one operation.
+        // Unreachable today because every writer sets `id`; a reader is not the
+        // right place to rely on that.
         if (rec.id) out.push(upcast(rec));
+        else unreadable.push(line);
       } catch {
         // A torn line costs one snapshot -- and it is NOT preserved, because a
         // half-written line is not a record from another version, it is

--- a/integrations/cline/hooks/token-optimizer/post-tool.mjs
+++ b/integrations/cline/hooks/token-optimizer/post-tool.mjs
@@ -8,7 +8,7 @@ process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.
-process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write';
+process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write,wiki_query';
 try {
   const { run } = await import('./lib/adapter.mjs');
   await run('cline', 'post-tool');

--- a/integrations/cline/hooks/token-optimizer/post-tool.mjs
+++ b/integrations/cline/hooks/token-optimizer/post-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/cline/hooks/token-optimizer/pre-tool.mjs
+++ b/integrations/cline/hooks/token-optimizer/pre-tool.mjs
@@ -8,7 +8,7 @@ process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.
-process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write';
+process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write,wiki_query';
 try {
   const { run } = await import('./lib/adapter.mjs');
   await run('cline', 'pre-tool');

--- a/integrations/cline/hooks/token-optimizer/pre-tool.mjs
+++ b/integrations/cline/hooks/token-optimizer/pre-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/cline/hooks/token-optimizer/session-start.mjs
+++ b/integrations/cline/hooks/token-optimizer/session-start.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/cline/hooks/token-optimizer/session-start.mjs
+++ b/integrations/cline/hooks/token-optimizer/session-start.mjs
@@ -8,7 +8,7 @@ process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.
-process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write';
+process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write,wiki_query';
 try {
   const { run } = await import('./lib/adapter.mjs');
   await run('cline', 'session-start');

--- a/integrations/codex/hooks/lib/adapter.mjs
+++ b/integrations/codex/hooks/lib/adapter.mjs
@@ -68,6 +68,7 @@ import {
   standingRules,
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
+import { observedWrite, queueInvalidation } from './pending.mjs';
 import { isArchived } from './transcript.mjs';
 import { isFsSafePath } from './paths.mjs';
 import {
@@ -881,6 +882,35 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Causal tracing is fail-open like every other hook optimization.
+    }
+
+    // EAGER INVALIDATION, finally connected. `invalidateOnWrite` has existed,
+    // been tested and been described in staleness.mjs's own header since
+    // staleness landed, and its only reference in shipped code was a COMMENT in
+    // the PreToolUse router -- so the path that header calls load-bearing had
+    // never run once in production. It matters most for exactly this event: the
+    // lazy check compares the anchor's stored hash against disk, and the
+    // capture below re-points that hash at the bytes this write just produced,
+    // so a write the session performed ITSELF is invisible to lazy staleness.
+    //
+    // QUEUED, NOT APPLIED. Applying needs the graph, and loading a megabyte of
+    // JSONL on the return path of every write is what this shape exists to
+    // avoid. The next graph read drains it before serving anything.
+    try {
+      if (mutationSucceeded(clientName, raw)) {
+        const evidence = observedWrite(payload, raw);
+        if (evidence) {
+          // THE SAME DIRECTORY THE GRAPH ITSELF USES. `observeAndInject` keys
+          // every write on `wikiDir(projectRootFor(path, payload.cwd))`, and a
+          // queue written anywhere else is a queue nothing ever drains.
+          queueInvalidation(
+            wikiDir(projectRootFor(evidence.path, payload.cwd)),
+            evidence
+          );
+        }
+      }
+    } catch {
+      // Bookkeeping for a call that already completed. Never let it cost one.
     }
   }
 

--- a/integrations/codex/hooks/lib/adapter.mjs
+++ b/integrations/codex/hooks/lib/adapter.mjs
@@ -64,6 +64,7 @@ import {
   forTouch,
   noteActClasses,
   relevantFindingIdsForContext,
+  sessionContext,
   sessionIndex,
   standingRules,
 } from './inject.mjs';
@@ -690,8 +691,23 @@ async function runHook(clientName, event, invocation) {
       rememberOptimizerTools(state, toolEvidence);
       saveState(sessionId, state);
     }
-    const parts = [
-      policyText(client.canDeny, toolEvidence.names, toolEvidence.proven),
+    // ASSEMBLED IN CACHE ORDER, not in whatever order this function happens to
+    // discover the blocks. Everything emitted here sits near the FRONT of the
+    // prompt prefix, and a prefix cache invalidates from the first differing
+    // byte onward -- so the block that changes most often has to sit LAST, or it
+    // re-prices every block behind it on every session. `sessionContext` sorts
+    // by the declared volatility; inject.mjs records how each number was
+    // assigned and why.
+    const blocks = [
+      {
+        id: 'policy',
+        volatility: 0,
+        text: policyText(
+          client.canDeny,
+          toolEvidence.names,
+          toolEvidence.proven
+        ),
+      },
     ];
     const cwd = raw.cwd || raw.working_directory || process.cwd();
     const root = projectRootFor(join(cwd, '__session__'), cwd);
@@ -705,7 +721,7 @@ async function runHook(clientName, event, invocation) {
         const graph = load(dir);
         const episode = episodeMeta({ client: clientName, raw });
         const rules = standingRules(dir, graph, { episode });
-        if (rules) parts.push(rules);
+        if (rules) blocks.push({ id: 'standing', volatility: 1, text: rules });
         const relevantFindingIds = relevantFindingIdsForContext(
           graph,
           sessionTaskContext(raw)
@@ -714,12 +730,12 @@ async function runHook(clientName, event, invocation) {
           episode,
           relevantFindingIds,
         });
-        if (index) parts.push(index);
+        if (index) blocks.push({ id: 'index', volatility: 2, text: index });
       } catch {
         // Retrieval is optional context; the policy must still reach the model.
       }
     }
-    const output = contextOutput(client, eventName, parts.join('\n\n'));
+    const output = contextOutput(client, eventName, sessionContext(blocks));
     if (output) emit(output);
     process.exit(0);
   }

--- a/integrations/codex/hooks/lib/adapter.mjs
+++ b/integrations/codex/hooks/lib/adapter.mjs
@@ -68,7 +68,7 @@ import {
   standingRules,
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
-import { observedWrite, queueInvalidation } from './pending.mjs';
+import { observedWrites, queueInvalidation } from './pending.mjs';
 import { isArchived } from './transcript.mjs';
 import { isFsSafePath } from './paths.mjs';
 import {
@@ -898,8 +898,7 @@ async function runHook(clientName, event, invocation) {
     // avoid. The next graph read drains it before serving anything.
     try {
       if (mutationSucceeded(clientName, raw)) {
-        const evidence = observedWrite(payload, raw);
-        if (evidence) {
+        for (const evidence of observedWrites(payload, raw)) {
           // THE SAME DIRECTORY THE GRAPH ITSELF USES. `observeAndInject` keys
           // every write on `wikiDir(projectRootFor(path, payload.cwd))`, and a
           // queue written anywhere else is a queue nothing ever drains.

--- a/integrations/codex/hooks/lib/capabilities.mjs
+++ b/integrations/codex/hooks/lib/capabilities.mjs
@@ -38,6 +38,10 @@ export const HOOK_MCP_TOOLS = Object.freeze([
   'optimize_session',
   'get_optimization_report',
   'wiki_write',
+  // The read side of the graph. The session index tells the model to "call
+  // wiki_query with a key for detail", so the hook needs positive evidence that
+  // the name it is advertising is actually registered in this host.
+  'wiki_query',
 ]);
 
 const HOOK_MCP_TOOL_SET = new Set(HOOK_MCP_TOOLS);

--- a/integrations/codex/hooks/lib/curate.mjs
+++ b/integrations/codex/hooks/lib/curate.mjs
@@ -22,7 +22,7 @@
  */
 
 import { randomBytes } from 'node:crypto';
-import { putNode, putNodeWithEdges, load, nodeId } from './wiki.mjs';
+import { putNode, putEdge, putNodeWithEdges, load, nodeId } from './wiki.mjs';
 import { indexFile } from './staleness.mjs';
 import { symbolKey } from './symbols.mjs';
 import { canonicalPath } from './paths.mjs';
@@ -178,6 +178,79 @@ export function retire(dir, key) {
   if (!existing) return false;
   putNode(dir, { ...existing, kind: 'finding', key, retired: true });
   return true;
+}
+
+/**
+ * Records that one finding disagrees with another.
+ *
+ * AN EDGE, NOT AN OVERWRITE -- the design is explicit about why: "when a belief
+ * changes, the graph should record THAT it changed and why, not quietly present
+ * the new one as though it had always been true." `contradicts` has been in
+ * EDGE_KINDS since the schema existed and was written by nothing, while
+ * `audit()` already READ it.
+ *
+ * The contradicted finding is deliberately NOT retired, and its claim is
+ * deliberately preserved. A reader needs to see both claims and the
+ * disagreement between them; retiring one silently picks a winner, and putNode
+ * does not merge -- it writes the whole record from what it is handed, so
+ * annotating the target without spreading it back in would blank the very claim
+ * this edge exists to keep visible. That is the overwrite by another name.
+ *
+ * THE EDGE IS WRITTEN FIRST, and the order is the guarantee. These are two
+ * appends and `append` fails open, so either can be the one that lands. Edge
+ * without annotation is a complete, readable disagreement missing only its
+ * reason. Annotation without edge is a finding that says "something contradicts
+ * me" with no contradictor -- a claim of proof with no proof, and invisible to
+ * `audit()` and to `hasOutstandingContradiction`, both of which read the edge.
+ */
+export function contradict(dir, { key, byKey, reason }) {
+  const graph = load(dir);
+  const target = findingByKey(graph, key);
+  const source = findingByKey(graph, byKey);
+  // Both ends must exist, or the edge is unresolvable and the disagreement is
+  // recorded against nothing -- the same un-invalidatable shape anchors prevent.
+  if (!target || !source) return false;
+  // A finding cannot disagree with itself. The self-edge resolves, so the guard
+  // above waves it through, and the result is a node permanently blocked from
+  // confidence promotion by a dispute no person can ever resolve: there is no
+  // second claim to choose between.
+  if (target.id === source.id) return false;
+
+  putEdge(dir, source.id, 'contradicts', target.id);
+  putNode(dir, {
+    ...target,
+    kind: 'finding',
+    key,
+    contradictedAt: Date.now(),
+    contradictionReason: String(reason || '').slice(0, 400),
+  });
+  return true;
+}
+
+/**
+ * Whether anything currently disagrees with this finding.
+ *
+ * Gates confidence promotion. Plan 2's per-finding utility measures whether a
+ * finding SUPPRESSES READS, and a confidently wrong finding suppresses reads
+ * better than a hedged true one -- so utility must never raise confidence on
+ * its own, and this is the check that stops it.
+ *
+ * SYMMETRIC, deliberately: BOTH ends of a `contradicts` edge are outstanding
+ * until a person resolves the disagreement. The named hazard in the design is
+ * presenting "the new one as though it had always been true", so gating only
+ * the older claim would leave the newer one -- which is just as likely to be
+ * the wrong one, since nothing here adjudicates -- free to be promoted on
+ * measured utility alone. That is the exact failure this gate exists to stop.
+ * It also matches `audit()`, the reader that has always been here: it puts both
+ * `from` and `to` in its `contradicted` bucket, because "until one looks, BOTH
+ * are being served".
+ */
+export function hasOutstandingContradiction(graph, key) {
+  const node = findingByKey(graph, key);
+  if (!node) return false;
+  return graph.edges.some(
+    (e) => e.edge === 'contradicts' && (e.to === node.id || e.from === node.id)
+  );
 }
 
 /**

--- a/integrations/codex/hooks/lib/curate.mjs
+++ b/integrations/codex/hooks/lib/curate.mjs
@@ -124,7 +124,17 @@ export function correct(
   const replacementKey = `${key}-c${Date.now().toString(36)}`;
 
   const edges = [{ edge: 'supersedes', to: originalId }];
-  // The correction inherits the original's anchors, so it can go stale too.
+  // The correction inherits the original's anchors, so it can go stale too --
+  // but it inherits NOTHING ELSE, and that is deliberate rather than incidental.
+  // The node written below is built field by field from `existing` instead of
+  // spreading it, which is what keeps the staleness fields (`stale`,
+  // `staleReason`, `diff`) off the successor: a correction is re-derived
+  // against the current code by definition, so being born carrying its
+  // predecessor's invalidation would discount it the moment it existed --
+  // `disclose.mjs` skips a stale finding outright and `utility.mjs` penalises
+  // one by 160. Any future edit here that reaches for `...existing` to pick up
+  // one more field re-introduces that, since `putNode` writes what it is handed
+  // wholesale; `tests/hooks/stale-clearing.test.mjs` is the guard.
   for (const edge of graph.edges) {
     if (edge.edge === 'derived_from' && edge.from === originalId) {
       edges.push({ edge: 'derived_from', to: edge.to });
@@ -244,13 +254,38 @@ export function contradict(dir, { key, byKey, reason }) {
  * It also matches `audit()`, the reader that has always been here: it puts both
  * `from` and `to` in its `contradicted` bucket, because "until one looks, BOTH
  * are being served".
+ *
+ * A RETIRED COUNTERPART DOES NOT COUNT, and that sentence quoted just above is
+ * the reason. This read edges ONLY, so retiring one end of a contradiction left
+ * the survivor gated against confidence promotion forever and served with a
+ * DISPUTED note naming a key `serve` refuses to hand anybody -- `serve`,
+ * `activeFindings`, `findingsFor` and `sessionIndex` all drop a retired
+ * finding. A retired claim is served to NOBODY, so "BOTH are being served" is
+ * false and the premise of the gate is gone: only one claim is in play, and
+ * there is nothing left to choose between. Retiring one end IS the person
+ * looking that this gate was waiting for -- so the edge counts as open only
+ * while NEITHER end is retired, answered the same way from both directions.
+ *
+ * AN UNRESOLVABLE END STILL COUNTS. An edge whose other side names no node
+ * proves nothing about whether that claim was withdrawn, and the conservative
+ * reading -- still disputed -- is the one that cannot promote a claim nobody
+ * adjudicated.
  */
 export function hasOutstandingContradiction(graph, key) {
   const node = findingByKey(graph, key);
-  if (!node) return false;
-  return graph.edges.some(
-    (e) => e.edge === 'contradicts' && (e.to === node.id || e.from === node.id)
-  );
+  // A withdrawn claim is not in a dispute either: a dispute needs two claims in
+  // play, and this one has been taken out of play. Without this the RETIRED end
+  // still reported an open disagreement, which is the same defect from the other
+  // side -- and the answer has to agree from both directions, since the gate is
+  // symmetric on purpose.
+  if (!node || node.retired) return false;
+  return graph.edges.some((e) => {
+    if (e.edge !== 'contradicts') return false;
+    const otherId = e.from === node.id ? e.to : e.to === node.id ? e.from : null;
+    if (!otherId) return false;
+    const other = graph.nodes.get(otherId);
+    return !other || !other.retired;
+  });
 }
 
 /**
@@ -334,11 +369,24 @@ export function audit(graph) {
       .map((e) => e.from)
   );
 
+  // THE SAME DEFINITION OF AN OPEN DISPUTE as hasOutstandingContradiction, and
+  // it has to be: that function's own comment claims it "matches audit()", and
+  // two rankings that disagree about what needs a human is worse than one that
+  // is wrong. A retired counterpart is a resolved dispute -- the retired claim
+  // is served to nobody -- so the survivor is not one of two claims in play and
+  // does not belong in the bucket of things needing a person to look.
+  //
+  // One pass, not a call per finding: this is a dashboard read over the whole
+  // graph, and the obvious rewrite is O(findings x edges).
   const contradicted = new Set();
   for (const edge of graph.edges) {
     if (edge.edge !== 'contradicts') continue;
-    contradicted.add(edge.from);
-    contradicted.add(edge.to);
+    const from = graph.nodes.get(edge.from);
+    const to = graph.nodes.get(edge.to);
+    // An end that resolves to nothing cannot be shown retired, so it still
+    // counts against the other end.
+    if (!to || !to.retired) contradicted.add(edge.from);
+    if (!from || !from.retired) contradicted.add(edge.to);
   }
 
   return {

--- a/integrations/codex/hooks/lib/curate.mjs
+++ b/integrations/codex/hooks/lib/curate.mjs
@@ -70,6 +70,38 @@ export function originWeight(origin) {
   return 1;
 }
 
+/**
+ * The claim-time anchor hashes, for a finding being written right now.
+ *
+ * THE CHECKABLE HALF OF PROVENANCE, and until now only `harvest-write.mjs`
+ * wrote it -- so the asymmetry ran exactly the wrong way. `reverify` and the
+ * automatic clear in `serve` both compare disk against these frozen hashes, and
+ * a finding without them can never have a stale flag cleared by anything. That
+ * meant HUMAN-asserted findings, the ones somebody deliberately created or
+ * corrected, were the only ones condemned to stay stale forever once marked,
+ * while machine-harvested claims could recover. The hashes are simply the anchor
+ * nodes' hashes at this moment, and every writer has them in hand.
+ *
+ * DELIBERATELY NOT THE WHOLE RECORD `derivationFor` BUILDS. That one joins the
+ * evidence log to find FILE-surface operations behind the claim; curation
+ * performs no such join, so `operations` is empty and `operationsComplete` says
+ * so. An empty list declared incomplete is honest -- "nothing recorded here, and
+ * do not read that as nothing happened" -- where an empty list declared complete
+ * would assert a fact nobody established.
+ *
+ * An anchor with no stored hash contributes no entry, and a finding whose
+ * anchors all lack one gets a record with no hashes -- which `claimTimeVerdict`
+ * reads as `unknown` and refuses to clear on, which is the correct reading.
+ */
+function claimTimeDerivation(graph, resolved) {
+  const anchors = {};
+  for (const id of resolved) {
+    const node = graph.nodes.get(id);
+    if (node && typeof node.hash === 'string') anchors[id] = node.hash;
+  }
+  return { at: Date.now(), anchors, operations: [], operationsComplete: false };
+}
+
 function findingByKey(graph, key) {
   return graph.nodes.get(nodeId('finding', key)) || null;
 }
@@ -124,6 +156,11 @@ export function correct(
   const replacementKey = `${key}-c${Date.now().toString(36)}`;
 
   const edges = [{ edge: 'supersedes', to: originalId }];
+  // Collected alongside the edges so the correction carries its own claim-time
+  // hashes: it is a NEW claim, re-derived against whatever the code says now, so
+  // its evidence is the anchors' current state -- not the predecessor's, which is
+  // precisely what went stale.
+  const inherited = [];
   // The correction inherits the original's anchors, so it can go stale too --
   // but it inherits NOTHING ELSE, and that is deliberate rather than incidental.
   // The node written below is built field by field from `existing` instead of
@@ -138,6 +175,7 @@ export function correct(
   for (const edge of graph.edges) {
     if (edge.edge === 'derived_from' && edge.from === originalId) {
       edges.push({ edge: 'derived_from', to: edge.to });
+      inherited.push(edge.to);
     }
   }
 
@@ -171,6 +209,11 @@ export function correct(
       // branches, and an unrecognised value already degrades to the neutral
       // ranking weight rather than doing damage.
       origin: typeof origin === 'string' && origin ? origin : ORIGIN_HUMAN,
+      // Without this a correction could never have a stale flag cleared: both
+      // clearing paths compare disk against these hashes, and a finding with
+      // none is `unknown` forever. A hand-written correction being the least
+      // recoverable record in the graph was the wrong way round.
+      derivation: claimTimeDerivation(graph, inherited),
     },
     edges
   );
@@ -339,7 +382,18 @@ export function create(dir, { claim, anchors, type = 'finding', confidence = 0.9
   // path. No process death required; one transient EBUSY is enough.
   const id = putNodeWithEdges(
     dir,
-    { kind: 'finding', key, claim, confidence, type, origin: ORIGIN_HUMAN },
+    {
+      kind: 'finding',
+      key,
+      claim,
+      confidence,
+      type,
+      origin: ORIGIN_HUMAN,
+      // Read AFTER the indexFile loop above, so the hashes are the ones the
+      // person's claim was actually made against rather than whatever the graph
+      // held before this call touched it.
+      derivation: claimTimeDerivation(loadGraph(dir), resolved),
+    },
     resolved.map((target) => ({ edge: 'derived_from', to: target }))
   );
   if (!id) return null;

--- a/integrations/codex/hooks/lib/decide.mjs
+++ b/integrations/codex/hooks/lib/decide.mjs
@@ -542,19 +542,92 @@ const TOOL_ALIASES = new Map(
     run_shell_command: 'Bash',
     run_terminal_cmd: 'Bash',
     terminal: 'Bash',
+
+    // THIS PROJECT'S OWN TOOLS, which the table did not list for as long as it
+    // existed. `plugin/hooks/hooks.json`'s PostToolUse matcher named
+    // `mcp__.*__(?:smart_edit|smart_write)` and Codex's AfterTool matcher named
+    // the bare `smart_edit|smart_write`, so both hooks fired -- and then
+    // `normalizeTool` returned null and the hook exited before a single line of
+    // accounting ran. Staleness, mutation counting and harvest pressure were all
+    // blind on exactly the path enforcement pushes the model toward, which is the
+    // worst place to be blind: the more effective the routing, the less the
+    // optimizer saw.
+    //
+    // These names are the CANONICAL operation, not a licence to redirect. A call
+    // that is already the replacement is excluded from routing by
+    // `isReplacementTool` below.
+    smart_read: 'Read',
+    smart_grep: 'Grep',
+    smart_glob: 'Glob',
+    smart_edit: 'Edit',
+    smart_write: 'Write',
+
+    // Claude Code's notebook editor. Same shape of gap: a real mutation of a
+    // real file on disk that arrived as null and so never reached
+    // `pending.mjs`'s MUTATING set, leaving every notebook write invisible to
+    // invalidation.
+    notebookedit: 'Edit',
+    notebook_edit: 'Edit',
   })
 );
 
-/** Maps a client's tool name onto the canonical one, or null if unhandled. */
+/**
+ * The optimizer's own replacement tools, by canonical trailing segment.
+ *
+ * Kept separate from the alias table because the two answer different questions.
+ * The table answers "what operation is this", which post-tool accounting needs.
+ * This set answers "is this call ALREADY the thing we would have recommended",
+ * which routing needs -- and conflating them is the loop hazard: `smart_edit`
+ * resolves to `Edit`, the Edit branch recommends `smart_edit`, and the model is
+ * told to call the tool it just called.
+ */
+const REPLACEMENT_TOOLS = new Set([
+  'smart_read',
+  'smart_grep',
+  'smart_glob',
+  'smart_edit',
+  'smart_write',
+]);
+
+/**
+ * The tool name with an `mcp__<server>__` prefix removed, if it had one.
+ *
+ * Server segments contain underscores freely (`plugin_token-optimizer_token-optimizer`)
+ * and so do tool names (`smart_edit`), so the split is taken at the LAST `__`
+ * after the `mcp__` sentinel. Both halves must be non-empty: `mcp__edit` names
+ * no server and is not a name any host emits, and treating it as `edit` would
+ * coerce an unrecognised string into a built-in.
+ */
+function withoutMcpPrefix(name) {
+  const match = /^mcp__(.+)__(.+)$/.exec(name);
+  return match ? match[2] : name;
+}
+
+/** Whether this call IS one of the optimizer's replacements, however spelled. */
+export function isReplacementTool(name) {
+  if (!name) return false;
+  return REPLACEMENT_TOOLS.has(withoutMcpPrefix(String(name)).toLowerCase());
+}
+
+/**
+ * Maps a client's tool name onto the canonical one, or null if unhandled.
+ *
+ * PERMISSIVE IN ONE DIRECTION ONLY. An MCP-prefixed name is resolved by its
+ * trailing segment, but only against the same table every other client is held
+ * to -- so `mcp__vendor__deploy_to_prod` stays null. Coercing an unrecognised
+ * MCP tool into a built-in would change a routing verdict for a tool nobody has
+ * considered, which is a far worse failure than not accounting for it.
+ */
 export function normalizeTool(name) {
   if (!name) return null;
+  const candidate = withoutMcpPrefix(String(name));
   if (
     ['Read', 'Grep', 'Glob', 'Edit', 'MultiEdit', 'Write', 'Bash'].includes(
-      name
+      candidate
     )
   )
-    return name;
-  return TOOL_ALIASES.get(String(name).toLowerCase()) || null;
+    return candidate;
+  return TOOL_ALIASES.get(candidate.toLowerCase()) || null;
 }
 
 /**
@@ -614,6 +687,13 @@ export function normalizePayload(raw) {
     transcript_path: raw.transcript_path ?? raw.transcriptPath ?? null,
     cwd,
     tool_name: normalizeTool(raw.tool_name ?? raw.toolName ?? raw.tool),
+    // WHETHER THIS CALL IS ALREADY THE REPLACEMENT, carried alongside the
+    // canonical name rather than inferred from it -- because it cannot be
+    // inferred from it. `smart_edit` and `Edit` both normalise to `Edit`, and
+    // routing has to treat them as opposites while accounting treats them as
+    // the same. Absent by default (`false`), so a payload assembled by hand in
+    // a test or by a caller that predates this field is a normal built-in call.
+    replacement: isReplacementTool(raw.tool_name ?? raw.toolName ?? raw.tool),
     tool_input: {
       ...input,
       // CANONICALISED HERE, once. Every consumer downstream -- the `seen` map
@@ -673,6 +753,19 @@ function replacementAvailable(availableTools, name) {
 }
 
 export function decide(payload, state, availableTools = undefined) {
+  // THE LOOP HAZARD, and the reason this guard is at the top rather than inside
+  // any one branch. Resolving `smart_edit` to `Edit` is what makes post-tool
+  // accounting work; it must not also make the Edit branch answer a smart_edit
+  // call with "call smart_edit instead". This is not theoretical on a matcher
+  // level either: Qwen's PreToolUse matcher is the unanchored regex
+  // `edit|write_file|run_shell_command`, and `edit` matches inside
+  // `mcp__x__smart_edit`, so that client really does hand the router calls to
+  // its own replacements.
+  //
+  // A tool that IS the replacement is never routed. There is nothing better to
+  // recommend, and every branch below would recommend itself.
+  if (payload.replacement) return null;
+
   const tool = payload.tool_name;
   const input = payload.tool_input || {};
   const threshold = largeFileBytes();
@@ -873,6 +966,12 @@ export function remember(payload, state) {
  */
 export function readCostBytes(payload) {
   if (payload.tool_name !== 'Read') return 0;
+  // A REPLACEMENT DID NOT SPEND THE WHOLE FILE. `smart_read` normalises to
+  // `Read` so the graph sees the touch, but it returns a diff -- charging the
+  // full file size here would feed the holdout comparison a cost that was never
+  // paid, on the arm the optimizer is trying to show is cheaper. Better to
+  // record nothing than to record a number in the wrong direction.
+  if (payload.replacement) return 0;
   const path = payload.tool_input?.file_path;
   if (!path || isBinaryPath(path)) return 0;
   const size = fileSize(path);

--- a/integrations/codex/hooks/lib/disclose.mjs
+++ b/integrations/codex/hooks/lib/disclose.mjs
@@ -294,6 +294,11 @@ export function verdictFor(graph, { anchors = [], question, minConfidence = 0.7 
     const id = nodeId('file', canonicalPath(anchor));
     if (!graph.nodes.has(id)) continue;
 
+    // READ-ONLY serve: no `dir` is threaded here, so this cannot clear a stale
+    // flag whose evidence is gone. That is deliberate -- this function takes a
+    // graph, not the directory it came from, and widening its signature to give
+    // an analysis path a write capability buys nothing: the injection path runs
+    // on every tool call and clears the same findings.
     const findings = serve(graph, findingsFor(graph, id, { limit: 4 }));
     for (const finding of findings) {
       if (finding.stale) continue;

--- a/integrations/codex/hooks/lib/harvest-write.mjs
+++ b/integrations/codex/hooks/lib/harvest-write.mjs
@@ -34,7 +34,7 @@ import { randomBytes } from 'node:crypto';
 import { realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
-import { readEvidence } from './metrics.mjs';
+import { readEvidence, evidenceTruncated } from './metrics.mjs';
 
 /**
  * The types that may cross a project boundary.
@@ -431,53 +431,84 @@ function resolveAnchor(dir, anchor, projectRoot) {
 /**
  * Which task actually produced this finding, when nothing said so directly.
  *
- * Session id was the only signal `answers` had, and a session id is exactly
- * what a caller may not have (`wiki_write`'s `sessionId` is optional and
- * nothing populates it today; the detached harvest worker's is gated behind
- * an opt-in). But the graph does not need to be TOLD which task this is: the
- * structural harvest already writes `task -[derived_from]-> file` for every
- * tool call, unconditionally, on every install. So the task is DERIVABLE --
- * it is whichever task node has a `derived_from` edge to one of the SAME
- * anchors this finding resolved to.
+ * ROUND 2's version scanned the WHOLE graph for any task sharing any anchor,
+ * broken by recency. An adversarial review constructed four cases where that
+ * attributes a finding to the WRONG task:
  *
- * "Most recent task, full stop" was rejected on purpose: a task that never
- * touched these files could still be the newest node in the graph (a
- * different file, a different concern, in a later session), and attaching
- * provenance to it would be a WRONG edge, not a missing one -- worse than no
- * edge, because a reader trusts it. So candidates are filtered to tasks that
- * touched at least one of these anchors FIRST, and only ties among THOSE are
- * broken by recency.
+ *   1. STALE PRIOR SESSION -- a session that reasons from injected memory and
+ *      writes a finding about `foo.ts` without touching it this session gets
+ *      attributed to whatever task last touched `foo.ts`, possibly days old,
+ *      possibly someone else's work.
+ *   2. CONCURRENT SESSION -- two windows on one repository; the other
+ *      session's task wins if its touch is a millisecond later.
+ *   3. OVERLAP, NOT COVERAGE -- a finding anchored to [a, b]; a task that
+ *      touched only `b` could still win over one that touched both.
+ *   4. THE TIE-BREAK CONTRADICTED ITS OWN COMMENT -- `Number(edge.at) || 0`
+ *      with strict `>` means the FIRST edge in log order wins on a tie,
+ *      which is the OLDER task, not "more recently" as documented.
  *
- * The tie-break is the edge's own `at`, not the task node's `at`. A task that
- * touched this file once, long ago, and then stayed active on unrelated files
- * for hours has a late node timestamp that says nothing about this anchor;
- * the edge timestamp says exactly when THIS task touched THIS anchor, which
- * is the question being asked. Among tasks sharing an anchor, the one whose
- * most recent touch to any shared anchor is latest wins -- recency of the
- * relevant work, not recency of the task in general.
+ * THE FIX IS NARROWER THAN A BETTER RANKING: SCOPE, THEN REQUIRE COVERAGE.
+ * A task only ever belongs to the session that created it -- `harvest()` and
+ * `linkCoOccurrence()` (wiki.mjs, inject.mjs) both key a task node by
+ * `sessionId`, always, so there is exactly ONE task node for "the current
+ * session" and it is `nodeId('task', sessionId)`. Restricting to that ONE
+ * node structurally eliminates cases 1 and 2 -- a prior or concurrent
+ * session's task has a DIFFERENT sessionId and therefore a different node
+ * id, so it is never even looked at, regardless of timing. No caller can
+ * supply a wrong sessionId and get someone ELSE's task; they can only fail
+ * to get a match.
+ *
+ * COVERAGE, NOT OVERLAP, fixes case 3: the session's task must have a
+ * `derived_from` edge to EVERY one of this finding's anchors, not merely one.
+ * A partial touch is not attribution.
+ *
+ * With the candidate set reduced to at most one node, there is nothing left
+ * to break a tie between -- case 4's comparator is not "fixed", it is
+ * deleted, because the scenario it was written for (two DIFFERENT tasks both
+ * legitimately eligible) cannot occur under this scoping: two task nodes can
+ * never share a key, and only the current session's key is ever considered.
+ * An edge's `at` therefore plays NO role here: presence of a `derived_from`
+ * edge from the session's task to an anchor is what "touched it" means, with
+ * or without a timestamp on that edge -- there is no ranking left for a
+ * missing timestamp to lose.
+ *
+ * `sessionId` absent means there is no identity to scope by, which means no
+ * candidate -- not "fall back to guessing". Absence is the correct answer
+ * when the graph cannot support attribution.
  */
-function taskForAnchors(graph, anchorIds) {
-  if (!anchorIds || !anchorIds.length) return null;
-  const anchors = new Set(anchorIds);
-  let best = null;
-  for (const edge of graph.edges) {
-    if (edge.edge !== 'derived_from' || !anchors.has(edge.to)) continue;
-    const from = graph.nodes.get(edge.from);
-    // `derived_from` is also how a FINDING cites its own anchors, so without
-    // this a finding that already cited the same file would be mistaken for
-    // the task that produced it.
-    if (!from || from.kind !== 'task') continue;
-    const at = Number(edge.at) || 0;
-    if (!best || at > best.at) best = { taskId: edge.from, at };
+function taskForAnchors(graph, anchorIds, sessionId) {
+  if (!sessionId || !anchorIds || !anchorIds.length) return null;
+  const taskTarget = nodeId('task', sessionId);
+  const task = graph.nodes.get(taskTarget);
+  if (!task || task.kind !== 'task') return null;
+
+  for (const anchor of anchorIds) {
+    const covered = graph.edges.some((edge) =>
+      edge.edge === 'derived_from' && edge.from === taskTarget && edge.to === anchor
+    );
+    // ONE missing anchor refuses the whole attribution. A finding cited three
+    // files; this session's task touched two of them -- that is evidence the
+    // task did SOME related work, not evidence it produced THIS finding.
+    if (!covered) return null;
   }
-  return best ? best.taskId : null;
+  return taskTarget;
 }
 
 /**
  * A file path the way `recordToolOutcome` (metrics.mjs) already truncates and
- * stores it on a `tool-outcome` event's `anchor` field, so a derivation record
- * can join against that log without a second, divergent notion of "the same
- * anchor".
+ * stores it on a FILE-surface `tool-outcome` event's `anchor` field, so a
+ * derivation record can join against that log without a second, divergent
+ * notion of "the same anchor".
+ *
+ * COMMAND-surface events are DECLARED OUT OF SCOPE, not silently missed:
+ * `adapter.mjs` stores the COMMAND TEXT in `anchor` for those
+ * (`String(command).slice(0, 120)`), so a build or test run can never share
+ * an anchor string with a canonical file path -- there is no join key in
+ * common, and inventing a command-to-file heuristic (which files did a given
+ * `npm test` invocation cover?) is not something this record can answer
+ * honestly. `operationsScope` on the returned record says so explicitly,
+ * rather than letting an empty `operations` array look like "no build or
+ * test ever ran" when the truth is "this join cannot see it".
  */
 function anchorLabel(rawAnchor) {
   const path = String(rawAnchor).split('#')[0];
@@ -497,7 +528,8 @@ const MAX_DERIVATION_OPERATIONS = 5;
  * that comparison be reconstructed for a specific claim rather than only for
  * the anchor in general: the hash each anchor carried at the moment this
  * finding was derived from it, plus what evidence exists that any work
- * actually happened against it.
+ * actually happened against it. `derivationCheck` (staleness.mjs) is the
+ * reader that actually performs that comparison at serve time.
  *
  * DELIBERATELY NOT DUPLICATING THE EDGES. `derived_from` already records
  * WHICH anchors this finding cites; restating that here would be a second,
@@ -506,14 +538,23 @@ const MAX_DERIVATION_OPERATIONS = 5;
  *
  * DELIBERATELY NOT A REPLAY LOG. Recording enough to mechanically re-run a
  * derivation is a separate subsystem with real storage cost. This stores only
- * what the evidence log already has: `tool-outcome` events matching these
- * anchors, each reduced to the fields that were actually captured. An event
- * that carries no exit code or output contributes none -- nothing here is
- * invented to fill a shape the pipeline does not evidence yet. If a future
- * capture pass adds `exit`/`output` to those events, this starts carrying them
- * with no change to this function.
+ * what the evidence log already has: FILE-surface `tool-outcome` events
+ * matching these anchors, each reduced to the fields that were actually
+ * captured. An event that carries no exit code or output contributes none --
+ * nothing here is invented to fill a shape the pipeline does not evidence
+ * yet. If a future capture pass adds `exit`/`output` to those events, this
+ * starts carrying them with no change to this function.
+ *
+ * INCOMPLETENESS IS MARKED, NOT IMPLIED. An empty `operations` array is
+ * genuinely ambiguous on its own -- it is the same shape whether nothing
+ * happened, or something happened but fell outside what this join can see.
+ * `operationsComplete` distinguishes them: false when the evidence log itself
+ * may have dropped older matches (`evidenceIncomplete`, from
+ * `metrics.evidenceTruncated`) OR when more matches existed than the cap
+ * kept. A reader can then tell "no operations happened" from "operations
+ * existed but are not recorded here" instead of guessing.
  */
-function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
+function derivationFor(graph, resolvedAnchors, evidence, evidenceIncomplete, anchorSpecs) {
   const anchorHashes = {};
   for (const id of resolvedAnchors) {
     const node = graph.nodes.get(id);
@@ -521,8 +562,10 @@ function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
   }
 
   const labels = new Set((anchorSpecs || []).map(anchorLabel));
-  const operations = evidence
-    .filter((event) => event.kind === 'tool-outcome' && labels.has(event.anchor))
+  const matching = evidence.filter(
+    (event) => event.kind === 'tool-outcome' && labels.has(event.anchor)
+  );
+  const operations = [...matching]
     .sort((a, b) => (Number(b.at) || 0) - (Number(a.at) || 0))
     .slice(0, MAX_DERIVATION_OPERATIONS)
     .map((event) => {
@@ -540,7 +583,16 @@ function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
       return op;
     });
 
-  return { at: Date.now(), anchors: anchorHashes, operations };
+  return {
+    at: Date.now(),
+    anchors: anchorHashes,
+    operations,
+    // FILE touches only -- see `anchorLabel`. Declared here, in the record
+    // itself, not only in this function's comment, so a reader who never
+    // opens this source file still learns builds and test runs are excluded.
+    operationsScope: 'file',
+    operationsComplete: !evidenceIncomplete && matching.length <= operations.length,
+  };
 }
 
 /**
@@ -588,6 +640,9 @@ export function writeHarvested(
   // it can hold thousands of lines, so re-reading it per finding would turn a
   // batch of N findings into N passes over the same bytes.
   const evidence = readEvidence(dir);
+  // Cheap: one stat call, checked once per batch rather than once per
+  // finding's derivation record.
+  const evidenceIncomplete = evidenceTruncated(dir);
 
   const written = [];
   for (const finding of findings) {
@@ -647,14 +702,16 @@ export function writeHarvested(
     // An explicit `taskId` is authoritative when a caller supplies one --
     // it OVERRIDES traversal rather than merely seeding it, so a caller that
     // knows better is never second-guessed by inference. Absent one, the task
-    // is DERIVED from the graph itself: `taskForAnchors` finds the task that
-    // actually touched these anchors, which needs no session id from anyone.
-    // Either way, held to the same discipline as the anchors above: a target
-    // that does not resolve to an existing task node produces no edge rather
-    // than a dangling one.
+    // is DERIVED from the graph itself: `taskForAnchors` finds the CURRENT
+    // session's task (scoped by `sessionId`, the same identity this write
+    // already carries for provenance) and requires it to have touched EVERY
+    // one of this finding's anchors, not merely one -- see that function's
+    // own comment for the four attacks this closes. Either way, held to the
+    // same discipline as the anchors above: a target that does not resolve to
+    // an existing task node produces no edge rather than a dangling one.
     const answersTarget = taskId
       ? nodeId('task', taskId)
-      : taskForAnchors(currentGraph, resolved);
+      : taskForAnchors(currentGraph, resolved, sessionId);
     if (answersTarget && currentGraph.nodes.has(answersTarget)) {
       edges.push({ edge: 'answers', to: answersTarget });
     }
@@ -707,7 +764,7 @@ export function writeHarvested(
         // `render()`/`renderSessionIndex()` in inject.mjs or `wiki_read`'s
         // `toFinding()` projection, neither of which reads this field, so it
         // is not part of the automatic per-touch injection `fit()` prices.
-        derivation: derivationFor(currentGraph, resolved, evidence, finding.anchors || []),
+        derivation: derivationFor(currentGraph, resolved, evidence, evidenceIncomplete, finding.anchors || []),
       },
       edges
     );

--- a/integrations/codex/hooks/lib/harvest-write.mjs
+++ b/integrations/codex/hooks/lib/harvest-write.mjs
@@ -452,11 +452,13 @@ function resolveAnchor(dir, anchor, projectRoot) {
  * `linkCoOccurrence()` (wiki.mjs, inject.mjs) both key a task node by
  * `sessionId`, always, so there is exactly ONE task node for "the current
  * session" and it is `nodeId('task', sessionId)`. Restricting to that ONE
- * node structurally eliminates cases 1 and 2 -- a prior or concurrent
- * session's task has a DIFFERENT sessionId and therefore a different node
- * id, so it is never even looked at, regardless of timing. No caller can
- * supply a wrong sessionId and get someone ELSE's task; they can only fail
- * to get a match.
+ * node structurally eliminates cases 1 and 2 PROVIDED the identity itself is
+ * trustworthy: an UNRELATED sessionId (typo'd, invented, or simply absent)
+ * cannot resolve to someone else's task, because a different key is a
+ * different node id, full stop, regardless of timing. That is NOT the same
+ * guarantee as "no caller can get someone else's task" -- see the note on
+ * `authoritativeSessionId` below for the residual this leaves when the
+ * identity is real but comes from an untrusted caller.
  *
  * COVERAGE, NOT OVERLAP, fixes case 3: the session's task must have a
  * `derived_from` edge to EVERY one of this finding's anchors, not merely one.
@@ -472,17 +474,41 @@ function resolveAnchor(dir, anchor, projectRoot) {
  * or without a timestamp on that edge -- there is no ranking left for a
  * missing timestamp to lose.
  *
- * `sessionId` absent means there is no identity to scope by, which means no
- * candidate -- not "fall back to guessing". Absence is the correct answer
- * when the graph cannot support attribution.
+ * NO IDENTITY MEANS NO CANDIDATE -- not "fall back to guessing". Absence is
+ * the correct answer when the graph cannot support attribution.
+ *
+ * ROUND 4: THE IDENTITY ITSELF MUST BE AUTHORITATIVE, not merely present.
+ * Scoping to `nodeId('task', sessionId)` only refuses an UNRELATED session;
+ * it does nothing against a FOREIGN BUT REAL one. `wiki_write`'s `sessionId`
+ * is a plain MCP tool argument the calling model supplies, unverified -- a
+ * model that names some OTHER, prior session whose task genuinely covered
+ * these anchors gets an `answers` edge to that stale task, because coverage
+ * cannot tell "this session" from "a session that really did touch these
+ * files, named by a string nothing cross-checked". Session id is not
+ * evidence unless the CALLER'S OWN CHANNEL is trustworthy, which is true of
+ * `plugin/hooks/harvest-worker.mjs` (Claude Code's own hook payload) and not
+ * true of a tool-call argument. So this parameter is named for what it must
+ * be, `authoritativeSessionId`, and every caller is a promise: pass this only
+ * when you did not just read it out of untrusted input. `wiki_write` passes
+ * NONE, which means its calls never traverse -- see `writeHarvested`'s own
+ * comment at the call site for what that costs and why it is accepted rather
+ * than worked around.
+ *
+ * COVERAGE IS CHECKED AGAINST RESOLVED ANCHORS, not the caller's original
+ * list. `writeHarvested` already drops any anchor `resolveAnchor` could not
+ * resolve before this function ever runs, so "every anchor" here means every
+ * anchor that survived that filter -- self-consistent with the
+ * `derived_from` edges the same resolved list produces, but worth stating:
+ * an anchor that failed to resolve cannot raise or lower the bar for the
+ * anchors that did.
  */
-function taskForAnchors(graph, anchorIds, sessionId) {
-  if (!sessionId || !anchorIds || !anchorIds.length) return null;
-  const taskTarget = nodeId('task', sessionId);
+function taskForAnchors(graph, resolvedAnchorIds, authoritativeSessionId) {
+  if (!authoritativeSessionId || !resolvedAnchorIds || !resolvedAnchorIds.length) return null;
+  const taskTarget = nodeId('task', authoritativeSessionId);
   const task = graph.nodes.get(taskTarget);
   if (!task || task.kind !== 'task') return null;
 
-  for (const anchor of anchorIds) {
+  for (const anchor of resolvedAnchorIds) {
     const covered = graph.edges.some((edge) =>
       edge.edge === 'derived_from' && edge.from === taskTarget && edge.to === anchor
     );
@@ -604,7 +630,19 @@ function derivationFor(graph, resolvedAnchors, evidence, evidenceIncomplete, anc
 export function writeHarvested(
   dir,
   findings,
-  { sessionId = null, origin = ORIGIN_HARVESTED, projectRoot = null, taskId = null } = {}
+  {
+    sessionId = null,
+    origin = ORIGIN_HARVESTED,
+    projectRoot = null,
+    taskId = null,
+    // Distinct from `sessionId`, which is stored on every finding for
+    // provenance/display regardless of trust. This one gates the `answers`
+    // traversal fallback specifically, and every caller passing it is
+    // asserting the identity came from a channel it does not control --
+    // Claude Code's own hook payload, not a tool-call argument a model
+    // typed. See `taskForAnchors`'s comment for the attack this closes.
+    authoritativeSessionId = null,
+  } = {}
 ) {
   if (!Array.isArray(findings) || !findings.length) return [];
 
@@ -702,16 +740,29 @@ export function writeHarvested(
     // An explicit `taskId` is authoritative when a caller supplies one --
     // it OVERRIDES traversal rather than merely seeding it, so a caller that
     // knows better is never second-guessed by inference. Absent one, the task
-    // is DERIVED from the graph itself: `taskForAnchors` finds the CURRENT
-    // session's task (scoped by `sessionId`, the same identity this write
-    // already carries for provenance) and requires it to have touched EVERY
-    // one of this finding's anchors, not merely one -- see that function's
-    // own comment for the four attacks this closes. Either way, held to the
-    // same discipline as the anchors above: a target that does not resolve to
-    // an existing task node produces no edge rather than a dangling one.
+    // is DERIVED from the graph itself, but ONLY when `authoritativeSessionId`
+    // is present: `taskForAnchors` scopes to that exact session's task and
+    // requires it to have touched EVERY one of this finding's anchors, not
+    // merely one -- see that function's own comment for why the identity
+    // itself must be trustworthy, not merely present.
+    //
+    // THE CONSEQUENCE, STATED PLAINLY: `wiki_write` never supplies
+    // `authoritativeSessionId` (its `sessionId` is a model-typed MCP
+    // argument nothing cross-checks), so its calls never traverse and
+    // `answers` never fires on that path. `plugin/hooks/harvest-worker.mjs`
+    // does supply it (Claude Code's own hook payload), so `answers` fires
+    // there -- opt-in gated. `answers` therefore does NOT fire on a default
+    // install today. Recovering default liveness needs an authoritative
+    // identity on a default-install path, which is what Plan 2's
+    // `hooks-core/derive.mjs` (running in the Stop hook, where the session id
+    // is real) is for -- not a weaker check here.
+    //
+    // Either way, held to the same discipline as the anchors above: a target
+    // that does not resolve to an existing task node produces no edge rather
+    // than a dangling one.
     const answersTarget = taskId
       ? nodeId('task', taskId)
-      : taskForAnchors(currentGraph, resolved, sessionId);
+      : taskForAnchors(currentGraph, resolved, authoritativeSessionId);
     if (answersTarget && currentGraph.nodes.has(answersTarget)) {
       edges.push({ edge: 'answers', to: answersTarget });
     }

--- a/integrations/codex/hooks/lib/harvest-write.mjs
+++ b/integrations/codex/hooks/lib/harvest-write.mjs
@@ -436,7 +436,7 @@ function resolveAnchor(dir, anchor, projectRoot) {
 export function writeHarvested(
   dir,
   findings,
-  { sessionId = null, origin = ORIGIN_HARVESTED, projectRoot = null } = {}
+  { sessionId = null, origin = ORIGIN_HARVESTED, projectRoot = null, taskId = null } = {}
 ) {
   if (!Array.isArray(findings) || !findings.length) return [];
 
@@ -516,6 +516,21 @@ export function writeHarvested(
     // collision vanishingly unlikely while keeping the timestamp readable.
     const provenance = provenanceFor(finding);
     const key = `${prefixFor(provenance)}-${Date.now().toString(36)}-${written.length}-${randomBytes(4).toString("hex")}`;
+
+    const edges = resolved.map((target) => ({ edge: 'derived_from', to: target }));
+    // `answers` closes the loop back to the task that produced the finding, so
+    // provenance can be traversed rather than inferred: "which session
+    // established this, and from what". Declared in EDGE_KINDS and written by
+    // nothing until now. Held to the same discipline as the anchors above: a
+    // taskId that does not resolve to an existing task node produces no edge
+    // rather than a dangling one.
+    if (taskId) {
+      const taskTarget = nodeId('task', taskId);
+      if (currentGraph.nodes.has(taskTarget)) {
+        edges.push({ edge: 'answers', to: taskTarget });
+      }
+    }
+
     // ONE APPEND for the finding and every anchor it resolved. This runs in a
     // detached worker, so "the process survives to finish the loop" is not a
     // safe assumption: a node written without its edges is an active finding
@@ -557,7 +572,7 @@ export function writeHarvested(
           : undefined,
         sessionId,
       },
-      resolved.map((target) => ({ edge: 'derived_from', to: target }))
+      edges
     );
     // A failed write returns null. Reporting the key anyway would tell the
     // caller a claim was stored that no later session can retrieve.

--- a/integrations/codex/hooks/lib/harvest-write.mjs
+++ b/integrations/codex/hooks/lib/harvest-write.mjs
@@ -34,6 +34,7 @@ import { randomBytes } from 'node:crypto';
 import { realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
+import { readEvidence } from './metrics.mjs';
 
 /**
  * The types that may cross a project boundary.
@@ -428,6 +429,121 @@ function resolveAnchor(dir, anchor, projectRoot) {
 }
 
 /**
+ * Which task actually produced this finding, when nothing said so directly.
+ *
+ * Session id was the only signal `answers` had, and a session id is exactly
+ * what a caller may not have (`wiki_write`'s `sessionId` is optional and
+ * nothing populates it today; the detached harvest worker's is gated behind
+ * an opt-in). But the graph does not need to be TOLD which task this is: the
+ * structural harvest already writes `task -[derived_from]-> file` for every
+ * tool call, unconditionally, on every install. So the task is DERIVABLE --
+ * it is whichever task node has a `derived_from` edge to one of the SAME
+ * anchors this finding resolved to.
+ *
+ * "Most recent task, full stop" was rejected on purpose: a task that never
+ * touched these files could still be the newest node in the graph (a
+ * different file, a different concern, in a later session), and attaching
+ * provenance to it would be a WRONG edge, not a missing one -- worse than no
+ * edge, because a reader trusts it. So candidates are filtered to tasks that
+ * touched at least one of these anchors FIRST, and only ties among THOSE are
+ * broken by recency.
+ *
+ * The tie-break is the edge's own `at`, not the task node's `at`. A task that
+ * touched this file once, long ago, and then stayed active on unrelated files
+ * for hours has a late node timestamp that says nothing about this anchor;
+ * the edge timestamp says exactly when THIS task touched THIS anchor, which
+ * is the question being asked. Among tasks sharing an anchor, the one whose
+ * most recent touch to any shared anchor is latest wins -- recency of the
+ * relevant work, not recency of the task in general.
+ */
+function taskForAnchors(graph, anchorIds) {
+  if (!anchorIds || !anchorIds.length) return null;
+  const anchors = new Set(anchorIds);
+  let best = null;
+  for (const edge of graph.edges) {
+    if (edge.edge !== 'derived_from' || !anchors.has(edge.to)) continue;
+    const from = graph.nodes.get(edge.from);
+    // `derived_from` is also how a FINDING cites its own anchors, so without
+    // this a finding that already cited the same file would be mistaken for
+    // the task that produced it.
+    if (!from || from.kind !== 'task') continue;
+    const at = Number(edge.at) || 0;
+    if (!best || at > best.at) best = { taskId: edge.from, at };
+  }
+  return best ? best.taskId : null;
+}
+
+/**
+ * A file path the way `recordToolOutcome` (metrics.mjs) already truncates and
+ * stores it on a `tool-outcome` event's `anchor` field, so a derivation record
+ * can join against that log without a second, divergent notion of "the same
+ * anchor".
+ */
+function anchorLabel(rawAnchor) {
+  const path = String(rawAnchor).split('#')[0];
+  return canonicalPath(path).slice(0, 120);
+}
+
+/** How many recorded operations a single finding's derivation may cite. */
+const MAX_DERIVATION_OPERATIONS = 5;
+
+/**
+ * The checkable half of provenance: not just where a finding came from, but
+ * whether that derivation still holds.
+ *
+ * Citation-style provenance (a session or task id) answers "where". It never
+ * answers "does this still apply" -- that is what staleness already computes,
+ * by comparing an anchor's STORED hash against disk. This record is what lets
+ * that comparison be reconstructed for a specific claim rather than only for
+ * the anchor in general: the hash each anchor carried at the moment this
+ * finding was derived from it, plus what evidence exists that any work
+ * actually happened against it.
+ *
+ * DELIBERATELY NOT DUPLICATING THE EDGES. `derived_from` already records
+ * WHICH anchors this finding cites; restating that here would be a second,
+ * driftable copy of the same fact. What is new here, and only here, is the
+ * HASH each anchor carried at claim time -- edges carry no such thing.
+ *
+ * DELIBERATELY NOT A REPLAY LOG. Recording enough to mechanically re-run a
+ * derivation is a separate subsystem with real storage cost. This stores only
+ * what the evidence log already has: `tool-outcome` events matching these
+ * anchors, each reduced to the fields that were actually captured. An event
+ * that carries no exit code or output contributes none -- nothing here is
+ * invented to fill a shape the pipeline does not evidence yet. If a future
+ * capture pass adds `exit`/`output` to those events, this starts carrying them
+ * with no change to this function.
+ */
+function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
+  const anchorHashes = {};
+  for (const id of resolvedAnchors) {
+    const node = graph.nodes.get(id);
+    if (node && typeof node.hash === 'string') anchorHashes[id] = node.hash;
+  }
+
+  const labels = new Set((anchorSpecs || []).map(anchorLabel));
+  const operations = evidence
+    .filter((event) => event.kind === 'tool-outcome' && labels.has(event.anchor))
+    .sort((a, b) => (Number(b.at) || 0) - (Number(a.at) || 0))
+    .slice(0, MAX_DERIVATION_OPERATIONS)
+    .map((event) => {
+      const op = {};
+      if (typeof event.toolName === 'string' && event.toolName)
+        op.tool = event.toolName.slice(0, 60);
+      if (typeof event.success === 'boolean') op.success = event.success;
+      if (typeof event.at === 'number') op.at = event.at;
+      // Forward-compatible, not fabricated: neither field exists on a
+      // `tool-outcome` event in this pipeline today, so every operation
+      // omits them until a capture pass actually evidences one.
+      if (typeof event.exit === 'number') op.exit = event.exit;
+      if (typeof event.output === 'string' && event.output)
+        op.output = event.output.slice(0, 200);
+      return op;
+    });
+
+  return { at: Date.now(), anchors: anchorHashes, operations };
+}
+
+/**
  * Writes validated findings, returning the keys actually stored.
  *
  * `findings` is the output of `harvest.validate()`, so type/claim/confidence
@@ -467,6 +583,11 @@ export function writeHarvested(
       : batch;
   const prefixFor = (p) =>
     p === ORIGIN_AGENT ? 'agent' : p === ORIGIN_HUMAN ? 'human' : 'harvested';
+
+  // Read once: every finding in this batch shares the same evidence log, and
+  // it can hold thousands of lines, so re-reading it per finding would turn a
+  // batch of N findings into N passes over the same bytes.
+  const evidence = readEvidence(dir);
 
   const written = [];
   for (const finding of findings) {
@@ -521,14 +642,21 @@ export function writeHarvested(
     // `answers` closes the loop back to the task that produced the finding, so
     // provenance can be traversed rather than inferred: "which session
     // established this, and from what". Declared in EDGE_KINDS and written by
-    // nothing until now. Held to the same discipline as the anchors above: a
-    // taskId that does not resolve to an existing task node produces no edge
-    // rather than a dangling one.
-    if (taskId) {
-      const taskTarget = nodeId('task', taskId);
-      if (currentGraph.nodes.has(taskTarget)) {
-        edges.push({ edge: 'answers', to: taskTarget });
-      }
+    // nothing until now.
+    //
+    // An explicit `taskId` is authoritative when a caller supplies one --
+    // it OVERRIDES traversal rather than merely seeding it, so a caller that
+    // knows better is never second-guessed by inference. Absent one, the task
+    // is DERIVED from the graph itself: `taskForAnchors` finds the task that
+    // actually touched these anchors, which needs no session id from anyone.
+    // Either way, held to the same discipline as the anchors above: a target
+    // that does not resolve to an existing task node produces no edge rather
+    // than a dangling one.
+    const answersTarget = taskId
+      ? nodeId('task', taskId)
+      : taskForAnchors(currentGraph, resolved);
+    if (answersTarget && currentGraph.nodes.has(answersTarget)) {
+      edges.push({ edge: 'answers', to: answersTarget });
     }
 
     // ONE APPEND for the finding and every anchor it resolved. This runs in a
@@ -571,6 +699,15 @@ export function writeHarvested(
           ? finding.quote
           : undefined,
         sessionId,
+        // THE CHECKABLE HALF OF PROVENANCE. Citation-style (this `sessionId`,
+        // the `answers` edge above) says WHERE a claim came from; it never
+        // says whether that derivation still applies. `derivationFor` reaches
+        // through `wiki_query`'s `node`/`get`/`search` operations only (those
+        // return a finding's stored fields wholesale) -- never through
+        // `render()`/`renderSessionIndex()` in inject.mjs or `wiki_read`'s
+        // `toFinding()` projection, neither of which reads this field, so it
+        // is not part of the automatic per-touch injection `fit()` prices.
+        derivation: derivationFor(currentGraph, resolved, evidence, finding.anchors || []),
       },
       edges
     );

--- a/integrations/codex/hooks/lib/inject.mjs
+++ b/integrations/codex/hooks/lib/inject.mjs
@@ -26,6 +26,7 @@ import {
 } from './wiki.mjs';
 import { basename } from 'node:path';
 import { serve, diffLines } from './staleness.mjs';
+import { drainInvalidations } from './pending.mjs';
 import { inHoldout, record, indexBudget } from './metrics.mjs';
 import { canonicalPath, resolvableCandidates } from './paths.mjs';
 import { annotatedSkeleton } from './skeleton.mjs';
@@ -142,6 +143,31 @@ function render(finding) {
 }
 
 /**
+ * Applies anything the post-tool hook queued, BEFORE anything is served.
+ *
+ * THIS IS WHERE EAGER STALENESS LANDS. `invalidateOnWrite` needs a graph, and
+ * loading one on the return path of every write is what pending.mjs exists to
+ * avoid -- so the hook queues and the next graph read applies. These two
+ * functions are that read: they already hold a freshly loaded graph, and they
+ * are the last thing to run before a finding reaches a model.
+ *
+ * RE-READ ONLY WHEN SOMETHING WAS ACTUALLY MARKED. The drain writes the stale
+ * flag to disk; it cannot mutate the caller's already-parsed graph, so serving
+ * from that copy would deliver the very "stale finding as fresh" this exists to
+ * prevent. A second load costs a parse, and it is paid once per observed write
+ * rather than once per tool call -- when nothing is queued this is one stat.
+ */
+function withPendingApplied(dir, graph) {
+  try {
+    return drainInvalidations(dir, graph) > 0 ? load(dir) : graph;
+  } catch {
+    // The lazy path still covers everything this would have caught early, and
+    // a hook must never fail because bookkeeping did.
+    return graph;
+  }
+}
+
+/**
  * What the model sees when it touches a file.
  *
  * Returns null when there is nothing to say, or when this touch fell into the
@@ -154,6 +180,7 @@ export function forTouch(
   rawPath,
   { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
+  graph = withPendingApplied(dir, graph);
   // Canonical, so a touch finds findings anchored under any other spelling.
   const filePath = canonicalPath(rawPath);
   const anchorId = nodeId('file', filePath);
@@ -322,6 +349,7 @@ export function forCommand(
   { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
   if (!command) return null;
+  graph = withPendingApplied(dir, graph);
 
   const candidates = [];
   for (const node of graph.nodes.values()) {

--- a/integrations/codex/hooks/lib/inject.mjs
+++ b/integrations/codex/hooks/lib/inject.mjs
@@ -33,6 +33,7 @@ import { annotatedSkeleton } from './skeleton.mjs';
 import { substitutionBudget } from './metrics.mjs';
 import { assessFindings } from './utility.mjs';
 import { quarantineSharedSource } from './harvest-write.mjs';
+import { cacheOrdered } from './cache.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
@@ -1152,6 +1153,53 @@ export function standingRules(dir, graph, { budget = standingBudget(), episode =
   // which is worse than saying there are more: a model that knows the list is
   // truncated can ask, one that does not will assume it is complete.
   return `${HEADING}${lines.join('\n')}${truncated}`;
+}
+
+/**
+ * SessionStart context, assembled in cache order: stable first, volatile last.
+ *
+ * WHY THE ORDER IS A CORRECTNESS PROPERTY AND NOT A STYLE CHOICE. Everything
+ * here lands near the FRONT of the prompt prefix, and a prefix cache is
+ * invalidated from the first differing byte onward. A block whose text changes
+ * between sessions therefore prices everything positioned after it: put the
+ * freshest block first and the whole remainder of the prefix is re-written
+ * every session; put it last and the invalidation is confined to its own tail.
+ * cache.mjs measures exactly this cost in the user's files -- this is the same
+ * discipline applied to our own output, which is the half nobody else has to
+ * think about because nobody else writes into the prefix.
+ *
+ * `cacheOrdered` existed for precisely this and had no caller, so the order was
+ * whatever order the call sites happened to push in. It was accidentally right;
+ * it is now enforced, which is the difference that matters the next time a
+ * block is added.
+ *
+ * VOLATILITY IS ASSIGNED FROM HOW OFTEN THE TEXT ACTUALLY DIFFERS BETWEEN
+ * SESSIONS, not from how important the block is:
+ *
+ *   0  policy -- the optimization notice and project briefing. Deliberately
+ *      cache-safe by construction: the routing facts are number-free and the
+ *      briefing passes through `stableText`, which DROPS any line that would
+ *      vary. It changes when the tool inventory or configuration changes.
+ *   1  standing -- pinned facts and human-verified corrections, rendered in
+ *      full. Changes only when a person pins, retires or corrects something.
+ *   2  index -- the bounded wiki index, selected per session from the task
+ *      text, and carrying [STALE]/[DISPUTED] markers that flip as the code
+ *      moves. Different on most sessions.
+ *   3  restoration -- present only when resuming from a compaction, and derived
+ *      from the anchors of the session that was just discarded. Never twice the
+ *      same.
+ *
+ * A block with no text is dropped rather than joined, so an absent block cannot
+ * open the assembly with a blank line.
+ */
+export function sessionContext(blocks) {
+  return cacheOrdered(
+    (Array.isArray(blocks) ? blocks : []).filter(
+      (block) => block && typeof block.text === 'string' && block.text.trim()
+    )
+  )
+    .map((block) => block.text)
+    .join('\n\n');
 }
 
 /**

--- a/integrations/codex/hooks/lib/inject.mjs
+++ b/integrations/codex/hooks/lib/inject.mjs
@@ -122,8 +122,29 @@ function fit(findings, budget) {
   return { kept, spent };
 }
 
+/**
+ * Discloses an open disagreement, on the same line as the claim it is about.
+ *
+ * BOTH HALVES, like the stale renderer below: the strong form names the other
+ * finding so the reader can fetch it, and the form without a key says only what
+ * is actually known. `serve` is what establishes the dispute; this only phrases
+ * it, and it phrases it in one short line because `fit` prices `render` against
+ * the injection budget -- a disagreement is worth a pointer, not both claims in
+ * full.
+ *
+ * NO DISMISSAL VOCABULARY, for the reason measured on the stale wording: an
+ * instruction to discount suppressed findings that were correct. This states
+ * that another claim exists and where to find it, and lets the reader decide.
+ */
+function disputeNote(finding) {
+  if (!finding.contradicted) return '';
+  return finding.contradictedBy
+    ? `\n  DISPUTED by ${finding.contradictedBy} -- wiki_query that key for the other claim`
+    : '\n  DISPUTED by another finding in this graph';
+}
+
 function render(finding) {
-  const head = `- [${finding.type || 'finding'}] ${finding.claim}`;
+  const head = `- [${finding.type || 'finding'}] ${finding.claim}${disputeNote(finding)}`;
   if (!finding.stale) return head;
 
   // A stale finding NEVER renders as though it were current. But the strength
@@ -997,7 +1018,15 @@ function renderSessionIndex(total, findings) {
       : finding.stale
         ? ' [possibly stale; verify before use]'
         : '';
-    return `- ${finding.key}${freshness}: ${finding.claim.slice(0, 90)}`;
+    // The session index is the first thing a session reads, so a disputed
+    // finding must not be listed there as settled either. Compressed to a
+    // marker and a key, matching the freshness markers beside it.
+    const dispute = finding.contradicted
+      ? finding.contradictedBy
+        ? ` [DISPUTED by ${finding.contradictedBy}]`
+        : ' [DISPUTED]'
+      : '';
+    return `- ${finding.key}${freshness}${dispute}: ${finding.claim.slice(0, 90)}`;
   });
   return `# Project wiki (${total} findings, ${findings.length} listed)
 

--- a/integrations/codex/hooks/lib/inject.mjs
+++ b/integrations/codex/hooks/lib/inject.mjs
@@ -139,9 +139,26 @@ function fit(findings, budget) {
  */
 function disputeNote(finding) {
   if (!finding.contradicted) return '';
-  return finding.contradictedBy
+  const head = finding.contradictedBy
     ? `\n  DISPUTED by ${finding.contradictedBy} -- wiki_query that key for the other claim`
     : '\n  DISPUTED by another finding in this graph';
+  // THE REASON A PERSON TYPED, rendered here because this is the fullest of the
+  // three dispute surfaces and the only one with room for a sentence. `contradict`
+  // has always stored up to 400 characters of human explanation and, until this
+  // line, nothing read it: the pointer told a reader where to look and withheld
+  // the one thing that would tell them whether looking was worth a tool call.
+  //
+  // TRUNCATED AT 140, because `fit` prices this string against the injection
+  // budget and a 400-character paragraph beside a one-line claim inverts the
+  // proportions. The compressed surfaces -- the session index and restore.mjs's
+  // "Likely next" list -- deliberately keep marker-and-key only; they are one
+  // line per finding by design, and `wiki_query` returns the reason in full.
+  if (typeof finding.contradictionReason !== 'string' || !finding.contradictionReason.trim()) {
+    return head;
+  }
+  const reason = finding.contradictionReason.trim();
+  const shown = reason.length > 140 ? `${reason.slice(0, 140)}...` : reason;
+  return `${head}\n  Reason given: ${shown}`;
 }
 
 /**

--- a/integrations/codex/hooks/lib/inject.mjs
+++ b/integrations/codex/hooks/lib/inject.mjs
@@ -276,7 +276,10 @@ export function forTouch(
   // others, so the comparison becomes within-file and the dominant source of
   // variance drops out. A session-pinned arm would destroy that.
   const holdout = inHoldout(filePath);
-  const served = serve(graph, candidates);
+  // `dir` so an eager flag whose evidence is gone is cleared here rather than
+  // waiting for somebody to open the dashboard. Same evidence test as the manual
+  // path -- see `serve`.
+  const served = serve(graph, candidates, { dir });
   const assessed = assessFindings(dir, served, {
     episodeId: episode.episodeId || sessionId,
     relevanceFor: () => 1,
@@ -463,7 +466,7 @@ export function forCommand(
   // only thing an uncapped list buys is the I/O.
   const considered = candidates.slice(0, MAX_COMMAND_CANDIDATES);
 
-  const served = serve(graph, considered);
+  const served = serve(graph, considered, { dir });
   const assessed = assessFindings(dir, served, {
     episodeId: episode.episodeId || sessionId,
     relevanceFor: (finding) => explicit(finding) ? 1 : 0.6,
@@ -990,7 +993,7 @@ export function sessionIndex(dir, graph, { episode = {}, relevantFindingIds = []
   // `serve` is the only path allowed to hand a finding to a model. In
   // particular, activating this previously-unwired index must not create a new
   // path that labels an invalidated content claim as current.
-  const served = serve(graph, selected);
+  const served = serve(graph, selected, { dir });
   if (!served.length) return null;
   // A stale marker is longer than the fresh preview used for candidate
   // selection. Trim from the lowest-ranked end until the ACTUAL message fits.

--- a/integrations/codex/hooks/lib/inject.mjs
+++ b/integrations/codex/hooks/lib/inject.mjs
@@ -156,9 +156,9 @@ function disputeNote(finding) {
 function derivationNote(finding) {
   if (finding.derivationHolds !== false) return '';
   const changed = Array.isArray(finding.derivationChanged) ? finding.derivationChanged : [];
-  return changed.length
-    ? `\n  DERIVATION CHANGED -- ${changed.join(', ')} no longer match what this claim was derived from`
-    : '\n  DERIVATION CHANGED since this claim was recorded';
+  if (!changed.length) return '\n  DERIVATION CHANGED since this claim was recorded';
+  const verb = changed.length === 1 ? 'no longer matches' : 'no longer match';
+  return `\n  DERIVATION CHANGED -- ${changed.join(', ')} ${verb} what this claim was derived from`;
 }
 
 function render(finding) {

--- a/integrations/codex/hooks/lib/inject.mjs
+++ b/integrations/codex/hooks/lib/inject.mjs
@@ -143,8 +143,26 @@ function disputeNote(finding) {
     : '\n  DISPUTED by another finding in this graph';
 }
 
+/**
+ * Discloses `derivationCheck`'s verdict (staleness.mjs) -- distinct from
+ * `disputeNote` (another finding disagrees) and from the STALE block below
+ * (the anchor NODE's current hash does not match disk). This is about
+ * whether the bytes THIS claim was actually derived from are still the bytes
+ * an anchor holds; see `derivationCheck`'s comment for the case that catches
+ * that the other two can miss. Silent when it holds -- the common case pays
+ * nothing -- and silent when it was never checked at all (an older finding
+ * with no `derivation` record).
+ */
+function derivationNote(finding) {
+  if (finding.derivationHolds !== false) return '';
+  const changed = Array.isArray(finding.derivationChanged) ? finding.derivationChanged : [];
+  return changed.length
+    ? `\n  DERIVATION CHANGED -- ${changed.join(', ')} no longer match what this claim was derived from`
+    : '\n  DERIVATION CHANGED since this claim was recorded';
+}
+
 function render(finding) {
-  const head = `- [${finding.type || 'finding'}] ${finding.claim}${disputeNote(finding)}`;
+  const head = `- [${finding.type || 'finding'}] ${finding.claim}${disputeNote(finding)}${derivationNote(finding)}`;
   if (!finding.stale) return head;
 
   // A stale finding NEVER renders as though it were current. But the strength

--- a/integrations/codex/hooks/lib/inject.mjs
+++ b/integrations/codex/hooks/lib/inject.mjs
@@ -157,9 +157,28 @@ function render(finding) {
  * prevent. A second load costs a parse, and it is paid once per observed write
  * rather than once per tool call -- when nothing is queued this is one stat.
  */
+/**
+ * Per process, per graph directory: did the drain change anything?
+ *
+ * THE SECOND CALLER IS WHY THIS EXISTS. SessionStart calls `standingRules` and
+ * then `sessionIndex` with the SAME graph object it loaded once. Without this
+ * memo the first call drains, marks, and re-reads privately -- and the second
+ * call finds an empty queue, marks nothing, and therefore serves from the
+ * caller's pre-drain copy, advertising as current the very finding the first
+ * call had just marked. Draining is not idempotent from the caller's point of
+ * view; remembering the ANSWER is what makes it so.
+ *
+ * A hook process handles one lifecycle event, so this map holds one or two
+ * entries and dies with the process.
+ */
+const drainedDirs = new Map();
+
 function withPendingApplied(dir, graph) {
   try {
-    return drainInvalidations(dir, graph) > 0 ? load(dir) : graph;
+    if (drainedDirs.has(dir)) return drainedDirs.get(dir) ? load(dir) : graph;
+    const marked = drainInvalidations(dir, graph) > 0;
+    drainedDirs.set(dir, marked);
+    return marked ? load(dir) : graph;
   } catch {
     // The lazy path still covers everything this would have caught early, and
     // a hook must never fail because bookkeeping did.
@@ -862,6 +881,12 @@ export function relevantFindingIdsForContext(graph, context, { limit = 8 } = {})
  * shrinks toward the floor. See metrics.indexBudget.
  */
 export function sessionIndex(dir, graph, { episode = {}, relevantFindingIds = [] } = {}) {
+  // DRAINED HERE TOO, and this is the worst place to be wrong. The session index
+  // is the FIRST thing a session sees and it arrives with no other context to
+  // correct it, so advertising a finding the graph already knows is stale is a
+  // false claim made at maximum leverage. The graph is loaded either way, so the
+  // only cost is the stat that finds no queue.
+  graph = withPendingApplied(dir, graph);
   const budget = indexBudget(dir);
   const relevant = new Set(relevantFindingIds);
   // Some SessionStart payloads have no task signal. Fail closed for situational
@@ -988,6 +1013,9 @@ ${lines.join('\n')}`;
  * is wallpaper, and the model stops reading the thing it always sees.
  */
 export function standingRules(dir, graph, { budget = standingBudget(), episode = {} } = {}) {
+  // Same reason as sessionIndex: always-on text, delivered before the first
+  // tool call, with nothing following it that could qualify what it said.
+  graph = withPendingApplied(dir, graph);
   const rules = [...graph.nodes.values()].filter(
     (n) =>
       n.kind === 'finding' &&

--- a/integrations/codex/hooks/lib/inject.mjs
+++ b/integrations/codex/hooks/lib/inject.mjs
@@ -143,6 +143,40 @@ function render(finding) {
 }
 
 /**
+ * Graph directories where a drain has already marked something in THIS process.
+ *
+ * THE SECOND CALLER IS WHY THIS EXISTS. SessionStart calls `standingRules` and
+ * then `sessionIndex` with the SAME graph object it loaded once. Without this,
+ * the first call drains, marks, and re-reads privately -- and the second call
+ * finds an empty queue, marks nothing, and therefore serves from the caller's
+ * pre-drain copy, advertising as current the very finding the first call had
+ * just marked. Draining is idempotent; its EFFECT on a caller's parsed graph is
+ * not, so what is remembered here is "a re-read is owed", nothing else.
+ *
+ * ONLY THE POSITIVE CASE IS REMEMBERED, and that is a correctness decision
+ * rather than a tuning one. Remembering "nothing was queued" would mean a queue
+ * arriving LATER in the same process is silently skipped and deferred to some
+ * future session. That cannot happen today, because `queueInvalidation` runs in
+ * the post-tool branch before any injection -- but that is an unguarded
+ * ordering dependency, and it stops being true the moment someone adds a call
+ * site. A repeated empty drain costs one `existsSync` on a file that is not
+ * there, which is a price worth paying to not have an invariant that depends on
+ * nobody reordering anything.
+ *
+ * KEYED CANONICALLY. Two spellings of one directory -- a trailing separator, a
+ * `..` segment, a lower-cased drive letter -- would otherwise be two entries,
+ * which reintroduces exactly the pre-drain-copy bug above. This is the same
+ * defect shape Task 2 on this branch shipped for real, where a tool resolved its
+ * graph from a raw cwd while the hooks resolved theirs through `projectRootFor`
+ * and the two halves of a metric landed in different directories. Path identity
+ * is why `canonicalKey` lives inside `nodeId` rather than at its call sites.
+ *
+ * A hook process handles one lifecycle event, so this set holds one or two
+ * entries and dies with the process.
+ */
+const drainedDirs = new Set();
+
+/**
  * Applies anything the post-tool hook queued, BEFORE anything is served.
  *
  * THIS IS WHERE EAGER STALENESS LANDS. `invalidateOnWrite` needs a graph, and
@@ -157,28 +191,14 @@ function render(finding) {
  * prevent. A second load costs a parse, and it is paid once per observed write
  * rather than once per tool call -- when nothing is queued this is one stat.
  */
-/**
- * Per process, per graph directory: did the drain change anything?
- *
- * THE SECOND CALLER IS WHY THIS EXISTS. SessionStart calls `standingRules` and
- * then `sessionIndex` with the SAME graph object it loaded once. Without this
- * memo the first call drains, marks, and re-reads privately -- and the second
- * call finds an empty queue, marks nothing, and therefore serves from the
- * caller's pre-drain copy, advertising as current the very finding the first
- * call had just marked. Draining is not idempotent from the caller's point of
- * view; remembering the ANSWER is what makes it so.
- *
- * A hook process handles one lifecycle event, so this map holds one or two
- * entries and dies with the process.
- */
-const drainedDirs = new Map();
-
 function withPendingApplied(dir, graph) {
   try {
-    if (drainedDirs.has(dir)) return drainedDirs.get(dir) ? load(dir) : graph;
-    const marked = drainInvalidations(dir, graph) > 0;
-    drainedDirs.set(dir, marked);
-    return marked ? load(dir) : graph;
+    const key = canonicalPath(dir);
+    // The drain runs EVERY time. It is one stat when there is nothing to do,
+    // and running it unconditionally is what keeps the memo from encoding an
+    // assumption about which hook branch ran first.
+    if (drainInvalidations(dir, graph) > 0) drainedDirs.add(key);
+    return drainedDirs.has(key) ? load(dir) : graph;
   } catch {
     // The lazy path still covers everything this would have caught early, and
     // a hook must never fail because bookkeeping did.

--- a/integrations/codex/hooks/lib/lexical.mjs
+++ b/integrations/codex/hooks/lib/lexical.mjs
@@ -1,0 +1,73 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/lexical.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * BM25 over findings. Pure, dependency-free, deterministic.
+ *
+ * WHY THIS REPLACES `includes()`. The dashboard filtered findings by substring,
+ * which cannot RANK -- and every consumer of retrieval here is under a hard
+ * token budget, so the budget kept whatever happened to match rather than what
+ * matched best. Ranking is the whole value at a budget.
+ *
+ * WHY BM25 AND NOT EMBEDDINGS. Deliberate, per docs/WIKI_GRAPH.md: deterministic,
+ * instant, explainable, and it cannot drift or need a rebuild. The known cost is
+ * recall on findings with no lexical overlap; Plan 2's recall probe measures that
+ * rather than assuming it away.
+ */
+
+/** Non-word split, lowercased. Short tokens are kept: `fs`, `id`, `os` matter here. */
+export function tokenize(text) {
+  return String(text || '')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+}
+
+/**
+ * Classic BM25. `k1` controls term-frequency saturation, `b` length normalisation.
+ * Defaults are the standard ones and are exposed so the recall probe can sweep them.
+ */
+export function rank(query, findings, { limit = 20, k1 = 1.2, b = 0.75 } = {}) {
+  const terms = tokenize(query);
+  if (!terms.length || !Array.isArray(findings) || !findings.length) return [];
+
+  // A finding's searchable text is its claim AND its key: the key is how the
+  // session index refers to it, so a model quoting a key must find it.
+  const docs = findings.map((finding) => ({
+    finding,
+    tokens: tokenize(`${finding.key || ''} ${finding.claim || ''}`),
+  }));
+
+  const avgLen = docs.reduce((sum, d) => sum + d.tokens.length, 0) / docs.length;
+  const N = docs.length;
+
+  const docFreq = new Map();
+  for (const { tokens } of docs) {
+    for (const term of new Set(tokens)) {
+      docFreq.set(term, (docFreq.get(term) || 0) + 1);
+    }
+  }
+
+  const scored = [];
+  for (const { finding, tokens } of docs) {
+    const counts = new Map();
+    for (const token of tokens) counts.set(token, (counts.get(token) || 0) + 1);
+
+    let score = 0;
+    for (const term of terms) {
+      const tf = counts.get(term);
+      if (!tf) continue;
+      const df = docFreq.get(term) || 0;
+      // Standard BM25 IDF, floored at zero so a term present in every document
+      // contributes nothing rather than a negative score.
+      const idf = Math.max(0, Math.log(1 + (N - df + 0.5) / (df + 0.5)));
+      const norm = tf + k1 * (1 - b + (b * tokens.length) / (avgLen || 1));
+      score += idf * ((tf * (k1 + 1)) / (norm || 1));
+    }
+
+    // Zero means no term matched. Omitted rather than returned, so a caller
+    // under a token budget never spends it on an irrelevant finding.
+    if (score > 0) scored.push({ finding, score });
+  }
+
+  return scored.sort((a, b2) => b2.score - a.score).slice(0, limit);
+}

--- a/integrations/codex/hooks/lib/lexical.mjs
+++ b/integrations/codex/hooks/lib/lexical.mjs
@@ -14,12 +14,54 @@
  * rather than assuming it away.
  */
 
-/** Non-word split, lowercased. Short tokens are kept: `fs`, `id`, `os` matter here. */
-export function tokenize(text) {
-  return String(text || '')
-    .toLowerCase()
-    .split(/[^a-z0-9]+/)
+/**
+ * Splits an identifier's alphanumeric run into its camelCase / letter-digit
+ * parts, e.g. `skipLibCheck` -> ['skip', 'Lib', 'Check'], `TS2345` ->
+ * ['TS', '2345']. Returns a single-element array when there is no internal
+ * boundary (e.g. `retry` -> ['retry']) so callers can skip emitting a
+ * redundant duplicate of the whole token.
+ */
+function splitIdentifierParts(word) {
+  return word
+    .replace(/([a-z])([A-Z])/g, '$1\0$2')
+    .replace(/([A-Za-z])([0-9])/g, '$1\0$2')
+    .replace(/([0-9])([A-Za-z])/g, '$1\0$2')
+    .split('\0')
     .filter(Boolean);
+}
+
+/**
+ * Non-word split, lowercased. Short tokens are kept: `fs`, `id`, `os` matter
+ * here.
+ *
+ * Emits sub-tokens for compound identifiers, in addition to the whole token.
+ * Delimited identifiers (`smart_read`, `wiki.mjs`, the flag in
+ * `--skipLibCheck`) already round-trip fine: the delimiter splits them, and
+ * because query and claim pass through this same function, a query typed
+ * with the same delimiters matches. The silent gap was CONCATENATED
+ * identifiers with no delimiter at all -- `skipLibCheck` collapsed to the
+ * single token `skiplibcheck`, so a query for "skip lib check" (or "TS 2345"
+ * against `TS2345`) never intersected it. No error, just an absent result --
+ * and findings are about code, where run-together identifiers are the
+ * common case. So every alphanumeric run keeps its whole-token form (a query
+ * for the concatenated form still matches) and ALSO contributes its
+ * camelCase / letter-digit parts (a query for the separated form now
+ * matches too). A lone incidental character -- e.g. the `c` split out of a
+ * Windows path `C:\Users\...` -- needs no special-casing: it is a real
+ * token like any other, and BM25's IDF already discounts a term that shows
+ * up in nearly every finding.
+ */
+export function tokenize(text) {
+  const words = String(text || '').match(/[A-Za-z0-9]+/g) || [];
+  const tokens = [];
+  for (const word of words) {
+    tokens.push(word.toLowerCase());
+    const parts = splitIdentifierParts(word);
+    if (parts.length > 1) {
+      for (const part of parts) tokens.push(part.toLowerCase());
+    }
+  }
+  return tokens;
 }
 
 /**
@@ -57,9 +99,15 @@ export function rank(query, findings, { limit = 20, k1 = 1.2, b = 0.75 } = {}) {
       const tf = counts.get(term);
       if (!tf) continue;
       const df = docFreq.get(term) || 0;
-      // Standard BM25 IDF, floored at zero so a term present in every document
-      // contributes nothing rather than a negative score.
-      const idf = Math.max(0, Math.log(1 + (N - df + 0.5) / (df + 0.5)));
+      // Smoothed BM25 idf: log(1 + (N - df + 0.5) / (df + 0.5)). Unlike the
+      // classic unsmoothed idf (log((N - df + 0.5) / (df + 0.5))), which goes
+      // negative once a term appears in most documents, this smoothed form
+      // is strictly positive for every df in [1, N]: even at df === N the
+      // ratio inside the log is (N + 1) / (N + 0.5), which is always
+      // strictly greater than 1, so log(1 + that) is always > 0. No floor
+      // is needed here, and none is applied -- there is no negative case
+      // for this formula to guard against.
+      const idf = Math.log(1 + (N - df + 0.5) / (df + 0.5));
       const norm = tf + k1 * (1 - b + (b * tokens.length) / (avgLen || 1));
       score += idf * ((tf * (k1 + 1)) / (norm || 1));
     }

--- a/integrations/codex/hooks/lib/lexical.mjs
+++ b/integrations/codex/hooks/lib/lexical.mjs
@@ -65,6 +65,43 @@ export function tokenize(text) {
 }
 
 /**
+ * Effective term-frequency credit for a document that has NO exact token
+ * match for a query term but DOES have a token that starts with it (e.g.
+ * query `custom` against a document containing `customer`). Deliberately
+ * less than one exact occurrence (`1`), and it is a flat credit rather than
+ * one that grows with the number of prefix-matching tokens in the document,
+ * so a prefix hit can never outscore an exact hit of the same term:
+ *
+ *   BM25's per-term contribution is `idf * tf * (k1 + 1) / (tf + K)`, where
+ *   `K = k1 * (1 - b + b * L / avgL)` depends only on document length, not
+ *   on which term or how it matched. As a function of `tf` alone, with `K`
+ *   fixed, `f(tf) = tf / (tf + K)` is non-decreasing for every `tf >= 0` and
+ *   `k1 >= 0` (its derivative `K / (tf + K)^2` is never negative). So for
+ *   ANY document length, and any number of prefix-only occurrences, using
+ *   `PREFIX_TF < 1` in place of `tf` scores no higher than an actual exact
+ *   occurrence (`tf = 1`) would in that same document -- there is no
+ *   PREFIX_TF-independent way to accumulate more evidence than one real hit
+ *   by matching only a prefix. This is also why the count of prefix matches
+ *   is otherwise irrelevant here: it never feeds back into the score.
+ *
+ * PREFIX MATCHING IS NOT SUBSTRING MATCHING. It restores recall for a
+ * fragment typed at the START of a word -- `custom` now finds `customer` --
+ * which is the common case (a user typing the first few letters of a term
+ * they remember). It does NOT restore the old `.includes()` filter's ability
+ * to find a term in the MIDDLE of a word: a query for `tomer` still will not
+ * find `customer`. That recall gap is accepted, not silently reintroduced.
+ */
+const PREFIX_TF = 0.5;
+
+/**
+ * Below this length, a query term is not eligible for prefix matching: a
+ * one- or two-character prefix (`a`, `re`) is a substring of a large
+ * fraction of any real vocabulary, so it would match nearly every document
+ * and IDF alone would not discount it enough to keep the results relevant.
+ */
+const PREFIX_MIN_TERM_LENGTH = 3;
+
+/**
  * Classic BM25. `k1` controls term-frequency saturation, `b` length normalisation.
  * Defaults are the standard ones and are exposed so the recall probe can sweep them.
  */
@@ -96,7 +133,21 @@ export function rank(query, findings, { limit = 20, k1 = 1.2, b = 0.75 } = {}) {
 
     let score = 0;
     for (const term of terms) {
-      const tf = counts.get(term);
+      let tf = counts.get(term) || 0;
+
+      // No exact occurrence: fall back to a prefix match, which is weaker
+      // evidence and so credited at a flat PREFIX_TF rather than a real
+      // count (see PREFIX_TF's comment for why that ordering is safe). Only
+      // considered when nothing already matched exactly and the term is
+      // long enough that "starts with" is a meaningful signal.
+      if (tf === 0 && term.length >= PREFIX_MIN_TERM_LENGTH) {
+        for (const token of counts.keys()) {
+          if (token !== term && token.startsWith(term)) {
+            tf = PREFIX_TF;
+            break;
+          }
+        }
+      }
       if (!tf) continue;
       const df = docFreq.get(term) || 0;
       // Smoothed BM25 idf: log(1 + (N - df + 0.5) / (df + 0.5)). Unlike the

--- a/integrations/codex/hooks/lib/metrics.mjs
+++ b/integrations/codex/hooks/lib/metrics.mjs
@@ -455,6 +455,23 @@ export function readBalance(dir) {
   return out;
 }
 
+/**
+ * True when `readEvidence` could not have read the whole log -- the file
+ * exceeds the byte cap, so anything written before the tail it kept is
+ * silently absent from what it returned. A caller that builds a per-claim
+ * record from `readEvidence` (the wiki graph's derivation record) needs this
+ * to say "operations existed but are not recorded here" rather than let an
+ * empty result read as "nothing happened".
+ */
+export function evidenceTruncated(dir) {
+  const path = evidencePath(dir);
+  try {
+    return statSync(path).size > MAX_BYTES;
+  } catch {
+    return false;
+  }
+}
+
 /** Every causal evidence record inside the byte cap, deduplicated by id. */
 export function readEvidence(dir) {
   const path = evidencePath(dir);

--- a/integrations/codex/hooks/lib/observability.mjs
+++ b/integrations/codex/hooks/lib/observability.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 /**
  * Privacy-safe, cross-client lifecycle diagnostics.
  *

--- a/integrations/codex/hooks/lib/pending.mjs
+++ b/integrations/codex/hooks/lib/pending.mjs
@@ -39,7 +39,7 @@ import {
   statSync,
 } from 'node:fs';
 import { join } from 'node:path';
-import { invalidateOnWrite } from './staleness.mjs';
+import { invalidateChangedAnchors, invalidateOnWrite } from './staleness.mjs';
 import { canonicalPath, isFsSafePath, resolvableCandidates } from './paths.mjs';
 
 const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
@@ -190,31 +190,85 @@ function hasEditEvidence(payload, raw) {
 }
 
 /**
- * The evidence a completed mutation left behind, or null when there is none.
+ * Canonical tool names that mean bytes on disk changed.
  *
- * Separate from `queueInvalidation` so the caller can be a hook branch that
- * knows nothing about diffs, and so the reconstruction above is testable
- * without a filesystem queue.
+ * THE NORMALISED SET, not any client's own vocabulary. `normalizePayload` has
+ * already mapped `replace`, `write_file`, `apply_patch`, `str_replace`,
+ * `search_replace` and the rest onto these three through decide.mjs's alias
+ * table -- and a tool that table cannot map arrives as null and exits the hook
+ * before this module is reached at all. So matching here is both complete for
+ * every client the adapter serves and impossible to spell wrong.
+ *
+ * `NotebookEdit` is absent because `normalizeTool` maps it to null, and the MCP
+ * `smart_edit`/`smart_write` tools are absent for the same reason. Both are gaps
+ * in that alias table rather than in this file, and widening it changes routing
+ * verdicts for every client -- so they are reported, not papered over here.
  */
-export function observedWrite(payload, raw) {
-  // CHEAP CHECK FIRST, because this runs after every tool call on every client.
-  // Reading the file is the expensive part, and there is no point paying for it
-  // on a Read, a Bash or a write whose before side cannot be reconstructed.
-  if (!hasEditEvidence(payload, raw)) return null;
+const MUTATING = new Set(['Edit', 'MultiEdit', 'Write']);
+
+/** Files an apply_patch-style program declares it is about to change. */
+function patchTargets(payload) {
+  const command = payload?.tool_input?.command;
+  if (typeof command !== 'string') return [];
+  const out = [];
+  for (const match of command.matchAll(
+    /^\*\*\* (?:Add|Update|Delete) File:\s*(.+)$/gm
+  )) {
+    const candidate = match[1].trim().replace(/^['"]|['"]$/g, '');
+    // Bounded: one patch naming a thousand files must not append a thousand
+    // queue records on a hook path.
+    if (candidate && out.length < 20) out.push(candidate);
+  }
+  return out;
+}
+
+/**
+ * Everything a completed mutation left behind that is worth queueing.
+ *
+ * TWO GRADES OF EVIDENCE, and the distinction is the point:
+ *
+ *   { path, before, after }  a reconstructable edit. The drain builds a real
+ *                            diff and marks only the symbols that moved.
+ *   { path }                 a whole-file write, or a patch program. No before
+ *                            side exists anywhere in the payload, so the drain
+ *                            compares stored hashes against disk instead.
+ *
+ * The second grade is what closes the biggest hole. A whole-file write is the
+ * commonest write shape there is, and before it was added those writes fell
+ * through to a lazy path that CANNOT see the session's own writes at all --
+ * `indexFile` refreshes the anchor before the lazy check ever looks at it. They
+ * were uncovered, not degraded.
+ *
+ * Returns an array, because one apply_patch program changes several files.
+ */
+export function observedWrites(payload, raw) {
+  if (!MUTATING.has(String(payload?.tool_name || ''))) return [];
 
   const path = writtenPath(payload, raw);
-  if (!path) return null;
+  if (path) {
+    // The expensive branch is guarded: reading the file only pays off when the
+    // payload can actually yield a before side.
+    if (hasEditEvidence(payload, raw)) {
+      const after = afterText(path);
+      if (after !== null && after.length <= MAX_SIDE_CHARS) {
+        const before = beforeText(payload, raw, after);
+        // Identical bytes: a formatter no-op, or a rewrite of the same content.
+        // Nothing changed, so nothing is stale.
+        if (before === after) return [];
+        if (before !== null && before.length <= MAX_SIDE_CHARS)
+          return [{ path, before, after }];
+      }
+    }
+    // Hash grade. Deliberately NOT `{ path, before: '', after }`: an empty
+    // before side makes every symbol in the file look changed, and the eager
+    // mark is a stored flag no later check ever clears.
+    return [{ path }];
+  }
 
-  const after = afterText(path);
-  if (after === null || after.length > MAX_SIDE_CHARS) return null;
-
-  const before = beforeText(payload, raw, after);
-  if (before === null || before.length > MAX_SIDE_CHARS) return null;
-  // Nothing changed: a formatter no-op, or a write of identical bytes. Queuing
-  // it would mark findings stale against an empty diff.
-  if (before === after) return null;
-
-  return { path, before, after };
+  // Codex and code-mode clients carry the whole patch as program text with no
+  // file_path field at all, which is why this recorded nothing for them. The
+  // hash grade needs only the path, so the patch headers are enough.
+  return patchTargets(payload).map((target) => ({ path: target }));
 }
 
 /**
@@ -226,9 +280,14 @@ export function observedWrite(payload, raw) {
 export function queueInvalidation(dir, { path, before, after, at } = {}) {
   try {
     if (typeof path !== 'string' || !path.trim()) return false;
-    if (typeof before !== 'string' || typeof after !== 'string') return false;
-    if (before.length > MAX_SIDE_CHARS || after.length > MAX_SIDE_CHARS)
-      return false;
+    // BOTH SIDES OR NEITHER. A record carrying only one of them cannot produce
+    // a diff and must not pretend to, so it is written as a path-only record
+    // and the drain resolves it by comparing hashes.
+    const diffable =
+      typeof before === 'string' &&
+      typeof after === 'string' &&
+      before.length <= MAX_SIDE_CHARS &&
+      after.length <= MAX_SIDE_CHARS;
 
     const file = queuePath(dir);
     try {
@@ -240,7 +299,11 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
     mkdirSync(dir, { recursive: true });
     appendFileSync(
       file,
-      `${JSON.stringify({ path: canonicalPath(path), before, after, at: at ?? Date.now() })}\n`,
+      `${JSON.stringify({
+        path: canonicalPath(path),
+        ...(diffable ? { before, after } : {}),
+        at: at ?? Date.now(),
+      })}\n`,
       'utf8'
     );
     return true;
@@ -284,16 +347,16 @@ export function drainInvalidations(dir, graph) {
   let marked = 0;
   for (const record of records) {
     if (!record || typeof record.path !== 'string' || !record.path) continue;
-    if (typeof record.before !== 'string' || typeof record.after !== 'string')
-      continue;
+    const diffable =
+      typeof record.before === 'string' && typeof record.after === 'string';
     try {
-      const result = invalidateOnWrite(
-        dir,
-        graph,
-        record.path,
-        record.before,
-        record.after
-      );
+      // TWO GRADES, ONE QUEUE. A record carrying both sides gets a real diff and
+      // symbol-precise marking; one carrying only a path gets the hash
+      // comparison -- the same comparison the lazy path makes, and one that is
+      // only meaningful HERE, before `indexFile` refreshes the anchor.
+      const result = diffable
+        ? invalidateOnWrite(dir, graph, record.path, record.before, record.after)
+        : invalidateChangedAnchors(dir, graph, record.path);
       marked += Array.isArray(result) ? result.length : 0;
     } catch {
       // One bad record must not stop the rest, and must not stop the tool call.

--- a/integrations/codex/hooks/lib/pending.mjs
+++ b/integrations/codex/hooks/lib/pending.mjs
@@ -1,0 +1,311 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/pending.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * The eager-invalidation queue: the missing half of staleness.mjs's header.
+ *
+ * That header describes TWO invalidation paths and says eager exists because
+ * lazy "would silently serve stale findings as fresh whenever a change came
+ * from outside the agent". `invalidateOnWrite` had been written, tested and
+ * documented -- and its only reference in shipped code was a COMMENT in the
+ * PreToolUse router. Staleness was lazy-only in production, and the router's
+ * own comment ("a write the hook observes is invalidated eagerly by
+ * `invalidateOnWrite`") described something that never happened.
+ *
+ * WHY THAT MATTERS MORE THAN IT SOUNDS. The lazy check compares the anchor's
+ * stored hash against disk -- and both the router and the adapter call
+ * `indexFile` on every file they observe, which re-points that hash at the new
+ * bytes. So for a write the session performed ITSELF, the lazy check is
+ * self-defeating: by the next retrieval the anchor already agrees with disk and
+ * the finding derived from the old content is served clean. Lazy catches the
+ * changes we never saw; only eager catches the ones we did.
+ *
+ * WHY A QUEUE AND NOT A DIRECT CALL. `invalidateOnWrite` needs the graph, and
+ * the graph is a megabyte of JSONL. Loading it on the return path of every
+ * write is the cost this shape exists to avoid. So the post-tool hook, which
+ * already holds the write's evidence, appends one record here and exits; the
+ * next graph read -- `forTouch`/`forCommand`, which load the graph anyway --
+ * drains it BEFORE serving anything.
+ *
+ * The guarantee is unchanged. What must never happen is SERVING a stale finding
+ * as fresh, and serve time is where that is enforced.
+ */
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { invalidateOnWrite } from './staleness.mjs';
+import { canonicalPath, isFsSafePath, resolvableCandidates } from './paths.mjs';
+
+const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
+
+/**
+ * Largest before/after side kept in a queue record.
+ *
+ * Matched to the graph's own snapshot limit for the same reason it has one: past
+ * this size the text is a bundle, a lockfile or a generated asset, and copying
+ * it into a queue file would mirror the repository into the graph directory one
+ * write at a time. Past the cap the write is simply not queued -- the lazy path
+ * still governs it, which is exactly the status quo for that file.
+ */
+const MAX_SIDE_CHARS = 262_144;
+
+/**
+ * Largest queue file appended to.
+ *
+ * A queue only grows while nothing drains it, which means the retrieval feature
+ * is off or every read has failed. Neither is a reason to keep writing: bounded
+ * here so a long unattended session cannot turn one directory into a log of
+ * every file it touched.
+ */
+const MAX_QUEUE_BYTES = 8 * 1024 * 1024;
+
+/** The tool payload fields that name the file a mutation landed on. */
+function writtenPath(payload, raw) {
+  const input = payload?.tool_input || {};
+  const response = raw?.tool_response || raw?.toolResponse || {};
+  for (const candidate of [
+    input.file_path,
+    input.path,
+    input.notebook_path,
+    response.filePath,
+    response.file_path,
+  ]) {
+    if (typeof candidate === 'string' && candidate.trim()) return candidate;
+  }
+  return null;
+}
+
+/** First string among several possible spellings of the same field. */
+function firstString(...values) {
+  for (const value of values) if (typeof value === 'string') return value;
+  return null;
+}
+
+/**
+ * The text before the write, reconstructed from a completed edit.
+ *
+ * PREFERENCE ORDER IS ABOUT EXACTNESS, not convenience. Claude Code's Edit
+ * response carries the whole pre-edit file (`originalFile`), which needs no
+ * reasoning at all. Failing that, an edit is a known substitution, so reverting
+ * `new_string` back to `old_string` in the post-write text reproduces the
+ * before side exactly -- but only when the substitution is unambiguous, which
+ * is why a `new_string` that now appears more than once is refused rather than
+ * guessed at.
+ *
+ * NULL MEANS "DO NOT QUEUE", and that is deliberate. An unknown before side
+ * could be passed as '' -- and `invalidateOnWrite` would then see every symbol
+ * in the file as changed and mark every finding anchored anywhere in it, which
+ * is the exact over-marking its own comments call worse than the file-level
+ * staleness symbols were introduced to avoid. A missed eager invalidation costs
+ * what today already costs; a wrong one permanently discounts correct findings.
+ */
+function beforeText(payload, raw, after) {
+  const input = payload?.tool_input || {};
+  const response = raw?.tool_response || raw?.toolResponse || {};
+
+  const original = firstString(
+    response.originalFile,
+    response.original_file,
+    response.originalContent,
+    response.original_content
+  );
+  if (original !== null) return original;
+
+  // MultiEdit applies its edits in order, so reverting walks them backwards.
+  const edits = Array.isArray(input.edits) ? input.edits : null;
+  if (edits) {
+    let text = after;
+    for (const edit of [...edits].reverse()) {
+      const reverted = revert(text, edit);
+      if (reverted === null) return null;
+      text = reverted;
+    }
+    return text;
+  }
+
+  return revert(after, input);
+}
+
+/** Undoes one old->new substitution, or null when it cannot be done exactly. */
+function revert(text, edit) {
+  const oldString = firstString(edit?.old_string, edit?.oldString);
+  const newString = firstString(edit?.new_string, edit?.newString);
+  if (oldString === null || newString === null || newString === '') return null;
+
+  const all = edit?.replace_all === true || edit?.replaceAll === true;
+  if (all) return text.split(newString).join(oldString);
+
+  const at = text.indexOf(newString);
+  if (at < 0) return null;
+  // Ambiguous: more than one candidate for the occurrence that was written, and
+  // reverting the wrong one fabricates a before side that never existed.
+  if (text.indexOf(newString, at + newString.length) >= 0) return null;
+  return text.slice(0, at) + oldString + text.slice(at + newString.length);
+}
+
+/** The post-write text, read from disk because that is what the write produced. */
+function afterText(path) {
+  if (!isFsSafePath(path)) return null;
+  for (const candidate of resolvableCandidates(path)) {
+    try {
+      if (statSync(candidate).size > MAX_SIDE_CHARS) return null;
+      return readFileSync(candidate, 'utf8');
+    } catch {
+      // Wrong spelling, or gone again already. Try the next one.
+    }
+  }
+  return null;
+}
+
+/**
+ * Does this payload carry enough to reconstruct a before side at all?
+ *
+ * Named tool lists were the alternative and were rejected: every client calls
+ * its editor something different (`Edit`, `replace`, `write_to_file`,
+ * `apply_patch`), and a list would silently exclude the ones nobody thought of
+ * while still charging a file read for every Read that matched by accident.
+ * Asking about the EVIDENCE instead covers any client that carries an edit in
+ * one of these shapes and costs nothing on the calls that do not.
+ */
+function hasEditEvidence(payload, raw) {
+  const input = payload?.tool_input || {};
+  const response = raw?.tool_response || raw?.toolResponse || {};
+  if (
+    firstString(
+      response.originalFile,
+      response.original_file,
+      response.originalContent,
+      response.original_content
+    ) !== null
+  )
+    return true;
+  if (Array.isArray(input.edits) && input.edits.length > 0) return true;
+  return firstString(input.old_string, input.oldString) !== null;
+}
+
+/**
+ * The evidence a completed mutation left behind, or null when there is none.
+ *
+ * Separate from `queueInvalidation` so the caller can be a hook branch that
+ * knows nothing about diffs, and so the reconstruction above is testable
+ * without a filesystem queue.
+ */
+export function observedWrite(payload, raw) {
+  // CHEAP CHECK FIRST, because this runs after every tool call on every client.
+  // Reading the file is the expensive part, and there is no point paying for it
+  // on a Read, a Bash or a write whose before side cannot be reconstructed.
+  if (!hasEditEvidence(payload, raw)) return null;
+
+  const path = writtenPath(payload, raw);
+  if (!path) return null;
+
+  const after = afterText(path);
+  if (after === null || after.length > MAX_SIDE_CHARS) return null;
+
+  const before = beforeText(payload, raw, after);
+  if (before === null || before.length > MAX_SIDE_CHARS) return null;
+  // Nothing changed: a formatter no-op, or a write of identical bytes. Queuing
+  // it would mark findings stale against an empty diff.
+  if (before === after) return null;
+
+  return { path, before, after };
+}
+
+/**
+ * Appends one pending write.
+ *
+ * NEVER THROWS. This runs on a hook's return path, and a queue that cannot be
+ * written degrades to the lazy path rather than costing the user a tool call.
+ */
+export function queueInvalidation(dir, { path, before, after, at } = {}) {
+  try {
+    if (typeof path !== 'string' || !path.trim()) return false;
+    if (typeof before !== 'string' || typeof after !== 'string') return false;
+    if (before.length > MAX_SIDE_CHARS || after.length > MAX_SIDE_CHARS)
+      return false;
+
+    const file = queuePath(dir);
+    try {
+      if (statSync(file).size > MAX_QUEUE_BYTES) return false;
+    } catch {
+      // No queue yet, which is the normal case.
+    }
+
+    mkdirSync(dir, { recursive: true });
+    appendFileSync(
+      file,
+      `${JSON.stringify({ path: canonicalPath(path), before, after, at: at ?? Date.now() })}\n`,
+      'utf8'
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Applies every queued invalidation and clears the queue.
+ *
+ * Returns the number of findings marked, so the caller knows whether its
+ * in-memory graph is now behind the file on disk and needs re-reading.
+ *
+ * CLEARED AFTER APPLYING AND UNCONDITIONALLY: a record that cannot be applied
+ * must not be retried on every tool call for the rest of the session, and the
+ * cost of dropping one is a single missed eager mark that the lazy path still
+ * has a chance at.
+ */
+export function drainInvalidations(dir, graph) {
+  let records;
+  try {
+    const file = queuePath(dir);
+    if (!existsSync(file)) return 0;
+    records = readFileSync(file, 'utf8')
+      .split('\n')
+      .filter((line) => line.trim())
+      .map((line) => {
+        try {
+          return JSON.parse(line);
+        } catch {
+          // A torn append costs one record, not the queue.
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch {
+    return 0;
+  }
+
+  let marked = 0;
+  for (const record of records) {
+    if (!record || typeof record.path !== 'string' || !record.path) continue;
+    if (typeof record.before !== 'string' || typeof record.after !== 'string')
+      continue;
+    try {
+      const result = invalidateOnWrite(
+        dir,
+        graph,
+        record.path,
+        record.before,
+        record.after
+      );
+      marked += Array.isArray(result) ? result.length : 0;
+    } catch {
+      // One bad record must not stop the rest, and must not stop the tool call.
+    }
+  }
+
+  try {
+    rmSync(queuePath(dir), { force: true });
+  } catch {
+    // Held open by a concurrent hook. The next drain re-applies these records,
+    // which is safe: marking an already-marked finding is idempotent.
+  }
+
+  return marked;
+}

--- a/integrations/codex/hooks/lib/pending.mjs
+++ b/integrations/codex/hooks/lib/pending.mjs
@@ -199,10 +199,11 @@ function hasEditEvidence(payload, raw) {
  * before this module is reached at all. So matching here is both complete for
  * every client the adapter serves and impossible to spell wrong.
  *
- * `NotebookEdit` is absent because `normalizeTool` maps it to null, and the MCP
- * `smart_edit`/`smart_write` tools are absent for the same reason. Both are gaps
- * in that alias table rather than in this file, and widening it changes routing
- * verdicts for every client -- so they are reported, not papered over here.
+ * `NotebookEdit` and the MCP `smart_edit`/`smart_write` tools were absent for as
+ * long as `normalizeTool` mapped them to null. That was a gap in the alias table
+ * rather than in this file, and it has since been closed there: all three now
+ * arrive as `Edit` or `Write` and are matched by the set below without it having
+ * to learn a fourth name.
  */
 const MUTATING = new Set(['Edit', 'MultiEdit', 'Write']);
 

--- a/integrations/codex/hooks/lib/pending.mjs
+++ b/integrations/codex/hooks/lib/pending.mjs
@@ -35,6 +35,7 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  renameSync,
   rmSync,
   statSync,
 } from 'node:fs';
@@ -43,6 +44,15 @@ import { invalidateChangedAnchors, invalidateOnWrite } from './staleness.mjs';
 import { canonicalPath, isFsSafePath, resolvableCandidates } from './paths.mjs';
 
 const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
+/**
+ * Where a drain moves the queue before reading it.
+ *
+ * PER PROCESS, not one shared name: two hooks draining the same graph directory
+ * at once would otherwise race for the same claim file, and the loser would
+ * either clobber the winner's records or delete them mid-read. A pid makes the
+ * claim private to the drainer that won the rename.
+ */
+const claimPath = (dir) => join(dir, `pending-invalidation.claim.${process.pid}.jsonl`);
 
 /**
  * Largest before/after side kept in a queue record.
@@ -319,17 +329,47 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
  * Returns the number of findings marked, so the caller knows whether its
  * in-memory graph is now behind the file on disk and needs re-reading.
  *
- * CLEARED AFTER APPLYING AND UNCONDITIONALLY: a record that cannot be applied
- * must not be retried on every tool call for the rest of the session, and the
- * cost of dropping one is a single missed eager mark that the lazy path still
- * has a chance at.
+ * CLAIMED BY RENAME, THEN READ, THEN DELETED -- and the order is the whole
+ * point. This used to read the queue and then `rmSync` the same path, so a
+ * post-tool hook appending between the read and the unlink had its record
+ * deleted having never been read. Parallel tool calls in one assistant turn are
+ * the ordinary way that happens, not an exotic race. `renameSync` makes the
+ * claim atomic: whatever the drainer took is exactly what it deletes, and a
+ * record appended a microsecond later lands on a fresh queue that the next drain
+ * will find.
+ *
+ * A LOST RECORD IS A PERMANENTLY MISSED INVALIDATION, which is why this is worth
+ * a rename. The comment here used to price it as "a single missed eager mark that
+ * the lazy path still has a chance at", and that premise is false: this module's
+ * own header states it. The lazy path compares the anchor's stored hash against
+ * disk, and `indexFile` re-points that hash at the bytes the session just wrote,
+ * so for the session's OWN writes lazy is structurally blind rather than merely
+ * late. Nothing else was ever going to catch a dropped record.
+ *
+ * A RECORD THAT CANNOT BE APPLIED IS STILL DROPPED, deliberately and
+ * unconditionally: retrying a permanently unapplicable record on every tool call
+ * for the rest of the session costs more than it can ever recover, and the claim
+ * file is deleted whether the loop marked anything or threw.
+ *
+ * FAIL-OPEN THROUGHOUT. A rename that loses a race, or fails for any other
+ * reason, returns 0 and leaves the queue for the next drain; it never throws
+ * into a hook.
  */
 export function drainInvalidations(dir, graph) {
   let records;
+  let claim;
   try {
     const file = queuePath(dir);
     if (!existsSync(file)) return 0;
-    records = readFileSync(file, 'utf8')
+    claim = claimPath(dir);
+    // A LEFTOVER CLAIM FROM A KILLED DRAIN IS OVERWRITTEN, not merged: rename
+    // onto an existing path replaces it. The pid in the name means the only way
+    // to hit that is this same pid having died mid-drain, whose records were
+    // already being applied when it went -- and re-applying is idempotent, so
+    // losing them is the cheaper of the two errors. Not doing the rename at all
+    // would strand the live queue forever.
+    renameSync(file, claim);
+    records = readFileSync(claim, 'utf8')
       .split('\n')
       .filter((line) => line.trim())
       .map((line) => {
@@ -342,6 +382,18 @@ export function drainInvalidations(dir, graph) {
       })
       .filter(Boolean);
   } catch {
+    // The rename lost a race, or the claim could not be read. Nothing is deleted
+    // unread and the hook proceeds. If the claim was taken and then could not be
+    // read, it is put back under the queue name so the next drain still sees it:
+    // a claim file nobody looks at again is the same lost record this rename
+    // exists to prevent.
+    try {
+      if (claim && existsSync(claim) && !existsSync(queuePath(dir))) {
+        renameSync(claim, queuePath(dir));
+      }
+    } catch {
+      // Best effort only. A hook must not fail because bookkeeping did.
+    }
     return 0;
   }
 
@@ -365,10 +417,13 @@ export function drainInvalidations(dir, graph) {
   }
 
   try {
-    rmSync(queuePath(dir), { force: true });
+    // THE CLAIM, NOT THE QUEUE. Deleting `queuePath` here is what dropped a
+    // concurrently appended record; this path holds exactly the bytes that were
+    // just read, so nothing unread can be inside it.
+    rmSync(claim, { force: true });
   } catch {
-    // Held open by a concurrent hook. The next drain re-applies these records,
-    // which is safe: marking an already-marked finding is idempotent.
+    // Held open by something else. The claim is not read again -- the next drain
+    // looks at the queue -- so this costs a stray file, never a record.
   }
 
   return marked;

--- a/integrations/codex/hooks/lib/restore.mjs
+++ b/integrations/codex/hooks/lib/restore.mjs
@@ -142,7 +142,7 @@ export function restorationPlan(dir, graph, context = {}) {
     for (const id of predicted) {
       const node = graph.nodes.get(id);
       if (!node) continue;
-      const findings = serve(graph, findingsFor(graph, id, { limit: 2 }));
+      const findings = serve(graph, findingsFor(graph, id, { limit: 2 }), { dir });
       for (const finding of findings) {
         // `! STALE` only where a diff actually exists to back it; see the
         // renderer in inject.mjs for the measurement behind this.

--- a/integrations/codex/hooks/lib/restore.mjs
+++ b/integrations/codex/hooks/lib/restore.mjs
@@ -158,7 +158,16 @@ export function restorationPlan(dir, graph, context = {}) {
             ? '! STALE '
             : '~ '
           : '';
-        lines.push(`${node.key}: ${mark}${finding.claim}`);
+        // A DISPUTE DISCLOSED ELSEWHERE AND SILENT HERE reads as "the dispute
+        // went away". `serve` already attached the fields; the only question is
+        // the wording, and this list is the most compressed surface in the
+        // system, so it gets the marker and the key and nothing else.
+        const disputed = finding.contradicted
+          ? finding.contradictedBy
+            ? ` (disputed by ${finding.contradictedBy})`
+            : ' (disputed)'
+          : '';
+        lines.push(`${node.key}: ${mark}${finding.claim}${disputed}`);
       }
     }
     section('Likely next', lines, total * split.forward);

--- a/integrations/codex/hooks/lib/skeleton.mjs
+++ b/integrations/codex/hooks/lib/skeleton.mjs
@@ -126,6 +126,11 @@ export function annotatedSkeleton(graph, rawPath, source, { budget = 1200, git =
 
   // Findings anchored to this file or the symbols inside it, served through the
   // one function that enforces the stale-plus-diff rule.
+  // READ-ONLY serve: no `dir` is threaded here, so this cannot clear a stale
+  // flag whose evidence is gone. That is deliberate -- this function takes a
+  // graph, not the directory it came from, and widening its signature to give
+  // an analysis path a write capability buys nothing: the injection path runs
+  // on every tool call and clears the same findings.
   const served = serve(graph, findingsFor(graph, nodeId('file', path), { limit: 40 }));
 
   // Index findings by the symbol they anchor to, so each one sits beside the

--- a/integrations/codex/hooks/lib/staleness.mjs
+++ b/integrations/codex/hooks/lib/staleness.mjs
@@ -31,6 +31,23 @@
  * Eager alone would silently serve stale findings as fresh whenever a change
  * came from outside the agent, which is the single failure mode the design
  * calls worse than no graph.
+ *
+ * AND LAZY ALONE IS BLIND TO THE AGENT'S OWN WRITES -- not degraded, BLIND.
+ * `indexFile` re-points an anchor's stored hash at the bytes it was just handed,
+ * and it is called on every file either hook observes: pretooluse-router.mjs
+ * (two call sites) and adapter.mjs (one). The lazy check then compares that
+ * refreshed hash against the same disk it came from and finds them equal. So
+ * for a file the session edited ITSELF, the lazy path cannot detect the change
+ * at all, and the finding derived from the pre-edit content is served CLEAN.
+ *
+ * Which means that until the eager path was connected, staleness for a file the
+ * agent edited did not work AT ALL: eager was dead code and lazy was defeated
+ * by re-indexing. Every account of this defect, including the one in this
+ * module's own git history, called it "lazy-only, therefore degraded". It was
+ * not degraded. `stale-before-reindex.test.mjs` states in its header that this
+ * case is covered by `invalidateOnWrite`, and `invalidateOnWrite` had never run
+ * once in production. The two paths are not redundant and never were: each is
+ * the ONLY cover for a whole class of change.
  */
 
 import { readFileSync, statSync } from 'node:fs';
@@ -622,6 +639,119 @@ export function invalidateOnWrite(dir, graph, rawPath, beforeText, afterText) {
   // Re-index so the anchors carry the new hashes; otherwise the lazy path would
   // report the same change again on every future retrieval.
   indexFile(dir, path, afterText);
+  return marked;
+}
+
+/**
+ * The eager path for a write with NO before/after pair: compare stored hashes
+ * against disk, and mark what actually moved.
+ *
+ * WHY THIS EXISTS AS A SECOND SHAPE. A whole-file `Write` replaces the file, so
+ * the payload carries the after side and nothing at all of the before -- and a
+ * whole-file write is the commonest write shape there is. `invalidateOnWrite`
+ * cannot serve it: passing '' as the before side makes every symbol in the file
+ * look changed, marks every finding anchored anywhere in it, and the eager mark
+ * is a stored flag no later check ever clears. False-stale is expensive and
+ * permanent, so it is not an acceptable price for coverage.
+ *
+ * But the hash comparison is available, and it is exactly the comparison the
+ * lazy path makes. The difference is WHEN: this runs at the top of injection,
+ * before `indexFile` refreshes the anchor, so the stored hash is still the
+ * pre-write one and the comparison is meaningful. That is the whole trick --
+ * lazy is not wrong, it is merely too late.
+ *
+ * SYMBOL-LEVEL, and from ONE read. Re-locating each symbol by name and
+ * comparing its own span hash is what keeps this from degenerating into
+ * file-level marking: editing one function must not stale a finding about
+ * another, which is the property symbol nodes exist to provide.
+ *
+ * WEAKER EVIDENCE, STATED AS SUCH. There is no before text, so no diff can be
+ * built -- the finding is marked with the two hashes and `serve` reports the
+ * evidence gap through `staleEvidence: false`, which the renderer turns into
+ * "no diff could be rebuilt" rather than promising a diff and showing nothing.
+ * A stale finding with weak evidence is far better than one served as fresh,
+ * but the reader has to be able to tell which one they are holding.
+ */
+export function invalidateChangedAnchors(dir, graph, rawPath) {
+  const path = canonicalPath(rawPath);
+  const marked = [];
+
+  // ONE read for the file and every symbol in it. checkAnchor would have been
+  // the obvious reuse and it reads per anchor, which on a file with fifty
+  // symbols is fifty-one reads of the same bytes on a hook path.
+  let source = null;
+  try {
+    source = readAnySpelling(path);
+  } catch {
+    // Deleted, or unreadable from this checkout. Handled below as a change,
+    // because a finding about a file that is no longer there is exactly the
+    // kind that must not be served as fresh.
+  }
+
+  const changed = [];
+  const fileNode = graph.nodes.get(nodeId('file', path));
+  const fileDigest = source === null ? null : hash(source);
+  if (fileNode && fileDigest !== fileNode.hash) {
+    changed.push({ node: fileNode, from: fileNode.hash, to: fileDigest });
+  }
+
+  const current = new Map(
+    source === null
+      ? []
+      : extractSymbols(path, source).map((s) => [s.name, hash(spanText(source, s))])
+  );
+  for (const node of graph.nodes.values()) {
+    if (node.kind !== 'symbol' || node.file !== path) continue;
+    const digest = current.has(node.name) ? current.get(node.name) : null;
+    if (digest !== node.hash) changed.push({ node, from: node.hash, to: digest });
+  }
+
+  if (changed.length) {
+    // Indexed once by target, for the reason invalidateOnWrite indexes: the
+    // nested alternative is O(nodes x edges) inside a hook.
+    const byTarget = new Map();
+    for (const edge of graph.edges) {
+      if (edge.edge !== 'derived_from') continue;
+      if (!byTarget.has(edge.to)) byTarget.set(edge.to, []);
+      byTarget.get(edge.to).push(edge);
+    }
+
+    for (const { node, from, to } of changed) {
+      for (const edge of byTarget.get(node.id) || []) {
+        const finding = graph.nodes.get(edge.from);
+        if (!finding || finding.kind !== 'finding') continue;
+        // The same type gate serve() applies, for the same reason it is applied
+        // in invalidateOnWrite: the flag is STORED, and disclose.mjs skips a
+        // stale finding while utility.mjs penalises one by 160.
+        if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) continue;
+        // ALREADY MARKED IS LEFT ALONE. Whatever marked it first had a diff or
+        // a more specific reason; overwriting that with a hash pair trades real
+        // evidence for less.
+        if (finding.stale) continue;
+
+        putNode(dir, {
+          ...finding,
+          kind: 'finding',
+          key: finding.key,
+          stale: true,
+          staleReason:
+            to === null
+              ? `the ${node.kind} it depends on is no longer present (was ${from})`
+              : `content hash changed during this session (${from} -> ${to}), observed without a before/after pair`,
+          // EXPLICITLY EMPTY, not absent. serve() reports `staleEvidence` from
+          // whether a diff survived, and the renderer says "no diff could be
+          // rebuilt" -- so the reader can tell "changed, diff unknown" from
+          // "changed, here is what changed".
+          diff: '',
+        });
+        marked.push(finding.key);
+      }
+    }
+  }
+
+  // Re-index for the same reason the diff path does: otherwise every future
+  // retrieval re-reports a change that has already been accounted for.
+  if (source !== null) indexFile(dir, path, source);
   return marked;
 }
 

--- a/integrations/codex/hooks/lib/staleness.mjs
+++ b/integrations/codex/hooks/lib/staleness.mjs
@@ -574,8 +574,20 @@ function derivationCheck(graph, finding) {
  * This is the only function that should ever hand a finding to a model, because
  * it is the one that enforces the rule: a stale finding leaves here carrying
  * `stale: true` AND a diff, or it does not leave at all.
+ *
+ * AND IT CLEARS A STORED FLAG WHOSE EVIDENCE IS GONE, when given a `dir` to
+ * write to. Clearing used to be reachable only by a person pressing Re-verify in
+ * the dashboard, which left the rot path fully open on every install where
+ * nobody opens the dashboard -- and that is most of them. The evidence test is
+ * what makes clearing safe, and it does not care who triggered it: the same
+ * `claimTimeVerdict` runs here as in `reverify`, so this cannot clear anything
+ * the button would not.
+ *
+ * `dir` IS OPTIONAL, AND OMITTING IT MAKES THIS READ-ONLY. Several callers hold
+ * a graph without the directory it came from, and a serve that silently did
+ * nothing would be worse than one that plainly cannot write.
  */
-export function serve(graph, findings) {
+export function serve(graph, findings, { dir = null } = {}) {
   const served = [];
 
   // RETIRED FINDINGS STOP HERE, unconditionally.
@@ -603,8 +615,42 @@ export function serve(graph, findings) {
       continue;
     }
 
+    // AUTOMATIC CLEARING, on the same evidence the manual path demands.
+    //
+    // ONLY THE STORED FLAG IS TOUCHED. The lazy loop below is left to run
+    // exactly as before and can independently mark this finding stale again on
+    // its own comparison -- disk against the anchor NODE's hash -- which answers
+    // a different question and is not this function's to overrule. Eager and
+    // lazy stay two mechanisms, as the module header insists.
+    //
+    // AND THE FIELDS GO WITH THE FLAG. `putNode` does not merge and neither does
+    // this spread: serving `{ ...finding, stale: false }` would hand back a
+    // finding that reads fresh while still carrying `staleReason` and `diff`
+    // from the record -- stale and fresh at once, which is worse than either.
+    // So the cleared record, not the stored one, is what the rest of this
+    // iteration reads and spreads.
+    //
+    // BOUNDED, and the bound is the point: this runs only for a finding whose
+    // flag is already STORED, only when a `derivation` record exists to check
+    // against, and it reads each of that finding's anchors at most once. A
+    // finding that is not flagged pays nothing. The lazy loop below already
+    // reads every anchor of every content-dependent finding served, so the worst
+    // case is twice the anchor reads on the already-stale subset alone.
+    //
+    // NOT ON THE NON-CONTENT-DEPENDENT EARLY RETURN ABOVE, deliberately. Both
+    // eager paths refuse to flag those types at all, so a flag there can only
+    // come from an older graph -- and reading anchors for a type whose truth
+    // does not depend on them is exactly the cost `CONTENT_DEPENDENT` exists to
+    // avoid.
+    let record = finding;
+    if (dir && finding.stale && claimTimeVerdict(graph, finding) === 'match') {
+      clearStale(dir, finding.key, { graph });
+      const { stale: _s, staleReason: _r, diff: _d, staleEvidence: _e, ...cleared } = finding;
+      record = cleared;
+    }
+
     const anchors = graph.edges
-      .filter((e) => e.edge === 'derived_from' && e.from === finding.id)
+      .filter((e) => e.edge === 'derived_from' && e.from === record.id)
       .map((e) => graph.nodes.get(e.to))
       .filter(Boolean);
 
@@ -629,10 +675,10 @@ export function serve(graph, findings) {
     // A finding already marked stale eagerly, whose diff was captured at write
     // time, keeps that diff -- the eager path saw the change we can no longer
     // reconstruct from disk alone.
-    if (!stale && finding.stale) {
+    if (!stale && record.stale) {
       stale = true;
-      diff = finding.diff || '';
-      reason = finding.staleReason || 'marked stale when the change was observed';
+      diff = record.diff || '';
+      reason = record.staleReason || 'marked stale when the change was observed';
     }
 
     if (stale && !diff) {
@@ -681,13 +727,19 @@ export function serve(graph, findings) {
     }
 
     served.push({
-      ...finding,
+      ...record,
       stale,
       ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
+      // BOTH OTHER DISCLOSURES SURVIVE A MID-SERVE CLEAR. `dispute` was computed
+      // above the content-dependence branch and is applied here untouched, and
+      // the derivation verdict is recomputed from the record -- which still
+      // carries its `derivation`, since clearing removes only the staleness
+      // fields. A finding whose flag was just cleared is still disclosed as
+      // disputed, and still reports whether its derivation holds.
       ...dispute,
       // Independent of `stale` above: see `derivationCheck`'s own comment for
       // the case it catches that node-level staleness can miss.
-      ...derivationCheck(graph, finding),
+      ...derivationCheck(graph, record),
     });
   }
   return served;
@@ -939,8 +991,21 @@ function anchorHashNow(anchor) {
  * Exposing it to a hook, a tool argument or an HTTP action would be a way to
  * turn a stale finding fresh on request, which is exactly what must not exist.
  */
-export function clearStale(dir, key) {
-  const node = load(dir).nodes.get(nodeId('finding', key));
+export function clearStale(dir, key, { graph = null } = {}) {
+  // A CALLER THAT ALREADY HOLDS THE GRAPH PASSES IT, and this is not
+  // micro-optimisation: `load` re-parses the entire append-only log, so clearing
+  // inside `serve`'s loop re-read and re-folded the whole graph once PER cleared
+  // finding. Measured on 40 findings all stale and all revertible -- the shape a
+  // mass revert produces -- that was 185 ms against 25 ms, a 7x regression on
+  // the injection path, all of it graph loading rather than the hashing this
+  // feature is actually for. With the graph passed through it is back in line.
+  //
+  // No new race: this store is last-write-wins with no compare-and-set anywhere,
+  // and every other caller that spreads a node back -- `pin`, `retire`,
+  // `contradict`, `correct` -- writes from a graph it loaded earlier too. Both
+  // callers here already DECIDED on this snapshot, so re-reading it purely for
+  // the write narrowed no window that was ever closed.
+  const node = (graph || load(dir)).nodes.get(nodeId('finding', key));
   if (!node || node.kind !== 'finding') return false;
   const { stale, staleReason, diff, staleEvidence, ...rest } = node;
   // Nothing to clear is a success, not a write: an unconditional putNode here
@@ -989,14 +1054,33 @@ export function clearStale(dir, key) {
  * silently un-mark findings nobody asked about. Staleness is disclosed to a
  * reader who then decides; clearing is an explicit act.
  */
-export function reverify(dir, key) {
-  const graph = load(dir);
-  const finding = graph.nodes.get(nodeId('finding', key));
-  if (!finding || finding.kind !== 'finding') return 'unknown';
-  // Idempotent: the postcondition -- no stale flag on this finding -- already
-  // holds, and reporting anything else would make a caller retry forever.
-  if (!finding.stale) return 'cleared';
-
+/**
+ * THE ONE EVIDENCE TEST. Does this finding's anchored content still hash to what
+ * the claim was actually made against?
+ *
+ * `'match'` -- every anchor on disk re-hashes to the value frozen into this
+ * finding's own `derivation.anchors` at claim time. The content IS what the
+ * claim was derived from: a revert, or a write that never moved the anchored
+ * bytes.
+ * `'differs'` -- at least one anchor does not, INCLUDING an anchor whose content
+ * is gone. Deleted is a difference, not a missing measurement.
+ * `'unknown'` -- there is nothing to compare: no `derivation.anchors`, no
+ * anchors, an anchor with no recorded hash, or one that no longer resolves.
+ *
+ * SHARED BY BOTH CLEARING PATHS ON PURPOSE, and that sharing is the guarantee
+ * rather than a convenience. `reverify` (a person pressing Re-verify) and
+ * `serve` (automatic, on every retrieval) call THIS function and nothing else,
+ * so the automatic path cannot clear anything the button would not, and neither
+ * can drift from the other. Two copies of this comparison would be two policies,
+ * and the weaker one would win wherever it ran more often -- which is the
+ * automatic one.
+ *
+ * NOT `checkAnchor`, for the reason `anchorHashNow` above spells out: that
+ * compares disk against the anchor NODE's stored hash, which both eager paths
+ * re-point at the very bytes that caused the mark, so it answers "fresh" for
+ * exactly the finding it just marked stale.
+ */
+function claimTimeVerdict(graph, finding) {
   const recorded = finding.derivation && finding.derivation.anchors;
   if (!recorded || typeof recorded !== 'object') return 'unknown';
 
@@ -1019,10 +1103,23 @@ export function reverify(dir, key) {
     if (node.kind !== 'file' && node.kind !== 'symbol') return 'unknown';
     // null means the content is gone -- deleted file, vanished symbol. That is a
     // difference, not an absence of evidence.
-    if (anchorHashNow(node) !== expected) return 'still-stale';
+    if (anchorHashNow(node) !== expected) return 'differs';
   }
+  return 'match';
+}
 
-  clearStale(dir, key);
+export function reverify(dir, key) {
+  const graph = load(dir);
+  const finding = graph.nodes.get(nodeId('finding', key));
+  if (!finding || finding.kind !== 'finding') return 'unknown';
+  // Idempotent: the postcondition -- no stale flag on this finding -- already
+  // holds, and reporting anything else would make a caller retry forever.
+  if (!finding.stale) return 'cleared';
+
+  const verdict = claimTimeVerdict(graph, finding);
+  if (verdict === 'unknown') return 'unknown';
+  if (verdict === 'differs') return 'still-stale';
+  clearStale(dir, key, { graph });
   return 'cleared';
 }
 

--- a/integrations/codex/hooks/lib/staleness.mjs
+++ b/integrations/codex/hooks/lib/staleness.mjs
@@ -53,7 +53,7 @@
 import { readFileSync, statSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { dirname, join } from 'node:path';
-import { putNode, putEdge, contentHash, nodeId } from './wiki.mjs';
+import { putNode, putEdge, contentHash, nodeId, load } from './wiki.mjs';
 import { hasOutstandingContradiction } from './curate.mjs';
 import { extractSymbols, spanText, symbolKey, extractImports } from './symbols.mjs';
 import { canonicalPath, resolvableCandidates, isFsSafePath } from './paths.mjs';
@@ -488,7 +488,16 @@ function disputeOf(graph, finding) {
     // An edge end that resolves to nothing names nothing. The dispute is still
     // disclosed -- the gate above already established it -- but without a key
     // the reader cannot be pointed anywhere, and inventing one would be worse.
-    if (other && typeof other.key === 'string' && !keys.includes(other.key)) keys.push(other.key);
+    //
+    // A RETIRED END IS NOT NAMED EITHER, for a sharper reason: the disclosure
+    // tells the reader to `wiki_query` that key, and `serve` refuses to return
+    // a retired finding at all. Naming it points them at a claim they cannot
+    // fetch. `hasOutstandingContradiction` above already declines to open the
+    // gate when EVERY disputant is retired; this is the same rule applied to
+    // each name, so a live disputant is still reported alongside a withdrawn one.
+    if (other && !other.retired && typeof other.key === 'string' && !keys.includes(other.key)) {
+      keys.push(other.key);
+    }
   }
 
   return { contradicted: true, ...(keys.length ? { contradictedBy: keys.join(', ') } : {}) };
@@ -870,6 +879,151 @@ export function invalidateChangedAnchors(dir, graph, rawPath) {
   // retrieval re-reports a change that has already been accounted for.
   if (source !== null) indexFile(dir, path, source);
   return marked;
+}
+
+/**
+ * The current content hash of an anchor, read from disk.
+ *
+ * DELIBERATELY NOT `checkAnchor`, and the difference is the whole of this
+ * clearing rule. `checkAnchor` compares disk against the anchor NODE's stored
+ * hash, and both eager paths call `indexFile` immediately after marking --
+ * which re-points that hash at the very bytes that caused the mark. So
+ * `checkAnchor` answers "fresh" for exactly the finding it just marked stale,
+ * and a clearing rule built on it would clear every flag it was handed,
+ * unconditionally. This returns a bare hash instead, so the caller can compare
+ * it against the FROZEN claim-time hash rather than against a value the marking
+ * path itself moved.
+ *
+ * Returns null when no content can be read at all -- a deleted file, or a
+ * symbol that no longer exists. A caller must treat that as "changed", never as
+ * "unknown": a claim about content that is gone certainly does not match the
+ * content it was made against.
+ */
+function anchorHashNow(anchor) {
+  const path = anchor.kind === 'symbol' ? anchor.file : anchor.key;
+  let source;
+  try {
+    source = readAnySpelling(path);
+  } catch {
+    return null;
+  }
+  if (anchor.kind !== 'symbol') return hash(source);
+
+  // By NAME, like checkAnchor: line numbers shift whenever anything above is
+  // edited, and re-locating by line would report a symbol as moved when only an
+  // unrelated insert happened above it.
+  const current = extractSymbols(path, source).find((s) => s.name === anchor.name);
+  if (!current) return null;
+  return hash(spanText(source, current));
+}
+
+/**
+ * Removes the staleness fields from a finding. Returns whether one was found.
+ *
+ * THE WHOLE NODE IS REWRITTEN, because `putNode` does not merge: it writes a
+ * full record from what it is handed and `load` replaces the node wholesale.
+ * Writing `{ kind, key, stale: false }` would blank the claim, the confidence
+ * and the provenance -- an overwrite by another name, and the same trap
+ * `contradict` documents. So the fields are destructured AWAY and everything
+ * else is spread back: no deletion primitive is needed, and the append-only rule
+ * is respected.
+ *
+ * `staleEvidence` is stripped as well, even though no writer stores it. It is
+ * added by `serve` to the object it hands out, so anything that ever writes a
+ * served finding back would carry it in -- at which point a cleared finding
+ * would still be advertising the quality of the evidence for a flag it no longer
+ * has.
+ *
+ * A PRIMITIVE, NOT A ROUTE. Nothing outside this module calls it: the only
+ * shipping caller is `reverify` below, which establishes the evidence first.
+ * Exposing it to a hook, a tool argument or an HTTP action would be a way to
+ * turn a stale finding fresh on request, which is exactly what must not exist.
+ */
+export function clearStale(dir, key) {
+  const node = load(dir).nodes.get(nodeId('finding', key));
+  if (!node || node.kind !== 'finding') return false;
+  const { stale, staleReason, diff, staleEvidence, ...rest } = node;
+  // Nothing to clear is a success, not a write: an unconditional putNode here
+  // would append a duplicate record to the log on every no-op call.
+  if (stale === undefined && staleReason === undefined
+    && diff === undefined && staleEvidence === undefined) return true;
+  putNode(dir, { ...rest, kind: 'finding', key: node.key });
+  return true;
+}
+
+/**
+ * Clears a stale flag when, and only when, the evidence for it is gone.
+ *
+ * WHY THIS HAS TO EXIST. Nothing in this codebase ever cleared a `stale` flag.
+ * That was harmless while eager invalidation was dead code; it fires now, so
+ * every finding on an edited file becomes permanently stale -- and permanently
+ * discounted, since `disclose.mjs` skips a stale finding outright and
+ * `utility.mjs` penalises one by 160. The graph degrades toward all-stale, and
+ * the eager path is over-eager on top of that: `invalidateOnWrite` marks every
+ * finding anchored to a FILE node on any observed write to that file, whether or
+ * not the bytes moved.
+ *
+ * WHAT COUNTS AS EVIDENCE, AND WHY IT IS NOT NEGOTIABLE. The only trustworthy
+ * record of what a claim was made against is `derivation.anchors` -- the hash
+ * each anchor carried at the moment the finding was written, frozen into the
+ * finding itself by `harvest-write.mjs`. Disk is re-hashed here and compared
+ * against that. If every anchor matches, the content IS what the claim was
+ * derived from: a revert, or a write that never moved the anchored bytes. The
+ * flag comes off. Anything else leaves it exactly as it was.
+ *
+ * IT IS NOT A LAUNDERING ROUTE, and that is a property of the comparison rather
+ * than of who is allowed to call it. A caller cannot make a finding fresh by
+ * asking; they can only make it fresh by putting the content back. There is no
+ * argument, no force flag and no second path -- and `clearStale` above, the one
+ * function that clears without checking, has no caller but this one.
+ *
+ * NO RECORD MEANS UNKNOWN, NEVER CLEAR. A finding with no `derivation.anchors`
+ * -- every one written before that record existed, and every hand-curated one --
+ * has nothing to compare disk against. That is an absence of evidence, and
+ * resolving it to "clear it" would hand back the laundering route through the
+ * side door. It reports `unknown` and changes nothing; re-recording the claim
+ * against the current code (`curate.correct`) is the way forward for those.
+ *
+ * DELIBERATELY NOT AUTOMATIC. This reads every anchor off disk, so running it on
+ * the serve path would put N file reads inside injection -- and, worse, it would
+ * silently un-mark findings nobody asked about. Staleness is disclosed to a
+ * reader who then decides; clearing is an explicit act.
+ */
+export function reverify(dir, key) {
+  const graph = load(dir);
+  const finding = graph.nodes.get(nodeId('finding', key));
+  if (!finding || finding.kind !== 'finding') return 'unknown';
+  // Idempotent: the postcondition -- no stale flag on this finding -- already
+  // holds, and reporting anything else would make a caller retry forever.
+  if (!finding.stale) return 'cleared';
+
+  const recorded = finding.derivation && finding.derivation.anchors;
+  if (!recorded || typeof recorded !== 'object') return 'unknown';
+
+  const anchorIds = new Set(
+    graph.edges
+      .filter((e) => e.edge === 'derived_from' && e.from === finding.id)
+      .map((e) => e.to)
+  );
+  // An unanchored finding cannot be checked against anything, which is the
+  // un-invalidatable shape the anchor discipline exists to refuse. It is equally
+  // un-VERIFIABLE, so it is reported as such rather than cleared.
+  if (!anchorIds.size) return 'unknown';
+
+  for (const id of anchorIds) {
+    const expected = recorded[id];
+    const node = graph.nodes.get(id);
+    // An anchor this finding never recorded a hash for, or one that no longer
+    // resolves to a node: nothing to compare, so nothing is concluded.
+    if (typeof expected !== 'string' || !expected || !node) return 'unknown';
+    if (node.kind !== 'file' && node.kind !== 'symbol') return 'unknown';
+    // null means the content is gone -- deleted file, vanished symbol. That is a
+    // difference, not an absence of evidence.
+    if (anchorHashNow(node) !== expected) return 'still-stale';
+  }
+
+  clearStale(dir, key);
+  return 'cleared';
 }
 
 export { contentHash };

--- a/integrations/codex/hooks/lib/staleness.mjs
+++ b/integrations/codex/hooks/lib/staleness.mjs
@@ -368,6 +368,12 @@ const DIFF_MAX_BYTES = () => {
  * line, and total bytes. Every truncation is announced in the output, because a
  * silently shortened diff is worse than a visibly shortened one -- a reader who
  * cannot tell content was elided believes they saw the whole change.
+ *
+ * `maxLines` BOUNDS THE BODY, MARKERS INCLUDED: at most `maxLines` lines of
+ * removed lines, added lines and "... N more" elision markers between them, plus
+ * at most one final notice when the byte cap dropped lines -- so `maxLines + 1`
+ * lines in total, and no more. That last line is outside the budget on purpose,
+ * for the reason stated where it is pushed.
  */
 export function diffLines(
   before,
@@ -418,10 +424,24 @@ export function diffLines(
     bytes += size;
   };
 
-  for (const line of removed.slice(0, maxLines / 2)) push('- ' + line);
-  if (removed.length > maxLines / 2) push(`  ... ${removed.length - maxLines / 2} more removed`);
-  for (const line of added.slice(0, maxLines / 2)) push('+ ' + line);
-  if (added.length > maxLines / 2) push(`  ... ${added.length - maxLines / 2} more added`);
+  // THE ELISION MARKER IS PAID FOR OUT OF THE SIDE'S OWN QUOTA, so `maxLines`
+  // bounds the whole body rather than only the content in it. It did not: at the
+  // default 40 the body could reach 42 lines -- 20 removed, 20 added and two
+  // "... N more" markers -- and the out-of-budget notice below made 43, against
+  // a documented bound of 40 and a test asserting 41. Three numbers, no two the
+  // same. A side that has to elide now shows one fewer content line and spends
+  // that line on saying so, which is the trade a reader wants anyway: knowing
+  // that 300 lines were cut matters more than the 20th of the 20 shown.
+  const half = Math.floor(maxLines / 2);
+  const emit = (lines, prefix, label) => {
+    const elides = lines.length > half;
+    const shown = elides ? Math.max(0, half - 1) : half;
+    for (const line of lines.slice(0, shown)) push(prefix + line);
+    if (elides) push(`  ... ${lines.length - shown} more ${label}`);
+  };
+
+  emit(removed, '- ', 'removed');
+  emit(added, '+ ', 'added');
 
   // Announced OUTSIDE the budget, deliberately: the one line a reader most
   // needs is the one saying the rest is missing, and dropping it to stay under
@@ -479,6 +499,15 @@ function disputeOf(graph, finding) {
   if (!hasOutstandingContradiction(graph, finding.key)) return {};
 
   const keys = [];
+  // AND THE REASON A PERSON TYPED, which had no reader anywhere. `contradict`
+  // stores `contradictionReason` -- up to 400 characters of human explanation --
+  // on the CONTRADICTED end only, and nothing outside its own test ever read it:
+  // this disclosure named the other key and stopped, `audit` counts ends, and the
+  // dashboard detail view renders neither. So the one field on the edge that says
+  // WHY was written on every contradiction and seen by nobody. It is collected
+  // from whichever end holds it, so both sides of a dispute disclose the same
+  // reason rather than only the claim that lost.
+  let reason = typeof finding.contradictionReason === 'string' ? finding.contradictionReason : '';
   for (const edge of graph.edges) {
     if (edge.edge !== 'contradicts') continue;
     const otherId =
@@ -497,10 +526,30 @@ function disputeOf(graph, finding) {
     // each name, so a live disputant is still reported alongside a withdrawn one.
     if (other && !other.retired && typeof other.key === 'string' && !keys.includes(other.key)) {
       keys.push(other.key);
+      // A RETIRED END'S REASON IS NOT BORROWED EITHER, which is why this sits
+      // inside the same guard as the key: `hasOutstandingContradiction` can be
+      // open on one live disputant while another is withdrawn, and quoting the
+      // withdrawn one's explanation would attribute the live dispute to a claim
+      // the reader cannot fetch.
+      if (!reason && typeof other.contradictionReason === 'string') {
+        reason = other.contradictionReason;
+      }
     }
   }
 
-  return { contradicted: true, ...(keys.length ? { contradictedBy: keys.join(', ') } : {}) };
+  return {
+    contradicted: true,
+    ...(keys.length ? { contradictedBy: keys.join(', ') } : {}),
+    // Trimmed here rather than at the renderer: an empty string is not a reason,
+    // and a consumer checking `if (reason)` should not have to trim first.
+    //
+    // SET UNCONDITIONALLY, INCLUDING TO `undefined`. `serve` spreads the stored
+    // record before this object, so omitting the key would let a whitespace-only
+    // stored reason through untouched and make the served value differ from the
+    // one this function decided on. The disclosure is authoritative or it is not
+    // a disclosure.
+    contradictionReason: reason.trim() || undefined,
+  };
 }
 
 /**
@@ -580,8 +629,15 @@ function derivationCheck(graph, finding) {
  * the dashboard, which left the rot path fully open on every install where
  * nobody opens the dashboard -- and that is most of them. The evidence test is
  * what makes clearing safe, and it does not care who triggered it: the same
- * `claimTimeVerdict` runs here as in `reverify`, so this cannot clear anything
+ * `claimTimeEvidence` runs here as in `reverify`, so this cannot clear anything
  * the button would not.
+ *
+ * A CLEAR ALSO RE-INDEXES THE ANCHORS IT VERIFIED. The three disclosures this
+ * function emits -- `stale`, `derivationHolds`, and the dispute -- are computed
+ * from three different comparisons, and clearing the flag without moving the
+ * anchor's stored hash made the first two contradict the clear on the revert
+ * path. `reindexVerifiedAnchors` explains the reproduction and why re-pointing
+ * the index is the fix rather than suppressing the disclosures.
  *
  * `dir` IS OPTIONAL, AND OMITTING IT MAKES THIS READ-ONLY. Several callers hold
  * a graph without the directory it came from, and a serve that silently did
@@ -617,11 +673,17 @@ export function serve(graph, findings, { dir = null } = {}) {
 
     // AUTOMATIC CLEARING, on the same evidence the manual path demands.
     //
-    // ONLY THE STORED FLAG IS TOUCHED. The lazy loop below is left to run
-    // exactly as before and can independently mark this finding stale again on
-    // its own comparison -- disk against the anchor NODE's hash -- which answers
-    // a different question and is not this function's to overrule. Eager and
-    // lazy stay two mechanisms, as the module header insists.
+    // THE FLAG AND THE INDEX MOVE TOGETHER. Clearing the flag alone made this
+    // function contradict itself on the revert path: the lazy loop below
+    // compares disk against the anchor NODE's hash, which the eager path
+    // re-pointed at the post-edit bytes, so a reverted file read as `stale:
+    // true, staleReason: 'file changed'` and `derivationHolds: false` inside the
+    // very object whose flag had just been cleared for matching its claim-time
+    // content. `reindexVerifiedAnchors` writes the verified bytes' hash back to
+    // the anchor, so all three disclosures are finally reading the same content
+    // and cannot disagree. Eager and lazy stay two mechanisms, as the module
+    // header insists -- what changed is that the index no longer holds a hash
+    // that matches no version of the file that exists.
     //
     // AND THE FIELDS GO WITH THE FLAG. `putNode` does not merge and neither does
     // this spread: serving `{ ...finding, stale: false }` would hand back a
@@ -630,12 +692,37 @@ export function serve(graph, findings, { dir = null } = {}) {
     // So the cleared record, not the stored one, is what the rest of this
     // iteration reads and spreads.
     //
-    // BOUNDED, and the bound is the point: this runs only for a finding whose
-    // flag is already STORED, only when a `derivation` record exists to check
-    // against, and it reads each of that finding's anchors at most once. A
-    // finding that is not flagged pays nothing. The lazy loop below already
+    // BOUNDED PER CALL, and the bound is the point: this runs only for a finding
+    // whose flag is already STORED, only when a `derivation` record exists to
+    // check against, and it reads each of that finding's anchors at most once.
+    // A finding that is not flagged pays nothing. The lazy loop below already
     // reads every anchor of every content-dependent finding served, so the worst
     // case is twice the anchor reads on the already-stale subset alone.
+    //
+    // AND THE PER-SESSION SHAPE, stated because the per-call bound alone reads
+    // as cheaper than it is. Measured on a synthetic 40-stale-finding graph, the
+    // serve path went 158 ms -> 217 ms (+37%), and for a GENUINELY stale finding
+    // that cost recurs on every call for the whole session: the verdict is
+    // `'differs'` forever, nothing is cleared, and the reads are repaid with
+    // nothing. What keeps it survivable in practice is not this bound but two
+    // others -- `findingsFor`'s result limit and inject.mjs's `alreadyInjected`
+    // gate, which together put it near 40 ms on the first touch of a hot file
+    // and zero on the touches after.
+    //
+    // THE REVERT CASE PAYS ONCE, AND THAT IS MEASURED, not argued. Same 40
+    // findings, all revertible, medians of 9 across three process launches: the
+    // read-only serve is 23-29 ms, the first clearing serve is 141-173 ms (the
+    // anchor reads plus one node append per cleared finding AND per re-pointed
+    // anchor), and the SECOND clearing serve is 21-28 ms -- back to the
+    // read-only baseline, because the flag is off and the index agrees, so this
+    // gate no longer fires. What the re-index changed is not that cost -- the
+    // gate stopped firing once the flag came off before, too -- but that every
+    // serve after the clear used to re-derive `stale: true` and
+    // `derivationHolds: false` from an index nobody had moved. The extra ~120 ms
+    // buys silence that is actually correct.
+    // On the genuinely-stale set the recurring cost is
+    // real and unchanged in kind: 26-45 ms read-only against 53-105 ms with
+    // clearing on, every call, clearing nothing.
     //
     // NOT ON THE NON-CONTENT-DEPENDENT EARLY RETURN ABOVE, deliberately. Both
     // eager paths refuse to flag those types at all, so a flag there can only
@@ -643,10 +730,14 @@ export function serve(graph, findings, { dir = null } = {}) {
     // does not depend on them is exactly the cost `CONTENT_DEPENDENT` exists to
     // avoid.
     let record = finding;
-    if (dir && finding.stale && claimTimeVerdict(graph, finding) === 'match') {
-      clearStale(dir, finding.key, { graph });
-      const { stale: _s, staleReason: _r, diff: _d, staleEvidence: _e, ...cleared } = finding;
-      record = cleared;
+    if (dir && finding.stale) {
+      const evidence = claimTimeEvidence(graph, finding);
+      if (evidence.verdict === 'match') {
+        reindexVerifiedAnchors(dir, graph, evidence.contents);
+        clearStale(dir, finding.key, { graph });
+        const { stale: _s, staleReason: _r, diff: _d, staleEvidence: _e, ...cleared } = finding;
+        record = cleared;
+      }
     }
 
     const anchors = graph.edges
@@ -736,6 +827,14 @@ export function serve(graph, findings, { dir = null } = {}) {
       // carries its `derivation`, since clearing removes only the staleness
       // fields. A finding whose flag was just cleared is still disclosed as
       // disputed, and still reports whether its derivation holds.
+      //
+      // AND THEY NO LONGER CONTRADICT THE CLEAR. Surviving is not the same as
+      // agreeing: for a whole serve this returned `stale: true, staleReason:
+      // 'file changed'` and `derivationHolds: false` on a finding it had just
+      // cleared, because the clear was decided against disk while these two read
+      // the anchor node's hash, and the eager path had moved it. All three now
+      // read the same content because the clear re-points the anchor; see
+      // `reindexVerifiedAnchors`.
       ...dispute,
       // Independent of `stale` above: see `derivationCheck`'s own comment for
       // the case it catches that node-level staleness can miss.
@@ -934,6 +1033,34 @@ export function invalidateChangedAnchors(dir, graph, rawPath) {
 }
 
 /**
+ * The current content of an anchor, read from disk: the whole file for a file
+ * anchor, the located span for a symbol one. Null when nothing can be read.
+ *
+ * SPLIT OUT FROM `anchorHashNow` SO THE BYTES SURVIVE THE COMPARISON. The
+ * clearing path hashes this to reach a verdict and, on `'match'`, re-indexes the
+ * anchor from the same bytes -- see `reindexVerifiedAnchors`. Returning only a
+ * hash forced a second read of a file that had just been read, for content
+ * already known to be identical.
+ */
+function anchorContentNow(anchor) {
+  const path = anchor.kind === 'symbol' ? anchor.file : anchor.key;
+  let source;
+  try {
+    source = readAnySpelling(path);
+  } catch {
+    return null;
+  }
+  if (anchor.kind !== 'symbol') return source;
+
+  // By NAME, like checkAnchor: line numbers shift whenever anything above is
+  // edited, and re-locating by line would report a symbol as moved when only an
+  // unrelated insert happened above it.
+  const current = extractSymbols(path, source).find((s) => s.name === anchor.name);
+  if (!current) return null;
+  return spanText(source, current);
+}
+
+/**
  * The current content hash of an anchor, read from disk.
  *
  * DELIBERATELY NOT `checkAnchor`, and the difference is the whole of this
@@ -952,21 +1079,8 @@ export function invalidateChangedAnchors(dir, graph, rawPath) {
  * content it was made against.
  */
 function anchorHashNow(anchor) {
-  const path = anchor.kind === 'symbol' ? anchor.file : anchor.key;
-  let source;
-  try {
-    source = readAnySpelling(path);
-  } catch {
-    return null;
-  }
-  if (anchor.kind !== 'symbol') return hash(source);
-
-  // By NAME, like checkAnchor: line numbers shift whenever anything above is
-  // edited, and re-locating by line would report a symbol as moved when only an
-  // unrelated insert happened above it.
-  const current = extractSymbols(path, source).find((s) => s.name === anchor.name);
-  if (!current) return null;
-  return hash(spanText(source, current));
+  const content = anchorContentNow(anchor);
+  return content === null ? null : hash(content);
 }
 
 /**
@@ -1005,21 +1119,51 @@ export function clearStale(dir, key, { graph = null } = {}) {
   // `contradict`, `correct` -- writes from a graph it loaded earlier too. Both
   // callers here already DECIDED on this snapshot, so re-reading it purely for
   // the write narrowed no window that was ever closed.
-  const node = (graph || load(dir)).nodes.get(nodeId('finding', key));
+  const id = nodeId('finding', key);
+  const node = (graph || load(dir)).nodes.get(id);
   if (!node || node.kind !== 'finding') return false;
   const { stale, staleReason, diff, staleEvidence, ...rest } = node;
   // Nothing to clear is a success, not a write: an unconditional putNode here
   // would append a duplicate record to the log on every no-op call.
   if (stale === undefined && staleReason === undefined
     && diff === undefined && staleEvidence === undefined) return true;
-  putNode(dir, { ...rest, kind: 'finding', key: node.key });
+  const cleared = { ...rest, kind: 'finding', key: node.key };
+  putNode(dir, cleared);
+  // AND THE CALLER'S GRAPH IS UPDATED, because the guard above reads THAT graph,
+  // not disk. Without this, a second `serve` on the same in-memory graph object
+  // -- two touched files anchored to one finding, or a lifecycle branch that
+  // serves twice from a graph it loaded once, as SessionStart does -- still saw
+  // `stale: true`, re-ran the evidence test, and appended a byte-identical clear
+  // record. The store is append-only, so that is permanent log growth for no
+  // change in state, and the "nothing to clear is a success, not a write"
+  // guarantee directly above was only true of the first call.
+  if (graph) graph.nodes.set(id, { ...cleared, id });
   return true;
 }
 
 /**
- * Clears a stale flag when, and only when, the evidence for it is gone.
+ * THE ONE EVIDENCE TEST, plus the bytes it read. Does this finding's anchored
+ * content still hash to what the claim was actually made against?
  *
- * WHY THIS HAS TO EXIST. Nothing in this codebase ever cleared a `stale` flag.
+ * `verdict` is one of:
+ *   `'match'`   -- every anchor on disk re-hashes to the value frozen into this
+ *                  finding's own `derivation.anchors` at claim time. The content
+ *                  IS what the claim was derived from: a revert, or a write that
+ *                  never moved the anchored bytes.
+ *   `'differs'` -- at least one anchor does not, INCLUDING an anchor whose
+ *                  content is gone. Deleted is a difference, not a missing
+ *                  measurement.
+ *   `'unknown'` -- there is nothing to compare: no `derivation.anchors`, no
+ *                  anchors, an anchor with no recorded hash, or one that no
+ *                  longer resolves.
+ *
+ * `contents` carries the disk bytes read to reach a `'match'`, keyed by anchor
+ * id, so the caller can re-index those anchors without reading them again. It is
+ * empty for the other two verdicts, which read no further than the first
+ * disagreement.
+ *
+ * WHY CLEARING HAS TO EXIST AT ALL. Nothing in this codebase ever cleared a
+ * `stale` flag.
  * That was harmless while eager invalidation was dead code; it fires now, so
  * every finding on an edited file becomes permanently stale -- and permanently
  * discounted, since `disclose.mjs` skips a stale finding outright and
@@ -1049,24 +1193,6 @@ export function clearStale(dir, key, { graph = null } = {}) {
  * side door. It reports `unknown` and changes nothing; re-recording the claim
  * against the current code (`curate.correct`) is the way forward for those.
  *
- * DELIBERATELY NOT AUTOMATIC. This reads every anchor off disk, so running it on
- * the serve path would put N file reads inside injection -- and, worse, it would
- * silently un-mark findings nobody asked about. Staleness is disclosed to a
- * reader who then decides; clearing is an explicit act.
- */
-/**
- * THE ONE EVIDENCE TEST. Does this finding's anchored content still hash to what
- * the claim was actually made against?
- *
- * `'match'` -- every anchor on disk re-hashes to the value frozen into this
- * finding's own `derivation.anchors` at claim time. The content IS what the
- * claim was derived from: a revert, or a write that never moved the anchored
- * bytes.
- * `'differs'` -- at least one anchor does not, INCLUDING an anchor whose content
- * is gone. Deleted is a difference, not a missing measurement.
- * `'unknown'` -- there is nothing to compare: no `derivation.anchors`, no
- * anchors, an anchor with no recorded hash, or one that no longer resolves.
- *
  * SHARED BY BOTH CLEARING PATHS ON PURPOSE, and that sharing is the guarantee
  * rather than a convenience. `reverify` (a person pressing Re-verify) and
  * `serve` (automatic, on every retrieval) call THIS function and nothing else,
@@ -1080,9 +1206,10 @@ export function clearStale(dir, key, { graph = null } = {}) {
  * re-point at the very bytes that caused the mark, so it answers "fresh" for
  * exactly the finding it just marked stale.
  */
-function claimTimeVerdict(graph, finding) {
+function claimTimeEvidence(graph, finding) {
+  const none = { verdict: 'unknown', contents: new Map() };
   const recorded = finding.derivation && finding.derivation.anchors;
-  if (!recorded || typeof recorded !== 'object') return 'unknown';
+  if (!recorded || typeof recorded !== 'object') return none;
 
   const anchorIds = new Set(
     graph.edges
@@ -1092,22 +1219,122 @@ function claimTimeVerdict(graph, finding) {
   // An unanchored finding cannot be checked against anything, which is the
   // un-invalidatable shape the anchor discipline exists to refuse. It is equally
   // un-VERIFIABLE, so it is reported as such rather than cleared.
-  if (!anchorIds.size) return 'unknown';
+  if (!anchorIds.size) return none;
 
+  const contents = new Map();
   for (const id of anchorIds) {
     const expected = recorded[id];
     const node = graph.nodes.get(id);
     // An anchor this finding never recorded a hash for, or one that no longer
     // resolves to a node: nothing to compare, so nothing is concluded.
-    if (typeof expected !== 'string' || !expected || !node) return 'unknown';
-    if (node.kind !== 'file' && node.kind !== 'symbol') return 'unknown';
+    if (typeof expected !== 'string' || !expected || !node) return none;
+    if (node.kind !== 'file' && node.kind !== 'symbol') return none;
     // null means the content is gone -- deleted file, vanished symbol. That is a
     // difference, not an absence of evidence.
-    if (anchorHashNow(node) !== expected) return 'differs';
+    const content = anchorContentNow(node);
+    if (content === null || hash(content) !== expected) {
+      return { verdict: 'differs', contents: new Map() };
+    }
+    contents.set(id, content);
   }
-  return 'match';
+  return { verdict: 'match', contents };
 }
 
+/** The verdict alone, for callers that do not re-index. */
+function claimTimeVerdict(graph, finding) {
+  return claimTimeEvidence(graph, finding).verdict;
+}
+
+/**
+ * Re-points every verified anchor at the content the evidence test just read.
+ *
+ * WHY A CLEAR IS NOT ENOUGH ON ITS OWN, reproduced end to end: index a file at
+ * H1, write a finding whose `derivation.anchors` records H1, edit and re-index so
+ * the node holds H2, let the eager path mark the finding, then REVERT the edit on
+ * disk. `claimTimeVerdict` now says `'match'` -- disk is H1, which is exactly
+ * what the claim was derived from -- and the flag comes off. But the node still
+ * holds H2, so the same `serve` call went on to emit `stale: true` with
+ * `staleReason: 'file changed'` from the lazy loop (disk H1 against node H2) and
+ * `derivationHolds: false` from `derivationCheck` (index H2 against claim H1).
+ * The model was shown DERIVATION CHANGED and STALE at the exact moment this
+ * module's own evidence test had concluded the derivation holds -- on every
+ * serve, until something unrelated happened to re-index the anchor.
+ *
+ * THE FIX IS TO MOVE THE INDEX, NOT TO SILENCE THE DISCLOSURES. Suppressing the
+ * lazy check and the derivation verdict for a cleared finding would leave the
+ * graph holding a hash that matches no version of the file that exists, so every
+ * OTHER finding on that anchor keeps reading stale, and the next reader has to be
+ * told which disclosures to disbelieve. The node hash is simply out of date, the
+ * bytes are already in hand from the comparison that just succeeded, and writing
+ * them makes all three disclosures agree because they are finally reading the
+ * same content.
+ *
+ * COSTS NO READ. `contents` comes from `claimTimeEvidence`, which read each
+ * anchor to reach `'match'`. The write is one node record per anchor whose hash
+ * actually moved, and it happens once per revert rather than once per serve: with
+ * the index re-pointed, the flag stays off and the gate in `serve` does not fire
+ * again.
+ *
+ * THE IN-MEMORY GRAPH IS UPDATED TOO, because the caller is mid-serve and is
+ * about to read these same nodes through the lazy loop and `derivationCheck`.
+ * Writing only to disk would fix the next process and leave this one contradicting
+ * itself, which is the whole defect.
+ *
+ * Line numbers are deliberately left alone on a symbol anchor: `checkAnchor` and
+ * `anchorContentNow` both re-locate by NAME, so a stored line is informational,
+ * and the body being byte-identical is what was just established.
+ */
+function reindexVerifiedAnchors(dir, graph, contents) {
+  for (const [id, content] of contents) {
+    const node = graph.nodes.get(id);
+    if (!node) continue;
+    const nextHash = hash(content);
+    // Already agrees: no record, no write. The common case once a revert has
+    // been accounted for.
+    if (node.hash === nextHash) continue;
+    const limit = node.kind === 'symbol' ? symbolSnapshotLimit() : snapshotLimit();
+    // Same bound as `indexFile`: past the cap the hash still drives staleness and
+    // only the reconstructed diff degrades.
+    const snapshot = content.length <= limit ? content : undefined;
+    const { hash: _h, snapshot: _s, ...rest } = node;
+    try {
+      putNode(dir, { ...rest, kind: node.kind, key: node.key, hash: nextHash, snapshot });
+    } catch {
+      // Fail open: a graph that could not be written is a disclosure that stays
+      // as it was, never a broken tool call. The in-memory copy is left alone to
+      // match, so this serve keeps agreeing with the store.
+      continue;
+    }
+    graph.nodes.set(id, { ...node, hash: nextHash, ...(snapshot ? { snapshot } : {}) });
+  }
+}
+
+/**
+ * Clears a stale flag on behalf of a person who asked for it -- the dashboard's
+ * Re-verify action -- and reports what the evidence said.
+ *
+ * `'cleared'` when the flag is gone (including when it was already gone, so a
+ * caller polling this does not retry forever), `'still-stale'` when the anchored
+ * content genuinely differs from what the claim was made against, `'unknown'`
+ * when there is nothing to compare and therefore nothing to conclude.
+ *
+ * NO LONGER THE ONLY CLEARING PATH, and the docblock that used to sit here said
+ * the opposite: that automatic clearing was refused because it would put N file
+ * reads inside injection and "silently un-mark findings nobody asked about".
+ * `serve` now does exactly that, on the same evidence, for the reason its own
+ * comment gives -- the manual path was reachable only where somebody opens the
+ * dashboard, which is almost nowhere, so the rot path stayed open on most
+ * installs. What survives of that objection is the cost, which `serve` bounds
+ * and states.
+ *
+ * WHAT THIS STILL ADDS over the automatic path: it loads the graph itself, so a
+ * caller holding nothing but a key and a directory can act; it reports the
+ * verdict rather than folding it into a served record; and it runs on demand
+ * rather than only when the finding happens to be retrieved. It re-indexes the
+ * verified anchors for the same reason `serve` does -- otherwise the button
+ * clears the flag and the very next retrieval re-derives a contradiction from a
+ * node hash nobody moved.
+ */
 export function reverify(dir, key) {
   const graph = load(dir);
   const finding = graph.nodes.get(nodeId('finding', key));
@@ -1116,9 +1343,10 @@ export function reverify(dir, key) {
   // holds, and reporting anything else would make a caller retry forever.
   if (!finding.stale) return 'cleared';
 
-  const verdict = claimTimeVerdict(graph, finding);
+  const { verdict, contents } = claimTimeEvidence(graph, finding);
   if (verdict === 'unknown') return 'unknown';
   if (verdict === 'differs') return 'still-stale';
+  reindexVerifiedAnchors(dir, graph, contents);
   clearStale(dir, key, { graph });
   return 'cleared';
 }

--- a/integrations/codex/hooks/lib/staleness.mjs
+++ b/integrations/codex/hooks/lib/staleness.mjs
@@ -17,7 +17,13 @@
  * TWO INVALIDATION PATHS, and each covers what the other cannot see:
  *
  *   EAGER  -- our PostToolUse hook saw a write, so the finding is marked at the
- *             moment it went stale, with the exact before/after in hand.
+ *             moment it went stale, with the exact before/after in hand. The
+ *             hook does not call `invalidateOnWrite` directly: it queues the
+ *             evidence through pending.mjs, and the next graph read -- which
+ *             loads the graph anyway -- applies it before serving anything.
+ *             That path is also the only one that catches a write the SESSION
+ *             made, because the lazy check below compares the stored hash
+ *             against disk and `indexFile` has already refreshed it.
  *   LAZY   -- at retrieval, the anchor's stored hash is compared against disk.
  *             This is what catches `git pull`, another editor, a teammate, or a
  *             build step: every change our hooks never observed.
@@ -291,14 +297,69 @@ export function checkAnchor(anchor) {
 }
 
 /**
+ * Characters kept from any single diff line.
+ *
+ * A LINE CAP IS NOT A SIZE CAP, and the gap was measured: with only `maxLines`
+ * in force, `diffLines('X'.repeat(200000), 'Y'.repeat(200000))` returned 2 lines
+ * and 400,005 bytes. Minified bundles, generated sources and single-line JSON
+ * all have that shape, and this output goes STRAIGHT INTO MODEL CONTEXT from
+ * inject.mjs's zero-turn refusal -- so a line bound alone let one pathological
+ * file spend hundreds of thousands of tokens.
+ *
+ * 200 characters is chosen because it is past the width at which a line is read
+ * as a line by anybody, human or model: a hand-written source line is under
+ * ~120 columns, so the cap cannot truncate a diff a reader was going to use,
+ * while the cases it does truncate are ones where the interesting change is not
+ * legible from the raw text anyway.
+ */
+const DIFF_MAX_LINE_CHARS = () => {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_DIFF_MAX_LINE_CHARS);
+  return Number.isFinite(raw) && raw > 0 ? raw : 200;
+};
+
+/**
+ * Total UTF-8 bytes of diff body.
+ *
+ * 4,000 bytes is roughly 1,000 tokens. It is deliberately larger than the
+ * per-file injection budget (`TOKEN_OPTIMIZER_TOUCH_BUDGET`, 500 tokens) and
+ * far smaller than a file, because the two consumers want different things: the
+ * injection surface fits the diff inside its own budget and drops it if it does
+ * not fit, while the zero-turn refusal is replacing a whole file read and can
+ * afford more. One cap that neither consumer has to think about is worth more
+ * than two tuned ones.
+ *
+ * WHAT IT COSTS, PLAINLY: a legitimately large diff now arrives truncated, so a
+ * model looking at a 300-line refactor sees the head of it and a count of what
+ * was elided rather than the whole change. That is the correct direction to
+ * fail -- the alternative was a bounded-looking function that could emit 400 KB.
+ */
+const DIFF_MAX_BYTES = () => {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_DIFF_MAX_BYTES);
+  return Number.isFinite(raw) && raw > 0 ? raw : 4_000;
+};
+
+/**
  * A compact line diff.
  *
  * Deliberately not a full unified diff with hunks and context: the consumer is
  * a model deciding whether an existing conclusion still holds, and for that the
  * changed lines are the signal. Output is capped because an unbounded diff
  * injected alongside a finding would spend more tokens than re-deriving it.
+ *
+ * BOUNDED IN THREE WAYS, and each one is load-bearing: lines, characters per
+ * line, and total bytes. Every truncation is announced in the output, because a
+ * silently shortened diff is worse than a visibly shortened one -- a reader who
+ * cannot tell content was elided believes they saw the whole change.
  */
-export function diffLines(before, after, { maxLines = 40 } = {}) {
+export function diffLines(
+  before,
+  after,
+  {
+    maxLines = 40,
+    maxLineChars = DIFF_MAX_LINE_CHARS(),
+    maxBytes = DIFF_MAX_BYTES(),
+  } = {}
+) {
   const a = String(before).split('\n');
   const b = String(after).split('\n');
 
@@ -314,33 +375,44 @@ export function diffLines(before, after, { maxLines = 40 } = {}) {
   const added = b.slice(head, b.length - tail);
 
   const out = [];
-  for (const line of removed.slice(0, maxLines / 2)) out.push('- ' + line);
-  if (removed.length > maxLines / 2) out.push(`  ... ${removed.length - maxLines / 2} more removed`);
-  for (const line of added.slice(0, maxLines / 2)) out.push('+ ' + line);
-  if (added.length > maxLines / 2) out.push(`  ... ${added.length - maxLines / 2} more added`);
+  let bytes = 0;
+  let dropped = 0;
+
+  // Per line first, so ONE enormous line cannot consume the whole budget and
+  // leave every other changed line unrepresented.
+  const clamp = (line) => {
+    const text = String(line);
+    if (text.length <= maxLineChars) return text;
+    return `${text.slice(0, maxLineChars)} [+${text.length - maxLineChars} chars cut]`;
+  };
+
+  // Bytes, not characters: the cap exists to bound what is sent, and a
+  // multi-byte source file would otherwise pass a character check while
+  // emitting several times the budget.
+  const push = (line) => {
+    const text = clamp(line);
+    const size = Buffer.byteLength(text, 'utf8') + 1;
+    if (bytes + size > maxBytes) {
+      dropped++;
+      return;
+    }
+    out.push(text);
+    bytes += size;
+  };
+
+  for (const line of removed.slice(0, maxLines / 2)) push('- ' + line);
+  if (removed.length > maxLines / 2) push(`  ... ${removed.length - maxLines / 2} more removed`);
+  for (const line of added.slice(0, maxLines / 2)) push('+ ' + line);
+  if (added.length > maxLines / 2) push(`  ... ${added.length - maxLines / 2} more added`);
+
+  // Announced OUTSIDE the budget, deliberately: the one line a reader most
+  // needs is the one saying the rest is missing, and dropping it to stay under
+  // a self-imposed cap would hand back a diff that lies about being complete.
+  if (dropped) out.push(`  ... ${dropped} more changed line(s) cut at the size limit`);
 
   return out.join('\n');
 }
 
-/**
- * Prepares findings for delivery, verifying each one lazily against disk.
- *
- * This is the only function that should ever hand a finding to a model, because
- * it is the one that enforces the rule: a stale finding leaves here carrying
- * `stale: true` AND a diff, or it does not leave at all.
- */
-export function serve(graph, findings) {
-  const served = [];
-
-  // RETIRED FINDINGS STOP HERE, unconditionally.
-  //
-  // findingsFor and sessionIndex already filter them, so this is redundant on
-  // every current path -- deliberately. This function's own contract is that it
-  // is the only thing that hands a finding to a model, which makes it the right
-  // place for the guarantee to live: a future caller that reaches into the
-  // graph directly cannot accidentally serve a claim a human explicitly
-  // withdrew. A withheld claim reappearing is not a bug anyone would notice
-  // quickly.
 /**
  * Types whose truth is a claim ABOUT the anchor's contents.
  *
@@ -363,6 +435,26 @@ export function serve(graph, findings) {
  * to ignore -- taking the rare true positive with it.
  */
 const CONTENT_DEPENDENT = new Set(['finding', 'map']);
+
+/**
+ * Prepares findings for delivery, verifying each one lazily against disk.
+ *
+ * This is the only function that should ever hand a finding to a model, because
+ * it is the one that enforces the rule: a stale finding leaves here carrying
+ * `stale: true` AND a diff, or it does not leave at all.
+ */
+export function serve(graph, findings) {
+  const served = [];
+
+  // RETIRED FINDINGS STOP HERE, unconditionally.
+  //
+  // findingsFor and sessionIndex already filter them, so this is redundant on
+  // every current path -- deliberately. This function's own contract is that it
+  // is the only thing that hands a finding to a model, which makes it the right
+  // place for the guarantee to live: a future caller that reaches into the
+  // graph directly cannot accidentally serve a claim a human explicitly
+  // withdrew. A withheld claim reappearing is not a bug anyone would notice
+  // quickly.
 
   for (const finding of findings.filter((f) => !f.retired)) {
     // A claim that does not depend on the anchor's contents cannot be
@@ -505,6 +597,15 @@ export function invalidateOnWrite(dir, graph, rawPath, beforeText, afterText) {
     for (const edge of byTarget.get(node.id) || []) {
       const finding = graph.nodes.get(edge.from);
       if (!finding || finding.kind !== 'finding') continue;
+      // THE SAME TYPE GATE `serve` APPLIES, and it has to be here too now that
+      // this path actually runs. `serve` ignores a stale flag on a type whose
+      // truth is not a claim about the anchor's contents -- but the flag is
+      // STORED, and disclose.mjs skips a stale finding outright while
+      // utility.mjs penalises one by 160. So writing it onto a `failure` or a
+      // `command` would suppress that claim everywhere except the one reader
+      // that knows to ignore it, which is exactly the harm measured in the
+      // comment on CONTENT_DEPENDENT above.
+      if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) continue;
 
       putNode(dir, {
         ...finding,

--- a/integrations/codex/hooks/lib/staleness.mjs
+++ b/integrations/codex/hooks/lib/staleness.mjs
@@ -495,6 +495,54 @@ function disputeOf(graph, finding) {
 }
 
 /**
+ * Whether THIS finding's own claim-time evidence still matches its anchors --
+ * the reader `harvest-write.mjs`'s `derivation` record was written for.
+ * Nothing consumed that record until now: a grep for it found only the writer
+ * and its own tests, which made "checkable rather than merely attributed" a
+ * claim with no code behind it.
+ *
+ * DISTINCT FROM `stale`/`checkAnchor`, DELIBERATELY, not a duplicate of it.
+ * `checkAnchor` compares disk against the anchor NODE's CURRENT stored hash,
+ * which is refreshed by `indexFile` every time ANYTHING touches that file --
+ * so it answers "has this file changed since the last time anyone indexed
+ * it", not "has it changed since THIS finding was derived from it". Those
+ * differ in a real case: file F changes, and a LATER, unrelated write
+ * (another finding, another session) re-indexes F, updating the node's
+ * stored hash to match the new content again. `checkAnchor` now reports
+ * "fresh" -- disk matches the node's current hash -- while this finding's own
+ * frozen `derivation.anchors[id]` snapshot, taken when IT was written, no
+ * longer matches. The bytes this claim was actually derived from are gone,
+ * and `stale` alone would never say so.
+ *
+ * Returns `{}` when there is nothing to check (no `derivation.anchors`
+ * recorded -- true of every finding written before this existed), so a
+ * caller can tell "not checked" from "checked and holds" by whether
+ * `derivationHolds` is present at all.
+ */
+function derivationCheck(graph, finding) {
+  const recorded = finding.derivation && finding.derivation.anchors;
+  if (!recorded || typeof recorded !== 'object') return {};
+  const ids = Object.keys(recorded);
+  if (!ids.length) return {};
+
+  const changed = [];
+  for (const id of ids) {
+    const node = graph.nodes.get(id);
+    const currentHash = node && typeof node.hash === 'string' ? node.hash : null;
+    // An anchor that no longer resolves at all cannot be confirmed either --
+    // treated the same as a changed hash, never as "still holds" by default.
+    if (currentHash === null || currentHash !== recorded[id]) {
+      changed.push(node && typeof node.key === 'string' ? node.key : id);
+    }
+  }
+
+  if (!changed.length) return { derivationHolds: true };
+  // Bounded: a finding with many anchors should not spend unbounded budget
+  // naming every one that moved.
+  return { derivationHolds: false, derivationChanged: changed.slice(0, 5) };
+}
+
+/**
  * Prepares findings for delivery, verifying each one lazily against disk.
  *
  * This is the only function that should ever hand a finding to a model, because
@@ -611,6 +659,9 @@ export function serve(graph, findings) {
       stale,
       ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
       ...dispute,
+      // Independent of `stale` above: see `derivationCheck`'s own comment for
+      // the case it catches that node-level staleness can miss.
+      ...derivationCheck(graph, finding),
     });
   }
   return served;

--- a/integrations/codex/hooks/lib/staleness.mjs
+++ b/integrations/codex/hooks/lib/staleness.mjs
@@ -518,6 +518,21 @@ function disputeOf(graph, finding) {
  * recorded -- true of every finding written before this existed), so a
  * caller can tell "not checked" from "checked and holds" by whether
  * `derivationHolds` is present at all.
+ *
+ * `derivationHolds: true` MEANS "MATCHES THE ANCHOR NODE'S LAST-INDEXED
+ * HASH", NOT "MATCHES DISK RIGHT NOW" -- and that distinction is stored in
+ * `derivationCheckedAgainst: 'index'` rather than left for a `wiki_query`
+ * consumer to infer from a field name alone. Two ways to close this gap were
+ * considered: recompute a live hash from disk here, or document precisely
+ * what is actually compared. `stale` (via `checkAnchor`, above) ALREADY owns
+ * the disk comparison -- re-reading the same file a second time on the same
+ * serve path, for the same anchor, from a second mechanism, is worse than
+ * one honest name. So: documented, not duplicated. A file changed on disk
+ * but never re-indexed by anything is still caught, correctly, by `stale`;
+ * `derivationHolds` answers a narrower, complementary question -- whether
+ * the LAST INDEXED state agrees with what this specific finding recorded --
+ * which is exactly the re-indexed-by-something-else case above that `stale`
+ * cannot see.
  */
 function derivationCheck(graph, finding) {
   const recorded = finding.derivation && finding.derivation.anchors;
@@ -536,10 +551,12 @@ function derivationCheck(graph, finding) {
     }
   }
 
-  if (!changed.length) return { derivationHolds: true };
+  // Declared on BOTH branches, not only the ambiguous one: a consumer should
+  // not have to already know the answer to know what was checked.
+  if (!changed.length) return { derivationHolds: true, derivationCheckedAgainst: 'index' };
   // Bounded: a finding with many anchors should not spend unbounded budget
   // naming every one that moved.
-  return { derivationHolds: false, derivationChanged: changed.slice(0, 5) };
+  return { derivationHolds: false, derivationChanged: changed.slice(0, 5), derivationCheckedAgainst: 'index' };
 }
 
 /**

--- a/integrations/codex/hooks/lib/staleness.mjs
+++ b/integrations/codex/hooks/lib/staleness.mjs
@@ -54,6 +54,7 @@ import { readFileSync, statSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { dirname, join } from 'node:path';
 import { putNode, putEdge, contentHash, nodeId } from './wiki.mjs';
+import { hasOutstandingContradiction } from './curate.mjs';
 import { extractSymbols, spanText, symbolKey, extractImports } from './symbols.mjs';
 import { canonicalPath, resolvableCandidates, isFsSafePath } from './paths.mjs';
 
@@ -454,6 +455,46 @@ export function diffLines(
 const CONTENT_DEPENDENT = new Set(['finding', 'map']);
 
 /**
+ * What, if anything, currently disagrees with this finding.
+ *
+ * DISCLOSED AT SERVE TIME, because that is the only moment the disagreement can
+ * do any good. `WIKI_GRAPH.md`'s whole argument for making `contradicts` an edge
+ * rather than an overwrite is that a reader "sees both claims and the
+ * disagreement between them" -- so handing a finding to a model while something
+ * in the graph disputes it, without saying so, throws away the reason the edge
+ * was recorded instead of an overwrite.
+ *
+ * `hasOutstandingContradiction` is the gate: it is the one definition of "an
+ * open dispute", shared with the confidence-promotion gate, so the two can never
+ * disagree about what counts. The loop only NAMES the other side, and it names a
+ * key rather than quoting a claim because the reader can call `wiki_query` with
+ * a key -- and because the injection path pays for every character it renders.
+ *
+ * SEPARATE FROM STALENESS on purpose. A finding can be disputed without being
+ * stale (nothing touched its anchor; another finding simply says otherwise) and
+ * stale without being disputed, so this adds its own fields rather than
+ * borrowing the stale ones, and the renderer discloses each on its own terms.
+ */
+function disputeOf(graph, finding) {
+  if (!hasOutstandingContradiction(graph, finding.key)) return {};
+
+  const keys = [];
+  for (const edge of graph.edges) {
+    if (edge.edge !== 'contradicts') continue;
+    const otherId =
+      edge.from === finding.id ? edge.to : edge.to === finding.id ? edge.from : null;
+    if (!otherId) continue;
+    const other = graph.nodes.get(otherId);
+    // An edge end that resolves to nothing names nothing. The dispute is still
+    // disclosed -- the gate above already established it -- but without a key
+    // the reader cannot be pointed anywhere, and inventing one would be worse.
+    if (other && typeof other.key === 'string' && !keys.includes(other.key)) keys.push(other.key);
+  }
+
+  return { contradicted: true, ...(keys.length ? { contradictedBy: keys.join(', ') } : {}) };
+}
+
+/**
  * Prepares findings for delivery, verifying each one lazily against disk.
  *
  * This is the only function that should ever hand a finding to a model, because
@@ -474,10 +515,17 @@ export function serve(graph, findings) {
   // quickly.
 
   for (const finding of findings.filter((f) => !f.retired)) {
+    // A DISPUTE TRAVELS WITH EVERY TYPE, which is why it is computed before the
+    // content-dependence branch below. A `command` or `rule` finding cannot be
+    // invalidated by an anchor's contents, but another finding can still
+    // disagree with it, and this early return is the path that would have
+    // quietly dropped that.
+    const dispute = disputeOf(graph, finding);
+
     // A claim that does not depend on the anchor's contents cannot be
     // invalidated by them. It is served as-is rather than discounted.
     if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) {
-      served.push({ ...finding });
+      served.push({ ...finding, ...dispute });
       continue;
     }
 
@@ -562,6 +610,7 @@ export function serve(graph, findings) {
       ...finding,
       stale,
       ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
+      ...dispute,
     });
   }
   return served;

--- a/integrations/codex/hooks/lib/waste.mjs
+++ b/integrations/codex/hooks/lib/waste.mjs
@@ -151,6 +151,11 @@ function reDerivation(events, graph) {
       const id = nodeId('file', canonicalPath(row.anchor));
       if (!graph.nodes.has(id)) continue;
 
+      // READ-ONLY serve: no `dir` is threaded here, so this cannot clear a stale
+      // flag whose evidence is gone. That is deliberate -- this function takes a
+      // graph, not the directory it came from, and widening its signature to give
+      // an analysis path a write capability buys nothing: the injection path runs
+      // on every tool call and clears the same findings.
       const findings = serve(graph, findingsFor(graph, id, { limit: 3 }))
         .filter((f) => !f.stale && (f.confidence ?? 0) >= 0.7);
       if (!findings.length) continue;

--- a/integrations/codex/hooks/lib/wiki.mjs
+++ b/integrations/codex/hooks/lib/wiki.mjs
@@ -64,18 +64,37 @@ export const SUPPORTED_VERSIONS = [1];
  * Identity today because GRAPH_VERSION is 1 and no shape has changed. It exists
  * now so the first change that DOES need it has somewhere to go other than an
  * equality check that silently deletes user data.
+ *
+ * CONTRACT for the first non-identity step:
+ *  - It must be IDEMPOTENT. `upcast(upcast(r))` must equal `upcast(r)`, because
+ *    compaction upcasts a record to key it and `load` upcasts the same record
+ *    again on every subsequent read. A step that is not idempotent applies twice
+ *    to anything compaction has touched.
+ *  - It must NOT be relied on to restamp `v`. Nothing in this file writes an
+ *    upcast record back to disk under a version it did not come from; the
+ *    version stamp on disk is always the one that wrote the bytes. See the
+ *    per-branch comments in `compactIfWasteful`.
  */
 export function upcast(record) {
   return record;
 }
 
-/** True when this reader can interpret the record at all. */
-function readable(record) {
+/**
+ * True when this reader can interpret the record at all.
+ *
+ * `versions` is a PARAMETER so the range semantics are testable independently of
+ * today's constants. With `SUPPORTED_VERSIONS = [1]` and `GRAPH_VERSION = 1` a
+ * range check and the old equality check are extensionally identical, so a test
+ * pinned to the live constants cannot tell them apart -- and cannot fail if
+ * someone reverts this to an equality. Exercised against `[1, 2]`, it can.
+ */
+export function readable(record, versions = SUPPORTED_VERSIONS) {
   const version = record.v ?? 0;
   // Forward-incompatible records are skipped: a v-from-the-future was written by
-  // a newer client and we cannot know its shape. Ignoring the future is safe;
-  // ignoring the past is data loss.
-  return SUPPORTED_VERSIONS.includes(version);
+  // a newer client and we cannot know its shape. Ignoring the future is safe for
+  // a READER -- but see `compactIfWasteful`, where "ignore" would mean "delete",
+  // because compaction rewrites the files it reads.
+  return versions.includes(version);
 }
 
 /** Node kinds. `file` and `symbol` are first-class so staleness can propagate. */
@@ -434,9 +453,20 @@ function compactIfWasteful(dir) {
     const nodes = new Map();
     const edges = new Map();
     const snaps = new Map();
-    for (const rec of readSnapshots(dir)) {
+    // KEPT VERBATIM THROUGH THE REBUILD, exactly as the main log keeps what it
+    // cannot parse. These lines are not evictable by the snapshot budget below
+    // because their size cannot be attributed to an id we understand -- and
+    // preserving bytes we may not need is strictly better than deleting bytes a
+    // newer client does. They stop accumulating as soon as the client that
+    // wrote them compacts, since it can read and dedupe them.
+    const sidecar = readSnapshots(dir);
+    const rawSnaps = sidecar.unreadable;
+    for (const rec of sidecar.records) {
       if (typeof rec.snapshot === 'string' && rec.snapshot) {
-        snaps.set(rec.id, { at: rec.at || 0, snapshot: rec.snapshot });
+        // `v` IS CARRIED, not restamped. Writing GRAPH_VERSION over a record
+        // from another version mislabels bytes this reader did not produce, and
+        // the label is the only thing a future reader has to go on.
+        snaps.set(rec.id, { at: rec.at || 0, snapshot: rec.snapshot, v: rec.v ?? GRAPH_VERSION });
       }
     }
     for (const line of readFileSync(path, 'utf8').split('\n')) {
@@ -458,27 +488,40 @@ function compactIfWasteful(dir) {
         edges.set('raw:' + edges.size, line);
         continue;
       }
-      // Upcast IN MEMORY only, to key and classify the record. What gets written
-      // back below is the ORIGINAL `line`: compaction reclaims superseded
-      // records, it does not migrate surviving ones, so the on-disk version is
-      // whatever wrote it and `load` upcasts it again on every read.
-      record = upcast(record);
-      if (record.t === 'n') {
+      // TWO OBJECTS, ON PURPOSE. `record` is exactly what the bytes on disk say;
+      // `view` is the in-memory current-shape reading of it, used only to KEY and
+      // CLASSIFY. Nothing derived from `view` is ever serialized, because
+      // compaction reclaims superseded records -- it does not migrate surviving
+      // ones -- so every version stamp it writes is the one that wrote the bytes.
+      //
+      // An earlier revision of this comment claimed "the ORIGINAL line is written
+      // back" for the whole block. That was FALSE for the inline-snapshot branch,
+      // which re-serializes. It re-serialized the upcast object while carrying
+      // the old `v`, so the first non-identity `upcast` would have written
+      // new-shape bytes under an old label and every later `load` would have
+      // upcast them a second time. Hence: strip from `record`, never from `view`.
+      const view = upcast(record);
+      if (view.t === 'n') {
         // MIGRATION. Graphs written before snapshots were split still carry
         // them inline, and those are exactly the graphs that are slow. Moving
         // them out here means one compaction fixes an existing install.
+        //
+        // THE ONLY RE-SERIALIZING BRANCH in this loop. It writes the original
+        // record minus its snapshot, so the surviving bytes keep their own shape
+        // and their own `v`, and the snapshot moved to the sidecar carries the
+        // same `v` as the node it came out of.
         if (typeof record.snapshot === 'string' && record.snapshot) {
           const { snapshot, ...rest } = record;
-          nodes.set(record.id, JSON.stringify(rest));
-          snaps.set(record.id, { at: record.at || 0, snapshot });
+          nodes.set(view.id, JSON.stringify(rest));
+          snaps.set(view.id, { at: record.at || 0, snapshot, v: record.v ?? GRAPH_VERSION });
         } else {
-          nodes.set(record.id, line);
+          nodes.set(view.id, line);
         }
-      } else if (record.t === 's') {
+      } else if (view.t === 's') {
         if (typeof record.snapshot === 'string' && record.snapshot) {
-          snaps.set(record.id, { at: record.at || 0, snapshot: record.snapshot });
+          snaps.set(view.id, { at: record.at || 0, snapshot: record.snapshot, v: record.v ?? GRAPH_VERSION });
         }
-      } else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
+      } else if (view.t === 'e') edges.set(`${view.from}|${view.edge}|${view.to}`, line);
       else edges.set('raw:' + edges.size, line);
     }
 
@@ -541,10 +584,20 @@ function compactIfWasteful(dir) {
     renameSync(tmp, path);
     // The surviving snapshots are rewritten to their own file, which is also
     // what migrates a graph that still had them inline.
-    const snapOut =
-      [...keep.entries()]
-        .map(([id, v]) => JSON.stringify({ t: 's', v: GRAPH_VERSION, id, snapshot: v.snapshot, at: v.at }))
-        .join('\n') + (keep.size ? '\n' : '');
+    //
+    // UNREADABLE LINES FIRST AND VERBATIM. This rebuild replaces the file, so
+    // anything omitted here is deleted permanently -- which made the missing
+    // counterpart to the main log's `raw:` bucket a real data-loss path, not a
+    // theoretical one. Each survivor also keeps ITS OWN `v` rather than being
+    // restamped to GRAPH_VERSION, so no record is relabelled as something this
+    // reader wrote.
+    const snapLines = [
+      ...rawSnaps,
+      ...[...keep.entries()].map(([id, s]) =>
+        JSON.stringify({ t: 's', v: s.v ?? GRAPH_VERSION, id, snapshot: s.snapshot, at: s.at })
+      ),
+    ];
+    const snapOut = snapLines.join('\n') + (snapLines.length ? '\n' : '');
     const snapTmp = snapshotsPath(dir) + '.compact';
     writeFileSync(snapTmp, snapOut, { mode: 0o600 });
     renameSync(snapTmp, snapshotsPath(dir));
@@ -689,9 +742,26 @@ function appendSnapshot(dir, record) {
   }
 }
 
-/** Every snapshot record, latest wins. Read only when a caller asks. */
+/**
+ * Every snapshot record, latest wins. Read only when a caller asks.
+ *
+ * `unreadable` collects the RAW LINES this reader rejected, and it is the reason
+ * this function reports them at all rather than just dropping them. `load` has
+ * no use for them -- a reader that cannot interpret a record must ignore it --
+ * but `compactIfWasteful` REBUILDS this file from what it read, so for the
+ * compactor "ignore" and "delete permanently" are the same operation. The main
+ * log already keeps what it cannot parse (the `raw:` bucket); the sidecar had no
+ * equivalent, which made it the one asymmetric, destructive path in an otherwise
+ * append-only store.
+ *
+ * This is not hypothetical here: hooks-core is vendored into eleven client
+ * directories that update independently, so a stale client compacting a graph a
+ * newer client has already written to is the expected steady state, not an edge
+ * case.
+ */
 function readSnapshots(dir) {
-  const out = [];
+  /** @type {object[]} */ const out = [];
+  /** @type {string[]} */ const unreadable = [];
   try {
     for (const line of readFileSync(snapshotsPath(dir), 'utf8').split('\n')) {
       if (!line) continue;
@@ -699,19 +769,23 @@ function readSnapshots(dir) {
         const rec = JSON.parse(line);
         // THE SAME RANGE AS THE MAIN LOG, deliberately. An equality check here
         // was the quietest of the three: a bump would have made every stored
-        // snapshot unreadable, and the very next compaction -- which rebuilds
-        // this file from what it could read -- would have deleted them for
-        // good. That is the one place in this store where a read filter turns
-        // into a permanent write.
-        if (readable(rec) && rec.id) out.push(upcast(rec));
+        // snapshot unreadable, and the very next compaction would have deleted
+        // them for good.
+        if (!readable(rec)) {
+          unreadable.push(line);
+          continue;
+        }
+        if (rec.id) out.push(upcast(rec));
       } catch {
-        /* a torn line costs one snapshot */
+        // A torn line costs one snapshot -- and it is NOT preserved, because a
+        // half-written line is not a record from another version, it is
+        // garbage. Distinguishing the two is the whole point of parsing first.
       }
     }
   } catch {
     /* no sidecar yet */
   }
-  return out;
+  return { records: out, unreadable };
 }
 
 /**
@@ -777,7 +851,9 @@ export function load(dir, { snapshots = false } = {}) {
   // Re-attached after the sweep, so a snapshot record may appear before or
   // after the node it belongs to.
   if (pending) {
-    for (const rec of readSnapshots(dir)) pending.set(rec.id, rec.snapshot);
+    // A reader has no use for the lines it could not interpret; only the
+    // compactor does, because only the compactor rewrites the file.
+    for (const rec of readSnapshots(dir).records) pending.set(rec.id, rec.snapshot);
     for (const [id, snapshot] of pending) {
       const node = nodes.get(id);
       if (node) nodes.set(id, { ...node, snapshot });

--- a/integrations/codex/hooks/lib/wiki.mjs
+++ b/integrations/codex/hooks/lib/wiki.mjs
@@ -28,17 +28,55 @@ import { canonicalPath, isFsSafePath } from './paths.mjs';
 /**
  * Schema version stamped on every record.
  *
- * There is exactly ONE version and no migration code, because nothing has been
- * released: a graph written by an older commit of an unreleased branch is a
- * development artifact, not user data, and carrying migration paths for it costs
- * real complexity to protect something nobody has. A record from any other
- * version is skipped rather than interpreted, so a stale dev graph degrades to
- * "rebuilds from use" instead of silently mixing incompatible identities.
+ * THIS PACKAGE IS RELEASED. It ships on npm, so every graph on disk is user
+ * data. An earlier version of this comment claimed nothing had been released
+ * and used that to justify having no migration path at all -- and the reader
+ * below compared for EQUALITY, so the first bump would have discarded every
+ * existing graph in silence. That justification is gone and so is the equality:
+ * `SUPPORTED_VERSIONS` is the range this reader accepts, and `upcast` is where a
+ * shape change is absorbed in memory.
  *
- * When this does ship, a bump here is where migration would be added -- with
- * users to protect, that trade reverses.
+ * A bump here is taken only when a record's SHAPE actually changes, and it comes
+ * with a new `upcast` step and an entry in `SUPPORTED_VERSIONS` in the same
+ * change. Adding a field that older readers can ignore is not a shape change.
  */
 export const GRAPH_VERSION = 1;
+
+/**
+ * Versions this reader accepts, oldest first.
+ *
+ * A RANGE, NOT AN EQUALITY. The equality check this replaces would have
+ * discarded every existing graph the moment anyone bumped the version -- and the
+ * header once justified that with "nothing has been released", which stopped
+ * being true at v5.7.0 on npm.
+ *
+ * Nothing on disk is ever rewritten to migrate: `upcast` runs in memory during
+ * the fold, so there is no migration pass to fail halfway and no race with the
+ * concurrent sessions this store is designed for. A mixed-version log is safe
+ * precisely because the original records are never mutated, and the existing
+ * compaction retires old ones naturally as it rewrites snapshots.
+ */
+export const SUPPORTED_VERSIONS = [1];
+
+/**
+ * Brings one record up to the current version. Pure, and one step per version.
+ *
+ * Identity today because GRAPH_VERSION is 1 and no shape has changed. It exists
+ * now so the first change that DOES need it has somewhere to go other than an
+ * equality check that silently deletes user data.
+ */
+export function upcast(record) {
+  return record;
+}
+
+/** True when this reader can interpret the record at all. */
+function readable(record) {
+  const version = record.v ?? 0;
+  // Forward-incompatible records are skipped: a v-from-the-future was written by
+  // a newer client and we cannot know its shape. Ignoring the future is safe;
+  // ignoring the past is data loss.
+  return SUPPORTED_VERSIONS.includes(version);
+}
 
 /** Node kinds. `file` and `symbol` are first-class so staleness can propagate. */
 export const NODE_KINDS = ['file', 'symbol', 'task', 'finding'];
@@ -409,13 +447,22 @@ function compactIfWasteful(dir) {
       } catch {
         continue;
       }
-      // A record from another schema is KEPT VERBATIM rather than reinterpreted.
-      // load() skips it, but discarding it here would make compaction a silent
-      // migration that deletes data a future version might understand.
-      if ((record.v ?? 0) !== GRAPH_VERSION) {
+      // A record this reader cannot interpret is KEPT VERBATIM rather than
+      // reinterpreted. load() skips it, but discarding it here would make
+      // compaction a silent migration that deletes data a future version might
+      // understand. THE RANGE MATTERS HERE TOO: with an equality check, a bump
+      // would have parked every existing v1 record in `raw`, undeduplicated, so
+      // compaction would stop reclaiming anything and inline snapshots would
+      // never migrate out -- the same loss by a second route.
+      if (!readable(record)) {
         edges.set('raw:' + edges.size, line);
         continue;
       }
+      // Upcast IN MEMORY only, to key and classify the record. What gets written
+      // back below is the ORIGINAL `line`: compaction reclaims superseded
+      // records, it does not migrate surviving ones, so the on-disk version is
+      // whatever wrote it and `load` upcasts it again on every read.
+      record = upcast(record);
       if (record.t === 'n') {
         // MIGRATION. Graphs written before snapshots were split still carry
         // them inline, and those are exactly the graphs that are slow. Moving
@@ -650,7 +697,13 @@ function readSnapshots(dir) {
       if (!line) continue;
       try {
         const rec = JSON.parse(line);
-        if ((rec.v ?? 0) === GRAPH_VERSION && rec.id) out.push(rec);
+        // THE SAME RANGE AS THE MAIN LOG, deliberately. An equality check here
+        // was the quietest of the three: a bump would have made every stored
+        // snapshot unreadable, and the very next compaction -- which rebuilds
+        // this file from what it could read -- would have deleted them for
+        // good. That is the one place in this store where a read filter turns
+        // into a permanent write.
+        if (readable(rec) && rec.id) out.push(upcast(rec));
       } catch {
         /* a torn line costs one snapshot */
       }
@@ -691,7 +744,12 @@ export function load(dir, { snapshots = false } = {}) {
       if (!snapshots) continue;
       try {
         const rec = JSON.parse(line);
-        if ((rec.v ?? 0) === GRAPH_VERSION) pending.set(rec.id, rec.snapshot);
+        // Inline snapshots from an older graph: same range, same reason. These
+        // are precisely the records most likely to predate a bump.
+        if (readable(rec)) {
+          const snap = upcast(rec);
+          pending.set(snap.id, snap.snapshot);
+        }
       } catch {
         /* a torn line costs one snapshot, not the graph */
       }
@@ -703,10 +761,14 @@ export function load(dir, { snapshots = false } = {}) {
     } catch {
       continue;
     }
-    // A record from another schema is skipped, not interpreted: its ids and
-    // hashes were derived differently, so honouring it produces confident
-    // nonsense rather than a visible error.
-    if ((record.v ?? 0) !== GRAPH_VERSION) continue;
+    // A record this reader cannot interpret is skipped, not guessed at: a
+    // version from the FUTURE derived its ids and hashes in a way we do not
+    // know, so honouring it produces confident nonsense rather than a visible
+    // error. A record from the PAST is upcast, never skipped -- skipping it is
+    // data loss, and this comparison used to be an equality, which made the
+    // first version bump a silent delete of every graph on disk.
+    if (!readable(record)) continue;
+    record = upcast(record);
     if (record.t === 'n') nodes.set(record.id, record);
     else if (record.t === 'e') edges.push(record);
   }

--- a/integrations/codex/hooks/lib/wiki.mjs
+++ b/integrations/codex/hooks/lib/wiki.mjs
@@ -775,7 +775,17 @@ function readSnapshots(dir) {
           unreadable.push(line);
           continue;
         }
+        // A RECORD WITH NO `id` IS KEPT VERBATIM, NOT DROPPED SILENTLY. It
+        // cannot be attributed to a node, so it is useless to `load` -- but this
+        // used to put it in neither bucket, and `compactIfWasteful` rebuilds the
+        // sidecar from `records` plus `unreadable`, so a line in neither was
+        // deleted permanently by the next compaction. That is the same shape as
+        // the Critical this reader's version check already fixed, and the same
+        // asymmetry: for the compactor, "ignore" and "destroy" are one operation.
+        // Unreachable today because every writer sets `id`; a reader is not the
+        // right place to rely on that.
         if (rec.id) out.push(upcast(rec));
+        else unreadable.push(line);
       } catch {
         // A torn line costs one snapshot -- and it is NOT preserved, because a
         // half-written line is not a record from another version, it is

--- a/integrations/codex/hooks/post-tool.mjs
+++ b/integrations/codex/hooks/post-tool.mjs
@@ -8,7 +8,7 @@ process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.
-process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write';
+process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write,wiki_query';
 try {
   const { run } = await import('./lib/adapter.mjs');
   await run('codex', 'post-tool');

--- a/integrations/codex/hooks/post-tool.mjs
+++ b/integrations/codex/hooks/post-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/codex/hooks/pre-tool.mjs
+++ b/integrations/codex/hooks/pre-tool.mjs
@@ -8,7 +8,7 @@ process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.
-process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write';
+process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write,wiki_query';
 try {
   const { run } = await import('./lib/adapter.mjs');
   await run('codex', 'pre-tool');

--- a/integrations/codex/hooks/pre-tool.mjs
+++ b/integrations/codex/hooks/pre-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/codex/hooks/session-start.mjs
+++ b/integrations/codex/hooks/session-start.mjs
@@ -8,7 +8,7 @@ process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.
-process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write';
+process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write,wiki_query';
 try {
   const { run } = await import('./lib/adapter.mjs');
   await run('codex', 'session-start');

--- a/integrations/codex/hooks/session-start.mjs
+++ b/integrations/codex/hooks/session-start.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/codex/hooks/stop.mjs
+++ b/integrations/codex/hooks/stop.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/codex/hooks/stop.mjs
+++ b/integrations/codex/hooks/stop.mjs
@@ -8,7 +8,7 @@ process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.
-process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write';
+process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write,wiki_query';
 try {
   const { run } = await import('./lib/adapter.mjs');
   await run('codex', 'stop');

--- a/integrations/codex/plugin/hooks/lib/adapter.mjs
+++ b/integrations/codex/plugin/hooks/lib/adapter.mjs
@@ -68,6 +68,7 @@ import {
   standingRules,
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
+import { observedWrite, queueInvalidation } from './pending.mjs';
 import { isArchived } from './transcript.mjs';
 import { isFsSafePath } from './paths.mjs';
 import {
@@ -881,6 +882,35 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Causal tracing is fail-open like every other hook optimization.
+    }
+
+    // EAGER INVALIDATION, finally connected. `invalidateOnWrite` has existed,
+    // been tested and been described in staleness.mjs's own header since
+    // staleness landed, and its only reference in shipped code was a COMMENT in
+    // the PreToolUse router -- so the path that header calls load-bearing had
+    // never run once in production. It matters most for exactly this event: the
+    // lazy check compares the anchor's stored hash against disk, and the
+    // capture below re-points that hash at the bytes this write just produced,
+    // so a write the session performed ITSELF is invisible to lazy staleness.
+    //
+    // QUEUED, NOT APPLIED. Applying needs the graph, and loading a megabyte of
+    // JSONL on the return path of every write is what this shape exists to
+    // avoid. The next graph read drains it before serving anything.
+    try {
+      if (mutationSucceeded(clientName, raw)) {
+        const evidence = observedWrite(payload, raw);
+        if (evidence) {
+          // THE SAME DIRECTORY THE GRAPH ITSELF USES. `observeAndInject` keys
+          // every write on `wikiDir(projectRootFor(path, payload.cwd))`, and a
+          // queue written anywhere else is a queue nothing ever drains.
+          queueInvalidation(
+            wikiDir(projectRootFor(evidence.path, payload.cwd)),
+            evidence
+          );
+        }
+      }
+    } catch {
+      // Bookkeeping for a call that already completed. Never let it cost one.
     }
   }
 

--- a/integrations/codex/plugin/hooks/lib/adapter.mjs
+++ b/integrations/codex/plugin/hooks/lib/adapter.mjs
@@ -64,6 +64,7 @@ import {
   forTouch,
   noteActClasses,
   relevantFindingIdsForContext,
+  sessionContext,
   sessionIndex,
   standingRules,
 } from './inject.mjs';
@@ -690,8 +691,23 @@ async function runHook(clientName, event, invocation) {
       rememberOptimizerTools(state, toolEvidence);
       saveState(sessionId, state);
     }
-    const parts = [
-      policyText(client.canDeny, toolEvidence.names, toolEvidence.proven),
+    // ASSEMBLED IN CACHE ORDER, not in whatever order this function happens to
+    // discover the blocks. Everything emitted here sits near the FRONT of the
+    // prompt prefix, and a prefix cache invalidates from the first differing
+    // byte onward -- so the block that changes most often has to sit LAST, or it
+    // re-prices every block behind it on every session. `sessionContext` sorts
+    // by the declared volatility; inject.mjs records how each number was
+    // assigned and why.
+    const blocks = [
+      {
+        id: 'policy',
+        volatility: 0,
+        text: policyText(
+          client.canDeny,
+          toolEvidence.names,
+          toolEvidence.proven
+        ),
+      },
     ];
     const cwd = raw.cwd || raw.working_directory || process.cwd();
     const root = projectRootFor(join(cwd, '__session__'), cwd);
@@ -705,7 +721,7 @@ async function runHook(clientName, event, invocation) {
         const graph = load(dir);
         const episode = episodeMeta({ client: clientName, raw });
         const rules = standingRules(dir, graph, { episode });
-        if (rules) parts.push(rules);
+        if (rules) blocks.push({ id: 'standing', volatility: 1, text: rules });
         const relevantFindingIds = relevantFindingIdsForContext(
           graph,
           sessionTaskContext(raw)
@@ -714,12 +730,12 @@ async function runHook(clientName, event, invocation) {
           episode,
           relevantFindingIds,
         });
-        if (index) parts.push(index);
+        if (index) blocks.push({ id: 'index', volatility: 2, text: index });
       } catch {
         // Retrieval is optional context; the policy must still reach the model.
       }
     }
-    const output = contextOutput(client, eventName, parts.join('\n\n'));
+    const output = contextOutput(client, eventName, sessionContext(blocks));
     if (output) emit(output);
     process.exit(0);
   }

--- a/integrations/codex/plugin/hooks/lib/adapter.mjs
+++ b/integrations/codex/plugin/hooks/lib/adapter.mjs
@@ -68,7 +68,7 @@ import {
   standingRules,
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
-import { observedWrite, queueInvalidation } from './pending.mjs';
+import { observedWrites, queueInvalidation } from './pending.mjs';
 import { isArchived } from './transcript.mjs';
 import { isFsSafePath } from './paths.mjs';
 import {
@@ -898,8 +898,7 @@ async function runHook(clientName, event, invocation) {
     // avoid. The next graph read drains it before serving anything.
     try {
       if (mutationSucceeded(clientName, raw)) {
-        const evidence = observedWrite(payload, raw);
-        if (evidence) {
+        for (const evidence of observedWrites(payload, raw)) {
           // THE SAME DIRECTORY THE GRAPH ITSELF USES. `observeAndInject` keys
           // every write on `wikiDir(projectRootFor(path, payload.cwd))`, and a
           // queue written anywhere else is a queue nothing ever drains.

--- a/integrations/codex/plugin/hooks/lib/capabilities.mjs
+++ b/integrations/codex/plugin/hooks/lib/capabilities.mjs
@@ -38,6 +38,10 @@ export const HOOK_MCP_TOOLS = Object.freeze([
   'optimize_session',
   'get_optimization_report',
   'wiki_write',
+  // The read side of the graph. The session index tells the model to "call
+  // wiki_query with a key for detail", so the hook needs positive evidence that
+  // the name it is advertising is actually registered in this host.
+  'wiki_query',
 ]);
 
 const HOOK_MCP_TOOL_SET = new Set(HOOK_MCP_TOOLS);

--- a/integrations/codex/plugin/hooks/lib/curate.mjs
+++ b/integrations/codex/plugin/hooks/lib/curate.mjs
@@ -22,7 +22,7 @@
  */
 
 import { randomBytes } from 'node:crypto';
-import { putNode, putNodeWithEdges, load, nodeId } from './wiki.mjs';
+import { putNode, putEdge, putNodeWithEdges, load, nodeId } from './wiki.mjs';
 import { indexFile } from './staleness.mjs';
 import { symbolKey } from './symbols.mjs';
 import { canonicalPath } from './paths.mjs';
@@ -178,6 +178,79 @@ export function retire(dir, key) {
   if (!existing) return false;
   putNode(dir, { ...existing, kind: 'finding', key, retired: true });
   return true;
+}
+
+/**
+ * Records that one finding disagrees with another.
+ *
+ * AN EDGE, NOT AN OVERWRITE -- the design is explicit about why: "when a belief
+ * changes, the graph should record THAT it changed and why, not quietly present
+ * the new one as though it had always been true." `contradicts` has been in
+ * EDGE_KINDS since the schema existed and was written by nothing, while
+ * `audit()` already READ it.
+ *
+ * The contradicted finding is deliberately NOT retired, and its claim is
+ * deliberately preserved. A reader needs to see both claims and the
+ * disagreement between them; retiring one silently picks a winner, and putNode
+ * does not merge -- it writes the whole record from what it is handed, so
+ * annotating the target without spreading it back in would blank the very claim
+ * this edge exists to keep visible. That is the overwrite by another name.
+ *
+ * THE EDGE IS WRITTEN FIRST, and the order is the guarantee. These are two
+ * appends and `append` fails open, so either can be the one that lands. Edge
+ * without annotation is a complete, readable disagreement missing only its
+ * reason. Annotation without edge is a finding that says "something contradicts
+ * me" with no contradictor -- a claim of proof with no proof, and invisible to
+ * `audit()` and to `hasOutstandingContradiction`, both of which read the edge.
+ */
+export function contradict(dir, { key, byKey, reason }) {
+  const graph = load(dir);
+  const target = findingByKey(graph, key);
+  const source = findingByKey(graph, byKey);
+  // Both ends must exist, or the edge is unresolvable and the disagreement is
+  // recorded against nothing -- the same un-invalidatable shape anchors prevent.
+  if (!target || !source) return false;
+  // A finding cannot disagree with itself. The self-edge resolves, so the guard
+  // above waves it through, and the result is a node permanently blocked from
+  // confidence promotion by a dispute no person can ever resolve: there is no
+  // second claim to choose between.
+  if (target.id === source.id) return false;
+
+  putEdge(dir, source.id, 'contradicts', target.id);
+  putNode(dir, {
+    ...target,
+    kind: 'finding',
+    key,
+    contradictedAt: Date.now(),
+    contradictionReason: String(reason || '').slice(0, 400),
+  });
+  return true;
+}
+
+/**
+ * Whether anything currently disagrees with this finding.
+ *
+ * Gates confidence promotion. Plan 2's per-finding utility measures whether a
+ * finding SUPPRESSES READS, and a confidently wrong finding suppresses reads
+ * better than a hedged true one -- so utility must never raise confidence on
+ * its own, and this is the check that stops it.
+ *
+ * SYMMETRIC, deliberately: BOTH ends of a `contradicts` edge are outstanding
+ * until a person resolves the disagreement. The named hazard in the design is
+ * presenting "the new one as though it had always been true", so gating only
+ * the older claim would leave the newer one -- which is just as likely to be
+ * the wrong one, since nothing here adjudicates -- free to be promoted on
+ * measured utility alone. That is the exact failure this gate exists to stop.
+ * It also matches `audit()`, the reader that has always been here: it puts both
+ * `from` and `to` in its `contradicted` bucket, because "until one looks, BOTH
+ * are being served".
+ */
+export function hasOutstandingContradiction(graph, key) {
+  const node = findingByKey(graph, key);
+  if (!node) return false;
+  return graph.edges.some(
+    (e) => e.edge === 'contradicts' && (e.to === node.id || e.from === node.id)
+  );
 }
 
 /**

--- a/integrations/codex/plugin/hooks/lib/curate.mjs
+++ b/integrations/codex/plugin/hooks/lib/curate.mjs
@@ -124,7 +124,17 @@ export function correct(
   const replacementKey = `${key}-c${Date.now().toString(36)}`;
 
   const edges = [{ edge: 'supersedes', to: originalId }];
-  // The correction inherits the original's anchors, so it can go stale too.
+  // The correction inherits the original's anchors, so it can go stale too --
+  // but it inherits NOTHING ELSE, and that is deliberate rather than incidental.
+  // The node written below is built field by field from `existing` instead of
+  // spreading it, which is what keeps the staleness fields (`stale`,
+  // `staleReason`, `diff`) off the successor: a correction is re-derived
+  // against the current code by definition, so being born carrying its
+  // predecessor's invalidation would discount it the moment it existed --
+  // `disclose.mjs` skips a stale finding outright and `utility.mjs` penalises
+  // one by 160. Any future edit here that reaches for `...existing` to pick up
+  // one more field re-introduces that, since `putNode` writes what it is handed
+  // wholesale; `tests/hooks/stale-clearing.test.mjs` is the guard.
   for (const edge of graph.edges) {
     if (edge.edge === 'derived_from' && edge.from === originalId) {
       edges.push({ edge: 'derived_from', to: edge.to });
@@ -244,13 +254,38 @@ export function contradict(dir, { key, byKey, reason }) {
  * It also matches `audit()`, the reader that has always been here: it puts both
  * `from` and `to` in its `contradicted` bucket, because "until one looks, BOTH
  * are being served".
+ *
+ * A RETIRED COUNTERPART DOES NOT COUNT, and that sentence quoted just above is
+ * the reason. This read edges ONLY, so retiring one end of a contradiction left
+ * the survivor gated against confidence promotion forever and served with a
+ * DISPUTED note naming a key `serve` refuses to hand anybody -- `serve`,
+ * `activeFindings`, `findingsFor` and `sessionIndex` all drop a retired
+ * finding. A retired claim is served to NOBODY, so "BOTH are being served" is
+ * false and the premise of the gate is gone: only one claim is in play, and
+ * there is nothing left to choose between. Retiring one end IS the person
+ * looking that this gate was waiting for -- so the edge counts as open only
+ * while NEITHER end is retired, answered the same way from both directions.
+ *
+ * AN UNRESOLVABLE END STILL COUNTS. An edge whose other side names no node
+ * proves nothing about whether that claim was withdrawn, and the conservative
+ * reading -- still disputed -- is the one that cannot promote a claim nobody
+ * adjudicated.
  */
 export function hasOutstandingContradiction(graph, key) {
   const node = findingByKey(graph, key);
-  if (!node) return false;
-  return graph.edges.some(
-    (e) => e.edge === 'contradicts' && (e.to === node.id || e.from === node.id)
-  );
+  // A withdrawn claim is not in a dispute either: a dispute needs two claims in
+  // play, and this one has been taken out of play. Without this the RETIRED end
+  // still reported an open disagreement, which is the same defect from the other
+  // side -- and the answer has to agree from both directions, since the gate is
+  // symmetric on purpose.
+  if (!node || node.retired) return false;
+  return graph.edges.some((e) => {
+    if (e.edge !== 'contradicts') return false;
+    const otherId = e.from === node.id ? e.to : e.to === node.id ? e.from : null;
+    if (!otherId) return false;
+    const other = graph.nodes.get(otherId);
+    return !other || !other.retired;
+  });
 }
 
 /**
@@ -334,11 +369,24 @@ export function audit(graph) {
       .map((e) => e.from)
   );
 
+  // THE SAME DEFINITION OF AN OPEN DISPUTE as hasOutstandingContradiction, and
+  // it has to be: that function's own comment claims it "matches audit()", and
+  // two rankings that disagree about what needs a human is worse than one that
+  // is wrong. A retired counterpart is a resolved dispute -- the retired claim
+  // is served to nobody -- so the survivor is not one of two claims in play and
+  // does not belong in the bucket of things needing a person to look.
+  //
+  // One pass, not a call per finding: this is a dashboard read over the whole
+  // graph, and the obvious rewrite is O(findings x edges).
   const contradicted = new Set();
   for (const edge of graph.edges) {
     if (edge.edge !== 'contradicts') continue;
-    contradicted.add(edge.from);
-    contradicted.add(edge.to);
+    const from = graph.nodes.get(edge.from);
+    const to = graph.nodes.get(edge.to);
+    // An end that resolves to nothing cannot be shown retired, so it still
+    // counts against the other end.
+    if (!to || !to.retired) contradicted.add(edge.from);
+    if (!from || !from.retired) contradicted.add(edge.to);
   }
 
   return {

--- a/integrations/codex/plugin/hooks/lib/curate.mjs
+++ b/integrations/codex/plugin/hooks/lib/curate.mjs
@@ -70,6 +70,38 @@ export function originWeight(origin) {
   return 1;
 }
 
+/**
+ * The claim-time anchor hashes, for a finding being written right now.
+ *
+ * THE CHECKABLE HALF OF PROVENANCE, and until now only `harvest-write.mjs`
+ * wrote it -- so the asymmetry ran exactly the wrong way. `reverify` and the
+ * automatic clear in `serve` both compare disk against these frozen hashes, and
+ * a finding without them can never have a stale flag cleared by anything. That
+ * meant HUMAN-asserted findings, the ones somebody deliberately created or
+ * corrected, were the only ones condemned to stay stale forever once marked,
+ * while machine-harvested claims could recover. The hashes are simply the anchor
+ * nodes' hashes at this moment, and every writer has them in hand.
+ *
+ * DELIBERATELY NOT THE WHOLE RECORD `derivationFor` BUILDS. That one joins the
+ * evidence log to find FILE-surface operations behind the claim; curation
+ * performs no such join, so `operations` is empty and `operationsComplete` says
+ * so. An empty list declared incomplete is honest -- "nothing recorded here, and
+ * do not read that as nothing happened" -- where an empty list declared complete
+ * would assert a fact nobody established.
+ *
+ * An anchor with no stored hash contributes no entry, and a finding whose
+ * anchors all lack one gets a record with no hashes -- which `claimTimeVerdict`
+ * reads as `unknown` and refuses to clear on, which is the correct reading.
+ */
+function claimTimeDerivation(graph, resolved) {
+  const anchors = {};
+  for (const id of resolved) {
+    const node = graph.nodes.get(id);
+    if (node && typeof node.hash === 'string') anchors[id] = node.hash;
+  }
+  return { at: Date.now(), anchors, operations: [], operationsComplete: false };
+}
+
 function findingByKey(graph, key) {
   return graph.nodes.get(nodeId('finding', key)) || null;
 }
@@ -124,6 +156,11 @@ export function correct(
   const replacementKey = `${key}-c${Date.now().toString(36)}`;
 
   const edges = [{ edge: 'supersedes', to: originalId }];
+  // Collected alongside the edges so the correction carries its own claim-time
+  // hashes: it is a NEW claim, re-derived against whatever the code says now, so
+  // its evidence is the anchors' current state -- not the predecessor's, which is
+  // precisely what went stale.
+  const inherited = [];
   // The correction inherits the original's anchors, so it can go stale too --
   // but it inherits NOTHING ELSE, and that is deliberate rather than incidental.
   // The node written below is built field by field from `existing` instead of
@@ -138,6 +175,7 @@ export function correct(
   for (const edge of graph.edges) {
     if (edge.edge === 'derived_from' && edge.from === originalId) {
       edges.push({ edge: 'derived_from', to: edge.to });
+      inherited.push(edge.to);
     }
   }
 
@@ -171,6 +209,11 @@ export function correct(
       // branches, and an unrecognised value already degrades to the neutral
       // ranking weight rather than doing damage.
       origin: typeof origin === 'string' && origin ? origin : ORIGIN_HUMAN,
+      // Without this a correction could never have a stale flag cleared: both
+      // clearing paths compare disk against these hashes, and a finding with
+      // none is `unknown` forever. A hand-written correction being the least
+      // recoverable record in the graph was the wrong way round.
+      derivation: claimTimeDerivation(graph, inherited),
     },
     edges
   );
@@ -339,7 +382,18 @@ export function create(dir, { claim, anchors, type = 'finding', confidence = 0.9
   // path. No process death required; one transient EBUSY is enough.
   const id = putNodeWithEdges(
     dir,
-    { kind: 'finding', key, claim, confidence, type, origin: ORIGIN_HUMAN },
+    {
+      kind: 'finding',
+      key,
+      claim,
+      confidence,
+      type,
+      origin: ORIGIN_HUMAN,
+      // Read AFTER the indexFile loop above, so the hashes are the ones the
+      // person's claim was actually made against rather than whatever the graph
+      // held before this call touched it.
+      derivation: claimTimeDerivation(loadGraph(dir), resolved),
+    },
     resolved.map((target) => ({ edge: 'derived_from', to: target }))
   );
   if (!id) return null;

--- a/integrations/codex/plugin/hooks/lib/decide.mjs
+++ b/integrations/codex/plugin/hooks/lib/decide.mjs
@@ -542,19 +542,92 @@ const TOOL_ALIASES = new Map(
     run_shell_command: 'Bash',
     run_terminal_cmd: 'Bash',
     terminal: 'Bash',
+
+    // THIS PROJECT'S OWN TOOLS, which the table did not list for as long as it
+    // existed. `plugin/hooks/hooks.json`'s PostToolUse matcher named
+    // `mcp__.*__(?:smart_edit|smart_write)` and Codex's AfterTool matcher named
+    // the bare `smart_edit|smart_write`, so both hooks fired -- and then
+    // `normalizeTool` returned null and the hook exited before a single line of
+    // accounting ran. Staleness, mutation counting and harvest pressure were all
+    // blind on exactly the path enforcement pushes the model toward, which is the
+    // worst place to be blind: the more effective the routing, the less the
+    // optimizer saw.
+    //
+    // These names are the CANONICAL operation, not a licence to redirect. A call
+    // that is already the replacement is excluded from routing by
+    // `isReplacementTool` below.
+    smart_read: 'Read',
+    smart_grep: 'Grep',
+    smart_glob: 'Glob',
+    smart_edit: 'Edit',
+    smart_write: 'Write',
+
+    // Claude Code's notebook editor. Same shape of gap: a real mutation of a
+    // real file on disk that arrived as null and so never reached
+    // `pending.mjs`'s MUTATING set, leaving every notebook write invisible to
+    // invalidation.
+    notebookedit: 'Edit',
+    notebook_edit: 'Edit',
   })
 );
 
-/** Maps a client's tool name onto the canonical one, or null if unhandled. */
+/**
+ * The optimizer's own replacement tools, by canonical trailing segment.
+ *
+ * Kept separate from the alias table because the two answer different questions.
+ * The table answers "what operation is this", which post-tool accounting needs.
+ * This set answers "is this call ALREADY the thing we would have recommended",
+ * which routing needs -- and conflating them is the loop hazard: `smart_edit`
+ * resolves to `Edit`, the Edit branch recommends `smart_edit`, and the model is
+ * told to call the tool it just called.
+ */
+const REPLACEMENT_TOOLS = new Set([
+  'smart_read',
+  'smart_grep',
+  'smart_glob',
+  'smart_edit',
+  'smart_write',
+]);
+
+/**
+ * The tool name with an `mcp__<server>__` prefix removed, if it had one.
+ *
+ * Server segments contain underscores freely (`plugin_token-optimizer_token-optimizer`)
+ * and so do tool names (`smart_edit`), so the split is taken at the LAST `__`
+ * after the `mcp__` sentinel. Both halves must be non-empty: `mcp__edit` names
+ * no server and is not a name any host emits, and treating it as `edit` would
+ * coerce an unrecognised string into a built-in.
+ */
+function withoutMcpPrefix(name) {
+  const match = /^mcp__(.+)__(.+)$/.exec(name);
+  return match ? match[2] : name;
+}
+
+/** Whether this call IS one of the optimizer's replacements, however spelled. */
+export function isReplacementTool(name) {
+  if (!name) return false;
+  return REPLACEMENT_TOOLS.has(withoutMcpPrefix(String(name)).toLowerCase());
+}
+
+/**
+ * Maps a client's tool name onto the canonical one, or null if unhandled.
+ *
+ * PERMISSIVE IN ONE DIRECTION ONLY. An MCP-prefixed name is resolved by its
+ * trailing segment, but only against the same table every other client is held
+ * to -- so `mcp__vendor__deploy_to_prod` stays null. Coercing an unrecognised
+ * MCP tool into a built-in would change a routing verdict for a tool nobody has
+ * considered, which is a far worse failure than not accounting for it.
+ */
 export function normalizeTool(name) {
   if (!name) return null;
+  const candidate = withoutMcpPrefix(String(name));
   if (
     ['Read', 'Grep', 'Glob', 'Edit', 'MultiEdit', 'Write', 'Bash'].includes(
-      name
+      candidate
     )
   )
-    return name;
-  return TOOL_ALIASES.get(String(name).toLowerCase()) || null;
+    return candidate;
+  return TOOL_ALIASES.get(candidate.toLowerCase()) || null;
 }
 
 /**
@@ -614,6 +687,13 @@ export function normalizePayload(raw) {
     transcript_path: raw.transcript_path ?? raw.transcriptPath ?? null,
     cwd,
     tool_name: normalizeTool(raw.tool_name ?? raw.toolName ?? raw.tool),
+    // WHETHER THIS CALL IS ALREADY THE REPLACEMENT, carried alongside the
+    // canonical name rather than inferred from it -- because it cannot be
+    // inferred from it. `smart_edit` and `Edit` both normalise to `Edit`, and
+    // routing has to treat them as opposites while accounting treats them as
+    // the same. Absent by default (`false`), so a payload assembled by hand in
+    // a test or by a caller that predates this field is a normal built-in call.
+    replacement: isReplacementTool(raw.tool_name ?? raw.toolName ?? raw.tool),
     tool_input: {
       ...input,
       // CANONICALISED HERE, once. Every consumer downstream -- the `seen` map
@@ -673,6 +753,19 @@ function replacementAvailable(availableTools, name) {
 }
 
 export function decide(payload, state, availableTools = undefined) {
+  // THE LOOP HAZARD, and the reason this guard is at the top rather than inside
+  // any one branch. Resolving `smart_edit` to `Edit` is what makes post-tool
+  // accounting work; it must not also make the Edit branch answer a smart_edit
+  // call with "call smart_edit instead". This is not theoretical on a matcher
+  // level either: Qwen's PreToolUse matcher is the unanchored regex
+  // `edit|write_file|run_shell_command`, and `edit` matches inside
+  // `mcp__x__smart_edit`, so that client really does hand the router calls to
+  // its own replacements.
+  //
+  // A tool that IS the replacement is never routed. There is nothing better to
+  // recommend, and every branch below would recommend itself.
+  if (payload.replacement) return null;
+
   const tool = payload.tool_name;
   const input = payload.tool_input || {};
   const threshold = largeFileBytes();
@@ -873,6 +966,12 @@ export function remember(payload, state) {
  */
 export function readCostBytes(payload) {
   if (payload.tool_name !== 'Read') return 0;
+  // A REPLACEMENT DID NOT SPEND THE WHOLE FILE. `smart_read` normalises to
+  // `Read` so the graph sees the touch, but it returns a diff -- charging the
+  // full file size here would feed the holdout comparison a cost that was never
+  // paid, on the arm the optimizer is trying to show is cheaper. Better to
+  // record nothing than to record a number in the wrong direction.
+  if (payload.replacement) return 0;
   const path = payload.tool_input?.file_path;
   if (!path || isBinaryPath(path)) return 0;
   const size = fileSize(path);

--- a/integrations/codex/plugin/hooks/lib/disclose.mjs
+++ b/integrations/codex/plugin/hooks/lib/disclose.mjs
@@ -294,6 +294,11 @@ export function verdictFor(graph, { anchors = [], question, minConfidence = 0.7 
     const id = nodeId('file', canonicalPath(anchor));
     if (!graph.nodes.has(id)) continue;
 
+    // READ-ONLY serve: no `dir` is threaded here, so this cannot clear a stale
+    // flag whose evidence is gone. That is deliberate -- this function takes a
+    // graph, not the directory it came from, and widening its signature to give
+    // an analysis path a write capability buys nothing: the injection path runs
+    // on every tool call and clears the same findings.
     const findings = serve(graph, findingsFor(graph, id, { limit: 4 }));
     for (const finding of findings) {
       if (finding.stale) continue;

--- a/integrations/codex/plugin/hooks/lib/harvest-write.mjs
+++ b/integrations/codex/plugin/hooks/lib/harvest-write.mjs
@@ -34,7 +34,7 @@ import { randomBytes } from 'node:crypto';
 import { realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
-import { readEvidence } from './metrics.mjs';
+import { readEvidence, evidenceTruncated } from './metrics.mjs';
 
 /**
  * The types that may cross a project boundary.
@@ -431,53 +431,84 @@ function resolveAnchor(dir, anchor, projectRoot) {
 /**
  * Which task actually produced this finding, when nothing said so directly.
  *
- * Session id was the only signal `answers` had, and a session id is exactly
- * what a caller may not have (`wiki_write`'s `sessionId` is optional and
- * nothing populates it today; the detached harvest worker's is gated behind
- * an opt-in). But the graph does not need to be TOLD which task this is: the
- * structural harvest already writes `task -[derived_from]-> file` for every
- * tool call, unconditionally, on every install. So the task is DERIVABLE --
- * it is whichever task node has a `derived_from` edge to one of the SAME
- * anchors this finding resolved to.
+ * ROUND 2's version scanned the WHOLE graph for any task sharing any anchor,
+ * broken by recency. An adversarial review constructed four cases where that
+ * attributes a finding to the WRONG task:
  *
- * "Most recent task, full stop" was rejected on purpose: a task that never
- * touched these files could still be the newest node in the graph (a
- * different file, a different concern, in a later session), and attaching
- * provenance to it would be a WRONG edge, not a missing one -- worse than no
- * edge, because a reader trusts it. So candidates are filtered to tasks that
- * touched at least one of these anchors FIRST, and only ties among THOSE are
- * broken by recency.
+ *   1. STALE PRIOR SESSION -- a session that reasons from injected memory and
+ *      writes a finding about `foo.ts` without touching it this session gets
+ *      attributed to whatever task last touched `foo.ts`, possibly days old,
+ *      possibly someone else's work.
+ *   2. CONCURRENT SESSION -- two windows on one repository; the other
+ *      session's task wins if its touch is a millisecond later.
+ *   3. OVERLAP, NOT COVERAGE -- a finding anchored to [a, b]; a task that
+ *      touched only `b` could still win over one that touched both.
+ *   4. THE TIE-BREAK CONTRADICTED ITS OWN COMMENT -- `Number(edge.at) || 0`
+ *      with strict `>` means the FIRST edge in log order wins on a tie,
+ *      which is the OLDER task, not "more recently" as documented.
  *
- * The tie-break is the edge's own `at`, not the task node's `at`. A task that
- * touched this file once, long ago, and then stayed active on unrelated files
- * for hours has a late node timestamp that says nothing about this anchor;
- * the edge timestamp says exactly when THIS task touched THIS anchor, which
- * is the question being asked. Among tasks sharing an anchor, the one whose
- * most recent touch to any shared anchor is latest wins -- recency of the
- * relevant work, not recency of the task in general.
+ * THE FIX IS NARROWER THAN A BETTER RANKING: SCOPE, THEN REQUIRE COVERAGE.
+ * A task only ever belongs to the session that created it -- `harvest()` and
+ * `linkCoOccurrence()` (wiki.mjs, inject.mjs) both key a task node by
+ * `sessionId`, always, so there is exactly ONE task node for "the current
+ * session" and it is `nodeId('task', sessionId)`. Restricting to that ONE
+ * node structurally eliminates cases 1 and 2 -- a prior or concurrent
+ * session's task has a DIFFERENT sessionId and therefore a different node
+ * id, so it is never even looked at, regardless of timing. No caller can
+ * supply a wrong sessionId and get someone ELSE's task; they can only fail
+ * to get a match.
+ *
+ * COVERAGE, NOT OVERLAP, fixes case 3: the session's task must have a
+ * `derived_from` edge to EVERY one of this finding's anchors, not merely one.
+ * A partial touch is not attribution.
+ *
+ * With the candidate set reduced to at most one node, there is nothing left
+ * to break a tie between -- case 4's comparator is not "fixed", it is
+ * deleted, because the scenario it was written for (two DIFFERENT tasks both
+ * legitimately eligible) cannot occur under this scoping: two task nodes can
+ * never share a key, and only the current session's key is ever considered.
+ * An edge's `at` therefore plays NO role here: presence of a `derived_from`
+ * edge from the session's task to an anchor is what "touched it" means, with
+ * or without a timestamp on that edge -- there is no ranking left for a
+ * missing timestamp to lose.
+ *
+ * `sessionId` absent means there is no identity to scope by, which means no
+ * candidate -- not "fall back to guessing". Absence is the correct answer
+ * when the graph cannot support attribution.
  */
-function taskForAnchors(graph, anchorIds) {
-  if (!anchorIds || !anchorIds.length) return null;
-  const anchors = new Set(anchorIds);
-  let best = null;
-  for (const edge of graph.edges) {
-    if (edge.edge !== 'derived_from' || !anchors.has(edge.to)) continue;
-    const from = graph.nodes.get(edge.from);
-    // `derived_from` is also how a FINDING cites its own anchors, so without
-    // this a finding that already cited the same file would be mistaken for
-    // the task that produced it.
-    if (!from || from.kind !== 'task') continue;
-    const at = Number(edge.at) || 0;
-    if (!best || at > best.at) best = { taskId: edge.from, at };
+function taskForAnchors(graph, anchorIds, sessionId) {
+  if (!sessionId || !anchorIds || !anchorIds.length) return null;
+  const taskTarget = nodeId('task', sessionId);
+  const task = graph.nodes.get(taskTarget);
+  if (!task || task.kind !== 'task') return null;
+
+  for (const anchor of anchorIds) {
+    const covered = graph.edges.some((edge) =>
+      edge.edge === 'derived_from' && edge.from === taskTarget && edge.to === anchor
+    );
+    // ONE missing anchor refuses the whole attribution. A finding cited three
+    // files; this session's task touched two of them -- that is evidence the
+    // task did SOME related work, not evidence it produced THIS finding.
+    if (!covered) return null;
   }
-  return best ? best.taskId : null;
+  return taskTarget;
 }
 
 /**
  * A file path the way `recordToolOutcome` (metrics.mjs) already truncates and
- * stores it on a `tool-outcome` event's `anchor` field, so a derivation record
- * can join against that log without a second, divergent notion of "the same
- * anchor".
+ * stores it on a FILE-surface `tool-outcome` event's `anchor` field, so a
+ * derivation record can join against that log without a second, divergent
+ * notion of "the same anchor".
+ *
+ * COMMAND-surface events are DECLARED OUT OF SCOPE, not silently missed:
+ * `adapter.mjs` stores the COMMAND TEXT in `anchor` for those
+ * (`String(command).slice(0, 120)`), so a build or test run can never share
+ * an anchor string with a canonical file path -- there is no join key in
+ * common, and inventing a command-to-file heuristic (which files did a given
+ * `npm test` invocation cover?) is not something this record can answer
+ * honestly. `operationsScope` on the returned record says so explicitly,
+ * rather than letting an empty `operations` array look like "no build or
+ * test ever ran" when the truth is "this join cannot see it".
  */
 function anchorLabel(rawAnchor) {
   const path = String(rawAnchor).split('#')[0];
@@ -497,7 +528,8 @@ const MAX_DERIVATION_OPERATIONS = 5;
  * that comparison be reconstructed for a specific claim rather than only for
  * the anchor in general: the hash each anchor carried at the moment this
  * finding was derived from it, plus what evidence exists that any work
- * actually happened against it.
+ * actually happened against it. `derivationCheck` (staleness.mjs) is the
+ * reader that actually performs that comparison at serve time.
  *
  * DELIBERATELY NOT DUPLICATING THE EDGES. `derived_from` already records
  * WHICH anchors this finding cites; restating that here would be a second,
@@ -506,14 +538,23 @@ const MAX_DERIVATION_OPERATIONS = 5;
  *
  * DELIBERATELY NOT A REPLAY LOG. Recording enough to mechanically re-run a
  * derivation is a separate subsystem with real storage cost. This stores only
- * what the evidence log already has: `tool-outcome` events matching these
- * anchors, each reduced to the fields that were actually captured. An event
- * that carries no exit code or output contributes none -- nothing here is
- * invented to fill a shape the pipeline does not evidence yet. If a future
- * capture pass adds `exit`/`output` to those events, this starts carrying them
- * with no change to this function.
+ * what the evidence log already has: FILE-surface `tool-outcome` events
+ * matching these anchors, each reduced to the fields that were actually
+ * captured. An event that carries no exit code or output contributes none --
+ * nothing here is invented to fill a shape the pipeline does not evidence
+ * yet. If a future capture pass adds `exit`/`output` to those events, this
+ * starts carrying them with no change to this function.
+ *
+ * INCOMPLETENESS IS MARKED, NOT IMPLIED. An empty `operations` array is
+ * genuinely ambiguous on its own -- it is the same shape whether nothing
+ * happened, or something happened but fell outside what this join can see.
+ * `operationsComplete` distinguishes them: false when the evidence log itself
+ * may have dropped older matches (`evidenceIncomplete`, from
+ * `metrics.evidenceTruncated`) OR when more matches existed than the cap
+ * kept. A reader can then tell "no operations happened" from "operations
+ * existed but are not recorded here" instead of guessing.
  */
-function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
+function derivationFor(graph, resolvedAnchors, evidence, evidenceIncomplete, anchorSpecs) {
   const anchorHashes = {};
   for (const id of resolvedAnchors) {
     const node = graph.nodes.get(id);
@@ -521,8 +562,10 @@ function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
   }
 
   const labels = new Set((anchorSpecs || []).map(anchorLabel));
-  const operations = evidence
-    .filter((event) => event.kind === 'tool-outcome' && labels.has(event.anchor))
+  const matching = evidence.filter(
+    (event) => event.kind === 'tool-outcome' && labels.has(event.anchor)
+  );
+  const operations = [...matching]
     .sort((a, b) => (Number(b.at) || 0) - (Number(a.at) || 0))
     .slice(0, MAX_DERIVATION_OPERATIONS)
     .map((event) => {
@@ -540,7 +583,16 @@ function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
       return op;
     });
 
-  return { at: Date.now(), anchors: anchorHashes, operations };
+  return {
+    at: Date.now(),
+    anchors: anchorHashes,
+    operations,
+    // FILE touches only -- see `anchorLabel`. Declared here, in the record
+    // itself, not only in this function's comment, so a reader who never
+    // opens this source file still learns builds and test runs are excluded.
+    operationsScope: 'file',
+    operationsComplete: !evidenceIncomplete && matching.length <= operations.length,
+  };
 }
 
 /**
@@ -588,6 +640,9 @@ export function writeHarvested(
   // it can hold thousands of lines, so re-reading it per finding would turn a
   // batch of N findings into N passes over the same bytes.
   const evidence = readEvidence(dir);
+  // Cheap: one stat call, checked once per batch rather than once per
+  // finding's derivation record.
+  const evidenceIncomplete = evidenceTruncated(dir);
 
   const written = [];
   for (const finding of findings) {
@@ -647,14 +702,16 @@ export function writeHarvested(
     // An explicit `taskId` is authoritative when a caller supplies one --
     // it OVERRIDES traversal rather than merely seeding it, so a caller that
     // knows better is never second-guessed by inference. Absent one, the task
-    // is DERIVED from the graph itself: `taskForAnchors` finds the task that
-    // actually touched these anchors, which needs no session id from anyone.
-    // Either way, held to the same discipline as the anchors above: a target
-    // that does not resolve to an existing task node produces no edge rather
-    // than a dangling one.
+    // is DERIVED from the graph itself: `taskForAnchors` finds the CURRENT
+    // session's task (scoped by `sessionId`, the same identity this write
+    // already carries for provenance) and requires it to have touched EVERY
+    // one of this finding's anchors, not merely one -- see that function's
+    // own comment for the four attacks this closes. Either way, held to the
+    // same discipline as the anchors above: a target that does not resolve to
+    // an existing task node produces no edge rather than a dangling one.
     const answersTarget = taskId
       ? nodeId('task', taskId)
-      : taskForAnchors(currentGraph, resolved);
+      : taskForAnchors(currentGraph, resolved, sessionId);
     if (answersTarget && currentGraph.nodes.has(answersTarget)) {
       edges.push({ edge: 'answers', to: answersTarget });
     }
@@ -707,7 +764,7 @@ export function writeHarvested(
         // `render()`/`renderSessionIndex()` in inject.mjs or `wiki_read`'s
         // `toFinding()` projection, neither of which reads this field, so it
         // is not part of the automatic per-touch injection `fit()` prices.
-        derivation: derivationFor(currentGraph, resolved, evidence, finding.anchors || []),
+        derivation: derivationFor(currentGraph, resolved, evidence, evidenceIncomplete, finding.anchors || []),
       },
       edges
     );

--- a/integrations/codex/plugin/hooks/lib/harvest-write.mjs
+++ b/integrations/codex/plugin/hooks/lib/harvest-write.mjs
@@ -452,11 +452,13 @@ function resolveAnchor(dir, anchor, projectRoot) {
  * `linkCoOccurrence()` (wiki.mjs, inject.mjs) both key a task node by
  * `sessionId`, always, so there is exactly ONE task node for "the current
  * session" and it is `nodeId('task', sessionId)`. Restricting to that ONE
- * node structurally eliminates cases 1 and 2 -- a prior or concurrent
- * session's task has a DIFFERENT sessionId and therefore a different node
- * id, so it is never even looked at, regardless of timing. No caller can
- * supply a wrong sessionId and get someone ELSE's task; they can only fail
- * to get a match.
+ * node structurally eliminates cases 1 and 2 PROVIDED the identity itself is
+ * trustworthy: an UNRELATED sessionId (typo'd, invented, or simply absent)
+ * cannot resolve to someone else's task, because a different key is a
+ * different node id, full stop, regardless of timing. That is NOT the same
+ * guarantee as "no caller can get someone else's task" -- see the note on
+ * `authoritativeSessionId` below for the residual this leaves when the
+ * identity is real but comes from an untrusted caller.
  *
  * COVERAGE, NOT OVERLAP, fixes case 3: the session's task must have a
  * `derived_from` edge to EVERY one of this finding's anchors, not merely one.
@@ -472,17 +474,41 @@ function resolveAnchor(dir, anchor, projectRoot) {
  * or without a timestamp on that edge -- there is no ranking left for a
  * missing timestamp to lose.
  *
- * `sessionId` absent means there is no identity to scope by, which means no
- * candidate -- not "fall back to guessing". Absence is the correct answer
- * when the graph cannot support attribution.
+ * NO IDENTITY MEANS NO CANDIDATE -- not "fall back to guessing". Absence is
+ * the correct answer when the graph cannot support attribution.
+ *
+ * ROUND 4: THE IDENTITY ITSELF MUST BE AUTHORITATIVE, not merely present.
+ * Scoping to `nodeId('task', sessionId)` only refuses an UNRELATED session;
+ * it does nothing against a FOREIGN BUT REAL one. `wiki_write`'s `sessionId`
+ * is a plain MCP tool argument the calling model supplies, unverified -- a
+ * model that names some OTHER, prior session whose task genuinely covered
+ * these anchors gets an `answers` edge to that stale task, because coverage
+ * cannot tell "this session" from "a session that really did touch these
+ * files, named by a string nothing cross-checked". Session id is not
+ * evidence unless the CALLER'S OWN CHANNEL is trustworthy, which is true of
+ * `plugin/hooks/harvest-worker.mjs` (Claude Code's own hook payload) and not
+ * true of a tool-call argument. So this parameter is named for what it must
+ * be, `authoritativeSessionId`, and every caller is a promise: pass this only
+ * when you did not just read it out of untrusted input. `wiki_write` passes
+ * NONE, which means its calls never traverse -- see `writeHarvested`'s own
+ * comment at the call site for what that costs and why it is accepted rather
+ * than worked around.
+ *
+ * COVERAGE IS CHECKED AGAINST RESOLVED ANCHORS, not the caller's original
+ * list. `writeHarvested` already drops any anchor `resolveAnchor` could not
+ * resolve before this function ever runs, so "every anchor" here means every
+ * anchor that survived that filter -- self-consistent with the
+ * `derived_from` edges the same resolved list produces, but worth stating:
+ * an anchor that failed to resolve cannot raise or lower the bar for the
+ * anchors that did.
  */
-function taskForAnchors(graph, anchorIds, sessionId) {
-  if (!sessionId || !anchorIds || !anchorIds.length) return null;
-  const taskTarget = nodeId('task', sessionId);
+function taskForAnchors(graph, resolvedAnchorIds, authoritativeSessionId) {
+  if (!authoritativeSessionId || !resolvedAnchorIds || !resolvedAnchorIds.length) return null;
+  const taskTarget = nodeId('task', authoritativeSessionId);
   const task = graph.nodes.get(taskTarget);
   if (!task || task.kind !== 'task') return null;
 
-  for (const anchor of anchorIds) {
+  for (const anchor of resolvedAnchorIds) {
     const covered = graph.edges.some((edge) =>
       edge.edge === 'derived_from' && edge.from === taskTarget && edge.to === anchor
     );
@@ -604,7 +630,19 @@ function derivationFor(graph, resolvedAnchors, evidence, evidenceIncomplete, anc
 export function writeHarvested(
   dir,
   findings,
-  { sessionId = null, origin = ORIGIN_HARVESTED, projectRoot = null, taskId = null } = {}
+  {
+    sessionId = null,
+    origin = ORIGIN_HARVESTED,
+    projectRoot = null,
+    taskId = null,
+    // Distinct from `sessionId`, which is stored on every finding for
+    // provenance/display regardless of trust. This one gates the `answers`
+    // traversal fallback specifically, and every caller passing it is
+    // asserting the identity came from a channel it does not control --
+    // Claude Code's own hook payload, not a tool-call argument a model
+    // typed. See `taskForAnchors`'s comment for the attack this closes.
+    authoritativeSessionId = null,
+  } = {}
 ) {
   if (!Array.isArray(findings) || !findings.length) return [];
 
@@ -702,16 +740,29 @@ export function writeHarvested(
     // An explicit `taskId` is authoritative when a caller supplies one --
     // it OVERRIDES traversal rather than merely seeding it, so a caller that
     // knows better is never second-guessed by inference. Absent one, the task
-    // is DERIVED from the graph itself: `taskForAnchors` finds the CURRENT
-    // session's task (scoped by `sessionId`, the same identity this write
-    // already carries for provenance) and requires it to have touched EVERY
-    // one of this finding's anchors, not merely one -- see that function's
-    // own comment for the four attacks this closes. Either way, held to the
-    // same discipline as the anchors above: a target that does not resolve to
-    // an existing task node produces no edge rather than a dangling one.
+    // is DERIVED from the graph itself, but ONLY when `authoritativeSessionId`
+    // is present: `taskForAnchors` scopes to that exact session's task and
+    // requires it to have touched EVERY one of this finding's anchors, not
+    // merely one -- see that function's own comment for why the identity
+    // itself must be trustworthy, not merely present.
+    //
+    // THE CONSEQUENCE, STATED PLAINLY: `wiki_write` never supplies
+    // `authoritativeSessionId` (its `sessionId` is a model-typed MCP
+    // argument nothing cross-checks), so its calls never traverse and
+    // `answers` never fires on that path. `plugin/hooks/harvest-worker.mjs`
+    // does supply it (Claude Code's own hook payload), so `answers` fires
+    // there -- opt-in gated. `answers` therefore does NOT fire on a default
+    // install today. Recovering default liveness needs an authoritative
+    // identity on a default-install path, which is what Plan 2's
+    // `hooks-core/derive.mjs` (running in the Stop hook, where the session id
+    // is real) is for -- not a weaker check here.
+    //
+    // Either way, held to the same discipline as the anchors above: a target
+    // that does not resolve to an existing task node produces no edge rather
+    // than a dangling one.
     const answersTarget = taskId
       ? nodeId('task', taskId)
-      : taskForAnchors(currentGraph, resolved, sessionId);
+      : taskForAnchors(currentGraph, resolved, authoritativeSessionId);
     if (answersTarget && currentGraph.nodes.has(answersTarget)) {
       edges.push({ edge: 'answers', to: answersTarget });
     }

--- a/integrations/codex/plugin/hooks/lib/harvest-write.mjs
+++ b/integrations/codex/plugin/hooks/lib/harvest-write.mjs
@@ -436,7 +436,7 @@ function resolveAnchor(dir, anchor, projectRoot) {
 export function writeHarvested(
   dir,
   findings,
-  { sessionId = null, origin = ORIGIN_HARVESTED, projectRoot = null } = {}
+  { sessionId = null, origin = ORIGIN_HARVESTED, projectRoot = null, taskId = null } = {}
 ) {
   if (!Array.isArray(findings) || !findings.length) return [];
 
@@ -516,6 +516,21 @@ export function writeHarvested(
     // collision vanishingly unlikely while keeping the timestamp readable.
     const provenance = provenanceFor(finding);
     const key = `${prefixFor(provenance)}-${Date.now().toString(36)}-${written.length}-${randomBytes(4).toString("hex")}`;
+
+    const edges = resolved.map((target) => ({ edge: 'derived_from', to: target }));
+    // `answers` closes the loop back to the task that produced the finding, so
+    // provenance can be traversed rather than inferred: "which session
+    // established this, and from what". Declared in EDGE_KINDS and written by
+    // nothing until now. Held to the same discipline as the anchors above: a
+    // taskId that does not resolve to an existing task node produces no edge
+    // rather than a dangling one.
+    if (taskId) {
+      const taskTarget = nodeId('task', taskId);
+      if (currentGraph.nodes.has(taskTarget)) {
+        edges.push({ edge: 'answers', to: taskTarget });
+      }
+    }
+
     // ONE APPEND for the finding and every anchor it resolved. This runs in a
     // detached worker, so "the process survives to finish the loop" is not a
     // safe assumption: a node written without its edges is an active finding
@@ -557,7 +572,7 @@ export function writeHarvested(
           : undefined,
         sessionId,
       },
-      resolved.map((target) => ({ edge: 'derived_from', to: target }))
+      edges
     );
     // A failed write returns null. Reporting the key anyway would tell the
     // caller a claim was stored that no later session can retrieve.

--- a/integrations/codex/plugin/hooks/lib/harvest-write.mjs
+++ b/integrations/codex/plugin/hooks/lib/harvest-write.mjs
@@ -34,6 +34,7 @@ import { randomBytes } from 'node:crypto';
 import { realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
+import { readEvidence } from './metrics.mjs';
 
 /**
  * The types that may cross a project boundary.
@@ -428,6 +429,121 @@ function resolveAnchor(dir, anchor, projectRoot) {
 }
 
 /**
+ * Which task actually produced this finding, when nothing said so directly.
+ *
+ * Session id was the only signal `answers` had, and a session id is exactly
+ * what a caller may not have (`wiki_write`'s `sessionId` is optional and
+ * nothing populates it today; the detached harvest worker's is gated behind
+ * an opt-in). But the graph does not need to be TOLD which task this is: the
+ * structural harvest already writes `task -[derived_from]-> file` for every
+ * tool call, unconditionally, on every install. So the task is DERIVABLE --
+ * it is whichever task node has a `derived_from` edge to one of the SAME
+ * anchors this finding resolved to.
+ *
+ * "Most recent task, full stop" was rejected on purpose: a task that never
+ * touched these files could still be the newest node in the graph (a
+ * different file, a different concern, in a later session), and attaching
+ * provenance to it would be a WRONG edge, not a missing one -- worse than no
+ * edge, because a reader trusts it. So candidates are filtered to tasks that
+ * touched at least one of these anchors FIRST, and only ties among THOSE are
+ * broken by recency.
+ *
+ * The tie-break is the edge's own `at`, not the task node's `at`. A task that
+ * touched this file once, long ago, and then stayed active on unrelated files
+ * for hours has a late node timestamp that says nothing about this anchor;
+ * the edge timestamp says exactly when THIS task touched THIS anchor, which
+ * is the question being asked. Among tasks sharing an anchor, the one whose
+ * most recent touch to any shared anchor is latest wins -- recency of the
+ * relevant work, not recency of the task in general.
+ */
+function taskForAnchors(graph, anchorIds) {
+  if (!anchorIds || !anchorIds.length) return null;
+  const anchors = new Set(anchorIds);
+  let best = null;
+  for (const edge of graph.edges) {
+    if (edge.edge !== 'derived_from' || !anchors.has(edge.to)) continue;
+    const from = graph.nodes.get(edge.from);
+    // `derived_from` is also how a FINDING cites its own anchors, so without
+    // this a finding that already cited the same file would be mistaken for
+    // the task that produced it.
+    if (!from || from.kind !== 'task') continue;
+    const at = Number(edge.at) || 0;
+    if (!best || at > best.at) best = { taskId: edge.from, at };
+  }
+  return best ? best.taskId : null;
+}
+
+/**
+ * A file path the way `recordToolOutcome` (metrics.mjs) already truncates and
+ * stores it on a `tool-outcome` event's `anchor` field, so a derivation record
+ * can join against that log without a second, divergent notion of "the same
+ * anchor".
+ */
+function anchorLabel(rawAnchor) {
+  const path = String(rawAnchor).split('#')[0];
+  return canonicalPath(path).slice(0, 120);
+}
+
+/** How many recorded operations a single finding's derivation may cite. */
+const MAX_DERIVATION_OPERATIONS = 5;
+
+/**
+ * The checkable half of provenance: not just where a finding came from, but
+ * whether that derivation still holds.
+ *
+ * Citation-style provenance (a session or task id) answers "where". It never
+ * answers "does this still apply" -- that is what staleness already computes,
+ * by comparing an anchor's STORED hash against disk. This record is what lets
+ * that comparison be reconstructed for a specific claim rather than only for
+ * the anchor in general: the hash each anchor carried at the moment this
+ * finding was derived from it, plus what evidence exists that any work
+ * actually happened against it.
+ *
+ * DELIBERATELY NOT DUPLICATING THE EDGES. `derived_from` already records
+ * WHICH anchors this finding cites; restating that here would be a second,
+ * driftable copy of the same fact. What is new here, and only here, is the
+ * HASH each anchor carried at claim time -- edges carry no such thing.
+ *
+ * DELIBERATELY NOT A REPLAY LOG. Recording enough to mechanically re-run a
+ * derivation is a separate subsystem with real storage cost. This stores only
+ * what the evidence log already has: `tool-outcome` events matching these
+ * anchors, each reduced to the fields that were actually captured. An event
+ * that carries no exit code or output contributes none -- nothing here is
+ * invented to fill a shape the pipeline does not evidence yet. If a future
+ * capture pass adds `exit`/`output` to those events, this starts carrying them
+ * with no change to this function.
+ */
+function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
+  const anchorHashes = {};
+  for (const id of resolvedAnchors) {
+    const node = graph.nodes.get(id);
+    if (node && typeof node.hash === 'string') anchorHashes[id] = node.hash;
+  }
+
+  const labels = new Set((anchorSpecs || []).map(anchorLabel));
+  const operations = evidence
+    .filter((event) => event.kind === 'tool-outcome' && labels.has(event.anchor))
+    .sort((a, b) => (Number(b.at) || 0) - (Number(a.at) || 0))
+    .slice(0, MAX_DERIVATION_OPERATIONS)
+    .map((event) => {
+      const op = {};
+      if (typeof event.toolName === 'string' && event.toolName)
+        op.tool = event.toolName.slice(0, 60);
+      if (typeof event.success === 'boolean') op.success = event.success;
+      if (typeof event.at === 'number') op.at = event.at;
+      // Forward-compatible, not fabricated: neither field exists on a
+      // `tool-outcome` event in this pipeline today, so every operation
+      // omits them until a capture pass actually evidences one.
+      if (typeof event.exit === 'number') op.exit = event.exit;
+      if (typeof event.output === 'string' && event.output)
+        op.output = event.output.slice(0, 200);
+      return op;
+    });
+
+  return { at: Date.now(), anchors: anchorHashes, operations };
+}
+
+/**
  * Writes validated findings, returning the keys actually stored.
  *
  * `findings` is the output of `harvest.validate()`, so type/claim/confidence
@@ -467,6 +583,11 @@ export function writeHarvested(
       : batch;
   const prefixFor = (p) =>
     p === ORIGIN_AGENT ? 'agent' : p === ORIGIN_HUMAN ? 'human' : 'harvested';
+
+  // Read once: every finding in this batch shares the same evidence log, and
+  // it can hold thousands of lines, so re-reading it per finding would turn a
+  // batch of N findings into N passes over the same bytes.
+  const evidence = readEvidence(dir);
 
   const written = [];
   for (const finding of findings) {
@@ -521,14 +642,21 @@ export function writeHarvested(
     // `answers` closes the loop back to the task that produced the finding, so
     // provenance can be traversed rather than inferred: "which session
     // established this, and from what". Declared in EDGE_KINDS and written by
-    // nothing until now. Held to the same discipline as the anchors above: a
-    // taskId that does not resolve to an existing task node produces no edge
-    // rather than a dangling one.
-    if (taskId) {
-      const taskTarget = nodeId('task', taskId);
-      if (currentGraph.nodes.has(taskTarget)) {
-        edges.push({ edge: 'answers', to: taskTarget });
-      }
+    // nothing until now.
+    //
+    // An explicit `taskId` is authoritative when a caller supplies one --
+    // it OVERRIDES traversal rather than merely seeding it, so a caller that
+    // knows better is never second-guessed by inference. Absent one, the task
+    // is DERIVED from the graph itself: `taskForAnchors` finds the task that
+    // actually touched these anchors, which needs no session id from anyone.
+    // Either way, held to the same discipline as the anchors above: a target
+    // that does not resolve to an existing task node produces no edge rather
+    // than a dangling one.
+    const answersTarget = taskId
+      ? nodeId('task', taskId)
+      : taskForAnchors(currentGraph, resolved);
+    if (answersTarget && currentGraph.nodes.has(answersTarget)) {
+      edges.push({ edge: 'answers', to: answersTarget });
     }
 
     // ONE APPEND for the finding and every anchor it resolved. This runs in a
@@ -571,6 +699,15 @@ export function writeHarvested(
           ? finding.quote
           : undefined,
         sessionId,
+        // THE CHECKABLE HALF OF PROVENANCE. Citation-style (this `sessionId`,
+        // the `answers` edge above) says WHERE a claim came from; it never
+        // says whether that derivation still applies. `derivationFor` reaches
+        // through `wiki_query`'s `node`/`get`/`search` operations only (those
+        // return a finding's stored fields wholesale) -- never through
+        // `render()`/`renderSessionIndex()` in inject.mjs or `wiki_read`'s
+        // `toFinding()` projection, neither of which reads this field, so it
+        // is not part of the automatic per-touch injection `fit()` prices.
+        derivation: derivationFor(currentGraph, resolved, evidence, finding.anchors || []),
       },
       edges
     );

--- a/integrations/codex/plugin/hooks/lib/inject.mjs
+++ b/integrations/codex/plugin/hooks/lib/inject.mjs
@@ -26,6 +26,7 @@ import {
 } from './wiki.mjs';
 import { basename } from 'node:path';
 import { serve, diffLines } from './staleness.mjs';
+import { drainInvalidations } from './pending.mjs';
 import { inHoldout, record, indexBudget } from './metrics.mjs';
 import { canonicalPath, resolvableCandidates } from './paths.mjs';
 import { annotatedSkeleton } from './skeleton.mjs';
@@ -142,6 +143,31 @@ function render(finding) {
 }
 
 /**
+ * Applies anything the post-tool hook queued, BEFORE anything is served.
+ *
+ * THIS IS WHERE EAGER STALENESS LANDS. `invalidateOnWrite` needs a graph, and
+ * loading one on the return path of every write is what pending.mjs exists to
+ * avoid -- so the hook queues and the next graph read applies. These two
+ * functions are that read: they already hold a freshly loaded graph, and they
+ * are the last thing to run before a finding reaches a model.
+ *
+ * RE-READ ONLY WHEN SOMETHING WAS ACTUALLY MARKED. The drain writes the stale
+ * flag to disk; it cannot mutate the caller's already-parsed graph, so serving
+ * from that copy would deliver the very "stale finding as fresh" this exists to
+ * prevent. A second load costs a parse, and it is paid once per observed write
+ * rather than once per tool call -- when nothing is queued this is one stat.
+ */
+function withPendingApplied(dir, graph) {
+  try {
+    return drainInvalidations(dir, graph) > 0 ? load(dir) : graph;
+  } catch {
+    // The lazy path still covers everything this would have caught early, and
+    // a hook must never fail because bookkeeping did.
+    return graph;
+  }
+}
+
+/**
  * What the model sees when it touches a file.
  *
  * Returns null when there is nothing to say, or when this touch fell into the
@@ -154,6 +180,7 @@ export function forTouch(
   rawPath,
   { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
+  graph = withPendingApplied(dir, graph);
   // Canonical, so a touch finds findings anchored under any other spelling.
   const filePath = canonicalPath(rawPath);
   const anchorId = nodeId('file', filePath);
@@ -322,6 +349,7 @@ export function forCommand(
   { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
   if (!command) return null;
+  graph = withPendingApplied(dir, graph);
 
   const candidates = [];
   for (const node of graph.nodes.values()) {

--- a/integrations/codex/plugin/hooks/lib/inject.mjs
+++ b/integrations/codex/plugin/hooks/lib/inject.mjs
@@ -33,6 +33,7 @@ import { annotatedSkeleton } from './skeleton.mjs';
 import { substitutionBudget } from './metrics.mjs';
 import { assessFindings } from './utility.mjs';
 import { quarantineSharedSource } from './harvest-write.mjs';
+import { cacheOrdered } from './cache.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
@@ -1152,6 +1153,53 @@ export function standingRules(dir, graph, { budget = standingBudget(), episode =
   // which is worse than saying there are more: a model that knows the list is
   // truncated can ask, one that does not will assume it is complete.
   return `${HEADING}${lines.join('\n')}${truncated}`;
+}
+
+/**
+ * SessionStart context, assembled in cache order: stable first, volatile last.
+ *
+ * WHY THE ORDER IS A CORRECTNESS PROPERTY AND NOT A STYLE CHOICE. Everything
+ * here lands near the FRONT of the prompt prefix, and a prefix cache is
+ * invalidated from the first differing byte onward. A block whose text changes
+ * between sessions therefore prices everything positioned after it: put the
+ * freshest block first and the whole remainder of the prefix is re-written
+ * every session; put it last and the invalidation is confined to its own tail.
+ * cache.mjs measures exactly this cost in the user's files -- this is the same
+ * discipline applied to our own output, which is the half nobody else has to
+ * think about because nobody else writes into the prefix.
+ *
+ * `cacheOrdered` existed for precisely this and had no caller, so the order was
+ * whatever order the call sites happened to push in. It was accidentally right;
+ * it is now enforced, which is the difference that matters the next time a
+ * block is added.
+ *
+ * VOLATILITY IS ASSIGNED FROM HOW OFTEN THE TEXT ACTUALLY DIFFERS BETWEEN
+ * SESSIONS, not from how important the block is:
+ *
+ *   0  policy -- the optimization notice and project briefing. Deliberately
+ *      cache-safe by construction: the routing facts are number-free and the
+ *      briefing passes through `stableText`, which DROPS any line that would
+ *      vary. It changes when the tool inventory or configuration changes.
+ *   1  standing -- pinned facts and human-verified corrections, rendered in
+ *      full. Changes only when a person pins, retires or corrects something.
+ *   2  index -- the bounded wiki index, selected per session from the task
+ *      text, and carrying [STALE]/[DISPUTED] markers that flip as the code
+ *      moves. Different on most sessions.
+ *   3  restoration -- present only when resuming from a compaction, and derived
+ *      from the anchors of the session that was just discarded. Never twice the
+ *      same.
+ *
+ * A block with no text is dropped rather than joined, so an absent block cannot
+ * open the assembly with a blank line.
+ */
+export function sessionContext(blocks) {
+  return cacheOrdered(
+    (Array.isArray(blocks) ? blocks : []).filter(
+      (block) => block && typeof block.text === 'string' && block.text.trim()
+    )
+  )
+    .map((block) => block.text)
+    .join('\n\n');
 }
 
 /**

--- a/integrations/codex/plugin/hooks/lib/inject.mjs
+++ b/integrations/codex/plugin/hooks/lib/inject.mjs
@@ -122,8 +122,29 @@ function fit(findings, budget) {
   return { kept, spent };
 }
 
+/**
+ * Discloses an open disagreement, on the same line as the claim it is about.
+ *
+ * BOTH HALVES, like the stale renderer below: the strong form names the other
+ * finding so the reader can fetch it, and the form without a key says only what
+ * is actually known. `serve` is what establishes the dispute; this only phrases
+ * it, and it phrases it in one short line because `fit` prices `render` against
+ * the injection budget -- a disagreement is worth a pointer, not both claims in
+ * full.
+ *
+ * NO DISMISSAL VOCABULARY, for the reason measured on the stale wording: an
+ * instruction to discount suppressed findings that were correct. This states
+ * that another claim exists and where to find it, and lets the reader decide.
+ */
+function disputeNote(finding) {
+  if (!finding.contradicted) return '';
+  return finding.contradictedBy
+    ? `\n  DISPUTED by ${finding.contradictedBy} -- wiki_query that key for the other claim`
+    : '\n  DISPUTED by another finding in this graph';
+}
+
 function render(finding) {
-  const head = `- [${finding.type || 'finding'}] ${finding.claim}`;
+  const head = `- [${finding.type || 'finding'}] ${finding.claim}${disputeNote(finding)}`;
   if (!finding.stale) return head;
 
   // A stale finding NEVER renders as though it were current. But the strength
@@ -997,7 +1018,15 @@ function renderSessionIndex(total, findings) {
       : finding.stale
         ? ' [possibly stale; verify before use]'
         : '';
-    return `- ${finding.key}${freshness}: ${finding.claim.slice(0, 90)}`;
+    // The session index is the first thing a session reads, so a disputed
+    // finding must not be listed there as settled either. Compressed to a
+    // marker and a key, matching the freshness markers beside it.
+    const dispute = finding.contradicted
+      ? finding.contradictedBy
+        ? ` [DISPUTED by ${finding.contradictedBy}]`
+        : ' [DISPUTED]'
+      : '';
+    return `- ${finding.key}${freshness}${dispute}: ${finding.claim.slice(0, 90)}`;
   });
   return `# Project wiki (${total} findings, ${findings.length} listed)
 

--- a/integrations/codex/plugin/hooks/lib/inject.mjs
+++ b/integrations/codex/plugin/hooks/lib/inject.mjs
@@ -139,9 +139,26 @@ function fit(findings, budget) {
  */
 function disputeNote(finding) {
   if (!finding.contradicted) return '';
-  return finding.contradictedBy
+  const head = finding.contradictedBy
     ? `\n  DISPUTED by ${finding.contradictedBy} -- wiki_query that key for the other claim`
     : '\n  DISPUTED by another finding in this graph';
+  // THE REASON A PERSON TYPED, rendered here because this is the fullest of the
+  // three dispute surfaces and the only one with room for a sentence. `contradict`
+  // has always stored up to 400 characters of human explanation and, until this
+  // line, nothing read it: the pointer told a reader where to look and withheld
+  // the one thing that would tell them whether looking was worth a tool call.
+  //
+  // TRUNCATED AT 140, because `fit` prices this string against the injection
+  // budget and a 400-character paragraph beside a one-line claim inverts the
+  // proportions. The compressed surfaces -- the session index and restore.mjs's
+  // "Likely next" list -- deliberately keep marker-and-key only; they are one
+  // line per finding by design, and `wiki_query` returns the reason in full.
+  if (typeof finding.contradictionReason !== 'string' || !finding.contradictionReason.trim()) {
+    return head;
+  }
+  const reason = finding.contradictionReason.trim();
+  const shown = reason.length > 140 ? `${reason.slice(0, 140)}...` : reason;
+  return `${head}\n  Reason given: ${shown}`;
 }
 
 /**

--- a/integrations/codex/plugin/hooks/lib/inject.mjs
+++ b/integrations/codex/plugin/hooks/lib/inject.mjs
@@ -276,7 +276,10 @@ export function forTouch(
   // others, so the comparison becomes within-file and the dominant source of
   // variance drops out. A session-pinned arm would destroy that.
   const holdout = inHoldout(filePath);
-  const served = serve(graph, candidates);
+  // `dir` so an eager flag whose evidence is gone is cleared here rather than
+  // waiting for somebody to open the dashboard. Same evidence test as the manual
+  // path -- see `serve`.
+  const served = serve(graph, candidates, { dir });
   const assessed = assessFindings(dir, served, {
     episodeId: episode.episodeId || sessionId,
     relevanceFor: () => 1,
@@ -463,7 +466,7 @@ export function forCommand(
   // only thing an uncapped list buys is the I/O.
   const considered = candidates.slice(0, MAX_COMMAND_CANDIDATES);
 
-  const served = serve(graph, considered);
+  const served = serve(graph, considered, { dir });
   const assessed = assessFindings(dir, served, {
     episodeId: episode.episodeId || sessionId,
     relevanceFor: (finding) => explicit(finding) ? 1 : 0.6,
@@ -990,7 +993,7 @@ export function sessionIndex(dir, graph, { episode = {}, relevantFindingIds = []
   // `serve` is the only path allowed to hand a finding to a model. In
   // particular, activating this previously-unwired index must not create a new
   // path that labels an invalidated content claim as current.
-  const served = serve(graph, selected);
+  const served = serve(graph, selected, { dir });
   if (!served.length) return null;
   // A stale marker is longer than the fresh preview used for candidate
   // selection. Trim from the lowest-ranked end until the ACTUAL message fits.

--- a/integrations/codex/plugin/hooks/lib/inject.mjs
+++ b/integrations/codex/plugin/hooks/lib/inject.mjs
@@ -156,9 +156,9 @@ function disputeNote(finding) {
 function derivationNote(finding) {
   if (finding.derivationHolds !== false) return '';
   const changed = Array.isArray(finding.derivationChanged) ? finding.derivationChanged : [];
-  return changed.length
-    ? `\n  DERIVATION CHANGED -- ${changed.join(', ')} no longer match what this claim was derived from`
-    : '\n  DERIVATION CHANGED since this claim was recorded';
+  if (!changed.length) return '\n  DERIVATION CHANGED since this claim was recorded';
+  const verb = changed.length === 1 ? 'no longer matches' : 'no longer match';
+  return `\n  DERIVATION CHANGED -- ${changed.join(', ')} ${verb} what this claim was derived from`;
 }
 
 function render(finding) {

--- a/integrations/codex/plugin/hooks/lib/inject.mjs
+++ b/integrations/codex/plugin/hooks/lib/inject.mjs
@@ -143,8 +143,26 @@ function disputeNote(finding) {
     : '\n  DISPUTED by another finding in this graph';
 }
 
+/**
+ * Discloses `derivationCheck`'s verdict (staleness.mjs) -- distinct from
+ * `disputeNote` (another finding disagrees) and from the STALE block below
+ * (the anchor NODE's current hash does not match disk). This is about
+ * whether the bytes THIS claim was actually derived from are still the bytes
+ * an anchor holds; see `derivationCheck`'s comment for the case that catches
+ * that the other two can miss. Silent when it holds -- the common case pays
+ * nothing -- and silent when it was never checked at all (an older finding
+ * with no `derivation` record).
+ */
+function derivationNote(finding) {
+  if (finding.derivationHolds !== false) return '';
+  const changed = Array.isArray(finding.derivationChanged) ? finding.derivationChanged : [];
+  return changed.length
+    ? `\n  DERIVATION CHANGED -- ${changed.join(', ')} no longer match what this claim was derived from`
+    : '\n  DERIVATION CHANGED since this claim was recorded';
+}
+
 function render(finding) {
-  const head = `- [${finding.type || 'finding'}] ${finding.claim}${disputeNote(finding)}`;
+  const head = `- [${finding.type || 'finding'}] ${finding.claim}${disputeNote(finding)}${derivationNote(finding)}`;
   if (!finding.stale) return head;
 
   // A stale finding NEVER renders as though it were current. But the strength

--- a/integrations/codex/plugin/hooks/lib/inject.mjs
+++ b/integrations/codex/plugin/hooks/lib/inject.mjs
@@ -157,9 +157,28 @@ function render(finding) {
  * prevent. A second load costs a parse, and it is paid once per observed write
  * rather than once per tool call -- when nothing is queued this is one stat.
  */
+/**
+ * Per process, per graph directory: did the drain change anything?
+ *
+ * THE SECOND CALLER IS WHY THIS EXISTS. SessionStart calls `standingRules` and
+ * then `sessionIndex` with the SAME graph object it loaded once. Without this
+ * memo the first call drains, marks, and re-reads privately -- and the second
+ * call finds an empty queue, marks nothing, and therefore serves from the
+ * caller's pre-drain copy, advertising as current the very finding the first
+ * call had just marked. Draining is not idempotent from the caller's point of
+ * view; remembering the ANSWER is what makes it so.
+ *
+ * A hook process handles one lifecycle event, so this map holds one or two
+ * entries and dies with the process.
+ */
+const drainedDirs = new Map();
+
 function withPendingApplied(dir, graph) {
   try {
-    return drainInvalidations(dir, graph) > 0 ? load(dir) : graph;
+    if (drainedDirs.has(dir)) return drainedDirs.get(dir) ? load(dir) : graph;
+    const marked = drainInvalidations(dir, graph) > 0;
+    drainedDirs.set(dir, marked);
+    return marked ? load(dir) : graph;
   } catch {
     // The lazy path still covers everything this would have caught early, and
     // a hook must never fail because bookkeeping did.
@@ -862,6 +881,12 @@ export function relevantFindingIdsForContext(graph, context, { limit = 8 } = {})
  * shrinks toward the floor. See metrics.indexBudget.
  */
 export function sessionIndex(dir, graph, { episode = {}, relevantFindingIds = [] } = {}) {
+  // DRAINED HERE TOO, and this is the worst place to be wrong. The session index
+  // is the FIRST thing a session sees and it arrives with no other context to
+  // correct it, so advertising a finding the graph already knows is stale is a
+  // false claim made at maximum leverage. The graph is loaded either way, so the
+  // only cost is the stat that finds no queue.
+  graph = withPendingApplied(dir, graph);
   const budget = indexBudget(dir);
   const relevant = new Set(relevantFindingIds);
   // Some SessionStart payloads have no task signal. Fail closed for situational
@@ -988,6 +1013,9 @@ ${lines.join('\n')}`;
  * is wallpaper, and the model stops reading the thing it always sees.
  */
 export function standingRules(dir, graph, { budget = standingBudget(), episode = {} } = {}) {
+  // Same reason as sessionIndex: always-on text, delivered before the first
+  // tool call, with nothing following it that could qualify what it said.
+  graph = withPendingApplied(dir, graph);
   const rules = [...graph.nodes.values()].filter(
     (n) =>
       n.kind === 'finding' &&

--- a/integrations/codex/plugin/hooks/lib/inject.mjs
+++ b/integrations/codex/plugin/hooks/lib/inject.mjs
@@ -143,6 +143,40 @@ function render(finding) {
 }
 
 /**
+ * Graph directories where a drain has already marked something in THIS process.
+ *
+ * THE SECOND CALLER IS WHY THIS EXISTS. SessionStart calls `standingRules` and
+ * then `sessionIndex` with the SAME graph object it loaded once. Without this,
+ * the first call drains, marks, and re-reads privately -- and the second call
+ * finds an empty queue, marks nothing, and therefore serves from the caller's
+ * pre-drain copy, advertising as current the very finding the first call had
+ * just marked. Draining is idempotent; its EFFECT on a caller's parsed graph is
+ * not, so what is remembered here is "a re-read is owed", nothing else.
+ *
+ * ONLY THE POSITIVE CASE IS REMEMBERED, and that is a correctness decision
+ * rather than a tuning one. Remembering "nothing was queued" would mean a queue
+ * arriving LATER in the same process is silently skipped and deferred to some
+ * future session. That cannot happen today, because `queueInvalidation` runs in
+ * the post-tool branch before any injection -- but that is an unguarded
+ * ordering dependency, and it stops being true the moment someone adds a call
+ * site. A repeated empty drain costs one `existsSync` on a file that is not
+ * there, which is a price worth paying to not have an invariant that depends on
+ * nobody reordering anything.
+ *
+ * KEYED CANONICALLY. Two spellings of one directory -- a trailing separator, a
+ * `..` segment, a lower-cased drive letter -- would otherwise be two entries,
+ * which reintroduces exactly the pre-drain-copy bug above. This is the same
+ * defect shape Task 2 on this branch shipped for real, where a tool resolved its
+ * graph from a raw cwd while the hooks resolved theirs through `projectRootFor`
+ * and the two halves of a metric landed in different directories. Path identity
+ * is why `canonicalKey` lives inside `nodeId` rather than at its call sites.
+ *
+ * A hook process handles one lifecycle event, so this set holds one or two
+ * entries and dies with the process.
+ */
+const drainedDirs = new Set();
+
+/**
  * Applies anything the post-tool hook queued, BEFORE anything is served.
  *
  * THIS IS WHERE EAGER STALENESS LANDS. `invalidateOnWrite` needs a graph, and
@@ -157,28 +191,14 @@ function render(finding) {
  * prevent. A second load costs a parse, and it is paid once per observed write
  * rather than once per tool call -- when nothing is queued this is one stat.
  */
-/**
- * Per process, per graph directory: did the drain change anything?
- *
- * THE SECOND CALLER IS WHY THIS EXISTS. SessionStart calls `standingRules` and
- * then `sessionIndex` with the SAME graph object it loaded once. Without this
- * memo the first call drains, marks, and re-reads privately -- and the second
- * call finds an empty queue, marks nothing, and therefore serves from the
- * caller's pre-drain copy, advertising as current the very finding the first
- * call had just marked. Draining is not idempotent from the caller's point of
- * view; remembering the ANSWER is what makes it so.
- *
- * A hook process handles one lifecycle event, so this map holds one or two
- * entries and dies with the process.
- */
-const drainedDirs = new Map();
-
 function withPendingApplied(dir, graph) {
   try {
-    if (drainedDirs.has(dir)) return drainedDirs.get(dir) ? load(dir) : graph;
-    const marked = drainInvalidations(dir, graph) > 0;
-    drainedDirs.set(dir, marked);
-    return marked ? load(dir) : graph;
+    const key = canonicalPath(dir);
+    // The drain runs EVERY time. It is one stat when there is nothing to do,
+    // and running it unconditionally is what keeps the memo from encoding an
+    // assumption about which hook branch ran first.
+    if (drainInvalidations(dir, graph) > 0) drainedDirs.add(key);
+    return drainedDirs.has(key) ? load(dir) : graph;
   } catch {
     // The lazy path still covers everything this would have caught early, and
     // a hook must never fail because bookkeeping did.

--- a/integrations/codex/plugin/hooks/lib/lexical.mjs
+++ b/integrations/codex/plugin/hooks/lib/lexical.mjs
@@ -1,0 +1,73 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/lexical.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * BM25 over findings. Pure, dependency-free, deterministic.
+ *
+ * WHY THIS REPLACES `includes()`. The dashboard filtered findings by substring,
+ * which cannot RANK -- and every consumer of retrieval here is under a hard
+ * token budget, so the budget kept whatever happened to match rather than what
+ * matched best. Ranking is the whole value at a budget.
+ *
+ * WHY BM25 AND NOT EMBEDDINGS. Deliberate, per docs/WIKI_GRAPH.md: deterministic,
+ * instant, explainable, and it cannot drift or need a rebuild. The known cost is
+ * recall on findings with no lexical overlap; Plan 2's recall probe measures that
+ * rather than assuming it away.
+ */
+
+/** Non-word split, lowercased. Short tokens are kept: `fs`, `id`, `os` matter here. */
+export function tokenize(text) {
+  return String(text || '')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+}
+
+/**
+ * Classic BM25. `k1` controls term-frequency saturation, `b` length normalisation.
+ * Defaults are the standard ones and are exposed so the recall probe can sweep them.
+ */
+export function rank(query, findings, { limit = 20, k1 = 1.2, b = 0.75 } = {}) {
+  const terms = tokenize(query);
+  if (!terms.length || !Array.isArray(findings) || !findings.length) return [];
+
+  // A finding's searchable text is its claim AND its key: the key is how the
+  // session index refers to it, so a model quoting a key must find it.
+  const docs = findings.map((finding) => ({
+    finding,
+    tokens: tokenize(`${finding.key || ''} ${finding.claim || ''}`),
+  }));
+
+  const avgLen = docs.reduce((sum, d) => sum + d.tokens.length, 0) / docs.length;
+  const N = docs.length;
+
+  const docFreq = new Map();
+  for (const { tokens } of docs) {
+    for (const term of new Set(tokens)) {
+      docFreq.set(term, (docFreq.get(term) || 0) + 1);
+    }
+  }
+
+  const scored = [];
+  for (const { finding, tokens } of docs) {
+    const counts = new Map();
+    for (const token of tokens) counts.set(token, (counts.get(token) || 0) + 1);
+
+    let score = 0;
+    for (const term of terms) {
+      const tf = counts.get(term);
+      if (!tf) continue;
+      const df = docFreq.get(term) || 0;
+      // Standard BM25 IDF, floored at zero so a term present in every document
+      // contributes nothing rather than a negative score.
+      const idf = Math.max(0, Math.log(1 + (N - df + 0.5) / (df + 0.5)));
+      const norm = tf + k1 * (1 - b + (b * tokens.length) / (avgLen || 1));
+      score += idf * ((tf * (k1 + 1)) / (norm || 1));
+    }
+
+    // Zero means no term matched. Omitted rather than returned, so a caller
+    // under a token budget never spends it on an irrelevant finding.
+    if (score > 0) scored.push({ finding, score });
+  }
+
+  return scored.sort((a, b2) => b2.score - a.score).slice(0, limit);
+}

--- a/integrations/codex/plugin/hooks/lib/lexical.mjs
+++ b/integrations/codex/plugin/hooks/lib/lexical.mjs
@@ -14,12 +14,54 @@
  * rather than assuming it away.
  */
 
-/** Non-word split, lowercased. Short tokens are kept: `fs`, `id`, `os` matter here. */
-export function tokenize(text) {
-  return String(text || '')
-    .toLowerCase()
-    .split(/[^a-z0-9]+/)
+/**
+ * Splits an identifier's alphanumeric run into its camelCase / letter-digit
+ * parts, e.g. `skipLibCheck` -> ['skip', 'Lib', 'Check'], `TS2345` ->
+ * ['TS', '2345']. Returns a single-element array when there is no internal
+ * boundary (e.g. `retry` -> ['retry']) so callers can skip emitting a
+ * redundant duplicate of the whole token.
+ */
+function splitIdentifierParts(word) {
+  return word
+    .replace(/([a-z])([A-Z])/g, '$1\0$2')
+    .replace(/([A-Za-z])([0-9])/g, '$1\0$2')
+    .replace(/([0-9])([A-Za-z])/g, '$1\0$2')
+    .split('\0')
     .filter(Boolean);
+}
+
+/**
+ * Non-word split, lowercased. Short tokens are kept: `fs`, `id`, `os` matter
+ * here.
+ *
+ * Emits sub-tokens for compound identifiers, in addition to the whole token.
+ * Delimited identifiers (`smart_read`, `wiki.mjs`, the flag in
+ * `--skipLibCheck`) already round-trip fine: the delimiter splits them, and
+ * because query and claim pass through this same function, a query typed
+ * with the same delimiters matches. The silent gap was CONCATENATED
+ * identifiers with no delimiter at all -- `skipLibCheck` collapsed to the
+ * single token `skiplibcheck`, so a query for "skip lib check" (or "TS 2345"
+ * against `TS2345`) never intersected it. No error, just an absent result --
+ * and findings are about code, where run-together identifiers are the
+ * common case. So every alphanumeric run keeps its whole-token form (a query
+ * for the concatenated form still matches) and ALSO contributes its
+ * camelCase / letter-digit parts (a query for the separated form now
+ * matches too). A lone incidental character -- e.g. the `c` split out of a
+ * Windows path `C:\Users\...` -- needs no special-casing: it is a real
+ * token like any other, and BM25's IDF already discounts a term that shows
+ * up in nearly every finding.
+ */
+export function tokenize(text) {
+  const words = String(text || '').match(/[A-Za-z0-9]+/g) || [];
+  const tokens = [];
+  for (const word of words) {
+    tokens.push(word.toLowerCase());
+    const parts = splitIdentifierParts(word);
+    if (parts.length > 1) {
+      for (const part of parts) tokens.push(part.toLowerCase());
+    }
+  }
+  return tokens;
 }
 
 /**
@@ -57,9 +99,15 @@ export function rank(query, findings, { limit = 20, k1 = 1.2, b = 0.75 } = {}) {
       const tf = counts.get(term);
       if (!tf) continue;
       const df = docFreq.get(term) || 0;
-      // Standard BM25 IDF, floored at zero so a term present in every document
-      // contributes nothing rather than a negative score.
-      const idf = Math.max(0, Math.log(1 + (N - df + 0.5) / (df + 0.5)));
+      // Smoothed BM25 idf: log(1 + (N - df + 0.5) / (df + 0.5)). Unlike the
+      // classic unsmoothed idf (log((N - df + 0.5) / (df + 0.5))), which goes
+      // negative once a term appears in most documents, this smoothed form
+      // is strictly positive for every df in [1, N]: even at df === N the
+      // ratio inside the log is (N + 1) / (N + 0.5), which is always
+      // strictly greater than 1, so log(1 + that) is always > 0. No floor
+      // is needed here, and none is applied -- there is no negative case
+      // for this formula to guard against.
+      const idf = Math.log(1 + (N - df + 0.5) / (df + 0.5));
       const norm = tf + k1 * (1 - b + (b * tokens.length) / (avgLen || 1));
       score += idf * ((tf * (k1 + 1)) / (norm || 1));
     }

--- a/integrations/codex/plugin/hooks/lib/lexical.mjs
+++ b/integrations/codex/plugin/hooks/lib/lexical.mjs
@@ -65,6 +65,43 @@ export function tokenize(text) {
 }
 
 /**
+ * Effective term-frequency credit for a document that has NO exact token
+ * match for a query term but DOES have a token that starts with it (e.g.
+ * query `custom` against a document containing `customer`). Deliberately
+ * less than one exact occurrence (`1`), and it is a flat credit rather than
+ * one that grows with the number of prefix-matching tokens in the document,
+ * so a prefix hit can never outscore an exact hit of the same term:
+ *
+ *   BM25's per-term contribution is `idf * tf * (k1 + 1) / (tf + K)`, where
+ *   `K = k1 * (1 - b + b * L / avgL)` depends only on document length, not
+ *   on which term or how it matched. As a function of `tf` alone, with `K`
+ *   fixed, `f(tf) = tf / (tf + K)` is non-decreasing for every `tf >= 0` and
+ *   `k1 >= 0` (its derivative `K / (tf + K)^2` is never negative). So for
+ *   ANY document length, and any number of prefix-only occurrences, using
+ *   `PREFIX_TF < 1` in place of `tf` scores no higher than an actual exact
+ *   occurrence (`tf = 1`) would in that same document -- there is no
+ *   PREFIX_TF-independent way to accumulate more evidence than one real hit
+ *   by matching only a prefix. This is also why the count of prefix matches
+ *   is otherwise irrelevant here: it never feeds back into the score.
+ *
+ * PREFIX MATCHING IS NOT SUBSTRING MATCHING. It restores recall for a
+ * fragment typed at the START of a word -- `custom` now finds `customer` --
+ * which is the common case (a user typing the first few letters of a term
+ * they remember). It does NOT restore the old `.includes()` filter's ability
+ * to find a term in the MIDDLE of a word: a query for `tomer` still will not
+ * find `customer`. That recall gap is accepted, not silently reintroduced.
+ */
+const PREFIX_TF = 0.5;
+
+/**
+ * Below this length, a query term is not eligible for prefix matching: a
+ * one- or two-character prefix (`a`, `re`) is a substring of a large
+ * fraction of any real vocabulary, so it would match nearly every document
+ * and IDF alone would not discount it enough to keep the results relevant.
+ */
+const PREFIX_MIN_TERM_LENGTH = 3;
+
+/**
  * Classic BM25. `k1` controls term-frequency saturation, `b` length normalisation.
  * Defaults are the standard ones and are exposed so the recall probe can sweep them.
  */
@@ -96,7 +133,21 @@ export function rank(query, findings, { limit = 20, k1 = 1.2, b = 0.75 } = {}) {
 
     let score = 0;
     for (const term of terms) {
-      const tf = counts.get(term);
+      let tf = counts.get(term) || 0;
+
+      // No exact occurrence: fall back to a prefix match, which is weaker
+      // evidence and so credited at a flat PREFIX_TF rather than a real
+      // count (see PREFIX_TF's comment for why that ordering is safe). Only
+      // considered when nothing already matched exactly and the term is
+      // long enough that "starts with" is a meaningful signal.
+      if (tf === 0 && term.length >= PREFIX_MIN_TERM_LENGTH) {
+        for (const token of counts.keys()) {
+          if (token !== term && token.startsWith(term)) {
+            tf = PREFIX_TF;
+            break;
+          }
+        }
+      }
       if (!tf) continue;
       const df = docFreq.get(term) || 0;
       // Smoothed BM25 idf: log(1 + (N - df + 0.5) / (df + 0.5)). Unlike the

--- a/integrations/codex/plugin/hooks/lib/metrics.mjs
+++ b/integrations/codex/plugin/hooks/lib/metrics.mjs
@@ -455,6 +455,23 @@ export function readBalance(dir) {
   return out;
 }
 
+/**
+ * True when `readEvidence` could not have read the whole log -- the file
+ * exceeds the byte cap, so anything written before the tail it kept is
+ * silently absent from what it returned. A caller that builds a per-claim
+ * record from `readEvidence` (the wiki graph's derivation record) needs this
+ * to say "operations existed but are not recorded here" rather than let an
+ * empty result read as "nothing happened".
+ */
+export function evidenceTruncated(dir) {
+  const path = evidencePath(dir);
+  try {
+    return statSync(path).size > MAX_BYTES;
+  } catch {
+    return false;
+  }
+}
+
 /** Every causal evidence record inside the byte cap, deduplicated by id. */
 export function readEvidence(dir) {
   const path = evidencePath(dir);

--- a/integrations/codex/plugin/hooks/lib/observability.mjs
+++ b/integrations/codex/plugin/hooks/lib/observability.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 /**
  * Privacy-safe, cross-client lifecycle diagnostics.
  *

--- a/integrations/codex/plugin/hooks/lib/pending.mjs
+++ b/integrations/codex/plugin/hooks/lib/pending.mjs
@@ -39,7 +39,7 @@ import {
   statSync,
 } from 'node:fs';
 import { join } from 'node:path';
-import { invalidateOnWrite } from './staleness.mjs';
+import { invalidateChangedAnchors, invalidateOnWrite } from './staleness.mjs';
 import { canonicalPath, isFsSafePath, resolvableCandidates } from './paths.mjs';
 
 const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
@@ -190,31 +190,85 @@ function hasEditEvidence(payload, raw) {
 }
 
 /**
- * The evidence a completed mutation left behind, or null when there is none.
+ * Canonical tool names that mean bytes on disk changed.
  *
- * Separate from `queueInvalidation` so the caller can be a hook branch that
- * knows nothing about diffs, and so the reconstruction above is testable
- * without a filesystem queue.
+ * THE NORMALISED SET, not any client's own vocabulary. `normalizePayload` has
+ * already mapped `replace`, `write_file`, `apply_patch`, `str_replace`,
+ * `search_replace` and the rest onto these three through decide.mjs's alias
+ * table -- and a tool that table cannot map arrives as null and exits the hook
+ * before this module is reached at all. So matching here is both complete for
+ * every client the adapter serves and impossible to spell wrong.
+ *
+ * `NotebookEdit` is absent because `normalizeTool` maps it to null, and the MCP
+ * `smart_edit`/`smart_write` tools are absent for the same reason. Both are gaps
+ * in that alias table rather than in this file, and widening it changes routing
+ * verdicts for every client -- so they are reported, not papered over here.
  */
-export function observedWrite(payload, raw) {
-  // CHEAP CHECK FIRST, because this runs after every tool call on every client.
-  // Reading the file is the expensive part, and there is no point paying for it
-  // on a Read, a Bash or a write whose before side cannot be reconstructed.
-  if (!hasEditEvidence(payload, raw)) return null;
+const MUTATING = new Set(['Edit', 'MultiEdit', 'Write']);
+
+/** Files an apply_patch-style program declares it is about to change. */
+function patchTargets(payload) {
+  const command = payload?.tool_input?.command;
+  if (typeof command !== 'string') return [];
+  const out = [];
+  for (const match of command.matchAll(
+    /^\*\*\* (?:Add|Update|Delete) File:\s*(.+)$/gm
+  )) {
+    const candidate = match[1].trim().replace(/^['"]|['"]$/g, '');
+    // Bounded: one patch naming a thousand files must not append a thousand
+    // queue records on a hook path.
+    if (candidate && out.length < 20) out.push(candidate);
+  }
+  return out;
+}
+
+/**
+ * Everything a completed mutation left behind that is worth queueing.
+ *
+ * TWO GRADES OF EVIDENCE, and the distinction is the point:
+ *
+ *   { path, before, after }  a reconstructable edit. The drain builds a real
+ *                            diff and marks only the symbols that moved.
+ *   { path }                 a whole-file write, or a patch program. No before
+ *                            side exists anywhere in the payload, so the drain
+ *                            compares stored hashes against disk instead.
+ *
+ * The second grade is what closes the biggest hole. A whole-file write is the
+ * commonest write shape there is, and before it was added those writes fell
+ * through to a lazy path that CANNOT see the session's own writes at all --
+ * `indexFile` refreshes the anchor before the lazy check ever looks at it. They
+ * were uncovered, not degraded.
+ *
+ * Returns an array, because one apply_patch program changes several files.
+ */
+export function observedWrites(payload, raw) {
+  if (!MUTATING.has(String(payload?.tool_name || ''))) return [];
 
   const path = writtenPath(payload, raw);
-  if (!path) return null;
+  if (path) {
+    // The expensive branch is guarded: reading the file only pays off when the
+    // payload can actually yield a before side.
+    if (hasEditEvidence(payload, raw)) {
+      const after = afterText(path);
+      if (after !== null && after.length <= MAX_SIDE_CHARS) {
+        const before = beforeText(payload, raw, after);
+        // Identical bytes: a formatter no-op, or a rewrite of the same content.
+        // Nothing changed, so nothing is stale.
+        if (before === after) return [];
+        if (before !== null && before.length <= MAX_SIDE_CHARS)
+          return [{ path, before, after }];
+      }
+    }
+    // Hash grade. Deliberately NOT `{ path, before: '', after }`: an empty
+    // before side makes every symbol in the file look changed, and the eager
+    // mark is a stored flag no later check ever clears.
+    return [{ path }];
+  }
 
-  const after = afterText(path);
-  if (after === null || after.length > MAX_SIDE_CHARS) return null;
-
-  const before = beforeText(payload, raw, after);
-  if (before === null || before.length > MAX_SIDE_CHARS) return null;
-  // Nothing changed: a formatter no-op, or a write of identical bytes. Queuing
-  // it would mark findings stale against an empty diff.
-  if (before === after) return null;
-
-  return { path, before, after };
+  // Codex and code-mode clients carry the whole patch as program text with no
+  // file_path field at all, which is why this recorded nothing for them. The
+  // hash grade needs only the path, so the patch headers are enough.
+  return patchTargets(payload).map((target) => ({ path: target }));
 }
 
 /**
@@ -226,9 +280,14 @@ export function observedWrite(payload, raw) {
 export function queueInvalidation(dir, { path, before, after, at } = {}) {
   try {
     if (typeof path !== 'string' || !path.trim()) return false;
-    if (typeof before !== 'string' || typeof after !== 'string') return false;
-    if (before.length > MAX_SIDE_CHARS || after.length > MAX_SIDE_CHARS)
-      return false;
+    // BOTH SIDES OR NEITHER. A record carrying only one of them cannot produce
+    // a diff and must not pretend to, so it is written as a path-only record
+    // and the drain resolves it by comparing hashes.
+    const diffable =
+      typeof before === 'string' &&
+      typeof after === 'string' &&
+      before.length <= MAX_SIDE_CHARS &&
+      after.length <= MAX_SIDE_CHARS;
 
     const file = queuePath(dir);
     try {
@@ -240,7 +299,11 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
     mkdirSync(dir, { recursive: true });
     appendFileSync(
       file,
-      `${JSON.stringify({ path: canonicalPath(path), before, after, at: at ?? Date.now() })}\n`,
+      `${JSON.stringify({
+        path: canonicalPath(path),
+        ...(diffable ? { before, after } : {}),
+        at: at ?? Date.now(),
+      })}\n`,
       'utf8'
     );
     return true;
@@ -284,16 +347,16 @@ export function drainInvalidations(dir, graph) {
   let marked = 0;
   for (const record of records) {
     if (!record || typeof record.path !== 'string' || !record.path) continue;
-    if (typeof record.before !== 'string' || typeof record.after !== 'string')
-      continue;
+    const diffable =
+      typeof record.before === 'string' && typeof record.after === 'string';
     try {
-      const result = invalidateOnWrite(
-        dir,
-        graph,
-        record.path,
-        record.before,
-        record.after
-      );
+      // TWO GRADES, ONE QUEUE. A record carrying both sides gets a real diff and
+      // symbol-precise marking; one carrying only a path gets the hash
+      // comparison -- the same comparison the lazy path makes, and one that is
+      // only meaningful HERE, before `indexFile` refreshes the anchor.
+      const result = diffable
+        ? invalidateOnWrite(dir, graph, record.path, record.before, record.after)
+        : invalidateChangedAnchors(dir, graph, record.path);
       marked += Array.isArray(result) ? result.length : 0;
     } catch {
       // One bad record must not stop the rest, and must not stop the tool call.

--- a/integrations/codex/plugin/hooks/lib/pending.mjs
+++ b/integrations/codex/plugin/hooks/lib/pending.mjs
@@ -1,0 +1,311 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/pending.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * The eager-invalidation queue: the missing half of staleness.mjs's header.
+ *
+ * That header describes TWO invalidation paths and says eager exists because
+ * lazy "would silently serve stale findings as fresh whenever a change came
+ * from outside the agent". `invalidateOnWrite` had been written, tested and
+ * documented -- and its only reference in shipped code was a COMMENT in the
+ * PreToolUse router. Staleness was lazy-only in production, and the router's
+ * own comment ("a write the hook observes is invalidated eagerly by
+ * `invalidateOnWrite`") described something that never happened.
+ *
+ * WHY THAT MATTERS MORE THAN IT SOUNDS. The lazy check compares the anchor's
+ * stored hash against disk -- and both the router and the adapter call
+ * `indexFile` on every file they observe, which re-points that hash at the new
+ * bytes. So for a write the session performed ITSELF, the lazy check is
+ * self-defeating: by the next retrieval the anchor already agrees with disk and
+ * the finding derived from the old content is served clean. Lazy catches the
+ * changes we never saw; only eager catches the ones we did.
+ *
+ * WHY A QUEUE AND NOT A DIRECT CALL. `invalidateOnWrite` needs the graph, and
+ * the graph is a megabyte of JSONL. Loading it on the return path of every
+ * write is the cost this shape exists to avoid. So the post-tool hook, which
+ * already holds the write's evidence, appends one record here and exits; the
+ * next graph read -- `forTouch`/`forCommand`, which load the graph anyway --
+ * drains it BEFORE serving anything.
+ *
+ * The guarantee is unchanged. What must never happen is SERVING a stale finding
+ * as fresh, and serve time is where that is enforced.
+ */
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { invalidateOnWrite } from './staleness.mjs';
+import { canonicalPath, isFsSafePath, resolvableCandidates } from './paths.mjs';
+
+const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
+
+/**
+ * Largest before/after side kept in a queue record.
+ *
+ * Matched to the graph's own snapshot limit for the same reason it has one: past
+ * this size the text is a bundle, a lockfile or a generated asset, and copying
+ * it into a queue file would mirror the repository into the graph directory one
+ * write at a time. Past the cap the write is simply not queued -- the lazy path
+ * still governs it, which is exactly the status quo for that file.
+ */
+const MAX_SIDE_CHARS = 262_144;
+
+/**
+ * Largest queue file appended to.
+ *
+ * A queue only grows while nothing drains it, which means the retrieval feature
+ * is off or every read has failed. Neither is a reason to keep writing: bounded
+ * here so a long unattended session cannot turn one directory into a log of
+ * every file it touched.
+ */
+const MAX_QUEUE_BYTES = 8 * 1024 * 1024;
+
+/** The tool payload fields that name the file a mutation landed on. */
+function writtenPath(payload, raw) {
+  const input = payload?.tool_input || {};
+  const response = raw?.tool_response || raw?.toolResponse || {};
+  for (const candidate of [
+    input.file_path,
+    input.path,
+    input.notebook_path,
+    response.filePath,
+    response.file_path,
+  ]) {
+    if (typeof candidate === 'string' && candidate.trim()) return candidate;
+  }
+  return null;
+}
+
+/** First string among several possible spellings of the same field. */
+function firstString(...values) {
+  for (const value of values) if (typeof value === 'string') return value;
+  return null;
+}
+
+/**
+ * The text before the write, reconstructed from a completed edit.
+ *
+ * PREFERENCE ORDER IS ABOUT EXACTNESS, not convenience. Claude Code's Edit
+ * response carries the whole pre-edit file (`originalFile`), which needs no
+ * reasoning at all. Failing that, an edit is a known substitution, so reverting
+ * `new_string` back to `old_string` in the post-write text reproduces the
+ * before side exactly -- but only when the substitution is unambiguous, which
+ * is why a `new_string` that now appears more than once is refused rather than
+ * guessed at.
+ *
+ * NULL MEANS "DO NOT QUEUE", and that is deliberate. An unknown before side
+ * could be passed as '' -- and `invalidateOnWrite` would then see every symbol
+ * in the file as changed and mark every finding anchored anywhere in it, which
+ * is the exact over-marking its own comments call worse than the file-level
+ * staleness symbols were introduced to avoid. A missed eager invalidation costs
+ * what today already costs; a wrong one permanently discounts correct findings.
+ */
+function beforeText(payload, raw, after) {
+  const input = payload?.tool_input || {};
+  const response = raw?.tool_response || raw?.toolResponse || {};
+
+  const original = firstString(
+    response.originalFile,
+    response.original_file,
+    response.originalContent,
+    response.original_content
+  );
+  if (original !== null) return original;
+
+  // MultiEdit applies its edits in order, so reverting walks them backwards.
+  const edits = Array.isArray(input.edits) ? input.edits : null;
+  if (edits) {
+    let text = after;
+    for (const edit of [...edits].reverse()) {
+      const reverted = revert(text, edit);
+      if (reverted === null) return null;
+      text = reverted;
+    }
+    return text;
+  }
+
+  return revert(after, input);
+}
+
+/** Undoes one old->new substitution, or null when it cannot be done exactly. */
+function revert(text, edit) {
+  const oldString = firstString(edit?.old_string, edit?.oldString);
+  const newString = firstString(edit?.new_string, edit?.newString);
+  if (oldString === null || newString === null || newString === '') return null;
+
+  const all = edit?.replace_all === true || edit?.replaceAll === true;
+  if (all) return text.split(newString).join(oldString);
+
+  const at = text.indexOf(newString);
+  if (at < 0) return null;
+  // Ambiguous: more than one candidate for the occurrence that was written, and
+  // reverting the wrong one fabricates a before side that never existed.
+  if (text.indexOf(newString, at + newString.length) >= 0) return null;
+  return text.slice(0, at) + oldString + text.slice(at + newString.length);
+}
+
+/** The post-write text, read from disk because that is what the write produced. */
+function afterText(path) {
+  if (!isFsSafePath(path)) return null;
+  for (const candidate of resolvableCandidates(path)) {
+    try {
+      if (statSync(candidate).size > MAX_SIDE_CHARS) return null;
+      return readFileSync(candidate, 'utf8');
+    } catch {
+      // Wrong spelling, or gone again already. Try the next one.
+    }
+  }
+  return null;
+}
+
+/**
+ * Does this payload carry enough to reconstruct a before side at all?
+ *
+ * Named tool lists were the alternative and were rejected: every client calls
+ * its editor something different (`Edit`, `replace`, `write_to_file`,
+ * `apply_patch`), and a list would silently exclude the ones nobody thought of
+ * while still charging a file read for every Read that matched by accident.
+ * Asking about the EVIDENCE instead covers any client that carries an edit in
+ * one of these shapes and costs nothing on the calls that do not.
+ */
+function hasEditEvidence(payload, raw) {
+  const input = payload?.tool_input || {};
+  const response = raw?.tool_response || raw?.toolResponse || {};
+  if (
+    firstString(
+      response.originalFile,
+      response.original_file,
+      response.originalContent,
+      response.original_content
+    ) !== null
+  )
+    return true;
+  if (Array.isArray(input.edits) && input.edits.length > 0) return true;
+  return firstString(input.old_string, input.oldString) !== null;
+}
+
+/**
+ * The evidence a completed mutation left behind, or null when there is none.
+ *
+ * Separate from `queueInvalidation` so the caller can be a hook branch that
+ * knows nothing about diffs, and so the reconstruction above is testable
+ * without a filesystem queue.
+ */
+export function observedWrite(payload, raw) {
+  // CHEAP CHECK FIRST, because this runs after every tool call on every client.
+  // Reading the file is the expensive part, and there is no point paying for it
+  // on a Read, a Bash or a write whose before side cannot be reconstructed.
+  if (!hasEditEvidence(payload, raw)) return null;
+
+  const path = writtenPath(payload, raw);
+  if (!path) return null;
+
+  const after = afterText(path);
+  if (after === null || after.length > MAX_SIDE_CHARS) return null;
+
+  const before = beforeText(payload, raw, after);
+  if (before === null || before.length > MAX_SIDE_CHARS) return null;
+  // Nothing changed: a formatter no-op, or a write of identical bytes. Queuing
+  // it would mark findings stale against an empty diff.
+  if (before === after) return null;
+
+  return { path, before, after };
+}
+
+/**
+ * Appends one pending write.
+ *
+ * NEVER THROWS. This runs on a hook's return path, and a queue that cannot be
+ * written degrades to the lazy path rather than costing the user a tool call.
+ */
+export function queueInvalidation(dir, { path, before, after, at } = {}) {
+  try {
+    if (typeof path !== 'string' || !path.trim()) return false;
+    if (typeof before !== 'string' || typeof after !== 'string') return false;
+    if (before.length > MAX_SIDE_CHARS || after.length > MAX_SIDE_CHARS)
+      return false;
+
+    const file = queuePath(dir);
+    try {
+      if (statSync(file).size > MAX_QUEUE_BYTES) return false;
+    } catch {
+      // No queue yet, which is the normal case.
+    }
+
+    mkdirSync(dir, { recursive: true });
+    appendFileSync(
+      file,
+      `${JSON.stringify({ path: canonicalPath(path), before, after, at: at ?? Date.now() })}\n`,
+      'utf8'
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Applies every queued invalidation and clears the queue.
+ *
+ * Returns the number of findings marked, so the caller knows whether its
+ * in-memory graph is now behind the file on disk and needs re-reading.
+ *
+ * CLEARED AFTER APPLYING AND UNCONDITIONALLY: a record that cannot be applied
+ * must not be retried on every tool call for the rest of the session, and the
+ * cost of dropping one is a single missed eager mark that the lazy path still
+ * has a chance at.
+ */
+export function drainInvalidations(dir, graph) {
+  let records;
+  try {
+    const file = queuePath(dir);
+    if (!existsSync(file)) return 0;
+    records = readFileSync(file, 'utf8')
+      .split('\n')
+      .filter((line) => line.trim())
+      .map((line) => {
+        try {
+          return JSON.parse(line);
+        } catch {
+          // A torn append costs one record, not the queue.
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch {
+    return 0;
+  }
+
+  let marked = 0;
+  for (const record of records) {
+    if (!record || typeof record.path !== 'string' || !record.path) continue;
+    if (typeof record.before !== 'string' || typeof record.after !== 'string')
+      continue;
+    try {
+      const result = invalidateOnWrite(
+        dir,
+        graph,
+        record.path,
+        record.before,
+        record.after
+      );
+      marked += Array.isArray(result) ? result.length : 0;
+    } catch {
+      // One bad record must not stop the rest, and must not stop the tool call.
+    }
+  }
+
+  try {
+    rmSync(queuePath(dir), { force: true });
+  } catch {
+    // Held open by a concurrent hook. The next drain re-applies these records,
+    // which is safe: marking an already-marked finding is idempotent.
+  }
+
+  return marked;
+}

--- a/integrations/codex/plugin/hooks/lib/pending.mjs
+++ b/integrations/codex/plugin/hooks/lib/pending.mjs
@@ -199,10 +199,11 @@ function hasEditEvidence(payload, raw) {
  * before this module is reached at all. So matching here is both complete for
  * every client the adapter serves and impossible to spell wrong.
  *
- * `NotebookEdit` is absent because `normalizeTool` maps it to null, and the MCP
- * `smart_edit`/`smart_write` tools are absent for the same reason. Both are gaps
- * in that alias table rather than in this file, and widening it changes routing
- * verdicts for every client -- so they are reported, not papered over here.
+ * `NotebookEdit` and the MCP `smart_edit`/`smart_write` tools were absent for as
+ * long as `normalizeTool` mapped them to null. That was a gap in the alias table
+ * rather than in this file, and it has since been closed there: all three now
+ * arrive as `Edit` or `Write` and are matched by the set below without it having
+ * to learn a fourth name.
  */
 const MUTATING = new Set(['Edit', 'MultiEdit', 'Write']);
 

--- a/integrations/codex/plugin/hooks/lib/pending.mjs
+++ b/integrations/codex/plugin/hooks/lib/pending.mjs
@@ -35,6 +35,7 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  renameSync,
   rmSync,
   statSync,
 } from 'node:fs';
@@ -43,6 +44,15 @@ import { invalidateChangedAnchors, invalidateOnWrite } from './staleness.mjs';
 import { canonicalPath, isFsSafePath, resolvableCandidates } from './paths.mjs';
 
 const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
+/**
+ * Where a drain moves the queue before reading it.
+ *
+ * PER PROCESS, not one shared name: two hooks draining the same graph directory
+ * at once would otherwise race for the same claim file, and the loser would
+ * either clobber the winner's records or delete them mid-read. A pid makes the
+ * claim private to the drainer that won the rename.
+ */
+const claimPath = (dir) => join(dir, `pending-invalidation.claim.${process.pid}.jsonl`);
 
 /**
  * Largest before/after side kept in a queue record.
@@ -319,17 +329,47 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
  * Returns the number of findings marked, so the caller knows whether its
  * in-memory graph is now behind the file on disk and needs re-reading.
  *
- * CLEARED AFTER APPLYING AND UNCONDITIONALLY: a record that cannot be applied
- * must not be retried on every tool call for the rest of the session, and the
- * cost of dropping one is a single missed eager mark that the lazy path still
- * has a chance at.
+ * CLAIMED BY RENAME, THEN READ, THEN DELETED -- and the order is the whole
+ * point. This used to read the queue and then `rmSync` the same path, so a
+ * post-tool hook appending between the read and the unlink had its record
+ * deleted having never been read. Parallel tool calls in one assistant turn are
+ * the ordinary way that happens, not an exotic race. `renameSync` makes the
+ * claim atomic: whatever the drainer took is exactly what it deletes, and a
+ * record appended a microsecond later lands on a fresh queue that the next drain
+ * will find.
+ *
+ * A LOST RECORD IS A PERMANENTLY MISSED INVALIDATION, which is why this is worth
+ * a rename. The comment here used to price it as "a single missed eager mark that
+ * the lazy path still has a chance at", and that premise is false: this module's
+ * own header states it. The lazy path compares the anchor's stored hash against
+ * disk, and `indexFile` re-points that hash at the bytes the session just wrote,
+ * so for the session's OWN writes lazy is structurally blind rather than merely
+ * late. Nothing else was ever going to catch a dropped record.
+ *
+ * A RECORD THAT CANNOT BE APPLIED IS STILL DROPPED, deliberately and
+ * unconditionally: retrying a permanently unapplicable record on every tool call
+ * for the rest of the session costs more than it can ever recover, and the claim
+ * file is deleted whether the loop marked anything or threw.
+ *
+ * FAIL-OPEN THROUGHOUT. A rename that loses a race, or fails for any other
+ * reason, returns 0 and leaves the queue for the next drain; it never throws
+ * into a hook.
  */
 export function drainInvalidations(dir, graph) {
   let records;
+  let claim;
   try {
     const file = queuePath(dir);
     if (!existsSync(file)) return 0;
-    records = readFileSync(file, 'utf8')
+    claim = claimPath(dir);
+    // A LEFTOVER CLAIM FROM A KILLED DRAIN IS OVERWRITTEN, not merged: rename
+    // onto an existing path replaces it. The pid in the name means the only way
+    // to hit that is this same pid having died mid-drain, whose records were
+    // already being applied when it went -- and re-applying is idempotent, so
+    // losing them is the cheaper of the two errors. Not doing the rename at all
+    // would strand the live queue forever.
+    renameSync(file, claim);
+    records = readFileSync(claim, 'utf8')
       .split('\n')
       .filter((line) => line.trim())
       .map((line) => {
@@ -342,6 +382,18 @@ export function drainInvalidations(dir, graph) {
       })
       .filter(Boolean);
   } catch {
+    // The rename lost a race, or the claim could not be read. Nothing is deleted
+    // unread and the hook proceeds. If the claim was taken and then could not be
+    // read, it is put back under the queue name so the next drain still sees it:
+    // a claim file nobody looks at again is the same lost record this rename
+    // exists to prevent.
+    try {
+      if (claim && existsSync(claim) && !existsSync(queuePath(dir))) {
+        renameSync(claim, queuePath(dir));
+      }
+    } catch {
+      // Best effort only. A hook must not fail because bookkeeping did.
+    }
     return 0;
   }
 
@@ -365,10 +417,13 @@ export function drainInvalidations(dir, graph) {
   }
 
   try {
-    rmSync(queuePath(dir), { force: true });
+    // THE CLAIM, NOT THE QUEUE. Deleting `queuePath` here is what dropped a
+    // concurrently appended record; this path holds exactly the bytes that were
+    // just read, so nothing unread can be inside it.
+    rmSync(claim, { force: true });
   } catch {
-    // Held open by a concurrent hook. The next drain re-applies these records,
-    // which is safe: marking an already-marked finding is idempotent.
+    // Held open by something else. The claim is not read again -- the next drain
+    // looks at the queue -- so this costs a stray file, never a record.
   }
 
   return marked;

--- a/integrations/codex/plugin/hooks/lib/restore.mjs
+++ b/integrations/codex/plugin/hooks/lib/restore.mjs
@@ -142,7 +142,7 @@ export function restorationPlan(dir, graph, context = {}) {
     for (const id of predicted) {
       const node = graph.nodes.get(id);
       if (!node) continue;
-      const findings = serve(graph, findingsFor(graph, id, { limit: 2 }));
+      const findings = serve(graph, findingsFor(graph, id, { limit: 2 }), { dir });
       for (const finding of findings) {
         // `! STALE` only where a diff actually exists to back it; see the
         // renderer in inject.mjs for the measurement behind this.

--- a/integrations/codex/plugin/hooks/lib/restore.mjs
+++ b/integrations/codex/plugin/hooks/lib/restore.mjs
@@ -158,7 +158,16 @@ export function restorationPlan(dir, graph, context = {}) {
             ? '! STALE '
             : '~ '
           : '';
-        lines.push(`${node.key}: ${mark}${finding.claim}`);
+        // A DISPUTE DISCLOSED ELSEWHERE AND SILENT HERE reads as "the dispute
+        // went away". `serve` already attached the fields; the only question is
+        // the wording, and this list is the most compressed surface in the
+        // system, so it gets the marker and the key and nothing else.
+        const disputed = finding.contradicted
+          ? finding.contradictedBy
+            ? ` (disputed by ${finding.contradictedBy})`
+            : ' (disputed)'
+          : '';
+        lines.push(`${node.key}: ${mark}${finding.claim}${disputed}`);
       }
     }
     section('Likely next', lines, total * split.forward);

--- a/integrations/codex/plugin/hooks/lib/skeleton.mjs
+++ b/integrations/codex/plugin/hooks/lib/skeleton.mjs
@@ -126,6 +126,11 @@ export function annotatedSkeleton(graph, rawPath, source, { budget = 1200, git =
 
   // Findings anchored to this file or the symbols inside it, served through the
   // one function that enforces the stale-plus-diff rule.
+  // READ-ONLY serve: no `dir` is threaded here, so this cannot clear a stale
+  // flag whose evidence is gone. That is deliberate -- this function takes a
+  // graph, not the directory it came from, and widening its signature to give
+  // an analysis path a write capability buys nothing: the injection path runs
+  // on every tool call and clears the same findings.
   const served = serve(graph, findingsFor(graph, nodeId('file', path), { limit: 40 }));
 
   // Index findings by the symbol they anchor to, so each one sits beside the

--- a/integrations/codex/plugin/hooks/lib/staleness.mjs
+++ b/integrations/codex/plugin/hooks/lib/staleness.mjs
@@ -31,6 +31,23 @@
  * Eager alone would silently serve stale findings as fresh whenever a change
  * came from outside the agent, which is the single failure mode the design
  * calls worse than no graph.
+ *
+ * AND LAZY ALONE IS BLIND TO THE AGENT'S OWN WRITES -- not degraded, BLIND.
+ * `indexFile` re-points an anchor's stored hash at the bytes it was just handed,
+ * and it is called on every file either hook observes: pretooluse-router.mjs
+ * (two call sites) and adapter.mjs (one). The lazy check then compares that
+ * refreshed hash against the same disk it came from and finds them equal. So
+ * for a file the session edited ITSELF, the lazy path cannot detect the change
+ * at all, and the finding derived from the pre-edit content is served CLEAN.
+ *
+ * Which means that until the eager path was connected, staleness for a file the
+ * agent edited did not work AT ALL: eager was dead code and lazy was defeated
+ * by re-indexing. Every account of this defect, including the one in this
+ * module's own git history, called it "lazy-only, therefore degraded". It was
+ * not degraded. `stale-before-reindex.test.mjs` states in its header that this
+ * case is covered by `invalidateOnWrite`, and `invalidateOnWrite` had never run
+ * once in production. The two paths are not redundant and never were: each is
+ * the ONLY cover for a whole class of change.
  */
 
 import { readFileSync, statSync } from 'node:fs';
@@ -622,6 +639,119 @@ export function invalidateOnWrite(dir, graph, rawPath, beforeText, afterText) {
   // Re-index so the anchors carry the new hashes; otherwise the lazy path would
   // report the same change again on every future retrieval.
   indexFile(dir, path, afterText);
+  return marked;
+}
+
+/**
+ * The eager path for a write with NO before/after pair: compare stored hashes
+ * against disk, and mark what actually moved.
+ *
+ * WHY THIS EXISTS AS A SECOND SHAPE. A whole-file `Write` replaces the file, so
+ * the payload carries the after side and nothing at all of the before -- and a
+ * whole-file write is the commonest write shape there is. `invalidateOnWrite`
+ * cannot serve it: passing '' as the before side makes every symbol in the file
+ * look changed, marks every finding anchored anywhere in it, and the eager mark
+ * is a stored flag no later check ever clears. False-stale is expensive and
+ * permanent, so it is not an acceptable price for coverage.
+ *
+ * But the hash comparison is available, and it is exactly the comparison the
+ * lazy path makes. The difference is WHEN: this runs at the top of injection,
+ * before `indexFile` refreshes the anchor, so the stored hash is still the
+ * pre-write one and the comparison is meaningful. That is the whole trick --
+ * lazy is not wrong, it is merely too late.
+ *
+ * SYMBOL-LEVEL, and from ONE read. Re-locating each symbol by name and
+ * comparing its own span hash is what keeps this from degenerating into
+ * file-level marking: editing one function must not stale a finding about
+ * another, which is the property symbol nodes exist to provide.
+ *
+ * WEAKER EVIDENCE, STATED AS SUCH. There is no before text, so no diff can be
+ * built -- the finding is marked with the two hashes and `serve` reports the
+ * evidence gap through `staleEvidence: false`, which the renderer turns into
+ * "no diff could be rebuilt" rather than promising a diff and showing nothing.
+ * A stale finding with weak evidence is far better than one served as fresh,
+ * but the reader has to be able to tell which one they are holding.
+ */
+export function invalidateChangedAnchors(dir, graph, rawPath) {
+  const path = canonicalPath(rawPath);
+  const marked = [];
+
+  // ONE read for the file and every symbol in it. checkAnchor would have been
+  // the obvious reuse and it reads per anchor, which on a file with fifty
+  // symbols is fifty-one reads of the same bytes on a hook path.
+  let source = null;
+  try {
+    source = readAnySpelling(path);
+  } catch {
+    // Deleted, or unreadable from this checkout. Handled below as a change,
+    // because a finding about a file that is no longer there is exactly the
+    // kind that must not be served as fresh.
+  }
+
+  const changed = [];
+  const fileNode = graph.nodes.get(nodeId('file', path));
+  const fileDigest = source === null ? null : hash(source);
+  if (fileNode && fileDigest !== fileNode.hash) {
+    changed.push({ node: fileNode, from: fileNode.hash, to: fileDigest });
+  }
+
+  const current = new Map(
+    source === null
+      ? []
+      : extractSymbols(path, source).map((s) => [s.name, hash(spanText(source, s))])
+  );
+  for (const node of graph.nodes.values()) {
+    if (node.kind !== 'symbol' || node.file !== path) continue;
+    const digest = current.has(node.name) ? current.get(node.name) : null;
+    if (digest !== node.hash) changed.push({ node, from: node.hash, to: digest });
+  }
+
+  if (changed.length) {
+    // Indexed once by target, for the reason invalidateOnWrite indexes: the
+    // nested alternative is O(nodes x edges) inside a hook.
+    const byTarget = new Map();
+    for (const edge of graph.edges) {
+      if (edge.edge !== 'derived_from') continue;
+      if (!byTarget.has(edge.to)) byTarget.set(edge.to, []);
+      byTarget.get(edge.to).push(edge);
+    }
+
+    for (const { node, from, to } of changed) {
+      for (const edge of byTarget.get(node.id) || []) {
+        const finding = graph.nodes.get(edge.from);
+        if (!finding || finding.kind !== 'finding') continue;
+        // The same type gate serve() applies, for the same reason it is applied
+        // in invalidateOnWrite: the flag is STORED, and disclose.mjs skips a
+        // stale finding while utility.mjs penalises one by 160.
+        if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) continue;
+        // ALREADY MARKED IS LEFT ALONE. Whatever marked it first had a diff or
+        // a more specific reason; overwriting that with a hash pair trades real
+        // evidence for less.
+        if (finding.stale) continue;
+
+        putNode(dir, {
+          ...finding,
+          kind: 'finding',
+          key: finding.key,
+          stale: true,
+          staleReason:
+            to === null
+              ? `the ${node.kind} it depends on is no longer present (was ${from})`
+              : `content hash changed during this session (${from} -> ${to}), observed without a before/after pair`,
+          // EXPLICITLY EMPTY, not absent. serve() reports `staleEvidence` from
+          // whether a diff survived, and the renderer says "no diff could be
+          // rebuilt" -- so the reader can tell "changed, diff unknown" from
+          // "changed, here is what changed".
+          diff: '',
+        });
+        marked.push(finding.key);
+      }
+    }
+  }
+
+  // Re-index for the same reason the diff path does: otherwise every future
+  // retrieval re-reports a change that has already been accounted for.
+  if (source !== null) indexFile(dir, path, source);
   return marked;
 }
 

--- a/integrations/codex/plugin/hooks/lib/staleness.mjs
+++ b/integrations/codex/plugin/hooks/lib/staleness.mjs
@@ -574,8 +574,20 @@ function derivationCheck(graph, finding) {
  * This is the only function that should ever hand a finding to a model, because
  * it is the one that enforces the rule: a stale finding leaves here carrying
  * `stale: true` AND a diff, or it does not leave at all.
+ *
+ * AND IT CLEARS A STORED FLAG WHOSE EVIDENCE IS GONE, when given a `dir` to
+ * write to. Clearing used to be reachable only by a person pressing Re-verify in
+ * the dashboard, which left the rot path fully open on every install where
+ * nobody opens the dashboard -- and that is most of them. The evidence test is
+ * what makes clearing safe, and it does not care who triggered it: the same
+ * `claimTimeVerdict` runs here as in `reverify`, so this cannot clear anything
+ * the button would not.
+ *
+ * `dir` IS OPTIONAL, AND OMITTING IT MAKES THIS READ-ONLY. Several callers hold
+ * a graph without the directory it came from, and a serve that silently did
+ * nothing would be worse than one that plainly cannot write.
  */
-export function serve(graph, findings) {
+export function serve(graph, findings, { dir = null } = {}) {
   const served = [];
 
   // RETIRED FINDINGS STOP HERE, unconditionally.
@@ -603,8 +615,42 @@ export function serve(graph, findings) {
       continue;
     }
 
+    // AUTOMATIC CLEARING, on the same evidence the manual path demands.
+    //
+    // ONLY THE STORED FLAG IS TOUCHED. The lazy loop below is left to run
+    // exactly as before and can independently mark this finding stale again on
+    // its own comparison -- disk against the anchor NODE's hash -- which answers
+    // a different question and is not this function's to overrule. Eager and
+    // lazy stay two mechanisms, as the module header insists.
+    //
+    // AND THE FIELDS GO WITH THE FLAG. `putNode` does not merge and neither does
+    // this spread: serving `{ ...finding, stale: false }` would hand back a
+    // finding that reads fresh while still carrying `staleReason` and `diff`
+    // from the record -- stale and fresh at once, which is worse than either.
+    // So the cleared record, not the stored one, is what the rest of this
+    // iteration reads and spreads.
+    //
+    // BOUNDED, and the bound is the point: this runs only for a finding whose
+    // flag is already STORED, only when a `derivation` record exists to check
+    // against, and it reads each of that finding's anchors at most once. A
+    // finding that is not flagged pays nothing. The lazy loop below already
+    // reads every anchor of every content-dependent finding served, so the worst
+    // case is twice the anchor reads on the already-stale subset alone.
+    //
+    // NOT ON THE NON-CONTENT-DEPENDENT EARLY RETURN ABOVE, deliberately. Both
+    // eager paths refuse to flag those types at all, so a flag there can only
+    // come from an older graph -- and reading anchors for a type whose truth
+    // does not depend on them is exactly the cost `CONTENT_DEPENDENT` exists to
+    // avoid.
+    let record = finding;
+    if (dir && finding.stale && claimTimeVerdict(graph, finding) === 'match') {
+      clearStale(dir, finding.key, { graph });
+      const { stale: _s, staleReason: _r, diff: _d, staleEvidence: _e, ...cleared } = finding;
+      record = cleared;
+    }
+
     const anchors = graph.edges
-      .filter((e) => e.edge === 'derived_from' && e.from === finding.id)
+      .filter((e) => e.edge === 'derived_from' && e.from === record.id)
       .map((e) => graph.nodes.get(e.to))
       .filter(Boolean);
 
@@ -629,10 +675,10 @@ export function serve(graph, findings) {
     // A finding already marked stale eagerly, whose diff was captured at write
     // time, keeps that diff -- the eager path saw the change we can no longer
     // reconstruct from disk alone.
-    if (!stale && finding.stale) {
+    if (!stale && record.stale) {
       stale = true;
-      diff = finding.diff || '';
-      reason = finding.staleReason || 'marked stale when the change was observed';
+      diff = record.diff || '';
+      reason = record.staleReason || 'marked stale when the change was observed';
     }
 
     if (stale && !diff) {
@@ -681,13 +727,19 @@ export function serve(graph, findings) {
     }
 
     served.push({
-      ...finding,
+      ...record,
       stale,
       ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
+      // BOTH OTHER DISCLOSURES SURVIVE A MID-SERVE CLEAR. `dispute` was computed
+      // above the content-dependence branch and is applied here untouched, and
+      // the derivation verdict is recomputed from the record -- which still
+      // carries its `derivation`, since clearing removes only the staleness
+      // fields. A finding whose flag was just cleared is still disclosed as
+      // disputed, and still reports whether its derivation holds.
       ...dispute,
       // Independent of `stale` above: see `derivationCheck`'s own comment for
       // the case it catches that node-level staleness can miss.
-      ...derivationCheck(graph, finding),
+      ...derivationCheck(graph, record),
     });
   }
   return served;
@@ -939,8 +991,21 @@ function anchorHashNow(anchor) {
  * Exposing it to a hook, a tool argument or an HTTP action would be a way to
  * turn a stale finding fresh on request, which is exactly what must not exist.
  */
-export function clearStale(dir, key) {
-  const node = load(dir).nodes.get(nodeId('finding', key));
+export function clearStale(dir, key, { graph = null } = {}) {
+  // A CALLER THAT ALREADY HOLDS THE GRAPH PASSES IT, and this is not
+  // micro-optimisation: `load` re-parses the entire append-only log, so clearing
+  // inside `serve`'s loop re-read and re-folded the whole graph once PER cleared
+  // finding. Measured on 40 findings all stale and all revertible -- the shape a
+  // mass revert produces -- that was 185 ms against 25 ms, a 7x regression on
+  // the injection path, all of it graph loading rather than the hashing this
+  // feature is actually for. With the graph passed through it is back in line.
+  //
+  // No new race: this store is last-write-wins with no compare-and-set anywhere,
+  // and every other caller that spreads a node back -- `pin`, `retire`,
+  // `contradict`, `correct` -- writes from a graph it loaded earlier too. Both
+  // callers here already DECIDED on this snapshot, so re-reading it purely for
+  // the write narrowed no window that was ever closed.
+  const node = (graph || load(dir)).nodes.get(nodeId('finding', key));
   if (!node || node.kind !== 'finding') return false;
   const { stale, staleReason, diff, staleEvidence, ...rest } = node;
   // Nothing to clear is a success, not a write: an unconditional putNode here
@@ -989,14 +1054,33 @@ export function clearStale(dir, key) {
  * silently un-mark findings nobody asked about. Staleness is disclosed to a
  * reader who then decides; clearing is an explicit act.
  */
-export function reverify(dir, key) {
-  const graph = load(dir);
-  const finding = graph.nodes.get(nodeId('finding', key));
-  if (!finding || finding.kind !== 'finding') return 'unknown';
-  // Idempotent: the postcondition -- no stale flag on this finding -- already
-  // holds, and reporting anything else would make a caller retry forever.
-  if (!finding.stale) return 'cleared';
-
+/**
+ * THE ONE EVIDENCE TEST. Does this finding's anchored content still hash to what
+ * the claim was actually made against?
+ *
+ * `'match'` -- every anchor on disk re-hashes to the value frozen into this
+ * finding's own `derivation.anchors` at claim time. The content IS what the
+ * claim was derived from: a revert, or a write that never moved the anchored
+ * bytes.
+ * `'differs'` -- at least one anchor does not, INCLUDING an anchor whose content
+ * is gone. Deleted is a difference, not a missing measurement.
+ * `'unknown'` -- there is nothing to compare: no `derivation.anchors`, no
+ * anchors, an anchor with no recorded hash, or one that no longer resolves.
+ *
+ * SHARED BY BOTH CLEARING PATHS ON PURPOSE, and that sharing is the guarantee
+ * rather than a convenience. `reverify` (a person pressing Re-verify) and
+ * `serve` (automatic, on every retrieval) call THIS function and nothing else,
+ * so the automatic path cannot clear anything the button would not, and neither
+ * can drift from the other. Two copies of this comparison would be two policies,
+ * and the weaker one would win wherever it ran more often -- which is the
+ * automatic one.
+ *
+ * NOT `checkAnchor`, for the reason `anchorHashNow` above spells out: that
+ * compares disk against the anchor NODE's stored hash, which both eager paths
+ * re-point at the very bytes that caused the mark, so it answers "fresh" for
+ * exactly the finding it just marked stale.
+ */
+function claimTimeVerdict(graph, finding) {
   const recorded = finding.derivation && finding.derivation.anchors;
   if (!recorded || typeof recorded !== 'object') return 'unknown';
 
@@ -1019,10 +1103,23 @@ export function reverify(dir, key) {
     if (node.kind !== 'file' && node.kind !== 'symbol') return 'unknown';
     // null means the content is gone -- deleted file, vanished symbol. That is a
     // difference, not an absence of evidence.
-    if (anchorHashNow(node) !== expected) return 'still-stale';
+    if (anchorHashNow(node) !== expected) return 'differs';
   }
+  return 'match';
+}
 
-  clearStale(dir, key);
+export function reverify(dir, key) {
+  const graph = load(dir);
+  const finding = graph.nodes.get(nodeId('finding', key));
+  if (!finding || finding.kind !== 'finding') return 'unknown';
+  // Idempotent: the postcondition -- no stale flag on this finding -- already
+  // holds, and reporting anything else would make a caller retry forever.
+  if (!finding.stale) return 'cleared';
+
+  const verdict = claimTimeVerdict(graph, finding);
+  if (verdict === 'unknown') return 'unknown';
+  if (verdict === 'differs') return 'still-stale';
+  clearStale(dir, key, { graph });
   return 'cleared';
 }
 

--- a/integrations/codex/plugin/hooks/lib/staleness.mjs
+++ b/integrations/codex/plugin/hooks/lib/staleness.mjs
@@ -53,7 +53,7 @@
 import { readFileSync, statSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { dirname, join } from 'node:path';
-import { putNode, putEdge, contentHash, nodeId } from './wiki.mjs';
+import { putNode, putEdge, contentHash, nodeId, load } from './wiki.mjs';
 import { hasOutstandingContradiction } from './curate.mjs';
 import { extractSymbols, spanText, symbolKey, extractImports } from './symbols.mjs';
 import { canonicalPath, resolvableCandidates, isFsSafePath } from './paths.mjs';
@@ -488,7 +488,16 @@ function disputeOf(graph, finding) {
     // An edge end that resolves to nothing names nothing. The dispute is still
     // disclosed -- the gate above already established it -- but without a key
     // the reader cannot be pointed anywhere, and inventing one would be worse.
-    if (other && typeof other.key === 'string' && !keys.includes(other.key)) keys.push(other.key);
+    //
+    // A RETIRED END IS NOT NAMED EITHER, for a sharper reason: the disclosure
+    // tells the reader to `wiki_query` that key, and `serve` refuses to return
+    // a retired finding at all. Naming it points them at a claim they cannot
+    // fetch. `hasOutstandingContradiction` above already declines to open the
+    // gate when EVERY disputant is retired; this is the same rule applied to
+    // each name, so a live disputant is still reported alongside a withdrawn one.
+    if (other && !other.retired && typeof other.key === 'string' && !keys.includes(other.key)) {
+      keys.push(other.key);
+    }
   }
 
   return { contradicted: true, ...(keys.length ? { contradictedBy: keys.join(', ') } : {}) };
@@ -870,6 +879,151 @@ export function invalidateChangedAnchors(dir, graph, rawPath) {
   // retrieval re-reports a change that has already been accounted for.
   if (source !== null) indexFile(dir, path, source);
   return marked;
+}
+
+/**
+ * The current content hash of an anchor, read from disk.
+ *
+ * DELIBERATELY NOT `checkAnchor`, and the difference is the whole of this
+ * clearing rule. `checkAnchor` compares disk against the anchor NODE's stored
+ * hash, and both eager paths call `indexFile` immediately after marking --
+ * which re-points that hash at the very bytes that caused the mark. So
+ * `checkAnchor` answers "fresh" for exactly the finding it just marked stale,
+ * and a clearing rule built on it would clear every flag it was handed,
+ * unconditionally. This returns a bare hash instead, so the caller can compare
+ * it against the FROZEN claim-time hash rather than against a value the marking
+ * path itself moved.
+ *
+ * Returns null when no content can be read at all -- a deleted file, or a
+ * symbol that no longer exists. A caller must treat that as "changed", never as
+ * "unknown": a claim about content that is gone certainly does not match the
+ * content it was made against.
+ */
+function anchorHashNow(anchor) {
+  const path = anchor.kind === 'symbol' ? anchor.file : anchor.key;
+  let source;
+  try {
+    source = readAnySpelling(path);
+  } catch {
+    return null;
+  }
+  if (anchor.kind !== 'symbol') return hash(source);
+
+  // By NAME, like checkAnchor: line numbers shift whenever anything above is
+  // edited, and re-locating by line would report a symbol as moved when only an
+  // unrelated insert happened above it.
+  const current = extractSymbols(path, source).find((s) => s.name === anchor.name);
+  if (!current) return null;
+  return hash(spanText(source, current));
+}
+
+/**
+ * Removes the staleness fields from a finding. Returns whether one was found.
+ *
+ * THE WHOLE NODE IS REWRITTEN, because `putNode` does not merge: it writes a
+ * full record from what it is handed and `load` replaces the node wholesale.
+ * Writing `{ kind, key, stale: false }` would blank the claim, the confidence
+ * and the provenance -- an overwrite by another name, and the same trap
+ * `contradict` documents. So the fields are destructured AWAY and everything
+ * else is spread back: no deletion primitive is needed, and the append-only rule
+ * is respected.
+ *
+ * `staleEvidence` is stripped as well, even though no writer stores it. It is
+ * added by `serve` to the object it hands out, so anything that ever writes a
+ * served finding back would carry it in -- at which point a cleared finding
+ * would still be advertising the quality of the evidence for a flag it no longer
+ * has.
+ *
+ * A PRIMITIVE, NOT A ROUTE. Nothing outside this module calls it: the only
+ * shipping caller is `reverify` below, which establishes the evidence first.
+ * Exposing it to a hook, a tool argument or an HTTP action would be a way to
+ * turn a stale finding fresh on request, which is exactly what must not exist.
+ */
+export function clearStale(dir, key) {
+  const node = load(dir).nodes.get(nodeId('finding', key));
+  if (!node || node.kind !== 'finding') return false;
+  const { stale, staleReason, diff, staleEvidence, ...rest } = node;
+  // Nothing to clear is a success, not a write: an unconditional putNode here
+  // would append a duplicate record to the log on every no-op call.
+  if (stale === undefined && staleReason === undefined
+    && diff === undefined && staleEvidence === undefined) return true;
+  putNode(dir, { ...rest, kind: 'finding', key: node.key });
+  return true;
+}
+
+/**
+ * Clears a stale flag when, and only when, the evidence for it is gone.
+ *
+ * WHY THIS HAS TO EXIST. Nothing in this codebase ever cleared a `stale` flag.
+ * That was harmless while eager invalidation was dead code; it fires now, so
+ * every finding on an edited file becomes permanently stale -- and permanently
+ * discounted, since `disclose.mjs` skips a stale finding outright and
+ * `utility.mjs` penalises one by 160. The graph degrades toward all-stale, and
+ * the eager path is over-eager on top of that: `invalidateOnWrite` marks every
+ * finding anchored to a FILE node on any observed write to that file, whether or
+ * not the bytes moved.
+ *
+ * WHAT COUNTS AS EVIDENCE, AND WHY IT IS NOT NEGOTIABLE. The only trustworthy
+ * record of what a claim was made against is `derivation.anchors` -- the hash
+ * each anchor carried at the moment the finding was written, frozen into the
+ * finding itself by `harvest-write.mjs`. Disk is re-hashed here and compared
+ * against that. If every anchor matches, the content IS what the claim was
+ * derived from: a revert, or a write that never moved the anchored bytes. The
+ * flag comes off. Anything else leaves it exactly as it was.
+ *
+ * IT IS NOT A LAUNDERING ROUTE, and that is a property of the comparison rather
+ * than of who is allowed to call it. A caller cannot make a finding fresh by
+ * asking; they can only make it fresh by putting the content back. There is no
+ * argument, no force flag and no second path -- and `clearStale` above, the one
+ * function that clears without checking, has no caller but this one.
+ *
+ * NO RECORD MEANS UNKNOWN, NEVER CLEAR. A finding with no `derivation.anchors`
+ * -- every one written before that record existed, and every hand-curated one --
+ * has nothing to compare disk against. That is an absence of evidence, and
+ * resolving it to "clear it" would hand back the laundering route through the
+ * side door. It reports `unknown` and changes nothing; re-recording the claim
+ * against the current code (`curate.correct`) is the way forward for those.
+ *
+ * DELIBERATELY NOT AUTOMATIC. This reads every anchor off disk, so running it on
+ * the serve path would put N file reads inside injection -- and, worse, it would
+ * silently un-mark findings nobody asked about. Staleness is disclosed to a
+ * reader who then decides; clearing is an explicit act.
+ */
+export function reverify(dir, key) {
+  const graph = load(dir);
+  const finding = graph.nodes.get(nodeId('finding', key));
+  if (!finding || finding.kind !== 'finding') return 'unknown';
+  // Idempotent: the postcondition -- no stale flag on this finding -- already
+  // holds, and reporting anything else would make a caller retry forever.
+  if (!finding.stale) return 'cleared';
+
+  const recorded = finding.derivation && finding.derivation.anchors;
+  if (!recorded || typeof recorded !== 'object') return 'unknown';
+
+  const anchorIds = new Set(
+    graph.edges
+      .filter((e) => e.edge === 'derived_from' && e.from === finding.id)
+      .map((e) => e.to)
+  );
+  // An unanchored finding cannot be checked against anything, which is the
+  // un-invalidatable shape the anchor discipline exists to refuse. It is equally
+  // un-VERIFIABLE, so it is reported as such rather than cleared.
+  if (!anchorIds.size) return 'unknown';
+
+  for (const id of anchorIds) {
+    const expected = recorded[id];
+    const node = graph.nodes.get(id);
+    // An anchor this finding never recorded a hash for, or one that no longer
+    // resolves to a node: nothing to compare, so nothing is concluded.
+    if (typeof expected !== 'string' || !expected || !node) return 'unknown';
+    if (node.kind !== 'file' && node.kind !== 'symbol') return 'unknown';
+    // null means the content is gone -- deleted file, vanished symbol. That is a
+    // difference, not an absence of evidence.
+    if (anchorHashNow(node) !== expected) return 'still-stale';
+  }
+
+  clearStale(dir, key);
+  return 'cleared';
 }
 
 export { contentHash };

--- a/integrations/codex/plugin/hooks/lib/staleness.mjs
+++ b/integrations/codex/plugin/hooks/lib/staleness.mjs
@@ -368,6 +368,12 @@ const DIFF_MAX_BYTES = () => {
  * line, and total bytes. Every truncation is announced in the output, because a
  * silently shortened diff is worse than a visibly shortened one -- a reader who
  * cannot tell content was elided believes they saw the whole change.
+ *
+ * `maxLines` BOUNDS THE BODY, MARKERS INCLUDED: at most `maxLines` lines of
+ * removed lines, added lines and "... N more" elision markers between them, plus
+ * at most one final notice when the byte cap dropped lines -- so `maxLines + 1`
+ * lines in total, and no more. That last line is outside the budget on purpose,
+ * for the reason stated where it is pushed.
  */
 export function diffLines(
   before,
@@ -418,10 +424,24 @@ export function diffLines(
     bytes += size;
   };
 
-  for (const line of removed.slice(0, maxLines / 2)) push('- ' + line);
-  if (removed.length > maxLines / 2) push(`  ... ${removed.length - maxLines / 2} more removed`);
-  for (const line of added.slice(0, maxLines / 2)) push('+ ' + line);
-  if (added.length > maxLines / 2) push(`  ... ${added.length - maxLines / 2} more added`);
+  // THE ELISION MARKER IS PAID FOR OUT OF THE SIDE'S OWN QUOTA, so `maxLines`
+  // bounds the whole body rather than only the content in it. It did not: at the
+  // default 40 the body could reach 42 lines -- 20 removed, 20 added and two
+  // "... N more" markers -- and the out-of-budget notice below made 43, against
+  // a documented bound of 40 and a test asserting 41. Three numbers, no two the
+  // same. A side that has to elide now shows one fewer content line and spends
+  // that line on saying so, which is the trade a reader wants anyway: knowing
+  // that 300 lines were cut matters more than the 20th of the 20 shown.
+  const half = Math.floor(maxLines / 2);
+  const emit = (lines, prefix, label) => {
+    const elides = lines.length > half;
+    const shown = elides ? Math.max(0, half - 1) : half;
+    for (const line of lines.slice(0, shown)) push(prefix + line);
+    if (elides) push(`  ... ${lines.length - shown} more ${label}`);
+  };
+
+  emit(removed, '- ', 'removed');
+  emit(added, '+ ', 'added');
 
   // Announced OUTSIDE the budget, deliberately: the one line a reader most
   // needs is the one saying the rest is missing, and dropping it to stay under
@@ -479,6 +499,15 @@ function disputeOf(graph, finding) {
   if (!hasOutstandingContradiction(graph, finding.key)) return {};
 
   const keys = [];
+  // AND THE REASON A PERSON TYPED, which had no reader anywhere. `contradict`
+  // stores `contradictionReason` -- up to 400 characters of human explanation --
+  // on the CONTRADICTED end only, and nothing outside its own test ever read it:
+  // this disclosure named the other key and stopped, `audit` counts ends, and the
+  // dashboard detail view renders neither. So the one field on the edge that says
+  // WHY was written on every contradiction and seen by nobody. It is collected
+  // from whichever end holds it, so both sides of a dispute disclose the same
+  // reason rather than only the claim that lost.
+  let reason = typeof finding.contradictionReason === 'string' ? finding.contradictionReason : '';
   for (const edge of graph.edges) {
     if (edge.edge !== 'contradicts') continue;
     const otherId =
@@ -497,10 +526,30 @@ function disputeOf(graph, finding) {
     // each name, so a live disputant is still reported alongside a withdrawn one.
     if (other && !other.retired && typeof other.key === 'string' && !keys.includes(other.key)) {
       keys.push(other.key);
+      // A RETIRED END'S REASON IS NOT BORROWED EITHER, which is why this sits
+      // inside the same guard as the key: `hasOutstandingContradiction` can be
+      // open on one live disputant while another is withdrawn, and quoting the
+      // withdrawn one's explanation would attribute the live dispute to a claim
+      // the reader cannot fetch.
+      if (!reason && typeof other.contradictionReason === 'string') {
+        reason = other.contradictionReason;
+      }
     }
   }
 
-  return { contradicted: true, ...(keys.length ? { contradictedBy: keys.join(', ') } : {}) };
+  return {
+    contradicted: true,
+    ...(keys.length ? { contradictedBy: keys.join(', ') } : {}),
+    // Trimmed here rather than at the renderer: an empty string is not a reason,
+    // and a consumer checking `if (reason)` should not have to trim first.
+    //
+    // SET UNCONDITIONALLY, INCLUDING TO `undefined`. `serve` spreads the stored
+    // record before this object, so omitting the key would let a whitespace-only
+    // stored reason through untouched and make the served value differ from the
+    // one this function decided on. The disclosure is authoritative or it is not
+    // a disclosure.
+    contradictionReason: reason.trim() || undefined,
+  };
 }
 
 /**
@@ -580,8 +629,15 @@ function derivationCheck(graph, finding) {
  * the dashboard, which left the rot path fully open on every install where
  * nobody opens the dashboard -- and that is most of them. The evidence test is
  * what makes clearing safe, and it does not care who triggered it: the same
- * `claimTimeVerdict` runs here as in `reverify`, so this cannot clear anything
+ * `claimTimeEvidence` runs here as in `reverify`, so this cannot clear anything
  * the button would not.
+ *
+ * A CLEAR ALSO RE-INDEXES THE ANCHORS IT VERIFIED. The three disclosures this
+ * function emits -- `stale`, `derivationHolds`, and the dispute -- are computed
+ * from three different comparisons, and clearing the flag without moving the
+ * anchor's stored hash made the first two contradict the clear on the revert
+ * path. `reindexVerifiedAnchors` explains the reproduction and why re-pointing
+ * the index is the fix rather than suppressing the disclosures.
  *
  * `dir` IS OPTIONAL, AND OMITTING IT MAKES THIS READ-ONLY. Several callers hold
  * a graph without the directory it came from, and a serve that silently did
@@ -617,11 +673,17 @@ export function serve(graph, findings, { dir = null } = {}) {
 
     // AUTOMATIC CLEARING, on the same evidence the manual path demands.
     //
-    // ONLY THE STORED FLAG IS TOUCHED. The lazy loop below is left to run
-    // exactly as before and can independently mark this finding stale again on
-    // its own comparison -- disk against the anchor NODE's hash -- which answers
-    // a different question and is not this function's to overrule. Eager and
-    // lazy stay two mechanisms, as the module header insists.
+    // THE FLAG AND THE INDEX MOVE TOGETHER. Clearing the flag alone made this
+    // function contradict itself on the revert path: the lazy loop below
+    // compares disk against the anchor NODE's hash, which the eager path
+    // re-pointed at the post-edit bytes, so a reverted file read as `stale:
+    // true, staleReason: 'file changed'` and `derivationHolds: false` inside the
+    // very object whose flag had just been cleared for matching its claim-time
+    // content. `reindexVerifiedAnchors` writes the verified bytes' hash back to
+    // the anchor, so all three disclosures are finally reading the same content
+    // and cannot disagree. Eager and lazy stay two mechanisms, as the module
+    // header insists -- what changed is that the index no longer holds a hash
+    // that matches no version of the file that exists.
     //
     // AND THE FIELDS GO WITH THE FLAG. `putNode` does not merge and neither does
     // this spread: serving `{ ...finding, stale: false }` would hand back a
@@ -630,12 +692,37 @@ export function serve(graph, findings, { dir = null } = {}) {
     // So the cleared record, not the stored one, is what the rest of this
     // iteration reads and spreads.
     //
-    // BOUNDED, and the bound is the point: this runs only for a finding whose
-    // flag is already STORED, only when a `derivation` record exists to check
-    // against, and it reads each of that finding's anchors at most once. A
-    // finding that is not flagged pays nothing. The lazy loop below already
+    // BOUNDED PER CALL, and the bound is the point: this runs only for a finding
+    // whose flag is already STORED, only when a `derivation` record exists to
+    // check against, and it reads each of that finding's anchors at most once.
+    // A finding that is not flagged pays nothing. The lazy loop below already
     // reads every anchor of every content-dependent finding served, so the worst
     // case is twice the anchor reads on the already-stale subset alone.
+    //
+    // AND THE PER-SESSION SHAPE, stated because the per-call bound alone reads
+    // as cheaper than it is. Measured on a synthetic 40-stale-finding graph, the
+    // serve path went 158 ms -> 217 ms (+37%), and for a GENUINELY stale finding
+    // that cost recurs on every call for the whole session: the verdict is
+    // `'differs'` forever, nothing is cleared, and the reads are repaid with
+    // nothing. What keeps it survivable in practice is not this bound but two
+    // others -- `findingsFor`'s result limit and inject.mjs's `alreadyInjected`
+    // gate, which together put it near 40 ms on the first touch of a hot file
+    // and zero on the touches after.
+    //
+    // THE REVERT CASE PAYS ONCE, AND THAT IS MEASURED, not argued. Same 40
+    // findings, all revertible, medians of 9 across three process launches: the
+    // read-only serve is 23-29 ms, the first clearing serve is 141-173 ms (the
+    // anchor reads plus one node append per cleared finding AND per re-pointed
+    // anchor), and the SECOND clearing serve is 21-28 ms -- back to the
+    // read-only baseline, because the flag is off and the index agrees, so this
+    // gate no longer fires. What the re-index changed is not that cost -- the
+    // gate stopped firing once the flag came off before, too -- but that every
+    // serve after the clear used to re-derive `stale: true` and
+    // `derivationHolds: false` from an index nobody had moved. The extra ~120 ms
+    // buys silence that is actually correct.
+    // On the genuinely-stale set the recurring cost is
+    // real and unchanged in kind: 26-45 ms read-only against 53-105 ms with
+    // clearing on, every call, clearing nothing.
     //
     // NOT ON THE NON-CONTENT-DEPENDENT EARLY RETURN ABOVE, deliberately. Both
     // eager paths refuse to flag those types at all, so a flag there can only
@@ -643,10 +730,14 @@ export function serve(graph, findings, { dir = null } = {}) {
     // does not depend on them is exactly the cost `CONTENT_DEPENDENT` exists to
     // avoid.
     let record = finding;
-    if (dir && finding.stale && claimTimeVerdict(graph, finding) === 'match') {
-      clearStale(dir, finding.key, { graph });
-      const { stale: _s, staleReason: _r, diff: _d, staleEvidence: _e, ...cleared } = finding;
-      record = cleared;
+    if (dir && finding.stale) {
+      const evidence = claimTimeEvidence(graph, finding);
+      if (evidence.verdict === 'match') {
+        reindexVerifiedAnchors(dir, graph, evidence.contents);
+        clearStale(dir, finding.key, { graph });
+        const { stale: _s, staleReason: _r, diff: _d, staleEvidence: _e, ...cleared } = finding;
+        record = cleared;
+      }
     }
 
     const anchors = graph.edges
@@ -736,6 +827,14 @@ export function serve(graph, findings, { dir = null } = {}) {
       // carries its `derivation`, since clearing removes only the staleness
       // fields. A finding whose flag was just cleared is still disclosed as
       // disputed, and still reports whether its derivation holds.
+      //
+      // AND THEY NO LONGER CONTRADICT THE CLEAR. Surviving is not the same as
+      // agreeing: for a whole serve this returned `stale: true, staleReason:
+      // 'file changed'` and `derivationHolds: false` on a finding it had just
+      // cleared, because the clear was decided against disk while these two read
+      // the anchor node's hash, and the eager path had moved it. All three now
+      // read the same content because the clear re-points the anchor; see
+      // `reindexVerifiedAnchors`.
       ...dispute,
       // Independent of `stale` above: see `derivationCheck`'s own comment for
       // the case it catches that node-level staleness can miss.
@@ -934,6 +1033,34 @@ export function invalidateChangedAnchors(dir, graph, rawPath) {
 }
 
 /**
+ * The current content of an anchor, read from disk: the whole file for a file
+ * anchor, the located span for a symbol one. Null when nothing can be read.
+ *
+ * SPLIT OUT FROM `anchorHashNow` SO THE BYTES SURVIVE THE COMPARISON. The
+ * clearing path hashes this to reach a verdict and, on `'match'`, re-indexes the
+ * anchor from the same bytes -- see `reindexVerifiedAnchors`. Returning only a
+ * hash forced a second read of a file that had just been read, for content
+ * already known to be identical.
+ */
+function anchorContentNow(anchor) {
+  const path = anchor.kind === 'symbol' ? anchor.file : anchor.key;
+  let source;
+  try {
+    source = readAnySpelling(path);
+  } catch {
+    return null;
+  }
+  if (anchor.kind !== 'symbol') return source;
+
+  // By NAME, like checkAnchor: line numbers shift whenever anything above is
+  // edited, and re-locating by line would report a symbol as moved when only an
+  // unrelated insert happened above it.
+  const current = extractSymbols(path, source).find((s) => s.name === anchor.name);
+  if (!current) return null;
+  return spanText(source, current);
+}
+
+/**
  * The current content hash of an anchor, read from disk.
  *
  * DELIBERATELY NOT `checkAnchor`, and the difference is the whole of this
@@ -952,21 +1079,8 @@ export function invalidateChangedAnchors(dir, graph, rawPath) {
  * content it was made against.
  */
 function anchorHashNow(anchor) {
-  const path = anchor.kind === 'symbol' ? anchor.file : anchor.key;
-  let source;
-  try {
-    source = readAnySpelling(path);
-  } catch {
-    return null;
-  }
-  if (anchor.kind !== 'symbol') return hash(source);
-
-  // By NAME, like checkAnchor: line numbers shift whenever anything above is
-  // edited, and re-locating by line would report a symbol as moved when only an
-  // unrelated insert happened above it.
-  const current = extractSymbols(path, source).find((s) => s.name === anchor.name);
-  if (!current) return null;
-  return hash(spanText(source, current));
+  const content = anchorContentNow(anchor);
+  return content === null ? null : hash(content);
 }
 
 /**
@@ -1005,21 +1119,51 @@ export function clearStale(dir, key, { graph = null } = {}) {
   // `contradict`, `correct` -- writes from a graph it loaded earlier too. Both
   // callers here already DECIDED on this snapshot, so re-reading it purely for
   // the write narrowed no window that was ever closed.
-  const node = (graph || load(dir)).nodes.get(nodeId('finding', key));
+  const id = nodeId('finding', key);
+  const node = (graph || load(dir)).nodes.get(id);
   if (!node || node.kind !== 'finding') return false;
   const { stale, staleReason, diff, staleEvidence, ...rest } = node;
   // Nothing to clear is a success, not a write: an unconditional putNode here
   // would append a duplicate record to the log on every no-op call.
   if (stale === undefined && staleReason === undefined
     && diff === undefined && staleEvidence === undefined) return true;
-  putNode(dir, { ...rest, kind: 'finding', key: node.key });
+  const cleared = { ...rest, kind: 'finding', key: node.key };
+  putNode(dir, cleared);
+  // AND THE CALLER'S GRAPH IS UPDATED, because the guard above reads THAT graph,
+  // not disk. Without this, a second `serve` on the same in-memory graph object
+  // -- two touched files anchored to one finding, or a lifecycle branch that
+  // serves twice from a graph it loaded once, as SessionStart does -- still saw
+  // `stale: true`, re-ran the evidence test, and appended a byte-identical clear
+  // record. The store is append-only, so that is permanent log growth for no
+  // change in state, and the "nothing to clear is a success, not a write"
+  // guarantee directly above was only true of the first call.
+  if (graph) graph.nodes.set(id, { ...cleared, id });
   return true;
 }
 
 /**
- * Clears a stale flag when, and only when, the evidence for it is gone.
+ * THE ONE EVIDENCE TEST, plus the bytes it read. Does this finding's anchored
+ * content still hash to what the claim was actually made against?
  *
- * WHY THIS HAS TO EXIST. Nothing in this codebase ever cleared a `stale` flag.
+ * `verdict` is one of:
+ *   `'match'`   -- every anchor on disk re-hashes to the value frozen into this
+ *                  finding's own `derivation.anchors` at claim time. The content
+ *                  IS what the claim was derived from: a revert, or a write that
+ *                  never moved the anchored bytes.
+ *   `'differs'` -- at least one anchor does not, INCLUDING an anchor whose
+ *                  content is gone. Deleted is a difference, not a missing
+ *                  measurement.
+ *   `'unknown'` -- there is nothing to compare: no `derivation.anchors`, no
+ *                  anchors, an anchor with no recorded hash, or one that no
+ *                  longer resolves.
+ *
+ * `contents` carries the disk bytes read to reach a `'match'`, keyed by anchor
+ * id, so the caller can re-index those anchors without reading them again. It is
+ * empty for the other two verdicts, which read no further than the first
+ * disagreement.
+ *
+ * WHY CLEARING HAS TO EXIST AT ALL. Nothing in this codebase ever cleared a
+ * `stale` flag.
  * That was harmless while eager invalidation was dead code; it fires now, so
  * every finding on an edited file becomes permanently stale -- and permanently
  * discounted, since `disclose.mjs` skips a stale finding outright and
@@ -1049,24 +1193,6 @@ export function clearStale(dir, key, { graph = null } = {}) {
  * side door. It reports `unknown` and changes nothing; re-recording the claim
  * against the current code (`curate.correct`) is the way forward for those.
  *
- * DELIBERATELY NOT AUTOMATIC. This reads every anchor off disk, so running it on
- * the serve path would put N file reads inside injection -- and, worse, it would
- * silently un-mark findings nobody asked about. Staleness is disclosed to a
- * reader who then decides; clearing is an explicit act.
- */
-/**
- * THE ONE EVIDENCE TEST. Does this finding's anchored content still hash to what
- * the claim was actually made against?
- *
- * `'match'` -- every anchor on disk re-hashes to the value frozen into this
- * finding's own `derivation.anchors` at claim time. The content IS what the
- * claim was derived from: a revert, or a write that never moved the anchored
- * bytes.
- * `'differs'` -- at least one anchor does not, INCLUDING an anchor whose content
- * is gone. Deleted is a difference, not a missing measurement.
- * `'unknown'` -- there is nothing to compare: no `derivation.anchors`, no
- * anchors, an anchor with no recorded hash, or one that no longer resolves.
- *
  * SHARED BY BOTH CLEARING PATHS ON PURPOSE, and that sharing is the guarantee
  * rather than a convenience. `reverify` (a person pressing Re-verify) and
  * `serve` (automatic, on every retrieval) call THIS function and nothing else,
@@ -1080,9 +1206,10 @@ export function clearStale(dir, key, { graph = null } = {}) {
  * re-point at the very bytes that caused the mark, so it answers "fresh" for
  * exactly the finding it just marked stale.
  */
-function claimTimeVerdict(graph, finding) {
+function claimTimeEvidence(graph, finding) {
+  const none = { verdict: 'unknown', contents: new Map() };
   const recorded = finding.derivation && finding.derivation.anchors;
-  if (!recorded || typeof recorded !== 'object') return 'unknown';
+  if (!recorded || typeof recorded !== 'object') return none;
 
   const anchorIds = new Set(
     graph.edges
@@ -1092,22 +1219,122 @@ function claimTimeVerdict(graph, finding) {
   // An unanchored finding cannot be checked against anything, which is the
   // un-invalidatable shape the anchor discipline exists to refuse. It is equally
   // un-VERIFIABLE, so it is reported as such rather than cleared.
-  if (!anchorIds.size) return 'unknown';
+  if (!anchorIds.size) return none;
 
+  const contents = new Map();
   for (const id of anchorIds) {
     const expected = recorded[id];
     const node = graph.nodes.get(id);
     // An anchor this finding never recorded a hash for, or one that no longer
     // resolves to a node: nothing to compare, so nothing is concluded.
-    if (typeof expected !== 'string' || !expected || !node) return 'unknown';
-    if (node.kind !== 'file' && node.kind !== 'symbol') return 'unknown';
+    if (typeof expected !== 'string' || !expected || !node) return none;
+    if (node.kind !== 'file' && node.kind !== 'symbol') return none;
     // null means the content is gone -- deleted file, vanished symbol. That is a
     // difference, not an absence of evidence.
-    if (anchorHashNow(node) !== expected) return 'differs';
+    const content = anchorContentNow(node);
+    if (content === null || hash(content) !== expected) {
+      return { verdict: 'differs', contents: new Map() };
+    }
+    contents.set(id, content);
   }
-  return 'match';
+  return { verdict: 'match', contents };
 }
 
+/** The verdict alone, for callers that do not re-index. */
+function claimTimeVerdict(graph, finding) {
+  return claimTimeEvidence(graph, finding).verdict;
+}
+
+/**
+ * Re-points every verified anchor at the content the evidence test just read.
+ *
+ * WHY A CLEAR IS NOT ENOUGH ON ITS OWN, reproduced end to end: index a file at
+ * H1, write a finding whose `derivation.anchors` records H1, edit and re-index so
+ * the node holds H2, let the eager path mark the finding, then REVERT the edit on
+ * disk. `claimTimeVerdict` now says `'match'` -- disk is H1, which is exactly
+ * what the claim was derived from -- and the flag comes off. But the node still
+ * holds H2, so the same `serve` call went on to emit `stale: true` with
+ * `staleReason: 'file changed'` from the lazy loop (disk H1 against node H2) and
+ * `derivationHolds: false` from `derivationCheck` (index H2 against claim H1).
+ * The model was shown DERIVATION CHANGED and STALE at the exact moment this
+ * module's own evidence test had concluded the derivation holds -- on every
+ * serve, until something unrelated happened to re-index the anchor.
+ *
+ * THE FIX IS TO MOVE THE INDEX, NOT TO SILENCE THE DISCLOSURES. Suppressing the
+ * lazy check and the derivation verdict for a cleared finding would leave the
+ * graph holding a hash that matches no version of the file that exists, so every
+ * OTHER finding on that anchor keeps reading stale, and the next reader has to be
+ * told which disclosures to disbelieve. The node hash is simply out of date, the
+ * bytes are already in hand from the comparison that just succeeded, and writing
+ * them makes all three disclosures agree because they are finally reading the
+ * same content.
+ *
+ * COSTS NO READ. `contents` comes from `claimTimeEvidence`, which read each
+ * anchor to reach `'match'`. The write is one node record per anchor whose hash
+ * actually moved, and it happens once per revert rather than once per serve: with
+ * the index re-pointed, the flag stays off and the gate in `serve` does not fire
+ * again.
+ *
+ * THE IN-MEMORY GRAPH IS UPDATED TOO, because the caller is mid-serve and is
+ * about to read these same nodes through the lazy loop and `derivationCheck`.
+ * Writing only to disk would fix the next process and leave this one contradicting
+ * itself, which is the whole defect.
+ *
+ * Line numbers are deliberately left alone on a symbol anchor: `checkAnchor` and
+ * `anchorContentNow` both re-locate by NAME, so a stored line is informational,
+ * and the body being byte-identical is what was just established.
+ */
+function reindexVerifiedAnchors(dir, graph, contents) {
+  for (const [id, content] of contents) {
+    const node = graph.nodes.get(id);
+    if (!node) continue;
+    const nextHash = hash(content);
+    // Already agrees: no record, no write. The common case once a revert has
+    // been accounted for.
+    if (node.hash === nextHash) continue;
+    const limit = node.kind === 'symbol' ? symbolSnapshotLimit() : snapshotLimit();
+    // Same bound as `indexFile`: past the cap the hash still drives staleness and
+    // only the reconstructed diff degrades.
+    const snapshot = content.length <= limit ? content : undefined;
+    const { hash: _h, snapshot: _s, ...rest } = node;
+    try {
+      putNode(dir, { ...rest, kind: node.kind, key: node.key, hash: nextHash, snapshot });
+    } catch {
+      // Fail open: a graph that could not be written is a disclosure that stays
+      // as it was, never a broken tool call. The in-memory copy is left alone to
+      // match, so this serve keeps agreeing with the store.
+      continue;
+    }
+    graph.nodes.set(id, { ...node, hash: nextHash, ...(snapshot ? { snapshot } : {}) });
+  }
+}
+
+/**
+ * Clears a stale flag on behalf of a person who asked for it -- the dashboard's
+ * Re-verify action -- and reports what the evidence said.
+ *
+ * `'cleared'` when the flag is gone (including when it was already gone, so a
+ * caller polling this does not retry forever), `'still-stale'` when the anchored
+ * content genuinely differs from what the claim was made against, `'unknown'`
+ * when there is nothing to compare and therefore nothing to conclude.
+ *
+ * NO LONGER THE ONLY CLEARING PATH, and the docblock that used to sit here said
+ * the opposite: that automatic clearing was refused because it would put N file
+ * reads inside injection and "silently un-mark findings nobody asked about".
+ * `serve` now does exactly that, on the same evidence, for the reason its own
+ * comment gives -- the manual path was reachable only where somebody opens the
+ * dashboard, which is almost nowhere, so the rot path stayed open on most
+ * installs. What survives of that objection is the cost, which `serve` bounds
+ * and states.
+ *
+ * WHAT THIS STILL ADDS over the automatic path: it loads the graph itself, so a
+ * caller holding nothing but a key and a directory can act; it reports the
+ * verdict rather than folding it into a served record; and it runs on demand
+ * rather than only when the finding happens to be retrieved. It re-indexes the
+ * verified anchors for the same reason `serve` does -- otherwise the button
+ * clears the flag and the very next retrieval re-derives a contradiction from a
+ * node hash nobody moved.
+ */
 export function reverify(dir, key) {
   const graph = load(dir);
   const finding = graph.nodes.get(nodeId('finding', key));
@@ -1116,9 +1343,10 @@ export function reverify(dir, key) {
   // holds, and reporting anything else would make a caller retry forever.
   if (!finding.stale) return 'cleared';
 
-  const verdict = claimTimeVerdict(graph, finding);
+  const { verdict, contents } = claimTimeEvidence(graph, finding);
   if (verdict === 'unknown') return 'unknown';
   if (verdict === 'differs') return 'still-stale';
+  reindexVerifiedAnchors(dir, graph, contents);
   clearStale(dir, key, { graph });
   return 'cleared';
 }

--- a/integrations/codex/plugin/hooks/lib/staleness.mjs
+++ b/integrations/codex/plugin/hooks/lib/staleness.mjs
@@ -17,7 +17,13 @@
  * TWO INVALIDATION PATHS, and each covers what the other cannot see:
  *
  *   EAGER  -- our PostToolUse hook saw a write, so the finding is marked at the
- *             moment it went stale, with the exact before/after in hand.
+ *             moment it went stale, with the exact before/after in hand. The
+ *             hook does not call `invalidateOnWrite` directly: it queues the
+ *             evidence through pending.mjs, and the next graph read -- which
+ *             loads the graph anyway -- applies it before serving anything.
+ *             That path is also the only one that catches a write the SESSION
+ *             made, because the lazy check below compares the stored hash
+ *             against disk and `indexFile` has already refreshed it.
  *   LAZY   -- at retrieval, the anchor's stored hash is compared against disk.
  *             This is what catches `git pull`, another editor, a teammate, or a
  *             build step: every change our hooks never observed.
@@ -291,14 +297,69 @@ export function checkAnchor(anchor) {
 }
 
 /**
+ * Characters kept from any single diff line.
+ *
+ * A LINE CAP IS NOT A SIZE CAP, and the gap was measured: with only `maxLines`
+ * in force, `diffLines('X'.repeat(200000), 'Y'.repeat(200000))` returned 2 lines
+ * and 400,005 bytes. Minified bundles, generated sources and single-line JSON
+ * all have that shape, and this output goes STRAIGHT INTO MODEL CONTEXT from
+ * inject.mjs's zero-turn refusal -- so a line bound alone let one pathological
+ * file spend hundreds of thousands of tokens.
+ *
+ * 200 characters is chosen because it is past the width at which a line is read
+ * as a line by anybody, human or model: a hand-written source line is under
+ * ~120 columns, so the cap cannot truncate a diff a reader was going to use,
+ * while the cases it does truncate are ones where the interesting change is not
+ * legible from the raw text anyway.
+ */
+const DIFF_MAX_LINE_CHARS = () => {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_DIFF_MAX_LINE_CHARS);
+  return Number.isFinite(raw) && raw > 0 ? raw : 200;
+};
+
+/**
+ * Total UTF-8 bytes of diff body.
+ *
+ * 4,000 bytes is roughly 1,000 tokens. It is deliberately larger than the
+ * per-file injection budget (`TOKEN_OPTIMIZER_TOUCH_BUDGET`, 500 tokens) and
+ * far smaller than a file, because the two consumers want different things: the
+ * injection surface fits the diff inside its own budget and drops it if it does
+ * not fit, while the zero-turn refusal is replacing a whole file read and can
+ * afford more. One cap that neither consumer has to think about is worth more
+ * than two tuned ones.
+ *
+ * WHAT IT COSTS, PLAINLY: a legitimately large diff now arrives truncated, so a
+ * model looking at a 300-line refactor sees the head of it and a count of what
+ * was elided rather than the whole change. That is the correct direction to
+ * fail -- the alternative was a bounded-looking function that could emit 400 KB.
+ */
+const DIFF_MAX_BYTES = () => {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_DIFF_MAX_BYTES);
+  return Number.isFinite(raw) && raw > 0 ? raw : 4_000;
+};
+
+/**
  * A compact line diff.
  *
  * Deliberately not a full unified diff with hunks and context: the consumer is
  * a model deciding whether an existing conclusion still holds, and for that the
  * changed lines are the signal. Output is capped because an unbounded diff
  * injected alongside a finding would spend more tokens than re-deriving it.
+ *
+ * BOUNDED IN THREE WAYS, and each one is load-bearing: lines, characters per
+ * line, and total bytes. Every truncation is announced in the output, because a
+ * silently shortened diff is worse than a visibly shortened one -- a reader who
+ * cannot tell content was elided believes they saw the whole change.
  */
-export function diffLines(before, after, { maxLines = 40 } = {}) {
+export function diffLines(
+  before,
+  after,
+  {
+    maxLines = 40,
+    maxLineChars = DIFF_MAX_LINE_CHARS(),
+    maxBytes = DIFF_MAX_BYTES(),
+  } = {}
+) {
   const a = String(before).split('\n');
   const b = String(after).split('\n');
 
@@ -314,33 +375,44 @@ export function diffLines(before, after, { maxLines = 40 } = {}) {
   const added = b.slice(head, b.length - tail);
 
   const out = [];
-  for (const line of removed.slice(0, maxLines / 2)) out.push('- ' + line);
-  if (removed.length > maxLines / 2) out.push(`  ... ${removed.length - maxLines / 2} more removed`);
-  for (const line of added.slice(0, maxLines / 2)) out.push('+ ' + line);
-  if (added.length > maxLines / 2) out.push(`  ... ${added.length - maxLines / 2} more added`);
+  let bytes = 0;
+  let dropped = 0;
+
+  // Per line first, so ONE enormous line cannot consume the whole budget and
+  // leave every other changed line unrepresented.
+  const clamp = (line) => {
+    const text = String(line);
+    if (text.length <= maxLineChars) return text;
+    return `${text.slice(0, maxLineChars)} [+${text.length - maxLineChars} chars cut]`;
+  };
+
+  // Bytes, not characters: the cap exists to bound what is sent, and a
+  // multi-byte source file would otherwise pass a character check while
+  // emitting several times the budget.
+  const push = (line) => {
+    const text = clamp(line);
+    const size = Buffer.byteLength(text, 'utf8') + 1;
+    if (bytes + size > maxBytes) {
+      dropped++;
+      return;
+    }
+    out.push(text);
+    bytes += size;
+  };
+
+  for (const line of removed.slice(0, maxLines / 2)) push('- ' + line);
+  if (removed.length > maxLines / 2) push(`  ... ${removed.length - maxLines / 2} more removed`);
+  for (const line of added.slice(0, maxLines / 2)) push('+ ' + line);
+  if (added.length > maxLines / 2) push(`  ... ${added.length - maxLines / 2} more added`);
+
+  // Announced OUTSIDE the budget, deliberately: the one line a reader most
+  // needs is the one saying the rest is missing, and dropping it to stay under
+  // a self-imposed cap would hand back a diff that lies about being complete.
+  if (dropped) out.push(`  ... ${dropped} more changed line(s) cut at the size limit`);
 
   return out.join('\n');
 }
 
-/**
- * Prepares findings for delivery, verifying each one lazily against disk.
- *
- * This is the only function that should ever hand a finding to a model, because
- * it is the one that enforces the rule: a stale finding leaves here carrying
- * `stale: true` AND a diff, or it does not leave at all.
- */
-export function serve(graph, findings) {
-  const served = [];
-
-  // RETIRED FINDINGS STOP HERE, unconditionally.
-  //
-  // findingsFor and sessionIndex already filter them, so this is redundant on
-  // every current path -- deliberately. This function's own contract is that it
-  // is the only thing that hands a finding to a model, which makes it the right
-  // place for the guarantee to live: a future caller that reaches into the
-  // graph directly cannot accidentally serve a claim a human explicitly
-  // withdrew. A withheld claim reappearing is not a bug anyone would notice
-  // quickly.
 /**
  * Types whose truth is a claim ABOUT the anchor's contents.
  *
@@ -363,6 +435,26 @@ export function serve(graph, findings) {
  * to ignore -- taking the rare true positive with it.
  */
 const CONTENT_DEPENDENT = new Set(['finding', 'map']);
+
+/**
+ * Prepares findings for delivery, verifying each one lazily against disk.
+ *
+ * This is the only function that should ever hand a finding to a model, because
+ * it is the one that enforces the rule: a stale finding leaves here carrying
+ * `stale: true` AND a diff, or it does not leave at all.
+ */
+export function serve(graph, findings) {
+  const served = [];
+
+  // RETIRED FINDINGS STOP HERE, unconditionally.
+  //
+  // findingsFor and sessionIndex already filter them, so this is redundant on
+  // every current path -- deliberately. This function's own contract is that it
+  // is the only thing that hands a finding to a model, which makes it the right
+  // place for the guarantee to live: a future caller that reaches into the
+  // graph directly cannot accidentally serve a claim a human explicitly
+  // withdrew. A withheld claim reappearing is not a bug anyone would notice
+  // quickly.
 
   for (const finding of findings.filter((f) => !f.retired)) {
     // A claim that does not depend on the anchor's contents cannot be
@@ -505,6 +597,15 @@ export function invalidateOnWrite(dir, graph, rawPath, beforeText, afterText) {
     for (const edge of byTarget.get(node.id) || []) {
       const finding = graph.nodes.get(edge.from);
       if (!finding || finding.kind !== 'finding') continue;
+      // THE SAME TYPE GATE `serve` APPLIES, and it has to be here too now that
+      // this path actually runs. `serve` ignores a stale flag on a type whose
+      // truth is not a claim about the anchor's contents -- but the flag is
+      // STORED, and disclose.mjs skips a stale finding outright while
+      // utility.mjs penalises one by 160. So writing it onto a `failure` or a
+      // `command` would suppress that claim everywhere except the one reader
+      // that knows to ignore it, which is exactly the harm measured in the
+      // comment on CONTENT_DEPENDENT above.
+      if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) continue;
 
       putNode(dir, {
         ...finding,

--- a/integrations/codex/plugin/hooks/lib/staleness.mjs
+++ b/integrations/codex/plugin/hooks/lib/staleness.mjs
@@ -495,6 +495,54 @@ function disputeOf(graph, finding) {
 }
 
 /**
+ * Whether THIS finding's own claim-time evidence still matches its anchors --
+ * the reader `harvest-write.mjs`'s `derivation` record was written for.
+ * Nothing consumed that record until now: a grep for it found only the writer
+ * and its own tests, which made "checkable rather than merely attributed" a
+ * claim with no code behind it.
+ *
+ * DISTINCT FROM `stale`/`checkAnchor`, DELIBERATELY, not a duplicate of it.
+ * `checkAnchor` compares disk against the anchor NODE's CURRENT stored hash,
+ * which is refreshed by `indexFile` every time ANYTHING touches that file --
+ * so it answers "has this file changed since the last time anyone indexed
+ * it", not "has it changed since THIS finding was derived from it". Those
+ * differ in a real case: file F changes, and a LATER, unrelated write
+ * (another finding, another session) re-indexes F, updating the node's
+ * stored hash to match the new content again. `checkAnchor` now reports
+ * "fresh" -- disk matches the node's current hash -- while this finding's own
+ * frozen `derivation.anchors[id]` snapshot, taken when IT was written, no
+ * longer matches. The bytes this claim was actually derived from are gone,
+ * and `stale` alone would never say so.
+ *
+ * Returns `{}` when there is nothing to check (no `derivation.anchors`
+ * recorded -- true of every finding written before this existed), so a
+ * caller can tell "not checked" from "checked and holds" by whether
+ * `derivationHolds` is present at all.
+ */
+function derivationCheck(graph, finding) {
+  const recorded = finding.derivation && finding.derivation.anchors;
+  if (!recorded || typeof recorded !== 'object') return {};
+  const ids = Object.keys(recorded);
+  if (!ids.length) return {};
+
+  const changed = [];
+  for (const id of ids) {
+    const node = graph.nodes.get(id);
+    const currentHash = node && typeof node.hash === 'string' ? node.hash : null;
+    // An anchor that no longer resolves at all cannot be confirmed either --
+    // treated the same as a changed hash, never as "still holds" by default.
+    if (currentHash === null || currentHash !== recorded[id]) {
+      changed.push(node && typeof node.key === 'string' ? node.key : id);
+    }
+  }
+
+  if (!changed.length) return { derivationHolds: true };
+  // Bounded: a finding with many anchors should not spend unbounded budget
+  // naming every one that moved.
+  return { derivationHolds: false, derivationChanged: changed.slice(0, 5) };
+}
+
+/**
  * Prepares findings for delivery, verifying each one lazily against disk.
  *
  * This is the only function that should ever hand a finding to a model, because
@@ -611,6 +659,9 @@ export function serve(graph, findings) {
       stale,
       ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
       ...dispute,
+      // Independent of `stale` above: see `derivationCheck`'s own comment for
+      // the case it catches that node-level staleness can miss.
+      ...derivationCheck(graph, finding),
     });
   }
   return served;

--- a/integrations/codex/plugin/hooks/lib/staleness.mjs
+++ b/integrations/codex/plugin/hooks/lib/staleness.mjs
@@ -518,6 +518,21 @@ function disputeOf(graph, finding) {
  * recorded -- true of every finding written before this existed), so a
  * caller can tell "not checked" from "checked and holds" by whether
  * `derivationHolds` is present at all.
+ *
+ * `derivationHolds: true` MEANS "MATCHES THE ANCHOR NODE'S LAST-INDEXED
+ * HASH", NOT "MATCHES DISK RIGHT NOW" -- and that distinction is stored in
+ * `derivationCheckedAgainst: 'index'` rather than left for a `wiki_query`
+ * consumer to infer from a field name alone. Two ways to close this gap were
+ * considered: recompute a live hash from disk here, or document precisely
+ * what is actually compared. `stale` (via `checkAnchor`, above) ALREADY owns
+ * the disk comparison -- re-reading the same file a second time on the same
+ * serve path, for the same anchor, from a second mechanism, is worse than
+ * one honest name. So: documented, not duplicated. A file changed on disk
+ * but never re-indexed by anything is still caught, correctly, by `stale`;
+ * `derivationHolds` answers a narrower, complementary question -- whether
+ * the LAST INDEXED state agrees with what this specific finding recorded --
+ * which is exactly the re-indexed-by-something-else case above that `stale`
+ * cannot see.
  */
 function derivationCheck(graph, finding) {
   const recorded = finding.derivation && finding.derivation.anchors;
@@ -536,10 +551,12 @@ function derivationCheck(graph, finding) {
     }
   }
 
-  if (!changed.length) return { derivationHolds: true };
+  // Declared on BOTH branches, not only the ambiguous one: a consumer should
+  // not have to already know the answer to know what was checked.
+  if (!changed.length) return { derivationHolds: true, derivationCheckedAgainst: 'index' };
   // Bounded: a finding with many anchors should not spend unbounded budget
   // naming every one that moved.
-  return { derivationHolds: false, derivationChanged: changed.slice(0, 5) };
+  return { derivationHolds: false, derivationChanged: changed.slice(0, 5), derivationCheckedAgainst: 'index' };
 }
 
 /**

--- a/integrations/codex/plugin/hooks/lib/staleness.mjs
+++ b/integrations/codex/plugin/hooks/lib/staleness.mjs
@@ -54,6 +54,7 @@ import { readFileSync, statSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { dirname, join } from 'node:path';
 import { putNode, putEdge, contentHash, nodeId } from './wiki.mjs';
+import { hasOutstandingContradiction } from './curate.mjs';
 import { extractSymbols, spanText, symbolKey, extractImports } from './symbols.mjs';
 import { canonicalPath, resolvableCandidates, isFsSafePath } from './paths.mjs';
 
@@ -454,6 +455,46 @@ export function diffLines(
 const CONTENT_DEPENDENT = new Set(['finding', 'map']);
 
 /**
+ * What, if anything, currently disagrees with this finding.
+ *
+ * DISCLOSED AT SERVE TIME, because that is the only moment the disagreement can
+ * do any good. `WIKI_GRAPH.md`'s whole argument for making `contradicts` an edge
+ * rather than an overwrite is that a reader "sees both claims and the
+ * disagreement between them" -- so handing a finding to a model while something
+ * in the graph disputes it, without saying so, throws away the reason the edge
+ * was recorded instead of an overwrite.
+ *
+ * `hasOutstandingContradiction` is the gate: it is the one definition of "an
+ * open dispute", shared with the confidence-promotion gate, so the two can never
+ * disagree about what counts. The loop only NAMES the other side, and it names a
+ * key rather than quoting a claim because the reader can call `wiki_query` with
+ * a key -- and because the injection path pays for every character it renders.
+ *
+ * SEPARATE FROM STALENESS on purpose. A finding can be disputed without being
+ * stale (nothing touched its anchor; another finding simply says otherwise) and
+ * stale without being disputed, so this adds its own fields rather than
+ * borrowing the stale ones, and the renderer discloses each on its own terms.
+ */
+function disputeOf(graph, finding) {
+  if (!hasOutstandingContradiction(graph, finding.key)) return {};
+
+  const keys = [];
+  for (const edge of graph.edges) {
+    if (edge.edge !== 'contradicts') continue;
+    const otherId =
+      edge.from === finding.id ? edge.to : edge.to === finding.id ? edge.from : null;
+    if (!otherId) continue;
+    const other = graph.nodes.get(otherId);
+    // An edge end that resolves to nothing names nothing. The dispute is still
+    // disclosed -- the gate above already established it -- but without a key
+    // the reader cannot be pointed anywhere, and inventing one would be worse.
+    if (other && typeof other.key === 'string' && !keys.includes(other.key)) keys.push(other.key);
+  }
+
+  return { contradicted: true, ...(keys.length ? { contradictedBy: keys.join(', ') } : {}) };
+}
+
+/**
  * Prepares findings for delivery, verifying each one lazily against disk.
  *
  * This is the only function that should ever hand a finding to a model, because
@@ -474,10 +515,17 @@ export function serve(graph, findings) {
   // quickly.
 
   for (const finding of findings.filter((f) => !f.retired)) {
+    // A DISPUTE TRAVELS WITH EVERY TYPE, which is why it is computed before the
+    // content-dependence branch below. A `command` or `rule` finding cannot be
+    // invalidated by an anchor's contents, but another finding can still
+    // disagree with it, and this early return is the path that would have
+    // quietly dropped that.
+    const dispute = disputeOf(graph, finding);
+
     // A claim that does not depend on the anchor's contents cannot be
     // invalidated by them. It is served as-is rather than discounted.
     if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) {
-      served.push({ ...finding });
+      served.push({ ...finding, ...dispute });
       continue;
     }
 
@@ -562,6 +610,7 @@ export function serve(graph, findings) {
       ...finding,
       stale,
       ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
+      ...dispute,
     });
   }
   return served;

--- a/integrations/codex/plugin/hooks/lib/waste.mjs
+++ b/integrations/codex/plugin/hooks/lib/waste.mjs
@@ -151,6 +151,11 @@ function reDerivation(events, graph) {
       const id = nodeId('file', canonicalPath(row.anchor));
       if (!graph.nodes.has(id)) continue;
 
+      // READ-ONLY serve: no `dir` is threaded here, so this cannot clear a stale
+      // flag whose evidence is gone. That is deliberate -- this function takes a
+      // graph, not the directory it came from, and widening its signature to give
+      // an analysis path a write capability buys nothing: the injection path runs
+      // on every tool call and clears the same findings.
       const findings = serve(graph, findingsFor(graph, id, { limit: 3 }))
         .filter((f) => !f.stale && (f.confidence ?? 0) >= 0.7);
       if (!findings.length) continue;

--- a/integrations/codex/plugin/hooks/lib/wiki.mjs
+++ b/integrations/codex/plugin/hooks/lib/wiki.mjs
@@ -64,18 +64,37 @@ export const SUPPORTED_VERSIONS = [1];
  * Identity today because GRAPH_VERSION is 1 and no shape has changed. It exists
  * now so the first change that DOES need it has somewhere to go other than an
  * equality check that silently deletes user data.
+ *
+ * CONTRACT for the first non-identity step:
+ *  - It must be IDEMPOTENT. `upcast(upcast(r))` must equal `upcast(r)`, because
+ *    compaction upcasts a record to key it and `load` upcasts the same record
+ *    again on every subsequent read. A step that is not idempotent applies twice
+ *    to anything compaction has touched.
+ *  - It must NOT be relied on to restamp `v`. Nothing in this file writes an
+ *    upcast record back to disk under a version it did not come from; the
+ *    version stamp on disk is always the one that wrote the bytes. See the
+ *    per-branch comments in `compactIfWasteful`.
  */
 export function upcast(record) {
   return record;
 }
 
-/** True when this reader can interpret the record at all. */
-function readable(record) {
+/**
+ * True when this reader can interpret the record at all.
+ *
+ * `versions` is a PARAMETER so the range semantics are testable independently of
+ * today's constants. With `SUPPORTED_VERSIONS = [1]` and `GRAPH_VERSION = 1` a
+ * range check and the old equality check are extensionally identical, so a test
+ * pinned to the live constants cannot tell them apart -- and cannot fail if
+ * someone reverts this to an equality. Exercised against `[1, 2]`, it can.
+ */
+export function readable(record, versions = SUPPORTED_VERSIONS) {
   const version = record.v ?? 0;
   // Forward-incompatible records are skipped: a v-from-the-future was written by
-  // a newer client and we cannot know its shape. Ignoring the future is safe;
-  // ignoring the past is data loss.
-  return SUPPORTED_VERSIONS.includes(version);
+  // a newer client and we cannot know its shape. Ignoring the future is safe for
+  // a READER -- but see `compactIfWasteful`, where "ignore" would mean "delete",
+  // because compaction rewrites the files it reads.
+  return versions.includes(version);
 }
 
 /** Node kinds. `file` and `symbol` are first-class so staleness can propagate. */
@@ -434,9 +453,20 @@ function compactIfWasteful(dir) {
     const nodes = new Map();
     const edges = new Map();
     const snaps = new Map();
-    for (const rec of readSnapshots(dir)) {
+    // KEPT VERBATIM THROUGH THE REBUILD, exactly as the main log keeps what it
+    // cannot parse. These lines are not evictable by the snapshot budget below
+    // because their size cannot be attributed to an id we understand -- and
+    // preserving bytes we may not need is strictly better than deleting bytes a
+    // newer client does. They stop accumulating as soon as the client that
+    // wrote them compacts, since it can read and dedupe them.
+    const sidecar = readSnapshots(dir);
+    const rawSnaps = sidecar.unreadable;
+    for (const rec of sidecar.records) {
       if (typeof rec.snapshot === 'string' && rec.snapshot) {
-        snaps.set(rec.id, { at: rec.at || 0, snapshot: rec.snapshot });
+        // `v` IS CARRIED, not restamped. Writing GRAPH_VERSION over a record
+        // from another version mislabels bytes this reader did not produce, and
+        // the label is the only thing a future reader has to go on.
+        snaps.set(rec.id, { at: rec.at || 0, snapshot: rec.snapshot, v: rec.v ?? GRAPH_VERSION });
       }
     }
     for (const line of readFileSync(path, 'utf8').split('\n')) {
@@ -458,27 +488,40 @@ function compactIfWasteful(dir) {
         edges.set('raw:' + edges.size, line);
         continue;
       }
-      // Upcast IN MEMORY only, to key and classify the record. What gets written
-      // back below is the ORIGINAL `line`: compaction reclaims superseded
-      // records, it does not migrate surviving ones, so the on-disk version is
-      // whatever wrote it and `load` upcasts it again on every read.
-      record = upcast(record);
-      if (record.t === 'n') {
+      // TWO OBJECTS, ON PURPOSE. `record` is exactly what the bytes on disk say;
+      // `view` is the in-memory current-shape reading of it, used only to KEY and
+      // CLASSIFY. Nothing derived from `view` is ever serialized, because
+      // compaction reclaims superseded records -- it does not migrate surviving
+      // ones -- so every version stamp it writes is the one that wrote the bytes.
+      //
+      // An earlier revision of this comment claimed "the ORIGINAL line is written
+      // back" for the whole block. That was FALSE for the inline-snapshot branch,
+      // which re-serializes. It re-serialized the upcast object while carrying
+      // the old `v`, so the first non-identity `upcast` would have written
+      // new-shape bytes under an old label and every later `load` would have
+      // upcast them a second time. Hence: strip from `record`, never from `view`.
+      const view = upcast(record);
+      if (view.t === 'n') {
         // MIGRATION. Graphs written before snapshots were split still carry
         // them inline, and those are exactly the graphs that are slow. Moving
         // them out here means one compaction fixes an existing install.
+        //
+        // THE ONLY RE-SERIALIZING BRANCH in this loop. It writes the original
+        // record minus its snapshot, so the surviving bytes keep their own shape
+        // and their own `v`, and the snapshot moved to the sidecar carries the
+        // same `v` as the node it came out of.
         if (typeof record.snapshot === 'string' && record.snapshot) {
           const { snapshot, ...rest } = record;
-          nodes.set(record.id, JSON.stringify(rest));
-          snaps.set(record.id, { at: record.at || 0, snapshot });
+          nodes.set(view.id, JSON.stringify(rest));
+          snaps.set(view.id, { at: record.at || 0, snapshot, v: record.v ?? GRAPH_VERSION });
         } else {
-          nodes.set(record.id, line);
+          nodes.set(view.id, line);
         }
-      } else if (record.t === 's') {
+      } else if (view.t === 's') {
         if (typeof record.snapshot === 'string' && record.snapshot) {
-          snaps.set(record.id, { at: record.at || 0, snapshot: record.snapshot });
+          snaps.set(view.id, { at: record.at || 0, snapshot: record.snapshot, v: record.v ?? GRAPH_VERSION });
         }
-      } else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
+      } else if (view.t === 'e') edges.set(`${view.from}|${view.edge}|${view.to}`, line);
       else edges.set('raw:' + edges.size, line);
     }
 
@@ -541,10 +584,20 @@ function compactIfWasteful(dir) {
     renameSync(tmp, path);
     // The surviving snapshots are rewritten to their own file, which is also
     // what migrates a graph that still had them inline.
-    const snapOut =
-      [...keep.entries()]
-        .map(([id, v]) => JSON.stringify({ t: 's', v: GRAPH_VERSION, id, snapshot: v.snapshot, at: v.at }))
-        .join('\n') + (keep.size ? '\n' : '');
+    //
+    // UNREADABLE LINES FIRST AND VERBATIM. This rebuild replaces the file, so
+    // anything omitted here is deleted permanently -- which made the missing
+    // counterpart to the main log's `raw:` bucket a real data-loss path, not a
+    // theoretical one. Each survivor also keeps ITS OWN `v` rather than being
+    // restamped to GRAPH_VERSION, so no record is relabelled as something this
+    // reader wrote.
+    const snapLines = [
+      ...rawSnaps,
+      ...[...keep.entries()].map(([id, s]) =>
+        JSON.stringify({ t: 's', v: s.v ?? GRAPH_VERSION, id, snapshot: s.snapshot, at: s.at })
+      ),
+    ];
+    const snapOut = snapLines.join('\n') + (snapLines.length ? '\n' : '');
     const snapTmp = snapshotsPath(dir) + '.compact';
     writeFileSync(snapTmp, snapOut, { mode: 0o600 });
     renameSync(snapTmp, snapshotsPath(dir));
@@ -689,9 +742,26 @@ function appendSnapshot(dir, record) {
   }
 }
 
-/** Every snapshot record, latest wins. Read only when a caller asks. */
+/**
+ * Every snapshot record, latest wins. Read only when a caller asks.
+ *
+ * `unreadable` collects the RAW LINES this reader rejected, and it is the reason
+ * this function reports them at all rather than just dropping them. `load` has
+ * no use for them -- a reader that cannot interpret a record must ignore it --
+ * but `compactIfWasteful` REBUILDS this file from what it read, so for the
+ * compactor "ignore" and "delete permanently" are the same operation. The main
+ * log already keeps what it cannot parse (the `raw:` bucket); the sidecar had no
+ * equivalent, which made it the one asymmetric, destructive path in an otherwise
+ * append-only store.
+ *
+ * This is not hypothetical here: hooks-core is vendored into eleven client
+ * directories that update independently, so a stale client compacting a graph a
+ * newer client has already written to is the expected steady state, not an edge
+ * case.
+ */
 function readSnapshots(dir) {
-  const out = [];
+  /** @type {object[]} */ const out = [];
+  /** @type {string[]} */ const unreadable = [];
   try {
     for (const line of readFileSync(snapshotsPath(dir), 'utf8').split('\n')) {
       if (!line) continue;
@@ -699,19 +769,23 @@ function readSnapshots(dir) {
         const rec = JSON.parse(line);
         // THE SAME RANGE AS THE MAIN LOG, deliberately. An equality check here
         // was the quietest of the three: a bump would have made every stored
-        // snapshot unreadable, and the very next compaction -- which rebuilds
-        // this file from what it could read -- would have deleted them for
-        // good. That is the one place in this store where a read filter turns
-        // into a permanent write.
-        if (readable(rec) && rec.id) out.push(upcast(rec));
+        // snapshot unreadable, and the very next compaction would have deleted
+        // them for good.
+        if (!readable(rec)) {
+          unreadable.push(line);
+          continue;
+        }
+        if (rec.id) out.push(upcast(rec));
       } catch {
-        /* a torn line costs one snapshot */
+        // A torn line costs one snapshot -- and it is NOT preserved, because a
+        // half-written line is not a record from another version, it is
+        // garbage. Distinguishing the two is the whole point of parsing first.
       }
     }
   } catch {
     /* no sidecar yet */
   }
-  return out;
+  return { records: out, unreadable };
 }
 
 /**
@@ -777,7 +851,9 @@ export function load(dir, { snapshots = false } = {}) {
   // Re-attached after the sweep, so a snapshot record may appear before or
   // after the node it belongs to.
   if (pending) {
-    for (const rec of readSnapshots(dir)) pending.set(rec.id, rec.snapshot);
+    // A reader has no use for the lines it could not interpret; only the
+    // compactor does, because only the compactor rewrites the file.
+    for (const rec of readSnapshots(dir).records) pending.set(rec.id, rec.snapshot);
     for (const [id, snapshot] of pending) {
       const node = nodes.get(id);
       if (node) nodes.set(id, { ...node, snapshot });

--- a/integrations/codex/plugin/hooks/lib/wiki.mjs
+++ b/integrations/codex/plugin/hooks/lib/wiki.mjs
@@ -28,17 +28,55 @@ import { canonicalPath, isFsSafePath } from './paths.mjs';
 /**
  * Schema version stamped on every record.
  *
- * There is exactly ONE version and no migration code, because nothing has been
- * released: a graph written by an older commit of an unreleased branch is a
- * development artifact, not user data, and carrying migration paths for it costs
- * real complexity to protect something nobody has. A record from any other
- * version is skipped rather than interpreted, so a stale dev graph degrades to
- * "rebuilds from use" instead of silently mixing incompatible identities.
+ * THIS PACKAGE IS RELEASED. It ships on npm, so every graph on disk is user
+ * data. An earlier version of this comment claimed nothing had been released
+ * and used that to justify having no migration path at all -- and the reader
+ * below compared for EQUALITY, so the first bump would have discarded every
+ * existing graph in silence. That justification is gone and so is the equality:
+ * `SUPPORTED_VERSIONS` is the range this reader accepts, and `upcast` is where a
+ * shape change is absorbed in memory.
  *
- * When this does ship, a bump here is where migration would be added -- with
- * users to protect, that trade reverses.
+ * A bump here is taken only when a record's SHAPE actually changes, and it comes
+ * with a new `upcast` step and an entry in `SUPPORTED_VERSIONS` in the same
+ * change. Adding a field that older readers can ignore is not a shape change.
  */
 export const GRAPH_VERSION = 1;
+
+/**
+ * Versions this reader accepts, oldest first.
+ *
+ * A RANGE, NOT AN EQUALITY. The equality check this replaces would have
+ * discarded every existing graph the moment anyone bumped the version -- and the
+ * header once justified that with "nothing has been released", which stopped
+ * being true at v5.7.0 on npm.
+ *
+ * Nothing on disk is ever rewritten to migrate: `upcast` runs in memory during
+ * the fold, so there is no migration pass to fail halfway and no race with the
+ * concurrent sessions this store is designed for. A mixed-version log is safe
+ * precisely because the original records are never mutated, and the existing
+ * compaction retires old ones naturally as it rewrites snapshots.
+ */
+export const SUPPORTED_VERSIONS = [1];
+
+/**
+ * Brings one record up to the current version. Pure, and one step per version.
+ *
+ * Identity today because GRAPH_VERSION is 1 and no shape has changed. It exists
+ * now so the first change that DOES need it has somewhere to go other than an
+ * equality check that silently deletes user data.
+ */
+export function upcast(record) {
+  return record;
+}
+
+/** True when this reader can interpret the record at all. */
+function readable(record) {
+  const version = record.v ?? 0;
+  // Forward-incompatible records are skipped: a v-from-the-future was written by
+  // a newer client and we cannot know its shape. Ignoring the future is safe;
+  // ignoring the past is data loss.
+  return SUPPORTED_VERSIONS.includes(version);
+}
 
 /** Node kinds. `file` and `symbol` are first-class so staleness can propagate. */
 export const NODE_KINDS = ['file', 'symbol', 'task', 'finding'];
@@ -409,13 +447,22 @@ function compactIfWasteful(dir) {
       } catch {
         continue;
       }
-      // A record from another schema is KEPT VERBATIM rather than reinterpreted.
-      // load() skips it, but discarding it here would make compaction a silent
-      // migration that deletes data a future version might understand.
-      if ((record.v ?? 0) !== GRAPH_VERSION) {
+      // A record this reader cannot interpret is KEPT VERBATIM rather than
+      // reinterpreted. load() skips it, but discarding it here would make
+      // compaction a silent migration that deletes data a future version might
+      // understand. THE RANGE MATTERS HERE TOO: with an equality check, a bump
+      // would have parked every existing v1 record in `raw`, undeduplicated, so
+      // compaction would stop reclaiming anything and inline snapshots would
+      // never migrate out -- the same loss by a second route.
+      if (!readable(record)) {
         edges.set('raw:' + edges.size, line);
         continue;
       }
+      // Upcast IN MEMORY only, to key and classify the record. What gets written
+      // back below is the ORIGINAL `line`: compaction reclaims superseded
+      // records, it does not migrate surviving ones, so the on-disk version is
+      // whatever wrote it and `load` upcasts it again on every read.
+      record = upcast(record);
       if (record.t === 'n') {
         // MIGRATION. Graphs written before snapshots were split still carry
         // them inline, and those are exactly the graphs that are slow. Moving
@@ -650,7 +697,13 @@ function readSnapshots(dir) {
       if (!line) continue;
       try {
         const rec = JSON.parse(line);
-        if ((rec.v ?? 0) === GRAPH_VERSION && rec.id) out.push(rec);
+        // THE SAME RANGE AS THE MAIN LOG, deliberately. An equality check here
+        // was the quietest of the three: a bump would have made every stored
+        // snapshot unreadable, and the very next compaction -- which rebuilds
+        // this file from what it could read -- would have deleted them for
+        // good. That is the one place in this store where a read filter turns
+        // into a permanent write.
+        if (readable(rec) && rec.id) out.push(upcast(rec));
       } catch {
         /* a torn line costs one snapshot */
       }
@@ -691,7 +744,12 @@ export function load(dir, { snapshots = false } = {}) {
       if (!snapshots) continue;
       try {
         const rec = JSON.parse(line);
-        if ((rec.v ?? 0) === GRAPH_VERSION) pending.set(rec.id, rec.snapshot);
+        // Inline snapshots from an older graph: same range, same reason. These
+        // are precisely the records most likely to predate a bump.
+        if (readable(rec)) {
+          const snap = upcast(rec);
+          pending.set(snap.id, snap.snapshot);
+        }
       } catch {
         /* a torn line costs one snapshot, not the graph */
       }
@@ -703,10 +761,14 @@ export function load(dir, { snapshots = false } = {}) {
     } catch {
       continue;
     }
-    // A record from another schema is skipped, not interpreted: its ids and
-    // hashes were derived differently, so honouring it produces confident
-    // nonsense rather than a visible error.
-    if ((record.v ?? 0) !== GRAPH_VERSION) continue;
+    // A record this reader cannot interpret is skipped, not guessed at: a
+    // version from the FUTURE derived its ids and hashes in a way we do not
+    // know, so honouring it produces confident nonsense rather than a visible
+    // error. A record from the PAST is upcast, never skipped -- skipping it is
+    // data loss, and this comparison used to be an equality, which made the
+    // first version bump a silent delete of every graph on disk.
+    if (!readable(record)) continue;
+    record = upcast(record);
     if (record.t === 'n') nodes.set(record.id, record);
     else if (record.t === 'e') edges.push(record);
   }

--- a/integrations/codex/plugin/hooks/lib/wiki.mjs
+++ b/integrations/codex/plugin/hooks/lib/wiki.mjs
@@ -775,7 +775,17 @@ function readSnapshots(dir) {
           unreadable.push(line);
           continue;
         }
+        // A RECORD WITH NO `id` IS KEPT VERBATIM, NOT DROPPED SILENTLY. It
+        // cannot be attributed to a node, so it is useless to `load` -- but this
+        // used to put it in neither bucket, and `compactIfWasteful` rebuilds the
+        // sidecar from `records` plus `unreadable`, so a line in neither was
+        // deleted permanently by the next compaction. That is the same shape as
+        // the Critical this reader's version check already fixed, and the same
+        // asymmetry: for the compactor, "ignore" and "destroy" are one operation.
+        // Unreachable today because every writer sets `id`; a reader is not the
+        // right place to rely on that.
         if (rec.id) out.push(upcast(rec));
+        else unreadable.push(line);
       } catch {
         // A torn line costs one snapshot -- and it is NOT preserved, because a
         // half-written line is not a record from another version, it is

--- a/integrations/codex/plugin/hooks/post-tool.mjs
+++ b/integrations/codex/plugin/hooks/post-tool.mjs
@@ -8,7 +8,7 @@ process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.
-process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write';
+process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write,wiki_query';
 try {
   const { run } = await import('./lib/adapter.mjs');
   await run('codex', 'post-tool');

--- a/integrations/codex/plugin/hooks/post-tool.mjs
+++ b/integrations/codex/plugin/hooks/post-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/codex/plugin/hooks/pre-tool.mjs
+++ b/integrations/codex/plugin/hooks/pre-tool.mjs
@@ -8,7 +8,7 @@ process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.
-process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write';
+process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write,wiki_query';
 try {
   const { run } = await import('./lib/adapter.mjs');
   await run('codex', 'pre-tool');

--- a/integrations/codex/plugin/hooks/pre-tool.mjs
+++ b/integrations/codex/plugin/hooks/pre-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/codex/plugin/hooks/session-start.mjs
+++ b/integrations/codex/plugin/hooks/session-start.mjs
@@ -8,7 +8,7 @@ process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.
-process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write';
+process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write,wiki_query';
 try {
   const { run } = await import('./lib/adapter.mjs');
   await run('codex', 'session-start');

--- a/integrations/codex/plugin/hooks/session-start.mjs
+++ b/integrations/codex/plugin/hooks/session-start.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/codex/plugin/hooks/stop.mjs
+++ b/integrations/codex/plugin/hooks/stop.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/codex/plugin/hooks/stop.mjs
+++ b/integrations/codex/plugin/hooks/stop.mjs
@@ -8,7 +8,7 @@ process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.
-process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write';
+process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write,wiki_query';
 try {
   const { run } = await import('./lib/adapter.mjs');
   await run('codex', 'stop');

--- a/integrations/copilot/.github/hooks/lib/adapter.mjs
+++ b/integrations/copilot/.github/hooks/lib/adapter.mjs
@@ -68,6 +68,7 @@ import {
   standingRules,
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
+import { observedWrite, queueInvalidation } from './pending.mjs';
 import { isArchived } from './transcript.mjs';
 import { isFsSafePath } from './paths.mjs';
 import {
@@ -881,6 +882,35 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Causal tracing is fail-open like every other hook optimization.
+    }
+
+    // EAGER INVALIDATION, finally connected. `invalidateOnWrite` has existed,
+    // been tested and been described in staleness.mjs's own header since
+    // staleness landed, and its only reference in shipped code was a COMMENT in
+    // the PreToolUse router -- so the path that header calls load-bearing had
+    // never run once in production. It matters most for exactly this event: the
+    // lazy check compares the anchor's stored hash against disk, and the
+    // capture below re-points that hash at the bytes this write just produced,
+    // so a write the session performed ITSELF is invisible to lazy staleness.
+    //
+    // QUEUED, NOT APPLIED. Applying needs the graph, and loading a megabyte of
+    // JSONL on the return path of every write is what this shape exists to
+    // avoid. The next graph read drains it before serving anything.
+    try {
+      if (mutationSucceeded(clientName, raw)) {
+        const evidence = observedWrite(payload, raw);
+        if (evidence) {
+          // THE SAME DIRECTORY THE GRAPH ITSELF USES. `observeAndInject` keys
+          // every write on `wikiDir(projectRootFor(path, payload.cwd))`, and a
+          // queue written anywhere else is a queue nothing ever drains.
+          queueInvalidation(
+            wikiDir(projectRootFor(evidence.path, payload.cwd)),
+            evidence
+          );
+        }
+      }
+    } catch {
+      // Bookkeeping for a call that already completed. Never let it cost one.
     }
   }
 

--- a/integrations/copilot/.github/hooks/lib/adapter.mjs
+++ b/integrations/copilot/.github/hooks/lib/adapter.mjs
@@ -64,6 +64,7 @@ import {
   forTouch,
   noteActClasses,
   relevantFindingIdsForContext,
+  sessionContext,
   sessionIndex,
   standingRules,
 } from './inject.mjs';
@@ -690,8 +691,23 @@ async function runHook(clientName, event, invocation) {
       rememberOptimizerTools(state, toolEvidence);
       saveState(sessionId, state);
     }
-    const parts = [
-      policyText(client.canDeny, toolEvidence.names, toolEvidence.proven),
+    // ASSEMBLED IN CACHE ORDER, not in whatever order this function happens to
+    // discover the blocks. Everything emitted here sits near the FRONT of the
+    // prompt prefix, and a prefix cache invalidates from the first differing
+    // byte onward -- so the block that changes most often has to sit LAST, or it
+    // re-prices every block behind it on every session. `sessionContext` sorts
+    // by the declared volatility; inject.mjs records how each number was
+    // assigned and why.
+    const blocks = [
+      {
+        id: 'policy',
+        volatility: 0,
+        text: policyText(
+          client.canDeny,
+          toolEvidence.names,
+          toolEvidence.proven
+        ),
+      },
     ];
     const cwd = raw.cwd || raw.working_directory || process.cwd();
     const root = projectRootFor(join(cwd, '__session__'), cwd);
@@ -705,7 +721,7 @@ async function runHook(clientName, event, invocation) {
         const graph = load(dir);
         const episode = episodeMeta({ client: clientName, raw });
         const rules = standingRules(dir, graph, { episode });
-        if (rules) parts.push(rules);
+        if (rules) blocks.push({ id: 'standing', volatility: 1, text: rules });
         const relevantFindingIds = relevantFindingIdsForContext(
           graph,
           sessionTaskContext(raw)
@@ -714,12 +730,12 @@ async function runHook(clientName, event, invocation) {
           episode,
           relevantFindingIds,
         });
-        if (index) parts.push(index);
+        if (index) blocks.push({ id: 'index', volatility: 2, text: index });
       } catch {
         // Retrieval is optional context; the policy must still reach the model.
       }
     }
-    const output = contextOutput(client, eventName, parts.join('\n\n'));
+    const output = contextOutput(client, eventName, sessionContext(blocks));
     if (output) emit(output);
     process.exit(0);
   }

--- a/integrations/copilot/.github/hooks/lib/adapter.mjs
+++ b/integrations/copilot/.github/hooks/lib/adapter.mjs
@@ -68,7 +68,7 @@ import {
   standingRules,
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
-import { observedWrite, queueInvalidation } from './pending.mjs';
+import { observedWrites, queueInvalidation } from './pending.mjs';
 import { isArchived } from './transcript.mjs';
 import { isFsSafePath } from './paths.mjs';
 import {
@@ -898,8 +898,7 @@ async function runHook(clientName, event, invocation) {
     // avoid. The next graph read drains it before serving anything.
     try {
       if (mutationSucceeded(clientName, raw)) {
-        const evidence = observedWrite(payload, raw);
-        if (evidence) {
+        for (const evidence of observedWrites(payload, raw)) {
           // THE SAME DIRECTORY THE GRAPH ITSELF USES. `observeAndInject` keys
           // every write on `wikiDir(projectRootFor(path, payload.cwd))`, and a
           // queue written anywhere else is a queue nothing ever drains.

--- a/integrations/copilot/.github/hooks/lib/capabilities.mjs
+++ b/integrations/copilot/.github/hooks/lib/capabilities.mjs
@@ -38,6 +38,10 @@ export const HOOK_MCP_TOOLS = Object.freeze([
   'optimize_session',
   'get_optimization_report',
   'wiki_write',
+  // The read side of the graph. The session index tells the model to "call
+  // wiki_query with a key for detail", so the hook needs positive evidence that
+  // the name it is advertising is actually registered in this host.
+  'wiki_query',
 ]);
 
 const HOOK_MCP_TOOL_SET = new Set(HOOK_MCP_TOOLS);

--- a/integrations/copilot/.github/hooks/lib/curate.mjs
+++ b/integrations/copilot/.github/hooks/lib/curate.mjs
@@ -22,7 +22,7 @@
  */
 
 import { randomBytes } from 'node:crypto';
-import { putNode, putNodeWithEdges, load, nodeId } from './wiki.mjs';
+import { putNode, putEdge, putNodeWithEdges, load, nodeId } from './wiki.mjs';
 import { indexFile } from './staleness.mjs';
 import { symbolKey } from './symbols.mjs';
 import { canonicalPath } from './paths.mjs';
@@ -178,6 +178,79 @@ export function retire(dir, key) {
   if (!existing) return false;
   putNode(dir, { ...existing, kind: 'finding', key, retired: true });
   return true;
+}
+
+/**
+ * Records that one finding disagrees with another.
+ *
+ * AN EDGE, NOT AN OVERWRITE -- the design is explicit about why: "when a belief
+ * changes, the graph should record THAT it changed and why, not quietly present
+ * the new one as though it had always been true." `contradicts` has been in
+ * EDGE_KINDS since the schema existed and was written by nothing, while
+ * `audit()` already READ it.
+ *
+ * The contradicted finding is deliberately NOT retired, and its claim is
+ * deliberately preserved. A reader needs to see both claims and the
+ * disagreement between them; retiring one silently picks a winner, and putNode
+ * does not merge -- it writes the whole record from what it is handed, so
+ * annotating the target without spreading it back in would blank the very claim
+ * this edge exists to keep visible. That is the overwrite by another name.
+ *
+ * THE EDGE IS WRITTEN FIRST, and the order is the guarantee. These are two
+ * appends and `append` fails open, so either can be the one that lands. Edge
+ * without annotation is a complete, readable disagreement missing only its
+ * reason. Annotation without edge is a finding that says "something contradicts
+ * me" with no contradictor -- a claim of proof with no proof, and invisible to
+ * `audit()` and to `hasOutstandingContradiction`, both of which read the edge.
+ */
+export function contradict(dir, { key, byKey, reason }) {
+  const graph = load(dir);
+  const target = findingByKey(graph, key);
+  const source = findingByKey(graph, byKey);
+  // Both ends must exist, or the edge is unresolvable and the disagreement is
+  // recorded against nothing -- the same un-invalidatable shape anchors prevent.
+  if (!target || !source) return false;
+  // A finding cannot disagree with itself. The self-edge resolves, so the guard
+  // above waves it through, and the result is a node permanently blocked from
+  // confidence promotion by a dispute no person can ever resolve: there is no
+  // second claim to choose between.
+  if (target.id === source.id) return false;
+
+  putEdge(dir, source.id, 'contradicts', target.id);
+  putNode(dir, {
+    ...target,
+    kind: 'finding',
+    key,
+    contradictedAt: Date.now(),
+    contradictionReason: String(reason || '').slice(0, 400),
+  });
+  return true;
+}
+
+/**
+ * Whether anything currently disagrees with this finding.
+ *
+ * Gates confidence promotion. Plan 2's per-finding utility measures whether a
+ * finding SUPPRESSES READS, and a confidently wrong finding suppresses reads
+ * better than a hedged true one -- so utility must never raise confidence on
+ * its own, and this is the check that stops it.
+ *
+ * SYMMETRIC, deliberately: BOTH ends of a `contradicts` edge are outstanding
+ * until a person resolves the disagreement. The named hazard in the design is
+ * presenting "the new one as though it had always been true", so gating only
+ * the older claim would leave the newer one -- which is just as likely to be
+ * the wrong one, since nothing here adjudicates -- free to be promoted on
+ * measured utility alone. That is the exact failure this gate exists to stop.
+ * It also matches `audit()`, the reader that has always been here: it puts both
+ * `from` and `to` in its `contradicted` bucket, because "until one looks, BOTH
+ * are being served".
+ */
+export function hasOutstandingContradiction(graph, key) {
+  const node = findingByKey(graph, key);
+  if (!node) return false;
+  return graph.edges.some(
+    (e) => e.edge === 'contradicts' && (e.to === node.id || e.from === node.id)
+  );
 }
 
 /**

--- a/integrations/copilot/.github/hooks/lib/curate.mjs
+++ b/integrations/copilot/.github/hooks/lib/curate.mjs
@@ -124,7 +124,17 @@ export function correct(
   const replacementKey = `${key}-c${Date.now().toString(36)}`;
 
   const edges = [{ edge: 'supersedes', to: originalId }];
-  // The correction inherits the original's anchors, so it can go stale too.
+  // The correction inherits the original's anchors, so it can go stale too --
+  // but it inherits NOTHING ELSE, and that is deliberate rather than incidental.
+  // The node written below is built field by field from `existing` instead of
+  // spreading it, which is what keeps the staleness fields (`stale`,
+  // `staleReason`, `diff`) off the successor: a correction is re-derived
+  // against the current code by definition, so being born carrying its
+  // predecessor's invalidation would discount it the moment it existed --
+  // `disclose.mjs` skips a stale finding outright and `utility.mjs` penalises
+  // one by 160. Any future edit here that reaches for `...existing` to pick up
+  // one more field re-introduces that, since `putNode` writes what it is handed
+  // wholesale; `tests/hooks/stale-clearing.test.mjs` is the guard.
   for (const edge of graph.edges) {
     if (edge.edge === 'derived_from' && edge.from === originalId) {
       edges.push({ edge: 'derived_from', to: edge.to });
@@ -244,13 +254,38 @@ export function contradict(dir, { key, byKey, reason }) {
  * It also matches `audit()`, the reader that has always been here: it puts both
  * `from` and `to` in its `contradicted` bucket, because "until one looks, BOTH
  * are being served".
+ *
+ * A RETIRED COUNTERPART DOES NOT COUNT, and that sentence quoted just above is
+ * the reason. This read edges ONLY, so retiring one end of a contradiction left
+ * the survivor gated against confidence promotion forever and served with a
+ * DISPUTED note naming a key `serve` refuses to hand anybody -- `serve`,
+ * `activeFindings`, `findingsFor` and `sessionIndex` all drop a retired
+ * finding. A retired claim is served to NOBODY, so "BOTH are being served" is
+ * false and the premise of the gate is gone: only one claim is in play, and
+ * there is nothing left to choose between. Retiring one end IS the person
+ * looking that this gate was waiting for -- so the edge counts as open only
+ * while NEITHER end is retired, answered the same way from both directions.
+ *
+ * AN UNRESOLVABLE END STILL COUNTS. An edge whose other side names no node
+ * proves nothing about whether that claim was withdrawn, and the conservative
+ * reading -- still disputed -- is the one that cannot promote a claim nobody
+ * adjudicated.
  */
 export function hasOutstandingContradiction(graph, key) {
   const node = findingByKey(graph, key);
-  if (!node) return false;
-  return graph.edges.some(
-    (e) => e.edge === 'contradicts' && (e.to === node.id || e.from === node.id)
-  );
+  // A withdrawn claim is not in a dispute either: a dispute needs two claims in
+  // play, and this one has been taken out of play. Without this the RETIRED end
+  // still reported an open disagreement, which is the same defect from the other
+  // side -- and the answer has to agree from both directions, since the gate is
+  // symmetric on purpose.
+  if (!node || node.retired) return false;
+  return graph.edges.some((e) => {
+    if (e.edge !== 'contradicts') return false;
+    const otherId = e.from === node.id ? e.to : e.to === node.id ? e.from : null;
+    if (!otherId) return false;
+    const other = graph.nodes.get(otherId);
+    return !other || !other.retired;
+  });
 }
 
 /**
@@ -334,11 +369,24 @@ export function audit(graph) {
       .map((e) => e.from)
   );
 
+  // THE SAME DEFINITION OF AN OPEN DISPUTE as hasOutstandingContradiction, and
+  // it has to be: that function's own comment claims it "matches audit()", and
+  // two rankings that disagree about what needs a human is worse than one that
+  // is wrong. A retired counterpart is a resolved dispute -- the retired claim
+  // is served to nobody -- so the survivor is not one of two claims in play and
+  // does not belong in the bucket of things needing a person to look.
+  //
+  // One pass, not a call per finding: this is a dashboard read over the whole
+  // graph, and the obvious rewrite is O(findings x edges).
   const contradicted = new Set();
   for (const edge of graph.edges) {
     if (edge.edge !== 'contradicts') continue;
-    contradicted.add(edge.from);
-    contradicted.add(edge.to);
+    const from = graph.nodes.get(edge.from);
+    const to = graph.nodes.get(edge.to);
+    // An end that resolves to nothing cannot be shown retired, so it still
+    // counts against the other end.
+    if (!to || !to.retired) contradicted.add(edge.from);
+    if (!from || !from.retired) contradicted.add(edge.to);
   }
 
   return {

--- a/integrations/copilot/.github/hooks/lib/curate.mjs
+++ b/integrations/copilot/.github/hooks/lib/curate.mjs
@@ -70,6 +70,38 @@ export function originWeight(origin) {
   return 1;
 }
 
+/**
+ * The claim-time anchor hashes, for a finding being written right now.
+ *
+ * THE CHECKABLE HALF OF PROVENANCE, and until now only `harvest-write.mjs`
+ * wrote it -- so the asymmetry ran exactly the wrong way. `reverify` and the
+ * automatic clear in `serve` both compare disk against these frozen hashes, and
+ * a finding without them can never have a stale flag cleared by anything. That
+ * meant HUMAN-asserted findings, the ones somebody deliberately created or
+ * corrected, were the only ones condemned to stay stale forever once marked,
+ * while machine-harvested claims could recover. The hashes are simply the anchor
+ * nodes' hashes at this moment, and every writer has them in hand.
+ *
+ * DELIBERATELY NOT THE WHOLE RECORD `derivationFor` BUILDS. That one joins the
+ * evidence log to find FILE-surface operations behind the claim; curation
+ * performs no such join, so `operations` is empty and `operationsComplete` says
+ * so. An empty list declared incomplete is honest -- "nothing recorded here, and
+ * do not read that as nothing happened" -- where an empty list declared complete
+ * would assert a fact nobody established.
+ *
+ * An anchor with no stored hash contributes no entry, and a finding whose
+ * anchors all lack one gets a record with no hashes -- which `claimTimeVerdict`
+ * reads as `unknown` and refuses to clear on, which is the correct reading.
+ */
+function claimTimeDerivation(graph, resolved) {
+  const anchors = {};
+  for (const id of resolved) {
+    const node = graph.nodes.get(id);
+    if (node && typeof node.hash === 'string') anchors[id] = node.hash;
+  }
+  return { at: Date.now(), anchors, operations: [], operationsComplete: false };
+}
+
 function findingByKey(graph, key) {
   return graph.nodes.get(nodeId('finding', key)) || null;
 }
@@ -124,6 +156,11 @@ export function correct(
   const replacementKey = `${key}-c${Date.now().toString(36)}`;
 
   const edges = [{ edge: 'supersedes', to: originalId }];
+  // Collected alongside the edges so the correction carries its own claim-time
+  // hashes: it is a NEW claim, re-derived against whatever the code says now, so
+  // its evidence is the anchors' current state -- not the predecessor's, which is
+  // precisely what went stale.
+  const inherited = [];
   // The correction inherits the original's anchors, so it can go stale too --
   // but it inherits NOTHING ELSE, and that is deliberate rather than incidental.
   // The node written below is built field by field from `existing` instead of
@@ -138,6 +175,7 @@ export function correct(
   for (const edge of graph.edges) {
     if (edge.edge === 'derived_from' && edge.from === originalId) {
       edges.push({ edge: 'derived_from', to: edge.to });
+      inherited.push(edge.to);
     }
   }
 
@@ -171,6 +209,11 @@ export function correct(
       // branches, and an unrecognised value already degrades to the neutral
       // ranking weight rather than doing damage.
       origin: typeof origin === 'string' && origin ? origin : ORIGIN_HUMAN,
+      // Without this a correction could never have a stale flag cleared: both
+      // clearing paths compare disk against these hashes, and a finding with
+      // none is `unknown` forever. A hand-written correction being the least
+      // recoverable record in the graph was the wrong way round.
+      derivation: claimTimeDerivation(graph, inherited),
     },
     edges
   );
@@ -339,7 +382,18 @@ export function create(dir, { claim, anchors, type = 'finding', confidence = 0.9
   // path. No process death required; one transient EBUSY is enough.
   const id = putNodeWithEdges(
     dir,
-    { kind: 'finding', key, claim, confidence, type, origin: ORIGIN_HUMAN },
+    {
+      kind: 'finding',
+      key,
+      claim,
+      confidence,
+      type,
+      origin: ORIGIN_HUMAN,
+      // Read AFTER the indexFile loop above, so the hashes are the ones the
+      // person's claim was actually made against rather than whatever the graph
+      // held before this call touched it.
+      derivation: claimTimeDerivation(loadGraph(dir), resolved),
+    },
     resolved.map((target) => ({ edge: 'derived_from', to: target }))
   );
   if (!id) return null;

--- a/integrations/copilot/.github/hooks/lib/decide.mjs
+++ b/integrations/copilot/.github/hooks/lib/decide.mjs
@@ -542,19 +542,92 @@ const TOOL_ALIASES = new Map(
     run_shell_command: 'Bash',
     run_terminal_cmd: 'Bash',
     terminal: 'Bash',
+
+    // THIS PROJECT'S OWN TOOLS, which the table did not list for as long as it
+    // existed. `plugin/hooks/hooks.json`'s PostToolUse matcher named
+    // `mcp__.*__(?:smart_edit|smart_write)` and Codex's AfterTool matcher named
+    // the bare `smart_edit|smart_write`, so both hooks fired -- and then
+    // `normalizeTool` returned null and the hook exited before a single line of
+    // accounting ran. Staleness, mutation counting and harvest pressure were all
+    // blind on exactly the path enforcement pushes the model toward, which is the
+    // worst place to be blind: the more effective the routing, the less the
+    // optimizer saw.
+    //
+    // These names are the CANONICAL operation, not a licence to redirect. A call
+    // that is already the replacement is excluded from routing by
+    // `isReplacementTool` below.
+    smart_read: 'Read',
+    smart_grep: 'Grep',
+    smart_glob: 'Glob',
+    smart_edit: 'Edit',
+    smart_write: 'Write',
+
+    // Claude Code's notebook editor. Same shape of gap: a real mutation of a
+    // real file on disk that arrived as null and so never reached
+    // `pending.mjs`'s MUTATING set, leaving every notebook write invisible to
+    // invalidation.
+    notebookedit: 'Edit',
+    notebook_edit: 'Edit',
   })
 );
 
-/** Maps a client's tool name onto the canonical one, or null if unhandled. */
+/**
+ * The optimizer's own replacement tools, by canonical trailing segment.
+ *
+ * Kept separate from the alias table because the two answer different questions.
+ * The table answers "what operation is this", which post-tool accounting needs.
+ * This set answers "is this call ALREADY the thing we would have recommended",
+ * which routing needs -- and conflating them is the loop hazard: `smart_edit`
+ * resolves to `Edit`, the Edit branch recommends `smart_edit`, and the model is
+ * told to call the tool it just called.
+ */
+const REPLACEMENT_TOOLS = new Set([
+  'smart_read',
+  'smart_grep',
+  'smart_glob',
+  'smart_edit',
+  'smart_write',
+]);
+
+/**
+ * The tool name with an `mcp__<server>__` prefix removed, if it had one.
+ *
+ * Server segments contain underscores freely (`plugin_token-optimizer_token-optimizer`)
+ * and so do tool names (`smart_edit`), so the split is taken at the LAST `__`
+ * after the `mcp__` sentinel. Both halves must be non-empty: `mcp__edit` names
+ * no server and is not a name any host emits, and treating it as `edit` would
+ * coerce an unrecognised string into a built-in.
+ */
+function withoutMcpPrefix(name) {
+  const match = /^mcp__(.+)__(.+)$/.exec(name);
+  return match ? match[2] : name;
+}
+
+/** Whether this call IS one of the optimizer's replacements, however spelled. */
+export function isReplacementTool(name) {
+  if (!name) return false;
+  return REPLACEMENT_TOOLS.has(withoutMcpPrefix(String(name)).toLowerCase());
+}
+
+/**
+ * Maps a client's tool name onto the canonical one, or null if unhandled.
+ *
+ * PERMISSIVE IN ONE DIRECTION ONLY. An MCP-prefixed name is resolved by its
+ * trailing segment, but only against the same table every other client is held
+ * to -- so `mcp__vendor__deploy_to_prod` stays null. Coercing an unrecognised
+ * MCP tool into a built-in would change a routing verdict for a tool nobody has
+ * considered, which is a far worse failure than not accounting for it.
+ */
 export function normalizeTool(name) {
   if (!name) return null;
+  const candidate = withoutMcpPrefix(String(name));
   if (
     ['Read', 'Grep', 'Glob', 'Edit', 'MultiEdit', 'Write', 'Bash'].includes(
-      name
+      candidate
     )
   )
-    return name;
-  return TOOL_ALIASES.get(String(name).toLowerCase()) || null;
+    return candidate;
+  return TOOL_ALIASES.get(candidate.toLowerCase()) || null;
 }
 
 /**
@@ -614,6 +687,13 @@ export function normalizePayload(raw) {
     transcript_path: raw.transcript_path ?? raw.transcriptPath ?? null,
     cwd,
     tool_name: normalizeTool(raw.tool_name ?? raw.toolName ?? raw.tool),
+    // WHETHER THIS CALL IS ALREADY THE REPLACEMENT, carried alongside the
+    // canonical name rather than inferred from it -- because it cannot be
+    // inferred from it. `smart_edit` and `Edit` both normalise to `Edit`, and
+    // routing has to treat them as opposites while accounting treats them as
+    // the same. Absent by default (`false`), so a payload assembled by hand in
+    // a test or by a caller that predates this field is a normal built-in call.
+    replacement: isReplacementTool(raw.tool_name ?? raw.toolName ?? raw.tool),
     tool_input: {
       ...input,
       // CANONICALISED HERE, once. Every consumer downstream -- the `seen` map
@@ -673,6 +753,19 @@ function replacementAvailable(availableTools, name) {
 }
 
 export function decide(payload, state, availableTools = undefined) {
+  // THE LOOP HAZARD, and the reason this guard is at the top rather than inside
+  // any one branch. Resolving `smart_edit` to `Edit` is what makes post-tool
+  // accounting work; it must not also make the Edit branch answer a smart_edit
+  // call with "call smart_edit instead". This is not theoretical on a matcher
+  // level either: Qwen's PreToolUse matcher is the unanchored regex
+  // `edit|write_file|run_shell_command`, and `edit` matches inside
+  // `mcp__x__smart_edit`, so that client really does hand the router calls to
+  // its own replacements.
+  //
+  // A tool that IS the replacement is never routed. There is nothing better to
+  // recommend, and every branch below would recommend itself.
+  if (payload.replacement) return null;
+
   const tool = payload.tool_name;
   const input = payload.tool_input || {};
   const threshold = largeFileBytes();
@@ -873,6 +966,12 @@ export function remember(payload, state) {
  */
 export function readCostBytes(payload) {
   if (payload.tool_name !== 'Read') return 0;
+  // A REPLACEMENT DID NOT SPEND THE WHOLE FILE. `smart_read` normalises to
+  // `Read` so the graph sees the touch, but it returns a diff -- charging the
+  // full file size here would feed the holdout comparison a cost that was never
+  // paid, on the arm the optimizer is trying to show is cheaper. Better to
+  // record nothing than to record a number in the wrong direction.
+  if (payload.replacement) return 0;
   const path = payload.tool_input?.file_path;
   if (!path || isBinaryPath(path)) return 0;
   const size = fileSize(path);

--- a/integrations/copilot/.github/hooks/lib/disclose.mjs
+++ b/integrations/copilot/.github/hooks/lib/disclose.mjs
@@ -294,6 +294,11 @@ export function verdictFor(graph, { anchors = [], question, minConfidence = 0.7 
     const id = nodeId('file', canonicalPath(anchor));
     if (!graph.nodes.has(id)) continue;
 
+    // READ-ONLY serve: no `dir` is threaded here, so this cannot clear a stale
+    // flag whose evidence is gone. That is deliberate -- this function takes a
+    // graph, not the directory it came from, and widening its signature to give
+    // an analysis path a write capability buys nothing: the injection path runs
+    // on every tool call and clears the same findings.
     const findings = serve(graph, findingsFor(graph, id, { limit: 4 }));
     for (const finding of findings) {
       if (finding.stale) continue;

--- a/integrations/copilot/.github/hooks/lib/harvest-write.mjs
+++ b/integrations/copilot/.github/hooks/lib/harvest-write.mjs
@@ -34,7 +34,7 @@ import { randomBytes } from 'node:crypto';
 import { realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
-import { readEvidence } from './metrics.mjs';
+import { readEvidence, evidenceTruncated } from './metrics.mjs';
 
 /**
  * The types that may cross a project boundary.
@@ -431,53 +431,84 @@ function resolveAnchor(dir, anchor, projectRoot) {
 /**
  * Which task actually produced this finding, when nothing said so directly.
  *
- * Session id was the only signal `answers` had, and a session id is exactly
- * what a caller may not have (`wiki_write`'s `sessionId` is optional and
- * nothing populates it today; the detached harvest worker's is gated behind
- * an opt-in). But the graph does not need to be TOLD which task this is: the
- * structural harvest already writes `task -[derived_from]-> file` for every
- * tool call, unconditionally, on every install. So the task is DERIVABLE --
- * it is whichever task node has a `derived_from` edge to one of the SAME
- * anchors this finding resolved to.
+ * ROUND 2's version scanned the WHOLE graph for any task sharing any anchor,
+ * broken by recency. An adversarial review constructed four cases where that
+ * attributes a finding to the WRONG task:
  *
- * "Most recent task, full stop" was rejected on purpose: a task that never
- * touched these files could still be the newest node in the graph (a
- * different file, a different concern, in a later session), and attaching
- * provenance to it would be a WRONG edge, not a missing one -- worse than no
- * edge, because a reader trusts it. So candidates are filtered to tasks that
- * touched at least one of these anchors FIRST, and only ties among THOSE are
- * broken by recency.
+ *   1. STALE PRIOR SESSION -- a session that reasons from injected memory and
+ *      writes a finding about `foo.ts` without touching it this session gets
+ *      attributed to whatever task last touched `foo.ts`, possibly days old,
+ *      possibly someone else's work.
+ *   2. CONCURRENT SESSION -- two windows on one repository; the other
+ *      session's task wins if its touch is a millisecond later.
+ *   3. OVERLAP, NOT COVERAGE -- a finding anchored to [a, b]; a task that
+ *      touched only `b` could still win over one that touched both.
+ *   4. THE TIE-BREAK CONTRADICTED ITS OWN COMMENT -- `Number(edge.at) || 0`
+ *      with strict `>` means the FIRST edge in log order wins on a tie,
+ *      which is the OLDER task, not "more recently" as documented.
  *
- * The tie-break is the edge's own `at`, not the task node's `at`. A task that
- * touched this file once, long ago, and then stayed active on unrelated files
- * for hours has a late node timestamp that says nothing about this anchor;
- * the edge timestamp says exactly when THIS task touched THIS anchor, which
- * is the question being asked. Among tasks sharing an anchor, the one whose
- * most recent touch to any shared anchor is latest wins -- recency of the
- * relevant work, not recency of the task in general.
+ * THE FIX IS NARROWER THAN A BETTER RANKING: SCOPE, THEN REQUIRE COVERAGE.
+ * A task only ever belongs to the session that created it -- `harvest()` and
+ * `linkCoOccurrence()` (wiki.mjs, inject.mjs) both key a task node by
+ * `sessionId`, always, so there is exactly ONE task node for "the current
+ * session" and it is `nodeId('task', sessionId)`. Restricting to that ONE
+ * node structurally eliminates cases 1 and 2 -- a prior or concurrent
+ * session's task has a DIFFERENT sessionId and therefore a different node
+ * id, so it is never even looked at, regardless of timing. No caller can
+ * supply a wrong sessionId and get someone ELSE's task; they can only fail
+ * to get a match.
+ *
+ * COVERAGE, NOT OVERLAP, fixes case 3: the session's task must have a
+ * `derived_from` edge to EVERY one of this finding's anchors, not merely one.
+ * A partial touch is not attribution.
+ *
+ * With the candidate set reduced to at most one node, there is nothing left
+ * to break a tie between -- case 4's comparator is not "fixed", it is
+ * deleted, because the scenario it was written for (two DIFFERENT tasks both
+ * legitimately eligible) cannot occur under this scoping: two task nodes can
+ * never share a key, and only the current session's key is ever considered.
+ * An edge's `at` therefore plays NO role here: presence of a `derived_from`
+ * edge from the session's task to an anchor is what "touched it" means, with
+ * or without a timestamp on that edge -- there is no ranking left for a
+ * missing timestamp to lose.
+ *
+ * `sessionId` absent means there is no identity to scope by, which means no
+ * candidate -- not "fall back to guessing". Absence is the correct answer
+ * when the graph cannot support attribution.
  */
-function taskForAnchors(graph, anchorIds) {
-  if (!anchorIds || !anchorIds.length) return null;
-  const anchors = new Set(anchorIds);
-  let best = null;
-  for (const edge of graph.edges) {
-    if (edge.edge !== 'derived_from' || !anchors.has(edge.to)) continue;
-    const from = graph.nodes.get(edge.from);
-    // `derived_from` is also how a FINDING cites its own anchors, so without
-    // this a finding that already cited the same file would be mistaken for
-    // the task that produced it.
-    if (!from || from.kind !== 'task') continue;
-    const at = Number(edge.at) || 0;
-    if (!best || at > best.at) best = { taskId: edge.from, at };
+function taskForAnchors(graph, anchorIds, sessionId) {
+  if (!sessionId || !anchorIds || !anchorIds.length) return null;
+  const taskTarget = nodeId('task', sessionId);
+  const task = graph.nodes.get(taskTarget);
+  if (!task || task.kind !== 'task') return null;
+
+  for (const anchor of anchorIds) {
+    const covered = graph.edges.some((edge) =>
+      edge.edge === 'derived_from' && edge.from === taskTarget && edge.to === anchor
+    );
+    // ONE missing anchor refuses the whole attribution. A finding cited three
+    // files; this session's task touched two of them -- that is evidence the
+    // task did SOME related work, not evidence it produced THIS finding.
+    if (!covered) return null;
   }
-  return best ? best.taskId : null;
+  return taskTarget;
 }
 
 /**
  * A file path the way `recordToolOutcome` (metrics.mjs) already truncates and
- * stores it on a `tool-outcome` event's `anchor` field, so a derivation record
- * can join against that log without a second, divergent notion of "the same
- * anchor".
+ * stores it on a FILE-surface `tool-outcome` event's `anchor` field, so a
+ * derivation record can join against that log without a second, divergent
+ * notion of "the same anchor".
+ *
+ * COMMAND-surface events are DECLARED OUT OF SCOPE, not silently missed:
+ * `adapter.mjs` stores the COMMAND TEXT in `anchor` for those
+ * (`String(command).slice(0, 120)`), so a build or test run can never share
+ * an anchor string with a canonical file path -- there is no join key in
+ * common, and inventing a command-to-file heuristic (which files did a given
+ * `npm test` invocation cover?) is not something this record can answer
+ * honestly. `operationsScope` on the returned record says so explicitly,
+ * rather than letting an empty `operations` array look like "no build or
+ * test ever ran" when the truth is "this join cannot see it".
  */
 function anchorLabel(rawAnchor) {
   const path = String(rawAnchor).split('#')[0];
@@ -497,7 +528,8 @@ const MAX_DERIVATION_OPERATIONS = 5;
  * that comparison be reconstructed for a specific claim rather than only for
  * the anchor in general: the hash each anchor carried at the moment this
  * finding was derived from it, plus what evidence exists that any work
- * actually happened against it.
+ * actually happened against it. `derivationCheck` (staleness.mjs) is the
+ * reader that actually performs that comparison at serve time.
  *
  * DELIBERATELY NOT DUPLICATING THE EDGES. `derived_from` already records
  * WHICH anchors this finding cites; restating that here would be a second,
@@ -506,14 +538,23 @@ const MAX_DERIVATION_OPERATIONS = 5;
  *
  * DELIBERATELY NOT A REPLAY LOG. Recording enough to mechanically re-run a
  * derivation is a separate subsystem with real storage cost. This stores only
- * what the evidence log already has: `tool-outcome` events matching these
- * anchors, each reduced to the fields that were actually captured. An event
- * that carries no exit code or output contributes none -- nothing here is
- * invented to fill a shape the pipeline does not evidence yet. If a future
- * capture pass adds `exit`/`output` to those events, this starts carrying them
- * with no change to this function.
+ * what the evidence log already has: FILE-surface `tool-outcome` events
+ * matching these anchors, each reduced to the fields that were actually
+ * captured. An event that carries no exit code or output contributes none --
+ * nothing here is invented to fill a shape the pipeline does not evidence
+ * yet. If a future capture pass adds `exit`/`output` to those events, this
+ * starts carrying them with no change to this function.
+ *
+ * INCOMPLETENESS IS MARKED, NOT IMPLIED. An empty `operations` array is
+ * genuinely ambiguous on its own -- it is the same shape whether nothing
+ * happened, or something happened but fell outside what this join can see.
+ * `operationsComplete` distinguishes them: false when the evidence log itself
+ * may have dropped older matches (`evidenceIncomplete`, from
+ * `metrics.evidenceTruncated`) OR when more matches existed than the cap
+ * kept. A reader can then tell "no operations happened" from "operations
+ * existed but are not recorded here" instead of guessing.
  */
-function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
+function derivationFor(graph, resolvedAnchors, evidence, evidenceIncomplete, anchorSpecs) {
   const anchorHashes = {};
   for (const id of resolvedAnchors) {
     const node = graph.nodes.get(id);
@@ -521,8 +562,10 @@ function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
   }
 
   const labels = new Set((anchorSpecs || []).map(anchorLabel));
-  const operations = evidence
-    .filter((event) => event.kind === 'tool-outcome' && labels.has(event.anchor))
+  const matching = evidence.filter(
+    (event) => event.kind === 'tool-outcome' && labels.has(event.anchor)
+  );
+  const operations = [...matching]
     .sort((a, b) => (Number(b.at) || 0) - (Number(a.at) || 0))
     .slice(0, MAX_DERIVATION_OPERATIONS)
     .map((event) => {
@@ -540,7 +583,16 @@ function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
       return op;
     });
 
-  return { at: Date.now(), anchors: anchorHashes, operations };
+  return {
+    at: Date.now(),
+    anchors: anchorHashes,
+    operations,
+    // FILE touches only -- see `anchorLabel`. Declared here, in the record
+    // itself, not only in this function's comment, so a reader who never
+    // opens this source file still learns builds and test runs are excluded.
+    operationsScope: 'file',
+    operationsComplete: !evidenceIncomplete && matching.length <= operations.length,
+  };
 }
 
 /**
@@ -588,6 +640,9 @@ export function writeHarvested(
   // it can hold thousands of lines, so re-reading it per finding would turn a
   // batch of N findings into N passes over the same bytes.
   const evidence = readEvidence(dir);
+  // Cheap: one stat call, checked once per batch rather than once per
+  // finding's derivation record.
+  const evidenceIncomplete = evidenceTruncated(dir);
 
   const written = [];
   for (const finding of findings) {
@@ -647,14 +702,16 @@ export function writeHarvested(
     // An explicit `taskId` is authoritative when a caller supplies one --
     // it OVERRIDES traversal rather than merely seeding it, so a caller that
     // knows better is never second-guessed by inference. Absent one, the task
-    // is DERIVED from the graph itself: `taskForAnchors` finds the task that
-    // actually touched these anchors, which needs no session id from anyone.
-    // Either way, held to the same discipline as the anchors above: a target
-    // that does not resolve to an existing task node produces no edge rather
-    // than a dangling one.
+    // is DERIVED from the graph itself: `taskForAnchors` finds the CURRENT
+    // session's task (scoped by `sessionId`, the same identity this write
+    // already carries for provenance) and requires it to have touched EVERY
+    // one of this finding's anchors, not merely one -- see that function's
+    // own comment for the four attacks this closes. Either way, held to the
+    // same discipline as the anchors above: a target that does not resolve to
+    // an existing task node produces no edge rather than a dangling one.
     const answersTarget = taskId
       ? nodeId('task', taskId)
-      : taskForAnchors(currentGraph, resolved);
+      : taskForAnchors(currentGraph, resolved, sessionId);
     if (answersTarget && currentGraph.nodes.has(answersTarget)) {
       edges.push({ edge: 'answers', to: answersTarget });
     }
@@ -707,7 +764,7 @@ export function writeHarvested(
         // `render()`/`renderSessionIndex()` in inject.mjs or `wiki_read`'s
         // `toFinding()` projection, neither of which reads this field, so it
         // is not part of the automatic per-touch injection `fit()` prices.
-        derivation: derivationFor(currentGraph, resolved, evidence, finding.anchors || []),
+        derivation: derivationFor(currentGraph, resolved, evidence, evidenceIncomplete, finding.anchors || []),
       },
       edges
     );

--- a/integrations/copilot/.github/hooks/lib/harvest-write.mjs
+++ b/integrations/copilot/.github/hooks/lib/harvest-write.mjs
@@ -452,11 +452,13 @@ function resolveAnchor(dir, anchor, projectRoot) {
  * `linkCoOccurrence()` (wiki.mjs, inject.mjs) both key a task node by
  * `sessionId`, always, so there is exactly ONE task node for "the current
  * session" and it is `nodeId('task', sessionId)`. Restricting to that ONE
- * node structurally eliminates cases 1 and 2 -- a prior or concurrent
- * session's task has a DIFFERENT sessionId and therefore a different node
- * id, so it is never even looked at, regardless of timing. No caller can
- * supply a wrong sessionId and get someone ELSE's task; they can only fail
- * to get a match.
+ * node structurally eliminates cases 1 and 2 PROVIDED the identity itself is
+ * trustworthy: an UNRELATED sessionId (typo'd, invented, or simply absent)
+ * cannot resolve to someone else's task, because a different key is a
+ * different node id, full stop, regardless of timing. That is NOT the same
+ * guarantee as "no caller can get someone else's task" -- see the note on
+ * `authoritativeSessionId` below for the residual this leaves when the
+ * identity is real but comes from an untrusted caller.
  *
  * COVERAGE, NOT OVERLAP, fixes case 3: the session's task must have a
  * `derived_from` edge to EVERY one of this finding's anchors, not merely one.
@@ -472,17 +474,41 @@ function resolveAnchor(dir, anchor, projectRoot) {
  * or without a timestamp on that edge -- there is no ranking left for a
  * missing timestamp to lose.
  *
- * `sessionId` absent means there is no identity to scope by, which means no
- * candidate -- not "fall back to guessing". Absence is the correct answer
- * when the graph cannot support attribution.
+ * NO IDENTITY MEANS NO CANDIDATE -- not "fall back to guessing". Absence is
+ * the correct answer when the graph cannot support attribution.
+ *
+ * ROUND 4: THE IDENTITY ITSELF MUST BE AUTHORITATIVE, not merely present.
+ * Scoping to `nodeId('task', sessionId)` only refuses an UNRELATED session;
+ * it does nothing against a FOREIGN BUT REAL one. `wiki_write`'s `sessionId`
+ * is a plain MCP tool argument the calling model supplies, unverified -- a
+ * model that names some OTHER, prior session whose task genuinely covered
+ * these anchors gets an `answers` edge to that stale task, because coverage
+ * cannot tell "this session" from "a session that really did touch these
+ * files, named by a string nothing cross-checked". Session id is not
+ * evidence unless the CALLER'S OWN CHANNEL is trustworthy, which is true of
+ * `plugin/hooks/harvest-worker.mjs` (Claude Code's own hook payload) and not
+ * true of a tool-call argument. So this parameter is named for what it must
+ * be, `authoritativeSessionId`, and every caller is a promise: pass this only
+ * when you did not just read it out of untrusted input. `wiki_write` passes
+ * NONE, which means its calls never traverse -- see `writeHarvested`'s own
+ * comment at the call site for what that costs and why it is accepted rather
+ * than worked around.
+ *
+ * COVERAGE IS CHECKED AGAINST RESOLVED ANCHORS, not the caller's original
+ * list. `writeHarvested` already drops any anchor `resolveAnchor` could not
+ * resolve before this function ever runs, so "every anchor" here means every
+ * anchor that survived that filter -- self-consistent with the
+ * `derived_from` edges the same resolved list produces, but worth stating:
+ * an anchor that failed to resolve cannot raise or lower the bar for the
+ * anchors that did.
  */
-function taskForAnchors(graph, anchorIds, sessionId) {
-  if (!sessionId || !anchorIds || !anchorIds.length) return null;
-  const taskTarget = nodeId('task', sessionId);
+function taskForAnchors(graph, resolvedAnchorIds, authoritativeSessionId) {
+  if (!authoritativeSessionId || !resolvedAnchorIds || !resolvedAnchorIds.length) return null;
+  const taskTarget = nodeId('task', authoritativeSessionId);
   const task = graph.nodes.get(taskTarget);
   if (!task || task.kind !== 'task') return null;
 
-  for (const anchor of anchorIds) {
+  for (const anchor of resolvedAnchorIds) {
     const covered = graph.edges.some((edge) =>
       edge.edge === 'derived_from' && edge.from === taskTarget && edge.to === anchor
     );
@@ -604,7 +630,19 @@ function derivationFor(graph, resolvedAnchors, evidence, evidenceIncomplete, anc
 export function writeHarvested(
   dir,
   findings,
-  { sessionId = null, origin = ORIGIN_HARVESTED, projectRoot = null, taskId = null } = {}
+  {
+    sessionId = null,
+    origin = ORIGIN_HARVESTED,
+    projectRoot = null,
+    taskId = null,
+    // Distinct from `sessionId`, which is stored on every finding for
+    // provenance/display regardless of trust. This one gates the `answers`
+    // traversal fallback specifically, and every caller passing it is
+    // asserting the identity came from a channel it does not control --
+    // Claude Code's own hook payload, not a tool-call argument a model
+    // typed. See `taskForAnchors`'s comment for the attack this closes.
+    authoritativeSessionId = null,
+  } = {}
 ) {
   if (!Array.isArray(findings) || !findings.length) return [];
 
@@ -702,16 +740,29 @@ export function writeHarvested(
     // An explicit `taskId` is authoritative when a caller supplies one --
     // it OVERRIDES traversal rather than merely seeding it, so a caller that
     // knows better is never second-guessed by inference. Absent one, the task
-    // is DERIVED from the graph itself: `taskForAnchors` finds the CURRENT
-    // session's task (scoped by `sessionId`, the same identity this write
-    // already carries for provenance) and requires it to have touched EVERY
-    // one of this finding's anchors, not merely one -- see that function's
-    // own comment for the four attacks this closes. Either way, held to the
-    // same discipline as the anchors above: a target that does not resolve to
-    // an existing task node produces no edge rather than a dangling one.
+    // is DERIVED from the graph itself, but ONLY when `authoritativeSessionId`
+    // is present: `taskForAnchors` scopes to that exact session's task and
+    // requires it to have touched EVERY one of this finding's anchors, not
+    // merely one -- see that function's own comment for why the identity
+    // itself must be trustworthy, not merely present.
+    //
+    // THE CONSEQUENCE, STATED PLAINLY: `wiki_write` never supplies
+    // `authoritativeSessionId` (its `sessionId` is a model-typed MCP
+    // argument nothing cross-checks), so its calls never traverse and
+    // `answers` never fires on that path. `plugin/hooks/harvest-worker.mjs`
+    // does supply it (Claude Code's own hook payload), so `answers` fires
+    // there -- opt-in gated. `answers` therefore does NOT fire on a default
+    // install today. Recovering default liveness needs an authoritative
+    // identity on a default-install path, which is what Plan 2's
+    // `hooks-core/derive.mjs` (running in the Stop hook, where the session id
+    // is real) is for -- not a weaker check here.
+    //
+    // Either way, held to the same discipline as the anchors above: a target
+    // that does not resolve to an existing task node produces no edge rather
+    // than a dangling one.
     const answersTarget = taskId
       ? nodeId('task', taskId)
-      : taskForAnchors(currentGraph, resolved, sessionId);
+      : taskForAnchors(currentGraph, resolved, authoritativeSessionId);
     if (answersTarget && currentGraph.nodes.has(answersTarget)) {
       edges.push({ edge: 'answers', to: answersTarget });
     }

--- a/integrations/copilot/.github/hooks/lib/harvest-write.mjs
+++ b/integrations/copilot/.github/hooks/lib/harvest-write.mjs
@@ -436,7 +436,7 @@ function resolveAnchor(dir, anchor, projectRoot) {
 export function writeHarvested(
   dir,
   findings,
-  { sessionId = null, origin = ORIGIN_HARVESTED, projectRoot = null } = {}
+  { sessionId = null, origin = ORIGIN_HARVESTED, projectRoot = null, taskId = null } = {}
 ) {
   if (!Array.isArray(findings) || !findings.length) return [];
 
@@ -516,6 +516,21 @@ export function writeHarvested(
     // collision vanishingly unlikely while keeping the timestamp readable.
     const provenance = provenanceFor(finding);
     const key = `${prefixFor(provenance)}-${Date.now().toString(36)}-${written.length}-${randomBytes(4).toString("hex")}`;
+
+    const edges = resolved.map((target) => ({ edge: 'derived_from', to: target }));
+    // `answers` closes the loop back to the task that produced the finding, so
+    // provenance can be traversed rather than inferred: "which session
+    // established this, and from what". Declared in EDGE_KINDS and written by
+    // nothing until now. Held to the same discipline as the anchors above: a
+    // taskId that does not resolve to an existing task node produces no edge
+    // rather than a dangling one.
+    if (taskId) {
+      const taskTarget = nodeId('task', taskId);
+      if (currentGraph.nodes.has(taskTarget)) {
+        edges.push({ edge: 'answers', to: taskTarget });
+      }
+    }
+
     // ONE APPEND for the finding and every anchor it resolved. This runs in a
     // detached worker, so "the process survives to finish the loop" is not a
     // safe assumption: a node written without its edges is an active finding
@@ -557,7 +572,7 @@ export function writeHarvested(
           : undefined,
         sessionId,
       },
-      resolved.map((target) => ({ edge: 'derived_from', to: target }))
+      edges
     );
     // A failed write returns null. Reporting the key anyway would tell the
     // caller a claim was stored that no later session can retrieve.

--- a/integrations/copilot/.github/hooks/lib/harvest-write.mjs
+++ b/integrations/copilot/.github/hooks/lib/harvest-write.mjs
@@ -34,6 +34,7 @@ import { randomBytes } from 'node:crypto';
 import { realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
+import { readEvidence } from './metrics.mjs';
 
 /**
  * The types that may cross a project boundary.
@@ -428,6 +429,121 @@ function resolveAnchor(dir, anchor, projectRoot) {
 }
 
 /**
+ * Which task actually produced this finding, when nothing said so directly.
+ *
+ * Session id was the only signal `answers` had, and a session id is exactly
+ * what a caller may not have (`wiki_write`'s `sessionId` is optional and
+ * nothing populates it today; the detached harvest worker's is gated behind
+ * an opt-in). But the graph does not need to be TOLD which task this is: the
+ * structural harvest already writes `task -[derived_from]-> file` for every
+ * tool call, unconditionally, on every install. So the task is DERIVABLE --
+ * it is whichever task node has a `derived_from` edge to one of the SAME
+ * anchors this finding resolved to.
+ *
+ * "Most recent task, full stop" was rejected on purpose: a task that never
+ * touched these files could still be the newest node in the graph (a
+ * different file, a different concern, in a later session), and attaching
+ * provenance to it would be a WRONG edge, not a missing one -- worse than no
+ * edge, because a reader trusts it. So candidates are filtered to tasks that
+ * touched at least one of these anchors FIRST, and only ties among THOSE are
+ * broken by recency.
+ *
+ * The tie-break is the edge's own `at`, not the task node's `at`. A task that
+ * touched this file once, long ago, and then stayed active on unrelated files
+ * for hours has a late node timestamp that says nothing about this anchor;
+ * the edge timestamp says exactly when THIS task touched THIS anchor, which
+ * is the question being asked. Among tasks sharing an anchor, the one whose
+ * most recent touch to any shared anchor is latest wins -- recency of the
+ * relevant work, not recency of the task in general.
+ */
+function taskForAnchors(graph, anchorIds) {
+  if (!anchorIds || !anchorIds.length) return null;
+  const anchors = new Set(anchorIds);
+  let best = null;
+  for (const edge of graph.edges) {
+    if (edge.edge !== 'derived_from' || !anchors.has(edge.to)) continue;
+    const from = graph.nodes.get(edge.from);
+    // `derived_from` is also how a FINDING cites its own anchors, so without
+    // this a finding that already cited the same file would be mistaken for
+    // the task that produced it.
+    if (!from || from.kind !== 'task') continue;
+    const at = Number(edge.at) || 0;
+    if (!best || at > best.at) best = { taskId: edge.from, at };
+  }
+  return best ? best.taskId : null;
+}
+
+/**
+ * A file path the way `recordToolOutcome` (metrics.mjs) already truncates and
+ * stores it on a `tool-outcome` event's `anchor` field, so a derivation record
+ * can join against that log without a second, divergent notion of "the same
+ * anchor".
+ */
+function anchorLabel(rawAnchor) {
+  const path = String(rawAnchor).split('#')[0];
+  return canonicalPath(path).slice(0, 120);
+}
+
+/** How many recorded operations a single finding's derivation may cite. */
+const MAX_DERIVATION_OPERATIONS = 5;
+
+/**
+ * The checkable half of provenance: not just where a finding came from, but
+ * whether that derivation still holds.
+ *
+ * Citation-style provenance (a session or task id) answers "where". It never
+ * answers "does this still apply" -- that is what staleness already computes,
+ * by comparing an anchor's STORED hash against disk. This record is what lets
+ * that comparison be reconstructed for a specific claim rather than only for
+ * the anchor in general: the hash each anchor carried at the moment this
+ * finding was derived from it, plus what evidence exists that any work
+ * actually happened against it.
+ *
+ * DELIBERATELY NOT DUPLICATING THE EDGES. `derived_from` already records
+ * WHICH anchors this finding cites; restating that here would be a second,
+ * driftable copy of the same fact. What is new here, and only here, is the
+ * HASH each anchor carried at claim time -- edges carry no such thing.
+ *
+ * DELIBERATELY NOT A REPLAY LOG. Recording enough to mechanically re-run a
+ * derivation is a separate subsystem with real storage cost. This stores only
+ * what the evidence log already has: `tool-outcome` events matching these
+ * anchors, each reduced to the fields that were actually captured. An event
+ * that carries no exit code or output contributes none -- nothing here is
+ * invented to fill a shape the pipeline does not evidence yet. If a future
+ * capture pass adds `exit`/`output` to those events, this starts carrying them
+ * with no change to this function.
+ */
+function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
+  const anchorHashes = {};
+  for (const id of resolvedAnchors) {
+    const node = graph.nodes.get(id);
+    if (node && typeof node.hash === 'string') anchorHashes[id] = node.hash;
+  }
+
+  const labels = new Set((anchorSpecs || []).map(anchorLabel));
+  const operations = evidence
+    .filter((event) => event.kind === 'tool-outcome' && labels.has(event.anchor))
+    .sort((a, b) => (Number(b.at) || 0) - (Number(a.at) || 0))
+    .slice(0, MAX_DERIVATION_OPERATIONS)
+    .map((event) => {
+      const op = {};
+      if (typeof event.toolName === 'string' && event.toolName)
+        op.tool = event.toolName.slice(0, 60);
+      if (typeof event.success === 'boolean') op.success = event.success;
+      if (typeof event.at === 'number') op.at = event.at;
+      // Forward-compatible, not fabricated: neither field exists on a
+      // `tool-outcome` event in this pipeline today, so every operation
+      // omits them until a capture pass actually evidences one.
+      if (typeof event.exit === 'number') op.exit = event.exit;
+      if (typeof event.output === 'string' && event.output)
+        op.output = event.output.slice(0, 200);
+      return op;
+    });
+
+  return { at: Date.now(), anchors: anchorHashes, operations };
+}
+
+/**
  * Writes validated findings, returning the keys actually stored.
  *
  * `findings` is the output of `harvest.validate()`, so type/claim/confidence
@@ -467,6 +583,11 @@ export function writeHarvested(
       : batch;
   const prefixFor = (p) =>
     p === ORIGIN_AGENT ? 'agent' : p === ORIGIN_HUMAN ? 'human' : 'harvested';
+
+  // Read once: every finding in this batch shares the same evidence log, and
+  // it can hold thousands of lines, so re-reading it per finding would turn a
+  // batch of N findings into N passes over the same bytes.
+  const evidence = readEvidence(dir);
 
   const written = [];
   for (const finding of findings) {
@@ -521,14 +642,21 @@ export function writeHarvested(
     // `answers` closes the loop back to the task that produced the finding, so
     // provenance can be traversed rather than inferred: "which session
     // established this, and from what". Declared in EDGE_KINDS and written by
-    // nothing until now. Held to the same discipline as the anchors above: a
-    // taskId that does not resolve to an existing task node produces no edge
-    // rather than a dangling one.
-    if (taskId) {
-      const taskTarget = nodeId('task', taskId);
-      if (currentGraph.nodes.has(taskTarget)) {
-        edges.push({ edge: 'answers', to: taskTarget });
-      }
+    // nothing until now.
+    //
+    // An explicit `taskId` is authoritative when a caller supplies one --
+    // it OVERRIDES traversal rather than merely seeding it, so a caller that
+    // knows better is never second-guessed by inference. Absent one, the task
+    // is DERIVED from the graph itself: `taskForAnchors` finds the task that
+    // actually touched these anchors, which needs no session id from anyone.
+    // Either way, held to the same discipline as the anchors above: a target
+    // that does not resolve to an existing task node produces no edge rather
+    // than a dangling one.
+    const answersTarget = taskId
+      ? nodeId('task', taskId)
+      : taskForAnchors(currentGraph, resolved);
+    if (answersTarget && currentGraph.nodes.has(answersTarget)) {
+      edges.push({ edge: 'answers', to: answersTarget });
     }
 
     // ONE APPEND for the finding and every anchor it resolved. This runs in a
@@ -571,6 +699,15 @@ export function writeHarvested(
           ? finding.quote
           : undefined,
         sessionId,
+        // THE CHECKABLE HALF OF PROVENANCE. Citation-style (this `sessionId`,
+        // the `answers` edge above) says WHERE a claim came from; it never
+        // says whether that derivation still applies. `derivationFor` reaches
+        // through `wiki_query`'s `node`/`get`/`search` operations only (those
+        // return a finding's stored fields wholesale) -- never through
+        // `render()`/`renderSessionIndex()` in inject.mjs or `wiki_read`'s
+        // `toFinding()` projection, neither of which reads this field, so it
+        // is not part of the automatic per-touch injection `fit()` prices.
+        derivation: derivationFor(currentGraph, resolved, evidence, finding.anchors || []),
       },
       edges
     );

--- a/integrations/copilot/.github/hooks/lib/inject.mjs
+++ b/integrations/copilot/.github/hooks/lib/inject.mjs
@@ -26,6 +26,7 @@ import {
 } from './wiki.mjs';
 import { basename } from 'node:path';
 import { serve, diffLines } from './staleness.mjs';
+import { drainInvalidations } from './pending.mjs';
 import { inHoldout, record, indexBudget } from './metrics.mjs';
 import { canonicalPath, resolvableCandidates } from './paths.mjs';
 import { annotatedSkeleton } from './skeleton.mjs';
@@ -142,6 +143,31 @@ function render(finding) {
 }
 
 /**
+ * Applies anything the post-tool hook queued, BEFORE anything is served.
+ *
+ * THIS IS WHERE EAGER STALENESS LANDS. `invalidateOnWrite` needs a graph, and
+ * loading one on the return path of every write is what pending.mjs exists to
+ * avoid -- so the hook queues and the next graph read applies. These two
+ * functions are that read: they already hold a freshly loaded graph, and they
+ * are the last thing to run before a finding reaches a model.
+ *
+ * RE-READ ONLY WHEN SOMETHING WAS ACTUALLY MARKED. The drain writes the stale
+ * flag to disk; it cannot mutate the caller's already-parsed graph, so serving
+ * from that copy would deliver the very "stale finding as fresh" this exists to
+ * prevent. A second load costs a parse, and it is paid once per observed write
+ * rather than once per tool call -- when nothing is queued this is one stat.
+ */
+function withPendingApplied(dir, graph) {
+  try {
+    return drainInvalidations(dir, graph) > 0 ? load(dir) : graph;
+  } catch {
+    // The lazy path still covers everything this would have caught early, and
+    // a hook must never fail because bookkeeping did.
+    return graph;
+  }
+}
+
+/**
  * What the model sees when it touches a file.
  *
  * Returns null when there is nothing to say, or when this touch fell into the
@@ -154,6 +180,7 @@ export function forTouch(
   rawPath,
   { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
+  graph = withPendingApplied(dir, graph);
   // Canonical, so a touch finds findings anchored under any other spelling.
   const filePath = canonicalPath(rawPath);
   const anchorId = nodeId('file', filePath);
@@ -322,6 +349,7 @@ export function forCommand(
   { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
   if (!command) return null;
+  graph = withPendingApplied(dir, graph);
 
   const candidates = [];
   for (const node of graph.nodes.values()) {

--- a/integrations/copilot/.github/hooks/lib/inject.mjs
+++ b/integrations/copilot/.github/hooks/lib/inject.mjs
@@ -33,6 +33,7 @@ import { annotatedSkeleton } from './skeleton.mjs';
 import { substitutionBudget } from './metrics.mjs';
 import { assessFindings } from './utility.mjs';
 import { quarantineSharedSource } from './harvest-write.mjs';
+import { cacheOrdered } from './cache.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
@@ -1152,6 +1153,53 @@ export function standingRules(dir, graph, { budget = standingBudget(), episode =
   // which is worse than saying there are more: a model that knows the list is
   // truncated can ask, one that does not will assume it is complete.
   return `${HEADING}${lines.join('\n')}${truncated}`;
+}
+
+/**
+ * SessionStart context, assembled in cache order: stable first, volatile last.
+ *
+ * WHY THE ORDER IS A CORRECTNESS PROPERTY AND NOT A STYLE CHOICE. Everything
+ * here lands near the FRONT of the prompt prefix, and a prefix cache is
+ * invalidated from the first differing byte onward. A block whose text changes
+ * between sessions therefore prices everything positioned after it: put the
+ * freshest block first and the whole remainder of the prefix is re-written
+ * every session; put it last and the invalidation is confined to its own tail.
+ * cache.mjs measures exactly this cost in the user's files -- this is the same
+ * discipline applied to our own output, which is the half nobody else has to
+ * think about because nobody else writes into the prefix.
+ *
+ * `cacheOrdered` existed for precisely this and had no caller, so the order was
+ * whatever order the call sites happened to push in. It was accidentally right;
+ * it is now enforced, which is the difference that matters the next time a
+ * block is added.
+ *
+ * VOLATILITY IS ASSIGNED FROM HOW OFTEN THE TEXT ACTUALLY DIFFERS BETWEEN
+ * SESSIONS, not from how important the block is:
+ *
+ *   0  policy -- the optimization notice and project briefing. Deliberately
+ *      cache-safe by construction: the routing facts are number-free and the
+ *      briefing passes through `stableText`, which DROPS any line that would
+ *      vary. It changes when the tool inventory or configuration changes.
+ *   1  standing -- pinned facts and human-verified corrections, rendered in
+ *      full. Changes only when a person pins, retires or corrects something.
+ *   2  index -- the bounded wiki index, selected per session from the task
+ *      text, and carrying [STALE]/[DISPUTED] markers that flip as the code
+ *      moves. Different on most sessions.
+ *   3  restoration -- present only when resuming from a compaction, and derived
+ *      from the anchors of the session that was just discarded. Never twice the
+ *      same.
+ *
+ * A block with no text is dropped rather than joined, so an absent block cannot
+ * open the assembly with a blank line.
+ */
+export function sessionContext(blocks) {
+  return cacheOrdered(
+    (Array.isArray(blocks) ? blocks : []).filter(
+      (block) => block && typeof block.text === 'string' && block.text.trim()
+    )
+  )
+    .map((block) => block.text)
+    .join('\n\n');
 }
 
 /**

--- a/integrations/copilot/.github/hooks/lib/inject.mjs
+++ b/integrations/copilot/.github/hooks/lib/inject.mjs
@@ -122,8 +122,29 @@ function fit(findings, budget) {
   return { kept, spent };
 }
 
+/**
+ * Discloses an open disagreement, on the same line as the claim it is about.
+ *
+ * BOTH HALVES, like the stale renderer below: the strong form names the other
+ * finding so the reader can fetch it, and the form without a key says only what
+ * is actually known. `serve` is what establishes the dispute; this only phrases
+ * it, and it phrases it in one short line because `fit` prices `render` against
+ * the injection budget -- a disagreement is worth a pointer, not both claims in
+ * full.
+ *
+ * NO DISMISSAL VOCABULARY, for the reason measured on the stale wording: an
+ * instruction to discount suppressed findings that were correct. This states
+ * that another claim exists and where to find it, and lets the reader decide.
+ */
+function disputeNote(finding) {
+  if (!finding.contradicted) return '';
+  return finding.contradictedBy
+    ? `\n  DISPUTED by ${finding.contradictedBy} -- wiki_query that key for the other claim`
+    : '\n  DISPUTED by another finding in this graph';
+}
+
 function render(finding) {
-  const head = `- [${finding.type || 'finding'}] ${finding.claim}`;
+  const head = `- [${finding.type || 'finding'}] ${finding.claim}${disputeNote(finding)}`;
   if (!finding.stale) return head;
 
   // A stale finding NEVER renders as though it were current. But the strength
@@ -997,7 +1018,15 @@ function renderSessionIndex(total, findings) {
       : finding.stale
         ? ' [possibly stale; verify before use]'
         : '';
-    return `- ${finding.key}${freshness}: ${finding.claim.slice(0, 90)}`;
+    // The session index is the first thing a session reads, so a disputed
+    // finding must not be listed there as settled either. Compressed to a
+    // marker and a key, matching the freshness markers beside it.
+    const dispute = finding.contradicted
+      ? finding.contradictedBy
+        ? ` [DISPUTED by ${finding.contradictedBy}]`
+        : ' [DISPUTED]'
+      : '';
+    return `- ${finding.key}${freshness}${dispute}: ${finding.claim.slice(0, 90)}`;
   });
   return `# Project wiki (${total} findings, ${findings.length} listed)
 

--- a/integrations/copilot/.github/hooks/lib/inject.mjs
+++ b/integrations/copilot/.github/hooks/lib/inject.mjs
@@ -139,9 +139,26 @@ function fit(findings, budget) {
  */
 function disputeNote(finding) {
   if (!finding.contradicted) return '';
-  return finding.contradictedBy
+  const head = finding.contradictedBy
     ? `\n  DISPUTED by ${finding.contradictedBy} -- wiki_query that key for the other claim`
     : '\n  DISPUTED by another finding in this graph';
+  // THE REASON A PERSON TYPED, rendered here because this is the fullest of the
+  // three dispute surfaces and the only one with room for a sentence. `contradict`
+  // has always stored up to 400 characters of human explanation and, until this
+  // line, nothing read it: the pointer told a reader where to look and withheld
+  // the one thing that would tell them whether looking was worth a tool call.
+  //
+  // TRUNCATED AT 140, because `fit` prices this string against the injection
+  // budget and a 400-character paragraph beside a one-line claim inverts the
+  // proportions. The compressed surfaces -- the session index and restore.mjs's
+  // "Likely next" list -- deliberately keep marker-and-key only; they are one
+  // line per finding by design, and `wiki_query` returns the reason in full.
+  if (typeof finding.contradictionReason !== 'string' || !finding.contradictionReason.trim()) {
+    return head;
+  }
+  const reason = finding.contradictionReason.trim();
+  const shown = reason.length > 140 ? `${reason.slice(0, 140)}...` : reason;
+  return `${head}\n  Reason given: ${shown}`;
 }
 
 /**

--- a/integrations/copilot/.github/hooks/lib/inject.mjs
+++ b/integrations/copilot/.github/hooks/lib/inject.mjs
@@ -276,7 +276,10 @@ export function forTouch(
   // others, so the comparison becomes within-file and the dominant source of
   // variance drops out. A session-pinned arm would destroy that.
   const holdout = inHoldout(filePath);
-  const served = serve(graph, candidates);
+  // `dir` so an eager flag whose evidence is gone is cleared here rather than
+  // waiting for somebody to open the dashboard. Same evidence test as the manual
+  // path -- see `serve`.
+  const served = serve(graph, candidates, { dir });
   const assessed = assessFindings(dir, served, {
     episodeId: episode.episodeId || sessionId,
     relevanceFor: () => 1,
@@ -463,7 +466,7 @@ export function forCommand(
   // only thing an uncapped list buys is the I/O.
   const considered = candidates.slice(0, MAX_COMMAND_CANDIDATES);
 
-  const served = serve(graph, considered);
+  const served = serve(graph, considered, { dir });
   const assessed = assessFindings(dir, served, {
     episodeId: episode.episodeId || sessionId,
     relevanceFor: (finding) => explicit(finding) ? 1 : 0.6,
@@ -990,7 +993,7 @@ export function sessionIndex(dir, graph, { episode = {}, relevantFindingIds = []
   // `serve` is the only path allowed to hand a finding to a model. In
   // particular, activating this previously-unwired index must not create a new
   // path that labels an invalidated content claim as current.
-  const served = serve(graph, selected);
+  const served = serve(graph, selected, { dir });
   if (!served.length) return null;
   // A stale marker is longer than the fresh preview used for candidate
   // selection. Trim from the lowest-ranked end until the ACTUAL message fits.

--- a/integrations/copilot/.github/hooks/lib/inject.mjs
+++ b/integrations/copilot/.github/hooks/lib/inject.mjs
@@ -156,9 +156,9 @@ function disputeNote(finding) {
 function derivationNote(finding) {
   if (finding.derivationHolds !== false) return '';
   const changed = Array.isArray(finding.derivationChanged) ? finding.derivationChanged : [];
-  return changed.length
-    ? `\n  DERIVATION CHANGED -- ${changed.join(', ')} no longer match what this claim was derived from`
-    : '\n  DERIVATION CHANGED since this claim was recorded';
+  if (!changed.length) return '\n  DERIVATION CHANGED since this claim was recorded';
+  const verb = changed.length === 1 ? 'no longer matches' : 'no longer match';
+  return `\n  DERIVATION CHANGED -- ${changed.join(', ')} ${verb} what this claim was derived from`;
 }
 
 function render(finding) {

--- a/integrations/copilot/.github/hooks/lib/inject.mjs
+++ b/integrations/copilot/.github/hooks/lib/inject.mjs
@@ -143,8 +143,26 @@ function disputeNote(finding) {
     : '\n  DISPUTED by another finding in this graph';
 }
 
+/**
+ * Discloses `derivationCheck`'s verdict (staleness.mjs) -- distinct from
+ * `disputeNote` (another finding disagrees) and from the STALE block below
+ * (the anchor NODE's current hash does not match disk). This is about
+ * whether the bytes THIS claim was actually derived from are still the bytes
+ * an anchor holds; see `derivationCheck`'s comment for the case that catches
+ * that the other two can miss. Silent when it holds -- the common case pays
+ * nothing -- and silent when it was never checked at all (an older finding
+ * with no `derivation` record).
+ */
+function derivationNote(finding) {
+  if (finding.derivationHolds !== false) return '';
+  const changed = Array.isArray(finding.derivationChanged) ? finding.derivationChanged : [];
+  return changed.length
+    ? `\n  DERIVATION CHANGED -- ${changed.join(', ')} no longer match what this claim was derived from`
+    : '\n  DERIVATION CHANGED since this claim was recorded';
+}
+
 function render(finding) {
-  const head = `- [${finding.type || 'finding'}] ${finding.claim}${disputeNote(finding)}`;
+  const head = `- [${finding.type || 'finding'}] ${finding.claim}${disputeNote(finding)}${derivationNote(finding)}`;
   if (!finding.stale) return head;
 
   // A stale finding NEVER renders as though it were current. But the strength

--- a/integrations/copilot/.github/hooks/lib/inject.mjs
+++ b/integrations/copilot/.github/hooks/lib/inject.mjs
@@ -157,9 +157,28 @@ function render(finding) {
  * prevent. A second load costs a parse, and it is paid once per observed write
  * rather than once per tool call -- when nothing is queued this is one stat.
  */
+/**
+ * Per process, per graph directory: did the drain change anything?
+ *
+ * THE SECOND CALLER IS WHY THIS EXISTS. SessionStart calls `standingRules` and
+ * then `sessionIndex` with the SAME graph object it loaded once. Without this
+ * memo the first call drains, marks, and re-reads privately -- and the second
+ * call finds an empty queue, marks nothing, and therefore serves from the
+ * caller's pre-drain copy, advertising as current the very finding the first
+ * call had just marked. Draining is not idempotent from the caller's point of
+ * view; remembering the ANSWER is what makes it so.
+ *
+ * A hook process handles one lifecycle event, so this map holds one or two
+ * entries and dies with the process.
+ */
+const drainedDirs = new Map();
+
 function withPendingApplied(dir, graph) {
   try {
-    return drainInvalidations(dir, graph) > 0 ? load(dir) : graph;
+    if (drainedDirs.has(dir)) return drainedDirs.get(dir) ? load(dir) : graph;
+    const marked = drainInvalidations(dir, graph) > 0;
+    drainedDirs.set(dir, marked);
+    return marked ? load(dir) : graph;
   } catch {
     // The lazy path still covers everything this would have caught early, and
     // a hook must never fail because bookkeeping did.
@@ -862,6 +881,12 @@ export function relevantFindingIdsForContext(graph, context, { limit = 8 } = {})
  * shrinks toward the floor. See metrics.indexBudget.
  */
 export function sessionIndex(dir, graph, { episode = {}, relevantFindingIds = [] } = {}) {
+  // DRAINED HERE TOO, and this is the worst place to be wrong. The session index
+  // is the FIRST thing a session sees and it arrives with no other context to
+  // correct it, so advertising a finding the graph already knows is stale is a
+  // false claim made at maximum leverage. The graph is loaded either way, so the
+  // only cost is the stat that finds no queue.
+  graph = withPendingApplied(dir, graph);
   const budget = indexBudget(dir);
   const relevant = new Set(relevantFindingIds);
   // Some SessionStart payloads have no task signal. Fail closed for situational
@@ -988,6 +1013,9 @@ ${lines.join('\n')}`;
  * is wallpaper, and the model stops reading the thing it always sees.
  */
 export function standingRules(dir, graph, { budget = standingBudget(), episode = {} } = {}) {
+  // Same reason as sessionIndex: always-on text, delivered before the first
+  // tool call, with nothing following it that could qualify what it said.
+  graph = withPendingApplied(dir, graph);
   const rules = [...graph.nodes.values()].filter(
     (n) =>
       n.kind === 'finding' &&

--- a/integrations/copilot/.github/hooks/lib/inject.mjs
+++ b/integrations/copilot/.github/hooks/lib/inject.mjs
@@ -143,6 +143,40 @@ function render(finding) {
 }
 
 /**
+ * Graph directories where a drain has already marked something in THIS process.
+ *
+ * THE SECOND CALLER IS WHY THIS EXISTS. SessionStart calls `standingRules` and
+ * then `sessionIndex` with the SAME graph object it loaded once. Without this,
+ * the first call drains, marks, and re-reads privately -- and the second call
+ * finds an empty queue, marks nothing, and therefore serves from the caller's
+ * pre-drain copy, advertising as current the very finding the first call had
+ * just marked. Draining is idempotent; its EFFECT on a caller's parsed graph is
+ * not, so what is remembered here is "a re-read is owed", nothing else.
+ *
+ * ONLY THE POSITIVE CASE IS REMEMBERED, and that is a correctness decision
+ * rather than a tuning one. Remembering "nothing was queued" would mean a queue
+ * arriving LATER in the same process is silently skipped and deferred to some
+ * future session. That cannot happen today, because `queueInvalidation` runs in
+ * the post-tool branch before any injection -- but that is an unguarded
+ * ordering dependency, and it stops being true the moment someone adds a call
+ * site. A repeated empty drain costs one `existsSync` on a file that is not
+ * there, which is a price worth paying to not have an invariant that depends on
+ * nobody reordering anything.
+ *
+ * KEYED CANONICALLY. Two spellings of one directory -- a trailing separator, a
+ * `..` segment, a lower-cased drive letter -- would otherwise be two entries,
+ * which reintroduces exactly the pre-drain-copy bug above. This is the same
+ * defect shape Task 2 on this branch shipped for real, where a tool resolved its
+ * graph from a raw cwd while the hooks resolved theirs through `projectRootFor`
+ * and the two halves of a metric landed in different directories. Path identity
+ * is why `canonicalKey` lives inside `nodeId` rather than at its call sites.
+ *
+ * A hook process handles one lifecycle event, so this set holds one or two
+ * entries and dies with the process.
+ */
+const drainedDirs = new Set();
+
+/**
  * Applies anything the post-tool hook queued, BEFORE anything is served.
  *
  * THIS IS WHERE EAGER STALENESS LANDS. `invalidateOnWrite` needs a graph, and
@@ -157,28 +191,14 @@ function render(finding) {
  * prevent. A second load costs a parse, and it is paid once per observed write
  * rather than once per tool call -- when nothing is queued this is one stat.
  */
-/**
- * Per process, per graph directory: did the drain change anything?
- *
- * THE SECOND CALLER IS WHY THIS EXISTS. SessionStart calls `standingRules` and
- * then `sessionIndex` with the SAME graph object it loaded once. Without this
- * memo the first call drains, marks, and re-reads privately -- and the second
- * call finds an empty queue, marks nothing, and therefore serves from the
- * caller's pre-drain copy, advertising as current the very finding the first
- * call had just marked. Draining is not idempotent from the caller's point of
- * view; remembering the ANSWER is what makes it so.
- *
- * A hook process handles one lifecycle event, so this map holds one or two
- * entries and dies with the process.
- */
-const drainedDirs = new Map();
-
 function withPendingApplied(dir, graph) {
   try {
-    if (drainedDirs.has(dir)) return drainedDirs.get(dir) ? load(dir) : graph;
-    const marked = drainInvalidations(dir, graph) > 0;
-    drainedDirs.set(dir, marked);
-    return marked ? load(dir) : graph;
+    const key = canonicalPath(dir);
+    // The drain runs EVERY time. It is one stat when there is nothing to do,
+    // and running it unconditionally is what keeps the memo from encoding an
+    // assumption about which hook branch ran first.
+    if (drainInvalidations(dir, graph) > 0) drainedDirs.add(key);
+    return drainedDirs.has(key) ? load(dir) : graph;
   } catch {
     // The lazy path still covers everything this would have caught early, and
     // a hook must never fail because bookkeeping did.

--- a/integrations/copilot/.github/hooks/lib/lexical.mjs
+++ b/integrations/copilot/.github/hooks/lib/lexical.mjs
@@ -1,0 +1,73 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/lexical.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * BM25 over findings. Pure, dependency-free, deterministic.
+ *
+ * WHY THIS REPLACES `includes()`. The dashboard filtered findings by substring,
+ * which cannot RANK -- and every consumer of retrieval here is under a hard
+ * token budget, so the budget kept whatever happened to match rather than what
+ * matched best. Ranking is the whole value at a budget.
+ *
+ * WHY BM25 AND NOT EMBEDDINGS. Deliberate, per docs/WIKI_GRAPH.md: deterministic,
+ * instant, explainable, and it cannot drift or need a rebuild. The known cost is
+ * recall on findings with no lexical overlap; Plan 2's recall probe measures that
+ * rather than assuming it away.
+ */
+
+/** Non-word split, lowercased. Short tokens are kept: `fs`, `id`, `os` matter here. */
+export function tokenize(text) {
+  return String(text || '')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+}
+
+/**
+ * Classic BM25. `k1` controls term-frequency saturation, `b` length normalisation.
+ * Defaults are the standard ones and are exposed so the recall probe can sweep them.
+ */
+export function rank(query, findings, { limit = 20, k1 = 1.2, b = 0.75 } = {}) {
+  const terms = tokenize(query);
+  if (!terms.length || !Array.isArray(findings) || !findings.length) return [];
+
+  // A finding's searchable text is its claim AND its key: the key is how the
+  // session index refers to it, so a model quoting a key must find it.
+  const docs = findings.map((finding) => ({
+    finding,
+    tokens: tokenize(`${finding.key || ''} ${finding.claim || ''}`),
+  }));
+
+  const avgLen = docs.reduce((sum, d) => sum + d.tokens.length, 0) / docs.length;
+  const N = docs.length;
+
+  const docFreq = new Map();
+  for (const { tokens } of docs) {
+    for (const term of new Set(tokens)) {
+      docFreq.set(term, (docFreq.get(term) || 0) + 1);
+    }
+  }
+
+  const scored = [];
+  for (const { finding, tokens } of docs) {
+    const counts = new Map();
+    for (const token of tokens) counts.set(token, (counts.get(token) || 0) + 1);
+
+    let score = 0;
+    for (const term of terms) {
+      const tf = counts.get(term);
+      if (!tf) continue;
+      const df = docFreq.get(term) || 0;
+      // Standard BM25 IDF, floored at zero so a term present in every document
+      // contributes nothing rather than a negative score.
+      const idf = Math.max(0, Math.log(1 + (N - df + 0.5) / (df + 0.5)));
+      const norm = tf + k1 * (1 - b + (b * tokens.length) / (avgLen || 1));
+      score += idf * ((tf * (k1 + 1)) / (norm || 1));
+    }
+
+    // Zero means no term matched. Omitted rather than returned, so a caller
+    // under a token budget never spends it on an irrelevant finding.
+    if (score > 0) scored.push({ finding, score });
+  }
+
+  return scored.sort((a, b2) => b2.score - a.score).slice(0, limit);
+}

--- a/integrations/copilot/.github/hooks/lib/lexical.mjs
+++ b/integrations/copilot/.github/hooks/lib/lexical.mjs
@@ -14,12 +14,54 @@
  * rather than assuming it away.
  */
 
-/** Non-word split, lowercased. Short tokens are kept: `fs`, `id`, `os` matter here. */
-export function tokenize(text) {
-  return String(text || '')
-    .toLowerCase()
-    .split(/[^a-z0-9]+/)
+/**
+ * Splits an identifier's alphanumeric run into its camelCase / letter-digit
+ * parts, e.g. `skipLibCheck` -> ['skip', 'Lib', 'Check'], `TS2345` ->
+ * ['TS', '2345']. Returns a single-element array when there is no internal
+ * boundary (e.g. `retry` -> ['retry']) so callers can skip emitting a
+ * redundant duplicate of the whole token.
+ */
+function splitIdentifierParts(word) {
+  return word
+    .replace(/([a-z])([A-Z])/g, '$1\0$2')
+    .replace(/([A-Za-z])([0-9])/g, '$1\0$2')
+    .replace(/([0-9])([A-Za-z])/g, '$1\0$2')
+    .split('\0')
     .filter(Boolean);
+}
+
+/**
+ * Non-word split, lowercased. Short tokens are kept: `fs`, `id`, `os` matter
+ * here.
+ *
+ * Emits sub-tokens for compound identifiers, in addition to the whole token.
+ * Delimited identifiers (`smart_read`, `wiki.mjs`, the flag in
+ * `--skipLibCheck`) already round-trip fine: the delimiter splits them, and
+ * because query and claim pass through this same function, a query typed
+ * with the same delimiters matches. The silent gap was CONCATENATED
+ * identifiers with no delimiter at all -- `skipLibCheck` collapsed to the
+ * single token `skiplibcheck`, so a query for "skip lib check" (or "TS 2345"
+ * against `TS2345`) never intersected it. No error, just an absent result --
+ * and findings are about code, where run-together identifiers are the
+ * common case. So every alphanumeric run keeps its whole-token form (a query
+ * for the concatenated form still matches) and ALSO contributes its
+ * camelCase / letter-digit parts (a query for the separated form now
+ * matches too). A lone incidental character -- e.g. the `c` split out of a
+ * Windows path `C:\Users\...` -- needs no special-casing: it is a real
+ * token like any other, and BM25's IDF already discounts a term that shows
+ * up in nearly every finding.
+ */
+export function tokenize(text) {
+  const words = String(text || '').match(/[A-Za-z0-9]+/g) || [];
+  const tokens = [];
+  for (const word of words) {
+    tokens.push(word.toLowerCase());
+    const parts = splitIdentifierParts(word);
+    if (parts.length > 1) {
+      for (const part of parts) tokens.push(part.toLowerCase());
+    }
+  }
+  return tokens;
 }
 
 /**
@@ -57,9 +99,15 @@ export function rank(query, findings, { limit = 20, k1 = 1.2, b = 0.75 } = {}) {
       const tf = counts.get(term);
       if (!tf) continue;
       const df = docFreq.get(term) || 0;
-      // Standard BM25 IDF, floored at zero so a term present in every document
-      // contributes nothing rather than a negative score.
-      const idf = Math.max(0, Math.log(1 + (N - df + 0.5) / (df + 0.5)));
+      // Smoothed BM25 idf: log(1 + (N - df + 0.5) / (df + 0.5)). Unlike the
+      // classic unsmoothed idf (log((N - df + 0.5) / (df + 0.5))), which goes
+      // negative once a term appears in most documents, this smoothed form
+      // is strictly positive for every df in [1, N]: even at df === N the
+      // ratio inside the log is (N + 1) / (N + 0.5), which is always
+      // strictly greater than 1, so log(1 + that) is always > 0. No floor
+      // is needed here, and none is applied -- there is no negative case
+      // for this formula to guard against.
+      const idf = Math.log(1 + (N - df + 0.5) / (df + 0.5));
       const norm = tf + k1 * (1 - b + (b * tokens.length) / (avgLen || 1));
       score += idf * ((tf * (k1 + 1)) / (norm || 1));
     }

--- a/integrations/copilot/.github/hooks/lib/lexical.mjs
+++ b/integrations/copilot/.github/hooks/lib/lexical.mjs
@@ -65,6 +65,43 @@ export function tokenize(text) {
 }
 
 /**
+ * Effective term-frequency credit for a document that has NO exact token
+ * match for a query term but DOES have a token that starts with it (e.g.
+ * query `custom` against a document containing `customer`). Deliberately
+ * less than one exact occurrence (`1`), and it is a flat credit rather than
+ * one that grows with the number of prefix-matching tokens in the document,
+ * so a prefix hit can never outscore an exact hit of the same term:
+ *
+ *   BM25's per-term contribution is `idf * tf * (k1 + 1) / (tf + K)`, where
+ *   `K = k1 * (1 - b + b * L / avgL)` depends only on document length, not
+ *   on which term or how it matched. As a function of `tf` alone, with `K`
+ *   fixed, `f(tf) = tf / (tf + K)` is non-decreasing for every `tf >= 0` and
+ *   `k1 >= 0` (its derivative `K / (tf + K)^2` is never negative). So for
+ *   ANY document length, and any number of prefix-only occurrences, using
+ *   `PREFIX_TF < 1` in place of `tf` scores no higher than an actual exact
+ *   occurrence (`tf = 1`) would in that same document -- there is no
+ *   PREFIX_TF-independent way to accumulate more evidence than one real hit
+ *   by matching only a prefix. This is also why the count of prefix matches
+ *   is otherwise irrelevant here: it never feeds back into the score.
+ *
+ * PREFIX MATCHING IS NOT SUBSTRING MATCHING. It restores recall for a
+ * fragment typed at the START of a word -- `custom` now finds `customer` --
+ * which is the common case (a user typing the first few letters of a term
+ * they remember). It does NOT restore the old `.includes()` filter's ability
+ * to find a term in the MIDDLE of a word: a query for `tomer` still will not
+ * find `customer`. That recall gap is accepted, not silently reintroduced.
+ */
+const PREFIX_TF = 0.5;
+
+/**
+ * Below this length, a query term is not eligible for prefix matching: a
+ * one- or two-character prefix (`a`, `re`) is a substring of a large
+ * fraction of any real vocabulary, so it would match nearly every document
+ * and IDF alone would not discount it enough to keep the results relevant.
+ */
+const PREFIX_MIN_TERM_LENGTH = 3;
+
+/**
  * Classic BM25. `k1` controls term-frequency saturation, `b` length normalisation.
  * Defaults are the standard ones and are exposed so the recall probe can sweep them.
  */
@@ -96,7 +133,21 @@ export function rank(query, findings, { limit = 20, k1 = 1.2, b = 0.75 } = {}) {
 
     let score = 0;
     for (const term of terms) {
-      const tf = counts.get(term);
+      let tf = counts.get(term) || 0;
+
+      // No exact occurrence: fall back to a prefix match, which is weaker
+      // evidence and so credited at a flat PREFIX_TF rather than a real
+      // count (see PREFIX_TF's comment for why that ordering is safe). Only
+      // considered when nothing already matched exactly and the term is
+      // long enough that "starts with" is a meaningful signal.
+      if (tf === 0 && term.length >= PREFIX_MIN_TERM_LENGTH) {
+        for (const token of counts.keys()) {
+          if (token !== term && token.startsWith(term)) {
+            tf = PREFIX_TF;
+            break;
+          }
+        }
+      }
       if (!tf) continue;
       const df = docFreq.get(term) || 0;
       // Smoothed BM25 idf: log(1 + (N - df + 0.5) / (df + 0.5)). Unlike the

--- a/integrations/copilot/.github/hooks/lib/metrics.mjs
+++ b/integrations/copilot/.github/hooks/lib/metrics.mjs
@@ -455,6 +455,23 @@ export function readBalance(dir) {
   return out;
 }
 
+/**
+ * True when `readEvidence` could not have read the whole log -- the file
+ * exceeds the byte cap, so anything written before the tail it kept is
+ * silently absent from what it returned. A caller that builds a per-claim
+ * record from `readEvidence` (the wiki graph's derivation record) needs this
+ * to say "operations existed but are not recorded here" rather than let an
+ * empty result read as "nothing happened".
+ */
+export function evidenceTruncated(dir) {
+  const path = evidencePath(dir);
+  try {
+    return statSync(path).size > MAX_BYTES;
+  } catch {
+    return false;
+  }
+}
+
 /** Every causal evidence record inside the byte cap, deduplicated by id. */
 export function readEvidence(dir) {
   const path = evidencePath(dir);

--- a/integrations/copilot/.github/hooks/lib/observability.mjs
+++ b/integrations/copilot/.github/hooks/lib/observability.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 /**
  * Privacy-safe, cross-client lifecycle diagnostics.
  *

--- a/integrations/copilot/.github/hooks/lib/pending.mjs
+++ b/integrations/copilot/.github/hooks/lib/pending.mjs
@@ -39,7 +39,7 @@ import {
   statSync,
 } from 'node:fs';
 import { join } from 'node:path';
-import { invalidateOnWrite } from './staleness.mjs';
+import { invalidateChangedAnchors, invalidateOnWrite } from './staleness.mjs';
 import { canonicalPath, isFsSafePath, resolvableCandidates } from './paths.mjs';
 
 const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
@@ -190,31 +190,85 @@ function hasEditEvidence(payload, raw) {
 }
 
 /**
- * The evidence a completed mutation left behind, or null when there is none.
+ * Canonical tool names that mean bytes on disk changed.
  *
- * Separate from `queueInvalidation` so the caller can be a hook branch that
- * knows nothing about diffs, and so the reconstruction above is testable
- * without a filesystem queue.
+ * THE NORMALISED SET, not any client's own vocabulary. `normalizePayload` has
+ * already mapped `replace`, `write_file`, `apply_patch`, `str_replace`,
+ * `search_replace` and the rest onto these three through decide.mjs's alias
+ * table -- and a tool that table cannot map arrives as null and exits the hook
+ * before this module is reached at all. So matching here is both complete for
+ * every client the adapter serves and impossible to spell wrong.
+ *
+ * `NotebookEdit` is absent because `normalizeTool` maps it to null, and the MCP
+ * `smart_edit`/`smart_write` tools are absent for the same reason. Both are gaps
+ * in that alias table rather than in this file, and widening it changes routing
+ * verdicts for every client -- so they are reported, not papered over here.
  */
-export function observedWrite(payload, raw) {
-  // CHEAP CHECK FIRST, because this runs after every tool call on every client.
-  // Reading the file is the expensive part, and there is no point paying for it
-  // on a Read, a Bash or a write whose before side cannot be reconstructed.
-  if (!hasEditEvidence(payload, raw)) return null;
+const MUTATING = new Set(['Edit', 'MultiEdit', 'Write']);
+
+/** Files an apply_patch-style program declares it is about to change. */
+function patchTargets(payload) {
+  const command = payload?.tool_input?.command;
+  if (typeof command !== 'string') return [];
+  const out = [];
+  for (const match of command.matchAll(
+    /^\*\*\* (?:Add|Update|Delete) File:\s*(.+)$/gm
+  )) {
+    const candidate = match[1].trim().replace(/^['"]|['"]$/g, '');
+    // Bounded: one patch naming a thousand files must not append a thousand
+    // queue records on a hook path.
+    if (candidate && out.length < 20) out.push(candidate);
+  }
+  return out;
+}
+
+/**
+ * Everything a completed mutation left behind that is worth queueing.
+ *
+ * TWO GRADES OF EVIDENCE, and the distinction is the point:
+ *
+ *   { path, before, after }  a reconstructable edit. The drain builds a real
+ *                            diff and marks only the symbols that moved.
+ *   { path }                 a whole-file write, or a patch program. No before
+ *                            side exists anywhere in the payload, so the drain
+ *                            compares stored hashes against disk instead.
+ *
+ * The second grade is what closes the biggest hole. A whole-file write is the
+ * commonest write shape there is, and before it was added those writes fell
+ * through to a lazy path that CANNOT see the session's own writes at all --
+ * `indexFile` refreshes the anchor before the lazy check ever looks at it. They
+ * were uncovered, not degraded.
+ *
+ * Returns an array, because one apply_patch program changes several files.
+ */
+export function observedWrites(payload, raw) {
+  if (!MUTATING.has(String(payload?.tool_name || ''))) return [];
 
   const path = writtenPath(payload, raw);
-  if (!path) return null;
+  if (path) {
+    // The expensive branch is guarded: reading the file only pays off when the
+    // payload can actually yield a before side.
+    if (hasEditEvidence(payload, raw)) {
+      const after = afterText(path);
+      if (after !== null && after.length <= MAX_SIDE_CHARS) {
+        const before = beforeText(payload, raw, after);
+        // Identical bytes: a formatter no-op, or a rewrite of the same content.
+        // Nothing changed, so nothing is stale.
+        if (before === after) return [];
+        if (before !== null && before.length <= MAX_SIDE_CHARS)
+          return [{ path, before, after }];
+      }
+    }
+    // Hash grade. Deliberately NOT `{ path, before: '', after }`: an empty
+    // before side makes every symbol in the file look changed, and the eager
+    // mark is a stored flag no later check ever clears.
+    return [{ path }];
+  }
 
-  const after = afterText(path);
-  if (after === null || after.length > MAX_SIDE_CHARS) return null;
-
-  const before = beforeText(payload, raw, after);
-  if (before === null || before.length > MAX_SIDE_CHARS) return null;
-  // Nothing changed: a formatter no-op, or a write of identical bytes. Queuing
-  // it would mark findings stale against an empty diff.
-  if (before === after) return null;
-
-  return { path, before, after };
+  // Codex and code-mode clients carry the whole patch as program text with no
+  // file_path field at all, which is why this recorded nothing for them. The
+  // hash grade needs only the path, so the patch headers are enough.
+  return patchTargets(payload).map((target) => ({ path: target }));
 }
 
 /**
@@ -226,9 +280,14 @@ export function observedWrite(payload, raw) {
 export function queueInvalidation(dir, { path, before, after, at } = {}) {
   try {
     if (typeof path !== 'string' || !path.trim()) return false;
-    if (typeof before !== 'string' || typeof after !== 'string') return false;
-    if (before.length > MAX_SIDE_CHARS || after.length > MAX_SIDE_CHARS)
-      return false;
+    // BOTH SIDES OR NEITHER. A record carrying only one of them cannot produce
+    // a diff and must not pretend to, so it is written as a path-only record
+    // and the drain resolves it by comparing hashes.
+    const diffable =
+      typeof before === 'string' &&
+      typeof after === 'string' &&
+      before.length <= MAX_SIDE_CHARS &&
+      after.length <= MAX_SIDE_CHARS;
 
     const file = queuePath(dir);
     try {
@@ -240,7 +299,11 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
     mkdirSync(dir, { recursive: true });
     appendFileSync(
       file,
-      `${JSON.stringify({ path: canonicalPath(path), before, after, at: at ?? Date.now() })}\n`,
+      `${JSON.stringify({
+        path: canonicalPath(path),
+        ...(diffable ? { before, after } : {}),
+        at: at ?? Date.now(),
+      })}\n`,
       'utf8'
     );
     return true;
@@ -284,16 +347,16 @@ export function drainInvalidations(dir, graph) {
   let marked = 0;
   for (const record of records) {
     if (!record || typeof record.path !== 'string' || !record.path) continue;
-    if (typeof record.before !== 'string' || typeof record.after !== 'string')
-      continue;
+    const diffable =
+      typeof record.before === 'string' && typeof record.after === 'string';
     try {
-      const result = invalidateOnWrite(
-        dir,
-        graph,
-        record.path,
-        record.before,
-        record.after
-      );
+      // TWO GRADES, ONE QUEUE. A record carrying both sides gets a real diff and
+      // symbol-precise marking; one carrying only a path gets the hash
+      // comparison -- the same comparison the lazy path makes, and one that is
+      // only meaningful HERE, before `indexFile` refreshes the anchor.
+      const result = diffable
+        ? invalidateOnWrite(dir, graph, record.path, record.before, record.after)
+        : invalidateChangedAnchors(dir, graph, record.path);
       marked += Array.isArray(result) ? result.length : 0;
     } catch {
       // One bad record must not stop the rest, and must not stop the tool call.

--- a/integrations/copilot/.github/hooks/lib/pending.mjs
+++ b/integrations/copilot/.github/hooks/lib/pending.mjs
@@ -1,0 +1,311 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/pending.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * The eager-invalidation queue: the missing half of staleness.mjs's header.
+ *
+ * That header describes TWO invalidation paths and says eager exists because
+ * lazy "would silently serve stale findings as fresh whenever a change came
+ * from outside the agent". `invalidateOnWrite` had been written, tested and
+ * documented -- and its only reference in shipped code was a COMMENT in the
+ * PreToolUse router. Staleness was lazy-only in production, and the router's
+ * own comment ("a write the hook observes is invalidated eagerly by
+ * `invalidateOnWrite`") described something that never happened.
+ *
+ * WHY THAT MATTERS MORE THAN IT SOUNDS. The lazy check compares the anchor's
+ * stored hash against disk -- and both the router and the adapter call
+ * `indexFile` on every file they observe, which re-points that hash at the new
+ * bytes. So for a write the session performed ITSELF, the lazy check is
+ * self-defeating: by the next retrieval the anchor already agrees with disk and
+ * the finding derived from the old content is served clean. Lazy catches the
+ * changes we never saw; only eager catches the ones we did.
+ *
+ * WHY A QUEUE AND NOT A DIRECT CALL. `invalidateOnWrite` needs the graph, and
+ * the graph is a megabyte of JSONL. Loading it on the return path of every
+ * write is the cost this shape exists to avoid. So the post-tool hook, which
+ * already holds the write's evidence, appends one record here and exits; the
+ * next graph read -- `forTouch`/`forCommand`, which load the graph anyway --
+ * drains it BEFORE serving anything.
+ *
+ * The guarantee is unchanged. What must never happen is SERVING a stale finding
+ * as fresh, and serve time is where that is enforced.
+ */
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { invalidateOnWrite } from './staleness.mjs';
+import { canonicalPath, isFsSafePath, resolvableCandidates } from './paths.mjs';
+
+const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
+
+/**
+ * Largest before/after side kept in a queue record.
+ *
+ * Matched to the graph's own snapshot limit for the same reason it has one: past
+ * this size the text is a bundle, a lockfile or a generated asset, and copying
+ * it into a queue file would mirror the repository into the graph directory one
+ * write at a time. Past the cap the write is simply not queued -- the lazy path
+ * still governs it, which is exactly the status quo for that file.
+ */
+const MAX_SIDE_CHARS = 262_144;
+
+/**
+ * Largest queue file appended to.
+ *
+ * A queue only grows while nothing drains it, which means the retrieval feature
+ * is off or every read has failed. Neither is a reason to keep writing: bounded
+ * here so a long unattended session cannot turn one directory into a log of
+ * every file it touched.
+ */
+const MAX_QUEUE_BYTES = 8 * 1024 * 1024;
+
+/** The tool payload fields that name the file a mutation landed on. */
+function writtenPath(payload, raw) {
+  const input = payload?.tool_input || {};
+  const response = raw?.tool_response || raw?.toolResponse || {};
+  for (const candidate of [
+    input.file_path,
+    input.path,
+    input.notebook_path,
+    response.filePath,
+    response.file_path,
+  ]) {
+    if (typeof candidate === 'string' && candidate.trim()) return candidate;
+  }
+  return null;
+}
+
+/** First string among several possible spellings of the same field. */
+function firstString(...values) {
+  for (const value of values) if (typeof value === 'string') return value;
+  return null;
+}
+
+/**
+ * The text before the write, reconstructed from a completed edit.
+ *
+ * PREFERENCE ORDER IS ABOUT EXACTNESS, not convenience. Claude Code's Edit
+ * response carries the whole pre-edit file (`originalFile`), which needs no
+ * reasoning at all. Failing that, an edit is a known substitution, so reverting
+ * `new_string` back to `old_string` in the post-write text reproduces the
+ * before side exactly -- but only when the substitution is unambiguous, which
+ * is why a `new_string` that now appears more than once is refused rather than
+ * guessed at.
+ *
+ * NULL MEANS "DO NOT QUEUE", and that is deliberate. An unknown before side
+ * could be passed as '' -- and `invalidateOnWrite` would then see every symbol
+ * in the file as changed and mark every finding anchored anywhere in it, which
+ * is the exact over-marking its own comments call worse than the file-level
+ * staleness symbols were introduced to avoid. A missed eager invalidation costs
+ * what today already costs; a wrong one permanently discounts correct findings.
+ */
+function beforeText(payload, raw, after) {
+  const input = payload?.tool_input || {};
+  const response = raw?.tool_response || raw?.toolResponse || {};
+
+  const original = firstString(
+    response.originalFile,
+    response.original_file,
+    response.originalContent,
+    response.original_content
+  );
+  if (original !== null) return original;
+
+  // MultiEdit applies its edits in order, so reverting walks them backwards.
+  const edits = Array.isArray(input.edits) ? input.edits : null;
+  if (edits) {
+    let text = after;
+    for (const edit of [...edits].reverse()) {
+      const reverted = revert(text, edit);
+      if (reverted === null) return null;
+      text = reverted;
+    }
+    return text;
+  }
+
+  return revert(after, input);
+}
+
+/** Undoes one old->new substitution, or null when it cannot be done exactly. */
+function revert(text, edit) {
+  const oldString = firstString(edit?.old_string, edit?.oldString);
+  const newString = firstString(edit?.new_string, edit?.newString);
+  if (oldString === null || newString === null || newString === '') return null;
+
+  const all = edit?.replace_all === true || edit?.replaceAll === true;
+  if (all) return text.split(newString).join(oldString);
+
+  const at = text.indexOf(newString);
+  if (at < 0) return null;
+  // Ambiguous: more than one candidate for the occurrence that was written, and
+  // reverting the wrong one fabricates a before side that never existed.
+  if (text.indexOf(newString, at + newString.length) >= 0) return null;
+  return text.slice(0, at) + oldString + text.slice(at + newString.length);
+}
+
+/** The post-write text, read from disk because that is what the write produced. */
+function afterText(path) {
+  if (!isFsSafePath(path)) return null;
+  for (const candidate of resolvableCandidates(path)) {
+    try {
+      if (statSync(candidate).size > MAX_SIDE_CHARS) return null;
+      return readFileSync(candidate, 'utf8');
+    } catch {
+      // Wrong spelling, or gone again already. Try the next one.
+    }
+  }
+  return null;
+}
+
+/**
+ * Does this payload carry enough to reconstruct a before side at all?
+ *
+ * Named tool lists were the alternative and were rejected: every client calls
+ * its editor something different (`Edit`, `replace`, `write_to_file`,
+ * `apply_patch`), and a list would silently exclude the ones nobody thought of
+ * while still charging a file read for every Read that matched by accident.
+ * Asking about the EVIDENCE instead covers any client that carries an edit in
+ * one of these shapes and costs nothing on the calls that do not.
+ */
+function hasEditEvidence(payload, raw) {
+  const input = payload?.tool_input || {};
+  const response = raw?.tool_response || raw?.toolResponse || {};
+  if (
+    firstString(
+      response.originalFile,
+      response.original_file,
+      response.originalContent,
+      response.original_content
+    ) !== null
+  )
+    return true;
+  if (Array.isArray(input.edits) && input.edits.length > 0) return true;
+  return firstString(input.old_string, input.oldString) !== null;
+}
+
+/**
+ * The evidence a completed mutation left behind, or null when there is none.
+ *
+ * Separate from `queueInvalidation` so the caller can be a hook branch that
+ * knows nothing about diffs, and so the reconstruction above is testable
+ * without a filesystem queue.
+ */
+export function observedWrite(payload, raw) {
+  // CHEAP CHECK FIRST, because this runs after every tool call on every client.
+  // Reading the file is the expensive part, and there is no point paying for it
+  // on a Read, a Bash or a write whose before side cannot be reconstructed.
+  if (!hasEditEvidence(payload, raw)) return null;
+
+  const path = writtenPath(payload, raw);
+  if (!path) return null;
+
+  const after = afterText(path);
+  if (after === null || after.length > MAX_SIDE_CHARS) return null;
+
+  const before = beforeText(payload, raw, after);
+  if (before === null || before.length > MAX_SIDE_CHARS) return null;
+  // Nothing changed: a formatter no-op, or a write of identical bytes. Queuing
+  // it would mark findings stale against an empty diff.
+  if (before === after) return null;
+
+  return { path, before, after };
+}
+
+/**
+ * Appends one pending write.
+ *
+ * NEVER THROWS. This runs on a hook's return path, and a queue that cannot be
+ * written degrades to the lazy path rather than costing the user a tool call.
+ */
+export function queueInvalidation(dir, { path, before, after, at } = {}) {
+  try {
+    if (typeof path !== 'string' || !path.trim()) return false;
+    if (typeof before !== 'string' || typeof after !== 'string') return false;
+    if (before.length > MAX_SIDE_CHARS || after.length > MAX_SIDE_CHARS)
+      return false;
+
+    const file = queuePath(dir);
+    try {
+      if (statSync(file).size > MAX_QUEUE_BYTES) return false;
+    } catch {
+      // No queue yet, which is the normal case.
+    }
+
+    mkdirSync(dir, { recursive: true });
+    appendFileSync(
+      file,
+      `${JSON.stringify({ path: canonicalPath(path), before, after, at: at ?? Date.now() })}\n`,
+      'utf8'
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Applies every queued invalidation and clears the queue.
+ *
+ * Returns the number of findings marked, so the caller knows whether its
+ * in-memory graph is now behind the file on disk and needs re-reading.
+ *
+ * CLEARED AFTER APPLYING AND UNCONDITIONALLY: a record that cannot be applied
+ * must not be retried on every tool call for the rest of the session, and the
+ * cost of dropping one is a single missed eager mark that the lazy path still
+ * has a chance at.
+ */
+export function drainInvalidations(dir, graph) {
+  let records;
+  try {
+    const file = queuePath(dir);
+    if (!existsSync(file)) return 0;
+    records = readFileSync(file, 'utf8')
+      .split('\n')
+      .filter((line) => line.trim())
+      .map((line) => {
+        try {
+          return JSON.parse(line);
+        } catch {
+          // A torn append costs one record, not the queue.
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch {
+    return 0;
+  }
+
+  let marked = 0;
+  for (const record of records) {
+    if (!record || typeof record.path !== 'string' || !record.path) continue;
+    if (typeof record.before !== 'string' || typeof record.after !== 'string')
+      continue;
+    try {
+      const result = invalidateOnWrite(
+        dir,
+        graph,
+        record.path,
+        record.before,
+        record.after
+      );
+      marked += Array.isArray(result) ? result.length : 0;
+    } catch {
+      // One bad record must not stop the rest, and must not stop the tool call.
+    }
+  }
+
+  try {
+    rmSync(queuePath(dir), { force: true });
+  } catch {
+    // Held open by a concurrent hook. The next drain re-applies these records,
+    // which is safe: marking an already-marked finding is idempotent.
+  }
+
+  return marked;
+}

--- a/integrations/copilot/.github/hooks/lib/pending.mjs
+++ b/integrations/copilot/.github/hooks/lib/pending.mjs
@@ -199,10 +199,11 @@ function hasEditEvidence(payload, raw) {
  * before this module is reached at all. So matching here is both complete for
  * every client the adapter serves and impossible to spell wrong.
  *
- * `NotebookEdit` is absent because `normalizeTool` maps it to null, and the MCP
- * `smart_edit`/`smart_write` tools are absent for the same reason. Both are gaps
- * in that alias table rather than in this file, and widening it changes routing
- * verdicts for every client -- so they are reported, not papered over here.
+ * `NotebookEdit` and the MCP `smart_edit`/`smart_write` tools were absent for as
+ * long as `normalizeTool` mapped them to null. That was a gap in the alias table
+ * rather than in this file, and it has since been closed there: all three now
+ * arrive as `Edit` or `Write` and are matched by the set below without it having
+ * to learn a fourth name.
  */
 const MUTATING = new Set(['Edit', 'MultiEdit', 'Write']);
 

--- a/integrations/copilot/.github/hooks/lib/pending.mjs
+++ b/integrations/copilot/.github/hooks/lib/pending.mjs
@@ -35,6 +35,7 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  renameSync,
   rmSync,
   statSync,
 } from 'node:fs';
@@ -43,6 +44,15 @@ import { invalidateChangedAnchors, invalidateOnWrite } from './staleness.mjs';
 import { canonicalPath, isFsSafePath, resolvableCandidates } from './paths.mjs';
 
 const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
+/**
+ * Where a drain moves the queue before reading it.
+ *
+ * PER PROCESS, not one shared name: two hooks draining the same graph directory
+ * at once would otherwise race for the same claim file, and the loser would
+ * either clobber the winner's records or delete them mid-read. A pid makes the
+ * claim private to the drainer that won the rename.
+ */
+const claimPath = (dir) => join(dir, `pending-invalidation.claim.${process.pid}.jsonl`);
 
 /**
  * Largest before/after side kept in a queue record.
@@ -319,17 +329,47 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
  * Returns the number of findings marked, so the caller knows whether its
  * in-memory graph is now behind the file on disk and needs re-reading.
  *
- * CLEARED AFTER APPLYING AND UNCONDITIONALLY: a record that cannot be applied
- * must not be retried on every tool call for the rest of the session, and the
- * cost of dropping one is a single missed eager mark that the lazy path still
- * has a chance at.
+ * CLAIMED BY RENAME, THEN READ, THEN DELETED -- and the order is the whole
+ * point. This used to read the queue and then `rmSync` the same path, so a
+ * post-tool hook appending between the read and the unlink had its record
+ * deleted having never been read. Parallel tool calls in one assistant turn are
+ * the ordinary way that happens, not an exotic race. `renameSync` makes the
+ * claim atomic: whatever the drainer took is exactly what it deletes, and a
+ * record appended a microsecond later lands on a fresh queue that the next drain
+ * will find.
+ *
+ * A LOST RECORD IS A PERMANENTLY MISSED INVALIDATION, which is why this is worth
+ * a rename. The comment here used to price it as "a single missed eager mark that
+ * the lazy path still has a chance at", and that premise is false: this module's
+ * own header states it. The lazy path compares the anchor's stored hash against
+ * disk, and `indexFile` re-points that hash at the bytes the session just wrote,
+ * so for the session's OWN writes lazy is structurally blind rather than merely
+ * late. Nothing else was ever going to catch a dropped record.
+ *
+ * A RECORD THAT CANNOT BE APPLIED IS STILL DROPPED, deliberately and
+ * unconditionally: retrying a permanently unapplicable record on every tool call
+ * for the rest of the session costs more than it can ever recover, and the claim
+ * file is deleted whether the loop marked anything or threw.
+ *
+ * FAIL-OPEN THROUGHOUT. A rename that loses a race, or fails for any other
+ * reason, returns 0 and leaves the queue for the next drain; it never throws
+ * into a hook.
  */
 export function drainInvalidations(dir, graph) {
   let records;
+  let claim;
   try {
     const file = queuePath(dir);
     if (!existsSync(file)) return 0;
-    records = readFileSync(file, 'utf8')
+    claim = claimPath(dir);
+    // A LEFTOVER CLAIM FROM A KILLED DRAIN IS OVERWRITTEN, not merged: rename
+    // onto an existing path replaces it. The pid in the name means the only way
+    // to hit that is this same pid having died mid-drain, whose records were
+    // already being applied when it went -- and re-applying is idempotent, so
+    // losing them is the cheaper of the two errors. Not doing the rename at all
+    // would strand the live queue forever.
+    renameSync(file, claim);
+    records = readFileSync(claim, 'utf8')
       .split('\n')
       .filter((line) => line.trim())
       .map((line) => {
@@ -342,6 +382,18 @@ export function drainInvalidations(dir, graph) {
       })
       .filter(Boolean);
   } catch {
+    // The rename lost a race, or the claim could not be read. Nothing is deleted
+    // unread and the hook proceeds. If the claim was taken and then could not be
+    // read, it is put back under the queue name so the next drain still sees it:
+    // a claim file nobody looks at again is the same lost record this rename
+    // exists to prevent.
+    try {
+      if (claim && existsSync(claim) && !existsSync(queuePath(dir))) {
+        renameSync(claim, queuePath(dir));
+      }
+    } catch {
+      // Best effort only. A hook must not fail because bookkeeping did.
+    }
     return 0;
   }
 
@@ -365,10 +417,13 @@ export function drainInvalidations(dir, graph) {
   }
 
   try {
-    rmSync(queuePath(dir), { force: true });
+    // THE CLAIM, NOT THE QUEUE. Deleting `queuePath` here is what dropped a
+    // concurrently appended record; this path holds exactly the bytes that were
+    // just read, so nothing unread can be inside it.
+    rmSync(claim, { force: true });
   } catch {
-    // Held open by a concurrent hook. The next drain re-applies these records,
-    // which is safe: marking an already-marked finding is idempotent.
+    // Held open by something else. The claim is not read again -- the next drain
+    // looks at the queue -- so this costs a stray file, never a record.
   }
 
   return marked;

--- a/integrations/copilot/.github/hooks/lib/restore.mjs
+++ b/integrations/copilot/.github/hooks/lib/restore.mjs
@@ -142,7 +142,7 @@ export function restorationPlan(dir, graph, context = {}) {
     for (const id of predicted) {
       const node = graph.nodes.get(id);
       if (!node) continue;
-      const findings = serve(graph, findingsFor(graph, id, { limit: 2 }));
+      const findings = serve(graph, findingsFor(graph, id, { limit: 2 }), { dir });
       for (const finding of findings) {
         // `! STALE` only where a diff actually exists to back it; see the
         // renderer in inject.mjs for the measurement behind this.

--- a/integrations/copilot/.github/hooks/lib/restore.mjs
+++ b/integrations/copilot/.github/hooks/lib/restore.mjs
@@ -158,7 +158,16 @@ export function restorationPlan(dir, graph, context = {}) {
             ? '! STALE '
             : '~ '
           : '';
-        lines.push(`${node.key}: ${mark}${finding.claim}`);
+        // A DISPUTE DISCLOSED ELSEWHERE AND SILENT HERE reads as "the dispute
+        // went away". `serve` already attached the fields; the only question is
+        // the wording, and this list is the most compressed surface in the
+        // system, so it gets the marker and the key and nothing else.
+        const disputed = finding.contradicted
+          ? finding.contradictedBy
+            ? ` (disputed by ${finding.contradictedBy})`
+            : ' (disputed)'
+          : '';
+        lines.push(`${node.key}: ${mark}${finding.claim}${disputed}`);
       }
     }
     section('Likely next', lines, total * split.forward);

--- a/integrations/copilot/.github/hooks/lib/skeleton.mjs
+++ b/integrations/copilot/.github/hooks/lib/skeleton.mjs
@@ -126,6 +126,11 @@ export function annotatedSkeleton(graph, rawPath, source, { budget = 1200, git =
 
   // Findings anchored to this file or the symbols inside it, served through the
   // one function that enforces the stale-plus-diff rule.
+  // READ-ONLY serve: no `dir` is threaded here, so this cannot clear a stale
+  // flag whose evidence is gone. That is deliberate -- this function takes a
+  // graph, not the directory it came from, and widening its signature to give
+  // an analysis path a write capability buys nothing: the injection path runs
+  // on every tool call and clears the same findings.
   const served = serve(graph, findingsFor(graph, nodeId('file', path), { limit: 40 }));
 
   // Index findings by the symbol they anchor to, so each one sits beside the

--- a/integrations/copilot/.github/hooks/lib/staleness.mjs
+++ b/integrations/copilot/.github/hooks/lib/staleness.mjs
@@ -31,6 +31,23 @@
  * Eager alone would silently serve stale findings as fresh whenever a change
  * came from outside the agent, which is the single failure mode the design
  * calls worse than no graph.
+ *
+ * AND LAZY ALONE IS BLIND TO THE AGENT'S OWN WRITES -- not degraded, BLIND.
+ * `indexFile` re-points an anchor's stored hash at the bytes it was just handed,
+ * and it is called on every file either hook observes: pretooluse-router.mjs
+ * (two call sites) and adapter.mjs (one). The lazy check then compares that
+ * refreshed hash against the same disk it came from and finds them equal. So
+ * for a file the session edited ITSELF, the lazy path cannot detect the change
+ * at all, and the finding derived from the pre-edit content is served CLEAN.
+ *
+ * Which means that until the eager path was connected, staleness for a file the
+ * agent edited did not work AT ALL: eager was dead code and lazy was defeated
+ * by re-indexing. Every account of this defect, including the one in this
+ * module's own git history, called it "lazy-only, therefore degraded". It was
+ * not degraded. `stale-before-reindex.test.mjs` states in its header that this
+ * case is covered by `invalidateOnWrite`, and `invalidateOnWrite` had never run
+ * once in production. The two paths are not redundant and never were: each is
+ * the ONLY cover for a whole class of change.
  */
 
 import { readFileSync, statSync } from 'node:fs';
@@ -622,6 +639,119 @@ export function invalidateOnWrite(dir, graph, rawPath, beforeText, afterText) {
   // Re-index so the anchors carry the new hashes; otherwise the lazy path would
   // report the same change again on every future retrieval.
   indexFile(dir, path, afterText);
+  return marked;
+}
+
+/**
+ * The eager path for a write with NO before/after pair: compare stored hashes
+ * against disk, and mark what actually moved.
+ *
+ * WHY THIS EXISTS AS A SECOND SHAPE. A whole-file `Write` replaces the file, so
+ * the payload carries the after side and nothing at all of the before -- and a
+ * whole-file write is the commonest write shape there is. `invalidateOnWrite`
+ * cannot serve it: passing '' as the before side makes every symbol in the file
+ * look changed, marks every finding anchored anywhere in it, and the eager mark
+ * is a stored flag no later check ever clears. False-stale is expensive and
+ * permanent, so it is not an acceptable price for coverage.
+ *
+ * But the hash comparison is available, and it is exactly the comparison the
+ * lazy path makes. The difference is WHEN: this runs at the top of injection,
+ * before `indexFile` refreshes the anchor, so the stored hash is still the
+ * pre-write one and the comparison is meaningful. That is the whole trick --
+ * lazy is not wrong, it is merely too late.
+ *
+ * SYMBOL-LEVEL, and from ONE read. Re-locating each symbol by name and
+ * comparing its own span hash is what keeps this from degenerating into
+ * file-level marking: editing one function must not stale a finding about
+ * another, which is the property symbol nodes exist to provide.
+ *
+ * WEAKER EVIDENCE, STATED AS SUCH. There is no before text, so no diff can be
+ * built -- the finding is marked with the two hashes and `serve` reports the
+ * evidence gap through `staleEvidence: false`, which the renderer turns into
+ * "no diff could be rebuilt" rather than promising a diff and showing nothing.
+ * A stale finding with weak evidence is far better than one served as fresh,
+ * but the reader has to be able to tell which one they are holding.
+ */
+export function invalidateChangedAnchors(dir, graph, rawPath) {
+  const path = canonicalPath(rawPath);
+  const marked = [];
+
+  // ONE read for the file and every symbol in it. checkAnchor would have been
+  // the obvious reuse and it reads per anchor, which on a file with fifty
+  // symbols is fifty-one reads of the same bytes on a hook path.
+  let source = null;
+  try {
+    source = readAnySpelling(path);
+  } catch {
+    // Deleted, or unreadable from this checkout. Handled below as a change,
+    // because a finding about a file that is no longer there is exactly the
+    // kind that must not be served as fresh.
+  }
+
+  const changed = [];
+  const fileNode = graph.nodes.get(nodeId('file', path));
+  const fileDigest = source === null ? null : hash(source);
+  if (fileNode && fileDigest !== fileNode.hash) {
+    changed.push({ node: fileNode, from: fileNode.hash, to: fileDigest });
+  }
+
+  const current = new Map(
+    source === null
+      ? []
+      : extractSymbols(path, source).map((s) => [s.name, hash(spanText(source, s))])
+  );
+  for (const node of graph.nodes.values()) {
+    if (node.kind !== 'symbol' || node.file !== path) continue;
+    const digest = current.has(node.name) ? current.get(node.name) : null;
+    if (digest !== node.hash) changed.push({ node, from: node.hash, to: digest });
+  }
+
+  if (changed.length) {
+    // Indexed once by target, for the reason invalidateOnWrite indexes: the
+    // nested alternative is O(nodes x edges) inside a hook.
+    const byTarget = new Map();
+    for (const edge of graph.edges) {
+      if (edge.edge !== 'derived_from') continue;
+      if (!byTarget.has(edge.to)) byTarget.set(edge.to, []);
+      byTarget.get(edge.to).push(edge);
+    }
+
+    for (const { node, from, to } of changed) {
+      for (const edge of byTarget.get(node.id) || []) {
+        const finding = graph.nodes.get(edge.from);
+        if (!finding || finding.kind !== 'finding') continue;
+        // The same type gate serve() applies, for the same reason it is applied
+        // in invalidateOnWrite: the flag is STORED, and disclose.mjs skips a
+        // stale finding while utility.mjs penalises one by 160.
+        if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) continue;
+        // ALREADY MARKED IS LEFT ALONE. Whatever marked it first had a diff or
+        // a more specific reason; overwriting that with a hash pair trades real
+        // evidence for less.
+        if (finding.stale) continue;
+
+        putNode(dir, {
+          ...finding,
+          kind: 'finding',
+          key: finding.key,
+          stale: true,
+          staleReason:
+            to === null
+              ? `the ${node.kind} it depends on is no longer present (was ${from})`
+              : `content hash changed during this session (${from} -> ${to}), observed without a before/after pair`,
+          // EXPLICITLY EMPTY, not absent. serve() reports `staleEvidence` from
+          // whether a diff survived, and the renderer says "no diff could be
+          // rebuilt" -- so the reader can tell "changed, diff unknown" from
+          // "changed, here is what changed".
+          diff: '',
+        });
+        marked.push(finding.key);
+      }
+    }
+  }
+
+  // Re-index for the same reason the diff path does: otherwise every future
+  // retrieval re-reports a change that has already been accounted for.
+  if (source !== null) indexFile(dir, path, source);
   return marked;
 }
 

--- a/integrations/copilot/.github/hooks/lib/staleness.mjs
+++ b/integrations/copilot/.github/hooks/lib/staleness.mjs
@@ -574,8 +574,20 @@ function derivationCheck(graph, finding) {
  * This is the only function that should ever hand a finding to a model, because
  * it is the one that enforces the rule: a stale finding leaves here carrying
  * `stale: true` AND a diff, or it does not leave at all.
+ *
+ * AND IT CLEARS A STORED FLAG WHOSE EVIDENCE IS GONE, when given a `dir` to
+ * write to. Clearing used to be reachable only by a person pressing Re-verify in
+ * the dashboard, which left the rot path fully open on every install where
+ * nobody opens the dashboard -- and that is most of them. The evidence test is
+ * what makes clearing safe, and it does not care who triggered it: the same
+ * `claimTimeVerdict` runs here as in `reverify`, so this cannot clear anything
+ * the button would not.
+ *
+ * `dir` IS OPTIONAL, AND OMITTING IT MAKES THIS READ-ONLY. Several callers hold
+ * a graph without the directory it came from, and a serve that silently did
+ * nothing would be worse than one that plainly cannot write.
  */
-export function serve(graph, findings) {
+export function serve(graph, findings, { dir = null } = {}) {
   const served = [];
 
   // RETIRED FINDINGS STOP HERE, unconditionally.
@@ -603,8 +615,42 @@ export function serve(graph, findings) {
       continue;
     }
 
+    // AUTOMATIC CLEARING, on the same evidence the manual path demands.
+    //
+    // ONLY THE STORED FLAG IS TOUCHED. The lazy loop below is left to run
+    // exactly as before and can independently mark this finding stale again on
+    // its own comparison -- disk against the anchor NODE's hash -- which answers
+    // a different question and is not this function's to overrule. Eager and
+    // lazy stay two mechanisms, as the module header insists.
+    //
+    // AND THE FIELDS GO WITH THE FLAG. `putNode` does not merge and neither does
+    // this spread: serving `{ ...finding, stale: false }` would hand back a
+    // finding that reads fresh while still carrying `staleReason` and `diff`
+    // from the record -- stale and fresh at once, which is worse than either.
+    // So the cleared record, not the stored one, is what the rest of this
+    // iteration reads and spreads.
+    //
+    // BOUNDED, and the bound is the point: this runs only for a finding whose
+    // flag is already STORED, only when a `derivation` record exists to check
+    // against, and it reads each of that finding's anchors at most once. A
+    // finding that is not flagged pays nothing. The lazy loop below already
+    // reads every anchor of every content-dependent finding served, so the worst
+    // case is twice the anchor reads on the already-stale subset alone.
+    //
+    // NOT ON THE NON-CONTENT-DEPENDENT EARLY RETURN ABOVE, deliberately. Both
+    // eager paths refuse to flag those types at all, so a flag there can only
+    // come from an older graph -- and reading anchors for a type whose truth
+    // does not depend on them is exactly the cost `CONTENT_DEPENDENT` exists to
+    // avoid.
+    let record = finding;
+    if (dir && finding.stale && claimTimeVerdict(graph, finding) === 'match') {
+      clearStale(dir, finding.key, { graph });
+      const { stale: _s, staleReason: _r, diff: _d, staleEvidence: _e, ...cleared } = finding;
+      record = cleared;
+    }
+
     const anchors = graph.edges
-      .filter((e) => e.edge === 'derived_from' && e.from === finding.id)
+      .filter((e) => e.edge === 'derived_from' && e.from === record.id)
       .map((e) => graph.nodes.get(e.to))
       .filter(Boolean);
 
@@ -629,10 +675,10 @@ export function serve(graph, findings) {
     // A finding already marked stale eagerly, whose diff was captured at write
     // time, keeps that diff -- the eager path saw the change we can no longer
     // reconstruct from disk alone.
-    if (!stale && finding.stale) {
+    if (!stale && record.stale) {
       stale = true;
-      diff = finding.diff || '';
-      reason = finding.staleReason || 'marked stale when the change was observed';
+      diff = record.diff || '';
+      reason = record.staleReason || 'marked stale when the change was observed';
     }
 
     if (stale && !diff) {
@@ -681,13 +727,19 @@ export function serve(graph, findings) {
     }
 
     served.push({
-      ...finding,
+      ...record,
       stale,
       ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
+      // BOTH OTHER DISCLOSURES SURVIVE A MID-SERVE CLEAR. `dispute` was computed
+      // above the content-dependence branch and is applied here untouched, and
+      // the derivation verdict is recomputed from the record -- which still
+      // carries its `derivation`, since clearing removes only the staleness
+      // fields. A finding whose flag was just cleared is still disclosed as
+      // disputed, and still reports whether its derivation holds.
       ...dispute,
       // Independent of `stale` above: see `derivationCheck`'s own comment for
       // the case it catches that node-level staleness can miss.
-      ...derivationCheck(graph, finding),
+      ...derivationCheck(graph, record),
     });
   }
   return served;
@@ -939,8 +991,21 @@ function anchorHashNow(anchor) {
  * Exposing it to a hook, a tool argument or an HTTP action would be a way to
  * turn a stale finding fresh on request, which is exactly what must not exist.
  */
-export function clearStale(dir, key) {
-  const node = load(dir).nodes.get(nodeId('finding', key));
+export function clearStale(dir, key, { graph = null } = {}) {
+  // A CALLER THAT ALREADY HOLDS THE GRAPH PASSES IT, and this is not
+  // micro-optimisation: `load` re-parses the entire append-only log, so clearing
+  // inside `serve`'s loop re-read and re-folded the whole graph once PER cleared
+  // finding. Measured on 40 findings all stale and all revertible -- the shape a
+  // mass revert produces -- that was 185 ms against 25 ms, a 7x regression on
+  // the injection path, all of it graph loading rather than the hashing this
+  // feature is actually for. With the graph passed through it is back in line.
+  //
+  // No new race: this store is last-write-wins with no compare-and-set anywhere,
+  // and every other caller that spreads a node back -- `pin`, `retire`,
+  // `contradict`, `correct` -- writes from a graph it loaded earlier too. Both
+  // callers here already DECIDED on this snapshot, so re-reading it purely for
+  // the write narrowed no window that was ever closed.
+  const node = (graph || load(dir)).nodes.get(nodeId('finding', key));
   if (!node || node.kind !== 'finding') return false;
   const { stale, staleReason, diff, staleEvidence, ...rest } = node;
   // Nothing to clear is a success, not a write: an unconditional putNode here
@@ -989,14 +1054,33 @@ export function clearStale(dir, key) {
  * silently un-mark findings nobody asked about. Staleness is disclosed to a
  * reader who then decides; clearing is an explicit act.
  */
-export function reverify(dir, key) {
-  const graph = load(dir);
-  const finding = graph.nodes.get(nodeId('finding', key));
-  if (!finding || finding.kind !== 'finding') return 'unknown';
-  // Idempotent: the postcondition -- no stale flag on this finding -- already
-  // holds, and reporting anything else would make a caller retry forever.
-  if (!finding.stale) return 'cleared';
-
+/**
+ * THE ONE EVIDENCE TEST. Does this finding's anchored content still hash to what
+ * the claim was actually made against?
+ *
+ * `'match'` -- every anchor on disk re-hashes to the value frozen into this
+ * finding's own `derivation.anchors` at claim time. The content IS what the
+ * claim was derived from: a revert, or a write that never moved the anchored
+ * bytes.
+ * `'differs'` -- at least one anchor does not, INCLUDING an anchor whose content
+ * is gone. Deleted is a difference, not a missing measurement.
+ * `'unknown'` -- there is nothing to compare: no `derivation.anchors`, no
+ * anchors, an anchor with no recorded hash, or one that no longer resolves.
+ *
+ * SHARED BY BOTH CLEARING PATHS ON PURPOSE, and that sharing is the guarantee
+ * rather than a convenience. `reverify` (a person pressing Re-verify) and
+ * `serve` (automatic, on every retrieval) call THIS function and nothing else,
+ * so the automatic path cannot clear anything the button would not, and neither
+ * can drift from the other. Two copies of this comparison would be two policies,
+ * and the weaker one would win wherever it ran more often -- which is the
+ * automatic one.
+ *
+ * NOT `checkAnchor`, for the reason `anchorHashNow` above spells out: that
+ * compares disk against the anchor NODE's stored hash, which both eager paths
+ * re-point at the very bytes that caused the mark, so it answers "fresh" for
+ * exactly the finding it just marked stale.
+ */
+function claimTimeVerdict(graph, finding) {
   const recorded = finding.derivation && finding.derivation.anchors;
   if (!recorded || typeof recorded !== 'object') return 'unknown';
 
@@ -1019,10 +1103,23 @@ export function reverify(dir, key) {
     if (node.kind !== 'file' && node.kind !== 'symbol') return 'unknown';
     // null means the content is gone -- deleted file, vanished symbol. That is a
     // difference, not an absence of evidence.
-    if (anchorHashNow(node) !== expected) return 'still-stale';
+    if (anchorHashNow(node) !== expected) return 'differs';
   }
+  return 'match';
+}
 
-  clearStale(dir, key);
+export function reverify(dir, key) {
+  const graph = load(dir);
+  const finding = graph.nodes.get(nodeId('finding', key));
+  if (!finding || finding.kind !== 'finding') return 'unknown';
+  // Idempotent: the postcondition -- no stale flag on this finding -- already
+  // holds, and reporting anything else would make a caller retry forever.
+  if (!finding.stale) return 'cleared';
+
+  const verdict = claimTimeVerdict(graph, finding);
+  if (verdict === 'unknown') return 'unknown';
+  if (verdict === 'differs') return 'still-stale';
+  clearStale(dir, key, { graph });
   return 'cleared';
 }
 

--- a/integrations/copilot/.github/hooks/lib/staleness.mjs
+++ b/integrations/copilot/.github/hooks/lib/staleness.mjs
@@ -53,7 +53,7 @@
 import { readFileSync, statSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { dirname, join } from 'node:path';
-import { putNode, putEdge, contentHash, nodeId } from './wiki.mjs';
+import { putNode, putEdge, contentHash, nodeId, load } from './wiki.mjs';
 import { hasOutstandingContradiction } from './curate.mjs';
 import { extractSymbols, spanText, symbolKey, extractImports } from './symbols.mjs';
 import { canonicalPath, resolvableCandidates, isFsSafePath } from './paths.mjs';
@@ -488,7 +488,16 @@ function disputeOf(graph, finding) {
     // An edge end that resolves to nothing names nothing. The dispute is still
     // disclosed -- the gate above already established it -- but without a key
     // the reader cannot be pointed anywhere, and inventing one would be worse.
-    if (other && typeof other.key === 'string' && !keys.includes(other.key)) keys.push(other.key);
+    //
+    // A RETIRED END IS NOT NAMED EITHER, for a sharper reason: the disclosure
+    // tells the reader to `wiki_query` that key, and `serve` refuses to return
+    // a retired finding at all. Naming it points them at a claim they cannot
+    // fetch. `hasOutstandingContradiction` above already declines to open the
+    // gate when EVERY disputant is retired; this is the same rule applied to
+    // each name, so a live disputant is still reported alongside a withdrawn one.
+    if (other && !other.retired && typeof other.key === 'string' && !keys.includes(other.key)) {
+      keys.push(other.key);
+    }
   }
 
   return { contradicted: true, ...(keys.length ? { contradictedBy: keys.join(', ') } : {}) };
@@ -870,6 +879,151 @@ export function invalidateChangedAnchors(dir, graph, rawPath) {
   // retrieval re-reports a change that has already been accounted for.
   if (source !== null) indexFile(dir, path, source);
   return marked;
+}
+
+/**
+ * The current content hash of an anchor, read from disk.
+ *
+ * DELIBERATELY NOT `checkAnchor`, and the difference is the whole of this
+ * clearing rule. `checkAnchor` compares disk against the anchor NODE's stored
+ * hash, and both eager paths call `indexFile` immediately after marking --
+ * which re-points that hash at the very bytes that caused the mark. So
+ * `checkAnchor` answers "fresh" for exactly the finding it just marked stale,
+ * and a clearing rule built on it would clear every flag it was handed,
+ * unconditionally. This returns a bare hash instead, so the caller can compare
+ * it against the FROZEN claim-time hash rather than against a value the marking
+ * path itself moved.
+ *
+ * Returns null when no content can be read at all -- a deleted file, or a
+ * symbol that no longer exists. A caller must treat that as "changed", never as
+ * "unknown": a claim about content that is gone certainly does not match the
+ * content it was made against.
+ */
+function anchorHashNow(anchor) {
+  const path = anchor.kind === 'symbol' ? anchor.file : anchor.key;
+  let source;
+  try {
+    source = readAnySpelling(path);
+  } catch {
+    return null;
+  }
+  if (anchor.kind !== 'symbol') return hash(source);
+
+  // By NAME, like checkAnchor: line numbers shift whenever anything above is
+  // edited, and re-locating by line would report a symbol as moved when only an
+  // unrelated insert happened above it.
+  const current = extractSymbols(path, source).find((s) => s.name === anchor.name);
+  if (!current) return null;
+  return hash(spanText(source, current));
+}
+
+/**
+ * Removes the staleness fields from a finding. Returns whether one was found.
+ *
+ * THE WHOLE NODE IS REWRITTEN, because `putNode` does not merge: it writes a
+ * full record from what it is handed and `load` replaces the node wholesale.
+ * Writing `{ kind, key, stale: false }` would blank the claim, the confidence
+ * and the provenance -- an overwrite by another name, and the same trap
+ * `contradict` documents. So the fields are destructured AWAY and everything
+ * else is spread back: no deletion primitive is needed, and the append-only rule
+ * is respected.
+ *
+ * `staleEvidence` is stripped as well, even though no writer stores it. It is
+ * added by `serve` to the object it hands out, so anything that ever writes a
+ * served finding back would carry it in -- at which point a cleared finding
+ * would still be advertising the quality of the evidence for a flag it no longer
+ * has.
+ *
+ * A PRIMITIVE, NOT A ROUTE. Nothing outside this module calls it: the only
+ * shipping caller is `reverify` below, which establishes the evidence first.
+ * Exposing it to a hook, a tool argument or an HTTP action would be a way to
+ * turn a stale finding fresh on request, which is exactly what must not exist.
+ */
+export function clearStale(dir, key) {
+  const node = load(dir).nodes.get(nodeId('finding', key));
+  if (!node || node.kind !== 'finding') return false;
+  const { stale, staleReason, diff, staleEvidence, ...rest } = node;
+  // Nothing to clear is a success, not a write: an unconditional putNode here
+  // would append a duplicate record to the log on every no-op call.
+  if (stale === undefined && staleReason === undefined
+    && diff === undefined && staleEvidence === undefined) return true;
+  putNode(dir, { ...rest, kind: 'finding', key: node.key });
+  return true;
+}
+
+/**
+ * Clears a stale flag when, and only when, the evidence for it is gone.
+ *
+ * WHY THIS HAS TO EXIST. Nothing in this codebase ever cleared a `stale` flag.
+ * That was harmless while eager invalidation was dead code; it fires now, so
+ * every finding on an edited file becomes permanently stale -- and permanently
+ * discounted, since `disclose.mjs` skips a stale finding outright and
+ * `utility.mjs` penalises one by 160. The graph degrades toward all-stale, and
+ * the eager path is over-eager on top of that: `invalidateOnWrite` marks every
+ * finding anchored to a FILE node on any observed write to that file, whether or
+ * not the bytes moved.
+ *
+ * WHAT COUNTS AS EVIDENCE, AND WHY IT IS NOT NEGOTIABLE. The only trustworthy
+ * record of what a claim was made against is `derivation.anchors` -- the hash
+ * each anchor carried at the moment the finding was written, frozen into the
+ * finding itself by `harvest-write.mjs`. Disk is re-hashed here and compared
+ * against that. If every anchor matches, the content IS what the claim was
+ * derived from: a revert, or a write that never moved the anchored bytes. The
+ * flag comes off. Anything else leaves it exactly as it was.
+ *
+ * IT IS NOT A LAUNDERING ROUTE, and that is a property of the comparison rather
+ * than of who is allowed to call it. A caller cannot make a finding fresh by
+ * asking; they can only make it fresh by putting the content back. There is no
+ * argument, no force flag and no second path -- and `clearStale` above, the one
+ * function that clears without checking, has no caller but this one.
+ *
+ * NO RECORD MEANS UNKNOWN, NEVER CLEAR. A finding with no `derivation.anchors`
+ * -- every one written before that record existed, and every hand-curated one --
+ * has nothing to compare disk against. That is an absence of evidence, and
+ * resolving it to "clear it" would hand back the laundering route through the
+ * side door. It reports `unknown` and changes nothing; re-recording the claim
+ * against the current code (`curate.correct`) is the way forward for those.
+ *
+ * DELIBERATELY NOT AUTOMATIC. This reads every anchor off disk, so running it on
+ * the serve path would put N file reads inside injection -- and, worse, it would
+ * silently un-mark findings nobody asked about. Staleness is disclosed to a
+ * reader who then decides; clearing is an explicit act.
+ */
+export function reverify(dir, key) {
+  const graph = load(dir);
+  const finding = graph.nodes.get(nodeId('finding', key));
+  if (!finding || finding.kind !== 'finding') return 'unknown';
+  // Idempotent: the postcondition -- no stale flag on this finding -- already
+  // holds, and reporting anything else would make a caller retry forever.
+  if (!finding.stale) return 'cleared';
+
+  const recorded = finding.derivation && finding.derivation.anchors;
+  if (!recorded || typeof recorded !== 'object') return 'unknown';
+
+  const anchorIds = new Set(
+    graph.edges
+      .filter((e) => e.edge === 'derived_from' && e.from === finding.id)
+      .map((e) => e.to)
+  );
+  // An unanchored finding cannot be checked against anything, which is the
+  // un-invalidatable shape the anchor discipline exists to refuse. It is equally
+  // un-VERIFIABLE, so it is reported as such rather than cleared.
+  if (!anchorIds.size) return 'unknown';
+
+  for (const id of anchorIds) {
+    const expected = recorded[id];
+    const node = graph.nodes.get(id);
+    // An anchor this finding never recorded a hash for, or one that no longer
+    // resolves to a node: nothing to compare, so nothing is concluded.
+    if (typeof expected !== 'string' || !expected || !node) return 'unknown';
+    if (node.kind !== 'file' && node.kind !== 'symbol') return 'unknown';
+    // null means the content is gone -- deleted file, vanished symbol. That is a
+    // difference, not an absence of evidence.
+    if (anchorHashNow(node) !== expected) return 'still-stale';
+  }
+
+  clearStale(dir, key);
+  return 'cleared';
 }
 
 export { contentHash };

--- a/integrations/copilot/.github/hooks/lib/staleness.mjs
+++ b/integrations/copilot/.github/hooks/lib/staleness.mjs
@@ -368,6 +368,12 @@ const DIFF_MAX_BYTES = () => {
  * line, and total bytes. Every truncation is announced in the output, because a
  * silently shortened diff is worse than a visibly shortened one -- a reader who
  * cannot tell content was elided believes they saw the whole change.
+ *
+ * `maxLines` BOUNDS THE BODY, MARKERS INCLUDED: at most `maxLines` lines of
+ * removed lines, added lines and "... N more" elision markers between them, plus
+ * at most one final notice when the byte cap dropped lines -- so `maxLines + 1`
+ * lines in total, and no more. That last line is outside the budget on purpose,
+ * for the reason stated where it is pushed.
  */
 export function diffLines(
   before,
@@ -418,10 +424,24 @@ export function diffLines(
     bytes += size;
   };
 
-  for (const line of removed.slice(0, maxLines / 2)) push('- ' + line);
-  if (removed.length > maxLines / 2) push(`  ... ${removed.length - maxLines / 2} more removed`);
-  for (const line of added.slice(0, maxLines / 2)) push('+ ' + line);
-  if (added.length > maxLines / 2) push(`  ... ${added.length - maxLines / 2} more added`);
+  // THE ELISION MARKER IS PAID FOR OUT OF THE SIDE'S OWN QUOTA, so `maxLines`
+  // bounds the whole body rather than only the content in it. It did not: at the
+  // default 40 the body could reach 42 lines -- 20 removed, 20 added and two
+  // "... N more" markers -- and the out-of-budget notice below made 43, against
+  // a documented bound of 40 and a test asserting 41. Three numbers, no two the
+  // same. A side that has to elide now shows one fewer content line and spends
+  // that line on saying so, which is the trade a reader wants anyway: knowing
+  // that 300 lines were cut matters more than the 20th of the 20 shown.
+  const half = Math.floor(maxLines / 2);
+  const emit = (lines, prefix, label) => {
+    const elides = lines.length > half;
+    const shown = elides ? Math.max(0, half - 1) : half;
+    for (const line of lines.slice(0, shown)) push(prefix + line);
+    if (elides) push(`  ... ${lines.length - shown} more ${label}`);
+  };
+
+  emit(removed, '- ', 'removed');
+  emit(added, '+ ', 'added');
 
   // Announced OUTSIDE the budget, deliberately: the one line a reader most
   // needs is the one saying the rest is missing, and dropping it to stay under
@@ -479,6 +499,15 @@ function disputeOf(graph, finding) {
   if (!hasOutstandingContradiction(graph, finding.key)) return {};
 
   const keys = [];
+  // AND THE REASON A PERSON TYPED, which had no reader anywhere. `contradict`
+  // stores `contradictionReason` -- up to 400 characters of human explanation --
+  // on the CONTRADICTED end only, and nothing outside its own test ever read it:
+  // this disclosure named the other key and stopped, `audit` counts ends, and the
+  // dashboard detail view renders neither. So the one field on the edge that says
+  // WHY was written on every contradiction and seen by nobody. It is collected
+  // from whichever end holds it, so both sides of a dispute disclose the same
+  // reason rather than only the claim that lost.
+  let reason = typeof finding.contradictionReason === 'string' ? finding.contradictionReason : '';
   for (const edge of graph.edges) {
     if (edge.edge !== 'contradicts') continue;
     const otherId =
@@ -497,10 +526,30 @@ function disputeOf(graph, finding) {
     // each name, so a live disputant is still reported alongside a withdrawn one.
     if (other && !other.retired && typeof other.key === 'string' && !keys.includes(other.key)) {
       keys.push(other.key);
+      // A RETIRED END'S REASON IS NOT BORROWED EITHER, which is why this sits
+      // inside the same guard as the key: `hasOutstandingContradiction` can be
+      // open on one live disputant while another is withdrawn, and quoting the
+      // withdrawn one's explanation would attribute the live dispute to a claim
+      // the reader cannot fetch.
+      if (!reason && typeof other.contradictionReason === 'string') {
+        reason = other.contradictionReason;
+      }
     }
   }
 
-  return { contradicted: true, ...(keys.length ? { contradictedBy: keys.join(', ') } : {}) };
+  return {
+    contradicted: true,
+    ...(keys.length ? { contradictedBy: keys.join(', ') } : {}),
+    // Trimmed here rather than at the renderer: an empty string is not a reason,
+    // and a consumer checking `if (reason)` should not have to trim first.
+    //
+    // SET UNCONDITIONALLY, INCLUDING TO `undefined`. `serve` spreads the stored
+    // record before this object, so omitting the key would let a whitespace-only
+    // stored reason through untouched and make the served value differ from the
+    // one this function decided on. The disclosure is authoritative or it is not
+    // a disclosure.
+    contradictionReason: reason.trim() || undefined,
+  };
 }
 
 /**
@@ -580,8 +629,15 @@ function derivationCheck(graph, finding) {
  * the dashboard, which left the rot path fully open on every install where
  * nobody opens the dashboard -- and that is most of them. The evidence test is
  * what makes clearing safe, and it does not care who triggered it: the same
- * `claimTimeVerdict` runs here as in `reverify`, so this cannot clear anything
+ * `claimTimeEvidence` runs here as in `reverify`, so this cannot clear anything
  * the button would not.
+ *
+ * A CLEAR ALSO RE-INDEXES THE ANCHORS IT VERIFIED. The three disclosures this
+ * function emits -- `stale`, `derivationHolds`, and the dispute -- are computed
+ * from three different comparisons, and clearing the flag without moving the
+ * anchor's stored hash made the first two contradict the clear on the revert
+ * path. `reindexVerifiedAnchors` explains the reproduction and why re-pointing
+ * the index is the fix rather than suppressing the disclosures.
  *
  * `dir` IS OPTIONAL, AND OMITTING IT MAKES THIS READ-ONLY. Several callers hold
  * a graph without the directory it came from, and a serve that silently did
@@ -617,11 +673,17 @@ export function serve(graph, findings, { dir = null } = {}) {
 
     // AUTOMATIC CLEARING, on the same evidence the manual path demands.
     //
-    // ONLY THE STORED FLAG IS TOUCHED. The lazy loop below is left to run
-    // exactly as before and can independently mark this finding stale again on
-    // its own comparison -- disk against the anchor NODE's hash -- which answers
-    // a different question and is not this function's to overrule. Eager and
-    // lazy stay two mechanisms, as the module header insists.
+    // THE FLAG AND THE INDEX MOVE TOGETHER. Clearing the flag alone made this
+    // function contradict itself on the revert path: the lazy loop below
+    // compares disk against the anchor NODE's hash, which the eager path
+    // re-pointed at the post-edit bytes, so a reverted file read as `stale:
+    // true, staleReason: 'file changed'` and `derivationHolds: false` inside the
+    // very object whose flag had just been cleared for matching its claim-time
+    // content. `reindexVerifiedAnchors` writes the verified bytes' hash back to
+    // the anchor, so all three disclosures are finally reading the same content
+    // and cannot disagree. Eager and lazy stay two mechanisms, as the module
+    // header insists -- what changed is that the index no longer holds a hash
+    // that matches no version of the file that exists.
     //
     // AND THE FIELDS GO WITH THE FLAG. `putNode` does not merge and neither does
     // this spread: serving `{ ...finding, stale: false }` would hand back a
@@ -630,12 +692,37 @@ export function serve(graph, findings, { dir = null } = {}) {
     // So the cleared record, not the stored one, is what the rest of this
     // iteration reads and spreads.
     //
-    // BOUNDED, and the bound is the point: this runs only for a finding whose
-    // flag is already STORED, only when a `derivation` record exists to check
-    // against, and it reads each of that finding's anchors at most once. A
-    // finding that is not flagged pays nothing. The lazy loop below already
+    // BOUNDED PER CALL, and the bound is the point: this runs only for a finding
+    // whose flag is already STORED, only when a `derivation` record exists to
+    // check against, and it reads each of that finding's anchors at most once.
+    // A finding that is not flagged pays nothing. The lazy loop below already
     // reads every anchor of every content-dependent finding served, so the worst
     // case is twice the anchor reads on the already-stale subset alone.
+    //
+    // AND THE PER-SESSION SHAPE, stated because the per-call bound alone reads
+    // as cheaper than it is. Measured on a synthetic 40-stale-finding graph, the
+    // serve path went 158 ms -> 217 ms (+37%), and for a GENUINELY stale finding
+    // that cost recurs on every call for the whole session: the verdict is
+    // `'differs'` forever, nothing is cleared, and the reads are repaid with
+    // nothing. What keeps it survivable in practice is not this bound but two
+    // others -- `findingsFor`'s result limit and inject.mjs's `alreadyInjected`
+    // gate, which together put it near 40 ms on the first touch of a hot file
+    // and zero on the touches after.
+    //
+    // THE REVERT CASE PAYS ONCE, AND THAT IS MEASURED, not argued. Same 40
+    // findings, all revertible, medians of 9 across three process launches: the
+    // read-only serve is 23-29 ms, the first clearing serve is 141-173 ms (the
+    // anchor reads plus one node append per cleared finding AND per re-pointed
+    // anchor), and the SECOND clearing serve is 21-28 ms -- back to the
+    // read-only baseline, because the flag is off and the index agrees, so this
+    // gate no longer fires. What the re-index changed is not that cost -- the
+    // gate stopped firing once the flag came off before, too -- but that every
+    // serve after the clear used to re-derive `stale: true` and
+    // `derivationHolds: false` from an index nobody had moved. The extra ~120 ms
+    // buys silence that is actually correct.
+    // On the genuinely-stale set the recurring cost is
+    // real and unchanged in kind: 26-45 ms read-only against 53-105 ms with
+    // clearing on, every call, clearing nothing.
     //
     // NOT ON THE NON-CONTENT-DEPENDENT EARLY RETURN ABOVE, deliberately. Both
     // eager paths refuse to flag those types at all, so a flag there can only
@@ -643,10 +730,14 @@ export function serve(graph, findings, { dir = null } = {}) {
     // does not depend on them is exactly the cost `CONTENT_DEPENDENT` exists to
     // avoid.
     let record = finding;
-    if (dir && finding.stale && claimTimeVerdict(graph, finding) === 'match') {
-      clearStale(dir, finding.key, { graph });
-      const { stale: _s, staleReason: _r, diff: _d, staleEvidence: _e, ...cleared } = finding;
-      record = cleared;
+    if (dir && finding.stale) {
+      const evidence = claimTimeEvidence(graph, finding);
+      if (evidence.verdict === 'match') {
+        reindexVerifiedAnchors(dir, graph, evidence.contents);
+        clearStale(dir, finding.key, { graph });
+        const { stale: _s, staleReason: _r, diff: _d, staleEvidence: _e, ...cleared } = finding;
+        record = cleared;
+      }
     }
 
     const anchors = graph.edges
@@ -736,6 +827,14 @@ export function serve(graph, findings, { dir = null } = {}) {
       // carries its `derivation`, since clearing removes only the staleness
       // fields. A finding whose flag was just cleared is still disclosed as
       // disputed, and still reports whether its derivation holds.
+      //
+      // AND THEY NO LONGER CONTRADICT THE CLEAR. Surviving is not the same as
+      // agreeing: for a whole serve this returned `stale: true, staleReason:
+      // 'file changed'` and `derivationHolds: false` on a finding it had just
+      // cleared, because the clear was decided against disk while these two read
+      // the anchor node's hash, and the eager path had moved it. All three now
+      // read the same content because the clear re-points the anchor; see
+      // `reindexVerifiedAnchors`.
       ...dispute,
       // Independent of `stale` above: see `derivationCheck`'s own comment for
       // the case it catches that node-level staleness can miss.
@@ -934,6 +1033,34 @@ export function invalidateChangedAnchors(dir, graph, rawPath) {
 }
 
 /**
+ * The current content of an anchor, read from disk: the whole file for a file
+ * anchor, the located span for a symbol one. Null when nothing can be read.
+ *
+ * SPLIT OUT FROM `anchorHashNow` SO THE BYTES SURVIVE THE COMPARISON. The
+ * clearing path hashes this to reach a verdict and, on `'match'`, re-indexes the
+ * anchor from the same bytes -- see `reindexVerifiedAnchors`. Returning only a
+ * hash forced a second read of a file that had just been read, for content
+ * already known to be identical.
+ */
+function anchorContentNow(anchor) {
+  const path = anchor.kind === 'symbol' ? anchor.file : anchor.key;
+  let source;
+  try {
+    source = readAnySpelling(path);
+  } catch {
+    return null;
+  }
+  if (anchor.kind !== 'symbol') return source;
+
+  // By NAME, like checkAnchor: line numbers shift whenever anything above is
+  // edited, and re-locating by line would report a symbol as moved when only an
+  // unrelated insert happened above it.
+  const current = extractSymbols(path, source).find((s) => s.name === anchor.name);
+  if (!current) return null;
+  return spanText(source, current);
+}
+
+/**
  * The current content hash of an anchor, read from disk.
  *
  * DELIBERATELY NOT `checkAnchor`, and the difference is the whole of this
@@ -952,21 +1079,8 @@ export function invalidateChangedAnchors(dir, graph, rawPath) {
  * content it was made against.
  */
 function anchorHashNow(anchor) {
-  const path = anchor.kind === 'symbol' ? anchor.file : anchor.key;
-  let source;
-  try {
-    source = readAnySpelling(path);
-  } catch {
-    return null;
-  }
-  if (anchor.kind !== 'symbol') return hash(source);
-
-  // By NAME, like checkAnchor: line numbers shift whenever anything above is
-  // edited, and re-locating by line would report a symbol as moved when only an
-  // unrelated insert happened above it.
-  const current = extractSymbols(path, source).find((s) => s.name === anchor.name);
-  if (!current) return null;
-  return hash(spanText(source, current));
+  const content = anchorContentNow(anchor);
+  return content === null ? null : hash(content);
 }
 
 /**
@@ -1005,21 +1119,51 @@ export function clearStale(dir, key, { graph = null } = {}) {
   // `contradict`, `correct` -- writes from a graph it loaded earlier too. Both
   // callers here already DECIDED on this snapshot, so re-reading it purely for
   // the write narrowed no window that was ever closed.
-  const node = (graph || load(dir)).nodes.get(nodeId('finding', key));
+  const id = nodeId('finding', key);
+  const node = (graph || load(dir)).nodes.get(id);
   if (!node || node.kind !== 'finding') return false;
   const { stale, staleReason, diff, staleEvidence, ...rest } = node;
   // Nothing to clear is a success, not a write: an unconditional putNode here
   // would append a duplicate record to the log on every no-op call.
   if (stale === undefined && staleReason === undefined
     && diff === undefined && staleEvidence === undefined) return true;
-  putNode(dir, { ...rest, kind: 'finding', key: node.key });
+  const cleared = { ...rest, kind: 'finding', key: node.key };
+  putNode(dir, cleared);
+  // AND THE CALLER'S GRAPH IS UPDATED, because the guard above reads THAT graph,
+  // not disk. Without this, a second `serve` on the same in-memory graph object
+  // -- two touched files anchored to one finding, or a lifecycle branch that
+  // serves twice from a graph it loaded once, as SessionStart does -- still saw
+  // `stale: true`, re-ran the evidence test, and appended a byte-identical clear
+  // record. The store is append-only, so that is permanent log growth for no
+  // change in state, and the "nothing to clear is a success, not a write"
+  // guarantee directly above was only true of the first call.
+  if (graph) graph.nodes.set(id, { ...cleared, id });
   return true;
 }
 
 /**
- * Clears a stale flag when, and only when, the evidence for it is gone.
+ * THE ONE EVIDENCE TEST, plus the bytes it read. Does this finding's anchored
+ * content still hash to what the claim was actually made against?
  *
- * WHY THIS HAS TO EXIST. Nothing in this codebase ever cleared a `stale` flag.
+ * `verdict` is one of:
+ *   `'match'`   -- every anchor on disk re-hashes to the value frozen into this
+ *                  finding's own `derivation.anchors` at claim time. The content
+ *                  IS what the claim was derived from: a revert, or a write that
+ *                  never moved the anchored bytes.
+ *   `'differs'` -- at least one anchor does not, INCLUDING an anchor whose
+ *                  content is gone. Deleted is a difference, not a missing
+ *                  measurement.
+ *   `'unknown'` -- there is nothing to compare: no `derivation.anchors`, no
+ *                  anchors, an anchor with no recorded hash, or one that no
+ *                  longer resolves.
+ *
+ * `contents` carries the disk bytes read to reach a `'match'`, keyed by anchor
+ * id, so the caller can re-index those anchors without reading them again. It is
+ * empty for the other two verdicts, which read no further than the first
+ * disagreement.
+ *
+ * WHY CLEARING HAS TO EXIST AT ALL. Nothing in this codebase ever cleared a
+ * `stale` flag.
  * That was harmless while eager invalidation was dead code; it fires now, so
  * every finding on an edited file becomes permanently stale -- and permanently
  * discounted, since `disclose.mjs` skips a stale finding outright and
@@ -1049,24 +1193,6 @@ export function clearStale(dir, key, { graph = null } = {}) {
  * side door. It reports `unknown` and changes nothing; re-recording the claim
  * against the current code (`curate.correct`) is the way forward for those.
  *
- * DELIBERATELY NOT AUTOMATIC. This reads every anchor off disk, so running it on
- * the serve path would put N file reads inside injection -- and, worse, it would
- * silently un-mark findings nobody asked about. Staleness is disclosed to a
- * reader who then decides; clearing is an explicit act.
- */
-/**
- * THE ONE EVIDENCE TEST. Does this finding's anchored content still hash to what
- * the claim was actually made against?
- *
- * `'match'` -- every anchor on disk re-hashes to the value frozen into this
- * finding's own `derivation.anchors` at claim time. The content IS what the
- * claim was derived from: a revert, or a write that never moved the anchored
- * bytes.
- * `'differs'` -- at least one anchor does not, INCLUDING an anchor whose content
- * is gone. Deleted is a difference, not a missing measurement.
- * `'unknown'` -- there is nothing to compare: no `derivation.anchors`, no
- * anchors, an anchor with no recorded hash, or one that no longer resolves.
- *
  * SHARED BY BOTH CLEARING PATHS ON PURPOSE, and that sharing is the guarantee
  * rather than a convenience. `reverify` (a person pressing Re-verify) and
  * `serve` (automatic, on every retrieval) call THIS function and nothing else,
@@ -1080,9 +1206,10 @@ export function clearStale(dir, key, { graph = null } = {}) {
  * re-point at the very bytes that caused the mark, so it answers "fresh" for
  * exactly the finding it just marked stale.
  */
-function claimTimeVerdict(graph, finding) {
+function claimTimeEvidence(graph, finding) {
+  const none = { verdict: 'unknown', contents: new Map() };
   const recorded = finding.derivation && finding.derivation.anchors;
-  if (!recorded || typeof recorded !== 'object') return 'unknown';
+  if (!recorded || typeof recorded !== 'object') return none;
 
   const anchorIds = new Set(
     graph.edges
@@ -1092,22 +1219,122 @@ function claimTimeVerdict(graph, finding) {
   // An unanchored finding cannot be checked against anything, which is the
   // un-invalidatable shape the anchor discipline exists to refuse. It is equally
   // un-VERIFIABLE, so it is reported as such rather than cleared.
-  if (!anchorIds.size) return 'unknown';
+  if (!anchorIds.size) return none;
 
+  const contents = new Map();
   for (const id of anchorIds) {
     const expected = recorded[id];
     const node = graph.nodes.get(id);
     // An anchor this finding never recorded a hash for, or one that no longer
     // resolves to a node: nothing to compare, so nothing is concluded.
-    if (typeof expected !== 'string' || !expected || !node) return 'unknown';
-    if (node.kind !== 'file' && node.kind !== 'symbol') return 'unknown';
+    if (typeof expected !== 'string' || !expected || !node) return none;
+    if (node.kind !== 'file' && node.kind !== 'symbol') return none;
     // null means the content is gone -- deleted file, vanished symbol. That is a
     // difference, not an absence of evidence.
-    if (anchorHashNow(node) !== expected) return 'differs';
+    const content = anchorContentNow(node);
+    if (content === null || hash(content) !== expected) {
+      return { verdict: 'differs', contents: new Map() };
+    }
+    contents.set(id, content);
   }
-  return 'match';
+  return { verdict: 'match', contents };
 }
 
+/** The verdict alone, for callers that do not re-index. */
+function claimTimeVerdict(graph, finding) {
+  return claimTimeEvidence(graph, finding).verdict;
+}
+
+/**
+ * Re-points every verified anchor at the content the evidence test just read.
+ *
+ * WHY A CLEAR IS NOT ENOUGH ON ITS OWN, reproduced end to end: index a file at
+ * H1, write a finding whose `derivation.anchors` records H1, edit and re-index so
+ * the node holds H2, let the eager path mark the finding, then REVERT the edit on
+ * disk. `claimTimeVerdict` now says `'match'` -- disk is H1, which is exactly
+ * what the claim was derived from -- and the flag comes off. But the node still
+ * holds H2, so the same `serve` call went on to emit `stale: true` with
+ * `staleReason: 'file changed'` from the lazy loop (disk H1 against node H2) and
+ * `derivationHolds: false` from `derivationCheck` (index H2 against claim H1).
+ * The model was shown DERIVATION CHANGED and STALE at the exact moment this
+ * module's own evidence test had concluded the derivation holds -- on every
+ * serve, until something unrelated happened to re-index the anchor.
+ *
+ * THE FIX IS TO MOVE THE INDEX, NOT TO SILENCE THE DISCLOSURES. Suppressing the
+ * lazy check and the derivation verdict for a cleared finding would leave the
+ * graph holding a hash that matches no version of the file that exists, so every
+ * OTHER finding on that anchor keeps reading stale, and the next reader has to be
+ * told which disclosures to disbelieve. The node hash is simply out of date, the
+ * bytes are already in hand from the comparison that just succeeded, and writing
+ * them makes all three disclosures agree because they are finally reading the
+ * same content.
+ *
+ * COSTS NO READ. `contents` comes from `claimTimeEvidence`, which read each
+ * anchor to reach `'match'`. The write is one node record per anchor whose hash
+ * actually moved, and it happens once per revert rather than once per serve: with
+ * the index re-pointed, the flag stays off and the gate in `serve` does not fire
+ * again.
+ *
+ * THE IN-MEMORY GRAPH IS UPDATED TOO, because the caller is mid-serve and is
+ * about to read these same nodes through the lazy loop and `derivationCheck`.
+ * Writing only to disk would fix the next process and leave this one contradicting
+ * itself, which is the whole defect.
+ *
+ * Line numbers are deliberately left alone on a symbol anchor: `checkAnchor` and
+ * `anchorContentNow` both re-locate by NAME, so a stored line is informational,
+ * and the body being byte-identical is what was just established.
+ */
+function reindexVerifiedAnchors(dir, graph, contents) {
+  for (const [id, content] of contents) {
+    const node = graph.nodes.get(id);
+    if (!node) continue;
+    const nextHash = hash(content);
+    // Already agrees: no record, no write. The common case once a revert has
+    // been accounted for.
+    if (node.hash === nextHash) continue;
+    const limit = node.kind === 'symbol' ? symbolSnapshotLimit() : snapshotLimit();
+    // Same bound as `indexFile`: past the cap the hash still drives staleness and
+    // only the reconstructed diff degrades.
+    const snapshot = content.length <= limit ? content : undefined;
+    const { hash: _h, snapshot: _s, ...rest } = node;
+    try {
+      putNode(dir, { ...rest, kind: node.kind, key: node.key, hash: nextHash, snapshot });
+    } catch {
+      // Fail open: a graph that could not be written is a disclosure that stays
+      // as it was, never a broken tool call. The in-memory copy is left alone to
+      // match, so this serve keeps agreeing with the store.
+      continue;
+    }
+    graph.nodes.set(id, { ...node, hash: nextHash, ...(snapshot ? { snapshot } : {}) });
+  }
+}
+
+/**
+ * Clears a stale flag on behalf of a person who asked for it -- the dashboard's
+ * Re-verify action -- and reports what the evidence said.
+ *
+ * `'cleared'` when the flag is gone (including when it was already gone, so a
+ * caller polling this does not retry forever), `'still-stale'` when the anchored
+ * content genuinely differs from what the claim was made against, `'unknown'`
+ * when there is nothing to compare and therefore nothing to conclude.
+ *
+ * NO LONGER THE ONLY CLEARING PATH, and the docblock that used to sit here said
+ * the opposite: that automatic clearing was refused because it would put N file
+ * reads inside injection and "silently un-mark findings nobody asked about".
+ * `serve` now does exactly that, on the same evidence, for the reason its own
+ * comment gives -- the manual path was reachable only where somebody opens the
+ * dashboard, which is almost nowhere, so the rot path stayed open on most
+ * installs. What survives of that objection is the cost, which `serve` bounds
+ * and states.
+ *
+ * WHAT THIS STILL ADDS over the automatic path: it loads the graph itself, so a
+ * caller holding nothing but a key and a directory can act; it reports the
+ * verdict rather than folding it into a served record; and it runs on demand
+ * rather than only when the finding happens to be retrieved. It re-indexes the
+ * verified anchors for the same reason `serve` does -- otherwise the button
+ * clears the flag and the very next retrieval re-derives a contradiction from a
+ * node hash nobody moved.
+ */
 export function reverify(dir, key) {
   const graph = load(dir);
   const finding = graph.nodes.get(nodeId('finding', key));
@@ -1116,9 +1343,10 @@ export function reverify(dir, key) {
   // holds, and reporting anything else would make a caller retry forever.
   if (!finding.stale) return 'cleared';
 
-  const verdict = claimTimeVerdict(graph, finding);
+  const { verdict, contents } = claimTimeEvidence(graph, finding);
   if (verdict === 'unknown') return 'unknown';
   if (verdict === 'differs') return 'still-stale';
+  reindexVerifiedAnchors(dir, graph, contents);
   clearStale(dir, key, { graph });
   return 'cleared';
 }

--- a/integrations/copilot/.github/hooks/lib/staleness.mjs
+++ b/integrations/copilot/.github/hooks/lib/staleness.mjs
@@ -17,7 +17,13 @@
  * TWO INVALIDATION PATHS, and each covers what the other cannot see:
  *
  *   EAGER  -- our PostToolUse hook saw a write, so the finding is marked at the
- *             moment it went stale, with the exact before/after in hand.
+ *             moment it went stale, with the exact before/after in hand. The
+ *             hook does not call `invalidateOnWrite` directly: it queues the
+ *             evidence through pending.mjs, and the next graph read -- which
+ *             loads the graph anyway -- applies it before serving anything.
+ *             That path is also the only one that catches a write the SESSION
+ *             made, because the lazy check below compares the stored hash
+ *             against disk and `indexFile` has already refreshed it.
  *   LAZY   -- at retrieval, the anchor's stored hash is compared against disk.
  *             This is what catches `git pull`, another editor, a teammate, or a
  *             build step: every change our hooks never observed.
@@ -291,14 +297,69 @@ export function checkAnchor(anchor) {
 }
 
 /**
+ * Characters kept from any single diff line.
+ *
+ * A LINE CAP IS NOT A SIZE CAP, and the gap was measured: with only `maxLines`
+ * in force, `diffLines('X'.repeat(200000), 'Y'.repeat(200000))` returned 2 lines
+ * and 400,005 bytes. Minified bundles, generated sources and single-line JSON
+ * all have that shape, and this output goes STRAIGHT INTO MODEL CONTEXT from
+ * inject.mjs's zero-turn refusal -- so a line bound alone let one pathological
+ * file spend hundreds of thousands of tokens.
+ *
+ * 200 characters is chosen because it is past the width at which a line is read
+ * as a line by anybody, human or model: a hand-written source line is under
+ * ~120 columns, so the cap cannot truncate a diff a reader was going to use,
+ * while the cases it does truncate are ones where the interesting change is not
+ * legible from the raw text anyway.
+ */
+const DIFF_MAX_LINE_CHARS = () => {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_DIFF_MAX_LINE_CHARS);
+  return Number.isFinite(raw) && raw > 0 ? raw : 200;
+};
+
+/**
+ * Total UTF-8 bytes of diff body.
+ *
+ * 4,000 bytes is roughly 1,000 tokens. It is deliberately larger than the
+ * per-file injection budget (`TOKEN_OPTIMIZER_TOUCH_BUDGET`, 500 tokens) and
+ * far smaller than a file, because the two consumers want different things: the
+ * injection surface fits the diff inside its own budget and drops it if it does
+ * not fit, while the zero-turn refusal is replacing a whole file read and can
+ * afford more. One cap that neither consumer has to think about is worth more
+ * than two tuned ones.
+ *
+ * WHAT IT COSTS, PLAINLY: a legitimately large diff now arrives truncated, so a
+ * model looking at a 300-line refactor sees the head of it and a count of what
+ * was elided rather than the whole change. That is the correct direction to
+ * fail -- the alternative was a bounded-looking function that could emit 400 KB.
+ */
+const DIFF_MAX_BYTES = () => {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_DIFF_MAX_BYTES);
+  return Number.isFinite(raw) && raw > 0 ? raw : 4_000;
+};
+
+/**
  * A compact line diff.
  *
  * Deliberately not a full unified diff with hunks and context: the consumer is
  * a model deciding whether an existing conclusion still holds, and for that the
  * changed lines are the signal. Output is capped because an unbounded diff
  * injected alongside a finding would spend more tokens than re-deriving it.
+ *
+ * BOUNDED IN THREE WAYS, and each one is load-bearing: lines, characters per
+ * line, and total bytes. Every truncation is announced in the output, because a
+ * silently shortened diff is worse than a visibly shortened one -- a reader who
+ * cannot tell content was elided believes they saw the whole change.
  */
-export function diffLines(before, after, { maxLines = 40 } = {}) {
+export function diffLines(
+  before,
+  after,
+  {
+    maxLines = 40,
+    maxLineChars = DIFF_MAX_LINE_CHARS(),
+    maxBytes = DIFF_MAX_BYTES(),
+  } = {}
+) {
   const a = String(before).split('\n');
   const b = String(after).split('\n');
 
@@ -314,33 +375,44 @@ export function diffLines(before, after, { maxLines = 40 } = {}) {
   const added = b.slice(head, b.length - tail);
 
   const out = [];
-  for (const line of removed.slice(0, maxLines / 2)) out.push('- ' + line);
-  if (removed.length > maxLines / 2) out.push(`  ... ${removed.length - maxLines / 2} more removed`);
-  for (const line of added.slice(0, maxLines / 2)) out.push('+ ' + line);
-  if (added.length > maxLines / 2) out.push(`  ... ${added.length - maxLines / 2} more added`);
+  let bytes = 0;
+  let dropped = 0;
+
+  // Per line first, so ONE enormous line cannot consume the whole budget and
+  // leave every other changed line unrepresented.
+  const clamp = (line) => {
+    const text = String(line);
+    if (text.length <= maxLineChars) return text;
+    return `${text.slice(0, maxLineChars)} [+${text.length - maxLineChars} chars cut]`;
+  };
+
+  // Bytes, not characters: the cap exists to bound what is sent, and a
+  // multi-byte source file would otherwise pass a character check while
+  // emitting several times the budget.
+  const push = (line) => {
+    const text = clamp(line);
+    const size = Buffer.byteLength(text, 'utf8') + 1;
+    if (bytes + size > maxBytes) {
+      dropped++;
+      return;
+    }
+    out.push(text);
+    bytes += size;
+  };
+
+  for (const line of removed.slice(0, maxLines / 2)) push('- ' + line);
+  if (removed.length > maxLines / 2) push(`  ... ${removed.length - maxLines / 2} more removed`);
+  for (const line of added.slice(0, maxLines / 2)) push('+ ' + line);
+  if (added.length > maxLines / 2) push(`  ... ${added.length - maxLines / 2} more added`);
+
+  // Announced OUTSIDE the budget, deliberately: the one line a reader most
+  // needs is the one saying the rest is missing, and dropping it to stay under
+  // a self-imposed cap would hand back a diff that lies about being complete.
+  if (dropped) out.push(`  ... ${dropped} more changed line(s) cut at the size limit`);
 
   return out.join('\n');
 }
 
-/**
- * Prepares findings for delivery, verifying each one lazily against disk.
- *
- * This is the only function that should ever hand a finding to a model, because
- * it is the one that enforces the rule: a stale finding leaves here carrying
- * `stale: true` AND a diff, or it does not leave at all.
- */
-export function serve(graph, findings) {
-  const served = [];
-
-  // RETIRED FINDINGS STOP HERE, unconditionally.
-  //
-  // findingsFor and sessionIndex already filter them, so this is redundant on
-  // every current path -- deliberately. This function's own contract is that it
-  // is the only thing that hands a finding to a model, which makes it the right
-  // place for the guarantee to live: a future caller that reaches into the
-  // graph directly cannot accidentally serve a claim a human explicitly
-  // withdrew. A withheld claim reappearing is not a bug anyone would notice
-  // quickly.
 /**
  * Types whose truth is a claim ABOUT the anchor's contents.
  *
@@ -363,6 +435,26 @@ export function serve(graph, findings) {
  * to ignore -- taking the rare true positive with it.
  */
 const CONTENT_DEPENDENT = new Set(['finding', 'map']);
+
+/**
+ * Prepares findings for delivery, verifying each one lazily against disk.
+ *
+ * This is the only function that should ever hand a finding to a model, because
+ * it is the one that enforces the rule: a stale finding leaves here carrying
+ * `stale: true` AND a diff, or it does not leave at all.
+ */
+export function serve(graph, findings) {
+  const served = [];
+
+  // RETIRED FINDINGS STOP HERE, unconditionally.
+  //
+  // findingsFor and sessionIndex already filter them, so this is redundant on
+  // every current path -- deliberately. This function's own contract is that it
+  // is the only thing that hands a finding to a model, which makes it the right
+  // place for the guarantee to live: a future caller that reaches into the
+  // graph directly cannot accidentally serve a claim a human explicitly
+  // withdrew. A withheld claim reappearing is not a bug anyone would notice
+  // quickly.
 
   for (const finding of findings.filter((f) => !f.retired)) {
     // A claim that does not depend on the anchor's contents cannot be
@@ -505,6 +597,15 @@ export function invalidateOnWrite(dir, graph, rawPath, beforeText, afterText) {
     for (const edge of byTarget.get(node.id) || []) {
       const finding = graph.nodes.get(edge.from);
       if (!finding || finding.kind !== 'finding') continue;
+      // THE SAME TYPE GATE `serve` APPLIES, and it has to be here too now that
+      // this path actually runs. `serve` ignores a stale flag on a type whose
+      // truth is not a claim about the anchor's contents -- but the flag is
+      // STORED, and disclose.mjs skips a stale finding outright while
+      // utility.mjs penalises one by 160. So writing it onto a `failure` or a
+      // `command` would suppress that claim everywhere except the one reader
+      // that knows to ignore it, which is exactly the harm measured in the
+      // comment on CONTENT_DEPENDENT above.
+      if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) continue;
 
       putNode(dir, {
         ...finding,

--- a/integrations/copilot/.github/hooks/lib/staleness.mjs
+++ b/integrations/copilot/.github/hooks/lib/staleness.mjs
@@ -495,6 +495,54 @@ function disputeOf(graph, finding) {
 }
 
 /**
+ * Whether THIS finding's own claim-time evidence still matches its anchors --
+ * the reader `harvest-write.mjs`'s `derivation` record was written for.
+ * Nothing consumed that record until now: a grep for it found only the writer
+ * and its own tests, which made "checkable rather than merely attributed" a
+ * claim with no code behind it.
+ *
+ * DISTINCT FROM `stale`/`checkAnchor`, DELIBERATELY, not a duplicate of it.
+ * `checkAnchor` compares disk against the anchor NODE's CURRENT stored hash,
+ * which is refreshed by `indexFile` every time ANYTHING touches that file --
+ * so it answers "has this file changed since the last time anyone indexed
+ * it", not "has it changed since THIS finding was derived from it". Those
+ * differ in a real case: file F changes, and a LATER, unrelated write
+ * (another finding, another session) re-indexes F, updating the node's
+ * stored hash to match the new content again. `checkAnchor` now reports
+ * "fresh" -- disk matches the node's current hash -- while this finding's own
+ * frozen `derivation.anchors[id]` snapshot, taken when IT was written, no
+ * longer matches. The bytes this claim was actually derived from are gone,
+ * and `stale` alone would never say so.
+ *
+ * Returns `{}` when there is nothing to check (no `derivation.anchors`
+ * recorded -- true of every finding written before this existed), so a
+ * caller can tell "not checked" from "checked and holds" by whether
+ * `derivationHolds` is present at all.
+ */
+function derivationCheck(graph, finding) {
+  const recorded = finding.derivation && finding.derivation.anchors;
+  if (!recorded || typeof recorded !== 'object') return {};
+  const ids = Object.keys(recorded);
+  if (!ids.length) return {};
+
+  const changed = [];
+  for (const id of ids) {
+    const node = graph.nodes.get(id);
+    const currentHash = node && typeof node.hash === 'string' ? node.hash : null;
+    // An anchor that no longer resolves at all cannot be confirmed either --
+    // treated the same as a changed hash, never as "still holds" by default.
+    if (currentHash === null || currentHash !== recorded[id]) {
+      changed.push(node && typeof node.key === 'string' ? node.key : id);
+    }
+  }
+
+  if (!changed.length) return { derivationHolds: true };
+  // Bounded: a finding with many anchors should not spend unbounded budget
+  // naming every one that moved.
+  return { derivationHolds: false, derivationChanged: changed.slice(0, 5) };
+}
+
+/**
  * Prepares findings for delivery, verifying each one lazily against disk.
  *
  * This is the only function that should ever hand a finding to a model, because
@@ -611,6 +659,9 @@ export function serve(graph, findings) {
       stale,
       ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
       ...dispute,
+      // Independent of `stale` above: see `derivationCheck`'s own comment for
+      // the case it catches that node-level staleness can miss.
+      ...derivationCheck(graph, finding),
     });
   }
   return served;

--- a/integrations/copilot/.github/hooks/lib/staleness.mjs
+++ b/integrations/copilot/.github/hooks/lib/staleness.mjs
@@ -518,6 +518,21 @@ function disputeOf(graph, finding) {
  * recorded -- true of every finding written before this existed), so a
  * caller can tell "not checked" from "checked and holds" by whether
  * `derivationHolds` is present at all.
+ *
+ * `derivationHolds: true` MEANS "MATCHES THE ANCHOR NODE'S LAST-INDEXED
+ * HASH", NOT "MATCHES DISK RIGHT NOW" -- and that distinction is stored in
+ * `derivationCheckedAgainst: 'index'` rather than left for a `wiki_query`
+ * consumer to infer from a field name alone. Two ways to close this gap were
+ * considered: recompute a live hash from disk here, or document precisely
+ * what is actually compared. `stale` (via `checkAnchor`, above) ALREADY owns
+ * the disk comparison -- re-reading the same file a second time on the same
+ * serve path, for the same anchor, from a second mechanism, is worse than
+ * one honest name. So: documented, not duplicated. A file changed on disk
+ * but never re-indexed by anything is still caught, correctly, by `stale`;
+ * `derivationHolds` answers a narrower, complementary question -- whether
+ * the LAST INDEXED state agrees with what this specific finding recorded --
+ * which is exactly the re-indexed-by-something-else case above that `stale`
+ * cannot see.
  */
 function derivationCheck(graph, finding) {
   const recorded = finding.derivation && finding.derivation.anchors;
@@ -536,10 +551,12 @@ function derivationCheck(graph, finding) {
     }
   }
 
-  if (!changed.length) return { derivationHolds: true };
+  // Declared on BOTH branches, not only the ambiguous one: a consumer should
+  // not have to already know the answer to know what was checked.
+  if (!changed.length) return { derivationHolds: true, derivationCheckedAgainst: 'index' };
   // Bounded: a finding with many anchors should not spend unbounded budget
   // naming every one that moved.
-  return { derivationHolds: false, derivationChanged: changed.slice(0, 5) };
+  return { derivationHolds: false, derivationChanged: changed.slice(0, 5), derivationCheckedAgainst: 'index' };
 }
 
 /**

--- a/integrations/copilot/.github/hooks/lib/staleness.mjs
+++ b/integrations/copilot/.github/hooks/lib/staleness.mjs
@@ -54,6 +54,7 @@ import { readFileSync, statSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { dirname, join } from 'node:path';
 import { putNode, putEdge, contentHash, nodeId } from './wiki.mjs';
+import { hasOutstandingContradiction } from './curate.mjs';
 import { extractSymbols, spanText, symbolKey, extractImports } from './symbols.mjs';
 import { canonicalPath, resolvableCandidates, isFsSafePath } from './paths.mjs';
 
@@ -454,6 +455,46 @@ export function diffLines(
 const CONTENT_DEPENDENT = new Set(['finding', 'map']);
 
 /**
+ * What, if anything, currently disagrees with this finding.
+ *
+ * DISCLOSED AT SERVE TIME, because that is the only moment the disagreement can
+ * do any good. `WIKI_GRAPH.md`'s whole argument for making `contradicts` an edge
+ * rather than an overwrite is that a reader "sees both claims and the
+ * disagreement between them" -- so handing a finding to a model while something
+ * in the graph disputes it, without saying so, throws away the reason the edge
+ * was recorded instead of an overwrite.
+ *
+ * `hasOutstandingContradiction` is the gate: it is the one definition of "an
+ * open dispute", shared with the confidence-promotion gate, so the two can never
+ * disagree about what counts. The loop only NAMES the other side, and it names a
+ * key rather than quoting a claim because the reader can call `wiki_query` with
+ * a key -- and because the injection path pays for every character it renders.
+ *
+ * SEPARATE FROM STALENESS on purpose. A finding can be disputed without being
+ * stale (nothing touched its anchor; another finding simply says otherwise) and
+ * stale without being disputed, so this adds its own fields rather than
+ * borrowing the stale ones, and the renderer discloses each on its own terms.
+ */
+function disputeOf(graph, finding) {
+  if (!hasOutstandingContradiction(graph, finding.key)) return {};
+
+  const keys = [];
+  for (const edge of graph.edges) {
+    if (edge.edge !== 'contradicts') continue;
+    const otherId =
+      edge.from === finding.id ? edge.to : edge.to === finding.id ? edge.from : null;
+    if (!otherId) continue;
+    const other = graph.nodes.get(otherId);
+    // An edge end that resolves to nothing names nothing. The dispute is still
+    // disclosed -- the gate above already established it -- but without a key
+    // the reader cannot be pointed anywhere, and inventing one would be worse.
+    if (other && typeof other.key === 'string' && !keys.includes(other.key)) keys.push(other.key);
+  }
+
+  return { contradicted: true, ...(keys.length ? { contradictedBy: keys.join(', ') } : {}) };
+}
+
+/**
  * Prepares findings for delivery, verifying each one lazily against disk.
  *
  * This is the only function that should ever hand a finding to a model, because
@@ -474,10 +515,17 @@ export function serve(graph, findings) {
   // quickly.
 
   for (const finding of findings.filter((f) => !f.retired)) {
+    // A DISPUTE TRAVELS WITH EVERY TYPE, which is why it is computed before the
+    // content-dependence branch below. A `command` or `rule` finding cannot be
+    // invalidated by an anchor's contents, but another finding can still
+    // disagree with it, and this early return is the path that would have
+    // quietly dropped that.
+    const dispute = disputeOf(graph, finding);
+
     // A claim that does not depend on the anchor's contents cannot be
     // invalidated by them. It is served as-is rather than discounted.
     if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) {
-      served.push({ ...finding });
+      served.push({ ...finding, ...dispute });
       continue;
     }
 
@@ -562,6 +610,7 @@ export function serve(graph, findings) {
       ...finding,
       stale,
       ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
+      ...dispute,
     });
   }
   return served;

--- a/integrations/copilot/.github/hooks/lib/waste.mjs
+++ b/integrations/copilot/.github/hooks/lib/waste.mjs
@@ -151,6 +151,11 @@ function reDerivation(events, graph) {
       const id = nodeId('file', canonicalPath(row.anchor));
       if (!graph.nodes.has(id)) continue;
 
+      // READ-ONLY serve: no `dir` is threaded here, so this cannot clear a stale
+      // flag whose evidence is gone. That is deliberate -- this function takes a
+      // graph, not the directory it came from, and widening its signature to give
+      // an analysis path a write capability buys nothing: the injection path runs
+      // on every tool call and clears the same findings.
       const findings = serve(graph, findingsFor(graph, id, { limit: 3 }))
         .filter((f) => !f.stale && (f.confidence ?? 0) >= 0.7);
       if (!findings.length) continue;

--- a/integrations/copilot/.github/hooks/lib/wiki.mjs
+++ b/integrations/copilot/.github/hooks/lib/wiki.mjs
@@ -64,18 +64,37 @@ export const SUPPORTED_VERSIONS = [1];
  * Identity today because GRAPH_VERSION is 1 and no shape has changed. It exists
  * now so the first change that DOES need it has somewhere to go other than an
  * equality check that silently deletes user data.
+ *
+ * CONTRACT for the first non-identity step:
+ *  - It must be IDEMPOTENT. `upcast(upcast(r))` must equal `upcast(r)`, because
+ *    compaction upcasts a record to key it and `load` upcasts the same record
+ *    again on every subsequent read. A step that is not idempotent applies twice
+ *    to anything compaction has touched.
+ *  - It must NOT be relied on to restamp `v`. Nothing in this file writes an
+ *    upcast record back to disk under a version it did not come from; the
+ *    version stamp on disk is always the one that wrote the bytes. See the
+ *    per-branch comments in `compactIfWasteful`.
  */
 export function upcast(record) {
   return record;
 }
 
-/** True when this reader can interpret the record at all. */
-function readable(record) {
+/**
+ * True when this reader can interpret the record at all.
+ *
+ * `versions` is a PARAMETER so the range semantics are testable independently of
+ * today's constants. With `SUPPORTED_VERSIONS = [1]` and `GRAPH_VERSION = 1` a
+ * range check and the old equality check are extensionally identical, so a test
+ * pinned to the live constants cannot tell them apart -- and cannot fail if
+ * someone reverts this to an equality. Exercised against `[1, 2]`, it can.
+ */
+export function readable(record, versions = SUPPORTED_VERSIONS) {
   const version = record.v ?? 0;
   // Forward-incompatible records are skipped: a v-from-the-future was written by
-  // a newer client and we cannot know its shape. Ignoring the future is safe;
-  // ignoring the past is data loss.
-  return SUPPORTED_VERSIONS.includes(version);
+  // a newer client and we cannot know its shape. Ignoring the future is safe for
+  // a READER -- but see `compactIfWasteful`, where "ignore" would mean "delete",
+  // because compaction rewrites the files it reads.
+  return versions.includes(version);
 }
 
 /** Node kinds. `file` and `symbol` are first-class so staleness can propagate. */
@@ -434,9 +453,20 @@ function compactIfWasteful(dir) {
     const nodes = new Map();
     const edges = new Map();
     const snaps = new Map();
-    for (const rec of readSnapshots(dir)) {
+    // KEPT VERBATIM THROUGH THE REBUILD, exactly as the main log keeps what it
+    // cannot parse. These lines are not evictable by the snapshot budget below
+    // because their size cannot be attributed to an id we understand -- and
+    // preserving bytes we may not need is strictly better than deleting bytes a
+    // newer client does. They stop accumulating as soon as the client that
+    // wrote them compacts, since it can read and dedupe them.
+    const sidecar = readSnapshots(dir);
+    const rawSnaps = sidecar.unreadable;
+    for (const rec of sidecar.records) {
       if (typeof rec.snapshot === 'string' && rec.snapshot) {
-        snaps.set(rec.id, { at: rec.at || 0, snapshot: rec.snapshot });
+        // `v` IS CARRIED, not restamped. Writing GRAPH_VERSION over a record
+        // from another version mislabels bytes this reader did not produce, and
+        // the label is the only thing a future reader has to go on.
+        snaps.set(rec.id, { at: rec.at || 0, snapshot: rec.snapshot, v: rec.v ?? GRAPH_VERSION });
       }
     }
     for (const line of readFileSync(path, 'utf8').split('\n')) {
@@ -458,27 +488,40 @@ function compactIfWasteful(dir) {
         edges.set('raw:' + edges.size, line);
         continue;
       }
-      // Upcast IN MEMORY only, to key and classify the record. What gets written
-      // back below is the ORIGINAL `line`: compaction reclaims superseded
-      // records, it does not migrate surviving ones, so the on-disk version is
-      // whatever wrote it and `load` upcasts it again on every read.
-      record = upcast(record);
-      if (record.t === 'n') {
+      // TWO OBJECTS, ON PURPOSE. `record` is exactly what the bytes on disk say;
+      // `view` is the in-memory current-shape reading of it, used only to KEY and
+      // CLASSIFY. Nothing derived from `view` is ever serialized, because
+      // compaction reclaims superseded records -- it does not migrate surviving
+      // ones -- so every version stamp it writes is the one that wrote the bytes.
+      //
+      // An earlier revision of this comment claimed "the ORIGINAL line is written
+      // back" for the whole block. That was FALSE for the inline-snapshot branch,
+      // which re-serializes. It re-serialized the upcast object while carrying
+      // the old `v`, so the first non-identity `upcast` would have written
+      // new-shape bytes under an old label and every later `load` would have
+      // upcast them a second time. Hence: strip from `record`, never from `view`.
+      const view = upcast(record);
+      if (view.t === 'n') {
         // MIGRATION. Graphs written before snapshots were split still carry
         // them inline, and those are exactly the graphs that are slow. Moving
         // them out here means one compaction fixes an existing install.
+        //
+        // THE ONLY RE-SERIALIZING BRANCH in this loop. It writes the original
+        // record minus its snapshot, so the surviving bytes keep their own shape
+        // and their own `v`, and the snapshot moved to the sidecar carries the
+        // same `v` as the node it came out of.
         if (typeof record.snapshot === 'string' && record.snapshot) {
           const { snapshot, ...rest } = record;
-          nodes.set(record.id, JSON.stringify(rest));
-          snaps.set(record.id, { at: record.at || 0, snapshot });
+          nodes.set(view.id, JSON.stringify(rest));
+          snaps.set(view.id, { at: record.at || 0, snapshot, v: record.v ?? GRAPH_VERSION });
         } else {
-          nodes.set(record.id, line);
+          nodes.set(view.id, line);
         }
-      } else if (record.t === 's') {
+      } else if (view.t === 's') {
         if (typeof record.snapshot === 'string' && record.snapshot) {
-          snaps.set(record.id, { at: record.at || 0, snapshot: record.snapshot });
+          snaps.set(view.id, { at: record.at || 0, snapshot: record.snapshot, v: record.v ?? GRAPH_VERSION });
         }
-      } else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
+      } else if (view.t === 'e') edges.set(`${view.from}|${view.edge}|${view.to}`, line);
       else edges.set('raw:' + edges.size, line);
     }
 
@@ -541,10 +584,20 @@ function compactIfWasteful(dir) {
     renameSync(tmp, path);
     // The surviving snapshots are rewritten to their own file, which is also
     // what migrates a graph that still had them inline.
-    const snapOut =
-      [...keep.entries()]
-        .map(([id, v]) => JSON.stringify({ t: 's', v: GRAPH_VERSION, id, snapshot: v.snapshot, at: v.at }))
-        .join('\n') + (keep.size ? '\n' : '');
+    //
+    // UNREADABLE LINES FIRST AND VERBATIM. This rebuild replaces the file, so
+    // anything omitted here is deleted permanently -- which made the missing
+    // counterpart to the main log's `raw:` bucket a real data-loss path, not a
+    // theoretical one. Each survivor also keeps ITS OWN `v` rather than being
+    // restamped to GRAPH_VERSION, so no record is relabelled as something this
+    // reader wrote.
+    const snapLines = [
+      ...rawSnaps,
+      ...[...keep.entries()].map(([id, s]) =>
+        JSON.stringify({ t: 's', v: s.v ?? GRAPH_VERSION, id, snapshot: s.snapshot, at: s.at })
+      ),
+    ];
+    const snapOut = snapLines.join('\n') + (snapLines.length ? '\n' : '');
     const snapTmp = snapshotsPath(dir) + '.compact';
     writeFileSync(snapTmp, snapOut, { mode: 0o600 });
     renameSync(snapTmp, snapshotsPath(dir));
@@ -689,9 +742,26 @@ function appendSnapshot(dir, record) {
   }
 }
 
-/** Every snapshot record, latest wins. Read only when a caller asks. */
+/**
+ * Every snapshot record, latest wins. Read only when a caller asks.
+ *
+ * `unreadable` collects the RAW LINES this reader rejected, and it is the reason
+ * this function reports them at all rather than just dropping them. `load` has
+ * no use for them -- a reader that cannot interpret a record must ignore it --
+ * but `compactIfWasteful` REBUILDS this file from what it read, so for the
+ * compactor "ignore" and "delete permanently" are the same operation. The main
+ * log already keeps what it cannot parse (the `raw:` bucket); the sidecar had no
+ * equivalent, which made it the one asymmetric, destructive path in an otherwise
+ * append-only store.
+ *
+ * This is not hypothetical here: hooks-core is vendored into eleven client
+ * directories that update independently, so a stale client compacting a graph a
+ * newer client has already written to is the expected steady state, not an edge
+ * case.
+ */
 function readSnapshots(dir) {
-  const out = [];
+  /** @type {object[]} */ const out = [];
+  /** @type {string[]} */ const unreadable = [];
   try {
     for (const line of readFileSync(snapshotsPath(dir), 'utf8').split('\n')) {
       if (!line) continue;
@@ -699,19 +769,23 @@ function readSnapshots(dir) {
         const rec = JSON.parse(line);
         // THE SAME RANGE AS THE MAIN LOG, deliberately. An equality check here
         // was the quietest of the three: a bump would have made every stored
-        // snapshot unreadable, and the very next compaction -- which rebuilds
-        // this file from what it could read -- would have deleted them for
-        // good. That is the one place in this store where a read filter turns
-        // into a permanent write.
-        if (readable(rec) && rec.id) out.push(upcast(rec));
+        // snapshot unreadable, and the very next compaction would have deleted
+        // them for good.
+        if (!readable(rec)) {
+          unreadable.push(line);
+          continue;
+        }
+        if (rec.id) out.push(upcast(rec));
       } catch {
-        /* a torn line costs one snapshot */
+        // A torn line costs one snapshot -- and it is NOT preserved, because a
+        // half-written line is not a record from another version, it is
+        // garbage. Distinguishing the two is the whole point of parsing first.
       }
     }
   } catch {
     /* no sidecar yet */
   }
-  return out;
+  return { records: out, unreadable };
 }
 
 /**
@@ -777,7 +851,9 @@ export function load(dir, { snapshots = false } = {}) {
   // Re-attached after the sweep, so a snapshot record may appear before or
   // after the node it belongs to.
   if (pending) {
-    for (const rec of readSnapshots(dir)) pending.set(rec.id, rec.snapshot);
+    // A reader has no use for the lines it could not interpret; only the
+    // compactor does, because only the compactor rewrites the file.
+    for (const rec of readSnapshots(dir).records) pending.set(rec.id, rec.snapshot);
     for (const [id, snapshot] of pending) {
       const node = nodes.get(id);
       if (node) nodes.set(id, { ...node, snapshot });

--- a/integrations/copilot/.github/hooks/lib/wiki.mjs
+++ b/integrations/copilot/.github/hooks/lib/wiki.mjs
@@ -28,17 +28,55 @@ import { canonicalPath, isFsSafePath } from './paths.mjs';
 /**
  * Schema version stamped on every record.
  *
- * There is exactly ONE version and no migration code, because nothing has been
- * released: a graph written by an older commit of an unreleased branch is a
- * development artifact, not user data, and carrying migration paths for it costs
- * real complexity to protect something nobody has. A record from any other
- * version is skipped rather than interpreted, so a stale dev graph degrades to
- * "rebuilds from use" instead of silently mixing incompatible identities.
+ * THIS PACKAGE IS RELEASED. It ships on npm, so every graph on disk is user
+ * data. An earlier version of this comment claimed nothing had been released
+ * and used that to justify having no migration path at all -- and the reader
+ * below compared for EQUALITY, so the first bump would have discarded every
+ * existing graph in silence. That justification is gone and so is the equality:
+ * `SUPPORTED_VERSIONS` is the range this reader accepts, and `upcast` is where a
+ * shape change is absorbed in memory.
  *
- * When this does ship, a bump here is where migration would be added -- with
- * users to protect, that trade reverses.
+ * A bump here is taken only when a record's SHAPE actually changes, and it comes
+ * with a new `upcast` step and an entry in `SUPPORTED_VERSIONS` in the same
+ * change. Adding a field that older readers can ignore is not a shape change.
  */
 export const GRAPH_VERSION = 1;
+
+/**
+ * Versions this reader accepts, oldest first.
+ *
+ * A RANGE, NOT AN EQUALITY. The equality check this replaces would have
+ * discarded every existing graph the moment anyone bumped the version -- and the
+ * header once justified that with "nothing has been released", which stopped
+ * being true at v5.7.0 on npm.
+ *
+ * Nothing on disk is ever rewritten to migrate: `upcast` runs in memory during
+ * the fold, so there is no migration pass to fail halfway and no race with the
+ * concurrent sessions this store is designed for. A mixed-version log is safe
+ * precisely because the original records are never mutated, and the existing
+ * compaction retires old ones naturally as it rewrites snapshots.
+ */
+export const SUPPORTED_VERSIONS = [1];
+
+/**
+ * Brings one record up to the current version. Pure, and one step per version.
+ *
+ * Identity today because GRAPH_VERSION is 1 and no shape has changed. It exists
+ * now so the first change that DOES need it has somewhere to go other than an
+ * equality check that silently deletes user data.
+ */
+export function upcast(record) {
+  return record;
+}
+
+/** True when this reader can interpret the record at all. */
+function readable(record) {
+  const version = record.v ?? 0;
+  // Forward-incompatible records are skipped: a v-from-the-future was written by
+  // a newer client and we cannot know its shape. Ignoring the future is safe;
+  // ignoring the past is data loss.
+  return SUPPORTED_VERSIONS.includes(version);
+}
 
 /** Node kinds. `file` and `symbol` are first-class so staleness can propagate. */
 export const NODE_KINDS = ['file', 'symbol', 'task', 'finding'];
@@ -409,13 +447,22 @@ function compactIfWasteful(dir) {
       } catch {
         continue;
       }
-      // A record from another schema is KEPT VERBATIM rather than reinterpreted.
-      // load() skips it, but discarding it here would make compaction a silent
-      // migration that deletes data a future version might understand.
-      if ((record.v ?? 0) !== GRAPH_VERSION) {
+      // A record this reader cannot interpret is KEPT VERBATIM rather than
+      // reinterpreted. load() skips it, but discarding it here would make
+      // compaction a silent migration that deletes data a future version might
+      // understand. THE RANGE MATTERS HERE TOO: with an equality check, a bump
+      // would have parked every existing v1 record in `raw`, undeduplicated, so
+      // compaction would stop reclaiming anything and inline snapshots would
+      // never migrate out -- the same loss by a second route.
+      if (!readable(record)) {
         edges.set('raw:' + edges.size, line);
         continue;
       }
+      // Upcast IN MEMORY only, to key and classify the record. What gets written
+      // back below is the ORIGINAL `line`: compaction reclaims superseded
+      // records, it does not migrate surviving ones, so the on-disk version is
+      // whatever wrote it and `load` upcasts it again on every read.
+      record = upcast(record);
       if (record.t === 'n') {
         // MIGRATION. Graphs written before snapshots were split still carry
         // them inline, and those are exactly the graphs that are slow. Moving
@@ -650,7 +697,13 @@ function readSnapshots(dir) {
       if (!line) continue;
       try {
         const rec = JSON.parse(line);
-        if ((rec.v ?? 0) === GRAPH_VERSION && rec.id) out.push(rec);
+        // THE SAME RANGE AS THE MAIN LOG, deliberately. An equality check here
+        // was the quietest of the three: a bump would have made every stored
+        // snapshot unreadable, and the very next compaction -- which rebuilds
+        // this file from what it could read -- would have deleted them for
+        // good. That is the one place in this store where a read filter turns
+        // into a permanent write.
+        if (readable(rec) && rec.id) out.push(upcast(rec));
       } catch {
         /* a torn line costs one snapshot */
       }
@@ -691,7 +744,12 @@ export function load(dir, { snapshots = false } = {}) {
       if (!snapshots) continue;
       try {
         const rec = JSON.parse(line);
-        if ((rec.v ?? 0) === GRAPH_VERSION) pending.set(rec.id, rec.snapshot);
+        // Inline snapshots from an older graph: same range, same reason. These
+        // are precisely the records most likely to predate a bump.
+        if (readable(rec)) {
+          const snap = upcast(rec);
+          pending.set(snap.id, snap.snapshot);
+        }
       } catch {
         /* a torn line costs one snapshot, not the graph */
       }
@@ -703,10 +761,14 @@ export function load(dir, { snapshots = false } = {}) {
     } catch {
       continue;
     }
-    // A record from another schema is skipped, not interpreted: its ids and
-    // hashes were derived differently, so honouring it produces confident
-    // nonsense rather than a visible error.
-    if ((record.v ?? 0) !== GRAPH_VERSION) continue;
+    // A record this reader cannot interpret is skipped, not guessed at: a
+    // version from the FUTURE derived its ids and hashes in a way we do not
+    // know, so honouring it produces confident nonsense rather than a visible
+    // error. A record from the PAST is upcast, never skipped -- skipping it is
+    // data loss, and this comparison used to be an equality, which made the
+    // first version bump a silent delete of every graph on disk.
+    if (!readable(record)) continue;
+    record = upcast(record);
     if (record.t === 'n') nodes.set(record.id, record);
     else if (record.t === 'e') edges.push(record);
   }

--- a/integrations/copilot/.github/hooks/lib/wiki.mjs
+++ b/integrations/copilot/.github/hooks/lib/wiki.mjs
@@ -775,7 +775,17 @@ function readSnapshots(dir) {
           unreadable.push(line);
           continue;
         }
+        // A RECORD WITH NO `id` IS KEPT VERBATIM, NOT DROPPED SILENTLY. It
+        // cannot be attributed to a node, so it is useless to `load` -- but this
+        // used to put it in neither bucket, and `compactIfWasteful` rebuilds the
+        // sidecar from `records` plus `unreadable`, so a line in neither was
+        // deleted permanently by the next compaction. That is the same shape as
+        // the Critical this reader's version check already fixed, and the same
+        // asymmetry: for the compactor, "ignore" and "destroy" are one operation.
+        // Unreachable today because every writer sets `id`; a reader is not the
+        // right place to rely on that.
         if (rec.id) out.push(upcast(rec));
+        else unreadable.push(line);
       } catch {
         // A torn line costs one snapshot -- and it is NOT preserved, because a
         // half-written line is not a record from another version, it is

--- a/integrations/copilot/.github/hooks/post-tool.mjs
+++ b/integrations/copilot/.github/hooks/post-tool.mjs
@@ -8,7 +8,7 @@ process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.
-process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write';
+process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write,wiki_query';
 try {
   const { run } = await import('./lib/adapter.mjs');
   await run('copilot', 'post-tool');

--- a/integrations/copilot/.github/hooks/post-tool.mjs
+++ b/integrations/copilot/.github/hooks/post-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/copilot/.github/hooks/pre-tool.mjs
+++ b/integrations/copilot/.github/hooks/pre-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/copilot/.github/hooks/pre-tool.mjs
+++ b/integrations/copilot/.github/hooks/pre-tool.mjs
@@ -8,7 +8,7 @@ process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.
-process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write';
+process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write,wiki_query';
 try {
   const { run } = await import('./lib/adapter.mjs');
   await run('copilot', 'pre-tool');

--- a/integrations/copilot/.github/hooks/session-start.mjs
+++ b/integrations/copilot/.github/hooks/session-start.mjs
@@ -8,7 +8,7 @@ process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.
-process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write';
+process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write,wiki_query';
 try {
   const { run } = await import('./lib/adapter.mjs');
   await run('copilot', 'session-start');

--- a/integrations/copilot/.github/hooks/session-start.mjs
+++ b/integrations/copilot/.github/hooks/session-start.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/copilot/.github/hooks/stop.mjs
+++ b/integrations/copilot/.github/hooks/stop.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/copilot/.github/hooks/stop.mjs
+++ b/integrations/copilot/.github/hooks/stop.mjs
@@ -8,7 +8,7 @@ process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.
-process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write';
+process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write,wiki_query';
 try {
   const { run } = await import('./lib/adapter.mjs');
   await run('copilot', 'stop');

--- a/integrations/cursor/hooks/lib/adapter.mjs
+++ b/integrations/cursor/hooks/lib/adapter.mjs
@@ -68,6 +68,7 @@ import {
   standingRules,
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
+import { observedWrite, queueInvalidation } from './pending.mjs';
 import { isArchived } from './transcript.mjs';
 import { isFsSafePath } from './paths.mjs';
 import {
@@ -881,6 +882,35 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Causal tracing is fail-open like every other hook optimization.
+    }
+
+    // EAGER INVALIDATION, finally connected. `invalidateOnWrite` has existed,
+    // been tested and been described in staleness.mjs's own header since
+    // staleness landed, and its only reference in shipped code was a COMMENT in
+    // the PreToolUse router -- so the path that header calls load-bearing had
+    // never run once in production. It matters most for exactly this event: the
+    // lazy check compares the anchor's stored hash against disk, and the
+    // capture below re-points that hash at the bytes this write just produced,
+    // so a write the session performed ITSELF is invisible to lazy staleness.
+    //
+    // QUEUED, NOT APPLIED. Applying needs the graph, and loading a megabyte of
+    // JSONL on the return path of every write is what this shape exists to
+    // avoid. The next graph read drains it before serving anything.
+    try {
+      if (mutationSucceeded(clientName, raw)) {
+        const evidence = observedWrite(payload, raw);
+        if (evidence) {
+          // THE SAME DIRECTORY THE GRAPH ITSELF USES. `observeAndInject` keys
+          // every write on `wikiDir(projectRootFor(path, payload.cwd))`, and a
+          // queue written anywhere else is a queue nothing ever drains.
+          queueInvalidation(
+            wikiDir(projectRootFor(evidence.path, payload.cwd)),
+            evidence
+          );
+        }
+      }
+    } catch {
+      // Bookkeeping for a call that already completed. Never let it cost one.
     }
   }
 

--- a/integrations/cursor/hooks/lib/adapter.mjs
+++ b/integrations/cursor/hooks/lib/adapter.mjs
@@ -64,6 +64,7 @@ import {
   forTouch,
   noteActClasses,
   relevantFindingIdsForContext,
+  sessionContext,
   sessionIndex,
   standingRules,
 } from './inject.mjs';
@@ -690,8 +691,23 @@ async function runHook(clientName, event, invocation) {
       rememberOptimizerTools(state, toolEvidence);
       saveState(sessionId, state);
     }
-    const parts = [
-      policyText(client.canDeny, toolEvidence.names, toolEvidence.proven),
+    // ASSEMBLED IN CACHE ORDER, not in whatever order this function happens to
+    // discover the blocks. Everything emitted here sits near the FRONT of the
+    // prompt prefix, and a prefix cache invalidates from the first differing
+    // byte onward -- so the block that changes most often has to sit LAST, or it
+    // re-prices every block behind it on every session. `sessionContext` sorts
+    // by the declared volatility; inject.mjs records how each number was
+    // assigned and why.
+    const blocks = [
+      {
+        id: 'policy',
+        volatility: 0,
+        text: policyText(
+          client.canDeny,
+          toolEvidence.names,
+          toolEvidence.proven
+        ),
+      },
     ];
     const cwd = raw.cwd || raw.working_directory || process.cwd();
     const root = projectRootFor(join(cwd, '__session__'), cwd);
@@ -705,7 +721,7 @@ async function runHook(clientName, event, invocation) {
         const graph = load(dir);
         const episode = episodeMeta({ client: clientName, raw });
         const rules = standingRules(dir, graph, { episode });
-        if (rules) parts.push(rules);
+        if (rules) blocks.push({ id: 'standing', volatility: 1, text: rules });
         const relevantFindingIds = relevantFindingIdsForContext(
           graph,
           sessionTaskContext(raw)
@@ -714,12 +730,12 @@ async function runHook(clientName, event, invocation) {
           episode,
           relevantFindingIds,
         });
-        if (index) parts.push(index);
+        if (index) blocks.push({ id: 'index', volatility: 2, text: index });
       } catch {
         // Retrieval is optional context; the policy must still reach the model.
       }
     }
-    const output = contextOutput(client, eventName, parts.join('\n\n'));
+    const output = contextOutput(client, eventName, sessionContext(blocks));
     if (output) emit(output);
     process.exit(0);
   }

--- a/integrations/cursor/hooks/lib/adapter.mjs
+++ b/integrations/cursor/hooks/lib/adapter.mjs
@@ -68,7 +68,7 @@ import {
   standingRules,
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
-import { observedWrite, queueInvalidation } from './pending.mjs';
+import { observedWrites, queueInvalidation } from './pending.mjs';
 import { isArchived } from './transcript.mjs';
 import { isFsSafePath } from './paths.mjs';
 import {
@@ -898,8 +898,7 @@ async function runHook(clientName, event, invocation) {
     // avoid. The next graph read drains it before serving anything.
     try {
       if (mutationSucceeded(clientName, raw)) {
-        const evidence = observedWrite(payload, raw);
-        if (evidence) {
+        for (const evidence of observedWrites(payload, raw)) {
           // THE SAME DIRECTORY THE GRAPH ITSELF USES. `observeAndInject` keys
           // every write on `wikiDir(projectRootFor(path, payload.cwd))`, and a
           // queue written anywhere else is a queue nothing ever drains.

--- a/integrations/cursor/hooks/lib/capabilities.mjs
+++ b/integrations/cursor/hooks/lib/capabilities.mjs
@@ -38,6 +38,10 @@ export const HOOK_MCP_TOOLS = Object.freeze([
   'optimize_session',
   'get_optimization_report',
   'wiki_write',
+  // The read side of the graph. The session index tells the model to "call
+  // wiki_query with a key for detail", so the hook needs positive evidence that
+  // the name it is advertising is actually registered in this host.
+  'wiki_query',
 ]);
 
 const HOOK_MCP_TOOL_SET = new Set(HOOK_MCP_TOOLS);

--- a/integrations/cursor/hooks/lib/curate.mjs
+++ b/integrations/cursor/hooks/lib/curate.mjs
@@ -22,7 +22,7 @@
  */
 
 import { randomBytes } from 'node:crypto';
-import { putNode, putNodeWithEdges, load, nodeId } from './wiki.mjs';
+import { putNode, putEdge, putNodeWithEdges, load, nodeId } from './wiki.mjs';
 import { indexFile } from './staleness.mjs';
 import { symbolKey } from './symbols.mjs';
 import { canonicalPath } from './paths.mjs';
@@ -178,6 +178,79 @@ export function retire(dir, key) {
   if (!existing) return false;
   putNode(dir, { ...existing, kind: 'finding', key, retired: true });
   return true;
+}
+
+/**
+ * Records that one finding disagrees with another.
+ *
+ * AN EDGE, NOT AN OVERWRITE -- the design is explicit about why: "when a belief
+ * changes, the graph should record THAT it changed and why, not quietly present
+ * the new one as though it had always been true." `contradicts` has been in
+ * EDGE_KINDS since the schema existed and was written by nothing, while
+ * `audit()` already READ it.
+ *
+ * The contradicted finding is deliberately NOT retired, and its claim is
+ * deliberately preserved. A reader needs to see both claims and the
+ * disagreement between them; retiring one silently picks a winner, and putNode
+ * does not merge -- it writes the whole record from what it is handed, so
+ * annotating the target without spreading it back in would blank the very claim
+ * this edge exists to keep visible. That is the overwrite by another name.
+ *
+ * THE EDGE IS WRITTEN FIRST, and the order is the guarantee. These are two
+ * appends and `append` fails open, so either can be the one that lands. Edge
+ * without annotation is a complete, readable disagreement missing only its
+ * reason. Annotation without edge is a finding that says "something contradicts
+ * me" with no contradictor -- a claim of proof with no proof, and invisible to
+ * `audit()` and to `hasOutstandingContradiction`, both of which read the edge.
+ */
+export function contradict(dir, { key, byKey, reason }) {
+  const graph = load(dir);
+  const target = findingByKey(graph, key);
+  const source = findingByKey(graph, byKey);
+  // Both ends must exist, or the edge is unresolvable and the disagreement is
+  // recorded against nothing -- the same un-invalidatable shape anchors prevent.
+  if (!target || !source) return false;
+  // A finding cannot disagree with itself. The self-edge resolves, so the guard
+  // above waves it through, and the result is a node permanently blocked from
+  // confidence promotion by a dispute no person can ever resolve: there is no
+  // second claim to choose between.
+  if (target.id === source.id) return false;
+
+  putEdge(dir, source.id, 'contradicts', target.id);
+  putNode(dir, {
+    ...target,
+    kind: 'finding',
+    key,
+    contradictedAt: Date.now(),
+    contradictionReason: String(reason || '').slice(0, 400),
+  });
+  return true;
+}
+
+/**
+ * Whether anything currently disagrees with this finding.
+ *
+ * Gates confidence promotion. Plan 2's per-finding utility measures whether a
+ * finding SUPPRESSES READS, and a confidently wrong finding suppresses reads
+ * better than a hedged true one -- so utility must never raise confidence on
+ * its own, and this is the check that stops it.
+ *
+ * SYMMETRIC, deliberately: BOTH ends of a `contradicts` edge are outstanding
+ * until a person resolves the disagreement. The named hazard in the design is
+ * presenting "the new one as though it had always been true", so gating only
+ * the older claim would leave the newer one -- which is just as likely to be
+ * the wrong one, since nothing here adjudicates -- free to be promoted on
+ * measured utility alone. That is the exact failure this gate exists to stop.
+ * It also matches `audit()`, the reader that has always been here: it puts both
+ * `from` and `to` in its `contradicted` bucket, because "until one looks, BOTH
+ * are being served".
+ */
+export function hasOutstandingContradiction(graph, key) {
+  const node = findingByKey(graph, key);
+  if (!node) return false;
+  return graph.edges.some(
+    (e) => e.edge === 'contradicts' && (e.to === node.id || e.from === node.id)
+  );
 }
 
 /**

--- a/integrations/cursor/hooks/lib/curate.mjs
+++ b/integrations/cursor/hooks/lib/curate.mjs
@@ -124,7 +124,17 @@ export function correct(
   const replacementKey = `${key}-c${Date.now().toString(36)}`;
 
   const edges = [{ edge: 'supersedes', to: originalId }];
-  // The correction inherits the original's anchors, so it can go stale too.
+  // The correction inherits the original's anchors, so it can go stale too --
+  // but it inherits NOTHING ELSE, and that is deliberate rather than incidental.
+  // The node written below is built field by field from `existing` instead of
+  // spreading it, which is what keeps the staleness fields (`stale`,
+  // `staleReason`, `diff`) off the successor: a correction is re-derived
+  // against the current code by definition, so being born carrying its
+  // predecessor's invalidation would discount it the moment it existed --
+  // `disclose.mjs` skips a stale finding outright and `utility.mjs` penalises
+  // one by 160. Any future edit here that reaches for `...existing` to pick up
+  // one more field re-introduces that, since `putNode` writes what it is handed
+  // wholesale; `tests/hooks/stale-clearing.test.mjs` is the guard.
   for (const edge of graph.edges) {
     if (edge.edge === 'derived_from' && edge.from === originalId) {
       edges.push({ edge: 'derived_from', to: edge.to });
@@ -244,13 +254,38 @@ export function contradict(dir, { key, byKey, reason }) {
  * It also matches `audit()`, the reader that has always been here: it puts both
  * `from` and `to` in its `contradicted` bucket, because "until one looks, BOTH
  * are being served".
+ *
+ * A RETIRED COUNTERPART DOES NOT COUNT, and that sentence quoted just above is
+ * the reason. This read edges ONLY, so retiring one end of a contradiction left
+ * the survivor gated against confidence promotion forever and served with a
+ * DISPUTED note naming a key `serve` refuses to hand anybody -- `serve`,
+ * `activeFindings`, `findingsFor` and `sessionIndex` all drop a retired
+ * finding. A retired claim is served to NOBODY, so "BOTH are being served" is
+ * false and the premise of the gate is gone: only one claim is in play, and
+ * there is nothing left to choose between. Retiring one end IS the person
+ * looking that this gate was waiting for -- so the edge counts as open only
+ * while NEITHER end is retired, answered the same way from both directions.
+ *
+ * AN UNRESOLVABLE END STILL COUNTS. An edge whose other side names no node
+ * proves nothing about whether that claim was withdrawn, and the conservative
+ * reading -- still disputed -- is the one that cannot promote a claim nobody
+ * adjudicated.
  */
 export function hasOutstandingContradiction(graph, key) {
   const node = findingByKey(graph, key);
-  if (!node) return false;
-  return graph.edges.some(
-    (e) => e.edge === 'contradicts' && (e.to === node.id || e.from === node.id)
-  );
+  // A withdrawn claim is not in a dispute either: a dispute needs two claims in
+  // play, and this one has been taken out of play. Without this the RETIRED end
+  // still reported an open disagreement, which is the same defect from the other
+  // side -- and the answer has to agree from both directions, since the gate is
+  // symmetric on purpose.
+  if (!node || node.retired) return false;
+  return graph.edges.some((e) => {
+    if (e.edge !== 'contradicts') return false;
+    const otherId = e.from === node.id ? e.to : e.to === node.id ? e.from : null;
+    if (!otherId) return false;
+    const other = graph.nodes.get(otherId);
+    return !other || !other.retired;
+  });
 }
 
 /**
@@ -334,11 +369,24 @@ export function audit(graph) {
       .map((e) => e.from)
   );
 
+  // THE SAME DEFINITION OF AN OPEN DISPUTE as hasOutstandingContradiction, and
+  // it has to be: that function's own comment claims it "matches audit()", and
+  // two rankings that disagree about what needs a human is worse than one that
+  // is wrong. A retired counterpart is a resolved dispute -- the retired claim
+  // is served to nobody -- so the survivor is not one of two claims in play and
+  // does not belong in the bucket of things needing a person to look.
+  //
+  // One pass, not a call per finding: this is a dashboard read over the whole
+  // graph, and the obvious rewrite is O(findings x edges).
   const contradicted = new Set();
   for (const edge of graph.edges) {
     if (edge.edge !== 'contradicts') continue;
-    contradicted.add(edge.from);
-    contradicted.add(edge.to);
+    const from = graph.nodes.get(edge.from);
+    const to = graph.nodes.get(edge.to);
+    // An end that resolves to nothing cannot be shown retired, so it still
+    // counts against the other end.
+    if (!to || !to.retired) contradicted.add(edge.from);
+    if (!from || !from.retired) contradicted.add(edge.to);
   }
 
   return {

--- a/integrations/cursor/hooks/lib/curate.mjs
+++ b/integrations/cursor/hooks/lib/curate.mjs
@@ -70,6 +70,38 @@ export function originWeight(origin) {
   return 1;
 }
 
+/**
+ * The claim-time anchor hashes, for a finding being written right now.
+ *
+ * THE CHECKABLE HALF OF PROVENANCE, and until now only `harvest-write.mjs`
+ * wrote it -- so the asymmetry ran exactly the wrong way. `reverify` and the
+ * automatic clear in `serve` both compare disk against these frozen hashes, and
+ * a finding without them can never have a stale flag cleared by anything. That
+ * meant HUMAN-asserted findings, the ones somebody deliberately created or
+ * corrected, were the only ones condemned to stay stale forever once marked,
+ * while machine-harvested claims could recover. The hashes are simply the anchor
+ * nodes' hashes at this moment, and every writer has them in hand.
+ *
+ * DELIBERATELY NOT THE WHOLE RECORD `derivationFor` BUILDS. That one joins the
+ * evidence log to find FILE-surface operations behind the claim; curation
+ * performs no such join, so `operations` is empty and `operationsComplete` says
+ * so. An empty list declared incomplete is honest -- "nothing recorded here, and
+ * do not read that as nothing happened" -- where an empty list declared complete
+ * would assert a fact nobody established.
+ *
+ * An anchor with no stored hash contributes no entry, and a finding whose
+ * anchors all lack one gets a record with no hashes -- which `claimTimeVerdict`
+ * reads as `unknown` and refuses to clear on, which is the correct reading.
+ */
+function claimTimeDerivation(graph, resolved) {
+  const anchors = {};
+  for (const id of resolved) {
+    const node = graph.nodes.get(id);
+    if (node && typeof node.hash === 'string') anchors[id] = node.hash;
+  }
+  return { at: Date.now(), anchors, operations: [], operationsComplete: false };
+}
+
 function findingByKey(graph, key) {
   return graph.nodes.get(nodeId('finding', key)) || null;
 }
@@ -124,6 +156,11 @@ export function correct(
   const replacementKey = `${key}-c${Date.now().toString(36)}`;
 
   const edges = [{ edge: 'supersedes', to: originalId }];
+  // Collected alongside the edges so the correction carries its own claim-time
+  // hashes: it is a NEW claim, re-derived against whatever the code says now, so
+  // its evidence is the anchors' current state -- not the predecessor's, which is
+  // precisely what went stale.
+  const inherited = [];
   // The correction inherits the original's anchors, so it can go stale too --
   // but it inherits NOTHING ELSE, and that is deliberate rather than incidental.
   // The node written below is built field by field from `existing` instead of
@@ -138,6 +175,7 @@ export function correct(
   for (const edge of graph.edges) {
     if (edge.edge === 'derived_from' && edge.from === originalId) {
       edges.push({ edge: 'derived_from', to: edge.to });
+      inherited.push(edge.to);
     }
   }
 
@@ -171,6 +209,11 @@ export function correct(
       // branches, and an unrecognised value already degrades to the neutral
       // ranking weight rather than doing damage.
       origin: typeof origin === 'string' && origin ? origin : ORIGIN_HUMAN,
+      // Without this a correction could never have a stale flag cleared: both
+      // clearing paths compare disk against these hashes, and a finding with
+      // none is `unknown` forever. A hand-written correction being the least
+      // recoverable record in the graph was the wrong way round.
+      derivation: claimTimeDerivation(graph, inherited),
     },
     edges
   );
@@ -339,7 +382,18 @@ export function create(dir, { claim, anchors, type = 'finding', confidence = 0.9
   // path. No process death required; one transient EBUSY is enough.
   const id = putNodeWithEdges(
     dir,
-    { kind: 'finding', key, claim, confidence, type, origin: ORIGIN_HUMAN },
+    {
+      kind: 'finding',
+      key,
+      claim,
+      confidence,
+      type,
+      origin: ORIGIN_HUMAN,
+      // Read AFTER the indexFile loop above, so the hashes are the ones the
+      // person's claim was actually made against rather than whatever the graph
+      // held before this call touched it.
+      derivation: claimTimeDerivation(loadGraph(dir), resolved),
+    },
     resolved.map((target) => ({ edge: 'derived_from', to: target }))
   );
   if (!id) return null;

--- a/integrations/cursor/hooks/lib/decide.mjs
+++ b/integrations/cursor/hooks/lib/decide.mjs
@@ -542,19 +542,92 @@ const TOOL_ALIASES = new Map(
     run_shell_command: 'Bash',
     run_terminal_cmd: 'Bash',
     terminal: 'Bash',
+
+    // THIS PROJECT'S OWN TOOLS, which the table did not list for as long as it
+    // existed. `plugin/hooks/hooks.json`'s PostToolUse matcher named
+    // `mcp__.*__(?:smart_edit|smart_write)` and Codex's AfterTool matcher named
+    // the bare `smart_edit|smart_write`, so both hooks fired -- and then
+    // `normalizeTool` returned null and the hook exited before a single line of
+    // accounting ran. Staleness, mutation counting and harvest pressure were all
+    // blind on exactly the path enforcement pushes the model toward, which is the
+    // worst place to be blind: the more effective the routing, the less the
+    // optimizer saw.
+    //
+    // These names are the CANONICAL operation, not a licence to redirect. A call
+    // that is already the replacement is excluded from routing by
+    // `isReplacementTool` below.
+    smart_read: 'Read',
+    smart_grep: 'Grep',
+    smart_glob: 'Glob',
+    smart_edit: 'Edit',
+    smart_write: 'Write',
+
+    // Claude Code's notebook editor. Same shape of gap: a real mutation of a
+    // real file on disk that arrived as null and so never reached
+    // `pending.mjs`'s MUTATING set, leaving every notebook write invisible to
+    // invalidation.
+    notebookedit: 'Edit',
+    notebook_edit: 'Edit',
   })
 );
 
-/** Maps a client's tool name onto the canonical one, or null if unhandled. */
+/**
+ * The optimizer's own replacement tools, by canonical trailing segment.
+ *
+ * Kept separate from the alias table because the two answer different questions.
+ * The table answers "what operation is this", which post-tool accounting needs.
+ * This set answers "is this call ALREADY the thing we would have recommended",
+ * which routing needs -- and conflating them is the loop hazard: `smart_edit`
+ * resolves to `Edit`, the Edit branch recommends `smart_edit`, and the model is
+ * told to call the tool it just called.
+ */
+const REPLACEMENT_TOOLS = new Set([
+  'smart_read',
+  'smart_grep',
+  'smart_glob',
+  'smart_edit',
+  'smart_write',
+]);
+
+/**
+ * The tool name with an `mcp__<server>__` prefix removed, if it had one.
+ *
+ * Server segments contain underscores freely (`plugin_token-optimizer_token-optimizer`)
+ * and so do tool names (`smart_edit`), so the split is taken at the LAST `__`
+ * after the `mcp__` sentinel. Both halves must be non-empty: `mcp__edit` names
+ * no server and is not a name any host emits, and treating it as `edit` would
+ * coerce an unrecognised string into a built-in.
+ */
+function withoutMcpPrefix(name) {
+  const match = /^mcp__(.+)__(.+)$/.exec(name);
+  return match ? match[2] : name;
+}
+
+/** Whether this call IS one of the optimizer's replacements, however spelled. */
+export function isReplacementTool(name) {
+  if (!name) return false;
+  return REPLACEMENT_TOOLS.has(withoutMcpPrefix(String(name)).toLowerCase());
+}
+
+/**
+ * Maps a client's tool name onto the canonical one, or null if unhandled.
+ *
+ * PERMISSIVE IN ONE DIRECTION ONLY. An MCP-prefixed name is resolved by its
+ * trailing segment, but only against the same table every other client is held
+ * to -- so `mcp__vendor__deploy_to_prod` stays null. Coercing an unrecognised
+ * MCP tool into a built-in would change a routing verdict for a tool nobody has
+ * considered, which is a far worse failure than not accounting for it.
+ */
 export function normalizeTool(name) {
   if (!name) return null;
+  const candidate = withoutMcpPrefix(String(name));
   if (
     ['Read', 'Grep', 'Glob', 'Edit', 'MultiEdit', 'Write', 'Bash'].includes(
-      name
+      candidate
     )
   )
-    return name;
-  return TOOL_ALIASES.get(String(name).toLowerCase()) || null;
+    return candidate;
+  return TOOL_ALIASES.get(candidate.toLowerCase()) || null;
 }
 
 /**
@@ -614,6 +687,13 @@ export function normalizePayload(raw) {
     transcript_path: raw.transcript_path ?? raw.transcriptPath ?? null,
     cwd,
     tool_name: normalizeTool(raw.tool_name ?? raw.toolName ?? raw.tool),
+    // WHETHER THIS CALL IS ALREADY THE REPLACEMENT, carried alongside the
+    // canonical name rather than inferred from it -- because it cannot be
+    // inferred from it. `smart_edit` and `Edit` both normalise to `Edit`, and
+    // routing has to treat them as opposites while accounting treats them as
+    // the same. Absent by default (`false`), so a payload assembled by hand in
+    // a test or by a caller that predates this field is a normal built-in call.
+    replacement: isReplacementTool(raw.tool_name ?? raw.toolName ?? raw.tool),
     tool_input: {
       ...input,
       // CANONICALISED HERE, once. Every consumer downstream -- the `seen` map
@@ -673,6 +753,19 @@ function replacementAvailable(availableTools, name) {
 }
 
 export function decide(payload, state, availableTools = undefined) {
+  // THE LOOP HAZARD, and the reason this guard is at the top rather than inside
+  // any one branch. Resolving `smart_edit` to `Edit` is what makes post-tool
+  // accounting work; it must not also make the Edit branch answer a smart_edit
+  // call with "call smart_edit instead". This is not theoretical on a matcher
+  // level either: Qwen's PreToolUse matcher is the unanchored regex
+  // `edit|write_file|run_shell_command`, and `edit` matches inside
+  // `mcp__x__smart_edit`, so that client really does hand the router calls to
+  // its own replacements.
+  //
+  // A tool that IS the replacement is never routed. There is nothing better to
+  // recommend, and every branch below would recommend itself.
+  if (payload.replacement) return null;
+
   const tool = payload.tool_name;
   const input = payload.tool_input || {};
   const threshold = largeFileBytes();
@@ -873,6 +966,12 @@ export function remember(payload, state) {
  */
 export function readCostBytes(payload) {
   if (payload.tool_name !== 'Read') return 0;
+  // A REPLACEMENT DID NOT SPEND THE WHOLE FILE. `smart_read` normalises to
+  // `Read` so the graph sees the touch, but it returns a diff -- charging the
+  // full file size here would feed the holdout comparison a cost that was never
+  // paid, on the arm the optimizer is trying to show is cheaper. Better to
+  // record nothing than to record a number in the wrong direction.
+  if (payload.replacement) return 0;
   const path = payload.tool_input?.file_path;
   if (!path || isBinaryPath(path)) return 0;
   const size = fileSize(path);

--- a/integrations/cursor/hooks/lib/disclose.mjs
+++ b/integrations/cursor/hooks/lib/disclose.mjs
@@ -294,6 +294,11 @@ export function verdictFor(graph, { anchors = [], question, minConfidence = 0.7 
     const id = nodeId('file', canonicalPath(anchor));
     if (!graph.nodes.has(id)) continue;
 
+    // READ-ONLY serve: no `dir` is threaded here, so this cannot clear a stale
+    // flag whose evidence is gone. That is deliberate -- this function takes a
+    // graph, not the directory it came from, and widening its signature to give
+    // an analysis path a write capability buys nothing: the injection path runs
+    // on every tool call and clears the same findings.
     const findings = serve(graph, findingsFor(graph, id, { limit: 4 }));
     for (const finding of findings) {
       if (finding.stale) continue;

--- a/integrations/cursor/hooks/lib/harvest-write.mjs
+++ b/integrations/cursor/hooks/lib/harvest-write.mjs
@@ -34,7 +34,7 @@ import { randomBytes } from 'node:crypto';
 import { realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
-import { readEvidence } from './metrics.mjs';
+import { readEvidence, evidenceTruncated } from './metrics.mjs';
 
 /**
  * The types that may cross a project boundary.
@@ -431,53 +431,84 @@ function resolveAnchor(dir, anchor, projectRoot) {
 /**
  * Which task actually produced this finding, when nothing said so directly.
  *
- * Session id was the only signal `answers` had, and a session id is exactly
- * what a caller may not have (`wiki_write`'s `sessionId` is optional and
- * nothing populates it today; the detached harvest worker's is gated behind
- * an opt-in). But the graph does not need to be TOLD which task this is: the
- * structural harvest already writes `task -[derived_from]-> file` for every
- * tool call, unconditionally, on every install. So the task is DERIVABLE --
- * it is whichever task node has a `derived_from` edge to one of the SAME
- * anchors this finding resolved to.
+ * ROUND 2's version scanned the WHOLE graph for any task sharing any anchor,
+ * broken by recency. An adversarial review constructed four cases where that
+ * attributes a finding to the WRONG task:
  *
- * "Most recent task, full stop" was rejected on purpose: a task that never
- * touched these files could still be the newest node in the graph (a
- * different file, a different concern, in a later session), and attaching
- * provenance to it would be a WRONG edge, not a missing one -- worse than no
- * edge, because a reader trusts it. So candidates are filtered to tasks that
- * touched at least one of these anchors FIRST, and only ties among THOSE are
- * broken by recency.
+ *   1. STALE PRIOR SESSION -- a session that reasons from injected memory and
+ *      writes a finding about `foo.ts` without touching it this session gets
+ *      attributed to whatever task last touched `foo.ts`, possibly days old,
+ *      possibly someone else's work.
+ *   2. CONCURRENT SESSION -- two windows on one repository; the other
+ *      session's task wins if its touch is a millisecond later.
+ *   3. OVERLAP, NOT COVERAGE -- a finding anchored to [a, b]; a task that
+ *      touched only `b` could still win over one that touched both.
+ *   4. THE TIE-BREAK CONTRADICTED ITS OWN COMMENT -- `Number(edge.at) || 0`
+ *      with strict `>` means the FIRST edge in log order wins on a tie,
+ *      which is the OLDER task, not "more recently" as documented.
  *
- * The tie-break is the edge's own `at`, not the task node's `at`. A task that
- * touched this file once, long ago, and then stayed active on unrelated files
- * for hours has a late node timestamp that says nothing about this anchor;
- * the edge timestamp says exactly when THIS task touched THIS anchor, which
- * is the question being asked. Among tasks sharing an anchor, the one whose
- * most recent touch to any shared anchor is latest wins -- recency of the
- * relevant work, not recency of the task in general.
+ * THE FIX IS NARROWER THAN A BETTER RANKING: SCOPE, THEN REQUIRE COVERAGE.
+ * A task only ever belongs to the session that created it -- `harvest()` and
+ * `linkCoOccurrence()` (wiki.mjs, inject.mjs) both key a task node by
+ * `sessionId`, always, so there is exactly ONE task node for "the current
+ * session" and it is `nodeId('task', sessionId)`. Restricting to that ONE
+ * node structurally eliminates cases 1 and 2 -- a prior or concurrent
+ * session's task has a DIFFERENT sessionId and therefore a different node
+ * id, so it is never even looked at, regardless of timing. No caller can
+ * supply a wrong sessionId and get someone ELSE's task; they can only fail
+ * to get a match.
+ *
+ * COVERAGE, NOT OVERLAP, fixes case 3: the session's task must have a
+ * `derived_from` edge to EVERY one of this finding's anchors, not merely one.
+ * A partial touch is not attribution.
+ *
+ * With the candidate set reduced to at most one node, there is nothing left
+ * to break a tie between -- case 4's comparator is not "fixed", it is
+ * deleted, because the scenario it was written for (two DIFFERENT tasks both
+ * legitimately eligible) cannot occur under this scoping: two task nodes can
+ * never share a key, and only the current session's key is ever considered.
+ * An edge's `at` therefore plays NO role here: presence of a `derived_from`
+ * edge from the session's task to an anchor is what "touched it" means, with
+ * or without a timestamp on that edge -- there is no ranking left for a
+ * missing timestamp to lose.
+ *
+ * `sessionId` absent means there is no identity to scope by, which means no
+ * candidate -- not "fall back to guessing". Absence is the correct answer
+ * when the graph cannot support attribution.
  */
-function taskForAnchors(graph, anchorIds) {
-  if (!anchorIds || !anchorIds.length) return null;
-  const anchors = new Set(anchorIds);
-  let best = null;
-  for (const edge of graph.edges) {
-    if (edge.edge !== 'derived_from' || !anchors.has(edge.to)) continue;
-    const from = graph.nodes.get(edge.from);
-    // `derived_from` is also how a FINDING cites its own anchors, so without
-    // this a finding that already cited the same file would be mistaken for
-    // the task that produced it.
-    if (!from || from.kind !== 'task') continue;
-    const at = Number(edge.at) || 0;
-    if (!best || at > best.at) best = { taskId: edge.from, at };
+function taskForAnchors(graph, anchorIds, sessionId) {
+  if (!sessionId || !anchorIds || !anchorIds.length) return null;
+  const taskTarget = nodeId('task', sessionId);
+  const task = graph.nodes.get(taskTarget);
+  if (!task || task.kind !== 'task') return null;
+
+  for (const anchor of anchorIds) {
+    const covered = graph.edges.some((edge) =>
+      edge.edge === 'derived_from' && edge.from === taskTarget && edge.to === anchor
+    );
+    // ONE missing anchor refuses the whole attribution. A finding cited three
+    // files; this session's task touched two of them -- that is evidence the
+    // task did SOME related work, not evidence it produced THIS finding.
+    if (!covered) return null;
   }
-  return best ? best.taskId : null;
+  return taskTarget;
 }
 
 /**
  * A file path the way `recordToolOutcome` (metrics.mjs) already truncates and
- * stores it on a `tool-outcome` event's `anchor` field, so a derivation record
- * can join against that log without a second, divergent notion of "the same
- * anchor".
+ * stores it on a FILE-surface `tool-outcome` event's `anchor` field, so a
+ * derivation record can join against that log without a second, divergent
+ * notion of "the same anchor".
+ *
+ * COMMAND-surface events are DECLARED OUT OF SCOPE, not silently missed:
+ * `adapter.mjs` stores the COMMAND TEXT in `anchor` for those
+ * (`String(command).slice(0, 120)`), so a build or test run can never share
+ * an anchor string with a canonical file path -- there is no join key in
+ * common, and inventing a command-to-file heuristic (which files did a given
+ * `npm test` invocation cover?) is not something this record can answer
+ * honestly. `operationsScope` on the returned record says so explicitly,
+ * rather than letting an empty `operations` array look like "no build or
+ * test ever ran" when the truth is "this join cannot see it".
  */
 function anchorLabel(rawAnchor) {
   const path = String(rawAnchor).split('#')[0];
@@ -497,7 +528,8 @@ const MAX_DERIVATION_OPERATIONS = 5;
  * that comparison be reconstructed for a specific claim rather than only for
  * the anchor in general: the hash each anchor carried at the moment this
  * finding was derived from it, plus what evidence exists that any work
- * actually happened against it.
+ * actually happened against it. `derivationCheck` (staleness.mjs) is the
+ * reader that actually performs that comparison at serve time.
  *
  * DELIBERATELY NOT DUPLICATING THE EDGES. `derived_from` already records
  * WHICH anchors this finding cites; restating that here would be a second,
@@ -506,14 +538,23 @@ const MAX_DERIVATION_OPERATIONS = 5;
  *
  * DELIBERATELY NOT A REPLAY LOG. Recording enough to mechanically re-run a
  * derivation is a separate subsystem with real storage cost. This stores only
- * what the evidence log already has: `tool-outcome` events matching these
- * anchors, each reduced to the fields that were actually captured. An event
- * that carries no exit code or output contributes none -- nothing here is
- * invented to fill a shape the pipeline does not evidence yet. If a future
- * capture pass adds `exit`/`output` to those events, this starts carrying them
- * with no change to this function.
+ * what the evidence log already has: FILE-surface `tool-outcome` events
+ * matching these anchors, each reduced to the fields that were actually
+ * captured. An event that carries no exit code or output contributes none --
+ * nothing here is invented to fill a shape the pipeline does not evidence
+ * yet. If a future capture pass adds `exit`/`output` to those events, this
+ * starts carrying them with no change to this function.
+ *
+ * INCOMPLETENESS IS MARKED, NOT IMPLIED. An empty `operations` array is
+ * genuinely ambiguous on its own -- it is the same shape whether nothing
+ * happened, or something happened but fell outside what this join can see.
+ * `operationsComplete` distinguishes them: false when the evidence log itself
+ * may have dropped older matches (`evidenceIncomplete`, from
+ * `metrics.evidenceTruncated`) OR when more matches existed than the cap
+ * kept. A reader can then tell "no operations happened" from "operations
+ * existed but are not recorded here" instead of guessing.
  */
-function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
+function derivationFor(graph, resolvedAnchors, evidence, evidenceIncomplete, anchorSpecs) {
   const anchorHashes = {};
   for (const id of resolvedAnchors) {
     const node = graph.nodes.get(id);
@@ -521,8 +562,10 @@ function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
   }
 
   const labels = new Set((anchorSpecs || []).map(anchorLabel));
-  const operations = evidence
-    .filter((event) => event.kind === 'tool-outcome' && labels.has(event.anchor))
+  const matching = evidence.filter(
+    (event) => event.kind === 'tool-outcome' && labels.has(event.anchor)
+  );
+  const operations = [...matching]
     .sort((a, b) => (Number(b.at) || 0) - (Number(a.at) || 0))
     .slice(0, MAX_DERIVATION_OPERATIONS)
     .map((event) => {
@@ -540,7 +583,16 @@ function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
       return op;
     });
 
-  return { at: Date.now(), anchors: anchorHashes, operations };
+  return {
+    at: Date.now(),
+    anchors: anchorHashes,
+    operations,
+    // FILE touches only -- see `anchorLabel`. Declared here, in the record
+    // itself, not only in this function's comment, so a reader who never
+    // opens this source file still learns builds and test runs are excluded.
+    operationsScope: 'file',
+    operationsComplete: !evidenceIncomplete && matching.length <= operations.length,
+  };
 }
 
 /**
@@ -588,6 +640,9 @@ export function writeHarvested(
   // it can hold thousands of lines, so re-reading it per finding would turn a
   // batch of N findings into N passes over the same bytes.
   const evidence = readEvidence(dir);
+  // Cheap: one stat call, checked once per batch rather than once per
+  // finding's derivation record.
+  const evidenceIncomplete = evidenceTruncated(dir);
 
   const written = [];
   for (const finding of findings) {
@@ -647,14 +702,16 @@ export function writeHarvested(
     // An explicit `taskId` is authoritative when a caller supplies one --
     // it OVERRIDES traversal rather than merely seeding it, so a caller that
     // knows better is never second-guessed by inference. Absent one, the task
-    // is DERIVED from the graph itself: `taskForAnchors` finds the task that
-    // actually touched these anchors, which needs no session id from anyone.
-    // Either way, held to the same discipline as the anchors above: a target
-    // that does not resolve to an existing task node produces no edge rather
-    // than a dangling one.
+    // is DERIVED from the graph itself: `taskForAnchors` finds the CURRENT
+    // session's task (scoped by `sessionId`, the same identity this write
+    // already carries for provenance) and requires it to have touched EVERY
+    // one of this finding's anchors, not merely one -- see that function's
+    // own comment for the four attacks this closes. Either way, held to the
+    // same discipline as the anchors above: a target that does not resolve to
+    // an existing task node produces no edge rather than a dangling one.
     const answersTarget = taskId
       ? nodeId('task', taskId)
-      : taskForAnchors(currentGraph, resolved);
+      : taskForAnchors(currentGraph, resolved, sessionId);
     if (answersTarget && currentGraph.nodes.has(answersTarget)) {
       edges.push({ edge: 'answers', to: answersTarget });
     }
@@ -707,7 +764,7 @@ export function writeHarvested(
         // `render()`/`renderSessionIndex()` in inject.mjs or `wiki_read`'s
         // `toFinding()` projection, neither of which reads this field, so it
         // is not part of the automatic per-touch injection `fit()` prices.
-        derivation: derivationFor(currentGraph, resolved, evidence, finding.anchors || []),
+        derivation: derivationFor(currentGraph, resolved, evidence, evidenceIncomplete, finding.anchors || []),
       },
       edges
     );

--- a/integrations/cursor/hooks/lib/harvest-write.mjs
+++ b/integrations/cursor/hooks/lib/harvest-write.mjs
@@ -452,11 +452,13 @@ function resolveAnchor(dir, anchor, projectRoot) {
  * `linkCoOccurrence()` (wiki.mjs, inject.mjs) both key a task node by
  * `sessionId`, always, so there is exactly ONE task node for "the current
  * session" and it is `nodeId('task', sessionId)`. Restricting to that ONE
- * node structurally eliminates cases 1 and 2 -- a prior or concurrent
- * session's task has a DIFFERENT sessionId and therefore a different node
- * id, so it is never even looked at, regardless of timing. No caller can
- * supply a wrong sessionId and get someone ELSE's task; they can only fail
- * to get a match.
+ * node structurally eliminates cases 1 and 2 PROVIDED the identity itself is
+ * trustworthy: an UNRELATED sessionId (typo'd, invented, or simply absent)
+ * cannot resolve to someone else's task, because a different key is a
+ * different node id, full stop, regardless of timing. That is NOT the same
+ * guarantee as "no caller can get someone else's task" -- see the note on
+ * `authoritativeSessionId` below for the residual this leaves when the
+ * identity is real but comes from an untrusted caller.
  *
  * COVERAGE, NOT OVERLAP, fixes case 3: the session's task must have a
  * `derived_from` edge to EVERY one of this finding's anchors, not merely one.
@@ -472,17 +474,41 @@ function resolveAnchor(dir, anchor, projectRoot) {
  * or without a timestamp on that edge -- there is no ranking left for a
  * missing timestamp to lose.
  *
- * `sessionId` absent means there is no identity to scope by, which means no
- * candidate -- not "fall back to guessing". Absence is the correct answer
- * when the graph cannot support attribution.
+ * NO IDENTITY MEANS NO CANDIDATE -- not "fall back to guessing". Absence is
+ * the correct answer when the graph cannot support attribution.
+ *
+ * ROUND 4: THE IDENTITY ITSELF MUST BE AUTHORITATIVE, not merely present.
+ * Scoping to `nodeId('task', sessionId)` only refuses an UNRELATED session;
+ * it does nothing against a FOREIGN BUT REAL one. `wiki_write`'s `sessionId`
+ * is a plain MCP tool argument the calling model supplies, unverified -- a
+ * model that names some OTHER, prior session whose task genuinely covered
+ * these anchors gets an `answers` edge to that stale task, because coverage
+ * cannot tell "this session" from "a session that really did touch these
+ * files, named by a string nothing cross-checked". Session id is not
+ * evidence unless the CALLER'S OWN CHANNEL is trustworthy, which is true of
+ * `plugin/hooks/harvest-worker.mjs` (Claude Code's own hook payload) and not
+ * true of a tool-call argument. So this parameter is named for what it must
+ * be, `authoritativeSessionId`, and every caller is a promise: pass this only
+ * when you did not just read it out of untrusted input. `wiki_write` passes
+ * NONE, which means its calls never traverse -- see `writeHarvested`'s own
+ * comment at the call site for what that costs and why it is accepted rather
+ * than worked around.
+ *
+ * COVERAGE IS CHECKED AGAINST RESOLVED ANCHORS, not the caller's original
+ * list. `writeHarvested` already drops any anchor `resolveAnchor` could not
+ * resolve before this function ever runs, so "every anchor" here means every
+ * anchor that survived that filter -- self-consistent with the
+ * `derived_from` edges the same resolved list produces, but worth stating:
+ * an anchor that failed to resolve cannot raise or lower the bar for the
+ * anchors that did.
  */
-function taskForAnchors(graph, anchorIds, sessionId) {
-  if (!sessionId || !anchorIds || !anchorIds.length) return null;
-  const taskTarget = nodeId('task', sessionId);
+function taskForAnchors(graph, resolvedAnchorIds, authoritativeSessionId) {
+  if (!authoritativeSessionId || !resolvedAnchorIds || !resolvedAnchorIds.length) return null;
+  const taskTarget = nodeId('task', authoritativeSessionId);
   const task = graph.nodes.get(taskTarget);
   if (!task || task.kind !== 'task') return null;
 
-  for (const anchor of anchorIds) {
+  for (const anchor of resolvedAnchorIds) {
     const covered = graph.edges.some((edge) =>
       edge.edge === 'derived_from' && edge.from === taskTarget && edge.to === anchor
     );
@@ -604,7 +630,19 @@ function derivationFor(graph, resolvedAnchors, evidence, evidenceIncomplete, anc
 export function writeHarvested(
   dir,
   findings,
-  { sessionId = null, origin = ORIGIN_HARVESTED, projectRoot = null, taskId = null } = {}
+  {
+    sessionId = null,
+    origin = ORIGIN_HARVESTED,
+    projectRoot = null,
+    taskId = null,
+    // Distinct from `sessionId`, which is stored on every finding for
+    // provenance/display regardless of trust. This one gates the `answers`
+    // traversal fallback specifically, and every caller passing it is
+    // asserting the identity came from a channel it does not control --
+    // Claude Code's own hook payload, not a tool-call argument a model
+    // typed. See `taskForAnchors`'s comment for the attack this closes.
+    authoritativeSessionId = null,
+  } = {}
 ) {
   if (!Array.isArray(findings) || !findings.length) return [];
 
@@ -702,16 +740,29 @@ export function writeHarvested(
     // An explicit `taskId` is authoritative when a caller supplies one --
     // it OVERRIDES traversal rather than merely seeding it, so a caller that
     // knows better is never second-guessed by inference. Absent one, the task
-    // is DERIVED from the graph itself: `taskForAnchors` finds the CURRENT
-    // session's task (scoped by `sessionId`, the same identity this write
-    // already carries for provenance) and requires it to have touched EVERY
-    // one of this finding's anchors, not merely one -- see that function's
-    // own comment for the four attacks this closes. Either way, held to the
-    // same discipline as the anchors above: a target that does not resolve to
-    // an existing task node produces no edge rather than a dangling one.
+    // is DERIVED from the graph itself, but ONLY when `authoritativeSessionId`
+    // is present: `taskForAnchors` scopes to that exact session's task and
+    // requires it to have touched EVERY one of this finding's anchors, not
+    // merely one -- see that function's own comment for why the identity
+    // itself must be trustworthy, not merely present.
+    //
+    // THE CONSEQUENCE, STATED PLAINLY: `wiki_write` never supplies
+    // `authoritativeSessionId` (its `sessionId` is a model-typed MCP
+    // argument nothing cross-checks), so its calls never traverse and
+    // `answers` never fires on that path. `plugin/hooks/harvest-worker.mjs`
+    // does supply it (Claude Code's own hook payload), so `answers` fires
+    // there -- opt-in gated. `answers` therefore does NOT fire on a default
+    // install today. Recovering default liveness needs an authoritative
+    // identity on a default-install path, which is what Plan 2's
+    // `hooks-core/derive.mjs` (running in the Stop hook, where the session id
+    // is real) is for -- not a weaker check here.
+    //
+    // Either way, held to the same discipline as the anchors above: a target
+    // that does not resolve to an existing task node produces no edge rather
+    // than a dangling one.
     const answersTarget = taskId
       ? nodeId('task', taskId)
-      : taskForAnchors(currentGraph, resolved, sessionId);
+      : taskForAnchors(currentGraph, resolved, authoritativeSessionId);
     if (answersTarget && currentGraph.nodes.has(answersTarget)) {
       edges.push({ edge: 'answers', to: answersTarget });
     }

--- a/integrations/cursor/hooks/lib/harvest-write.mjs
+++ b/integrations/cursor/hooks/lib/harvest-write.mjs
@@ -436,7 +436,7 @@ function resolveAnchor(dir, anchor, projectRoot) {
 export function writeHarvested(
   dir,
   findings,
-  { sessionId = null, origin = ORIGIN_HARVESTED, projectRoot = null } = {}
+  { sessionId = null, origin = ORIGIN_HARVESTED, projectRoot = null, taskId = null } = {}
 ) {
   if (!Array.isArray(findings) || !findings.length) return [];
 
@@ -516,6 +516,21 @@ export function writeHarvested(
     // collision vanishingly unlikely while keeping the timestamp readable.
     const provenance = provenanceFor(finding);
     const key = `${prefixFor(provenance)}-${Date.now().toString(36)}-${written.length}-${randomBytes(4).toString("hex")}`;
+
+    const edges = resolved.map((target) => ({ edge: 'derived_from', to: target }));
+    // `answers` closes the loop back to the task that produced the finding, so
+    // provenance can be traversed rather than inferred: "which session
+    // established this, and from what". Declared in EDGE_KINDS and written by
+    // nothing until now. Held to the same discipline as the anchors above: a
+    // taskId that does not resolve to an existing task node produces no edge
+    // rather than a dangling one.
+    if (taskId) {
+      const taskTarget = nodeId('task', taskId);
+      if (currentGraph.nodes.has(taskTarget)) {
+        edges.push({ edge: 'answers', to: taskTarget });
+      }
+    }
+
     // ONE APPEND for the finding and every anchor it resolved. This runs in a
     // detached worker, so "the process survives to finish the loop" is not a
     // safe assumption: a node written without its edges is an active finding
@@ -557,7 +572,7 @@ export function writeHarvested(
           : undefined,
         sessionId,
       },
-      resolved.map((target) => ({ edge: 'derived_from', to: target }))
+      edges
     );
     // A failed write returns null. Reporting the key anyway would tell the
     // caller a claim was stored that no later session can retrieve.

--- a/integrations/cursor/hooks/lib/harvest-write.mjs
+++ b/integrations/cursor/hooks/lib/harvest-write.mjs
@@ -34,6 +34,7 @@ import { randomBytes } from 'node:crypto';
 import { realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
+import { readEvidence } from './metrics.mjs';
 
 /**
  * The types that may cross a project boundary.
@@ -428,6 +429,121 @@ function resolveAnchor(dir, anchor, projectRoot) {
 }
 
 /**
+ * Which task actually produced this finding, when nothing said so directly.
+ *
+ * Session id was the only signal `answers` had, and a session id is exactly
+ * what a caller may not have (`wiki_write`'s `sessionId` is optional and
+ * nothing populates it today; the detached harvest worker's is gated behind
+ * an opt-in). But the graph does not need to be TOLD which task this is: the
+ * structural harvest already writes `task -[derived_from]-> file` for every
+ * tool call, unconditionally, on every install. So the task is DERIVABLE --
+ * it is whichever task node has a `derived_from` edge to one of the SAME
+ * anchors this finding resolved to.
+ *
+ * "Most recent task, full stop" was rejected on purpose: a task that never
+ * touched these files could still be the newest node in the graph (a
+ * different file, a different concern, in a later session), and attaching
+ * provenance to it would be a WRONG edge, not a missing one -- worse than no
+ * edge, because a reader trusts it. So candidates are filtered to tasks that
+ * touched at least one of these anchors FIRST, and only ties among THOSE are
+ * broken by recency.
+ *
+ * The tie-break is the edge's own `at`, not the task node's `at`. A task that
+ * touched this file once, long ago, and then stayed active on unrelated files
+ * for hours has a late node timestamp that says nothing about this anchor;
+ * the edge timestamp says exactly when THIS task touched THIS anchor, which
+ * is the question being asked. Among tasks sharing an anchor, the one whose
+ * most recent touch to any shared anchor is latest wins -- recency of the
+ * relevant work, not recency of the task in general.
+ */
+function taskForAnchors(graph, anchorIds) {
+  if (!anchorIds || !anchorIds.length) return null;
+  const anchors = new Set(anchorIds);
+  let best = null;
+  for (const edge of graph.edges) {
+    if (edge.edge !== 'derived_from' || !anchors.has(edge.to)) continue;
+    const from = graph.nodes.get(edge.from);
+    // `derived_from` is also how a FINDING cites its own anchors, so without
+    // this a finding that already cited the same file would be mistaken for
+    // the task that produced it.
+    if (!from || from.kind !== 'task') continue;
+    const at = Number(edge.at) || 0;
+    if (!best || at > best.at) best = { taskId: edge.from, at };
+  }
+  return best ? best.taskId : null;
+}
+
+/**
+ * A file path the way `recordToolOutcome` (metrics.mjs) already truncates and
+ * stores it on a `tool-outcome` event's `anchor` field, so a derivation record
+ * can join against that log without a second, divergent notion of "the same
+ * anchor".
+ */
+function anchorLabel(rawAnchor) {
+  const path = String(rawAnchor).split('#')[0];
+  return canonicalPath(path).slice(0, 120);
+}
+
+/** How many recorded operations a single finding's derivation may cite. */
+const MAX_DERIVATION_OPERATIONS = 5;
+
+/**
+ * The checkable half of provenance: not just where a finding came from, but
+ * whether that derivation still holds.
+ *
+ * Citation-style provenance (a session or task id) answers "where". It never
+ * answers "does this still apply" -- that is what staleness already computes,
+ * by comparing an anchor's STORED hash against disk. This record is what lets
+ * that comparison be reconstructed for a specific claim rather than only for
+ * the anchor in general: the hash each anchor carried at the moment this
+ * finding was derived from it, plus what evidence exists that any work
+ * actually happened against it.
+ *
+ * DELIBERATELY NOT DUPLICATING THE EDGES. `derived_from` already records
+ * WHICH anchors this finding cites; restating that here would be a second,
+ * driftable copy of the same fact. What is new here, and only here, is the
+ * HASH each anchor carried at claim time -- edges carry no such thing.
+ *
+ * DELIBERATELY NOT A REPLAY LOG. Recording enough to mechanically re-run a
+ * derivation is a separate subsystem with real storage cost. This stores only
+ * what the evidence log already has: `tool-outcome` events matching these
+ * anchors, each reduced to the fields that were actually captured. An event
+ * that carries no exit code or output contributes none -- nothing here is
+ * invented to fill a shape the pipeline does not evidence yet. If a future
+ * capture pass adds `exit`/`output` to those events, this starts carrying them
+ * with no change to this function.
+ */
+function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
+  const anchorHashes = {};
+  for (const id of resolvedAnchors) {
+    const node = graph.nodes.get(id);
+    if (node && typeof node.hash === 'string') anchorHashes[id] = node.hash;
+  }
+
+  const labels = new Set((anchorSpecs || []).map(anchorLabel));
+  const operations = evidence
+    .filter((event) => event.kind === 'tool-outcome' && labels.has(event.anchor))
+    .sort((a, b) => (Number(b.at) || 0) - (Number(a.at) || 0))
+    .slice(0, MAX_DERIVATION_OPERATIONS)
+    .map((event) => {
+      const op = {};
+      if (typeof event.toolName === 'string' && event.toolName)
+        op.tool = event.toolName.slice(0, 60);
+      if (typeof event.success === 'boolean') op.success = event.success;
+      if (typeof event.at === 'number') op.at = event.at;
+      // Forward-compatible, not fabricated: neither field exists on a
+      // `tool-outcome` event in this pipeline today, so every operation
+      // omits them until a capture pass actually evidences one.
+      if (typeof event.exit === 'number') op.exit = event.exit;
+      if (typeof event.output === 'string' && event.output)
+        op.output = event.output.slice(0, 200);
+      return op;
+    });
+
+  return { at: Date.now(), anchors: anchorHashes, operations };
+}
+
+/**
  * Writes validated findings, returning the keys actually stored.
  *
  * `findings` is the output of `harvest.validate()`, so type/claim/confidence
@@ -467,6 +583,11 @@ export function writeHarvested(
       : batch;
   const prefixFor = (p) =>
     p === ORIGIN_AGENT ? 'agent' : p === ORIGIN_HUMAN ? 'human' : 'harvested';
+
+  // Read once: every finding in this batch shares the same evidence log, and
+  // it can hold thousands of lines, so re-reading it per finding would turn a
+  // batch of N findings into N passes over the same bytes.
+  const evidence = readEvidence(dir);
 
   const written = [];
   for (const finding of findings) {
@@ -521,14 +642,21 @@ export function writeHarvested(
     // `answers` closes the loop back to the task that produced the finding, so
     // provenance can be traversed rather than inferred: "which session
     // established this, and from what". Declared in EDGE_KINDS and written by
-    // nothing until now. Held to the same discipline as the anchors above: a
-    // taskId that does not resolve to an existing task node produces no edge
-    // rather than a dangling one.
-    if (taskId) {
-      const taskTarget = nodeId('task', taskId);
-      if (currentGraph.nodes.has(taskTarget)) {
-        edges.push({ edge: 'answers', to: taskTarget });
-      }
+    // nothing until now.
+    //
+    // An explicit `taskId` is authoritative when a caller supplies one --
+    // it OVERRIDES traversal rather than merely seeding it, so a caller that
+    // knows better is never second-guessed by inference. Absent one, the task
+    // is DERIVED from the graph itself: `taskForAnchors` finds the task that
+    // actually touched these anchors, which needs no session id from anyone.
+    // Either way, held to the same discipline as the anchors above: a target
+    // that does not resolve to an existing task node produces no edge rather
+    // than a dangling one.
+    const answersTarget = taskId
+      ? nodeId('task', taskId)
+      : taskForAnchors(currentGraph, resolved);
+    if (answersTarget && currentGraph.nodes.has(answersTarget)) {
+      edges.push({ edge: 'answers', to: answersTarget });
     }
 
     // ONE APPEND for the finding and every anchor it resolved. This runs in a
@@ -571,6 +699,15 @@ export function writeHarvested(
           ? finding.quote
           : undefined,
         sessionId,
+        // THE CHECKABLE HALF OF PROVENANCE. Citation-style (this `sessionId`,
+        // the `answers` edge above) says WHERE a claim came from; it never
+        // says whether that derivation still applies. `derivationFor` reaches
+        // through `wiki_query`'s `node`/`get`/`search` operations only (those
+        // return a finding's stored fields wholesale) -- never through
+        // `render()`/`renderSessionIndex()` in inject.mjs or `wiki_read`'s
+        // `toFinding()` projection, neither of which reads this field, so it
+        // is not part of the automatic per-touch injection `fit()` prices.
+        derivation: derivationFor(currentGraph, resolved, evidence, finding.anchors || []),
       },
       edges
     );

--- a/integrations/cursor/hooks/lib/inject.mjs
+++ b/integrations/cursor/hooks/lib/inject.mjs
@@ -26,6 +26,7 @@ import {
 } from './wiki.mjs';
 import { basename } from 'node:path';
 import { serve, diffLines } from './staleness.mjs';
+import { drainInvalidations } from './pending.mjs';
 import { inHoldout, record, indexBudget } from './metrics.mjs';
 import { canonicalPath, resolvableCandidates } from './paths.mjs';
 import { annotatedSkeleton } from './skeleton.mjs';
@@ -142,6 +143,31 @@ function render(finding) {
 }
 
 /**
+ * Applies anything the post-tool hook queued, BEFORE anything is served.
+ *
+ * THIS IS WHERE EAGER STALENESS LANDS. `invalidateOnWrite` needs a graph, and
+ * loading one on the return path of every write is what pending.mjs exists to
+ * avoid -- so the hook queues and the next graph read applies. These two
+ * functions are that read: they already hold a freshly loaded graph, and they
+ * are the last thing to run before a finding reaches a model.
+ *
+ * RE-READ ONLY WHEN SOMETHING WAS ACTUALLY MARKED. The drain writes the stale
+ * flag to disk; it cannot mutate the caller's already-parsed graph, so serving
+ * from that copy would deliver the very "stale finding as fresh" this exists to
+ * prevent. A second load costs a parse, and it is paid once per observed write
+ * rather than once per tool call -- when nothing is queued this is one stat.
+ */
+function withPendingApplied(dir, graph) {
+  try {
+    return drainInvalidations(dir, graph) > 0 ? load(dir) : graph;
+  } catch {
+    // The lazy path still covers everything this would have caught early, and
+    // a hook must never fail because bookkeeping did.
+    return graph;
+  }
+}
+
+/**
  * What the model sees when it touches a file.
  *
  * Returns null when there is nothing to say, or when this touch fell into the
@@ -154,6 +180,7 @@ export function forTouch(
   rawPath,
   { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
+  graph = withPendingApplied(dir, graph);
   // Canonical, so a touch finds findings anchored under any other spelling.
   const filePath = canonicalPath(rawPath);
   const anchorId = nodeId('file', filePath);
@@ -322,6 +349,7 @@ export function forCommand(
   { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
   if (!command) return null;
+  graph = withPendingApplied(dir, graph);
 
   const candidates = [];
   for (const node of graph.nodes.values()) {

--- a/integrations/cursor/hooks/lib/inject.mjs
+++ b/integrations/cursor/hooks/lib/inject.mjs
@@ -33,6 +33,7 @@ import { annotatedSkeleton } from './skeleton.mjs';
 import { substitutionBudget } from './metrics.mjs';
 import { assessFindings } from './utility.mjs';
 import { quarantineSharedSource } from './harvest-write.mjs';
+import { cacheOrdered } from './cache.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
@@ -1152,6 +1153,53 @@ export function standingRules(dir, graph, { budget = standingBudget(), episode =
   // which is worse than saying there are more: a model that knows the list is
   // truncated can ask, one that does not will assume it is complete.
   return `${HEADING}${lines.join('\n')}${truncated}`;
+}
+
+/**
+ * SessionStart context, assembled in cache order: stable first, volatile last.
+ *
+ * WHY THE ORDER IS A CORRECTNESS PROPERTY AND NOT A STYLE CHOICE. Everything
+ * here lands near the FRONT of the prompt prefix, and a prefix cache is
+ * invalidated from the first differing byte onward. A block whose text changes
+ * between sessions therefore prices everything positioned after it: put the
+ * freshest block first and the whole remainder of the prefix is re-written
+ * every session; put it last and the invalidation is confined to its own tail.
+ * cache.mjs measures exactly this cost in the user's files -- this is the same
+ * discipline applied to our own output, which is the half nobody else has to
+ * think about because nobody else writes into the prefix.
+ *
+ * `cacheOrdered` existed for precisely this and had no caller, so the order was
+ * whatever order the call sites happened to push in. It was accidentally right;
+ * it is now enforced, which is the difference that matters the next time a
+ * block is added.
+ *
+ * VOLATILITY IS ASSIGNED FROM HOW OFTEN THE TEXT ACTUALLY DIFFERS BETWEEN
+ * SESSIONS, not from how important the block is:
+ *
+ *   0  policy -- the optimization notice and project briefing. Deliberately
+ *      cache-safe by construction: the routing facts are number-free and the
+ *      briefing passes through `stableText`, which DROPS any line that would
+ *      vary. It changes when the tool inventory or configuration changes.
+ *   1  standing -- pinned facts and human-verified corrections, rendered in
+ *      full. Changes only when a person pins, retires or corrects something.
+ *   2  index -- the bounded wiki index, selected per session from the task
+ *      text, and carrying [STALE]/[DISPUTED] markers that flip as the code
+ *      moves. Different on most sessions.
+ *   3  restoration -- present only when resuming from a compaction, and derived
+ *      from the anchors of the session that was just discarded. Never twice the
+ *      same.
+ *
+ * A block with no text is dropped rather than joined, so an absent block cannot
+ * open the assembly with a blank line.
+ */
+export function sessionContext(blocks) {
+  return cacheOrdered(
+    (Array.isArray(blocks) ? blocks : []).filter(
+      (block) => block && typeof block.text === 'string' && block.text.trim()
+    )
+  )
+    .map((block) => block.text)
+    .join('\n\n');
 }
 
 /**

--- a/integrations/cursor/hooks/lib/inject.mjs
+++ b/integrations/cursor/hooks/lib/inject.mjs
@@ -122,8 +122,29 @@ function fit(findings, budget) {
   return { kept, spent };
 }
 
+/**
+ * Discloses an open disagreement, on the same line as the claim it is about.
+ *
+ * BOTH HALVES, like the stale renderer below: the strong form names the other
+ * finding so the reader can fetch it, and the form without a key says only what
+ * is actually known. `serve` is what establishes the dispute; this only phrases
+ * it, and it phrases it in one short line because `fit` prices `render` against
+ * the injection budget -- a disagreement is worth a pointer, not both claims in
+ * full.
+ *
+ * NO DISMISSAL VOCABULARY, for the reason measured on the stale wording: an
+ * instruction to discount suppressed findings that were correct. This states
+ * that another claim exists and where to find it, and lets the reader decide.
+ */
+function disputeNote(finding) {
+  if (!finding.contradicted) return '';
+  return finding.contradictedBy
+    ? `\n  DISPUTED by ${finding.contradictedBy} -- wiki_query that key for the other claim`
+    : '\n  DISPUTED by another finding in this graph';
+}
+
 function render(finding) {
-  const head = `- [${finding.type || 'finding'}] ${finding.claim}`;
+  const head = `- [${finding.type || 'finding'}] ${finding.claim}${disputeNote(finding)}`;
   if (!finding.stale) return head;
 
   // A stale finding NEVER renders as though it were current. But the strength
@@ -997,7 +1018,15 @@ function renderSessionIndex(total, findings) {
       : finding.stale
         ? ' [possibly stale; verify before use]'
         : '';
-    return `- ${finding.key}${freshness}: ${finding.claim.slice(0, 90)}`;
+    // The session index is the first thing a session reads, so a disputed
+    // finding must not be listed there as settled either. Compressed to a
+    // marker and a key, matching the freshness markers beside it.
+    const dispute = finding.contradicted
+      ? finding.contradictedBy
+        ? ` [DISPUTED by ${finding.contradictedBy}]`
+        : ' [DISPUTED]'
+      : '';
+    return `- ${finding.key}${freshness}${dispute}: ${finding.claim.slice(0, 90)}`;
   });
   return `# Project wiki (${total} findings, ${findings.length} listed)
 

--- a/integrations/cursor/hooks/lib/inject.mjs
+++ b/integrations/cursor/hooks/lib/inject.mjs
@@ -139,9 +139,26 @@ function fit(findings, budget) {
  */
 function disputeNote(finding) {
   if (!finding.contradicted) return '';
-  return finding.contradictedBy
+  const head = finding.contradictedBy
     ? `\n  DISPUTED by ${finding.contradictedBy} -- wiki_query that key for the other claim`
     : '\n  DISPUTED by another finding in this graph';
+  // THE REASON A PERSON TYPED, rendered here because this is the fullest of the
+  // three dispute surfaces and the only one with room for a sentence. `contradict`
+  // has always stored up to 400 characters of human explanation and, until this
+  // line, nothing read it: the pointer told a reader where to look and withheld
+  // the one thing that would tell them whether looking was worth a tool call.
+  //
+  // TRUNCATED AT 140, because `fit` prices this string against the injection
+  // budget and a 400-character paragraph beside a one-line claim inverts the
+  // proportions. The compressed surfaces -- the session index and restore.mjs's
+  // "Likely next" list -- deliberately keep marker-and-key only; they are one
+  // line per finding by design, and `wiki_query` returns the reason in full.
+  if (typeof finding.contradictionReason !== 'string' || !finding.contradictionReason.trim()) {
+    return head;
+  }
+  const reason = finding.contradictionReason.trim();
+  const shown = reason.length > 140 ? `${reason.slice(0, 140)}...` : reason;
+  return `${head}\n  Reason given: ${shown}`;
 }
 
 /**

--- a/integrations/cursor/hooks/lib/inject.mjs
+++ b/integrations/cursor/hooks/lib/inject.mjs
@@ -276,7 +276,10 @@ export function forTouch(
   // others, so the comparison becomes within-file and the dominant source of
   // variance drops out. A session-pinned arm would destroy that.
   const holdout = inHoldout(filePath);
-  const served = serve(graph, candidates);
+  // `dir` so an eager flag whose evidence is gone is cleared here rather than
+  // waiting for somebody to open the dashboard. Same evidence test as the manual
+  // path -- see `serve`.
+  const served = serve(graph, candidates, { dir });
   const assessed = assessFindings(dir, served, {
     episodeId: episode.episodeId || sessionId,
     relevanceFor: () => 1,
@@ -463,7 +466,7 @@ export function forCommand(
   // only thing an uncapped list buys is the I/O.
   const considered = candidates.slice(0, MAX_COMMAND_CANDIDATES);
 
-  const served = serve(graph, considered);
+  const served = serve(graph, considered, { dir });
   const assessed = assessFindings(dir, served, {
     episodeId: episode.episodeId || sessionId,
     relevanceFor: (finding) => explicit(finding) ? 1 : 0.6,
@@ -990,7 +993,7 @@ export function sessionIndex(dir, graph, { episode = {}, relevantFindingIds = []
   // `serve` is the only path allowed to hand a finding to a model. In
   // particular, activating this previously-unwired index must not create a new
   // path that labels an invalidated content claim as current.
-  const served = serve(graph, selected);
+  const served = serve(graph, selected, { dir });
   if (!served.length) return null;
   // A stale marker is longer than the fresh preview used for candidate
   // selection. Trim from the lowest-ranked end until the ACTUAL message fits.

--- a/integrations/cursor/hooks/lib/inject.mjs
+++ b/integrations/cursor/hooks/lib/inject.mjs
@@ -156,9 +156,9 @@ function disputeNote(finding) {
 function derivationNote(finding) {
   if (finding.derivationHolds !== false) return '';
   const changed = Array.isArray(finding.derivationChanged) ? finding.derivationChanged : [];
-  return changed.length
-    ? `\n  DERIVATION CHANGED -- ${changed.join(', ')} no longer match what this claim was derived from`
-    : '\n  DERIVATION CHANGED since this claim was recorded';
+  if (!changed.length) return '\n  DERIVATION CHANGED since this claim was recorded';
+  const verb = changed.length === 1 ? 'no longer matches' : 'no longer match';
+  return `\n  DERIVATION CHANGED -- ${changed.join(', ')} ${verb} what this claim was derived from`;
 }
 
 function render(finding) {

--- a/integrations/cursor/hooks/lib/inject.mjs
+++ b/integrations/cursor/hooks/lib/inject.mjs
@@ -143,8 +143,26 @@ function disputeNote(finding) {
     : '\n  DISPUTED by another finding in this graph';
 }
 
+/**
+ * Discloses `derivationCheck`'s verdict (staleness.mjs) -- distinct from
+ * `disputeNote` (another finding disagrees) and from the STALE block below
+ * (the anchor NODE's current hash does not match disk). This is about
+ * whether the bytes THIS claim was actually derived from are still the bytes
+ * an anchor holds; see `derivationCheck`'s comment for the case that catches
+ * that the other two can miss. Silent when it holds -- the common case pays
+ * nothing -- and silent when it was never checked at all (an older finding
+ * with no `derivation` record).
+ */
+function derivationNote(finding) {
+  if (finding.derivationHolds !== false) return '';
+  const changed = Array.isArray(finding.derivationChanged) ? finding.derivationChanged : [];
+  return changed.length
+    ? `\n  DERIVATION CHANGED -- ${changed.join(', ')} no longer match what this claim was derived from`
+    : '\n  DERIVATION CHANGED since this claim was recorded';
+}
+
 function render(finding) {
-  const head = `- [${finding.type || 'finding'}] ${finding.claim}${disputeNote(finding)}`;
+  const head = `- [${finding.type || 'finding'}] ${finding.claim}${disputeNote(finding)}${derivationNote(finding)}`;
   if (!finding.stale) return head;
 
   // A stale finding NEVER renders as though it were current. But the strength

--- a/integrations/cursor/hooks/lib/inject.mjs
+++ b/integrations/cursor/hooks/lib/inject.mjs
@@ -157,9 +157,28 @@ function render(finding) {
  * prevent. A second load costs a parse, and it is paid once per observed write
  * rather than once per tool call -- when nothing is queued this is one stat.
  */
+/**
+ * Per process, per graph directory: did the drain change anything?
+ *
+ * THE SECOND CALLER IS WHY THIS EXISTS. SessionStart calls `standingRules` and
+ * then `sessionIndex` with the SAME graph object it loaded once. Without this
+ * memo the first call drains, marks, and re-reads privately -- and the second
+ * call finds an empty queue, marks nothing, and therefore serves from the
+ * caller's pre-drain copy, advertising as current the very finding the first
+ * call had just marked. Draining is not idempotent from the caller's point of
+ * view; remembering the ANSWER is what makes it so.
+ *
+ * A hook process handles one lifecycle event, so this map holds one or two
+ * entries and dies with the process.
+ */
+const drainedDirs = new Map();
+
 function withPendingApplied(dir, graph) {
   try {
-    return drainInvalidations(dir, graph) > 0 ? load(dir) : graph;
+    if (drainedDirs.has(dir)) return drainedDirs.get(dir) ? load(dir) : graph;
+    const marked = drainInvalidations(dir, graph) > 0;
+    drainedDirs.set(dir, marked);
+    return marked ? load(dir) : graph;
   } catch {
     // The lazy path still covers everything this would have caught early, and
     // a hook must never fail because bookkeeping did.
@@ -862,6 +881,12 @@ export function relevantFindingIdsForContext(graph, context, { limit = 8 } = {})
  * shrinks toward the floor. See metrics.indexBudget.
  */
 export function sessionIndex(dir, graph, { episode = {}, relevantFindingIds = [] } = {}) {
+  // DRAINED HERE TOO, and this is the worst place to be wrong. The session index
+  // is the FIRST thing a session sees and it arrives with no other context to
+  // correct it, so advertising a finding the graph already knows is stale is a
+  // false claim made at maximum leverage. The graph is loaded either way, so the
+  // only cost is the stat that finds no queue.
+  graph = withPendingApplied(dir, graph);
   const budget = indexBudget(dir);
   const relevant = new Set(relevantFindingIds);
   // Some SessionStart payloads have no task signal. Fail closed for situational
@@ -988,6 +1013,9 @@ ${lines.join('\n')}`;
  * is wallpaper, and the model stops reading the thing it always sees.
  */
 export function standingRules(dir, graph, { budget = standingBudget(), episode = {} } = {}) {
+  // Same reason as sessionIndex: always-on text, delivered before the first
+  // tool call, with nothing following it that could qualify what it said.
+  graph = withPendingApplied(dir, graph);
   const rules = [...graph.nodes.values()].filter(
     (n) =>
       n.kind === 'finding' &&

--- a/integrations/cursor/hooks/lib/inject.mjs
+++ b/integrations/cursor/hooks/lib/inject.mjs
@@ -143,6 +143,40 @@ function render(finding) {
 }
 
 /**
+ * Graph directories where a drain has already marked something in THIS process.
+ *
+ * THE SECOND CALLER IS WHY THIS EXISTS. SessionStart calls `standingRules` and
+ * then `sessionIndex` with the SAME graph object it loaded once. Without this,
+ * the first call drains, marks, and re-reads privately -- and the second call
+ * finds an empty queue, marks nothing, and therefore serves from the caller's
+ * pre-drain copy, advertising as current the very finding the first call had
+ * just marked. Draining is idempotent; its EFFECT on a caller's parsed graph is
+ * not, so what is remembered here is "a re-read is owed", nothing else.
+ *
+ * ONLY THE POSITIVE CASE IS REMEMBERED, and that is a correctness decision
+ * rather than a tuning one. Remembering "nothing was queued" would mean a queue
+ * arriving LATER in the same process is silently skipped and deferred to some
+ * future session. That cannot happen today, because `queueInvalidation` runs in
+ * the post-tool branch before any injection -- but that is an unguarded
+ * ordering dependency, and it stops being true the moment someone adds a call
+ * site. A repeated empty drain costs one `existsSync` on a file that is not
+ * there, which is a price worth paying to not have an invariant that depends on
+ * nobody reordering anything.
+ *
+ * KEYED CANONICALLY. Two spellings of one directory -- a trailing separator, a
+ * `..` segment, a lower-cased drive letter -- would otherwise be two entries,
+ * which reintroduces exactly the pre-drain-copy bug above. This is the same
+ * defect shape Task 2 on this branch shipped for real, where a tool resolved its
+ * graph from a raw cwd while the hooks resolved theirs through `projectRootFor`
+ * and the two halves of a metric landed in different directories. Path identity
+ * is why `canonicalKey` lives inside `nodeId` rather than at its call sites.
+ *
+ * A hook process handles one lifecycle event, so this set holds one or two
+ * entries and dies with the process.
+ */
+const drainedDirs = new Set();
+
+/**
  * Applies anything the post-tool hook queued, BEFORE anything is served.
  *
  * THIS IS WHERE EAGER STALENESS LANDS. `invalidateOnWrite` needs a graph, and
@@ -157,28 +191,14 @@ function render(finding) {
  * prevent. A second load costs a parse, and it is paid once per observed write
  * rather than once per tool call -- when nothing is queued this is one stat.
  */
-/**
- * Per process, per graph directory: did the drain change anything?
- *
- * THE SECOND CALLER IS WHY THIS EXISTS. SessionStart calls `standingRules` and
- * then `sessionIndex` with the SAME graph object it loaded once. Without this
- * memo the first call drains, marks, and re-reads privately -- and the second
- * call finds an empty queue, marks nothing, and therefore serves from the
- * caller's pre-drain copy, advertising as current the very finding the first
- * call had just marked. Draining is not idempotent from the caller's point of
- * view; remembering the ANSWER is what makes it so.
- *
- * A hook process handles one lifecycle event, so this map holds one or two
- * entries and dies with the process.
- */
-const drainedDirs = new Map();
-
 function withPendingApplied(dir, graph) {
   try {
-    if (drainedDirs.has(dir)) return drainedDirs.get(dir) ? load(dir) : graph;
-    const marked = drainInvalidations(dir, graph) > 0;
-    drainedDirs.set(dir, marked);
-    return marked ? load(dir) : graph;
+    const key = canonicalPath(dir);
+    // The drain runs EVERY time. It is one stat when there is nothing to do,
+    // and running it unconditionally is what keeps the memo from encoding an
+    // assumption about which hook branch ran first.
+    if (drainInvalidations(dir, graph) > 0) drainedDirs.add(key);
+    return drainedDirs.has(key) ? load(dir) : graph;
   } catch {
     // The lazy path still covers everything this would have caught early, and
     // a hook must never fail because bookkeeping did.

--- a/integrations/cursor/hooks/lib/lexical.mjs
+++ b/integrations/cursor/hooks/lib/lexical.mjs
@@ -1,0 +1,73 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/lexical.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * BM25 over findings. Pure, dependency-free, deterministic.
+ *
+ * WHY THIS REPLACES `includes()`. The dashboard filtered findings by substring,
+ * which cannot RANK -- and every consumer of retrieval here is under a hard
+ * token budget, so the budget kept whatever happened to match rather than what
+ * matched best. Ranking is the whole value at a budget.
+ *
+ * WHY BM25 AND NOT EMBEDDINGS. Deliberate, per docs/WIKI_GRAPH.md: deterministic,
+ * instant, explainable, and it cannot drift or need a rebuild. The known cost is
+ * recall on findings with no lexical overlap; Plan 2's recall probe measures that
+ * rather than assuming it away.
+ */
+
+/** Non-word split, lowercased. Short tokens are kept: `fs`, `id`, `os` matter here. */
+export function tokenize(text) {
+  return String(text || '')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+}
+
+/**
+ * Classic BM25. `k1` controls term-frequency saturation, `b` length normalisation.
+ * Defaults are the standard ones and are exposed so the recall probe can sweep them.
+ */
+export function rank(query, findings, { limit = 20, k1 = 1.2, b = 0.75 } = {}) {
+  const terms = tokenize(query);
+  if (!terms.length || !Array.isArray(findings) || !findings.length) return [];
+
+  // A finding's searchable text is its claim AND its key: the key is how the
+  // session index refers to it, so a model quoting a key must find it.
+  const docs = findings.map((finding) => ({
+    finding,
+    tokens: tokenize(`${finding.key || ''} ${finding.claim || ''}`),
+  }));
+
+  const avgLen = docs.reduce((sum, d) => sum + d.tokens.length, 0) / docs.length;
+  const N = docs.length;
+
+  const docFreq = new Map();
+  for (const { tokens } of docs) {
+    for (const term of new Set(tokens)) {
+      docFreq.set(term, (docFreq.get(term) || 0) + 1);
+    }
+  }
+
+  const scored = [];
+  for (const { finding, tokens } of docs) {
+    const counts = new Map();
+    for (const token of tokens) counts.set(token, (counts.get(token) || 0) + 1);
+
+    let score = 0;
+    for (const term of terms) {
+      const tf = counts.get(term);
+      if (!tf) continue;
+      const df = docFreq.get(term) || 0;
+      // Standard BM25 IDF, floored at zero so a term present in every document
+      // contributes nothing rather than a negative score.
+      const idf = Math.max(0, Math.log(1 + (N - df + 0.5) / (df + 0.5)));
+      const norm = tf + k1 * (1 - b + (b * tokens.length) / (avgLen || 1));
+      score += idf * ((tf * (k1 + 1)) / (norm || 1));
+    }
+
+    // Zero means no term matched. Omitted rather than returned, so a caller
+    // under a token budget never spends it on an irrelevant finding.
+    if (score > 0) scored.push({ finding, score });
+  }
+
+  return scored.sort((a, b2) => b2.score - a.score).slice(0, limit);
+}

--- a/integrations/cursor/hooks/lib/lexical.mjs
+++ b/integrations/cursor/hooks/lib/lexical.mjs
@@ -14,12 +14,54 @@
  * rather than assuming it away.
  */
 
-/** Non-word split, lowercased. Short tokens are kept: `fs`, `id`, `os` matter here. */
-export function tokenize(text) {
-  return String(text || '')
-    .toLowerCase()
-    .split(/[^a-z0-9]+/)
+/**
+ * Splits an identifier's alphanumeric run into its camelCase / letter-digit
+ * parts, e.g. `skipLibCheck` -> ['skip', 'Lib', 'Check'], `TS2345` ->
+ * ['TS', '2345']. Returns a single-element array when there is no internal
+ * boundary (e.g. `retry` -> ['retry']) so callers can skip emitting a
+ * redundant duplicate of the whole token.
+ */
+function splitIdentifierParts(word) {
+  return word
+    .replace(/([a-z])([A-Z])/g, '$1\0$2')
+    .replace(/([A-Za-z])([0-9])/g, '$1\0$2')
+    .replace(/([0-9])([A-Za-z])/g, '$1\0$2')
+    .split('\0')
     .filter(Boolean);
+}
+
+/**
+ * Non-word split, lowercased. Short tokens are kept: `fs`, `id`, `os` matter
+ * here.
+ *
+ * Emits sub-tokens for compound identifiers, in addition to the whole token.
+ * Delimited identifiers (`smart_read`, `wiki.mjs`, the flag in
+ * `--skipLibCheck`) already round-trip fine: the delimiter splits them, and
+ * because query and claim pass through this same function, a query typed
+ * with the same delimiters matches. The silent gap was CONCATENATED
+ * identifiers with no delimiter at all -- `skipLibCheck` collapsed to the
+ * single token `skiplibcheck`, so a query for "skip lib check" (or "TS 2345"
+ * against `TS2345`) never intersected it. No error, just an absent result --
+ * and findings are about code, where run-together identifiers are the
+ * common case. So every alphanumeric run keeps its whole-token form (a query
+ * for the concatenated form still matches) and ALSO contributes its
+ * camelCase / letter-digit parts (a query for the separated form now
+ * matches too). A lone incidental character -- e.g. the `c` split out of a
+ * Windows path `C:\Users\...` -- needs no special-casing: it is a real
+ * token like any other, and BM25's IDF already discounts a term that shows
+ * up in nearly every finding.
+ */
+export function tokenize(text) {
+  const words = String(text || '').match(/[A-Za-z0-9]+/g) || [];
+  const tokens = [];
+  for (const word of words) {
+    tokens.push(word.toLowerCase());
+    const parts = splitIdentifierParts(word);
+    if (parts.length > 1) {
+      for (const part of parts) tokens.push(part.toLowerCase());
+    }
+  }
+  return tokens;
 }
 
 /**
@@ -57,9 +99,15 @@ export function rank(query, findings, { limit = 20, k1 = 1.2, b = 0.75 } = {}) {
       const tf = counts.get(term);
       if (!tf) continue;
       const df = docFreq.get(term) || 0;
-      // Standard BM25 IDF, floored at zero so a term present in every document
-      // contributes nothing rather than a negative score.
-      const idf = Math.max(0, Math.log(1 + (N - df + 0.5) / (df + 0.5)));
+      // Smoothed BM25 idf: log(1 + (N - df + 0.5) / (df + 0.5)). Unlike the
+      // classic unsmoothed idf (log((N - df + 0.5) / (df + 0.5))), which goes
+      // negative once a term appears in most documents, this smoothed form
+      // is strictly positive for every df in [1, N]: even at df === N the
+      // ratio inside the log is (N + 1) / (N + 0.5), which is always
+      // strictly greater than 1, so log(1 + that) is always > 0. No floor
+      // is needed here, and none is applied -- there is no negative case
+      // for this formula to guard against.
+      const idf = Math.log(1 + (N - df + 0.5) / (df + 0.5));
       const norm = tf + k1 * (1 - b + (b * tokens.length) / (avgLen || 1));
       score += idf * ((tf * (k1 + 1)) / (norm || 1));
     }

--- a/integrations/cursor/hooks/lib/lexical.mjs
+++ b/integrations/cursor/hooks/lib/lexical.mjs
@@ -65,6 +65,43 @@ export function tokenize(text) {
 }
 
 /**
+ * Effective term-frequency credit for a document that has NO exact token
+ * match for a query term but DOES have a token that starts with it (e.g.
+ * query `custom` against a document containing `customer`). Deliberately
+ * less than one exact occurrence (`1`), and it is a flat credit rather than
+ * one that grows with the number of prefix-matching tokens in the document,
+ * so a prefix hit can never outscore an exact hit of the same term:
+ *
+ *   BM25's per-term contribution is `idf * tf * (k1 + 1) / (tf + K)`, where
+ *   `K = k1 * (1 - b + b * L / avgL)` depends only on document length, not
+ *   on which term or how it matched. As a function of `tf` alone, with `K`
+ *   fixed, `f(tf) = tf / (tf + K)` is non-decreasing for every `tf >= 0` and
+ *   `k1 >= 0` (its derivative `K / (tf + K)^2` is never negative). So for
+ *   ANY document length, and any number of prefix-only occurrences, using
+ *   `PREFIX_TF < 1` in place of `tf` scores no higher than an actual exact
+ *   occurrence (`tf = 1`) would in that same document -- there is no
+ *   PREFIX_TF-independent way to accumulate more evidence than one real hit
+ *   by matching only a prefix. This is also why the count of prefix matches
+ *   is otherwise irrelevant here: it never feeds back into the score.
+ *
+ * PREFIX MATCHING IS NOT SUBSTRING MATCHING. It restores recall for a
+ * fragment typed at the START of a word -- `custom` now finds `customer` --
+ * which is the common case (a user typing the first few letters of a term
+ * they remember). It does NOT restore the old `.includes()` filter's ability
+ * to find a term in the MIDDLE of a word: a query for `tomer` still will not
+ * find `customer`. That recall gap is accepted, not silently reintroduced.
+ */
+const PREFIX_TF = 0.5;
+
+/**
+ * Below this length, a query term is not eligible for prefix matching: a
+ * one- or two-character prefix (`a`, `re`) is a substring of a large
+ * fraction of any real vocabulary, so it would match nearly every document
+ * and IDF alone would not discount it enough to keep the results relevant.
+ */
+const PREFIX_MIN_TERM_LENGTH = 3;
+
+/**
  * Classic BM25. `k1` controls term-frequency saturation, `b` length normalisation.
  * Defaults are the standard ones and are exposed so the recall probe can sweep them.
  */
@@ -96,7 +133,21 @@ export function rank(query, findings, { limit = 20, k1 = 1.2, b = 0.75 } = {}) {
 
     let score = 0;
     for (const term of terms) {
-      const tf = counts.get(term);
+      let tf = counts.get(term) || 0;
+
+      // No exact occurrence: fall back to a prefix match, which is weaker
+      // evidence and so credited at a flat PREFIX_TF rather than a real
+      // count (see PREFIX_TF's comment for why that ordering is safe). Only
+      // considered when nothing already matched exactly and the term is
+      // long enough that "starts with" is a meaningful signal.
+      if (tf === 0 && term.length >= PREFIX_MIN_TERM_LENGTH) {
+        for (const token of counts.keys()) {
+          if (token !== term && token.startsWith(term)) {
+            tf = PREFIX_TF;
+            break;
+          }
+        }
+      }
       if (!tf) continue;
       const df = docFreq.get(term) || 0;
       // Smoothed BM25 idf: log(1 + (N - df + 0.5) / (df + 0.5)). Unlike the

--- a/integrations/cursor/hooks/lib/metrics.mjs
+++ b/integrations/cursor/hooks/lib/metrics.mjs
@@ -455,6 +455,23 @@ export function readBalance(dir) {
   return out;
 }
 
+/**
+ * True when `readEvidence` could not have read the whole log -- the file
+ * exceeds the byte cap, so anything written before the tail it kept is
+ * silently absent from what it returned. A caller that builds a per-claim
+ * record from `readEvidence` (the wiki graph's derivation record) needs this
+ * to say "operations existed but are not recorded here" rather than let an
+ * empty result read as "nothing happened".
+ */
+export function evidenceTruncated(dir) {
+  const path = evidencePath(dir);
+  try {
+    return statSync(path).size > MAX_BYTES;
+  } catch {
+    return false;
+  }
+}
+
 /** Every causal evidence record inside the byte cap, deduplicated by id. */
 export function readEvidence(dir) {
   const path = evidencePath(dir);

--- a/integrations/cursor/hooks/lib/observability.mjs
+++ b/integrations/cursor/hooks/lib/observability.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 /**
  * Privacy-safe, cross-client lifecycle diagnostics.
  *

--- a/integrations/cursor/hooks/lib/pending.mjs
+++ b/integrations/cursor/hooks/lib/pending.mjs
@@ -39,7 +39,7 @@ import {
   statSync,
 } from 'node:fs';
 import { join } from 'node:path';
-import { invalidateOnWrite } from './staleness.mjs';
+import { invalidateChangedAnchors, invalidateOnWrite } from './staleness.mjs';
 import { canonicalPath, isFsSafePath, resolvableCandidates } from './paths.mjs';
 
 const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
@@ -190,31 +190,85 @@ function hasEditEvidence(payload, raw) {
 }
 
 /**
- * The evidence a completed mutation left behind, or null when there is none.
+ * Canonical tool names that mean bytes on disk changed.
  *
- * Separate from `queueInvalidation` so the caller can be a hook branch that
- * knows nothing about diffs, and so the reconstruction above is testable
- * without a filesystem queue.
+ * THE NORMALISED SET, not any client's own vocabulary. `normalizePayload` has
+ * already mapped `replace`, `write_file`, `apply_patch`, `str_replace`,
+ * `search_replace` and the rest onto these three through decide.mjs's alias
+ * table -- and a tool that table cannot map arrives as null and exits the hook
+ * before this module is reached at all. So matching here is both complete for
+ * every client the adapter serves and impossible to spell wrong.
+ *
+ * `NotebookEdit` is absent because `normalizeTool` maps it to null, and the MCP
+ * `smart_edit`/`smart_write` tools are absent for the same reason. Both are gaps
+ * in that alias table rather than in this file, and widening it changes routing
+ * verdicts for every client -- so they are reported, not papered over here.
  */
-export function observedWrite(payload, raw) {
-  // CHEAP CHECK FIRST, because this runs after every tool call on every client.
-  // Reading the file is the expensive part, and there is no point paying for it
-  // on a Read, a Bash or a write whose before side cannot be reconstructed.
-  if (!hasEditEvidence(payload, raw)) return null;
+const MUTATING = new Set(['Edit', 'MultiEdit', 'Write']);
+
+/** Files an apply_patch-style program declares it is about to change. */
+function patchTargets(payload) {
+  const command = payload?.tool_input?.command;
+  if (typeof command !== 'string') return [];
+  const out = [];
+  for (const match of command.matchAll(
+    /^\*\*\* (?:Add|Update|Delete) File:\s*(.+)$/gm
+  )) {
+    const candidate = match[1].trim().replace(/^['"]|['"]$/g, '');
+    // Bounded: one patch naming a thousand files must not append a thousand
+    // queue records on a hook path.
+    if (candidate && out.length < 20) out.push(candidate);
+  }
+  return out;
+}
+
+/**
+ * Everything a completed mutation left behind that is worth queueing.
+ *
+ * TWO GRADES OF EVIDENCE, and the distinction is the point:
+ *
+ *   { path, before, after }  a reconstructable edit. The drain builds a real
+ *                            diff and marks only the symbols that moved.
+ *   { path }                 a whole-file write, or a patch program. No before
+ *                            side exists anywhere in the payload, so the drain
+ *                            compares stored hashes against disk instead.
+ *
+ * The second grade is what closes the biggest hole. A whole-file write is the
+ * commonest write shape there is, and before it was added those writes fell
+ * through to a lazy path that CANNOT see the session's own writes at all --
+ * `indexFile` refreshes the anchor before the lazy check ever looks at it. They
+ * were uncovered, not degraded.
+ *
+ * Returns an array, because one apply_patch program changes several files.
+ */
+export function observedWrites(payload, raw) {
+  if (!MUTATING.has(String(payload?.tool_name || ''))) return [];
 
   const path = writtenPath(payload, raw);
-  if (!path) return null;
+  if (path) {
+    // The expensive branch is guarded: reading the file only pays off when the
+    // payload can actually yield a before side.
+    if (hasEditEvidence(payload, raw)) {
+      const after = afterText(path);
+      if (after !== null && after.length <= MAX_SIDE_CHARS) {
+        const before = beforeText(payload, raw, after);
+        // Identical bytes: a formatter no-op, or a rewrite of the same content.
+        // Nothing changed, so nothing is stale.
+        if (before === after) return [];
+        if (before !== null && before.length <= MAX_SIDE_CHARS)
+          return [{ path, before, after }];
+      }
+    }
+    // Hash grade. Deliberately NOT `{ path, before: '', after }`: an empty
+    // before side makes every symbol in the file look changed, and the eager
+    // mark is a stored flag no later check ever clears.
+    return [{ path }];
+  }
 
-  const after = afterText(path);
-  if (after === null || after.length > MAX_SIDE_CHARS) return null;
-
-  const before = beforeText(payload, raw, after);
-  if (before === null || before.length > MAX_SIDE_CHARS) return null;
-  // Nothing changed: a formatter no-op, or a write of identical bytes. Queuing
-  // it would mark findings stale against an empty diff.
-  if (before === after) return null;
-
-  return { path, before, after };
+  // Codex and code-mode clients carry the whole patch as program text with no
+  // file_path field at all, which is why this recorded nothing for them. The
+  // hash grade needs only the path, so the patch headers are enough.
+  return patchTargets(payload).map((target) => ({ path: target }));
 }
 
 /**
@@ -226,9 +280,14 @@ export function observedWrite(payload, raw) {
 export function queueInvalidation(dir, { path, before, after, at } = {}) {
   try {
     if (typeof path !== 'string' || !path.trim()) return false;
-    if (typeof before !== 'string' || typeof after !== 'string') return false;
-    if (before.length > MAX_SIDE_CHARS || after.length > MAX_SIDE_CHARS)
-      return false;
+    // BOTH SIDES OR NEITHER. A record carrying only one of them cannot produce
+    // a diff and must not pretend to, so it is written as a path-only record
+    // and the drain resolves it by comparing hashes.
+    const diffable =
+      typeof before === 'string' &&
+      typeof after === 'string' &&
+      before.length <= MAX_SIDE_CHARS &&
+      after.length <= MAX_SIDE_CHARS;
 
     const file = queuePath(dir);
     try {
@@ -240,7 +299,11 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
     mkdirSync(dir, { recursive: true });
     appendFileSync(
       file,
-      `${JSON.stringify({ path: canonicalPath(path), before, after, at: at ?? Date.now() })}\n`,
+      `${JSON.stringify({
+        path: canonicalPath(path),
+        ...(diffable ? { before, after } : {}),
+        at: at ?? Date.now(),
+      })}\n`,
       'utf8'
     );
     return true;
@@ -284,16 +347,16 @@ export function drainInvalidations(dir, graph) {
   let marked = 0;
   for (const record of records) {
     if (!record || typeof record.path !== 'string' || !record.path) continue;
-    if (typeof record.before !== 'string' || typeof record.after !== 'string')
-      continue;
+    const diffable =
+      typeof record.before === 'string' && typeof record.after === 'string';
     try {
-      const result = invalidateOnWrite(
-        dir,
-        graph,
-        record.path,
-        record.before,
-        record.after
-      );
+      // TWO GRADES, ONE QUEUE. A record carrying both sides gets a real diff and
+      // symbol-precise marking; one carrying only a path gets the hash
+      // comparison -- the same comparison the lazy path makes, and one that is
+      // only meaningful HERE, before `indexFile` refreshes the anchor.
+      const result = diffable
+        ? invalidateOnWrite(dir, graph, record.path, record.before, record.after)
+        : invalidateChangedAnchors(dir, graph, record.path);
       marked += Array.isArray(result) ? result.length : 0;
     } catch {
       // One bad record must not stop the rest, and must not stop the tool call.

--- a/integrations/cursor/hooks/lib/pending.mjs
+++ b/integrations/cursor/hooks/lib/pending.mjs
@@ -1,0 +1,311 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/pending.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * The eager-invalidation queue: the missing half of staleness.mjs's header.
+ *
+ * That header describes TWO invalidation paths and says eager exists because
+ * lazy "would silently serve stale findings as fresh whenever a change came
+ * from outside the agent". `invalidateOnWrite` had been written, tested and
+ * documented -- and its only reference in shipped code was a COMMENT in the
+ * PreToolUse router. Staleness was lazy-only in production, and the router's
+ * own comment ("a write the hook observes is invalidated eagerly by
+ * `invalidateOnWrite`") described something that never happened.
+ *
+ * WHY THAT MATTERS MORE THAN IT SOUNDS. The lazy check compares the anchor's
+ * stored hash against disk -- and both the router and the adapter call
+ * `indexFile` on every file they observe, which re-points that hash at the new
+ * bytes. So for a write the session performed ITSELF, the lazy check is
+ * self-defeating: by the next retrieval the anchor already agrees with disk and
+ * the finding derived from the old content is served clean. Lazy catches the
+ * changes we never saw; only eager catches the ones we did.
+ *
+ * WHY A QUEUE AND NOT A DIRECT CALL. `invalidateOnWrite` needs the graph, and
+ * the graph is a megabyte of JSONL. Loading it on the return path of every
+ * write is the cost this shape exists to avoid. So the post-tool hook, which
+ * already holds the write's evidence, appends one record here and exits; the
+ * next graph read -- `forTouch`/`forCommand`, which load the graph anyway --
+ * drains it BEFORE serving anything.
+ *
+ * The guarantee is unchanged. What must never happen is SERVING a stale finding
+ * as fresh, and serve time is where that is enforced.
+ */
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { invalidateOnWrite } from './staleness.mjs';
+import { canonicalPath, isFsSafePath, resolvableCandidates } from './paths.mjs';
+
+const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
+
+/**
+ * Largest before/after side kept in a queue record.
+ *
+ * Matched to the graph's own snapshot limit for the same reason it has one: past
+ * this size the text is a bundle, a lockfile or a generated asset, and copying
+ * it into a queue file would mirror the repository into the graph directory one
+ * write at a time. Past the cap the write is simply not queued -- the lazy path
+ * still governs it, which is exactly the status quo for that file.
+ */
+const MAX_SIDE_CHARS = 262_144;
+
+/**
+ * Largest queue file appended to.
+ *
+ * A queue only grows while nothing drains it, which means the retrieval feature
+ * is off or every read has failed. Neither is a reason to keep writing: bounded
+ * here so a long unattended session cannot turn one directory into a log of
+ * every file it touched.
+ */
+const MAX_QUEUE_BYTES = 8 * 1024 * 1024;
+
+/** The tool payload fields that name the file a mutation landed on. */
+function writtenPath(payload, raw) {
+  const input = payload?.tool_input || {};
+  const response = raw?.tool_response || raw?.toolResponse || {};
+  for (const candidate of [
+    input.file_path,
+    input.path,
+    input.notebook_path,
+    response.filePath,
+    response.file_path,
+  ]) {
+    if (typeof candidate === 'string' && candidate.trim()) return candidate;
+  }
+  return null;
+}
+
+/** First string among several possible spellings of the same field. */
+function firstString(...values) {
+  for (const value of values) if (typeof value === 'string') return value;
+  return null;
+}
+
+/**
+ * The text before the write, reconstructed from a completed edit.
+ *
+ * PREFERENCE ORDER IS ABOUT EXACTNESS, not convenience. Claude Code's Edit
+ * response carries the whole pre-edit file (`originalFile`), which needs no
+ * reasoning at all. Failing that, an edit is a known substitution, so reverting
+ * `new_string` back to `old_string` in the post-write text reproduces the
+ * before side exactly -- but only when the substitution is unambiguous, which
+ * is why a `new_string` that now appears more than once is refused rather than
+ * guessed at.
+ *
+ * NULL MEANS "DO NOT QUEUE", and that is deliberate. An unknown before side
+ * could be passed as '' -- and `invalidateOnWrite` would then see every symbol
+ * in the file as changed and mark every finding anchored anywhere in it, which
+ * is the exact over-marking its own comments call worse than the file-level
+ * staleness symbols were introduced to avoid. A missed eager invalidation costs
+ * what today already costs; a wrong one permanently discounts correct findings.
+ */
+function beforeText(payload, raw, after) {
+  const input = payload?.tool_input || {};
+  const response = raw?.tool_response || raw?.toolResponse || {};
+
+  const original = firstString(
+    response.originalFile,
+    response.original_file,
+    response.originalContent,
+    response.original_content
+  );
+  if (original !== null) return original;
+
+  // MultiEdit applies its edits in order, so reverting walks them backwards.
+  const edits = Array.isArray(input.edits) ? input.edits : null;
+  if (edits) {
+    let text = after;
+    for (const edit of [...edits].reverse()) {
+      const reverted = revert(text, edit);
+      if (reverted === null) return null;
+      text = reverted;
+    }
+    return text;
+  }
+
+  return revert(after, input);
+}
+
+/** Undoes one old->new substitution, or null when it cannot be done exactly. */
+function revert(text, edit) {
+  const oldString = firstString(edit?.old_string, edit?.oldString);
+  const newString = firstString(edit?.new_string, edit?.newString);
+  if (oldString === null || newString === null || newString === '') return null;
+
+  const all = edit?.replace_all === true || edit?.replaceAll === true;
+  if (all) return text.split(newString).join(oldString);
+
+  const at = text.indexOf(newString);
+  if (at < 0) return null;
+  // Ambiguous: more than one candidate for the occurrence that was written, and
+  // reverting the wrong one fabricates a before side that never existed.
+  if (text.indexOf(newString, at + newString.length) >= 0) return null;
+  return text.slice(0, at) + oldString + text.slice(at + newString.length);
+}
+
+/** The post-write text, read from disk because that is what the write produced. */
+function afterText(path) {
+  if (!isFsSafePath(path)) return null;
+  for (const candidate of resolvableCandidates(path)) {
+    try {
+      if (statSync(candidate).size > MAX_SIDE_CHARS) return null;
+      return readFileSync(candidate, 'utf8');
+    } catch {
+      // Wrong spelling, or gone again already. Try the next one.
+    }
+  }
+  return null;
+}
+
+/**
+ * Does this payload carry enough to reconstruct a before side at all?
+ *
+ * Named tool lists were the alternative and were rejected: every client calls
+ * its editor something different (`Edit`, `replace`, `write_to_file`,
+ * `apply_patch`), and a list would silently exclude the ones nobody thought of
+ * while still charging a file read for every Read that matched by accident.
+ * Asking about the EVIDENCE instead covers any client that carries an edit in
+ * one of these shapes and costs nothing on the calls that do not.
+ */
+function hasEditEvidence(payload, raw) {
+  const input = payload?.tool_input || {};
+  const response = raw?.tool_response || raw?.toolResponse || {};
+  if (
+    firstString(
+      response.originalFile,
+      response.original_file,
+      response.originalContent,
+      response.original_content
+    ) !== null
+  )
+    return true;
+  if (Array.isArray(input.edits) && input.edits.length > 0) return true;
+  return firstString(input.old_string, input.oldString) !== null;
+}
+
+/**
+ * The evidence a completed mutation left behind, or null when there is none.
+ *
+ * Separate from `queueInvalidation` so the caller can be a hook branch that
+ * knows nothing about diffs, and so the reconstruction above is testable
+ * without a filesystem queue.
+ */
+export function observedWrite(payload, raw) {
+  // CHEAP CHECK FIRST, because this runs after every tool call on every client.
+  // Reading the file is the expensive part, and there is no point paying for it
+  // on a Read, a Bash or a write whose before side cannot be reconstructed.
+  if (!hasEditEvidence(payload, raw)) return null;
+
+  const path = writtenPath(payload, raw);
+  if (!path) return null;
+
+  const after = afterText(path);
+  if (after === null || after.length > MAX_SIDE_CHARS) return null;
+
+  const before = beforeText(payload, raw, after);
+  if (before === null || before.length > MAX_SIDE_CHARS) return null;
+  // Nothing changed: a formatter no-op, or a write of identical bytes. Queuing
+  // it would mark findings stale against an empty diff.
+  if (before === after) return null;
+
+  return { path, before, after };
+}
+
+/**
+ * Appends one pending write.
+ *
+ * NEVER THROWS. This runs on a hook's return path, and a queue that cannot be
+ * written degrades to the lazy path rather than costing the user a tool call.
+ */
+export function queueInvalidation(dir, { path, before, after, at } = {}) {
+  try {
+    if (typeof path !== 'string' || !path.trim()) return false;
+    if (typeof before !== 'string' || typeof after !== 'string') return false;
+    if (before.length > MAX_SIDE_CHARS || after.length > MAX_SIDE_CHARS)
+      return false;
+
+    const file = queuePath(dir);
+    try {
+      if (statSync(file).size > MAX_QUEUE_BYTES) return false;
+    } catch {
+      // No queue yet, which is the normal case.
+    }
+
+    mkdirSync(dir, { recursive: true });
+    appendFileSync(
+      file,
+      `${JSON.stringify({ path: canonicalPath(path), before, after, at: at ?? Date.now() })}\n`,
+      'utf8'
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Applies every queued invalidation and clears the queue.
+ *
+ * Returns the number of findings marked, so the caller knows whether its
+ * in-memory graph is now behind the file on disk and needs re-reading.
+ *
+ * CLEARED AFTER APPLYING AND UNCONDITIONALLY: a record that cannot be applied
+ * must not be retried on every tool call for the rest of the session, and the
+ * cost of dropping one is a single missed eager mark that the lazy path still
+ * has a chance at.
+ */
+export function drainInvalidations(dir, graph) {
+  let records;
+  try {
+    const file = queuePath(dir);
+    if (!existsSync(file)) return 0;
+    records = readFileSync(file, 'utf8')
+      .split('\n')
+      .filter((line) => line.trim())
+      .map((line) => {
+        try {
+          return JSON.parse(line);
+        } catch {
+          // A torn append costs one record, not the queue.
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch {
+    return 0;
+  }
+
+  let marked = 0;
+  for (const record of records) {
+    if (!record || typeof record.path !== 'string' || !record.path) continue;
+    if (typeof record.before !== 'string' || typeof record.after !== 'string')
+      continue;
+    try {
+      const result = invalidateOnWrite(
+        dir,
+        graph,
+        record.path,
+        record.before,
+        record.after
+      );
+      marked += Array.isArray(result) ? result.length : 0;
+    } catch {
+      // One bad record must not stop the rest, and must not stop the tool call.
+    }
+  }
+
+  try {
+    rmSync(queuePath(dir), { force: true });
+  } catch {
+    // Held open by a concurrent hook. The next drain re-applies these records,
+    // which is safe: marking an already-marked finding is idempotent.
+  }
+
+  return marked;
+}

--- a/integrations/cursor/hooks/lib/pending.mjs
+++ b/integrations/cursor/hooks/lib/pending.mjs
@@ -199,10 +199,11 @@ function hasEditEvidence(payload, raw) {
  * before this module is reached at all. So matching here is both complete for
  * every client the adapter serves and impossible to spell wrong.
  *
- * `NotebookEdit` is absent because `normalizeTool` maps it to null, and the MCP
- * `smart_edit`/`smart_write` tools are absent for the same reason. Both are gaps
- * in that alias table rather than in this file, and widening it changes routing
- * verdicts for every client -- so they are reported, not papered over here.
+ * `NotebookEdit` and the MCP `smart_edit`/`smart_write` tools were absent for as
+ * long as `normalizeTool` mapped them to null. That was a gap in the alias table
+ * rather than in this file, and it has since been closed there: all three now
+ * arrive as `Edit` or `Write` and are matched by the set below without it having
+ * to learn a fourth name.
  */
 const MUTATING = new Set(['Edit', 'MultiEdit', 'Write']);
 

--- a/integrations/cursor/hooks/lib/pending.mjs
+++ b/integrations/cursor/hooks/lib/pending.mjs
@@ -35,6 +35,7 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  renameSync,
   rmSync,
   statSync,
 } from 'node:fs';
@@ -43,6 +44,15 @@ import { invalidateChangedAnchors, invalidateOnWrite } from './staleness.mjs';
 import { canonicalPath, isFsSafePath, resolvableCandidates } from './paths.mjs';
 
 const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
+/**
+ * Where a drain moves the queue before reading it.
+ *
+ * PER PROCESS, not one shared name: two hooks draining the same graph directory
+ * at once would otherwise race for the same claim file, and the loser would
+ * either clobber the winner's records or delete them mid-read. A pid makes the
+ * claim private to the drainer that won the rename.
+ */
+const claimPath = (dir) => join(dir, `pending-invalidation.claim.${process.pid}.jsonl`);
 
 /**
  * Largest before/after side kept in a queue record.
@@ -319,17 +329,47 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
  * Returns the number of findings marked, so the caller knows whether its
  * in-memory graph is now behind the file on disk and needs re-reading.
  *
- * CLEARED AFTER APPLYING AND UNCONDITIONALLY: a record that cannot be applied
- * must not be retried on every tool call for the rest of the session, and the
- * cost of dropping one is a single missed eager mark that the lazy path still
- * has a chance at.
+ * CLAIMED BY RENAME, THEN READ, THEN DELETED -- and the order is the whole
+ * point. This used to read the queue and then `rmSync` the same path, so a
+ * post-tool hook appending between the read and the unlink had its record
+ * deleted having never been read. Parallel tool calls in one assistant turn are
+ * the ordinary way that happens, not an exotic race. `renameSync` makes the
+ * claim atomic: whatever the drainer took is exactly what it deletes, and a
+ * record appended a microsecond later lands on a fresh queue that the next drain
+ * will find.
+ *
+ * A LOST RECORD IS A PERMANENTLY MISSED INVALIDATION, which is why this is worth
+ * a rename. The comment here used to price it as "a single missed eager mark that
+ * the lazy path still has a chance at", and that premise is false: this module's
+ * own header states it. The lazy path compares the anchor's stored hash against
+ * disk, and `indexFile` re-points that hash at the bytes the session just wrote,
+ * so for the session's OWN writes lazy is structurally blind rather than merely
+ * late. Nothing else was ever going to catch a dropped record.
+ *
+ * A RECORD THAT CANNOT BE APPLIED IS STILL DROPPED, deliberately and
+ * unconditionally: retrying a permanently unapplicable record on every tool call
+ * for the rest of the session costs more than it can ever recover, and the claim
+ * file is deleted whether the loop marked anything or threw.
+ *
+ * FAIL-OPEN THROUGHOUT. A rename that loses a race, or fails for any other
+ * reason, returns 0 and leaves the queue for the next drain; it never throws
+ * into a hook.
  */
 export function drainInvalidations(dir, graph) {
   let records;
+  let claim;
   try {
     const file = queuePath(dir);
     if (!existsSync(file)) return 0;
-    records = readFileSync(file, 'utf8')
+    claim = claimPath(dir);
+    // A LEFTOVER CLAIM FROM A KILLED DRAIN IS OVERWRITTEN, not merged: rename
+    // onto an existing path replaces it. The pid in the name means the only way
+    // to hit that is this same pid having died mid-drain, whose records were
+    // already being applied when it went -- and re-applying is idempotent, so
+    // losing them is the cheaper of the two errors. Not doing the rename at all
+    // would strand the live queue forever.
+    renameSync(file, claim);
+    records = readFileSync(claim, 'utf8')
       .split('\n')
       .filter((line) => line.trim())
       .map((line) => {
@@ -342,6 +382,18 @@ export function drainInvalidations(dir, graph) {
       })
       .filter(Boolean);
   } catch {
+    // The rename lost a race, or the claim could not be read. Nothing is deleted
+    // unread and the hook proceeds. If the claim was taken and then could not be
+    // read, it is put back under the queue name so the next drain still sees it:
+    // a claim file nobody looks at again is the same lost record this rename
+    // exists to prevent.
+    try {
+      if (claim && existsSync(claim) && !existsSync(queuePath(dir))) {
+        renameSync(claim, queuePath(dir));
+      }
+    } catch {
+      // Best effort only. A hook must not fail because bookkeeping did.
+    }
     return 0;
   }
 
@@ -365,10 +417,13 @@ export function drainInvalidations(dir, graph) {
   }
 
   try {
-    rmSync(queuePath(dir), { force: true });
+    // THE CLAIM, NOT THE QUEUE. Deleting `queuePath` here is what dropped a
+    // concurrently appended record; this path holds exactly the bytes that were
+    // just read, so nothing unread can be inside it.
+    rmSync(claim, { force: true });
   } catch {
-    // Held open by a concurrent hook. The next drain re-applies these records,
-    // which is safe: marking an already-marked finding is idempotent.
+    // Held open by something else. The claim is not read again -- the next drain
+    // looks at the queue -- so this costs a stray file, never a record.
   }
 
   return marked;

--- a/integrations/cursor/hooks/lib/restore.mjs
+++ b/integrations/cursor/hooks/lib/restore.mjs
@@ -142,7 +142,7 @@ export function restorationPlan(dir, graph, context = {}) {
     for (const id of predicted) {
       const node = graph.nodes.get(id);
       if (!node) continue;
-      const findings = serve(graph, findingsFor(graph, id, { limit: 2 }));
+      const findings = serve(graph, findingsFor(graph, id, { limit: 2 }), { dir });
       for (const finding of findings) {
         // `! STALE` only where a diff actually exists to back it; see the
         // renderer in inject.mjs for the measurement behind this.

--- a/integrations/cursor/hooks/lib/restore.mjs
+++ b/integrations/cursor/hooks/lib/restore.mjs
@@ -158,7 +158,16 @@ export function restorationPlan(dir, graph, context = {}) {
             ? '! STALE '
             : '~ '
           : '';
-        lines.push(`${node.key}: ${mark}${finding.claim}`);
+        // A DISPUTE DISCLOSED ELSEWHERE AND SILENT HERE reads as "the dispute
+        // went away". `serve` already attached the fields; the only question is
+        // the wording, and this list is the most compressed surface in the
+        // system, so it gets the marker and the key and nothing else.
+        const disputed = finding.contradicted
+          ? finding.contradictedBy
+            ? ` (disputed by ${finding.contradictedBy})`
+            : ' (disputed)'
+          : '';
+        lines.push(`${node.key}: ${mark}${finding.claim}${disputed}`);
       }
     }
     section('Likely next', lines, total * split.forward);

--- a/integrations/cursor/hooks/lib/skeleton.mjs
+++ b/integrations/cursor/hooks/lib/skeleton.mjs
@@ -126,6 +126,11 @@ export function annotatedSkeleton(graph, rawPath, source, { budget = 1200, git =
 
   // Findings anchored to this file or the symbols inside it, served through the
   // one function that enforces the stale-plus-diff rule.
+  // READ-ONLY serve: no `dir` is threaded here, so this cannot clear a stale
+  // flag whose evidence is gone. That is deliberate -- this function takes a
+  // graph, not the directory it came from, and widening its signature to give
+  // an analysis path a write capability buys nothing: the injection path runs
+  // on every tool call and clears the same findings.
   const served = serve(graph, findingsFor(graph, nodeId('file', path), { limit: 40 }));
 
   // Index findings by the symbol they anchor to, so each one sits beside the

--- a/integrations/cursor/hooks/lib/staleness.mjs
+++ b/integrations/cursor/hooks/lib/staleness.mjs
@@ -31,6 +31,23 @@
  * Eager alone would silently serve stale findings as fresh whenever a change
  * came from outside the agent, which is the single failure mode the design
  * calls worse than no graph.
+ *
+ * AND LAZY ALONE IS BLIND TO THE AGENT'S OWN WRITES -- not degraded, BLIND.
+ * `indexFile` re-points an anchor's stored hash at the bytes it was just handed,
+ * and it is called on every file either hook observes: pretooluse-router.mjs
+ * (two call sites) and adapter.mjs (one). The lazy check then compares that
+ * refreshed hash against the same disk it came from and finds them equal. So
+ * for a file the session edited ITSELF, the lazy path cannot detect the change
+ * at all, and the finding derived from the pre-edit content is served CLEAN.
+ *
+ * Which means that until the eager path was connected, staleness for a file the
+ * agent edited did not work AT ALL: eager was dead code and lazy was defeated
+ * by re-indexing. Every account of this defect, including the one in this
+ * module's own git history, called it "lazy-only, therefore degraded". It was
+ * not degraded. `stale-before-reindex.test.mjs` states in its header that this
+ * case is covered by `invalidateOnWrite`, and `invalidateOnWrite` had never run
+ * once in production. The two paths are not redundant and never were: each is
+ * the ONLY cover for a whole class of change.
  */
 
 import { readFileSync, statSync } from 'node:fs';
@@ -622,6 +639,119 @@ export function invalidateOnWrite(dir, graph, rawPath, beforeText, afterText) {
   // Re-index so the anchors carry the new hashes; otherwise the lazy path would
   // report the same change again on every future retrieval.
   indexFile(dir, path, afterText);
+  return marked;
+}
+
+/**
+ * The eager path for a write with NO before/after pair: compare stored hashes
+ * against disk, and mark what actually moved.
+ *
+ * WHY THIS EXISTS AS A SECOND SHAPE. A whole-file `Write` replaces the file, so
+ * the payload carries the after side and nothing at all of the before -- and a
+ * whole-file write is the commonest write shape there is. `invalidateOnWrite`
+ * cannot serve it: passing '' as the before side makes every symbol in the file
+ * look changed, marks every finding anchored anywhere in it, and the eager mark
+ * is a stored flag no later check ever clears. False-stale is expensive and
+ * permanent, so it is not an acceptable price for coverage.
+ *
+ * But the hash comparison is available, and it is exactly the comparison the
+ * lazy path makes. The difference is WHEN: this runs at the top of injection,
+ * before `indexFile` refreshes the anchor, so the stored hash is still the
+ * pre-write one and the comparison is meaningful. That is the whole trick --
+ * lazy is not wrong, it is merely too late.
+ *
+ * SYMBOL-LEVEL, and from ONE read. Re-locating each symbol by name and
+ * comparing its own span hash is what keeps this from degenerating into
+ * file-level marking: editing one function must not stale a finding about
+ * another, which is the property symbol nodes exist to provide.
+ *
+ * WEAKER EVIDENCE, STATED AS SUCH. There is no before text, so no diff can be
+ * built -- the finding is marked with the two hashes and `serve` reports the
+ * evidence gap through `staleEvidence: false`, which the renderer turns into
+ * "no diff could be rebuilt" rather than promising a diff and showing nothing.
+ * A stale finding with weak evidence is far better than one served as fresh,
+ * but the reader has to be able to tell which one they are holding.
+ */
+export function invalidateChangedAnchors(dir, graph, rawPath) {
+  const path = canonicalPath(rawPath);
+  const marked = [];
+
+  // ONE read for the file and every symbol in it. checkAnchor would have been
+  // the obvious reuse and it reads per anchor, which on a file with fifty
+  // symbols is fifty-one reads of the same bytes on a hook path.
+  let source = null;
+  try {
+    source = readAnySpelling(path);
+  } catch {
+    // Deleted, or unreadable from this checkout. Handled below as a change,
+    // because a finding about a file that is no longer there is exactly the
+    // kind that must not be served as fresh.
+  }
+
+  const changed = [];
+  const fileNode = graph.nodes.get(nodeId('file', path));
+  const fileDigest = source === null ? null : hash(source);
+  if (fileNode && fileDigest !== fileNode.hash) {
+    changed.push({ node: fileNode, from: fileNode.hash, to: fileDigest });
+  }
+
+  const current = new Map(
+    source === null
+      ? []
+      : extractSymbols(path, source).map((s) => [s.name, hash(spanText(source, s))])
+  );
+  for (const node of graph.nodes.values()) {
+    if (node.kind !== 'symbol' || node.file !== path) continue;
+    const digest = current.has(node.name) ? current.get(node.name) : null;
+    if (digest !== node.hash) changed.push({ node, from: node.hash, to: digest });
+  }
+
+  if (changed.length) {
+    // Indexed once by target, for the reason invalidateOnWrite indexes: the
+    // nested alternative is O(nodes x edges) inside a hook.
+    const byTarget = new Map();
+    for (const edge of graph.edges) {
+      if (edge.edge !== 'derived_from') continue;
+      if (!byTarget.has(edge.to)) byTarget.set(edge.to, []);
+      byTarget.get(edge.to).push(edge);
+    }
+
+    for (const { node, from, to } of changed) {
+      for (const edge of byTarget.get(node.id) || []) {
+        const finding = graph.nodes.get(edge.from);
+        if (!finding || finding.kind !== 'finding') continue;
+        // The same type gate serve() applies, for the same reason it is applied
+        // in invalidateOnWrite: the flag is STORED, and disclose.mjs skips a
+        // stale finding while utility.mjs penalises one by 160.
+        if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) continue;
+        // ALREADY MARKED IS LEFT ALONE. Whatever marked it first had a diff or
+        // a more specific reason; overwriting that with a hash pair trades real
+        // evidence for less.
+        if (finding.stale) continue;
+
+        putNode(dir, {
+          ...finding,
+          kind: 'finding',
+          key: finding.key,
+          stale: true,
+          staleReason:
+            to === null
+              ? `the ${node.kind} it depends on is no longer present (was ${from})`
+              : `content hash changed during this session (${from} -> ${to}), observed without a before/after pair`,
+          // EXPLICITLY EMPTY, not absent. serve() reports `staleEvidence` from
+          // whether a diff survived, and the renderer says "no diff could be
+          // rebuilt" -- so the reader can tell "changed, diff unknown" from
+          // "changed, here is what changed".
+          diff: '',
+        });
+        marked.push(finding.key);
+      }
+    }
+  }
+
+  // Re-index for the same reason the diff path does: otherwise every future
+  // retrieval re-reports a change that has already been accounted for.
+  if (source !== null) indexFile(dir, path, source);
   return marked;
 }
 

--- a/integrations/cursor/hooks/lib/staleness.mjs
+++ b/integrations/cursor/hooks/lib/staleness.mjs
@@ -574,8 +574,20 @@ function derivationCheck(graph, finding) {
  * This is the only function that should ever hand a finding to a model, because
  * it is the one that enforces the rule: a stale finding leaves here carrying
  * `stale: true` AND a diff, or it does not leave at all.
+ *
+ * AND IT CLEARS A STORED FLAG WHOSE EVIDENCE IS GONE, when given a `dir` to
+ * write to. Clearing used to be reachable only by a person pressing Re-verify in
+ * the dashboard, which left the rot path fully open on every install where
+ * nobody opens the dashboard -- and that is most of them. The evidence test is
+ * what makes clearing safe, and it does not care who triggered it: the same
+ * `claimTimeVerdict` runs here as in `reverify`, so this cannot clear anything
+ * the button would not.
+ *
+ * `dir` IS OPTIONAL, AND OMITTING IT MAKES THIS READ-ONLY. Several callers hold
+ * a graph without the directory it came from, and a serve that silently did
+ * nothing would be worse than one that plainly cannot write.
  */
-export function serve(graph, findings) {
+export function serve(graph, findings, { dir = null } = {}) {
   const served = [];
 
   // RETIRED FINDINGS STOP HERE, unconditionally.
@@ -603,8 +615,42 @@ export function serve(graph, findings) {
       continue;
     }
 
+    // AUTOMATIC CLEARING, on the same evidence the manual path demands.
+    //
+    // ONLY THE STORED FLAG IS TOUCHED. The lazy loop below is left to run
+    // exactly as before and can independently mark this finding stale again on
+    // its own comparison -- disk against the anchor NODE's hash -- which answers
+    // a different question and is not this function's to overrule. Eager and
+    // lazy stay two mechanisms, as the module header insists.
+    //
+    // AND THE FIELDS GO WITH THE FLAG. `putNode` does not merge and neither does
+    // this spread: serving `{ ...finding, stale: false }` would hand back a
+    // finding that reads fresh while still carrying `staleReason` and `diff`
+    // from the record -- stale and fresh at once, which is worse than either.
+    // So the cleared record, not the stored one, is what the rest of this
+    // iteration reads and spreads.
+    //
+    // BOUNDED, and the bound is the point: this runs only for a finding whose
+    // flag is already STORED, only when a `derivation` record exists to check
+    // against, and it reads each of that finding's anchors at most once. A
+    // finding that is not flagged pays nothing. The lazy loop below already
+    // reads every anchor of every content-dependent finding served, so the worst
+    // case is twice the anchor reads on the already-stale subset alone.
+    //
+    // NOT ON THE NON-CONTENT-DEPENDENT EARLY RETURN ABOVE, deliberately. Both
+    // eager paths refuse to flag those types at all, so a flag there can only
+    // come from an older graph -- and reading anchors for a type whose truth
+    // does not depend on them is exactly the cost `CONTENT_DEPENDENT` exists to
+    // avoid.
+    let record = finding;
+    if (dir && finding.stale && claimTimeVerdict(graph, finding) === 'match') {
+      clearStale(dir, finding.key, { graph });
+      const { stale: _s, staleReason: _r, diff: _d, staleEvidence: _e, ...cleared } = finding;
+      record = cleared;
+    }
+
     const anchors = graph.edges
-      .filter((e) => e.edge === 'derived_from' && e.from === finding.id)
+      .filter((e) => e.edge === 'derived_from' && e.from === record.id)
       .map((e) => graph.nodes.get(e.to))
       .filter(Boolean);
 
@@ -629,10 +675,10 @@ export function serve(graph, findings) {
     // A finding already marked stale eagerly, whose diff was captured at write
     // time, keeps that diff -- the eager path saw the change we can no longer
     // reconstruct from disk alone.
-    if (!stale && finding.stale) {
+    if (!stale && record.stale) {
       stale = true;
-      diff = finding.diff || '';
-      reason = finding.staleReason || 'marked stale when the change was observed';
+      diff = record.diff || '';
+      reason = record.staleReason || 'marked stale when the change was observed';
     }
 
     if (stale && !diff) {
@@ -681,13 +727,19 @@ export function serve(graph, findings) {
     }
 
     served.push({
-      ...finding,
+      ...record,
       stale,
       ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
+      // BOTH OTHER DISCLOSURES SURVIVE A MID-SERVE CLEAR. `dispute` was computed
+      // above the content-dependence branch and is applied here untouched, and
+      // the derivation verdict is recomputed from the record -- which still
+      // carries its `derivation`, since clearing removes only the staleness
+      // fields. A finding whose flag was just cleared is still disclosed as
+      // disputed, and still reports whether its derivation holds.
       ...dispute,
       // Independent of `stale` above: see `derivationCheck`'s own comment for
       // the case it catches that node-level staleness can miss.
-      ...derivationCheck(graph, finding),
+      ...derivationCheck(graph, record),
     });
   }
   return served;
@@ -939,8 +991,21 @@ function anchorHashNow(anchor) {
  * Exposing it to a hook, a tool argument or an HTTP action would be a way to
  * turn a stale finding fresh on request, which is exactly what must not exist.
  */
-export function clearStale(dir, key) {
-  const node = load(dir).nodes.get(nodeId('finding', key));
+export function clearStale(dir, key, { graph = null } = {}) {
+  // A CALLER THAT ALREADY HOLDS THE GRAPH PASSES IT, and this is not
+  // micro-optimisation: `load` re-parses the entire append-only log, so clearing
+  // inside `serve`'s loop re-read and re-folded the whole graph once PER cleared
+  // finding. Measured on 40 findings all stale and all revertible -- the shape a
+  // mass revert produces -- that was 185 ms against 25 ms, a 7x regression on
+  // the injection path, all of it graph loading rather than the hashing this
+  // feature is actually for. With the graph passed through it is back in line.
+  //
+  // No new race: this store is last-write-wins with no compare-and-set anywhere,
+  // and every other caller that spreads a node back -- `pin`, `retire`,
+  // `contradict`, `correct` -- writes from a graph it loaded earlier too. Both
+  // callers here already DECIDED on this snapshot, so re-reading it purely for
+  // the write narrowed no window that was ever closed.
+  const node = (graph || load(dir)).nodes.get(nodeId('finding', key));
   if (!node || node.kind !== 'finding') return false;
   const { stale, staleReason, diff, staleEvidence, ...rest } = node;
   // Nothing to clear is a success, not a write: an unconditional putNode here
@@ -989,14 +1054,33 @@ export function clearStale(dir, key) {
  * silently un-mark findings nobody asked about. Staleness is disclosed to a
  * reader who then decides; clearing is an explicit act.
  */
-export function reverify(dir, key) {
-  const graph = load(dir);
-  const finding = graph.nodes.get(nodeId('finding', key));
-  if (!finding || finding.kind !== 'finding') return 'unknown';
-  // Idempotent: the postcondition -- no stale flag on this finding -- already
-  // holds, and reporting anything else would make a caller retry forever.
-  if (!finding.stale) return 'cleared';
-
+/**
+ * THE ONE EVIDENCE TEST. Does this finding's anchored content still hash to what
+ * the claim was actually made against?
+ *
+ * `'match'` -- every anchor on disk re-hashes to the value frozen into this
+ * finding's own `derivation.anchors` at claim time. The content IS what the
+ * claim was derived from: a revert, or a write that never moved the anchored
+ * bytes.
+ * `'differs'` -- at least one anchor does not, INCLUDING an anchor whose content
+ * is gone. Deleted is a difference, not a missing measurement.
+ * `'unknown'` -- there is nothing to compare: no `derivation.anchors`, no
+ * anchors, an anchor with no recorded hash, or one that no longer resolves.
+ *
+ * SHARED BY BOTH CLEARING PATHS ON PURPOSE, and that sharing is the guarantee
+ * rather than a convenience. `reverify` (a person pressing Re-verify) and
+ * `serve` (automatic, on every retrieval) call THIS function and nothing else,
+ * so the automatic path cannot clear anything the button would not, and neither
+ * can drift from the other. Two copies of this comparison would be two policies,
+ * and the weaker one would win wherever it ran more often -- which is the
+ * automatic one.
+ *
+ * NOT `checkAnchor`, for the reason `anchorHashNow` above spells out: that
+ * compares disk against the anchor NODE's stored hash, which both eager paths
+ * re-point at the very bytes that caused the mark, so it answers "fresh" for
+ * exactly the finding it just marked stale.
+ */
+function claimTimeVerdict(graph, finding) {
   const recorded = finding.derivation && finding.derivation.anchors;
   if (!recorded || typeof recorded !== 'object') return 'unknown';
 
@@ -1019,10 +1103,23 @@ export function reverify(dir, key) {
     if (node.kind !== 'file' && node.kind !== 'symbol') return 'unknown';
     // null means the content is gone -- deleted file, vanished symbol. That is a
     // difference, not an absence of evidence.
-    if (anchorHashNow(node) !== expected) return 'still-stale';
+    if (anchorHashNow(node) !== expected) return 'differs';
   }
+  return 'match';
+}
 
-  clearStale(dir, key);
+export function reverify(dir, key) {
+  const graph = load(dir);
+  const finding = graph.nodes.get(nodeId('finding', key));
+  if (!finding || finding.kind !== 'finding') return 'unknown';
+  // Idempotent: the postcondition -- no stale flag on this finding -- already
+  // holds, and reporting anything else would make a caller retry forever.
+  if (!finding.stale) return 'cleared';
+
+  const verdict = claimTimeVerdict(graph, finding);
+  if (verdict === 'unknown') return 'unknown';
+  if (verdict === 'differs') return 'still-stale';
+  clearStale(dir, key, { graph });
   return 'cleared';
 }
 

--- a/integrations/cursor/hooks/lib/staleness.mjs
+++ b/integrations/cursor/hooks/lib/staleness.mjs
@@ -53,7 +53,7 @@
 import { readFileSync, statSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { dirname, join } from 'node:path';
-import { putNode, putEdge, contentHash, nodeId } from './wiki.mjs';
+import { putNode, putEdge, contentHash, nodeId, load } from './wiki.mjs';
 import { hasOutstandingContradiction } from './curate.mjs';
 import { extractSymbols, spanText, symbolKey, extractImports } from './symbols.mjs';
 import { canonicalPath, resolvableCandidates, isFsSafePath } from './paths.mjs';
@@ -488,7 +488,16 @@ function disputeOf(graph, finding) {
     // An edge end that resolves to nothing names nothing. The dispute is still
     // disclosed -- the gate above already established it -- but without a key
     // the reader cannot be pointed anywhere, and inventing one would be worse.
-    if (other && typeof other.key === 'string' && !keys.includes(other.key)) keys.push(other.key);
+    //
+    // A RETIRED END IS NOT NAMED EITHER, for a sharper reason: the disclosure
+    // tells the reader to `wiki_query` that key, and `serve` refuses to return
+    // a retired finding at all. Naming it points them at a claim they cannot
+    // fetch. `hasOutstandingContradiction` above already declines to open the
+    // gate when EVERY disputant is retired; this is the same rule applied to
+    // each name, so a live disputant is still reported alongside a withdrawn one.
+    if (other && !other.retired && typeof other.key === 'string' && !keys.includes(other.key)) {
+      keys.push(other.key);
+    }
   }
 
   return { contradicted: true, ...(keys.length ? { contradictedBy: keys.join(', ') } : {}) };
@@ -870,6 +879,151 @@ export function invalidateChangedAnchors(dir, graph, rawPath) {
   // retrieval re-reports a change that has already been accounted for.
   if (source !== null) indexFile(dir, path, source);
   return marked;
+}
+
+/**
+ * The current content hash of an anchor, read from disk.
+ *
+ * DELIBERATELY NOT `checkAnchor`, and the difference is the whole of this
+ * clearing rule. `checkAnchor` compares disk against the anchor NODE's stored
+ * hash, and both eager paths call `indexFile` immediately after marking --
+ * which re-points that hash at the very bytes that caused the mark. So
+ * `checkAnchor` answers "fresh" for exactly the finding it just marked stale,
+ * and a clearing rule built on it would clear every flag it was handed,
+ * unconditionally. This returns a bare hash instead, so the caller can compare
+ * it against the FROZEN claim-time hash rather than against a value the marking
+ * path itself moved.
+ *
+ * Returns null when no content can be read at all -- a deleted file, or a
+ * symbol that no longer exists. A caller must treat that as "changed", never as
+ * "unknown": a claim about content that is gone certainly does not match the
+ * content it was made against.
+ */
+function anchorHashNow(anchor) {
+  const path = anchor.kind === 'symbol' ? anchor.file : anchor.key;
+  let source;
+  try {
+    source = readAnySpelling(path);
+  } catch {
+    return null;
+  }
+  if (anchor.kind !== 'symbol') return hash(source);
+
+  // By NAME, like checkAnchor: line numbers shift whenever anything above is
+  // edited, and re-locating by line would report a symbol as moved when only an
+  // unrelated insert happened above it.
+  const current = extractSymbols(path, source).find((s) => s.name === anchor.name);
+  if (!current) return null;
+  return hash(spanText(source, current));
+}
+
+/**
+ * Removes the staleness fields from a finding. Returns whether one was found.
+ *
+ * THE WHOLE NODE IS REWRITTEN, because `putNode` does not merge: it writes a
+ * full record from what it is handed and `load` replaces the node wholesale.
+ * Writing `{ kind, key, stale: false }` would blank the claim, the confidence
+ * and the provenance -- an overwrite by another name, and the same trap
+ * `contradict` documents. So the fields are destructured AWAY and everything
+ * else is spread back: no deletion primitive is needed, and the append-only rule
+ * is respected.
+ *
+ * `staleEvidence` is stripped as well, even though no writer stores it. It is
+ * added by `serve` to the object it hands out, so anything that ever writes a
+ * served finding back would carry it in -- at which point a cleared finding
+ * would still be advertising the quality of the evidence for a flag it no longer
+ * has.
+ *
+ * A PRIMITIVE, NOT A ROUTE. Nothing outside this module calls it: the only
+ * shipping caller is `reverify` below, which establishes the evidence first.
+ * Exposing it to a hook, a tool argument or an HTTP action would be a way to
+ * turn a stale finding fresh on request, which is exactly what must not exist.
+ */
+export function clearStale(dir, key) {
+  const node = load(dir).nodes.get(nodeId('finding', key));
+  if (!node || node.kind !== 'finding') return false;
+  const { stale, staleReason, diff, staleEvidence, ...rest } = node;
+  // Nothing to clear is a success, not a write: an unconditional putNode here
+  // would append a duplicate record to the log on every no-op call.
+  if (stale === undefined && staleReason === undefined
+    && diff === undefined && staleEvidence === undefined) return true;
+  putNode(dir, { ...rest, kind: 'finding', key: node.key });
+  return true;
+}
+
+/**
+ * Clears a stale flag when, and only when, the evidence for it is gone.
+ *
+ * WHY THIS HAS TO EXIST. Nothing in this codebase ever cleared a `stale` flag.
+ * That was harmless while eager invalidation was dead code; it fires now, so
+ * every finding on an edited file becomes permanently stale -- and permanently
+ * discounted, since `disclose.mjs` skips a stale finding outright and
+ * `utility.mjs` penalises one by 160. The graph degrades toward all-stale, and
+ * the eager path is over-eager on top of that: `invalidateOnWrite` marks every
+ * finding anchored to a FILE node on any observed write to that file, whether or
+ * not the bytes moved.
+ *
+ * WHAT COUNTS AS EVIDENCE, AND WHY IT IS NOT NEGOTIABLE. The only trustworthy
+ * record of what a claim was made against is `derivation.anchors` -- the hash
+ * each anchor carried at the moment the finding was written, frozen into the
+ * finding itself by `harvest-write.mjs`. Disk is re-hashed here and compared
+ * against that. If every anchor matches, the content IS what the claim was
+ * derived from: a revert, or a write that never moved the anchored bytes. The
+ * flag comes off. Anything else leaves it exactly as it was.
+ *
+ * IT IS NOT A LAUNDERING ROUTE, and that is a property of the comparison rather
+ * than of who is allowed to call it. A caller cannot make a finding fresh by
+ * asking; they can only make it fresh by putting the content back. There is no
+ * argument, no force flag and no second path -- and `clearStale` above, the one
+ * function that clears without checking, has no caller but this one.
+ *
+ * NO RECORD MEANS UNKNOWN, NEVER CLEAR. A finding with no `derivation.anchors`
+ * -- every one written before that record existed, and every hand-curated one --
+ * has nothing to compare disk against. That is an absence of evidence, and
+ * resolving it to "clear it" would hand back the laundering route through the
+ * side door. It reports `unknown` and changes nothing; re-recording the claim
+ * against the current code (`curate.correct`) is the way forward for those.
+ *
+ * DELIBERATELY NOT AUTOMATIC. This reads every anchor off disk, so running it on
+ * the serve path would put N file reads inside injection -- and, worse, it would
+ * silently un-mark findings nobody asked about. Staleness is disclosed to a
+ * reader who then decides; clearing is an explicit act.
+ */
+export function reverify(dir, key) {
+  const graph = load(dir);
+  const finding = graph.nodes.get(nodeId('finding', key));
+  if (!finding || finding.kind !== 'finding') return 'unknown';
+  // Idempotent: the postcondition -- no stale flag on this finding -- already
+  // holds, and reporting anything else would make a caller retry forever.
+  if (!finding.stale) return 'cleared';
+
+  const recorded = finding.derivation && finding.derivation.anchors;
+  if (!recorded || typeof recorded !== 'object') return 'unknown';
+
+  const anchorIds = new Set(
+    graph.edges
+      .filter((e) => e.edge === 'derived_from' && e.from === finding.id)
+      .map((e) => e.to)
+  );
+  // An unanchored finding cannot be checked against anything, which is the
+  // un-invalidatable shape the anchor discipline exists to refuse. It is equally
+  // un-VERIFIABLE, so it is reported as such rather than cleared.
+  if (!anchorIds.size) return 'unknown';
+
+  for (const id of anchorIds) {
+    const expected = recorded[id];
+    const node = graph.nodes.get(id);
+    // An anchor this finding never recorded a hash for, or one that no longer
+    // resolves to a node: nothing to compare, so nothing is concluded.
+    if (typeof expected !== 'string' || !expected || !node) return 'unknown';
+    if (node.kind !== 'file' && node.kind !== 'symbol') return 'unknown';
+    // null means the content is gone -- deleted file, vanished symbol. That is a
+    // difference, not an absence of evidence.
+    if (anchorHashNow(node) !== expected) return 'still-stale';
+  }
+
+  clearStale(dir, key);
+  return 'cleared';
 }
 
 export { contentHash };

--- a/integrations/cursor/hooks/lib/staleness.mjs
+++ b/integrations/cursor/hooks/lib/staleness.mjs
@@ -368,6 +368,12 @@ const DIFF_MAX_BYTES = () => {
  * line, and total bytes. Every truncation is announced in the output, because a
  * silently shortened diff is worse than a visibly shortened one -- a reader who
  * cannot tell content was elided believes they saw the whole change.
+ *
+ * `maxLines` BOUNDS THE BODY, MARKERS INCLUDED: at most `maxLines` lines of
+ * removed lines, added lines and "... N more" elision markers between them, plus
+ * at most one final notice when the byte cap dropped lines -- so `maxLines + 1`
+ * lines in total, and no more. That last line is outside the budget on purpose,
+ * for the reason stated where it is pushed.
  */
 export function diffLines(
   before,
@@ -418,10 +424,24 @@ export function diffLines(
     bytes += size;
   };
 
-  for (const line of removed.slice(0, maxLines / 2)) push('- ' + line);
-  if (removed.length > maxLines / 2) push(`  ... ${removed.length - maxLines / 2} more removed`);
-  for (const line of added.slice(0, maxLines / 2)) push('+ ' + line);
-  if (added.length > maxLines / 2) push(`  ... ${added.length - maxLines / 2} more added`);
+  // THE ELISION MARKER IS PAID FOR OUT OF THE SIDE'S OWN QUOTA, so `maxLines`
+  // bounds the whole body rather than only the content in it. It did not: at the
+  // default 40 the body could reach 42 lines -- 20 removed, 20 added and two
+  // "... N more" markers -- and the out-of-budget notice below made 43, against
+  // a documented bound of 40 and a test asserting 41. Three numbers, no two the
+  // same. A side that has to elide now shows one fewer content line and spends
+  // that line on saying so, which is the trade a reader wants anyway: knowing
+  // that 300 lines were cut matters more than the 20th of the 20 shown.
+  const half = Math.floor(maxLines / 2);
+  const emit = (lines, prefix, label) => {
+    const elides = lines.length > half;
+    const shown = elides ? Math.max(0, half - 1) : half;
+    for (const line of lines.slice(0, shown)) push(prefix + line);
+    if (elides) push(`  ... ${lines.length - shown} more ${label}`);
+  };
+
+  emit(removed, '- ', 'removed');
+  emit(added, '+ ', 'added');
 
   // Announced OUTSIDE the budget, deliberately: the one line a reader most
   // needs is the one saying the rest is missing, and dropping it to stay under
@@ -479,6 +499,15 @@ function disputeOf(graph, finding) {
   if (!hasOutstandingContradiction(graph, finding.key)) return {};
 
   const keys = [];
+  // AND THE REASON A PERSON TYPED, which had no reader anywhere. `contradict`
+  // stores `contradictionReason` -- up to 400 characters of human explanation --
+  // on the CONTRADICTED end only, and nothing outside its own test ever read it:
+  // this disclosure named the other key and stopped, `audit` counts ends, and the
+  // dashboard detail view renders neither. So the one field on the edge that says
+  // WHY was written on every contradiction and seen by nobody. It is collected
+  // from whichever end holds it, so both sides of a dispute disclose the same
+  // reason rather than only the claim that lost.
+  let reason = typeof finding.contradictionReason === 'string' ? finding.contradictionReason : '';
   for (const edge of graph.edges) {
     if (edge.edge !== 'contradicts') continue;
     const otherId =
@@ -497,10 +526,30 @@ function disputeOf(graph, finding) {
     // each name, so a live disputant is still reported alongside a withdrawn one.
     if (other && !other.retired && typeof other.key === 'string' && !keys.includes(other.key)) {
       keys.push(other.key);
+      // A RETIRED END'S REASON IS NOT BORROWED EITHER, which is why this sits
+      // inside the same guard as the key: `hasOutstandingContradiction` can be
+      // open on one live disputant while another is withdrawn, and quoting the
+      // withdrawn one's explanation would attribute the live dispute to a claim
+      // the reader cannot fetch.
+      if (!reason && typeof other.contradictionReason === 'string') {
+        reason = other.contradictionReason;
+      }
     }
   }
 
-  return { contradicted: true, ...(keys.length ? { contradictedBy: keys.join(', ') } : {}) };
+  return {
+    contradicted: true,
+    ...(keys.length ? { contradictedBy: keys.join(', ') } : {}),
+    // Trimmed here rather than at the renderer: an empty string is not a reason,
+    // and a consumer checking `if (reason)` should not have to trim first.
+    //
+    // SET UNCONDITIONALLY, INCLUDING TO `undefined`. `serve` spreads the stored
+    // record before this object, so omitting the key would let a whitespace-only
+    // stored reason through untouched and make the served value differ from the
+    // one this function decided on. The disclosure is authoritative or it is not
+    // a disclosure.
+    contradictionReason: reason.trim() || undefined,
+  };
 }
 
 /**
@@ -580,8 +629,15 @@ function derivationCheck(graph, finding) {
  * the dashboard, which left the rot path fully open on every install where
  * nobody opens the dashboard -- and that is most of them. The evidence test is
  * what makes clearing safe, and it does not care who triggered it: the same
- * `claimTimeVerdict` runs here as in `reverify`, so this cannot clear anything
+ * `claimTimeEvidence` runs here as in `reverify`, so this cannot clear anything
  * the button would not.
+ *
+ * A CLEAR ALSO RE-INDEXES THE ANCHORS IT VERIFIED. The three disclosures this
+ * function emits -- `stale`, `derivationHolds`, and the dispute -- are computed
+ * from three different comparisons, and clearing the flag without moving the
+ * anchor's stored hash made the first two contradict the clear on the revert
+ * path. `reindexVerifiedAnchors` explains the reproduction and why re-pointing
+ * the index is the fix rather than suppressing the disclosures.
  *
  * `dir` IS OPTIONAL, AND OMITTING IT MAKES THIS READ-ONLY. Several callers hold
  * a graph without the directory it came from, and a serve that silently did
@@ -617,11 +673,17 @@ export function serve(graph, findings, { dir = null } = {}) {
 
     // AUTOMATIC CLEARING, on the same evidence the manual path demands.
     //
-    // ONLY THE STORED FLAG IS TOUCHED. The lazy loop below is left to run
-    // exactly as before and can independently mark this finding stale again on
-    // its own comparison -- disk against the anchor NODE's hash -- which answers
-    // a different question and is not this function's to overrule. Eager and
-    // lazy stay two mechanisms, as the module header insists.
+    // THE FLAG AND THE INDEX MOVE TOGETHER. Clearing the flag alone made this
+    // function contradict itself on the revert path: the lazy loop below
+    // compares disk against the anchor NODE's hash, which the eager path
+    // re-pointed at the post-edit bytes, so a reverted file read as `stale:
+    // true, staleReason: 'file changed'` and `derivationHolds: false` inside the
+    // very object whose flag had just been cleared for matching its claim-time
+    // content. `reindexVerifiedAnchors` writes the verified bytes' hash back to
+    // the anchor, so all three disclosures are finally reading the same content
+    // and cannot disagree. Eager and lazy stay two mechanisms, as the module
+    // header insists -- what changed is that the index no longer holds a hash
+    // that matches no version of the file that exists.
     //
     // AND THE FIELDS GO WITH THE FLAG. `putNode` does not merge and neither does
     // this spread: serving `{ ...finding, stale: false }` would hand back a
@@ -630,12 +692,37 @@ export function serve(graph, findings, { dir = null } = {}) {
     // So the cleared record, not the stored one, is what the rest of this
     // iteration reads and spreads.
     //
-    // BOUNDED, and the bound is the point: this runs only for a finding whose
-    // flag is already STORED, only when a `derivation` record exists to check
-    // against, and it reads each of that finding's anchors at most once. A
-    // finding that is not flagged pays nothing. The lazy loop below already
+    // BOUNDED PER CALL, and the bound is the point: this runs only for a finding
+    // whose flag is already STORED, only when a `derivation` record exists to
+    // check against, and it reads each of that finding's anchors at most once.
+    // A finding that is not flagged pays nothing. The lazy loop below already
     // reads every anchor of every content-dependent finding served, so the worst
     // case is twice the anchor reads on the already-stale subset alone.
+    //
+    // AND THE PER-SESSION SHAPE, stated because the per-call bound alone reads
+    // as cheaper than it is. Measured on a synthetic 40-stale-finding graph, the
+    // serve path went 158 ms -> 217 ms (+37%), and for a GENUINELY stale finding
+    // that cost recurs on every call for the whole session: the verdict is
+    // `'differs'` forever, nothing is cleared, and the reads are repaid with
+    // nothing. What keeps it survivable in practice is not this bound but two
+    // others -- `findingsFor`'s result limit and inject.mjs's `alreadyInjected`
+    // gate, which together put it near 40 ms on the first touch of a hot file
+    // and zero on the touches after.
+    //
+    // THE REVERT CASE PAYS ONCE, AND THAT IS MEASURED, not argued. Same 40
+    // findings, all revertible, medians of 9 across three process launches: the
+    // read-only serve is 23-29 ms, the first clearing serve is 141-173 ms (the
+    // anchor reads plus one node append per cleared finding AND per re-pointed
+    // anchor), and the SECOND clearing serve is 21-28 ms -- back to the
+    // read-only baseline, because the flag is off and the index agrees, so this
+    // gate no longer fires. What the re-index changed is not that cost -- the
+    // gate stopped firing once the flag came off before, too -- but that every
+    // serve after the clear used to re-derive `stale: true` and
+    // `derivationHolds: false` from an index nobody had moved. The extra ~120 ms
+    // buys silence that is actually correct.
+    // On the genuinely-stale set the recurring cost is
+    // real and unchanged in kind: 26-45 ms read-only against 53-105 ms with
+    // clearing on, every call, clearing nothing.
     //
     // NOT ON THE NON-CONTENT-DEPENDENT EARLY RETURN ABOVE, deliberately. Both
     // eager paths refuse to flag those types at all, so a flag there can only
@@ -643,10 +730,14 @@ export function serve(graph, findings, { dir = null } = {}) {
     // does not depend on them is exactly the cost `CONTENT_DEPENDENT` exists to
     // avoid.
     let record = finding;
-    if (dir && finding.stale && claimTimeVerdict(graph, finding) === 'match') {
-      clearStale(dir, finding.key, { graph });
-      const { stale: _s, staleReason: _r, diff: _d, staleEvidence: _e, ...cleared } = finding;
-      record = cleared;
+    if (dir && finding.stale) {
+      const evidence = claimTimeEvidence(graph, finding);
+      if (evidence.verdict === 'match') {
+        reindexVerifiedAnchors(dir, graph, evidence.contents);
+        clearStale(dir, finding.key, { graph });
+        const { stale: _s, staleReason: _r, diff: _d, staleEvidence: _e, ...cleared } = finding;
+        record = cleared;
+      }
     }
 
     const anchors = graph.edges
@@ -736,6 +827,14 @@ export function serve(graph, findings, { dir = null } = {}) {
       // carries its `derivation`, since clearing removes only the staleness
       // fields. A finding whose flag was just cleared is still disclosed as
       // disputed, and still reports whether its derivation holds.
+      //
+      // AND THEY NO LONGER CONTRADICT THE CLEAR. Surviving is not the same as
+      // agreeing: for a whole serve this returned `stale: true, staleReason:
+      // 'file changed'` and `derivationHolds: false` on a finding it had just
+      // cleared, because the clear was decided against disk while these two read
+      // the anchor node's hash, and the eager path had moved it. All three now
+      // read the same content because the clear re-points the anchor; see
+      // `reindexVerifiedAnchors`.
       ...dispute,
       // Independent of `stale` above: see `derivationCheck`'s own comment for
       // the case it catches that node-level staleness can miss.
@@ -934,6 +1033,34 @@ export function invalidateChangedAnchors(dir, graph, rawPath) {
 }
 
 /**
+ * The current content of an anchor, read from disk: the whole file for a file
+ * anchor, the located span for a symbol one. Null when nothing can be read.
+ *
+ * SPLIT OUT FROM `anchorHashNow` SO THE BYTES SURVIVE THE COMPARISON. The
+ * clearing path hashes this to reach a verdict and, on `'match'`, re-indexes the
+ * anchor from the same bytes -- see `reindexVerifiedAnchors`. Returning only a
+ * hash forced a second read of a file that had just been read, for content
+ * already known to be identical.
+ */
+function anchorContentNow(anchor) {
+  const path = anchor.kind === 'symbol' ? anchor.file : anchor.key;
+  let source;
+  try {
+    source = readAnySpelling(path);
+  } catch {
+    return null;
+  }
+  if (anchor.kind !== 'symbol') return source;
+
+  // By NAME, like checkAnchor: line numbers shift whenever anything above is
+  // edited, and re-locating by line would report a symbol as moved when only an
+  // unrelated insert happened above it.
+  const current = extractSymbols(path, source).find((s) => s.name === anchor.name);
+  if (!current) return null;
+  return spanText(source, current);
+}
+
+/**
  * The current content hash of an anchor, read from disk.
  *
  * DELIBERATELY NOT `checkAnchor`, and the difference is the whole of this
@@ -952,21 +1079,8 @@ export function invalidateChangedAnchors(dir, graph, rawPath) {
  * content it was made against.
  */
 function anchorHashNow(anchor) {
-  const path = anchor.kind === 'symbol' ? anchor.file : anchor.key;
-  let source;
-  try {
-    source = readAnySpelling(path);
-  } catch {
-    return null;
-  }
-  if (anchor.kind !== 'symbol') return hash(source);
-
-  // By NAME, like checkAnchor: line numbers shift whenever anything above is
-  // edited, and re-locating by line would report a symbol as moved when only an
-  // unrelated insert happened above it.
-  const current = extractSymbols(path, source).find((s) => s.name === anchor.name);
-  if (!current) return null;
-  return hash(spanText(source, current));
+  const content = anchorContentNow(anchor);
+  return content === null ? null : hash(content);
 }
 
 /**
@@ -1005,21 +1119,51 @@ export function clearStale(dir, key, { graph = null } = {}) {
   // `contradict`, `correct` -- writes from a graph it loaded earlier too. Both
   // callers here already DECIDED on this snapshot, so re-reading it purely for
   // the write narrowed no window that was ever closed.
-  const node = (graph || load(dir)).nodes.get(nodeId('finding', key));
+  const id = nodeId('finding', key);
+  const node = (graph || load(dir)).nodes.get(id);
   if (!node || node.kind !== 'finding') return false;
   const { stale, staleReason, diff, staleEvidence, ...rest } = node;
   // Nothing to clear is a success, not a write: an unconditional putNode here
   // would append a duplicate record to the log on every no-op call.
   if (stale === undefined && staleReason === undefined
     && diff === undefined && staleEvidence === undefined) return true;
-  putNode(dir, { ...rest, kind: 'finding', key: node.key });
+  const cleared = { ...rest, kind: 'finding', key: node.key };
+  putNode(dir, cleared);
+  // AND THE CALLER'S GRAPH IS UPDATED, because the guard above reads THAT graph,
+  // not disk. Without this, a second `serve` on the same in-memory graph object
+  // -- two touched files anchored to one finding, or a lifecycle branch that
+  // serves twice from a graph it loaded once, as SessionStart does -- still saw
+  // `stale: true`, re-ran the evidence test, and appended a byte-identical clear
+  // record. The store is append-only, so that is permanent log growth for no
+  // change in state, and the "nothing to clear is a success, not a write"
+  // guarantee directly above was only true of the first call.
+  if (graph) graph.nodes.set(id, { ...cleared, id });
   return true;
 }
 
 /**
- * Clears a stale flag when, and only when, the evidence for it is gone.
+ * THE ONE EVIDENCE TEST, plus the bytes it read. Does this finding's anchored
+ * content still hash to what the claim was actually made against?
  *
- * WHY THIS HAS TO EXIST. Nothing in this codebase ever cleared a `stale` flag.
+ * `verdict` is one of:
+ *   `'match'`   -- every anchor on disk re-hashes to the value frozen into this
+ *                  finding's own `derivation.anchors` at claim time. The content
+ *                  IS what the claim was derived from: a revert, or a write that
+ *                  never moved the anchored bytes.
+ *   `'differs'` -- at least one anchor does not, INCLUDING an anchor whose
+ *                  content is gone. Deleted is a difference, not a missing
+ *                  measurement.
+ *   `'unknown'` -- there is nothing to compare: no `derivation.anchors`, no
+ *                  anchors, an anchor with no recorded hash, or one that no
+ *                  longer resolves.
+ *
+ * `contents` carries the disk bytes read to reach a `'match'`, keyed by anchor
+ * id, so the caller can re-index those anchors without reading them again. It is
+ * empty for the other two verdicts, which read no further than the first
+ * disagreement.
+ *
+ * WHY CLEARING HAS TO EXIST AT ALL. Nothing in this codebase ever cleared a
+ * `stale` flag.
  * That was harmless while eager invalidation was dead code; it fires now, so
  * every finding on an edited file becomes permanently stale -- and permanently
  * discounted, since `disclose.mjs` skips a stale finding outright and
@@ -1049,24 +1193,6 @@ export function clearStale(dir, key, { graph = null } = {}) {
  * side door. It reports `unknown` and changes nothing; re-recording the claim
  * against the current code (`curate.correct`) is the way forward for those.
  *
- * DELIBERATELY NOT AUTOMATIC. This reads every anchor off disk, so running it on
- * the serve path would put N file reads inside injection -- and, worse, it would
- * silently un-mark findings nobody asked about. Staleness is disclosed to a
- * reader who then decides; clearing is an explicit act.
- */
-/**
- * THE ONE EVIDENCE TEST. Does this finding's anchored content still hash to what
- * the claim was actually made against?
- *
- * `'match'` -- every anchor on disk re-hashes to the value frozen into this
- * finding's own `derivation.anchors` at claim time. The content IS what the
- * claim was derived from: a revert, or a write that never moved the anchored
- * bytes.
- * `'differs'` -- at least one anchor does not, INCLUDING an anchor whose content
- * is gone. Deleted is a difference, not a missing measurement.
- * `'unknown'` -- there is nothing to compare: no `derivation.anchors`, no
- * anchors, an anchor with no recorded hash, or one that no longer resolves.
- *
  * SHARED BY BOTH CLEARING PATHS ON PURPOSE, and that sharing is the guarantee
  * rather than a convenience. `reverify` (a person pressing Re-verify) and
  * `serve` (automatic, on every retrieval) call THIS function and nothing else,
@@ -1080,9 +1206,10 @@ export function clearStale(dir, key, { graph = null } = {}) {
  * re-point at the very bytes that caused the mark, so it answers "fresh" for
  * exactly the finding it just marked stale.
  */
-function claimTimeVerdict(graph, finding) {
+function claimTimeEvidence(graph, finding) {
+  const none = { verdict: 'unknown', contents: new Map() };
   const recorded = finding.derivation && finding.derivation.anchors;
-  if (!recorded || typeof recorded !== 'object') return 'unknown';
+  if (!recorded || typeof recorded !== 'object') return none;
 
   const anchorIds = new Set(
     graph.edges
@@ -1092,22 +1219,122 @@ function claimTimeVerdict(graph, finding) {
   // An unanchored finding cannot be checked against anything, which is the
   // un-invalidatable shape the anchor discipline exists to refuse. It is equally
   // un-VERIFIABLE, so it is reported as such rather than cleared.
-  if (!anchorIds.size) return 'unknown';
+  if (!anchorIds.size) return none;
 
+  const contents = new Map();
   for (const id of anchorIds) {
     const expected = recorded[id];
     const node = graph.nodes.get(id);
     // An anchor this finding never recorded a hash for, or one that no longer
     // resolves to a node: nothing to compare, so nothing is concluded.
-    if (typeof expected !== 'string' || !expected || !node) return 'unknown';
-    if (node.kind !== 'file' && node.kind !== 'symbol') return 'unknown';
+    if (typeof expected !== 'string' || !expected || !node) return none;
+    if (node.kind !== 'file' && node.kind !== 'symbol') return none;
     // null means the content is gone -- deleted file, vanished symbol. That is a
     // difference, not an absence of evidence.
-    if (anchorHashNow(node) !== expected) return 'differs';
+    const content = anchorContentNow(node);
+    if (content === null || hash(content) !== expected) {
+      return { verdict: 'differs', contents: new Map() };
+    }
+    contents.set(id, content);
   }
-  return 'match';
+  return { verdict: 'match', contents };
 }
 
+/** The verdict alone, for callers that do not re-index. */
+function claimTimeVerdict(graph, finding) {
+  return claimTimeEvidence(graph, finding).verdict;
+}
+
+/**
+ * Re-points every verified anchor at the content the evidence test just read.
+ *
+ * WHY A CLEAR IS NOT ENOUGH ON ITS OWN, reproduced end to end: index a file at
+ * H1, write a finding whose `derivation.anchors` records H1, edit and re-index so
+ * the node holds H2, let the eager path mark the finding, then REVERT the edit on
+ * disk. `claimTimeVerdict` now says `'match'` -- disk is H1, which is exactly
+ * what the claim was derived from -- and the flag comes off. But the node still
+ * holds H2, so the same `serve` call went on to emit `stale: true` with
+ * `staleReason: 'file changed'` from the lazy loop (disk H1 against node H2) and
+ * `derivationHolds: false` from `derivationCheck` (index H2 against claim H1).
+ * The model was shown DERIVATION CHANGED and STALE at the exact moment this
+ * module's own evidence test had concluded the derivation holds -- on every
+ * serve, until something unrelated happened to re-index the anchor.
+ *
+ * THE FIX IS TO MOVE THE INDEX, NOT TO SILENCE THE DISCLOSURES. Suppressing the
+ * lazy check and the derivation verdict for a cleared finding would leave the
+ * graph holding a hash that matches no version of the file that exists, so every
+ * OTHER finding on that anchor keeps reading stale, and the next reader has to be
+ * told which disclosures to disbelieve. The node hash is simply out of date, the
+ * bytes are already in hand from the comparison that just succeeded, and writing
+ * them makes all three disclosures agree because they are finally reading the
+ * same content.
+ *
+ * COSTS NO READ. `contents` comes from `claimTimeEvidence`, which read each
+ * anchor to reach `'match'`. The write is one node record per anchor whose hash
+ * actually moved, and it happens once per revert rather than once per serve: with
+ * the index re-pointed, the flag stays off and the gate in `serve` does not fire
+ * again.
+ *
+ * THE IN-MEMORY GRAPH IS UPDATED TOO, because the caller is mid-serve and is
+ * about to read these same nodes through the lazy loop and `derivationCheck`.
+ * Writing only to disk would fix the next process and leave this one contradicting
+ * itself, which is the whole defect.
+ *
+ * Line numbers are deliberately left alone on a symbol anchor: `checkAnchor` and
+ * `anchorContentNow` both re-locate by NAME, so a stored line is informational,
+ * and the body being byte-identical is what was just established.
+ */
+function reindexVerifiedAnchors(dir, graph, contents) {
+  for (const [id, content] of contents) {
+    const node = graph.nodes.get(id);
+    if (!node) continue;
+    const nextHash = hash(content);
+    // Already agrees: no record, no write. The common case once a revert has
+    // been accounted for.
+    if (node.hash === nextHash) continue;
+    const limit = node.kind === 'symbol' ? symbolSnapshotLimit() : snapshotLimit();
+    // Same bound as `indexFile`: past the cap the hash still drives staleness and
+    // only the reconstructed diff degrades.
+    const snapshot = content.length <= limit ? content : undefined;
+    const { hash: _h, snapshot: _s, ...rest } = node;
+    try {
+      putNode(dir, { ...rest, kind: node.kind, key: node.key, hash: nextHash, snapshot });
+    } catch {
+      // Fail open: a graph that could not be written is a disclosure that stays
+      // as it was, never a broken tool call. The in-memory copy is left alone to
+      // match, so this serve keeps agreeing with the store.
+      continue;
+    }
+    graph.nodes.set(id, { ...node, hash: nextHash, ...(snapshot ? { snapshot } : {}) });
+  }
+}
+
+/**
+ * Clears a stale flag on behalf of a person who asked for it -- the dashboard's
+ * Re-verify action -- and reports what the evidence said.
+ *
+ * `'cleared'` when the flag is gone (including when it was already gone, so a
+ * caller polling this does not retry forever), `'still-stale'` when the anchored
+ * content genuinely differs from what the claim was made against, `'unknown'`
+ * when there is nothing to compare and therefore nothing to conclude.
+ *
+ * NO LONGER THE ONLY CLEARING PATH, and the docblock that used to sit here said
+ * the opposite: that automatic clearing was refused because it would put N file
+ * reads inside injection and "silently un-mark findings nobody asked about".
+ * `serve` now does exactly that, on the same evidence, for the reason its own
+ * comment gives -- the manual path was reachable only where somebody opens the
+ * dashboard, which is almost nowhere, so the rot path stayed open on most
+ * installs. What survives of that objection is the cost, which `serve` bounds
+ * and states.
+ *
+ * WHAT THIS STILL ADDS over the automatic path: it loads the graph itself, so a
+ * caller holding nothing but a key and a directory can act; it reports the
+ * verdict rather than folding it into a served record; and it runs on demand
+ * rather than only when the finding happens to be retrieved. It re-indexes the
+ * verified anchors for the same reason `serve` does -- otherwise the button
+ * clears the flag and the very next retrieval re-derives a contradiction from a
+ * node hash nobody moved.
+ */
 export function reverify(dir, key) {
   const graph = load(dir);
   const finding = graph.nodes.get(nodeId('finding', key));
@@ -1116,9 +1343,10 @@ export function reverify(dir, key) {
   // holds, and reporting anything else would make a caller retry forever.
   if (!finding.stale) return 'cleared';
 
-  const verdict = claimTimeVerdict(graph, finding);
+  const { verdict, contents } = claimTimeEvidence(graph, finding);
   if (verdict === 'unknown') return 'unknown';
   if (verdict === 'differs') return 'still-stale';
+  reindexVerifiedAnchors(dir, graph, contents);
   clearStale(dir, key, { graph });
   return 'cleared';
 }

--- a/integrations/cursor/hooks/lib/staleness.mjs
+++ b/integrations/cursor/hooks/lib/staleness.mjs
@@ -17,7 +17,13 @@
  * TWO INVALIDATION PATHS, and each covers what the other cannot see:
  *
  *   EAGER  -- our PostToolUse hook saw a write, so the finding is marked at the
- *             moment it went stale, with the exact before/after in hand.
+ *             moment it went stale, with the exact before/after in hand. The
+ *             hook does not call `invalidateOnWrite` directly: it queues the
+ *             evidence through pending.mjs, and the next graph read -- which
+ *             loads the graph anyway -- applies it before serving anything.
+ *             That path is also the only one that catches a write the SESSION
+ *             made, because the lazy check below compares the stored hash
+ *             against disk and `indexFile` has already refreshed it.
  *   LAZY   -- at retrieval, the anchor's stored hash is compared against disk.
  *             This is what catches `git pull`, another editor, a teammate, or a
  *             build step: every change our hooks never observed.
@@ -291,14 +297,69 @@ export function checkAnchor(anchor) {
 }
 
 /**
+ * Characters kept from any single diff line.
+ *
+ * A LINE CAP IS NOT A SIZE CAP, and the gap was measured: with only `maxLines`
+ * in force, `diffLines('X'.repeat(200000), 'Y'.repeat(200000))` returned 2 lines
+ * and 400,005 bytes. Minified bundles, generated sources and single-line JSON
+ * all have that shape, and this output goes STRAIGHT INTO MODEL CONTEXT from
+ * inject.mjs's zero-turn refusal -- so a line bound alone let one pathological
+ * file spend hundreds of thousands of tokens.
+ *
+ * 200 characters is chosen because it is past the width at which a line is read
+ * as a line by anybody, human or model: a hand-written source line is under
+ * ~120 columns, so the cap cannot truncate a diff a reader was going to use,
+ * while the cases it does truncate are ones where the interesting change is not
+ * legible from the raw text anyway.
+ */
+const DIFF_MAX_LINE_CHARS = () => {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_DIFF_MAX_LINE_CHARS);
+  return Number.isFinite(raw) && raw > 0 ? raw : 200;
+};
+
+/**
+ * Total UTF-8 bytes of diff body.
+ *
+ * 4,000 bytes is roughly 1,000 tokens. It is deliberately larger than the
+ * per-file injection budget (`TOKEN_OPTIMIZER_TOUCH_BUDGET`, 500 tokens) and
+ * far smaller than a file, because the two consumers want different things: the
+ * injection surface fits the diff inside its own budget and drops it if it does
+ * not fit, while the zero-turn refusal is replacing a whole file read and can
+ * afford more. One cap that neither consumer has to think about is worth more
+ * than two tuned ones.
+ *
+ * WHAT IT COSTS, PLAINLY: a legitimately large diff now arrives truncated, so a
+ * model looking at a 300-line refactor sees the head of it and a count of what
+ * was elided rather than the whole change. That is the correct direction to
+ * fail -- the alternative was a bounded-looking function that could emit 400 KB.
+ */
+const DIFF_MAX_BYTES = () => {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_DIFF_MAX_BYTES);
+  return Number.isFinite(raw) && raw > 0 ? raw : 4_000;
+};
+
+/**
  * A compact line diff.
  *
  * Deliberately not a full unified diff with hunks and context: the consumer is
  * a model deciding whether an existing conclusion still holds, and for that the
  * changed lines are the signal. Output is capped because an unbounded diff
  * injected alongside a finding would spend more tokens than re-deriving it.
+ *
+ * BOUNDED IN THREE WAYS, and each one is load-bearing: lines, characters per
+ * line, and total bytes. Every truncation is announced in the output, because a
+ * silently shortened diff is worse than a visibly shortened one -- a reader who
+ * cannot tell content was elided believes they saw the whole change.
  */
-export function diffLines(before, after, { maxLines = 40 } = {}) {
+export function diffLines(
+  before,
+  after,
+  {
+    maxLines = 40,
+    maxLineChars = DIFF_MAX_LINE_CHARS(),
+    maxBytes = DIFF_MAX_BYTES(),
+  } = {}
+) {
   const a = String(before).split('\n');
   const b = String(after).split('\n');
 
@@ -314,33 +375,44 @@ export function diffLines(before, after, { maxLines = 40 } = {}) {
   const added = b.slice(head, b.length - tail);
 
   const out = [];
-  for (const line of removed.slice(0, maxLines / 2)) out.push('- ' + line);
-  if (removed.length > maxLines / 2) out.push(`  ... ${removed.length - maxLines / 2} more removed`);
-  for (const line of added.slice(0, maxLines / 2)) out.push('+ ' + line);
-  if (added.length > maxLines / 2) out.push(`  ... ${added.length - maxLines / 2} more added`);
+  let bytes = 0;
+  let dropped = 0;
+
+  // Per line first, so ONE enormous line cannot consume the whole budget and
+  // leave every other changed line unrepresented.
+  const clamp = (line) => {
+    const text = String(line);
+    if (text.length <= maxLineChars) return text;
+    return `${text.slice(0, maxLineChars)} [+${text.length - maxLineChars} chars cut]`;
+  };
+
+  // Bytes, not characters: the cap exists to bound what is sent, and a
+  // multi-byte source file would otherwise pass a character check while
+  // emitting several times the budget.
+  const push = (line) => {
+    const text = clamp(line);
+    const size = Buffer.byteLength(text, 'utf8') + 1;
+    if (bytes + size > maxBytes) {
+      dropped++;
+      return;
+    }
+    out.push(text);
+    bytes += size;
+  };
+
+  for (const line of removed.slice(0, maxLines / 2)) push('- ' + line);
+  if (removed.length > maxLines / 2) push(`  ... ${removed.length - maxLines / 2} more removed`);
+  for (const line of added.slice(0, maxLines / 2)) push('+ ' + line);
+  if (added.length > maxLines / 2) push(`  ... ${added.length - maxLines / 2} more added`);
+
+  // Announced OUTSIDE the budget, deliberately: the one line a reader most
+  // needs is the one saying the rest is missing, and dropping it to stay under
+  // a self-imposed cap would hand back a diff that lies about being complete.
+  if (dropped) out.push(`  ... ${dropped} more changed line(s) cut at the size limit`);
 
   return out.join('\n');
 }
 
-/**
- * Prepares findings for delivery, verifying each one lazily against disk.
- *
- * This is the only function that should ever hand a finding to a model, because
- * it is the one that enforces the rule: a stale finding leaves here carrying
- * `stale: true` AND a diff, or it does not leave at all.
- */
-export function serve(graph, findings) {
-  const served = [];
-
-  // RETIRED FINDINGS STOP HERE, unconditionally.
-  //
-  // findingsFor and sessionIndex already filter them, so this is redundant on
-  // every current path -- deliberately. This function's own contract is that it
-  // is the only thing that hands a finding to a model, which makes it the right
-  // place for the guarantee to live: a future caller that reaches into the
-  // graph directly cannot accidentally serve a claim a human explicitly
-  // withdrew. A withheld claim reappearing is not a bug anyone would notice
-  // quickly.
 /**
  * Types whose truth is a claim ABOUT the anchor's contents.
  *
@@ -363,6 +435,26 @@ export function serve(graph, findings) {
  * to ignore -- taking the rare true positive with it.
  */
 const CONTENT_DEPENDENT = new Set(['finding', 'map']);
+
+/**
+ * Prepares findings for delivery, verifying each one lazily against disk.
+ *
+ * This is the only function that should ever hand a finding to a model, because
+ * it is the one that enforces the rule: a stale finding leaves here carrying
+ * `stale: true` AND a diff, or it does not leave at all.
+ */
+export function serve(graph, findings) {
+  const served = [];
+
+  // RETIRED FINDINGS STOP HERE, unconditionally.
+  //
+  // findingsFor and sessionIndex already filter them, so this is redundant on
+  // every current path -- deliberately. This function's own contract is that it
+  // is the only thing that hands a finding to a model, which makes it the right
+  // place for the guarantee to live: a future caller that reaches into the
+  // graph directly cannot accidentally serve a claim a human explicitly
+  // withdrew. A withheld claim reappearing is not a bug anyone would notice
+  // quickly.
 
   for (const finding of findings.filter((f) => !f.retired)) {
     // A claim that does not depend on the anchor's contents cannot be
@@ -505,6 +597,15 @@ export function invalidateOnWrite(dir, graph, rawPath, beforeText, afterText) {
     for (const edge of byTarget.get(node.id) || []) {
       const finding = graph.nodes.get(edge.from);
       if (!finding || finding.kind !== 'finding') continue;
+      // THE SAME TYPE GATE `serve` APPLIES, and it has to be here too now that
+      // this path actually runs. `serve` ignores a stale flag on a type whose
+      // truth is not a claim about the anchor's contents -- but the flag is
+      // STORED, and disclose.mjs skips a stale finding outright while
+      // utility.mjs penalises one by 160. So writing it onto a `failure` or a
+      // `command` would suppress that claim everywhere except the one reader
+      // that knows to ignore it, which is exactly the harm measured in the
+      // comment on CONTENT_DEPENDENT above.
+      if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) continue;
 
       putNode(dir, {
         ...finding,

--- a/integrations/cursor/hooks/lib/staleness.mjs
+++ b/integrations/cursor/hooks/lib/staleness.mjs
@@ -495,6 +495,54 @@ function disputeOf(graph, finding) {
 }
 
 /**
+ * Whether THIS finding's own claim-time evidence still matches its anchors --
+ * the reader `harvest-write.mjs`'s `derivation` record was written for.
+ * Nothing consumed that record until now: a grep for it found only the writer
+ * and its own tests, which made "checkable rather than merely attributed" a
+ * claim with no code behind it.
+ *
+ * DISTINCT FROM `stale`/`checkAnchor`, DELIBERATELY, not a duplicate of it.
+ * `checkAnchor` compares disk against the anchor NODE's CURRENT stored hash,
+ * which is refreshed by `indexFile` every time ANYTHING touches that file --
+ * so it answers "has this file changed since the last time anyone indexed
+ * it", not "has it changed since THIS finding was derived from it". Those
+ * differ in a real case: file F changes, and a LATER, unrelated write
+ * (another finding, another session) re-indexes F, updating the node's
+ * stored hash to match the new content again. `checkAnchor` now reports
+ * "fresh" -- disk matches the node's current hash -- while this finding's own
+ * frozen `derivation.anchors[id]` snapshot, taken when IT was written, no
+ * longer matches. The bytes this claim was actually derived from are gone,
+ * and `stale` alone would never say so.
+ *
+ * Returns `{}` when there is nothing to check (no `derivation.anchors`
+ * recorded -- true of every finding written before this existed), so a
+ * caller can tell "not checked" from "checked and holds" by whether
+ * `derivationHolds` is present at all.
+ */
+function derivationCheck(graph, finding) {
+  const recorded = finding.derivation && finding.derivation.anchors;
+  if (!recorded || typeof recorded !== 'object') return {};
+  const ids = Object.keys(recorded);
+  if (!ids.length) return {};
+
+  const changed = [];
+  for (const id of ids) {
+    const node = graph.nodes.get(id);
+    const currentHash = node && typeof node.hash === 'string' ? node.hash : null;
+    // An anchor that no longer resolves at all cannot be confirmed either --
+    // treated the same as a changed hash, never as "still holds" by default.
+    if (currentHash === null || currentHash !== recorded[id]) {
+      changed.push(node && typeof node.key === 'string' ? node.key : id);
+    }
+  }
+
+  if (!changed.length) return { derivationHolds: true };
+  // Bounded: a finding with many anchors should not spend unbounded budget
+  // naming every one that moved.
+  return { derivationHolds: false, derivationChanged: changed.slice(0, 5) };
+}
+
+/**
  * Prepares findings for delivery, verifying each one lazily against disk.
  *
  * This is the only function that should ever hand a finding to a model, because
@@ -611,6 +659,9 @@ export function serve(graph, findings) {
       stale,
       ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
       ...dispute,
+      // Independent of `stale` above: see `derivationCheck`'s own comment for
+      // the case it catches that node-level staleness can miss.
+      ...derivationCheck(graph, finding),
     });
   }
   return served;

--- a/integrations/cursor/hooks/lib/staleness.mjs
+++ b/integrations/cursor/hooks/lib/staleness.mjs
@@ -518,6 +518,21 @@ function disputeOf(graph, finding) {
  * recorded -- true of every finding written before this existed), so a
  * caller can tell "not checked" from "checked and holds" by whether
  * `derivationHolds` is present at all.
+ *
+ * `derivationHolds: true` MEANS "MATCHES THE ANCHOR NODE'S LAST-INDEXED
+ * HASH", NOT "MATCHES DISK RIGHT NOW" -- and that distinction is stored in
+ * `derivationCheckedAgainst: 'index'` rather than left for a `wiki_query`
+ * consumer to infer from a field name alone. Two ways to close this gap were
+ * considered: recompute a live hash from disk here, or document precisely
+ * what is actually compared. `stale` (via `checkAnchor`, above) ALREADY owns
+ * the disk comparison -- re-reading the same file a second time on the same
+ * serve path, for the same anchor, from a second mechanism, is worse than
+ * one honest name. So: documented, not duplicated. A file changed on disk
+ * but never re-indexed by anything is still caught, correctly, by `stale`;
+ * `derivationHolds` answers a narrower, complementary question -- whether
+ * the LAST INDEXED state agrees with what this specific finding recorded --
+ * which is exactly the re-indexed-by-something-else case above that `stale`
+ * cannot see.
  */
 function derivationCheck(graph, finding) {
   const recorded = finding.derivation && finding.derivation.anchors;
@@ -536,10 +551,12 @@ function derivationCheck(graph, finding) {
     }
   }
 
-  if (!changed.length) return { derivationHolds: true };
+  // Declared on BOTH branches, not only the ambiguous one: a consumer should
+  // not have to already know the answer to know what was checked.
+  if (!changed.length) return { derivationHolds: true, derivationCheckedAgainst: 'index' };
   // Bounded: a finding with many anchors should not spend unbounded budget
   // naming every one that moved.
-  return { derivationHolds: false, derivationChanged: changed.slice(0, 5) };
+  return { derivationHolds: false, derivationChanged: changed.slice(0, 5), derivationCheckedAgainst: 'index' };
 }
 
 /**

--- a/integrations/cursor/hooks/lib/staleness.mjs
+++ b/integrations/cursor/hooks/lib/staleness.mjs
@@ -54,6 +54,7 @@ import { readFileSync, statSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { dirname, join } from 'node:path';
 import { putNode, putEdge, contentHash, nodeId } from './wiki.mjs';
+import { hasOutstandingContradiction } from './curate.mjs';
 import { extractSymbols, spanText, symbolKey, extractImports } from './symbols.mjs';
 import { canonicalPath, resolvableCandidates, isFsSafePath } from './paths.mjs';
 
@@ -454,6 +455,46 @@ export function diffLines(
 const CONTENT_DEPENDENT = new Set(['finding', 'map']);
 
 /**
+ * What, if anything, currently disagrees with this finding.
+ *
+ * DISCLOSED AT SERVE TIME, because that is the only moment the disagreement can
+ * do any good. `WIKI_GRAPH.md`'s whole argument for making `contradicts` an edge
+ * rather than an overwrite is that a reader "sees both claims and the
+ * disagreement between them" -- so handing a finding to a model while something
+ * in the graph disputes it, without saying so, throws away the reason the edge
+ * was recorded instead of an overwrite.
+ *
+ * `hasOutstandingContradiction` is the gate: it is the one definition of "an
+ * open dispute", shared with the confidence-promotion gate, so the two can never
+ * disagree about what counts. The loop only NAMES the other side, and it names a
+ * key rather than quoting a claim because the reader can call `wiki_query` with
+ * a key -- and because the injection path pays for every character it renders.
+ *
+ * SEPARATE FROM STALENESS on purpose. A finding can be disputed without being
+ * stale (nothing touched its anchor; another finding simply says otherwise) and
+ * stale without being disputed, so this adds its own fields rather than
+ * borrowing the stale ones, and the renderer discloses each on its own terms.
+ */
+function disputeOf(graph, finding) {
+  if (!hasOutstandingContradiction(graph, finding.key)) return {};
+
+  const keys = [];
+  for (const edge of graph.edges) {
+    if (edge.edge !== 'contradicts') continue;
+    const otherId =
+      edge.from === finding.id ? edge.to : edge.to === finding.id ? edge.from : null;
+    if (!otherId) continue;
+    const other = graph.nodes.get(otherId);
+    // An edge end that resolves to nothing names nothing. The dispute is still
+    // disclosed -- the gate above already established it -- but without a key
+    // the reader cannot be pointed anywhere, and inventing one would be worse.
+    if (other && typeof other.key === 'string' && !keys.includes(other.key)) keys.push(other.key);
+  }
+
+  return { contradicted: true, ...(keys.length ? { contradictedBy: keys.join(', ') } : {}) };
+}
+
+/**
  * Prepares findings for delivery, verifying each one lazily against disk.
  *
  * This is the only function that should ever hand a finding to a model, because
@@ -474,10 +515,17 @@ export function serve(graph, findings) {
   // quickly.
 
   for (const finding of findings.filter((f) => !f.retired)) {
+    // A DISPUTE TRAVELS WITH EVERY TYPE, which is why it is computed before the
+    // content-dependence branch below. A `command` or `rule` finding cannot be
+    // invalidated by an anchor's contents, but another finding can still
+    // disagree with it, and this early return is the path that would have
+    // quietly dropped that.
+    const dispute = disputeOf(graph, finding);
+
     // A claim that does not depend on the anchor's contents cannot be
     // invalidated by them. It is served as-is rather than discounted.
     if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) {
-      served.push({ ...finding });
+      served.push({ ...finding, ...dispute });
       continue;
     }
 
@@ -562,6 +610,7 @@ export function serve(graph, findings) {
       ...finding,
       stale,
       ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
+      ...dispute,
     });
   }
   return served;

--- a/integrations/cursor/hooks/lib/waste.mjs
+++ b/integrations/cursor/hooks/lib/waste.mjs
@@ -151,6 +151,11 @@ function reDerivation(events, graph) {
       const id = nodeId('file', canonicalPath(row.anchor));
       if (!graph.nodes.has(id)) continue;
 
+      // READ-ONLY serve: no `dir` is threaded here, so this cannot clear a stale
+      // flag whose evidence is gone. That is deliberate -- this function takes a
+      // graph, not the directory it came from, and widening its signature to give
+      // an analysis path a write capability buys nothing: the injection path runs
+      // on every tool call and clears the same findings.
       const findings = serve(graph, findingsFor(graph, id, { limit: 3 }))
         .filter((f) => !f.stale && (f.confidence ?? 0) >= 0.7);
       if (!findings.length) continue;

--- a/integrations/cursor/hooks/lib/wiki.mjs
+++ b/integrations/cursor/hooks/lib/wiki.mjs
@@ -64,18 +64,37 @@ export const SUPPORTED_VERSIONS = [1];
  * Identity today because GRAPH_VERSION is 1 and no shape has changed. It exists
  * now so the first change that DOES need it has somewhere to go other than an
  * equality check that silently deletes user data.
+ *
+ * CONTRACT for the first non-identity step:
+ *  - It must be IDEMPOTENT. `upcast(upcast(r))` must equal `upcast(r)`, because
+ *    compaction upcasts a record to key it and `load` upcasts the same record
+ *    again on every subsequent read. A step that is not idempotent applies twice
+ *    to anything compaction has touched.
+ *  - It must NOT be relied on to restamp `v`. Nothing in this file writes an
+ *    upcast record back to disk under a version it did not come from; the
+ *    version stamp on disk is always the one that wrote the bytes. See the
+ *    per-branch comments in `compactIfWasteful`.
  */
 export function upcast(record) {
   return record;
 }
 
-/** True when this reader can interpret the record at all. */
-function readable(record) {
+/**
+ * True when this reader can interpret the record at all.
+ *
+ * `versions` is a PARAMETER so the range semantics are testable independently of
+ * today's constants. With `SUPPORTED_VERSIONS = [1]` and `GRAPH_VERSION = 1` a
+ * range check and the old equality check are extensionally identical, so a test
+ * pinned to the live constants cannot tell them apart -- and cannot fail if
+ * someone reverts this to an equality. Exercised against `[1, 2]`, it can.
+ */
+export function readable(record, versions = SUPPORTED_VERSIONS) {
   const version = record.v ?? 0;
   // Forward-incompatible records are skipped: a v-from-the-future was written by
-  // a newer client and we cannot know its shape. Ignoring the future is safe;
-  // ignoring the past is data loss.
-  return SUPPORTED_VERSIONS.includes(version);
+  // a newer client and we cannot know its shape. Ignoring the future is safe for
+  // a READER -- but see `compactIfWasteful`, where "ignore" would mean "delete",
+  // because compaction rewrites the files it reads.
+  return versions.includes(version);
 }
 
 /** Node kinds. `file` and `symbol` are first-class so staleness can propagate. */
@@ -434,9 +453,20 @@ function compactIfWasteful(dir) {
     const nodes = new Map();
     const edges = new Map();
     const snaps = new Map();
-    for (const rec of readSnapshots(dir)) {
+    // KEPT VERBATIM THROUGH THE REBUILD, exactly as the main log keeps what it
+    // cannot parse. These lines are not evictable by the snapshot budget below
+    // because their size cannot be attributed to an id we understand -- and
+    // preserving bytes we may not need is strictly better than deleting bytes a
+    // newer client does. They stop accumulating as soon as the client that
+    // wrote them compacts, since it can read and dedupe them.
+    const sidecar = readSnapshots(dir);
+    const rawSnaps = sidecar.unreadable;
+    for (const rec of sidecar.records) {
       if (typeof rec.snapshot === 'string' && rec.snapshot) {
-        snaps.set(rec.id, { at: rec.at || 0, snapshot: rec.snapshot });
+        // `v` IS CARRIED, not restamped. Writing GRAPH_VERSION over a record
+        // from another version mislabels bytes this reader did not produce, and
+        // the label is the only thing a future reader has to go on.
+        snaps.set(rec.id, { at: rec.at || 0, snapshot: rec.snapshot, v: rec.v ?? GRAPH_VERSION });
       }
     }
     for (const line of readFileSync(path, 'utf8').split('\n')) {
@@ -458,27 +488,40 @@ function compactIfWasteful(dir) {
         edges.set('raw:' + edges.size, line);
         continue;
       }
-      // Upcast IN MEMORY only, to key and classify the record. What gets written
-      // back below is the ORIGINAL `line`: compaction reclaims superseded
-      // records, it does not migrate surviving ones, so the on-disk version is
-      // whatever wrote it and `load` upcasts it again on every read.
-      record = upcast(record);
-      if (record.t === 'n') {
+      // TWO OBJECTS, ON PURPOSE. `record` is exactly what the bytes on disk say;
+      // `view` is the in-memory current-shape reading of it, used only to KEY and
+      // CLASSIFY. Nothing derived from `view` is ever serialized, because
+      // compaction reclaims superseded records -- it does not migrate surviving
+      // ones -- so every version stamp it writes is the one that wrote the bytes.
+      //
+      // An earlier revision of this comment claimed "the ORIGINAL line is written
+      // back" for the whole block. That was FALSE for the inline-snapshot branch,
+      // which re-serializes. It re-serialized the upcast object while carrying
+      // the old `v`, so the first non-identity `upcast` would have written
+      // new-shape bytes under an old label and every later `load` would have
+      // upcast them a second time. Hence: strip from `record`, never from `view`.
+      const view = upcast(record);
+      if (view.t === 'n') {
         // MIGRATION. Graphs written before snapshots were split still carry
         // them inline, and those are exactly the graphs that are slow. Moving
         // them out here means one compaction fixes an existing install.
+        //
+        // THE ONLY RE-SERIALIZING BRANCH in this loop. It writes the original
+        // record minus its snapshot, so the surviving bytes keep their own shape
+        // and their own `v`, and the snapshot moved to the sidecar carries the
+        // same `v` as the node it came out of.
         if (typeof record.snapshot === 'string' && record.snapshot) {
           const { snapshot, ...rest } = record;
-          nodes.set(record.id, JSON.stringify(rest));
-          snaps.set(record.id, { at: record.at || 0, snapshot });
+          nodes.set(view.id, JSON.stringify(rest));
+          snaps.set(view.id, { at: record.at || 0, snapshot, v: record.v ?? GRAPH_VERSION });
         } else {
-          nodes.set(record.id, line);
+          nodes.set(view.id, line);
         }
-      } else if (record.t === 's') {
+      } else if (view.t === 's') {
         if (typeof record.snapshot === 'string' && record.snapshot) {
-          snaps.set(record.id, { at: record.at || 0, snapshot: record.snapshot });
+          snaps.set(view.id, { at: record.at || 0, snapshot: record.snapshot, v: record.v ?? GRAPH_VERSION });
         }
-      } else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
+      } else if (view.t === 'e') edges.set(`${view.from}|${view.edge}|${view.to}`, line);
       else edges.set('raw:' + edges.size, line);
     }
 
@@ -541,10 +584,20 @@ function compactIfWasteful(dir) {
     renameSync(tmp, path);
     // The surviving snapshots are rewritten to their own file, which is also
     // what migrates a graph that still had them inline.
-    const snapOut =
-      [...keep.entries()]
-        .map(([id, v]) => JSON.stringify({ t: 's', v: GRAPH_VERSION, id, snapshot: v.snapshot, at: v.at }))
-        .join('\n') + (keep.size ? '\n' : '');
+    //
+    // UNREADABLE LINES FIRST AND VERBATIM. This rebuild replaces the file, so
+    // anything omitted here is deleted permanently -- which made the missing
+    // counterpart to the main log's `raw:` bucket a real data-loss path, not a
+    // theoretical one. Each survivor also keeps ITS OWN `v` rather than being
+    // restamped to GRAPH_VERSION, so no record is relabelled as something this
+    // reader wrote.
+    const snapLines = [
+      ...rawSnaps,
+      ...[...keep.entries()].map(([id, s]) =>
+        JSON.stringify({ t: 's', v: s.v ?? GRAPH_VERSION, id, snapshot: s.snapshot, at: s.at })
+      ),
+    ];
+    const snapOut = snapLines.join('\n') + (snapLines.length ? '\n' : '');
     const snapTmp = snapshotsPath(dir) + '.compact';
     writeFileSync(snapTmp, snapOut, { mode: 0o600 });
     renameSync(snapTmp, snapshotsPath(dir));
@@ -689,9 +742,26 @@ function appendSnapshot(dir, record) {
   }
 }
 
-/** Every snapshot record, latest wins. Read only when a caller asks. */
+/**
+ * Every snapshot record, latest wins. Read only when a caller asks.
+ *
+ * `unreadable` collects the RAW LINES this reader rejected, and it is the reason
+ * this function reports them at all rather than just dropping them. `load` has
+ * no use for them -- a reader that cannot interpret a record must ignore it --
+ * but `compactIfWasteful` REBUILDS this file from what it read, so for the
+ * compactor "ignore" and "delete permanently" are the same operation. The main
+ * log already keeps what it cannot parse (the `raw:` bucket); the sidecar had no
+ * equivalent, which made it the one asymmetric, destructive path in an otherwise
+ * append-only store.
+ *
+ * This is not hypothetical here: hooks-core is vendored into eleven client
+ * directories that update independently, so a stale client compacting a graph a
+ * newer client has already written to is the expected steady state, not an edge
+ * case.
+ */
 function readSnapshots(dir) {
-  const out = [];
+  /** @type {object[]} */ const out = [];
+  /** @type {string[]} */ const unreadable = [];
   try {
     for (const line of readFileSync(snapshotsPath(dir), 'utf8').split('\n')) {
       if (!line) continue;
@@ -699,19 +769,23 @@ function readSnapshots(dir) {
         const rec = JSON.parse(line);
         // THE SAME RANGE AS THE MAIN LOG, deliberately. An equality check here
         // was the quietest of the three: a bump would have made every stored
-        // snapshot unreadable, and the very next compaction -- which rebuilds
-        // this file from what it could read -- would have deleted them for
-        // good. That is the one place in this store where a read filter turns
-        // into a permanent write.
-        if (readable(rec) && rec.id) out.push(upcast(rec));
+        // snapshot unreadable, and the very next compaction would have deleted
+        // them for good.
+        if (!readable(rec)) {
+          unreadable.push(line);
+          continue;
+        }
+        if (rec.id) out.push(upcast(rec));
       } catch {
-        /* a torn line costs one snapshot */
+        // A torn line costs one snapshot -- and it is NOT preserved, because a
+        // half-written line is not a record from another version, it is
+        // garbage. Distinguishing the two is the whole point of parsing first.
       }
     }
   } catch {
     /* no sidecar yet */
   }
-  return out;
+  return { records: out, unreadable };
 }
 
 /**
@@ -777,7 +851,9 @@ export function load(dir, { snapshots = false } = {}) {
   // Re-attached after the sweep, so a snapshot record may appear before or
   // after the node it belongs to.
   if (pending) {
-    for (const rec of readSnapshots(dir)) pending.set(rec.id, rec.snapshot);
+    // A reader has no use for the lines it could not interpret; only the
+    // compactor does, because only the compactor rewrites the file.
+    for (const rec of readSnapshots(dir).records) pending.set(rec.id, rec.snapshot);
     for (const [id, snapshot] of pending) {
       const node = nodes.get(id);
       if (node) nodes.set(id, { ...node, snapshot });

--- a/integrations/cursor/hooks/lib/wiki.mjs
+++ b/integrations/cursor/hooks/lib/wiki.mjs
@@ -28,17 +28,55 @@ import { canonicalPath, isFsSafePath } from './paths.mjs';
 /**
  * Schema version stamped on every record.
  *
- * There is exactly ONE version and no migration code, because nothing has been
- * released: a graph written by an older commit of an unreleased branch is a
- * development artifact, not user data, and carrying migration paths for it costs
- * real complexity to protect something nobody has. A record from any other
- * version is skipped rather than interpreted, so a stale dev graph degrades to
- * "rebuilds from use" instead of silently mixing incompatible identities.
+ * THIS PACKAGE IS RELEASED. It ships on npm, so every graph on disk is user
+ * data. An earlier version of this comment claimed nothing had been released
+ * and used that to justify having no migration path at all -- and the reader
+ * below compared for EQUALITY, so the first bump would have discarded every
+ * existing graph in silence. That justification is gone and so is the equality:
+ * `SUPPORTED_VERSIONS` is the range this reader accepts, and `upcast` is where a
+ * shape change is absorbed in memory.
  *
- * When this does ship, a bump here is where migration would be added -- with
- * users to protect, that trade reverses.
+ * A bump here is taken only when a record's SHAPE actually changes, and it comes
+ * with a new `upcast` step and an entry in `SUPPORTED_VERSIONS` in the same
+ * change. Adding a field that older readers can ignore is not a shape change.
  */
 export const GRAPH_VERSION = 1;
+
+/**
+ * Versions this reader accepts, oldest first.
+ *
+ * A RANGE, NOT AN EQUALITY. The equality check this replaces would have
+ * discarded every existing graph the moment anyone bumped the version -- and the
+ * header once justified that with "nothing has been released", which stopped
+ * being true at v5.7.0 on npm.
+ *
+ * Nothing on disk is ever rewritten to migrate: `upcast` runs in memory during
+ * the fold, so there is no migration pass to fail halfway and no race with the
+ * concurrent sessions this store is designed for. A mixed-version log is safe
+ * precisely because the original records are never mutated, and the existing
+ * compaction retires old ones naturally as it rewrites snapshots.
+ */
+export const SUPPORTED_VERSIONS = [1];
+
+/**
+ * Brings one record up to the current version. Pure, and one step per version.
+ *
+ * Identity today because GRAPH_VERSION is 1 and no shape has changed. It exists
+ * now so the first change that DOES need it has somewhere to go other than an
+ * equality check that silently deletes user data.
+ */
+export function upcast(record) {
+  return record;
+}
+
+/** True when this reader can interpret the record at all. */
+function readable(record) {
+  const version = record.v ?? 0;
+  // Forward-incompatible records are skipped: a v-from-the-future was written by
+  // a newer client and we cannot know its shape. Ignoring the future is safe;
+  // ignoring the past is data loss.
+  return SUPPORTED_VERSIONS.includes(version);
+}
 
 /** Node kinds. `file` and `symbol` are first-class so staleness can propagate. */
 export const NODE_KINDS = ['file', 'symbol', 'task', 'finding'];
@@ -409,13 +447,22 @@ function compactIfWasteful(dir) {
       } catch {
         continue;
       }
-      // A record from another schema is KEPT VERBATIM rather than reinterpreted.
-      // load() skips it, but discarding it here would make compaction a silent
-      // migration that deletes data a future version might understand.
-      if ((record.v ?? 0) !== GRAPH_VERSION) {
+      // A record this reader cannot interpret is KEPT VERBATIM rather than
+      // reinterpreted. load() skips it, but discarding it here would make
+      // compaction a silent migration that deletes data a future version might
+      // understand. THE RANGE MATTERS HERE TOO: with an equality check, a bump
+      // would have parked every existing v1 record in `raw`, undeduplicated, so
+      // compaction would stop reclaiming anything and inline snapshots would
+      // never migrate out -- the same loss by a second route.
+      if (!readable(record)) {
         edges.set('raw:' + edges.size, line);
         continue;
       }
+      // Upcast IN MEMORY only, to key and classify the record. What gets written
+      // back below is the ORIGINAL `line`: compaction reclaims superseded
+      // records, it does not migrate surviving ones, so the on-disk version is
+      // whatever wrote it and `load` upcasts it again on every read.
+      record = upcast(record);
       if (record.t === 'n') {
         // MIGRATION. Graphs written before snapshots were split still carry
         // them inline, and those are exactly the graphs that are slow. Moving
@@ -650,7 +697,13 @@ function readSnapshots(dir) {
       if (!line) continue;
       try {
         const rec = JSON.parse(line);
-        if ((rec.v ?? 0) === GRAPH_VERSION && rec.id) out.push(rec);
+        // THE SAME RANGE AS THE MAIN LOG, deliberately. An equality check here
+        // was the quietest of the three: a bump would have made every stored
+        // snapshot unreadable, and the very next compaction -- which rebuilds
+        // this file from what it could read -- would have deleted them for
+        // good. That is the one place in this store where a read filter turns
+        // into a permanent write.
+        if (readable(rec) && rec.id) out.push(upcast(rec));
       } catch {
         /* a torn line costs one snapshot */
       }
@@ -691,7 +744,12 @@ export function load(dir, { snapshots = false } = {}) {
       if (!snapshots) continue;
       try {
         const rec = JSON.parse(line);
-        if ((rec.v ?? 0) === GRAPH_VERSION) pending.set(rec.id, rec.snapshot);
+        // Inline snapshots from an older graph: same range, same reason. These
+        // are precisely the records most likely to predate a bump.
+        if (readable(rec)) {
+          const snap = upcast(rec);
+          pending.set(snap.id, snap.snapshot);
+        }
       } catch {
         /* a torn line costs one snapshot, not the graph */
       }
@@ -703,10 +761,14 @@ export function load(dir, { snapshots = false } = {}) {
     } catch {
       continue;
     }
-    // A record from another schema is skipped, not interpreted: its ids and
-    // hashes were derived differently, so honouring it produces confident
-    // nonsense rather than a visible error.
-    if ((record.v ?? 0) !== GRAPH_VERSION) continue;
+    // A record this reader cannot interpret is skipped, not guessed at: a
+    // version from the FUTURE derived its ids and hashes in a way we do not
+    // know, so honouring it produces confident nonsense rather than a visible
+    // error. A record from the PAST is upcast, never skipped -- skipping it is
+    // data loss, and this comparison used to be an equality, which made the
+    // first version bump a silent delete of every graph on disk.
+    if (!readable(record)) continue;
+    record = upcast(record);
     if (record.t === 'n') nodes.set(record.id, record);
     else if (record.t === 'e') edges.push(record);
   }

--- a/integrations/cursor/hooks/lib/wiki.mjs
+++ b/integrations/cursor/hooks/lib/wiki.mjs
@@ -775,7 +775,17 @@ function readSnapshots(dir) {
           unreadable.push(line);
           continue;
         }
+        // A RECORD WITH NO `id` IS KEPT VERBATIM, NOT DROPPED SILENTLY. It
+        // cannot be attributed to a node, so it is useless to `load` -- but this
+        // used to put it in neither bucket, and `compactIfWasteful` rebuilds the
+        // sidecar from `records` plus `unreadable`, so a line in neither was
+        // deleted permanently by the next compaction. That is the same shape as
+        // the Critical this reader's version check already fixed, and the same
+        // asymmetry: for the compactor, "ignore" and "destroy" are one operation.
+        // Unreachable today because every writer sets `id`; a reader is not the
+        // right place to rely on that.
         if (rec.id) out.push(upcast(rec));
+        else unreadable.push(line);
       } catch {
         // A torn line costs one snapshot -- and it is NOT preserved, because a
         // half-written line is not a record from another version, it is

--- a/integrations/cursor/hooks/post-tool.mjs
+++ b/integrations/cursor/hooks/post-tool.mjs
@@ -8,7 +8,7 @@ process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.
-process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write';
+process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write,wiki_query';
 try {
   const { run } = await import('./lib/adapter.mjs');
   await run('cursor', 'post-tool');

--- a/integrations/cursor/hooks/post-tool.mjs
+++ b/integrations/cursor/hooks/post-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/cursor/hooks/pre-tool.mjs
+++ b/integrations/cursor/hooks/pre-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/cursor/hooks/pre-tool.mjs
+++ b/integrations/cursor/hooks/pre-tool.mjs
@@ -8,7 +8,7 @@ process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.
-process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write';
+process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write,wiki_query';
 try {
   const { run } = await import('./lib/adapter.mjs');
   await run('cursor', 'pre-tool');

--- a/integrations/cursor/hooks/session-start.mjs
+++ b/integrations/cursor/hooks/session-start.mjs
@@ -8,7 +8,7 @@ process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.
-process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write';
+process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write,wiki_query';
 try {
   const { run } = await import('./lib/adapter.mjs');
   await run('cursor', 'session-start');

--- a/integrations/cursor/hooks/session-start.mjs
+++ b/integrations/cursor/hooks/session-start.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/cursor/hooks/stop.mjs
+++ b/integrations/cursor/hooks/stop.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/cursor/hooks/stop.mjs
+++ b/integrations/cursor/hooks/stop.mjs
@@ -8,7 +8,7 @@ process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.
-process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write';
+process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write,wiki_query';
 try {
   const { run } = await import('./lib/adapter.mjs');
   await run('cursor', 'stop');

--- a/integrations/gemini/hooks/lib/adapter.mjs
+++ b/integrations/gemini/hooks/lib/adapter.mjs
@@ -68,6 +68,7 @@ import {
   standingRules,
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
+import { observedWrite, queueInvalidation } from './pending.mjs';
 import { isArchived } from './transcript.mjs';
 import { isFsSafePath } from './paths.mjs';
 import {
@@ -881,6 +882,35 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Causal tracing is fail-open like every other hook optimization.
+    }
+
+    // EAGER INVALIDATION, finally connected. `invalidateOnWrite` has existed,
+    // been tested and been described in staleness.mjs's own header since
+    // staleness landed, and its only reference in shipped code was a COMMENT in
+    // the PreToolUse router -- so the path that header calls load-bearing had
+    // never run once in production. It matters most for exactly this event: the
+    // lazy check compares the anchor's stored hash against disk, and the
+    // capture below re-points that hash at the bytes this write just produced,
+    // so a write the session performed ITSELF is invisible to lazy staleness.
+    //
+    // QUEUED, NOT APPLIED. Applying needs the graph, and loading a megabyte of
+    // JSONL on the return path of every write is what this shape exists to
+    // avoid. The next graph read drains it before serving anything.
+    try {
+      if (mutationSucceeded(clientName, raw)) {
+        const evidence = observedWrite(payload, raw);
+        if (evidence) {
+          // THE SAME DIRECTORY THE GRAPH ITSELF USES. `observeAndInject` keys
+          // every write on `wikiDir(projectRootFor(path, payload.cwd))`, and a
+          // queue written anywhere else is a queue nothing ever drains.
+          queueInvalidation(
+            wikiDir(projectRootFor(evidence.path, payload.cwd)),
+            evidence
+          );
+        }
+      }
+    } catch {
+      // Bookkeeping for a call that already completed. Never let it cost one.
     }
   }
 

--- a/integrations/gemini/hooks/lib/adapter.mjs
+++ b/integrations/gemini/hooks/lib/adapter.mjs
@@ -64,6 +64,7 @@ import {
   forTouch,
   noteActClasses,
   relevantFindingIdsForContext,
+  sessionContext,
   sessionIndex,
   standingRules,
 } from './inject.mjs';
@@ -690,8 +691,23 @@ async function runHook(clientName, event, invocation) {
       rememberOptimizerTools(state, toolEvidence);
       saveState(sessionId, state);
     }
-    const parts = [
-      policyText(client.canDeny, toolEvidence.names, toolEvidence.proven),
+    // ASSEMBLED IN CACHE ORDER, not in whatever order this function happens to
+    // discover the blocks. Everything emitted here sits near the FRONT of the
+    // prompt prefix, and a prefix cache invalidates from the first differing
+    // byte onward -- so the block that changes most often has to sit LAST, or it
+    // re-prices every block behind it on every session. `sessionContext` sorts
+    // by the declared volatility; inject.mjs records how each number was
+    // assigned and why.
+    const blocks = [
+      {
+        id: 'policy',
+        volatility: 0,
+        text: policyText(
+          client.canDeny,
+          toolEvidence.names,
+          toolEvidence.proven
+        ),
+      },
     ];
     const cwd = raw.cwd || raw.working_directory || process.cwd();
     const root = projectRootFor(join(cwd, '__session__'), cwd);
@@ -705,7 +721,7 @@ async function runHook(clientName, event, invocation) {
         const graph = load(dir);
         const episode = episodeMeta({ client: clientName, raw });
         const rules = standingRules(dir, graph, { episode });
-        if (rules) parts.push(rules);
+        if (rules) blocks.push({ id: 'standing', volatility: 1, text: rules });
         const relevantFindingIds = relevantFindingIdsForContext(
           graph,
           sessionTaskContext(raw)
@@ -714,12 +730,12 @@ async function runHook(clientName, event, invocation) {
           episode,
           relevantFindingIds,
         });
-        if (index) parts.push(index);
+        if (index) blocks.push({ id: 'index', volatility: 2, text: index });
       } catch {
         // Retrieval is optional context; the policy must still reach the model.
       }
     }
-    const output = contextOutput(client, eventName, parts.join('\n\n'));
+    const output = contextOutput(client, eventName, sessionContext(blocks));
     if (output) emit(output);
     process.exit(0);
   }

--- a/integrations/gemini/hooks/lib/adapter.mjs
+++ b/integrations/gemini/hooks/lib/adapter.mjs
@@ -68,7 +68,7 @@ import {
   standingRules,
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
-import { observedWrite, queueInvalidation } from './pending.mjs';
+import { observedWrites, queueInvalidation } from './pending.mjs';
 import { isArchived } from './transcript.mjs';
 import { isFsSafePath } from './paths.mjs';
 import {
@@ -898,8 +898,7 @@ async function runHook(clientName, event, invocation) {
     // avoid. The next graph read drains it before serving anything.
     try {
       if (mutationSucceeded(clientName, raw)) {
-        const evidence = observedWrite(payload, raw);
-        if (evidence) {
+        for (const evidence of observedWrites(payload, raw)) {
           // THE SAME DIRECTORY THE GRAPH ITSELF USES. `observeAndInject` keys
           // every write on `wikiDir(projectRootFor(path, payload.cwd))`, and a
           // queue written anywhere else is a queue nothing ever drains.

--- a/integrations/gemini/hooks/lib/capabilities.mjs
+++ b/integrations/gemini/hooks/lib/capabilities.mjs
@@ -38,6 +38,10 @@ export const HOOK_MCP_TOOLS = Object.freeze([
   'optimize_session',
   'get_optimization_report',
   'wiki_write',
+  // The read side of the graph. The session index tells the model to "call
+  // wiki_query with a key for detail", so the hook needs positive evidence that
+  // the name it is advertising is actually registered in this host.
+  'wiki_query',
 ]);
 
 const HOOK_MCP_TOOL_SET = new Set(HOOK_MCP_TOOLS);

--- a/integrations/gemini/hooks/lib/curate.mjs
+++ b/integrations/gemini/hooks/lib/curate.mjs
@@ -22,7 +22,7 @@
  */
 
 import { randomBytes } from 'node:crypto';
-import { putNode, putNodeWithEdges, load, nodeId } from './wiki.mjs';
+import { putNode, putEdge, putNodeWithEdges, load, nodeId } from './wiki.mjs';
 import { indexFile } from './staleness.mjs';
 import { symbolKey } from './symbols.mjs';
 import { canonicalPath } from './paths.mjs';
@@ -178,6 +178,79 @@ export function retire(dir, key) {
   if (!existing) return false;
   putNode(dir, { ...existing, kind: 'finding', key, retired: true });
   return true;
+}
+
+/**
+ * Records that one finding disagrees with another.
+ *
+ * AN EDGE, NOT AN OVERWRITE -- the design is explicit about why: "when a belief
+ * changes, the graph should record THAT it changed and why, not quietly present
+ * the new one as though it had always been true." `contradicts` has been in
+ * EDGE_KINDS since the schema existed and was written by nothing, while
+ * `audit()` already READ it.
+ *
+ * The contradicted finding is deliberately NOT retired, and its claim is
+ * deliberately preserved. A reader needs to see both claims and the
+ * disagreement between them; retiring one silently picks a winner, and putNode
+ * does not merge -- it writes the whole record from what it is handed, so
+ * annotating the target without spreading it back in would blank the very claim
+ * this edge exists to keep visible. That is the overwrite by another name.
+ *
+ * THE EDGE IS WRITTEN FIRST, and the order is the guarantee. These are two
+ * appends and `append` fails open, so either can be the one that lands. Edge
+ * without annotation is a complete, readable disagreement missing only its
+ * reason. Annotation without edge is a finding that says "something contradicts
+ * me" with no contradictor -- a claim of proof with no proof, and invisible to
+ * `audit()` and to `hasOutstandingContradiction`, both of which read the edge.
+ */
+export function contradict(dir, { key, byKey, reason }) {
+  const graph = load(dir);
+  const target = findingByKey(graph, key);
+  const source = findingByKey(graph, byKey);
+  // Both ends must exist, or the edge is unresolvable and the disagreement is
+  // recorded against nothing -- the same un-invalidatable shape anchors prevent.
+  if (!target || !source) return false;
+  // A finding cannot disagree with itself. The self-edge resolves, so the guard
+  // above waves it through, and the result is a node permanently blocked from
+  // confidence promotion by a dispute no person can ever resolve: there is no
+  // second claim to choose between.
+  if (target.id === source.id) return false;
+
+  putEdge(dir, source.id, 'contradicts', target.id);
+  putNode(dir, {
+    ...target,
+    kind: 'finding',
+    key,
+    contradictedAt: Date.now(),
+    contradictionReason: String(reason || '').slice(0, 400),
+  });
+  return true;
+}
+
+/**
+ * Whether anything currently disagrees with this finding.
+ *
+ * Gates confidence promotion. Plan 2's per-finding utility measures whether a
+ * finding SUPPRESSES READS, and a confidently wrong finding suppresses reads
+ * better than a hedged true one -- so utility must never raise confidence on
+ * its own, and this is the check that stops it.
+ *
+ * SYMMETRIC, deliberately: BOTH ends of a `contradicts` edge are outstanding
+ * until a person resolves the disagreement. The named hazard in the design is
+ * presenting "the new one as though it had always been true", so gating only
+ * the older claim would leave the newer one -- which is just as likely to be
+ * the wrong one, since nothing here adjudicates -- free to be promoted on
+ * measured utility alone. That is the exact failure this gate exists to stop.
+ * It also matches `audit()`, the reader that has always been here: it puts both
+ * `from` and `to` in its `contradicted` bucket, because "until one looks, BOTH
+ * are being served".
+ */
+export function hasOutstandingContradiction(graph, key) {
+  const node = findingByKey(graph, key);
+  if (!node) return false;
+  return graph.edges.some(
+    (e) => e.edge === 'contradicts' && (e.to === node.id || e.from === node.id)
+  );
 }
 
 /**

--- a/integrations/gemini/hooks/lib/curate.mjs
+++ b/integrations/gemini/hooks/lib/curate.mjs
@@ -124,7 +124,17 @@ export function correct(
   const replacementKey = `${key}-c${Date.now().toString(36)}`;
 
   const edges = [{ edge: 'supersedes', to: originalId }];
-  // The correction inherits the original's anchors, so it can go stale too.
+  // The correction inherits the original's anchors, so it can go stale too --
+  // but it inherits NOTHING ELSE, and that is deliberate rather than incidental.
+  // The node written below is built field by field from `existing` instead of
+  // spreading it, which is what keeps the staleness fields (`stale`,
+  // `staleReason`, `diff`) off the successor: a correction is re-derived
+  // against the current code by definition, so being born carrying its
+  // predecessor's invalidation would discount it the moment it existed --
+  // `disclose.mjs` skips a stale finding outright and `utility.mjs` penalises
+  // one by 160. Any future edit here that reaches for `...existing` to pick up
+  // one more field re-introduces that, since `putNode` writes what it is handed
+  // wholesale; `tests/hooks/stale-clearing.test.mjs` is the guard.
   for (const edge of graph.edges) {
     if (edge.edge === 'derived_from' && edge.from === originalId) {
       edges.push({ edge: 'derived_from', to: edge.to });
@@ -244,13 +254,38 @@ export function contradict(dir, { key, byKey, reason }) {
  * It also matches `audit()`, the reader that has always been here: it puts both
  * `from` and `to` in its `contradicted` bucket, because "until one looks, BOTH
  * are being served".
+ *
+ * A RETIRED COUNTERPART DOES NOT COUNT, and that sentence quoted just above is
+ * the reason. This read edges ONLY, so retiring one end of a contradiction left
+ * the survivor gated against confidence promotion forever and served with a
+ * DISPUTED note naming a key `serve` refuses to hand anybody -- `serve`,
+ * `activeFindings`, `findingsFor` and `sessionIndex` all drop a retired
+ * finding. A retired claim is served to NOBODY, so "BOTH are being served" is
+ * false and the premise of the gate is gone: only one claim is in play, and
+ * there is nothing left to choose between. Retiring one end IS the person
+ * looking that this gate was waiting for -- so the edge counts as open only
+ * while NEITHER end is retired, answered the same way from both directions.
+ *
+ * AN UNRESOLVABLE END STILL COUNTS. An edge whose other side names no node
+ * proves nothing about whether that claim was withdrawn, and the conservative
+ * reading -- still disputed -- is the one that cannot promote a claim nobody
+ * adjudicated.
  */
 export function hasOutstandingContradiction(graph, key) {
   const node = findingByKey(graph, key);
-  if (!node) return false;
-  return graph.edges.some(
-    (e) => e.edge === 'contradicts' && (e.to === node.id || e.from === node.id)
-  );
+  // A withdrawn claim is not in a dispute either: a dispute needs two claims in
+  // play, and this one has been taken out of play. Without this the RETIRED end
+  // still reported an open disagreement, which is the same defect from the other
+  // side -- and the answer has to agree from both directions, since the gate is
+  // symmetric on purpose.
+  if (!node || node.retired) return false;
+  return graph.edges.some((e) => {
+    if (e.edge !== 'contradicts') return false;
+    const otherId = e.from === node.id ? e.to : e.to === node.id ? e.from : null;
+    if (!otherId) return false;
+    const other = graph.nodes.get(otherId);
+    return !other || !other.retired;
+  });
 }
 
 /**
@@ -334,11 +369,24 @@ export function audit(graph) {
       .map((e) => e.from)
   );
 
+  // THE SAME DEFINITION OF AN OPEN DISPUTE as hasOutstandingContradiction, and
+  // it has to be: that function's own comment claims it "matches audit()", and
+  // two rankings that disagree about what needs a human is worse than one that
+  // is wrong. A retired counterpart is a resolved dispute -- the retired claim
+  // is served to nobody -- so the survivor is not one of two claims in play and
+  // does not belong in the bucket of things needing a person to look.
+  //
+  // One pass, not a call per finding: this is a dashboard read over the whole
+  // graph, and the obvious rewrite is O(findings x edges).
   const contradicted = new Set();
   for (const edge of graph.edges) {
     if (edge.edge !== 'contradicts') continue;
-    contradicted.add(edge.from);
-    contradicted.add(edge.to);
+    const from = graph.nodes.get(edge.from);
+    const to = graph.nodes.get(edge.to);
+    // An end that resolves to nothing cannot be shown retired, so it still
+    // counts against the other end.
+    if (!to || !to.retired) contradicted.add(edge.from);
+    if (!from || !from.retired) contradicted.add(edge.to);
   }
 
   return {

--- a/integrations/gemini/hooks/lib/curate.mjs
+++ b/integrations/gemini/hooks/lib/curate.mjs
@@ -70,6 +70,38 @@ export function originWeight(origin) {
   return 1;
 }
 
+/**
+ * The claim-time anchor hashes, for a finding being written right now.
+ *
+ * THE CHECKABLE HALF OF PROVENANCE, and until now only `harvest-write.mjs`
+ * wrote it -- so the asymmetry ran exactly the wrong way. `reverify` and the
+ * automatic clear in `serve` both compare disk against these frozen hashes, and
+ * a finding without them can never have a stale flag cleared by anything. That
+ * meant HUMAN-asserted findings, the ones somebody deliberately created or
+ * corrected, were the only ones condemned to stay stale forever once marked,
+ * while machine-harvested claims could recover. The hashes are simply the anchor
+ * nodes' hashes at this moment, and every writer has them in hand.
+ *
+ * DELIBERATELY NOT THE WHOLE RECORD `derivationFor` BUILDS. That one joins the
+ * evidence log to find FILE-surface operations behind the claim; curation
+ * performs no such join, so `operations` is empty and `operationsComplete` says
+ * so. An empty list declared incomplete is honest -- "nothing recorded here, and
+ * do not read that as nothing happened" -- where an empty list declared complete
+ * would assert a fact nobody established.
+ *
+ * An anchor with no stored hash contributes no entry, and a finding whose
+ * anchors all lack one gets a record with no hashes -- which `claimTimeVerdict`
+ * reads as `unknown` and refuses to clear on, which is the correct reading.
+ */
+function claimTimeDerivation(graph, resolved) {
+  const anchors = {};
+  for (const id of resolved) {
+    const node = graph.nodes.get(id);
+    if (node && typeof node.hash === 'string') anchors[id] = node.hash;
+  }
+  return { at: Date.now(), anchors, operations: [], operationsComplete: false };
+}
+
 function findingByKey(graph, key) {
   return graph.nodes.get(nodeId('finding', key)) || null;
 }
@@ -124,6 +156,11 @@ export function correct(
   const replacementKey = `${key}-c${Date.now().toString(36)}`;
 
   const edges = [{ edge: 'supersedes', to: originalId }];
+  // Collected alongside the edges so the correction carries its own claim-time
+  // hashes: it is a NEW claim, re-derived against whatever the code says now, so
+  // its evidence is the anchors' current state -- not the predecessor's, which is
+  // precisely what went stale.
+  const inherited = [];
   // The correction inherits the original's anchors, so it can go stale too --
   // but it inherits NOTHING ELSE, and that is deliberate rather than incidental.
   // The node written below is built field by field from `existing` instead of
@@ -138,6 +175,7 @@ export function correct(
   for (const edge of graph.edges) {
     if (edge.edge === 'derived_from' && edge.from === originalId) {
       edges.push({ edge: 'derived_from', to: edge.to });
+      inherited.push(edge.to);
     }
   }
 
@@ -171,6 +209,11 @@ export function correct(
       // branches, and an unrecognised value already degrades to the neutral
       // ranking weight rather than doing damage.
       origin: typeof origin === 'string' && origin ? origin : ORIGIN_HUMAN,
+      // Without this a correction could never have a stale flag cleared: both
+      // clearing paths compare disk against these hashes, and a finding with
+      // none is `unknown` forever. A hand-written correction being the least
+      // recoverable record in the graph was the wrong way round.
+      derivation: claimTimeDerivation(graph, inherited),
     },
     edges
   );
@@ -339,7 +382,18 @@ export function create(dir, { claim, anchors, type = 'finding', confidence = 0.9
   // path. No process death required; one transient EBUSY is enough.
   const id = putNodeWithEdges(
     dir,
-    { kind: 'finding', key, claim, confidence, type, origin: ORIGIN_HUMAN },
+    {
+      kind: 'finding',
+      key,
+      claim,
+      confidence,
+      type,
+      origin: ORIGIN_HUMAN,
+      // Read AFTER the indexFile loop above, so the hashes are the ones the
+      // person's claim was actually made against rather than whatever the graph
+      // held before this call touched it.
+      derivation: claimTimeDerivation(loadGraph(dir), resolved),
+    },
     resolved.map((target) => ({ edge: 'derived_from', to: target }))
   );
   if (!id) return null;

--- a/integrations/gemini/hooks/lib/decide.mjs
+++ b/integrations/gemini/hooks/lib/decide.mjs
@@ -542,19 +542,92 @@ const TOOL_ALIASES = new Map(
     run_shell_command: 'Bash',
     run_terminal_cmd: 'Bash',
     terminal: 'Bash',
+
+    // THIS PROJECT'S OWN TOOLS, which the table did not list for as long as it
+    // existed. `plugin/hooks/hooks.json`'s PostToolUse matcher named
+    // `mcp__.*__(?:smart_edit|smart_write)` and Codex's AfterTool matcher named
+    // the bare `smart_edit|smart_write`, so both hooks fired -- and then
+    // `normalizeTool` returned null and the hook exited before a single line of
+    // accounting ran. Staleness, mutation counting and harvest pressure were all
+    // blind on exactly the path enforcement pushes the model toward, which is the
+    // worst place to be blind: the more effective the routing, the less the
+    // optimizer saw.
+    //
+    // These names are the CANONICAL operation, not a licence to redirect. A call
+    // that is already the replacement is excluded from routing by
+    // `isReplacementTool` below.
+    smart_read: 'Read',
+    smart_grep: 'Grep',
+    smart_glob: 'Glob',
+    smart_edit: 'Edit',
+    smart_write: 'Write',
+
+    // Claude Code's notebook editor. Same shape of gap: a real mutation of a
+    // real file on disk that arrived as null and so never reached
+    // `pending.mjs`'s MUTATING set, leaving every notebook write invisible to
+    // invalidation.
+    notebookedit: 'Edit',
+    notebook_edit: 'Edit',
   })
 );
 
-/** Maps a client's tool name onto the canonical one, or null if unhandled. */
+/**
+ * The optimizer's own replacement tools, by canonical trailing segment.
+ *
+ * Kept separate from the alias table because the two answer different questions.
+ * The table answers "what operation is this", which post-tool accounting needs.
+ * This set answers "is this call ALREADY the thing we would have recommended",
+ * which routing needs -- and conflating them is the loop hazard: `smart_edit`
+ * resolves to `Edit`, the Edit branch recommends `smart_edit`, and the model is
+ * told to call the tool it just called.
+ */
+const REPLACEMENT_TOOLS = new Set([
+  'smart_read',
+  'smart_grep',
+  'smart_glob',
+  'smart_edit',
+  'smart_write',
+]);
+
+/**
+ * The tool name with an `mcp__<server>__` prefix removed, if it had one.
+ *
+ * Server segments contain underscores freely (`plugin_token-optimizer_token-optimizer`)
+ * and so do tool names (`smart_edit`), so the split is taken at the LAST `__`
+ * after the `mcp__` sentinel. Both halves must be non-empty: `mcp__edit` names
+ * no server and is not a name any host emits, and treating it as `edit` would
+ * coerce an unrecognised string into a built-in.
+ */
+function withoutMcpPrefix(name) {
+  const match = /^mcp__(.+)__(.+)$/.exec(name);
+  return match ? match[2] : name;
+}
+
+/** Whether this call IS one of the optimizer's replacements, however spelled. */
+export function isReplacementTool(name) {
+  if (!name) return false;
+  return REPLACEMENT_TOOLS.has(withoutMcpPrefix(String(name)).toLowerCase());
+}
+
+/**
+ * Maps a client's tool name onto the canonical one, or null if unhandled.
+ *
+ * PERMISSIVE IN ONE DIRECTION ONLY. An MCP-prefixed name is resolved by its
+ * trailing segment, but only against the same table every other client is held
+ * to -- so `mcp__vendor__deploy_to_prod` stays null. Coercing an unrecognised
+ * MCP tool into a built-in would change a routing verdict for a tool nobody has
+ * considered, which is a far worse failure than not accounting for it.
+ */
 export function normalizeTool(name) {
   if (!name) return null;
+  const candidate = withoutMcpPrefix(String(name));
   if (
     ['Read', 'Grep', 'Glob', 'Edit', 'MultiEdit', 'Write', 'Bash'].includes(
-      name
+      candidate
     )
   )
-    return name;
-  return TOOL_ALIASES.get(String(name).toLowerCase()) || null;
+    return candidate;
+  return TOOL_ALIASES.get(candidate.toLowerCase()) || null;
 }
 
 /**
@@ -614,6 +687,13 @@ export function normalizePayload(raw) {
     transcript_path: raw.transcript_path ?? raw.transcriptPath ?? null,
     cwd,
     tool_name: normalizeTool(raw.tool_name ?? raw.toolName ?? raw.tool),
+    // WHETHER THIS CALL IS ALREADY THE REPLACEMENT, carried alongside the
+    // canonical name rather than inferred from it -- because it cannot be
+    // inferred from it. `smart_edit` and `Edit` both normalise to `Edit`, and
+    // routing has to treat them as opposites while accounting treats them as
+    // the same. Absent by default (`false`), so a payload assembled by hand in
+    // a test or by a caller that predates this field is a normal built-in call.
+    replacement: isReplacementTool(raw.tool_name ?? raw.toolName ?? raw.tool),
     tool_input: {
       ...input,
       // CANONICALISED HERE, once. Every consumer downstream -- the `seen` map
@@ -673,6 +753,19 @@ function replacementAvailable(availableTools, name) {
 }
 
 export function decide(payload, state, availableTools = undefined) {
+  // THE LOOP HAZARD, and the reason this guard is at the top rather than inside
+  // any one branch. Resolving `smart_edit` to `Edit` is what makes post-tool
+  // accounting work; it must not also make the Edit branch answer a smart_edit
+  // call with "call smart_edit instead". This is not theoretical on a matcher
+  // level either: Qwen's PreToolUse matcher is the unanchored regex
+  // `edit|write_file|run_shell_command`, and `edit` matches inside
+  // `mcp__x__smart_edit`, so that client really does hand the router calls to
+  // its own replacements.
+  //
+  // A tool that IS the replacement is never routed. There is nothing better to
+  // recommend, and every branch below would recommend itself.
+  if (payload.replacement) return null;
+
   const tool = payload.tool_name;
   const input = payload.tool_input || {};
   const threshold = largeFileBytes();
@@ -873,6 +966,12 @@ export function remember(payload, state) {
  */
 export function readCostBytes(payload) {
   if (payload.tool_name !== 'Read') return 0;
+  // A REPLACEMENT DID NOT SPEND THE WHOLE FILE. `smart_read` normalises to
+  // `Read` so the graph sees the touch, but it returns a diff -- charging the
+  // full file size here would feed the holdout comparison a cost that was never
+  // paid, on the arm the optimizer is trying to show is cheaper. Better to
+  // record nothing than to record a number in the wrong direction.
+  if (payload.replacement) return 0;
   const path = payload.tool_input?.file_path;
   if (!path || isBinaryPath(path)) return 0;
   const size = fileSize(path);

--- a/integrations/gemini/hooks/lib/disclose.mjs
+++ b/integrations/gemini/hooks/lib/disclose.mjs
@@ -294,6 +294,11 @@ export function verdictFor(graph, { anchors = [], question, minConfidence = 0.7 
     const id = nodeId('file', canonicalPath(anchor));
     if (!graph.nodes.has(id)) continue;
 
+    // READ-ONLY serve: no `dir` is threaded here, so this cannot clear a stale
+    // flag whose evidence is gone. That is deliberate -- this function takes a
+    // graph, not the directory it came from, and widening its signature to give
+    // an analysis path a write capability buys nothing: the injection path runs
+    // on every tool call and clears the same findings.
     const findings = serve(graph, findingsFor(graph, id, { limit: 4 }));
     for (const finding of findings) {
       if (finding.stale) continue;

--- a/integrations/gemini/hooks/lib/harvest-write.mjs
+++ b/integrations/gemini/hooks/lib/harvest-write.mjs
@@ -34,7 +34,7 @@ import { randomBytes } from 'node:crypto';
 import { realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
-import { readEvidence } from './metrics.mjs';
+import { readEvidence, evidenceTruncated } from './metrics.mjs';
 
 /**
  * The types that may cross a project boundary.
@@ -431,53 +431,84 @@ function resolveAnchor(dir, anchor, projectRoot) {
 /**
  * Which task actually produced this finding, when nothing said so directly.
  *
- * Session id was the only signal `answers` had, and a session id is exactly
- * what a caller may not have (`wiki_write`'s `sessionId` is optional and
- * nothing populates it today; the detached harvest worker's is gated behind
- * an opt-in). But the graph does not need to be TOLD which task this is: the
- * structural harvest already writes `task -[derived_from]-> file` for every
- * tool call, unconditionally, on every install. So the task is DERIVABLE --
- * it is whichever task node has a `derived_from` edge to one of the SAME
- * anchors this finding resolved to.
+ * ROUND 2's version scanned the WHOLE graph for any task sharing any anchor,
+ * broken by recency. An adversarial review constructed four cases where that
+ * attributes a finding to the WRONG task:
  *
- * "Most recent task, full stop" was rejected on purpose: a task that never
- * touched these files could still be the newest node in the graph (a
- * different file, a different concern, in a later session), and attaching
- * provenance to it would be a WRONG edge, not a missing one -- worse than no
- * edge, because a reader trusts it. So candidates are filtered to tasks that
- * touched at least one of these anchors FIRST, and only ties among THOSE are
- * broken by recency.
+ *   1. STALE PRIOR SESSION -- a session that reasons from injected memory and
+ *      writes a finding about `foo.ts` without touching it this session gets
+ *      attributed to whatever task last touched `foo.ts`, possibly days old,
+ *      possibly someone else's work.
+ *   2. CONCURRENT SESSION -- two windows on one repository; the other
+ *      session's task wins if its touch is a millisecond later.
+ *   3. OVERLAP, NOT COVERAGE -- a finding anchored to [a, b]; a task that
+ *      touched only `b` could still win over one that touched both.
+ *   4. THE TIE-BREAK CONTRADICTED ITS OWN COMMENT -- `Number(edge.at) || 0`
+ *      with strict `>` means the FIRST edge in log order wins on a tie,
+ *      which is the OLDER task, not "more recently" as documented.
  *
- * The tie-break is the edge's own `at`, not the task node's `at`. A task that
- * touched this file once, long ago, and then stayed active on unrelated files
- * for hours has a late node timestamp that says nothing about this anchor;
- * the edge timestamp says exactly when THIS task touched THIS anchor, which
- * is the question being asked. Among tasks sharing an anchor, the one whose
- * most recent touch to any shared anchor is latest wins -- recency of the
- * relevant work, not recency of the task in general.
+ * THE FIX IS NARROWER THAN A BETTER RANKING: SCOPE, THEN REQUIRE COVERAGE.
+ * A task only ever belongs to the session that created it -- `harvest()` and
+ * `linkCoOccurrence()` (wiki.mjs, inject.mjs) both key a task node by
+ * `sessionId`, always, so there is exactly ONE task node for "the current
+ * session" and it is `nodeId('task', sessionId)`. Restricting to that ONE
+ * node structurally eliminates cases 1 and 2 -- a prior or concurrent
+ * session's task has a DIFFERENT sessionId and therefore a different node
+ * id, so it is never even looked at, regardless of timing. No caller can
+ * supply a wrong sessionId and get someone ELSE's task; they can only fail
+ * to get a match.
+ *
+ * COVERAGE, NOT OVERLAP, fixes case 3: the session's task must have a
+ * `derived_from` edge to EVERY one of this finding's anchors, not merely one.
+ * A partial touch is not attribution.
+ *
+ * With the candidate set reduced to at most one node, there is nothing left
+ * to break a tie between -- case 4's comparator is not "fixed", it is
+ * deleted, because the scenario it was written for (two DIFFERENT tasks both
+ * legitimately eligible) cannot occur under this scoping: two task nodes can
+ * never share a key, and only the current session's key is ever considered.
+ * An edge's `at` therefore plays NO role here: presence of a `derived_from`
+ * edge from the session's task to an anchor is what "touched it" means, with
+ * or without a timestamp on that edge -- there is no ranking left for a
+ * missing timestamp to lose.
+ *
+ * `sessionId` absent means there is no identity to scope by, which means no
+ * candidate -- not "fall back to guessing". Absence is the correct answer
+ * when the graph cannot support attribution.
  */
-function taskForAnchors(graph, anchorIds) {
-  if (!anchorIds || !anchorIds.length) return null;
-  const anchors = new Set(anchorIds);
-  let best = null;
-  for (const edge of graph.edges) {
-    if (edge.edge !== 'derived_from' || !anchors.has(edge.to)) continue;
-    const from = graph.nodes.get(edge.from);
-    // `derived_from` is also how a FINDING cites its own anchors, so without
-    // this a finding that already cited the same file would be mistaken for
-    // the task that produced it.
-    if (!from || from.kind !== 'task') continue;
-    const at = Number(edge.at) || 0;
-    if (!best || at > best.at) best = { taskId: edge.from, at };
+function taskForAnchors(graph, anchorIds, sessionId) {
+  if (!sessionId || !anchorIds || !anchorIds.length) return null;
+  const taskTarget = nodeId('task', sessionId);
+  const task = graph.nodes.get(taskTarget);
+  if (!task || task.kind !== 'task') return null;
+
+  for (const anchor of anchorIds) {
+    const covered = graph.edges.some((edge) =>
+      edge.edge === 'derived_from' && edge.from === taskTarget && edge.to === anchor
+    );
+    // ONE missing anchor refuses the whole attribution. A finding cited three
+    // files; this session's task touched two of them -- that is evidence the
+    // task did SOME related work, not evidence it produced THIS finding.
+    if (!covered) return null;
   }
-  return best ? best.taskId : null;
+  return taskTarget;
 }
 
 /**
  * A file path the way `recordToolOutcome` (metrics.mjs) already truncates and
- * stores it on a `tool-outcome` event's `anchor` field, so a derivation record
- * can join against that log without a second, divergent notion of "the same
- * anchor".
+ * stores it on a FILE-surface `tool-outcome` event's `anchor` field, so a
+ * derivation record can join against that log without a second, divergent
+ * notion of "the same anchor".
+ *
+ * COMMAND-surface events are DECLARED OUT OF SCOPE, not silently missed:
+ * `adapter.mjs` stores the COMMAND TEXT in `anchor` for those
+ * (`String(command).slice(0, 120)`), so a build or test run can never share
+ * an anchor string with a canonical file path -- there is no join key in
+ * common, and inventing a command-to-file heuristic (which files did a given
+ * `npm test` invocation cover?) is not something this record can answer
+ * honestly. `operationsScope` on the returned record says so explicitly,
+ * rather than letting an empty `operations` array look like "no build or
+ * test ever ran" when the truth is "this join cannot see it".
  */
 function anchorLabel(rawAnchor) {
   const path = String(rawAnchor).split('#')[0];
@@ -497,7 +528,8 @@ const MAX_DERIVATION_OPERATIONS = 5;
  * that comparison be reconstructed for a specific claim rather than only for
  * the anchor in general: the hash each anchor carried at the moment this
  * finding was derived from it, plus what evidence exists that any work
- * actually happened against it.
+ * actually happened against it. `derivationCheck` (staleness.mjs) is the
+ * reader that actually performs that comparison at serve time.
  *
  * DELIBERATELY NOT DUPLICATING THE EDGES. `derived_from` already records
  * WHICH anchors this finding cites; restating that here would be a second,
@@ -506,14 +538,23 @@ const MAX_DERIVATION_OPERATIONS = 5;
  *
  * DELIBERATELY NOT A REPLAY LOG. Recording enough to mechanically re-run a
  * derivation is a separate subsystem with real storage cost. This stores only
- * what the evidence log already has: `tool-outcome` events matching these
- * anchors, each reduced to the fields that were actually captured. An event
- * that carries no exit code or output contributes none -- nothing here is
- * invented to fill a shape the pipeline does not evidence yet. If a future
- * capture pass adds `exit`/`output` to those events, this starts carrying them
- * with no change to this function.
+ * what the evidence log already has: FILE-surface `tool-outcome` events
+ * matching these anchors, each reduced to the fields that were actually
+ * captured. An event that carries no exit code or output contributes none --
+ * nothing here is invented to fill a shape the pipeline does not evidence
+ * yet. If a future capture pass adds `exit`/`output` to those events, this
+ * starts carrying them with no change to this function.
+ *
+ * INCOMPLETENESS IS MARKED, NOT IMPLIED. An empty `operations` array is
+ * genuinely ambiguous on its own -- it is the same shape whether nothing
+ * happened, or something happened but fell outside what this join can see.
+ * `operationsComplete` distinguishes them: false when the evidence log itself
+ * may have dropped older matches (`evidenceIncomplete`, from
+ * `metrics.evidenceTruncated`) OR when more matches existed than the cap
+ * kept. A reader can then tell "no operations happened" from "operations
+ * existed but are not recorded here" instead of guessing.
  */
-function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
+function derivationFor(graph, resolvedAnchors, evidence, evidenceIncomplete, anchorSpecs) {
   const anchorHashes = {};
   for (const id of resolvedAnchors) {
     const node = graph.nodes.get(id);
@@ -521,8 +562,10 @@ function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
   }
 
   const labels = new Set((anchorSpecs || []).map(anchorLabel));
-  const operations = evidence
-    .filter((event) => event.kind === 'tool-outcome' && labels.has(event.anchor))
+  const matching = evidence.filter(
+    (event) => event.kind === 'tool-outcome' && labels.has(event.anchor)
+  );
+  const operations = [...matching]
     .sort((a, b) => (Number(b.at) || 0) - (Number(a.at) || 0))
     .slice(0, MAX_DERIVATION_OPERATIONS)
     .map((event) => {
@@ -540,7 +583,16 @@ function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
       return op;
     });
 
-  return { at: Date.now(), anchors: anchorHashes, operations };
+  return {
+    at: Date.now(),
+    anchors: anchorHashes,
+    operations,
+    // FILE touches only -- see `anchorLabel`. Declared here, in the record
+    // itself, not only in this function's comment, so a reader who never
+    // opens this source file still learns builds and test runs are excluded.
+    operationsScope: 'file',
+    operationsComplete: !evidenceIncomplete && matching.length <= operations.length,
+  };
 }
 
 /**
@@ -588,6 +640,9 @@ export function writeHarvested(
   // it can hold thousands of lines, so re-reading it per finding would turn a
   // batch of N findings into N passes over the same bytes.
   const evidence = readEvidence(dir);
+  // Cheap: one stat call, checked once per batch rather than once per
+  // finding's derivation record.
+  const evidenceIncomplete = evidenceTruncated(dir);
 
   const written = [];
   for (const finding of findings) {
@@ -647,14 +702,16 @@ export function writeHarvested(
     // An explicit `taskId` is authoritative when a caller supplies one --
     // it OVERRIDES traversal rather than merely seeding it, so a caller that
     // knows better is never second-guessed by inference. Absent one, the task
-    // is DERIVED from the graph itself: `taskForAnchors` finds the task that
-    // actually touched these anchors, which needs no session id from anyone.
-    // Either way, held to the same discipline as the anchors above: a target
-    // that does not resolve to an existing task node produces no edge rather
-    // than a dangling one.
+    // is DERIVED from the graph itself: `taskForAnchors` finds the CURRENT
+    // session's task (scoped by `sessionId`, the same identity this write
+    // already carries for provenance) and requires it to have touched EVERY
+    // one of this finding's anchors, not merely one -- see that function's
+    // own comment for the four attacks this closes. Either way, held to the
+    // same discipline as the anchors above: a target that does not resolve to
+    // an existing task node produces no edge rather than a dangling one.
     const answersTarget = taskId
       ? nodeId('task', taskId)
-      : taskForAnchors(currentGraph, resolved);
+      : taskForAnchors(currentGraph, resolved, sessionId);
     if (answersTarget && currentGraph.nodes.has(answersTarget)) {
       edges.push({ edge: 'answers', to: answersTarget });
     }
@@ -707,7 +764,7 @@ export function writeHarvested(
         // `render()`/`renderSessionIndex()` in inject.mjs or `wiki_read`'s
         // `toFinding()` projection, neither of which reads this field, so it
         // is not part of the automatic per-touch injection `fit()` prices.
-        derivation: derivationFor(currentGraph, resolved, evidence, finding.anchors || []),
+        derivation: derivationFor(currentGraph, resolved, evidence, evidenceIncomplete, finding.anchors || []),
       },
       edges
     );

--- a/integrations/gemini/hooks/lib/harvest-write.mjs
+++ b/integrations/gemini/hooks/lib/harvest-write.mjs
@@ -452,11 +452,13 @@ function resolveAnchor(dir, anchor, projectRoot) {
  * `linkCoOccurrence()` (wiki.mjs, inject.mjs) both key a task node by
  * `sessionId`, always, so there is exactly ONE task node for "the current
  * session" and it is `nodeId('task', sessionId)`. Restricting to that ONE
- * node structurally eliminates cases 1 and 2 -- a prior or concurrent
- * session's task has a DIFFERENT sessionId and therefore a different node
- * id, so it is never even looked at, regardless of timing. No caller can
- * supply a wrong sessionId and get someone ELSE's task; they can only fail
- * to get a match.
+ * node structurally eliminates cases 1 and 2 PROVIDED the identity itself is
+ * trustworthy: an UNRELATED sessionId (typo'd, invented, or simply absent)
+ * cannot resolve to someone else's task, because a different key is a
+ * different node id, full stop, regardless of timing. That is NOT the same
+ * guarantee as "no caller can get someone else's task" -- see the note on
+ * `authoritativeSessionId` below for the residual this leaves when the
+ * identity is real but comes from an untrusted caller.
  *
  * COVERAGE, NOT OVERLAP, fixes case 3: the session's task must have a
  * `derived_from` edge to EVERY one of this finding's anchors, not merely one.
@@ -472,17 +474,41 @@ function resolveAnchor(dir, anchor, projectRoot) {
  * or without a timestamp on that edge -- there is no ranking left for a
  * missing timestamp to lose.
  *
- * `sessionId` absent means there is no identity to scope by, which means no
- * candidate -- not "fall back to guessing". Absence is the correct answer
- * when the graph cannot support attribution.
+ * NO IDENTITY MEANS NO CANDIDATE -- not "fall back to guessing". Absence is
+ * the correct answer when the graph cannot support attribution.
+ *
+ * ROUND 4: THE IDENTITY ITSELF MUST BE AUTHORITATIVE, not merely present.
+ * Scoping to `nodeId('task', sessionId)` only refuses an UNRELATED session;
+ * it does nothing against a FOREIGN BUT REAL one. `wiki_write`'s `sessionId`
+ * is a plain MCP tool argument the calling model supplies, unverified -- a
+ * model that names some OTHER, prior session whose task genuinely covered
+ * these anchors gets an `answers` edge to that stale task, because coverage
+ * cannot tell "this session" from "a session that really did touch these
+ * files, named by a string nothing cross-checked". Session id is not
+ * evidence unless the CALLER'S OWN CHANNEL is trustworthy, which is true of
+ * `plugin/hooks/harvest-worker.mjs` (Claude Code's own hook payload) and not
+ * true of a tool-call argument. So this parameter is named for what it must
+ * be, `authoritativeSessionId`, and every caller is a promise: pass this only
+ * when you did not just read it out of untrusted input. `wiki_write` passes
+ * NONE, which means its calls never traverse -- see `writeHarvested`'s own
+ * comment at the call site for what that costs and why it is accepted rather
+ * than worked around.
+ *
+ * COVERAGE IS CHECKED AGAINST RESOLVED ANCHORS, not the caller's original
+ * list. `writeHarvested` already drops any anchor `resolveAnchor` could not
+ * resolve before this function ever runs, so "every anchor" here means every
+ * anchor that survived that filter -- self-consistent with the
+ * `derived_from` edges the same resolved list produces, but worth stating:
+ * an anchor that failed to resolve cannot raise or lower the bar for the
+ * anchors that did.
  */
-function taskForAnchors(graph, anchorIds, sessionId) {
-  if (!sessionId || !anchorIds || !anchorIds.length) return null;
-  const taskTarget = nodeId('task', sessionId);
+function taskForAnchors(graph, resolvedAnchorIds, authoritativeSessionId) {
+  if (!authoritativeSessionId || !resolvedAnchorIds || !resolvedAnchorIds.length) return null;
+  const taskTarget = nodeId('task', authoritativeSessionId);
   const task = graph.nodes.get(taskTarget);
   if (!task || task.kind !== 'task') return null;
 
-  for (const anchor of anchorIds) {
+  for (const anchor of resolvedAnchorIds) {
     const covered = graph.edges.some((edge) =>
       edge.edge === 'derived_from' && edge.from === taskTarget && edge.to === anchor
     );
@@ -604,7 +630,19 @@ function derivationFor(graph, resolvedAnchors, evidence, evidenceIncomplete, anc
 export function writeHarvested(
   dir,
   findings,
-  { sessionId = null, origin = ORIGIN_HARVESTED, projectRoot = null, taskId = null } = {}
+  {
+    sessionId = null,
+    origin = ORIGIN_HARVESTED,
+    projectRoot = null,
+    taskId = null,
+    // Distinct from `sessionId`, which is stored on every finding for
+    // provenance/display regardless of trust. This one gates the `answers`
+    // traversal fallback specifically, and every caller passing it is
+    // asserting the identity came from a channel it does not control --
+    // Claude Code's own hook payload, not a tool-call argument a model
+    // typed. See `taskForAnchors`'s comment for the attack this closes.
+    authoritativeSessionId = null,
+  } = {}
 ) {
   if (!Array.isArray(findings) || !findings.length) return [];
 
@@ -702,16 +740,29 @@ export function writeHarvested(
     // An explicit `taskId` is authoritative when a caller supplies one --
     // it OVERRIDES traversal rather than merely seeding it, so a caller that
     // knows better is never second-guessed by inference. Absent one, the task
-    // is DERIVED from the graph itself: `taskForAnchors` finds the CURRENT
-    // session's task (scoped by `sessionId`, the same identity this write
-    // already carries for provenance) and requires it to have touched EVERY
-    // one of this finding's anchors, not merely one -- see that function's
-    // own comment for the four attacks this closes. Either way, held to the
-    // same discipline as the anchors above: a target that does not resolve to
-    // an existing task node produces no edge rather than a dangling one.
+    // is DERIVED from the graph itself, but ONLY when `authoritativeSessionId`
+    // is present: `taskForAnchors` scopes to that exact session's task and
+    // requires it to have touched EVERY one of this finding's anchors, not
+    // merely one -- see that function's own comment for why the identity
+    // itself must be trustworthy, not merely present.
+    //
+    // THE CONSEQUENCE, STATED PLAINLY: `wiki_write` never supplies
+    // `authoritativeSessionId` (its `sessionId` is a model-typed MCP
+    // argument nothing cross-checks), so its calls never traverse and
+    // `answers` never fires on that path. `plugin/hooks/harvest-worker.mjs`
+    // does supply it (Claude Code's own hook payload), so `answers` fires
+    // there -- opt-in gated. `answers` therefore does NOT fire on a default
+    // install today. Recovering default liveness needs an authoritative
+    // identity on a default-install path, which is what Plan 2's
+    // `hooks-core/derive.mjs` (running in the Stop hook, where the session id
+    // is real) is for -- not a weaker check here.
+    //
+    // Either way, held to the same discipline as the anchors above: a target
+    // that does not resolve to an existing task node produces no edge rather
+    // than a dangling one.
     const answersTarget = taskId
       ? nodeId('task', taskId)
-      : taskForAnchors(currentGraph, resolved, sessionId);
+      : taskForAnchors(currentGraph, resolved, authoritativeSessionId);
     if (answersTarget && currentGraph.nodes.has(answersTarget)) {
       edges.push({ edge: 'answers', to: answersTarget });
     }

--- a/integrations/gemini/hooks/lib/harvest-write.mjs
+++ b/integrations/gemini/hooks/lib/harvest-write.mjs
@@ -436,7 +436,7 @@ function resolveAnchor(dir, anchor, projectRoot) {
 export function writeHarvested(
   dir,
   findings,
-  { sessionId = null, origin = ORIGIN_HARVESTED, projectRoot = null } = {}
+  { sessionId = null, origin = ORIGIN_HARVESTED, projectRoot = null, taskId = null } = {}
 ) {
   if (!Array.isArray(findings) || !findings.length) return [];
 
@@ -516,6 +516,21 @@ export function writeHarvested(
     // collision vanishingly unlikely while keeping the timestamp readable.
     const provenance = provenanceFor(finding);
     const key = `${prefixFor(provenance)}-${Date.now().toString(36)}-${written.length}-${randomBytes(4).toString("hex")}`;
+
+    const edges = resolved.map((target) => ({ edge: 'derived_from', to: target }));
+    // `answers` closes the loop back to the task that produced the finding, so
+    // provenance can be traversed rather than inferred: "which session
+    // established this, and from what". Declared in EDGE_KINDS and written by
+    // nothing until now. Held to the same discipline as the anchors above: a
+    // taskId that does not resolve to an existing task node produces no edge
+    // rather than a dangling one.
+    if (taskId) {
+      const taskTarget = nodeId('task', taskId);
+      if (currentGraph.nodes.has(taskTarget)) {
+        edges.push({ edge: 'answers', to: taskTarget });
+      }
+    }
+
     // ONE APPEND for the finding and every anchor it resolved. This runs in a
     // detached worker, so "the process survives to finish the loop" is not a
     // safe assumption: a node written without its edges is an active finding
@@ -557,7 +572,7 @@ export function writeHarvested(
           : undefined,
         sessionId,
       },
-      resolved.map((target) => ({ edge: 'derived_from', to: target }))
+      edges
     );
     // A failed write returns null. Reporting the key anyway would tell the
     // caller a claim was stored that no later session can retrieve.

--- a/integrations/gemini/hooks/lib/harvest-write.mjs
+++ b/integrations/gemini/hooks/lib/harvest-write.mjs
@@ -34,6 +34,7 @@ import { randomBytes } from 'node:crypto';
 import { realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
+import { readEvidence } from './metrics.mjs';
 
 /**
  * The types that may cross a project boundary.
@@ -428,6 +429,121 @@ function resolveAnchor(dir, anchor, projectRoot) {
 }
 
 /**
+ * Which task actually produced this finding, when nothing said so directly.
+ *
+ * Session id was the only signal `answers` had, and a session id is exactly
+ * what a caller may not have (`wiki_write`'s `sessionId` is optional and
+ * nothing populates it today; the detached harvest worker's is gated behind
+ * an opt-in). But the graph does not need to be TOLD which task this is: the
+ * structural harvest already writes `task -[derived_from]-> file` for every
+ * tool call, unconditionally, on every install. So the task is DERIVABLE --
+ * it is whichever task node has a `derived_from` edge to one of the SAME
+ * anchors this finding resolved to.
+ *
+ * "Most recent task, full stop" was rejected on purpose: a task that never
+ * touched these files could still be the newest node in the graph (a
+ * different file, a different concern, in a later session), and attaching
+ * provenance to it would be a WRONG edge, not a missing one -- worse than no
+ * edge, because a reader trusts it. So candidates are filtered to tasks that
+ * touched at least one of these anchors FIRST, and only ties among THOSE are
+ * broken by recency.
+ *
+ * The tie-break is the edge's own `at`, not the task node's `at`. A task that
+ * touched this file once, long ago, and then stayed active on unrelated files
+ * for hours has a late node timestamp that says nothing about this anchor;
+ * the edge timestamp says exactly when THIS task touched THIS anchor, which
+ * is the question being asked. Among tasks sharing an anchor, the one whose
+ * most recent touch to any shared anchor is latest wins -- recency of the
+ * relevant work, not recency of the task in general.
+ */
+function taskForAnchors(graph, anchorIds) {
+  if (!anchorIds || !anchorIds.length) return null;
+  const anchors = new Set(anchorIds);
+  let best = null;
+  for (const edge of graph.edges) {
+    if (edge.edge !== 'derived_from' || !anchors.has(edge.to)) continue;
+    const from = graph.nodes.get(edge.from);
+    // `derived_from` is also how a FINDING cites its own anchors, so without
+    // this a finding that already cited the same file would be mistaken for
+    // the task that produced it.
+    if (!from || from.kind !== 'task') continue;
+    const at = Number(edge.at) || 0;
+    if (!best || at > best.at) best = { taskId: edge.from, at };
+  }
+  return best ? best.taskId : null;
+}
+
+/**
+ * A file path the way `recordToolOutcome` (metrics.mjs) already truncates and
+ * stores it on a `tool-outcome` event's `anchor` field, so a derivation record
+ * can join against that log without a second, divergent notion of "the same
+ * anchor".
+ */
+function anchorLabel(rawAnchor) {
+  const path = String(rawAnchor).split('#')[0];
+  return canonicalPath(path).slice(0, 120);
+}
+
+/** How many recorded operations a single finding's derivation may cite. */
+const MAX_DERIVATION_OPERATIONS = 5;
+
+/**
+ * The checkable half of provenance: not just where a finding came from, but
+ * whether that derivation still holds.
+ *
+ * Citation-style provenance (a session or task id) answers "where". It never
+ * answers "does this still apply" -- that is what staleness already computes,
+ * by comparing an anchor's STORED hash against disk. This record is what lets
+ * that comparison be reconstructed for a specific claim rather than only for
+ * the anchor in general: the hash each anchor carried at the moment this
+ * finding was derived from it, plus what evidence exists that any work
+ * actually happened against it.
+ *
+ * DELIBERATELY NOT DUPLICATING THE EDGES. `derived_from` already records
+ * WHICH anchors this finding cites; restating that here would be a second,
+ * driftable copy of the same fact. What is new here, and only here, is the
+ * HASH each anchor carried at claim time -- edges carry no such thing.
+ *
+ * DELIBERATELY NOT A REPLAY LOG. Recording enough to mechanically re-run a
+ * derivation is a separate subsystem with real storage cost. This stores only
+ * what the evidence log already has: `tool-outcome` events matching these
+ * anchors, each reduced to the fields that were actually captured. An event
+ * that carries no exit code or output contributes none -- nothing here is
+ * invented to fill a shape the pipeline does not evidence yet. If a future
+ * capture pass adds `exit`/`output` to those events, this starts carrying them
+ * with no change to this function.
+ */
+function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
+  const anchorHashes = {};
+  for (const id of resolvedAnchors) {
+    const node = graph.nodes.get(id);
+    if (node && typeof node.hash === 'string') anchorHashes[id] = node.hash;
+  }
+
+  const labels = new Set((anchorSpecs || []).map(anchorLabel));
+  const operations = evidence
+    .filter((event) => event.kind === 'tool-outcome' && labels.has(event.anchor))
+    .sort((a, b) => (Number(b.at) || 0) - (Number(a.at) || 0))
+    .slice(0, MAX_DERIVATION_OPERATIONS)
+    .map((event) => {
+      const op = {};
+      if (typeof event.toolName === 'string' && event.toolName)
+        op.tool = event.toolName.slice(0, 60);
+      if (typeof event.success === 'boolean') op.success = event.success;
+      if (typeof event.at === 'number') op.at = event.at;
+      // Forward-compatible, not fabricated: neither field exists on a
+      // `tool-outcome` event in this pipeline today, so every operation
+      // omits them until a capture pass actually evidences one.
+      if (typeof event.exit === 'number') op.exit = event.exit;
+      if (typeof event.output === 'string' && event.output)
+        op.output = event.output.slice(0, 200);
+      return op;
+    });
+
+  return { at: Date.now(), anchors: anchorHashes, operations };
+}
+
+/**
  * Writes validated findings, returning the keys actually stored.
  *
  * `findings` is the output of `harvest.validate()`, so type/claim/confidence
@@ -467,6 +583,11 @@ export function writeHarvested(
       : batch;
   const prefixFor = (p) =>
     p === ORIGIN_AGENT ? 'agent' : p === ORIGIN_HUMAN ? 'human' : 'harvested';
+
+  // Read once: every finding in this batch shares the same evidence log, and
+  // it can hold thousands of lines, so re-reading it per finding would turn a
+  // batch of N findings into N passes over the same bytes.
+  const evidence = readEvidence(dir);
 
   const written = [];
   for (const finding of findings) {
@@ -521,14 +642,21 @@ export function writeHarvested(
     // `answers` closes the loop back to the task that produced the finding, so
     // provenance can be traversed rather than inferred: "which session
     // established this, and from what". Declared in EDGE_KINDS and written by
-    // nothing until now. Held to the same discipline as the anchors above: a
-    // taskId that does not resolve to an existing task node produces no edge
-    // rather than a dangling one.
-    if (taskId) {
-      const taskTarget = nodeId('task', taskId);
-      if (currentGraph.nodes.has(taskTarget)) {
-        edges.push({ edge: 'answers', to: taskTarget });
-      }
+    // nothing until now.
+    //
+    // An explicit `taskId` is authoritative when a caller supplies one --
+    // it OVERRIDES traversal rather than merely seeding it, so a caller that
+    // knows better is never second-guessed by inference. Absent one, the task
+    // is DERIVED from the graph itself: `taskForAnchors` finds the task that
+    // actually touched these anchors, which needs no session id from anyone.
+    // Either way, held to the same discipline as the anchors above: a target
+    // that does not resolve to an existing task node produces no edge rather
+    // than a dangling one.
+    const answersTarget = taskId
+      ? nodeId('task', taskId)
+      : taskForAnchors(currentGraph, resolved);
+    if (answersTarget && currentGraph.nodes.has(answersTarget)) {
+      edges.push({ edge: 'answers', to: answersTarget });
     }
 
     // ONE APPEND for the finding and every anchor it resolved. This runs in a
@@ -571,6 +699,15 @@ export function writeHarvested(
           ? finding.quote
           : undefined,
         sessionId,
+        // THE CHECKABLE HALF OF PROVENANCE. Citation-style (this `sessionId`,
+        // the `answers` edge above) says WHERE a claim came from; it never
+        // says whether that derivation still applies. `derivationFor` reaches
+        // through `wiki_query`'s `node`/`get`/`search` operations only (those
+        // return a finding's stored fields wholesale) -- never through
+        // `render()`/`renderSessionIndex()` in inject.mjs or `wiki_read`'s
+        // `toFinding()` projection, neither of which reads this field, so it
+        // is not part of the automatic per-touch injection `fit()` prices.
+        derivation: derivationFor(currentGraph, resolved, evidence, finding.anchors || []),
       },
       edges
     );

--- a/integrations/gemini/hooks/lib/inject.mjs
+++ b/integrations/gemini/hooks/lib/inject.mjs
@@ -26,6 +26,7 @@ import {
 } from './wiki.mjs';
 import { basename } from 'node:path';
 import { serve, diffLines } from './staleness.mjs';
+import { drainInvalidations } from './pending.mjs';
 import { inHoldout, record, indexBudget } from './metrics.mjs';
 import { canonicalPath, resolvableCandidates } from './paths.mjs';
 import { annotatedSkeleton } from './skeleton.mjs';
@@ -142,6 +143,31 @@ function render(finding) {
 }
 
 /**
+ * Applies anything the post-tool hook queued, BEFORE anything is served.
+ *
+ * THIS IS WHERE EAGER STALENESS LANDS. `invalidateOnWrite` needs a graph, and
+ * loading one on the return path of every write is what pending.mjs exists to
+ * avoid -- so the hook queues and the next graph read applies. These two
+ * functions are that read: they already hold a freshly loaded graph, and they
+ * are the last thing to run before a finding reaches a model.
+ *
+ * RE-READ ONLY WHEN SOMETHING WAS ACTUALLY MARKED. The drain writes the stale
+ * flag to disk; it cannot mutate the caller's already-parsed graph, so serving
+ * from that copy would deliver the very "stale finding as fresh" this exists to
+ * prevent. A second load costs a parse, and it is paid once per observed write
+ * rather than once per tool call -- when nothing is queued this is one stat.
+ */
+function withPendingApplied(dir, graph) {
+  try {
+    return drainInvalidations(dir, graph) > 0 ? load(dir) : graph;
+  } catch {
+    // The lazy path still covers everything this would have caught early, and
+    // a hook must never fail because bookkeeping did.
+    return graph;
+  }
+}
+
+/**
  * What the model sees when it touches a file.
  *
  * Returns null when there is nothing to say, or when this touch fell into the
@@ -154,6 +180,7 @@ export function forTouch(
   rawPath,
   { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
+  graph = withPendingApplied(dir, graph);
   // Canonical, so a touch finds findings anchored under any other spelling.
   const filePath = canonicalPath(rawPath);
   const anchorId = nodeId('file', filePath);
@@ -322,6 +349,7 @@ export function forCommand(
   { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
   if (!command) return null;
+  graph = withPendingApplied(dir, graph);
 
   const candidates = [];
   for (const node of graph.nodes.values()) {

--- a/integrations/gemini/hooks/lib/inject.mjs
+++ b/integrations/gemini/hooks/lib/inject.mjs
@@ -33,6 +33,7 @@ import { annotatedSkeleton } from './skeleton.mjs';
 import { substitutionBudget } from './metrics.mjs';
 import { assessFindings } from './utility.mjs';
 import { quarantineSharedSource } from './harvest-write.mjs';
+import { cacheOrdered } from './cache.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
@@ -1152,6 +1153,53 @@ export function standingRules(dir, graph, { budget = standingBudget(), episode =
   // which is worse than saying there are more: a model that knows the list is
   // truncated can ask, one that does not will assume it is complete.
   return `${HEADING}${lines.join('\n')}${truncated}`;
+}
+
+/**
+ * SessionStart context, assembled in cache order: stable first, volatile last.
+ *
+ * WHY THE ORDER IS A CORRECTNESS PROPERTY AND NOT A STYLE CHOICE. Everything
+ * here lands near the FRONT of the prompt prefix, and a prefix cache is
+ * invalidated from the first differing byte onward. A block whose text changes
+ * between sessions therefore prices everything positioned after it: put the
+ * freshest block first and the whole remainder of the prefix is re-written
+ * every session; put it last and the invalidation is confined to its own tail.
+ * cache.mjs measures exactly this cost in the user's files -- this is the same
+ * discipline applied to our own output, which is the half nobody else has to
+ * think about because nobody else writes into the prefix.
+ *
+ * `cacheOrdered` existed for precisely this and had no caller, so the order was
+ * whatever order the call sites happened to push in. It was accidentally right;
+ * it is now enforced, which is the difference that matters the next time a
+ * block is added.
+ *
+ * VOLATILITY IS ASSIGNED FROM HOW OFTEN THE TEXT ACTUALLY DIFFERS BETWEEN
+ * SESSIONS, not from how important the block is:
+ *
+ *   0  policy -- the optimization notice and project briefing. Deliberately
+ *      cache-safe by construction: the routing facts are number-free and the
+ *      briefing passes through `stableText`, which DROPS any line that would
+ *      vary. It changes when the tool inventory or configuration changes.
+ *   1  standing -- pinned facts and human-verified corrections, rendered in
+ *      full. Changes only when a person pins, retires or corrects something.
+ *   2  index -- the bounded wiki index, selected per session from the task
+ *      text, and carrying [STALE]/[DISPUTED] markers that flip as the code
+ *      moves. Different on most sessions.
+ *   3  restoration -- present only when resuming from a compaction, and derived
+ *      from the anchors of the session that was just discarded. Never twice the
+ *      same.
+ *
+ * A block with no text is dropped rather than joined, so an absent block cannot
+ * open the assembly with a blank line.
+ */
+export function sessionContext(blocks) {
+  return cacheOrdered(
+    (Array.isArray(blocks) ? blocks : []).filter(
+      (block) => block && typeof block.text === 'string' && block.text.trim()
+    )
+  )
+    .map((block) => block.text)
+    .join('\n\n');
 }
 
 /**

--- a/integrations/gemini/hooks/lib/inject.mjs
+++ b/integrations/gemini/hooks/lib/inject.mjs
@@ -122,8 +122,29 @@ function fit(findings, budget) {
   return { kept, spent };
 }
 
+/**
+ * Discloses an open disagreement, on the same line as the claim it is about.
+ *
+ * BOTH HALVES, like the stale renderer below: the strong form names the other
+ * finding so the reader can fetch it, and the form without a key says only what
+ * is actually known. `serve` is what establishes the dispute; this only phrases
+ * it, and it phrases it in one short line because `fit` prices `render` against
+ * the injection budget -- a disagreement is worth a pointer, not both claims in
+ * full.
+ *
+ * NO DISMISSAL VOCABULARY, for the reason measured on the stale wording: an
+ * instruction to discount suppressed findings that were correct. This states
+ * that another claim exists and where to find it, and lets the reader decide.
+ */
+function disputeNote(finding) {
+  if (!finding.contradicted) return '';
+  return finding.contradictedBy
+    ? `\n  DISPUTED by ${finding.contradictedBy} -- wiki_query that key for the other claim`
+    : '\n  DISPUTED by another finding in this graph';
+}
+
 function render(finding) {
-  const head = `- [${finding.type || 'finding'}] ${finding.claim}`;
+  const head = `- [${finding.type || 'finding'}] ${finding.claim}${disputeNote(finding)}`;
   if (!finding.stale) return head;
 
   // A stale finding NEVER renders as though it were current. But the strength
@@ -997,7 +1018,15 @@ function renderSessionIndex(total, findings) {
       : finding.stale
         ? ' [possibly stale; verify before use]'
         : '';
-    return `- ${finding.key}${freshness}: ${finding.claim.slice(0, 90)}`;
+    // The session index is the first thing a session reads, so a disputed
+    // finding must not be listed there as settled either. Compressed to a
+    // marker and a key, matching the freshness markers beside it.
+    const dispute = finding.contradicted
+      ? finding.contradictedBy
+        ? ` [DISPUTED by ${finding.contradictedBy}]`
+        : ' [DISPUTED]'
+      : '';
+    return `- ${finding.key}${freshness}${dispute}: ${finding.claim.slice(0, 90)}`;
   });
   return `# Project wiki (${total} findings, ${findings.length} listed)
 

--- a/integrations/gemini/hooks/lib/inject.mjs
+++ b/integrations/gemini/hooks/lib/inject.mjs
@@ -139,9 +139,26 @@ function fit(findings, budget) {
  */
 function disputeNote(finding) {
   if (!finding.contradicted) return '';
-  return finding.contradictedBy
+  const head = finding.contradictedBy
     ? `\n  DISPUTED by ${finding.contradictedBy} -- wiki_query that key for the other claim`
     : '\n  DISPUTED by another finding in this graph';
+  // THE REASON A PERSON TYPED, rendered here because this is the fullest of the
+  // three dispute surfaces and the only one with room for a sentence. `contradict`
+  // has always stored up to 400 characters of human explanation and, until this
+  // line, nothing read it: the pointer told a reader where to look and withheld
+  // the one thing that would tell them whether looking was worth a tool call.
+  //
+  // TRUNCATED AT 140, because `fit` prices this string against the injection
+  // budget and a 400-character paragraph beside a one-line claim inverts the
+  // proportions. The compressed surfaces -- the session index and restore.mjs's
+  // "Likely next" list -- deliberately keep marker-and-key only; they are one
+  // line per finding by design, and `wiki_query` returns the reason in full.
+  if (typeof finding.contradictionReason !== 'string' || !finding.contradictionReason.trim()) {
+    return head;
+  }
+  const reason = finding.contradictionReason.trim();
+  const shown = reason.length > 140 ? `${reason.slice(0, 140)}...` : reason;
+  return `${head}\n  Reason given: ${shown}`;
 }
 
 /**

--- a/integrations/gemini/hooks/lib/inject.mjs
+++ b/integrations/gemini/hooks/lib/inject.mjs
@@ -276,7 +276,10 @@ export function forTouch(
   // others, so the comparison becomes within-file and the dominant source of
   // variance drops out. A session-pinned arm would destroy that.
   const holdout = inHoldout(filePath);
-  const served = serve(graph, candidates);
+  // `dir` so an eager flag whose evidence is gone is cleared here rather than
+  // waiting for somebody to open the dashboard. Same evidence test as the manual
+  // path -- see `serve`.
+  const served = serve(graph, candidates, { dir });
   const assessed = assessFindings(dir, served, {
     episodeId: episode.episodeId || sessionId,
     relevanceFor: () => 1,
@@ -463,7 +466,7 @@ export function forCommand(
   // only thing an uncapped list buys is the I/O.
   const considered = candidates.slice(0, MAX_COMMAND_CANDIDATES);
 
-  const served = serve(graph, considered);
+  const served = serve(graph, considered, { dir });
   const assessed = assessFindings(dir, served, {
     episodeId: episode.episodeId || sessionId,
     relevanceFor: (finding) => explicit(finding) ? 1 : 0.6,
@@ -990,7 +993,7 @@ export function sessionIndex(dir, graph, { episode = {}, relevantFindingIds = []
   // `serve` is the only path allowed to hand a finding to a model. In
   // particular, activating this previously-unwired index must not create a new
   // path that labels an invalidated content claim as current.
-  const served = serve(graph, selected);
+  const served = serve(graph, selected, { dir });
   if (!served.length) return null;
   // A stale marker is longer than the fresh preview used for candidate
   // selection. Trim from the lowest-ranked end until the ACTUAL message fits.

--- a/integrations/gemini/hooks/lib/inject.mjs
+++ b/integrations/gemini/hooks/lib/inject.mjs
@@ -156,9 +156,9 @@ function disputeNote(finding) {
 function derivationNote(finding) {
   if (finding.derivationHolds !== false) return '';
   const changed = Array.isArray(finding.derivationChanged) ? finding.derivationChanged : [];
-  return changed.length
-    ? `\n  DERIVATION CHANGED -- ${changed.join(', ')} no longer match what this claim was derived from`
-    : '\n  DERIVATION CHANGED since this claim was recorded';
+  if (!changed.length) return '\n  DERIVATION CHANGED since this claim was recorded';
+  const verb = changed.length === 1 ? 'no longer matches' : 'no longer match';
+  return `\n  DERIVATION CHANGED -- ${changed.join(', ')} ${verb} what this claim was derived from`;
 }
 
 function render(finding) {

--- a/integrations/gemini/hooks/lib/inject.mjs
+++ b/integrations/gemini/hooks/lib/inject.mjs
@@ -143,8 +143,26 @@ function disputeNote(finding) {
     : '\n  DISPUTED by another finding in this graph';
 }
 
+/**
+ * Discloses `derivationCheck`'s verdict (staleness.mjs) -- distinct from
+ * `disputeNote` (another finding disagrees) and from the STALE block below
+ * (the anchor NODE's current hash does not match disk). This is about
+ * whether the bytes THIS claim was actually derived from are still the bytes
+ * an anchor holds; see `derivationCheck`'s comment for the case that catches
+ * that the other two can miss. Silent when it holds -- the common case pays
+ * nothing -- and silent when it was never checked at all (an older finding
+ * with no `derivation` record).
+ */
+function derivationNote(finding) {
+  if (finding.derivationHolds !== false) return '';
+  const changed = Array.isArray(finding.derivationChanged) ? finding.derivationChanged : [];
+  return changed.length
+    ? `\n  DERIVATION CHANGED -- ${changed.join(', ')} no longer match what this claim was derived from`
+    : '\n  DERIVATION CHANGED since this claim was recorded';
+}
+
 function render(finding) {
-  const head = `- [${finding.type || 'finding'}] ${finding.claim}${disputeNote(finding)}`;
+  const head = `- [${finding.type || 'finding'}] ${finding.claim}${disputeNote(finding)}${derivationNote(finding)}`;
   if (!finding.stale) return head;
 
   // A stale finding NEVER renders as though it were current. But the strength

--- a/integrations/gemini/hooks/lib/inject.mjs
+++ b/integrations/gemini/hooks/lib/inject.mjs
@@ -157,9 +157,28 @@ function render(finding) {
  * prevent. A second load costs a parse, and it is paid once per observed write
  * rather than once per tool call -- when nothing is queued this is one stat.
  */
+/**
+ * Per process, per graph directory: did the drain change anything?
+ *
+ * THE SECOND CALLER IS WHY THIS EXISTS. SessionStart calls `standingRules` and
+ * then `sessionIndex` with the SAME graph object it loaded once. Without this
+ * memo the first call drains, marks, and re-reads privately -- and the second
+ * call finds an empty queue, marks nothing, and therefore serves from the
+ * caller's pre-drain copy, advertising as current the very finding the first
+ * call had just marked. Draining is not idempotent from the caller's point of
+ * view; remembering the ANSWER is what makes it so.
+ *
+ * A hook process handles one lifecycle event, so this map holds one or two
+ * entries and dies with the process.
+ */
+const drainedDirs = new Map();
+
 function withPendingApplied(dir, graph) {
   try {
-    return drainInvalidations(dir, graph) > 0 ? load(dir) : graph;
+    if (drainedDirs.has(dir)) return drainedDirs.get(dir) ? load(dir) : graph;
+    const marked = drainInvalidations(dir, graph) > 0;
+    drainedDirs.set(dir, marked);
+    return marked ? load(dir) : graph;
   } catch {
     // The lazy path still covers everything this would have caught early, and
     // a hook must never fail because bookkeeping did.
@@ -862,6 +881,12 @@ export function relevantFindingIdsForContext(graph, context, { limit = 8 } = {})
  * shrinks toward the floor. See metrics.indexBudget.
  */
 export function sessionIndex(dir, graph, { episode = {}, relevantFindingIds = [] } = {}) {
+  // DRAINED HERE TOO, and this is the worst place to be wrong. The session index
+  // is the FIRST thing a session sees and it arrives with no other context to
+  // correct it, so advertising a finding the graph already knows is stale is a
+  // false claim made at maximum leverage. The graph is loaded either way, so the
+  // only cost is the stat that finds no queue.
+  graph = withPendingApplied(dir, graph);
   const budget = indexBudget(dir);
   const relevant = new Set(relevantFindingIds);
   // Some SessionStart payloads have no task signal. Fail closed for situational
@@ -988,6 +1013,9 @@ ${lines.join('\n')}`;
  * is wallpaper, and the model stops reading the thing it always sees.
  */
 export function standingRules(dir, graph, { budget = standingBudget(), episode = {} } = {}) {
+  // Same reason as sessionIndex: always-on text, delivered before the first
+  // tool call, with nothing following it that could qualify what it said.
+  graph = withPendingApplied(dir, graph);
   const rules = [...graph.nodes.values()].filter(
     (n) =>
       n.kind === 'finding' &&

--- a/integrations/gemini/hooks/lib/inject.mjs
+++ b/integrations/gemini/hooks/lib/inject.mjs
@@ -143,6 +143,40 @@ function render(finding) {
 }
 
 /**
+ * Graph directories where a drain has already marked something in THIS process.
+ *
+ * THE SECOND CALLER IS WHY THIS EXISTS. SessionStart calls `standingRules` and
+ * then `sessionIndex` with the SAME graph object it loaded once. Without this,
+ * the first call drains, marks, and re-reads privately -- and the second call
+ * finds an empty queue, marks nothing, and therefore serves from the caller's
+ * pre-drain copy, advertising as current the very finding the first call had
+ * just marked. Draining is idempotent; its EFFECT on a caller's parsed graph is
+ * not, so what is remembered here is "a re-read is owed", nothing else.
+ *
+ * ONLY THE POSITIVE CASE IS REMEMBERED, and that is a correctness decision
+ * rather than a tuning one. Remembering "nothing was queued" would mean a queue
+ * arriving LATER in the same process is silently skipped and deferred to some
+ * future session. That cannot happen today, because `queueInvalidation` runs in
+ * the post-tool branch before any injection -- but that is an unguarded
+ * ordering dependency, and it stops being true the moment someone adds a call
+ * site. A repeated empty drain costs one `existsSync` on a file that is not
+ * there, which is a price worth paying to not have an invariant that depends on
+ * nobody reordering anything.
+ *
+ * KEYED CANONICALLY. Two spellings of one directory -- a trailing separator, a
+ * `..` segment, a lower-cased drive letter -- would otherwise be two entries,
+ * which reintroduces exactly the pre-drain-copy bug above. This is the same
+ * defect shape Task 2 on this branch shipped for real, where a tool resolved its
+ * graph from a raw cwd while the hooks resolved theirs through `projectRootFor`
+ * and the two halves of a metric landed in different directories. Path identity
+ * is why `canonicalKey` lives inside `nodeId` rather than at its call sites.
+ *
+ * A hook process handles one lifecycle event, so this set holds one or two
+ * entries and dies with the process.
+ */
+const drainedDirs = new Set();
+
+/**
  * Applies anything the post-tool hook queued, BEFORE anything is served.
  *
  * THIS IS WHERE EAGER STALENESS LANDS. `invalidateOnWrite` needs a graph, and
@@ -157,28 +191,14 @@ function render(finding) {
  * prevent. A second load costs a parse, and it is paid once per observed write
  * rather than once per tool call -- when nothing is queued this is one stat.
  */
-/**
- * Per process, per graph directory: did the drain change anything?
- *
- * THE SECOND CALLER IS WHY THIS EXISTS. SessionStart calls `standingRules` and
- * then `sessionIndex` with the SAME graph object it loaded once. Without this
- * memo the first call drains, marks, and re-reads privately -- and the second
- * call finds an empty queue, marks nothing, and therefore serves from the
- * caller's pre-drain copy, advertising as current the very finding the first
- * call had just marked. Draining is not idempotent from the caller's point of
- * view; remembering the ANSWER is what makes it so.
- *
- * A hook process handles one lifecycle event, so this map holds one or two
- * entries and dies with the process.
- */
-const drainedDirs = new Map();
-
 function withPendingApplied(dir, graph) {
   try {
-    if (drainedDirs.has(dir)) return drainedDirs.get(dir) ? load(dir) : graph;
-    const marked = drainInvalidations(dir, graph) > 0;
-    drainedDirs.set(dir, marked);
-    return marked ? load(dir) : graph;
+    const key = canonicalPath(dir);
+    // The drain runs EVERY time. It is one stat when there is nothing to do,
+    // and running it unconditionally is what keeps the memo from encoding an
+    // assumption about which hook branch ran first.
+    if (drainInvalidations(dir, graph) > 0) drainedDirs.add(key);
+    return drainedDirs.has(key) ? load(dir) : graph;
   } catch {
     // The lazy path still covers everything this would have caught early, and
     // a hook must never fail because bookkeeping did.

--- a/integrations/gemini/hooks/lib/lexical.mjs
+++ b/integrations/gemini/hooks/lib/lexical.mjs
@@ -1,0 +1,73 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/lexical.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * BM25 over findings. Pure, dependency-free, deterministic.
+ *
+ * WHY THIS REPLACES `includes()`. The dashboard filtered findings by substring,
+ * which cannot RANK -- and every consumer of retrieval here is under a hard
+ * token budget, so the budget kept whatever happened to match rather than what
+ * matched best. Ranking is the whole value at a budget.
+ *
+ * WHY BM25 AND NOT EMBEDDINGS. Deliberate, per docs/WIKI_GRAPH.md: deterministic,
+ * instant, explainable, and it cannot drift or need a rebuild. The known cost is
+ * recall on findings with no lexical overlap; Plan 2's recall probe measures that
+ * rather than assuming it away.
+ */
+
+/** Non-word split, lowercased. Short tokens are kept: `fs`, `id`, `os` matter here. */
+export function tokenize(text) {
+  return String(text || '')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+}
+
+/**
+ * Classic BM25. `k1` controls term-frequency saturation, `b` length normalisation.
+ * Defaults are the standard ones and are exposed so the recall probe can sweep them.
+ */
+export function rank(query, findings, { limit = 20, k1 = 1.2, b = 0.75 } = {}) {
+  const terms = tokenize(query);
+  if (!terms.length || !Array.isArray(findings) || !findings.length) return [];
+
+  // A finding's searchable text is its claim AND its key: the key is how the
+  // session index refers to it, so a model quoting a key must find it.
+  const docs = findings.map((finding) => ({
+    finding,
+    tokens: tokenize(`${finding.key || ''} ${finding.claim || ''}`),
+  }));
+
+  const avgLen = docs.reduce((sum, d) => sum + d.tokens.length, 0) / docs.length;
+  const N = docs.length;
+
+  const docFreq = new Map();
+  for (const { tokens } of docs) {
+    for (const term of new Set(tokens)) {
+      docFreq.set(term, (docFreq.get(term) || 0) + 1);
+    }
+  }
+
+  const scored = [];
+  for (const { finding, tokens } of docs) {
+    const counts = new Map();
+    for (const token of tokens) counts.set(token, (counts.get(token) || 0) + 1);
+
+    let score = 0;
+    for (const term of terms) {
+      const tf = counts.get(term);
+      if (!tf) continue;
+      const df = docFreq.get(term) || 0;
+      // Standard BM25 IDF, floored at zero so a term present in every document
+      // contributes nothing rather than a negative score.
+      const idf = Math.max(0, Math.log(1 + (N - df + 0.5) / (df + 0.5)));
+      const norm = tf + k1 * (1 - b + (b * tokens.length) / (avgLen || 1));
+      score += idf * ((tf * (k1 + 1)) / (norm || 1));
+    }
+
+    // Zero means no term matched. Omitted rather than returned, so a caller
+    // under a token budget never spends it on an irrelevant finding.
+    if (score > 0) scored.push({ finding, score });
+  }
+
+  return scored.sort((a, b2) => b2.score - a.score).slice(0, limit);
+}

--- a/integrations/gemini/hooks/lib/lexical.mjs
+++ b/integrations/gemini/hooks/lib/lexical.mjs
@@ -14,12 +14,54 @@
  * rather than assuming it away.
  */
 
-/** Non-word split, lowercased. Short tokens are kept: `fs`, `id`, `os` matter here. */
-export function tokenize(text) {
-  return String(text || '')
-    .toLowerCase()
-    .split(/[^a-z0-9]+/)
+/**
+ * Splits an identifier's alphanumeric run into its camelCase / letter-digit
+ * parts, e.g. `skipLibCheck` -> ['skip', 'Lib', 'Check'], `TS2345` ->
+ * ['TS', '2345']. Returns a single-element array when there is no internal
+ * boundary (e.g. `retry` -> ['retry']) so callers can skip emitting a
+ * redundant duplicate of the whole token.
+ */
+function splitIdentifierParts(word) {
+  return word
+    .replace(/([a-z])([A-Z])/g, '$1\0$2')
+    .replace(/([A-Za-z])([0-9])/g, '$1\0$2')
+    .replace(/([0-9])([A-Za-z])/g, '$1\0$2')
+    .split('\0')
     .filter(Boolean);
+}
+
+/**
+ * Non-word split, lowercased. Short tokens are kept: `fs`, `id`, `os` matter
+ * here.
+ *
+ * Emits sub-tokens for compound identifiers, in addition to the whole token.
+ * Delimited identifiers (`smart_read`, `wiki.mjs`, the flag in
+ * `--skipLibCheck`) already round-trip fine: the delimiter splits them, and
+ * because query and claim pass through this same function, a query typed
+ * with the same delimiters matches. The silent gap was CONCATENATED
+ * identifiers with no delimiter at all -- `skipLibCheck` collapsed to the
+ * single token `skiplibcheck`, so a query for "skip lib check" (or "TS 2345"
+ * against `TS2345`) never intersected it. No error, just an absent result --
+ * and findings are about code, where run-together identifiers are the
+ * common case. So every alphanumeric run keeps its whole-token form (a query
+ * for the concatenated form still matches) and ALSO contributes its
+ * camelCase / letter-digit parts (a query for the separated form now
+ * matches too). A lone incidental character -- e.g. the `c` split out of a
+ * Windows path `C:\Users\...` -- needs no special-casing: it is a real
+ * token like any other, and BM25's IDF already discounts a term that shows
+ * up in nearly every finding.
+ */
+export function tokenize(text) {
+  const words = String(text || '').match(/[A-Za-z0-9]+/g) || [];
+  const tokens = [];
+  for (const word of words) {
+    tokens.push(word.toLowerCase());
+    const parts = splitIdentifierParts(word);
+    if (parts.length > 1) {
+      for (const part of parts) tokens.push(part.toLowerCase());
+    }
+  }
+  return tokens;
 }
 
 /**
@@ -57,9 +99,15 @@ export function rank(query, findings, { limit = 20, k1 = 1.2, b = 0.75 } = {}) {
       const tf = counts.get(term);
       if (!tf) continue;
       const df = docFreq.get(term) || 0;
-      // Standard BM25 IDF, floored at zero so a term present in every document
-      // contributes nothing rather than a negative score.
-      const idf = Math.max(0, Math.log(1 + (N - df + 0.5) / (df + 0.5)));
+      // Smoothed BM25 idf: log(1 + (N - df + 0.5) / (df + 0.5)). Unlike the
+      // classic unsmoothed idf (log((N - df + 0.5) / (df + 0.5))), which goes
+      // negative once a term appears in most documents, this smoothed form
+      // is strictly positive for every df in [1, N]: even at df === N the
+      // ratio inside the log is (N + 1) / (N + 0.5), which is always
+      // strictly greater than 1, so log(1 + that) is always > 0. No floor
+      // is needed here, and none is applied -- there is no negative case
+      // for this formula to guard against.
+      const idf = Math.log(1 + (N - df + 0.5) / (df + 0.5));
       const norm = tf + k1 * (1 - b + (b * tokens.length) / (avgLen || 1));
       score += idf * ((tf * (k1 + 1)) / (norm || 1));
     }

--- a/integrations/gemini/hooks/lib/lexical.mjs
+++ b/integrations/gemini/hooks/lib/lexical.mjs
@@ -65,6 +65,43 @@ export function tokenize(text) {
 }
 
 /**
+ * Effective term-frequency credit for a document that has NO exact token
+ * match for a query term but DOES have a token that starts with it (e.g.
+ * query `custom` against a document containing `customer`). Deliberately
+ * less than one exact occurrence (`1`), and it is a flat credit rather than
+ * one that grows with the number of prefix-matching tokens in the document,
+ * so a prefix hit can never outscore an exact hit of the same term:
+ *
+ *   BM25's per-term contribution is `idf * tf * (k1 + 1) / (tf + K)`, where
+ *   `K = k1 * (1 - b + b * L / avgL)` depends only on document length, not
+ *   on which term or how it matched. As a function of `tf` alone, with `K`
+ *   fixed, `f(tf) = tf / (tf + K)` is non-decreasing for every `tf >= 0` and
+ *   `k1 >= 0` (its derivative `K / (tf + K)^2` is never negative). So for
+ *   ANY document length, and any number of prefix-only occurrences, using
+ *   `PREFIX_TF < 1` in place of `tf` scores no higher than an actual exact
+ *   occurrence (`tf = 1`) would in that same document -- there is no
+ *   PREFIX_TF-independent way to accumulate more evidence than one real hit
+ *   by matching only a prefix. This is also why the count of prefix matches
+ *   is otherwise irrelevant here: it never feeds back into the score.
+ *
+ * PREFIX MATCHING IS NOT SUBSTRING MATCHING. It restores recall for a
+ * fragment typed at the START of a word -- `custom` now finds `customer` --
+ * which is the common case (a user typing the first few letters of a term
+ * they remember). It does NOT restore the old `.includes()` filter's ability
+ * to find a term in the MIDDLE of a word: a query for `tomer` still will not
+ * find `customer`. That recall gap is accepted, not silently reintroduced.
+ */
+const PREFIX_TF = 0.5;
+
+/**
+ * Below this length, a query term is not eligible for prefix matching: a
+ * one- or two-character prefix (`a`, `re`) is a substring of a large
+ * fraction of any real vocabulary, so it would match nearly every document
+ * and IDF alone would not discount it enough to keep the results relevant.
+ */
+const PREFIX_MIN_TERM_LENGTH = 3;
+
+/**
  * Classic BM25. `k1` controls term-frequency saturation, `b` length normalisation.
  * Defaults are the standard ones and are exposed so the recall probe can sweep them.
  */
@@ -96,7 +133,21 @@ export function rank(query, findings, { limit = 20, k1 = 1.2, b = 0.75 } = {}) {
 
     let score = 0;
     for (const term of terms) {
-      const tf = counts.get(term);
+      let tf = counts.get(term) || 0;
+
+      // No exact occurrence: fall back to a prefix match, which is weaker
+      // evidence and so credited at a flat PREFIX_TF rather than a real
+      // count (see PREFIX_TF's comment for why that ordering is safe). Only
+      // considered when nothing already matched exactly and the term is
+      // long enough that "starts with" is a meaningful signal.
+      if (tf === 0 && term.length >= PREFIX_MIN_TERM_LENGTH) {
+        for (const token of counts.keys()) {
+          if (token !== term && token.startsWith(term)) {
+            tf = PREFIX_TF;
+            break;
+          }
+        }
+      }
       if (!tf) continue;
       const df = docFreq.get(term) || 0;
       // Smoothed BM25 idf: log(1 + (N - df + 0.5) / (df + 0.5)). Unlike the

--- a/integrations/gemini/hooks/lib/metrics.mjs
+++ b/integrations/gemini/hooks/lib/metrics.mjs
@@ -455,6 +455,23 @@ export function readBalance(dir) {
   return out;
 }
 
+/**
+ * True when `readEvidence` could not have read the whole log -- the file
+ * exceeds the byte cap, so anything written before the tail it kept is
+ * silently absent from what it returned. A caller that builds a per-claim
+ * record from `readEvidence` (the wiki graph's derivation record) needs this
+ * to say "operations existed but are not recorded here" rather than let an
+ * empty result read as "nothing happened".
+ */
+export function evidenceTruncated(dir) {
+  const path = evidencePath(dir);
+  try {
+    return statSync(path).size > MAX_BYTES;
+  } catch {
+    return false;
+  }
+}
+
 /** Every causal evidence record inside the byte cap, deduplicated by id. */
 export function readEvidence(dir) {
   const path = evidencePath(dir);

--- a/integrations/gemini/hooks/lib/observability.mjs
+++ b/integrations/gemini/hooks/lib/observability.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 /**
  * Privacy-safe, cross-client lifecycle diagnostics.
  *

--- a/integrations/gemini/hooks/lib/pending.mjs
+++ b/integrations/gemini/hooks/lib/pending.mjs
@@ -39,7 +39,7 @@ import {
   statSync,
 } from 'node:fs';
 import { join } from 'node:path';
-import { invalidateOnWrite } from './staleness.mjs';
+import { invalidateChangedAnchors, invalidateOnWrite } from './staleness.mjs';
 import { canonicalPath, isFsSafePath, resolvableCandidates } from './paths.mjs';
 
 const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
@@ -190,31 +190,85 @@ function hasEditEvidence(payload, raw) {
 }
 
 /**
- * The evidence a completed mutation left behind, or null when there is none.
+ * Canonical tool names that mean bytes on disk changed.
  *
- * Separate from `queueInvalidation` so the caller can be a hook branch that
- * knows nothing about diffs, and so the reconstruction above is testable
- * without a filesystem queue.
+ * THE NORMALISED SET, not any client's own vocabulary. `normalizePayload` has
+ * already mapped `replace`, `write_file`, `apply_patch`, `str_replace`,
+ * `search_replace` and the rest onto these three through decide.mjs's alias
+ * table -- and a tool that table cannot map arrives as null and exits the hook
+ * before this module is reached at all. So matching here is both complete for
+ * every client the adapter serves and impossible to spell wrong.
+ *
+ * `NotebookEdit` is absent because `normalizeTool` maps it to null, and the MCP
+ * `smart_edit`/`smart_write` tools are absent for the same reason. Both are gaps
+ * in that alias table rather than in this file, and widening it changes routing
+ * verdicts for every client -- so they are reported, not papered over here.
  */
-export function observedWrite(payload, raw) {
-  // CHEAP CHECK FIRST, because this runs after every tool call on every client.
-  // Reading the file is the expensive part, and there is no point paying for it
-  // on a Read, a Bash or a write whose before side cannot be reconstructed.
-  if (!hasEditEvidence(payload, raw)) return null;
+const MUTATING = new Set(['Edit', 'MultiEdit', 'Write']);
+
+/** Files an apply_patch-style program declares it is about to change. */
+function patchTargets(payload) {
+  const command = payload?.tool_input?.command;
+  if (typeof command !== 'string') return [];
+  const out = [];
+  for (const match of command.matchAll(
+    /^\*\*\* (?:Add|Update|Delete) File:\s*(.+)$/gm
+  )) {
+    const candidate = match[1].trim().replace(/^['"]|['"]$/g, '');
+    // Bounded: one patch naming a thousand files must not append a thousand
+    // queue records on a hook path.
+    if (candidate && out.length < 20) out.push(candidate);
+  }
+  return out;
+}
+
+/**
+ * Everything a completed mutation left behind that is worth queueing.
+ *
+ * TWO GRADES OF EVIDENCE, and the distinction is the point:
+ *
+ *   { path, before, after }  a reconstructable edit. The drain builds a real
+ *                            diff and marks only the symbols that moved.
+ *   { path }                 a whole-file write, or a patch program. No before
+ *                            side exists anywhere in the payload, so the drain
+ *                            compares stored hashes against disk instead.
+ *
+ * The second grade is what closes the biggest hole. A whole-file write is the
+ * commonest write shape there is, and before it was added those writes fell
+ * through to a lazy path that CANNOT see the session's own writes at all --
+ * `indexFile` refreshes the anchor before the lazy check ever looks at it. They
+ * were uncovered, not degraded.
+ *
+ * Returns an array, because one apply_patch program changes several files.
+ */
+export function observedWrites(payload, raw) {
+  if (!MUTATING.has(String(payload?.tool_name || ''))) return [];
 
   const path = writtenPath(payload, raw);
-  if (!path) return null;
+  if (path) {
+    // The expensive branch is guarded: reading the file only pays off when the
+    // payload can actually yield a before side.
+    if (hasEditEvidence(payload, raw)) {
+      const after = afterText(path);
+      if (after !== null && after.length <= MAX_SIDE_CHARS) {
+        const before = beforeText(payload, raw, after);
+        // Identical bytes: a formatter no-op, or a rewrite of the same content.
+        // Nothing changed, so nothing is stale.
+        if (before === after) return [];
+        if (before !== null && before.length <= MAX_SIDE_CHARS)
+          return [{ path, before, after }];
+      }
+    }
+    // Hash grade. Deliberately NOT `{ path, before: '', after }`: an empty
+    // before side makes every symbol in the file look changed, and the eager
+    // mark is a stored flag no later check ever clears.
+    return [{ path }];
+  }
 
-  const after = afterText(path);
-  if (after === null || after.length > MAX_SIDE_CHARS) return null;
-
-  const before = beforeText(payload, raw, after);
-  if (before === null || before.length > MAX_SIDE_CHARS) return null;
-  // Nothing changed: a formatter no-op, or a write of identical bytes. Queuing
-  // it would mark findings stale against an empty diff.
-  if (before === after) return null;
-
-  return { path, before, after };
+  // Codex and code-mode clients carry the whole patch as program text with no
+  // file_path field at all, which is why this recorded nothing for them. The
+  // hash grade needs only the path, so the patch headers are enough.
+  return patchTargets(payload).map((target) => ({ path: target }));
 }
 
 /**
@@ -226,9 +280,14 @@ export function observedWrite(payload, raw) {
 export function queueInvalidation(dir, { path, before, after, at } = {}) {
   try {
     if (typeof path !== 'string' || !path.trim()) return false;
-    if (typeof before !== 'string' || typeof after !== 'string') return false;
-    if (before.length > MAX_SIDE_CHARS || after.length > MAX_SIDE_CHARS)
-      return false;
+    // BOTH SIDES OR NEITHER. A record carrying only one of them cannot produce
+    // a diff and must not pretend to, so it is written as a path-only record
+    // and the drain resolves it by comparing hashes.
+    const diffable =
+      typeof before === 'string' &&
+      typeof after === 'string' &&
+      before.length <= MAX_SIDE_CHARS &&
+      after.length <= MAX_SIDE_CHARS;
 
     const file = queuePath(dir);
     try {
@@ -240,7 +299,11 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
     mkdirSync(dir, { recursive: true });
     appendFileSync(
       file,
-      `${JSON.stringify({ path: canonicalPath(path), before, after, at: at ?? Date.now() })}\n`,
+      `${JSON.stringify({
+        path: canonicalPath(path),
+        ...(diffable ? { before, after } : {}),
+        at: at ?? Date.now(),
+      })}\n`,
       'utf8'
     );
     return true;
@@ -284,16 +347,16 @@ export function drainInvalidations(dir, graph) {
   let marked = 0;
   for (const record of records) {
     if (!record || typeof record.path !== 'string' || !record.path) continue;
-    if (typeof record.before !== 'string' || typeof record.after !== 'string')
-      continue;
+    const diffable =
+      typeof record.before === 'string' && typeof record.after === 'string';
     try {
-      const result = invalidateOnWrite(
-        dir,
-        graph,
-        record.path,
-        record.before,
-        record.after
-      );
+      // TWO GRADES, ONE QUEUE. A record carrying both sides gets a real diff and
+      // symbol-precise marking; one carrying only a path gets the hash
+      // comparison -- the same comparison the lazy path makes, and one that is
+      // only meaningful HERE, before `indexFile` refreshes the anchor.
+      const result = diffable
+        ? invalidateOnWrite(dir, graph, record.path, record.before, record.after)
+        : invalidateChangedAnchors(dir, graph, record.path);
       marked += Array.isArray(result) ? result.length : 0;
     } catch {
       // One bad record must not stop the rest, and must not stop the tool call.

--- a/integrations/gemini/hooks/lib/pending.mjs
+++ b/integrations/gemini/hooks/lib/pending.mjs
@@ -1,0 +1,311 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/pending.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * The eager-invalidation queue: the missing half of staleness.mjs's header.
+ *
+ * That header describes TWO invalidation paths and says eager exists because
+ * lazy "would silently serve stale findings as fresh whenever a change came
+ * from outside the agent". `invalidateOnWrite` had been written, tested and
+ * documented -- and its only reference in shipped code was a COMMENT in the
+ * PreToolUse router. Staleness was lazy-only in production, and the router's
+ * own comment ("a write the hook observes is invalidated eagerly by
+ * `invalidateOnWrite`") described something that never happened.
+ *
+ * WHY THAT MATTERS MORE THAN IT SOUNDS. The lazy check compares the anchor's
+ * stored hash against disk -- and both the router and the adapter call
+ * `indexFile` on every file they observe, which re-points that hash at the new
+ * bytes. So for a write the session performed ITSELF, the lazy check is
+ * self-defeating: by the next retrieval the anchor already agrees with disk and
+ * the finding derived from the old content is served clean. Lazy catches the
+ * changes we never saw; only eager catches the ones we did.
+ *
+ * WHY A QUEUE AND NOT A DIRECT CALL. `invalidateOnWrite` needs the graph, and
+ * the graph is a megabyte of JSONL. Loading it on the return path of every
+ * write is the cost this shape exists to avoid. So the post-tool hook, which
+ * already holds the write's evidence, appends one record here and exits; the
+ * next graph read -- `forTouch`/`forCommand`, which load the graph anyway --
+ * drains it BEFORE serving anything.
+ *
+ * The guarantee is unchanged. What must never happen is SERVING a stale finding
+ * as fresh, and serve time is where that is enforced.
+ */
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { invalidateOnWrite } from './staleness.mjs';
+import { canonicalPath, isFsSafePath, resolvableCandidates } from './paths.mjs';
+
+const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
+
+/**
+ * Largest before/after side kept in a queue record.
+ *
+ * Matched to the graph's own snapshot limit for the same reason it has one: past
+ * this size the text is a bundle, a lockfile or a generated asset, and copying
+ * it into a queue file would mirror the repository into the graph directory one
+ * write at a time. Past the cap the write is simply not queued -- the lazy path
+ * still governs it, which is exactly the status quo for that file.
+ */
+const MAX_SIDE_CHARS = 262_144;
+
+/**
+ * Largest queue file appended to.
+ *
+ * A queue only grows while nothing drains it, which means the retrieval feature
+ * is off or every read has failed. Neither is a reason to keep writing: bounded
+ * here so a long unattended session cannot turn one directory into a log of
+ * every file it touched.
+ */
+const MAX_QUEUE_BYTES = 8 * 1024 * 1024;
+
+/** The tool payload fields that name the file a mutation landed on. */
+function writtenPath(payload, raw) {
+  const input = payload?.tool_input || {};
+  const response = raw?.tool_response || raw?.toolResponse || {};
+  for (const candidate of [
+    input.file_path,
+    input.path,
+    input.notebook_path,
+    response.filePath,
+    response.file_path,
+  ]) {
+    if (typeof candidate === 'string' && candidate.trim()) return candidate;
+  }
+  return null;
+}
+
+/** First string among several possible spellings of the same field. */
+function firstString(...values) {
+  for (const value of values) if (typeof value === 'string') return value;
+  return null;
+}
+
+/**
+ * The text before the write, reconstructed from a completed edit.
+ *
+ * PREFERENCE ORDER IS ABOUT EXACTNESS, not convenience. Claude Code's Edit
+ * response carries the whole pre-edit file (`originalFile`), which needs no
+ * reasoning at all. Failing that, an edit is a known substitution, so reverting
+ * `new_string` back to `old_string` in the post-write text reproduces the
+ * before side exactly -- but only when the substitution is unambiguous, which
+ * is why a `new_string` that now appears more than once is refused rather than
+ * guessed at.
+ *
+ * NULL MEANS "DO NOT QUEUE", and that is deliberate. An unknown before side
+ * could be passed as '' -- and `invalidateOnWrite` would then see every symbol
+ * in the file as changed and mark every finding anchored anywhere in it, which
+ * is the exact over-marking its own comments call worse than the file-level
+ * staleness symbols were introduced to avoid. A missed eager invalidation costs
+ * what today already costs; a wrong one permanently discounts correct findings.
+ */
+function beforeText(payload, raw, after) {
+  const input = payload?.tool_input || {};
+  const response = raw?.tool_response || raw?.toolResponse || {};
+
+  const original = firstString(
+    response.originalFile,
+    response.original_file,
+    response.originalContent,
+    response.original_content
+  );
+  if (original !== null) return original;
+
+  // MultiEdit applies its edits in order, so reverting walks them backwards.
+  const edits = Array.isArray(input.edits) ? input.edits : null;
+  if (edits) {
+    let text = after;
+    for (const edit of [...edits].reverse()) {
+      const reverted = revert(text, edit);
+      if (reverted === null) return null;
+      text = reverted;
+    }
+    return text;
+  }
+
+  return revert(after, input);
+}
+
+/** Undoes one old->new substitution, or null when it cannot be done exactly. */
+function revert(text, edit) {
+  const oldString = firstString(edit?.old_string, edit?.oldString);
+  const newString = firstString(edit?.new_string, edit?.newString);
+  if (oldString === null || newString === null || newString === '') return null;
+
+  const all = edit?.replace_all === true || edit?.replaceAll === true;
+  if (all) return text.split(newString).join(oldString);
+
+  const at = text.indexOf(newString);
+  if (at < 0) return null;
+  // Ambiguous: more than one candidate for the occurrence that was written, and
+  // reverting the wrong one fabricates a before side that never existed.
+  if (text.indexOf(newString, at + newString.length) >= 0) return null;
+  return text.slice(0, at) + oldString + text.slice(at + newString.length);
+}
+
+/** The post-write text, read from disk because that is what the write produced. */
+function afterText(path) {
+  if (!isFsSafePath(path)) return null;
+  for (const candidate of resolvableCandidates(path)) {
+    try {
+      if (statSync(candidate).size > MAX_SIDE_CHARS) return null;
+      return readFileSync(candidate, 'utf8');
+    } catch {
+      // Wrong spelling, or gone again already. Try the next one.
+    }
+  }
+  return null;
+}
+
+/**
+ * Does this payload carry enough to reconstruct a before side at all?
+ *
+ * Named tool lists were the alternative and were rejected: every client calls
+ * its editor something different (`Edit`, `replace`, `write_to_file`,
+ * `apply_patch`), and a list would silently exclude the ones nobody thought of
+ * while still charging a file read for every Read that matched by accident.
+ * Asking about the EVIDENCE instead covers any client that carries an edit in
+ * one of these shapes and costs nothing on the calls that do not.
+ */
+function hasEditEvidence(payload, raw) {
+  const input = payload?.tool_input || {};
+  const response = raw?.tool_response || raw?.toolResponse || {};
+  if (
+    firstString(
+      response.originalFile,
+      response.original_file,
+      response.originalContent,
+      response.original_content
+    ) !== null
+  )
+    return true;
+  if (Array.isArray(input.edits) && input.edits.length > 0) return true;
+  return firstString(input.old_string, input.oldString) !== null;
+}
+
+/**
+ * The evidence a completed mutation left behind, or null when there is none.
+ *
+ * Separate from `queueInvalidation` so the caller can be a hook branch that
+ * knows nothing about diffs, and so the reconstruction above is testable
+ * without a filesystem queue.
+ */
+export function observedWrite(payload, raw) {
+  // CHEAP CHECK FIRST, because this runs after every tool call on every client.
+  // Reading the file is the expensive part, and there is no point paying for it
+  // on a Read, a Bash or a write whose before side cannot be reconstructed.
+  if (!hasEditEvidence(payload, raw)) return null;
+
+  const path = writtenPath(payload, raw);
+  if (!path) return null;
+
+  const after = afterText(path);
+  if (after === null || after.length > MAX_SIDE_CHARS) return null;
+
+  const before = beforeText(payload, raw, after);
+  if (before === null || before.length > MAX_SIDE_CHARS) return null;
+  // Nothing changed: a formatter no-op, or a write of identical bytes. Queuing
+  // it would mark findings stale against an empty diff.
+  if (before === after) return null;
+
+  return { path, before, after };
+}
+
+/**
+ * Appends one pending write.
+ *
+ * NEVER THROWS. This runs on a hook's return path, and a queue that cannot be
+ * written degrades to the lazy path rather than costing the user a tool call.
+ */
+export function queueInvalidation(dir, { path, before, after, at } = {}) {
+  try {
+    if (typeof path !== 'string' || !path.trim()) return false;
+    if (typeof before !== 'string' || typeof after !== 'string') return false;
+    if (before.length > MAX_SIDE_CHARS || after.length > MAX_SIDE_CHARS)
+      return false;
+
+    const file = queuePath(dir);
+    try {
+      if (statSync(file).size > MAX_QUEUE_BYTES) return false;
+    } catch {
+      // No queue yet, which is the normal case.
+    }
+
+    mkdirSync(dir, { recursive: true });
+    appendFileSync(
+      file,
+      `${JSON.stringify({ path: canonicalPath(path), before, after, at: at ?? Date.now() })}\n`,
+      'utf8'
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Applies every queued invalidation and clears the queue.
+ *
+ * Returns the number of findings marked, so the caller knows whether its
+ * in-memory graph is now behind the file on disk and needs re-reading.
+ *
+ * CLEARED AFTER APPLYING AND UNCONDITIONALLY: a record that cannot be applied
+ * must not be retried on every tool call for the rest of the session, and the
+ * cost of dropping one is a single missed eager mark that the lazy path still
+ * has a chance at.
+ */
+export function drainInvalidations(dir, graph) {
+  let records;
+  try {
+    const file = queuePath(dir);
+    if (!existsSync(file)) return 0;
+    records = readFileSync(file, 'utf8')
+      .split('\n')
+      .filter((line) => line.trim())
+      .map((line) => {
+        try {
+          return JSON.parse(line);
+        } catch {
+          // A torn append costs one record, not the queue.
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch {
+    return 0;
+  }
+
+  let marked = 0;
+  for (const record of records) {
+    if (!record || typeof record.path !== 'string' || !record.path) continue;
+    if (typeof record.before !== 'string' || typeof record.after !== 'string')
+      continue;
+    try {
+      const result = invalidateOnWrite(
+        dir,
+        graph,
+        record.path,
+        record.before,
+        record.after
+      );
+      marked += Array.isArray(result) ? result.length : 0;
+    } catch {
+      // One bad record must not stop the rest, and must not stop the tool call.
+    }
+  }
+
+  try {
+    rmSync(queuePath(dir), { force: true });
+  } catch {
+    // Held open by a concurrent hook. The next drain re-applies these records,
+    // which is safe: marking an already-marked finding is idempotent.
+  }
+
+  return marked;
+}

--- a/integrations/gemini/hooks/lib/pending.mjs
+++ b/integrations/gemini/hooks/lib/pending.mjs
@@ -199,10 +199,11 @@ function hasEditEvidence(payload, raw) {
  * before this module is reached at all. So matching here is both complete for
  * every client the adapter serves and impossible to spell wrong.
  *
- * `NotebookEdit` is absent because `normalizeTool` maps it to null, and the MCP
- * `smart_edit`/`smart_write` tools are absent for the same reason. Both are gaps
- * in that alias table rather than in this file, and widening it changes routing
- * verdicts for every client -- so they are reported, not papered over here.
+ * `NotebookEdit` and the MCP `smart_edit`/`smart_write` tools were absent for as
+ * long as `normalizeTool` mapped them to null. That was a gap in the alias table
+ * rather than in this file, and it has since been closed there: all three now
+ * arrive as `Edit` or `Write` and are matched by the set below without it having
+ * to learn a fourth name.
  */
 const MUTATING = new Set(['Edit', 'MultiEdit', 'Write']);
 

--- a/integrations/gemini/hooks/lib/pending.mjs
+++ b/integrations/gemini/hooks/lib/pending.mjs
@@ -35,6 +35,7 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  renameSync,
   rmSync,
   statSync,
 } from 'node:fs';
@@ -43,6 +44,15 @@ import { invalidateChangedAnchors, invalidateOnWrite } from './staleness.mjs';
 import { canonicalPath, isFsSafePath, resolvableCandidates } from './paths.mjs';
 
 const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
+/**
+ * Where a drain moves the queue before reading it.
+ *
+ * PER PROCESS, not one shared name: two hooks draining the same graph directory
+ * at once would otherwise race for the same claim file, and the loser would
+ * either clobber the winner's records or delete them mid-read. A pid makes the
+ * claim private to the drainer that won the rename.
+ */
+const claimPath = (dir) => join(dir, `pending-invalidation.claim.${process.pid}.jsonl`);
 
 /**
  * Largest before/after side kept in a queue record.
@@ -319,17 +329,47 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
  * Returns the number of findings marked, so the caller knows whether its
  * in-memory graph is now behind the file on disk and needs re-reading.
  *
- * CLEARED AFTER APPLYING AND UNCONDITIONALLY: a record that cannot be applied
- * must not be retried on every tool call for the rest of the session, and the
- * cost of dropping one is a single missed eager mark that the lazy path still
- * has a chance at.
+ * CLAIMED BY RENAME, THEN READ, THEN DELETED -- and the order is the whole
+ * point. This used to read the queue and then `rmSync` the same path, so a
+ * post-tool hook appending between the read and the unlink had its record
+ * deleted having never been read. Parallel tool calls in one assistant turn are
+ * the ordinary way that happens, not an exotic race. `renameSync` makes the
+ * claim atomic: whatever the drainer took is exactly what it deletes, and a
+ * record appended a microsecond later lands on a fresh queue that the next drain
+ * will find.
+ *
+ * A LOST RECORD IS A PERMANENTLY MISSED INVALIDATION, which is why this is worth
+ * a rename. The comment here used to price it as "a single missed eager mark that
+ * the lazy path still has a chance at", and that premise is false: this module's
+ * own header states it. The lazy path compares the anchor's stored hash against
+ * disk, and `indexFile` re-points that hash at the bytes the session just wrote,
+ * so for the session's OWN writes lazy is structurally blind rather than merely
+ * late. Nothing else was ever going to catch a dropped record.
+ *
+ * A RECORD THAT CANNOT BE APPLIED IS STILL DROPPED, deliberately and
+ * unconditionally: retrying a permanently unapplicable record on every tool call
+ * for the rest of the session costs more than it can ever recover, and the claim
+ * file is deleted whether the loop marked anything or threw.
+ *
+ * FAIL-OPEN THROUGHOUT. A rename that loses a race, or fails for any other
+ * reason, returns 0 and leaves the queue for the next drain; it never throws
+ * into a hook.
  */
 export function drainInvalidations(dir, graph) {
   let records;
+  let claim;
   try {
     const file = queuePath(dir);
     if (!existsSync(file)) return 0;
-    records = readFileSync(file, 'utf8')
+    claim = claimPath(dir);
+    // A LEFTOVER CLAIM FROM A KILLED DRAIN IS OVERWRITTEN, not merged: rename
+    // onto an existing path replaces it. The pid in the name means the only way
+    // to hit that is this same pid having died mid-drain, whose records were
+    // already being applied when it went -- and re-applying is idempotent, so
+    // losing them is the cheaper of the two errors. Not doing the rename at all
+    // would strand the live queue forever.
+    renameSync(file, claim);
+    records = readFileSync(claim, 'utf8')
       .split('\n')
       .filter((line) => line.trim())
       .map((line) => {
@@ -342,6 +382,18 @@ export function drainInvalidations(dir, graph) {
       })
       .filter(Boolean);
   } catch {
+    // The rename lost a race, or the claim could not be read. Nothing is deleted
+    // unread and the hook proceeds. If the claim was taken and then could not be
+    // read, it is put back under the queue name so the next drain still sees it:
+    // a claim file nobody looks at again is the same lost record this rename
+    // exists to prevent.
+    try {
+      if (claim && existsSync(claim) && !existsSync(queuePath(dir))) {
+        renameSync(claim, queuePath(dir));
+      }
+    } catch {
+      // Best effort only. A hook must not fail because bookkeeping did.
+    }
     return 0;
   }
 
@@ -365,10 +417,13 @@ export function drainInvalidations(dir, graph) {
   }
 
   try {
-    rmSync(queuePath(dir), { force: true });
+    // THE CLAIM, NOT THE QUEUE. Deleting `queuePath` here is what dropped a
+    // concurrently appended record; this path holds exactly the bytes that were
+    // just read, so nothing unread can be inside it.
+    rmSync(claim, { force: true });
   } catch {
-    // Held open by a concurrent hook. The next drain re-applies these records,
-    // which is safe: marking an already-marked finding is idempotent.
+    // Held open by something else. The claim is not read again -- the next drain
+    // looks at the queue -- so this costs a stray file, never a record.
   }
 
   return marked;

--- a/integrations/gemini/hooks/lib/restore.mjs
+++ b/integrations/gemini/hooks/lib/restore.mjs
@@ -142,7 +142,7 @@ export function restorationPlan(dir, graph, context = {}) {
     for (const id of predicted) {
       const node = graph.nodes.get(id);
       if (!node) continue;
-      const findings = serve(graph, findingsFor(graph, id, { limit: 2 }));
+      const findings = serve(graph, findingsFor(graph, id, { limit: 2 }), { dir });
       for (const finding of findings) {
         // `! STALE` only where a diff actually exists to back it; see the
         // renderer in inject.mjs for the measurement behind this.

--- a/integrations/gemini/hooks/lib/restore.mjs
+++ b/integrations/gemini/hooks/lib/restore.mjs
@@ -158,7 +158,16 @@ export function restorationPlan(dir, graph, context = {}) {
             ? '! STALE '
             : '~ '
           : '';
-        lines.push(`${node.key}: ${mark}${finding.claim}`);
+        // A DISPUTE DISCLOSED ELSEWHERE AND SILENT HERE reads as "the dispute
+        // went away". `serve` already attached the fields; the only question is
+        // the wording, and this list is the most compressed surface in the
+        // system, so it gets the marker and the key and nothing else.
+        const disputed = finding.contradicted
+          ? finding.contradictedBy
+            ? ` (disputed by ${finding.contradictedBy})`
+            : ' (disputed)'
+          : '';
+        lines.push(`${node.key}: ${mark}${finding.claim}${disputed}`);
       }
     }
     section('Likely next', lines, total * split.forward);

--- a/integrations/gemini/hooks/lib/skeleton.mjs
+++ b/integrations/gemini/hooks/lib/skeleton.mjs
@@ -126,6 +126,11 @@ export function annotatedSkeleton(graph, rawPath, source, { budget = 1200, git =
 
   // Findings anchored to this file or the symbols inside it, served through the
   // one function that enforces the stale-plus-diff rule.
+  // READ-ONLY serve: no `dir` is threaded here, so this cannot clear a stale
+  // flag whose evidence is gone. That is deliberate -- this function takes a
+  // graph, not the directory it came from, and widening its signature to give
+  // an analysis path a write capability buys nothing: the injection path runs
+  // on every tool call and clears the same findings.
   const served = serve(graph, findingsFor(graph, nodeId('file', path), { limit: 40 }));
 
   // Index findings by the symbol they anchor to, so each one sits beside the

--- a/integrations/gemini/hooks/lib/staleness.mjs
+++ b/integrations/gemini/hooks/lib/staleness.mjs
@@ -31,6 +31,23 @@
  * Eager alone would silently serve stale findings as fresh whenever a change
  * came from outside the agent, which is the single failure mode the design
  * calls worse than no graph.
+ *
+ * AND LAZY ALONE IS BLIND TO THE AGENT'S OWN WRITES -- not degraded, BLIND.
+ * `indexFile` re-points an anchor's stored hash at the bytes it was just handed,
+ * and it is called on every file either hook observes: pretooluse-router.mjs
+ * (two call sites) and adapter.mjs (one). The lazy check then compares that
+ * refreshed hash against the same disk it came from and finds them equal. So
+ * for a file the session edited ITSELF, the lazy path cannot detect the change
+ * at all, and the finding derived from the pre-edit content is served CLEAN.
+ *
+ * Which means that until the eager path was connected, staleness for a file the
+ * agent edited did not work AT ALL: eager was dead code and lazy was defeated
+ * by re-indexing. Every account of this defect, including the one in this
+ * module's own git history, called it "lazy-only, therefore degraded". It was
+ * not degraded. `stale-before-reindex.test.mjs` states in its header that this
+ * case is covered by `invalidateOnWrite`, and `invalidateOnWrite` had never run
+ * once in production. The two paths are not redundant and never were: each is
+ * the ONLY cover for a whole class of change.
  */
 
 import { readFileSync, statSync } from 'node:fs';
@@ -622,6 +639,119 @@ export function invalidateOnWrite(dir, graph, rawPath, beforeText, afterText) {
   // Re-index so the anchors carry the new hashes; otherwise the lazy path would
   // report the same change again on every future retrieval.
   indexFile(dir, path, afterText);
+  return marked;
+}
+
+/**
+ * The eager path for a write with NO before/after pair: compare stored hashes
+ * against disk, and mark what actually moved.
+ *
+ * WHY THIS EXISTS AS A SECOND SHAPE. A whole-file `Write` replaces the file, so
+ * the payload carries the after side and nothing at all of the before -- and a
+ * whole-file write is the commonest write shape there is. `invalidateOnWrite`
+ * cannot serve it: passing '' as the before side makes every symbol in the file
+ * look changed, marks every finding anchored anywhere in it, and the eager mark
+ * is a stored flag no later check ever clears. False-stale is expensive and
+ * permanent, so it is not an acceptable price for coverage.
+ *
+ * But the hash comparison is available, and it is exactly the comparison the
+ * lazy path makes. The difference is WHEN: this runs at the top of injection,
+ * before `indexFile` refreshes the anchor, so the stored hash is still the
+ * pre-write one and the comparison is meaningful. That is the whole trick --
+ * lazy is not wrong, it is merely too late.
+ *
+ * SYMBOL-LEVEL, and from ONE read. Re-locating each symbol by name and
+ * comparing its own span hash is what keeps this from degenerating into
+ * file-level marking: editing one function must not stale a finding about
+ * another, which is the property symbol nodes exist to provide.
+ *
+ * WEAKER EVIDENCE, STATED AS SUCH. There is no before text, so no diff can be
+ * built -- the finding is marked with the two hashes and `serve` reports the
+ * evidence gap through `staleEvidence: false`, which the renderer turns into
+ * "no diff could be rebuilt" rather than promising a diff and showing nothing.
+ * A stale finding with weak evidence is far better than one served as fresh,
+ * but the reader has to be able to tell which one they are holding.
+ */
+export function invalidateChangedAnchors(dir, graph, rawPath) {
+  const path = canonicalPath(rawPath);
+  const marked = [];
+
+  // ONE read for the file and every symbol in it. checkAnchor would have been
+  // the obvious reuse and it reads per anchor, which on a file with fifty
+  // symbols is fifty-one reads of the same bytes on a hook path.
+  let source = null;
+  try {
+    source = readAnySpelling(path);
+  } catch {
+    // Deleted, or unreadable from this checkout. Handled below as a change,
+    // because a finding about a file that is no longer there is exactly the
+    // kind that must not be served as fresh.
+  }
+
+  const changed = [];
+  const fileNode = graph.nodes.get(nodeId('file', path));
+  const fileDigest = source === null ? null : hash(source);
+  if (fileNode && fileDigest !== fileNode.hash) {
+    changed.push({ node: fileNode, from: fileNode.hash, to: fileDigest });
+  }
+
+  const current = new Map(
+    source === null
+      ? []
+      : extractSymbols(path, source).map((s) => [s.name, hash(spanText(source, s))])
+  );
+  for (const node of graph.nodes.values()) {
+    if (node.kind !== 'symbol' || node.file !== path) continue;
+    const digest = current.has(node.name) ? current.get(node.name) : null;
+    if (digest !== node.hash) changed.push({ node, from: node.hash, to: digest });
+  }
+
+  if (changed.length) {
+    // Indexed once by target, for the reason invalidateOnWrite indexes: the
+    // nested alternative is O(nodes x edges) inside a hook.
+    const byTarget = new Map();
+    for (const edge of graph.edges) {
+      if (edge.edge !== 'derived_from') continue;
+      if (!byTarget.has(edge.to)) byTarget.set(edge.to, []);
+      byTarget.get(edge.to).push(edge);
+    }
+
+    for (const { node, from, to } of changed) {
+      for (const edge of byTarget.get(node.id) || []) {
+        const finding = graph.nodes.get(edge.from);
+        if (!finding || finding.kind !== 'finding') continue;
+        // The same type gate serve() applies, for the same reason it is applied
+        // in invalidateOnWrite: the flag is STORED, and disclose.mjs skips a
+        // stale finding while utility.mjs penalises one by 160.
+        if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) continue;
+        // ALREADY MARKED IS LEFT ALONE. Whatever marked it first had a diff or
+        // a more specific reason; overwriting that with a hash pair trades real
+        // evidence for less.
+        if (finding.stale) continue;
+
+        putNode(dir, {
+          ...finding,
+          kind: 'finding',
+          key: finding.key,
+          stale: true,
+          staleReason:
+            to === null
+              ? `the ${node.kind} it depends on is no longer present (was ${from})`
+              : `content hash changed during this session (${from} -> ${to}), observed without a before/after pair`,
+          // EXPLICITLY EMPTY, not absent. serve() reports `staleEvidence` from
+          // whether a diff survived, and the renderer says "no diff could be
+          // rebuilt" -- so the reader can tell "changed, diff unknown" from
+          // "changed, here is what changed".
+          diff: '',
+        });
+        marked.push(finding.key);
+      }
+    }
+  }
+
+  // Re-index for the same reason the diff path does: otherwise every future
+  // retrieval re-reports a change that has already been accounted for.
+  if (source !== null) indexFile(dir, path, source);
   return marked;
 }
 

--- a/integrations/gemini/hooks/lib/staleness.mjs
+++ b/integrations/gemini/hooks/lib/staleness.mjs
@@ -574,8 +574,20 @@ function derivationCheck(graph, finding) {
  * This is the only function that should ever hand a finding to a model, because
  * it is the one that enforces the rule: a stale finding leaves here carrying
  * `stale: true` AND a diff, or it does not leave at all.
+ *
+ * AND IT CLEARS A STORED FLAG WHOSE EVIDENCE IS GONE, when given a `dir` to
+ * write to. Clearing used to be reachable only by a person pressing Re-verify in
+ * the dashboard, which left the rot path fully open on every install where
+ * nobody opens the dashboard -- and that is most of them. The evidence test is
+ * what makes clearing safe, and it does not care who triggered it: the same
+ * `claimTimeVerdict` runs here as in `reverify`, so this cannot clear anything
+ * the button would not.
+ *
+ * `dir` IS OPTIONAL, AND OMITTING IT MAKES THIS READ-ONLY. Several callers hold
+ * a graph without the directory it came from, and a serve that silently did
+ * nothing would be worse than one that plainly cannot write.
  */
-export function serve(graph, findings) {
+export function serve(graph, findings, { dir = null } = {}) {
   const served = [];
 
   // RETIRED FINDINGS STOP HERE, unconditionally.
@@ -603,8 +615,42 @@ export function serve(graph, findings) {
       continue;
     }
 
+    // AUTOMATIC CLEARING, on the same evidence the manual path demands.
+    //
+    // ONLY THE STORED FLAG IS TOUCHED. The lazy loop below is left to run
+    // exactly as before and can independently mark this finding stale again on
+    // its own comparison -- disk against the anchor NODE's hash -- which answers
+    // a different question and is not this function's to overrule. Eager and
+    // lazy stay two mechanisms, as the module header insists.
+    //
+    // AND THE FIELDS GO WITH THE FLAG. `putNode` does not merge and neither does
+    // this spread: serving `{ ...finding, stale: false }` would hand back a
+    // finding that reads fresh while still carrying `staleReason` and `diff`
+    // from the record -- stale and fresh at once, which is worse than either.
+    // So the cleared record, not the stored one, is what the rest of this
+    // iteration reads and spreads.
+    //
+    // BOUNDED, and the bound is the point: this runs only for a finding whose
+    // flag is already STORED, only when a `derivation` record exists to check
+    // against, and it reads each of that finding's anchors at most once. A
+    // finding that is not flagged pays nothing. The lazy loop below already
+    // reads every anchor of every content-dependent finding served, so the worst
+    // case is twice the anchor reads on the already-stale subset alone.
+    //
+    // NOT ON THE NON-CONTENT-DEPENDENT EARLY RETURN ABOVE, deliberately. Both
+    // eager paths refuse to flag those types at all, so a flag there can only
+    // come from an older graph -- and reading anchors for a type whose truth
+    // does not depend on them is exactly the cost `CONTENT_DEPENDENT` exists to
+    // avoid.
+    let record = finding;
+    if (dir && finding.stale && claimTimeVerdict(graph, finding) === 'match') {
+      clearStale(dir, finding.key, { graph });
+      const { stale: _s, staleReason: _r, diff: _d, staleEvidence: _e, ...cleared } = finding;
+      record = cleared;
+    }
+
     const anchors = graph.edges
-      .filter((e) => e.edge === 'derived_from' && e.from === finding.id)
+      .filter((e) => e.edge === 'derived_from' && e.from === record.id)
       .map((e) => graph.nodes.get(e.to))
       .filter(Boolean);
 
@@ -629,10 +675,10 @@ export function serve(graph, findings) {
     // A finding already marked stale eagerly, whose diff was captured at write
     // time, keeps that diff -- the eager path saw the change we can no longer
     // reconstruct from disk alone.
-    if (!stale && finding.stale) {
+    if (!stale && record.stale) {
       stale = true;
-      diff = finding.diff || '';
-      reason = finding.staleReason || 'marked stale when the change was observed';
+      diff = record.diff || '';
+      reason = record.staleReason || 'marked stale when the change was observed';
     }
 
     if (stale && !diff) {
@@ -681,13 +727,19 @@ export function serve(graph, findings) {
     }
 
     served.push({
-      ...finding,
+      ...record,
       stale,
       ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
+      // BOTH OTHER DISCLOSURES SURVIVE A MID-SERVE CLEAR. `dispute` was computed
+      // above the content-dependence branch and is applied here untouched, and
+      // the derivation verdict is recomputed from the record -- which still
+      // carries its `derivation`, since clearing removes only the staleness
+      // fields. A finding whose flag was just cleared is still disclosed as
+      // disputed, and still reports whether its derivation holds.
       ...dispute,
       // Independent of `stale` above: see `derivationCheck`'s own comment for
       // the case it catches that node-level staleness can miss.
-      ...derivationCheck(graph, finding),
+      ...derivationCheck(graph, record),
     });
   }
   return served;
@@ -939,8 +991,21 @@ function anchorHashNow(anchor) {
  * Exposing it to a hook, a tool argument or an HTTP action would be a way to
  * turn a stale finding fresh on request, which is exactly what must not exist.
  */
-export function clearStale(dir, key) {
-  const node = load(dir).nodes.get(nodeId('finding', key));
+export function clearStale(dir, key, { graph = null } = {}) {
+  // A CALLER THAT ALREADY HOLDS THE GRAPH PASSES IT, and this is not
+  // micro-optimisation: `load` re-parses the entire append-only log, so clearing
+  // inside `serve`'s loop re-read and re-folded the whole graph once PER cleared
+  // finding. Measured on 40 findings all stale and all revertible -- the shape a
+  // mass revert produces -- that was 185 ms against 25 ms, a 7x regression on
+  // the injection path, all of it graph loading rather than the hashing this
+  // feature is actually for. With the graph passed through it is back in line.
+  //
+  // No new race: this store is last-write-wins with no compare-and-set anywhere,
+  // and every other caller that spreads a node back -- `pin`, `retire`,
+  // `contradict`, `correct` -- writes from a graph it loaded earlier too. Both
+  // callers here already DECIDED on this snapshot, so re-reading it purely for
+  // the write narrowed no window that was ever closed.
+  const node = (graph || load(dir)).nodes.get(nodeId('finding', key));
   if (!node || node.kind !== 'finding') return false;
   const { stale, staleReason, diff, staleEvidence, ...rest } = node;
   // Nothing to clear is a success, not a write: an unconditional putNode here
@@ -989,14 +1054,33 @@ export function clearStale(dir, key) {
  * silently un-mark findings nobody asked about. Staleness is disclosed to a
  * reader who then decides; clearing is an explicit act.
  */
-export function reverify(dir, key) {
-  const graph = load(dir);
-  const finding = graph.nodes.get(nodeId('finding', key));
-  if (!finding || finding.kind !== 'finding') return 'unknown';
-  // Idempotent: the postcondition -- no stale flag on this finding -- already
-  // holds, and reporting anything else would make a caller retry forever.
-  if (!finding.stale) return 'cleared';
-
+/**
+ * THE ONE EVIDENCE TEST. Does this finding's anchored content still hash to what
+ * the claim was actually made against?
+ *
+ * `'match'` -- every anchor on disk re-hashes to the value frozen into this
+ * finding's own `derivation.anchors` at claim time. The content IS what the
+ * claim was derived from: a revert, or a write that never moved the anchored
+ * bytes.
+ * `'differs'` -- at least one anchor does not, INCLUDING an anchor whose content
+ * is gone. Deleted is a difference, not a missing measurement.
+ * `'unknown'` -- there is nothing to compare: no `derivation.anchors`, no
+ * anchors, an anchor with no recorded hash, or one that no longer resolves.
+ *
+ * SHARED BY BOTH CLEARING PATHS ON PURPOSE, and that sharing is the guarantee
+ * rather than a convenience. `reverify` (a person pressing Re-verify) and
+ * `serve` (automatic, on every retrieval) call THIS function and nothing else,
+ * so the automatic path cannot clear anything the button would not, and neither
+ * can drift from the other. Two copies of this comparison would be two policies,
+ * and the weaker one would win wherever it ran more often -- which is the
+ * automatic one.
+ *
+ * NOT `checkAnchor`, for the reason `anchorHashNow` above spells out: that
+ * compares disk against the anchor NODE's stored hash, which both eager paths
+ * re-point at the very bytes that caused the mark, so it answers "fresh" for
+ * exactly the finding it just marked stale.
+ */
+function claimTimeVerdict(graph, finding) {
   const recorded = finding.derivation && finding.derivation.anchors;
   if (!recorded || typeof recorded !== 'object') return 'unknown';
 
@@ -1019,10 +1103,23 @@ export function reverify(dir, key) {
     if (node.kind !== 'file' && node.kind !== 'symbol') return 'unknown';
     // null means the content is gone -- deleted file, vanished symbol. That is a
     // difference, not an absence of evidence.
-    if (anchorHashNow(node) !== expected) return 'still-stale';
+    if (anchorHashNow(node) !== expected) return 'differs';
   }
+  return 'match';
+}
 
-  clearStale(dir, key);
+export function reverify(dir, key) {
+  const graph = load(dir);
+  const finding = graph.nodes.get(nodeId('finding', key));
+  if (!finding || finding.kind !== 'finding') return 'unknown';
+  // Idempotent: the postcondition -- no stale flag on this finding -- already
+  // holds, and reporting anything else would make a caller retry forever.
+  if (!finding.stale) return 'cleared';
+
+  const verdict = claimTimeVerdict(graph, finding);
+  if (verdict === 'unknown') return 'unknown';
+  if (verdict === 'differs') return 'still-stale';
+  clearStale(dir, key, { graph });
   return 'cleared';
 }
 

--- a/integrations/gemini/hooks/lib/staleness.mjs
+++ b/integrations/gemini/hooks/lib/staleness.mjs
@@ -53,7 +53,7 @@
 import { readFileSync, statSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { dirname, join } from 'node:path';
-import { putNode, putEdge, contentHash, nodeId } from './wiki.mjs';
+import { putNode, putEdge, contentHash, nodeId, load } from './wiki.mjs';
 import { hasOutstandingContradiction } from './curate.mjs';
 import { extractSymbols, spanText, symbolKey, extractImports } from './symbols.mjs';
 import { canonicalPath, resolvableCandidates, isFsSafePath } from './paths.mjs';
@@ -488,7 +488,16 @@ function disputeOf(graph, finding) {
     // An edge end that resolves to nothing names nothing. The dispute is still
     // disclosed -- the gate above already established it -- but without a key
     // the reader cannot be pointed anywhere, and inventing one would be worse.
-    if (other && typeof other.key === 'string' && !keys.includes(other.key)) keys.push(other.key);
+    //
+    // A RETIRED END IS NOT NAMED EITHER, for a sharper reason: the disclosure
+    // tells the reader to `wiki_query` that key, and `serve` refuses to return
+    // a retired finding at all. Naming it points them at a claim they cannot
+    // fetch. `hasOutstandingContradiction` above already declines to open the
+    // gate when EVERY disputant is retired; this is the same rule applied to
+    // each name, so a live disputant is still reported alongside a withdrawn one.
+    if (other && !other.retired && typeof other.key === 'string' && !keys.includes(other.key)) {
+      keys.push(other.key);
+    }
   }
 
   return { contradicted: true, ...(keys.length ? { contradictedBy: keys.join(', ') } : {}) };
@@ -870,6 +879,151 @@ export function invalidateChangedAnchors(dir, graph, rawPath) {
   // retrieval re-reports a change that has already been accounted for.
   if (source !== null) indexFile(dir, path, source);
   return marked;
+}
+
+/**
+ * The current content hash of an anchor, read from disk.
+ *
+ * DELIBERATELY NOT `checkAnchor`, and the difference is the whole of this
+ * clearing rule. `checkAnchor` compares disk against the anchor NODE's stored
+ * hash, and both eager paths call `indexFile` immediately after marking --
+ * which re-points that hash at the very bytes that caused the mark. So
+ * `checkAnchor` answers "fresh" for exactly the finding it just marked stale,
+ * and a clearing rule built on it would clear every flag it was handed,
+ * unconditionally. This returns a bare hash instead, so the caller can compare
+ * it against the FROZEN claim-time hash rather than against a value the marking
+ * path itself moved.
+ *
+ * Returns null when no content can be read at all -- a deleted file, or a
+ * symbol that no longer exists. A caller must treat that as "changed", never as
+ * "unknown": a claim about content that is gone certainly does not match the
+ * content it was made against.
+ */
+function anchorHashNow(anchor) {
+  const path = anchor.kind === 'symbol' ? anchor.file : anchor.key;
+  let source;
+  try {
+    source = readAnySpelling(path);
+  } catch {
+    return null;
+  }
+  if (anchor.kind !== 'symbol') return hash(source);
+
+  // By NAME, like checkAnchor: line numbers shift whenever anything above is
+  // edited, and re-locating by line would report a symbol as moved when only an
+  // unrelated insert happened above it.
+  const current = extractSymbols(path, source).find((s) => s.name === anchor.name);
+  if (!current) return null;
+  return hash(spanText(source, current));
+}
+
+/**
+ * Removes the staleness fields from a finding. Returns whether one was found.
+ *
+ * THE WHOLE NODE IS REWRITTEN, because `putNode` does not merge: it writes a
+ * full record from what it is handed and `load` replaces the node wholesale.
+ * Writing `{ kind, key, stale: false }` would blank the claim, the confidence
+ * and the provenance -- an overwrite by another name, and the same trap
+ * `contradict` documents. So the fields are destructured AWAY and everything
+ * else is spread back: no deletion primitive is needed, and the append-only rule
+ * is respected.
+ *
+ * `staleEvidence` is stripped as well, even though no writer stores it. It is
+ * added by `serve` to the object it hands out, so anything that ever writes a
+ * served finding back would carry it in -- at which point a cleared finding
+ * would still be advertising the quality of the evidence for a flag it no longer
+ * has.
+ *
+ * A PRIMITIVE, NOT A ROUTE. Nothing outside this module calls it: the only
+ * shipping caller is `reverify` below, which establishes the evidence first.
+ * Exposing it to a hook, a tool argument or an HTTP action would be a way to
+ * turn a stale finding fresh on request, which is exactly what must not exist.
+ */
+export function clearStale(dir, key) {
+  const node = load(dir).nodes.get(nodeId('finding', key));
+  if (!node || node.kind !== 'finding') return false;
+  const { stale, staleReason, diff, staleEvidence, ...rest } = node;
+  // Nothing to clear is a success, not a write: an unconditional putNode here
+  // would append a duplicate record to the log on every no-op call.
+  if (stale === undefined && staleReason === undefined
+    && diff === undefined && staleEvidence === undefined) return true;
+  putNode(dir, { ...rest, kind: 'finding', key: node.key });
+  return true;
+}
+
+/**
+ * Clears a stale flag when, and only when, the evidence for it is gone.
+ *
+ * WHY THIS HAS TO EXIST. Nothing in this codebase ever cleared a `stale` flag.
+ * That was harmless while eager invalidation was dead code; it fires now, so
+ * every finding on an edited file becomes permanently stale -- and permanently
+ * discounted, since `disclose.mjs` skips a stale finding outright and
+ * `utility.mjs` penalises one by 160. The graph degrades toward all-stale, and
+ * the eager path is over-eager on top of that: `invalidateOnWrite` marks every
+ * finding anchored to a FILE node on any observed write to that file, whether or
+ * not the bytes moved.
+ *
+ * WHAT COUNTS AS EVIDENCE, AND WHY IT IS NOT NEGOTIABLE. The only trustworthy
+ * record of what a claim was made against is `derivation.anchors` -- the hash
+ * each anchor carried at the moment the finding was written, frozen into the
+ * finding itself by `harvest-write.mjs`. Disk is re-hashed here and compared
+ * against that. If every anchor matches, the content IS what the claim was
+ * derived from: a revert, or a write that never moved the anchored bytes. The
+ * flag comes off. Anything else leaves it exactly as it was.
+ *
+ * IT IS NOT A LAUNDERING ROUTE, and that is a property of the comparison rather
+ * than of who is allowed to call it. A caller cannot make a finding fresh by
+ * asking; they can only make it fresh by putting the content back. There is no
+ * argument, no force flag and no second path -- and `clearStale` above, the one
+ * function that clears without checking, has no caller but this one.
+ *
+ * NO RECORD MEANS UNKNOWN, NEVER CLEAR. A finding with no `derivation.anchors`
+ * -- every one written before that record existed, and every hand-curated one --
+ * has nothing to compare disk against. That is an absence of evidence, and
+ * resolving it to "clear it" would hand back the laundering route through the
+ * side door. It reports `unknown` and changes nothing; re-recording the claim
+ * against the current code (`curate.correct`) is the way forward for those.
+ *
+ * DELIBERATELY NOT AUTOMATIC. This reads every anchor off disk, so running it on
+ * the serve path would put N file reads inside injection -- and, worse, it would
+ * silently un-mark findings nobody asked about. Staleness is disclosed to a
+ * reader who then decides; clearing is an explicit act.
+ */
+export function reverify(dir, key) {
+  const graph = load(dir);
+  const finding = graph.nodes.get(nodeId('finding', key));
+  if (!finding || finding.kind !== 'finding') return 'unknown';
+  // Idempotent: the postcondition -- no stale flag on this finding -- already
+  // holds, and reporting anything else would make a caller retry forever.
+  if (!finding.stale) return 'cleared';
+
+  const recorded = finding.derivation && finding.derivation.anchors;
+  if (!recorded || typeof recorded !== 'object') return 'unknown';
+
+  const anchorIds = new Set(
+    graph.edges
+      .filter((e) => e.edge === 'derived_from' && e.from === finding.id)
+      .map((e) => e.to)
+  );
+  // An unanchored finding cannot be checked against anything, which is the
+  // un-invalidatable shape the anchor discipline exists to refuse. It is equally
+  // un-VERIFIABLE, so it is reported as such rather than cleared.
+  if (!anchorIds.size) return 'unknown';
+
+  for (const id of anchorIds) {
+    const expected = recorded[id];
+    const node = graph.nodes.get(id);
+    // An anchor this finding never recorded a hash for, or one that no longer
+    // resolves to a node: nothing to compare, so nothing is concluded.
+    if (typeof expected !== 'string' || !expected || !node) return 'unknown';
+    if (node.kind !== 'file' && node.kind !== 'symbol') return 'unknown';
+    // null means the content is gone -- deleted file, vanished symbol. That is a
+    // difference, not an absence of evidence.
+    if (anchorHashNow(node) !== expected) return 'still-stale';
+  }
+
+  clearStale(dir, key);
+  return 'cleared';
 }
 
 export { contentHash };

--- a/integrations/gemini/hooks/lib/staleness.mjs
+++ b/integrations/gemini/hooks/lib/staleness.mjs
@@ -368,6 +368,12 @@ const DIFF_MAX_BYTES = () => {
  * line, and total bytes. Every truncation is announced in the output, because a
  * silently shortened diff is worse than a visibly shortened one -- a reader who
  * cannot tell content was elided believes they saw the whole change.
+ *
+ * `maxLines` BOUNDS THE BODY, MARKERS INCLUDED: at most `maxLines` lines of
+ * removed lines, added lines and "... N more" elision markers between them, plus
+ * at most one final notice when the byte cap dropped lines -- so `maxLines + 1`
+ * lines in total, and no more. That last line is outside the budget on purpose,
+ * for the reason stated where it is pushed.
  */
 export function diffLines(
   before,
@@ -418,10 +424,24 @@ export function diffLines(
     bytes += size;
   };
 
-  for (const line of removed.slice(0, maxLines / 2)) push('- ' + line);
-  if (removed.length > maxLines / 2) push(`  ... ${removed.length - maxLines / 2} more removed`);
-  for (const line of added.slice(0, maxLines / 2)) push('+ ' + line);
-  if (added.length > maxLines / 2) push(`  ... ${added.length - maxLines / 2} more added`);
+  // THE ELISION MARKER IS PAID FOR OUT OF THE SIDE'S OWN QUOTA, so `maxLines`
+  // bounds the whole body rather than only the content in it. It did not: at the
+  // default 40 the body could reach 42 lines -- 20 removed, 20 added and two
+  // "... N more" markers -- and the out-of-budget notice below made 43, against
+  // a documented bound of 40 and a test asserting 41. Three numbers, no two the
+  // same. A side that has to elide now shows one fewer content line and spends
+  // that line on saying so, which is the trade a reader wants anyway: knowing
+  // that 300 lines were cut matters more than the 20th of the 20 shown.
+  const half = Math.floor(maxLines / 2);
+  const emit = (lines, prefix, label) => {
+    const elides = lines.length > half;
+    const shown = elides ? Math.max(0, half - 1) : half;
+    for (const line of lines.slice(0, shown)) push(prefix + line);
+    if (elides) push(`  ... ${lines.length - shown} more ${label}`);
+  };
+
+  emit(removed, '- ', 'removed');
+  emit(added, '+ ', 'added');
 
   // Announced OUTSIDE the budget, deliberately: the one line a reader most
   // needs is the one saying the rest is missing, and dropping it to stay under
@@ -479,6 +499,15 @@ function disputeOf(graph, finding) {
   if (!hasOutstandingContradiction(graph, finding.key)) return {};
 
   const keys = [];
+  // AND THE REASON A PERSON TYPED, which had no reader anywhere. `contradict`
+  // stores `contradictionReason` -- up to 400 characters of human explanation --
+  // on the CONTRADICTED end only, and nothing outside its own test ever read it:
+  // this disclosure named the other key and stopped, `audit` counts ends, and the
+  // dashboard detail view renders neither. So the one field on the edge that says
+  // WHY was written on every contradiction and seen by nobody. It is collected
+  // from whichever end holds it, so both sides of a dispute disclose the same
+  // reason rather than only the claim that lost.
+  let reason = typeof finding.contradictionReason === 'string' ? finding.contradictionReason : '';
   for (const edge of graph.edges) {
     if (edge.edge !== 'contradicts') continue;
     const otherId =
@@ -497,10 +526,30 @@ function disputeOf(graph, finding) {
     // each name, so a live disputant is still reported alongside a withdrawn one.
     if (other && !other.retired && typeof other.key === 'string' && !keys.includes(other.key)) {
       keys.push(other.key);
+      // A RETIRED END'S REASON IS NOT BORROWED EITHER, which is why this sits
+      // inside the same guard as the key: `hasOutstandingContradiction` can be
+      // open on one live disputant while another is withdrawn, and quoting the
+      // withdrawn one's explanation would attribute the live dispute to a claim
+      // the reader cannot fetch.
+      if (!reason && typeof other.contradictionReason === 'string') {
+        reason = other.contradictionReason;
+      }
     }
   }
 
-  return { contradicted: true, ...(keys.length ? { contradictedBy: keys.join(', ') } : {}) };
+  return {
+    contradicted: true,
+    ...(keys.length ? { contradictedBy: keys.join(', ') } : {}),
+    // Trimmed here rather than at the renderer: an empty string is not a reason,
+    // and a consumer checking `if (reason)` should not have to trim first.
+    //
+    // SET UNCONDITIONALLY, INCLUDING TO `undefined`. `serve` spreads the stored
+    // record before this object, so omitting the key would let a whitespace-only
+    // stored reason through untouched and make the served value differ from the
+    // one this function decided on. The disclosure is authoritative or it is not
+    // a disclosure.
+    contradictionReason: reason.trim() || undefined,
+  };
 }
 
 /**
@@ -580,8 +629,15 @@ function derivationCheck(graph, finding) {
  * the dashboard, which left the rot path fully open on every install where
  * nobody opens the dashboard -- and that is most of them. The evidence test is
  * what makes clearing safe, and it does not care who triggered it: the same
- * `claimTimeVerdict` runs here as in `reverify`, so this cannot clear anything
+ * `claimTimeEvidence` runs here as in `reverify`, so this cannot clear anything
  * the button would not.
+ *
+ * A CLEAR ALSO RE-INDEXES THE ANCHORS IT VERIFIED. The three disclosures this
+ * function emits -- `stale`, `derivationHolds`, and the dispute -- are computed
+ * from three different comparisons, and clearing the flag without moving the
+ * anchor's stored hash made the first two contradict the clear on the revert
+ * path. `reindexVerifiedAnchors` explains the reproduction and why re-pointing
+ * the index is the fix rather than suppressing the disclosures.
  *
  * `dir` IS OPTIONAL, AND OMITTING IT MAKES THIS READ-ONLY. Several callers hold
  * a graph without the directory it came from, and a serve that silently did
@@ -617,11 +673,17 @@ export function serve(graph, findings, { dir = null } = {}) {
 
     // AUTOMATIC CLEARING, on the same evidence the manual path demands.
     //
-    // ONLY THE STORED FLAG IS TOUCHED. The lazy loop below is left to run
-    // exactly as before and can independently mark this finding stale again on
-    // its own comparison -- disk against the anchor NODE's hash -- which answers
-    // a different question and is not this function's to overrule. Eager and
-    // lazy stay two mechanisms, as the module header insists.
+    // THE FLAG AND THE INDEX MOVE TOGETHER. Clearing the flag alone made this
+    // function contradict itself on the revert path: the lazy loop below
+    // compares disk against the anchor NODE's hash, which the eager path
+    // re-pointed at the post-edit bytes, so a reverted file read as `stale:
+    // true, staleReason: 'file changed'` and `derivationHolds: false` inside the
+    // very object whose flag had just been cleared for matching its claim-time
+    // content. `reindexVerifiedAnchors` writes the verified bytes' hash back to
+    // the anchor, so all three disclosures are finally reading the same content
+    // and cannot disagree. Eager and lazy stay two mechanisms, as the module
+    // header insists -- what changed is that the index no longer holds a hash
+    // that matches no version of the file that exists.
     //
     // AND THE FIELDS GO WITH THE FLAG. `putNode` does not merge and neither does
     // this spread: serving `{ ...finding, stale: false }` would hand back a
@@ -630,12 +692,37 @@ export function serve(graph, findings, { dir = null } = {}) {
     // So the cleared record, not the stored one, is what the rest of this
     // iteration reads and spreads.
     //
-    // BOUNDED, and the bound is the point: this runs only for a finding whose
-    // flag is already STORED, only when a `derivation` record exists to check
-    // against, and it reads each of that finding's anchors at most once. A
-    // finding that is not flagged pays nothing. The lazy loop below already
+    // BOUNDED PER CALL, and the bound is the point: this runs only for a finding
+    // whose flag is already STORED, only when a `derivation` record exists to
+    // check against, and it reads each of that finding's anchors at most once.
+    // A finding that is not flagged pays nothing. The lazy loop below already
     // reads every anchor of every content-dependent finding served, so the worst
     // case is twice the anchor reads on the already-stale subset alone.
+    //
+    // AND THE PER-SESSION SHAPE, stated because the per-call bound alone reads
+    // as cheaper than it is. Measured on a synthetic 40-stale-finding graph, the
+    // serve path went 158 ms -> 217 ms (+37%), and for a GENUINELY stale finding
+    // that cost recurs on every call for the whole session: the verdict is
+    // `'differs'` forever, nothing is cleared, and the reads are repaid with
+    // nothing. What keeps it survivable in practice is not this bound but two
+    // others -- `findingsFor`'s result limit and inject.mjs's `alreadyInjected`
+    // gate, which together put it near 40 ms on the first touch of a hot file
+    // and zero on the touches after.
+    //
+    // THE REVERT CASE PAYS ONCE, AND THAT IS MEASURED, not argued. Same 40
+    // findings, all revertible, medians of 9 across three process launches: the
+    // read-only serve is 23-29 ms, the first clearing serve is 141-173 ms (the
+    // anchor reads plus one node append per cleared finding AND per re-pointed
+    // anchor), and the SECOND clearing serve is 21-28 ms -- back to the
+    // read-only baseline, because the flag is off and the index agrees, so this
+    // gate no longer fires. What the re-index changed is not that cost -- the
+    // gate stopped firing once the flag came off before, too -- but that every
+    // serve after the clear used to re-derive `stale: true` and
+    // `derivationHolds: false` from an index nobody had moved. The extra ~120 ms
+    // buys silence that is actually correct.
+    // On the genuinely-stale set the recurring cost is
+    // real and unchanged in kind: 26-45 ms read-only against 53-105 ms with
+    // clearing on, every call, clearing nothing.
     //
     // NOT ON THE NON-CONTENT-DEPENDENT EARLY RETURN ABOVE, deliberately. Both
     // eager paths refuse to flag those types at all, so a flag there can only
@@ -643,10 +730,14 @@ export function serve(graph, findings, { dir = null } = {}) {
     // does not depend on them is exactly the cost `CONTENT_DEPENDENT` exists to
     // avoid.
     let record = finding;
-    if (dir && finding.stale && claimTimeVerdict(graph, finding) === 'match') {
-      clearStale(dir, finding.key, { graph });
-      const { stale: _s, staleReason: _r, diff: _d, staleEvidence: _e, ...cleared } = finding;
-      record = cleared;
+    if (dir && finding.stale) {
+      const evidence = claimTimeEvidence(graph, finding);
+      if (evidence.verdict === 'match') {
+        reindexVerifiedAnchors(dir, graph, evidence.contents);
+        clearStale(dir, finding.key, { graph });
+        const { stale: _s, staleReason: _r, diff: _d, staleEvidence: _e, ...cleared } = finding;
+        record = cleared;
+      }
     }
 
     const anchors = graph.edges
@@ -736,6 +827,14 @@ export function serve(graph, findings, { dir = null } = {}) {
       // carries its `derivation`, since clearing removes only the staleness
       // fields. A finding whose flag was just cleared is still disclosed as
       // disputed, and still reports whether its derivation holds.
+      //
+      // AND THEY NO LONGER CONTRADICT THE CLEAR. Surviving is not the same as
+      // agreeing: for a whole serve this returned `stale: true, staleReason:
+      // 'file changed'` and `derivationHolds: false` on a finding it had just
+      // cleared, because the clear was decided against disk while these two read
+      // the anchor node's hash, and the eager path had moved it. All three now
+      // read the same content because the clear re-points the anchor; see
+      // `reindexVerifiedAnchors`.
       ...dispute,
       // Independent of `stale` above: see `derivationCheck`'s own comment for
       // the case it catches that node-level staleness can miss.
@@ -934,6 +1033,34 @@ export function invalidateChangedAnchors(dir, graph, rawPath) {
 }
 
 /**
+ * The current content of an anchor, read from disk: the whole file for a file
+ * anchor, the located span for a symbol one. Null when nothing can be read.
+ *
+ * SPLIT OUT FROM `anchorHashNow` SO THE BYTES SURVIVE THE COMPARISON. The
+ * clearing path hashes this to reach a verdict and, on `'match'`, re-indexes the
+ * anchor from the same bytes -- see `reindexVerifiedAnchors`. Returning only a
+ * hash forced a second read of a file that had just been read, for content
+ * already known to be identical.
+ */
+function anchorContentNow(anchor) {
+  const path = anchor.kind === 'symbol' ? anchor.file : anchor.key;
+  let source;
+  try {
+    source = readAnySpelling(path);
+  } catch {
+    return null;
+  }
+  if (anchor.kind !== 'symbol') return source;
+
+  // By NAME, like checkAnchor: line numbers shift whenever anything above is
+  // edited, and re-locating by line would report a symbol as moved when only an
+  // unrelated insert happened above it.
+  const current = extractSymbols(path, source).find((s) => s.name === anchor.name);
+  if (!current) return null;
+  return spanText(source, current);
+}
+
+/**
  * The current content hash of an anchor, read from disk.
  *
  * DELIBERATELY NOT `checkAnchor`, and the difference is the whole of this
@@ -952,21 +1079,8 @@ export function invalidateChangedAnchors(dir, graph, rawPath) {
  * content it was made against.
  */
 function anchorHashNow(anchor) {
-  const path = anchor.kind === 'symbol' ? anchor.file : anchor.key;
-  let source;
-  try {
-    source = readAnySpelling(path);
-  } catch {
-    return null;
-  }
-  if (anchor.kind !== 'symbol') return hash(source);
-
-  // By NAME, like checkAnchor: line numbers shift whenever anything above is
-  // edited, and re-locating by line would report a symbol as moved when only an
-  // unrelated insert happened above it.
-  const current = extractSymbols(path, source).find((s) => s.name === anchor.name);
-  if (!current) return null;
-  return hash(spanText(source, current));
+  const content = anchorContentNow(anchor);
+  return content === null ? null : hash(content);
 }
 
 /**
@@ -1005,21 +1119,51 @@ export function clearStale(dir, key, { graph = null } = {}) {
   // `contradict`, `correct` -- writes from a graph it loaded earlier too. Both
   // callers here already DECIDED on this snapshot, so re-reading it purely for
   // the write narrowed no window that was ever closed.
-  const node = (graph || load(dir)).nodes.get(nodeId('finding', key));
+  const id = nodeId('finding', key);
+  const node = (graph || load(dir)).nodes.get(id);
   if (!node || node.kind !== 'finding') return false;
   const { stale, staleReason, diff, staleEvidence, ...rest } = node;
   // Nothing to clear is a success, not a write: an unconditional putNode here
   // would append a duplicate record to the log on every no-op call.
   if (stale === undefined && staleReason === undefined
     && diff === undefined && staleEvidence === undefined) return true;
-  putNode(dir, { ...rest, kind: 'finding', key: node.key });
+  const cleared = { ...rest, kind: 'finding', key: node.key };
+  putNode(dir, cleared);
+  // AND THE CALLER'S GRAPH IS UPDATED, because the guard above reads THAT graph,
+  // not disk. Without this, a second `serve` on the same in-memory graph object
+  // -- two touched files anchored to one finding, or a lifecycle branch that
+  // serves twice from a graph it loaded once, as SessionStart does -- still saw
+  // `stale: true`, re-ran the evidence test, and appended a byte-identical clear
+  // record. The store is append-only, so that is permanent log growth for no
+  // change in state, and the "nothing to clear is a success, not a write"
+  // guarantee directly above was only true of the first call.
+  if (graph) graph.nodes.set(id, { ...cleared, id });
   return true;
 }
 
 /**
- * Clears a stale flag when, and only when, the evidence for it is gone.
+ * THE ONE EVIDENCE TEST, plus the bytes it read. Does this finding's anchored
+ * content still hash to what the claim was actually made against?
  *
- * WHY THIS HAS TO EXIST. Nothing in this codebase ever cleared a `stale` flag.
+ * `verdict` is one of:
+ *   `'match'`   -- every anchor on disk re-hashes to the value frozen into this
+ *                  finding's own `derivation.anchors` at claim time. The content
+ *                  IS what the claim was derived from: a revert, or a write that
+ *                  never moved the anchored bytes.
+ *   `'differs'` -- at least one anchor does not, INCLUDING an anchor whose
+ *                  content is gone. Deleted is a difference, not a missing
+ *                  measurement.
+ *   `'unknown'` -- there is nothing to compare: no `derivation.anchors`, no
+ *                  anchors, an anchor with no recorded hash, or one that no
+ *                  longer resolves.
+ *
+ * `contents` carries the disk bytes read to reach a `'match'`, keyed by anchor
+ * id, so the caller can re-index those anchors without reading them again. It is
+ * empty for the other two verdicts, which read no further than the first
+ * disagreement.
+ *
+ * WHY CLEARING HAS TO EXIST AT ALL. Nothing in this codebase ever cleared a
+ * `stale` flag.
  * That was harmless while eager invalidation was dead code; it fires now, so
  * every finding on an edited file becomes permanently stale -- and permanently
  * discounted, since `disclose.mjs` skips a stale finding outright and
@@ -1049,24 +1193,6 @@ export function clearStale(dir, key, { graph = null } = {}) {
  * side door. It reports `unknown` and changes nothing; re-recording the claim
  * against the current code (`curate.correct`) is the way forward for those.
  *
- * DELIBERATELY NOT AUTOMATIC. This reads every anchor off disk, so running it on
- * the serve path would put N file reads inside injection -- and, worse, it would
- * silently un-mark findings nobody asked about. Staleness is disclosed to a
- * reader who then decides; clearing is an explicit act.
- */
-/**
- * THE ONE EVIDENCE TEST. Does this finding's anchored content still hash to what
- * the claim was actually made against?
- *
- * `'match'` -- every anchor on disk re-hashes to the value frozen into this
- * finding's own `derivation.anchors` at claim time. The content IS what the
- * claim was derived from: a revert, or a write that never moved the anchored
- * bytes.
- * `'differs'` -- at least one anchor does not, INCLUDING an anchor whose content
- * is gone. Deleted is a difference, not a missing measurement.
- * `'unknown'` -- there is nothing to compare: no `derivation.anchors`, no
- * anchors, an anchor with no recorded hash, or one that no longer resolves.
- *
  * SHARED BY BOTH CLEARING PATHS ON PURPOSE, and that sharing is the guarantee
  * rather than a convenience. `reverify` (a person pressing Re-verify) and
  * `serve` (automatic, on every retrieval) call THIS function and nothing else,
@@ -1080,9 +1206,10 @@ export function clearStale(dir, key, { graph = null } = {}) {
  * re-point at the very bytes that caused the mark, so it answers "fresh" for
  * exactly the finding it just marked stale.
  */
-function claimTimeVerdict(graph, finding) {
+function claimTimeEvidence(graph, finding) {
+  const none = { verdict: 'unknown', contents: new Map() };
   const recorded = finding.derivation && finding.derivation.anchors;
-  if (!recorded || typeof recorded !== 'object') return 'unknown';
+  if (!recorded || typeof recorded !== 'object') return none;
 
   const anchorIds = new Set(
     graph.edges
@@ -1092,22 +1219,122 @@ function claimTimeVerdict(graph, finding) {
   // An unanchored finding cannot be checked against anything, which is the
   // un-invalidatable shape the anchor discipline exists to refuse. It is equally
   // un-VERIFIABLE, so it is reported as such rather than cleared.
-  if (!anchorIds.size) return 'unknown';
+  if (!anchorIds.size) return none;
 
+  const contents = new Map();
   for (const id of anchorIds) {
     const expected = recorded[id];
     const node = graph.nodes.get(id);
     // An anchor this finding never recorded a hash for, or one that no longer
     // resolves to a node: nothing to compare, so nothing is concluded.
-    if (typeof expected !== 'string' || !expected || !node) return 'unknown';
-    if (node.kind !== 'file' && node.kind !== 'symbol') return 'unknown';
+    if (typeof expected !== 'string' || !expected || !node) return none;
+    if (node.kind !== 'file' && node.kind !== 'symbol') return none;
     // null means the content is gone -- deleted file, vanished symbol. That is a
     // difference, not an absence of evidence.
-    if (anchorHashNow(node) !== expected) return 'differs';
+    const content = anchorContentNow(node);
+    if (content === null || hash(content) !== expected) {
+      return { verdict: 'differs', contents: new Map() };
+    }
+    contents.set(id, content);
   }
-  return 'match';
+  return { verdict: 'match', contents };
 }
 
+/** The verdict alone, for callers that do not re-index. */
+function claimTimeVerdict(graph, finding) {
+  return claimTimeEvidence(graph, finding).verdict;
+}
+
+/**
+ * Re-points every verified anchor at the content the evidence test just read.
+ *
+ * WHY A CLEAR IS NOT ENOUGH ON ITS OWN, reproduced end to end: index a file at
+ * H1, write a finding whose `derivation.anchors` records H1, edit and re-index so
+ * the node holds H2, let the eager path mark the finding, then REVERT the edit on
+ * disk. `claimTimeVerdict` now says `'match'` -- disk is H1, which is exactly
+ * what the claim was derived from -- and the flag comes off. But the node still
+ * holds H2, so the same `serve` call went on to emit `stale: true` with
+ * `staleReason: 'file changed'` from the lazy loop (disk H1 against node H2) and
+ * `derivationHolds: false` from `derivationCheck` (index H2 against claim H1).
+ * The model was shown DERIVATION CHANGED and STALE at the exact moment this
+ * module's own evidence test had concluded the derivation holds -- on every
+ * serve, until something unrelated happened to re-index the anchor.
+ *
+ * THE FIX IS TO MOVE THE INDEX, NOT TO SILENCE THE DISCLOSURES. Suppressing the
+ * lazy check and the derivation verdict for a cleared finding would leave the
+ * graph holding a hash that matches no version of the file that exists, so every
+ * OTHER finding on that anchor keeps reading stale, and the next reader has to be
+ * told which disclosures to disbelieve. The node hash is simply out of date, the
+ * bytes are already in hand from the comparison that just succeeded, and writing
+ * them makes all three disclosures agree because they are finally reading the
+ * same content.
+ *
+ * COSTS NO READ. `contents` comes from `claimTimeEvidence`, which read each
+ * anchor to reach `'match'`. The write is one node record per anchor whose hash
+ * actually moved, and it happens once per revert rather than once per serve: with
+ * the index re-pointed, the flag stays off and the gate in `serve` does not fire
+ * again.
+ *
+ * THE IN-MEMORY GRAPH IS UPDATED TOO, because the caller is mid-serve and is
+ * about to read these same nodes through the lazy loop and `derivationCheck`.
+ * Writing only to disk would fix the next process and leave this one contradicting
+ * itself, which is the whole defect.
+ *
+ * Line numbers are deliberately left alone on a symbol anchor: `checkAnchor` and
+ * `anchorContentNow` both re-locate by NAME, so a stored line is informational,
+ * and the body being byte-identical is what was just established.
+ */
+function reindexVerifiedAnchors(dir, graph, contents) {
+  for (const [id, content] of contents) {
+    const node = graph.nodes.get(id);
+    if (!node) continue;
+    const nextHash = hash(content);
+    // Already agrees: no record, no write. The common case once a revert has
+    // been accounted for.
+    if (node.hash === nextHash) continue;
+    const limit = node.kind === 'symbol' ? symbolSnapshotLimit() : snapshotLimit();
+    // Same bound as `indexFile`: past the cap the hash still drives staleness and
+    // only the reconstructed diff degrades.
+    const snapshot = content.length <= limit ? content : undefined;
+    const { hash: _h, snapshot: _s, ...rest } = node;
+    try {
+      putNode(dir, { ...rest, kind: node.kind, key: node.key, hash: nextHash, snapshot });
+    } catch {
+      // Fail open: a graph that could not be written is a disclosure that stays
+      // as it was, never a broken tool call. The in-memory copy is left alone to
+      // match, so this serve keeps agreeing with the store.
+      continue;
+    }
+    graph.nodes.set(id, { ...node, hash: nextHash, ...(snapshot ? { snapshot } : {}) });
+  }
+}
+
+/**
+ * Clears a stale flag on behalf of a person who asked for it -- the dashboard's
+ * Re-verify action -- and reports what the evidence said.
+ *
+ * `'cleared'` when the flag is gone (including when it was already gone, so a
+ * caller polling this does not retry forever), `'still-stale'` when the anchored
+ * content genuinely differs from what the claim was made against, `'unknown'`
+ * when there is nothing to compare and therefore nothing to conclude.
+ *
+ * NO LONGER THE ONLY CLEARING PATH, and the docblock that used to sit here said
+ * the opposite: that automatic clearing was refused because it would put N file
+ * reads inside injection and "silently un-mark findings nobody asked about".
+ * `serve` now does exactly that, on the same evidence, for the reason its own
+ * comment gives -- the manual path was reachable only where somebody opens the
+ * dashboard, which is almost nowhere, so the rot path stayed open on most
+ * installs. What survives of that objection is the cost, which `serve` bounds
+ * and states.
+ *
+ * WHAT THIS STILL ADDS over the automatic path: it loads the graph itself, so a
+ * caller holding nothing but a key and a directory can act; it reports the
+ * verdict rather than folding it into a served record; and it runs on demand
+ * rather than only when the finding happens to be retrieved. It re-indexes the
+ * verified anchors for the same reason `serve` does -- otherwise the button
+ * clears the flag and the very next retrieval re-derives a contradiction from a
+ * node hash nobody moved.
+ */
 export function reverify(dir, key) {
   const graph = load(dir);
   const finding = graph.nodes.get(nodeId('finding', key));
@@ -1116,9 +1343,10 @@ export function reverify(dir, key) {
   // holds, and reporting anything else would make a caller retry forever.
   if (!finding.stale) return 'cleared';
 
-  const verdict = claimTimeVerdict(graph, finding);
+  const { verdict, contents } = claimTimeEvidence(graph, finding);
   if (verdict === 'unknown') return 'unknown';
   if (verdict === 'differs') return 'still-stale';
+  reindexVerifiedAnchors(dir, graph, contents);
   clearStale(dir, key, { graph });
   return 'cleared';
 }

--- a/integrations/gemini/hooks/lib/staleness.mjs
+++ b/integrations/gemini/hooks/lib/staleness.mjs
@@ -17,7 +17,13 @@
  * TWO INVALIDATION PATHS, and each covers what the other cannot see:
  *
  *   EAGER  -- our PostToolUse hook saw a write, so the finding is marked at the
- *             moment it went stale, with the exact before/after in hand.
+ *             moment it went stale, with the exact before/after in hand. The
+ *             hook does not call `invalidateOnWrite` directly: it queues the
+ *             evidence through pending.mjs, and the next graph read -- which
+ *             loads the graph anyway -- applies it before serving anything.
+ *             That path is also the only one that catches a write the SESSION
+ *             made, because the lazy check below compares the stored hash
+ *             against disk and `indexFile` has already refreshed it.
  *   LAZY   -- at retrieval, the anchor's stored hash is compared against disk.
  *             This is what catches `git pull`, another editor, a teammate, or a
  *             build step: every change our hooks never observed.
@@ -291,14 +297,69 @@ export function checkAnchor(anchor) {
 }
 
 /**
+ * Characters kept from any single diff line.
+ *
+ * A LINE CAP IS NOT A SIZE CAP, and the gap was measured: with only `maxLines`
+ * in force, `diffLines('X'.repeat(200000), 'Y'.repeat(200000))` returned 2 lines
+ * and 400,005 bytes. Minified bundles, generated sources and single-line JSON
+ * all have that shape, and this output goes STRAIGHT INTO MODEL CONTEXT from
+ * inject.mjs's zero-turn refusal -- so a line bound alone let one pathological
+ * file spend hundreds of thousands of tokens.
+ *
+ * 200 characters is chosen because it is past the width at which a line is read
+ * as a line by anybody, human or model: a hand-written source line is under
+ * ~120 columns, so the cap cannot truncate a diff a reader was going to use,
+ * while the cases it does truncate are ones where the interesting change is not
+ * legible from the raw text anyway.
+ */
+const DIFF_MAX_LINE_CHARS = () => {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_DIFF_MAX_LINE_CHARS);
+  return Number.isFinite(raw) && raw > 0 ? raw : 200;
+};
+
+/**
+ * Total UTF-8 bytes of diff body.
+ *
+ * 4,000 bytes is roughly 1,000 tokens. It is deliberately larger than the
+ * per-file injection budget (`TOKEN_OPTIMIZER_TOUCH_BUDGET`, 500 tokens) and
+ * far smaller than a file, because the two consumers want different things: the
+ * injection surface fits the diff inside its own budget and drops it if it does
+ * not fit, while the zero-turn refusal is replacing a whole file read and can
+ * afford more. One cap that neither consumer has to think about is worth more
+ * than two tuned ones.
+ *
+ * WHAT IT COSTS, PLAINLY: a legitimately large diff now arrives truncated, so a
+ * model looking at a 300-line refactor sees the head of it and a count of what
+ * was elided rather than the whole change. That is the correct direction to
+ * fail -- the alternative was a bounded-looking function that could emit 400 KB.
+ */
+const DIFF_MAX_BYTES = () => {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_DIFF_MAX_BYTES);
+  return Number.isFinite(raw) && raw > 0 ? raw : 4_000;
+};
+
+/**
  * A compact line diff.
  *
  * Deliberately not a full unified diff with hunks and context: the consumer is
  * a model deciding whether an existing conclusion still holds, and for that the
  * changed lines are the signal. Output is capped because an unbounded diff
  * injected alongside a finding would spend more tokens than re-deriving it.
+ *
+ * BOUNDED IN THREE WAYS, and each one is load-bearing: lines, characters per
+ * line, and total bytes. Every truncation is announced in the output, because a
+ * silently shortened diff is worse than a visibly shortened one -- a reader who
+ * cannot tell content was elided believes they saw the whole change.
  */
-export function diffLines(before, after, { maxLines = 40 } = {}) {
+export function diffLines(
+  before,
+  after,
+  {
+    maxLines = 40,
+    maxLineChars = DIFF_MAX_LINE_CHARS(),
+    maxBytes = DIFF_MAX_BYTES(),
+  } = {}
+) {
   const a = String(before).split('\n');
   const b = String(after).split('\n');
 
@@ -314,33 +375,44 @@ export function diffLines(before, after, { maxLines = 40 } = {}) {
   const added = b.slice(head, b.length - tail);
 
   const out = [];
-  for (const line of removed.slice(0, maxLines / 2)) out.push('- ' + line);
-  if (removed.length > maxLines / 2) out.push(`  ... ${removed.length - maxLines / 2} more removed`);
-  for (const line of added.slice(0, maxLines / 2)) out.push('+ ' + line);
-  if (added.length > maxLines / 2) out.push(`  ... ${added.length - maxLines / 2} more added`);
+  let bytes = 0;
+  let dropped = 0;
+
+  // Per line first, so ONE enormous line cannot consume the whole budget and
+  // leave every other changed line unrepresented.
+  const clamp = (line) => {
+    const text = String(line);
+    if (text.length <= maxLineChars) return text;
+    return `${text.slice(0, maxLineChars)} [+${text.length - maxLineChars} chars cut]`;
+  };
+
+  // Bytes, not characters: the cap exists to bound what is sent, and a
+  // multi-byte source file would otherwise pass a character check while
+  // emitting several times the budget.
+  const push = (line) => {
+    const text = clamp(line);
+    const size = Buffer.byteLength(text, 'utf8') + 1;
+    if (bytes + size > maxBytes) {
+      dropped++;
+      return;
+    }
+    out.push(text);
+    bytes += size;
+  };
+
+  for (const line of removed.slice(0, maxLines / 2)) push('- ' + line);
+  if (removed.length > maxLines / 2) push(`  ... ${removed.length - maxLines / 2} more removed`);
+  for (const line of added.slice(0, maxLines / 2)) push('+ ' + line);
+  if (added.length > maxLines / 2) push(`  ... ${added.length - maxLines / 2} more added`);
+
+  // Announced OUTSIDE the budget, deliberately: the one line a reader most
+  // needs is the one saying the rest is missing, and dropping it to stay under
+  // a self-imposed cap would hand back a diff that lies about being complete.
+  if (dropped) out.push(`  ... ${dropped} more changed line(s) cut at the size limit`);
 
   return out.join('\n');
 }
 
-/**
- * Prepares findings for delivery, verifying each one lazily against disk.
- *
- * This is the only function that should ever hand a finding to a model, because
- * it is the one that enforces the rule: a stale finding leaves here carrying
- * `stale: true` AND a diff, or it does not leave at all.
- */
-export function serve(graph, findings) {
-  const served = [];
-
-  // RETIRED FINDINGS STOP HERE, unconditionally.
-  //
-  // findingsFor and sessionIndex already filter them, so this is redundant on
-  // every current path -- deliberately. This function's own contract is that it
-  // is the only thing that hands a finding to a model, which makes it the right
-  // place for the guarantee to live: a future caller that reaches into the
-  // graph directly cannot accidentally serve a claim a human explicitly
-  // withdrew. A withheld claim reappearing is not a bug anyone would notice
-  // quickly.
 /**
  * Types whose truth is a claim ABOUT the anchor's contents.
  *
@@ -363,6 +435,26 @@ export function serve(graph, findings) {
  * to ignore -- taking the rare true positive with it.
  */
 const CONTENT_DEPENDENT = new Set(['finding', 'map']);
+
+/**
+ * Prepares findings for delivery, verifying each one lazily against disk.
+ *
+ * This is the only function that should ever hand a finding to a model, because
+ * it is the one that enforces the rule: a stale finding leaves here carrying
+ * `stale: true` AND a diff, or it does not leave at all.
+ */
+export function serve(graph, findings) {
+  const served = [];
+
+  // RETIRED FINDINGS STOP HERE, unconditionally.
+  //
+  // findingsFor and sessionIndex already filter them, so this is redundant on
+  // every current path -- deliberately. This function's own contract is that it
+  // is the only thing that hands a finding to a model, which makes it the right
+  // place for the guarantee to live: a future caller that reaches into the
+  // graph directly cannot accidentally serve a claim a human explicitly
+  // withdrew. A withheld claim reappearing is not a bug anyone would notice
+  // quickly.
 
   for (const finding of findings.filter((f) => !f.retired)) {
     // A claim that does not depend on the anchor's contents cannot be
@@ -505,6 +597,15 @@ export function invalidateOnWrite(dir, graph, rawPath, beforeText, afterText) {
     for (const edge of byTarget.get(node.id) || []) {
       const finding = graph.nodes.get(edge.from);
       if (!finding || finding.kind !== 'finding') continue;
+      // THE SAME TYPE GATE `serve` APPLIES, and it has to be here too now that
+      // this path actually runs. `serve` ignores a stale flag on a type whose
+      // truth is not a claim about the anchor's contents -- but the flag is
+      // STORED, and disclose.mjs skips a stale finding outright while
+      // utility.mjs penalises one by 160. So writing it onto a `failure` or a
+      // `command` would suppress that claim everywhere except the one reader
+      // that knows to ignore it, which is exactly the harm measured in the
+      // comment on CONTENT_DEPENDENT above.
+      if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) continue;
 
       putNode(dir, {
         ...finding,

--- a/integrations/gemini/hooks/lib/staleness.mjs
+++ b/integrations/gemini/hooks/lib/staleness.mjs
@@ -495,6 +495,54 @@ function disputeOf(graph, finding) {
 }
 
 /**
+ * Whether THIS finding's own claim-time evidence still matches its anchors --
+ * the reader `harvest-write.mjs`'s `derivation` record was written for.
+ * Nothing consumed that record until now: a grep for it found only the writer
+ * and its own tests, which made "checkable rather than merely attributed" a
+ * claim with no code behind it.
+ *
+ * DISTINCT FROM `stale`/`checkAnchor`, DELIBERATELY, not a duplicate of it.
+ * `checkAnchor` compares disk against the anchor NODE's CURRENT stored hash,
+ * which is refreshed by `indexFile` every time ANYTHING touches that file --
+ * so it answers "has this file changed since the last time anyone indexed
+ * it", not "has it changed since THIS finding was derived from it". Those
+ * differ in a real case: file F changes, and a LATER, unrelated write
+ * (another finding, another session) re-indexes F, updating the node's
+ * stored hash to match the new content again. `checkAnchor` now reports
+ * "fresh" -- disk matches the node's current hash -- while this finding's own
+ * frozen `derivation.anchors[id]` snapshot, taken when IT was written, no
+ * longer matches. The bytes this claim was actually derived from are gone,
+ * and `stale` alone would never say so.
+ *
+ * Returns `{}` when there is nothing to check (no `derivation.anchors`
+ * recorded -- true of every finding written before this existed), so a
+ * caller can tell "not checked" from "checked and holds" by whether
+ * `derivationHolds` is present at all.
+ */
+function derivationCheck(graph, finding) {
+  const recorded = finding.derivation && finding.derivation.anchors;
+  if (!recorded || typeof recorded !== 'object') return {};
+  const ids = Object.keys(recorded);
+  if (!ids.length) return {};
+
+  const changed = [];
+  for (const id of ids) {
+    const node = graph.nodes.get(id);
+    const currentHash = node && typeof node.hash === 'string' ? node.hash : null;
+    // An anchor that no longer resolves at all cannot be confirmed either --
+    // treated the same as a changed hash, never as "still holds" by default.
+    if (currentHash === null || currentHash !== recorded[id]) {
+      changed.push(node && typeof node.key === 'string' ? node.key : id);
+    }
+  }
+
+  if (!changed.length) return { derivationHolds: true };
+  // Bounded: a finding with many anchors should not spend unbounded budget
+  // naming every one that moved.
+  return { derivationHolds: false, derivationChanged: changed.slice(0, 5) };
+}
+
+/**
  * Prepares findings for delivery, verifying each one lazily against disk.
  *
  * This is the only function that should ever hand a finding to a model, because
@@ -611,6 +659,9 @@ export function serve(graph, findings) {
       stale,
       ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
       ...dispute,
+      // Independent of `stale` above: see `derivationCheck`'s own comment for
+      // the case it catches that node-level staleness can miss.
+      ...derivationCheck(graph, finding),
     });
   }
   return served;

--- a/integrations/gemini/hooks/lib/staleness.mjs
+++ b/integrations/gemini/hooks/lib/staleness.mjs
@@ -518,6 +518,21 @@ function disputeOf(graph, finding) {
  * recorded -- true of every finding written before this existed), so a
  * caller can tell "not checked" from "checked and holds" by whether
  * `derivationHolds` is present at all.
+ *
+ * `derivationHolds: true` MEANS "MATCHES THE ANCHOR NODE'S LAST-INDEXED
+ * HASH", NOT "MATCHES DISK RIGHT NOW" -- and that distinction is stored in
+ * `derivationCheckedAgainst: 'index'` rather than left for a `wiki_query`
+ * consumer to infer from a field name alone. Two ways to close this gap were
+ * considered: recompute a live hash from disk here, or document precisely
+ * what is actually compared. `stale` (via `checkAnchor`, above) ALREADY owns
+ * the disk comparison -- re-reading the same file a second time on the same
+ * serve path, for the same anchor, from a second mechanism, is worse than
+ * one honest name. So: documented, not duplicated. A file changed on disk
+ * but never re-indexed by anything is still caught, correctly, by `stale`;
+ * `derivationHolds` answers a narrower, complementary question -- whether
+ * the LAST INDEXED state agrees with what this specific finding recorded --
+ * which is exactly the re-indexed-by-something-else case above that `stale`
+ * cannot see.
  */
 function derivationCheck(graph, finding) {
   const recorded = finding.derivation && finding.derivation.anchors;
@@ -536,10 +551,12 @@ function derivationCheck(graph, finding) {
     }
   }
 
-  if (!changed.length) return { derivationHolds: true };
+  // Declared on BOTH branches, not only the ambiguous one: a consumer should
+  // not have to already know the answer to know what was checked.
+  if (!changed.length) return { derivationHolds: true, derivationCheckedAgainst: 'index' };
   // Bounded: a finding with many anchors should not spend unbounded budget
   // naming every one that moved.
-  return { derivationHolds: false, derivationChanged: changed.slice(0, 5) };
+  return { derivationHolds: false, derivationChanged: changed.slice(0, 5), derivationCheckedAgainst: 'index' };
 }
 
 /**

--- a/integrations/gemini/hooks/lib/staleness.mjs
+++ b/integrations/gemini/hooks/lib/staleness.mjs
@@ -54,6 +54,7 @@ import { readFileSync, statSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { dirname, join } from 'node:path';
 import { putNode, putEdge, contentHash, nodeId } from './wiki.mjs';
+import { hasOutstandingContradiction } from './curate.mjs';
 import { extractSymbols, spanText, symbolKey, extractImports } from './symbols.mjs';
 import { canonicalPath, resolvableCandidates, isFsSafePath } from './paths.mjs';
 
@@ -454,6 +455,46 @@ export function diffLines(
 const CONTENT_DEPENDENT = new Set(['finding', 'map']);
 
 /**
+ * What, if anything, currently disagrees with this finding.
+ *
+ * DISCLOSED AT SERVE TIME, because that is the only moment the disagreement can
+ * do any good. `WIKI_GRAPH.md`'s whole argument for making `contradicts` an edge
+ * rather than an overwrite is that a reader "sees both claims and the
+ * disagreement between them" -- so handing a finding to a model while something
+ * in the graph disputes it, without saying so, throws away the reason the edge
+ * was recorded instead of an overwrite.
+ *
+ * `hasOutstandingContradiction` is the gate: it is the one definition of "an
+ * open dispute", shared with the confidence-promotion gate, so the two can never
+ * disagree about what counts. The loop only NAMES the other side, and it names a
+ * key rather than quoting a claim because the reader can call `wiki_query` with
+ * a key -- and because the injection path pays for every character it renders.
+ *
+ * SEPARATE FROM STALENESS on purpose. A finding can be disputed without being
+ * stale (nothing touched its anchor; another finding simply says otherwise) and
+ * stale without being disputed, so this adds its own fields rather than
+ * borrowing the stale ones, and the renderer discloses each on its own terms.
+ */
+function disputeOf(graph, finding) {
+  if (!hasOutstandingContradiction(graph, finding.key)) return {};
+
+  const keys = [];
+  for (const edge of graph.edges) {
+    if (edge.edge !== 'contradicts') continue;
+    const otherId =
+      edge.from === finding.id ? edge.to : edge.to === finding.id ? edge.from : null;
+    if (!otherId) continue;
+    const other = graph.nodes.get(otherId);
+    // An edge end that resolves to nothing names nothing. The dispute is still
+    // disclosed -- the gate above already established it -- but without a key
+    // the reader cannot be pointed anywhere, and inventing one would be worse.
+    if (other && typeof other.key === 'string' && !keys.includes(other.key)) keys.push(other.key);
+  }
+
+  return { contradicted: true, ...(keys.length ? { contradictedBy: keys.join(', ') } : {}) };
+}
+
+/**
  * Prepares findings for delivery, verifying each one lazily against disk.
  *
  * This is the only function that should ever hand a finding to a model, because
@@ -474,10 +515,17 @@ export function serve(graph, findings) {
   // quickly.
 
   for (const finding of findings.filter((f) => !f.retired)) {
+    // A DISPUTE TRAVELS WITH EVERY TYPE, which is why it is computed before the
+    // content-dependence branch below. A `command` or `rule` finding cannot be
+    // invalidated by an anchor's contents, but another finding can still
+    // disagree with it, and this early return is the path that would have
+    // quietly dropped that.
+    const dispute = disputeOf(graph, finding);
+
     // A claim that does not depend on the anchor's contents cannot be
     // invalidated by them. It is served as-is rather than discounted.
     if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) {
-      served.push({ ...finding });
+      served.push({ ...finding, ...dispute });
       continue;
     }
 
@@ -562,6 +610,7 @@ export function serve(graph, findings) {
       ...finding,
       stale,
       ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
+      ...dispute,
     });
   }
   return served;

--- a/integrations/gemini/hooks/lib/waste.mjs
+++ b/integrations/gemini/hooks/lib/waste.mjs
@@ -151,6 +151,11 @@ function reDerivation(events, graph) {
       const id = nodeId('file', canonicalPath(row.anchor));
       if (!graph.nodes.has(id)) continue;
 
+      // READ-ONLY serve: no `dir` is threaded here, so this cannot clear a stale
+      // flag whose evidence is gone. That is deliberate -- this function takes a
+      // graph, not the directory it came from, and widening its signature to give
+      // an analysis path a write capability buys nothing: the injection path runs
+      // on every tool call and clears the same findings.
       const findings = serve(graph, findingsFor(graph, id, { limit: 3 }))
         .filter((f) => !f.stale && (f.confidence ?? 0) >= 0.7);
       if (!findings.length) continue;

--- a/integrations/gemini/hooks/lib/wiki.mjs
+++ b/integrations/gemini/hooks/lib/wiki.mjs
@@ -64,18 +64,37 @@ export const SUPPORTED_VERSIONS = [1];
  * Identity today because GRAPH_VERSION is 1 and no shape has changed. It exists
  * now so the first change that DOES need it has somewhere to go other than an
  * equality check that silently deletes user data.
+ *
+ * CONTRACT for the first non-identity step:
+ *  - It must be IDEMPOTENT. `upcast(upcast(r))` must equal `upcast(r)`, because
+ *    compaction upcasts a record to key it and `load` upcasts the same record
+ *    again on every subsequent read. A step that is not idempotent applies twice
+ *    to anything compaction has touched.
+ *  - It must NOT be relied on to restamp `v`. Nothing in this file writes an
+ *    upcast record back to disk under a version it did not come from; the
+ *    version stamp on disk is always the one that wrote the bytes. See the
+ *    per-branch comments in `compactIfWasteful`.
  */
 export function upcast(record) {
   return record;
 }
 
-/** True when this reader can interpret the record at all. */
-function readable(record) {
+/**
+ * True when this reader can interpret the record at all.
+ *
+ * `versions` is a PARAMETER so the range semantics are testable independently of
+ * today's constants. With `SUPPORTED_VERSIONS = [1]` and `GRAPH_VERSION = 1` a
+ * range check and the old equality check are extensionally identical, so a test
+ * pinned to the live constants cannot tell them apart -- and cannot fail if
+ * someone reverts this to an equality. Exercised against `[1, 2]`, it can.
+ */
+export function readable(record, versions = SUPPORTED_VERSIONS) {
   const version = record.v ?? 0;
   // Forward-incompatible records are skipped: a v-from-the-future was written by
-  // a newer client and we cannot know its shape. Ignoring the future is safe;
-  // ignoring the past is data loss.
-  return SUPPORTED_VERSIONS.includes(version);
+  // a newer client and we cannot know its shape. Ignoring the future is safe for
+  // a READER -- but see `compactIfWasteful`, where "ignore" would mean "delete",
+  // because compaction rewrites the files it reads.
+  return versions.includes(version);
 }
 
 /** Node kinds. `file` and `symbol` are first-class so staleness can propagate. */
@@ -434,9 +453,20 @@ function compactIfWasteful(dir) {
     const nodes = new Map();
     const edges = new Map();
     const snaps = new Map();
-    for (const rec of readSnapshots(dir)) {
+    // KEPT VERBATIM THROUGH THE REBUILD, exactly as the main log keeps what it
+    // cannot parse. These lines are not evictable by the snapshot budget below
+    // because their size cannot be attributed to an id we understand -- and
+    // preserving bytes we may not need is strictly better than deleting bytes a
+    // newer client does. They stop accumulating as soon as the client that
+    // wrote them compacts, since it can read and dedupe them.
+    const sidecar = readSnapshots(dir);
+    const rawSnaps = sidecar.unreadable;
+    for (const rec of sidecar.records) {
       if (typeof rec.snapshot === 'string' && rec.snapshot) {
-        snaps.set(rec.id, { at: rec.at || 0, snapshot: rec.snapshot });
+        // `v` IS CARRIED, not restamped. Writing GRAPH_VERSION over a record
+        // from another version mislabels bytes this reader did not produce, and
+        // the label is the only thing a future reader has to go on.
+        snaps.set(rec.id, { at: rec.at || 0, snapshot: rec.snapshot, v: rec.v ?? GRAPH_VERSION });
       }
     }
     for (const line of readFileSync(path, 'utf8').split('\n')) {
@@ -458,27 +488,40 @@ function compactIfWasteful(dir) {
         edges.set('raw:' + edges.size, line);
         continue;
       }
-      // Upcast IN MEMORY only, to key and classify the record. What gets written
-      // back below is the ORIGINAL `line`: compaction reclaims superseded
-      // records, it does not migrate surviving ones, so the on-disk version is
-      // whatever wrote it and `load` upcasts it again on every read.
-      record = upcast(record);
-      if (record.t === 'n') {
+      // TWO OBJECTS, ON PURPOSE. `record` is exactly what the bytes on disk say;
+      // `view` is the in-memory current-shape reading of it, used only to KEY and
+      // CLASSIFY. Nothing derived from `view` is ever serialized, because
+      // compaction reclaims superseded records -- it does not migrate surviving
+      // ones -- so every version stamp it writes is the one that wrote the bytes.
+      //
+      // An earlier revision of this comment claimed "the ORIGINAL line is written
+      // back" for the whole block. That was FALSE for the inline-snapshot branch,
+      // which re-serializes. It re-serialized the upcast object while carrying
+      // the old `v`, so the first non-identity `upcast` would have written
+      // new-shape bytes under an old label and every later `load` would have
+      // upcast them a second time. Hence: strip from `record`, never from `view`.
+      const view = upcast(record);
+      if (view.t === 'n') {
         // MIGRATION. Graphs written before snapshots were split still carry
         // them inline, and those are exactly the graphs that are slow. Moving
         // them out here means one compaction fixes an existing install.
+        //
+        // THE ONLY RE-SERIALIZING BRANCH in this loop. It writes the original
+        // record minus its snapshot, so the surviving bytes keep their own shape
+        // and their own `v`, and the snapshot moved to the sidecar carries the
+        // same `v` as the node it came out of.
         if (typeof record.snapshot === 'string' && record.snapshot) {
           const { snapshot, ...rest } = record;
-          nodes.set(record.id, JSON.stringify(rest));
-          snaps.set(record.id, { at: record.at || 0, snapshot });
+          nodes.set(view.id, JSON.stringify(rest));
+          snaps.set(view.id, { at: record.at || 0, snapshot, v: record.v ?? GRAPH_VERSION });
         } else {
-          nodes.set(record.id, line);
+          nodes.set(view.id, line);
         }
-      } else if (record.t === 's') {
+      } else if (view.t === 's') {
         if (typeof record.snapshot === 'string' && record.snapshot) {
-          snaps.set(record.id, { at: record.at || 0, snapshot: record.snapshot });
+          snaps.set(view.id, { at: record.at || 0, snapshot: record.snapshot, v: record.v ?? GRAPH_VERSION });
         }
-      } else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
+      } else if (view.t === 'e') edges.set(`${view.from}|${view.edge}|${view.to}`, line);
       else edges.set('raw:' + edges.size, line);
     }
 
@@ -541,10 +584,20 @@ function compactIfWasteful(dir) {
     renameSync(tmp, path);
     // The surviving snapshots are rewritten to their own file, which is also
     // what migrates a graph that still had them inline.
-    const snapOut =
-      [...keep.entries()]
-        .map(([id, v]) => JSON.stringify({ t: 's', v: GRAPH_VERSION, id, snapshot: v.snapshot, at: v.at }))
-        .join('\n') + (keep.size ? '\n' : '');
+    //
+    // UNREADABLE LINES FIRST AND VERBATIM. This rebuild replaces the file, so
+    // anything omitted here is deleted permanently -- which made the missing
+    // counterpart to the main log's `raw:` bucket a real data-loss path, not a
+    // theoretical one. Each survivor also keeps ITS OWN `v` rather than being
+    // restamped to GRAPH_VERSION, so no record is relabelled as something this
+    // reader wrote.
+    const snapLines = [
+      ...rawSnaps,
+      ...[...keep.entries()].map(([id, s]) =>
+        JSON.stringify({ t: 's', v: s.v ?? GRAPH_VERSION, id, snapshot: s.snapshot, at: s.at })
+      ),
+    ];
+    const snapOut = snapLines.join('\n') + (snapLines.length ? '\n' : '');
     const snapTmp = snapshotsPath(dir) + '.compact';
     writeFileSync(snapTmp, snapOut, { mode: 0o600 });
     renameSync(snapTmp, snapshotsPath(dir));
@@ -689,9 +742,26 @@ function appendSnapshot(dir, record) {
   }
 }
 
-/** Every snapshot record, latest wins. Read only when a caller asks. */
+/**
+ * Every snapshot record, latest wins. Read only when a caller asks.
+ *
+ * `unreadable` collects the RAW LINES this reader rejected, and it is the reason
+ * this function reports them at all rather than just dropping them. `load` has
+ * no use for them -- a reader that cannot interpret a record must ignore it --
+ * but `compactIfWasteful` REBUILDS this file from what it read, so for the
+ * compactor "ignore" and "delete permanently" are the same operation. The main
+ * log already keeps what it cannot parse (the `raw:` bucket); the sidecar had no
+ * equivalent, which made it the one asymmetric, destructive path in an otherwise
+ * append-only store.
+ *
+ * This is not hypothetical here: hooks-core is vendored into eleven client
+ * directories that update independently, so a stale client compacting a graph a
+ * newer client has already written to is the expected steady state, not an edge
+ * case.
+ */
 function readSnapshots(dir) {
-  const out = [];
+  /** @type {object[]} */ const out = [];
+  /** @type {string[]} */ const unreadable = [];
   try {
     for (const line of readFileSync(snapshotsPath(dir), 'utf8').split('\n')) {
       if (!line) continue;
@@ -699,19 +769,23 @@ function readSnapshots(dir) {
         const rec = JSON.parse(line);
         // THE SAME RANGE AS THE MAIN LOG, deliberately. An equality check here
         // was the quietest of the three: a bump would have made every stored
-        // snapshot unreadable, and the very next compaction -- which rebuilds
-        // this file from what it could read -- would have deleted them for
-        // good. That is the one place in this store where a read filter turns
-        // into a permanent write.
-        if (readable(rec) && rec.id) out.push(upcast(rec));
+        // snapshot unreadable, and the very next compaction would have deleted
+        // them for good.
+        if (!readable(rec)) {
+          unreadable.push(line);
+          continue;
+        }
+        if (rec.id) out.push(upcast(rec));
       } catch {
-        /* a torn line costs one snapshot */
+        // A torn line costs one snapshot -- and it is NOT preserved, because a
+        // half-written line is not a record from another version, it is
+        // garbage. Distinguishing the two is the whole point of parsing first.
       }
     }
   } catch {
     /* no sidecar yet */
   }
-  return out;
+  return { records: out, unreadable };
 }
 
 /**
@@ -777,7 +851,9 @@ export function load(dir, { snapshots = false } = {}) {
   // Re-attached after the sweep, so a snapshot record may appear before or
   // after the node it belongs to.
   if (pending) {
-    for (const rec of readSnapshots(dir)) pending.set(rec.id, rec.snapshot);
+    // A reader has no use for the lines it could not interpret; only the
+    // compactor does, because only the compactor rewrites the file.
+    for (const rec of readSnapshots(dir).records) pending.set(rec.id, rec.snapshot);
     for (const [id, snapshot] of pending) {
       const node = nodes.get(id);
       if (node) nodes.set(id, { ...node, snapshot });

--- a/integrations/gemini/hooks/lib/wiki.mjs
+++ b/integrations/gemini/hooks/lib/wiki.mjs
@@ -28,17 +28,55 @@ import { canonicalPath, isFsSafePath } from './paths.mjs';
 /**
  * Schema version stamped on every record.
  *
- * There is exactly ONE version and no migration code, because nothing has been
- * released: a graph written by an older commit of an unreleased branch is a
- * development artifact, not user data, and carrying migration paths for it costs
- * real complexity to protect something nobody has. A record from any other
- * version is skipped rather than interpreted, so a stale dev graph degrades to
- * "rebuilds from use" instead of silently mixing incompatible identities.
+ * THIS PACKAGE IS RELEASED. It ships on npm, so every graph on disk is user
+ * data. An earlier version of this comment claimed nothing had been released
+ * and used that to justify having no migration path at all -- and the reader
+ * below compared for EQUALITY, so the first bump would have discarded every
+ * existing graph in silence. That justification is gone and so is the equality:
+ * `SUPPORTED_VERSIONS` is the range this reader accepts, and `upcast` is where a
+ * shape change is absorbed in memory.
  *
- * When this does ship, a bump here is where migration would be added -- with
- * users to protect, that trade reverses.
+ * A bump here is taken only when a record's SHAPE actually changes, and it comes
+ * with a new `upcast` step and an entry in `SUPPORTED_VERSIONS` in the same
+ * change. Adding a field that older readers can ignore is not a shape change.
  */
 export const GRAPH_VERSION = 1;
+
+/**
+ * Versions this reader accepts, oldest first.
+ *
+ * A RANGE, NOT AN EQUALITY. The equality check this replaces would have
+ * discarded every existing graph the moment anyone bumped the version -- and the
+ * header once justified that with "nothing has been released", which stopped
+ * being true at v5.7.0 on npm.
+ *
+ * Nothing on disk is ever rewritten to migrate: `upcast` runs in memory during
+ * the fold, so there is no migration pass to fail halfway and no race with the
+ * concurrent sessions this store is designed for. A mixed-version log is safe
+ * precisely because the original records are never mutated, and the existing
+ * compaction retires old ones naturally as it rewrites snapshots.
+ */
+export const SUPPORTED_VERSIONS = [1];
+
+/**
+ * Brings one record up to the current version. Pure, and one step per version.
+ *
+ * Identity today because GRAPH_VERSION is 1 and no shape has changed. It exists
+ * now so the first change that DOES need it has somewhere to go other than an
+ * equality check that silently deletes user data.
+ */
+export function upcast(record) {
+  return record;
+}
+
+/** True when this reader can interpret the record at all. */
+function readable(record) {
+  const version = record.v ?? 0;
+  // Forward-incompatible records are skipped: a v-from-the-future was written by
+  // a newer client and we cannot know its shape. Ignoring the future is safe;
+  // ignoring the past is data loss.
+  return SUPPORTED_VERSIONS.includes(version);
+}
 
 /** Node kinds. `file` and `symbol` are first-class so staleness can propagate. */
 export const NODE_KINDS = ['file', 'symbol', 'task', 'finding'];
@@ -409,13 +447,22 @@ function compactIfWasteful(dir) {
       } catch {
         continue;
       }
-      // A record from another schema is KEPT VERBATIM rather than reinterpreted.
-      // load() skips it, but discarding it here would make compaction a silent
-      // migration that deletes data a future version might understand.
-      if ((record.v ?? 0) !== GRAPH_VERSION) {
+      // A record this reader cannot interpret is KEPT VERBATIM rather than
+      // reinterpreted. load() skips it, but discarding it here would make
+      // compaction a silent migration that deletes data a future version might
+      // understand. THE RANGE MATTERS HERE TOO: with an equality check, a bump
+      // would have parked every existing v1 record in `raw`, undeduplicated, so
+      // compaction would stop reclaiming anything and inline snapshots would
+      // never migrate out -- the same loss by a second route.
+      if (!readable(record)) {
         edges.set('raw:' + edges.size, line);
         continue;
       }
+      // Upcast IN MEMORY only, to key and classify the record. What gets written
+      // back below is the ORIGINAL `line`: compaction reclaims superseded
+      // records, it does not migrate surviving ones, so the on-disk version is
+      // whatever wrote it and `load` upcasts it again on every read.
+      record = upcast(record);
       if (record.t === 'n') {
         // MIGRATION. Graphs written before snapshots were split still carry
         // them inline, and those are exactly the graphs that are slow. Moving
@@ -650,7 +697,13 @@ function readSnapshots(dir) {
       if (!line) continue;
       try {
         const rec = JSON.parse(line);
-        if ((rec.v ?? 0) === GRAPH_VERSION && rec.id) out.push(rec);
+        // THE SAME RANGE AS THE MAIN LOG, deliberately. An equality check here
+        // was the quietest of the three: a bump would have made every stored
+        // snapshot unreadable, and the very next compaction -- which rebuilds
+        // this file from what it could read -- would have deleted them for
+        // good. That is the one place in this store where a read filter turns
+        // into a permanent write.
+        if (readable(rec) && rec.id) out.push(upcast(rec));
       } catch {
         /* a torn line costs one snapshot */
       }
@@ -691,7 +744,12 @@ export function load(dir, { snapshots = false } = {}) {
       if (!snapshots) continue;
       try {
         const rec = JSON.parse(line);
-        if ((rec.v ?? 0) === GRAPH_VERSION) pending.set(rec.id, rec.snapshot);
+        // Inline snapshots from an older graph: same range, same reason. These
+        // are precisely the records most likely to predate a bump.
+        if (readable(rec)) {
+          const snap = upcast(rec);
+          pending.set(snap.id, snap.snapshot);
+        }
       } catch {
         /* a torn line costs one snapshot, not the graph */
       }
@@ -703,10 +761,14 @@ export function load(dir, { snapshots = false } = {}) {
     } catch {
       continue;
     }
-    // A record from another schema is skipped, not interpreted: its ids and
-    // hashes were derived differently, so honouring it produces confident
-    // nonsense rather than a visible error.
-    if ((record.v ?? 0) !== GRAPH_VERSION) continue;
+    // A record this reader cannot interpret is skipped, not guessed at: a
+    // version from the FUTURE derived its ids and hashes in a way we do not
+    // know, so honouring it produces confident nonsense rather than a visible
+    // error. A record from the PAST is upcast, never skipped -- skipping it is
+    // data loss, and this comparison used to be an equality, which made the
+    // first version bump a silent delete of every graph on disk.
+    if (!readable(record)) continue;
+    record = upcast(record);
     if (record.t === 'n') nodes.set(record.id, record);
     else if (record.t === 'e') edges.push(record);
   }

--- a/integrations/gemini/hooks/lib/wiki.mjs
+++ b/integrations/gemini/hooks/lib/wiki.mjs
@@ -775,7 +775,17 @@ function readSnapshots(dir) {
           unreadable.push(line);
           continue;
         }
+        // A RECORD WITH NO `id` IS KEPT VERBATIM, NOT DROPPED SILENTLY. It
+        // cannot be attributed to a node, so it is useless to `load` -- but this
+        // used to put it in neither bucket, and `compactIfWasteful` rebuilds the
+        // sidecar from `records` plus `unreadable`, so a line in neither was
+        // deleted permanently by the next compaction. That is the same shape as
+        // the Critical this reader's version check already fixed, and the same
+        // asymmetry: for the compactor, "ignore" and "destroy" are one operation.
+        // Unreachable today because every writer sets `id`; a reader is not the
+        // right place to rely on that.
         if (rec.id) out.push(upcast(rec));
+        else unreadable.push(line);
       } catch {
         // A torn line costs one snapshot -- and it is NOT preserved, because a
         // half-written line is not a record from another version, it is

--- a/integrations/gemini/hooks/post-tool.mjs
+++ b/integrations/gemini/hooks/post-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/gemini/hooks/post-tool.mjs
+++ b/integrations/gemini/hooks/post-tool.mjs
@@ -8,7 +8,7 @@ process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.
-process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write';
+process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write,wiki_query';
 try {
   const { run } = await import('./lib/adapter.mjs');
   await run('gemini', 'post-tool');

--- a/integrations/gemini/hooks/pre-tool.mjs
+++ b/integrations/gemini/hooks/pre-tool.mjs
@@ -8,7 +8,7 @@ process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.
-process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write';
+process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write,wiki_query';
 try {
   const { run } = await import('./lib/adapter.mjs');
   await run('gemini', 'pre-tool');

--- a/integrations/gemini/hooks/pre-tool.mjs
+++ b/integrations/gemini/hooks/pre-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/gemini/hooks/session-start.mjs
+++ b/integrations/gemini/hooks/session-start.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/gemini/hooks/session-start.mjs
+++ b/integrations/gemini/hooks/session-start.mjs
@@ -8,7 +8,7 @@ process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.
-process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write';
+process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write,wiki_query';
 try {
   const { run } = await import('./lib/adapter.mjs');
   await run('gemini', 'session-start');

--- a/integrations/gemini/hooks/stop.mjs
+++ b/integrations/gemini/hooks/stop.mjs
@@ -8,7 +8,7 @@ process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.
-process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write';
+process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write,wiki_query';
 try {
   const { run } = await import('./lib/adapter.mjs');
   await run('gemini', 'stop');

--- a/integrations/gemini/hooks/stop.mjs
+++ b/integrations/gemini/hooks/stop.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/kilo/hooks/lib/adapter.mjs
+++ b/integrations/kilo/hooks/lib/adapter.mjs
@@ -68,6 +68,7 @@ import {
   standingRules,
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
+import { observedWrite, queueInvalidation } from './pending.mjs';
 import { isArchived } from './transcript.mjs';
 import { isFsSafePath } from './paths.mjs';
 import {
@@ -881,6 +882,35 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Causal tracing is fail-open like every other hook optimization.
+    }
+
+    // EAGER INVALIDATION, finally connected. `invalidateOnWrite` has existed,
+    // been tested and been described in staleness.mjs's own header since
+    // staleness landed, and its only reference in shipped code was a COMMENT in
+    // the PreToolUse router -- so the path that header calls load-bearing had
+    // never run once in production. It matters most for exactly this event: the
+    // lazy check compares the anchor's stored hash against disk, and the
+    // capture below re-points that hash at the bytes this write just produced,
+    // so a write the session performed ITSELF is invisible to lazy staleness.
+    //
+    // QUEUED, NOT APPLIED. Applying needs the graph, and loading a megabyte of
+    // JSONL on the return path of every write is what this shape exists to
+    // avoid. The next graph read drains it before serving anything.
+    try {
+      if (mutationSucceeded(clientName, raw)) {
+        const evidence = observedWrite(payload, raw);
+        if (evidence) {
+          // THE SAME DIRECTORY THE GRAPH ITSELF USES. `observeAndInject` keys
+          // every write on `wikiDir(projectRootFor(path, payload.cwd))`, and a
+          // queue written anywhere else is a queue nothing ever drains.
+          queueInvalidation(
+            wikiDir(projectRootFor(evidence.path, payload.cwd)),
+            evidence
+          );
+        }
+      }
+    } catch {
+      // Bookkeeping for a call that already completed. Never let it cost one.
     }
   }
 

--- a/integrations/kilo/hooks/lib/adapter.mjs
+++ b/integrations/kilo/hooks/lib/adapter.mjs
@@ -64,6 +64,7 @@ import {
   forTouch,
   noteActClasses,
   relevantFindingIdsForContext,
+  sessionContext,
   sessionIndex,
   standingRules,
 } from './inject.mjs';
@@ -690,8 +691,23 @@ async function runHook(clientName, event, invocation) {
       rememberOptimizerTools(state, toolEvidence);
       saveState(sessionId, state);
     }
-    const parts = [
-      policyText(client.canDeny, toolEvidence.names, toolEvidence.proven),
+    // ASSEMBLED IN CACHE ORDER, not in whatever order this function happens to
+    // discover the blocks. Everything emitted here sits near the FRONT of the
+    // prompt prefix, and a prefix cache invalidates from the first differing
+    // byte onward -- so the block that changes most often has to sit LAST, or it
+    // re-prices every block behind it on every session. `sessionContext` sorts
+    // by the declared volatility; inject.mjs records how each number was
+    // assigned and why.
+    const blocks = [
+      {
+        id: 'policy',
+        volatility: 0,
+        text: policyText(
+          client.canDeny,
+          toolEvidence.names,
+          toolEvidence.proven
+        ),
+      },
     ];
     const cwd = raw.cwd || raw.working_directory || process.cwd();
     const root = projectRootFor(join(cwd, '__session__'), cwd);
@@ -705,7 +721,7 @@ async function runHook(clientName, event, invocation) {
         const graph = load(dir);
         const episode = episodeMeta({ client: clientName, raw });
         const rules = standingRules(dir, graph, { episode });
-        if (rules) parts.push(rules);
+        if (rules) blocks.push({ id: 'standing', volatility: 1, text: rules });
         const relevantFindingIds = relevantFindingIdsForContext(
           graph,
           sessionTaskContext(raw)
@@ -714,12 +730,12 @@ async function runHook(clientName, event, invocation) {
           episode,
           relevantFindingIds,
         });
-        if (index) parts.push(index);
+        if (index) blocks.push({ id: 'index', volatility: 2, text: index });
       } catch {
         // Retrieval is optional context; the policy must still reach the model.
       }
     }
-    const output = contextOutput(client, eventName, parts.join('\n\n'));
+    const output = contextOutput(client, eventName, sessionContext(blocks));
     if (output) emit(output);
     process.exit(0);
   }

--- a/integrations/kilo/hooks/lib/adapter.mjs
+++ b/integrations/kilo/hooks/lib/adapter.mjs
@@ -68,7 +68,7 @@ import {
   standingRules,
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
-import { observedWrite, queueInvalidation } from './pending.mjs';
+import { observedWrites, queueInvalidation } from './pending.mjs';
 import { isArchived } from './transcript.mjs';
 import { isFsSafePath } from './paths.mjs';
 import {
@@ -898,8 +898,7 @@ async function runHook(clientName, event, invocation) {
     // avoid. The next graph read drains it before serving anything.
     try {
       if (mutationSucceeded(clientName, raw)) {
-        const evidence = observedWrite(payload, raw);
-        if (evidence) {
+        for (const evidence of observedWrites(payload, raw)) {
           // THE SAME DIRECTORY THE GRAPH ITSELF USES. `observeAndInject` keys
           // every write on `wikiDir(projectRootFor(path, payload.cwd))`, and a
           // queue written anywhere else is a queue nothing ever drains.

--- a/integrations/kilo/hooks/lib/capabilities.mjs
+++ b/integrations/kilo/hooks/lib/capabilities.mjs
@@ -38,6 +38,10 @@ export const HOOK_MCP_TOOLS = Object.freeze([
   'optimize_session',
   'get_optimization_report',
   'wiki_write',
+  // The read side of the graph. The session index tells the model to "call
+  // wiki_query with a key for detail", so the hook needs positive evidence that
+  // the name it is advertising is actually registered in this host.
+  'wiki_query',
 ]);
 
 const HOOK_MCP_TOOL_SET = new Set(HOOK_MCP_TOOLS);

--- a/integrations/kilo/hooks/lib/curate.mjs
+++ b/integrations/kilo/hooks/lib/curate.mjs
@@ -22,7 +22,7 @@
  */
 
 import { randomBytes } from 'node:crypto';
-import { putNode, putNodeWithEdges, load, nodeId } from './wiki.mjs';
+import { putNode, putEdge, putNodeWithEdges, load, nodeId } from './wiki.mjs';
 import { indexFile } from './staleness.mjs';
 import { symbolKey } from './symbols.mjs';
 import { canonicalPath } from './paths.mjs';
@@ -178,6 +178,79 @@ export function retire(dir, key) {
   if (!existing) return false;
   putNode(dir, { ...existing, kind: 'finding', key, retired: true });
   return true;
+}
+
+/**
+ * Records that one finding disagrees with another.
+ *
+ * AN EDGE, NOT AN OVERWRITE -- the design is explicit about why: "when a belief
+ * changes, the graph should record THAT it changed and why, not quietly present
+ * the new one as though it had always been true." `contradicts` has been in
+ * EDGE_KINDS since the schema existed and was written by nothing, while
+ * `audit()` already READ it.
+ *
+ * The contradicted finding is deliberately NOT retired, and its claim is
+ * deliberately preserved. A reader needs to see both claims and the
+ * disagreement between them; retiring one silently picks a winner, and putNode
+ * does not merge -- it writes the whole record from what it is handed, so
+ * annotating the target without spreading it back in would blank the very claim
+ * this edge exists to keep visible. That is the overwrite by another name.
+ *
+ * THE EDGE IS WRITTEN FIRST, and the order is the guarantee. These are two
+ * appends and `append` fails open, so either can be the one that lands. Edge
+ * without annotation is a complete, readable disagreement missing only its
+ * reason. Annotation without edge is a finding that says "something contradicts
+ * me" with no contradictor -- a claim of proof with no proof, and invisible to
+ * `audit()` and to `hasOutstandingContradiction`, both of which read the edge.
+ */
+export function contradict(dir, { key, byKey, reason }) {
+  const graph = load(dir);
+  const target = findingByKey(graph, key);
+  const source = findingByKey(graph, byKey);
+  // Both ends must exist, or the edge is unresolvable and the disagreement is
+  // recorded against nothing -- the same un-invalidatable shape anchors prevent.
+  if (!target || !source) return false;
+  // A finding cannot disagree with itself. The self-edge resolves, so the guard
+  // above waves it through, and the result is a node permanently blocked from
+  // confidence promotion by a dispute no person can ever resolve: there is no
+  // second claim to choose between.
+  if (target.id === source.id) return false;
+
+  putEdge(dir, source.id, 'contradicts', target.id);
+  putNode(dir, {
+    ...target,
+    kind: 'finding',
+    key,
+    contradictedAt: Date.now(),
+    contradictionReason: String(reason || '').slice(0, 400),
+  });
+  return true;
+}
+
+/**
+ * Whether anything currently disagrees with this finding.
+ *
+ * Gates confidence promotion. Plan 2's per-finding utility measures whether a
+ * finding SUPPRESSES READS, and a confidently wrong finding suppresses reads
+ * better than a hedged true one -- so utility must never raise confidence on
+ * its own, and this is the check that stops it.
+ *
+ * SYMMETRIC, deliberately: BOTH ends of a `contradicts` edge are outstanding
+ * until a person resolves the disagreement. The named hazard in the design is
+ * presenting "the new one as though it had always been true", so gating only
+ * the older claim would leave the newer one -- which is just as likely to be
+ * the wrong one, since nothing here adjudicates -- free to be promoted on
+ * measured utility alone. That is the exact failure this gate exists to stop.
+ * It also matches `audit()`, the reader that has always been here: it puts both
+ * `from` and `to` in its `contradicted` bucket, because "until one looks, BOTH
+ * are being served".
+ */
+export function hasOutstandingContradiction(graph, key) {
+  const node = findingByKey(graph, key);
+  if (!node) return false;
+  return graph.edges.some(
+    (e) => e.edge === 'contradicts' && (e.to === node.id || e.from === node.id)
+  );
 }
 
 /**

--- a/integrations/kilo/hooks/lib/curate.mjs
+++ b/integrations/kilo/hooks/lib/curate.mjs
@@ -124,7 +124,17 @@ export function correct(
   const replacementKey = `${key}-c${Date.now().toString(36)}`;
 
   const edges = [{ edge: 'supersedes', to: originalId }];
-  // The correction inherits the original's anchors, so it can go stale too.
+  // The correction inherits the original's anchors, so it can go stale too --
+  // but it inherits NOTHING ELSE, and that is deliberate rather than incidental.
+  // The node written below is built field by field from `existing` instead of
+  // spreading it, which is what keeps the staleness fields (`stale`,
+  // `staleReason`, `diff`) off the successor: a correction is re-derived
+  // against the current code by definition, so being born carrying its
+  // predecessor's invalidation would discount it the moment it existed --
+  // `disclose.mjs` skips a stale finding outright and `utility.mjs` penalises
+  // one by 160. Any future edit here that reaches for `...existing` to pick up
+  // one more field re-introduces that, since `putNode` writes what it is handed
+  // wholesale; `tests/hooks/stale-clearing.test.mjs` is the guard.
   for (const edge of graph.edges) {
     if (edge.edge === 'derived_from' && edge.from === originalId) {
       edges.push({ edge: 'derived_from', to: edge.to });
@@ -244,13 +254,38 @@ export function contradict(dir, { key, byKey, reason }) {
  * It also matches `audit()`, the reader that has always been here: it puts both
  * `from` and `to` in its `contradicted` bucket, because "until one looks, BOTH
  * are being served".
+ *
+ * A RETIRED COUNTERPART DOES NOT COUNT, and that sentence quoted just above is
+ * the reason. This read edges ONLY, so retiring one end of a contradiction left
+ * the survivor gated against confidence promotion forever and served with a
+ * DISPUTED note naming a key `serve` refuses to hand anybody -- `serve`,
+ * `activeFindings`, `findingsFor` and `sessionIndex` all drop a retired
+ * finding. A retired claim is served to NOBODY, so "BOTH are being served" is
+ * false and the premise of the gate is gone: only one claim is in play, and
+ * there is nothing left to choose between. Retiring one end IS the person
+ * looking that this gate was waiting for -- so the edge counts as open only
+ * while NEITHER end is retired, answered the same way from both directions.
+ *
+ * AN UNRESOLVABLE END STILL COUNTS. An edge whose other side names no node
+ * proves nothing about whether that claim was withdrawn, and the conservative
+ * reading -- still disputed -- is the one that cannot promote a claim nobody
+ * adjudicated.
  */
 export function hasOutstandingContradiction(graph, key) {
   const node = findingByKey(graph, key);
-  if (!node) return false;
-  return graph.edges.some(
-    (e) => e.edge === 'contradicts' && (e.to === node.id || e.from === node.id)
-  );
+  // A withdrawn claim is not in a dispute either: a dispute needs two claims in
+  // play, and this one has been taken out of play. Without this the RETIRED end
+  // still reported an open disagreement, which is the same defect from the other
+  // side -- and the answer has to agree from both directions, since the gate is
+  // symmetric on purpose.
+  if (!node || node.retired) return false;
+  return graph.edges.some((e) => {
+    if (e.edge !== 'contradicts') return false;
+    const otherId = e.from === node.id ? e.to : e.to === node.id ? e.from : null;
+    if (!otherId) return false;
+    const other = graph.nodes.get(otherId);
+    return !other || !other.retired;
+  });
 }
 
 /**
@@ -334,11 +369,24 @@ export function audit(graph) {
       .map((e) => e.from)
   );
 
+  // THE SAME DEFINITION OF AN OPEN DISPUTE as hasOutstandingContradiction, and
+  // it has to be: that function's own comment claims it "matches audit()", and
+  // two rankings that disagree about what needs a human is worse than one that
+  // is wrong. A retired counterpart is a resolved dispute -- the retired claim
+  // is served to nobody -- so the survivor is not one of two claims in play and
+  // does not belong in the bucket of things needing a person to look.
+  //
+  // One pass, not a call per finding: this is a dashboard read over the whole
+  // graph, and the obvious rewrite is O(findings x edges).
   const contradicted = new Set();
   for (const edge of graph.edges) {
     if (edge.edge !== 'contradicts') continue;
-    contradicted.add(edge.from);
-    contradicted.add(edge.to);
+    const from = graph.nodes.get(edge.from);
+    const to = graph.nodes.get(edge.to);
+    // An end that resolves to nothing cannot be shown retired, so it still
+    // counts against the other end.
+    if (!to || !to.retired) contradicted.add(edge.from);
+    if (!from || !from.retired) contradicted.add(edge.to);
   }
 
   return {

--- a/integrations/kilo/hooks/lib/curate.mjs
+++ b/integrations/kilo/hooks/lib/curate.mjs
@@ -70,6 +70,38 @@ export function originWeight(origin) {
   return 1;
 }
 
+/**
+ * The claim-time anchor hashes, for a finding being written right now.
+ *
+ * THE CHECKABLE HALF OF PROVENANCE, and until now only `harvest-write.mjs`
+ * wrote it -- so the asymmetry ran exactly the wrong way. `reverify` and the
+ * automatic clear in `serve` both compare disk against these frozen hashes, and
+ * a finding without them can never have a stale flag cleared by anything. That
+ * meant HUMAN-asserted findings, the ones somebody deliberately created or
+ * corrected, were the only ones condemned to stay stale forever once marked,
+ * while machine-harvested claims could recover. The hashes are simply the anchor
+ * nodes' hashes at this moment, and every writer has them in hand.
+ *
+ * DELIBERATELY NOT THE WHOLE RECORD `derivationFor` BUILDS. That one joins the
+ * evidence log to find FILE-surface operations behind the claim; curation
+ * performs no such join, so `operations` is empty and `operationsComplete` says
+ * so. An empty list declared incomplete is honest -- "nothing recorded here, and
+ * do not read that as nothing happened" -- where an empty list declared complete
+ * would assert a fact nobody established.
+ *
+ * An anchor with no stored hash contributes no entry, and a finding whose
+ * anchors all lack one gets a record with no hashes -- which `claimTimeVerdict`
+ * reads as `unknown` and refuses to clear on, which is the correct reading.
+ */
+function claimTimeDerivation(graph, resolved) {
+  const anchors = {};
+  for (const id of resolved) {
+    const node = graph.nodes.get(id);
+    if (node && typeof node.hash === 'string') anchors[id] = node.hash;
+  }
+  return { at: Date.now(), anchors, operations: [], operationsComplete: false };
+}
+
 function findingByKey(graph, key) {
   return graph.nodes.get(nodeId('finding', key)) || null;
 }
@@ -124,6 +156,11 @@ export function correct(
   const replacementKey = `${key}-c${Date.now().toString(36)}`;
 
   const edges = [{ edge: 'supersedes', to: originalId }];
+  // Collected alongside the edges so the correction carries its own claim-time
+  // hashes: it is a NEW claim, re-derived against whatever the code says now, so
+  // its evidence is the anchors' current state -- not the predecessor's, which is
+  // precisely what went stale.
+  const inherited = [];
   // The correction inherits the original's anchors, so it can go stale too --
   // but it inherits NOTHING ELSE, and that is deliberate rather than incidental.
   // The node written below is built field by field from `existing` instead of
@@ -138,6 +175,7 @@ export function correct(
   for (const edge of graph.edges) {
     if (edge.edge === 'derived_from' && edge.from === originalId) {
       edges.push({ edge: 'derived_from', to: edge.to });
+      inherited.push(edge.to);
     }
   }
 
@@ -171,6 +209,11 @@ export function correct(
       // branches, and an unrecognised value already degrades to the neutral
       // ranking weight rather than doing damage.
       origin: typeof origin === 'string' && origin ? origin : ORIGIN_HUMAN,
+      // Without this a correction could never have a stale flag cleared: both
+      // clearing paths compare disk against these hashes, and a finding with
+      // none is `unknown` forever. A hand-written correction being the least
+      // recoverable record in the graph was the wrong way round.
+      derivation: claimTimeDerivation(graph, inherited),
     },
     edges
   );
@@ -339,7 +382,18 @@ export function create(dir, { claim, anchors, type = 'finding', confidence = 0.9
   // path. No process death required; one transient EBUSY is enough.
   const id = putNodeWithEdges(
     dir,
-    { kind: 'finding', key, claim, confidence, type, origin: ORIGIN_HUMAN },
+    {
+      kind: 'finding',
+      key,
+      claim,
+      confidence,
+      type,
+      origin: ORIGIN_HUMAN,
+      // Read AFTER the indexFile loop above, so the hashes are the ones the
+      // person's claim was actually made against rather than whatever the graph
+      // held before this call touched it.
+      derivation: claimTimeDerivation(loadGraph(dir), resolved),
+    },
     resolved.map((target) => ({ edge: 'derived_from', to: target }))
   );
   if (!id) return null;

--- a/integrations/kilo/hooks/lib/decide.mjs
+++ b/integrations/kilo/hooks/lib/decide.mjs
@@ -542,19 +542,92 @@ const TOOL_ALIASES = new Map(
     run_shell_command: 'Bash',
     run_terminal_cmd: 'Bash',
     terminal: 'Bash',
+
+    // THIS PROJECT'S OWN TOOLS, which the table did not list for as long as it
+    // existed. `plugin/hooks/hooks.json`'s PostToolUse matcher named
+    // `mcp__.*__(?:smart_edit|smart_write)` and Codex's AfterTool matcher named
+    // the bare `smart_edit|smart_write`, so both hooks fired -- and then
+    // `normalizeTool` returned null and the hook exited before a single line of
+    // accounting ran. Staleness, mutation counting and harvest pressure were all
+    // blind on exactly the path enforcement pushes the model toward, which is the
+    // worst place to be blind: the more effective the routing, the less the
+    // optimizer saw.
+    //
+    // These names are the CANONICAL operation, not a licence to redirect. A call
+    // that is already the replacement is excluded from routing by
+    // `isReplacementTool` below.
+    smart_read: 'Read',
+    smart_grep: 'Grep',
+    smart_glob: 'Glob',
+    smart_edit: 'Edit',
+    smart_write: 'Write',
+
+    // Claude Code's notebook editor. Same shape of gap: a real mutation of a
+    // real file on disk that arrived as null and so never reached
+    // `pending.mjs`'s MUTATING set, leaving every notebook write invisible to
+    // invalidation.
+    notebookedit: 'Edit',
+    notebook_edit: 'Edit',
   })
 );
 
-/** Maps a client's tool name onto the canonical one, or null if unhandled. */
+/**
+ * The optimizer's own replacement tools, by canonical trailing segment.
+ *
+ * Kept separate from the alias table because the two answer different questions.
+ * The table answers "what operation is this", which post-tool accounting needs.
+ * This set answers "is this call ALREADY the thing we would have recommended",
+ * which routing needs -- and conflating them is the loop hazard: `smart_edit`
+ * resolves to `Edit`, the Edit branch recommends `smart_edit`, and the model is
+ * told to call the tool it just called.
+ */
+const REPLACEMENT_TOOLS = new Set([
+  'smart_read',
+  'smart_grep',
+  'smart_glob',
+  'smart_edit',
+  'smart_write',
+]);
+
+/**
+ * The tool name with an `mcp__<server>__` prefix removed, if it had one.
+ *
+ * Server segments contain underscores freely (`plugin_token-optimizer_token-optimizer`)
+ * and so do tool names (`smart_edit`), so the split is taken at the LAST `__`
+ * after the `mcp__` sentinel. Both halves must be non-empty: `mcp__edit` names
+ * no server and is not a name any host emits, and treating it as `edit` would
+ * coerce an unrecognised string into a built-in.
+ */
+function withoutMcpPrefix(name) {
+  const match = /^mcp__(.+)__(.+)$/.exec(name);
+  return match ? match[2] : name;
+}
+
+/** Whether this call IS one of the optimizer's replacements, however spelled. */
+export function isReplacementTool(name) {
+  if (!name) return false;
+  return REPLACEMENT_TOOLS.has(withoutMcpPrefix(String(name)).toLowerCase());
+}
+
+/**
+ * Maps a client's tool name onto the canonical one, or null if unhandled.
+ *
+ * PERMISSIVE IN ONE DIRECTION ONLY. An MCP-prefixed name is resolved by its
+ * trailing segment, but only against the same table every other client is held
+ * to -- so `mcp__vendor__deploy_to_prod` stays null. Coercing an unrecognised
+ * MCP tool into a built-in would change a routing verdict for a tool nobody has
+ * considered, which is a far worse failure than not accounting for it.
+ */
 export function normalizeTool(name) {
   if (!name) return null;
+  const candidate = withoutMcpPrefix(String(name));
   if (
     ['Read', 'Grep', 'Glob', 'Edit', 'MultiEdit', 'Write', 'Bash'].includes(
-      name
+      candidate
     )
   )
-    return name;
-  return TOOL_ALIASES.get(String(name).toLowerCase()) || null;
+    return candidate;
+  return TOOL_ALIASES.get(candidate.toLowerCase()) || null;
 }
 
 /**
@@ -614,6 +687,13 @@ export function normalizePayload(raw) {
     transcript_path: raw.transcript_path ?? raw.transcriptPath ?? null,
     cwd,
     tool_name: normalizeTool(raw.tool_name ?? raw.toolName ?? raw.tool),
+    // WHETHER THIS CALL IS ALREADY THE REPLACEMENT, carried alongside the
+    // canonical name rather than inferred from it -- because it cannot be
+    // inferred from it. `smart_edit` and `Edit` both normalise to `Edit`, and
+    // routing has to treat them as opposites while accounting treats them as
+    // the same. Absent by default (`false`), so a payload assembled by hand in
+    // a test or by a caller that predates this field is a normal built-in call.
+    replacement: isReplacementTool(raw.tool_name ?? raw.toolName ?? raw.tool),
     tool_input: {
       ...input,
       // CANONICALISED HERE, once. Every consumer downstream -- the `seen` map
@@ -673,6 +753,19 @@ function replacementAvailable(availableTools, name) {
 }
 
 export function decide(payload, state, availableTools = undefined) {
+  // THE LOOP HAZARD, and the reason this guard is at the top rather than inside
+  // any one branch. Resolving `smart_edit` to `Edit` is what makes post-tool
+  // accounting work; it must not also make the Edit branch answer a smart_edit
+  // call with "call smart_edit instead". This is not theoretical on a matcher
+  // level either: Qwen's PreToolUse matcher is the unanchored regex
+  // `edit|write_file|run_shell_command`, and `edit` matches inside
+  // `mcp__x__smart_edit`, so that client really does hand the router calls to
+  // its own replacements.
+  //
+  // A tool that IS the replacement is never routed. There is nothing better to
+  // recommend, and every branch below would recommend itself.
+  if (payload.replacement) return null;
+
   const tool = payload.tool_name;
   const input = payload.tool_input || {};
   const threshold = largeFileBytes();
@@ -873,6 +966,12 @@ export function remember(payload, state) {
  */
 export function readCostBytes(payload) {
   if (payload.tool_name !== 'Read') return 0;
+  // A REPLACEMENT DID NOT SPEND THE WHOLE FILE. `smart_read` normalises to
+  // `Read` so the graph sees the touch, but it returns a diff -- charging the
+  // full file size here would feed the holdout comparison a cost that was never
+  // paid, on the arm the optimizer is trying to show is cheaper. Better to
+  // record nothing than to record a number in the wrong direction.
+  if (payload.replacement) return 0;
   const path = payload.tool_input?.file_path;
   if (!path || isBinaryPath(path)) return 0;
   const size = fileSize(path);

--- a/integrations/kilo/hooks/lib/disclose.mjs
+++ b/integrations/kilo/hooks/lib/disclose.mjs
@@ -294,6 +294,11 @@ export function verdictFor(graph, { anchors = [], question, minConfidence = 0.7 
     const id = nodeId('file', canonicalPath(anchor));
     if (!graph.nodes.has(id)) continue;
 
+    // READ-ONLY serve: no `dir` is threaded here, so this cannot clear a stale
+    // flag whose evidence is gone. That is deliberate -- this function takes a
+    // graph, not the directory it came from, and widening its signature to give
+    // an analysis path a write capability buys nothing: the injection path runs
+    // on every tool call and clears the same findings.
     const findings = serve(graph, findingsFor(graph, id, { limit: 4 }));
     for (const finding of findings) {
       if (finding.stale) continue;

--- a/integrations/kilo/hooks/lib/harvest-write.mjs
+++ b/integrations/kilo/hooks/lib/harvest-write.mjs
@@ -34,7 +34,7 @@ import { randomBytes } from 'node:crypto';
 import { realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
-import { readEvidence } from './metrics.mjs';
+import { readEvidence, evidenceTruncated } from './metrics.mjs';
 
 /**
  * The types that may cross a project boundary.
@@ -431,53 +431,84 @@ function resolveAnchor(dir, anchor, projectRoot) {
 /**
  * Which task actually produced this finding, when nothing said so directly.
  *
- * Session id was the only signal `answers` had, and a session id is exactly
- * what a caller may not have (`wiki_write`'s `sessionId` is optional and
- * nothing populates it today; the detached harvest worker's is gated behind
- * an opt-in). But the graph does not need to be TOLD which task this is: the
- * structural harvest already writes `task -[derived_from]-> file` for every
- * tool call, unconditionally, on every install. So the task is DERIVABLE --
- * it is whichever task node has a `derived_from` edge to one of the SAME
- * anchors this finding resolved to.
+ * ROUND 2's version scanned the WHOLE graph for any task sharing any anchor,
+ * broken by recency. An adversarial review constructed four cases where that
+ * attributes a finding to the WRONG task:
  *
- * "Most recent task, full stop" was rejected on purpose: a task that never
- * touched these files could still be the newest node in the graph (a
- * different file, a different concern, in a later session), and attaching
- * provenance to it would be a WRONG edge, not a missing one -- worse than no
- * edge, because a reader trusts it. So candidates are filtered to tasks that
- * touched at least one of these anchors FIRST, and only ties among THOSE are
- * broken by recency.
+ *   1. STALE PRIOR SESSION -- a session that reasons from injected memory and
+ *      writes a finding about `foo.ts` without touching it this session gets
+ *      attributed to whatever task last touched `foo.ts`, possibly days old,
+ *      possibly someone else's work.
+ *   2. CONCURRENT SESSION -- two windows on one repository; the other
+ *      session's task wins if its touch is a millisecond later.
+ *   3. OVERLAP, NOT COVERAGE -- a finding anchored to [a, b]; a task that
+ *      touched only `b` could still win over one that touched both.
+ *   4. THE TIE-BREAK CONTRADICTED ITS OWN COMMENT -- `Number(edge.at) || 0`
+ *      with strict `>` means the FIRST edge in log order wins on a tie,
+ *      which is the OLDER task, not "more recently" as documented.
  *
- * The tie-break is the edge's own `at`, not the task node's `at`. A task that
- * touched this file once, long ago, and then stayed active on unrelated files
- * for hours has a late node timestamp that says nothing about this anchor;
- * the edge timestamp says exactly when THIS task touched THIS anchor, which
- * is the question being asked. Among tasks sharing an anchor, the one whose
- * most recent touch to any shared anchor is latest wins -- recency of the
- * relevant work, not recency of the task in general.
+ * THE FIX IS NARROWER THAN A BETTER RANKING: SCOPE, THEN REQUIRE COVERAGE.
+ * A task only ever belongs to the session that created it -- `harvest()` and
+ * `linkCoOccurrence()` (wiki.mjs, inject.mjs) both key a task node by
+ * `sessionId`, always, so there is exactly ONE task node for "the current
+ * session" and it is `nodeId('task', sessionId)`. Restricting to that ONE
+ * node structurally eliminates cases 1 and 2 -- a prior or concurrent
+ * session's task has a DIFFERENT sessionId and therefore a different node
+ * id, so it is never even looked at, regardless of timing. No caller can
+ * supply a wrong sessionId and get someone ELSE's task; they can only fail
+ * to get a match.
+ *
+ * COVERAGE, NOT OVERLAP, fixes case 3: the session's task must have a
+ * `derived_from` edge to EVERY one of this finding's anchors, not merely one.
+ * A partial touch is not attribution.
+ *
+ * With the candidate set reduced to at most one node, there is nothing left
+ * to break a tie between -- case 4's comparator is not "fixed", it is
+ * deleted, because the scenario it was written for (two DIFFERENT tasks both
+ * legitimately eligible) cannot occur under this scoping: two task nodes can
+ * never share a key, and only the current session's key is ever considered.
+ * An edge's `at` therefore plays NO role here: presence of a `derived_from`
+ * edge from the session's task to an anchor is what "touched it" means, with
+ * or without a timestamp on that edge -- there is no ranking left for a
+ * missing timestamp to lose.
+ *
+ * `sessionId` absent means there is no identity to scope by, which means no
+ * candidate -- not "fall back to guessing". Absence is the correct answer
+ * when the graph cannot support attribution.
  */
-function taskForAnchors(graph, anchorIds) {
-  if (!anchorIds || !anchorIds.length) return null;
-  const anchors = new Set(anchorIds);
-  let best = null;
-  for (const edge of graph.edges) {
-    if (edge.edge !== 'derived_from' || !anchors.has(edge.to)) continue;
-    const from = graph.nodes.get(edge.from);
-    // `derived_from` is also how a FINDING cites its own anchors, so without
-    // this a finding that already cited the same file would be mistaken for
-    // the task that produced it.
-    if (!from || from.kind !== 'task') continue;
-    const at = Number(edge.at) || 0;
-    if (!best || at > best.at) best = { taskId: edge.from, at };
+function taskForAnchors(graph, anchorIds, sessionId) {
+  if (!sessionId || !anchorIds || !anchorIds.length) return null;
+  const taskTarget = nodeId('task', sessionId);
+  const task = graph.nodes.get(taskTarget);
+  if (!task || task.kind !== 'task') return null;
+
+  for (const anchor of anchorIds) {
+    const covered = graph.edges.some((edge) =>
+      edge.edge === 'derived_from' && edge.from === taskTarget && edge.to === anchor
+    );
+    // ONE missing anchor refuses the whole attribution. A finding cited three
+    // files; this session's task touched two of them -- that is evidence the
+    // task did SOME related work, not evidence it produced THIS finding.
+    if (!covered) return null;
   }
-  return best ? best.taskId : null;
+  return taskTarget;
 }
 
 /**
  * A file path the way `recordToolOutcome` (metrics.mjs) already truncates and
- * stores it on a `tool-outcome` event's `anchor` field, so a derivation record
- * can join against that log without a second, divergent notion of "the same
- * anchor".
+ * stores it on a FILE-surface `tool-outcome` event's `anchor` field, so a
+ * derivation record can join against that log without a second, divergent
+ * notion of "the same anchor".
+ *
+ * COMMAND-surface events are DECLARED OUT OF SCOPE, not silently missed:
+ * `adapter.mjs` stores the COMMAND TEXT in `anchor` for those
+ * (`String(command).slice(0, 120)`), so a build or test run can never share
+ * an anchor string with a canonical file path -- there is no join key in
+ * common, and inventing a command-to-file heuristic (which files did a given
+ * `npm test` invocation cover?) is not something this record can answer
+ * honestly. `operationsScope` on the returned record says so explicitly,
+ * rather than letting an empty `operations` array look like "no build or
+ * test ever ran" when the truth is "this join cannot see it".
  */
 function anchorLabel(rawAnchor) {
   const path = String(rawAnchor).split('#')[0];
@@ -497,7 +528,8 @@ const MAX_DERIVATION_OPERATIONS = 5;
  * that comparison be reconstructed for a specific claim rather than only for
  * the anchor in general: the hash each anchor carried at the moment this
  * finding was derived from it, plus what evidence exists that any work
- * actually happened against it.
+ * actually happened against it. `derivationCheck` (staleness.mjs) is the
+ * reader that actually performs that comparison at serve time.
  *
  * DELIBERATELY NOT DUPLICATING THE EDGES. `derived_from` already records
  * WHICH anchors this finding cites; restating that here would be a second,
@@ -506,14 +538,23 @@ const MAX_DERIVATION_OPERATIONS = 5;
  *
  * DELIBERATELY NOT A REPLAY LOG. Recording enough to mechanically re-run a
  * derivation is a separate subsystem with real storage cost. This stores only
- * what the evidence log already has: `tool-outcome` events matching these
- * anchors, each reduced to the fields that were actually captured. An event
- * that carries no exit code or output contributes none -- nothing here is
- * invented to fill a shape the pipeline does not evidence yet. If a future
- * capture pass adds `exit`/`output` to those events, this starts carrying them
- * with no change to this function.
+ * what the evidence log already has: FILE-surface `tool-outcome` events
+ * matching these anchors, each reduced to the fields that were actually
+ * captured. An event that carries no exit code or output contributes none --
+ * nothing here is invented to fill a shape the pipeline does not evidence
+ * yet. If a future capture pass adds `exit`/`output` to those events, this
+ * starts carrying them with no change to this function.
+ *
+ * INCOMPLETENESS IS MARKED, NOT IMPLIED. An empty `operations` array is
+ * genuinely ambiguous on its own -- it is the same shape whether nothing
+ * happened, or something happened but fell outside what this join can see.
+ * `operationsComplete` distinguishes them: false when the evidence log itself
+ * may have dropped older matches (`evidenceIncomplete`, from
+ * `metrics.evidenceTruncated`) OR when more matches existed than the cap
+ * kept. A reader can then tell "no operations happened" from "operations
+ * existed but are not recorded here" instead of guessing.
  */
-function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
+function derivationFor(graph, resolvedAnchors, evidence, evidenceIncomplete, anchorSpecs) {
   const anchorHashes = {};
   for (const id of resolvedAnchors) {
     const node = graph.nodes.get(id);
@@ -521,8 +562,10 @@ function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
   }
 
   const labels = new Set((anchorSpecs || []).map(anchorLabel));
-  const operations = evidence
-    .filter((event) => event.kind === 'tool-outcome' && labels.has(event.anchor))
+  const matching = evidence.filter(
+    (event) => event.kind === 'tool-outcome' && labels.has(event.anchor)
+  );
+  const operations = [...matching]
     .sort((a, b) => (Number(b.at) || 0) - (Number(a.at) || 0))
     .slice(0, MAX_DERIVATION_OPERATIONS)
     .map((event) => {
@@ -540,7 +583,16 @@ function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
       return op;
     });
 
-  return { at: Date.now(), anchors: anchorHashes, operations };
+  return {
+    at: Date.now(),
+    anchors: anchorHashes,
+    operations,
+    // FILE touches only -- see `anchorLabel`. Declared here, in the record
+    // itself, not only in this function's comment, so a reader who never
+    // opens this source file still learns builds and test runs are excluded.
+    operationsScope: 'file',
+    operationsComplete: !evidenceIncomplete && matching.length <= operations.length,
+  };
 }
 
 /**
@@ -588,6 +640,9 @@ export function writeHarvested(
   // it can hold thousands of lines, so re-reading it per finding would turn a
   // batch of N findings into N passes over the same bytes.
   const evidence = readEvidence(dir);
+  // Cheap: one stat call, checked once per batch rather than once per
+  // finding's derivation record.
+  const evidenceIncomplete = evidenceTruncated(dir);
 
   const written = [];
   for (const finding of findings) {
@@ -647,14 +702,16 @@ export function writeHarvested(
     // An explicit `taskId` is authoritative when a caller supplies one --
     // it OVERRIDES traversal rather than merely seeding it, so a caller that
     // knows better is never second-guessed by inference. Absent one, the task
-    // is DERIVED from the graph itself: `taskForAnchors` finds the task that
-    // actually touched these anchors, which needs no session id from anyone.
-    // Either way, held to the same discipline as the anchors above: a target
-    // that does not resolve to an existing task node produces no edge rather
-    // than a dangling one.
+    // is DERIVED from the graph itself: `taskForAnchors` finds the CURRENT
+    // session's task (scoped by `sessionId`, the same identity this write
+    // already carries for provenance) and requires it to have touched EVERY
+    // one of this finding's anchors, not merely one -- see that function's
+    // own comment for the four attacks this closes. Either way, held to the
+    // same discipline as the anchors above: a target that does not resolve to
+    // an existing task node produces no edge rather than a dangling one.
     const answersTarget = taskId
       ? nodeId('task', taskId)
-      : taskForAnchors(currentGraph, resolved);
+      : taskForAnchors(currentGraph, resolved, sessionId);
     if (answersTarget && currentGraph.nodes.has(answersTarget)) {
       edges.push({ edge: 'answers', to: answersTarget });
     }
@@ -707,7 +764,7 @@ export function writeHarvested(
         // `render()`/`renderSessionIndex()` in inject.mjs or `wiki_read`'s
         // `toFinding()` projection, neither of which reads this field, so it
         // is not part of the automatic per-touch injection `fit()` prices.
-        derivation: derivationFor(currentGraph, resolved, evidence, finding.anchors || []),
+        derivation: derivationFor(currentGraph, resolved, evidence, evidenceIncomplete, finding.anchors || []),
       },
       edges
     );

--- a/integrations/kilo/hooks/lib/harvest-write.mjs
+++ b/integrations/kilo/hooks/lib/harvest-write.mjs
@@ -452,11 +452,13 @@ function resolveAnchor(dir, anchor, projectRoot) {
  * `linkCoOccurrence()` (wiki.mjs, inject.mjs) both key a task node by
  * `sessionId`, always, so there is exactly ONE task node for "the current
  * session" and it is `nodeId('task', sessionId)`. Restricting to that ONE
- * node structurally eliminates cases 1 and 2 -- a prior or concurrent
- * session's task has a DIFFERENT sessionId and therefore a different node
- * id, so it is never even looked at, regardless of timing. No caller can
- * supply a wrong sessionId and get someone ELSE's task; they can only fail
- * to get a match.
+ * node structurally eliminates cases 1 and 2 PROVIDED the identity itself is
+ * trustworthy: an UNRELATED sessionId (typo'd, invented, or simply absent)
+ * cannot resolve to someone else's task, because a different key is a
+ * different node id, full stop, regardless of timing. That is NOT the same
+ * guarantee as "no caller can get someone else's task" -- see the note on
+ * `authoritativeSessionId` below for the residual this leaves when the
+ * identity is real but comes from an untrusted caller.
  *
  * COVERAGE, NOT OVERLAP, fixes case 3: the session's task must have a
  * `derived_from` edge to EVERY one of this finding's anchors, not merely one.
@@ -472,17 +474,41 @@ function resolveAnchor(dir, anchor, projectRoot) {
  * or without a timestamp on that edge -- there is no ranking left for a
  * missing timestamp to lose.
  *
- * `sessionId` absent means there is no identity to scope by, which means no
- * candidate -- not "fall back to guessing". Absence is the correct answer
- * when the graph cannot support attribution.
+ * NO IDENTITY MEANS NO CANDIDATE -- not "fall back to guessing". Absence is
+ * the correct answer when the graph cannot support attribution.
+ *
+ * ROUND 4: THE IDENTITY ITSELF MUST BE AUTHORITATIVE, not merely present.
+ * Scoping to `nodeId('task', sessionId)` only refuses an UNRELATED session;
+ * it does nothing against a FOREIGN BUT REAL one. `wiki_write`'s `sessionId`
+ * is a plain MCP tool argument the calling model supplies, unverified -- a
+ * model that names some OTHER, prior session whose task genuinely covered
+ * these anchors gets an `answers` edge to that stale task, because coverage
+ * cannot tell "this session" from "a session that really did touch these
+ * files, named by a string nothing cross-checked". Session id is not
+ * evidence unless the CALLER'S OWN CHANNEL is trustworthy, which is true of
+ * `plugin/hooks/harvest-worker.mjs` (Claude Code's own hook payload) and not
+ * true of a tool-call argument. So this parameter is named for what it must
+ * be, `authoritativeSessionId`, and every caller is a promise: pass this only
+ * when you did not just read it out of untrusted input. `wiki_write` passes
+ * NONE, which means its calls never traverse -- see `writeHarvested`'s own
+ * comment at the call site for what that costs and why it is accepted rather
+ * than worked around.
+ *
+ * COVERAGE IS CHECKED AGAINST RESOLVED ANCHORS, not the caller's original
+ * list. `writeHarvested` already drops any anchor `resolveAnchor` could not
+ * resolve before this function ever runs, so "every anchor" here means every
+ * anchor that survived that filter -- self-consistent with the
+ * `derived_from` edges the same resolved list produces, but worth stating:
+ * an anchor that failed to resolve cannot raise or lower the bar for the
+ * anchors that did.
  */
-function taskForAnchors(graph, anchorIds, sessionId) {
-  if (!sessionId || !anchorIds || !anchorIds.length) return null;
-  const taskTarget = nodeId('task', sessionId);
+function taskForAnchors(graph, resolvedAnchorIds, authoritativeSessionId) {
+  if (!authoritativeSessionId || !resolvedAnchorIds || !resolvedAnchorIds.length) return null;
+  const taskTarget = nodeId('task', authoritativeSessionId);
   const task = graph.nodes.get(taskTarget);
   if (!task || task.kind !== 'task') return null;
 
-  for (const anchor of anchorIds) {
+  for (const anchor of resolvedAnchorIds) {
     const covered = graph.edges.some((edge) =>
       edge.edge === 'derived_from' && edge.from === taskTarget && edge.to === anchor
     );
@@ -604,7 +630,19 @@ function derivationFor(graph, resolvedAnchors, evidence, evidenceIncomplete, anc
 export function writeHarvested(
   dir,
   findings,
-  { sessionId = null, origin = ORIGIN_HARVESTED, projectRoot = null, taskId = null } = {}
+  {
+    sessionId = null,
+    origin = ORIGIN_HARVESTED,
+    projectRoot = null,
+    taskId = null,
+    // Distinct from `sessionId`, which is stored on every finding for
+    // provenance/display regardless of trust. This one gates the `answers`
+    // traversal fallback specifically, and every caller passing it is
+    // asserting the identity came from a channel it does not control --
+    // Claude Code's own hook payload, not a tool-call argument a model
+    // typed. See `taskForAnchors`'s comment for the attack this closes.
+    authoritativeSessionId = null,
+  } = {}
 ) {
   if (!Array.isArray(findings) || !findings.length) return [];
 
@@ -702,16 +740,29 @@ export function writeHarvested(
     // An explicit `taskId` is authoritative when a caller supplies one --
     // it OVERRIDES traversal rather than merely seeding it, so a caller that
     // knows better is never second-guessed by inference. Absent one, the task
-    // is DERIVED from the graph itself: `taskForAnchors` finds the CURRENT
-    // session's task (scoped by `sessionId`, the same identity this write
-    // already carries for provenance) and requires it to have touched EVERY
-    // one of this finding's anchors, not merely one -- see that function's
-    // own comment for the four attacks this closes. Either way, held to the
-    // same discipline as the anchors above: a target that does not resolve to
-    // an existing task node produces no edge rather than a dangling one.
+    // is DERIVED from the graph itself, but ONLY when `authoritativeSessionId`
+    // is present: `taskForAnchors` scopes to that exact session's task and
+    // requires it to have touched EVERY one of this finding's anchors, not
+    // merely one -- see that function's own comment for why the identity
+    // itself must be trustworthy, not merely present.
+    //
+    // THE CONSEQUENCE, STATED PLAINLY: `wiki_write` never supplies
+    // `authoritativeSessionId` (its `sessionId` is a model-typed MCP
+    // argument nothing cross-checks), so its calls never traverse and
+    // `answers` never fires on that path. `plugin/hooks/harvest-worker.mjs`
+    // does supply it (Claude Code's own hook payload), so `answers` fires
+    // there -- opt-in gated. `answers` therefore does NOT fire on a default
+    // install today. Recovering default liveness needs an authoritative
+    // identity on a default-install path, which is what Plan 2's
+    // `hooks-core/derive.mjs` (running in the Stop hook, where the session id
+    // is real) is for -- not a weaker check here.
+    //
+    // Either way, held to the same discipline as the anchors above: a target
+    // that does not resolve to an existing task node produces no edge rather
+    // than a dangling one.
     const answersTarget = taskId
       ? nodeId('task', taskId)
-      : taskForAnchors(currentGraph, resolved, sessionId);
+      : taskForAnchors(currentGraph, resolved, authoritativeSessionId);
     if (answersTarget && currentGraph.nodes.has(answersTarget)) {
       edges.push({ edge: 'answers', to: answersTarget });
     }

--- a/integrations/kilo/hooks/lib/harvest-write.mjs
+++ b/integrations/kilo/hooks/lib/harvest-write.mjs
@@ -436,7 +436,7 @@ function resolveAnchor(dir, anchor, projectRoot) {
 export function writeHarvested(
   dir,
   findings,
-  { sessionId = null, origin = ORIGIN_HARVESTED, projectRoot = null } = {}
+  { sessionId = null, origin = ORIGIN_HARVESTED, projectRoot = null, taskId = null } = {}
 ) {
   if (!Array.isArray(findings) || !findings.length) return [];
 
@@ -516,6 +516,21 @@ export function writeHarvested(
     // collision vanishingly unlikely while keeping the timestamp readable.
     const provenance = provenanceFor(finding);
     const key = `${prefixFor(provenance)}-${Date.now().toString(36)}-${written.length}-${randomBytes(4).toString("hex")}`;
+
+    const edges = resolved.map((target) => ({ edge: 'derived_from', to: target }));
+    // `answers` closes the loop back to the task that produced the finding, so
+    // provenance can be traversed rather than inferred: "which session
+    // established this, and from what". Declared in EDGE_KINDS and written by
+    // nothing until now. Held to the same discipline as the anchors above: a
+    // taskId that does not resolve to an existing task node produces no edge
+    // rather than a dangling one.
+    if (taskId) {
+      const taskTarget = nodeId('task', taskId);
+      if (currentGraph.nodes.has(taskTarget)) {
+        edges.push({ edge: 'answers', to: taskTarget });
+      }
+    }
+
     // ONE APPEND for the finding and every anchor it resolved. This runs in a
     // detached worker, so "the process survives to finish the loop" is not a
     // safe assumption: a node written without its edges is an active finding
@@ -557,7 +572,7 @@ export function writeHarvested(
           : undefined,
         sessionId,
       },
-      resolved.map((target) => ({ edge: 'derived_from', to: target }))
+      edges
     );
     // A failed write returns null. Reporting the key anyway would tell the
     // caller a claim was stored that no later session can retrieve.

--- a/integrations/kilo/hooks/lib/harvest-write.mjs
+++ b/integrations/kilo/hooks/lib/harvest-write.mjs
@@ -34,6 +34,7 @@ import { randomBytes } from 'node:crypto';
 import { realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
+import { readEvidence } from './metrics.mjs';
 
 /**
  * The types that may cross a project boundary.
@@ -428,6 +429,121 @@ function resolveAnchor(dir, anchor, projectRoot) {
 }
 
 /**
+ * Which task actually produced this finding, when nothing said so directly.
+ *
+ * Session id was the only signal `answers` had, and a session id is exactly
+ * what a caller may not have (`wiki_write`'s `sessionId` is optional and
+ * nothing populates it today; the detached harvest worker's is gated behind
+ * an opt-in). But the graph does not need to be TOLD which task this is: the
+ * structural harvest already writes `task -[derived_from]-> file` for every
+ * tool call, unconditionally, on every install. So the task is DERIVABLE --
+ * it is whichever task node has a `derived_from` edge to one of the SAME
+ * anchors this finding resolved to.
+ *
+ * "Most recent task, full stop" was rejected on purpose: a task that never
+ * touched these files could still be the newest node in the graph (a
+ * different file, a different concern, in a later session), and attaching
+ * provenance to it would be a WRONG edge, not a missing one -- worse than no
+ * edge, because a reader trusts it. So candidates are filtered to tasks that
+ * touched at least one of these anchors FIRST, and only ties among THOSE are
+ * broken by recency.
+ *
+ * The tie-break is the edge's own `at`, not the task node's `at`. A task that
+ * touched this file once, long ago, and then stayed active on unrelated files
+ * for hours has a late node timestamp that says nothing about this anchor;
+ * the edge timestamp says exactly when THIS task touched THIS anchor, which
+ * is the question being asked. Among tasks sharing an anchor, the one whose
+ * most recent touch to any shared anchor is latest wins -- recency of the
+ * relevant work, not recency of the task in general.
+ */
+function taskForAnchors(graph, anchorIds) {
+  if (!anchorIds || !anchorIds.length) return null;
+  const anchors = new Set(anchorIds);
+  let best = null;
+  for (const edge of graph.edges) {
+    if (edge.edge !== 'derived_from' || !anchors.has(edge.to)) continue;
+    const from = graph.nodes.get(edge.from);
+    // `derived_from` is also how a FINDING cites its own anchors, so without
+    // this a finding that already cited the same file would be mistaken for
+    // the task that produced it.
+    if (!from || from.kind !== 'task') continue;
+    const at = Number(edge.at) || 0;
+    if (!best || at > best.at) best = { taskId: edge.from, at };
+  }
+  return best ? best.taskId : null;
+}
+
+/**
+ * A file path the way `recordToolOutcome` (metrics.mjs) already truncates and
+ * stores it on a `tool-outcome` event's `anchor` field, so a derivation record
+ * can join against that log without a second, divergent notion of "the same
+ * anchor".
+ */
+function anchorLabel(rawAnchor) {
+  const path = String(rawAnchor).split('#')[0];
+  return canonicalPath(path).slice(0, 120);
+}
+
+/** How many recorded operations a single finding's derivation may cite. */
+const MAX_DERIVATION_OPERATIONS = 5;
+
+/**
+ * The checkable half of provenance: not just where a finding came from, but
+ * whether that derivation still holds.
+ *
+ * Citation-style provenance (a session or task id) answers "where". It never
+ * answers "does this still apply" -- that is what staleness already computes,
+ * by comparing an anchor's STORED hash against disk. This record is what lets
+ * that comparison be reconstructed for a specific claim rather than only for
+ * the anchor in general: the hash each anchor carried at the moment this
+ * finding was derived from it, plus what evidence exists that any work
+ * actually happened against it.
+ *
+ * DELIBERATELY NOT DUPLICATING THE EDGES. `derived_from` already records
+ * WHICH anchors this finding cites; restating that here would be a second,
+ * driftable copy of the same fact. What is new here, and only here, is the
+ * HASH each anchor carried at claim time -- edges carry no such thing.
+ *
+ * DELIBERATELY NOT A REPLAY LOG. Recording enough to mechanically re-run a
+ * derivation is a separate subsystem with real storage cost. This stores only
+ * what the evidence log already has: `tool-outcome` events matching these
+ * anchors, each reduced to the fields that were actually captured. An event
+ * that carries no exit code or output contributes none -- nothing here is
+ * invented to fill a shape the pipeline does not evidence yet. If a future
+ * capture pass adds `exit`/`output` to those events, this starts carrying them
+ * with no change to this function.
+ */
+function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
+  const anchorHashes = {};
+  for (const id of resolvedAnchors) {
+    const node = graph.nodes.get(id);
+    if (node && typeof node.hash === 'string') anchorHashes[id] = node.hash;
+  }
+
+  const labels = new Set((anchorSpecs || []).map(anchorLabel));
+  const operations = evidence
+    .filter((event) => event.kind === 'tool-outcome' && labels.has(event.anchor))
+    .sort((a, b) => (Number(b.at) || 0) - (Number(a.at) || 0))
+    .slice(0, MAX_DERIVATION_OPERATIONS)
+    .map((event) => {
+      const op = {};
+      if (typeof event.toolName === 'string' && event.toolName)
+        op.tool = event.toolName.slice(0, 60);
+      if (typeof event.success === 'boolean') op.success = event.success;
+      if (typeof event.at === 'number') op.at = event.at;
+      // Forward-compatible, not fabricated: neither field exists on a
+      // `tool-outcome` event in this pipeline today, so every operation
+      // omits them until a capture pass actually evidences one.
+      if (typeof event.exit === 'number') op.exit = event.exit;
+      if (typeof event.output === 'string' && event.output)
+        op.output = event.output.slice(0, 200);
+      return op;
+    });
+
+  return { at: Date.now(), anchors: anchorHashes, operations };
+}
+
+/**
  * Writes validated findings, returning the keys actually stored.
  *
  * `findings` is the output of `harvest.validate()`, so type/claim/confidence
@@ -467,6 +583,11 @@ export function writeHarvested(
       : batch;
   const prefixFor = (p) =>
     p === ORIGIN_AGENT ? 'agent' : p === ORIGIN_HUMAN ? 'human' : 'harvested';
+
+  // Read once: every finding in this batch shares the same evidence log, and
+  // it can hold thousands of lines, so re-reading it per finding would turn a
+  // batch of N findings into N passes over the same bytes.
+  const evidence = readEvidence(dir);
 
   const written = [];
   for (const finding of findings) {
@@ -521,14 +642,21 @@ export function writeHarvested(
     // `answers` closes the loop back to the task that produced the finding, so
     // provenance can be traversed rather than inferred: "which session
     // established this, and from what". Declared in EDGE_KINDS and written by
-    // nothing until now. Held to the same discipline as the anchors above: a
-    // taskId that does not resolve to an existing task node produces no edge
-    // rather than a dangling one.
-    if (taskId) {
-      const taskTarget = nodeId('task', taskId);
-      if (currentGraph.nodes.has(taskTarget)) {
-        edges.push({ edge: 'answers', to: taskTarget });
-      }
+    // nothing until now.
+    //
+    // An explicit `taskId` is authoritative when a caller supplies one --
+    // it OVERRIDES traversal rather than merely seeding it, so a caller that
+    // knows better is never second-guessed by inference. Absent one, the task
+    // is DERIVED from the graph itself: `taskForAnchors` finds the task that
+    // actually touched these anchors, which needs no session id from anyone.
+    // Either way, held to the same discipline as the anchors above: a target
+    // that does not resolve to an existing task node produces no edge rather
+    // than a dangling one.
+    const answersTarget = taskId
+      ? nodeId('task', taskId)
+      : taskForAnchors(currentGraph, resolved);
+    if (answersTarget && currentGraph.nodes.has(answersTarget)) {
+      edges.push({ edge: 'answers', to: answersTarget });
     }
 
     // ONE APPEND for the finding and every anchor it resolved. This runs in a
@@ -571,6 +699,15 @@ export function writeHarvested(
           ? finding.quote
           : undefined,
         sessionId,
+        // THE CHECKABLE HALF OF PROVENANCE. Citation-style (this `sessionId`,
+        // the `answers` edge above) says WHERE a claim came from; it never
+        // says whether that derivation still applies. `derivationFor` reaches
+        // through `wiki_query`'s `node`/`get`/`search` operations only (those
+        // return a finding's stored fields wholesale) -- never through
+        // `render()`/`renderSessionIndex()` in inject.mjs or `wiki_read`'s
+        // `toFinding()` projection, neither of which reads this field, so it
+        // is not part of the automatic per-touch injection `fit()` prices.
+        derivation: derivationFor(currentGraph, resolved, evidence, finding.anchors || []),
       },
       edges
     );

--- a/integrations/kilo/hooks/lib/inject.mjs
+++ b/integrations/kilo/hooks/lib/inject.mjs
@@ -26,6 +26,7 @@ import {
 } from './wiki.mjs';
 import { basename } from 'node:path';
 import { serve, diffLines } from './staleness.mjs';
+import { drainInvalidations } from './pending.mjs';
 import { inHoldout, record, indexBudget } from './metrics.mjs';
 import { canonicalPath, resolvableCandidates } from './paths.mjs';
 import { annotatedSkeleton } from './skeleton.mjs';
@@ -142,6 +143,31 @@ function render(finding) {
 }
 
 /**
+ * Applies anything the post-tool hook queued, BEFORE anything is served.
+ *
+ * THIS IS WHERE EAGER STALENESS LANDS. `invalidateOnWrite` needs a graph, and
+ * loading one on the return path of every write is what pending.mjs exists to
+ * avoid -- so the hook queues and the next graph read applies. These two
+ * functions are that read: they already hold a freshly loaded graph, and they
+ * are the last thing to run before a finding reaches a model.
+ *
+ * RE-READ ONLY WHEN SOMETHING WAS ACTUALLY MARKED. The drain writes the stale
+ * flag to disk; it cannot mutate the caller's already-parsed graph, so serving
+ * from that copy would deliver the very "stale finding as fresh" this exists to
+ * prevent. A second load costs a parse, and it is paid once per observed write
+ * rather than once per tool call -- when nothing is queued this is one stat.
+ */
+function withPendingApplied(dir, graph) {
+  try {
+    return drainInvalidations(dir, graph) > 0 ? load(dir) : graph;
+  } catch {
+    // The lazy path still covers everything this would have caught early, and
+    // a hook must never fail because bookkeeping did.
+    return graph;
+  }
+}
+
+/**
  * What the model sees when it touches a file.
  *
  * Returns null when there is nothing to say, or when this touch fell into the
@@ -154,6 +180,7 @@ export function forTouch(
   rawPath,
   { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
+  graph = withPendingApplied(dir, graph);
   // Canonical, so a touch finds findings anchored under any other spelling.
   const filePath = canonicalPath(rawPath);
   const anchorId = nodeId('file', filePath);
@@ -322,6 +349,7 @@ export function forCommand(
   { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
   if (!command) return null;
+  graph = withPendingApplied(dir, graph);
 
   const candidates = [];
   for (const node of graph.nodes.values()) {

--- a/integrations/kilo/hooks/lib/inject.mjs
+++ b/integrations/kilo/hooks/lib/inject.mjs
@@ -33,6 +33,7 @@ import { annotatedSkeleton } from './skeleton.mjs';
 import { substitutionBudget } from './metrics.mjs';
 import { assessFindings } from './utility.mjs';
 import { quarantineSharedSource } from './harvest-write.mjs';
+import { cacheOrdered } from './cache.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
@@ -1152,6 +1153,53 @@ export function standingRules(dir, graph, { budget = standingBudget(), episode =
   // which is worse than saying there are more: a model that knows the list is
   // truncated can ask, one that does not will assume it is complete.
   return `${HEADING}${lines.join('\n')}${truncated}`;
+}
+
+/**
+ * SessionStart context, assembled in cache order: stable first, volatile last.
+ *
+ * WHY THE ORDER IS A CORRECTNESS PROPERTY AND NOT A STYLE CHOICE. Everything
+ * here lands near the FRONT of the prompt prefix, and a prefix cache is
+ * invalidated from the first differing byte onward. A block whose text changes
+ * between sessions therefore prices everything positioned after it: put the
+ * freshest block first and the whole remainder of the prefix is re-written
+ * every session; put it last and the invalidation is confined to its own tail.
+ * cache.mjs measures exactly this cost in the user's files -- this is the same
+ * discipline applied to our own output, which is the half nobody else has to
+ * think about because nobody else writes into the prefix.
+ *
+ * `cacheOrdered` existed for precisely this and had no caller, so the order was
+ * whatever order the call sites happened to push in. It was accidentally right;
+ * it is now enforced, which is the difference that matters the next time a
+ * block is added.
+ *
+ * VOLATILITY IS ASSIGNED FROM HOW OFTEN THE TEXT ACTUALLY DIFFERS BETWEEN
+ * SESSIONS, not from how important the block is:
+ *
+ *   0  policy -- the optimization notice and project briefing. Deliberately
+ *      cache-safe by construction: the routing facts are number-free and the
+ *      briefing passes through `stableText`, which DROPS any line that would
+ *      vary. It changes when the tool inventory or configuration changes.
+ *   1  standing -- pinned facts and human-verified corrections, rendered in
+ *      full. Changes only when a person pins, retires or corrects something.
+ *   2  index -- the bounded wiki index, selected per session from the task
+ *      text, and carrying [STALE]/[DISPUTED] markers that flip as the code
+ *      moves. Different on most sessions.
+ *   3  restoration -- present only when resuming from a compaction, and derived
+ *      from the anchors of the session that was just discarded. Never twice the
+ *      same.
+ *
+ * A block with no text is dropped rather than joined, so an absent block cannot
+ * open the assembly with a blank line.
+ */
+export function sessionContext(blocks) {
+  return cacheOrdered(
+    (Array.isArray(blocks) ? blocks : []).filter(
+      (block) => block && typeof block.text === 'string' && block.text.trim()
+    )
+  )
+    .map((block) => block.text)
+    .join('\n\n');
 }
 
 /**

--- a/integrations/kilo/hooks/lib/inject.mjs
+++ b/integrations/kilo/hooks/lib/inject.mjs
@@ -122,8 +122,29 @@ function fit(findings, budget) {
   return { kept, spent };
 }
 
+/**
+ * Discloses an open disagreement, on the same line as the claim it is about.
+ *
+ * BOTH HALVES, like the stale renderer below: the strong form names the other
+ * finding so the reader can fetch it, and the form without a key says only what
+ * is actually known. `serve` is what establishes the dispute; this only phrases
+ * it, and it phrases it in one short line because `fit` prices `render` against
+ * the injection budget -- a disagreement is worth a pointer, not both claims in
+ * full.
+ *
+ * NO DISMISSAL VOCABULARY, for the reason measured on the stale wording: an
+ * instruction to discount suppressed findings that were correct. This states
+ * that another claim exists and where to find it, and lets the reader decide.
+ */
+function disputeNote(finding) {
+  if (!finding.contradicted) return '';
+  return finding.contradictedBy
+    ? `\n  DISPUTED by ${finding.contradictedBy} -- wiki_query that key for the other claim`
+    : '\n  DISPUTED by another finding in this graph';
+}
+
 function render(finding) {
-  const head = `- [${finding.type || 'finding'}] ${finding.claim}`;
+  const head = `- [${finding.type || 'finding'}] ${finding.claim}${disputeNote(finding)}`;
   if (!finding.stale) return head;
 
   // A stale finding NEVER renders as though it were current. But the strength
@@ -997,7 +1018,15 @@ function renderSessionIndex(total, findings) {
       : finding.stale
         ? ' [possibly stale; verify before use]'
         : '';
-    return `- ${finding.key}${freshness}: ${finding.claim.slice(0, 90)}`;
+    // The session index is the first thing a session reads, so a disputed
+    // finding must not be listed there as settled either. Compressed to a
+    // marker and a key, matching the freshness markers beside it.
+    const dispute = finding.contradicted
+      ? finding.contradictedBy
+        ? ` [DISPUTED by ${finding.contradictedBy}]`
+        : ' [DISPUTED]'
+      : '';
+    return `- ${finding.key}${freshness}${dispute}: ${finding.claim.slice(0, 90)}`;
   });
   return `# Project wiki (${total} findings, ${findings.length} listed)
 

--- a/integrations/kilo/hooks/lib/inject.mjs
+++ b/integrations/kilo/hooks/lib/inject.mjs
@@ -139,9 +139,26 @@ function fit(findings, budget) {
  */
 function disputeNote(finding) {
   if (!finding.contradicted) return '';
-  return finding.contradictedBy
+  const head = finding.contradictedBy
     ? `\n  DISPUTED by ${finding.contradictedBy} -- wiki_query that key for the other claim`
     : '\n  DISPUTED by another finding in this graph';
+  // THE REASON A PERSON TYPED, rendered here because this is the fullest of the
+  // three dispute surfaces and the only one with room for a sentence. `contradict`
+  // has always stored up to 400 characters of human explanation and, until this
+  // line, nothing read it: the pointer told a reader where to look and withheld
+  // the one thing that would tell them whether looking was worth a tool call.
+  //
+  // TRUNCATED AT 140, because `fit` prices this string against the injection
+  // budget and a 400-character paragraph beside a one-line claim inverts the
+  // proportions. The compressed surfaces -- the session index and restore.mjs's
+  // "Likely next" list -- deliberately keep marker-and-key only; they are one
+  // line per finding by design, and `wiki_query` returns the reason in full.
+  if (typeof finding.contradictionReason !== 'string' || !finding.contradictionReason.trim()) {
+    return head;
+  }
+  const reason = finding.contradictionReason.trim();
+  const shown = reason.length > 140 ? `${reason.slice(0, 140)}...` : reason;
+  return `${head}\n  Reason given: ${shown}`;
 }
 
 /**

--- a/integrations/kilo/hooks/lib/inject.mjs
+++ b/integrations/kilo/hooks/lib/inject.mjs
@@ -276,7 +276,10 @@ export function forTouch(
   // others, so the comparison becomes within-file and the dominant source of
   // variance drops out. A session-pinned arm would destroy that.
   const holdout = inHoldout(filePath);
-  const served = serve(graph, candidates);
+  // `dir` so an eager flag whose evidence is gone is cleared here rather than
+  // waiting for somebody to open the dashboard. Same evidence test as the manual
+  // path -- see `serve`.
+  const served = serve(graph, candidates, { dir });
   const assessed = assessFindings(dir, served, {
     episodeId: episode.episodeId || sessionId,
     relevanceFor: () => 1,
@@ -463,7 +466,7 @@ export function forCommand(
   // only thing an uncapped list buys is the I/O.
   const considered = candidates.slice(0, MAX_COMMAND_CANDIDATES);
 
-  const served = serve(graph, considered);
+  const served = serve(graph, considered, { dir });
   const assessed = assessFindings(dir, served, {
     episodeId: episode.episodeId || sessionId,
     relevanceFor: (finding) => explicit(finding) ? 1 : 0.6,
@@ -990,7 +993,7 @@ export function sessionIndex(dir, graph, { episode = {}, relevantFindingIds = []
   // `serve` is the only path allowed to hand a finding to a model. In
   // particular, activating this previously-unwired index must not create a new
   // path that labels an invalidated content claim as current.
-  const served = serve(graph, selected);
+  const served = serve(graph, selected, { dir });
   if (!served.length) return null;
   // A stale marker is longer than the fresh preview used for candidate
   // selection. Trim from the lowest-ranked end until the ACTUAL message fits.

--- a/integrations/kilo/hooks/lib/inject.mjs
+++ b/integrations/kilo/hooks/lib/inject.mjs
@@ -156,9 +156,9 @@ function disputeNote(finding) {
 function derivationNote(finding) {
   if (finding.derivationHolds !== false) return '';
   const changed = Array.isArray(finding.derivationChanged) ? finding.derivationChanged : [];
-  return changed.length
-    ? `\n  DERIVATION CHANGED -- ${changed.join(', ')} no longer match what this claim was derived from`
-    : '\n  DERIVATION CHANGED since this claim was recorded';
+  if (!changed.length) return '\n  DERIVATION CHANGED since this claim was recorded';
+  const verb = changed.length === 1 ? 'no longer matches' : 'no longer match';
+  return `\n  DERIVATION CHANGED -- ${changed.join(', ')} ${verb} what this claim was derived from`;
 }
 
 function render(finding) {

--- a/integrations/kilo/hooks/lib/inject.mjs
+++ b/integrations/kilo/hooks/lib/inject.mjs
@@ -143,8 +143,26 @@ function disputeNote(finding) {
     : '\n  DISPUTED by another finding in this graph';
 }
 
+/**
+ * Discloses `derivationCheck`'s verdict (staleness.mjs) -- distinct from
+ * `disputeNote` (another finding disagrees) and from the STALE block below
+ * (the anchor NODE's current hash does not match disk). This is about
+ * whether the bytes THIS claim was actually derived from are still the bytes
+ * an anchor holds; see `derivationCheck`'s comment for the case that catches
+ * that the other two can miss. Silent when it holds -- the common case pays
+ * nothing -- and silent when it was never checked at all (an older finding
+ * with no `derivation` record).
+ */
+function derivationNote(finding) {
+  if (finding.derivationHolds !== false) return '';
+  const changed = Array.isArray(finding.derivationChanged) ? finding.derivationChanged : [];
+  return changed.length
+    ? `\n  DERIVATION CHANGED -- ${changed.join(', ')} no longer match what this claim was derived from`
+    : '\n  DERIVATION CHANGED since this claim was recorded';
+}
+
 function render(finding) {
-  const head = `- [${finding.type || 'finding'}] ${finding.claim}${disputeNote(finding)}`;
+  const head = `- [${finding.type || 'finding'}] ${finding.claim}${disputeNote(finding)}${derivationNote(finding)}`;
   if (!finding.stale) return head;
 
   // A stale finding NEVER renders as though it were current. But the strength

--- a/integrations/kilo/hooks/lib/inject.mjs
+++ b/integrations/kilo/hooks/lib/inject.mjs
@@ -157,9 +157,28 @@ function render(finding) {
  * prevent. A second load costs a parse, and it is paid once per observed write
  * rather than once per tool call -- when nothing is queued this is one stat.
  */
+/**
+ * Per process, per graph directory: did the drain change anything?
+ *
+ * THE SECOND CALLER IS WHY THIS EXISTS. SessionStart calls `standingRules` and
+ * then `sessionIndex` with the SAME graph object it loaded once. Without this
+ * memo the first call drains, marks, and re-reads privately -- and the second
+ * call finds an empty queue, marks nothing, and therefore serves from the
+ * caller's pre-drain copy, advertising as current the very finding the first
+ * call had just marked. Draining is not idempotent from the caller's point of
+ * view; remembering the ANSWER is what makes it so.
+ *
+ * A hook process handles one lifecycle event, so this map holds one or two
+ * entries and dies with the process.
+ */
+const drainedDirs = new Map();
+
 function withPendingApplied(dir, graph) {
   try {
-    return drainInvalidations(dir, graph) > 0 ? load(dir) : graph;
+    if (drainedDirs.has(dir)) return drainedDirs.get(dir) ? load(dir) : graph;
+    const marked = drainInvalidations(dir, graph) > 0;
+    drainedDirs.set(dir, marked);
+    return marked ? load(dir) : graph;
   } catch {
     // The lazy path still covers everything this would have caught early, and
     // a hook must never fail because bookkeeping did.
@@ -862,6 +881,12 @@ export function relevantFindingIdsForContext(graph, context, { limit = 8 } = {})
  * shrinks toward the floor. See metrics.indexBudget.
  */
 export function sessionIndex(dir, graph, { episode = {}, relevantFindingIds = [] } = {}) {
+  // DRAINED HERE TOO, and this is the worst place to be wrong. The session index
+  // is the FIRST thing a session sees and it arrives with no other context to
+  // correct it, so advertising a finding the graph already knows is stale is a
+  // false claim made at maximum leverage. The graph is loaded either way, so the
+  // only cost is the stat that finds no queue.
+  graph = withPendingApplied(dir, graph);
   const budget = indexBudget(dir);
   const relevant = new Set(relevantFindingIds);
   // Some SessionStart payloads have no task signal. Fail closed for situational
@@ -988,6 +1013,9 @@ ${lines.join('\n')}`;
  * is wallpaper, and the model stops reading the thing it always sees.
  */
 export function standingRules(dir, graph, { budget = standingBudget(), episode = {} } = {}) {
+  // Same reason as sessionIndex: always-on text, delivered before the first
+  // tool call, with nothing following it that could qualify what it said.
+  graph = withPendingApplied(dir, graph);
   const rules = [...graph.nodes.values()].filter(
     (n) =>
       n.kind === 'finding' &&

--- a/integrations/kilo/hooks/lib/inject.mjs
+++ b/integrations/kilo/hooks/lib/inject.mjs
@@ -143,6 +143,40 @@ function render(finding) {
 }
 
 /**
+ * Graph directories where a drain has already marked something in THIS process.
+ *
+ * THE SECOND CALLER IS WHY THIS EXISTS. SessionStart calls `standingRules` and
+ * then `sessionIndex` with the SAME graph object it loaded once. Without this,
+ * the first call drains, marks, and re-reads privately -- and the second call
+ * finds an empty queue, marks nothing, and therefore serves from the caller's
+ * pre-drain copy, advertising as current the very finding the first call had
+ * just marked. Draining is idempotent; its EFFECT on a caller's parsed graph is
+ * not, so what is remembered here is "a re-read is owed", nothing else.
+ *
+ * ONLY THE POSITIVE CASE IS REMEMBERED, and that is a correctness decision
+ * rather than a tuning one. Remembering "nothing was queued" would mean a queue
+ * arriving LATER in the same process is silently skipped and deferred to some
+ * future session. That cannot happen today, because `queueInvalidation` runs in
+ * the post-tool branch before any injection -- but that is an unguarded
+ * ordering dependency, and it stops being true the moment someone adds a call
+ * site. A repeated empty drain costs one `existsSync` on a file that is not
+ * there, which is a price worth paying to not have an invariant that depends on
+ * nobody reordering anything.
+ *
+ * KEYED CANONICALLY. Two spellings of one directory -- a trailing separator, a
+ * `..` segment, a lower-cased drive letter -- would otherwise be two entries,
+ * which reintroduces exactly the pre-drain-copy bug above. This is the same
+ * defect shape Task 2 on this branch shipped for real, where a tool resolved its
+ * graph from a raw cwd while the hooks resolved theirs through `projectRootFor`
+ * and the two halves of a metric landed in different directories. Path identity
+ * is why `canonicalKey` lives inside `nodeId` rather than at its call sites.
+ *
+ * A hook process handles one lifecycle event, so this set holds one or two
+ * entries and dies with the process.
+ */
+const drainedDirs = new Set();
+
+/**
  * Applies anything the post-tool hook queued, BEFORE anything is served.
  *
  * THIS IS WHERE EAGER STALENESS LANDS. `invalidateOnWrite` needs a graph, and
@@ -157,28 +191,14 @@ function render(finding) {
  * prevent. A second load costs a parse, and it is paid once per observed write
  * rather than once per tool call -- when nothing is queued this is one stat.
  */
-/**
- * Per process, per graph directory: did the drain change anything?
- *
- * THE SECOND CALLER IS WHY THIS EXISTS. SessionStart calls `standingRules` and
- * then `sessionIndex` with the SAME graph object it loaded once. Without this
- * memo the first call drains, marks, and re-reads privately -- and the second
- * call finds an empty queue, marks nothing, and therefore serves from the
- * caller's pre-drain copy, advertising as current the very finding the first
- * call had just marked. Draining is not idempotent from the caller's point of
- * view; remembering the ANSWER is what makes it so.
- *
- * A hook process handles one lifecycle event, so this map holds one or two
- * entries and dies with the process.
- */
-const drainedDirs = new Map();
-
 function withPendingApplied(dir, graph) {
   try {
-    if (drainedDirs.has(dir)) return drainedDirs.get(dir) ? load(dir) : graph;
-    const marked = drainInvalidations(dir, graph) > 0;
-    drainedDirs.set(dir, marked);
-    return marked ? load(dir) : graph;
+    const key = canonicalPath(dir);
+    // The drain runs EVERY time. It is one stat when there is nothing to do,
+    // and running it unconditionally is what keeps the memo from encoding an
+    // assumption about which hook branch ran first.
+    if (drainInvalidations(dir, graph) > 0) drainedDirs.add(key);
+    return drainedDirs.has(key) ? load(dir) : graph;
   } catch {
     // The lazy path still covers everything this would have caught early, and
     // a hook must never fail because bookkeeping did.

--- a/integrations/kilo/hooks/lib/lexical.mjs
+++ b/integrations/kilo/hooks/lib/lexical.mjs
@@ -1,0 +1,73 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/lexical.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * BM25 over findings. Pure, dependency-free, deterministic.
+ *
+ * WHY THIS REPLACES `includes()`. The dashboard filtered findings by substring,
+ * which cannot RANK -- and every consumer of retrieval here is under a hard
+ * token budget, so the budget kept whatever happened to match rather than what
+ * matched best. Ranking is the whole value at a budget.
+ *
+ * WHY BM25 AND NOT EMBEDDINGS. Deliberate, per docs/WIKI_GRAPH.md: deterministic,
+ * instant, explainable, and it cannot drift or need a rebuild. The known cost is
+ * recall on findings with no lexical overlap; Plan 2's recall probe measures that
+ * rather than assuming it away.
+ */
+
+/** Non-word split, lowercased. Short tokens are kept: `fs`, `id`, `os` matter here. */
+export function tokenize(text) {
+  return String(text || '')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+}
+
+/**
+ * Classic BM25. `k1` controls term-frequency saturation, `b` length normalisation.
+ * Defaults are the standard ones and are exposed so the recall probe can sweep them.
+ */
+export function rank(query, findings, { limit = 20, k1 = 1.2, b = 0.75 } = {}) {
+  const terms = tokenize(query);
+  if (!terms.length || !Array.isArray(findings) || !findings.length) return [];
+
+  // A finding's searchable text is its claim AND its key: the key is how the
+  // session index refers to it, so a model quoting a key must find it.
+  const docs = findings.map((finding) => ({
+    finding,
+    tokens: tokenize(`${finding.key || ''} ${finding.claim || ''}`),
+  }));
+
+  const avgLen = docs.reduce((sum, d) => sum + d.tokens.length, 0) / docs.length;
+  const N = docs.length;
+
+  const docFreq = new Map();
+  for (const { tokens } of docs) {
+    for (const term of new Set(tokens)) {
+      docFreq.set(term, (docFreq.get(term) || 0) + 1);
+    }
+  }
+
+  const scored = [];
+  for (const { finding, tokens } of docs) {
+    const counts = new Map();
+    for (const token of tokens) counts.set(token, (counts.get(token) || 0) + 1);
+
+    let score = 0;
+    for (const term of terms) {
+      const tf = counts.get(term);
+      if (!tf) continue;
+      const df = docFreq.get(term) || 0;
+      // Standard BM25 IDF, floored at zero so a term present in every document
+      // contributes nothing rather than a negative score.
+      const idf = Math.max(0, Math.log(1 + (N - df + 0.5) / (df + 0.5)));
+      const norm = tf + k1 * (1 - b + (b * tokens.length) / (avgLen || 1));
+      score += idf * ((tf * (k1 + 1)) / (norm || 1));
+    }
+
+    // Zero means no term matched. Omitted rather than returned, so a caller
+    // under a token budget never spends it on an irrelevant finding.
+    if (score > 0) scored.push({ finding, score });
+  }
+
+  return scored.sort((a, b2) => b2.score - a.score).slice(0, limit);
+}

--- a/integrations/kilo/hooks/lib/lexical.mjs
+++ b/integrations/kilo/hooks/lib/lexical.mjs
@@ -14,12 +14,54 @@
  * rather than assuming it away.
  */
 
-/** Non-word split, lowercased. Short tokens are kept: `fs`, `id`, `os` matter here. */
-export function tokenize(text) {
-  return String(text || '')
-    .toLowerCase()
-    .split(/[^a-z0-9]+/)
+/**
+ * Splits an identifier's alphanumeric run into its camelCase / letter-digit
+ * parts, e.g. `skipLibCheck` -> ['skip', 'Lib', 'Check'], `TS2345` ->
+ * ['TS', '2345']. Returns a single-element array when there is no internal
+ * boundary (e.g. `retry` -> ['retry']) so callers can skip emitting a
+ * redundant duplicate of the whole token.
+ */
+function splitIdentifierParts(word) {
+  return word
+    .replace(/([a-z])([A-Z])/g, '$1\0$2')
+    .replace(/([A-Za-z])([0-9])/g, '$1\0$2')
+    .replace(/([0-9])([A-Za-z])/g, '$1\0$2')
+    .split('\0')
     .filter(Boolean);
+}
+
+/**
+ * Non-word split, lowercased. Short tokens are kept: `fs`, `id`, `os` matter
+ * here.
+ *
+ * Emits sub-tokens for compound identifiers, in addition to the whole token.
+ * Delimited identifiers (`smart_read`, `wiki.mjs`, the flag in
+ * `--skipLibCheck`) already round-trip fine: the delimiter splits them, and
+ * because query and claim pass through this same function, a query typed
+ * with the same delimiters matches. The silent gap was CONCATENATED
+ * identifiers with no delimiter at all -- `skipLibCheck` collapsed to the
+ * single token `skiplibcheck`, so a query for "skip lib check" (or "TS 2345"
+ * against `TS2345`) never intersected it. No error, just an absent result --
+ * and findings are about code, where run-together identifiers are the
+ * common case. So every alphanumeric run keeps its whole-token form (a query
+ * for the concatenated form still matches) and ALSO contributes its
+ * camelCase / letter-digit parts (a query for the separated form now
+ * matches too). A lone incidental character -- e.g. the `c` split out of a
+ * Windows path `C:\Users\...` -- needs no special-casing: it is a real
+ * token like any other, and BM25's IDF already discounts a term that shows
+ * up in nearly every finding.
+ */
+export function tokenize(text) {
+  const words = String(text || '').match(/[A-Za-z0-9]+/g) || [];
+  const tokens = [];
+  for (const word of words) {
+    tokens.push(word.toLowerCase());
+    const parts = splitIdentifierParts(word);
+    if (parts.length > 1) {
+      for (const part of parts) tokens.push(part.toLowerCase());
+    }
+  }
+  return tokens;
 }
 
 /**
@@ -57,9 +99,15 @@ export function rank(query, findings, { limit = 20, k1 = 1.2, b = 0.75 } = {}) {
       const tf = counts.get(term);
       if (!tf) continue;
       const df = docFreq.get(term) || 0;
-      // Standard BM25 IDF, floored at zero so a term present in every document
-      // contributes nothing rather than a negative score.
-      const idf = Math.max(0, Math.log(1 + (N - df + 0.5) / (df + 0.5)));
+      // Smoothed BM25 idf: log(1 + (N - df + 0.5) / (df + 0.5)). Unlike the
+      // classic unsmoothed idf (log((N - df + 0.5) / (df + 0.5))), which goes
+      // negative once a term appears in most documents, this smoothed form
+      // is strictly positive for every df in [1, N]: even at df === N the
+      // ratio inside the log is (N + 1) / (N + 0.5), which is always
+      // strictly greater than 1, so log(1 + that) is always > 0. No floor
+      // is needed here, and none is applied -- there is no negative case
+      // for this formula to guard against.
+      const idf = Math.log(1 + (N - df + 0.5) / (df + 0.5));
       const norm = tf + k1 * (1 - b + (b * tokens.length) / (avgLen || 1));
       score += idf * ((tf * (k1 + 1)) / (norm || 1));
     }

--- a/integrations/kilo/hooks/lib/lexical.mjs
+++ b/integrations/kilo/hooks/lib/lexical.mjs
@@ -65,6 +65,43 @@ export function tokenize(text) {
 }
 
 /**
+ * Effective term-frequency credit for a document that has NO exact token
+ * match for a query term but DOES have a token that starts with it (e.g.
+ * query `custom` against a document containing `customer`). Deliberately
+ * less than one exact occurrence (`1`), and it is a flat credit rather than
+ * one that grows with the number of prefix-matching tokens in the document,
+ * so a prefix hit can never outscore an exact hit of the same term:
+ *
+ *   BM25's per-term contribution is `idf * tf * (k1 + 1) / (tf + K)`, where
+ *   `K = k1 * (1 - b + b * L / avgL)` depends only on document length, not
+ *   on which term or how it matched. As a function of `tf` alone, with `K`
+ *   fixed, `f(tf) = tf / (tf + K)` is non-decreasing for every `tf >= 0` and
+ *   `k1 >= 0` (its derivative `K / (tf + K)^2` is never negative). So for
+ *   ANY document length, and any number of prefix-only occurrences, using
+ *   `PREFIX_TF < 1` in place of `tf` scores no higher than an actual exact
+ *   occurrence (`tf = 1`) would in that same document -- there is no
+ *   PREFIX_TF-independent way to accumulate more evidence than one real hit
+ *   by matching only a prefix. This is also why the count of prefix matches
+ *   is otherwise irrelevant here: it never feeds back into the score.
+ *
+ * PREFIX MATCHING IS NOT SUBSTRING MATCHING. It restores recall for a
+ * fragment typed at the START of a word -- `custom` now finds `customer` --
+ * which is the common case (a user typing the first few letters of a term
+ * they remember). It does NOT restore the old `.includes()` filter's ability
+ * to find a term in the MIDDLE of a word: a query for `tomer` still will not
+ * find `customer`. That recall gap is accepted, not silently reintroduced.
+ */
+const PREFIX_TF = 0.5;
+
+/**
+ * Below this length, a query term is not eligible for prefix matching: a
+ * one- or two-character prefix (`a`, `re`) is a substring of a large
+ * fraction of any real vocabulary, so it would match nearly every document
+ * and IDF alone would not discount it enough to keep the results relevant.
+ */
+const PREFIX_MIN_TERM_LENGTH = 3;
+
+/**
  * Classic BM25. `k1` controls term-frequency saturation, `b` length normalisation.
  * Defaults are the standard ones and are exposed so the recall probe can sweep them.
  */
@@ -96,7 +133,21 @@ export function rank(query, findings, { limit = 20, k1 = 1.2, b = 0.75 } = {}) {
 
     let score = 0;
     for (const term of terms) {
-      const tf = counts.get(term);
+      let tf = counts.get(term) || 0;
+
+      // No exact occurrence: fall back to a prefix match, which is weaker
+      // evidence and so credited at a flat PREFIX_TF rather than a real
+      // count (see PREFIX_TF's comment for why that ordering is safe). Only
+      // considered when nothing already matched exactly and the term is
+      // long enough that "starts with" is a meaningful signal.
+      if (tf === 0 && term.length >= PREFIX_MIN_TERM_LENGTH) {
+        for (const token of counts.keys()) {
+          if (token !== term && token.startsWith(term)) {
+            tf = PREFIX_TF;
+            break;
+          }
+        }
+      }
       if (!tf) continue;
       const df = docFreq.get(term) || 0;
       // Smoothed BM25 idf: log(1 + (N - df + 0.5) / (df + 0.5)). Unlike the

--- a/integrations/kilo/hooks/lib/metrics.mjs
+++ b/integrations/kilo/hooks/lib/metrics.mjs
@@ -455,6 +455,23 @@ export function readBalance(dir) {
   return out;
 }
 
+/**
+ * True when `readEvidence` could not have read the whole log -- the file
+ * exceeds the byte cap, so anything written before the tail it kept is
+ * silently absent from what it returned. A caller that builds a per-claim
+ * record from `readEvidence` (the wiki graph's derivation record) needs this
+ * to say "operations existed but are not recorded here" rather than let an
+ * empty result read as "nothing happened".
+ */
+export function evidenceTruncated(dir) {
+  const path = evidencePath(dir);
+  try {
+    return statSync(path).size > MAX_BYTES;
+  } catch {
+    return false;
+  }
+}
+
 /** Every causal evidence record inside the byte cap, deduplicated by id. */
 export function readEvidence(dir) {
   const path = evidencePath(dir);

--- a/integrations/kilo/hooks/lib/observability.mjs
+++ b/integrations/kilo/hooks/lib/observability.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 /**
  * Privacy-safe, cross-client lifecycle diagnostics.
  *

--- a/integrations/kilo/hooks/lib/pending.mjs
+++ b/integrations/kilo/hooks/lib/pending.mjs
@@ -39,7 +39,7 @@ import {
   statSync,
 } from 'node:fs';
 import { join } from 'node:path';
-import { invalidateOnWrite } from './staleness.mjs';
+import { invalidateChangedAnchors, invalidateOnWrite } from './staleness.mjs';
 import { canonicalPath, isFsSafePath, resolvableCandidates } from './paths.mjs';
 
 const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
@@ -190,31 +190,85 @@ function hasEditEvidence(payload, raw) {
 }
 
 /**
- * The evidence a completed mutation left behind, or null when there is none.
+ * Canonical tool names that mean bytes on disk changed.
  *
- * Separate from `queueInvalidation` so the caller can be a hook branch that
- * knows nothing about diffs, and so the reconstruction above is testable
- * without a filesystem queue.
+ * THE NORMALISED SET, not any client's own vocabulary. `normalizePayload` has
+ * already mapped `replace`, `write_file`, `apply_patch`, `str_replace`,
+ * `search_replace` and the rest onto these three through decide.mjs's alias
+ * table -- and a tool that table cannot map arrives as null and exits the hook
+ * before this module is reached at all. So matching here is both complete for
+ * every client the adapter serves and impossible to spell wrong.
+ *
+ * `NotebookEdit` is absent because `normalizeTool` maps it to null, and the MCP
+ * `smart_edit`/`smart_write` tools are absent for the same reason. Both are gaps
+ * in that alias table rather than in this file, and widening it changes routing
+ * verdicts for every client -- so they are reported, not papered over here.
  */
-export function observedWrite(payload, raw) {
-  // CHEAP CHECK FIRST, because this runs after every tool call on every client.
-  // Reading the file is the expensive part, and there is no point paying for it
-  // on a Read, a Bash or a write whose before side cannot be reconstructed.
-  if (!hasEditEvidence(payload, raw)) return null;
+const MUTATING = new Set(['Edit', 'MultiEdit', 'Write']);
+
+/** Files an apply_patch-style program declares it is about to change. */
+function patchTargets(payload) {
+  const command = payload?.tool_input?.command;
+  if (typeof command !== 'string') return [];
+  const out = [];
+  for (const match of command.matchAll(
+    /^\*\*\* (?:Add|Update|Delete) File:\s*(.+)$/gm
+  )) {
+    const candidate = match[1].trim().replace(/^['"]|['"]$/g, '');
+    // Bounded: one patch naming a thousand files must not append a thousand
+    // queue records on a hook path.
+    if (candidate && out.length < 20) out.push(candidate);
+  }
+  return out;
+}
+
+/**
+ * Everything a completed mutation left behind that is worth queueing.
+ *
+ * TWO GRADES OF EVIDENCE, and the distinction is the point:
+ *
+ *   { path, before, after }  a reconstructable edit. The drain builds a real
+ *                            diff and marks only the symbols that moved.
+ *   { path }                 a whole-file write, or a patch program. No before
+ *                            side exists anywhere in the payload, so the drain
+ *                            compares stored hashes against disk instead.
+ *
+ * The second grade is what closes the biggest hole. A whole-file write is the
+ * commonest write shape there is, and before it was added those writes fell
+ * through to a lazy path that CANNOT see the session's own writes at all --
+ * `indexFile` refreshes the anchor before the lazy check ever looks at it. They
+ * were uncovered, not degraded.
+ *
+ * Returns an array, because one apply_patch program changes several files.
+ */
+export function observedWrites(payload, raw) {
+  if (!MUTATING.has(String(payload?.tool_name || ''))) return [];
 
   const path = writtenPath(payload, raw);
-  if (!path) return null;
+  if (path) {
+    // The expensive branch is guarded: reading the file only pays off when the
+    // payload can actually yield a before side.
+    if (hasEditEvidence(payload, raw)) {
+      const after = afterText(path);
+      if (after !== null && after.length <= MAX_SIDE_CHARS) {
+        const before = beforeText(payload, raw, after);
+        // Identical bytes: a formatter no-op, or a rewrite of the same content.
+        // Nothing changed, so nothing is stale.
+        if (before === after) return [];
+        if (before !== null && before.length <= MAX_SIDE_CHARS)
+          return [{ path, before, after }];
+      }
+    }
+    // Hash grade. Deliberately NOT `{ path, before: '', after }`: an empty
+    // before side makes every symbol in the file look changed, and the eager
+    // mark is a stored flag no later check ever clears.
+    return [{ path }];
+  }
 
-  const after = afterText(path);
-  if (after === null || after.length > MAX_SIDE_CHARS) return null;
-
-  const before = beforeText(payload, raw, after);
-  if (before === null || before.length > MAX_SIDE_CHARS) return null;
-  // Nothing changed: a formatter no-op, or a write of identical bytes. Queuing
-  // it would mark findings stale against an empty diff.
-  if (before === after) return null;
-
-  return { path, before, after };
+  // Codex and code-mode clients carry the whole patch as program text with no
+  // file_path field at all, which is why this recorded nothing for them. The
+  // hash grade needs only the path, so the patch headers are enough.
+  return patchTargets(payload).map((target) => ({ path: target }));
 }
 
 /**
@@ -226,9 +280,14 @@ export function observedWrite(payload, raw) {
 export function queueInvalidation(dir, { path, before, after, at } = {}) {
   try {
     if (typeof path !== 'string' || !path.trim()) return false;
-    if (typeof before !== 'string' || typeof after !== 'string') return false;
-    if (before.length > MAX_SIDE_CHARS || after.length > MAX_SIDE_CHARS)
-      return false;
+    // BOTH SIDES OR NEITHER. A record carrying only one of them cannot produce
+    // a diff and must not pretend to, so it is written as a path-only record
+    // and the drain resolves it by comparing hashes.
+    const diffable =
+      typeof before === 'string' &&
+      typeof after === 'string' &&
+      before.length <= MAX_SIDE_CHARS &&
+      after.length <= MAX_SIDE_CHARS;
 
     const file = queuePath(dir);
     try {
@@ -240,7 +299,11 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
     mkdirSync(dir, { recursive: true });
     appendFileSync(
       file,
-      `${JSON.stringify({ path: canonicalPath(path), before, after, at: at ?? Date.now() })}\n`,
+      `${JSON.stringify({
+        path: canonicalPath(path),
+        ...(diffable ? { before, after } : {}),
+        at: at ?? Date.now(),
+      })}\n`,
       'utf8'
     );
     return true;
@@ -284,16 +347,16 @@ export function drainInvalidations(dir, graph) {
   let marked = 0;
   for (const record of records) {
     if (!record || typeof record.path !== 'string' || !record.path) continue;
-    if (typeof record.before !== 'string' || typeof record.after !== 'string')
-      continue;
+    const diffable =
+      typeof record.before === 'string' && typeof record.after === 'string';
     try {
-      const result = invalidateOnWrite(
-        dir,
-        graph,
-        record.path,
-        record.before,
-        record.after
-      );
+      // TWO GRADES, ONE QUEUE. A record carrying both sides gets a real diff and
+      // symbol-precise marking; one carrying only a path gets the hash
+      // comparison -- the same comparison the lazy path makes, and one that is
+      // only meaningful HERE, before `indexFile` refreshes the anchor.
+      const result = diffable
+        ? invalidateOnWrite(dir, graph, record.path, record.before, record.after)
+        : invalidateChangedAnchors(dir, graph, record.path);
       marked += Array.isArray(result) ? result.length : 0;
     } catch {
       // One bad record must not stop the rest, and must not stop the tool call.

--- a/integrations/kilo/hooks/lib/pending.mjs
+++ b/integrations/kilo/hooks/lib/pending.mjs
@@ -1,0 +1,311 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/pending.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * The eager-invalidation queue: the missing half of staleness.mjs's header.
+ *
+ * That header describes TWO invalidation paths and says eager exists because
+ * lazy "would silently serve stale findings as fresh whenever a change came
+ * from outside the agent". `invalidateOnWrite` had been written, tested and
+ * documented -- and its only reference in shipped code was a COMMENT in the
+ * PreToolUse router. Staleness was lazy-only in production, and the router's
+ * own comment ("a write the hook observes is invalidated eagerly by
+ * `invalidateOnWrite`") described something that never happened.
+ *
+ * WHY THAT MATTERS MORE THAN IT SOUNDS. The lazy check compares the anchor's
+ * stored hash against disk -- and both the router and the adapter call
+ * `indexFile` on every file they observe, which re-points that hash at the new
+ * bytes. So for a write the session performed ITSELF, the lazy check is
+ * self-defeating: by the next retrieval the anchor already agrees with disk and
+ * the finding derived from the old content is served clean. Lazy catches the
+ * changes we never saw; only eager catches the ones we did.
+ *
+ * WHY A QUEUE AND NOT A DIRECT CALL. `invalidateOnWrite` needs the graph, and
+ * the graph is a megabyte of JSONL. Loading it on the return path of every
+ * write is the cost this shape exists to avoid. So the post-tool hook, which
+ * already holds the write's evidence, appends one record here and exits; the
+ * next graph read -- `forTouch`/`forCommand`, which load the graph anyway --
+ * drains it BEFORE serving anything.
+ *
+ * The guarantee is unchanged. What must never happen is SERVING a stale finding
+ * as fresh, and serve time is where that is enforced.
+ */
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { invalidateOnWrite } from './staleness.mjs';
+import { canonicalPath, isFsSafePath, resolvableCandidates } from './paths.mjs';
+
+const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
+
+/**
+ * Largest before/after side kept in a queue record.
+ *
+ * Matched to the graph's own snapshot limit for the same reason it has one: past
+ * this size the text is a bundle, a lockfile or a generated asset, and copying
+ * it into a queue file would mirror the repository into the graph directory one
+ * write at a time. Past the cap the write is simply not queued -- the lazy path
+ * still governs it, which is exactly the status quo for that file.
+ */
+const MAX_SIDE_CHARS = 262_144;
+
+/**
+ * Largest queue file appended to.
+ *
+ * A queue only grows while nothing drains it, which means the retrieval feature
+ * is off or every read has failed. Neither is a reason to keep writing: bounded
+ * here so a long unattended session cannot turn one directory into a log of
+ * every file it touched.
+ */
+const MAX_QUEUE_BYTES = 8 * 1024 * 1024;
+
+/** The tool payload fields that name the file a mutation landed on. */
+function writtenPath(payload, raw) {
+  const input = payload?.tool_input || {};
+  const response = raw?.tool_response || raw?.toolResponse || {};
+  for (const candidate of [
+    input.file_path,
+    input.path,
+    input.notebook_path,
+    response.filePath,
+    response.file_path,
+  ]) {
+    if (typeof candidate === 'string' && candidate.trim()) return candidate;
+  }
+  return null;
+}
+
+/** First string among several possible spellings of the same field. */
+function firstString(...values) {
+  for (const value of values) if (typeof value === 'string') return value;
+  return null;
+}
+
+/**
+ * The text before the write, reconstructed from a completed edit.
+ *
+ * PREFERENCE ORDER IS ABOUT EXACTNESS, not convenience. Claude Code's Edit
+ * response carries the whole pre-edit file (`originalFile`), which needs no
+ * reasoning at all. Failing that, an edit is a known substitution, so reverting
+ * `new_string` back to `old_string` in the post-write text reproduces the
+ * before side exactly -- but only when the substitution is unambiguous, which
+ * is why a `new_string` that now appears more than once is refused rather than
+ * guessed at.
+ *
+ * NULL MEANS "DO NOT QUEUE", and that is deliberate. An unknown before side
+ * could be passed as '' -- and `invalidateOnWrite` would then see every symbol
+ * in the file as changed and mark every finding anchored anywhere in it, which
+ * is the exact over-marking its own comments call worse than the file-level
+ * staleness symbols were introduced to avoid. A missed eager invalidation costs
+ * what today already costs; a wrong one permanently discounts correct findings.
+ */
+function beforeText(payload, raw, after) {
+  const input = payload?.tool_input || {};
+  const response = raw?.tool_response || raw?.toolResponse || {};
+
+  const original = firstString(
+    response.originalFile,
+    response.original_file,
+    response.originalContent,
+    response.original_content
+  );
+  if (original !== null) return original;
+
+  // MultiEdit applies its edits in order, so reverting walks them backwards.
+  const edits = Array.isArray(input.edits) ? input.edits : null;
+  if (edits) {
+    let text = after;
+    for (const edit of [...edits].reverse()) {
+      const reverted = revert(text, edit);
+      if (reverted === null) return null;
+      text = reverted;
+    }
+    return text;
+  }
+
+  return revert(after, input);
+}
+
+/** Undoes one old->new substitution, or null when it cannot be done exactly. */
+function revert(text, edit) {
+  const oldString = firstString(edit?.old_string, edit?.oldString);
+  const newString = firstString(edit?.new_string, edit?.newString);
+  if (oldString === null || newString === null || newString === '') return null;
+
+  const all = edit?.replace_all === true || edit?.replaceAll === true;
+  if (all) return text.split(newString).join(oldString);
+
+  const at = text.indexOf(newString);
+  if (at < 0) return null;
+  // Ambiguous: more than one candidate for the occurrence that was written, and
+  // reverting the wrong one fabricates a before side that never existed.
+  if (text.indexOf(newString, at + newString.length) >= 0) return null;
+  return text.slice(0, at) + oldString + text.slice(at + newString.length);
+}
+
+/** The post-write text, read from disk because that is what the write produced. */
+function afterText(path) {
+  if (!isFsSafePath(path)) return null;
+  for (const candidate of resolvableCandidates(path)) {
+    try {
+      if (statSync(candidate).size > MAX_SIDE_CHARS) return null;
+      return readFileSync(candidate, 'utf8');
+    } catch {
+      // Wrong spelling, or gone again already. Try the next one.
+    }
+  }
+  return null;
+}
+
+/**
+ * Does this payload carry enough to reconstruct a before side at all?
+ *
+ * Named tool lists were the alternative and were rejected: every client calls
+ * its editor something different (`Edit`, `replace`, `write_to_file`,
+ * `apply_patch`), and a list would silently exclude the ones nobody thought of
+ * while still charging a file read for every Read that matched by accident.
+ * Asking about the EVIDENCE instead covers any client that carries an edit in
+ * one of these shapes and costs nothing on the calls that do not.
+ */
+function hasEditEvidence(payload, raw) {
+  const input = payload?.tool_input || {};
+  const response = raw?.tool_response || raw?.toolResponse || {};
+  if (
+    firstString(
+      response.originalFile,
+      response.original_file,
+      response.originalContent,
+      response.original_content
+    ) !== null
+  )
+    return true;
+  if (Array.isArray(input.edits) && input.edits.length > 0) return true;
+  return firstString(input.old_string, input.oldString) !== null;
+}
+
+/**
+ * The evidence a completed mutation left behind, or null when there is none.
+ *
+ * Separate from `queueInvalidation` so the caller can be a hook branch that
+ * knows nothing about diffs, and so the reconstruction above is testable
+ * without a filesystem queue.
+ */
+export function observedWrite(payload, raw) {
+  // CHEAP CHECK FIRST, because this runs after every tool call on every client.
+  // Reading the file is the expensive part, and there is no point paying for it
+  // on a Read, a Bash or a write whose before side cannot be reconstructed.
+  if (!hasEditEvidence(payload, raw)) return null;
+
+  const path = writtenPath(payload, raw);
+  if (!path) return null;
+
+  const after = afterText(path);
+  if (after === null || after.length > MAX_SIDE_CHARS) return null;
+
+  const before = beforeText(payload, raw, after);
+  if (before === null || before.length > MAX_SIDE_CHARS) return null;
+  // Nothing changed: a formatter no-op, or a write of identical bytes. Queuing
+  // it would mark findings stale against an empty diff.
+  if (before === after) return null;
+
+  return { path, before, after };
+}
+
+/**
+ * Appends one pending write.
+ *
+ * NEVER THROWS. This runs on a hook's return path, and a queue that cannot be
+ * written degrades to the lazy path rather than costing the user a tool call.
+ */
+export function queueInvalidation(dir, { path, before, after, at } = {}) {
+  try {
+    if (typeof path !== 'string' || !path.trim()) return false;
+    if (typeof before !== 'string' || typeof after !== 'string') return false;
+    if (before.length > MAX_SIDE_CHARS || after.length > MAX_SIDE_CHARS)
+      return false;
+
+    const file = queuePath(dir);
+    try {
+      if (statSync(file).size > MAX_QUEUE_BYTES) return false;
+    } catch {
+      // No queue yet, which is the normal case.
+    }
+
+    mkdirSync(dir, { recursive: true });
+    appendFileSync(
+      file,
+      `${JSON.stringify({ path: canonicalPath(path), before, after, at: at ?? Date.now() })}\n`,
+      'utf8'
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Applies every queued invalidation and clears the queue.
+ *
+ * Returns the number of findings marked, so the caller knows whether its
+ * in-memory graph is now behind the file on disk and needs re-reading.
+ *
+ * CLEARED AFTER APPLYING AND UNCONDITIONALLY: a record that cannot be applied
+ * must not be retried on every tool call for the rest of the session, and the
+ * cost of dropping one is a single missed eager mark that the lazy path still
+ * has a chance at.
+ */
+export function drainInvalidations(dir, graph) {
+  let records;
+  try {
+    const file = queuePath(dir);
+    if (!existsSync(file)) return 0;
+    records = readFileSync(file, 'utf8')
+      .split('\n')
+      .filter((line) => line.trim())
+      .map((line) => {
+        try {
+          return JSON.parse(line);
+        } catch {
+          // A torn append costs one record, not the queue.
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch {
+    return 0;
+  }
+
+  let marked = 0;
+  for (const record of records) {
+    if (!record || typeof record.path !== 'string' || !record.path) continue;
+    if (typeof record.before !== 'string' || typeof record.after !== 'string')
+      continue;
+    try {
+      const result = invalidateOnWrite(
+        dir,
+        graph,
+        record.path,
+        record.before,
+        record.after
+      );
+      marked += Array.isArray(result) ? result.length : 0;
+    } catch {
+      // One bad record must not stop the rest, and must not stop the tool call.
+    }
+  }
+
+  try {
+    rmSync(queuePath(dir), { force: true });
+  } catch {
+    // Held open by a concurrent hook. The next drain re-applies these records,
+    // which is safe: marking an already-marked finding is idempotent.
+  }
+
+  return marked;
+}

--- a/integrations/kilo/hooks/lib/pending.mjs
+++ b/integrations/kilo/hooks/lib/pending.mjs
@@ -199,10 +199,11 @@ function hasEditEvidence(payload, raw) {
  * before this module is reached at all. So matching here is both complete for
  * every client the adapter serves and impossible to spell wrong.
  *
- * `NotebookEdit` is absent because `normalizeTool` maps it to null, and the MCP
- * `smart_edit`/`smart_write` tools are absent for the same reason. Both are gaps
- * in that alias table rather than in this file, and widening it changes routing
- * verdicts for every client -- so they are reported, not papered over here.
+ * `NotebookEdit` and the MCP `smart_edit`/`smart_write` tools were absent for as
+ * long as `normalizeTool` mapped them to null. That was a gap in the alias table
+ * rather than in this file, and it has since been closed there: all three now
+ * arrive as `Edit` or `Write` and are matched by the set below without it having
+ * to learn a fourth name.
  */
 const MUTATING = new Set(['Edit', 'MultiEdit', 'Write']);
 

--- a/integrations/kilo/hooks/lib/pending.mjs
+++ b/integrations/kilo/hooks/lib/pending.mjs
@@ -35,6 +35,7 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  renameSync,
   rmSync,
   statSync,
 } from 'node:fs';
@@ -43,6 +44,15 @@ import { invalidateChangedAnchors, invalidateOnWrite } from './staleness.mjs';
 import { canonicalPath, isFsSafePath, resolvableCandidates } from './paths.mjs';
 
 const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
+/**
+ * Where a drain moves the queue before reading it.
+ *
+ * PER PROCESS, not one shared name: two hooks draining the same graph directory
+ * at once would otherwise race for the same claim file, and the loser would
+ * either clobber the winner's records or delete them mid-read. A pid makes the
+ * claim private to the drainer that won the rename.
+ */
+const claimPath = (dir) => join(dir, `pending-invalidation.claim.${process.pid}.jsonl`);
 
 /**
  * Largest before/after side kept in a queue record.
@@ -319,17 +329,47 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
  * Returns the number of findings marked, so the caller knows whether its
  * in-memory graph is now behind the file on disk and needs re-reading.
  *
- * CLEARED AFTER APPLYING AND UNCONDITIONALLY: a record that cannot be applied
- * must not be retried on every tool call for the rest of the session, and the
- * cost of dropping one is a single missed eager mark that the lazy path still
- * has a chance at.
+ * CLAIMED BY RENAME, THEN READ, THEN DELETED -- and the order is the whole
+ * point. This used to read the queue and then `rmSync` the same path, so a
+ * post-tool hook appending between the read and the unlink had its record
+ * deleted having never been read. Parallel tool calls in one assistant turn are
+ * the ordinary way that happens, not an exotic race. `renameSync` makes the
+ * claim atomic: whatever the drainer took is exactly what it deletes, and a
+ * record appended a microsecond later lands on a fresh queue that the next drain
+ * will find.
+ *
+ * A LOST RECORD IS A PERMANENTLY MISSED INVALIDATION, which is why this is worth
+ * a rename. The comment here used to price it as "a single missed eager mark that
+ * the lazy path still has a chance at", and that premise is false: this module's
+ * own header states it. The lazy path compares the anchor's stored hash against
+ * disk, and `indexFile` re-points that hash at the bytes the session just wrote,
+ * so for the session's OWN writes lazy is structurally blind rather than merely
+ * late. Nothing else was ever going to catch a dropped record.
+ *
+ * A RECORD THAT CANNOT BE APPLIED IS STILL DROPPED, deliberately and
+ * unconditionally: retrying a permanently unapplicable record on every tool call
+ * for the rest of the session costs more than it can ever recover, and the claim
+ * file is deleted whether the loop marked anything or threw.
+ *
+ * FAIL-OPEN THROUGHOUT. A rename that loses a race, or fails for any other
+ * reason, returns 0 and leaves the queue for the next drain; it never throws
+ * into a hook.
  */
 export function drainInvalidations(dir, graph) {
   let records;
+  let claim;
   try {
     const file = queuePath(dir);
     if (!existsSync(file)) return 0;
-    records = readFileSync(file, 'utf8')
+    claim = claimPath(dir);
+    // A LEFTOVER CLAIM FROM A KILLED DRAIN IS OVERWRITTEN, not merged: rename
+    // onto an existing path replaces it. The pid in the name means the only way
+    // to hit that is this same pid having died mid-drain, whose records were
+    // already being applied when it went -- and re-applying is idempotent, so
+    // losing them is the cheaper of the two errors. Not doing the rename at all
+    // would strand the live queue forever.
+    renameSync(file, claim);
+    records = readFileSync(claim, 'utf8')
       .split('\n')
       .filter((line) => line.trim())
       .map((line) => {
@@ -342,6 +382,18 @@ export function drainInvalidations(dir, graph) {
       })
       .filter(Boolean);
   } catch {
+    // The rename lost a race, or the claim could not be read. Nothing is deleted
+    // unread and the hook proceeds. If the claim was taken and then could not be
+    // read, it is put back under the queue name so the next drain still sees it:
+    // a claim file nobody looks at again is the same lost record this rename
+    // exists to prevent.
+    try {
+      if (claim && existsSync(claim) && !existsSync(queuePath(dir))) {
+        renameSync(claim, queuePath(dir));
+      }
+    } catch {
+      // Best effort only. A hook must not fail because bookkeeping did.
+    }
     return 0;
   }
 
@@ -365,10 +417,13 @@ export function drainInvalidations(dir, graph) {
   }
 
   try {
-    rmSync(queuePath(dir), { force: true });
+    // THE CLAIM, NOT THE QUEUE. Deleting `queuePath` here is what dropped a
+    // concurrently appended record; this path holds exactly the bytes that were
+    // just read, so nothing unread can be inside it.
+    rmSync(claim, { force: true });
   } catch {
-    // Held open by a concurrent hook. The next drain re-applies these records,
-    // which is safe: marking an already-marked finding is idempotent.
+    // Held open by something else. The claim is not read again -- the next drain
+    // looks at the queue -- so this costs a stray file, never a record.
   }
 
   return marked;

--- a/integrations/kilo/hooks/lib/restore.mjs
+++ b/integrations/kilo/hooks/lib/restore.mjs
@@ -142,7 +142,7 @@ export function restorationPlan(dir, graph, context = {}) {
     for (const id of predicted) {
       const node = graph.nodes.get(id);
       if (!node) continue;
-      const findings = serve(graph, findingsFor(graph, id, { limit: 2 }));
+      const findings = serve(graph, findingsFor(graph, id, { limit: 2 }), { dir });
       for (const finding of findings) {
         // `! STALE` only where a diff actually exists to back it; see the
         // renderer in inject.mjs for the measurement behind this.

--- a/integrations/kilo/hooks/lib/restore.mjs
+++ b/integrations/kilo/hooks/lib/restore.mjs
@@ -158,7 +158,16 @@ export function restorationPlan(dir, graph, context = {}) {
             ? '! STALE '
             : '~ '
           : '';
-        lines.push(`${node.key}: ${mark}${finding.claim}`);
+        // A DISPUTE DISCLOSED ELSEWHERE AND SILENT HERE reads as "the dispute
+        // went away". `serve` already attached the fields; the only question is
+        // the wording, and this list is the most compressed surface in the
+        // system, so it gets the marker and the key and nothing else.
+        const disputed = finding.contradicted
+          ? finding.contradictedBy
+            ? ` (disputed by ${finding.contradictedBy})`
+            : ' (disputed)'
+          : '';
+        lines.push(`${node.key}: ${mark}${finding.claim}${disputed}`);
       }
     }
     section('Likely next', lines, total * split.forward);

--- a/integrations/kilo/hooks/lib/skeleton.mjs
+++ b/integrations/kilo/hooks/lib/skeleton.mjs
@@ -126,6 +126,11 @@ export function annotatedSkeleton(graph, rawPath, source, { budget = 1200, git =
 
   // Findings anchored to this file or the symbols inside it, served through the
   // one function that enforces the stale-plus-diff rule.
+  // READ-ONLY serve: no `dir` is threaded here, so this cannot clear a stale
+  // flag whose evidence is gone. That is deliberate -- this function takes a
+  // graph, not the directory it came from, and widening its signature to give
+  // an analysis path a write capability buys nothing: the injection path runs
+  // on every tool call and clears the same findings.
   const served = serve(graph, findingsFor(graph, nodeId('file', path), { limit: 40 }));
 
   // Index findings by the symbol they anchor to, so each one sits beside the

--- a/integrations/kilo/hooks/lib/staleness.mjs
+++ b/integrations/kilo/hooks/lib/staleness.mjs
@@ -31,6 +31,23 @@
  * Eager alone would silently serve stale findings as fresh whenever a change
  * came from outside the agent, which is the single failure mode the design
  * calls worse than no graph.
+ *
+ * AND LAZY ALONE IS BLIND TO THE AGENT'S OWN WRITES -- not degraded, BLIND.
+ * `indexFile` re-points an anchor's stored hash at the bytes it was just handed,
+ * and it is called on every file either hook observes: pretooluse-router.mjs
+ * (two call sites) and adapter.mjs (one). The lazy check then compares that
+ * refreshed hash against the same disk it came from and finds them equal. So
+ * for a file the session edited ITSELF, the lazy path cannot detect the change
+ * at all, and the finding derived from the pre-edit content is served CLEAN.
+ *
+ * Which means that until the eager path was connected, staleness for a file the
+ * agent edited did not work AT ALL: eager was dead code and lazy was defeated
+ * by re-indexing. Every account of this defect, including the one in this
+ * module's own git history, called it "lazy-only, therefore degraded". It was
+ * not degraded. `stale-before-reindex.test.mjs` states in its header that this
+ * case is covered by `invalidateOnWrite`, and `invalidateOnWrite` had never run
+ * once in production. The two paths are not redundant and never were: each is
+ * the ONLY cover for a whole class of change.
  */
 
 import { readFileSync, statSync } from 'node:fs';
@@ -622,6 +639,119 @@ export function invalidateOnWrite(dir, graph, rawPath, beforeText, afterText) {
   // Re-index so the anchors carry the new hashes; otherwise the lazy path would
   // report the same change again on every future retrieval.
   indexFile(dir, path, afterText);
+  return marked;
+}
+
+/**
+ * The eager path for a write with NO before/after pair: compare stored hashes
+ * against disk, and mark what actually moved.
+ *
+ * WHY THIS EXISTS AS A SECOND SHAPE. A whole-file `Write` replaces the file, so
+ * the payload carries the after side and nothing at all of the before -- and a
+ * whole-file write is the commonest write shape there is. `invalidateOnWrite`
+ * cannot serve it: passing '' as the before side makes every symbol in the file
+ * look changed, marks every finding anchored anywhere in it, and the eager mark
+ * is a stored flag no later check ever clears. False-stale is expensive and
+ * permanent, so it is not an acceptable price for coverage.
+ *
+ * But the hash comparison is available, and it is exactly the comparison the
+ * lazy path makes. The difference is WHEN: this runs at the top of injection,
+ * before `indexFile` refreshes the anchor, so the stored hash is still the
+ * pre-write one and the comparison is meaningful. That is the whole trick --
+ * lazy is not wrong, it is merely too late.
+ *
+ * SYMBOL-LEVEL, and from ONE read. Re-locating each symbol by name and
+ * comparing its own span hash is what keeps this from degenerating into
+ * file-level marking: editing one function must not stale a finding about
+ * another, which is the property symbol nodes exist to provide.
+ *
+ * WEAKER EVIDENCE, STATED AS SUCH. There is no before text, so no diff can be
+ * built -- the finding is marked with the two hashes and `serve` reports the
+ * evidence gap through `staleEvidence: false`, which the renderer turns into
+ * "no diff could be rebuilt" rather than promising a diff and showing nothing.
+ * A stale finding with weak evidence is far better than one served as fresh,
+ * but the reader has to be able to tell which one they are holding.
+ */
+export function invalidateChangedAnchors(dir, graph, rawPath) {
+  const path = canonicalPath(rawPath);
+  const marked = [];
+
+  // ONE read for the file and every symbol in it. checkAnchor would have been
+  // the obvious reuse and it reads per anchor, which on a file with fifty
+  // symbols is fifty-one reads of the same bytes on a hook path.
+  let source = null;
+  try {
+    source = readAnySpelling(path);
+  } catch {
+    // Deleted, or unreadable from this checkout. Handled below as a change,
+    // because a finding about a file that is no longer there is exactly the
+    // kind that must not be served as fresh.
+  }
+
+  const changed = [];
+  const fileNode = graph.nodes.get(nodeId('file', path));
+  const fileDigest = source === null ? null : hash(source);
+  if (fileNode && fileDigest !== fileNode.hash) {
+    changed.push({ node: fileNode, from: fileNode.hash, to: fileDigest });
+  }
+
+  const current = new Map(
+    source === null
+      ? []
+      : extractSymbols(path, source).map((s) => [s.name, hash(spanText(source, s))])
+  );
+  for (const node of graph.nodes.values()) {
+    if (node.kind !== 'symbol' || node.file !== path) continue;
+    const digest = current.has(node.name) ? current.get(node.name) : null;
+    if (digest !== node.hash) changed.push({ node, from: node.hash, to: digest });
+  }
+
+  if (changed.length) {
+    // Indexed once by target, for the reason invalidateOnWrite indexes: the
+    // nested alternative is O(nodes x edges) inside a hook.
+    const byTarget = new Map();
+    for (const edge of graph.edges) {
+      if (edge.edge !== 'derived_from') continue;
+      if (!byTarget.has(edge.to)) byTarget.set(edge.to, []);
+      byTarget.get(edge.to).push(edge);
+    }
+
+    for (const { node, from, to } of changed) {
+      for (const edge of byTarget.get(node.id) || []) {
+        const finding = graph.nodes.get(edge.from);
+        if (!finding || finding.kind !== 'finding') continue;
+        // The same type gate serve() applies, for the same reason it is applied
+        // in invalidateOnWrite: the flag is STORED, and disclose.mjs skips a
+        // stale finding while utility.mjs penalises one by 160.
+        if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) continue;
+        // ALREADY MARKED IS LEFT ALONE. Whatever marked it first had a diff or
+        // a more specific reason; overwriting that with a hash pair trades real
+        // evidence for less.
+        if (finding.stale) continue;
+
+        putNode(dir, {
+          ...finding,
+          kind: 'finding',
+          key: finding.key,
+          stale: true,
+          staleReason:
+            to === null
+              ? `the ${node.kind} it depends on is no longer present (was ${from})`
+              : `content hash changed during this session (${from} -> ${to}), observed without a before/after pair`,
+          // EXPLICITLY EMPTY, not absent. serve() reports `staleEvidence` from
+          // whether a diff survived, and the renderer says "no diff could be
+          // rebuilt" -- so the reader can tell "changed, diff unknown" from
+          // "changed, here is what changed".
+          diff: '',
+        });
+        marked.push(finding.key);
+      }
+    }
+  }
+
+  // Re-index for the same reason the diff path does: otherwise every future
+  // retrieval re-reports a change that has already been accounted for.
+  if (source !== null) indexFile(dir, path, source);
   return marked;
 }
 

--- a/integrations/kilo/hooks/lib/staleness.mjs
+++ b/integrations/kilo/hooks/lib/staleness.mjs
@@ -574,8 +574,20 @@ function derivationCheck(graph, finding) {
  * This is the only function that should ever hand a finding to a model, because
  * it is the one that enforces the rule: a stale finding leaves here carrying
  * `stale: true` AND a diff, or it does not leave at all.
+ *
+ * AND IT CLEARS A STORED FLAG WHOSE EVIDENCE IS GONE, when given a `dir` to
+ * write to. Clearing used to be reachable only by a person pressing Re-verify in
+ * the dashboard, which left the rot path fully open on every install where
+ * nobody opens the dashboard -- and that is most of them. The evidence test is
+ * what makes clearing safe, and it does not care who triggered it: the same
+ * `claimTimeVerdict` runs here as in `reverify`, so this cannot clear anything
+ * the button would not.
+ *
+ * `dir` IS OPTIONAL, AND OMITTING IT MAKES THIS READ-ONLY. Several callers hold
+ * a graph without the directory it came from, and a serve that silently did
+ * nothing would be worse than one that plainly cannot write.
  */
-export function serve(graph, findings) {
+export function serve(graph, findings, { dir = null } = {}) {
   const served = [];
 
   // RETIRED FINDINGS STOP HERE, unconditionally.
@@ -603,8 +615,42 @@ export function serve(graph, findings) {
       continue;
     }
 
+    // AUTOMATIC CLEARING, on the same evidence the manual path demands.
+    //
+    // ONLY THE STORED FLAG IS TOUCHED. The lazy loop below is left to run
+    // exactly as before and can independently mark this finding stale again on
+    // its own comparison -- disk against the anchor NODE's hash -- which answers
+    // a different question and is not this function's to overrule. Eager and
+    // lazy stay two mechanisms, as the module header insists.
+    //
+    // AND THE FIELDS GO WITH THE FLAG. `putNode` does not merge and neither does
+    // this spread: serving `{ ...finding, stale: false }` would hand back a
+    // finding that reads fresh while still carrying `staleReason` and `diff`
+    // from the record -- stale and fresh at once, which is worse than either.
+    // So the cleared record, not the stored one, is what the rest of this
+    // iteration reads and spreads.
+    //
+    // BOUNDED, and the bound is the point: this runs only for a finding whose
+    // flag is already STORED, only when a `derivation` record exists to check
+    // against, and it reads each of that finding's anchors at most once. A
+    // finding that is not flagged pays nothing. The lazy loop below already
+    // reads every anchor of every content-dependent finding served, so the worst
+    // case is twice the anchor reads on the already-stale subset alone.
+    //
+    // NOT ON THE NON-CONTENT-DEPENDENT EARLY RETURN ABOVE, deliberately. Both
+    // eager paths refuse to flag those types at all, so a flag there can only
+    // come from an older graph -- and reading anchors for a type whose truth
+    // does not depend on them is exactly the cost `CONTENT_DEPENDENT` exists to
+    // avoid.
+    let record = finding;
+    if (dir && finding.stale && claimTimeVerdict(graph, finding) === 'match') {
+      clearStale(dir, finding.key, { graph });
+      const { stale: _s, staleReason: _r, diff: _d, staleEvidence: _e, ...cleared } = finding;
+      record = cleared;
+    }
+
     const anchors = graph.edges
-      .filter((e) => e.edge === 'derived_from' && e.from === finding.id)
+      .filter((e) => e.edge === 'derived_from' && e.from === record.id)
       .map((e) => graph.nodes.get(e.to))
       .filter(Boolean);
 
@@ -629,10 +675,10 @@ export function serve(graph, findings) {
     // A finding already marked stale eagerly, whose diff was captured at write
     // time, keeps that diff -- the eager path saw the change we can no longer
     // reconstruct from disk alone.
-    if (!stale && finding.stale) {
+    if (!stale && record.stale) {
       stale = true;
-      diff = finding.diff || '';
-      reason = finding.staleReason || 'marked stale when the change was observed';
+      diff = record.diff || '';
+      reason = record.staleReason || 'marked stale when the change was observed';
     }
 
     if (stale && !diff) {
@@ -681,13 +727,19 @@ export function serve(graph, findings) {
     }
 
     served.push({
-      ...finding,
+      ...record,
       stale,
       ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
+      // BOTH OTHER DISCLOSURES SURVIVE A MID-SERVE CLEAR. `dispute` was computed
+      // above the content-dependence branch and is applied here untouched, and
+      // the derivation verdict is recomputed from the record -- which still
+      // carries its `derivation`, since clearing removes only the staleness
+      // fields. A finding whose flag was just cleared is still disclosed as
+      // disputed, and still reports whether its derivation holds.
       ...dispute,
       // Independent of `stale` above: see `derivationCheck`'s own comment for
       // the case it catches that node-level staleness can miss.
-      ...derivationCheck(graph, finding),
+      ...derivationCheck(graph, record),
     });
   }
   return served;
@@ -939,8 +991,21 @@ function anchorHashNow(anchor) {
  * Exposing it to a hook, a tool argument or an HTTP action would be a way to
  * turn a stale finding fresh on request, which is exactly what must not exist.
  */
-export function clearStale(dir, key) {
-  const node = load(dir).nodes.get(nodeId('finding', key));
+export function clearStale(dir, key, { graph = null } = {}) {
+  // A CALLER THAT ALREADY HOLDS THE GRAPH PASSES IT, and this is not
+  // micro-optimisation: `load` re-parses the entire append-only log, so clearing
+  // inside `serve`'s loop re-read and re-folded the whole graph once PER cleared
+  // finding. Measured on 40 findings all stale and all revertible -- the shape a
+  // mass revert produces -- that was 185 ms against 25 ms, a 7x regression on
+  // the injection path, all of it graph loading rather than the hashing this
+  // feature is actually for. With the graph passed through it is back in line.
+  //
+  // No new race: this store is last-write-wins with no compare-and-set anywhere,
+  // and every other caller that spreads a node back -- `pin`, `retire`,
+  // `contradict`, `correct` -- writes from a graph it loaded earlier too. Both
+  // callers here already DECIDED on this snapshot, so re-reading it purely for
+  // the write narrowed no window that was ever closed.
+  const node = (graph || load(dir)).nodes.get(nodeId('finding', key));
   if (!node || node.kind !== 'finding') return false;
   const { stale, staleReason, diff, staleEvidence, ...rest } = node;
   // Nothing to clear is a success, not a write: an unconditional putNode here
@@ -989,14 +1054,33 @@ export function clearStale(dir, key) {
  * silently un-mark findings nobody asked about. Staleness is disclosed to a
  * reader who then decides; clearing is an explicit act.
  */
-export function reverify(dir, key) {
-  const graph = load(dir);
-  const finding = graph.nodes.get(nodeId('finding', key));
-  if (!finding || finding.kind !== 'finding') return 'unknown';
-  // Idempotent: the postcondition -- no stale flag on this finding -- already
-  // holds, and reporting anything else would make a caller retry forever.
-  if (!finding.stale) return 'cleared';
-
+/**
+ * THE ONE EVIDENCE TEST. Does this finding's anchored content still hash to what
+ * the claim was actually made against?
+ *
+ * `'match'` -- every anchor on disk re-hashes to the value frozen into this
+ * finding's own `derivation.anchors` at claim time. The content IS what the
+ * claim was derived from: a revert, or a write that never moved the anchored
+ * bytes.
+ * `'differs'` -- at least one anchor does not, INCLUDING an anchor whose content
+ * is gone. Deleted is a difference, not a missing measurement.
+ * `'unknown'` -- there is nothing to compare: no `derivation.anchors`, no
+ * anchors, an anchor with no recorded hash, or one that no longer resolves.
+ *
+ * SHARED BY BOTH CLEARING PATHS ON PURPOSE, and that sharing is the guarantee
+ * rather than a convenience. `reverify` (a person pressing Re-verify) and
+ * `serve` (automatic, on every retrieval) call THIS function and nothing else,
+ * so the automatic path cannot clear anything the button would not, and neither
+ * can drift from the other. Two copies of this comparison would be two policies,
+ * and the weaker one would win wherever it ran more often -- which is the
+ * automatic one.
+ *
+ * NOT `checkAnchor`, for the reason `anchorHashNow` above spells out: that
+ * compares disk against the anchor NODE's stored hash, which both eager paths
+ * re-point at the very bytes that caused the mark, so it answers "fresh" for
+ * exactly the finding it just marked stale.
+ */
+function claimTimeVerdict(graph, finding) {
   const recorded = finding.derivation && finding.derivation.anchors;
   if (!recorded || typeof recorded !== 'object') return 'unknown';
 
@@ -1019,10 +1103,23 @@ export function reverify(dir, key) {
     if (node.kind !== 'file' && node.kind !== 'symbol') return 'unknown';
     // null means the content is gone -- deleted file, vanished symbol. That is a
     // difference, not an absence of evidence.
-    if (anchorHashNow(node) !== expected) return 'still-stale';
+    if (anchorHashNow(node) !== expected) return 'differs';
   }
+  return 'match';
+}
 
-  clearStale(dir, key);
+export function reverify(dir, key) {
+  const graph = load(dir);
+  const finding = graph.nodes.get(nodeId('finding', key));
+  if (!finding || finding.kind !== 'finding') return 'unknown';
+  // Idempotent: the postcondition -- no stale flag on this finding -- already
+  // holds, and reporting anything else would make a caller retry forever.
+  if (!finding.stale) return 'cleared';
+
+  const verdict = claimTimeVerdict(graph, finding);
+  if (verdict === 'unknown') return 'unknown';
+  if (verdict === 'differs') return 'still-stale';
+  clearStale(dir, key, { graph });
   return 'cleared';
 }
 

--- a/integrations/kilo/hooks/lib/staleness.mjs
+++ b/integrations/kilo/hooks/lib/staleness.mjs
@@ -53,7 +53,7 @@
 import { readFileSync, statSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { dirname, join } from 'node:path';
-import { putNode, putEdge, contentHash, nodeId } from './wiki.mjs';
+import { putNode, putEdge, contentHash, nodeId, load } from './wiki.mjs';
 import { hasOutstandingContradiction } from './curate.mjs';
 import { extractSymbols, spanText, symbolKey, extractImports } from './symbols.mjs';
 import { canonicalPath, resolvableCandidates, isFsSafePath } from './paths.mjs';
@@ -488,7 +488,16 @@ function disputeOf(graph, finding) {
     // An edge end that resolves to nothing names nothing. The dispute is still
     // disclosed -- the gate above already established it -- but without a key
     // the reader cannot be pointed anywhere, and inventing one would be worse.
-    if (other && typeof other.key === 'string' && !keys.includes(other.key)) keys.push(other.key);
+    //
+    // A RETIRED END IS NOT NAMED EITHER, for a sharper reason: the disclosure
+    // tells the reader to `wiki_query` that key, and `serve` refuses to return
+    // a retired finding at all. Naming it points them at a claim they cannot
+    // fetch. `hasOutstandingContradiction` above already declines to open the
+    // gate when EVERY disputant is retired; this is the same rule applied to
+    // each name, so a live disputant is still reported alongside a withdrawn one.
+    if (other && !other.retired && typeof other.key === 'string' && !keys.includes(other.key)) {
+      keys.push(other.key);
+    }
   }
 
   return { contradicted: true, ...(keys.length ? { contradictedBy: keys.join(', ') } : {}) };
@@ -870,6 +879,151 @@ export function invalidateChangedAnchors(dir, graph, rawPath) {
   // retrieval re-reports a change that has already been accounted for.
   if (source !== null) indexFile(dir, path, source);
   return marked;
+}
+
+/**
+ * The current content hash of an anchor, read from disk.
+ *
+ * DELIBERATELY NOT `checkAnchor`, and the difference is the whole of this
+ * clearing rule. `checkAnchor` compares disk against the anchor NODE's stored
+ * hash, and both eager paths call `indexFile` immediately after marking --
+ * which re-points that hash at the very bytes that caused the mark. So
+ * `checkAnchor` answers "fresh" for exactly the finding it just marked stale,
+ * and a clearing rule built on it would clear every flag it was handed,
+ * unconditionally. This returns a bare hash instead, so the caller can compare
+ * it against the FROZEN claim-time hash rather than against a value the marking
+ * path itself moved.
+ *
+ * Returns null when no content can be read at all -- a deleted file, or a
+ * symbol that no longer exists. A caller must treat that as "changed", never as
+ * "unknown": a claim about content that is gone certainly does not match the
+ * content it was made against.
+ */
+function anchorHashNow(anchor) {
+  const path = anchor.kind === 'symbol' ? anchor.file : anchor.key;
+  let source;
+  try {
+    source = readAnySpelling(path);
+  } catch {
+    return null;
+  }
+  if (anchor.kind !== 'symbol') return hash(source);
+
+  // By NAME, like checkAnchor: line numbers shift whenever anything above is
+  // edited, and re-locating by line would report a symbol as moved when only an
+  // unrelated insert happened above it.
+  const current = extractSymbols(path, source).find((s) => s.name === anchor.name);
+  if (!current) return null;
+  return hash(spanText(source, current));
+}
+
+/**
+ * Removes the staleness fields from a finding. Returns whether one was found.
+ *
+ * THE WHOLE NODE IS REWRITTEN, because `putNode` does not merge: it writes a
+ * full record from what it is handed and `load` replaces the node wholesale.
+ * Writing `{ kind, key, stale: false }` would blank the claim, the confidence
+ * and the provenance -- an overwrite by another name, and the same trap
+ * `contradict` documents. So the fields are destructured AWAY and everything
+ * else is spread back: no deletion primitive is needed, and the append-only rule
+ * is respected.
+ *
+ * `staleEvidence` is stripped as well, even though no writer stores it. It is
+ * added by `serve` to the object it hands out, so anything that ever writes a
+ * served finding back would carry it in -- at which point a cleared finding
+ * would still be advertising the quality of the evidence for a flag it no longer
+ * has.
+ *
+ * A PRIMITIVE, NOT A ROUTE. Nothing outside this module calls it: the only
+ * shipping caller is `reverify` below, which establishes the evidence first.
+ * Exposing it to a hook, a tool argument or an HTTP action would be a way to
+ * turn a stale finding fresh on request, which is exactly what must not exist.
+ */
+export function clearStale(dir, key) {
+  const node = load(dir).nodes.get(nodeId('finding', key));
+  if (!node || node.kind !== 'finding') return false;
+  const { stale, staleReason, diff, staleEvidence, ...rest } = node;
+  // Nothing to clear is a success, not a write: an unconditional putNode here
+  // would append a duplicate record to the log on every no-op call.
+  if (stale === undefined && staleReason === undefined
+    && diff === undefined && staleEvidence === undefined) return true;
+  putNode(dir, { ...rest, kind: 'finding', key: node.key });
+  return true;
+}
+
+/**
+ * Clears a stale flag when, and only when, the evidence for it is gone.
+ *
+ * WHY THIS HAS TO EXIST. Nothing in this codebase ever cleared a `stale` flag.
+ * That was harmless while eager invalidation was dead code; it fires now, so
+ * every finding on an edited file becomes permanently stale -- and permanently
+ * discounted, since `disclose.mjs` skips a stale finding outright and
+ * `utility.mjs` penalises one by 160. The graph degrades toward all-stale, and
+ * the eager path is over-eager on top of that: `invalidateOnWrite` marks every
+ * finding anchored to a FILE node on any observed write to that file, whether or
+ * not the bytes moved.
+ *
+ * WHAT COUNTS AS EVIDENCE, AND WHY IT IS NOT NEGOTIABLE. The only trustworthy
+ * record of what a claim was made against is `derivation.anchors` -- the hash
+ * each anchor carried at the moment the finding was written, frozen into the
+ * finding itself by `harvest-write.mjs`. Disk is re-hashed here and compared
+ * against that. If every anchor matches, the content IS what the claim was
+ * derived from: a revert, or a write that never moved the anchored bytes. The
+ * flag comes off. Anything else leaves it exactly as it was.
+ *
+ * IT IS NOT A LAUNDERING ROUTE, and that is a property of the comparison rather
+ * than of who is allowed to call it. A caller cannot make a finding fresh by
+ * asking; they can only make it fresh by putting the content back. There is no
+ * argument, no force flag and no second path -- and `clearStale` above, the one
+ * function that clears without checking, has no caller but this one.
+ *
+ * NO RECORD MEANS UNKNOWN, NEVER CLEAR. A finding with no `derivation.anchors`
+ * -- every one written before that record existed, and every hand-curated one --
+ * has nothing to compare disk against. That is an absence of evidence, and
+ * resolving it to "clear it" would hand back the laundering route through the
+ * side door. It reports `unknown` and changes nothing; re-recording the claim
+ * against the current code (`curate.correct`) is the way forward for those.
+ *
+ * DELIBERATELY NOT AUTOMATIC. This reads every anchor off disk, so running it on
+ * the serve path would put N file reads inside injection -- and, worse, it would
+ * silently un-mark findings nobody asked about. Staleness is disclosed to a
+ * reader who then decides; clearing is an explicit act.
+ */
+export function reverify(dir, key) {
+  const graph = load(dir);
+  const finding = graph.nodes.get(nodeId('finding', key));
+  if (!finding || finding.kind !== 'finding') return 'unknown';
+  // Idempotent: the postcondition -- no stale flag on this finding -- already
+  // holds, and reporting anything else would make a caller retry forever.
+  if (!finding.stale) return 'cleared';
+
+  const recorded = finding.derivation && finding.derivation.anchors;
+  if (!recorded || typeof recorded !== 'object') return 'unknown';
+
+  const anchorIds = new Set(
+    graph.edges
+      .filter((e) => e.edge === 'derived_from' && e.from === finding.id)
+      .map((e) => e.to)
+  );
+  // An unanchored finding cannot be checked against anything, which is the
+  // un-invalidatable shape the anchor discipline exists to refuse. It is equally
+  // un-VERIFIABLE, so it is reported as such rather than cleared.
+  if (!anchorIds.size) return 'unknown';
+
+  for (const id of anchorIds) {
+    const expected = recorded[id];
+    const node = graph.nodes.get(id);
+    // An anchor this finding never recorded a hash for, or one that no longer
+    // resolves to a node: nothing to compare, so nothing is concluded.
+    if (typeof expected !== 'string' || !expected || !node) return 'unknown';
+    if (node.kind !== 'file' && node.kind !== 'symbol') return 'unknown';
+    // null means the content is gone -- deleted file, vanished symbol. That is a
+    // difference, not an absence of evidence.
+    if (anchorHashNow(node) !== expected) return 'still-stale';
+  }
+
+  clearStale(dir, key);
+  return 'cleared';
 }
 
 export { contentHash };

--- a/integrations/kilo/hooks/lib/staleness.mjs
+++ b/integrations/kilo/hooks/lib/staleness.mjs
@@ -368,6 +368,12 @@ const DIFF_MAX_BYTES = () => {
  * line, and total bytes. Every truncation is announced in the output, because a
  * silently shortened diff is worse than a visibly shortened one -- a reader who
  * cannot tell content was elided believes they saw the whole change.
+ *
+ * `maxLines` BOUNDS THE BODY, MARKERS INCLUDED: at most `maxLines` lines of
+ * removed lines, added lines and "... N more" elision markers between them, plus
+ * at most one final notice when the byte cap dropped lines -- so `maxLines + 1`
+ * lines in total, and no more. That last line is outside the budget on purpose,
+ * for the reason stated where it is pushed.
  */
 export function diffLines(
   before,
@@ -418,10 +424,24 @@ export function diffLines(
     bytes += size;
   };
 
-  for (const line of removed.slice(0, maxLines / 2)) push('- ' + line);
-  if (removed.length > maxLines / 2) push(`  ... ${removed.length - maxLines / 2} more removed`);
-  for (const line of added.slice(0, maxLines / 2)) push('+ ' + line);
-  if (added.length > maxLines / 2) push(`  ... ${added.length - maxLines / 2} more added`);
+  // THE ELISION MARKER IS PAID FOR OUT OF THE SIDE'S OWN QUOTA, so `maxLines`
+  // bounds the whole body rather than only the content in it. It did not: at the
+  // default 40 the body could reach 42 lines -- 20 removed, 20 added and two
+  // "... N more" markers -- and the out-of-budget notice below made 43, against
+  // a documented bound of 40 and a test asserting 41. Three numbers, no two the
+  // same. A side that has to elide now shows one fewer content line and spends
+  // that line on saying so, which is the trade a reader wants anyway: knowing
+  // that 300 lines were cut matters more than the 20th of the 20 shown.
+  const half = Math.floor(maxLines / 2);
+  const emit = (lines, prefix, label) => {
+    const elides = lines.length > half;
+    const shown = elides ? Math.max(0, half - 1) : half;
+    for (const line of lines.slice(0, shown)) push(prefix + line);
+    if (elides) push(`  ... ${lines.length - shown} more ${label}`);
+  };
+
+  emit(removed, '- ', 'removed');
+  emit(added, '+ ', 'added');
 
   // Announced OUTSIDE the budget, deliberately: the one line a reader most
   // needs is the one saying the rest is missing, and dropping it to stay under
@@ -479,6 +499,15 @@ function disputeOf(graph, finding) {
   if (!hasOutstandingContradiction(graph, finding.key)) return {};
 
   const keys = [];
+  // AND THE REASON A PERSON TYPED, which had no reader anywhere. `contradict`
+  // stores `contradictionReason` -- up to 400 characters of human explanation --
+  // on the CONTRADICTED end only, and nothing outside its own test ever read it:
+  // this disclosure named the other key and stopped, `audit` counts ends, and the
+  // dashboard detail view renders neither. So the one field on the edge that says
+  // WHY was written on every contradiction and seen by nobody. It is collected
+  // from whichever end holds it, so both sides of a dispute disclose the same
+  // reason rather than only the claim that lost.
+  let reason = typeof finding.contradictionReason === 'string' ? finding.contradictionReason : '';
   for (const edge of graph.edges) {
     if (edge.edge !== 'contradicts') continue;
     const otherId =
@@ -497,10 +526,30 @@ function disputeOf(graph, finding) {
     // each name, so a live disputant is still reported alongside a withdrawn one.
     if (other && !other.retired && typeof other.key === 'string' && !keys.includes(other.key)) {
       keys.push(other.key);
+      // A RETIRED END'S REASON IS NOT BORROWED EITHER, which is why this sits
+      // inside the same guard as the key: `hasOutstandingContradiction` can be
+      // open on one live disputant while another is withdrawn, and quoting the
+      // withdrawn one's explanation would attribute the live dispute to a claim
+      // the reader cannot fetch.
+      if (!reason && typeof other.contradictionReason === 'string') {
+        reason = other.contradictionReason;
+      }
     }
   }
 
-  return { contradicted: true, ...(keys.length ? { contradictedBy: keys.join(', ') } : {}) };
+  return {
+    contradicted: true,
+    ...(keys.length ? { contradictedBy: keys.join(', ') } : {}),
+    // Trimmed here rather than at the renderer: an empty string is not a reason,
+    // and a consumer checking `if (reason)` should not have to trim first.
+    //
+    // SET UNCONDITIONALLY, INCLUDING TO `undefined`. `serve` spreads the stored
+    // record before this object, so omitting the key would let a whitespace-only
+    // stored reason through untouched and make the served value differ from the
+    // one this function decided on. The disclosure is authoritative or it is not
+    // a disclosure.
+    contradictionReason: reason.trim() || undefined,
+  };
 }
 
 /**
@@ -580,8 +629,15 @@ function derivationCheck(graph, finding) {
  * the dashboard, which left the rot path fully open on every install where
  * nobody opens the dashboard -- and that is most of them. The evidence test is
  * what makes clearing safe, and it does not care who triggered it: the same
- * `claimTimeVerdict` runs here as in `reverify`, so this cannot clear anything
+ * `claimTimeEvidence` runs here as in `reverify`, so this cannot clear anything
  * the button would not.
+ *
+ * A CLEAR ALSO RE-INDEXES THE ANCHORS IT VERIFIED. The three disclosures this
+ * function emits -- `stale`, `derivationHolds`, and the dispute -- are computed
+ * from three different comparisons, and clearing the flag without moving the
+ * anchor's stored hash made the first two contradict the clear on the revert
+ * path. `reindexVerifiedAnchors` explains the reproduction and why re-pointing
+ * the index is the fix rather than suppressing the disclosures.
  *
  * `dir` IS OPTIONAL, AND OMITTING IT MAKES THIS READ-ONLY. Several callers hold
  * a graph without the directory it came from, and a serve that silently did
@@ -617,11 +673,17 @@ export function serve(graph, findings, { dir = null } = {}) {
 
     // AUTOMATIC CLEARING, on the same evidence the manual path demands.
     //
-    // ONLY THE STORED FLAG IS TOUCHED. The lazy loop below is left to run
-    // exactly as before and can independently mark this finding stale again on
-    // its own comparison -- disk against the anchor NODE's hash -- which answers
-    // a different question and is not this function's to overrule. Eager and
-    // lazy stay two mechanisms, as the module header insists.
+    // THE FLAG AND THE INDEX MOVE TOGETHER. Clearing the flag alone made this
+    // function contradict itself on the revert path: the lazy loop below
+    // compares disk against the anchor NODE's hash, which the eager path
+    // re-pointed at the post-edit bytes, so a reverted file read as `stale:
+    // true, staleReason: 'file changed'` and `derivationHolds: false` inside the
+    // very object whose flag had just been cleared for matching its claim-time
+    // content. `reindexVerifiedAnchors` writes the verified bytes' hash back to
+    // the anchor, so all three disclosures are finally reading the same content
+    // and cannot disagree. Eager and lazy stay two mechanisms, as the module
+    // header insists -- what changed is that the index no longer holds a hash
+    // that matches no version of the file that exists.
     //
     // AND THE FIELDS GO WITH THE FLAG. `putNode` does not merge and neither does
     // this spread: serving `{ ...finding, stale: false }` would hand back a
@@ -630,12 +692,37 @@ export function serve(graph, findings, { dir = null } = {}) {
     // So the cleared record, not the stored one, is what the rest of this
     // iteration reads and spreads.
     //
-    // BOUNDED, and the bound is the point: this runs only for a finding whose
-    // flag is already STORED, only when a `derivation` record exists to check
-    // against, and it reads each of that finding's anchors at most once. A
-    // finding that is not flagged pays nothing. The lazy loop below already
+    // BOUNDED PER CALL, and the bound is the point: this runs only for a finding
+    // whose flag is already STORED, only when a `derivation` record exists to
+    // check against, and it reads each of that finding's anchors at most once.
+    // A finding that is not flagged pays nothing. The lazy loop below already
     // reads every anchor of every content-dependent finding served, so the worst
     // case is twice the anchor reads on the already-stale subset alone.
+    //
+    // AND THE PER-SESSION SHAPE, stated because the per-call bound alone reads
+    // as cheaper than it is. Measured on a synthetic 40-stale-finding graph, the
+    // serve path went 158 ms -> 217 ms (+37%), and for a GENUINELY stale finding
+    // that cost recurs on every call for the whole session: the verdict is
+    // `'differs'` forever, nothing is cleared, and the reads are repaid with
+    // nothing. What keeps it survivable in practice is not this bound but two
+    // others -- `findingsFor`'s result limit and inject.mjs's `alreadyInjected`
+    // gate, which together put it near 40 ms on the first touch of a hot file
+    // and zero on the touches after.
+    //
+    // THE REVERT CASE PAYS ONCE, AND THAT IS MEASURED, not argued. Same 40
+    // findings, all revertible, medians of 9 across three process launches: the
+    // read-only serve is 23-29 ms, the first clearing serve is 141-173 ms (the
+    // anchor reads plus one node append per cleared finding AND per re-pointed
+    // anchor), and the SECOND clearing serve is 21-28 ms -- back to the
+    // read-only baseline, because the flag is off and the index agrees, so this
+    // gate no longer fires. What the re-index changed is not that cost -- the
+    // gate stopped firing once the flag came off before, too -- but that every
+    // serve after the clear used to re-derive `stale: true` and
+    // `derivationHolds: false` from an index nobody had moved. The extra ~120 ms
+    // buys silence that is actually correct.
+    // On the genuinely-stale set the recurring cost is
+    // real and unchanged in kind: 26-45 ms read-only against 53-105 ms with
+    // clearing on, every call, clearing nothing.
     //
     // NOT ON THE NON-CONTENT-DEPENDENT EARLY RETURN ABOVE, deliberately. Both
     // eager paths refuse to flag those types at all, so a flag there can only
@@ -643,10 +730,14 @@ export function serve(graph, findings, { dir = null } = {}) {
     // does not depend on them is exactly the cost `CONTENT_DEPENDENT` exists to
     // avoid.
     let record = finding;
-    if (dir && finding.stale && claimTimeVerdict(graph, finding) === 'match') {
-      clearStale(dir, finding.key, { graph });
-      const { stale: _s, staleReason: _r, diff: _d, staleEvidence: _e, ...cleared } = finding;
-      record = cleared;
+    if (dir && finding.stale) {
+      const evidence = claimTimeEvidence(graph, finding);
+      if (evidence.verdict === 'match') {
+        reindexVerifiedAnchors(dir, graph, evidence.contents);
+        clearStale(dir, finding.key, { graph });
+        const { stale: _s, staleReason: _r, diff: _d, staleEvidence: _e, ...cleared } = finding;
+        record = cleared;
+      }
     }
 
     const anchors = graph.edges
@@ -736,6 +827,14 @@ export function serve(graph, findings, { dir = null } = {}) {
       // carries its `derivation`, since clearing removes only the staleness
       // fields. A finding whose flag was just cleared is still disclosed as
       // disputed, and still reports whether its derivation holds.
+      //
+      // AND THEY NO LONGER CONTRADICT THE CLEAR. Surviving is not the same as
+      // agreeing: for a whole serve this returned `stale: true, staleReason:
+      // 'file changed'` and `derivationHolds: false` on a finding it had just
+      // cleared, because the clear was decided against disk while these two read
+      // the anchor node's hash, and the eager path had moved it. All three now
+      // read the same content because the clear re-points the anchor; see
+      // `reindexVerifiedAnchors`.
       ...dispute,
       // Independent of `stale` above: see `derivationCheck`'s own comment for
       // the case it catches that node-level staleness can miss.
@@ -934,6 +1033,34 @@ export function invalidateChangedAnchors(dir, graph, rawPath) {
 }
 
 /**
+ * The current content of an anchor, read from disk: the whole file for a file
+ * anchor, the located span for a symbol one. Null when nothing can be read.
+ *
+ * SPLIT OUT FROM `anchorHashNow` SO THE BYTES SURVIVE THE COMPARISON. The
+ * clearing path hashes this to reach a verdict and, on `'match'`, re-indexes the
+ * anchor from the same bytes -- see `reindexVerifiedAnchors`. Returning only a
+ * hash forced a second read of a file that had just been read, for content
+ * already known to be identical.
+ */
+function anchorContentNow(anchor) {
+  const path = anchor.kind === 'symbol' ? anchor.file : anchor.key;
+  let source;
+  try {
+    source = readAnySpelling(path);
+  } catch {
+    return null;
+  }
+  if (anchor.kind !== 'symbol') return source;
+
+  // By NAME, like checkAnchor: line numbers shift whenever anything above is
+  // edited, and re-locating by line would report a symbol as moved when only an
+  // unrelated insert happened above it.
+  const current = extractSymbols(path, source).find((s) => s.name === anchor.name);
+  if (!current) return null;
+  return spanText(source, current);
+}
+
+/**
  * The current content hash of an anchor, read from disk.
  *
  * DELIBERATELY NOT `checkAnchor`, and the difference is the whole of this
@@ -952,21 +1079,8 @@ export function invalidateChangedAnchors(dir, graph, rawPath) {
  * content it was made against.
  */
 function anchorHashNow(anchor) {
-  const path = anchor.kind === 'symbol' ? anchor.file : anchor.key;
-  let source;
-  try {
-    source = readAnySpelling(path);
-  } catch {
-    return null;
-  }
-  if (anchor.kind !== 'symbol') return hash(source);
-
-  // By NAME, like checkAnchor: line numbers shift whenever anything above is
-  // edited, and re-locating by line would report a symbol as moved when only an
-  // unrelated insert happened above it.
-  const current = extractSymbols(path, source).find((s) => s.name === anchor.name);
-  if (!current) return null;
-  return hash(spanText(source, current));
+  const content = anchorContentNow(anchor);
+  return content === null ? null : hash(content);
 }
 
 /**
@@ -1005,21 +1119,51 @@ export function clearStale(dir, key, { graph = null } = {}) {
   // `contradict`, `correct` -- writes from a graph it loaded earlier too. Both
   // callers here already DECIDED on this snapshot, so re-reading it purely for
   // the write narrowed no window that was ever closed.
-  const node = (graph || load(dir)).nodes.get(nodeId('finding', key));
+  const id = nodeId('finding', key);
+  const node = (graph || load(dir)).nodes.get(id);
   if (!node || node.kind !== 'finding') return false;
   const { stale, staleReason, diff, staleEvidence, ...rest } = node;
   // Nothing to clear is a success, not a write: an unconditional putNode here
   // would append a duplicate record to the log on every no-op call.
   if (stale === undefined && staleReason === undefined
     && diff === undefined && staleEvidence === undefined) return true;
-  putNode(dir, { ...rest, kind: 'finding', key: node.key });
+  const cleared = { ...rest, kind: 'finding', key: node.key };
+  putNode(dir, cleared);
+  // AND THE CALLER'S GRAPH IS UPDATED, because the guard above reads THAT graph,
+  // not disk. Without this, a second `serve` on the same in-memory graph object
+  // -- two touched files anchored to one finding, or a lifecycle branch that
+  // serves twice from a graph it loaded once, as SessionStart does -- still saw
+  // `stale: true`, re-ran the evidence test, and appended a byte-identical clear
+  // record. The store is append-only, so that is permanent log growth for no
+  // change in state, and the "nothing to clear is a success, not a write"
+  // guarantee directly above was only true of the first call.
+  if (graph) graph.nodes.set(id, { ...cleared, id });
   return true;
 }
 
 /**
- * Clears a stale flag when, and only when, the evidence for it is gone.
+ * THE ONE EVIDENCE TEST, plus the bytes it read. Does this finding's anchored
+ * content still hash to what the claim was actually made against?
  *
- * WHY THIS HAS TO EXIST. Nothing in this codebase ever cleared a `stale` flag.
+ * `verdict` is one of:
+ *   `'match'`   -- every anchor on disk re-hashes to the value frozen into this
+ *                  finding's own `derivation.anchors` at claim time. The content
+ *                  IS what the claim was derived from: a revert, or a write that
+ *                  never moved the anchored bytes.
+ *   `'differs'` -- at least one anchor does not, INCLUDING an anchor whose
+ *                  content is gone. Deleted is a difference, not a missing
+ *                  measurement.
+ *   `'unknown'` -- there is nothing to compare: no `derivation.anchors`, no
+ *                  anchors, an anchor with no recorded hash, or one that no
+ *                  longer resolves.
+ *
+ * `contents` carries the disk bytes read to reach a `'match'`, keyed by anchor
+ * id, so the caller can re-index those anchors without reading them again. It is
+ * empty for the other two verdicts, which read no further than the first
+ * disagreement.
+ *
+ * WHY CLEARING HAS TO EXIST AT ALL. Nothing in this codebase ever cleared a
+ * `stale` flag.
  * That was harmless while eager invalidation was dead code; it fires now, so
  * every finding on an edited file becomes permanently stale -- and permanently
  * discounted, since `disclose.mjs` skips a stale finding outright and
@@ -1049,24 +1193,6 @@ export function clearStale(dir, key, { graph = null } = {}) {
  * side door. It reports `unknown` and changes nothing; re-recording the claim
  * against the current code (`curate.correct`) is the way forward for those.
  *
- * DELIBERATELY NOT AUTOMATIC. This reads every anchor off disk, so running it on
- * the serve path would put N file reads inside injection -- and, worse, it would
- * silently un-mark findings nobody asked about. Staleness is disclosed to a
- * reader who then decides; clearing is an explicit act.
- */
-/**
- * THE ONE EVIDENCE TEST. Does this finding's anchored content still hash to what
- * the claim was actually made against?
- *
- * `'match'` -- every anchor on disk re-hashes to the value frozen into this
- * finding's own `derivation.anchors` at claim time. The content IS what the
- * claim was derived from: a revert, or a write that never moved the anchored
- * bytes.
- * `'differs'` -- at least one anchor does not, INCLUDING an anchor whose content
- * is gone. Deleted is a difference, not a missing measurement.
- * `'unknown'` -- there is nothing to compare: no `derivation.anchors`, no
- * anchors, an anchor with no recorded hash, or one that no longer resolves.
- *
  * SHARED BY BOTH CLEARING PATHS ON PURPOSE, and that sharing is the guarantee
  * rather than a convenience. `reverify` (a person pressing Re-verify) and
  * `serve` (automatic, on every retrieval) call THIS function and nothing else,
@@ -1080,9 +1206,10 @@ export function clearStale(dir, key, { graph = null } = {}) {
  * re-point at the very bytes that caused the mark, so it answers "fresh" for
  * exactly the finding it just marked stale.
  */
-function claimTimeVerdict(graph, finding) {
+function claimTimeEvidence(graph, finding) {
+  const none = { verdict: 'unknown', contents: new Map() };
   const recorded = finding.derivation && finding.derivation.anchors;
-  if (!recorded || typeof recorded !== 'object') return 'unknown';
+  if (!recorded || typeof recorded !== 'object') return none;
 
   const anchorIds = new Set(
     graph.edges
@@ -1092,22 +1219,122 @@ function claimTimeVerdict(graph, finding) {
   // An unanchored finding cannot be checked against anything, which is the
   // un-invalidatable shape the anchor discipline exists to refuse. It is equally
   // un-VERIFIABLE, so it is reported as such rather than cleared.
-  if (!anchorIds.size) return 'unknown';
+  if (!anchorIds.size) return none;
 
+  const contents = new Map();
   for (const id of anchorIds) {
     const expected = recorded[id];
     const node = graph.nodes.get(id);
     // An anchor this finding never recorded a hash for, or one that no longer
     // resolves to a node: nothing to compare, so nothing is concluded.
-    if (typeof expected !== 'string' || !expected || !node) return 'unknown';
-    if (node.kind !== 'file' && node.kind !== 'symbol') return 'unknown';
+    if (typeof expected !== 'string' || !expected || !node) return none;
+    if (node.kind !== 'file' && node.kind !== 'symbol') return none;
     // null means the content is gone -- deleted file, vanished symbol. That is a
     // difference, not an absence of evidence.
-    if (anchorHashNow(node) !== expected) return 'differs';
+    const content = anchorContentNow(node);
+    if (content === null || hash(content) !== expected) {
+      return { verdict: 'differs', contents: new Map() };
+    }
+    contents.set(id, content);
   }
-  return 'match';
+  return { verdict: 'match', contents };
 }
 
+/** The verdict alone, for callers that do not re-index. */
+function claimTimeVerdict(graph, finding) {
+  return claimTimeEvidence(graph, finding).verdict;
+}
+
+/**
+ * Re-points every verified anchor at the content the evidence test just read.
+ *
+ * WHY A CLEAR IS NOT ENOUGH ON ITS OWN, reproduced end to end: index a file at
+ * H1, write a finding whose `derivation.anchors` records H1, edit and re-index so
+ * the node holds H2, let the eager path mark the finding, then REVERT the edit on
+ * disk. `claimTimeVerdict` now says `'match'` -- disk is H1, which is exactly
+ * what the claim was derived from -- and the flag comes off. But the node still
+ * holds H2, so the same `serve` call went on to emit `stale: true` with
+ * `staleReason: 'file changed'` from the lazy loop (disk H1 against node H2) and
+ * `derivationHolds: false` from `derivationCheck` (index H2 against claim H1).
+ * The model was shown DERIVATION CHANGED and STALE at the exact moment this
+ * module's own evidence test had concluded the derivation holds -- on every
+ * serve, until something unrelated happened to re-index the anchor.
+ *
+ * THE FIX IS TO MOVE THE INDEX, NOT TO SILENCE THE DISCLOSURES. Suppressing the
+ * lazy check and the derivation verdict for a cleared finding would leave the
+ * graph holding a hash that matches no version of the file that exists, so every
+ * OTHER finding on that anchor keeps reading stale, and the next reader has to be
+ * told which disclosures to disbelieve. The node hash is simply out of date, the
+ * bytes are already in hand from the comparison that just succeeded, and writing
+ * them makes all three disclosures agree because they are finally reading the
+ * same content.
+ *
+ * COSTS NO READ. `contents` comes from `claimTimeEvidence`, which read each
+ * anchor to reach `'match'`. The write is one node record per anchor whose hash
+ * actually moved, and it happens once per revert rather than once per serve: with
+ * the index re-pointed, the flag stays off and the gate in `serve` does not fire
+ * again.
+ *
+ * THE IN-MEMORY GRAPH IS UPDATED TOO, because the caller is mid-serve and is
+ * about to read these same nodes through the lazy loop and `derivationCheck`.
+ * Writing only to disk would fix the next process and leave this one contradicting
+ * itself, which is the whole defect.
+ *
+ * Line numbers are deliberately left alone on a symbol anchor: `checkAnchor` and
+ * `anchorContentNow` both re-locate by NAME, so a stored line is informational,
+ * and the body being byte-identical is what was just established.
+ */
+function reindexVerifiedAnchors(dir, graph, contents) {
+  for (const [id, content] of contents) {
+    const node = graph.nodes.get(id);
+    if (!node) continue;
+    const nextHash = hash(content);
+    // Already agrees: no record, no write. The common case once a revert has
+    // been accounted for.
+    if (node.hash === nextHash) continue;
+    const limit = node.kind === 'symbol' ? symbolSnapshotLimit() : snapshotLimit();
+    // Same bound as `indexFile`: past the cap the hash still drives staleness and
+    // only the reconstructed diff degrades.
+    const snapshot = content.length <= limit ? content : undefined;
+    const { hash: _h, snapshot: _s, ...rest } = node;
+    try {
+      putNode(dir, { ...rest, kind: node.kind, key: node.key, hash: nextHash, snapshot });
+    } catch {
+      // Fail open: a graph that could not be written is a disclosure that stays
+      // as it was, never a broken tool call. The in-memory copy is left alone to
+      // match, so this serve keeps agreeing with the store.
+      continue;
+    }
+    graph.nodes.set(id, { ...node, hash: nextHash, ...(snapshot ? { snapshot } : {}) });
+  }
+}
+
+/**
+ * Clears a stale flag on behalf of a person who asked for it -- the dashboard's
+ * Re-verify action -- and reports what the evidence said.
+ *
+ * `'cleared'` when the flag is gone (including when it was already gone, so a
+ * caller polling this does not retry forever), `'still-stale'` when the anchored
+ * content genuinely differs from what the claim was made against, `'unknown'`
+ * when there is nothing to compare and therefore nothing to conclude.
+ *
+ * NO LONGER THE ONLY CLEARING PATH, and the docblock that used to sit here said
+ * the opposite: that automatic clearing was refused because it would put N file
+ * reads inside injection and "silently un-mark findings nobody asked about".
+ * `serve` now does exactly that, on the same evidence, for the reason its own
+ * comment gives -- the manual path was reachable only where somebody opens the
+ * dashboard, which is almost nowhere, so the rot path stayed open on most
+ * installs. What survives of that objection is the cost, which `serve` bounds
+ * and states.
+ *
+ * WHAT THIS STILL ADDS over the automatic path: it loads the graph itself, so a
+ * caller holding nothing but a key and a directory can act; it reports the
+ * verdict rather than folding it into a served record; and it runs on demand
+ * rather than only when the finding happens to be retrieved. It re-indexes the
+ * verified anchors for the same reason `serve` does -- otherwise the button
+ * clears the flag and the very next retrieval re-derives a contradiction from a
+ * node hash nobody moved.
+ */
 export function reverify(dir, key) {
   const graph = load(dir);
   const finding = graph.nodes.get(nodeId('finding', key));
@@ -1116,9 +1343,10 @@ export function reverify(dir, key) {
   // holds, and reporting anything else would make a caller retry forever.
   if (!finding.stale) return 'cleared';
 
-  const verdict = claimTimeVerdict(graph, finding);
+  const { verdict, contents } = claimTimeEvidence(graph, finding);
   if (verdict === 'unknown') return 'unknown';
   if (verdict === 'differs') return 'still-stale';
+  reindexVerifiedAnchors(dir, graph, contents);
   clearStale(dir, key, { graph });
   return 'cleared';
 }

--- a/integrations/kilo/hooks/lib/staleness.mjs
+++ b/integrations/kilo/hooks/lib/staleness.mjs
@@ -17,7 +17,13 @@
  * TWO INVALIDATION PATHS, and each covers what the other cannot see:
  *
  *   EAGER  -- our PostToolUse hook saw a write, so the finding is marked at the
- *             moment it went stale, with the exact before/after in hand.
+ *             moment it went stale, with the exact before/after in hand. The
+ *             hook does not call `invalidateOnWrite` directly: it queues the
+ *             evidence through pending.mjs, and the next graph read -- which
+ *             loads the graph anyway -- applies it before serving anything.
+ *             That path is also the only one that catches a write the SESSION
+ *             made, because the lazy check below compares the stored hash
+ *             against disk and `indexFile` has already refreshed it.
  *   LAZY   -- at retrieval, the anchor's stored hash is compared against disk.
  *             This is what catches `git pull`, another editor, a teammate, or a
  *             build step: every change our hooks never observed.
@@ -291,14 +297,69 @@ export function checkAnchor(anchor) {
 }
 
 /**
+ * Characters kept from any single diff line.
+ *
+ * A LINE CAP IS NOT A SIZE CAP, and the gap was measured: with only `maxLines`
+ * in force, `diffLines('X'.repeat(200000), 'Y'.repeat(200000))` returned 2 lines
+ * and 400,005 bytes. Minified bundles, generated sources and single-line JSON
+ * all have that shape, and this output goes STRAIGHT INTO MODEL CONTEXT from
+ * inject.mjs's zero-turn refusal -- so a line bound alone let one pathological
+ * file spend hundreds of thousands of tokens.
+ *
+ * 200 characters is chosen because it is past the width at which a line is read
+ * as a line by anybody, human or model: a hand-written source line is under
+ * ~120 columns, so the cap cannot truncate a diff a reader was going to use,
+ * while the cases it does truncate are ones where the interesting change is not
+ * legible from the raw text anyway.
+ */
+const DIFF_MAX_LINE_CHARS = () => {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_DIFF_MAX_LINE_CHARS);
+  return Number.isFinite(raw) && raw > 0 ? raw : 200;
+};
+
+/**
+ * Total UTF-8 bytes of diff body.
+ *
+ * 4,000 bytes is roughly 1,000 tokens. It is deliberately larger than the
+ * per-file injection budget (`TOKEN_OPTIMIZER_TOUCH_BUDGET`, 500 tokens) and
+ * far smaller than a file, because the two consumers want different things: the
+ * injection surface fits the diff inside its own budget and drops it if it does
+ * not fit, while the zero-turn refusal is replacing a whole file read and can
+ * afford more. One cap that neither consumer has to think about is worth more
+ * than two tuned ones.
+ *
+ * WHAT IT COSTS, PLAINLY: a legitimately large diff now arrives truncated, so a
+ * model looking at a 300-line refactor sees the head of it and a count of what
+ * was elided rather than the whole change. That is the correct direction to
+ * fail -- the alternative was a bounded-looking function that could emit 400 KB.
+ */
+const DIFF_MAX_BYTES = () => {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_DIFF_MAX_BYTES);
+  return Number.isFinite(raw) && raw > 0 ? raw : 4_000;
+};
+
+/**
  * A compact line diff.
  *
  * Deliberately not a full unified diff with hunks and context: the consumer is
  * a model deciding whether an existing conclusion still holds, and for that the
  * changed lines are the signal. Output is capped because an unbounded diff
  * injected alongside a finding would spend more tokens than re-deriving it.
+ *
+ * BOUNDED IN THREE WAYS, and each one is load-bearing: lines, characters per
+ * line, and total bytes. Every truncation is announced in the output, because a
+ * silently shortened diff is worse than a visibly shortened one -- a reader who
+ * cannot tell content was elided believes they saw the whole change.
  */
-export function diffLines(before, after, { maxLines = 40 } = {}) {
+export function diffLines(
+  before,
+  after,
+  {
+    maxLines = 40,
+    maxLineChars = DIFF_MAX_LINE_CHARS(),
+    maxBytes = DIFF_MAX_BYTES(),
+  } = {}
+) {
   const a = String(before).split('\n');
   const b = String(after).split('\n');
 
@@ -314,33 +375,44 @@ export function diffLines(before, after, { maxLines = 40 } = {}) {
   const added = b.slice(head, b.length - tail);
 
   const out = [];
-  for (const line of removed.slice(0, maxLines / 2)) out.push('- ' + line);
-  if (removed.length > maxLines / 2) out.push(`  ... ${removed.length - maxLines / 2} more removed`);
-  for (const line of added.slice(0, maxLines / 2)) out.push('+ ' + line);
-  if (added.length > maxLines / 2) out.push(`  ... ${added.length - maxLines / 2} more added`);
+  let bytes = 0;
+  let dropped = 0;
+
+  // Per line first, so ONE enormous line cannot consume the whole budget and
+  // leave every other changed line unrepresented.
+  const clamp = (line) => {
+    const text = String(line);
+    if (text.length <= maxLineChars) return text;
+    return `${text.slice(0, maxLineChars)} [+${text.length - maxLineChars} chars cut]`;
+  };
+
+  // Bytes, not characters: the cap exists to bound what is sent, and a
+  // multi-byte source file would otherwise pass a character check while
+  // emitting several times the budget.
+  const push = (line) => {
+    const text = clamp(line);
+    const size = Buffer.byteLength(text, 'utf8') + 1;
+    if (bytes + size > maxBytes) {
+      dropped++;
+      return;
+    }
+    out.push(text);
+    bytes += size;
+  };
+
+  for (const line of removed.slice(0, maxLines / 2)) push('- ' + line);
+  if (removed.length > maxLines / 2) push(`  ... ${removed.length - maxLines / 2} more removed`);
+  for (const line of added.slice(0, maxLines / 2)) push('+ ' + line);
+  if (added.length > maxLines / 2) push(`  ... ${added.length - maxLines / 2} more added`);
+
+  // Announced OUTSIDE the budget, deliberately: the one line a reader most
+  // needs is the one saying the rest is missing, and dropping it to stay under
+  // a self-imposed cap would hand back a diff that lies about being complete.
+  if (dropped) out.push(`  ... ${dropped} more changed line(s) cut at the size limit`);
 
   return out.join('\n');
 }
 
-/**
- * Prepares findings for delivery, verifying each one lazily against disk.
- *
- * This is the only function that should ever hand a finding to a model, because
- * it is the one that enforces the rule: a stale finding leaves here carrying
- * `stale: true` AND a diff, or it does not leave at all.
- */
-export function serve(graph, findings) {
-  const served = [];
-
-  // RETIRED FINDINGS STOP HERE, unconditionally.
-  //
-  // findingsFor and sessionIndex already filter them, so this is redundant on
-  // every current path -- deliberately. This function's own contract is that it
-  // is the only thing that hands a finding to a model, which makes it the right
-  // place for the guarantee to live: a future caller that reaches into the
-  // graph directly cannot accidentally serve a claim a human explicitly
-  // withdrew. A withheld claim reappearing is not a bug anyone would notice
-  // quickly.
 /**
  * Types whose truth is a claim ABOUT the anchor's contents.
  *
@@ -363,6 +435,26 @@ export function serve(graph, findings) {
  * to ignore -- taking the rare true positive with it.
  */
 const CONTENT_DEPENDENT = new Set(['finding', 'map']);
+
+/**
+ * Prepares findings for delivery, verifying each one lazily against disk.
+ *
+ * This is the only function that should ever hand a finding to a model, because
+ * it is the one that enforces the rule: a stale finding leaves here carrying
+ * `stale: true` AND a diff, or it does not leave at all.
+ */
+export function serve(graph, findings) {
+  const served = [];
+
+  // RETIRED FINDINGS STOP HERE, unconditionally.
+  //
+  // findingsFor and sessionIndex already filter them, so this is redundant on
+  // every current path -- deliberately. This function's own contract is that it
+  // is the only thing that hands a finding to a model, which makes it the right
+  // place for the guarantee to live: a future caller that reaches into the
+  // graph directly cannot accidentally serve a claim a human explicitly
+  // withdrew. A withheld claim reappearing is not a bug anyone would notice
+  // quickly.
 
   for (const finding of findings.filter((f) => !f.retired)) {
     // A claim that does not depend on the anchor's contents cannot be
@@ -505,6 +597,15 @@ export function invalidateOnWrite(dir, graph, rawPath, beforeText, afterText) {
     for (const edge of byTarget.get(node.id) || []) {
       const finding = graph.nodes.get(edge.from);
       if (!finding || finding.kind !== 'finding') continue;
+      // THE SAME TYPE GATE `serve` APPLIES, and it has to be here too now that
+      // this path actually runs. `serve` ignores a stale flag on a type whose
+      // truth is not a claim about the anchor's contents -- but the flag is
+      // STORED, and disclose.mjs skips a stale finding outright while
+      // utility.mjs penalises one by 160. So writing it onto a `failure` or a
+      // `command` would suppress that claim everywhere except the one reader
+      // that knows to ignore it, which is exactly the harm measured in the
+      // comment on CONTENT_DEPENDENT above.
+      if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) continue;
 
       putNode(dir, {
         ...finding,

--- a/integrations/kilo/hooks/lib/staleness.mjs
+++ b/integrations/kilo/hooks/lib/staleness.mjs
@@ -495,6 +495,54 @@ function disputeOf(graph, finding) {
 }
 
 /**
+ * Whether THIS finding's own claim-time evidence still matches its anchors --
+ * the reader `harvest-write.mjs`'s `derivation` record was written for.
+ * Nothing consumed that record until now: a grep for it found only the writer
+ * and its own tests, which made "checkable rather than merely attributed" a
+ * claim with no code behind it.
+ *
+ * DISTINCT FROM `stale`/`checkAnchor`, DELIBERATELY, not a duplicate of it.
+ * `checkAnchor` compares disk against the anchor NODE's CURRENT stored hash,
+ * which is refreshed by `indexFile` every time ANYTHING touches that file --
+ * so it answers "has this file changed since the last time anyone indexed
+ * it", not "has it changed since THIS finding was derived from it". Those
+ * differ in a real case: file F changes, and a LATER, unrelated write
+ * (another finding, another session) re-indexes F, updating the node's
+ * stored hash to match the new content again. `checkAnchor` now reports
+ * "fresh" -- disk matches the node's current hash -- while this finding's own
+ * frozen `derivation.anchors[id]` snapshot, taken when IT was written, no
+ * longer matches. The bytes this claim was actually derived from are gone,
+ * and `stale` alone would never say so.
+ *
+ * Returns `{}` when there is nothing to check (no `derivation.anchors`
+ * recorded -- true of every finding written before this existed), so a
+ * caller can tell "not checked" from "checked and holds" by whether
+ * `derivationHolds` is present at all.
+ */
+function derivationCheck(graph, finding) {
+  const recorded = finding.derivation && finding.derivation.anchors;
+  if (!recorded || typeof recorded !== 'object') return {};
+  const ids = Object.keys(recorded);
+  if (!ids.length) return {};
+
+  const changed = [];
+  for (const id of ids) {
+    const node = graph.nodes.get(id);
+    const currentHash = node && typeof node.hash === 'string' ? node.hash : null;
+    // An anchor that no longer resolves at all cannot be confirmed either --
+    // treated the same as a changed hash, never as "still holds" by default.
+    if (currentHash === null || currentHash !== recorded[id]) {
+      changed.push(node && typeof node.key === 'string' ? node.key : id);
+    }
+  }
+
+  if (!changed.length) return { derivationHolds: true };
+  // Bounded: a finding with many anchors should not spend unbounded budget
+  // naming every one that moved.
+  return { derivationHolds: false, derivationChanged: changed.slice(0, 5) };
+}
+
+/**
  * Prepares findings for delivery, verifying each one lazily against disk.
  *
  * This is the only function that should ever hand a finding to a model, because
@@ -611,6 +659,9 @@ export function serve(graph, findings) {
       stale,
       ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
       ...dispute,
+      // Independent of `stale` above: see `derivationCheck`'s own comment for
+      // the case it catches that node-level staleness can miss.
+      ...derivationCheck(graph, finding),
     });
   }
   return served;

--- a/integrations/kilo/hooks/lib/staleness.mjs
+++ b/integrations/kilo/hooks/lib/staleness.mjs
@@ -518,6 +518,21 @@ function disputeOf(graph, finding) {
  * recorded -- true of every finding written before this existed), so a
  * caller can tell "not checked" from "checked and holds" by whether
  * `derivationHolds` is present at all.
+ *
+ * `derivationHolds: true` MEANS "MATCHES THE ANCHOR NODE'S LAST-INDEXED
+ * HASH", NOT "MATCHES DISK RIGHT NOW" -- and that distinction is stored in
+ * `derivationCheckedAgainst: 'index'` rather than left for a `wiki_query`
+ * consumer to infer from a field name alone. Two ways to close this gap were
+ * considered: recompute a live hash from disk here, or document precisely
+ * what is actually compared. `stale` (via `checkAnchor`, above) ALREADY owns
+ * the disk comparison -- re-reading the same file a second time on the same
+ * serve path, for the same anchor, from a second mechanism, is worse than
+ * one honest name. So: documented, not duplicated. A file changed on disk
+ * but never re-indexed by anything is still caught, correctly, by `stale`;
+ * `derivationHolds` answers a narrower, complementary question -- whether
+ * the LAST INDEXED state agrees with what this specific finding recorded --
+ * which is exactly the re-indexed-by-something-else case above that `stale`
+ * cannot see.
  */
 function derivationCheck(graph, finding) {
   const recorded = finding.derivation && finding.derivation.anchors;
@@ -536,10 +551,12 @@ function derivationCheck(graph, finding) {
     }
   }
 
-  if (!changed.length) return { derivationHolds: true };
+  // Declared on BOTH branches, not only the ambiguous one: a consumer should
+  // not have to already know the answer to know what was checked.
+  if (!changed.length) return { derivationHolds: true, derivationCheckedAgainst: 'index' };
   // Bounded: a finding with many anchors should not spend unbounded budget
   // naming every one that moved.
-  return { derivationHolds: false, derivationChanged: changed.slice(0, 5) };
+  return { derivationHolds: false, derivationChanged: changed.slice(0, 5), derivationCheckedAgainst: 'index' };
 }
 
 /**

--- a/integrations/kilo/hooks/lib/staleness.mjs
+++ b/integrations/kilo/hooks/lib/staleness.mjs
@@ -54,6 +54,7 @@ import { readFileSync, statSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { dirname, join } from 'node:path';
 import { putNode, putEdge, contentHash, nodeId } from './wiki.mjs';
+import { hasOutstandingContradiction } from './curate.mjs';
 import { extractSymbols, spanText, symbolKey, extractImports } from './symbols.mjs';
 import { canonicalPath, resolvableCandidates, isFsSafePath } from './paths.mjs';
 
@@ -454,6 +455,46 @@ export function diffLines(
 const CONTENT_DEPENDENT = new Set(['finding', 'map']);
 
 /**
+ * What, if anything, currently disagrees with this finding.
+ *
+ * DISCLOSED AT SERVE TIME, because that is the only moment the disagreement can
+ * do any good. `WIKI_GRAPH.md`'s whole argument for making `contradicts` an edge
+ * rather than an overwrite is that a reader "sees both claims and the
+ * disagreement between them" -- so handing a finding to a model while something
+ * in the graph disputes it, without saying so, throws away the reason the edge
+ * was recorded instead of an overwrite.
+ *
+ * `hasOutstandingContradiction` is the gate: it is the one definition of "an
+ * open dispute", shared with the confidence-promotion gate, so the two can never
+ * disagree about what counts. The loop only NAMES the other side, and it names a
+ * key rather than quoting a claim because the reader can call `wiki_query` with
+ * a key -- and because the injection path pays for every character it renders.
+ *
+ * SEPARATE FROM STALENESS on purpose. A finding can be disputed without being
+ * stale (nothing touched its anchor; another finding simply says otherwise) and
+ * stale without being disputed, so this adds its own fields rather than
+ * borrowing the stale ones, and the renderer discloses each on its own terms.
+ */
+function disputeOf(graph, finding) {
+  if (!hasOutstandingContradiction(graph, finding.key)) return {};
+
+  const keys = [];
+  for (const edge of graph.edges) {
+    if (edge.edge !== 'contradicts') continue;
+    const otherId =
+      edge.from === finding.id ? edge.to : edge.to === finding.id ? edge.from : null;
+    if (!otherId) continue;
+    const other = graph.nodes.get(otherId);
+    // An edge end that resolves to nothing names nothing. The dispute is still
+    // disclosed -- the gate above already established it -- but without a key
+    // the reader cannot be pointed anywhere, and inventing one would be worse.
+    if (other && typeof other.key === 'string' && !keys.includes(other.key)) keys.push(other.key);
+  }
+
+  return { contradicted: true, ...(keys.length ? { contradictedBy: keys.join(', ') } : {}) };
+}
+
+/**
  * Prepares findings for delivery, verifying each one lazily against disk.
  *
  * This is the only function that should ever hand a finding to a model, because
@@ -474,10 +515,17 @@ export function serve(graph, findings) {
   // quickly.
 
   for (const finding of findings.filter((f) => !f.retired)) {
+    // A DISPUTE TRAVELS WITH EVERY TYPE, which is why it is computed before the
+    // content-dependence branch below. A `command` or `rule` finding cannot be
+    // invalidated by an anchor's contents, but another finding can still
+    // disagree with it, and this early return is the path that would have
+    // quietly dropped that.
+    const dispute = disputeOf(graph, finding);
+
     // A claim that does not depend on the anchor's contents cannot be
     // invalidated by them. It is served as-is rather than discounted.
     if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) {
-      served.push({ ...finding });
+      served.push({ ...finding, ...dispute });
       continue;
     }
 
@@ -562,6 +610,7 @@ export function serve(graph, findings) {
       ...finding,
       stale,
       ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
+      ...dispute,
     });
   }
   return served;

--- a/integrations/kilo/hooks/lib/waste.mjs
+++ b/integrations/kilo/hooks/lib/waste.mjs
@@ -151,6 +151,11 @@ function reDerivation(events, graph) {
       const id = nodeId('file', canonicalPath(row.anchor));
       if (!graph.nodes.has(id)) continue;
 
+      // READ-ONLY serve: no `dir` is threaded here, so this cannot clear a stale
+      // flag whose evidence is gone. That is deliberate -- this function takes a
+      // graph, not the directory it came from, and widening its signature to give
+      // an analysis path a write capability buys nothing: the injection path runs
+      // on every tool call and clears the same findings.
       const findings = serve(graph, findingsFor(graph, id, { limit: 3 }))
         .filter((f) => !f.stale && (f.confidence ?? 0) >= 0.7);
       if (!findings.length) continue;

--- a/integrations/kilo/hooks/lib/wiki.mjs
+++ b/integrations/kilo/hooks/lib/wiki.mjs
@@ -64,18 +64,37 @@ export const SUPPORTED_VERSIONS = [1];
  * Identity today because GRAPH_VERSION is 1 and no shape has changed. It exists
  * now so the first change that DOES need it has somewhere to go other than an
  * equality check that silently deletes user data.
+ *
+ * CONTRACT for the first non-identity step:
+ *  - It must be IDEMPOTENT. `upcast(upcast(r))` must equal `upcast(r)`, because
+ *    compaction upcasts a record to key it and `load` upcasts the same record
+ *    again on every subsequent read. A step that is not idempotent applies twice
+ *    to anything compaction has touched.
+ *  - It must NOT be relied on to restamp `v`. Nothing in this file writes an
+ *    upcast record back to disk under a version it did not come from; the
+ *    version stamp on disk is always the one that wrote the bytes. See the
+ *    per-branch comments in `compactIfWasteful`.
  */
 export function upcast(record) {
   return record;
 }
 
-/** True when this reader can interpret the record at all. */
-function readable(record) {
+/**
+ * True when this reader can interpret the record at all.
+ *
+ * `versions` is a PARAMETER so the range semantics are testable independently of
+ * today's constants. With `SUPPORTED_VERSIONS = [1]` and `GRAPH_VERSION = 1` a
+ * range check and the old equality check are extensionally identical, so a test
+ * pinned to the live constants cannot tell them apart -- and cannot fail if
+ * someone reverts this to an equality. Exercised against `[1, 2]`, it can.
+ */
+export function readable(record, versions = SUPPORTED_VERSIONS) {
   const version = record.v ?? 0;
   // Forward-incompatible records are skipped: a v-from-the-future was written by
-  // a newer client and we cannot know its shape. Ignoring the future is safe;
-  // ignoring the past is data loss.
-  return SUPPORTED_VERSIONS.includes(version);
+  // a newer client and we cannot know its shape. Ignoring the future is safe for
+  // a READER -- but see `compactIfWasteful`, where "ignore" would mean "delete",
+  // because compaction rewrites the files it reads.
+  return versions.includes(version);
 }
 
 /** Node kinds. `file` and `symbol` are first-class so staleness can propagate. */
@@ -434,9 +453,20 @@ function compactIfWasteful(dir) {
     const nodes = new Map();
     const edges = new Map();
     const snaps = new Map();
-    for (const rec of readSnapshots(dir)) {
+    // KEPT VERBATIM THROUGH THE REBUILD, exactly as the main log keeps what it
+    // cannot parse. These lines are not evictable by the snapshot budget below
+    // because their size cannot be attributed to an id we understand -- and
+    // preserving bytes we may not need is strictly better than deleting bytes a
+    // newer client does. They stop accumulating as soon as the client that
+    // wrote them compacts, since it can read and dedupe them.
+    const sidecar = readSnapshots(dir);
+    const rawSnaps = sidecar.unreadable;
+    for (const rec of sidecar.records) {
       if (typeof rec.snapshot === 'string' && rec.snapshot) {
-        snaps.set(rec.id, { at: rec.at || 0, snapshot: rec.snapshot });
+        // `v` IS CARRIED, not restamped. Writing GRAPH_VERSION over a record
+        // from another version mislabels bytes this reader did not produce, and
+        // the label is the only thing a future reader has to go on.
+        snaps.set(rec.id, { at: rec.at || 0, snapshot: rec.snapshot, v: rec.v ?? GRAPH_VERSION });
       }
     }
     for (const line of readFileSync(path, 'utf8').split('\n')) {
@@ -458,27 +488,40 @@ function compactIfWasteful(dir) {
         edges.set('raw:' + edges.size, line);
         continue;
       }
-      // Upcast IN MEMORY only, to key and classify the record. What gets written
-      // back below is the ORIGINAL `line`: compaction reclaims superseded
-      // records, it does not migrate surviving ones, so the on-disk version is
-      // whatever wrote it and `load` upcasts it again on every read.
-      record = upcast(record);
-      if (record.t === 'n') {
+      // TWO OBJECTS, ON PURPOSE. `record` is exactly what the bytes on disk say;
+      // `view` is the in-memory current-shape reading of it, used only to KEY and
+      // CLASSIFY. Nothing derived from `view` is ever serialized, because
+      // compaction reclaims superseded records -- it does not migrate surviving
+      // ones -- so every version stamp it writes is the one that wrote the bytes.
+      //
+      // An earlier revision of this comment claimed "the ORIGINAL line is written
+      // back" for the whole block. That was FALSE for the inline-snapshot branch,
+      // which re-serializes. It re-serialized the upcast object while carrying
+      // the old `v`, so the first non-identity `upcast` would have written
+      // new-shape bytes under an old label and every later `load` would have
+      // upcast them a second time. Hence: strip from `record`, never from `view`.
+      const view = upcast(record);
+      if (view.t === 'n') {
         // MIGRATION. Graphs written before snapshots were split still carry
         // them inline, and those are exactly the graphs that are slow. Moving
         // them out here means one compaction fixes an existing install.
+        //
+        // THE ONLY RE-SERIALIZING BRANCH in this loop. It writes the original
+        // record minus its snapshot, so the surviving bytes keep their own shape
+        // and their own `v`, and the snapshot moved to the sidecar carries the
+        // same `v` as the node it came out of.
         if (typeof record.snapshot === 'string' && record.snapshot) {
           const { snapshot, ...rest } = record;
-          nodes.set(record.id, JSON.stringify(rest));
-          snaps.set(record.id, { at: record.at || 0, snapshot });
+          nodes.set(view.id, JSON.stringify(rest));
+          snaps.set(view.id, { at: record.at || 0, snapshot, v: record.v ?? GRAPH_VERSION });
         } else {
-          nodes.set(record.id, line);
+          nodes.set(view.id, line);
         }
-      } else if (record.t === 's') {
+      } else if (view.t === 's') {
         if (typeof record.snapshot === 'string' && record.snapshot) {
-          snaps.set(record.id, { at: record.at || 0, snapshot: record.snapshot });
+          snaps.set(view.id, { at: record.at || 0, snapshot: record.snapshot, v: record.v ?? GRAPH_VERSION });
         }
-      } else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
+      } else if (view.t === 'e') edges.set(`${view.from}|${view.edge}|${view.to}`, line);
       else edges.set('raw:' + edges.size, line);
     }
 
@@ -541,10 +584,20 @@ function compactIfWasteful(dir) {
     renameSync(tmp, path);
     // The surviving snapshots are rewritten to their own file, which is also
     // what migrates a graph that still had them inline.
-    const snapOut =
-      [...keep.entries()]
-        .map(([id, v]) => JSON.stringify({ t: 's', v: GRAPH_VERSION, id, snapshot: v.snapshot, at: v.at }))
-        .join('\n') + (keep.size ? '\n' : '');
+    //
+    // UNREADABLE LINES FIRST AND VERBATIM. This rebuild replaces the file, so
+    // anything omitted here is deleted permanently -- which made the missing
+    // counterpart to the main log's `raw:` bucket a real data-loss path, not a
+    // theoretical one. Each survivor also keeps ITS OWN `v` rather than being
+    // restamped to GRAPH_VERSION, so no record is relabelled as something this
+    // reader wrote.
+    const snapLines = [
+      ...rawSnaps,
+      ...[...keep.entries()].map(([id, s]) =>
+        JSON.stringify({ t: 's', v: s.v ?? GRAPH_VERSION, id, snapshot: s.snapshot, at: s.at })
+      ),
+    ];
+    const snapOut = snapLines.join('\n') + (snapLines.length ? '\n' : '');
     const snapTmp = snapshotsPath(dir) + '.compact';
     writeFileSync(snapTmp, snapOut, { mode: 0o600 });
     renameSync(snapTmp, snapshotsPath(dir));
@@ -689,9 +742,26 @@ function appendSnapshot(dir, record) {
   }
 }
 
-/** Every snapshot record, latest wins. Read only when a caller asks. */
+/**
+ * Every snapshot record, latest wins. Read only when a caller asks.
+ *
+ * `unreadable` collects the RAW LINES this reader rejected, and it is the reason
+ * this function reports them at all rather than just dropping them. `load` has
+ * no use for them -- a reader that cannot interpret a record must ignore it --
+ * but `compactIfWasteful` REBUILDS this file from what it read, so for the
+ * compactor "ignore" and "delete permanently" are the same operation. The main
+ * log already keeps what it cannot parse (the `raw:` bucket); the sidecar had no
+ * equivalent, which made it the one asymmetric, destructive path in an otherwise
+ * append-only store.
+ *
+ * This is not hypothetical here: hooks-core is vendored into eleven client
+ * directories that update independently, so a stale client compacting a graph a
+ * newer client has already written to is the expected steady state, not an edge
+ * case.
+ */
 function readSnapshots(dir) {
-  const out = [];
+  /** @type {object[]} */ const out = [];
+  /** @type {string[]} */ const unreadable = [];
   try {
     for (const line of readFileSync(snapshotsPath(dir), 'utf8').split('\n')) {
       if (!line) continue;
@@ -699,19 +769,23 @@ function readSnapshots(dir) {
         const rec = JSON.parse(line);
         // THE SAME RANGE AS THE MAIN LOG, deliberately. An equality check here
         // was the quietest of the three: a bump would have made every stored
-        // snapshot unreadable, and the very next compaction -- which rebuilds
-        // this file from what it could read -- would have deleted them for
-        // good. That is the one place in this store where a read filter turns
-        // into a permanent write.
-        if (readable(rec) && rec.id) out.push(upcast(rec));
+        // snapshot unreadable, and the very next compaction would have deleted
+        // them for good.
+        if (!readable(rec)) {
+          unreadable.push(line);
+          continue;
+        }
+        if (rec.id) out.push(upcast(rec));
       } catch {
-        /* a torn line costs one snapshot */
+        // A torn line costs one snapshot -- and it is NOT preserved, because a
+        // half-written line is not a record from another version, it is
+        // garbage. Distinguishing the two is the whole point of parsing first.
       }
     }
   } catch {
     /* no sidecar yet */
   }
-  return out;
+  return { records: out, unreadable };
 }
 
 /**
@@ -777,7 +851,9 @@ export function load(dir, { snapshots = false } = {}) {
   // Re-attached after the sweep, so a snapshot record may appear before or
   // after the node it belongs to.
   if (pending) {
-    for (const rec of readSnapshots(dir)) pending.set(rec.id, rec.snapshot);
+    // A reader has no use for the lines it could not interpret; only the
+    // compactor does, because only the compactor rewrites the file.
+    for (const rec of readSnapshots(dir).records) pending.set(rec.id, rec.snapshot);
     for (const [id, snapshot] of pending) {
       const node = nodes.get(id);
       if (node) nodes.set(id, { ...node, snapshot });

--- a/integrations/kilo/hooks/lib/wiki.mjs
+++ b/integrations/kilo/hooks/lib/wiki.mjs
@@ -28,17 +28,55 @@ import { canonicalPath, isFsSafePath } from './paths.mjs';
 /**
  * Schema version stamped on every record.
  *
- * There is exactly ONE version and no migration code, because nothing has been
- * released: a graph written by an older commit of an unreleased branch is a
- * development artifact, not user data, and carrying migration paths for it costs
- * real complexity to protect something nobody has. A record from any other
- * version is skipped rather than interpreted, so a stale dev graph degrades to
- * "rebuilds from use" instead of silently mixing incompatible identities.
+ * THIS PACKAGE IS RELEASED. It ships on npm, so every graph on disk is user
+ * data. An earlier version of this comment claimed nothing had been released
+ * and used that to justify having no migration path at all -- and the reader
+ * below compared for EQUALITY, so the first bump would have discarded every
+ * existing graph in silence. That justification is gone and so is the equality:
+ * `SUPPORTED_VERSIONS` is the range this reader accepts, and `upcast` is where a
+ * shape change is absorbed in memory.
  *
- * When this does ship, a bump here is where migration would be added -- with
- * users to protect, that trade reverses.
+ * A bump here is taken only when a record's SHAPE actually changes, and it comes
+ * with a new `upcast` step and an entry in `SUPPORTED_VERSIONS` in the same
+ * change. Adding a field that older readers can ignore is not a shape change.
  */
 export const GRAPH_VERSION = 1;
+
+/**
+ * Versions this reader accepts, oldest first.
+ *
+ * A RANGE, NOT AN EQUALITY. The equality check this replaces would have
+ * discarded every existing graph the moment anyone bumped the version -- and the
+ * header once justified that with "nothing has been released", which stopped
+ * being true at v5.7.0 on npm.
+ *
+ * Nothing on disk is ever rewritten to migrate: `upcast` runs in memory during
+ * the fold, so there is no migration pass to fail halfway and no race with the
+ * concurrent sessions this store is designed for. A mixed-version log is safe
+ * precisely because the original records are never mutated, and the existing
+ * compaction retires old ones naturally as it rewrites snapshots.
+ */
+export const SUPPORTED_VERSIONS = [1];
+
+/**
+ * Brings one record up to the current version. Pure, and one step per version.
+ *
+ * Identity today because GRAPH_VERSION is 1 and no shape has changed. It exists
+ * now so the first change that DOES need it has somewhere to go other than an
+ * equality check that silently deletes user data.
+ */
+export function upcast(record) {
+  return record;
+}
+
+/** True when this reader can interpret the record at all. */
+function readable(record) {
+  const version = record.v ?? 0;
+  // Forward-incompatible records are skipped: a v-from-the-future was written by
+  // a newer client and we cannot know its shape. Ignoring the future is safe;
+  // ignoring the past is data loss.
+  return SUPPORTED_VERSIONS.includes(version);
+}
 
 /** Node kinds. `file` and `symbol` are first-class so staleness can propagate. */
 export const NODE_KINDS = ['file', 'symbol', 'task', 'finding'];
@@ -409,13 +447,22 @@ function compactIfWasteful(dir) {
       } catch {
         continue;
       }
-      // A record from another schema is KEPT VERBATIM rather than reinterpreted.
-      // load() skips it, but discarding it here would make compaction a silent
-      // migration that deletes data a future version might understand.
-      if ((record.v ?? 0) !== GRAPH_VERSION) {
+      // A record this reader cannot interpret is KEPT VERBATIM rather than
+      // reinterpreted. load() skips it, but discarding it here would make
+      // compaction a silent migration that deletes data a future version might
+      // understand. THE RANGE MATTERS HERE TOO: with an equality check, a bump
+      // would have parked every existing v1 record in `raw`, undeduplicated, so
+      // compaction would stop reclaiming anything and inline snapshots would
+      // never migrate out -- the same loss by a second route.
+      if (!readable(record)) {
         edges.set('raw:' + edges.size, line);
         continue;
       }
+      // Upcast IN MEMORY only, to key and classify the record. What gets written
+      // back below is the ORIGINAL `line`: compaction reclaims superseded
+      // records, it does not migrate surviving ones, so the on-disk version is
+      // whatever wrote it and `load` upcasts it again on every read.
+      record = upcast(record);
       if (record.t === 'n') {
         // MIGRATION. Graphs written before snapshots were split still carry
         // them inline, and those are exactly the graphs that are slow. Moving
@@ -650,7 +697,13 @@ function readSnapshots(dir) {
       if (!line) continue;
       try {
         const rec = JSON.parse(line);
-        if ((rec.v ?? 0) === GRAPH_VERSION && rec.id) out.push(rec);
+        // THE SAME RANGE AS THE MAIN LOG, deliberately. An equality check here
+        // was the quietest of the three: a bump would have made every stored
+        // snapshot unreadable, and the very next compaction -- which rebuilds
+        // this file from what it could read -- would have deleted them for
+        // good. That is the one place in this store where a read filter turns
+        // into a permanent write.
+        if (readable(rec) && rec.id) out.push(upcast(rec));
       } catch {
         /* a torn line costs one snapshot */
       }
@@ -691,7 +744,12 @@ export function load(dir, { snapshots = false } = {}) {
       if (!snapshots) continue;
       try {
         const rec = JSON.parse(line);
-        if ((rec.v ?? 0) === GRAPH_VERSION) pending.set(rec.id, rec.snapshot);
+        // Inline snapshots from an older graph: same range, same reason. These
+        // are precisely the records most likely to predate a bump.
+        if (readable(rec)) {
+          const snap = upcast(rec);
+          pending.set(snap.id, snap.snapshot);
+        }
       } catch {
         /* a torn line costs one snapshot, not the graph */
       }
@@ -703,10 +761,14 @@ export function load(dir, { snapshots = false } = {}) {
     } catch {
       continue;
     }
-    // A record from another schema is skipped, not interpreted: its ids and
-    // hashes were derived differently, so honouring it produces confident
-    // nonsense rather than a visible error.
-    if ((record.v ?? 0) !== GRAPH_VERSION) continue;
+    // A record this reader cannot interpret is skipped, not guessed at: a
+    // version from the FUTURE derived its ids and hashes in a way we do not
+    // know, so honouring it produces confident nonsense rather than a visible
+    // error. A record from the PAST is upcast, never skipped -- skipping it is
+    // data loss, and this comparison used to be an equality, which made the
+    // first version bump a silent delete of every graph on disk.
+    if (!readable(record)) continue;
+    record = upcast(record);
     if (record.t === 'n') nodes.set(record.id, record);
     else if (record.t === 'e') edges.push(record);
   }

--- a/integrations/kilo/hooks/lib/wiki.mjs
+++ b/integrations/kilo/hooks/lib/wiki.mjs
@@ -775,7 +775,17 @@ function readSnapshots(dir) {
           unreadable.push(line);
           continue;
         }
+        // A RECORD WITH NO `id` IS KEPT VERBATIM, NOT DROPPED SILENTLY. It
+        // cannot be attributed to a node, so it is useless to `load` -- but this
+        // used to put it in neither bucket, and `compactIfWasteful` rebuilds the
+        // sidecar from `records` plus `unreadable`, so a line in neither was
+        // deleted permanently by the next compaction. That is the same shape as
+        // the Critical this reader's version check already fixed, and the same
+        // asymmetry: for the compactor, "ignore" and "destroy" are one operation.
+        // Unreachable today because every writer sets `id`; a reader is not the
+        // right place to rely on that.
         if (rec.id) out.push(upcast(rec));
+        else unreadable.push(line);
       } catch {
         // A torn line costs one snapshot -- and it is NOT preserved, because a
         // half-written line is not a record from another version, it is

--- a/integrations/kilo/hooks/post-tool.mjs
+++ b/integrations/kilo/hooks/post-tool.mjs
@@ -8,7 +8,7 @@ process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.
-process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write';
+process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write,wiki_query';
 try {
   const { run } = await import('./lib/adapter.mjs');
   await run('kilo', 'post-tool');

--- a/integrations/kilo/hooks/post-tool.mjs
+++ b/integrations/kilo/hooks/post-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/kilo/hooks/pre-tool.mjs
+++ b/integrations/kilo/hooks/pre-tool.mjs
@@ -8,7 +8,7 @@ process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.
-process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write';
+process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write,wiki_query';
 try {
   const { run } = await import('./lib/adapter.mjs');
   await run('kilo', 'pre-tool');

--- a/integrations/kilo/hooks/pre-tool.mjs
+++ b/integrations/kilo/hooks/pre-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/kilo/hooks/session-start.mjs
+++ b/integrations/kilo/hooks/session-start.mjs
@@ -8,7 +8,7 @@ process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.
-process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write';
+process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write,wiki_query';
 try {
   const { run } = await import('./lib/adapter.mjs');
   await run('kilo', 'session-start');

--- a/integrations/kilo/hooks/session-start.mjs
+++ b/integrations/kilo/hooks/session-start.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/opencode/hooks/lib/adapter.mjs
+++ b/integrations/opencode/hooks/lib/adapter.mjs
@@ -68,6 +68,7 @@ import {
   standingRules,
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
+import { observedWrite, queueInvalidation } from './pending.mjs';
 import { isArchived } from './transcript.mjs';
 import { isFsSafePath } from './paths.mjs';
 import {
@@ -881,6 +882,35 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Causal tracing is fail-open like every other hook optimization.
+    }
+
+    // EAGER INVALIDATION, finally connected. `invalidateOnWrite` has existed,
+    // been tested and been described in staleness.mjs's own header since
+    // staleness landed, and its only reference in shipped code was a COMMENT in
+    // the PreToolUse router -- so the path that header calls load-bearing had
+    // never run once in production. It matters most for exactly this event: the
+    // lazy check compares the anchor's stored hash against disk, and the
+    // capture below re-points that hash at the bytes this write just produced,
+    // so a write the session performed ITSELF is invisible to lazy staleness.
+    //
+    // QUEUED, NOT APPLIED. Applying needs the graph, and loading a megabyte of
+    // JSONL on the return path of every write is what this shape exists to
+    // avoid. The next graph read drains it before serving anything.
+    try {
+      if (mutationSucceeded(clientName, raw)) {
+        const evidence = observedWrite(payload, raw);
+        if (evidence) {
+          // THE SAME DIRECTORY THE GRAPH ITSELF USES. `observeAndInject` keys
+          // every write on `wikiDir(projectRootFor(path, payload.cwd))`, and a
+          // queue written anywhere else is a queue nothing ever drains.
+          queueInvalidation(
+            wikiDir(projectRootFor(evidence.path, payload.cwd)),
+            evidence
+          );
+        }
+      }
+    } catch {
+      // Bookkeeping for a call that already completed. Never let it cost one.
     }
   }
 

--- a/integrations/opencode/hooks/lib/adapter.mjs
+++ b/integrations/opencode/hooks/lib/adapter.mjs
@@ -64,6 +64,7 @@ import {
   forTouch,
   noteActClasses,
   relevantFindingIdsForContext,
+  sessionContext,
   sessionIndex,
   standingRules,
 } from './inject.mjs';
@@ -690,8 +691,23 @@ async function runHook(clientName, event, invocation) {
       rememberOptimizerTools(state, toolEvidence);
       saveState(sessionId, state);
     }
-    const parts = [
-      policyText(client.canDeny, toolEvidence.names, toolEvidence.proven),
+    // ASSEMBLED IN CACHE ORDER, not in whatever order this function happens to
+    // discover the blocks. Everything emitted here sits near the FRONT of the
+    // prompt prefix, and a prefix cache invalidates from the first differing
+    // byte onward -- so the block that changes most often has to sit LAST, or it
+    // re-prices every block behind it on every session. `sessionContext` sorts
+    // by the declared volatility; inject.mjs records how each number was
+    // assigned and why.
+    const blocks = [
+      {
+        id: 'policy',
+        volatility: 0,
+        text: policyText(
+          client.canDeny,
+          toolEvidence.names,
+          toolEvidence.proven
+        ),
+      },
     ];
     const cwd = raw.cwd || raw.working_directory || process.cwd();
     const root = projectRootFor(join(cwd, '__session__'), cwd);
@@ -705,7 +721,7 @@ async function runHook(clientName, event, invocation) {
         const graph = load(dir);
         const episode = episodeMeta({ client: clientName, raw });
         const rules = standingRules(dir, graph, { episode });
-        if (rules) parts.push(rules);
+        if (rules) blocks.push({ id: 'standing', volatility: 1, text: rules });
         const relevantFindingIds = relevantFindingIdsForContext(
           graph,
           sessionTaskContext(raw)
@@ -714,12 +730,12 @@ async function runHook(clientName, event, invocation) {
           episode,
           relevantFindingIds,
         });
-        if (index) parts.push(index);
+        if (index) blocks.push({ id: 'index', volatility: 2, text: index });
       } catch {
         // Retrieval is optional context; the policy must still reach the model.
       }
     }
-    const output = contextOutput(client, eventName, parts.join('\n\n'));
+    const output = contextOutput(client, eventName, sessionContext(blocks));
     if (output) emit(output);
     process.exit(0);
   }

--- a/integrations/opencode/hooks/lib/adapter.mjs
+++ b/integrations/opencode/hooks/lib/adapter.mjs
@@ -68,7 +68,7 @@ import {
   standingRules,
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
-import { observedWrite, queueInvalidation } from './pending.mjs';
+import { observedWrites, queueInvalidation } from './pending.mjs';
 import { isArchived } from './transcript.mjs';
 import { isFsSafePath } from './paths.mjs';
 import {
@@ -898,8 +898,7 @@ async function runHook(clientName, event, invocation) {
     // avoid. The next graph read drains it before serving anything.
     try {
       if (mutationSucceeded(clientName, raw)) {
-        const evidence = observedWrite(payload, raw);
-        if (evidence) {
+        for (const evidence of observedWrites(payload, raw)) {
           // THE SAME DIRECTORY THE GRAPH ITSELF USES. `observeAndInject` keys
           // every write on `wikiDir(projectRootFor(path, payload.cwd))`, and a
           // queue written anywhere else is a queue nothing ever drains.

--- a/integrations/opencode/hooks/lib/capabilities.mjs
+++ b/integrations/opencode/hooks/lib/capabilities.mjs
@@ -38,6 +38,10 @@ export const HOOK_MCP_TOOLS = Object.freeze([
   'optimize_session',
   'get_optimization_report',
   'wiki_write',
+  // The read side of the graph. The session index tells the model to "call
+  // wiki_query with a key for detail", so the hook needs positive evidence that
+  // the name it is advertising is actually registered in this host.
+  'wiki_query',
 ]);
 
 const HOOK_MCP_TOOL_SET = new Set(HOOK_MCP_TOOLS);

--- a/integrations/opencode/hooks/lib/curate.mjs
+++ b/integrations/opencode/hooks/lib/curate.mjs
@@ -22,7 +22,7 @@
  */
 
 import { randomBytes } from 'node:crypto';
-import { putNode, putNodeWithEdges, load, nodeId } from './wiki.mjs';
+import { putNode, putEdge, putNodeWithEdges, load, nodeId } from './wiki.mjs';
 import { indexFile } from './staleness.mjs';
 import { symbolKey } from './symbols.mjs';
 import { canonicalPath } from './paths.mjs';
@@ -178,6 +178,79 @@ export function retire(dir, key) {
   if (!existing) return false;
   putNode(dir, { ...existing, kind: 'finding', key, retired: true });
   return true;
+}
+
+/**
+ * Records that one finding disagrees with another.
+ *
+ * AN EDGE, NOT AN OVERWRITE -- the design is explicit about why: "when a belief
+ * changes, the graph should record THAT it changed and why, not quietly present
+ * the new one as though it had always been true." `contradicts` has been in
+ * EDGE_KINDS since the schema existed and was written by nothing, while
+ * `audit()` already READ it.
+ *
+ * The contradicted finding is deliberately NOT retired, and its claim is
+ * deliberately preserved. A reader needs to see both claims and the
+ * disagreement between them; retiring one silently picks a winner, and putNode
+ * does not merge -- it writes the whole record from what it is handed, so
+ * annotating the target without spreading it back in would blank the very claim
+ * this edge exists to keep visible. That is the overwrite by another name.
+ *
+ * THE EDGE IS WRITTEN FIRST, and the order is the guarantee. These are two
+ * appends and `append` fails open, so either can be the one that lands. Edge
+ * without annotation is a complete, readable disagreement missing only its
+ * reason. Annotation without edge is a finding that says "something contradicts
+ * me" with no contradictor -- a claim of proof with no proof, and invisible to
+ * `audit()` and to `hasOutstandingContradiction`, both of which read the edge.
+ */
+export function contradict(dir, { key, byKey, reason }) {
+  const graph = load(dir);
+  const target = findingByKey(graph, key);
+  const source = findingByKey(graph, byKey);
+  // Both ends must exist, or the edge is unresolvable and the disagreement is
+  // recorded against nothing -- the same un-invalidatable shape anchors prevent.
+  if (!target || !source) return false;
+  // A finding cannot disagree with itself. The self-edge resolves, so the guard
+  // above waves it through, and the result is a node permanently blocked from
+  // confidence promotion by a dispute no person can ever resolve: there is no
+  // second claim to choose between.
+  if (target.id === source.id) return false;
+
+  putEdge(dir, source.id, 'contradicts', target.id);
+  putNode(dir, {
+    ...target,
+    kind: 'finding',
+    key,
+    contradictedAt: Date.now(),
+    contradictionReason: String(reason || '').slice(0, 400),
+  });
+  return true;
+}
+
+/**
+ * Whether anything currently disagrees with this finding.
+ *
+ * Gates confidence promotion. Plan 2's per-finding utility measures whether a
+ * finding SUPPRESSES READS, and a confidently wrong finding suppresses reads
+ * better than a hedged true one -- so utility must never raise confidence on
+ * its own, and this is the check that stops it.
+ *
+ * SYMMETRIC, deliberately: BOTH ends of a `contradicts` edge are outstanding
+ * until a person resolves the disagreement. The named hazard in the design is
+ * presenting "the new one as though it had always been true", so gating only
+ * the older claim would leave the newer one -- which is just as likely to be
+ * the wrong one, since nothing here adjudicates -- free to be promoted on
+ * measured utility alone. That is the exact failure this gate exists to stop.
+ * It also matches `audit()`, the reader that has always been here: it puts both
+ * `from` and `to` in its `contradicted` bucket, because "until one looks, BOTH
+ * are being served".
+ */
+export function hasOutstandingContradiction(graph, key) {
+  const node = findingByKey(graph, key);
+  if (!node) return false;
+  return graph.edges.some(
+    (e) => e.edge === 'contradicts' && (e.to === node.id || e.from === node.id)
+  );
 }
 
 /**

--- a/integrations/opencode/hooks/lib/curate.mjs
+++ b/integrations/opencode/hooks/lib/curate.mjs
@@ -124,7 +124,17 @@ export function correct(
   const replacementKey = `${key}-c${Date.now().toString(36)}`;
 
   const edges = [{ edge: 'supersedes', to: originalId }];
-  // The correction inherits the original's anchors, so it can go stale too.
+  // The correction inherits the original's anchors, so it can go stale too --
+  // but it inherits NOTHING ELSE, and that is deliberate rather than incidental.
+  // The node written below is built field by field from `existing` instead of
+  // spreading it, which is what keeps the staleness fields (`stale`,
+  // `staleReason`, `diff`) off the successor: a correction is re-derived
+  // against the current code by definition, so being born carrying its
+  // predecessor's invalidation would discount it the moment it existed --
+  // `disclose.mjs` skips a stale finding outright and `utility.mjs` penalises
+  // one by 160. Any future edit here that reaches for `...existing` to pick up
+  // one more field re-introduces that, since `putNode` writes what it is handed
+  // wholesale; `tests/hooks/stale-clearing.test.mjs` is the guard.
   for (const edge of graph.edges) {
     if (edge.edge === 'derived_from' && edge.from === originalId) {
       edges.push({ edge: 'derived_from', to: edge.to });
@@ -244,13 +254,38 @@ export function contradict(dir, { key, byKey, reason }) {
  * It also matches `audit()`, the reader that has always been here: it puts both
  * `from` and `to` in its `contradicted` bucket, because "until one looks, BOTH
  * are being served".
+ *
+ * A RETIRED COUNTERPART DOES NOT COUNT, and that sentence quoted just above is
+ * the reason. This read edges ONLY, so retiring one end of a contradiction left
+ * the survivor gated against confidence promotion forever and served with a
+ * DISPUTED note naming a key `serve` refuses to hand anybody -- `serve`,
+ * `activeFindings`, `findingsFor` and `sessionIndex` all drop a retired
+ * finding. A retired claim is served to NOBODY, so "BOTH are being served" is
+ * false and the premise of the gate is gone: only one claim is in play, and
+ * there is nothing left to choose between. Retiring one end IS the person
+ * looking that this gate was waiting for -- so the edge counts as open only
+ * while NEITHER end is retired, answered the same way from both directions.
+ *
+ * AN UNRESOLVABLE END STILL COUNTS. An edge whose other side names no node
+ * proves nothing about whether that claim was withdrawn, and the conservative
+ * reading -- still disputed -- is the one that cannot promote a claim nobody
+ * adjudicated.
  */
 export function hasOutstandingContradiction(graph, key) {
   const node = findingByKey(graph, key);
-  if (!node) return false;
-  return graph.edges.some(
-    (e) => e.edge === 'contradicts' && (e.to === node.id || e.from === node.id)
-  );
+  // A withdrawn claim is not in a dispute either: a dispute needs two claims in
+  // play, and this one has been taken out of play. Without this the RETIRED end
+  // still reported an open disagreement, which is the same defect from the other
+  // side -- and the answer has to agree from both directions, since the gate is
+  // symmetric on purpose.
+  if (!node || node.retired) return false;
+  return graph.edges.some((e) => {
+    if (e.edge !== 'contradicts') return false;
+    const otherId = e.from === node.id ? e.to : e.to === node.id ? e.from : null;
+    if (!otherId) return false;
+    const other = graph.nodes.get(otherId);
+    return !other || !other.retired;
+  });
 }
 
 /**
@@ -334,11 +369,24 @@ export function audit(graph) {
       .map((e) => e.from)
   );
 
+  // THE SAME DEFINITION OF AN OPEN DISPUTE as hasOutstandingContradiction, and
+  // it has to be: that function's own comment claims it "matches audit()", and
+  // two rankings that disagree about what needs a human is worse than one that
+  // is wrong. A retired counterpart is a resolved dispute -- the retired claim
+  // is served to nobody -- so the survivor is not one of two claims in play and
+  // does not belong in the bucket of things needing a person to look.
+  //
+  // One pass, not a call per finding: this is a dashboard read over the whole
+  // graph, and the obvious rewrite is O(findings x edges).
   const contradicted = new Set();
   for (const edge of graph.edges) {
     if (edge.edge !== 'contradicts') continue;
-    contradicted.add(edge.from);
-    contradicted.add(edge.to);
+    const from = graph.nodes.get(edge.from);
+    const to = graph.nodes.get(edge.to);
+    // An end that resolves to nothing cannot be shown retired, so it still
+    // counts against the other end.
+    if (!to || !to.retired) contradicted.add(edge.from);
+    if (!from || !from.retired) contradicted.add(edge.to);
   }
 
   return {

--- a/integrations/opencode/hooks/lib/curate.mjs
+++ b/integrations/opencode/hooks/lib/curate.mjs
@@ -70,6 +70,38 @@ export function originWeight(origin) {
   return 1;
 }
 
+/**
+ * The claim-time anchor hashes, for a finding being written right now.
+ *
+ * THE CHECKABLE HALF OF PROVENANCE, and until now only `harvest-write.mjs`
+ * wrote it -- so the asymmetry ran exactly the wrong way. `reverify` and the
+ * automatic clear in `serve` both compare disk against these frozen hashes, and
+ * a finding without them can never have a stale flag cleared by anything. That
+ * meant HUMAN-asserted findings, the ones somebody deliberately created or
+ * corrected, were the only ones condemned to stay stale forever once marked,
+ * while machine-harvested claims could recover. The hashes are simply the anchor
+ * nodes' hashes at this moment, and every writer has them in hand.
+ *
+ * DELIBERATELY NOT THE WHOLE RECORD `derivationFor` BUILDS. That one joins the
+ * evidence log to find FILE-surface operations behind the claim; curation
+ * performs no such join, so `operations` is empty and `operationsComplete` says
+ * so. An empty list declared incomplete is honest -- "nothing recorded here, and
+ * do not read that as nothing happened" -- where an empty list declared complete
+ * would assert a fact nobody established.
+ *
+ * An anchor with no stored hash contributes no entry, and a finding whose
+ * anchors all lack one gets a record with no hashes -- which `claimTimeVerdict`
+ * reads as `unknown` and refuses to clear on, which is the correct reading.
+ */
+function claimTimeDerivation(graph, resolved) {
+  const anchors = {};
+  for (const id of resolved) {
+    const node = graph.nodes.get(id);
+    if (node && typeof node.hash === 'string') anchors[id] = node.hash;
+  }
+  return { at: Date.now(), anchors, operations: [], operationsComplete: false };
+}
+
 function findingByKey(graph, key) {
   return graph.nodes.get(nodeId('finding', key)) || null;
 }
@@ -124,6 +156,11 @@ export function correct(
   const replacementKey = `${key}-c${Date.now().toString(36)}`;
 
   const edges = [{ edge: 'supersedes', to: originalId }];
+  // Collected alongside the edges so the correction carries its own claim-time
+  // hashes: it is a NEW claim, re-derived against whatever the code says now, so
+  // its evidence is the anchors' current state -- not the predecessor's, which is
+  // precisely what went stale.
+  const inherited = [];
   // The correction inherits the original's anchors, so it can go stale too --
   // but it inherits NOTHING ELSE, and that is deliberate rather than incidental.
   // The node written below is built field by field from `existing` instead of
@@ -138,6 +175,7 @@ export function correct(
   for (const edge of graph.edges) {
     if (edge.edge === 'derived_from' && edge.from === originalId) {
       edges.push({ edge: 'derived_from', to: edge.to });
+      inherited.push(edge.to);
     }
   }
 
@@ -171,6 +209,11 @@ export function correct(
       // branches, and an unrecognised value already degrades to the neutral
       // ranking weight rather than doing damage.
       origin: typeof origin === 'string' && origin ? origin : ORIGIN_HUMAN,
+      // Without this a correction could never have a stale flag cleared: both
+      // clearing paths compare disk against these hashes, and a finding with
+      // none is `unknown` forever. A hand-written correction being the least
+      // recoverable record in the graph was the wrong way round.
+      derivation: claimTimeDerivation(graph, inherited),
     },
     edges
   );
@@ -339,7 +382,18 @@ export function create(dir, { claim, anchors, type = 'finding', confidence = 0.9
   // path. No process death required; one transient EBUSY is enough.
   const id = putNodeWithEdges(
     dir,
-    { kind: 'finding', key, claim, confidence, type, origin: ORIGIN_HUMAN },
+    {
+      kind: 'finding',
+      key,
+      claim,
+      confidence,
+      type,
+      origin: ORIGIN_HUMAN,
+      // Read AFTER the indexFile loop above, so the hashes are the ones the
+      // person's claim was actually made against rather than whatever the graph
+      // held before this call touched it.
+      derivation: claimTimeDerivation(loadGraph(dir), resolved),
+    },
     resolved.map((target) => ({ edge: 'derived_from', to: target }))
   );
   if (!id) return null;

--- a/integrations/opencode/hooks/lib/decide.mjs
+++ b/integrations/opencode/hooks/lib/decide.mjs
@@ -542,19 +542,92 @@ const TOOL_ALIASES = new Map(
     run_shell_command: 'Bash',
     run_terminal_cmd: 'Bash',
     terminal: 'Bash',
+
+    // THIS PROJECT'S OWN TOOLS, which the table did not list for as long as it
+    // existed. `plugin/hooks/hooks.json`'s PostToolUse matcher named
+    // `mcp__.*__(?:smart_edit|smart_write)` and Codex's AfterTool matcher named
+    // the bare `smart_edit|smart_write`, so both hooks fired -- and then
+    // `normalizeTool` returned null and the hook exited before a single line of
+    // accounting ran. Staleness, mutation counting and harvest pressure were all
+    // blind on exactly the path enforcement pushes the model toward, which is the
+    // worst place to be blind: the more effective the routing, the less the
+    // optimizer saw.
+    //
+    // These names are the CANONICAL operation, not a licence to redirect. A call
+    // that is already the replacement is excluded from routing by
+    // `isReplacementTool` below.
+    smart_read: 'Read',
+    smart_grep: 'Grep',
+    smart_glob: 'Glob',
+    smart_edit: 'Edit',
+    smart_write: 'Write',
+
+    // Claude Code's notebook editor. Same shape of gap: a real mutation of a
+    // real file on disk that arrived as null and so never reached
+    // `pending.mjs`'s MUTATING set, leaving every notebook write invisible to
+    // invalidation.
+    notebookedit: 'Edit',
+    notebook_edit: 'Edit',
   })
 );
 
-/** Maps a client's tool name onto the canonical one, or null if unhandled. */
+/**
+ * The optimizer's own replacement tools, by canonical trailing segment.
+ *
+ * Kept separate from the alias table because the two answer different questions.
+ * The table answers "what operation is this", which post-tool accounting needs.
+ * This set answers "is this call ALREADY the thing we would have recommended",
+ * which routing needs -- and conflating them is the loop hazard: `smart_edit`
+ * resolves to `Edit`, the Edit branch recommends `smart_edit`, and the model is
+ * told to call the tool it just called.
+ */
+const REPLACEMENT_TOOLS = new Set([
+  'smart_read',
+  'smart_grep',
+  'smart_glob',
+  'smart_edit',
+  'smart_write',
+]);
+
+/**
+ * The tool name with an `mcp__<server>__` prefix removed, if it had one.
+ *
+ * Server segments contain underscores freely (`plugin_token-optimizer_token-optimizer`)
+ * and so do tool names (`smart_edit`), so the split is taken at the LAST `__`
+ * after the `mcp__` sentinel. Both halves must be non-empty: `mcp__edit` names
+ * no server and is not a name any host emits, and treating it as `edit` would
+ * coerce an unrecognised string into a built-in.
+ */
+function withoutMcpPrefix(name) {
+  const match = /^mcp__(.+)__(.+)$/.exec(name);
+  return match ? match[2] : name;
+}
+
+/** Whether this call IS one of the optimizer's replacements, however spelled. */
+export function isReplacementTool(name) {
+  if (!name) return false;
+  return REPLACEMENT_TOOLS.has(withoutMcpPrefix(String(name)).toLowerCase());
+}
+
+/**
+ * Maps a client's tool name onto the canonical one, or null if unhandled.
+ *
+ * PERMISSIVE IN ONE DIRECTION ONLY. An MCP-prefixed name is resolved by its
+ * trailing segment, but only against the same table every other client is held
+ * to -- so `mcp__vendor__deploy_to_prod` stays null. Coercing an unrecognised
+ * MCP tool into a built-in would change a routing verdict for a tool nobody has
+ * considered, which is a far worse failure than not accounting for it.
+ */
 export function normalizeTool(name) {
   if (!name) return null;
+  const candidate = withoutMcpPrefix(String(name));
   if (
     ['Read', 'Grep', 'Glob', 'Edit', 'MultiEdit', 'Write', 'Bash'].includes(
-      name
+      candidate
     )
   )
-    return name;
-  return TOOL_ALIASES.get(String(name).toLowerCase()) || null;
+    return candidate;
+  return TOOL_ALIASES.get(candidate.toLowerCase()) || null;
 }
 
 /**
@@ -614,6 +687,13 @@ export function normalizePayload(raw) {
     transcript_path: raw.transcript_path ?? raw.transcriptPath ?? null,
     cwd,
     tool_name: normalizeTool(raw.tool_name ?? raw.toolName ?? raw.tool),
+    // WHETHER THIS CALL IS ALREADY THE REPLACEMENT, carried alongside the
+    // canonical name rather than inferred from it -- because it cannot be
+    // inferred from it. `smart_edit` and `Edit` both normalise to `Edit`, and
+    // routing has to treat them as opposites while accounting treats them as
+    // the same. Absent by default (`false`), so a payload assembled by hand in
+    // a test or by a caller that predates this field is a normal built-in call.
+    replacement: isReplacementTool(raw.tool_name ?? raw.toolName ?? raw.tool),
     tool_input: {
       ...input,
       // CANONICALISED HERE, once. Every consumer downstream -- the `seen` map
@@ -673,6 +753,19 @@ function replacementAvailable(availableTools, name) {
 }
 
 export function decide(payload, state, availableTools = undefined) {
+  // THE LOOP HAZARD, and the reason this guard is at the top rather than inside
+  // any one branch. Resolving `smart_edit` to `Edit` is what makes post-tool
+  // accounting work; it must not also make the Edit branch answer a smart_edit
+  // call with "call smart_edit instead". This is not theoretical on a matcher
+  // level either: Qwen's PreToolUse matcher is the unanchored regex
+  // `edit|write_file|run_shell_command`, and `edit` matches inside
+  // `mcp__x__smart_edit`, so that client really does hand the router calls to
+  // its own replacements.
+  //
+  // A tool that IS the replacement is never routed. There is nothing better to
+  // recommend, and every branch below would recommend itself.
+  if (payload.replacement) return null;
+
   const tool = payload.tool_name;
   const input = payload.tool_input || {};
   const threshold = largeFileBytes();
@@ -873,6 +966,12 @@ export function remember(payload, state) {
  */
 export function readCostBytes(payload) {
   if (payload.tool_name !== 'Read') return 0;
+  // A REPLACEMENT DID NOT SPEND THE WHOLE FILE. `smart_read` normalises to
+  // `Read` so the graph sees the touch, but it returns a diff -- charging the
+  // full file size here would feed the holdout comparison a cost that was never
+  // paid, on the arm the optimizer is trying to show is cheaper. Better to
+  // record nothing than to record a number in the wrong direction.
+  if (payload.replacement) return 0;
   const path = payload.tool_input?.file_path;
   if (!path || isBinaryPath(path)) return 0;
   const size = fileSize(path);

--- a/integrations/opencode/hooks/lib/disclose.mjs
+++ b/integrations/opencode/hooks/lib/disclose.mjs
@@ -294,6 +294,11 @@ export function verdictFor(graph, { anchors = [], question, minConfidence = 0.7 
     const id = nodeId('file', canonicalPath(anchor));
     if (!graph.nodes.has(id)) continue;
 
+    // READ-ONLY serve: no `dir` is threaded here, so this cannot clear a stale
+    // flag whose evidence is gone. That is deliberate -- this function takes a
+    // graph, not the directory it came from, and widening its signature to give
+    // an analysis path a write capability buys nothing: the injection path runs
+    // on every tool call and clears the same findings.
     const findings = serve(graph, findingsFor(graph, id, { limit: 4 }));
     for (const finding of findings) {
       if (finding.stale) continue;

--- a/integrations/opencode/hooks/lib/harvest-write.mjs
+++ b/integrations/opencode/hooks/lib/harvest-write.mjs
@@ -34,7 +34,7 @@ import { randomBytes } from 'node:crypto';
 import { realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
-import { readEvidence } from './metrics.mjs';
+import { readEvidence, evidenceTruncated } from './metrics.mjs';
 
 /**
  * The types that may cross a project boundary.
@@ -431,53 +431,84 @@ function resolveAnchor(dir, anchor, projectRoot) {
 /**
  * Which task actually produced this finding, when nothing said so directly.
  *
- * Session id was the only signal `answers` had, and a session id is exactly
- * what a caller may not have (`wiki_write`'s `sessionId` is optional and
- * nothing populates it today; the detached harvest worker's is gated behind
- * an opt-in). But the graph does not need to be TOLD which task this is: the
- * structural harvest already writes `task -[derived_from]-> file` for every
- * tool call, unconditionally, on every install. So the task is DERIVABLE --
- * it is whichever task node has a `derived_from` edge to one of the SAME
- * anchors this finding resolved to.
+ * ROUND 2's version scanned the WHOLE graph for any task sharing any anchor,
+ * broken by recency. An adversarial review constructed four cases where that
+ * attributes a finding to the WRONG task:
  *
- * "Most recent task, full stop" was rejected on purpose: a task that never
- * touched these files could still be the newest node in the graph (a
- * different file, a different concern, in a later session), and attaching
- * provenance to it would be a WRONG edge, not a missing one -- worse than no
- * edge, because a reader trusts it. So candidates are filtered to tasks that
- * touched at least one of these anchors FIRST, and only ties among THOSE are
- * broken by recency.
+ *   1. STALE PRIOR SESSION -- a session that reasons from injected memory and
+ *      writes a finding about `foo.ts` without touching it this session gets
+ *      attributed to whatever task last touched `foo.ts`, possibly days old,
+ *      possibly someone else's work.
+ *   2. CONCURRENT SESSION -- two windows on one repository; the other
+ *      session's task wins if its touch is a millisecond later.
+ *   3. OVERLAP, NOT COVERAGE -- a finding anchored to [a, b]; a task that
+ *      touched only `b` could still win over one that touched both.
+ *   4. THE TIE-BREAK CONTRADICTED ITS OWN COMMENT -- `Number(edge.at) || 0`
+ *      with strict `>` means the FIRST edge in log order wins on a tie,
+ *      which is the OLDER task, not "more recently" as documented.
  *
- * The tie-break is the edge's own `at`, not the task node's `at`. A task that
- * touched this file once, long ago, and then stayed active on unrelated files
- * for hours has a late node timestamp that says nothing about this anchor;
- * the edge timestamp says exactly when THIS task touched THIS anchor, which
- * is the question being asked. Among tasks sharing an anchor, the one whose
- * most recent touch to any shared anchor is latest wins -- recency of the
- * relevant work, not recency of the task in general.
+ * THE FIX IS NARROWER THAN A BETTER RANKING: SCOPE, THEN REQUIRE COVERAGE.
+ * A task only ever belongs to the session that created it -- `harvest()` and
+ * `linkCoOccurrence()` (wiki.mjs, inject.mjs) both key a task node by
+ * `sessionId`, always, so there is exactly ONE task node for "the current
+ * session" and it is `nodeId('task', sessionId)`. Restricting to that ONE
+ * node structurally eliminates cases 1 and 2 -- a prior or concurrent
+ * session's task has a DIFFERENT sessionId and therefore a different node
+ * id, so it is never even looked at, regardless of timing. No caller can
+ * supply a wrong sessionId and get someone ELSE's task; they can only fail
+ * to get a match.
+ *
+ * COVERAGE, NOT OVERLAP, fixes case 3: the session's task must have a
+ * `derived_from` edge to EVERY one of this finding's anchors, not merely one.
+ * A partial touch is not attribution.
+ *
+ * With the candidate set reduced to at most one node, there is nothing left
+ * to break a tie between -- case 4's comparator is not "fixed", it is
+ * deleted, because the scenario it was written for (two DIFFERENT tasks both
+ * legitimately eligible) cannot occur under this scoping: two task nodes can
+ * never share a key, and only the current session's key is ever considered.
+ * An edge's `at` therefore plays NO role here: presence of a `derived_from`
+ * edge from the session's task to an anchor is what "touched it" means, with
+ * or without a timestamp on that edge -- there is no ranking left for a
+ * missing timestamp to lose.
+ *
+ * `sessionId` absent means there is no identity to scope by, which means no
+ * candidate -- not "fall back to guessing". Absence is the correct answer
+ * when the graph cannot support attribution.
  */
-function taskForAnchors(graph, anchorIds) {
-  if (!anchorIds || !anchorIds.length) return null;
-  const anchors = new Set(anchorIds);
-  let best = null;
-  for (const edge of graph.edges) {
-    if (edge.edge !== 'derived_from' || !anchors.has(edge.to)) continue;
-    const from = graph.nodes.get(edge.from);
-    // `derived_from` is also how a FINDING cites its own anchors, so without
-    // this a finding that already cited the same file would be mistaken for
-    // the task that produced it.
-    if (!from || from.kind !== 'task') continue;
-    const at = Number(edge.at) || 0;
-    if (!best || at > best.at) best = { taskId: edge.from, at };
+function taskForAnchors(graph, anchorIds, sessionId) {
+  if (!sessionId || !anchorIds || !anchorIds.length) return null;
+  const taskTarget = nodeId('task', sessionId);
+  const task = graph.nodes.get(taskTarget);
+  if (!task || task.kind !== 'task') return null;
+
+  for (const anchor of anchorIds) {
+    const covered = graph.edges.some((edge) =>
+      edge.edge === 'derived_from' && edge.from === taskTarget && edge.to === anchor
+    );
+    // ONE missing anchor refuses the whole attribution. A finding cited three
+    // files; this session's task touched two of them -- that is evidence the
+    // task did SOME related work, not evidence it produced THIS finding.
+    if (!covered) return null;
   }
-  return best ? best.taskId : null;
+  return taskTarget;
 }
 
 /**
  * A file path the way `recordToolOutcome` (metrics.mjs) already truncates and
- * stores it on a `tool-outcome` event's `anchor` field, so a derivation record
- * can join against that log without a second, divergent notion of "the same
- * anchor".
+ * stores it on a FILE-surface `tool-outcome` event's `anchor` field, so a
+ * derivation record can join against that log without a second, divergent
+ * notion of "the same anchor".
+ *
+ * COMMAND-surface events are DECLARED OUT OF SCOPE, not silently missed:
+ * `adapter.mjs` stores the COMMAND TEXT in `anchor` for those
+ * (`String(command).slice(0, 120)`), so a build or test run can never share
+ * an anchor string with a canonical file path -- there is no join key in
+ * common, and inventing a command-to-file heuristic (which files did a given
+ * `npm test` invocation cover?) is not something this record can answer
+ * honestly. `operationsScope` on the returned record says so explicitly,
+ * rather than letting an empty `operations` array look like "no build or
+ * test ever ran" when the truth is "this join cannot see it".
  */
 function anchorLabel(rawAnchor) {
   const path = String(rawAnchor).split('#')[0];
@@ -497,7 +528,8 @@ const MAX_DERIVATION_OPERATIONS = 5;
  * that comparison be reconstructed for a specific claim rather than only for
  * the anchor in general: the hash each anchor carried at the moment this
  * finding was derived from it, plus what evidence exists that any work
- * actually happened against it.
+ * actually happened against it. `derivationCheck` (staleness.mjs) is the
+ * reader that actually performs that comparison at serve time.
  *
  * DELIBERATELY NOT DUPLICATING THE EDGES. `derived_from` already records
  * WHICH anchors this finding cites; restating that here would be a second,
@@ -506,14 +538,23 @@ const MAX_DERIVATION_OPERATIONS = 5;
  *
  * DELIBERATELY NOT A REPLAY LOG. Recording enough to mechanically re-run a
  * derivation is a separate subsystem with real storage cost. This stores only
- * what the evidence log already has: `tool-outcome` events matching these
- * anchors, each reduced to the fields that were actually captured. An event
- * that carries no exit code or output contributes none -- nothing here is
- * invented to fill a shape the pipeline does not evidence yet. If a future
- * capture pass adds `exit`/`output` to those events, this starts carrying them
- * with no change to this function.
+ * what the evidence log already has: FILE-surface `tool-outcome` events
+ * matching these anchors, each reduced to the fields that were actually
+ * captured. An event that carries no exit code or output contributes none --
+ * nothing here is invented to fill a shape the pipeline does not evidence
+ * yet. If a future capture pass adds `exit`/`output` to those events, this
+ * starts carrying them with no change to this function.
+ *
+ * INCOMPLETENESS IS MARKED, NOT IMPLIED. An empty `operations` array is
+ * genuinely ambiguous on its own -- it is the same shape whether nothing
+ * happened, or something happened but fell outside what this join can see.
+ * `operationsComplete` distinguishes them: false when the evidence log itself
+ * may have dropped older matches (`evidenceIncomplete`, from
+ * `metrics.evidenceTruncated`) OR when more matches existed than the cap
+ * kept. A reader can then tell "no operations happened" from "operations
+ * existed but are not recorded here" instead of guessing.
  */
-function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
+function derivationFor(graph, resolvedAnchors, evidence, evidenceIncomplete, anchorSpecs) {
   const anchorHashes = {};
   for (const id of resolvedAnchors) {
     const node = graph.nodes.get(id);
@@ -521,8 +562,10 @@ function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
   }
 
   const labels = new Set((anchorSpecs || []).map(anchorLabel));
-  const operations = evidence
-    .filter((event) => event.kind === 'tool-outcome' && labels.has(event.anchor))
+  const matching = evidence.filter(
+    (event) => event.kind === 'tool-outcome' && labels.has(event.anchor)
+  );
+  const operations = [...matching]
     .sort((a, b) => (Number(b.at) || 0) - (Number(a.at) || 0))
     .slice(0, MAX_DERIVATION_OPERATIONS)
     .map((event) => {
@@ -540,7 +583,16 @@ function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
       return op;
     });
 
-  return { at: Date.now(), anchors: anchorHashes, operations };
+  return {
+    at: Date.now(),
+    anchors: anchorHashes,
+    operations,
+    // FILE touches only -- see `anchorLabel`. Declared here, in the record
+    // itself, not only in this function's comment, so a reader who never
+    // opens this source file still learns builds and test runs are excluded.
+    operationsScope: 'file',
+    operationsComplete: !evidenceIncomplete && matching.length <= operations.length,
+  };
 }
 
 /**
@@ -588,6 +640,9 @@ export function writeHarvested(
   // it can hold thousands of lines, so re-reading it per finding would turn a
   // batch of N findings into N passes over the same bytes.
   const evidence = readEvidence(dir);
+  // Cheap: one stat call, checked once per batch rather than once per
+  // finding's derivation record.
+  const evidenceIncomplete = evidenceTruncated(dir);
 
   const written = [];
   for (const finding of findings) {
@@ -647,14 +702,16 @@ export function writeHarvested(
     // An explicit `taskId` is authoritative when a caller supplies one --
     // it OVERRIDES traversal rather than merely seeding it, so a caller that
     // knows better is never second-guessed by inference. Absent one, the task
-    // is DERIVED from the graph itself: `taskForAnchors` finds the task that
-    // actually touched these anchors, which needs no session id from anyone.
-    // Either way, held to the same discipline as the anchors above: a target
-    // that does not resolve to an existing task node produces no edge rather
-    // than a dangling one.
+    // is DERIVED from the graph itself: `taskForAnchors` finds the CURRENT
+    // session's task (scoped by `sessionId`, the same identity this write
+    // already carries for provenance) and requires it to have touched EVERY
+    // one of this finding's anchors, not merely one -- see that function's
+    // own comment for the four attacks this closes. Either way, held to the
+    // same discipline as the anchors above: a target that does not resolve to
+    // an existing task node produces no edge rather than a dangling one.
     const answersTarget = taskId
       ? nodeId('task', taskId)
-      : taskForAnchors(currentGraph, resolved);
+      : taskForAnchors(currentGraph, resolved, sessionId);
     if (answersTarget && currentGraph.nodes.has(answersTarget)) {
       edges.push({ edge: 'answers', to: answersTarget });
     }
@@ -707,7 +764,7 @@ export function writeHarvested(
         // `render()`/`renderSessionIndex()` in inject.mjs or `wiki_read`'s
         // `toFinding()` projection, neither of which reads this field, so it
         // is not part of the automatic per-touch injection `fit()` prices.
-        derivation: derivationFor(currentGraph, resolved, evidence, finding.anchors || []),
+        derivation: derivationFor(currentGraph, resolved, evidence, evidenceIncomplete, finding.anchors || []),
       },
       edges
     );

--- a/integrations/opencode/hooks/lib/harvest-write.mjs
+++ b/integrations/opencode/hooks/lib/harvest-write.mjs
@@ -452,11 +452,13 @@ function resolveAnchor(dir, anchor, projectRoot) {
  * `linkCoOccurrence()` (wiki.mjs, inject.mjs) both key a task node by
  * `sessionId`, always, so there is exactly ONE task node for "the current
  * session" and it is `nodeId('task', sessionId)`. Restricting to that ONE
- * node structurally eliminates cases 1 and 2 -- a prior or concurrent
- * session's task has a DIFFERENT sessionId and therefore a different node
- * id, so it is never even looked at, regardless of timing. No caller can
- * supply a wrong sessionId and get someone ELSE's task; they can only fail
- * to get a match.
+ * node structurally eliminates cases 1 and 2 PROVIDED the identity itself is
+ * trustworthy: an UNRELATED sessionId (typo'd, invented, or simply absent)
+ * cannot resolve to someone else's task, because a different key is a
+ * different node id, full stop, regardless of timing. That is NOT the same
+ * guarantee as "no caller can get someone else's task" -- see the note on
+ * `authoritativeSessionId` below for the residual this leaves when the
+ * identity is real but comes from an untrusted caller.
  *
  * COVERAGE, NOT OVERLAP, fixes case 3: the session's task must have a
  * `derived_from` edge to EVERY one of this finding's anchors, not merely one.
@@ -472,17 +474,41 @@ function resolveAnchor(dir, anchor, projectRoot) {
  * or without a timestamp on that edge -- there is no ranking left for a
  * missing timestamp to lose.
  *
- * `sessionId` absent means there is no identity to scope by, which means no
- * candidate -- not "fall back to guessing". Absence is the correct answer
- * when the graph cannot support attribution.
+ * NO IDENTITY MEANS NO CANDIDATE -- not "fall back to guessing". Absence is
+ * the correct answer when the graph cannot support attribution.
+ *
+ * ROUND 4: THE IDENTITY ITSELF MUST BE AUTHORITATIVE, not merely present.
+ * Scoping to `nodeId('task', sessionId)` only refuses an UNRELATED session;
+ * it does nothing against a FOREIGN BUT REAL one. `wiki_write`'s `sessionId`
+ * is a plain MCP tool argument the calling model supplies, unverified -- a
+ * model that names some OTHER, prior session whose task genuinely covered
+ * these anchors gets an `answers` edge to that stale task, because coverage
+ * cannot tell "this session" from "a session that really did touch these
+ * files, named by a string nothing cross-checked". Session id is not
+ * evidence unless the CALLER'S OWN CHANNEL is trustworthy, which is true of
+ * `plugin/hooks/harvest-worker.mjs` (Claude Code's own hook payload) and not
+ * true of a tool-call argument. So this parameter is named for what it must
+ * be, `authoritativeSessionId`, and every caller is a promise: pass this only
+ * when you did not just read it out of untrusted input. `wiki_write` passes
+ * NONE, which means its calls never traverse -- see `writeHarvested`'s own
+ * comment at the call site for what that costs and why it is accepted rather
+ * than worked around.
+ *
+ * COVERAGE IS CHECKED AGAINST RESOLVED ANCHORS, not the caller's original
+ * list. `writeHarvested` already drops any anchor `resolveAnchor` could not
+ * resolve before this function ever runs, so "every anchor" here means every
+ * anchor that survived that filter -- self-consistent with the
+ * `derived_from` edges the same resolved list produces, but worth stating:
+ * an anchor that failed to resolve cannot raise or lower the bar for the
+ * anchors that did.
  */
-function taskForAnchors(graph, anchorIds, sessionId) {
-  if (!sessionId || !anchorIds || !anchorIds.length) return null;
-  const taskTarget = nodeId('task', sessionId);
+function taskForAnchors(graph, resolvedAnchorIds, authoritativeSessionId) {
+  if (!authoritativeSessionId || !resolvedAnchorIds || !resolvedAnchorIds.length) return null;
+  const taskTarget = nodeId('task', authoritativeSessionId);
   const task = graph.nodes.get(taskTarget);
   if (!task || task.kind !== 'task') return null;
 
-  for (const anchor of anchorIds) {
+  for (const anchor of resolvedAnchorIds) {
     const covered = graph.edges.some((edge) =>
       edge.edge === 'derived_from' && edge.from === taskTarget && edge.to === anchor
     );
@@ -604,7 +630,19 @@ function derivationFor(graph, resolvedAnchors, evidence, evidenceIncomplete, anc
 export function writeHarvested(
   dir,
   findings,
-  { sessionId = null, origin = ORIGIN_HARVESTED, projectRoot = null, taskId = null } = {}
+  {
+    sessionId = null,
+    origin = ORIGIN_HARVESTED,
+    projectRoot = null,
+    taskId = null,
+    // Distinct from `sessionId`, which is stored on every finding for
+    // provenance/display regardless of trust. This one gates the `answers`
+    // traversal fallback specifically, and every caller passing it is
+    // asserting the identity came from a channel it does not control --
+    // Claude Code's own hook payload, not a tool-call argument a model
+    // typed. See `taskForAnchors`'s comment for the attack this closes.
+    authoritativeSessionId = null,
+  } = {}
 ) {
   if (!Array.isArray(findings) || !findings.length) return [];
 
@@ -702,16 +740,29 @@ export function writeHarvested(
     // An explicit `taskId` is authoritative when a caller supplies one --
     // it OVERRIDES traversal rather than merely seeding it, so a caller that
     // knows better is never second-guessed by inference. Absent one, the task
-    // is DERIVED from the graph itself: `taskForAnchors` finds the CURRENT
-    // session's task (scoped by `sessionId`, the same identity this write
-    // already carries for provenance) and requires it to have touched EVERY
-    // one of this finding's anchors, not merely one -- see that function's
-    // own comment for the four attacks this closes. Either way, held to the
-    // same discipline as the anchors above: a target that does not resolve to
-    // an existing task node produces no edge rather than a dangling one.
+    // is DERIVED from the graph itself, but ONLY when `authoritativeSessionId`
+    // is present: `taskForAnchors` scopes to that exact session's task and
+    // requires it to have touched EVERY one of this finding's anchors, not
+    // merely one -- see that function's own comment for why the identity
+    // itself must be trustworthy, not merely present.
+    //
+    // THE CONSEQUENCE, STATED PLAINLY: `wiki_write` never supplies
+    // `authoritativeSessionId` (its `sessionId` is a model-typed MCP
+    // argument nothing cross-checks), so its calls never traverse and
+    // `answers` never fires on that path. `plugin/hooks/harvest-worker.mjs`
+    // does supply it (Claude Code's own hook payload), so `answers` fires
+    // there -- opt-in gated. `answers` therefore does NOT fire on a default
+    // install today. Recovering default liveness needs an authoritative
+    // identity on a default-install path, which is what Plan 2's
+    // `hooks-core/derive.mjs` (running in the Stop hook, where the session id
+    // is real) is for -- not a weaker check here.
+    //
+    // Either way, held to the same discipline as the anchors above: a target
+    // that does not resolve to an existing task node produces no edge rather
+    // than a dangling one.
     const answersTarget = taskId
       ? nodeId('task', taskId)
-      : taskForAnchors(currentGraph, resolved, sessionId);
+      : taskForAnchors(currentGraph, resolved, authoritativeSessionId);
     if (answersTarget && currentGraph.nodes.has(answersTarget)) {
       edges.push({ edge: 'answers', to: answersTarget });
     }

--- a/integrations/opencode/hooks/lib/harvest-write.mjs
+++ b/integrations/opencode/hooks/lib/harvest-write.mjs
@@ -436,7 +436,7 @@ function resolveAnchor(dir, anchor, projectRoot) {
 export function writeHarvested(
   dir,
   findings,
-  { sessionId = null, origin = ORIGIN_HARVESTED, projectRoot = null } = {}
+  { sessionId = null, origin = ORIGIN_HARVESTED, projectRoot = null, taskId = null } = {}
 ) {
   if (!Array.isArray(findings) || !findings.length) return [];
 
@@ -516,6 +516,21 @@ export function writeHarvested(
     // collision vanishingly unlikely while keeping the timestamp readable.
     const provenance = provenanceFor(finding);
     const key = `${prefixFor(provenance)}-${Date.now().toString(36)}-${written.length}-${randomBytes(4).toString("hex")}`;
+
+    const edges = resolved.map((target) => ({ edge: 'derived_from', to: target }));
+    // `answers` closes the loop back to the task that produced the finding, so
+    // provenance can be traversed rather than inferred: "which session
+    // established this, and from what". Declared in EDGE_KINDS and written by
+    // nothing until now. Held to the same discipline as the anchors above: a
+    // taskId that does not resolve to an existing task node produces no edge
+    // rather than a dangling one.
+    if (taskId) {
+      const taskTarget = nodeId('task', taskId);
+      if (currentGraph.nodes.has(taskTarget)) {
+        edges.push({ edge: 'answers', to: taskTarget });
+      }
+    }
+
     // ONE APPEND for the finding and every anchor it resolved. This runs in a
     // detached worker, so "the process survives to finish the loop" is not a
     // safe assumption: a node written without its edges is an active finding
@@ -557,7 +572,7 @@ export function writeHarvested(
           : undefined,
         sessionId,
       },
-      resolved.map((target) => ({ edge: 'derived_from', to: target }))
+      edges
     );
     // A failed write returns null. Reporting the key anyway would tell the
     // caller a claim was stored that no later session can retrieve.

--- a/integrations/opencode/hooks/lib/harvest-write.mjs
+++ b/integrations/opencode/hooks/lib/harvest-write.mjs
@@ -34,6 +34,7 @@ import { randomBytes } from 'node:crypto';
 import { realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
+import { readEvidence } from './metrics.mjs';
 
 /**
  * The types that may cross a project boundary.
@@ -428,6 +429,121 @@ function resolveAnchor(dir, anchor, projectRoot) {
 }
 
 /**
+ * Which task actually produced this finding, when nothing said so directly.
+ *
+ * Session id was the only signal `answers` had, and a session id is exactly
+ * what a caller may not have (`wiki_write`'s `sessionId` is optional and
+ * nothing populates it today; the detached harvest worker's is gated behind
+ * an opt-in). But the graph does not need to be TOLD which task this is: the
+ * structural harvest already writes `task -[derived_from]-> file` for every
+ * tool call, unconditionally, on every install. So the task is DERIVABLE --
+ * it is whichever task node has a `derived_from` edge to one of the SAME
+ * anchors this finding resolved to.
+ *
+ * "Most recent task, full stop" was rejected on purpose: a task that never
+ * touched these files could still be the newest node in the graph (a
+ * different file, a different concern, in a later session), and attaching
+ * provenance to it would be a WRONG edge, not a missing one -- worse than no
+ * edge, because a reader trusts it. So candidates are filtered to tasks that
+ * touched at least one of these anchors FIRST, and only ties among THOSE are
+ * broken by recency.
+ *
+ * The tie-break is the edge's own `at`, not the task node's `at`. A task that
+ * touched this file once, long ago, and then stayed active on unrelated files
+ * for hours has a late node timestamp that says nothing about this anchor;
+ * the edge timestamp says exactly when THIS task touched THIS anchor, which
+ * is the question being asked. Among tasks sharing an anchor, the one whose
+ * most recent touch to any shared anchor is latest wins -- recency of the
+ * relevant work, not recency of the task in general.
+ */
+function taskForAnchors(graph, anchorIds) {
+  if (!anchorIds || !anchorIds.length) return null;
+  const anchors = new Set(anchorIds);
+  let best = null;
+  for (const edge of graph.edges) {
+    if (edge.edge !== 'derived_from' || !anchors.has(edge.to)) continue;
+    const from = graph.nodes.get(edge.from);
+    // `derived_from` is also how a FINDING cites its own anchors, so without
+    // this a finding that already cited the same file would be mistaken for
+    // the task that produced it.
+    if (!from || from.kind !== 'task') continue;
+    const at = Number(edge.at) || 0;
+    if (!best || at > best.at) best = { taskId: edge.from, at };
+  }
+  return best ? best.taskId : null;
+}
+
+/**
+ * A file path the way `recordToolOutcome` (metrics.mjs) already truncates and
+ * stores it on a `tool-outcome` event's `anchor` field, so a derivation record
+ * can join against that log without a second, divergent notion of "the same
+ * anchor".
+ */
+function anchorLabel(rawAnchor) {
+  const path = String(rawAnchor).split('#')[0];
+  return canonicalPath(path).slice(0, 120);
+}
+
+/** How many recorded operations a single finding's derivation may cite. */
+const MAX_DERIVATION_OPERATIONS = 5;
+
+/**
+ * The checkable half of provenance: not just where a finding came from, but
+ * whether that derivation still holds.
+ *
+ * Citation-style provenance (a session or task id) answers "where". It never
+ * answers "does this still apply" -- that is what staleness already computes,
+ * by comparing an anchor's STORED hash against disk. This record is what lets
+ * that comparison be reconstructed for a specific claim rather than only for
+ * the anchor in general: the hash each anchor carried at the moment this
+ * finding was derived from it, plus what evidence exists that any work
+ * actually happened against it.
+ *
+ * DELIBERATELY NOT DUPLICATING THE EDGES. `derived_from` already records
+ * WHICH anchors this finding cites; restating that here would be a second,
+ * driftable copy of the same fact. What is new here, and only here, is the
+ * HASH each anchor carried at claim time -- edges carry no such thing.
+ *
+ * DELIBERATELY NOT A REPLAY LOG. Recording enough to mechanically re-run a
+ * derivation is a separate subsystem with real storage cost. This stores only
+ * what the evidence log already has: `tool-outcome` events matching these
+ * anchors, each reduced to the fields that were actually captured. An event
+ * that carries no exit code or output contributes none -- nothing here is
+ * invented to fill a shape the pipeline does not evidence yet. If a future
+ * capture pass adds `exit`/`output` to those events, this starts carrying them
+ * with no change to this function.
+ */
+function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
+  const anchorHashes = {};
+  for (const id of resolvedAnchors) {
+    const node = graph.nodes.get(id);
+    if (node && typeof node.hash === 'string') anchorHashes[id] = node.hash;
+  }
+
+  const labels = new Set((anchorSpecs || []).map(anchorLabel));
+  const operations = evidence
+    .filter((event) => event.kind === 'tool-outcome' && labels.has(event.anchor))
+    .sort((a, b) => (Number(b.at) || 0) - (Number(a.at) || 0))
+    .slice(0, MAX_DERIVATION_OPERATIONS)
+    .map((event) => {
+      const op = {};
+      if (typeof event.toolName === 'string' && event.toolName)
+        op.tool = event.toolName.slice(0, 60);
+      if (typeof event.success === 'boolean') op.success = event.success;
+      if (typeof event.at === 'number') op.at = event.at;
+      // Forward-compatible, not fabricated: neither field exists on a
+      // `tool-outcome` event in this pipeline today, so every operation
+      // omits them until a capture pass actually evidences one.
+      if (typeof event.exit === 'number') op.exit = event.exit;
+      if (typeof event.output === 'string' && event.output)
+        op.output = event.output.slice(0, 200);
+      return op;
+    });
+
+  return { at: Date.now(), anchors: anchorHashes, operations };
+}
+
+/**
  * Writes validated findings, returning the keys actually stored.
  *
  * `findings` is the output of `harvest.validate()`, so type/claim/confidence
@@ -467,6 +583,11 @@ export function writeHarvested(
       : batch;
   const prefixFor = (p) =>
     p === ORIGIN_AGENT ? 'agent' : p === ORIGIN_HUMAN ? 'human' : 'harvested';
+
+  // Read once: every finding in this batch shares the same evidence log, and
+  // it can hold thousands of lines, so re-reading it per finding would turn a
+  // batch of N findings into N passes over the same bytes.
+  const evidence = readEvidence(dir);
 
   const written = [];
   for (const finding of findings) {
@@ -521,14 +642,21 @@ export function writeHarvested(
     // `answers` closes the loop back to the task that produced the finding, so
     // provenance can be traversed rather than inferred: "which session
     // established this, and from what". Declared in EDGE_KINDS and written by
-    // nothing until now. Held to the same discipline as the anchors above: a
-    // taskId that does not resolve to an existing task node produces no edge
-    // rather than a dangling one.
-    if (taskId) {
-      const taskTarget = nodeId('task', taskId);
-      if (currentGraph.nodes.has(taskTarget)) {
-        edges.push({ edge: 'answers', to: taskTarget });
-      }
+    // nothing until now.
+    //
+    // An explicit `taskId` is authoritative when a caller supplies one --
+    // it OVERRIDES traversal rather than merely seeding it, so a caller that
+    // knows better is never second-guessed by inference. Absent one, the task
+    // is DERIVED from the graph itself: `taskForAnchors` finds the task that
+    // actually touched these anchors, which needs no session id from anyone.
+    // Either way, held to the same discipline as the anchors above: a target
+    // that does not resolve to an existing task node produces no edge rather
+    // than a dangling one.
+    const answersTarget = taskId
+      ? nodeId('task', taskId)
+      : taskForAnchors(currentGraph, resolved);
+    if (answersTarget && currentGraph.nodes.has(answersTarget)) {
+      edges.push({ edge: 'answers', to: answersTarget });
     }
 
     // ONE APPEND for the finding and every anchor it resolved. This runs in a
@@ -571,6 +699,15 @@ export function writeHarvested(
           ? finding.quote
           : undefined,
         sessionId,
+        // THE CHECKABLE HALF OF PROVENANCE. Citation-style (this `sessionId`,
+        // the `answers` edge above) says WHERE a claim came from; it never
+        // says whether that derivation still applies. `derivationFor` reaches
+        // through `wiki_query`'s `node`/`get`/`search` operations only (those
+        // return a finding's stored fields wholesale) -- never through
+        // `render()`/`renderSessionIndex()` in inject.mjs or `wiki_read`'s
+        // `toFinding()` projection, neither of which reads this field, so it
+        // is not part of the automatic per-touch injection `fit()` prices.
+        derivation: derivationFor(currentGraph, resolved, evidence, finding.anchors || []),
       },
       edges
     );

--- a/integrations/opencode/hooks/lib/inject.mjs
+++ b/integrations/opencode/hooks/lib/inject.mjs
@@ -26,6 +26,7 @@ import {
 } from './wiki.mjs';
 import { basename } from 'node:path';
 import { serve, diffLines } from './staleness.mjs';
+import { drainInvalidations } from './pending.mjs';
 import { inHoldout, record, indexBudget } from './metrics.mjs';
 import { canonicalPath, resolvableCandidates } from './paths.mjs';
 import { annotatedSkeleton } from './skeleton.mjs';
@@ -142,6 +143,31 @@ function render(finding) {
 }
 
 /**
+ * Applies anything the post-tool hook queued, BEFORE anything is served.
+ *
+ * THIS IS WHERE EAGER STALENESS LANDS. `invalidateOnWrite` needs a graph, and
+ * loading one on the return path of every write is what pending.mjs exists to
+ * avoid -- so the hook queues and the next graph read applies. These two
+ * functions are that read: they already hold a freshly loaded graph, and they
+ * are the last thing to run before a finding reaches a model.
+ *
+ * RE-READ ONLY WHEN SOMETHING WAS ACTUALLY MARKED. The drain writes the stale
+ * flag to disk; it cannot mutate the caller's already-parsed graph, so serving
+ * from that copy would deliver the very "stale finding as fresh" this exists to
+ * prevent. A second load costs a parse, and it is paid once per observed write
+ * rather than once per tool call -- when nothing is queued this is one stat.
+ */
+function withPendingApplied(dir, graph) {
+  try {
+    return drainInvalidations(dir, graph) > 0 ? load(dir) : graph;
+  } catch {
+    // The lazy path still covers everything this would have caught early, and
+    // a hook must never fail because bookkeeping did.
+    return graph;
+  }
+}
+
+/**
  * What the model sees when it touches a file.
  *
  * Returns null when there is nothing to say, or when this touch fell into the
@@ -154,6 +180,7 @@ export function forTouch(
   rawPath,
   { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
+  graph = withPendingApplied(dir, graph);
   // Canonical, so a touch finds findings anchored under any other spelling.
   const filePath = canonicalPath(rawPath);
   const anchorId = nodeId('file', filePath);
@@ -322,6 +349,7 @@ export function forCommand(
   { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
   if (!command) return null;
+  graph = withPendingApplied(dir, graph);
 
   const candidates = [];
   for (const node of graph.nodes.values()) {

--- a/integrations/opencode/hooks/lib/inject.mjs
+++ b/integrations/opencode/hooks/lib/inject.mjs
@@ -33,6 +33,7 @@ import { annotatedSkeleton } from './skeleton.mjs';
 import { substitutionBudget } from './metrics.mjs';
 import { assessFindings } from './utility.mjs';
 import { quarantineSharedSource } from './harvest-write.mjs';
+import { cacheOrdered } from './cache.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
@@ -1152,6 +1153,53 @@ export function standingRules(dir, graph, { budget = standingBudget(), episode =
   // which is worse than saying there are more: a model that knows the list is
   // truncated can ask, one that does not will assume it is complete.
   return `${HEADING}${lines.join('\n')}${truncated}`;
+}
+
+/**
+ * SessionStart context, assembled in cache order: stable first, volatile last.
+ *
+ * WHY THE ORDER IS A CORRECTNESS PROPERTY AND NOT A STYLE CHOICE. Everything
+ * here lands near the FRONT of the prompt prefix, and a prefix cache is
+ * invalidated from the first differing byte onward. A block whose text changes
+ * between sessions therefore prices everything positioned after it: put the
+ * freshest block first and the whole remainder of the prefix is re-written
+ * every session; put it last and the invalidation is confined to its own tail.
+ * cache.mjs measures exactly this cost in the user's files -- this is the same
+ * discipline applied to our own output, which is the half nobody else has to
+ * think about because nobody else writes into the prefix.
+ *
+ * `cacheOrdered` existed for precisely this and had no caller, so the order was
+ * whatever order the call sites happened to push in. It was accidentally right;
+ * it is now enforced, which is the difference that matters the next time a
+ * block is added.
+ *
+ * VOLATILITY IS ASSIGNED FROM HOW OFTEN THE TEXT ACTUALLY DIFFERS BETWEEN
+ * SESSIONS, not from how important the block is:
+ *
+ *   0  policy -- the optimization notice and project briefing. Deliberately
+ *      cache-safe by construction: the routing facts are number-free and the
+ *      briefing passes through `stableText`, which DROPS any line that would
+ *      vary. It changes when the tool inventory or configuration changes.
+ *   1  standing -- pinned facts and human-verified corrections, rendered in
+ *      full. Changes only when a person pins, retires or corrects something.
+ *   2  index -- the bounded wiki index, selected per session from the task
+ *      text, and carrying [STALE]/[DISPUTED] markers that flip as the code
+ *      moves. Different on most sessions.
+ *   3  restoration -- present only when resuming from a compaction, and derived
+ *      from the anchors of the session that was just discarded. Never twice the
+ *      same.
+ *
+ * A block with no text is dropped rather than joined, so an absent block cannot
+ * open the assembly with a blank line.
+ */
+export function sessionContext(blocks) {
+  return cacheOrdered(
+    (Array.isArray(blocks) ? blocks : []).filter(
+      (block) => block && typeof block.text === 'string' && block.text.trim()
+    )
+  )
+    .map((block) => block.text)
+    .join('\n\n');
 }
 
 /**

--- a/integrations/opencode/hooks/lib/inject.mjs
+++ b/integrations/opencode/hooks/lib/inject.mjs
@@ -122,8 +122,29 @@ function fit(findings, budget) {
   return { kept, spent };
 }
 
+/**
+ * Discloses an open disagreement, on the same line as the claim it is about.
+ *
+ * BOTH HALVES, like the stale renderer below: the strong form names the other
+ * finding so the reader can fetch it, and the form without a key says only what
+ * is actually known. `serve` is what establishes the dispute; this only phrases
+ * it, and it phrases it in one short line because `fit` prices `render` against
+ * the injection budget -- a disagreement is worth a pointer, not both claims in
+ * full.
+ *
+ * NO DISMISSAL VOCABULARY, for the reason measured on the stale wording: an
+ * instruction to discount suppressed findings that were correct. This states
+ * that another claim exists and where to find it, and lets the reader decide.
+ */
+function disputeNote(finding) {
+  if (!finding.contradicted) return '';
+  return finding.contradictedBy
+    ? `\n  DISPUTED by ${finding.contradictedBy} -- wiki_query that key for the other claim`
+    : '\n  DISPUTED by another finding in this graph';
+}
+
 function render(finding) {
-  const head = `- [${finding.type || 'finding'}] ${finding.claim}`;
+  const head = `- [${finding.type || 'finding'}] ${finding.claim}${disputeNote(finding)}`;
   if (!finding.stale) return head;
 
   // A stale finding NEVER renders as though it were current. But the strength
@@ -997,7 +1018,15 @@ function renderSessionIndex(total, findings) {
       : finding.stale
         ? ' [possibly stale; verify before use]'
         : '';
-    return `- ${finding.key}${freshness}: ${finding.claim.slice(0, 90)}`;
+    // The session index is the first thing a session reads, so a disputed
+    // finding must not be listed there as settled either. Compressed to a
+    // marker and a key, matching the freshness markers beside it.
+    const dispute = finding.contradicted
+      ? finding.contradictedBy
+        ? ` [DISPUTED by ${finding.contradictedBy}]`
+        : ' [DISPUTED]'
+      : '';
+    return `- ${finding.key}${freshness}${dispute}: ${finding.claim.slice(0, 90)}`;
   });
   return `# Project wiki (${total} findings, ${findings.length} listed)
 

--- a/integrations/opencode/hooks/lib/inject.mjs
+++ b/integrations/opencode/hooks/lib/inject.mjs
@@ -139,9 +139,26 @@ function fit(findings, budget) {
  */
 function disputeNote(finding) {
   if (!finding.contradicted) return '';
-  return finding.contradictedBy
+  const head = finding.contradictedBy
     ? `\n  DISPUTED by ${finding.contradictedBy} -- wiki_query that key for the other claim`
     : '\n  DISPUTED by another finding in this graph';
+  // THE REASON A PERSON TYPED, rendered here because this is the fullest of the
+  // three dispute surfaces and the only one with room for a sentence. `contradict`
+  // has always stored up to 400 characters of human explanation and, until this
+  // line, nothing read it: the pointer told a reader where to look and withheld
+  // the one thing that would tell them whether looking was worth a tool call.
+  //
+  // TRUNCATED AT 140, because `fit` prices this string against the injection
+  // budget and a 400-character paragraph beside a one-line claim inverts the
+  // proportions. The compressed surfaces -- the session index and restore.mjs's
+  // "Likely next" list -- deliberately keep marker-and-key only; they are one
+  // line per finding by design, and `wiki_query` returns the reason in full.
+  if (typeof finding.contradictionReason !== 'string' || !finding.contradictionReason.trim()) {
+    return head;
+  }
+  const reason = finding.contradictionReason.trim();
+  const shown = reason.length > 140 ? `${reason.slice(0, 140)}...` : reason;
+  return `${head}\n  Reason given: ${shown}`;
 }
 
 /**

--- a/integrations/opencode/hooks/lib/inject.mjs
+++ b/integrations/opencode/hooks/lib/inject.mjs
@@ -276,7 +276,10 @@ export function forTouch(
   // others, so the comparison becomes within-file and the dominant source of
   // variance drops out. A session-pinned arm would destroy that.
   const holdout = inHoldout(filePath);
-  const served = serve(graph, candidates);
+  // `dir` so an eager flag whose evidence is gone is cleared here rather than
+  // waiting for somebody to open the dashboard. Same evidence test as the manual
+  // path -- see `serve`.
+  const served = serve(graph, candidates, { dir });
   const assessed = assessFindings(dir, served, {
     episodeId: episode.episodeId || sessionId,
     relevanceFor: () => 1,
@@ -463,7 +466,7 @@ export function forCommand(
   // only thing an uncapped list buys is the I/O.
   const considered = candidates.slice(0, MAX_COMMAND_CANDIDATES);
 
-  const served = serve(graph, considered);
+  const served = serve(graph, considered, { dir });
   const assessed = assessFindings(dir, served, {
     episodeId: episode.episodeId || sessionId,
     relevanceFor: (finding) => explicit(finding) ? 1 : 0.6,
@@ -990,7 +993,7 @@ export function sessionIndex(dir, graph, { episode = {}, relevantFindingIds = []
   // `serve` is the only path allowed to hand a finding to a model. In
   // particular, activating this previously-unwired index must not create a new
   // path that labels an invalidated content claim as current.
-  const served = serve(graph, selected);
+  const served = serve(graph, selected, { dir });
   if (!served.length) return null;
   // A stale marker is longer than the fresh preview used for candidate
   // selection. Trim from the lowest-ranked end until the ACTUAL message fits.

--- a/integrations/opencode/hooks/lib/inject.mjs
+++ b/integrations/opencode/hooks/lib/inject.mjs
@@ -156,9 +156,9 @@ function disputeNote(finding) {
 function derivationNote(finding) {
   if (finding.derivationHolds !== false) return '';
   const changed = Array.isArray(finding.derivationChanged) ? finding.derivationChanged : [];
-  return changed.length
-    ? `\n  DERIVATION CHANGED -- ${changed.join(', ')} no longer match what this claim was derived from`
-    : '\n  DERIVATION CHANGED since this claim was recorded';
+  if (!changed.length) return '\n  DERIVATION CHANGED since this claim was recorded';
+  const verb = changed.length === 1 ? 'no longer matches' : 'no longer match';
+  return `\n  DERIVATION CHANGED -- ${changed.join(', ')} ${verb} what this claim was derived from`;
 }
 
 function render(finding) {

--- a/integrations/opencode/hooks/lib/inject.mjs
+++ b/integrations/opencode/hooks/lib/inject.mjs
@@ -143,8 +143,26 @@ function disputeNote(finding) {
     : '\n  DISPUTED by another finding in this graph';
 }
 
+/**
+ * Discloses `derivationCheck`'s verdict (staleness.mjs) -- distinct from
+ * `disputeNote` (another finding disagrees) and from the STALE block below
+ * (the anchor NODE's current hash does not match disk). This is about
+ * whether the bytes THIS claim was actually derived from are still the bytes
+ * an anchor holds; see `derivationCheck`'s comment for the case that catches
+ * that the other two can miss. Silent when it holds -- the common case pays
+ * nothing -- and silent when it was never checked at all (an older finding
+ * with no `derivation` record).
+ */
+function derivationNote(finding) {
+  if (finding.derivationHolds !== false) return '';
+  const changed = Array.isArray(finding.derivationChanged) ? finding.derivationChanged : [];
+  return changed.length
+    ? `\n  DERIVATION CHANGED -- ${changed.join(', ')} no longer match what this claim was derived from`
+    : '\n  DERIVATION CHANGED since this claim was recorded';
+}
+
 function render(finding) {
-  const head = `- [${finding.type || 'finding'}] ${finding.claim}${disputeNote(finding)}`;
+  const head = `- [${finding.type || 'finding'}] ${finding.claim}${disputeNote(finding)}${derivationNote(finding)}`;
   if (!finding.stale) return head;
 
   // A stale finding NEVER renders as though it were current. But the strength

--- a/integrations/opencode/hooks/lib/inject.mjs
+++ b/integrations/opencode/hooks/lib/inject.mjs
@@ -157,9 +157,28 @@ function render(finding) {
  * prevent. A second load costs a parse, and it is paid once per observed write
  * rather than once per tool call -- when nothing is queued this is one stat.
  */
+/**
+ * Per process, per graph directory: did the drain change anything?
+ *
+ * THE SECOND CALLER IS WHY THIS EXISTS. SessionStart calls `standingRules` and
+ * then `sessionIndex` with the SAME graph object it loaded once. Without this
+ * memo the first call drains, marks, and re-reads privately -- and the second
+ * call finds an empty queue, marks nothing, and therefore serves from the
+ * caller's pre-drain copy, advertising as current the very finding the first
+ * call had just marked. Draining is not idempotent from the caller's point of
+ * view; remembering the ANSWER is what makes it so.
+ *
+ * A hook process handles one lifecycle event, so this map holds one or two
+ * entries and dies with the process.
+ */
+const drainedDirs = new Map();
+
 function withPendingApplied(dir, graph) {
   try {
-    return drainInvalidations(dir, graph) > 0 ? load(dir) : graph;
+    if (drainedDirs.has(dir)) return drainedDirs.get(dir) ? load(dir) : graph;
+    const marked = drainInvalidations(dir, graph) > 0;
+    drainedDirs.set(dir, marked);
+    return marked ? load(dir) : graph;
   } catch {
     // The lazy path still covers everything this would have caught early, and
     // a hook must never fail because bookkeeping did.
@@ -862,6 +881,12 @@ export function relevantFindingIdsForContext(graph, context, { limit = 8 } = {})
  * shrinks toward the floor. See metrics.indexBudget.
  */
 export function sessionIndex(dir, graph, { episode = {}, relevantFindingIds = [] } = {}) {
+  // DRAINED HERE TOO, and this is the worst place to be wrong. The session index
+  // is the FIRST thing a session sees and it arrives with no other context to
+  // correct it, so advertising a finding the graph already knows is stale is a
+  // false claim made at maximum leverage. The graph is loaded either way, so the
+  // only cost is the stat that finds no queue.
+  graph = withPendingApplied(dir, graph);
   const budget = indexBudget(dir);
   const relevant = new Set(relevantFindingIds);
   // Some SessionStart payloads have no task signal. Fail closed for situational
@@ -988,6 +1013,9 @@ ${lines.join('\n')}`;
  * is wallpaper, and the model stops reading the thing it always sees.
  */
 export function standingRules(dir, graph, { budget = standingBudget(), episode = {} } = {}) {
+  // Same reason as sessionIndex: always-on text, delivered before the first
+  // tool call, with nothing following it that could qualify what it said.
+  graph = withPendingApplied(dir, graph);
   const rules = [...graph.nodes.values()].filter(
     (n) =>
       n.kind === 'finding' &&

--- a/integrations/opencode/hooks/lib/inject.mjs
+++ b/integrations/opencode/hooks/lib/inject.mjs
@@ -143,6 +143,40 @@ function render(finding) {
 }
 
 /**
+ * Graph directories where a drain has already marked something in THIS process.
+ *
+ * THE SECOND CALLER IS WHY THIS EXISTS. SessionStart calls `standingRules` and
+ * then `sessionIndex` with the SAME graph object it loaded once. Without this,
+ * the first call drains, marks, and re-reads privately -- and the second call
+ * finds an empty queue, marks nothing, and therefore serves from the caller's
+ * pre-drain copy, advertising as current the very finding the first call had
+ * just marked. Draining is idempotent; its EFFECT on a caller's parsed graph is
+ * not, so what is remembered here is "a re-read is owed", nothing else.
+ *
+ * ONLY THE POSITIVE CASE IS REMEMBERED, and that is a correctness decision
+ * rather than a tuning one. Remembering "nothing was queued" would mean a queue
+ * arriving LATER in the same process is silently skipped and deferred to some
+ * future session. That cannot happen today, because `queueInvalidation` runs in
+ * the post-tool branch before any injection -- but that is an unguarded
+ * ordering dependency, and it stops being true the moment someone adds a call
+ * site. A repeated empty drain costs one `existsSync` on a file that is not
+ * there, which is a price worth paying to not have an invariant that depends on
+ * nobody reordering anything.
+ *
+ * KEYED CANONICALLY. Two spellings of one directory -- a trailing separator, a
+ * `..` segment, a lower-cased drive letter -- would otherwise be two entries,
+ * which reintroduces exactly the pre-drain-copy bug above. This is the same
+ * defect shape Task 2 on this branch shipped for real, where a tool resolved its
+ * graph from a raw cwd while the hooks resolved theirs through `projectRootFor`
+ * and the two halves of a metric landed in different directories. Path identity
+ * is why `canonicalKey` lives inside `nodeId` rather than at its call sites.
+ *
+ * A hook process handles one lifecycle event, so this set holds one or two
+ * entries and dies with the process.
+ */
+const drainedDirs = new Set();
+
+/**
  * Applies anything the post-tool hook queued, BEFORE anything is served.
  *
  * THIS IS WHERE EAGER STALENESS LANDS. `invalidateOnWrite` needs a graph, and
@@ -157,28 +191,14 @@ function render(finding) {
  * prevent. A second load costs a parse, and it is paid once per observed write
  * rather than once per tool call -- when nothing is queued this is one stat.
  */
-/**
- * Per process, per graph directory: did the drain change anything?
- *
- * THE SECOND CALLER IS WHY THIS EXISTS. SessionStart calls `standingRules` and
- * then `sessionIndex` with the SAME graph object it loaded once. Without this
- * memo the first call drains, marks, and re-reads privately -- and the second
- * call finds an empty queue, marks nothing, and therefore serves from the
- * caller's pre-drain copy, advertising as current the very finding the first
- * call had just marked. Draining is not idempotent from the caller's point of
- * view; remembering the ANSWER is what makes it so.
- *
- * A hook process handles one lifecycle event, so this map holds one or two
- * entries and dies with the process.
- */
-const drainedDirs = new Map();
-
 function withPendingApplied(dir, graph) {
   try {
-    if (drainedDirs.has(dir)) return drainedDirs.get(dir) ? load(dir) : graph;
-    const marked = drainInvalidations(dir, graph) > 0;
-    drainedDirs.set(dir, marked);
-    return marked ? load(dir) : graph;
+    const key = canonicalPath(dir);
+    // The drain runs EVERY time. It is one stat when there is nothing to do,
+    // and running it unconditionally is what keeps the memo from encoding an
+    // assumption about which hook branch ran first.
+    if (drainInvalidations(dir, graph) > 0) drainedDirs.add(key);
+    return drainedDirs.has(key) ? load(dir) : graph;
   } catch {
     // The lazy path still covers everything this would have caught early, and
     // a hook must never fail because bookkeeping did.

--- a/integrations/opencode/hooks/lib/lexical.mjs
+++ b/integrations/opencode/hooks/lib/lexical.mjs
@@ -1,0 +1,73 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/lexical.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * BM25 over findings. Pure, dependency-free, deterministic.
+ *
+ * WHY THIS REPLACES `includes()`. The dashboard filtered findings by substring,
+ * which cannot RANK -- and every consumer of retrieval here is under a hard
+ * token budget, so the budget kept whatever happened to match rather than what
+ * matched best. Ranking is the whole value at a budget.
+ *
+ * WHY BM25 AND NOT EMBEDDINGS. Deliberate, per docs/WIKI_GRAPH.md: deterministic,
+ * instant, explainable, and it cannot drift or need a rebuild. The known cost is
+ * recall on findings with no lexical overlap; Plan 2's recall probe measures that
+ * rather than assuming it away.
+ */
+
+/** Non-word split, lowercased. Short tokens are kept: `fs`, `id`, `os` matter here. */
+export function tokenize(text) {
+  return String(text || '')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+}
+
+/**
+ * Classic BM25. `k1` controls term-frequency saturation, `b` length normalisation.
+ * Defaults are the standard ones and are exposed so the recall probe can sweep them.
+ */
+export function rank(query, findings, { limit = 20, k1 = 1.2, b = 0.75 } = {}) {
+  const terms = tokenize(query);
+  if (!terms.length || !Array.isArray(findings) || !findings.length) return [];
+
+  // A finding's searchable text is its claim AND its key: the key is how the
+  // session index refers to it, so a model quoting a key must find it.
+  const docs = findings.map((finding) => ({
+    finding,
+    tokens: tokenize(`${finding.key || ''} ${finding.claim || ''}`),
+  }));
+
+  const avgLen = docs.reduce((sum, d) => sum + d.tokens.length, 0) / docs.length;
+  const N = docs.length;
+
+  const docFreq = new Map();
+  for (const { tokens } of docs) {
+    for (const term of new Set(tokens)) {
+      docFreq.set(term, (docFreq.get(term) || 0) + 1);
+    }
+  }
+
+  const scored = [];
+  for (const { finding, tokens } of docs) {
+    const counts = new Map();
+    for (const token of tokens) counts.set(token, (counts.get(token) || 0) + 1);
+
+    let score = 0;
+    for (const term of terms) {
+      const tf = counts.get(term);
+      if (!tf) continue;
+      const df = docFreq.get(term) || 0;
+      // Standard BM25 IDF, floored at zero so a term present in every document
+      // contributes nothing rather than a negative score.
+      const idf = Math.max(0, Math.log(1 + (N - df + 0.5) / (df + 0.5)));
+      const norm = tf + k1 * (1 - b + (b * tokens.length) / (avgLen || 1));
+      score += idf * ((tf * (k1 + 1)) / (norm || 1));
+    }
+
+    // Zero means no term matched. Omitted rather than returned, so a caller
+    // under a token budget never spends it on an irrelevant finding.
+    if (score > 0) scored.push({ finding, score });
+  }
+
+  return scored.sort((a, b2) => b2.score - a.score).slice(0, limit);
+}

--- a/integrations/opencode/hooks/lib/lexical.mjs
+++ b/integrations/opencode/hooks/lib/lexical.mjs
@@ -14,12 +14,54 @@
  * rather than assuming it away.
  */
 
-/** Non-word split, lowercased. Short tokens are kept: `fs`, `id`, `os` matter here. */
-export function tokenize(text) {
-  return String(text || '')
-    .toLowerCase()
-    .split(/[^a-z0-9]+/)
+/**
+ * Splits an identifier's alphanumeric run into its camelCase / letter-digit
+ * parts, e.g. `skipLibCheck` -> ['skip', 'Lib', 'Check'], `TS2345` ->
+ * ['TS', '2345']. Returns a single-element array when there is no internal
+ * boundary (e.g. `retry` -> ['retry']) so callers can skip emitting a
+ * redundant duplicate of the whole token.
+ */
+function splitIdentifierParts(word) {
+  return word
+    .replace(/([a-z])([A-Z])/g, '$1\0$2')
+    .replace(/([A-Za-z])([0-9])/g, '$1\0$2')
+    .replace(/([0-9])([A-Za-z])/g, '$1\0$2')
+    .split('\0')
     .filter(Boolean);
+}
+
+/**
+ * Non-word split, lowercased. Short tokens are kept: `fs`, `id`, `os` matter
+ * here.
+ *
+ * Emits sub-tokens for compound identifiers, in addition to the whole token.
+ * Delimited identifiers (`smart_read`, `wiki.mjs`, the flag in
+ * `--skipLibCheck`) already round-trip fine: the delimiter splits them, and
+ * because query and claim pass through this same function, a query typed
+ * with the same delimiters matches. The silent gap was CONCATENATED
+ * identifiers with no delimiter at all -- `skipLibCheck` collapsed to the
+ * single token `skiplibcheck`, so a query for "skip lib check" (or "TS 2345"
+ * against `TS2345`) never intersected it. No error, just an absent result --
+ * and findings are about code, where run-together identifiers are the
+ * common case. So every alphanumeric run keeps its whole-token form (a query
+ * for the concatenated form still matches) and ALSO contributes its
+ * camelCase / letter-digit parts (a query for the separated form now
+ * matches too). A lone incidental character -- e.g. the `c` split out of a
+ * Windows path `C:\Users\...` -- needs no special-casing: it is a real
+ * token like any other, and BM25's IDF already discounts a term that shows
+ * up in nearly every finding.
+ */
+export function tokenize(text) {
+  const words = String(text || '').match(/[A-Za-z0-9]+/g) || [];
+  const tokens = [];
+  for (const word of words) {
+    tokens.push(word.toLowerCase());
+    const parts = splitIdentifierParts(word);
+    if (parts.length > 1) {
+      for (const part of parts) tokens.push(part.toLowerCase());
+    }
+  }
+  return tokens;
 }
 
 /**
@@ -57,9 +99,15 @@ export function rank(query, findings, { limit = 20, k1 = 1.2, b = 0.75 } = {}) {
       const tf = counts.get(term);
       if (!tf) continue;
       const df = docFreq.get(term) || 0;
-      // Standard BM25 IDF, floored at zero so a term present in every document
-      // contributes nothing rather than a negative score.
-      const idf = Math.max(0, Math.log(1 + (N - df + 0.5) / (df + 0.5)));
+      // Smoothed BM25 idf: log(1 + (N - df + 0.5) / (df + 0.5)). Unlike the
+      // classic unsmoothed idf (log((N - df + 0.5) / (df + 0.5))), which goes
+      // negative once a term appears in most documents, this smoothed form
+      // is strictly positive for every df in [1, N]: even at df === N the
+      // ratio inside the log is (N + 1) / (N + 0.5), which is always
+      // strictly greater than 1, so log(1 + that) is always > 0. No floor
+      // is needed here, and none is applied -- there is no negative case
+      // for this formula to guard against.
+      const idf = Math.log(1 + (N - df + 0.5) / (df + 0.5));
       const norm = tf + k1 * (1 - b + (b * tokens.length) / (avgLen || 1));
       score += idf * ((tf * (k1 + 1)) / (norm || 1));
     }

--- a/integrations/opencode/hooks/lib/lexical.mjs
+++ b/integrations/opencode/hooks/lib/lexical.mjs
@@ -65,6 +65,43 @@ export function tokenize(text) {
 }
 
 /**
+ * Effective term-frequency credit for a document that has NO exact token
+ * match for a query term but DOES have a token that starts with it (e.g.
+ * query `custom` against a document containing `customer`). Deliberately
+ * less than one exact occurrence (`1`), and it is a flat credit rather than
+ * one that grows with the number of prefix-matching tokens in the document,
+ * so a prefix hit can never outscore an exact hit of the same term:
+ *
+ *   BM25's per-term contribution is `idf * tf * (k1 + 1) / (tf + K)`, where
+ *   `K = k1 * (1 - b + b * L / avgL)` depends only on document length, not
+ *   on which term or how it matched. As a function of `tf` alone, with `K`
+ *   fixed, `f(tf) = tf / (tf + K)` is non-decreasing for every `tf >= 0` and
+ *   `k1 >= 0` (its derivative `K / (tf + K)^2` is never negative). So for
+ *   ANY document length, and any number of prefix-only occurrences, using
+ *   `PREFIX_TF < 1` in place of `tf` scores no higher than an actual exact
+ *   occurrence (`tf = 1`) would in that same document -- there is no
+ *   PREFIX_TF-independent way to accumulate more evidence than one real hit
+ *   by matching only a prefix. This is also why the count of prefix matches
+ *   is otherwise irrelevant here: it never feeds back into the score.
+ *
+ * PREFIX MATCHING IS NOT SUBSTRING MATCHING. It restores recall for a
+ * fragment typed at the START of a word -- `custom` now finds `customer` --
+ * which is the common case (a user typing the first few letters of a term
+ * they remember). It does NOT restore the old `.includes()` filter's ability
+ * to find a term in the MIDDLE of a word: a query for `tomer` still will not
+ * find `customer`. That recall gap is accepted, not silently reintroduced.
+ */
+const PREFIX_TF = 0.5;
+
+/**
+ * Below this length, a query term is not eligible for prefix matching: a
+ * one- or two-character prefix (`a`, `re`) is a substring of a large
+ * fraction of any real vocabulary, so it would match nearly every document
+ * and IDF alone would not discount it enough to keep the results relevant.
+ */
+const PREFIX_MIN_TERM_LENGTH = 3;
+
+/**
  * Classic BM25. `k1` controls term-frequency saturation, `b` length normalisation.
  * Defaults are the standard ones and are exposed so the recall probe can sweep them.
  */
@@ -96,7 +133,21 @@ export function rank(query, findings, { limit = 20, k1 = 1.2, b = 0.75 } = {}) {
 
     let score = 0;
     for (const term of terms) {
-      const tf = counts.get(term);
+      let tf = counts.get(term) || 0;
+
+      // No exact occurrence: fall back to a prefix match, which is weaker
+      // evidence and so credited at a flat PREFIX_TF rather than a real
+      // count (see PREFIX_TF's comment for why that ordering is safe). Only
+      // considered when nothing already matched exactly and the term is
+      // long enough that "starts with" is a meaningful signal.
+      if (tf === 0 && term.length >= PREFIX_MIN_TERM_LENGTH) {
+        for (const token of counts.keys()) {
+          if (token !== term && token.startsWith(term)) {
+            tf = PREFIX_TF;
+            break;
+          }
+        }
+      }
       if (!tf) continue;
       const df = docFreq.get(term) || 0;
       // Smoothed BM25 idf: log(1 + (N - df + 0.5) / (df + 0.5)). Unlike the

--- a/integrations/opencode/hooks/lib/metrics.mjs
+++ b/integrations/opencode/hooks/lib/metrics.mjs
@@ -455,6 +455,23 @@ export function readBalance(dir) {
   return out;
 }
 
+/**
+ * True when `readEvidence` could not have read the whole log -- the file
+ * exceeds the byte cap, so anything written before the tail it kept is
+ * silently absent from what it returned. A caller that builds a per-claim
+ * record from `readEvidence` (the wiki graph's derivation record) needs this
+ * to say "operations existed but are not recorded here" rather than let an
+ * empty result read as "nothing happened".
+ */
+export function evidenceTruncated(dir) {
+  const path = evidencePath(dir);
+  try {
+    return statSync(path).size > MAX_BYTES;
+  } catch {
+    return false;
+  }
+}
+
 /** Every causal evidence record inside the byte cap, deduplicated by id. */
 export function readEvidence(dir) {
   const path = evidencePath(dir);

--- a/integrations/opencode/hooks/lib/observability.mjs
+++ b/integrations/opencode/hooks/lib/observability.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 /**
  * Privacy-safe, cross-client lifecycle diagnostics.
  *

--- a/integrations/opencode/hooks/lib/pending.mjs
+++ b/integrations/opencode/hooks/lib/pending.mjs
@@ -39,7 +39,7 @@ import {
   statSync,
 } from 'node:fs';
 import { join } from 'node:path';
-import { invalidateOnWrite } from './staleness.mjs';
+import { invalidateChangedAnchors, invalidateOnWrite } from './staleness.mjs';
 import { canonicalPath, isFsSafePath, resolvableCandidates } from './paths.mjs';
 
 const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
@@ -190,31 +190,85 @@ function hasEditEvidence(payload, raw) {
 }
 
 /**
- * The evidence a completed mutation left behind, or null when there is none.
+ * Canonical tool names that mean bytes on disk changed.
  *
- * Separate from `queueInvalidation` so the caller can be a hook branch that
- * knows nothing about diffs, and so the reconstruction above is testable
- * without a filesystem queue.
+ * THE NORMALISED SET, not any client's own vocabulary. `normalizePayload` has
+ * already mapped `replace`, `write_file`, `apply_patch`, `str_replace`,
+ * `search_replace` and the rest onto these three through decide.mjs's alias
+ * table -- and a tool that table cannot map arrives as null and exits the hook
+ * before this module is reached at all. So matching here is both complete for
+ * every client the adapter serves and impossible to spell wrong.
+ *
+ * `NotebookEdit` is absent because `normalizeTool` maps it to null, and the MCP
+ * `smart_edit`/`smart_write` tools are absent for the same reason. Both are gaps
+ * in that alias table rather than in this file, and widening it changes routing
+ * verdicts for every client -- so they are reported, not papered over here.
  */
-export function observedWrite(payload, raw) {
-  // CHEAP CHECK FIRST, because this runs after every tool call on every client.
-  // Reading the file is the expensive part, and there is no point paying for it
-  // on a Read, a Bash or a write whose before side cannot be reconstructed.
-  if (!hasEditEvidence(payload, raw)) return null;
+const MUTATING = new Set(['Edit', 'MultiEdit', 'Write']);
+
+/** Files an apply_patch-style program declares it is about to change. */
+function patchTargets(payload) {
+  const command = payload?.tool_input?.command;
+  if (typeof command !== 'string') return [];
+  const out = [];
+  for (const match of command.matchAll(
+    /^\*\*\* (?:Add|Update|Delete) File:\s*(.+)$/gm
+  )) {
+    const candidate = match[1].trim().replace(/^['"]|['"]$/g, '');
+    // Bounded: one patch naming a thousand files must not append a thousand
+    // queue records on a hook path.
+    if (candidate && out.length < 20) out.push(candidate);
+  }
+  return out;
+}
+
+/**
+ * Everything a completed mutation left behind that is worth queueing.
+ *
+ * TWO GRADES OF EVIDENCE, and the distinction is the point:
+ *
+ *   { path, before, after }  a reconstructable edit. The drain builds a real
+ *                            diff and marks only the symbols that moved.
+ *   { path }                 a whole-file write, or a patch program. No before
+ *                            side exists anywhere in the payload, so the drain
+ *                            compares stored hashes against disk instead.
+ *
+ * The second grade is what closes the biggest hole. A whole-file write is the
+ * commonest write shape there is, and before it was added those writes fell
+ * through to a lazy path that CANNOT see the session's own writes at all --
+ * `indexFile` refreshes the anchor before the lazy check ever looks at it. They
+ * were uncovered, not degraded.
+ *
+ * Returns an array, because one apply_patch program changes several files.
+ */
+export function observedWrites(payload, raw) {
+  if (!MUTATING.has(String(payload?.tool_name || ''))) return [];
 
   const path = writtenPath(payload, raw);
-  if (!path) return null;
+  if (path) {
+    // The expensive branch is guarded: reading the file only pays off when the
+    // payload can actually yield a before side.
+    if (hasEditEvidence(payload, raw)) {
+      const after = afterText(path);
+      if (after !== null && after.length <= MAX_SIDE_CHARS) {
+        const before = beforeText(payload, raw, after);
+        // Identical bytes: a formatter no-op, or a rewrite of the same content.
+        // Nothing changed, so nothing is stale.
+        if (before === after) return [];
+        if (before !== null && before.length <= MAX_SIDE_CHARS)
+          return [{ path, before, after }];
+      }
+    }
+    // Hash grade. Deliberately NOT `{ path, before: '', after }`: an empty
+    // before side makes every symbol in the file look changed, and the eager
+    // mark is a stored flag no later check ever clears.
+    return [{ path }];
+  }
 
-  const after = afterText(path);
-  if (after === null || after.length > MAX_SIDE_CHARS) return null;
-
-  const before = beforeText(payload, raw, after);
-  if (before === null || before.length > MAX_SIDE_CHARS) return null;
-  // Nothing changed: a formatter no-op, or a write of identical bytes. Queuing
-  // it would mark findings stale against an empty diff.
-  if (before === after) return null;
-
-  return { path, before, after };
+  // Codex and code-mode clients carry the whole patch as program text with no
+  // file_path field at all, which is why this recorded nothing for them. The
+  // hash grade needs only the path, so the patch headers are enough.
+  return patchTargets(payload).map((target) => ({ path: target }));
 }
 
 /**
@@ -226,9 +280,14 @@ export function observedWrite(payload, raw) {
 export function queueInvalidation(dir, { path, before, after, at } = {}) {
   try {
     if (typeof path !== 'string' || !path.trim()) return false;
-    if (typeof before !== 'string' || typeof after !== 'string') return false;
-    if (before.length > MAX_SIDE_CHARS || after.length > MAX_SIDE_CHARS)
-      return false;
+    // BOTH SIDES OR NEITHER. A record carrying only one of them cannot produce
+    // a diff and must not pretend to, so it is written as a path-only record
+    // and the drain resolves it by comparing hashes.
+    const diffable =
+      typeof before === 'string' &&
+      typeof after === 'string' &&
+      before.length <= MAX_SIDE_CHARS &&
+      after.length <= MAX_SIDE_CHARS;
 
     const file = queuePath(dir);
     try {
@@ -240,7 +299,11 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
     mkdirSync(dir, { recursive: true });
     appendFileSync(
       file,
-      `${JSON.stringify({ path: canonicalPath(path), before, after, at: at ?? Date.now() })}\n`,
+      `${JSON.stringify({
+        path: canonicalPath(path),
+        ...(diffable ? { before, after } : {}),
+        at: at ?? Date.now(),
+      })}\n`,
       'utf8'
     );
     return true;
@@ -284,16 +347,16 @@ export function drainInvalidations(dir, graph) {
   let marked = 0;
   for (const record of records) {
     if (!record || typeof record.path !== 'string' || !record.path) continue;
-    if (typeof record.before !== 'string' || typeof record.after !== 'string')
-      continue;
+    const diffable =
+      typeof record.before === 'string' && typeof record.after === 'string';
     try {
-      const result = invalidateOnWrite(
-        dir,
-        graph,
-        record.path,
-        record.before,
-        record.after
-      );
+      // TWO GRADES, ONE QUEUE. A record carrying both sides gets a real diff and
+      // symbol-precise marking; one carrying only a path gets the hash
+      // comparison -- the same comparison the lazy path makes, and one that is
+      // only meaningful HERE, before `indexFile` refreshes the anchor.
+      const result = diffable
+        ? invalidateOnWrite(dir, graph, record.path, record.before, record.after)
+        : invalidateChangedAnchors(dir, graph, record.path);
       marked += Array.isArray(result) ? result.length : 0;
     } catch {
       // One bad record must not stop the rest, and must not stop the tool call.

--- a/integrations/opencode/hooks/lib/pending.mjs
+++ b/integrations/opencode/hooks/lib/pending.mjs
@@ -1,0 +1,311 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/pending.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * The eager-invalidation queue: the missing half of staleness.mjs's header.
+ *
+ * That header describes TWO invalidation paths and says eager exists because
+ * lazy "would silently serve stale findings as fresh whenever a change came
+ * from outside the agent". `invalidateOnWrite` had been written, tested and
+ * documented -- and its only reference in shipped code was a COMMENT in the
+ * PreToolUse router. Staleness was lazy-only in production, and the router's
+ * own comment ("a write the hook observes is invalidated eagerly by
+ * `invalidateOnWrite`") described something that never happened.
+ *
+ * WHY THAT MATTERS MORE THAN IT SOUNDS. The lazy check compares the anchor's
+ * stored hash against disk -- and both the router and the adapter call
+ * `indexFile` on every file they observe, which re-points that hash at the new
+ * bytes. So for a write the session performed ITSELF, the lazy check is
+ * self-defeating: by the next retrieval the anchor already agrees with disk and
+ * the finding derived from the old content is served clean. Lazy catches the
+ * changes we never saw; only eager catches the ones we did.
+ *
+ * WHY A QUEUE AND NOT A DIRECT CALL. `invalidateOnWrite` needs the graph, and
+ * the graph is a megabyte of JSONL. Loading it on the return path of every
+ * write is the cost this shape exists to avoid. So the post-tool hook, which
+ * already holds the write's evidence, appends one record here and exits; the
+ * next graph read -- `forTouch`/`forCommand`, which load the graph anyway --
+ * drains it BEFORE serving anything.
+ *
+ * The guarantee is unchanged. What must never happen is SERVING a stale finding
+ * as fresh, and serve time is where that is enforced.
+ */
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { invalidateOnWrite } from './staleness.mjs';
+import { canonicalPath, isFsSafePath, resolvableCandidates } from './paths.mjs';
+
+const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
+
+/**
+ * Largest before/after side kept in a queue record.
+ *
+ * Matched to the graph's own snapshot limit for the same reason it has one: past
+ * this size the text is a bundle, a lockfile or a generated asset, and copying
+ * it into a queue file would mirror the repository into the graph directory one
+ * write at a time. Past the cap the write is simply not queued -- the lazy path
+ * still governs it, which is exactly the status quo for that file.
+ */
+const MAX_SIDE_CHARS = 262_144;
+
+/**
+ * Largest queue file appended to.
+ *
+ * A queue only grows while nothing drains it, which means the retrieval feature
+ * is off or every read has failed. Neither is a reason to keep writing: bounded
+ * here so a long unattended session cannot turn one directory into a log of
+ * every file it touched.
+ */
+const MAX_QUEUE_BYTES = 8 * 1024 * 1024;
+
+/** The tool payload fields that name the file a mutation landed on. */
+function writtenPath(payload, raw) {
+  const input = payload?.tool_input || {};
+  const response = raw?.tool_response || raw?.toolResponse || {};
+  for (const candidate of [
+    input.file_path,
+    input.path,
+    input.notebook_path,
+    response.filePath,
+    response.file_path,
+  ]) {
+    if (typeof candidate === 'string' && candidate.trim()) return candidate;
+  }
+  return null;
+}
+
+/** First string among several possible spellings of the same field. */
+function firstString(...values) {
+  for (const value of values) if (typeof value === 'string') return value;
+  return null;
+}
+
+/**
+ * The text before the write, reconstructed from a completed edit.
+ *
+ * PREFERENCE ORDER IS ABOUT EXACTNESS, not convenience. Claude Code's Edit
+ * response carries the whole pre-edit file (`originalFile`), which needs no
+ * reasoning at all. Failing that, an edit is a known substitution, so reverting
+ * `new_string` back to `old_string` in the post-write text reproduces the
+ * before side exactly -- but only when the substitution is unambiguous, which
+ * is why a `new_string` that now appears more than once is refused rather than
+ * guessed at.
+ *
+ * NULL MEANS "DO NOT QUEUE", and that is deliberate. An unknown before side
+ * could be passed as '' -- and `invalidateOnWrite` would then see every symbol
+ * in the file as changed and mark every finding anchored anywhere in it, which
+ * is the exact over-marking its own comments call worse than the file-level
+ * staleness symbols were introduced to avoid. A missed eager invalidation costs
+ * what today already costs; a wrong one permanently discounts correct findings.
+ */
+function beforeText(payload, raw, after) {
+  const input = payload?.tool_input || {};
+  const response = raw?.tool_response || raw?.toolResponse || {};
+
+  const original = firstString(
+    response.originalFile,
+    response.original_file,
+    response.originalContent,
+    response.original_content
+  );
+  if (original !== null) return original;
+
+  // MultiEdit applies its edits in order, so reverting walks them backwards.
+  const edits = Array.isArray(input.edits) ? input.edits : null;
+  if (edits) {
+    let text = after;
+    for (const edit of [...edits].reverse()) {
+      const reverted = revert(text, edit);
+      if (reverted === null) return null;
+      text = reverted;
+    }
+    return text;
+  }
+
+  return revert(after, input);
+}
+
+/** Undoes one old->new substitution, or null when it cannot be done exactly. */
+function revert(text, edit) {
+  const oldString = firstString(edit?.old_string, edit?.oldString);
+  const newString = firstString(edit?.new_string, edit?.newString);
+  if (oldString === null || newString === null || newString === '') return null;
+
+  const all = edit?.replace_all === true || edit?.replaceAll === true;
+  if (all) return text.split(newString).join(oldString);
+
+  const at = text.indexOf(newString);
+  if (at < 0) return null;
+  // Ambiguous: more than one candidate for the occurrence that was written, and
+  // reverting the wrong one fabricates a before side that never existed.
+  if (text.indexOf(newString, at + newString.length) >= 0) return null;
+  return text.slice(0, at) + oldString + text.slice(at + newString.length);
+}
+
+/** The post-write text, read from disk because that is what the write produced. */
+function afterText(path) {
+  if (!isFsSafePath(path)) return null;
+  for (const candidate of resolvableCandidates(path)) {
+    try {
+      if (statSync(candidate).size > MAX_SIDE_CHARS) return null;
+      return readFileSync(candidate, 'utf8');
+    } catch {
+      // Wrong spelling, or gone again already. Try the next one.
+    }
+  }
+  return null;
+}
+
+/**
+ * Does this payload carry enough to reconstruct a before side at all?
+ *
+ * Named tool lists were the alternative and were rejected: every client calls
+ * its editor something different (`Edit`, `replace`, `write_to_file`,
+ * `apply_patch`), and a list would silently exclude the ones nobody thought of
+ * while still charging a file read for every Read that matched by accident.
+ * Asking about the EVIDENCE instead covers any client that carries an edit in
+ * one of these shapes and costs nothing on the calls that do not.
+ */
+function hasEditEvidence(payload, raw) {
+  const input = payload?.tool_input || {};
+  const response = raw?.tool_response || raw?.toolResponse || {};
+  if (
+    firstString(
+      response.originalFile,
+      response.original_file,
+      response.originalContent,
+      response.original_content
+    ) !== null
+  )
+    return true;
+  if (Array.isArray(input.edits) && input.edits.length > 0) return true;
+  return firstString(input.old_string, input.oldString) !== null;
+}
+
+/**
+ * The evidence a completed mutation left behind, or null when there is none.
+ *
+ * Separate from `queueInvalidation` so the caller can be a hook branch that
+ * knows nothing about diffs, and so the reconstruction above is testable
+ * without a filesystem queue.
+ */
+export function observedWrite(payload, raw) {
+  // CHEAP CHECK FIRST, because this runs after every tool call on every client.
+  // Reading the file is the expensive part, and there is no point paying for it
+  // on a Read, a Bash or a write whose before side cannot be reconstructed.
+  if (!hasEditEvidence(payload, raw)) return null;
+
+  const path = writtenPath(payload, raw);
+  if (!path) return null;
+
+  const after = afterText(path);
+  if (after === null || after.length > MAX_SIDE_CHARS) return null;
+
+  const before = beforeText(payload, raw, after);
+  if (before === null || before.length > MAX_SIDE_CHARS) return null;
+  // Nothing changed: a formatter no-op, or a write of identical bytes. Queuing
+  // it would mark findings stale against an empty diff.
+  if (before === after) return null;
+
+  return { path, before, after };
+}
+
+/**
+ * Appends one pending write.
+ *
+ * NEVER THROWS. This runs on a hook's return path, and a queue that cannot be
+ * written degrades to the lazy path rather than costing the user a tool call.
+ */
+export function queueInvalidation(dir, { path, before, after, at } = {}) {
+  try {
+    if (typeof path !== 'string' || !path.trim()) return false;
+    if (typeof before !== 'string' || typeof after !== 'string') return false;
+    if (before.length > MAX_SIDE_CHARS || after.length > MAX_SIDE_CHARS)
+      return false;
+
+    const file = queuePath(dir);
+    try {
+      if (statSync(file).size > MAX_QUEUE_BYTES) return false;
+    } catch {
+      // No queue yet, which is the normal case.
+    }
+
+    mkdirSync(dir, { recursive: true });
+    appendFileSync(
+      file,
+      `${JSON.stringify({ path: canonicalPath(path), before, after, at: at ?? Date.now() })}\n`,
+      'utf8'
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Applies every queued invalidation and clears the queue.
+ *
+ * Returns the number of findings marked, so the caller knows whether its
+ * in-memory graph is now behind the file on disk and needs re-reading.
+ *
+ * CLEARED AFTER APPLYING AND UNCONDITIONALLY: a record that cannot be applied
+ * must not be retried on every tool call for the rest of the session, and the
+ * cost of dropping one is a single missed eager mark that the lazy path still
+ * has a chance at.
+ */
+export function drainInvalidations(dir, graph) {
+  let records;
+  try {
+    const file = queuePath(dir);
+    if (!existsSync(file)) return 0;
+    records = readFileSync(file, 'utf8')
+      .split('\n')
+      .filter((line) => line.trim())
+      .map((line) => {
+        try {
+          return JSON.parse(line);
+        } catch {
+          // A torn append costs one record, not the queue.
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch {
+    return 0;
+  }
+
+  let marked = 0;
+  for (const record of records) {
+    if (!record || typeof record.path !== 'string' || !record.path) continue;
+    if (typeof record.before !== 'string' || typeof record.after !== 'string')
+      continue;
+    try {
+      const result = invalidateOnWrite(
+        dir,
+        graph,
+        record.path,
+        record.before,
+        record.after
+      );
+      marked += Array.isArray(result) ? result.length : 0;
+    } catch {
+      // One bad record must not stop the rest, and must not stop the tool call.
+    }
+  }
+
+  try {
+    rmSync(queuePath(dir), { force: true });
+  } catch {
+    // Held open by a concurrent hook. The next drain re-applies these records,
+    // which is safe: marking an already-marked finding is idempotent.
+  }
+
+  return marked;
+}

--- a/integrations/opencode/hooks/lib/pending.mjs
+++ b/integrations/opencode/hooks/lib/pending.mjs
@@ -199,10 +199,11 @@ function hasEditEvidence(payload, raw) {
  * before this module is reached at all. So matching here is both complete for
  * every client the adapter serves and impossible to spell wrong.
  *
- * `NotebookEdit` is absent because `normalizeTool` maps it to null, and the MCP
- * `smart_edit`/`smart_write` tools are absent for the same reason. Both are gaps
- * in that alias table rather than in this file, and widening it changes routing
- * verdicts for every client -- so they are reported, not papered over here.
+ * `NotebookEdit` and the MCP `smart_edit`/`smart_write` tools were absent for as
+ * long as `normalizeTool` mapped them to null. That was a gap in the alias table
+ * rather than in this file, and it has since been closed there: all three now
+ * arrive as `Edit` or `Write` and are matched by the set below without it having
+ * to learn a fourth name.
  */
 const MUTATING = new Set(['Edit', 'MultiEdit', 'Write']);
 

--- a/integrations/opencode/hooks/lib/pending.mjs
+++ b/integrations/opencode/hooks/lib/pending.mjs
@@ -35,6 +35,7 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  renameSync,
   rmSync,
   statSync,
 } from 'node:fs';
@@ -43,6 +44,15 @@ import { invalidateChangedAnchors, invalidateOnWrite } from './staleness.mjs';
 import { canonicalPath, isFsSafePath, resolvableCandidates } from './paths.mjs';
 
 const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
+/**
+ * Where a drain moves the queue before reading it.
+ *
+ * PER PROCESS, not one shared name: two hooks draining the same graph directory
+ * at once would otherwise race for the same claim file, and the loser would
+ * either clobber the winner's records or delete them mid-read. A pid makes the
+ * claim private to the drainer that won the rename.
+ */
+const claimPath = (dir) => join(dir, `pending-invalidation.claim.${process.pid}.jsonl`);
 
 /**
  * Largest before/after side kept in a queue record.
@@ -319,17 +329,47 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
  * Returns the number of findings marked, so the caller knows whether its
  * in-memory graph is now behind the file on disk and needs re-reading.
  *
- * CLEARED AFTER APPLYING AND UNCONDITIONALLY: a record that cannot be applied
- * must not be retried on every tool call for the rest of the session, and the
- * cost of dropping one is a single missed eager mark that the lazy path still
- * has a chance at.
+ * CLAIMED BY RENAME, THEN READ, THEN DELETED -- and the order is the whole
+ * point. This used to read the queue and then `rmSync` the same path, so a
+ * post-tool hook appending between the read and the unlink had its record
+ * deleted having never been read. Parallel tool calls in one assistant turn are
+ * the ordinary way that happens, not an exotic race. `renameSync` makes the
+ * claim atomic: whatever the drainer took is exactly what it deletes, and a
+ * record appended a microsecond later lands on a fresh queue that the next drain
+ * will find.
+ *
+ * A LOST RECORD IS A PERMANENTLY MISSED INVALIDATION, which is why this is worth
+ * a rename. The comment here used to price it as "a single missed eager mark that
+ * the lazy path still has a chance at", and that premise is false: this module's
+ * own header states it. The lazy path compares the anchor's stored hash against
+ * disk, and `indexFile` re-points that hash at the bytes the session just wrote,
+ * so for the session's OWN writes lazy is structurally blind rather than merely
+ * late. Nothing else was ever going to catch a dropped record.
+ *
+ * A RECORD THAT CANNOT BE APPLIED IS STILL DROPPED, deliberately and
+ * unconditionally: retrying a permanently unapplicable record on every tool call
+ * for the rest of the session costs more than it can ever recover, and the claim
+ * file is deleted whether the loop marked anything or threw.
+ *
+ * FAIL-OPEN THROUGHOUT. A rename that loses a race, or fails for any other
+ * reason, returns 0 and leaves the queue for the next drain; it never throws
+ * into a hook.
  */
 export function drainInvalidations(dir, graph) {
   let records;
+  let claim;
   try {
     const file = queuePath(dir);
     if (!existsSync(file)) return 0;
-    records = readFileSync(file, 'utf8')
+    claim = claimPath(dir);
+    // A LEFTOVER CLAIM FROM A KILLED DRAIN IS OVERWRITTEN, not merged: rename
+    // onto an existing path replaces it. The pid in the name means the only way
+    // to hit that is this same pid having died mid-drain, whose records were
+    // already being applied when it went -- and re-applying is idempotent, so
+    // losing them is the cheaper of the two errors. Not doing the rename at all
+    // would strand the live queue forever.
+    renameSync(file, claim);
+    records = readFileSync(claim, 'utf8')
       .split('\n')
       .filter((line) => line.trim())
       .map((line) => {
@@ -342,6 +382,18 @@ export function drainInvalidations(dir, graph) {
       })
       .filter(Boolean);
   } catch {
+    // The rename lost a race, or the claim could not be read. Nothing is deleted
+    // unread and the hook proceeds. If the claim was taken and then could not be
+    // read, it is put back under the queue name so the next drain still sees it:
+    // a claim file nobody looks at again is the same lost record this rename
+    // exists to prevent.
+    try {
+      if (claim && existsSync(claim) && !existsSync(queuePath(dir))) {
+        renameSync(claim, queuePath(dir));
+      }
+    } catch {
+      // Best effort only. A hook must not fail because bookkeeping did.
+    }
     return 0;
   }
 
@@ -365,10 +417,13 @@ export function drainInvalidations(dir, graph) {
   }
 
   try {
-    rmSync(queuePath(dir), { force: true });
+    // THE CLAIM, NOT THE QUEUE. Deleting `queuePath` here is what dropped a
+    // concurrently appended record; this path holds exactly the bytes that were
+    // just read, so nothing unread can be inside it.
+    rmSync(claim, { force: true });
   } catch {
-    // Held open by a concurrent hook. The next drain re-applies these records,
-    // which is safe: marking an already-marked finding is idempotent.
+    // Held open by something else. The claim is not read again -- the next drain
+    // looks at the queue -- so this costs a stray file, never a record.
   }
 
   return marked;

--- a/integrations/opencode/hooks/lib/restore.mjs
+++ b/integrations/opencode/hooks/lib/restore.mjs
@@ -142,7 +142,7 @@ export function restorationPlan(dir, graph, context = {}) {
     for (const id of predicted) {
       const node = graph.nodes.get(id);
       if (!node) continue;
-      const findings = serve(graph, findingsFor(graph, id, { limit: 2 }));
+      const findings = serve(graph, findingsFor(graph, id, { limit: 2 }), { dir });
       for (const finding of findings) {
         // `! STALE` only where a diff actually exists to back it; see the
         // renderer in inject.mjs for the measurement behind this.

--- a/integrations/opencode/hooks/lib/restore.mjs
+++ b/integrations/opencode/hooks/lib/restore.mjs
@@ -158,7 +158,16 @@ export function restorationPlan(dir, graph, context = {}) {
             ? '! STALE '
             : '~ '
           : '';
-        lines.push(`${node.key}: ${mark}${finding.claim}`);
+        // A DISPUTE DISCLOSED ELSEWHERE AND SILENT HERE reads as "the dispute
+        // went away". `serve` already attached the fields; the only question is
+        // the wording, and this list is the most compressed surface in the
+        // system, so it gets the marker and the key and nothing else.
+        const disputed = finding.contradicted
+          ? finding.contradictedBy
+            ? ` (disputed by ${finding.contradictedBy})`
+            : ' (disputed)'
+          : '';
+        lines.push(`${node.key}: ${mark}${finding.claim}${disputed}`);
       }
     }
     section('Likely next', lines, total * split.forward);

--- a/integrations/opencode/hooks/lib/skeleton.mjs
+++ b/integrations/opencode/hooks/lib/skeleton.mjs
@@ -126,6 +126,11 @@ export function annotatedSkeleton(graph, rawPath, source, { budget = 1200, git =
 
   // Findings anchored to this file or the symbols inside it, served through the
   // one function that enforces the stale-plus-diff rule.
+  // READ-ONLY serve: no `dir` is threaded here, so this cannot clear a stale
+  // flag whose evidence is gone. That is deliberate -- this function takes a
+  // graph, not the directory it came from, and widening its signature to give
+  // an analysis path a write capability buys nothing: the injection path runs
+  // on every tool call and clears the same findings.
   const served = serve(graph, findingsFor(graph, nodeId('file', path), { limit: 40 }));
 
   // Index findings by the symbol they anchor to, so each one sits beside the

--- a/integrations/opencode/hooks/lib/staleness.mjs
+++ b/integrations/opencode/hooks/lib/staleness.mjs
@@ -31,6 +31,23 @@
  * Eager alone would silently serve stale findings as fresh whenever a change
  * came from outside the agent, which is the single failure mode the design
  * calls worse than no graph.
+ *
+ * AND LAZY ALONE IS BLIND TO THE AGENT'S OWN WRITES -- not degraded, BLIND.
+ * `indexFile` re-points an anchor's stored hash at the bytes it was just handed,
+ * and it is called on every file either hook observes: pretooluse-router.mjs
+ * (two call sites) and adapter.mjs (one). The lazy check then compares that
+ * refreshed hash against the same disk it came from and finds them equal. So
+ * for a file the session edited ITSELF, the lazy path cannot detect the change
+ * at all, and the finding derived from the pre-edit content is served CLEAN.
+ *
+ * Which means that until the eager path was connected, staleness for a file the
+ * agent edited did not work AT ALL: eager was dead code and lazy was defeated
+ * by re-indexing. Every account of this defect, including the one in this
+ * module's own git history, called it "lazy-only, therefore degraded". It was
+ * not degraded. `stale-before-reindex.test.mjs` states in its header that this
+ * case is covered by `invalidateOnWrite`, and `invalidateOnWrite` had never run
+ * once in production. The two paths are not redundant and never were: each is
+ * the ONLY cover for a whole class of change.
  */
 
 import { readFileSync, statSync } from 'node:fs';
@@ -622,6 +639,119 @@ export function invalidateOnWrite(dir, graph, rawPath, beforeText, afterText) {
   // Re-index so the anchors carry the new hashes; otherwise the lazy path would
   // report the same change again on every future retrieval.
   indexFile(dir, path, afterText);
+  return marked;
+}
+
+/**
+ * The eager path for a write with NO before/after pair: compare stored hashes
+ * against disk, and mark what actually moved.
+ *
+ * WHY THIS EXISTS AS A SECOND SHAPE. A whole-file `Write` replaces the file, so
+ * the payload carries the after side and nothing at all of the before -- and a
+ * whole-file write is the commonest write shape there is. `invalidateOnWrite`
+ * cannot serve it: passing '' as the before side makes every symbol in the file
+ * look changed, marks every finding anchored anywhere in it, and the eager mark
+ * is a stored flag no later check ever clears. False-stale is expensive and
+ * permanent, so it is not an acceptable price for coverage.
+ *
+ * But the hash comparison is available, and it is exactly the comparison the
+ * lazy path makes. The difference is WHEN: this runs at the top of injection,
+ * before `indexFile` refreshes the anchor, so the stored hash is still the
+ * pre-write one and the comparison is meaningful. That is the whole trick --
+ * lazy is not wrong, it is merely too late.
+ *
+ * SYMBOL-LEVEL, and from ONE read. Re-locating each symbol by name and
+ * comparing its own span hash is what keeps this from degenerating into
+ * file-level marking: editing one function must not stale a finding about
+ * another, which is the property symbol nodes exist to provide.
+ *
+ * WEAKER EVIDENCE, STATED AS SUCH. There is no before text, so no diff can be
+ * built -- the finding is marked with the two hashes and `serve` reports the
+ * evidence gap through `staleEvidence: false`, which the renderer turns into
+ * "no diff could be rebuilt" rather than promising a diff and showing nothing.
+ * A stale finding with weak evidence is far better than one served as fresh,
+ * but the reader has to be able to tell which one they are holding.
+ */
+export function invalidateChangedAnchors(dir, graph, rawPath) {
+  const path = canonicalPath(rawPath);
+  const marked = [];
+
+  // ONE read for the file and every symbol in it. checkAnchor would have been
+  // the obvious reuse and it reads per anchor, which on a file with fifty
+  // symbols is fifty-one reads of the same bytes on a hook path.
+  let source = null;
+  try {
+    source = readAnySpelling(path);
+  } catch {
+    // Deleted, or unreadable from this checkout. Handled below as a change,
+    // because a finding about a file that is no longer there is exactly the
+    // kind that must not be served as fresh.
+  }
+
+  const changed = [];
+  const fileNode = graph.nodes.get(nodeId('file', path));
+  const fileDigest = source === null ? null : hash(source);
+  if (fileNode && fileDigest !== fileNode.hash) {
+    changed.push({ node: fileNode, from: fileNode.hash, to: fileDigest });
+  }
+
+  const current = new Map(
+    source === null
+      ? []
+      : extractSymbols(path, source).map((s) => [s.name, hash(spanText(source, s))])
+  );
+  for (const node of graph.nodes.values()) {
+    if (node.kind !== 'symbol' || node.file !== path) continue;
+    const digest = current.has(node.name) ? current.get(node.name) : null;
+    if (digest !== node.hash) changed.push({ node, from: node.hash, to: digest });
+  }
+
+  if (changed.length) {
+    // Indexed once by target, for the reason invalidateOnWrite indexes: the
+    // nested alternative is O(nodes x edges) inside a hook.
+    const byTarget = new Map();
+    for (const edge of graph.edges) {
+      if (edge.edge !== 'derived_from') continue;
+      if (!byTarget.has(edge.to)) byTarget.set(edge.to, []);
+      byTarget.get(edge.to).push(edge);
+    }
+
+    for (const { node, from, to } of changed) {
+      for (const edge of byTarget.get(node.id) || []) {
+        const finding = graph.nodes.get(edge.from);
+        if (!finding || finding.kind !== 'finding') continue;
+        // The same type gate serve() applies, for the same reason it is applied
+        // in invalidateOnWrite: the flag is STORED, and disclose.mjs skips a
+        // stale finding while utility.mjs penalises one by 160.
+        if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) continue;
+        // ALREADY MARKED IS LEFT ALONE. Whatever marked it first had a diff or
+        // a more specific reason; overwriting that with a hash pair trades real
+        // evidence for less.
+        if (finding.stale) continue;
+
+        putNode(dir, {
+          ...finding,
+          kind: 'finding',
+          key: finding.key,
+          stale: true,
+          staleReason:
+            to === null
+              ? `the ${node.kind} it depends on is no longer present (was ${from})`
+              : `content hash changed during this session (${from} -> ${to}), observed without a before/after pair`,
+          // EXPLICITLY EMPTY, not absent. serve() reports `staleEvidence` from
+          // whether a diff survived, and the renderer says "no diff could be
+          // rebuilt" -- so the reader can tell "changed, diff unknown" from
+          // "changed, here is what changed".
+          diff: '',
+        });
+        marked.push(finding.key);
+      }
+    }
+  }
+
+  // Re-index for the same reason the diff path does: otherwise every future
+  // retrieval re-reports a change that has already been accounted for.
+  if (source !== null) indexFile(dir, path, source);
   return marked;
 }
 

--- a/integrations/opencode/hooks/lib/staleness.mjs
+++ b/integrations/opencode/hooks/lib/staleness.mjs
@@ -574,8 +574,20 @@ function derivationCheck(graph, finding) {
  * This is the only function that should ever hand a finding to a model, because
  * it is the one that enforces the rule: a stale finding leaves here carrying
  * `stale: true` AND a diff, or it does not leave at all.
+ *
+ * AND IT CLEARS A STORED FLAG WHOSE EVIDENCE IS GONE, when given a `dir` to
+ * write to. Clearing used to be reachable only by a person pressing Re-verify in
+ * the dashboard, which left the rot path fully open on every install where
+ * nobody opens the dashboard -- and that is most of them. The evidence test is
+ * what makes clearing safe, and it does not care who triggered it: the same
+ * `claimTimeVerdict` runs here as in `reverify`, so this cannot clear anything
+ * the button would not.
+ *
+ * `dir` IS OPTIONAL, AND OMITTING IT MAKES THIS READ-ONLY. Several callers hold
+ * a graph without the directory it came from, and a serve that silently did
+ * nothing would be worse than one that plainly cannot write.
  */
-export function serve(graph, findings) {
+export function serve(graph, findings, { dir = null } = {}) {
   const served = [];
 
   // RETIRED FINDINGS STOP HERE, unconditionally.
@@ -603,8 +615,42 @@ export function serve(graph, findings) {
       continue;
     }
 
+    // AUTOMATIC CLEARING, on the same evidence the manual path demands.
+    //
+    // ONLY THE STORED FLAG IS TOUCHED. The lazy loop below is left to run
+    // exactly as before and can independently mark this finding stale again on
+    // its own comparison -- disk against the anchor NODE's hash -- which answers
+    // a different question and is not this function's to overrule. Eager and
+    // lazy stay two mechanisms, as the module header insists.
+    //
+    // AND THE FIELDS GO WITH THE FLAG. `putNode` does not merge and neither does
+    // this spread: serving `{ ...finding, stale: false }` would hand back a
+    // finding that reads fresh while still carrying `staleReason` and `diff`
+    // from the record -- stale and fresh at once, which is worse than either.
+    // So the cleared record, not the stored one, is what the rest of this
+    // iteration reads and spreads.
+    //
+    // BOUNDED, and the bound is the point: this runs only for a finding whose
+    // flag is already STORED, only when a `derivation` record exists to check
+    // against, and it reads each of that finding's anchors at most once. A
+    // finding that is not flagged pays nothing. The lazy loop below already
+    // reads every anchor of every content-dependent finding served, so the worst
+    // case is twice the anchor reads on the already-stale subset alone.
+    //
+    // NOT ON THE NON-CONTENT-DEPENDENT EARLY RETURN ABOVE, deliberately. Both
+    // eager paths refuse to flag those types at all, so a flag there can only
+    // come from an older graph -- and reading anchors for a type whose truth
+    // does not depend on them is exactly the cost `CONTENT_DEPENDENT` exists to
+    // avoid.
+    let record = finding;
+    if (dir && finding.stale && claimTimeVerdict(graph, finding) === 'match') {
+      clearStale(dir, finding.key, { graph });
+      const { stale: _s, staleReason: _r, diff: _d, staleEvidence: _e, ...cleared } = finding;
+      record = cleared;
+    }
+
     const anchors = graph.edges
-      .filter((e) => e.edge === 'derived_from' && e.from === finding.id)
+      .filter((e) => e.edge === 'derived_from' && e.from === record.id)
       .map((e) => graph.nodes.get(e.to))
       .filter(Boolean);
 
@@ -629,10 +675,10 @@ export function serve(graph, findings) {
     // A finding already marked stale eagerly, whose diff was captured at write
     // time, keeps that diff -- the eager path saw the change we can no longer
     // reconstruct from disk alone.
-    if (!stale && finding.stale) {
+    if (!stale && record.stale) {
       stale = true;
-      diff = finding.diff || '';
-      reason = finding.staleReason || 'marked stale when the change was observed';
+      diff = record.diff || '';
+      reason = record.staleReason || 'marked stale when the change was observed';
     }
 
     if (stale && !diff) {
@@ -681,13 +727,19 @@ export function serve(graph, findings) {
     }
 
     served.push({
-      ...finding,
+      ...record,
       stale,
       ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
+      // BOTH OTHER DISCLOSURES SURVIVE A MID-SERVE CLEAR. `dispute` was computed
+      // above the content-dependence branch and is applied here untouched, and
+      // the derivation verdict is recomputed from the record -- which still
+      // carries its `derivation`, since clearing removes only the staleness
+      // fields. A finding whose flag was just cleared is still disclosed as
+      // disputed, and still reports whether its derivation holds.
       ...dispute,
       // Independent of `stale` above: see `derivationCheck`'s own comment for
       // the case it catches that node-level staleness can miss.
-      ...derivationCheck(graph, finding),
+      ...derivationCheck(graph, record),
     });
   }
   return served;
@@ -939,8 +991,21 @@ function anchorHashNow(anchor) {
  * Exposing it to a hook, a tool argument or an HTTP action would be a way to
  * turn a stale finding fresh on request, which is exactly what must not exist.
  */
-export function clearStale(dir, key) {
-  const node = load(dir).nodes.get(nodeId('finding', key));
+export function clearStale(dir, key, { graph = null } = {}) {
+  // A CALLER THAT ALREADY HOLDS THE GRAPH PASSES IT, and this is not
+  // micro-optimisation: `load` re-parses the entire append-only log, so clearing
+  // inside `serve`'s loop re-read and re-folded the whole graph once PER cleared
+  // finding. Measured on 40 findings all stale and all revertible -- the shape a
+  // mass revert produces -- that was 185 ms against 25 ms, a 7x regression on
+  // the injection path, all of it graph loading rather than the hashing this
+  // feature is actually for. With the graph passed through it is back in line.
+  //
+  // No new race: this store is last-write-wins with no compare-and-set anywhere,
+  // and every other caller that spreads a node back -- `pin`, `retire`,
+  // `contradict`, `correct` -- writes from a graph it loaded earlier too. Both
+  // callers here already DECIDED on this snapshot, so re-reading it purely for
+  // the write narrowed no window that was ever closed.
+  const node = (graph || load(dir)).nodes.get(nodeId('finding', key));
   if (!node || node.kind !== 'finding') return false;
   const { stale, staleReason, diff, staleEvidence, ...rest } = node;
   // Nothing to clear is a success, not a write: an unconditional putNode here
@@ -989,14 +1054,33 @@ export function clearStale(dir, key) {
  * silently un-mark findings nobody asked about. Staleness is disclosed to a
  * reader who then decides; clearing is an explicit act.
  */
-export function reverify(dir, key) {
-  const graph = load(dir);
-  const finding = graph.nodes.get(nodeId('finding', key));
-  if (!finding || finding.kind !== 'finding') return 'unknown';
-  // Idempotent: the postcondition -- no stale flag on this finding -- already
-  // holds, and reporting anything else would make a caller retry forever.
-  if (!finding.stale) return 'cleared';
-
+/**
+ * THE ONE EVIDENCE TEST. Does this finding's anchored content still hash to what
+ * the claim was actually made against?
+ *
+ * `'match'` -- every anchor on disk re-hashes to the value frozen into this
+ * finding's own `derivation.anchors` at claim time. The content IS what the
+ * claim was derived from: a revert, or a write that never moved the anchored
+ * bytes.
+ * `'differs'` -- at least one anchor does not, INCLUDING an anchor whose content
+ * is gone. Deleted is a difference, not a missing measurement.
+ * `'unknown'` -- there is nothing to compare: no `derivation.anchors`, no
+ * anchors, an anchor with no recorded hash, or one that no longer resolves.
+ *
+ * SHARED BY BOTH CLEARING PATHS ON PURPOSE, and that sharing is the guarantee
+ * rather than a convenience. `reverify` (a person pressing Re-verify) and
+ * `serve` (automatic, on every retrieval) call THIS function and nothing else,
+ * so the automatic path cannot clear anything the button would not, and neither
+ * can drift from the other. Two copies of this comparison would be two policies,
+ * and the weaker one would win wherever it ran more often -- which is the
+ * automatic one.
+ *
+ * NOT `checkAnchor`, for the reason `anchorHashNow` above spells out: that
+ * compares disk against the anchor NODE's stored hash, which both eager paths
+ * re-point at the very bytes that caused the mark, so it answers "fresh" for
+ * exactly the finding it just marked stale.
+ */
+function claimTimeVerdict(graph, finding) {
   const recorded = finding.derivation && finding.derivation.anchors;
   if (!recorded || typeof recorded !== 'object') return 'unknown';
 
@@ -1019,10 +1103,23 @@ export function reverify(dir, key) {
     if (node.kind !== 'file' && node.kind !== 'symbol') return 'unknown';
     // null means the content is gone -- deleted file, vanished symbol. That is a
     // difference, not an absence of evidence.
-    if (anchorHashNow(node) !== expected) return 'still-stale';
+    if (anchorHashNow(node) !== expected) return 'differs';
   }
+  return 'match';
+}
 
-  clearStale(dir, key);
+export function reverify(dir, key) {
+  const graph = load(dir);
+  const finding = graph.nodes.get(nodeId('finding', key));
+  if (!finding || finding.kind !== 'finding') return 'unknown';
+  // Idempotent: the postcondition -- no stale flag on this finding -- already
+  // holds, and reporting anything else would make a caller retry forever.
+  if (!finding.stale) return 'cleared';
+
+  const verdict = claimTimeVerdict(graph, finding);
+  if (verdict === 'unknown') return 'unknown';
+  if (verdict === 'differs') return 'still-stale';
+  clearStale(dir, key, { graph });
   return 'cleared';
 }
 

--- a/integrations/opencode/hooks/lib/staleness.mjs
+++ b/integrations/opencode/hooks/lib/staleness.mjs
@@ -53,7 +53,7 @@
 import { readFileSync, statSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { dirname, join } from 'node:path';
-import { putNode, putEdge, contentHash, nodeId } from './wiki.mjs';
+import { putNode, putEdge, contentHash, nodeId, load } from './wiki.mjs';
 import { hasOutstandingContradiction } from './curate.mjs';
 import { extractSymbols, spanText, symbolKey, extractImports } from './symbols.mjs';
 import { canonicalPath, resolvableCandidates, isFsSafePath } from './paths.mjs';
@@ -488,7 +488,16 @@ function disputeOf(graph, finding) {
     // An edge end that resolves to nothing names nothing. The dispute is still
     // disclosed -- the gate above already established it -- but without a key
     // the reader cannot be pointed anywhere, and inventing one would be worse.
-    if (other && typeof other.key === 'string' && !keys.includes(other.key)) keys.push(other.key);
+    //
+    // A RETIRED END IS NOT NAMED EITHER, for a sharper reason: the disclosure
+    // tells the reader to `wiki_query` that key, and `serve` refuses to return
+    // a retired finding at all. Naming it points them at a claim they cannot
+    // fetch. `hasOutstandingContradiction` above already declines to open the
+    // gate when EVERY disputant is retired; this is the same rule applied to
+    // each name, so a live disputant is still reported alongside a withdrawn one.
+    if (other && !other.retired && typeof other.key === 'string' && !keys.includes(other.key)) {
+      keys.push(other.key);
+    }
   }
 
   return { contradicted: true, ...(keys.length ? { contradictedBy: keys.join(', ') } : {}) };
@@ -870,6 +879,151 @@ export function invalidateChangedAnchors(dir, graph, rawPath) {
   // retrieval re-reports a change that has already been accounted for.
   if (source !== null) indexFile(dir, path, source);
   return marked;
+}
+
+/**
+ * The current content hash of an anchor, read from disk.
+ *
+ * DELIBERATELY NOT `checkAnchor`, and the difference is the whole of this
+ * clearing rule. `checkAnchor` compares disk against the anchor NODE's stored
+ * hash, and both eager paths call `indexFile` immediately after marking --
+ * which re-points that hash at the very bytes that caused the mark. So
+ * `checkAnchor` answers "fresh" for exactly the finding it just marked stale,
+ * and a clearing rule built on it would clear every flag it was handed,
+ * unconditionally. This returns a bare hash instead, so the caller can compare
+ * it against the FROZEN claim-time hash rather than against a value the marking
+ * path itself moved.
+ *
+ * Returns null when no content can be read at all -- a deleted file, or a
+ * symbol that no longer exists. A caller must treat that as "changed", never as
+ * "unknown": a claim about content that is gone certainly does not match the
+ * content it was made against.
+ */
+function anchorHashNow(anchor) {
+  const path = anchor.kind === 'symbol' ? anchor.file : anchor.key;
+  let source;
+  try {
+    source = readAnySpelling(path);
+  } catch {
+    return null;
+  }
+  if (anchor.kind !== 'symbol') return hash(source);
+
+  // By NAME, like checkAnchor: line numbers shift whenever anything above is
+  // edited, and re-locating by line would report a symbol as moved when only an
+  // unrelated insert happened above it.
+  const current = extractSymbols(path, source).find((s) => s.name === anchor.name);
+  if (!current) return null;
+  return hash(spanText(source, current));
+}
+
+/**
+ * Removes the staleness fields from a finding. Returns whether one was found.
+ *
+ * THE WHOLE NODE IS REWRITTEN, because `putNode` does not merge: it writes a
+ * full record from what it is handed and `load` replaces the node wholesale.
+ * Writing `{ kind, key, stale: false }` would blank the claim, the confidence
+ * and the provenance -- an overwrite by another name, and the same trap
+ * `contradict` documents. So the fields are destructured AWAY and everything
+ * else is spread back: no deletion primitive is needed, and the append-only rule
+ * is respected.
+ *
+ * `staleEvidence` is stripped as well, even though no writer stores it. It is
+ * added by `serve` to the object it hands out, so anything that ever writes a
+ * served finding back would carry it in -- at which point a cleared finding
+ * would still be advertising the quality of the evidence for a flag it no longer
+ * has.
+ *
+ * A PRIMITIVE, NOT A ROUTE. Nothing outside this module calls it: the only
+ * shipping caller is `reverify` below, which establishes the evidence first.
+ * Exposing it to a hook, a tool argument or an HTTP action would be a way to
+ * turn a stale finding fresh on request, which is exactly what must not exist.
+ */
+export function clearStale(dir, key) {
+  const node = load(dir).nodes.get(nodeId('finding', key));
+  if (!node || node.kind !== 'finding') return false;
+  const { stale, staleReason, diff, staleEvidence, ...rest } = node;
+  // Nothing to clear is a success, not a write: an unconditional putNode here
+  // would append a duplicate record to the log on every no-op call.
+  if (stale === undefined && staleReason === undefined
+    && diff === undefined && staleEvidence === undefined) return true;
+  putNode(dir, { ...rest, kind: 'finding', key: node.key });
+  return true;
+}
+
+/**
+ * Clears a stale flag when, and only when, the evidence for it is gone.
+ *
+ * WHY THIS HAS TO EXIST. Nothing in this codebase ever cleared a `stale` flag.
+ * That was harmless while eager invalidation was dead code; it fires now, so
+ * every finding on an edited file becomes permanently stale -- and permanently
+ * discounted, since `disclose.mjs` skips a stale finding outright and
+ * `utility.mjs` penalises one by 160. The graph degrades toward all-stale, and
+ * the eager path is over-eager on top of that: `invalidateOnWrite` marks every
+ * finding anchored to a FILE node on any observed write to that file, whether or
+ * not the bytes moved.
+ *
+ * WHAT COUNTS AS EVIDENCE, AND WHY IT IS NOT NEGOTIABLE. The only trustworthy
+ * record of what a claim was made against is `derivation.anchors` -- the hash
+ * each anchor carried at the moment the finding was written, frozen into the
+ * finding itself by `harvest-write.mjs`. Disk is re-hashed here and compared
+ * against that. If every anchor matches, the content IS what the claim was
+ * derived from: a revert, or a write that never moved the anchored bytes. The
+ * flag comes off. Anything else leaves it exactly as it was.
+ *
+ * IT IS NOT A LAUNDERING ROUTE, and that is a property of the comparison rather
+ * than of who is allowed to call it. A caller cannot make a finding fresh by
+ * asking; they can only make it fresh by putting the content back. There is no
+ * argument, no force flag and no second path -- and `clearStale` above, the one
+ * function that clears without checking, has no caller but this one.
+ *
+ * NO RECORD MEANS UNKNOWN, NEVER CLEAR. A finding with no `derivation.anchors`
+ * -- every one written before that record existed, and every hand-curated one --
+ * has nothing to compare disk against. That is an absence of evidence, and
+ * resolving it to "clear it" would hand back the laundering route through the
+ * side door. It reports `unknown` and changes nothing; re-recording the claim
+ * against the current code (`curate.correct`) is the way forward for those.
+ *
+ * DELIBERATELY NOT AUTOMATIC. This reads every anchor off disk, so running it on
+ * the serve path would put N file reads inside injection -- and, worse, it would
+ * silently un-mark findings nobody asked about. Staleness is disclosed to a
+ * reader who then decides; clearing is an explicit act.
+ */
+export function reverify(dir, key) {
+  const graph = load(dir);
+  const finding = graph.nodes.get(nodeId('finding', key));
+  if (!finding || finding.kind !== 'finding') return 'unknown';
+  // Idempotent: the postcondition -- no stale flag on this finding -- already
+  // holds, and reporting anything else would make a caller retry forever.
+  if (!finding.stale) return 'cleared';
+
+  const recorded = finding.derivation && finding.derivation.anchors;
+  if (!recorded || typeof recorded !== 'object') return 'unknown';
+
+  const anchorIds = new Set(
+    graph.edges
+      .filter((e) => e.edge === 'derived_from' && e.from === finding.id)
+      .map((e) => e.to)
+  );
+  // An unanchored finding cannot be checked against anything, which is the
+  // un-invalidatable shape the anchor discipline exists to refuse. It is equally
+  // un-VERIFIABLE, so it is reported as such rather than cleared.
+  if (!anchorIds.size) return 'unknown';
+
+  for (const id of anchorIds) {
+    const expected = recorded[id];
+    const node = graph.nodes.get(id);
+    // An anchor this finding never recorded a hash for, or one that no longer
+    // resolves to a node: nothing to compare, so nothing is concluded.
+    if (typeof expected !== 'string' || !expected || !node) return 'unknown';
+    if (node.kind !== 'file' && node.kind !== 'symbol') return 'unknown';
+    // null means the content is gone -- deleted file, vanished symbol. That is a
+    // difference, not an absence of evidence.
+    if (anchorHashNow(node) !== expected) return 'still-stale';
+  }
+
+  clearStale(dir, key);
+  return 'cleared';
 }
 
 export { contentHash };

--- a/integrations/opencode/hooks/lib/staleness.mjs
+++ b/integrations/opencode/hooks/lib/staleness.mjs
@@ -368,6 +368,12 @@ const DIFF_MAX_BYTES = () => {
  * line, and total bytes. Every truncation is announced in the output, because a
  * silently shortened diff is worse than a visibly shortened one -- a reader who
  * cannot tell content was elided believes they saw the whole change.
+ *
+ * `maxLines` BOUNDS THE BODY, MARKERS INCLUDED: at most `maxLines` lines of
+ * removed lines, added lines and "... N more" elision markers between them, plus
+ * at most one final notice when the byte cap dropped lines -- so `maxLines + 1`
+ * lines in total, and no more. That last line is outside the budget on purpose,
+ * for the reason stated where it is pushed.
  */
 export function diffLines(
   before,
@@ -418,10 +424,24 @@ export function diffLines(
     bytes += size;
   };
 
-  for (const line of removed.slice(0, maxLines / 2)) push('- ' + line);
-  if (removed.length > maxLines / 2) push(`  ... ${removed.length - maxLines / 2} more removed`);
-  for (const line of added.slice(0, maxLines / 2)) push('+ ' + line);
-  if (added.length > maxLines / 2) push(`  ... ${added.length - maxLines / 2} more added`);
+  // THE ELISION MARKER IS PAID FOR OUT OF THE SIDE'S OWN QUOTA, so `maxLines`
+  // bounds the whole body rather than only the content in it. It did not: at the
+  // default 40 the body could reach 42 lines -- 20 removed, 20 added and two
+  // "... N more" markers -- and the out-of-budget notice below made 43, against
+  // a documented bound of 40 and a test asserting 41. Three numbers, no two the
+  // same. A side that has to elide now shows one fewer content line and spends
+  // that line on saying so, which is the trade a reader wants anyway: knowing
+  // that 300 lines were cut matters more than the 20th of the 20 shown.
+  const half = Math.floor(maxLines / 2);
+  const emit = (lines, prefix, label) => {
+    const elides = lines.length > half;
+    const shown = elides ? Math.max(0, half - 1) : half;
+    for (const line of lines.slice(0, shown)) push(prefix + line);
+    if (elides) push(`  ... ${lines.length - shown} more ${label}`);
+  };
+
+  emit(removed, '- ', 'removed');
+  emit(added, '+ ', 'added');
 
   // Announced OUTSIDE the budget, deliberately: the one line a reader most
   // needs is the one saying the rest is missing, and dropping it to stay under
@@ -479,6 +499,15 @@ function disputeOf(graph, finding) {
   if (!hasOutstandingContradiction(graph, finding.key)) return {};
 
   const keys = [];
+  // AND THE REASON A PERSON TYPED, which had no reader anywhere. `contradict`
+  // stores `contradictionReason` -- up to 400 characters of human explanation --
+  // on the CONTRADICTED end only, and nothing outside its own test ever read it:
+  // this disclosure named the other key and stopped, `audit` counts ends, and the
+  // dashboard detail view renders neither. So the one field on the edge that says
+  // WHY was written on every contradiction and seen by nobody. It is collected
+  // from whichever end holds it, so both sides of a dispute disclose the same
+  // reason rather than only the claim that lost.
+  let reason = typeof finding.contradictionReason === 'string' ? finding.contradictionReason : '';
   for (const edge of graph.edges) {
     if (edge.edge !== 'contradicts') continue;
     const otherId =
@@ -497,10 +526,30 @@ function disputeOf(graph, finding) {
     // each name, so a live disputant is still reported alongside a withdrawn one.
     if (other && !other.retired && typeof other.key === 'string' && !keys.includes(other.key)) {
       keys.push(other.key);
+      // A RETIRED END'S REASON IS NOT BORROWED EITHER, which is why this sits
+      // inside the same guard as the key: `hasOutstandingContradiction` can be
+      // open on one live disputant while another is withdrawn, and quoting the
+      // withdrawn one's explanation would attribute the live dispute to a claim
+      // the reader cannot fetch.
+      if (!reason && typeof other.contradictionReason === 'string') {
+        reason = other.contradictionReason;
+      }
     }
   }
 
-  return { contradicted: true, ...(keys.length ? { contradictedBy: keys.join(', ') } : {}) };
+  return {
+    contradicted: true,
+    ...(keys.length ? { contradictedBy: keys.join(', ') } : {}),
+    // Trimmed here rather than at the renderer: an empty string is not a reason,
+    // and a consumer checking `if (reason)` should not have to trim first.
+    //
+    // SET UNCONDITIONALLY, INCLUDING TO `undefined`. `serve` spreads the stored
+    // record before this object, so omitting the key would let a whitespace-only
+    // stored reason through untouched and make the served value differ from the
+    // one this function decided on. The disclosure is authoritative or it is not
+    // a disclosure.
+    contradictionReason: reason.trim() || undefined,
+  };
 }
 
 /**
@@ -580,8 +629,15 @@ function derivationCheck(graph, finding) {
  * the dashboard, which left the rot path fully open on every install where
  * nobody opens the dashboard -- and that is most of them. The evidence test is
  * what makes clearing safe, and it does not care who triggered it: the same
- * `claimTimeVerdict` runs here as in `reverify`, so this cannot clear anything
+ * `claimTimeEvidence` runs here as in `reverify`, so this cannot clear anything
  * the button would not.
+ *
+ * A CLEAR ALSO RE-INDEXES THE ANCHORS IT VERIFIED. The three disclosures this
+ * function emits -- `stale`, `derivationHolds`, and the dispute -- are computed
+ * from three different comparisons, and clearing the flag without moving the
+ * anchor's stored hash made the first two contradict the clear on the revert
+ * path. `reindexVerifiedAnchors` explains the reproduction and why re-pointing
+ * the index is the fix rather than suppressing the disclosures.
  *
  * `dir` IS OPTIONAL, AND OMITTING IT MAKES THIS READ-ONLY. Several callers hold
  * a graph without the directory it came from, and a serve that silently did
@@ -617,11 +673,17 @@ export function serve(graph, findings, { dir = null } = {}) {
 
     // AUTOMATIC CLEARING, on the same evidence the manual path demands.
     //
-    // ONLY THE STORED FLAG IS TOUCHED. The lazy loop below is left to run
-    // exactly as before and can independently mark this finding stale again on
-    // its own comparison -- disk against the anchor NODE's hash -- which answers
-    // a different question and is not this function's to overrule. Eager and
-    // lazy stay two mechanisms, as the module header insists.
+    // THE FLAG AND THE INDEX MOVE TOGETHER. Clearing the flag alone made this
+    // function contradict itself on the revert path: the lazy loop below
+    // compares disk against the anchor NODE's hash, which the eager path
+    // re-pointed at the post-edit bytes, so a reverted file read as `stale:
+    // true, staleReason: 'file changed'` and `derivationHolds: false` inside the
+    // very object whose flag had just been cleared for matching its claim-time
+    // content. `reindexVerifiedAnchors` writes the verified bytes' hash back to
+    // the anchor, so all three disclosures are finally reading the same content
+    // and cannot disagree. Eager and lazy stay two mechanisms, as the module
+    // header insists -- what changed is that the index no longer holds a hash
+    // that matches no version of the file that exists.
     //
     // AND THE FIELDS GO WITH THE FLAG. `putNode` does not merge and neither does
     // this spread: serving `{ ...finding, stale: false }` would hand back a
@@ -630,12 +692,37 @@ export function serve(graph, findings, { dir = null } = {}) {
     // So the cleared record, not the stored one, is what the rest of this
     // iteration reads and spreads.
     //
-    // BOUNDED, and the bound is the point: this runs only for a finding whose
-    // flag is already STORED, only when a `derivation` record exists to check
-    // against, and it reads each of that finding's anchors at most once. A
-    // finding that is not flagged pays nothing. The lazy loop below already
+    // BOUNDED PER CALL, and the bound is the point: this runs only for a finding
+    // whose flag is already STORED, only when a `derivation` record exists to
+    // check against, and it reads each of that finding's anchors at most once.
+    // A finding that is not flagged pays nothing. The lazy loop below already
     // reads every anchor of every content-dependent finding served, so the worst
     // case is twice the anchor reads on the already-stale subset alone.
+    //
+    // AND THE PER-SESSION SHAPE, stated because the per-call bound alone reads
+    // as cheaper than it is. Measured on a synthetic 40-stale-finding graph, the
+    // serve path went 158 ms -> 217 ms (+37%), and for a GENUINELY stale finding
+    // that cost recurs on every call for the whole session: the verdict is
+    // `'differs'` forever, nothing is cleared, and the reads are repaid with
+    // nothing. What keeps it survivable in practice is not this bound but two
+    // others -- `findingsFor`'s result limit and inject.mjs's `alreadyInjected`
+    // gate, which together put it near 40 ms on the first touch of a hot file
+    // and zero on the touches after.
+    //
+    // THE REVERT CASE PAYS ONCE, AND THAT IS MEASURED, not argued. Same 40
+    // findings, all revertible, medians of 9 across three process launches: the
+    // read-only serve is 23-29 ms, the first clearing serve is 141-173 ms (the
+    // anchor reads plus one node append per cleared finding AND per re-pointed
+    // anchor), and the SECOND clearing serve is 21-28 ms -- back to the
+    // read-only baseline, because the flag is off and the index agrees, so this
+    // gate no longer fires. What the re-index changed is not that cost -- the
+    // gate stopped firing once the flag came off before, too -- but that every
+    // serve after the clear used to re-derive `stale: true` and
+    // `derivationHolds: false` from an index nobody had moved. The extra ~120 ms
+    // buys silence that is actually correct.
+    // On the genuinely-stale set the recurring cost is
+    // real and unchanged in kind: 26-45 ms read-only against 53-105 ms with
+    // clearing on, every call, clearing nothing.
     //
     // NOT ON THE NON-CONTENT-DEPENDENT EARLY RETURN ABOVE, deliberately. Both
     // eager paths refuse to flag those types at all, so a flag there can only
@@ -643,10 +730,14 @@ export function serve(graph, findings, { dir = null } = {}) {
     // does not depend on them is exactly the cost `CONTENT_DEPENDENT` exists to
     // avoid.
     let record = finding;
-    if (dir && finding.stale && claimTimeVerdict(graph, finding) === 'match') {
-      clearStale(dir, finding.key, { graph });
-      const { stale: _s, staleReason: _r, diff: _d, staleEvidence: _e, ...cleared } = finding;
-      record = cleared;
+    if (dir && finding.stale) {
+      const evidence = claimTimeEvidence(graph, finding);
+      if (evidence.verdict === 'match') {
+        reindexVerifiedAnchors(dir, graph, evidence.contents);
+        clearStale(dir, finding.key, { graph });
+        const { stale: _s, staleReason: _r, diff: _d, staleEvidence: _e, ...cleared } = finding;
+        record = cleared;
+      }
     }
 
     const anchors = graph.edges
@@ -736,6 +827,14 @@ export function serve(graph, findings, { dir = null } = {}) {
       // carries its `derivation`, since clearing removes only the staleness
       // fields. A finding whose flag was just cleared is still disclosed as
       // disputed, and still reports whether its derivation holds.
+      //
+      // AND THEY NO LONGER CONTRADICT THE CLEAR. Surviving is not the same as
+      // agreeing: for a whole serve this returned `stale: true, staleReason:
+      // 'file changed'` and `derivationHolds: false` on a finding it had just
+      // cleared, because the clear was decided against disk while these two read
+      // the anchor node's hash, and the eager path had moved it. All three now
+      // read the same content because the clear re-points the anchor; see
+      // `reindexVerifiedAnchors`.
       ...dispute,
       // Independent of `stale` above: see `derivationCheck`'s own comment for
       // the case it catches that node-level staleness can miss.
@@ -934,6 +1033,34 @@ export function invalidateChangedAnchors(dir, graph, rawPath) {
 }
 
 /**
+ * The current content of an anchor, read from disk: the whole file for a file
+ * anchor, the located span for a symbol one. Null when nothing can be read.
+ *
+ * SPLIT OUT FROM `anchorHashNow` SO THE BYTES SURVIVE THE COMPARISON. The
+ * clearing path hashes this to reach a verdict and, on `'match'`, re-indexes the
+ * anchor from the same bytes -- see `reindexVerifiedAnchors`. Returning only a
+ * hash forced a second read of a file that had just been read, for content
+ * already known to be identical.
+ */
+function anchorContentNow(anchor) {
+  const path = anchor.kind === 'symbol' ? anchor.file : anchor.key;
+  let source;
+  try {
+    source = readAnySpelling(path);
+  } catch {
+    return null;
+  }
+  if (anchor.kind !== 'symbol') return source;
+
+  // By NAME, like checkAnchor: line numbers shift whenever anything above is
+  // edited, and re-locating by line would report a symbol as moved when only an
+  // unrelated insert happened above it.
+  const current = extractSymbols(path, source).find((s) => s.name === anchor.name);
+  if (!current) return null;
+  return spanText(source, current);
+}
+
+/**
  * The current content hash of an anchor, read from disk.
  *
  * DELIBERATELY NOT `checkAnchor`, and the difference is the whole of this
@@ -952,21 +1079,8 @@ export function invalidateChangedAnchors(dir, graph, rawPath) {
  * content it was made against.
  */
 function anchorHashNow(anchor) {
-  const path = anchor.kind === 'symbol' ? anchor.file : anchor.key;
-  let source;
-  try {
-    source = readAnySpelling(path);
-  } catch {
-    return null;
-  }
-  if (anchor.kind !== 'symbol') return hash(source);
-
-  // By NAME, like checkAnchor: line numbers shift whenever anything above is
-  // edited, and re-locating by line would report a symbol as moved when only an
-  // unrelated insert happened above it.
-  const current = extractSymbols(path, source).find((s) => s.name === anchor.name);
-  if (!current) return null;
-  return hash(spanText(source, current));
+  const content = anchorContentNow(anchor);
+  return content === null ? null : hash(content);
 }
 
 /**
@@ -1005,21 +1119,51 @@ export function clearStale(dir, key, { graph = null } = {}) {
   // `contradict`, `correct` -- writes from a graph it loaded earlier too. Both
   // callers here already DECIDED on this snapshot, so re-reading it purely for
   // the write narrowed no window that was ever closed.
-  const node = (graph || load(dir)).nodes.get(nodeId('finding', key));
+  const id = nodeId('finding', key);
+  const node = (graph || load(dir)).nodes.get(id);
   if (!node || node.kind !== 'finding') return false;
   const { stale, staleReason, diff, staleEvidence, ...rest } = node;
   // Nothing to clear is a success, not a write: an unconditional putNode here
   // would append a duplicate record to the log on every no-op call.
   if (stale === undefined && staleReason === undefined
     && diff === undefined && staleEvidence === undefined) return true;
-  putNode(dir, { ...rest, kind: 'finding', key: node.key });
+  const cleared = { ...rest, kind: 'finding', key: node.key };
+  putNode(dir, cleared);
+  // AND THE CALLER'S GRAPH IS UPDATED, because the guard above reads THAT graph,
+  // not disk. Without this, a second `serve` on the same in-memory graph object
+  // -- two touched files anchored to one finding, or a lifecycle branch that
+  // serves twice from a graph it loaded once, as SessionStart does -- still saw
+  // `stale: true`, re-ran the evidence test, and appended a byte-identical clear
+  // record. The store is append-only, so that is permanent log growth for no
+  // change in state, and the "nothing to clear is a success, not a write"
+  // guarantee directly above was only true of the first call.
+  if (graph) graph.nodes.set(id, { ...cleared, id });
   return true;
 }
 
 /**
- * Clears a stale flag when, and only when, the evidence for it is gone.
+ * THE ONE EVIDENCE TEST, plus the bytes it read. Does this finding's anchored
+ * content still hash to what the claim was actually made against?
  *
- * WHY THIS HAS TO EXIST. Nothing in this codebase ever cleared a `stale` flag.
+ * `verdict` is one of:
+ *   `'match'`   -- every anchor on disk re-hashes to the value frozen into this
+ *                  finding's own `derivation.anchors` at claim time. The content
+ *                  IS what the claim was derived from: a revert, or a write that
+ *                  never moved the anchored bytes.
+ *   `'differs'` -- at least one anchor does not, INCLUDING an anchor whose
+ *                  content is gone. Deleted is a difference, not a missing
+ *                  measurement.
+ *   `'unknown'` -- there is nothing to compare: no `derivation.anchors`, no
+ *                  anchors, an anchor with no recorded hash, or one that no
+ *                  longer resolves.
+ *
+ * `contents` carries the disk bytes read to reach a `'match'`, keyed by anchor
+ * id, so the caller can re-index those anchors without reading them again. It is
+ * empty for the other two verdicts, which read no further than the first
+ * disagreement.
+ *
+ * WHY CLEARING HAS TO EXIST AT ALL. Nothing in this codebase ever cleared a
+ * `stale` flag.
  * That was harmless while eager invalidation was dead code; it fires now, so
  * every finding on an edited file becomes permanently stale -- and permanently
  * discounted, since `disclose.mjs` skips a stale finding outright and
@@ -1049,24 +1193,6 @@ export function clearStale(dir, key, { graph = null } = {}) {
  * side door. It reports `unknown` and changes nothing; re-recording the claim
  * against the current code (`curate.correct`) is the way forward for those.
  *
- * DELIBERATELY NOT AUTOMATIC. This reads every anchor off disk, so running it on
- * the serve path would put N file reads inside injection -- and, worse, it would
- * silently un-mark findings nobody asked about. Staleness is disclosed to a
- * reader who then decides; clearing is an explicit act.
- */
-/**
- * THE ONE EVIDENCE TEST. Does this finding's anchored content still hash to what
- * the claim was actually made against?
- *
- * `'match'` -- every anchor on disk re-hashes to the value frozen into this
- * finding's own `derivation.anchors` at claim time. The content IS what the
- * claim was derived from: a revert, or a write that never moved the anchored
- * bytes.
- * `'differs'` -- at least one anchor does not, INCLUDING an anchor whose content
- * is gone. Deleted is a difference, not a missing measurement.
- * `'unknown'` -- there is nothing to compare: no `derivation.anchors`, no
- * anchors, an anchor with no recorded hash, or one that no longer resolves.
- *
  * SHARED BY BOTH CLEARING PATHS ON PURPOSE, and that sharing is the guarantee
  * rather than a convenience. `reverify` (a person pressing Re-verify) and
  * `serve` (automatic, on every retrieval) call THIS function and nothing else,
@@ -1080,9 +1206,10 @@ export function clearStale(dir, key, { graph = null } = {}) {
  * re-point at the very bytes that caused the mark, so it answers "fresh" for
  * exactly the finding it just marked stale.
  */
-function claimTimeVerdict(graph, finding) {
+function claimTimeEvidence(graph, finding) {
+  const none = { verdict: 'unknown', contents: new Map() };
   const recorded = finding.derivation && finding.derivation.anchors;
-  if (!recorded || typeof recorded !== 'object') return 'unknown';
+  if (!recorded || typeof recorded !== 'object') return none;
 
   const anchorIds = new Set(
     graph.edges
@@ -1092,22 +1219,122 @@ function claimTimeVerdict(graph, finding) {
   // An unanchored finding cannot be checked against anything, which is the
   // un-invalidatable shape the anchor discipline exists to refuse. It is equally
   // un-VERIFIABLE, so it is reported as such rather than cleared.
-  if (!anchorIds.size) return 'unknown';
+  if (!anchorIds.size) return none;
 
+  const contents = new Map();
   for (const id of anchorIds) {
     const expected = recorded[id];
     const node = graph.nodes.get(id);
     // An anchor this finding never recorded a hash for, or one that no longer
     // resolves to a node: nothing to compare, so nothing is concluded.
-    if (typeof expected !== 'string' || !expected || !node) return 'unknown';
-    if (node.kind !== 'file' && node.kind !== 'symbol') return 'unknown';
+    if (typeof expected !== 'string' || !expected || !node) return none;
+    if (node.kind !== 'file' && node.kind !== 'symbol') return none;
     // null means the content is gone -- deleted file, vanished symbol. That is a
     // difference, not an absence of evidence.
-    if (anchorHashNow(node) !== expected) return 'differs';
+    const content = anchorContentNow(node);
+    if (content === null || hash(content) !== expected) {
+      return { verdict: 'differs', contents: new Map() };
+    }
+    contents.set(id, content);
   }
-  return 'match';
+  return { verdict: 'match', contents };
 }
 
+/** The verdict alone, for callers that do not re-index. */
+function claimTimeVerdict(graph, finding) {
+  return claimTimeEvidence(graph, finding).verdict;
+}
+
+/**
+ * Re-points every verified anchor at the content the evidence test just read.
+ *
+ * WHY A CLEAR IS NOT ENOUGH ON ITS OWN, reproduced end to end: index a file at
+ * H1, write a finding whose `derivation.anchors` records H1, edit and re-index so
+ * the node holds H2, let the eager path mark the finding, then REVERT the edit on
+ * disk. `claimTimeVerdict` now says `'match'` -- disk is H1, which is exactly
+ * what the claim was derived from -- and the flag comes off. But the node still
+ * holds H2, so the same `serve` call went on to emit `stale: true` with
+ * `staleReason: 'file changed'` from the lazy loop (disk H1 against node H2) and
+ * `derivationHolds: false` from `derivationCheck` (index H2 against claim H1).
+ * The model was shown DERIVATION CHANGED and STALE at the exact moment this
+ * module's own evidence test had concluded the derivation holds -- on every
+ * serve, until something unrelated happened to re-index the anchor.
+ *
+ * THE FIX IS TO MOVE THE INDEX, NOT TO SILENCE THE DISCLOSURES. Suppressing the
+ * lazy check and the derivation verdict for a cleared finding would leave the
+ * graph holding a hash that matches no version of the file that exists, so every
+ * OTHER finding on that anchor keeps reading stale, and the next reader has to be
+ * told which disclosures to disbelieve. The node hash is simply out of date, the
+ * bytes are already in hand from the comparison that just succeeded, and writing
+ * them makes all three disclosures agree because they are finally reading the
+ * same content.
+ *
+ * COSTS NO READ. `contents` comes from `claimTimeEvidence`, which read each
+ * anchor to reach `'match'`. The write is one node record per anchor whose hash
+ * actually moved, and it happens once per revert rather than once per serve: with
+ * the index re-pointed, the flag stays off and the gate in `serve` does not fire
+ * again.
+ *
+ * THE IN-MEMORY GRAPH IS UPDATED TOO, because the caller is mid-serve and is
+ * about to read these same nodes through the lazy loop and `derivationCheck`.
+ * Writing only to disk would fix the next process and leave this one contradicting
+ * itself, which is the whole defect.
+ *
+ * Line numbers are deliberately left alone on a symbol anchor: `checkAnchor` and
+ * `anchorContentNow` both re-locate by NAME, so a stored line is informational,
+ * and the body being byte-identical is what was just established.
+ */
+function reindexVerifiedAnchors(dir, graph, contents) {
+  for (const [id, content] of contents) {
+    const node = graph.nodes.get(id);
+    if (!node) continue;
+    const nextHash = hash(content);
+    // Already agrees: no record, no write. The common case once a revert has
+    // been accounted for.
+    if (node.hash === nextHash) continue;
+    const limit = node.kind === 'symbol' ? symbolSnapshotLimit() : snapshotLimit();
+    // Same bound as `indexFile`: past the cap the hash still drives staleness and
+    // only the reconstructed diff degrades.
+    const snapshot = content.length <= limit ? content : undefined;
+    const { hash: _h, snapshot: _s, ...rest } = node;
+    try {
+      putNode(dir, { ...rest, kind: node.kind, key: node.key, hash: nextHash, snapshot });
+    } catch {
+      // Fail open: a graph that could not be written is a disclosure that stays
+      // as it was, never a broken tool call. The in-memory copy is left alone to
+      // match, so this serve keeps agreeing with the store.
+      continue;
+    }
+    graph.nodes.set(id, { ...node, hash: nextHash, ...(snapshot ? { snapshot } : {}) });
+  }
+}
+
+/**
+ * Clears a stale flag on behalf of a person who asked for it -- the dashboard's
+ * Re-verify action -- and reports what the evidence said.
+ *
+ * `'cleared'` when the flag is gone (including when it was already gone, so a
+ * caller polling this does not retry forever), `'still-stale'` when the anchored
+ * content genuinely differs from what the claim was made against, `'unknown'`
+ * when there is nothing to compare and therefore nothing to conclude.
+ *
+ * NO LONGER THE ONLY CLEARING PATH, and the docblock that used to sit here said
+ * the opposite: that automatic clearing was refused because it would put N file
+ * reads inside injection and "silently un-mark findings nobody asked about".
+ * `serve` now does exactly that, on the same evidence, for the reason its own
+ * comment gives -- the manual path was reachable only where somebody opens the
+ * dashboard, which is almost nowhere, so the rot path stayed open on most
+ * installs. What survives of that objection is the cost, which `serve` bounds
+ * and states.
+ *
+ * WHAT THIS STILL ADDS over the automatic path: it loads the graph itself, so a
+ * caller holding nothing but a key and a directory can act; it reports the
+ * verdict rather than folding it into a served record; and it runs on demand
+ * rather than only when the finding happens to be retrieved. It re-indexes the
+ * verified anchors for the same reason `serve` does -- otherwise the button
+ * clears the flag and the very next retrieval re-derives a contradiction from a
+ * node hash nobody moved.
+ */
 export function reverify(dir, key) {
   const graph = load(dir);
   const finding = graph.nodes.get(nodeId('finding', key));
@@ -1116,9 +1343,10 @@ export function reverify(dir, key) {
   // holds, and reporting anything else would make a caller retry forever.
   if (!finding.stale) return 'cleared';
 
-  const verdict = claimTimeVerdict(graph, finding);
+  const { verdict, contents } = claimTimeEvidence(graph, finding);
   if (verdict === 'unknown') return 'unknown';
   if (verdict === 'differs') return 'still-stale';
+  reindexVerifiedAnchors(dir, graph, contents);
   clearStale(dir, key, { graph });
   return 'cleared';
 }

--- a/integrations/opencode/hooks/lib/staleness.mjs
+++ b/integrations/opencode/hooks/lib/staleness.mjs
@@ -17,7 +17,13 @@
  * TWO INVALIDATION PATHS, and each covers what the other cannot see:
  *
  *   EAGER  -- our PostToolUse hook saw a write, so the finding is marked at the
- *             moment it went stale, with the exact before/after in hand.
+ *             moment it went stale, with the exact before/after in hand. The
+ *             hook does not call `invalidateOnWrite` directly: it queues the
+ *             evidence through pending.mjs, and the next graph read -- which
+ *             loads the graph anyway -- applies it before serving anything.
+ *             That path is also the only one that catches a write the SESSION
+ *             made, because the lazy check below compares the stored hash
+ *             against disk and `indexFile` has already refreshed it.
  *   LAZY   -- at retrieval, the anchor's stored hash is compared against disk.
  *             This is what catches `git pull`, another editor, a teammate, or a
  *             build step: every change our hooks never observed.
@@ -291,14 +297,69 @@ export function checkAnchor(anchor) {
 }
 
 /**
+ * Characters kept from any single diff line.
+ *
+ * A LINE CAP IS NOT A SIZE CAP, and the gap was measured: with only `maxLines`
+ * in force, `diffLines('X'.repeat(200000), 'Y'.repeat(200000))` returned 2 lines
+ * and 400,005 bytes. Minified bundles, generated sources and single-line JSON
+ * all have that shape, and this output goes STRAIGHT INTO MODEL CONTEXT from
+ * inject.mjs's zero-turn refusal -- so a line bound alone let one pathological
+ * file spend hundreds of thousands of tokens.
+ *
+ * 200 characters is chosen because it is past the width at which a line is read
+ * as a line by anybody, human or model: a hand-written source line is under
+ * ~120 columns, so the cap cannot truncate a diff a reader was going to use,
+ * while the cases it does truncate are ones where the interesting change is not
+ * legible from the raw text anyway.
+ */
+const DIFF_MAX_LINE_CHARS = () => {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_DIFF_MAX_LINE_CHARS);
+  return Number.isFinite(raw) && raw > 0 ? raw : 200;
+};
+
+/**
+ * Total UTF-8 bytes of diff body.
+ *
+ * 4,000 bytes is roughly 1,000 tokens. It is deliberately larger than the
+ * per-file injection budget (`TOKEN_OPTIMIZER_TOUCH_BUDGET`, 500 tokens) and
+ * far smaller than a file, because the two consumers want different things: the
+ * injection surface fits the diff inside its own budget and drops it if it does
+ * not fit, while the zero-turn refusal is replacing a whole file read and can
+ * afford more. One cap that neither consumer has to think about is worth more
+ * than two tuned ones.
+ *
+ * WHAT IT COSTS, PLAINLY: a legitimately large diff now arrives truncated, so a
+ * model looking at a 300-line refactor sees the head of it and a count of what
+ * was elided rather than the whole change. That is the correct direction to
+ * fail -- the alternative was a bounded-looking function that could emit 400 KB.
+ */
+const DIFF_MAX_BYTES = () => {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_DIFF_MAX_BYTES);
+  return Number.isFinite(raw) && raw > 0 ? raw : 4_000;
+};
+
+/**
  * A compact line diff.
  *
  * Deliberately not a full unified diff with hunks and context: the consumer is
  * a model deciding whether an existing conclusion still holds, and for that the
  * changed lines are the signal. Output is capped because an unbounded diff
  * injected alongside a finding would spend more tokens than re-deriving it.
+ *
+ * BOUNDED IN THREE WAYS, and each one is load-bearing: lines, characters per
+ * line, and total bytes. Every truncation is announced in the output, because a
+ * silently shortened diff is worse than a visibly shortened one -- a reader who
+ * cannot tell content was elided believes they saw the whole change.
  */
-export function diffLines(before, after, { maxLines = 40 } = {}) {
+export function diffLines(
+  before,
+  after,
+  {
+    maxLines = 40,
+    maxLineChars = DIFF_MAX_LINE_CHARS(),
+    maxBytes = DIFF_MAX_BYTES(),
+  } = {}
+) {
   const a = String(before).split('\n');
   const b = String(after).split('\n');
 
@@ -314,33 +375,44 @@ export function diffLines(before, after, { maxLines = 40 } = {}) {
   const added = b.slice(head, b.length - tail);
 
   const out = [];
-  for (const line of removed.slice(0, maxLines / 2)) out.push('- ' + line);
-  if (removed.length > maxLines / 2) out.push(`  ... ${removed.length - maxLines / 2} more removed`);
-  for (const line of added.slice(0, maxLines / 2)) out.push('+ ' + line);
-  if (added.length > maxLines / 2) out.push(`  ... ${added.length - maxLines / 2} more added`);
+  let bytes = 0;
+  let dropped = 0;
+
+  // Per line first, so ONE enormous line cannot consume the whole budget and
+  // leave every other changed line unrepresented.
+  const clamp = (line) => {
+    const text = String(line);
+    if (text.length <= maxLineChars) return text;
+    return `${text.slice(0, maxLineChars)} [+${text.length - maxLineChars} chars cut]`;
+  };
+
+  // Bytes, not characters: the cap exists to bound what is sent, and a
+  // multi-byte source file would otherwise pass a character check while
+  // emitting several times the budget.
+  const push = (line) => {
+    const text = clamp(line);
+    const size = Buffer.byteLength(text, 'utf8') + 1;
+    if (bytes + size > maxBytes) {
+      dropped++;
+      return;
+    }
+    out.push(text);
+    bytes += size;
+  };
+
+  for (const line of removed.slice(0, maxLines / 2)) push('- ' + line);
+  if (removed.length > maxLines / 2) push(`  ... ${removed.length - maxLines / 2} more removed`);
+  for (const line of added.slice(0, maxLines / 2)) push('+ ' + line);
+  if (added.length > maxLines / 2) push(`  ... ${added.length - maxLines / 2} more added`);
+
+  // Announced OUTSIDE the budget, deliberately: the one line a reader most
+  // needs is the one saying the rest is missing, and dropping it to stay under
+  // a self-imposed cap would hand back a diff that lies about being complete.
+  if (dropped) out.push(`  ... ${dropped} more changed line(s) cut at the size limit`);
 
   return out.join('\n');
 }
 
-/**
- * Prepares findings for delivery, verifying each one lazily against disk.
- *
- * This is the only function that should ever hand a finding to a model, because
- * it is the one that enforces the rule: a stale finding leaves here carrying
- * `stale: true` AND a diff, or it does not leave at all.
- */
-export function serve(graph, findings) {
-  const served = [];
-
-  // RETIRED FINDINGS STOP HERE, unconditionally.
-  //
-  // findingsFor and sessionIndex already filter them, so this is redundant on
-  // every current path -- deliberately. This function's own contract is that it
-  // is the only thing that hands a finding to a model, which makes it the right
-  // place for the guarantee to live: a future caller that reaches into the
-  // graph directly cannot accidentally serve a claim a human explicitly
-  // withdrew. A withheld claim reappearing is not a bug anyone would notice
-  // quickly.
 /**
  * Types whose truth is a claim ABOUT the anchor's contents.
  *
@@ -363,6 +435,26 @@ export function serve(graph, findings) {
  * to ignore -- taking the rare true positive with it.
  */
 const CONTENT_DEPENDENT = new Set(['finding', 'map']);
+
+/**
+ * Prepares findings for delivery, verifying each one lazily against disk.
+ *
+ * This is the only function that should ever hand a finding to a model, because
+ * it is the one that enforces the rule: a stale finding leaves here carrying
+ * `stale: true` AND a diff, or it does not leave at all.
+ */
+export function serve(graph, findings) {
+  const served = [];
+
+  // RETIRED FINDINGS STOP HERE, unconditionally.
+  //
+  // findingsFor and sessionIndex already filter them, so this is redundant on
+  // every current path -- deliberately. This function's own contract is that it
+  // is the only thing that hands a finding to a model, which makes it the right
+  // place for the guarantee to live: a future caller that reaches into the
+  // graph directly cannot accidentally serve a claim a human explicitly
+  // withdrew. A withheld claim reappearing is not a bug anyone would notice
+  // quickly.
 
   for (const finding of findings.filter((f) => !f.retired)) {
     // A claim that does not depend on the anchor's contents cannot be
@@ -505,6 +597,15 @@ export function invalidateOnWrite(dir, graph, rawPath, beforeText, afterText) {
     for (const edge of byTarget.get(node.id) || []) {
       const finding = graph.nodes.get(edge.from);
       if (!finding || finding.kind !== 'finding') continue;
+      // THE SAME TYPE GATE `serve` APPLIES, and it has to be here too now that
+      // this path actually runs. `serve` ignores a stale flag on a type whose
+      // truth is not a claim about the anchor's contents -- but the flag is
+      // STORED, and disclose.mjs skips a stale finding outright while
+      // utility.mjs penalises one by 160. So writing it onto a `failure` or a
+      // `command` would suppress that claim everywhere except the one reader
+      // that knows to ignore it, which is exactly the harm measured in the
+      // comment on CONTENT_DEPENDENT above.
+      if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) continue;
 
       putNode(dir, {
         ...finding,

--- a/integrations/opencode/hooks/lib/staleness.mjs
+++ b/integrations/opencode/hooks/lib/staleness.mjs
@@ -495,6 +495,54 @@ function disputeOf(graph, finding) {
 }
 
 /**
+ * Whether THIS finding's own claim-time evidence still matches its anchors --
+ * the reader `harvest-write.mjs`'s `derivation` record was written for.
+ * Nothing consumed that record until now: a grep for it found only the writer
+ * and its own tests, which made "checkable rather than merely attributed" a
+ * claim with no code behind it.
+ *
+ * DISTINCT FROM `stale`/`checkAnchor`, DELIBERATELY, not a duplicate of it.
+ * `checkAnchor` compares disk against the anchor NODE's CURRENT stored hash,
+ * which is refreshed by `indexFile` every time ANYTHING touches that file --
+ * so it answers "has this file changed since the last time anyone indexed
+ * it", not "has it changed since THIS finding was derived from it". Those
+ * differ in a real case: file F changes, and a LATER, unrelated write
+ * (another finding, another session) re-indexes F, updating the node's
+ * stored hash to match the new content again. `checkAnchor` now reports
+ * "fresh" -- disk matches the node's current hash -- while this finding's own
+ * frozen `derivation.anchors[id]` snapshot, taken when IT was written, no
+ * longer matches. The bytes this claim was actually derived from are gone,
+ * and `stale` alone would never say so.
+ *
+ * Returns `{}` when there is nothing to check (no `derivation.anchors`
+ * recorded -- true of every finding written before this existed), so a
+ * caller can tell "not checked" from "checked and holds" by whether
+ * `derivationHolds` is present at all.
+ */
+function derivationCheck(graph, finding) {
+  const recorded = finding.derivation && finding.derivation.anchors;
+  if (!recorded || typeof recorded !== 'object') return {};
+  const ids = Object.keys(recorded);
+  if (!ids.length) return {};
+
+  const changed = [];
+  for (const id of ids) {
+    const node = graph.nodes.get(id);
+    const currentHash = node && typeof node.hash === 'string' ? node.hash : null;
+    // An anchor that no longer resolves at all cannot be confirmed either --
+    // treated the same as a changed hash, never as "still holds" by default.
+    if (currentHash === null || currentHash !== recorded[id]) {
+      changed.push(node && typeof node.key === 'string' ? node.key : id);
+    }
+  }
+
+  if (!changed.length) return { derivationHolds: true };
+  // Bounded: a finding with many anchors should not spend unbounded budget
+  // naming every one that moved.
+  return { derivationHolds: false, derivationChanged: changed.slice(0, 5) };
+}
+
+/**
  * Prepares findings for delivery, verifying each one lazily against disk.
  *
  * This is the only function that should ever hand a finding to a model, because
@@ -611,6 +659,9 @@ export function serve(graph, findings) {
       stale,
       ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
       ...dispute,
+      // Independent of `stale` above: see `derivationCheck`'s own comment for
+      // the case it catches that node-level staleness can miss.
+      ...derivationCheck(graph, finding),
     });
   }
   return served;

--- a/integrations/opencode/hooks/lib/staleness.mjs
+++ b/integrations/opencode/hooks/lib/staleness.mjs
@@ -518,6 +518,21 @@ function disputeOf(graph, finding) {
  * recorded -- true of every finding written before this existed), so a
  * caller can tell "not checked" from "checked and holds" by whether
  * `derivationHolds` is present at all.
+ *
+ * `derivationHolds: true` MEANS "MATCHES THE ANCHOR NODE'S LAST-INDEXED
+ * HASH", NOT "MATCHES DISK RIGHT NOW" -- and that distinction is stored in
+ * `derivationCheckedAgainst: 'index'` rather than left for a `wiki_query`
+ * consumer to infer from a field name alone. Two ways to close this gap were
+ * considered: recompute a live hash from disk here, or document precisely
+ * what is actually compared. `stale` (via `checkAnchor`, above) ALREADY owns
+ * the disk comparison -- re-reading the same file a second time on the same
+ * serve path, for the same anchor, from a second mechanism, is worse than
+ * one honest name. So: documented, not duplicated. A file changed on disk
+ * but never re-indexed by anything is still caught, correctly, by `stale`;
+ * `derivationHolds` answers a narrower, complementary question -- whether
+ * the LAST INDEXED state agrees with what this specific finding recorded --
+ * which is exactly the re-indexed-by-something-else case above that `stale`
+ * cannot see.
  */
 function derivationCheck(graph, finding) {
   const recorded = finding.derivation && finding.derivation.anchors;
@@ -536,10 +551,12 @@ function derivationCheck(graph, finding) {
     }
   }
 
-  if (!changed.length) return { derivationHolds: true };
+  // Declared on BOTH branches, not only the ambiguous one: a consumer should
+  // not have to already know the answer to know what was checked.
+  if (!changed.length) return { derivationHolds: true, derivationCheckedAgainst: 'index' };
   // Bounded: a finding with many anchors should not spend unbounded budget
   // naming every one that moved.
-  return { derivationHolds: false, derivationChanged: changed.slice(0, 5) };
+  return { derivationHolds: false, derivationChanged: changed.slice(0, 5), derivationCheckedAgainst: 'index' };
 }
 
 /**

--- a/integrations/opencode/hooks/lib/staleness.mjs
+++ b/integrations/opencode/hooks/lib/staleness.mjs
@@ -54,6 +54,7 @@ import { readFileSync, statSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { dirname, join } from 'node:path';
 import { putNode, putEdge, contentHash, nodeId } from './wiki.mjs';
+import { hasOutstandingContradiction } from './curate.mjs';
 import { extractSymbols, spanText, symbolKey, extractImports } from './symbols.mjs';
 import { canonicalPath, resolvableCandidates, isFsSafePath } from './paths.mjs';
 
@@ -454,6 +455,46 @@ export function diffLines(
 const CONTENT_DEPENDENT = new Set(['finding', 'map']);
 
 /**
+ * What, if anything, currently disagrees with this finding.
+ *
+ * DISCLOSED AT SERVE TIME, because that is the only moment the disagreement can
+ * do any good. `WIKI_GRAPH.md`'s whole argument for making `contradicts` an edge
+ * rather than an overwrite is that a reader "sees both claims and the
+ * disagreement between them" -- so handing a finding to a model while something
+ * in the graph disputes it, without saying so, throws away the reason the edge
+ * was recorded instead of an overwrite.
+ *
+ * `hasOutstandingContradiction` is the gate: it is the one definition of "an
+ * open dispute", shared with the confidence-promotion gate, so the two can never
+ * disagree about what counts. The loop only NAMES the other side, and it names a
+ * key rather than quoting a claim because the reader can call `wiki_query` with
+ * a key -- and because the injection path pays for every character it renders.
+ *
+ * SEPARATE FROM STALENESS on purpose. A finding can be disputed without being
+ * stale (nothing touched its anchor; another finding simply says otherwise) and
+ * stale without being disputed, so this adds its own fields rather than
+ * borrowing the stale ones, and the renderer discloses each on its own terms.
+ */
+function disputeOf(graph, finding) {
+  if (!hasOutstandingContradiction(graph, finding.key)) return {};
+
+  const keys = [];
+  for (const edge of graph.edges) {
+    if (edge.edge !== 'contradicts') continue;
+    const otherId =
+      edge.from === finding.id ? edge.to : edge.to === finding.id ? edge.from : null;
+    if (!otherId) continue;
+    const other = graph.nodes.get(otherId);
+    // An edge end that resolves to nothing names nothing. The dispute is still
+    // disclosed -- the gate above already established it -- but without a key
+    // the reader cannot be pointed anywhere, and inventing one would be worse.
+    if (other && typeof other.key === 'string' && !keys.includes(other.key)) keys.push(other.key);
+  }
+
+  return { contradicted: true, ...(keys.length ? { contradictedBy: keys.join(', ') } : {}) };
+}
+
+/**
  * Prepares findings for delivery, verifying each one lazily against disk.
  *
  * This is the only function that should ever hand a finding to a model, because
@@ -474,10 +515,17 @@ export function serve(graph, findings) {
   // quickly.
 
   for (const finding of findings.filter((f) => !f.retired)) {
+    // A DISPUTE TRAVELS WITH EVERY TYPE, which is why it is computed before the
+    // content-dependence branch below. A `command` or `rule` finding cannot be
+    // invalidated by an anchor's contents, but another finding can still
+    // disagree with it, and this early return is the path that would have
+    // quietly dropped that.
+    const dispute = disputeOf(graph, finding);
+
     // A claim that does not depend on the anchor's contents cannot be
     // invalidated by them. It is served as-is rather than discounted.
     if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) {
-      served.push({ ...finding });
+      served.push({ ...finding, ...dispute });
       continue;
     }
 
@@ -562,6 +610,7 @@ export function serve(graph, findings) {
       ...finding,
       stale,
       ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
+      ...dispute,
     });
   }
   return served;

--- a/integrations/opencode/hooks/lib/waste.mjs
+++ b/integrations/opencode/hooks/lib/waste.mjs
@@ -151,6 +151,11 @@ function reDerivation(events, graph) {
       const id = nodeId('file', canonicalPath(row.anchor));
       if (!graph.nodes.has(id)) continue;
 
+      // READ-ONLY serve: no `dir` is threaded here, so this cannot clear a stale
+      // flag whose evidence is gone. That is deliberate -- this function takes a
+      // graph, not the directory it came from, and widening its signature to give
+      // an analysis path a write capability buys nothing: the injection path runs
+      // on every tool call and clears the same findings.
       const findings = serve(graph, findingsFor(graph, id, { limit: 3 }))
         .filter((f) => !f.stale && (f.confidence ?? 0) >= 0.7);
       if (!findings.length) continue;

--- a/integrations/opencode/hooks/lib/wiki.mjs
+++ b/integrations/opencode/hooks/lib/wiki.mjs
@@ -64,18 +64,37 @@ export const SUPPORTED_VERSIONS = [1];
  * Identity today because GRAPH_VERSION is 1 and no shape has changed. It exists
  * now so the first change that DOES need it has somewhere to go other than an
  * equality check that silently deletes user data.
+ *
+ * CONTRACT for the first non-identity step:
+ *  - It must be IDEMPOTENT. `upcast(upcast(r))` must equal `upcast(r)`, because
+ *    compaction upcasts a record to key it and `load` upcasts the same record
+ *    again on every subsequent read. A step that is not idempotent applies twice
+ *    to anything compaction has touched.
+ *  - It must NOT be relied on to restamp `v`. Nothing in this file writes an
+ *    upcast record back to disk under a version it did not come from; the
+ *    version stamp on disk is always the one that wrote the bytes. See the
+ *    per-branch comments in `compactIfWasteful`.
  */
 export function upcast(record) {
   return record;
 }
 
-/** True when this reader can interpret the record at all. */
-function readable(record) {
+/**
+ * True when this reader can interpret the record at all.
+ *
+ * `versions` is a PARAMETER so the range semantics are testable independently of
+ * today's constants. With `SUPPORTED_VERSIONS = [1]` and `GRAPH_VERSION = 1` a
+ * range check and the old equality check are extensionally identical, so a test
+ * pinned to the live constants cannot tell them apart -- and cannot fail if
+ * someone reverts this to an equality. Exercised against `[1, 2]`, it can.
+ */
+export function readable(record, versions = SUPPORTED_VERSIONS) {
   const version = record.v ?? 0;
   // Forward-incompatible records are skipped: a v-from-the-future was written by
-  // a newer client and we cannot know its shape. Ignoring the future is safe;
-  // ignoring the past is data loss.
-  return SUPPORTED_VERSIONS.includes(version);
+  // a newer client and we cannot know its shape. Ignoring the future is safe for
+  // a READER -- but see `compactIfWasteful`, where "ignore" would mean "delete",
+  // because compaction rewrites the files it reads.
+  return versions.includes(version);
 }
 
 /** Node kinds. `file` and `symbol` are first-class so staleness can propagate. */
@@ -434,9 +453,20 @@ function compactIfWasteful(dir) {
     const nodes = new Map();
     const edges = new Map();
     const snaps = new Map();
-    for (const rec of readSnapshots(dir)) {
+    // KEPT VERBATIM THROUGH THE REBUILD, exactly as the main log keeps what it
+    // cannot parse. These lines are not evictable by the snapshot budget below
+    // because their size cannot be attributed to an id we understand -- and
+    // preserving bytes we may not need is strictly better than deleting bytes a
+    // newer client does. They stop accumulating as soon as the client that
+    // wrote them compacts, since it can read and dedupe them.
+    const sidecar = readSnapshots(dir);
+    const rawSnaps = sidecar.unreadable;
+    for (const rec of sidecar.records) {
       if (typeof rec.snapshot === 'string' && rec.snapshot) {
-        snaps.set(rec.id, { at: rec.at || 0, snapshot: rec.snapshot });
+        // `v` IS CARRIED, not restamped. Writing GRAPH_VERSION over a record
+        // from another version mislabels bytes this reader did not produce, and
+        // the label is the only thing a future reader has to go on.
+        snaps.set(rec.id, { at: rec.at || 0, snapshot: rec.snapshot, v: rec.v ?? GRAPH_VERSION });
       }
     }
     for (const line of readFileSync(path, 'utf8').split('\n')) {
@@ -458,27 +488,40 @@ function compactIfWasteful(dir) {
         edges.set('raw:' + edges.size, line);
         continue;
       }
-      // Upcast IN MEMORY only, to key and classify the record. What gets written
-      // back below is the ORIGINAL `line`: compaction reclaims superseded
-      // records, it does not migrate surviving ones, so the on-disk version is
-      // whatever wrote it and `load` upcasts it again on every read.
-      record = upcast(record);
-      if (record.t === 'n') {
+      // TWO OBJECTS, ON PURPOSE. `record` is exactly what the bytes on disk say;
+      // `view` is the in-memory current-shape reading of it, used only to KEY and
+      // CLASSIFY. Nothing derived from `view` is ever serialized, because
+      // compaction reclaims superseded records -- it does not migrate surviving
+      // ones -- so every version stamp it writes is the one that wrote the bytes.
+      //
+      // An earlier revision of this comment claimed "the ORIGINAL line is written
+      // back" for the whole block. That was FALSE for the inline-snapshot branch,
+      // which re-serializes. It re-serialized the upcast object while carrying
+      // the old `v`, so the first non-identity `upcast` would have written
+      // new-shape bytes under an old label and every later `load` would have
+      // upcast them a second time. Hence: strip from `record`, never from `view`.
+      const view = upcast(record);
+      if (view.t === 'n') {
         // MIGRATION. Graphs written before snapshots were split still carry
         // them inline, and those are exactly the graphs that are slow. Moving
         // them out here means one compaction fixes an existing install.
+        //
+        // THE ONLY RE-SERIALIZING BRANCH in this loop. It writes the original
+        // record minus its snapshot, so the surviving bytes keep their own shape
+        // and their own `v`, and the snapshot moved to the sidecar carries the
+        // same `v` as the node it came out of.
         if (typeof record.snapshot === 'string' && record.snapshot) {
           const { snapshot, ...rest } = record;
-          nodes.set(record.id, JSON.stringify(rest));
-          snaps.set(record.id, { at: record.at || 0, snapshot });
+          nodes.set(view.id, JSON.stringify(rest));
+          snaps.set(view.id, { at: record.at || 0, snapshot, v: record.v ?? GRAPH_VERSION });
         } else {
-          nodes.set(record.id, line);
+          nodes.set(view.id, line);
         }
-      } else if (record.t === 's') {
+      } else if (view.t === 's') {
         if (typeof record.snapshot === 'string' && record.snapshot) {
-          snaps.set(record.id, { at: record.at || 0, snapshot: record.snapshot });
+          snaps.set(view.id, { at: record.at || 0, snapshot: record.snapshot, v: record.v ?? GRAPH_VERSION });
         }
-      } else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
+      } else if (view.t === 'e') edges.set(`${view.from}|${view.edge}|${view.to}`, line);
       else edges.set('raw:' + edges.size, line);
     }
 
@@ -541,10 +584,20 @@ function compactIfWasteful(dir) {
     renameSync(tmp, path);
     // The surviving snapshots are rewritten to their own file, which is also
     // what migrates a graph that still had them inline.
-    const snapOut =
-      [...keep.entries()]
-        .map(([id, v]) => JSON.stringify({ t: 's', v: GRAPH_VERSION, id, snapshot: v.snapshot, at: v.at }))
-        .join('\n') + (keep.size ? '\n' : '');
+    //
+    // UNREADABLE LINES FIRST AND VERBATIM. This rebuild replaces the file, so
+    // anything omitted here is deleted permanently -- which made the missing
+    // counterpart to the main log's `raw:` bucket a real data-loss path, not a
+    // theoretical one. Each survivor also keeps ITS OWN `v` rather than being
+    // restamped to GRAPH_VERSION, so no record is relabelled as something this
+    // reader wrote.
+    const snapLines = [
+      ...rawSnaps,
+      ...[...keep.entries()].map(([id, s]) =>
+        JSON.stringify({ t: 's', v: s.v ?? GRAPH_VERSION, id, snapshot: s.snapshot, at: s.at })
+      ),
+    ];
+    const snapOut = snapLines.join('\n') + (snapLines.length ? '\n' : '');
     const snapTmp = snapshotsPath(dir) + '.compact';
     writeFileSync(snapTmp, snapOut, { mode: 0o600 });
     renameSync(snapTmp, snapshotsPath(dir));
@@ -689,9 +742,26 @@ function appendSnapshot(dir, record) {
   }
 }
 
-/** Every snapshot record, latest wins. Read only when a caller asks. */
+/**
+ * Every snapshot record, latest wins. Read only when a caller asks.
+ *
+ * `unreadable` collects the RAW LINES this reader rejected, and it is the reason
+ * this function reports them at all rather than just dropping them. `load` has
+ * no use for them -- a reader that cannot interpret a record must ignore it --
+ * but `compactIfWasteful` REBUILDS this file from what it read, so for the
+ * compactor "ignore" and "delete permanently" are the same operation. The main
+ * log already keeps what it cannot parse (the `raw:` bucket); the sidecar had no
+ * equivalent, which made it the one asymmetric, destructive path in an otherwise
+ * append-only store.
+ *
+ * This is not hypothetical here: hooks-core is vendored into eleven client
+ * directories that update independently, so a stale client compacting a graph a
+ * newer client has already written to is the expected steady state, not an edge
+ * case.
+ */
 function readSnapshots(dir) {
-  const out = [];
+  /** @type {object[]} */ const out = [];
+  /** @type {string[]} */ const unreadable = [];
   try {
     for (const line of readFileSync(snapshotsPath(dir), 'utf8').split('\n')) {
       if (!line) continue;
@@ -699,19 +769,23 @@ function readSnapshots(dir) {
         const rec = JSON.parse(line);
         // THE SAME RANGE AS THE MAIN LOG, deliberately. An equality check here
         // was the quietest of the three: a bump would have made every stored
-        // snapshot unreadable, and the very next compaction -- which rebuilds
-        // this file from what it could read -- would have deleted them for
-        // good. That is the one place in this store where a read filter turns
-        // into a permanent write.
-        if (readable(rec) && rec.id) out.push(upcast(rec));
+        // snapshot unreadable, and the very next compaction would have deleted
+        // them for good.
+        if (!readable(rec)) {
+          unreadable.push(line);
+          continue;
+        }
+        if (rec.id) out.push(upcast(rec));
       } catch {
-        /* a torn line costs one snapshot */
+        // A torn line costs one snapshot -- and it is NOT preserved, because a
+        // half-written line is not a record from another version, it is
+        // garbage. Distinguishing the two is the whole point of parsing first.
       }
     }
   } catch {
     /* no sidecar yet */
   }
-  return out;
+  return { records: out, unreadable };
 }
 
 /**
@@ -777,7 +851,9 @@ export function load(dir, { snapshots = false } = {}) {
   // Re-attached after the sweep, so a snapshot record may appear before or
   // after the node it belongs to.
   if (pending) {
-    for (const rec of readSnapshots(dir)) pending.set(rec.id, rec.snapshot);
+    // A reader has no use for the lines it could not interpret; only the
+    // compactor does, because only the compactor rewrites the file.
+    for (const rec of readSnapshots(dir).records) pending.set(rec.id, rec.snapshot);
     for (const [id, snapshot] of pending) {
       const node = nodes.get(id);
       if (node) nodes.set(id, { ...node, snapshot });

--- a/integrations/opencode/hooks/lib/wiki.mjs
+++ b/integrations/opencode/hooks/lib/wiki.mjs
@@ -28,17 +28,55 @@ import { canonicalPath, isFsSafePath } from './paths.mjs';
 /**
  * Schema version stamped on every record.
  *
- * There is exactly ONE version and no migration code, because nothing has been
- * released: a graph written by an older commit of an unreleased branch is a
- * development artifact, not user data, and carrying migration paths for it costs
- * real complexity to protect something nobody has. A record from any other
- * version is skipped rather than interpreted, so a stale dev graph degrades to
- * "rebuilds from use" instead of silently mixing incompatible identities.
+ * THIS PACKAGE IS RELEASED. It ships on npm, so every graph on disk is user
+ * data. An earlier version of this comment claimed nothing had been released
+ * and used that to justify having no migration path at all -- and the reader
+ * below compared for EQUALITY, so the first bump would have discarded every
+ * existing graph in silence. That justification is gone and so is the equality:
+ * `SUPPORTED_VERSIONS` is the range this reader accepts, and `upcast` is where a
+ * shape change is absorbed in memory.
  *
- * When this does ship, a bump here is where migration would be added -- with
- * users to protect, that trade reverses.
+ * A bump here is taken only when a record's SHAPE actually changes, and it comes
+ * with a new `upcast` step and an entry in `SUPPORTED_VERSIONS` in the same
+ * change. Adding a field that older readers can ignore is not a shape change.
  */
 export const GRAPH_VERSION = 1;
+
+/**
+ * Versions this reader accepts, oldest first.
+ *
+ * A RANGE, NOT AN EQUALITY. The equality check this replaces would have
+ * discarded every existing graph the moment anyone bumped the version -- and the
+ * header once justified that with "nothing has been released", which stopped
+ * being true at v5.7.0 on npm.
+ *
+ * Nothing on disk is ever rewritten to migrate: `upcast` runs in memory during
+ * the fold, so there is no migration pass to fail halfway and no race with the
+ * concurrent sessions this store is designed for. A mixed-version log is safe
+ * precisely because the original records are never mutated, and the existing
+ * compaction retires old ones naturally as it rewrites snapshots.
+ */
+export const SUPPORTED_VERSIONS = [1];
+
+/**
+ * Brings one record up to the current version. Pure, and one step per version.
+ *
+ * Identity today because GRAPH_VERSION is 1 and no shape has changed. It exists
+ * now so the first change that DOES need it has somewhere to go other than an
+ * equality check that silently deletes user data.
+ */
+export function upcast(record) {
+  return record;
+}
+
+/** True when this reader can interpret the record at all. */
+function readable(record) {
+  const version = record.v ?? 0;
+  // Forward-incompatible records are skipped: a v-from-the-future was written by
+  // a newer client and we cannot know its shape. Ignoring the future is safe;
+  // ignoring the past is data loss.
+  return SUPPORTED_VERSIONS.includes(version);
+}
 
 /** Node kinds. `file` and `symbol` are first-class so staleness can propagate. */
 export const NODE_KINDS = ['file', 'symbol', 'task', 'finding'];
@@ -409,13 +447,22 @@ function compactIfWasteful(dir) {
       } catch {
         continue;
       }
-      // A record from another schema is KEPT VERBATIM rather than reinterpreted.
-      // load() skips it, but discarding it here would make compaction a silent
-      // migration that deletes data a future version might understand.
-      if ((record.v ?? 0) !== GRAPH_VERSION) {
+      // A record this reader cannot interpret is KEPT VERBATIM rather than
+      // reinterpreted. load() skips it, but discarding it here would make
+      // compaction a silent migration that deletes data a future version might
+      // understand. THE RANGE MATTERS HERE TOO: with an equality check, a bump
+      // would have parked every existing v1 record in `raw`, undeduplicated, so
+      // compaction would stop reclaiming anything and inline snapshots would
+      // never migrate out -- the same loss by a second route.
+      if (!readable(record)) {
         edges.set('raw:' + edges.size, line);
         continue;
       }
+      // Upcast IN MEMORY only, to key and classify the record. What gets written
+      // back below is the ORIGINAL `line`: compaction reclaims superseded
+      // records, it does not migrate surviving ones, so the on-disk version is
+      // whatever wrote it and `load` upcasts it again on every read.
+      record = upcast(record);
       if (record.t === 'n') {
         // MIGRATION. Graphs written before snapshots were split still carry
         // them inline, and those are exactly the graphs that are slow. Moving
@@ -650,7 +697,13 @@ function readSnapshots(dir) {
       if (!line) continue;
       try {
         const rec = JSON.parse(line);
-        if ((rec.v ?? 0) === GRAPH_VERSION && rec.id) out.push(rec);
+        // THE SAME RANGE AS THE MAIN LOG, deliberately. An equality check here
+        // was the quietest of the three: a bump would have made every stored
+        // snapshot unreadable, and the very next compaction -- which rebuilds
+        // this file from what it could read -- would have deleted them for
+        // good. That is the one place in this store where a read filter turns
+        // into a permanent write.
+        if (readable(rec) && rec.id) out.push(upcast(rec));
       } catch {
         /* a torn line costs one snapshot */
       }
@@ -691,7 +744,12 @@ export function load(dir, { snapshots = false } = {}) {
       if (!snapshots) continue;
       try {
         const rec = JSON.parse(line);
-        if ((rec.v ?? 0) === GRAPH_VERSION) pending.set(rec.id, rec.snapshot);
+        // Inline snapshots from an older graph: same range, same reason. These
+        // are precisely the records most likely to predate a bump.
+        if (readable(rec)) {
+          const snap = upcast(rec);
+          pending.set(snap.id, snap.snapshot);
+        }
       } catch {
         /* a torn line costs one snapshot, not the graph */
       }
@@ -703,10 +761,14 @@ export function load(dir, { snapshots = false } = {}) {
     } catch {
       continue;
     }
-    // A record from another schema is skipped, not interpreted: its ids and
-    // hashes were derived differently, so honouring it produces confident
-    // nonsense rather than a visible error.
-    if ((record.v ?? 0) !== GRAPH_VERSION) continue;
+    // A record this reader cannot interpret is skipped, not guessed at: a
+    // version from the FUTURE derived its ids and hashes in a way we do not
+    // know, so honouring it produces confident nonsense rather than a visible
+    // error. A record from the PAST is upcast, never skipped -- skipping it is
+    // data loss, and this comparison used to be an equality, which made the
+    // first version bump a silent delete of every graph on disk.
+    if (!readable(record)) continue;
+    record = upcast(record);
     if (record.t === 'n') nodes.set(record.id, record);
     else if (record.t === 'e') edges.push(record);
   }

--- a/integrations/opencode/hooks/lib/wiki.mjs
+++ b/integrations/opencode/hooks/lib/wiki.mjs
@@ -775,7 +775,17 @@ function readSnapshots(dir) {
           unreadable.push(line);
           continue;
         }
+        // A RECORD WITH NO `id` IS KEPT VERBATIM, NOT DROPPED SILENTLY. It
+        // cannot be attributed to a node, so it is useless to `load` -- but this
+        // used to put it in neither bucket, and `compactIfWasteful` rebuilds the
+        // sidecar from `records` plus `unreadable`, so a line in neither was
+        // deleted permanently by the next compaction. That is the same shape as
+        // the Critical this reader's version check already fixed, and the same
+        // asymmetry: for the compactor, "ignore" and "destroy" are one operation.
+        // Unreachable today because every writer sets `id`; a reader is not the
+        // right place to rely on that.
         if (rec.id) out.push(upcast(rec));
+        else unreadable.push(line);
       } catch {
         // A torn line costs one snapshot -- and it is NOT preserved, because a
         // half-written line is not a record from another version, it is

--- a/integrations/opencode/hooks/post-tool.mjs
+++ b/integrations/opencode/hooks/post-tool.mjs
@@ -8,7 +8,7 @@ process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.
-process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write';
+process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write,wiki_query';
 try {
   const { run } = await import('./lib/adapter.mjs');
   await run('opencode', 'post-tool');

--- a/integrations/opencode/hooks/post-tool.mjs
+++ b/integrations/opencode/hooks/post-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/opencode/hooks/pre-tool.mjs
+++ b/integrations/opencode/hooks/pre-tool.mjs
@@ -8,7 +8,7 @@ process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.
-process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write';
+process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write,wiki_query';
 try {
   const { run } = await import('./lib/adapter.mjs');
   await run('opencode', 'pre-tool');

--- a/integrations/opencode/hooks/pre-tool.mjs
+++ b/integrations/opencode/hooks/pre-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/opencode/hooks/session-start.mjs
+++ b/integrations/opencode/hooks/session-start.mjs
@@ -8,7 +8,7 @@ process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.
-process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write';
+process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write,wiki_query';
 try {
   const { run } = await import('./lib/adapter.mjs');
   await run('opencode', 'session-start');

--- a/integrations/opencode/hooks/session-start.mjs
+++ b/integrations/opencode/hooks/session-start.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/qwen/hooks/lib/adapter.mjs
+++ b/integrations/qwen/hooks/lib/adapter.mjs
@@ -68,6 +68,7 @@ import {
   standingRules,
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
+import { observedWrite, queueInvalidation } from './pending.mjs';
 import { isArchived } from './transcript.mjs';
 import { isFsSafePath } from './paths.mjs';
 import {
@@ -881,6 +882,35 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Causal tracing is fail-open like every other hook optimization.
+    }
+
+    // EAGER INVALIDATION, finally connected. `invalidateOnWrite` has existed,
+    // been tested and been described in staleness.mjs's own header since
+    // staleness landed, and its only reference in shipped code was a COMMENT in
+    // the PreToolUse router -- so the path that header calls load-bearing had
+    // never run once in production. It matters most for exactly this event: the
+    // lazy check compares the anchor's stored hash against disk, and the
+    // capture below re-points that hash at the bytes this write just produced,
+    // so a write the session performed ITSELF is invisible to lazy staleness.
+    //
+    // QUEUED, NOT APPLIED. Applying needs the graph, and loading a megabyte of
+    // JSONL on the return path of every write is what this shape exists to
+    // avoid. The next graph read drains it before serving anything.
+    try {
+      if (mutationSucceeded(clientName, raw)) {
+        const evidence = observedWrite(payload, raw);
+        if (evidence) {
+          // THE SAME DIRECTORY THE GRAPH ITSELF USES. `observeAndInject` keys
+          // every write on `wikiDir(projectRootFor(path, payload.cwd))`, and a
+          // queue written anywhere else is a queue nothing ever drains.
+          queueInvalidation(
+            wikiDir(projectRootFor(evidence.path, payload.cwd)),
+            evidence
+          );
+        }
+      }
+    } catch {
+      // Bookkeeping for a call that already completed. Never let it cost one.
     }
   }
 

--- a/integrations/qwen/hooks/lib/adapter.mjs
+++ b/integrations/qwen/hooks/lib/adapter.mjs
@@ -64,6 +64,7 @@ import {
   forTouch,
   noteActClasses,
   relevantFindingIdsForContext,
+  sessionContext,
   sessionIndex,
   standingRules,
 } from './inject.mjs';
@@ -690,8 +691,23 @@ async function runHook(clientName, event, invocation) {
       rememberOptimizerTools(state, toolEvidence);
       saveState(sessionId, state);
     }
-    const parts = [
-      policyText(client.canDeny, toolEvidence.names, toolEvidence.proven),
+    // ASSEMBLED IN CACHE ORDER, not in whatever order this function happens to
+    // discover the blocks. Everything emitted here sits near the FRONT of the
+    // prompt prefix, and a prefix cache invalidates from the first differing
+    // byte onward -- so the block that changes most often has to sit LAST, or it
+    // re-prices every block behind it on every session. `sessionContext` sorts
+    // by the declared volatility; inject.mjs records how each number was
+    // assigned and why.
+    const blocks = [
+      {
+        id: 'policy',
+        volatility: 0,
+        text: policyText(
+          client.canDeny,
+          toolEvidence.names,
+          toolEvidence.proven
+        ),
+      },
     ];
     const cwd = raw.cwd || raw.working_directory || process.cwd();
     const root = projectRootFor(join(cwd, '__session__'), cwd);
@@ -705,7 +721,7 @@ async function runHook(clientName, event, invocation) {
         const graph = load(dir);
         const episode = episodeMeta({ client: clientName, raw });
         const rules = standingRules(dir, graph, { episode });
-        if (rules) parts.push(rules);
+        if (rules) blocks.push({ id: 'standing', volatility: 1, text: rules });
         const relevantFindingIds = relevantFindingIdsForContext(
           graph,
           sessionTaskContext(raw)
@@ -714,12 +730,12 @@ async function runHook(clientName, event, invocation) {
           episode,
           relevantFindingIds,
         });
-        if (index) parts.push(index);
+        if (index) blocks.push({ id: 'index', volatility: 2, text: index });
       } catch {
         // Retrieval is optional context; the policy must still reach the model.
       }
     }
-    const output = contextOutput(client, eventName, parts.join('\n\n'));
+    const output = contextOutput(client, eventName, sessionContext(blocks));
     if (output) emit(output);
     process.exit(0);
   }

--- a/integrations/qwen/hooks/lib/adapter.mjs
+++ b/integrations/qwen/hooks/lib/adapter.mjs
@@ -68,7 +68,7 @@ import {
   standingRules,
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
-import { observedWrite, queueInvalidation } from './pending.mjs';
+import { observedWrites, queueInvalidation } from './pending.mjs';
 import { isArchived } from './transcript.mjs';
 import { isFsSafePath } from './paths.mjs';
 import {
@@ -898,8 +898,7 @@ async function runHook(clientName, event, invocation) {
     // avoid. The next graph read drains it before serving anything.
     try {
       if (mutationSucceeded(clientName, raw)) {
-        const evidence = observedWrite(payload, raw);
-        if (evidence) {
+        for (const evidence of observedWrites(payload, raw)) {
           // THE SAME DIRECTORY THE GRAPH ITSELF USES. `observeAndInject` keys
           // every write on `wikiDir(projectRootFor(path, payload.cwd))`, and a
           // queue written anywhere else is a queue nothing ever drains.

--- a/integrations/qwen/hooks/lib/capabilities.mjs
+++ b/integrations/qwen/hooks/lib/capabilities.mjs
@@ -38,6 +38,10 @@ export const HOOK_MCP_TOOLS = Object.freeze([
   'optimize_session',
   'get_optimization_report',
   'wiki_write',
+  // The read side of the graph. The session index tells the model to "call
+  // wiki_query with a key for detail", so the hook needs positive evidence that
+  // the name it is advertising is actually registered in this host.
+  'wiki_query',
 ]);
 
 const HOOK_MCP_TOOL_SET = new Set(HOOK_MCP_TOOLS);

--- a/integrations/qwen/hooks/lib/curate.mjs
+++ b/integrations/qwen/hooks/lib/curate.mjs
@@ -22,7 +22,7 @@
  */
 
 import { randomBytes } from 'node:crypto';
-import { putNode, putNodeWithEdges, load, nodeId } from './wiki.mjs';
+import { putNode, putEdge, putNodeWithEdges, load, nodeId } from './wiki.mjs';
 import { indexFile } from './staleness.mjs';
 import { symbolKey } from './symbols.mjs';
 import { canonicalPath } from './paths.mjs';
@@ -178,6 +178,79 @@ export function retire(dir, key) {
   if (!existing) return false;
   putNode(dir, { ...existing, kind: 'finding', key, retired: true });
   return true;
+}
+
+/**
+ * Records that one finding disagrees with another.
+ *
+ * AN EDGE, NOT AN OVERWRITE -- the design is explicit about why: "when a belief
+ * changes, the graph should record THAT it changed and why, not quietly present
+ * the new one as though it had always been true." `contradicts` has been in
+ * EDGE_KINDS since the schema existed and was written by nothing, while
+ * `audit()` already READ it.
+ *
+ * The contradicted finding is deliberately NOT retired, and its claim is
+ * deliberately preserved. A reader needs to see both claims and the
+ * disagreement between them; retiring one silently picks a winner, and putNode
+ * does not merge -- it writes the whole record from what it is handed, so
+ * annotating the target without spreading it back in would blank the very claim
+ * this edge exists to keep visible. That is the overwrite by another name.
+ *
+ * THE EDGE IS WRITTEN FIRST, and the order is the guarantee. These are two
+ * appends and `append` fails open, so either can be the one that lands. Edge
+ * without annotation is a complete, readable disagreement missing only its
+ * reason. Annotation without edge is a finding that says "something contradicts
+ * me" with no contradictor -- a claim of proof with no proof, and invisible to
+ * `audit()` and to `hasOutstandingContradiction`, both of which read the edge.
+ */
+export function contradict(dir, { key, byKey, reason }) {
+  const graph = load(dir);
+  const target = findingByKey(graph, key);
+  const source = findingByKey(graph, byKey);
+  // Both ends must exist, or the edge is unresolvable and the disagreement is
+  // recorded against nothing -- the same un-invalidatable shape anchors prevent.
+  if (!target || !source) return false;
+  // A finding cannot disagree with itself. The self-edge resolves, so the guard
+  // above waves it through, and the result is a node permanently blocked from
+  // confidence promotion by a dispute no person can ever resolve: there is no
+  // second claim to choose between.
+  if (target.id === source.id) return false;
+
+  putEdge(dir, source.id, 'contradicts', target.id);
+  putNode(dir, {
+    ...target,
+    kind: 'finding',
+    key,
+    contradictedAt: Date.now(),
+    contradictionReason: String(reason || '').slice(0, 400),
+  });
+  return true;
+}
+
+/**
+ * Whether anything currently disagrees with this finding.
+ *
+ * Gates confidence promotion. Plan 2's per-finding utility measures whether a
+ * finding SUPPRESSES READS, and a confidently wrong finding suppresses reads
+ * better than a hedged true one -- so utility must never raise confidence on
+ * its own, and this is the check that stops it.
+ *
+ * SYMMETRIC, deliberately: BOTH ends of a `contradicts` edge are outstanding
+ * until a person resolves the disagreement. The named hazard in the design is
+ * presenting "the new one as though it had always been true", so gating only
+ * the older claim would leave the newer one -- which is just as likely to be
+ * the wrong one, since nothing here adjudicates -- free to be promoted on
+ * measured utility alone. That is the exact failure this gate exists to stop.
+ * It also matches `audit()`, the reader that has always been here: it puts both
+ * `from` and `to` in its `contradicted` bucket, because "until one looks, BOTH
+ * are being served".
+ */
+export function hasOutstandingContradiction(graph, key) {
+  const node = findingByKey(graph, key);
+  if (!node) return false;
+  return graph.edges.some(
+    (e) => e.edge === 'contradicts' && (e.to === node.id || e.from === node.id)
+  );
 }
 
 /**

--- a/integrations/qwen/hooks/lib/curate.mjs
+++ b/integrations/qwen/hooks/lib/curate.mjs
@@ -124,7 +124,17 @@ export function correct(
   const replacementKey = `${key}-c${Date.now().toString(36)}`;
 
   const edges = [{ edge: 'supersedes', to: originalId }];
-  // The correction inherits the original's anchors, so it can go stale too.
+  // The correction inherits the original's anchors, so it can go stale too --
+  // but it inherits NOTHING ELSE, and that is deliberate rather than incidental.
+  // The node written below is built field by field from `existing` instead of
+  // spreading it, which is what keeps the staleness fields (`stale`,
+  // `staleReason`, `diff`) off the successor: a correction is re-derived
+  // against the current code by definition, so being born carrying its
+  // predecessor's invalidation would discount it the moment it existed --
+  // `disclose.mjs` skips a stale finding outright and `utility.mjs` penalises
+  // one by 160. Any future edit here that reaches for `...existing` to pick up
+  // one more field re-introduces that, since `putNode` writes what it is handed
+  // wholesale; `tests/hooks/stale-clearing.test.mjs` is the guard.
   for (const edge of graph.edges) {
     if (edge.edge === 'derived_from' && edge.from === originalId) {
       edges.push({ edge: 'derived_from', to: edge.to });
@@ -244,13 +254,38 @@ export function contradict(dir, { key, byKey, reason }) {
  * It also matches `audit()`, the reader that has always been here: it puts both
  * `from` and `to` in its `contradicted` bucket, because "until one looks, BOTH
  * are being served".
+ *
+ * A RETIRED COUNTERPART DOES NOT COUNT, and that sentence quoted just above is
+ * the reason. This read edges ONLY, so retiring one end of a contradiction left
+ * the survivor gated against confidence promotion forever and served with a
+ * DISPUTED note naming a key `serve` refuses to hand anybody -- `serve`,
+ * `activeFindings`, `findingsFor` and `sessionIndex` all drop a retired
+ * finding. A retired claim is served to NOBODY, so "BOTH are being served" is
+ * false and the premise of the gate is gone: only one claim is in play, and
+ * there is nothing left to choose between. Retiring one end IS the person
+ * looking that this gate was waiting for -- so the edge counts as open only
+ * while NEITHER end is retired, answered the same way from both directions.
+ *
+ * AN UNRESOLVABLE END STILL COUNTS. An edge whose other side names no node
+ * proves nothing about whether that claim was withdrawn, and the conservative
+ * reading -- still disputed -- is the one that cannot promote a claim nobody
+ * adjudicated.
  */
 export function hasOutstandingContradiction(graph, key) {
   const node = findingByKey(graph, key);
-  if (!node) return false;
-  return graph.edges.some(
-    (e) => e.edge === 'contradicts' && (e.to === node.id || e.from === node.id)
-  );
+  // A withdrawn claim is not in a dispute either: a dispute needs two claims in
+  // play, and this one has been taken out of play. Without this the RETIRED end
+  // still reported an open disagreement, which is the same defect from the other
+  // side -- and the answer has to agree from both directions, since the gate is
+  // symmetric on purpose.
+  if (!node || node.retired) return false;
+  return graph.edges.some((e) => {
+    if (e.edge !== 'contradicts') return false;
+    const otherId = e.from === node.id ? e.to : e.to === node.id ? e.from : null;
+    if (!otherId) return false;
+    const other = graph.nodes.get(otherId);
+    return !other || !other.retired;
+  });
 }
 
 /**
@@ -334,11 +369,24 @@ export function audit(graph) {
       .map((e) => e.from)
   );
 
+  // THE SAME DEFINITION OF AN OPEN DISPUTE as hasOutstandingContradiction, and
+  // it has to be: that function's own comment claims it "matches audit()", and
+  // two rankings that disagree about what needs a human is worse than one that
+  // is wrong. A retired counterpart is a resolved dispute -- the retired claim
+  // is served to nobody -- so the survivor is not one of two claims in play and
+  // does not belong in the bucket of things needing a person to look.
+  //
+  // One pass, not a call per finding: this is a dashboard read over the whole
+  // graph, and the obvious rewrite is O(findings x edges).
   const contradicted = new Set();
   for (const edge of graph.edges) {
     if (edge.edge !== 'contradicts') continue;
-    contradicted.add(edge.from);
-    contradicted.add(edge.to);
+    const from = graph.nodes.get(edge.from);
+    const to = graph.nodes.get(edge.to);
+    // An end that resolves to nothing cannot be shown retired, so it still
+    // counts against the other end.
+    if (!to || !to.retired) contradicted.add(edge.from);
+    if (!from || !from.retired) contradicted.add(edge.to);
   }
 
   return {

--- a/integrations/qwen/hooks/lib/curate.mjs
+++ b/integrations/qwen/hooks/lib/curate.mjs
@@ -70,6 +70,38 @@ export function originWeight(origin) {
   return 1;
 }
 
+/**
+ * The claim-time anchor hashes, for a finding being written right now.
+ *
+ * THE CHECKABLE HALF OF PROVENANCE, and until now only `harvest-write.mjs`
+ * wrote it -- so the asymmetry ran exactly the wrong way. `reverify` and the
+ * automatic clear in `serve` both compare disk against these frozen hashes, and
+ * a finding without them can never have a stale flag cleared by anything. That
+ * meant HUMAN-asserted findings, the ones somebody deliberately created or
+ * corrected, were the only ones condemned to stay stale forever once marked,
+ * while machine-harvested claims could recover. The hashes are simply the anchor
+ * nodes' hashes at this moment, and every writer has them in hand.
+ *
+ * DELIBERATELY NOT THE WHOLE RECORD `derivationFor` BUILDS. That one joins the
+ * evidence log to find FILE-surface operations behind the claim; curation
+ * performs no such join, so `operations` is empty and `operationsComplete` says
+ * so. An empty list declared incomplete is honest -- "nothing recorded here, and
+ * do not read that as nothing happened" -- where an empty list declared complete
+ * would assert a fact nobody established.
+ *
+ * An anchor with no stored hash contributes no entry, and a finding whose
+ * anchors all lack one gets a record with no hashes -- which `claimTimeVerdict`
+ * reads as `unknown` and refuses to clear on, which is the correct reading.
+ */
+function claimTimeDerivation(graph, resolved) {
+  const anchors = {};
+  for (const id of resolved) {
+    const node = graph.nodes.get(id);
+    if (node && typeof node.hash === 'string') anchors[id] = node.hash;
+  }
+  return { at: Date.now(), anchors, operations: [], operationsComplete: false };
+}
+
 function findingByKey(graph, key) {
   return graph.nodes.get(nodeId('finding', key)) || null;
 }
@@ -124,6 +156,11 @@ export function correct(
   const replacementKey = `${key}-c${Date.now().toString(36)}`;
 
   const edges = [{ edge: 'supersedes', to: originalId }];
+  // Collected alongside the edges so the correction carries its own claim-time
+  // hashes: it is a NEW claim, re-derived against whatever the code says now, so
+  // its evidence is the anchors' current state -- not the predecessor's, which is
+  // precisely what went stale.
+  const inherited = [];
   // The correction inherits the original's anchors, so it can go stale too --
   // but it inherits NOTHING ELSE, and that is deliberate rather than incidental.
   // The node written below is built field by field from `existing` instead of
@@ -138,6 +175,7 @@ export function correct(
   for (const edge of graph.edges) {
     if (edge.edge === 'derived_from' && edge.from === originalId) {
       edges.push({ edge: 'derived_from', to: edge.to });
+      inherited.push(edge.to);
     }
   }
 
@@ -171,6 +209,11 @@ export function correct(
       // branches, and an unrecognised value already degrades to the neutral
       // ranking weight rather than doing damage.
       origin: typeof origin === 'string' && origin ? origin : ORIGIN_HUMAN,
+      // Without this a correction could never have a stale flag cleared: both
+      // clearing paths compare disk against these hashes, and a finding with
+      // none is `unknown` forever. A hand-written correction being the least
+      // recoverable record in the graph was the wrong way round.
+      derivation: claimTimeDerivation(graph, inherited),
     },
     edges
   );
@@ -339,7 +382,18 @@ export function create(dir, { claim, anchors, type = 'finding', confidence = 0.9
   // path. No process death required; one transient EBUSY is enough.
   const id = putNodeWithEdges(
     dir,
-    { kind: 'finding', key, claim, confidence, type, origin: ORIGIN_HUMAN },
+    {
+      kind: 'finding',
+      key,
+      claim,
+      confidence,
+      type,
+      origin: ORIGIN_HUMAN,
+      // Read AFTER the indexFile loop above, so the hashes are the ones the
+      // person's claim was actually made against rather than whatever the graph
+      // held before this call touched it.
+      derivation: claimTimeDerivation(loadGraph(dir), resolved),
+    },
     resolved.map((target) => ({ edge: 'derived_from', to: target }))
   );
   if (!id) return null;

--- a/integrations/qwen/hooks/lib/decide.mjs
+++ b/integrations/qwen/hooks/lib/decide.mjs
@@ -542,19 +542,92 @@ const TOOL_ALIASES = new Map(
     run_shell_command: 'Bash',
     run_terminal_cmd: 'Bash',
     terminal: 'Bash',
+
+    // THIS PROJECT'S OWN TOOLS, which the table did not list for as long as it
+    // existed. `plugin/hooks/hooks.json`'s PostToolUse matcher named
+    // `mcp__.*__(?:smart_edit|smart_write)` and Codex's AfterTool matcher named
+    // the bare `smart_edit|smart_write`, so both hooks fired -- and then
+    // `normalizeTool` returned null and the hook exited before a single line of
+    // accounting ran. Staleness, mutation counting and harvest pressure were all
+    // blind on exactly the path enforcement pushes the model toward, which is the
+    // worst place to be blind: the more effective the routing, the less the
+    // optimizer saw.
+    //
+    // These names are the CANONICAL operation, not a licence to redirect. A call
+    // that is already the replacement is excluded from routing by
+    // `isReplacementTool` below.
+    smart_read: 'Read',
+    smart_grep: 'Grep',
+    smart_glob: 'Glob',
+    smart_edit: 'Edit',
+    smart_write: 'Write',
+
+    // Claude Code's notebook editor. Same shape of gap: a real mutation of a
+    // real file on disk that arrived as null and so never reached
+    // `pending.mjs`'s MUTATING set, leaving every notebook write invisible to
+    // invalidation.
+    notebookedit: 'Edit',
+    notebook_edit: 'Edit',
   })
 );
 
-/** Maps a client's tool name onto the canonical one, or null if unhandled. */
+/**
+ * The optimizer's own replacement tools, by canonical trailing segment.
+ *
+ * Kept separate from the alias table because the two answer different questions.
+ * The table answers "what operation is this", which post-tool accounting needs.
+ * This set answers "is this call ALREADY the thing we would have recommended",
+ * which routing needs -- and conflating them is the loop hazard: `smart_edit`
+ * resolves to `Edit`, the Edit branch recommends `smart_edit`, and the model is
+ * told to call the tool it just called.
+ */
+const REPLACEMENT_TOOLS = new Set([
+  'smart_read',
+  'smart_grep',
+  'smart_glob',
+  'smart_edit',
+  'smart_write',
+]);
+
+/**
+ * The tool name with an `mcp__<server>__` prefix removed, if it had one.
+ *
+ * Server segments contain underscores freely (`plugin_token-optimizer_token-optimizer`)
+ * and so do tool names (`smart_edit`), so the split is taken at the LAST `__`
+ * after the `mcp__` sentinel. Both halves must be non-empty: `mcp__edit` names
+ * no server and is not a name any host emits, and treating it as `edit` would
+ * coerce an unrecognised string into a built-in.
+ */
+function withoutMcpPrefix(name) {
+  const match = /^mcp__(.+)__(.+)$/.exec(name);
+  return match ? match[2] : name;
+}
+
+/** Whether this call IS one of the optimizer's replacements, however spelled. */
+export function isReplacementTool(name) {
+  if (!name) return false;
+  return REPLACEMENT_TOOLS.has(withoutMcpPrefix(String(name)).toLowerCase());
+}
+
+/**
+ * Maps a client's tool name onto the canonical one, or null if unhandled.
+ *
+ * PERMISSIVE IN ONE DIRECTION ONLY. An MCP-prefixed name is resolved by its
+ * trailing segment, but only against the same table every other client is held
+ * to -- so `mcp__vendor__deploy_to_prod` stays null. Coercing an unrecognised
+ * MCP tool into a built-in would change a routing verdict for a tool nobody has
+ * considered, which is a far worse failure than not accounting for it.
+ */
 export function normalizeTool(name) {
   if (!name) return null;
+  const candidate = withoutMcpPrefix(String(name));
   if (
     ['Read', 'Grep', 'Glob', 'Edit', 'MultiEdit', 'Write', 'Bash'].includes(
-      name
+      candidate
     )
   )
-    return name;
-  return TOOL_ALIASES.get(String(name).toLowerCase()) || null;
+    return candidate;
+  return TOOL_ALIASES.get(candidate.toLowerCase()) || null;
 }
 
 /**
@@ -614,6 +687,13 @@ export function normalizePayload(raw) {
     transcript_path: raw.transcript_path ?? raw.transcriptPath ?? null,
     cwd,
     tool_name: normalizeTool(raw.tool_name ?? raw.toolName ?? raw.tool),
+    // WHETHER THIS CALL IS ALREADY THE REPLACEMENT, carried alongside the
+    // canonical name rather than inferred from it -- because it cannot be
+    // inferred from it. `smart_edit` and `Edit` both normalise to `Edit`, and
+    // routing has to treat them as opposites while accounting treats them as
+    // the same. Absent by default (`false`), so a payload assembled by hand in
+    // a test or by a caller that predates this field is a normal built-in call.
+    replacement: isReplacementTool(raw.tool_name ?? raw.toolName ?? raw.tool),
     tool_input: {
       ...input,
       // CANONICALISED HERE, once. Every consumer downstream -- the `seen` map
@@ -673,6 +753,19 @@ function replacementAvailable(availableTools, name) {
 }
 
 export function decide(payload, state, availableTools = undefined) {
+  // THE LOOP HAZARD, and the reason this guard is at the top rather than inside
+  // any one branch. Resolving `smart_edit` to `Edit` is what makes post-tool
+  // accounting work; it must not also make the Edit branch answer a smart_edit
+  // call with "call smart_edit instead". This is not theoretical on a matcher
+  // level either: Qwen's PreToolUse matcher is the unanchored regex
+  // `edit|write_file|run_shell_command`, and `edit` matches inside
+  // `mcp__x__smart_edit`, so that client really does hand the router calls to
+  // its own replacements.
+  //
+  // A tool that IS the replacement is never routed. There is nothing better to
+  // recommend, and every branch below would recommend itself.
+  if (payload.replacement) return null;
+
   const tool = payload.tool_name;
   const input = payload.tool_input || {};
   const threshold = largeFileBytes();
@@ -873,6 +966,12 @@ export function remember(payload, state) {
  */
 export function readCostBytes(payload) {
   if (payload.tool_name !== 'Read') return 0;
+  // A REPLACEMENT DID NOT SPEND THE WHOLE FILE. `smart_read` normalises to
+  // `Read` so the graph sees the touch, but it returns a diff -- charging the
+  // full file size here would feed the holdout comparison a cost that was never
+  // paid, on the arm the optimizer is trying to show is cheaper. Better to
+  // record nothing than to record a number in the wrong direction.
+  if (payload.replacement) return 0;
   const path = payload.tool_input?.file_path;
   if (!path || isBinaryPath(path)) return 0;
   const size = fileSize(path);

--- a/integrations/qwen/hooks/lib/disclose.mjs
+++ b/integrations/qwen/hooks/lib/disclose.mjs
@@ -294,6 +294,11 @@ export function verdictFor(graph, { anchors = [], question, minConfidence = 0.7 
     const id = nodeId('file', canonicalPath(anchor));
     if (!graph.nodes.has(id)) continue;
 
+    // READ-ONLY serve: no `dir` is threaded here, so this cannot clear a stale
+    // flag whose evidence is gone. That is deliberate -- this function takes a
+    // graph, not the directory it came from, and widening its signature to give
+    // an analysis path a write capability buys nothing: the injection path runs
+    // on every tool call and clears the same findings.
     const findings = serve(graph, findingsFor(graph, id, { limit: 4 }));
     for (const finding of findings) {
       if (finding.stale) continue;

--- a/integrations/qwen/hooks/lib/harvest-write.mjs
+++ b/integrations/qwen/hooks/lib/harvest-write.mjs
@@ -34,7 +34,7 @@ import { randomBytes } from 'node:crypto';
 import { realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
-import { readEvidence } from './metrics.mjs';
+import { readEvidence, evidenceTruncated } from './metrics.mjs';
 
 /**
  * The types that may cross a project boundary.
@@ -431,53 +431,84 @@ function resolveAnchor(dir, anchor, projectRoot) {
 /**
  * Which task actually produced this finding, when nothing said so directly.
  *
- * Session id was the only signal `answers` had, and a session id is exactly
- * what a caller may not have (`wiki_write`'s `sessionId` is optional and
- * nothing populates it today; the detached harvest worker's is gated behind
- * an opt-in). But the graph does not need to be TOLD which task this is: the
- * structural harvest already writes `task -[derived_from]-> file` for every
- * tool call, unconditionally, on every install. So the task is DERIVABLE --
- * it is whichever task node has a `derived_from` edge to one of the SAME
- * anchors this finding resolved to.
+ * ROUND 2's version scanned the WHOLE graph for any task sharing any anchor,
+ * broken by recency. An adversarial review constructed four cases where that
+ * attributes a finding to the WRONG task:
  *
- * "Most recent task, full stop" was rejected on purpose: a task that never
- * touched these files could still be the newest node in the graph (a
- * different file, a different concern, in a later session), and attaching
- * provenance to it would be a WRONG edge, not a missing one -- worse than no
- * edge, because a reader trusts it. So candidates are filtered to tasks that
- * touched at least one of these anchors FIRST, and only ties among THOSE are
- * broken by recency.
+ *   1. STALE PRIOR SESSION -- a session that reasons from injected memory and
+ *      writes a finding about `foo.ts` without touching it this session gets
+ *      attributed to whatever task last touched `foo.ts`, possibly days old,
+ *      possibly someone else's work.
+ *   2. CONCURRENT SESSION -- two windows on one repository; the other
+ *      session's task wins if its touch is a millisecond later.
+ *   3. OVERLAP, NOT COVERAGE -- a finding anchored to [a, b]; a task that
+ *      touched only `b` could still win over one that touched both.
+ *   4. THE TIE-BREAK CONTRADICTED ITS OWN COMMENT -- `Number(edge.at) || 0`
+ *      with strict `>` means the FIRST edge in log order wins on a tie,
+ *      which is the OLDER task, not "more recently" as documented.
  *
- * The tie-break is the edge's own `at`, not the task node's `at`. A task that
- * touched this file once, long ago, and then stayed active on unrelated files
- * for hours has a late node timestamp that says nothing about this anchor;
- * the edge timestamp says exactly when THIS task touched THIS anchor, which
- * is the question being asked. Among tasks sharing an anchor, the one whose
- * most recent touch to any shared anchor is latest wins -- recency of the
- * relevant work, not recency of the task in general.
+ * THE FIX IS NARROWER THAN A BETTER RANKING: SCOPE, THEN REQUIRE COVERAGE.
+ * A task only ever belongs to the session that created it -- `harvest()` and
+ * `linkCoOccurrence()` (wiki.mjs, inject.mjs) both key a task node by
+ * `sessionId`, always, so there is exactly ONE task node for "the current
+ * session" and it is `nodeId('task', sessionId)`. Restricting to that ONE
+ * node structurally eliminates cases 1 and 2 -- a prior or concurrent
+ * session's task has a DIFFERENT sessionId and therefore a different node
+ * id, so it is never even looked at, regardless of timing. No caller can
+ * supply a wrong sessionId and get someone ELSE's task; they can only fail
+ * to get a match.
+ *
+ * COVERAGE, NOT OVERLAP, fixes case 3: the session's task must have a
+ * `derived_from` edge to EVERY one of this finding's anchors, not merely one.
+ * A partial touch is not attribution.
+ *
+ * With the candidate set reduced to at most one node, there is nothing left
+ * to break a tie between -- case 4's comparator is not "fixed", it is
+ * deleted, because the scenario it was written for (two DIFFERENT tasks both
+ * legitimately eligible) cannot occur under this scoping: two task nodes can
+ * never share a key, and only the current session's key is ever considered.
+ * An edge's `at` therefore plays NO role here: presence of a `derived_from`
+ * edge from the session's task to an anchor is what "touched it" means, with
+ * or without a timestamp on that edge -- there is no ranking left for a
+ * missing timestamp to lose.
+ *
+ * `sessionId` absent means there is no identity to scope by, which means no
+ * candidate -- not "fall back to guessing". Absence is the correct answer
+ * when the graph cannot support attribution.
  */
-function taskForAnchors(graph, anchorIds) {
-  if (!anchorIds || !anchorIds.length) return null;
-  const anchors = new Set(anchorIds);
-  let best = null;
-  for (const edge of graph.edges) {
-    if (edge.edge !== 'derived_from' || !anchors.has(edge.to)) continue;
-    const from = graph.nodes.get(edge.from);
-    // `derived_from` is also how a FINDING cites its own anchors, so without
-    // this a finding that already cited the same file would be mistaken for
-    // the task that produced it.
-    if (!from || from.kind !== 'task') continue;
-    const at = Number(edge.at) || 0;
-    if (!best || at > best.at) best = { taskId: edge.from, at };
+function taskForAnchors(graph, anchorIds, sessionId) {
+  if (!sessionId || !anchorIds || !anchorIds.length) return null;
+  const taskTarget = nodeId('task', sessionId);
+  const task = graph.nodes.get(taskTarget);
+  if (!task || task.kind !== 'task') return null;
+
+  for (const anchor of anchorIds) {
+    const covered = graph.edges.some((edge) =>
+      edge.edge === 'derived_from' && edge.from === taskTarget && edge.to === anchor
+    );
+    // ONE missing anchor refuses the whole attribution. A finding cited three
+    // files; this session's task touched two of them -- that is evidence the
+    // task did SOME related work, not evidence it produced THIS finding.
+    if (!covered) return null;
   }
-  return best ? best.taskId : null;
+  return taskTarget;
 }
 
 /**
  * A file path the way `recordToolOutcome` (metrics.mjs) already truncates and
- * stores it on a `tool-outcome` event's `anchor` field, so a derivation record
- * can join against that log without a second, divergent notion of "the same
- * anchor".
+ * stores it on a FILE-surface `tool-outcome` event's `anchor` field, so a
+ * derivation record can join against that log without a second, divergent
+ * notion of "the same anchor".
+ *
+ * COMMAND-surface events are DECLARED OUT OF SCOPE, not silently missed:
+ * `adapter.mjs` stores the COMMAND TEXT in `anchor` for those
+ * (`String(command).slice(0, 120)`), so a build or test run can never share
+ * an anchor string with a canonical file path -- there is no join key in
+ * common, and inventing a command-to-file heuristic (which files did a given
+ * `npm test` invocation cover?) is not something this record can answer
+ * honestly. `operationsScope` on the returned record says so explicitly,
+ * rather than letting an empty `operations` array look like "no build or
+ * test ever ran" when the truth is "this join cannot see it".
  */
 function anchorLabel(rawAnchor) {
   const path = String(rawAnchor).split('#')[0];
@@ -497,7 +528,8 @@ const MAX_DERIVATION_OPERATIONS = 5;
  * that comparison be reconstructed for a specific claim rather than only for
  * the anchor in general: the hash each anchor carried at the moment this
  * finding was derived from it, plus what evidence exists that any work
- * actually happened against it.
+ * actually happened against it. `derivationCheck` (staleness.mjs) is the
+ * reader that actually performs that comparison at serve time.
  *
  * DELIBERATELY NOT DUPLICATING THE EDGES. `derived_from` already records
  * WHICH anchors this finding cites; restating that here would be a second,
@@ -506,14 +538,23 @@ const MAX_DERIVATION_OPERATIONS = 5;
  *
  * DELIBERATELY NOT A REPLAY LOG. Recording enough to mechanically re-run a
  * derivation is a separate subsystem with real storage cost. This stores only
- * what the evidence log already has: `tool-outcome` events matching these
- * anchors, each reduced to the fields that were actually captured. An event
- * that carries no exit code or output contributes none -- nothing here is
- * invented to fill a shape the pipeline does not evidence yet. If a future
- * capture pass adds `exit`/`output` to those events, this starts carrying them
- * with no change to this function.
+ * what the evidence log already has: FILE-surface `tool-outcome` events
+ * matching these anchors, each reduced to the fields that were actually
+ * captured. An event that carries no exit code or output contributes none --
+ * nothing here is invented to fill a shape the pipeline does not evidence
+ * yet. If a future capture pass adds `exit`/`output` to those events, this
+ * starts carrying them with no change to this function.
+ *
+ * INCOMPLETENESS IS MARKED, NOT IMPLIED. An empty `operations` array is
+ * genuinely ambiguous on its own -- it is the same shape whether nothing
+ * happened, or something happened but fell outside what this join can see.
+ * `operationsComplete` distinguishes them: false when the evidence log itself
+ * may have dropped older matches (`evidenceIncomplete`, from
+ * `metrics.evidenceTruncated`) OR when more matches existed than the cap
+ * kept. A reader can then tell "no operations happened" from "operations
+ * existed but are not recorded here" instead of guessing.
  */
-function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
+function derivationFor(graph, resolvedAnchors, evidence, evidenceIncomplete, anchorSpecs) {
   const anchorHashes = {};
   for (const id of resolvedAnchors) {
     const node = graph.nodes.get(id);
@@ -521,8 +562,10 @@ function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
   }
 
   const labels = new Set((anchorSpecs || []).map(anchorLabel));
-  const operations = evidence
-    .filter((event) => event.kind === 'tool-outcome' && labels.has(event.anchor))
+  const matching = evidence.filter(
+    (event) => event.kind === 'tool-outcome' && labels.has(event.anchor)
+  );
+  const operations = [...matching]
     .sort((a, b) => (Number(b.at) || 0) - (Number(a.at) || 0))
     .slice(0, MAX_DERIVATION_OPERATIONS)
     .map((event) => {
@@ -540,7 +583,16 @@ function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
       return op;
     });
 
-  return { at: Date.now(), anchors: anchorHashes, operations };
+  return {
+    at: Date.now(),
+    anchors: anchorHashes,
+    operations,
+    // FILE touches only -- see `anchorLabel`. Declared here, in the record
+    // itself, not only in this function's comment, so a reader who never
+    // opens this source file still learns builds and test runs are excluded.
+    operationsScope: 'file',
+    operationsComplete: !evidenceIncomplete && matching.length <= operations.length,
+  };
 }
 
 /**
@@ -588,6 +640,9 @@ export function writeHarvested(
   // it can hold thousands of lines, so re-reading it per finding would turn a
   // batch of N findings into N passes over the same bytes.
   const evidence = readEvidence(dir);
+  // Cheap: one stat call, checked once per batch rather than once per
+  // finding's derivation record.
+  const evidenceIncomplete = evidenceTruncated(dir);
 
   const written = [];
   for (const finding of findings) {
@@ -647,14 +702,16 @@ export function writeHarvested(
     // An explicit `taskId` is authoritative when a caller supplies one --
     // it OVERRIDES traversal rather than merely seeding it, so a caller that
     // knows better is never second-guessed by inference. Absent one, the task
-    // is DERIVED from the graph itself: `taskForAnchors` finds the task that
-    // actually touched these anchors, which needs no session id from anyone.
-    // Either way, held to the same discipline as the anchors above: a target
-    // that does not resolve to an existing task node produces no edge rather
-    // than a dangling one.
+    // is DERIVED from the graph itself: `taskForAnchors` finds the CURRENT
+    // session's task (scoped by `sessionId`, the same identity this write
+    // already carries for provenance) and requires it to have touched EVERY
+    // one of this finding's anchors, not merely one -- see that function's
+    // own comment for the four attacks this closes. Either way, held to the
+    // same discipline as the anchors above: a target that does not resolve to
+    // an existing task node produces no edge rather than a dangling one.
     const answersTarget = taskId
       ? nodeId('task', taskId)
-      : taskForAnchors(currentGraph, resolved);
+      : taskForAnchors(currentGraph, resolved, sessionId);
     if (answersTarget && currentGraph.nodes.has(answersTarget)) {
       edges.push({ edge: 'answers', to: answersTarget });
     }
@@ -707,7 +764,7 @@ export function writeHarvested(
         // `render()`/`renderSessionIndex()` in inject.mjs or `wiki_read`'s
         // `toFinding()` projection, neither of which reads this field, so it
         // is not part of the automatic per-touch injection `fit()` prices.
-        derivation: derivationFor(currentGraph, resolved, evidence, finding.anchors || []),
+        derivation: derivationFor(currentGraph, resolved, evidence, evidenceIncomplete, finding.anchors || []),
       },
       edges
     );

--- a/integrations/qwen/hooks/lib/harvest-write.mjs
+++ b/integrations/qwen/hooks/lib/harvest-write.mjs
@@ -452,11 +452,13 @@ function resolveAnchor(dir, anchor, projectRoot) {
  * `linkCoOccurrence()` (wiki.mjs, inject.mjs) both key a task node by
  * `sessionId`, always, so there is exactly ONE task node for "the current
  * session" and it is `nodeId('task', sessionId)`. Restricting to that ONE
- * node structurally eliminates cases 1 and 2 -- a prior or concurrent
- * session's task has a DIFFERENT sessionId and therefore a different node
- * id, so it is never even looked at, regardless of timing. No caller can
- * supply a wrong sessionId and get someone ELSE's task; they can only fail
- * to get a match.
+ * node structurally eliminates cases 1 and 2 PROVIDED the identity itself is
+ * trustworthy: an UNRELATED sessionId (typo'd, invented, or simply absent)
+ * cannot resolve to someone else's task, because a different key is a
+ * different node id, full stop, regardless of timing. That is NOT the same
+ * guarantee as "no caller can get someone else's task" -- see the note on
+ * `authoritativeSessionId` below for the residual this leaves when the
+ * identity is real but comes from an untrusted caller.
  *
  * COVERAGE, NOT OVERLAP, fixes case 3: the session's task must have a
  * `derived_from` edge to EVERY one of this finding's anchors, not merely one.
@@ -472,17 +474,41 @@ function resolveAnchor(dir, anchor, projectRoot) {
  * or without a timestamp on that edge -- there is no ranking left for a
  * missing timestamp to lose.
  *
- * `sessionId` absent means there is no identity to scope by, which means no
- * candidate -- not "fall back to guessing". Absence is the correct answer
- * when the graph cannot support attribution.
+ * NO IDENTITY MEANS NO CANDIDATE -- not "fall back to guessing". Absence is
+ * the correct answer when the graph cannot support attribution.
+ *
+ * ROUND 4: THE IDENTITY ITSELF MUST BE AUTHORITATIVE, not merely present.
+ * Scoping to `nodeId('task', sessionId)` only refuses an UNRELATED session;
+ * it does nothing against a FOREIGN BUT REAL one. `wiki_write`'s `sessionId`
+ * is a plain MCP tool argument the calling model supplies, unverified -- a
+ * model that names some OTHER, prior session whose task genuinely covered
+ * these anchors gets an `answers` edge to that stale task, because coverage
+ * cannot tell "this session" from "a session that really did touch these
+ * files, named by a string nothing cross-checked". Session id is not
+ * evidence unless the CALLER'S OWN CHANNEL is trustworthy, which is true of
+ * `plugin/hooks/harvest-worker.mjs` (Claude Code's own hook payload) and not
+ * true of a tool-call argument. So this parameter is named for what it must
+ * be, `authoritativeSessionId`, and every caller is a promise: pass this only
+ * when you did not just read it out of untrusted input. `wiki_write` passes
+ * NONE, which means its calls never traverse -- see `writeHarvested`'s own
+ * comment at the call site for what that costs and why it is accepted rather
+ * than worked around.
+ *
+ * COVERAGE IS CHECKED AGAINST RESOLVED ANCHORS, not the caller's original
+ * list. `writeHarvested` already drops any anchor `resolveAnchor` could not
+ * resolve before this function ever runs, so "every anchor" here means every
+ * anchor that survived that filter -- self-consistent with the
+ * `derived_from` edges the same resolved list produces, but worth stating:
+ * an anchor that failed to resolve cannot raise or lower the bar for the
+ * anchors that did.
  */
-function taskForAnchors(graph, anchorIds, sessionId) {
-  if (!sessionId || !anchorIds || !anchorIds.length) return null;
-  const taskTarget = nodeId('task', sessionId);
+function taskForAnchors(graph, resolvedAnchorIds, authoritativeSessionId) {
+  if (!authoritativeSessionId || !resolvedAnchorIds || !resolvedAnchorIds.length) return null;
+  const taskTarget = nodeId('task', authoritativeSessionId);
   const task = graph.nodes.get(taskTarget);
   if (!task || task.kind !== 'task') return null;
 
-  for (const anchor of anchorIds) {
+  for (const anchor of resolvedAnchorIds) {
     const covered = graph.edges.some((edge) =>
       edge.edge === 'derived_from' && edge.from === taskTarget && edge.to === anchor
     );
@@ -604,7 +630,19 @@ function derivationFor(graph, resolvedAnchors, evidence, evidenceIncomplete, anc
 export function writeHarvested(
   dir,
   findings,
-  { sessionId = null, origin = ORIGIN_HARVESTED, projectRoot = null, taskId = null } = {}
+  {
+    sessionId = null,
+    origin = ORIGIN_HARVESTED,
+    projectRoot = null,
+    taskId = null,
+    // Distinct from `sessionId`, which is stored on every finding for
+    // provenance/display regardless of trust. This one gates the `answers`
+    // traversal fallback specifically, and every caller passing it is
+    // asserting the identity came from a channel it does not control --
+    // Claude Code's own hook payload, not a tool-call argument a model
+    // typed. See `taskForAnchors`'s comment for the attack this closes.
+    authoritativeSessionId = null,
+  } = {}
 ) {
   if (!Array.isArray(findings) || !findings.length) return [];
 
@@ -702,16 +740,29 @@ export function writeHarvested(
     // An explicit `taskId` is authoritative when a caller supplies one --
     // it OVERRIDES traversal rather than merely seeding it, so a caller that
     // knows better is never second-guessed by inference. Absent one, the task
-    // is DERIVED from the graph itself: `taskForAnchors` finds the CURRENT
-    // session's task (scoped by `sessionId`, the same identity this write
-    // already carries for provenance) and requires it to have touched EVERY
-    // one of this finding's anchors, not merely one -- see that function's
-    // own comment for the four attacks this closes. Either way, held to the
-    // same discipline as the anchors above: a target that does not resolve to
-    // an existing task node produces no edge rather than a dangling one.
+    // is DERIVED from the graph itself, but ONLY when `authoritativeSessionId`
+    // is present: `taskForAnchors` scopes to that exact session's task and
+    // requires it to have touched EVERY one of this finding's anchors, not
+    // merely one -- see that function's own comment for why the identity
+    // itself must be trustworthy, not merely present.
+    //
+    // THE CONSEQUENCE, STATED PLAINLY: `wiki_write` never supplies
+    // `authoritativeSessionId` (its `sessionId` is a model-typed MCP
+    // argument nothing cross-checks), so its calls never traverse and
+    // `answers` never fires on that path. `plugin/hooks/harvest-worker.mjs`
+    // does supply it (Claude Code's own hook payload), so `answers` fires
+    // there -- opt-in gated. `answers` therefore does NOT fire on a default
+    // install today. Recovering default liveness needs an authoritative
+    // identity on a default-install path, which is what Plan 2's
+    // `hooks-core/derive.mjs` (running in the Stop hook, where the session id
+    // is real) is for -- not a weaker check here.
+    //
+    // Either way, held to the same discipline as the anchors above: a target
+    // that does not resolve to an existing task node produces no edge rather
+    // than a dangling one.
     const answersTarget = taskId
       ? nodeId('task', taskId)
-      : taskForAnchors(currentGraph, resolved, sessionId);
+      : taskForAnchors(currentGraph, resolved, authoritativeSessionId);
     if (answersTarget && currentGraph.nodes.has(answersTarget)) {
       edges.push({ edge: 'answers', to: answersTarget });
     }

--- a/integrations/qwen/hooks/lib/harvest-write.mjs
+++ b/integrations/qwen/hooks/lib/harvest-write.mjs
@@ -436,7 +436,7 @@ function resolveAnchor(dir, anchor, projectRoot) {
 export function writeHarvested(
   dir,
   findings,
-  { sessionId = null, origin = ORIGIN_HARVESTED, projectRoot = null } = {}
+  { sessionId = null, origin = ORIGIN_HARVESTED, projectRoot = null, taskId = null } = {}
 ) {
   if (!Array.isArray(findings) || !findings.length) return [];
 
@@ -516,6 +516,21 @@ export function writeHarvested(
     // collision vanishingly unlikely while keeping the timestamp readable.
     const provenance = provenanceFor(finding);
     const key = `${prefixFor(provenance)}-${Date.now().toString(36)}-${written.length}-${randomBytes(4).toString("hex")}`;
+
+    const edges = resolved.map((target) => ({ edge: 'derived_from', to: target }));
+    // `answers` closes the loop back to the task that produced the finding, so
+    // provenance can be traversed rather than inferred: "which session
+    // established this, and from what". Declared in EDGE_KINDS and written by
+    // nothing until now. Held to the same discipline as the anchors above: a
+    // taskId that does not resolve to an existing task node produces no edge
+    // rather than a dangling one.
+    if (taskId) {
+      const taskTarget = nodeId('task', taskId);
+      if (currentGraph.nodes.has(taskTarget)) {
+        edges.push({ edge: 'answers', to: taskTarget });
+      }
+    }
+
     // ONE APPEND for the finding and every anchor it resolved. This runs in a
     // detached worker, so "the process survives to finish the loop" is not a
     // safe assumption: a node written without its edges is an active finding
@@ -557,7 +572,7 @@ export function writeHarvested(
           : undefined,
         sessionId,
       },
-      resolved.map((target) => ({ edge: 'derived_from', to: target }))
+      edges
     );
     // A failed write returns null. Reporting the key anyway would tell the
     // caller a claim was stored that no later session can retrieve.

--- a/integrations/qwen/hooks/lib/harvest-write.mjs
+++ b/integrations/qwen/hooks/lib/harvest-write.mjs
@@ -34,6 +34,7 @@ import { randomBytes } from 'node:crypto';
 import { realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
+import { readEvidence } from './metrics.mjs';
 
 /**
  * The types that may cross a project boundary.
@@ -428,6 +429,121 @@ function resolveAnchor(dir, anchor, projectRoot) {
 }
 
 /**
+ * Which task actually produced this finding, when nothing said so directly.
+ *
+ * Session id was the only signal `answers` had, and a session id is exactly
+ * what a caller may not have (`wiki_write`'s `sessionId` is optional and
+ * nothing populates it today; the detached harvest worker's is gated behind
+ * an opt-in). But the graph does not need to be TOLD which task this is: the
+ * structural harvest already writes `task -[derived_from]-> file` for every
+ * tool call, unconditionally, on every install. So the task is DERIVABLE --
+ * it is whichever task node has a `derived_from` edge to one of the SAME
+ * anchors this finding resolved to.
+ *
+ * "Most recent task, full stop" was rejected on purpose: a task that never
+ * touched these files could still be the newest node in the graph (a
+ * different file, a different concern, in a later session), and attaching
+ * provenance to it would be a WRONG edge, not a missing one -- worse than no
+ * edge, because a reader trusts it. So candidates are filtered to tasks that
+ * touched at least one of these anchors FIRST, and only ties among THOSE are
+ * broken by recency.
+ *
+ * The tie-break is the edge's own `at`, not the task node's `at`. A task that
+ * touched this file once, long ago, and then stayed active on unrelated files
+ * for hours has a late node timestamp that says nothing about this anchor;
+ * the edge timestamp says exactly when THIS task touched THIS anchor, which
+ * is the question being asked. Among tasks sharing an anchor, the one whose
+ * most recent touch to any shared anchor is latest wins -- recency of the
+ * relevant work, not recency of the task in general.
+ */
+function taskForAnchors(graph, anchorIds) {
+  if (!anchorIds || !anchorIds.length) return null;
+  const anchors = new Set(anchorIds);
+  let best = null;
+  for (const edge of graph.edges) {
+    if (edge.edge !== 'derived_from' || !anchors.has(edge.to)) continue;
+    const from = graph.nodes.get(edge.from);
+    // `derived_from` is also how a FINDING cites its own anchors, so without
+    // this a finding that already cited the same file would be mistaken for
+    // the task that produced it.
+    if (!from || from.kind !== 'task') continue;
+    const at = Number(edge.at) || 0;
+    if (!best || at > best.at) best = { taskId: edge.from, at };
+  }
+  return best ? best.taskId : null;
+}
+
+/**
+ * A file path the way `recordToolOutcome` (metrics.mjs) already truncates and
+ * stores it on a `tool-outcome` event's `anchor` field, so a derivation record
+ * can join against that log without a second, divergent notion of "the same
+ * anchor".
+ */
+function anchorLabel(rawAnchor) {
+  const path = String(rawAnchor).split('#')[0];
+  return canonicalPath(path).slice(0, 120);
+}
+
+/** How many recorded operations a single finding's derivation may cite. */
+const MAX_DERIVATION_OPERATIONS = 5;
+
+/**
+ * The checkable half of provenance: not just where a finding came from, but
+ * whether that derivation still holds.
+ *
+ * Citation-style provenance (a session or task id) answers "where". It never
+ * answers "does this still apply" -- that is what staleness already computes,
+ * by comparing an anchor's STORED hash against disk. This record is what lets
+ * that comparison be reconstructed for a specific claim rather than only for
+ * the anchor in general: the hash each anchor carried at the moment this
+ * finding was derived from it, plus what evidence exists that any work
+ * actually happened against it.
+ *
+ * DELIBERATELY NOT DUPLICATING THE EDGES. `derived_from` already records
+ * WHICH anchors this finding cites; restating that here would be a second,
+ * driftable copy of the same fact. What is new here, and only here, is the
+ * HASH each anchor carried at claim time -- edges carry no such thing.
+ *
+ * DELIBERATELY NOT A REPLAY LOG. Recording enough to mechanically re-run a
+ * derivation is a separate subsystem with real storage cost. This stores only
+ * what the evidence log already has: `tool-outcome` events matching these
+ * anchors, each reduced to the fields that were actually captured. An event
+ * that carries no exit code or output contributes none -- nothing here is
+ * invented to fill a shape the pipeline does not evidence yet. If a future
+ * capture pass adds `exit`/`output` to those events, this starts carrying them
+ * with no change to this function.
+ */
+function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
+  const anchorHashes = {};
+  for (const id of resolvedAnchors) {
+    const node = graph.nodes.get(id);
+    if (node && typeof node.hash === 'string') anchorHashes[id] = node.hash;
+  }
+
+  const labels = new Set((anchorSpecs || []).map(anchorLabel));
+  const operations = evidence
+    .filter((event) => event.kind === 'tool-outcome' && labels.has(event.anchor))
+    .sort((a, b) => (Number(b.at) || 0) - (Number(a.at) || 0))
+    .slice(0, MAX_DERIVATION_OPERATIONS)
+    .map((event) => {
+      const op = {};
+      if (typeof event.toolName === 'string' && event.toolName)
+        op.tool = event.toolName.slice(0, 60);
+      if (typeof event.success === 'boolean') op.success = event.success;
+      if (typeof event.at === 'number') op.at = event.at;
+      // Forward-compatible, not fabricated: neither field exists on a
+      // `tool-outcome` event in this pipeline today, so every operation
+      // omits them until a capture pass actually evidences one.
+      if (typeof event.exit === 'number') op.exit = event.exit;
+      if (typeof event.output === 'string' && event.output)
+        op.output = event.output.slice(0, 200);
+      return op;
+    });
+
+  return { at: Date.now(), anchors: anchorHashes, operations };
+}
+
+/**
  * Writes validated findings, returning the keys actually stored.
  *
  * `findings` is the output of `harvest.validate()`, so type/claim/confidence
@@ -467,6 +583,11 @@ export function writeHarvested(
       : batch;
   const prefixFor = (p) =>
     p === ORIGIN_AGENT ? 'agent' : p === ORIGIN_HUMAN ? 'human' : 'harvested';
+
+  // Read once: every finding in this batch shares the same evidence log, and
+  // it can hold thousands of lines, so re-reading it per finding would turn a
+  // batch of N findings into N passes over the same bytes.
+  const evidence = readEvidence(dir);
 
   const written = [];
   for (const finding of findings) {
@@ -521,14 +642,21 @@ export function writeHarvested(
     // `answers` closes the loop back to the task that produced the finding, so
     // provenance can be traversed rather than inferred: "which session
     // established this, and from what". Declared in EDGE_KINDS and written by
-    // nothing until now. Held to the same discipline as the anchors above: a
-    // taskId that does not resolve to an existing task node produces no edge
-    // rather than a dangling one.
-    if (taskId) {
-      const taskTarget = nodeId('task', taskId);
-      if (currentGraph.nodes.has(taskTarget)) {
-        edges.push({ edge: 'answers', to: taskTarget });
-      }
+    // nothing until now.
+    //
+    // An explicit `taskId` is authoritative when a caller supplies one --
+    // it OVERRIDES traversal rather than merely seeding it, so a caller that
+    // knows better is never second-guessed by inference. Absent one, the task
+    // is DERIVED from the graph itself: `taskForAnchors` finds the task that
+    // actually touched these anchors, which needs no session id from anyone.
+    // Either way, held to the same discipline as the anchors above: a target
+    // that does not resolve to an existing task node produces no edge rather
+    // than a dangling one.
+    const answersTarget = taskId
+      ? nodeId('task', taskId)
+      : taskForAnchors(currentGraph, resolved);
+    if (answersTarget && currentGraph.nodes.has(answersTarget)) {
+      edges.push({ edge: 'answers', to: answersTarget });
     }
 
     // ONE APPEND for the finding and every anchor it resolved. This runs in a
@@ -571,6 +699,15 @@ export function writeHarvested(
           ? finding.quote
           : undefined,
         sessionId,
+        // THE CHECKABLE HALF OF PROVENANCE. Citation-style (this `sessionId`,
+        // the `answers` edge above) says WHERE a claim came from; it never
+        // says whether that derivation still applies. `derivationFor` reaches
+        // through `wiki_query`'s `node`/`get`/`search` operations only (those
+        // return a finding's stored fields wholesale) -- never through
+        // `render()`/`renderSessionIndex()` in inject.mjs or `wiki_read`'s
+        // `toFinding()` projection, neither of which reads this field, so it
+        // is not part of the automatic per-touch injection `fit()` prices.
+        derivation: derivationFor(currentGraph, resolved, evidence, finding.anchors || []),
       },
       edges
     );

--- a/integrations/qwen/hooks/lib/inject.mjs
+++ b/integrations/qwen/hooks/lib/inject.mjs
@@ -26,6 +26,7 @@ import {
 } from './wiki.mjs';
 import { basename } from 'node:path';
 import { serve, diffLines } from './staleness.mjs';
+import { drainInvalidations } from './pending.mjs';
 import { inHoldout, record, indexBudget } from './metrics.mjs';
 import { canonicalPath, resolvableCandidates } from './paths.mjs';
 import { annotatedSkeleton } from './skeleton.mjs';
@@ -142,6 +143,31 @@ function render(finding) {
 }
 
 /**
+ * Applies anything the post-tool hook queued, BEFORE anything is served.
+ *
+ * THIS IS WHERE EAGER STALENESS LANDS. `invalidateOnWrite` needs a graph, and
+ * loading one on the return path of every write is what pending.mjs exists to
+ * avoid -- so the hook queues and the next graph read applies. These two
+ * functions are that read: they already hold a freshly loaded graph, and they
+ * are the last thing to run before a finding reaches a model.
+ *
+ * RE-READ ONLY WHEN SOMETHING WAS ACTUALLY MARKED. The drain writes the stale
+ * flag to disk; it cannot mutate the caller's already-parsed graph, so serving
+ * from that copy would deliver the very "stale finding as fresh" this exists to
+ * prevent. A second load costs a parse, and it is paid once per observed write
+ * rather than once per tool call -- when nothing is queued this is one stat.
+ */
+function withPendingApplied(dir, graph) {
+  try {
+    return drainInvalidations(dir, graph) > 0 ? load(dir) : graph;
+  } catch {
+    // The lazy path still covers everything this would have caught early, and
+    // a hook must never fail because bookkeeping did.
+    return graph;
+  }
+}
+
+/**
  * What the model sees when it touches a file.
  *
  * Returns null when there is nothing to say, or when this touch fell into the
@@ -154,6 +180,7 @@ export function forTouch(
   rawPath,
   { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
+  graph = withPendingApplied(dir, graph);
   // Canonical, so a touch finds findings anchored under any other spelling.
   const filePath = canonicalPath(rawPath);
   const anchorId = nodeId('file', filePath);
@@ -322,6 +349,7 @@ export function forCommand(
   { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
   if (!command) return null;
+  graph = withPendingApplied(dir, graph);
 
   const candidates = [];
   for (const node of graph.nodes.values()) {

--- a/integrations/qwen/hooks/lib/inject.mjs
+++ b/integrations/qwen/hooks/lib/inject.mjs
@@ -33,6 +33,7 @@ import { annotatedSkeleton } from './skeleton.mjs';
 import { substitutionBudget } from './metrics.mjs';
 import { assessFindings } from './utility.mjs';
 import { quarantineSharedSource } from './harvest-write.mjs';
+import { cacheOrdered } from './cache.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
@@ -1152,6 +1153,53 @@ export function standingRules(dir, graph, { budget = standingBudget(), episode =
   // which is worse than saying there are more: a model that knows the list is
   // truncated can ask, one that does not will assume it is complete.
   return `${HEADING}${lines.join('\n')}${truncated}`;
+}
+
+/**
+ * SessionStart context, assembled in cache order: stable first, volatile last.
+ *
+ * WHY THE ORDER IS A CORRECTNESS PROPERTY AND NOT A STYLE CHOICE. Everything
+ * here lands near the FRONT of the prompt prefix, and a prefix cache is
+ * invalidated from the first differing byte onward. A block whose text changes
+ * between sessions therefore prices everything positioned after it: put the
+ * freshest block first and the whole remainder of the prefix is re-written
+ * every session; put it last and the invalidation is confined to its own tail.
+ * cache.mjs measures exactly this cost in the user's files -- this is the same
+ * discipline applied to our own output, which is the half nobody else has to
+ * think about because nobody else writes into the prefix.
+ *
+ * `cacheOrdered` existed for precisely this and had no caller, so the order was
+ * whatever order the call sites happened to push in. It was accidentally right;
+ * it is now enforced, which is the difference that matters the next time a
+ * block is added.
+ *
+ * VOLATILITY IS ASSIGNED FROM HOW OFTEN THE TEXT ACTUALLY DIFFERS BETWEEN
+ * SESSIONS, not from how important the block is:
+ *
+ *   0  policy -- the optimization notice and project briefing. Deliberately
+ *      cache-safe by construction: the routing facts are number-free and the
+ *      briefing passes through `stableText`, which DROPS any line that would
+ *      vary. It changes when the tool inventory or configuration changes.
+ *   1  standing -- pinned facts and human-verified corrections, rendered in
+ *      full. Changes only when a person pins, retires or corrects something.
+ *   2  index -- the bounded wiki index, selected per session from the task
+ *      text, and carrying [STALE]/[DISPUTED] markers that flip as the code
+ *      moves. Different on most sessions.
+ *   3  restoration -- present only when resuming from a compaction, and derived
+ *      from the anchors of the session that was just discarded. Never twice the
+ *      same.
+ *
+ * A block with no text is dropped rather than joined, so an absent block cannot
+ * open the assembly with a blank line.
+ */
+export function sessionContext(blocks) {
+  return cacheOrdered(
+    (Array.isArray(blocks) ? blocks : []).filter(
+      (block) => block && typeof block.text === 'string' && block.text.trim()
+    )
+  )
+    .map((block) => block.text)
+    .join('\n\n');
 }
 
 /**

--- a/integrations/qwen/hooks/lib/inject.mjs
+++ b/integrations/qwen/hooks/lib/inject.mjs
@@ -122,8 +122,29 @@ function fit(findings, budget) {
   return { kept, spent };
 }
 
+/**
+ * Discloses an open disagreement, on the same line as the claim it is about.
+ *
+ * BOTH HALVES, like the stale renderer below: the strong form names the other
+ * finding so the reader can fetch it, and the form without a key says only what
+ * is actually known. `serve` is what establishes the dispute; this only phrases
+ * it, and it phrases it in one short line because `fit` prices `render` against
+ * the injection budget -- a disagreement is worth a pointer, not both claims in
+ * full.
+ *
+ * NO DISMISSAL VOCABULARY, for the reason measured on the stale wording: an
+ * instruction to discount suppressed findings that were correct. This states
+ * that another claim exists and where to find it, and lets the reader decide.
+ */
+function disputeNote(finding) {
+  if (!finding.contradicted) return '';
+  return finding.contradictedBy
+    ? `\n  DISPUTED by ${finding.contradictedBy} -- wiki_query that key for the other claim`
+    : '\n  DISPUTED by another finding in this graph';
+}
+
 function render(finding) {
-  const head = `- [${finding.type || 'finding'}] ${finding.claim}`;
+  const head = `- [${finding.type || 'finding'}] ${finding.claim}${disputeNote(finding)}`;
   if (!finding.stale) return head;
 
   // A stale finding NEVER renders as though it were current. But the strength
@@ -997,7 +1018,15 @@ function renderSessionIndex(total, findings) {
       : finding.stale
         ? ' [possibly stale; verify before use]'
         : '';
-    return `- ${finding.key}${freshness}: ${finding.claim.slice(0, 90)}`;
+    // The session index is the first thing a session reads, so a disputed
+    // finding must not be listed there as settled either. Compressed to a
+    // marker and a key, matching the freshness markers beside it.
+    const dispute = finding.contradicted
+      ? finding.contradictedBy
+        ? ` [DISPUTED by ${finding.contradictedBy}]`
+        : ' [DISPUTED]'
+      : '';
+    return `- ${finding.key}${freshness}${dispute}: ${finding.claim.slice(0, 90)}`;
   });
   return `# Project wiki (${total} findings, ${findings.length} listed)
 

--- a/integrations/qwen/hooks/lib/inject.mjs
+++ b/integrations/qwen/hooks/lib/inject.mjs
@@ -139,9 +139,26 @@ function fit(findings, budget) {
  */
 function disputeNote(finding) {
   if (!finding.contradicted) return '';
-  return finding.contradictedBy
+  const head = finding.contradictedBy
     ? `\n  DISPUTED by ${finding.contradictedBy} -- wiki_query that key for the other claim`
     : '\n  DISPUTED by another finding in this graph';
+  // THE REASON A PERSON TYPED, rendered here because this is the fullest of the
+  // three dispute surfaces and the only one with room for a sentence. `contradict`
+  // has always stored up to 400 characters of human explanation and, until this
+  // line, nothing read it: the pointer told a reader where to look and withheld
+  // the one thing that would tell them whether looking was worth a tool call.
+  //
+  // TRUNCATED AT 140, because `fit` prices this string against the injection
+  // budget and a 400-character paragraph beside a one-line claim inverts the
+  // proportions. The compressed surfaces -- the session index and restore.mjs's
+  // "Likely next" list -- deliberately keep marker-and-key only; they are one
+  // line per finding by design, and `wiki_query` returns the reason in full.
+  if (typeof finding.contradictionReason !== 'string' || !finding.contradictionReason.trim()) {
+    return head;
+  }
+  const reason = finding.contradictionReason.trim();
+  const shown = reason.length > 140 ? `${reason.slice(0, 140)}...` : reason;
+  return `${head}\n  Reason given: ${shown}`;
 }
 
 /**

--- a/integrations/qwen/hooks/lib/inject.mjs
+++ b/integrations/qwen/hooks/lib/inject.mjs
@@ -276,7 +276,10 @@ export function forTouch(
   // others, so the comparison becomes within-file and the dominant source of
   // variance drops out. A session-pinned arm would destroy that.
   const holdout = inHoldout(filePath);
-  const served = serve(graph, candidates);
+  // `dir` so an eager flag whose evidence is gone is cleared here rather than
+  // waiting for somebody to open the dashboard. Same evidence test as the manual
+  // path -- see `serve`.
+  const served = serve(graph, candidates, { dir });
   const assessed = assessFindings(dir, served, {
     episodeId: episode.episodeId || sessionId,
     relevanceFor: () => 1,
@@ -463,7 +466,7 @@ export function forCommand(
   // only thing an uncapped list buys is the I/O.
   const considered = candidates.slice(0, MAX_COMMAND_CANDIDATES);
 
-  const served = serve(graph, considered);
+  const served = serve(graph, considered, { dir });
   const assessed = assessFindings(dir, served, {
     episodeId: episode.episodeId || sessionId,
     relevanceFor: (finding) => explicit(finding) ? 1 : 0.6,
@@ -990,7 +993,7 @@ export function sessionIndex(dir, graph, { episode = {}, relevantFindingIds = []
   // `serve` is the only path allowed to hand a finding to a model. In
   // particular, activating this previously-unwired index must not create a new
   // path that labels an invalidated content claim as current.
-  const served = serve(graph, selected);
+  const served = serve(graph, selected, { dir });
   if (!served.length) return null;
   // A stale marker is longer than the fresh preview used for candidate
   // selection. Trim from the lowest-ranked end until the ACTUAL message fits.

--- a/integrations/qwen/hooks/lib/inject.mjs
+++ b/integrations/qwen/hooks/lib/inject.mjs
@@ -156,9 +156,9 @@ function disputeNote(finding) {
 function derivationNote(finding) {
   if (finding.derivationHolds !== false) return '';
   const changed = Array.isArray(finding.derivationChanged) ? finding.derivationChanged : [];
-  return changed.length
-    ? `\n  DERIVATION CHANGED -- ${changed.join(', ')} no longer match what this claim was derived from`
-    : '\n  DERIVATION CHANGED since this claim was recorded';
+  if (!changed.length) return '\n  DERIVATION CHANGED since this claim was recorded';
+  const verb = changed.length === 1 ? 'no longer matches' : 'no longer match';
+  return `\n  DERIVATION CHANGED -- ${changed.join(', ')} ${verb} what this claim was derived from`;
 }
 
 function render(finding) {

--- a/integrations/qwen/hooks/lib/inject.mjs
+++ b/integrations/qwen/hooks/lib/inject.mjs
@@ -143,8 +143,26 @@ function disputeNote(finding) {
     : '\n  DISPUTED by another finding in this graph';
 }
 
+/**
+ * Discloses `derivationCheck`'s verdict (staleness.mjs) -- distinct from
+ * `disputeNote` (another finding disagrees) and from the STALE block below
+ * (the anchor NODE's current hash does not match disk). This is about
+ * whether the bytes THIS claim was actually derived from are still the bytes
+ * an anchor holds; see `derivationCheck`'s comment for the case that catches
+ * that the other two can miss. Silent when it holds -- the common case pays
+ * nothing -- and silent when it was never checked at all (an older finding
+ * with no `derivation` record).
+ */
+function derivationNote(finding) {
+  if (finding.derivationHolds !== false) return '';
+  const changed = Array.isArray(finding.derivationChanged) ? finding.derivationChanged : [];
+  return changed.length
+    ? `\n  DERIVATION CHANGED -- ${changed.join(', ')} no longer match what this claim was derived from`
+    : '\n  DERIVATION CHANGED since this claim was recorded';
+}
+
 function render(finding) {
-  const head = `- [${finding.type || 'finding'}] ${finding.claim}${disputeNote(finding)}`;
+  const head = `- [${finding.type || 'finding'}] ${finding.claim}${disputeNote(finding)}${derivationNote(finding)}`;
   if (!finding.stale) return head;
 
   // A stale finding NEVER renders as though it were current. But the strength

--- a/integrations/qwen/hooks/lib/inject.mjs
+++ b/integrations/qwen/hooks/lib/inject.mjs
@@ -157,9 +157,28 @@ function render(finding) {
  * prevent. A second load costs a parse, and it is paid once per observed write
  * rather than once per tool call -- when nothing is queued this is one stat.
  */
+/**
+ * Per process, per graph directory: did the drain change anything?
+ *
+ * THE SECOND CALLER IS WHY THIS EXISTS. SessionStart calls `standingRules` and
+ * then `sessionIndex` with the SAME graph object it loaded once. Without this
+ * memo the first call drains, marks, and re-reads privately -- and the second
+ * call finds an empty queue, marks nothing, and therefore serves from the
+ * caller's pre-drain copy, advertising as current the very finding the first
+ * call had just marked. Draining is not idempotent from the caller's point of
+ * view; remembering the ANSWER is what makes it so.
+ *
+ * A hook process handles one lifecycle event, so this map holds one or two
+ * entries and dies with the process.
+ */
+const drainedDirs = new Map();
+
 function withPendingApplied(dir, graph) {
   try {
-    return drainInvalidations(dir, graph) > 0 ? load(dir) : graph;
+    if (drainedDirs.has(dir)) return drainedDirs.get(dir) ? load(dir) : graph;
+    const marked = drainInvalidations(dir, graph) > 0;
+    drainedDirs.set(dir, marked);
+    return marked ? load(dir) : graph;
   } catch {
     // The lazy path still covers everything this would have caught early, and
     // a hook must never fail because bookkeeping did.
@@ -862,6 +881,12 @@ export function relevantFindingIdsForContext(graph, context, { limit = 8 } = {})
  * shrinks toward the floor. See metrics.indexBudget.
  */
 export function sessionIndex(dir, graph, { episode = {}, relevantFindingIds = [] } = {}) {
+  // DRAINED HERE TOO, and this is the worst place to be wrong. The session index
+  // is the FIRST thing a session sees and it arrives with no other context to
+  // correct it, so advertising a finding the graph already knows is stale is a
+  // false claim made at maximum leverage. The graph is loaded either way, so the
+  // only cost is the stat that finds no queue.
+  graph = withPendingApplied(dir, graph);
   const budget = indexBudget(dir);
   const relevant = new Set(relevantFindingIds);
   // Some SessionStart payloads have no task signal. Fail closed for situational
@@ -988,6 +1013,9 @@ ${lines.join('\n')}`;
  * is wallpaper, and the model stops reading the thing it always sees.
  */
 export function standingRules(dir, graph, { budget = standingBudget(), episode = {} } = {}) {
+  // Same reason as sessionIndex: always-on text, delivered before the first
+  // tool call, with nothing following it that could qualify what it said.
+  graph = withPendingApplied(dir, graph);
   const rules = [...graph.nodes.values()].filter(
     (n) =>
       n.kind === 'finding' &&

--- a/integrations/qwen/hooks/lib/inject.mjs
+++ b/integrations/qwen/hooks/lib/inject.mjs
@@ -143,6 +143,40 @@ function render(finding) {
 }
 
 /**
+ * Graph directories where a drain has already marked something in THIS process.
+ *
+ * THE SECOND CALLER IS WHY THIS EXISTS. SessionStart calls `standingRules` and
+ * then `sessionIndex` with the SAME graph object it loaded once. Without this,
+ * the first call drains, marks, and re-reads privately -- and the second call
+ * finds an empty queue, marks nothing, and therefore serves from the caller's
+ * pre-drain copy, advertising as current the very finding the first call had
+ * just marked. Draining is idempotent; its EFFECT on a caller's parsed graph is
+ * not, so what is remembered here is "a re-read is owed", nothing else.
+ *
+ * ONLY THE POSITIVE CASE IS REMEMBERED, and that is a correctness decision
+ * rather than a tuning one. Remembering "nothing was queued" would mean a queue
+ * arriving LATER in the same process is silently skipped and deferred to some
+ * future session. That cannot happen today, because `queueInvalidation` runs in
+ * the post-tool branch before any injection -- but that is an unguarded
+ * ordering dependency, and it stops being true the moment someone adds a call
+ * site. A repeated empty drain costs one `existsSync` on a file that is not
+ * there, which is a price worth paying to not have an invariant that depends on
+ * nobody reordering anything.
+ *
+ * KEYED CANONICALLY. Two spellings of one directory -- a trailing separator, a
+ * `..` segment, a lower-cased drive letter -- would otherwise be two entries,
+ * which reintroduces exactly the pre-drain-copy bug above. This is the same
+ * defect shape Task 2 on this branch shipped for real, where a tool resolved its
+ * graph from a raw cwd while the hooks resolved theirs through `projectRootFor`
+ * and the two halves of a metric landed in different directories. Path identity
+ * is why `canonicalKey` lives inside `nodeId` rather than at its call sites.
+ *
+ * A hook process handles one lifecycle event, so this set holds one or two
+ * entries and dies with the process.
+ */
+const drainedDirs = new Set();
+
+/**
  * Applies anything the post-tool hook queued, BEFORE anything is served.
  *
  * THIS IS WHERE EAGER STALENESS LANDS. `invalidateOnWrite` needs a graph, and
@@ -157,28 +191,14 @@ function render(finding) {
  * prevent. A second load costs a parse, and it is paid once per observed write
  * rather than once per tool call -- when nothing is queued this is one stat.
  */
-/**
- * Per process, per graph directory: did the drain change anything?
- *
- * THE SECOND CALLER IS WHY THIS EXISTS. SessionStart calls `standingRules` and
- * then `sessionIndex` with the SAME graph object it loaded once. Without this
- * memo the first call drains, marks, and re-reads privately -- and the second
- * call finds an empty queue, marks nothing, and therefore serves from the
- * caller's pre-drain copy, advertising as current the very finding the first
- * call had just marked. Draining is not idempotent from the caller's point of
- * view; remembering the ANSWER is what makes it so.
- *
- * A hook process handles one lifecycle event, so this map holds one or two
- * entries and dies with the process.
- */
-const drainedDirs = new Map();
-
 function withPendingApplied(dir, graph) {
   try {
-    if (drainedDirs.has(dir)) return drainedDirs.get(dir) ? load(dir) : graph;
-    const marked = drainInvalidations(dir, graph) > 0;
-    drainedDirs.set(dir, marked);
-    return marked ? load(dir) : graph;
+    const key = canonicalPath(dir);
+    // The drain runs EVERY time. It is one stat when there is nothing to do,
+    // and running it unconditionally is what keeps the memo from encoding an
+    // assumption about which hook branch ran first.
+    if (drainInvalidations(dir, graph) > 0) drainedDirs.add(key);
+    return drainedDirs.has(key) ? load(dir) : graph;
   } catch {
     // The lazy path still covers everything this would have caught early, and
     // a hook must never fail because bookkeeping did.

--- a/integrations/qwen/hooks/lib/lexical.mjs
+++ b/integrations/qwen/hooks/lib/lexical.mjs
@@ -1,0 +1,73 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/lexical.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * BM25 over findings. Pure, dependency-free, deterministic.
+ *
+ * WHY THIS REPLACES `includes()`. The dashboard filtered findings by substring,
+ * which cannot RANK -- and every consumer of retrieval here is under a hard
+ * token budget, so the budget kept whatever happened to match rather than what
+ * matched best. Ranking is the whole value at a budget.
+ *
+ * WHY BM25 AND NOT EMBEDDINGS. Deliberate, per docs/WIKI_GRAPH.md: deterministic,
+ * instant, explainable, and it cannot drift or need a rebuild. The known cost is
+ * recall on findings with no lexical overlap; Plan 2's recall probe measures that
+ * rather than assuming it away.
+ */
+
+/** Non-word split, lowercased. Short tokens are kept: `fs`, `id`, `os` matter here. */
+export function tokenize(text) {
+  return String(text || '')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+}
+
+/**
+ * Classic BM25. `k1` controls term-frequency saturation, `b` length normalisation.
+ * Defaults are the standard ones and are exposed so the recall probe can sweep them.
+ */
+export function rank(query, findings, { limit = 20, k1 = 1.2, b = 0.75 } = {}) {
+  const terms = tokenize(query);
+  if (!terms.length || !Array.isArray(findings) || !findings.length) return [];
+
+  // A finding's searchable text is its claim AND its key: the key is how the
+  // session index refers to it, so a model quoting a key must find it.
+  const docs = findings.map((finding) => ({
+    finding,
+    tokens: tokenize(`${finding.key || ''} ${finding.claim || ''}`),
+  }));
+
+  const avgLen = docs.reduce((sum, d) => sum + d.tokens.length, 0) / docs.length;
+  const N = docs.length;
+
+  const docFreq = new Map();
+  for (const { tokens } of docs) {
+    for (const term of new Set(tokens)) {
+      docFreq.set(term, (docFreq.get(term) || 0) + 1);
+    }
+  }
+
+  const scored = [];
+  for (const { finding, tokens } of docs) {
+    const counts = new Map();
+    for (const token of tokens) counts.set(token, (counts.get(token) || 0) + 1);
+
+    let score = 0;
+    for (const term of terms) {
+      const tf = counts.get(term);
+      if (!tf) continue;
+      const df = docFreq.get(term) || 0;
+      // Standard BM25 IDF, floored at zero so a term present in every document
+      // contributes nothing rather than a negative score.
+      const idf = Math.max(0, Math.log(1 + (N - df + 0.5) / (df + 0.5)));
+      const norm = tf + k1 * (1 - b + (b * tokens.length) / (avgLen || 1));
+      score += idf * ((tf * (k1 + 1)) / (norm || 1));
+    }
+
+    // Zero means no term matched. Omitted rather than returned, so a caller
+    // under a token budget never spends it on an irrelevant finding.
+    if (score > 0) scored.push({ finding, score });
+  }
+
+  return scored.sort((a, b2) => b2.score - a.score).slice(0, limit);
+}

--- a/integrations/qwen/hooks/lib/lexical.mjs
+++ b/integrations/qwen/hooks/lib/lexical.mjs
@@ -14,12 +14,54 @@
  * rather than assuming it away.
  */
 
-/** Non-word split, lowercased. Short tokens are kept: `fs`, `id`, `os` matter here. */
-export function tokenize(text) {
-  return String(text || '')
-    .toLowerCase()
-    .split(/[^a-z0-9]+/)
+/**
+ * Splits an identifier's alphanumeric run into its camelCase / letter-digit
+ * parts, e.g. `skipLibCheck` -> ['skip', 'Lib', 'Check'], `TS2345` ->
+ * ['TS', '2345']. Returns a single-element array when there is no internal
+ * boundary (e.g. `retry` -> ['retry']) so callers can skip emitting a
+ * redundant duplicate of the whole token.
+ */
+function splitIdentifierParts(word) {
+  return word
+    .replace(/([a-z])([A-Z])/g, '$1\0$2')
+    .replace(/([A-Za-z])([0-9])/g, '$1\0$2')
+    .replace(/([0-9])([A-Za-z])/g, '$1\0$2')
+    .split('\0')
     .filter(Boolean);
+}
+
+/**
+ * Non-word split, lowercased. Short tokens are kept: `fs`, `id`, `os` matter
+ * here.
+ *
+ * Emits sub-tokens for compound identifiers, in addition to the whole token.
+ * Delimited identifiers (`smart_read`, `wiki.mjs`, the flag in
+ * `--skipLibCheck`) already round-trip fine: the delimiter splits them, and
+ * because query and claim pass through this same function, a query typed
+ * with the same delimiters matches. The silent gap was CONCATENATED
+ * identifiers with no delimiter at all -- `skipLibCheck` collapsed to the
+ * single token `skiplibcheck`, so a query for "skip lib check" (or "TS 2345"
+ * against `TS2345`) never intersected it. No error, just an absent result --
+ * and findings are about code, where run-together identifiers are the
+ * common case. So every alphanumeric run keeps its whole-token form (a query
+ * for the concatenated form still matches) and ALSO contributes its
+ * camelCase / letter-digit parts (a query for the separated form now
+ * matches too). A lone incidental character -- e.g. the `c` split out of a
+ * Windows path `C:\Users\...` -- needs no special-casing: it is a real
+ * token like any other, and BM25's IDF already discounts a term that shows
+ * up in nearly every finding.
+ */
+export function tokenize(text) {
+  const words = String(text || '').match(/[A-Za-z0-9]+/g) || [];
+  const tokens = [];
+  for (const word of words) {
+    tokens.push(word.toLowerCase());
+    const parts = splitIdentifierParts(word);
+    if (parts.length > 1) {
+      for (const part of parts) tokens.push(part.toLowerCase());
+    }
+  }
+  return tokens;
 }
 
 /**
@@ -57,9 +99,15 @@ export function rank(query, findings, { limit = 20, k1 = 1.2, b = 0.75 } = {}) {
       const tf = counts.get(term);
       if (!tf) continue;
       const df = docFreq.get(term) || 0;
-      // Standard BM25 IDF, floored at zero so a term present in every document
-      // contributes nothing rather than a negative score.
-      const idf = Math.max(0, Math.log(1 + (N - df + 0.5) / (df + 0.5)));
+      // Smoothed BM25 idf: log(1 + (N - df + 0.5) / (df + 0.5)). Unlike the
+      // classic unsmoothed idf (log((N - df + 0.5) / (df + 0.5))), which goes
+      // negative once a term appears in most documents, this smoothed form
+      // is strictly positive for every df in [1, N]: even at df === N the
+      // ratio inside the log is (N + 1) / (N + 0.5), which is always
+      // strictly greater than 1, so log(1 + that) is always > 0. No floor
+      // is needed here, and none is applied -- there is no negative case
+      // for this formula to guard against.
+      const idf = Math.log(1 + (N - df + 0.5) / (df + 0.5));
       const norm = tf + k1 * (1 - b + (b * tokens.length) / (avgLen || 1));
       score += idf * ((tf * (k1 + 1)) / (norm || 1));
     }

--- a/integrations/qwen/hooks/lib/lexical.mjs
+++ b/integrations/qwen/hooks/lib/lexical.mjs
@@ -65,6 +65,43 @@ export function tokenize(text) {
 }
 
 /**
+ * Effective term-frequency credit for a document that has NO exact token
+ * match for a query term but DOES have a token that starts with it (e.g.
+ * query `custom` against a document containing `customer`). Deliberately
+ * less than one exact occurrence (`1`), and it is a flat credit rather than
+ * one that grows with the number of prefix-matching tokens in the document,
+ * so a prefix hit can never outscore an exact hit of the same term:
+ *
+ *   BM25's per-term contribution is `idf * tf * (k1 + 1) / (tf + K)`, where
+ *   `K = k1 * (1 - b + b * L / avgL)` depends only on document length, not
+ *   on which term or how it matched. As a function of `tf` alone, with `K`
+ *   fixed, `f(tf) = tf / (tf + K)` is non-decreasing for every `tf >= 0` and
+ *   `k1 >= 0` (its derivative `K / (tf + K)^2` is never negative). So for
+ *   ANY document length, and any number of prefix-only occurrences, using
+ *   `PREFIX_TF < 1` in place of `tf` scores no higher than an actual exact
+ *   occurrence (`tf = 1`) would in that same document -- there is no
+ *   PREFIX_TF-independent way to accumulate more evidence than one real hit
+ *   by matching only a prefix. This is also why the count of prefix matches
+ *   is otherwise irrelevant here: it never feeds back into the score.
+ *
+ * PREFIX MATCHING IS NOT SUBSTRING MATCHING. It restores recall for a
+ * fragment typed at the START of a word -- `custom` now finds `customer` --
+ * which is the common case (a user typing the first few letters of a term
+ * they remember). It does NOT restore the old `.includes()` filter's ability
+ * to find a term in the MIDDLE of a word: a query for `tomer` still will not
+ * find `customer`. That recall gap is accepted, not silently reintroduced.
+ */
+const PREFIX_TF = 0.5;
+
+/**
+ * Below this length, a query term is not eligible for prefix matching: a
+ * one- or two-character prefix (`a`, `re`) is a substring of a large
+ * fraction of any real vocabulary, so it would match nearly every document
+ * and IDF alone would not discount it enough to keep the results relevant.
+ */
+const PREFIX_MIN_TERM_LENGTH = 3;
+
+/**
  * Classic BM25. `k1` controls term-frequency saturation, `b` length normalisation.
  * Defaults are the standard ones and are exposed so the recall probe can sweep them.
  */
@@ -96,7 +133,21 @@ export function rank(query, findings, { limit = 20, k1 = 1.2, b = 0.75 } = {}) {
 
     let score = 0;
     for (const term of terms) {
-      const tf = counts.get(term);
+      let tf = counts.get(term) || 0;
+
+      // No exact occurrence: fall back to a prefix match, which is weaker
+      // evidence and so credited at a flat PREFIX_TF rather than a real
+      // count (see PREFIX_TF's comment for why that ordering is safe). Only
+      // considered when nothing already matched exactly and the term is
+      // long enough that "starts with" is a meaningful signal.
+      if (tf === 0 && term.length >= PREFIX_MIN_TERM_LENGTH) {
+        for (const token of counts.keys()) {
+          if (token !== term && token.startsWith(term)) {
+            tf = PREFIX_TF;
+            break;
+          }
+        }
+      }
       if (!tf) continue;
       const df = docFreq.get(term) || 0;
       // Smoothed BM25 idf: log(1 + (N - df + 0.5) / (df + 0.5)). Unlike the

--- a/integrations/qwen/hooks/lib/metrics.mjs
+++ b/integrations/qwen/hooks/lib/metrics.mjs
@@ -455,6 +455,23 @@ export function readBalance(dir) {
   return out;
 }
 
+/**
+ * True when `readEvidence` could not have read the whole log -- the file
+ * exceeds the byte cap, so anything written before the tail it kept is
+ * silently absent from what it returned. A caller that builds a per-claim
+ * record from `readEvidence` (the wiki graph's derivation record) needs this
+ * to say "operations existed but are not recorded here" rather than let an
+ * empty result read as "nothing happened".
+ */
+export function evidenceTruncated(dir) {
+  const path = evidencePath(dir);
+  try {
+    return statSync(path).size > MAX_BYTES;
+  } catch {
+    return false;
+  }
+}
+
 /** Every causal evidence record inside the byte cap, deduplicated by id. */
 export function readEvidence(dir) {
   const path = evidencePath(dir);

--- a/integrations/qwen/hooks/lib/observability.mjs
+++ b/integrations/qwen/hooks/lib/observability.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 /**
  * Privacy-safe, cross-client lifecycle diagnostics.
  *

--- a/integrations/qwen/hooks/lib/pending.mjs
+++ b/integrations/qwen/hooks/lib/pending.mjs
@@ -39,7 +39,7 @@ import {
   statSync,
 } from 'node:fs';
 import { join } from 'node:path';
-import { invalidateOnWrite } from './staleness.mjs';
+import { invalidateChangedAnchors, invalidateOnWrite } from './staleness.mjs';
 import { canonicalPath, isFsSafePath, resolvableCandidates } from './paths.mjs';
 
 const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
@@ -190,31 +190,85 @@ function hasEditEvidence(payload, raw) {
 }
 
 /**
- * The evidence a completed mutation left behind, or null when there is none.
+ * Canonical tool names that mean bytes on disk changed.
  *
- * Separate from `queueInvalidation` so the caller can be a hook branch that
- * knows nothing about diffs, and so the reconstruction above is testable
- * without a filesystem queue.
+ * THE NORMALISED SET, not any client's own vocabulary. `normalizePayload` has
+ * already mapped `replace`, `write_file`, `apply_patch`, `str_replace`,
+ * `search_replace` and the rest onto these three through decide.mjs's alias
+ * table -- and a tool that table cannot map arrives as null and exits the hook
+ * before this module is reached at all. So matching here is both complete for
+ * every client the adapter serves and impossible to spell wrong.
+ *
+ * `NotebookEdit` is absent because `normalizeTool` maps it to null, and the MCP
+ * `smart_edit`/`smart_write` tools are absent for the same reason. Both are gaps
+ * in that alias table rather than in this file, and widening it changes routing
+ * verdicts for every client -- so they are reported, not papered over here.
  */
-export function observedWrite(payload, raw) {
-  // CHEAP CHECK FIRST, because this runs after every tool call on every client.
-  // Reading the file is the expensive part, and there is no point paying for it
-  // on a Read, a Bash or a write whose before side cannot be reconstructed.
-  if (!hasEditEvidence(payload, raw)) return null;
+const MUTATING = new Set(['Edit', 'MultiEdit', 'Write']);
+
+/** Files an apply_patch-style program declares it is about to change. */
+function patchTargets(payload) {
+  const command = payload?.tool_input?.command;
+  if (typeof command !== 'string') return [];
+  const out = [];
+  for (const match of command.matchAll(
+    /^\*\*\* (?:Add|Update|Delete) File:\s*(.+)$/gm
+  )) {
+    const candidate = match[1].trim().replace(/^['"]|['"]$/g, '');
+    // Bounded: one patch naming a thousand files must not append a thousand
+    // queue records on a hook path.
+    if (candidate && out.length < 20) out.push(candidate);
+  }
+  return out;
+}
+
+/**
+ * Everything a completed mutation left behind that is worth queueing.
+ *
+ * TWO GRADES OF EVIDENCE, and the distinction is the point:
+ *
+ *   { path, before, after }  a reconstructable edit. The drain builds a real
+ *                            diff and marks only the symbols that moved.
+ *   { path }                 a whole-file write, or a patch program. No before
+ *                            side exists anywhere in the payload, so the drain
+ *                            compares stored hashes against disk instead.
+ *
+ * The second grade is what closes the biggest hole. A whole-file write is the
+ * commonest write shape there is, and before it was added those writes fell
+ * through to a lazy path that CANNOT see the session's own writes at all --
+ * `indexFile` refreshes the anchor before the lazy check ever looks at it. They
+ * were uncovered, not degraded.
+ *
+ * Returns an array, because one apply_patch program changes several files.
+ */
+export function observedWrites(payload, raw) {
+  if (!MUTATING.has(String(payload?.tool_name || ''))) return [];
 
   const path = writtenPath(payload, raw);
-  if (!path) return null;
+  if (path) {
+    // The expensive branch is guarded: reading the file only pays off when the
+    // payload can actually yield a before side.
+    if (hasEditEvidence(payload, raw)) {
+      const after = afterText(path);
+      if (after !== null && after.length <= MAX_SIDE_CHARS) {
+        const before = beforeText(payload, raw, after);
+        // Identical bytes: a formatter no-op, or a rewrite of the same content.
+        // Nothing changed, so nothing is stale.
+        if (before === after) return [];
+        if (before !== null && before.length <= MAX_SIDE_CHARS)
+          return [{ path, before, after }];
+      }
+    }
+    // Hash grade. Deliberately NOT `{ path, before: '', after }`: an empty
+    // before side makes every symbol in the file look changed, and the eager
+    // mark is a stored flag no later check ever clears.
+    return [{ path }];
+  }
 
-  const after = afterText(path);
-  if (after === null || after.length > MAX_SIDE_CHARS) return null;
-
-  const before = beforeText(payload, raw, after);
-  if (before === null || before.length > MAX_SIDE_CHARS) return null;
-  // Nothing changed: a formatter no-op, or a write of identical bytes. Queuing
-  // it would mark findings stale against an empty diff.
-  if (before === after) return null;
-
-  return { path, before, after };
+  // Codex and code-mode clients carry the whole patch as program text with no
+  // file_path field at all, which is why this recorded nothing for them. The
+  // hash grade needs only the path, so the patch headers are enough.
+  return patchTargets(payload).map((target) => ({ path: target }));
 }
 
 /**
@@ -226,9 +280,14 @@ export function observedWrite(payload, raw) {
 export function queueInvalidation(dir, { path, before, after, at } = {}) {
   try {
     if (typeof path !== 'string' || !path.trim()) return false;
-    if (typeof before !== 'string' || typeof after !== 'string') return false;
-    if (before.length > MAX_SIDE_CHARS || after.length > MAX_SIDE_CHARS)
-      return false;
+    // BOTH SIDES OR NEITHER. A record carrying only one of them cannot produce
+    // a diff and must not pretend to, so it is written as a path-only record
+    // and the drain resolves it by comparing hashes.
+    const diffable =
+      typeof before === 'string' &&
+      typeof after === 'string' &&
+      before.length <= MAX_SIDE_CHARS &&
+      after.length <= MAX_SIDE_CHARS;
 
     const file = queuePath(dir);
     try {
@@ -240,7 +299,11 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
     mkdirSync(dir, { recursive: true });
     appendFileSync(
       file,
-      `${JSON.stringify({ path: canonicalPath(path), before, after, at: at ?? Date.now() })}\n`,
+      `${JSON.stringify({
+        path: canonicalPath(path),
+        ...(diffable ? { before, after } : {}),
+        at: at ?? Date.now(),
+      })}\n`,
       'utf8'
     );
     return true;
@@ -284,16 +347,16 @@ export function drainInvalidations(dir, graph) {
   let marked = 0;
   for (const record of records) {
     if (!record || typeof record.path !== 'string' || !record.path) continue;
-    if (typeof record.before !== 'string' || typeof record.after !== 'string')
-      continue;
+    const diffable =
+      typeof record.before === 'string' && typeof record.after === 'string';
     try {
-      const result = invalidateOnWrite(
-        dir,
-        graph,
-        record.path,
-        record.before,
-        record.after
-      );
+      // TWO GRADES, ONE QUEUE. A record carrying both sides gets a real diff and
+      // symbol-precise marking; one carrying only a path gets the hash
+      // comparison -- the same comparison the lazy path makes, and one that is
+      // only meaningful HERE, before `indexFile` refreshes the anchor.
+      const result = diffable
+        ? invalidateOnWrite(dir, graph, record.path, record.before, record.after)
+        : invalidateChangedAnchors(dir, graph, record.path);
       marked += Array.isArray(result) ? result.length : 0;
     } catch {
       // One bad record must not stop the rest, and must not stop the tool call.

--- a/integrations/qwen/hooks/lib/pending.mjs
+++ b/integrations/qwen/hooks/lib/pending.mjs
@@ -1,0 +1,311 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/pending.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * The eager-invalidation queue: the missing half of staleness.mjs's header.
+ *
+ * That header describes TWO invalidation paths and says eager exists because
+ * lazy "would silently serve stale findings as fresh whenever a change came
+ * from outside the agent". `invalidateOnWrite` had been written, tested and
+ * documented -- and its only reference in shipped code was a COMMENT in the
+ * PreToolUse router. Staleness was lazy-only in production, and the router's
+ * own comment ("a write the hook observes is invalidated eagerly by
+ * `invalidateOnWrite`") described something that never happened.
+ *
+ * WHY THAT MATTERS MORE THAN IT SOUNDS. The lazy check compares the anchor's
+ * stored hash against disk -- and both the router and the adapter call
+ * `indexFile` on every file they observe, which re-points that hash at the new
+ * bytes. So for a write the session performed ITSELF, the lazy check is
+ * self-defeating: by the next retrieval the anchor already agrees with disk and
+ * the finding derived from the old content is served clean. Lazy catches the
+ * changes we never saw; only eager catches the ones we did.
+ *
+ * WHY A QUEUE AND NOT A DIRECT CALL. `invalidateOnWrite` needs the graph, and
+ * the graph is a megabyte of JSONL. Loading it on the return path of every
+ * write is the cost this shape exists to avoid. So the post-tool hook, which
+ * already holds the write's evidence, appends one record here and exits; the
+ * next graph read -- `forTouch`/`forCommand`, which load the graph anyway --
+ * drains it BEFORE serving anything.
+ *
+ * The guarantee is unchanged. What must never happen is SERVING a stale finding
+ * as fresh, and serve time is where that is enforced.
+ */
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { invalidateOnWrite } from './staleness.mjs';
+import { canonicalPath, isFsSafePath, resolvableCandidates } from './paths.mjs';
+
+const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
+
+/**
+ * Largest before/after side kept in a queue record.
+ *
+ * Matched to the graph's own snapshot limit for the same reason it has one: past
+ * this size the text is a bundle, a lockfile or a generated asset, and copying
+ * it into a queue file would mirror the repository into the graph directory one
+ * write at a time. Past the cap the write is simply not queued -- the lazy path
+ * still governs it, which is exactly the status quo for that file.
+ */
+const MAX_SIDE_CHARS = 262_144;
+
+/**
+ * Largest queue file appended to.
+ *
+ * A queue only grows while nothing drains it, which means the retrieval feature
+ * is off or every read has failed. Neither is a reason to keep writing: bounded
+ * here so a long unattended session cannot turn one directory into a log of
+ * every file it touched.
+ */
+const MAX_QUEUE_BYTES = 8 * 1024 * 1024;
+
+/** The tool payload fields that name the file a mutation landed on. */
+function writtenPath(payload, raw) {
+  const input = payload?.tool_input || {};
+  const response = raw?.tool_response || raw?.toolResponse || {};
+  for (const candidate of [
+    input.file_path,
+    input.path,
+    input.notebook_path,
+    response.filePath,
+    response.file_path,
+  ]) {
+    if (typeof candidate === 'string' && candidate.trim()) return candidate;
+  }
+  return null;
+}
+
+/** First string among several possible spellings of the same field. */
+function firstString(...values) {
+  for (const value of values) if (typeof value === 'string') return value;
+  return null;
+}
+
+/**
+ * The text before the write, reconstructed from a completed edit.
+ *
+ * PREFERENCE ORDER IS ABOUT EXACTNESS, not convenience. Claude Code's Edit
+ * response carries the whole pre-edit file (`originalFile`), which needs no
+ * reasoning at all. Failing that, an edit is a known substitution, so reverting
+ * `new_string` back to `old_string` in the post-write text reproduces the
+ * before side exactly -- but only when the substitution is unambiguous, which
+ * is why a `new_string` that now appears more than once is refused rather than
+ * guessed at.
+ *
+ * NULL MEANS "DO NOT QUEUE", and that is deliberate. An unknown before side
+ * could be passed as '' -- and `invalidateOnWrite` would then see every symbol
+ * in the file as changed and mark every finding anchored anywhere in it, which
+ * is the exact over-marking its own comments call worse than the file-level
+ * staleness symbols were introduced to avoid. A missed eager invalidation costs
+ * what today already costs; a wrong one permanently discounts correct findings.
+ */
+function beforeText(payload, raw, after) {
+  const input = payload?.tool_input || {};
+  const response = raw?.tool_response || raw?.toolResponse || {};
+
+  const original = firstString(
+    response.originalFile,
+    response.original_file,
+    response.originalContent,
+    response.original_content
+  );
+  if (original !== null) return original;
+
+  // MultiEdit applies its edits in order, so reverting walks them backwards.
+  const edits = Array.isArray(input.edits) ? input.edits : null;
+  if (edits) {
+    let text = after;
+    for (const edit of [...edits].reverse()) {
+      const reverted = revert(text, edit);
+      if (reverted === null) return null;
+      text = reverted;
+    }
+    return text;
+  }
+
+  return revert(after, input);
+}
+
+/** Undoes one old->new substitution, or null when it cannot be done exactly. */
+function revert(text, edit) {
+  const oldString = firstString(edit?.old_string, edit?.oldString);
+  const newString = firstString(edit?.new_string, edit?.newString);
+  if (oldString === null || newString === null || newString === '') return null;
+
+  const all = edit?.replace_all === true || edit?.replaceAll === true;
+  if (all) return text.split(newString).join(oldString);
+
+  const at = text.indexOf(newString);
+  if (at < 0) return null;
+  // Ambiguous: more than one candidate for the occurrence that was written, and
+  // reverting the wrong one fabricates a before side that never existed.
+  if (text.indexOf(newString, at + newString.length) >= 0) return null;
+  return text.slice(0, at) + oldString + text.slice(at + newString.length);
+}
+
+/** The post-write text, read from disk because that is what the write produced. */
+function afterText(path) {
+  if (!isFsSafePath(path)) return null;
+  for (const candidate of resolvableCandidates(path)) {
+    try {
+      if (statSync(candidate).size > MAX_SIDE_CHARS) return null;
+      return readFileSync(candidate, 'utf8');
+    } catch {
+      // Wrong spelling, or gone again already. Try the next one.
+    }
+  }
+  return null;
+}
+
+/**
+ * Does this payload carry enough to reconstruct a before side at all?
+ *
+ * Named tool lists were the alternative and were rejected: every client calls
+ * its editor something different (`Edit`, `replace`, `write_to_file`,
+ * `apply_patch`), and a list would silently exclude the ones nobody thought of
+ * while still charging a file read for every Read that matched by accident.
+ * Asking about the EVIDENCE instead covers any client that carries an edit in
+ * one of these shapes and costs nothing on the calls that do not.
+ */
+function hasEditEvidence(payload, raw) {
+  const input = payload?.tool_input || {};
+  const response = raw?.tool_response || raw?.toolResponse || {};
+  if (
+    firstString(
+      response.originalFile,
+      response.original_file,
+      response.originalContent,
+      response.original_content
+    ) !== null
+  )
+    return true;
+  if (Array.isArray(input.edits) && input.edits.length > 0) return true;
+  return firstString(input.old_string, input.oldString) !== null;
+}
+
+/**
+ * The evidence a completed mutation left behind, or null when there is none.
+ *
+ * Separate from `queueInvalidation` so the caller can be a hook branch that
+ * knows nothing about diffs, and so the reconstruction above is testable
+ * without a filesystem queue.
+ */
+export function observedWrite(payload, raw) {
+  // CHEAP CHECK FIRST, because this runs after every tool call on every client.
+  // Reading the file is the expensive part, and there is no point paying for it
+  // on a Read, a Bash or a write whose before side cannot be reconstructed.
+  if (!hasEditEvidence(payload, raw)) return null;
+
+  const path = writtenPath(payload, raw);
+  if (!path) return null;
+
+  const after = afterText(path);
+  if (after === null || after.length > MAX_SIDE_CHARS) return null;
+
+  const before = beforeText(payload, raw, after);
+  if (before === null || before.length > MAX_SIDE_CHARS) return null;
+  // Nothing changed: a formatter no-op, or a write of identical bytes. Queuing
+  // it would mark findings stale against an empty diff.
+  if (before === after) return null;
+
+  return { path, before, after };
+}
+
+/**
+ * Appends one pending write.
+ *
+ * NEVER THROWS. This runs on a hook's return path, and a queue that cannot be
+ * written degrades to the lazy path rather than costing the user a tool call.
+ */
+export function queueInvalidation(dir, { path, before, after, at } = {}) {
+  try {
+    if (typeof path !== 'string' || !path.trim()) return false;
+    if (typeof before !== 'string' || typeof after !== 'string') return false;
+    if (before.length > MAX_SIDE_CHARS || after.length > MAX_SIDE_CHARS)
+      return false;
+
+    const file = queuePath(dir);
+    try {
+      if (statSync(file).size > MAX_QUEUE_BYTES) return false;
+    } catch {
+      // No queue yet, which is the normal case.
+    }
+
+    mkdirSync(dir, { recursive: true });
+    appendFileSync(
+      file,
+      `${JSON.stringify({ path: canonicalPath(path), before, after, at: at ?? Date.now() })}\n`,
+      'utf8'
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Applies every queued invalidation and clears the queue.
+ *
+ * Returns the number of findings marked, so the caller knows whether its
+ * in-memory graph is now behind the file on disk and needs re-reading.
+ *
+ * CLEARED AFTER APPLYING AND UNCONDITIONALLY: a record that cannot be applied
+ * must not be retried on every tool call for the rest of the session, and the
+ * cost of dropping one is a single missed eager mark that the lazy path still
+ * has a chance at.
+ */
+export function drainInvalidations(dir, graph) {
+  let records;
+  try {
+    const file = queuePath(dir);
+    if (!existsSync(file)) return 0;
+    records = readFileSync(file, 'utf8')
+      .split('\n')
+      .filter((line) => line.trim())
+      .map((line) => {
+        try {
+          return JSON.parse(line);
+        } catch {
+          // A torn append costs one record, not the queue.
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch {
+    return 0;
+  }
+
+  let marked = 0;
+  for (const record of records) {
+    if (!record || typeof record.path !== 'string' || !record.path) continue;
+    if (typeof record.before !== 'string' || typeof record.after !== 'string')
+      continue;
+    try {
+      const result = invalidateOnWrite(
+        dir,
+        graph,
+        record.path,
+        record.before,
+        record.after
+      );
+      marked += Array.isArray(result) ? result.length : 0;
+    } catch {
+      // One bad record must not stop the rest, and must not stop the tool call.
+    }
+  }
+
+  try {
+    rmSync(queuePath(dir), { force: true });
+  } catch {
+    // Held open by a concurrent hook. The next drain re-applies these records,
+    // which is safe: marking an already-marked finding is idempotent.
+  }
+
+  return marked;
+}

--- a/integrations/qwen/hooks/lib/pending.mjs
+++ b/integrations/qwen/hooks/lib/pending.mjs
@@ -199,10 +199,11 @@ function hasEditEvidence(payload, raw) {
  * before this module is reached at all. So matching here is both complete for
  * every client the adapter serves and impossible to spell wrong.
  *
- * `NotebookEdit` is absent because `normalizeTool` maps it to null, and the MCP
- * `smart_edit`/`smart_write` tools are absent for the same reason. Both are gaps
- * in that alias table rather than in this file, and widening it changes routing
- * verdicts for every client -- so they are reported, not papered over here.
+ * `NotebookEdit` and the MCP `smart_edit`/`smart_write` tools were absent for as
+ * long as `normalizeTool` mapped them to null. That was a gap in the alias table
+ * rather than in this file, and it has since been closed there: all three now
+ * arrive as `Edit` or `Write` and are matched by the set below without it having
+ * to learn a fourth name.
  */
 const MUTATING = new Set(['Edit', 'MultiEdit', 'Write']);
 

--- a/integrations/qwen/hooks/lib/pending.mjs
+++ b/integrations/qwen/hooks/lib/pending.mjs
@@ -35,6 +35,7 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  renameSync,
   rmSync,
   statSync,
 } from 'node:fs';
@@ -43,6 +44,15 @@ import { invalidateChangedAnchors, invalidateOnWrite } from './staleness.mjs';
 import { canonicalPath, isFsSafePath, resolvableCandidates } from './paths.mjs';
 
 const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
+/**
+ * Where a drain moves the queue before reading it.
+ *
+ * PER PROCESS, not one shared name: two hooks draining the same graph directory
+ * at once would otherwise race for the same claim file, and the loser would
+ * either clobber the winner's records or delete them mid-read. A pid makes the
+ * claim private to the drainer that won the rename.
+ */
+const claimPath = (dir) => join(dir, `pending-invalidation.claim.${process.pid}.jsonl`);
 
 /**
  * Largest before/after side kept in a queue record.
@@ -319,17 +329,47 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
  * Returns the number of findings marked, so the caller knows whether its
  * in-memory graph is now behind the file on disk and needs re-reading.
  *
- * CLEARED AFTER APPLYING AND UNCONDITIONALLY: a record that cannot be applied
- * must not be retried on every tool call for the rest of the session, and the
- * cost of dropping one is a single missed eager mark that the lazy path still
- * has a chance at.
+ * CLAIMED BY RENAME, THEN READ, THEN DELETED -- and the order is the whole
+ * point. This used to read the queue and then `rmSync` the same path, so a
+ * post-tool hook appending between the read and the unlink had its record
+ * deleted having never been read. Parallel tool calls in one assistant turn are
+ * the ordinary way that happens, not an exotic race. `renameSync` makes the
+ * claim atomic: whatever the drainer took is exactly what it deletes, and a
+ * record appended a microsecond later lands on a fresh queue that the next drain
+ * will find.
+ *
+ * A LOST RECORD IS A PERMANENTLY MISSED INVALIDATION, which is why this is worth
+ * a rename. The comment here used to price it as "a single missed eager mark that
+ * the lazy path still has a chance at", and that premise is false: this module's
+ * own header states it. The lazy path compares the anchor's stored hash against
+ * disk, and `indexFile` re-points that hash at the bytes the session just wrote,
+ * so for the session's OWN writes lazy is structurally blind rather than merely
+ * late. Nothing else was ever going to catch a dropped record.
+ *
+ * A RECORD THAT CANNOT BE APPLIED IS STILL DROPPED, deliberately and
+ * unconditionally: retrying a permanently unapplicable record on every tool call
+ * for the rest of the session costs more than it can ever recover, and the claim
+ * file is deleted whether the loop marked anything or threw.
+ *
+ * FAIL-OPEN THROUGHOUT. A rename that loses a race, or fails for any other
+ * reason, returns 0 and leaves the queue for the next drain; it never throws
+ * into a hook.
  */
 export function drainInvalidations(dir, graph) {
   let records;
+  let claim;
   try {
     const file = queuePath(dir);
     if (!existsSync(file)) return 0;
-    records = readFileSync(file, 'utf8')
+    claim = claimPath(dir);
+    // A LEFTOVER CLAIM FROM A KILLED DRAIN IS OVERWRITTEN, not merged: rename
+    // onto an existing path replaces it. The pid in the name means the only way
+    // to hit that is this same pid having died mid-drain, whose records were
+    // already being applied when it went -- and re-applying is idempotent, so
+    // losing them is the cheaper of the two errors. Not doing the rename at all
+    // would strand the live queue forever.
+    renameSync(file, claim);
+    records = readFileSync(claim, 'utf8')
       .split('\n')
       .filter((line) => line.trim())
       .map((line) => {
@@ -342,6 +382,18 @@ export function drainInvalidations(dir, graph) {
       })
       .filter(Boolean);
   } catch {
+    // The rename lost a race, or the claim could not be read. Nothing is deleted
+    // unread and the hook proceeds. If the claim was taken and then could not be
+    // read, it is put back under the queue name so the next drain still sees it:
+    // a claim file nobody looks at again is the same lost record this rename
+    // exists to prevent.
+    try {
+      if (claim && existsSync(claim) && !existsSync(queuePath(dir))) {
+        renameSync(claim, queuePath(dir));
+      }
+    } catch {
+      // Best effort only. A hook must not fail because bookkeeping did.
+    }
     return 0;
   }
 
@@ -365,10 +417,13 @@ export function drainInvalidations(dir, graph) {
   }
 
   try {
-    rmSync(queuePath(dir), { force: true });
+    // THE CLAIM, NOT THE QUEUE. Deleting `queuePath` here is what dropped a
+    // concurrently appended record; this path holds exactly the bytes that were
+    // just read, so nothing unread can be inside it.
+    rmSync(claim, { force: true });
   } catch {
-    // Held open by a concurrent hook. The next drain re-applies these records,
-    // which is safe: marking an already-marked finding is idempotent.
+    // Held open by something else. The claim is not read again -- the next drain
+    // looks at the queue -- so this costs a stray file, never a record.
   }
 
   return marked;

--- a/integrations/qwen/hooks/lib/restore.mjs
+++ b/integrations/qwen/hooks/lib/restore.mjs
@@ -142,7 +142,7 @@ export function restorationPlan(dir, graph, context = {}) {
     for (const id of predicted) {
       const node = graph.nodes.get(id);
       if (!node) continue;
-      const findings = serve(graph, findingsFor(graph, id, { limit: 2 }));
+      const findings = serve(graph, findingsFor(graph, id, { limit: 2 }), { dir });
       for (const finding of findings) {
         // `! STALE` only where a diff actually exists to back it; see the
         // renderer in inject.mjs for the measurement behind this.

--- a/integrations/qwen/hooks/lib/restore.mjs
+++ b/integrations/qwen/hooks/lib/restore.mjs
@@ -158,7 +158,16 @@ export function restorationPlan(dir, graph, context = {}) {
             ? '! STALE '
             : '~ '
           : '';
-        lines.push(`${node.key}: ${mark}${finding.claim}`);
+        // A DISPUTE DISCLOSED ELSEWHERE AND SILENT HERE reads as "the dispute
+        // went away". `serve` already attached the fields; the only question is
+        // the wording, and this list is the most compressed surface in the
+        // system, so it gets the marker and the key and nothing else.
+        const disputed = finding.contradicted
+          ? finding.contradictedBy
+            ? ` (disputed by ${finding.contradictedBy})`
+            : ' (disputed)'
+          : '';
+        lines.push(`${node.key}: ${mark}${finding.claim}${disputed}`);
       }
     }
     section('Likely next', lines, total * split.forward);

--- a/integrations/qwen/hooks/lib/skeleton.mjs
+++ b/integrations/qwen/hooks/lib/skeleton.mjs
@@ -126,6 +126,11 @@ export function annotatedSkeleton(graph, rawPath, source, { budget = 1200, git =
 
   // Findings anchored to this file or the symbols inside it, served through the
   // one function that enforces the stale-plus-diff rule.
+  // READ-ONLY serve: no `dir` is threaded here, so this cannot clear a stale
+  // flag whose evidence is gone. That is deliberate -- this function takes a
+  // graph, not the directory it came from, and widening its signature to give
+  // an analysis path a write capability buys nothing: the injection path runs
+  // on every tool call and clears the same findings.
   const served = serve(graph, findingsFor(graph, nodeId('file', path), { limit: 40 }));
 
   // Index findings by the symbol they anchor to, so each one sits beside the

--- a/integrations/qwen/hooks/lib/staleness.mjs
+++ b/integrations/qwen/hooks/lib/staleness.mjs
@@ -31,6 +31,23 @@
  * Eager alone would silently serve stale findings as fresh whenever a change
  * came from outside the agent, which is the single failure mode the design
  * calls worse than no graph.
+ *
+ * AND LAZY ALONE IS BLIND TO THE AGENT'S OWN WRITES -- not degraded, BLIND.
+ * `indexFile` re-points an anchor's stored hash at the bytes it was just handed,
+ * and it is called on every file either hook observes: pretooluse-router.mjs
+ * (two call sites) and adapter.mjs (one). The lazy check then compares that
+ * refreshed hash against the same disk it came from and finds them equal. So
+ * for a file the session edited ITSELF, the lazy path cannot detect the change
+ * at all, and the finding derived from the pre-edit content is served CLEAN.
+ *
+ * Which means that until the eager path was connected, staleness for a file the
+ * agent edited did not work AT ALL: eager was dead code and lazy was defeated
+ * by re-indexing. Every account of this defect, including the one in this
+ * module's own git history, called it "lazy-only, therefore degraded". It was
+ * not degraded. `stale-before-reindex.test.mjs` states in its header that this
+ * case is covered by `invalidateOnWrite`, and `invalidateOnWrite` had never run
+ * once in production. The two paths are not redundant and never were: each is
+ * the ONLY cover for a whole class of change.
  */
 
 import { readFileSync, statSync } from 'node:fs';
@@ -622,6 +639,119 @@ export function invalidateOnWrite(dir, graph, rawPath, beforeText, afterText) {
   // Re-index so the anchors carry the new hashes; otherwise the lazy path would
   // report the same change again on every future retrieval.
   indexFile(dir, path, afterText);
+  return marked;
+}
+
+/**
+ * The eager path for a write with NO before/after pair: compare stored hashes
+ * against disk, and mark what actually moved.
+ *
+ * WHY THIS EXISTS AS A SECOND SHAPE. A whole-file `Write` replaces the file, so
+ * the payload carries the after side and nothing at all of the before -- and a
+ * whole-file write is the commonest write shape there is. `invalidateOnWrite`
+ * cannot serve it: passing '' as the before side makes every symbol in the file
+ * look changed, marks every finding anchored anywhere in it, and the eager mark
+ * is a stored flag no later check ever clears. False-stale is expensive and
+ * permanent, so it is not an acceptable price for coverage.
+ *
+ * But the hash comparison is available, and it is exactly the comparison the
+ * lazy path makes. The difference is WHEN: this runs at the top of injection,
+ * before `indexFile` refreshes the anchor, so the stored hash is still the
+ * pre-write one and the comparison is meaningful. That is the whole trick --
+ * lazy is not wrong, it is merely too late.
+ *
+ * SYMBOL-LEVEL, and from ONE read. Re-locating each symbol by name and
+ * comparing its own span hash is what keeps this from degenerating into
+ * file-level marking: editing one function must not stale a finding about
+ * another, which is the property symbol nodes exist to provide.
+ *
+ * WEAKER EVIDENCE, STATED AS SUCH. There is no before text, so no diff can be
+ * built -- the finding is marked with the two hashes and `serve` reports the
+ * evidence gap through `staleEvidence: false`, which the renderer turns into
+ * "no diff could be rebuilt" rather than promising a diff and showing nothing.
+ * A stale finding with weak evidence is far better than one served as fresh,
+ * but the reader has to be able to tell which one they are holding.
+ */
+export function invalidateChangedAnchors(dir, graph, rawPath) {
+  const path = canonicalPath(rawPath);
+  const marked = [];
+
+  // ONE read for the file and every symbol in it. checkAnchor would have been
+  // the obvious reuse and it reads per anchor, which on a file with fifty
+  // symbols is fifty-one reads of the same bytes on a hook path.
+  let source = null;
+  try {
+    source = readAnySpelling(path);
+  } catch {
+    // Deleted, or unreadable from this checkout. Handled below as a change,
+    // because a finding about a file that is no longer there is exactly the
+    // kind that must not be served as fresh.
+  }
+
+  const changed = [];
+  const fileNode = graph.nodes.get(nodeId('file', path));
+  const fileDigest = source === null ? null : hash(source);
+  if (fileNode && fileDigest !== fileNode.hash) {
+    changed.push({ node: fileNode, from: fileNode.hash, to: fileDigest });
+  }
+
+  const current = new Map(
+    source === null
+      ? []
+      : extractSymbols(path, source).map((s) => [s.name, hash(spanText(source, s))])
+  );
+  for (const node of graph.nodes.values()) {
+    if (node.kind !== 'symbol' || node.file !== path) continue;
+    const digest = current.has(node.name) ? current.get(node.name) : null;
+    if (digest !== node.hash) changed.push({ node, from: node.hash, to: digest });
+  }
+
+  if (changed.length) {
+    // Indexed once by target, for the reason invalidateOnWrite indexes: the
+    // nested alternative is O(nodes x edges) inside a hook.
+    const byTarget = new Map();
+    for (const edge of graph.edges) {
+      if (edge.edge !== 'derived_from') continue;
+      if (!byTarget.has(edge.to)) byTarget.set(edge.to, []);
+      byTarget.get(edge.to).push(edge);
+    }
+
+    for (const { node, from, to } of changed) {
+      for (const edge of byTarget.get(node.id) || []) {
+        const finding = graph.nodes.get(edge.from);
+        if (!finding || finding.kind !== 'finding') continue;
+        // The same type gate serve() applies, for the same reason it is applied
+        // in invalidateOnWrite: the flag is STORED, and disclose.mjs skips a
+        // stale finding while utility.mjs penalises one by 160.
+        if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) continue;
+        // ALREADY MARKED IS LEFT ALONE. Whatever marked it first had a diff or
+        // a more specific reason; overwriting that with a hash pair trades real
+        // evidence for less.
+        if (finding.stale) continue;
+
+        putNode(dir, {
+          ...finding,
+          kind: 'finding',
+          key: finding.key,
+          stale: true,
+          staleReason:
+            to === null
+              ? `the ${node.kind} it depends on is no longer present (was ${from})`
+              : `content hash changed during this session (${from} -> ${to}), observed without a before/after pair`,
+          // EXPLICITLY EMPTY, not absent. serve() reports `staleEvidence` from
+          // whether a diff survived, and the renderer says "no diff could be
+          // rebuilt" -- so the reader can tell "changed, diff unknown" from
+          // "changed, here is what changed".
+          diff: '',
+        });
+        marked.push(finding.key);
+      }
+    }
+  }
+
+  // Re-index for the same reason the diff path does: otherwise every future
+  // retrieval re-reports a change that has already been accounted for.
+  if (source !== null) indexFile(dir, path, source);
   return marked;
 }
 

--- a/integrations/qwen/hooks/lib/staleness.mjs
+++ b/integrations/qwen/hooks/lib/staleness.mjs
@@ -574,8 +574,20 @@ function derivationCheck(graph, finding) {
  * This is the only function that should ever hand a finding to a model, because
  * it is the one that enforces the rule: a stale finding leaves here carrying
  * `stale: true` AND a diff, or it does not leave at all.
+ *
+ * AND IT CLEARS A STORED FLAG WHOSE EVIDENCE IS GONE, when given a `dir` to
+ * write to. Clearing used to be reachable only by a person pressing Re-verify in
+ * the dashboard, which left the rot path fully open on every install where
+ * nobody opens the dashboard -- and that is most of them. The evidence test is
+ * what makes clearing safe, and it does not care who triggered it: the same
+ * `claimTimeVerdict` runs here as in `reverify`, so this cannot clear anything
+ * the button would not.
+ *
+ * `dir` IS OPTIONAL, AND OMITTING IT MAKES THIS READ-ONLY. Several callers hold
+ * a graph without the directory it came from, and a serve that silently did
+ * nothing would be worse than one that plainly cannot write.
  */
-export function serve(graph, findings) {
+export function serve(graph, findings, { dir = null } = {}) {
   const served = [];
 
   // RETIRED FINDINGS STOP HERE, unconditionally.
@@ -603,8 +615,42 @@ export function serve(graph, findings) {
       continue;
     }
 
+    // AUTOMATIC CLEARING, on the same evidence the manual path demands.
+    //
+    // ONLY THE STORED FLAG IS TOUCHED. The lazy loop below is left to run
+    // exactly as before and can independently mark this finding stale again on
+    // its own comparison -- disk against the anchor NODE's hash -- which answers
+    // a different question and is not this function's to overrule. Eager and
+    // lazy stay two mechanisms, as the module header insists.
+    //
+    // AND THE FIELDS GO WITH THE FLAG. `putNode` does not merge and neither does
+    // this spread: serving `{ ...finding, stale: false }` would hand back a
+    // finding that reads fresh while still carrying `staleReason` and `diff`
+    // from the record -- stale and fresh at once, which is worse than either.
+    // So the cleared record, not the stored one, is what the rest of this
+    // iteration reads and spreads.
+    //
+    // BOUNDED, and the bound is the point: this runs only for a finding whose
+    // flag is already STORED, only when a `derivation` record exists to check
+    // against, and it reads each of that finding's anchors at most once. A
+    // finding that is not flagged pays nothing. The lazy loop below already
+    // reads every anchor of every content-dependent finding served, so the worst
+    // case is twice the anchor reads on the already-stale subset alone.
+    //
+    // NOT ON THE NON-CONTENT-DEPENDENT EARLY RETURN ABOVE, deliberately. Both
+    // eager paths refuse to flag those types at all, so a flag there can only
+    // come from an older graph -- and reading anchors for a type whose truth
+    // does not depend on them is exactly the cost `CONTENT_DEPENDENT` exists to
+    // avoid.
+    let record = finding;
+    if (dir && finding.stale && claimTimeVerdict(graph, finding) === 'match') {
+      clearStale(dir, finding.key, { graph });
+      const { stale: _s, staleReason: _r, diff: _d, staleEvidence: _e, ...cleared } = finding;
+      record = cleared;
+    }
+
     const anchors = graph.edges
-      .filter((e) => e.edge === 'derived_from' && e.from === finding.id)
+      .filter((e) => e.edge === 'derived_from' && e.from === record.id)
       .map((e) => graph.nodes.get(e.to))
       .filter(Boolean);
 
@@ -629,10 +675,10 @@ export function serve(graph, findings) {
     // A finding already marked stale eagerly, whose diff was captured at write
     // time, keeps that diff -- the eager path saw the change we can no longer
     // reconstruct from disk alone.
-    if (!stale && finding.stale) {
+    if (!stale && record.stale) {
       stale = true;
-      diff = finding.diff || '';
-      reason = finding.staleReason || 'marked stale when the change was observed';
+      diff = record.diff || '';
+      reason = record.staleReason || 'marked stale when the change was observed';
     }
 
     if (stale && !diff) {
@@ -681,13 +727,19 @@ export function serve(graph, findings) {
     }
 
     served.push({
-      ...finding,
+      ...record,
       stale,
       ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
+      // BOTH OTHER DISCLOSURES SURVIVE A MID-SERVE CLEAR. `dispute` was computed
+      // above the content-dependence branch and is applied here untouched, and
+      // the derivation verdict is recomputed from the record -- which still
+      // carries its `derivation`, since clearing removes only the staleness
+      // fields. A finding whose flag was just cleared is still disclosed as
+      // disputed, and still reports whether its derivation holds.
       ...dispute,
       // Independent of `stale` above: see `derivationCheck`'s own comment for
       // the case it catches that node-level staleness can miss.
-      ...derivationCheck(graph, finding),
+      ...derivationCheck(graph, record),
     });
   }
   return served;
@@ -939,8 +991,21 @@ function anchorHashNow(anchor) {
  * Exposing it to a hook, a tool argument or an HTTP action would be a way to
  * turn a stale finding fresh on request, which is exactly what must not exist.
  */
-export function clearStale(dir, key) {
-  const node = load(dir).nodes.get(nodeId('finding', key));
+export function clearStale(dir, key, { graph = null } = {}) {
+  // A CALLER THAT ALREADY HOLDS THE GRAPH PASSES IT, and this is not
+  // micro-optimisation: `load` re-parses the entire append-only log, so clearing
+  // inside `serve`'s loop re-read and re-folded the whole graph once PER cleared
+  // finding. Measured on 40 findings all stale and all revertible -- the shape a
+  // mass revert produces -- that was 185 ms against 25 ms, a 7x regression on
+  // the injection path, all of it graph loading rather than the hashing this
+  // feature is actually for. With the graph passed through it is back in line.
+  //
+  // No new race: this store is last-write-wins with no compare-and-set anywhere,
+  // and every other caller that spreads a node back -- `pin`, `retire`,
+  // `contradict`, `correct` -- writes from a graph it loaded earlier too. Both
+  // callers here already DECIDED on this snapshot, so re-reading it purely for
+  // the write narrowed no window that was ever closed.
+  const node = (graph || load(dir)).nodes.get(nodeId('finding', key));
   if (!node || node.kind !== 'finding') return false;
   const { stale, staleReason, diff, staleEvidence, ...rest } = node;
   // Nothing to clear is a success, not a write: an unconditional putNode here
@@ -989,14 +1054,33 @@ export function clearStale(dir, key) {
  * silently un-mark findings nobody asked about. Staleness is disclosed to a
  * reader who then decides; clearing is an explicit act.
  */
-export function reverify(dir, key) {
-  const graph = load(dir);
-  const finding = graph.nodes.get(nodeId('finding', key));
-  if (!finding || finding.kind !== 'finding') return 'unknown';
-  // Idempotent: the postcondition -- no stale flag on this finding -- already
-  // holds, and reporting anything else would make a caller retry forever.
-  if (!finding.stale) return 'cleared';
-
+/**
+ * THE ONE EVIDENCE TEST. Does this finding's anchored content still hash to what
+ * the claim was actually made against?
+ *
+ * `'match'` -- every anchor on disk re-hashes to the value frozen into this
+ * finding's own `derivation.anchors` at claim time. The content IS what the
+ * claim was derived from: a revert, or a write that never moved the anchored
+ * bytes.
+ * `'differs'` -- at least one anchor does not, INCLUDING an anchor whose content
+ * is gone. Deleted is a difference, not a missing measurement.
+ * `'unknown'` -- there is nothing to compare: no `derivation.anchors`, no
+ * anchors, an anchor with no recorded hash, or one that no longer resolves.
+ *
+ * SHARED BY BOTH CLEARING PATHS ON PURPOSE, and that sharing is the guarantee
+ * rather than a convenience. `reverify` (a person pressing Re-verify) and
+ * `serve` (automatic, on every retrieval) call THIS function and nothing else,
+ * so the automatic path cannot clear anything the button would not, and neither
+ * can drift from the other. Two copies of this comparison would be two policies,
+ * and the weaker one would win wherever it ran more often -- which is the
+ * automatic one.
+ *
+ * NOT `checkAnchor`, for the reason `anchorHashNow` above spells out: that
+ * compares disk against the anchor NODE's stored hash, which both eager paths
+ * re-point at the very bytes that caused the mark, so it answers "fresh" for
+ * exactly the finding it just marked stale.
+ */
+function claimTimeVerdict(graph, finding) {
   const recorded = finding.derivation && finding.derivation.anchors;
   if (!recorded || typeof recorded !== 'object') return 'unknown';
 
@@ -1019,10 +1103,23 @@ export function reverify(dir, key) {
     if (node.kind !== 'file' && node.kind !== 'symbol') return 'unknown';
     // null means the content is gone -- deleted file, vanished symbol. That is a
     // difference, not an absence of evidence.
-    if (anchorHashNow(node) !== expected) return 'still-stale';
+    if (anchorHashNow(node) !== expected) return 'differs';
   }
+  return 'match';
+}
 
-  clearStale(dir, key);
+export function reverify(dir, key) {
+  const graph = load(dir);
+  const finding = graph.nodes.get(nodeId('finding', key));
+  if (!finding || finding.kind !== 'finding') return 'unknown';
+  // Idempotent: the postcondition -- no stale flag on this finding -- already
+  // holds, and reporting anything else would make a caller retry forever.
+  if (!finding.stale) return 'cleared';
+
+  const verdict = claimTimeVerdict(graph, finding);
+  if (verdict === 'unknown') return 'unknown';
+  if (verdict === 'differs') return 'still-stale';
+  clearStale(dir, key, { graph });
   return 'cleared';
 }
 

--- a/integrations/qwen/hooks/lib/staleness.mjs
+++ b/integrations/qwen/hooks/lib/staleness.mjs
@@ -53,7 +53,7 @@
 import { readFileSync, statSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { dirname, join } from 'node:path';
-import { putNode, putEdge, contentHash, nodeId } from './wiki.mjs';
+import { putNode, putEdge, contentHash, nodeId, load } from './wiki.mjs';
 import { hasOutstandingContradiction } from './curate.mjs';
 import { extractSymbols, spanText, symbolKey, extractImports } from './symbols.mjs';
 import { canonicalPath, resolvableCandidates, isFsSafePath } from './paths.mjs';
@@ -488,7 +488,16 @@ function disputeOf(graph, finding) {
     // An edge end that resolves to nothing names nothing. The dispute is still
     // disclosed -- the gate above already established it -- but without a key
     // the reader cannot be pointed anywhere, and inventing one would be worse.
-    if (other && typeof other.key === 'string' && !keys.includes(other.key)) keys.push(other.key);
+    //
+    // A RETIRED END IS NOT NAMED EITHER, for a sharper reason: the disclosure
+    // tells the reader to `wiki_query` that key, and `serve` refuses to return
+    // a retired finding at all. Naming it points them at a claim they cannot
+    // fetch. `hasOutstandingContradiction` above already declines to open the
+    // gate when EVERY disputant is retired; this is the same rule applied to
+    // each name, so a live disputant is still reported alongside a withdrawn one.
+    if (other && !other.retired && typeof other.key === 'string' && !keys.includes(other.key)) {
+      keys.push(other.key);
+    }
   }
 
   return { contradicted: true, ...(keys.length ? { contradictedBy: keys.join(', ') } : {}) };
@@ -870,6 +879,151 @@ export function invalidateChangedAnchors(dir, graph, rawPath) {
   // retrieval re-reports a change that has already been accounted for.
   if (source !== null) indexFile(dir, path, source);
   return marked;
+}
+
+/**
+ * The current content hash of an anchor, read from disk.
+ *
+ * DELIBERATELY NOT `checkAnchor`, and the difference is the whole of this
+ * clearing rule. `checkAnchor` compares disk against the anchor NODE's stored
+ * hash, and both eager paths call `indexFile` immediately after marking --
+ * which re-points that hash at the very bytes that caused the mark. So
+ * `checkAnchor` answers "fresh" for exactly the finding it just marked stale,
+ * and a clearing rule built on it would clear every flag it was handed,
+ * unconditionally. This returns a bare hash instead, so the caller can compare
+ * it against the FROZEN claim-time hash rather than against a value the marking
+ * path itself moved.
+ *
+ * Returns null when no content can be read at all -- a deleted file, or a
+ * symbol that no longer exists. A caller must treat that as "changed", never as
+ * "unknown": a claim about content that is gone certainly does not match the
+ * content it was made against.
+ */
+function anchorHashNow(anchor) {
+  const path = anchor.kind === 'symbol' ? anchor.file : anchor.key;
+  let source;
+  try {
+    source = readAnySpelling(path);
+  } catch {
+    return null;
+  }
+  if (anchor.kind !== 'symbol') return hash(source);
+
+  // By NAME, like checkAnchor: line numbers shift whenever anything above is
+  // edited, and re-locating by line would report a symbol as moved when only an
+  // unrelated insert happened above it.
+  const current = extractSymbols(path, source).find((s) => s.name === anchor.name);
+  if (!current) return null;
+  return hash(spanText(source, current));
+}
+
+/**
+ * Removes the staleness fields from a finding. Returns whether one was found.
+ *
+ * THE WHOLE NODE IS REWRITTEN, because `putNode` does not merge: it writes a
+ * full record from what it is handed and `load` replaces the node wholesale.
+ * Writing `{ kind, key, stale: false }` would blank the claim, the confidence
+ * and the provenance -- an overwrite by another name, and the same trap
+ * `contradict` documents. So the fields are destructured AWAY and everything
+ * else is spread back: no deletion primitive is needed, and the append-only rule
+ * is respected.
+ *
+ * `staleEvidence` is stripped as well, even though no writer stores it. It is
+ * added by `serve` to the object it hands out, so anything that ever writes a
+ * served finding back would carry it in -- at which point a cleared finding
+ * would still be advertising the quality of the evidence for a flag it no longer
+ * has.
+ *
+ * A PRIMITIVE, NOT A ROUTE. Nothing outside this module calls it: the only
+ * shipping caller is `reverify` below, which establishes the evidence first.
+ * Exposing it to a hook, a tool argument or an HTTP action would be a way to
+ * turn a stale finding fresh on request, which is exactly what must not exist.
+ */
+export function clearStale(dir, key) {
+  const node = load(dir).nodes.get(nodeId('finding', key));
+  if (!node || node.kind !== 'finding') return false;
+  const { stale, staleReason, diff, staleEvidence, ...rest } = node;
+  // Nothing to clear is a success, not a write: an unconditional putNode here
+  // would append a duplicate record to the log on every no-op call.
+  if (stale === undefined && staleReason === undefined
+    && diff === undefined && staleEvidence === undefined) return true;
+  putNode(dir, { ...rest, kind: 'finding', key: node.key });
+  return true;
+}
+
+/**
+ * Clears a stale flag when, and only when, the evidence for it is gone.
+ *
+ * WHY THIS HAS TO EXIST. Nothing in this codebase ever cleared a `stale` flag.
+ * That was harmless while eager invalidation was dead code; it fires now, so
+ * every finding on an edited file becomes permanently stale -- and permanently
+ * discounted, since `disclose.mjs` skips a stale finding outright and
+ * `utility.mjs` penalises one by 160. The graph degrades toward all-stale, and
+ * the eager path is over-eager on top of that: `invalidateOnWrite` marks every
+ * finding anchored to a FILE node on any observed write to that file, whether or
+ * not the bytes moved.
+ *
+ * WHAT COUNTS AS EVIDENCE, AND WHY IT IS NOT NEGOTIABLE. The only trustworthy
+ * record of what a claim was made against is `derivation.anchors` -- the hash
+ * each anchor carried at the moment the finding was written, frozen into the
+ * finding itself by `harvest-write.mjs`. Disk is re-hashed here and compared
+ * against that. If every anchor matches, the content IS what the claim was
+ * derived from: a revert, or a write that never moved the anchored bytes. The
+ * flag comes off. Anything else leaves it exactly as it was.
+ *
+ * IT IS NOT A LAUNDERING ROUTE, and that is a property of the comparison rather
+ * than of who is allowed to call it. A caller cannot make a finding fresh by
+ * asking; they can only make it fresh by putting the content back. There is no
+ * argument, no force flag and no second path -- and `clearStale` above, the one
+ * function that clears without checking, has no caller but this one.
+ *
+ * NO RECORD MEANS UNKNOWN, NEVER CLEAR. A finding with no `derivation.anchors`
+ * -- every one written before that record existed, and every hand-curated one --
+ * has nothing to compare disk against. That is an absence of evidence, and
+ * resolving it to "clear it" would hand back the laundering route through the
+ * side door. It reports `unknown` and changes nothing; re-recording the claim
+ * against the current code (`curate.correct`) is the way forward for those.
+ *
+ * DELIBERATELY NOT AUTOMATIC. This reads every anchor off disk, so running it on
+ * the serve path would put N file reads inside injection -- and, worse, it would
+ * silently un-mark findings nobody asked about. Staleness is disclosed to a
+ * reader who then decides; clearing is an explicit act.
+ */
+export function reverify(dir, key) {
+  const graph = load(dir);
+  const finding = graph.nodes.get(nodeId('finding', key));
+  if (!finding || finding.kind !== 'finding') return 'unknown';
+  // Idempotent: the postcondition -- no stale flag on this finding -- already
+  // holds, and reporting anything else would make a caller retry forever.
+  if (!finding.stale) return 'cleared';
+
+  const recorded = finding.derivation && finding.derivation.anchors;
+  if (!recorded || typeof recorded !== 'object') return 'unknown';
+
+  const anchorIds = new Set(
+    graph.edges
+      .filter((e) => e.edge === 'derived_from' && e.from === finding.id)
+      .map((e) => e.to)
+  );
+  // An unanchored finding cannot be checked against anything, which is the
+  // un-invalidatable shape the anchor discipline exists to refuse. It is equally
+  // un-VERIFIABLE, so it is reported as such rather than cleared.
+  if (!anchorIds.size) return 'unknown';
+
+  for (const id of anchorIds) {
+    const expected = recorded[id];
+    const node = graph.nodes.get(id);
+    // An anchor this finding never recorded a hash for, or one that no longer
+    // resolves to a node: nothing to compare, so nothing is concluded.
+    if (typeof expected !== 'string' || !expected || !node) return 'unknown';
+    if (node.kind !== 'file' && node.kind !== 'symbol') return 'unknown';
+    // null means the content is gone -- deleted file, vanished symbol. That is a
+    // difference, not an absence of evidence.
+    if (anchorHashNow(node) !== expected) return 'still-stale';
+  }
+
+  clearStale(dir, key);
+  return 'cleared';
 }
 
 export { contentHash };

--- a/integrations/qwen/hooks/lib/staleness.mjs
+++ b/integrations/qwen/hooks/lib/staleness.mjs
@@ -368,6 +368,12 @@ const DIFF_MAX_BYTES = () => {
  * line, and total bytes. Every truncation is announced in the output, because a
  * silently shortened diff is worse than a visibly shortened one -- a reader who
  * cannot tell content was elided believes they saw the whole change.
+ *
+ * `maxLines` BOUNDS THE BODY, MARKERS INCLUDED: at most `maxLines` lines of
+ * removed lines, added lines and "... N more" elision markers between them, plus
+ * at most one final notice when the byte cap dropped lines -- so `maxLines + 1`
+ * lines in total, and no more. That last line is outside the budget on purpose,
+ * for the reason stated where it is pushed.
  */
 export function diffLines(
   before,
@@ -418,10 +424,24 @@ export function diffLines(
     bytes += size;
   };
 
-  for (const line of removed.slice(0, maxLines / 2)) push('- ' + line);
-  if (removed.length > maxLines / 2) push(`  ... ${removed.length - maxLines / 2} more removed`);
-  for (const line of added.slice(0, maxLines / 2)) push('+ ' + line);
-  if (added.length > maxLines / 2) push(`  ... ${added.length - maxLines / 2} more added`);
+  // THE ELISION MARKER IS PAID FOR OUT OF THE SIDE'S OWN QUOTA, so `maxLines`
+  // bounds the whole body rather than only the content in it. It did not: at the
+  // default 40 the body could reach 42 lines -- 20 removed, 20 added and two
+  // "... N more" markers -- and the out-of-budget notice below made 43, against
+  // a documented bound of 40 and a test asserting 41. Three numbers, no two the
+  // same. A side that has to elide now shows one fewer content line and spends
+  // that line on saying so, which is the trade a reader wants anyway: knowing
+  // that 300 lines were cut matters more than the 20th of the 20 shown.
+  const half = Math.floor(maxLines / 2);
+  const emit = (lines, prefix, label) => {
+    const elides = lines.length > half;
+    const shown = elides ? Math.max(0, half - 1) : half;
+    for (const line of lines.slice(0, shown)) push(prefix + line);
+    if (elides) push(`  ... ${lines.length - shown} more ${label}`);
+  };
+
+  emit(removed, '- ', 'removed');
+  emit(added, '+ ', 'added');
 
   // Announced OUTSIDE the budget, deliberately: the one line a reader most
   // needs is the one saying the rest is missing, and dropping it to stay under
@@ -479,6 +499,15 @@ function disputeOf(graph, finding) {
   if (!hasOutstandingContradiction(graph, finding.key)) return {};
 
   const keys = [];
+  // AND THE REASON A PERSON TYPED, which had no reader anywhere. `contradict`
+  // stores `contradictionReason` -- up to 400 characters of human explanation --
+  // on the CONTRADICTED end only, and nothing outside its own test ever read it:
+  // this disclosure named the other key and stopped, `audit` counts ends, and the
+  // dashboard detail view renders neither. So the one field on the edge that says
+  // WHY was written on every contradiction and seen by nobody. It is collected
+  // from whichever end holds it, so both sides of a dispute disclose the same
+  // reason rather than only the claim that lost.
+  let reason = typeof finding.contradictionReason === 'string' ? finding.contradictionReason : '';
   for (const edge of graph.edges) {
     if (edge.edge !== 'contradicts') continue;
     const otherId =
@@ -497,10 +526,30 @@ function disputeOf(graph, finding) {
     // each name, so a live disputant is still reported alongside a withdrawn one.
     if (other && !other.retired && typeof other.key === 'string' && !keys.includes(other.key)) {
       keys.push(other.key);
+      // A RETIRED END'S REASON IS NOT BORROWED EITHER, which is why this sits
+      // inside the same guard as the key: `hasOutstandingContradiction` can be
+      // open on one live disputant while another is withdrawn, and quoting the
+      // withdrawn one's explanation would attribute the live dispute to a claim
+      // the reader cannot fetch.
+      if (!reason && typeof other.contradictionReason === 'string') {
+        reason = other.contradictionReason;
+      }
     }
   }
 
-  return { contradicted: true, ...(keys.length ? { contradictedBy: keys.join(', ') } : {}) };
+  return {
+    contradicted: true,
+    ...(keys.length ? { contradictedBy: keys.join(', ') } : {}),
+    // Trimmed here rather than at the renderer: an empty string is not a reason,
+    // and a consumer checking `if (reason)` should not have to trim first.
+    //
+    // SET UNCONDITIONALLY, INCLUDING TO `undefined`. `serve` spreads the stored
+    // record before this object, so omitting the key would let a whitespace-only
+    // stored reason through untouched and make the served value differ from the
+    // one this function decided on. The disclosure is authoritative or it is not
+    // a disclosure.
+    contradictionReason: reason.trim() || undefined,
+  };
 }
 
 /**
@@ -580,8 +629,15 @@ function derivationCheck(graph, finding) {
  * the dashboard, which left the rot path fully open on every install where
  * nobody opens the dashboard -- and that is most of them. The evidence test is
  * what makes clearing safe, and it does not care who triggered it: the same
- * `claimTimeVerdict` runs here as in `reverify`, so this cannot clear anything
+ * `claimTimeEvidence` runs here as in `reverify`, so this cannot clear anything
  * the button would not.
+ *
+ * A CLEAR ALSO RE-INDEXES THE ANCHORS IT VERIFIED. The three disclosures this
+ * function emits -- `stale`, `derivationHolds`, and the dispute -- are computed
+ * from three different comparisons, and clearing the flag without moving the
+ * anchor's stored hash made the first two contradict the clear on the revert
+ * path. `reindexVerifiedAnchors` explains the reproduction and why re-pointing
+ * the index is the fix rather than suppressing the disclosures.
  *
  * `dir` IS OPTIONAL, AND OMITTING IT MAKES THIS READ-ONLY. Several callers hold
  * a graph without the directory it came from, and a serve that silently did
@@ -617,11 +673,17 @@ export function serve(graph, findings, { dir = null } = {}) {
 
     // AUTOMATIC CLEARING, on the same evidence the manual path demands.
     //
-    // ONLY THE STORED FLAG IS TOUCHED. The lazy loop below is left to run
-    // exactly as before and can independently mark this finding stale again on
-    // its own comparison -- disk against the anchor NODE's hash -- which answers
-    // a different question and is not this function's to overrule. Eager and
-    // lazy stay two mechanisms, as the module header insists.
+    // THE FLAG AND THE INDEX MOVE TOGETHER. Clearing the flag alone made this
+    // function contradict itself on the revert path: the lazy loop below
+    // compares disk against the anchor NODE's hash, which the eager path
+    // re-pointed at the post-edit bytes, so a reverted file read as `stale:
+    // true, staleReason: 'file changed'` and `derivationHolds: false` inside the
+    // very object whose flag had just been cleared for matching its claim-time
+    // content. `reindexVerifiedAnchors` writes the verified bytes' hash back to
+    // the anchor, so all three disclosures are finally reading the same content
+    // and cannot disagree. Eager and lazy stay two mechanisms, as the module
+    // header insists -- what changed is that the index no longer holds a hash
+    // that matches no version of the file that exists.
     //
     // AND THE FIELDS GO WITH THE FLAG. `putNode` does not merge and neither does
     // this spread: serving `{ ...finding, stale: false }` would hand back a
@@ -630,12 +692,37 @@ export function serve(graph, findings, { dir = null } = {}) {
     // So the cleared record, not the stored one, is what the rest of this
     // iteration reads and spreads.
     //
-    // BOUNDED, and the bound is the point: this runs only for a finding whose
-    // flag is already STORED, only when a `derivation` record exists to check
-    // against, and it reads each of that finding's anchors at most once. A
-    // finding that is not flagged pays nothing. The lazy loop below already
+    // BOUNDED PER CALL, and the bound is the point: this runs only for a finding
+    // whose flag is already STORED, only when a `derivation` record exists to
+    // check against, and it reads each of that finding's anchors at most once.
+    // A finding that is not flagged pays nothing. The lazy loop below already
     // reads every anchor of every content-dependent finding served, so the worst
     // case is twice the anchor reads on the already-stale subset alone.
+    //
+    // AND THE PER-SESSION SHAPE, stated because the per-call bound alone reads
+    // as cheaper than it is. Measured on a synthetic 40-stale-finding graph, the
+    // serve path went 158 ms -> 217 ms (+37%), and for a GENUINELY stale finding
+    // that cost recurs on every call for the whole session: the verdict is
+    // `'differs'` forever, nothing is cleared, and the reads are repaid with
+    // nothing. What keeps it survivable in practice is not this bound but two
+    // others -- `findingsFor`'s result limit and inject.mjs's `alreadyInjected`
+    // gate, which together put it near 40 ms on the first touch of a hot file
+    // and zero on the touches after.
+    //
+    // THE REVERT CASE PAYS ONCE, AND THAT IS MEASURED, not argued. Same 40
+    // findings, all revertible, medians of 9 across three process launches: the
+    // read-only serve is 23-29 ms, the first clearing serve is 141-173 ms (the
+    // anchor reads plus one node append per cleared finding AND per re-pointed
+    // anchor), and the SECOND clearing serve is 21-28 ms -- back to the
+    // read-only baseline, because the flag is off and the index agrees, so this
+    // gate no longer fires. What the re-index changed is not that cost -- the
+    // gate stopped firing once the flag came off before, too -- but that every
+    // serve after the clear used to re-derive `stale: true` and
+    // `derivationHolds: false` from an index nobody had moved. The extra ~120 ms
+    // buys silence that is actually correct.
+    // On the genuinely-stale set the recurring cost is
+    // real and unchanged in kind: 26-45 ms read-only against 53-105 ms with
+    // clearing on, every call, clearing nothing.
     //
     // NOT ON THE NON-CONTENT-DEPENDENT EARLY RETURN ABOVE, deliberately. Both
     // eager paths refuse to flag those types at all, so a flag there can only
@@ -643,10 +730,14 @@ export function serve(graph, findings, { dir = null } = {}) {
     // does not depend on them is exactly the cost `CONTENT_DEPENDENT` exists to
     // avoid.
     let record = finding;
-    if (dir && finding.stale && claimTimeVerdict(graph, finding) === 'match') {
-      clearStale(dir, finding.key, { graph });
-      const { stale: _s, staleReason: _r, diff: _d, staleEvidence: _e, ...cleared } = finding;
-      record = cleared;
+    if (dir && finding.stale) {
+      const evidence = claimTimeEvidence(graph, finding);
+      if (evidence.verdict === 'match') {
+        reindexVerifiedAnchors(dir, graph, evidence.contents);
+        clearStale(dir, finding.key, { graph });
+        const { stale: _s, staleReason: _r, diff: _d, staleEvidence: _e, ...cleared } = finding;
+        record = cleared;
+      }
     }
 
     const anchors = graph.edges
@@ -736,6 +827,14 @@ export function serve(graph, findings, { dir = null } = {}) {
       // carries its `derivation`, since clearing removes only the staleness
       // fields. A finding whose flag was just cleared is still disclosed as
       // disputed, and still reports whether its derivation holds.
+      //
+      // AND THEY NO LONGER CONTRADICT THE CLEAR. Surviving is not the same as
+      // agreeing: for a whole serve this returned `stale: true, staleReason:
+      // 'file changed'` and `derivationHolds: false` on a finding it had just
+      // cleared, because the clear was decided against disk while these two read
+      // the anchor node's hash, and the eager path had moved it. All three now
+      // read the same content because the clear re-points the anchor; see
+      // `reindexVerifiedAnchors`.
       ...dispute,
       // Independent of `stale` above: see `derivationCheck`'s own comment for
       // the case it catches that node-level staleness can miss.
@@ -934,6 +1033,34 @@ export function invalidateChangedAnchors(dir, graph, rawPath) {
 }
 
 /**
+ * The current content of an anchor, read from disk: the whole file for a file
+ * anchor, the located span for a symbol one. Null when nothing can be read.
+ *
+ * SPLIT OUT FROM `anchorHashNow` SO THE BYTES SURVIVE THE COMPARISON. The
+ * clearing path hashes this to reach a verdict and, on `'match'`, re-indexes the
+ * anchor from the same bytes -- see `reindexVerifiedAnchors`. Returning only a
+ * hash forced a second read of a file that had just been read, for content
+ * already known to be identical.
+ */
+function anchorContentNow(anchor) {
+  const path = anchor.kind === 'symbol' ? anchor.file : anchor.key;
+  let source;
+  try {
+    source = readAnySpelling(path);
+  } catch {
+    return null;
+  }
+  if (anchor.kind !== 'symbol') return source;
+
+  // By NAME, like checkAnchor: line numbers shift whenever anything above is
+  // edited, and re-locating by line would report a symbol as moved when only an
+  // unrelated insert happened above it.
+  const current = extractSymbols(path, source).find((s) => s.name === anchor.name);
+  if (!current) return null;
+  return spanText(source, current);
+}
+
+/**
  * The current content hash of an anchor, read from disk.
  *
  * DELIBERATELY NOT `checkAnchor`, and the difference is the whole of this
@@ -952,21 +1079,8 @@ export function invalidateChangedAnchors(dir, graph, rawPath) {
  * content it was made against.
  */
 function anchorHashNow(anchor) {
-  const path = anchor.kind === 'symbol' ? anchor.file : anchor.key;
-  let source;
-  try {
-    source = readAnySpelling(path);
-  } catch {
-    return null;
-  }
-  if (anchor.kind !== 'symbol') return hash(source);
-
-  // By NAME, like checkAnchor: line numbers shift whenever anything above is
-  // edited, and re-locating by line would report a symbol as moved when only an
-  // unrelated insert happened above it.
-  const current = extractSymbols(path, source).find((s) => s.name === anchor.name);
-  if (!current) return null;
-  return hash(spanText(source, current));
+  const content = anchorContentNow(anchor);
+  return content === null ? null : hash(content);
 }
 
 /**
@@ -1005,21 +1119,51 @@ export function clearStale(dir, key, { graph = null } = {}) {
   // `contradict`, `correct` -- writes from a graph it loaded earlier too. Both
   // callers here already DECIDED on this snapshot, so re-reading it purely for
   // the write narrowed no window that was ever closed.
-  const node = (graph || load(dir)).nodes.get(nodeId('finding', key));
+  const id = nodeId('finding', key);
+  const node = (graph || load(dir)).nodes.get(id);
   if (!node || node.kind !== 'finding') return false;
   const { stale, staleReason, diff, staleEvidence, ...rest } = node;
   // Nothing to clear is a success, not a write: an unconditional putNode here
   // would append a duplicate record to the log on every no-op call.
   if (stale === undefined && staleReason === undefined
     && diff === undefined && staleEvidence === undefined) return true;
-  putNode(dir, { ...rest, kind: 'finding', key: node.key });
+  const cleared = { ...rest, kind: 'finding', key: node.key };
+  putNode(dir, cleared);
+  // AND THE CALLER'S GRAPH IS UPDATED, because the guard above reads THAT graph,
+  // not disk. Without this, a second `serve` on the same in-memory graph object
+  // -- two touched files anchored to one finding, or a lifecycle branch that
+  // serves twice from a graph it loaded once, as SessionStart does -- still saw
+  // `stale: true`, re-ran the evidence test, and appended a byte-identical clear
+  // record. The store is append-only, so that is permanent log growth for no
+  // change in state, and the "nothing to clear is a success, not a write"
+  // guarantee directly above was only true of the first call.
+  if (graph) graph.nodes.set(id, { ...cleared, id });
   return true;
 }
 
 /**
- * Clears a stale flag when, and only when, the evidence for it is gone.
+ * THE ONE EVIDENCE TEST, plus the bytes it read. Does this finding's anchored
+ * content still hash to what the claim was actually made against?
  *
- * WHY THIS HAS TO EXIST. Nothing in this codebase ever cleared a `stale` flag.
+ * `verdict` is one of:
+ *   `'match'`   -- every anchor on disk re-hashes to the value frozen into this
+ *                  finding's own `derivation.anchors` at claim time. The content
+ *                  IS what the claim was derived from: a revert, or a write that
+ *                  never moved the anchored bytes.
+ *   `'differs'` -- at least one anchor does not, INCLUDING an anchor whose
+ *                  content is gone. Deleted is a difference, not a missing
+ *                  measurement.
+ *   `'unknown'` -- there is nothing to compare: no `derivation.anchors`, no
+ *                  anchors, an anchor with no recorded hash, or one that no
+ *                  longer resolves.
+ *
+ * `contents` carries the disk bytes read to reach a `'match'`, keyed by anchor
+ * id, so the caller can re-index those anchors without reading them again. It is
+ * empty for the other two verdicts, which read no further than the first
+ * disagreement.
+ *
+ * WHY CLEARING HAS TO EXIST AT ALL. Nothing in this codebase ever cleared a
+ * `stale` flag.
  * That was harmless while eager invalidation was dead code; it fires now, so
  * every finding on an edited file becomes permanently stale -- and permanently
  * discounted, since `disclose.mjs` skips a stale finding outright and
@@ -1049,24 +1193,6 @@ export function clearStale(dir, key, { graph = null } = {}) {
  * side door. It reports `unknown` and changes nothing; re-recording the claim
  * against the current code (`curate.correct`) is the way forward for those.
  *
- * DELIBERATELY NOT AUTOMATIC. This reads every anchor off disk, so running it on
- * the serve path would put N file reads inside injection -- and, worse, it would
- * silently un-mark findings nobody asked about. Staleness is disclosed to a
- * reader who then decides; clearing is an explicit act.
- */
-/**
- * THE ONE EVIDENCE TEST. Does this finding's anchored content still hash to what
- * the claim was actually made against?
- *
- * `'match'` -- every anchor on disk re-hashes to the value frozen into this
- * finding's own `derivation.anchors` at claim time. The content IS what the
- * claim was derived from: a revert, or a write that never moved the anchored
- * bytes.
- * `'differs'` -- at least one anchor does not, INCLUDING an anchor whose content
- * is gone. Deleted is a difference, not a missing measurement.
- * `'unknown'` -- there is nothing to compare: no `derivation.anchors`, no
- * anchors, an anchor with no recorded hash, or one that no longer resolves.
- *
  * SHARED BY BOTH CLEARING PATHS ON PURPOSE, and that sharing is the guarantee
  * rather than a convenience. `reverify` (a person pressing Re-verify) and
  * `serve` (automatic, on every retrieval) call THIS function and nothing else,
@@ -1080,9 +1206,10 @@ export function clearStale(dir, key, { graph = null } = {}) {
  * re-point at the very bytes that caused the mark, so it answers "fresh" for
  * exactly the finding it just marked stale.
  */
-function claimTimeVerdict(graph, finding) {
+function claimTimeEvidence(graph, finding) {
+  const none = { verdict: 'unknown', contents: new Map() };
   const recorded = finding.derivation && finding.derivation.anchors;
-  if (!recorded || typeof recorded !== 'object') return 'unknown';
+  if (!recorded || typeof recorded !== 'object') return none;
 
   const anchorIds = new Set(
     graph.edges
@@ -1092,22 +1219,122 @@ function claimTimeVerdict(graph, finding) {
   // An unanchored finding cannot be checked against anything, which is the
   // un-invalidatable shape the anchor discipline exists to refuse. It is equally
   // un-VERIFIABLE, so it is reported as such rather than cleared.
-  if (!anchorIds.size) return 'unknown';
+  if (!anchorIds.size) return none;
 
+  const contents = new Map();
   for (const id of anchorIds) {
     const expected = recorded[id];
     const node = graph.nodes.get(id);
     // An anchor this finding never recorded a hash for, or one that no longer
     // resolves to a node: nothing to compare, so nothing is concluded.
-    if (typeof expected !== 'string' || !expected || !node) return 'unknown';
-    if (node.kind !== 'file' && node.kind !== 'symbol') return 'unknown';
+    if (typeof expected !== 'string' || !expected || !node) return none;
+    if (node.kind !== 'file' && node.kind !== 'symbol') return none;
     // null means the content is gone -- deleted file, vanished symbol. That is a
     // difference, not an absence of evidence.
-    if (anchorHashNow(node) !== expected) return 'differs';
+    const content = anchorContentNow(node);
+    if (content === null || hash(content) !== expected) {
+      return { verdict: 'differs', contents: new Map() };
+    }
+    contents.set(id, content);
   }
-  return 'match';
+  return { verdict: 'match', contents };
 }
 
+/** The verdict alone, for callers that do not re-index. */
+function claimTimeVerdict(graph, finding) {
+  return claimTimeEvidence(graph, finding).verdict;
+}
+
+/**
+ * Re-points every verified anchor at the content the evidence test just read.
+ *
+ * WHY A CLEAR IS NOT ENOUGH ON ITS OWN, reproduced end to end: index a file at
+ * H1, write a finding whose `derivation.anchors` records H1, edit and re-index so
+ * the node holds H2, let the eager path mark the finding, then REVERT the edit on
+ * disk. `claimTimeVerdict` now says `'match'` -- disk is H1, which is exactly
+ * what the claim was derived from -- and the flag comes off. But the node still
+ * holds H2, so the same `serve` call went on to emit `stale: true` with
+ * `staleReason: 'file changed'` from the lazy loop (disk H1 against node H2) and
+ * `derivationHolds: false` from `derivationCheck` (index H2 against claim H1).
+ * The model was shown DERIVATION CHANGED and STALE at the exact moment this
+ * module's own evidence test had concluded the derivation holds -- on every
+ * serve, until something unrelated happened to re-index the anchor.
+ *
+ * THE FIX IS TO MOVE THE INDEX, NOT TO SILENCE THE DISCLOSURES. Suppressing the
+ * lazy check and the derivation verdict for a cleared finding would leave the
+ * graph holding a hash that matches no version of the file that exists, so every
+ * OTHER finding on that anchor keeps reading stale, and the next reader has to be
+ * told which disclosures to disbelieve. The node hash is simply out of date, the
+ * bytes are already in hand from the comparison that just succeeded, and writing
+ * them makes all three disclosures agree because they are finally reading the
+ * same content.
+ *
+ * COSTS NO READ. `contents` comes from `claimTimeEvidence`, which read each
+ * anchor to reach `'match'`. The write is one node record per anchor whose hash
+ * actually moved, and it happens once per revert rather than once per serve: with
+ * the index re-pointed, the flag stays off and the gate in `serve` does not fire
+ * again.
+ *
+ * THE IN-MEMORY GRAPH IS UPDATED TOO, because the caller is mid-serve and is
+ * about to read these same nodes through the lazy loop and `derivationCheck`.
+ * Writing only to disk would fix the next process and leave this one contradicting
+ * itself, which is the whole defect.
+ *
+ * Line numbers are deliberately left alone on a symbol anchor: `checkAnchor` and
+ * `anchorContentNow` both re-locate by NAME, so a stored line is informational,
+ * and the body being byte-identical is what was just established.
+ */
+function reindexVerifiedAnchors(dir, graph, contents) {
+  for (const [id, content] of contents) {
+    const node = graph.nodes.get(id);
+    if (!node) continue;
+    const nextHash = hash(content);
+    // Already agrees: no record, no write. The common case once a revert has
+    // been accounted for.
+    if (node.hash === nextHash) continue;
+    const limit = node.kind === 'symbol' ? symbolSnapshotLimit() : snapshotLimit();
+    // Same bound as `indexFile`: past the cap the hash still drives staleness and
+    // only the reconstructed diff degrades.
+    const snapshot = content.length <= limit ? content : undefined;
+    const { hash: _h, snapshot: _s, ...rest } = node;
+    try {
+      putNode(dir, { ...rest, kind: node.kind, key: node.key, hash: nextHash, snapshot });
+    } catch {
+      // Fail open: a graph that could not be written is a disclosure that stays
+      // as it was, never a broken tool call. The in-memory copy is left alone to
+      // match, so this serve keeps agreeing with the store.
+      continue;
+    }
+    graph.nodes.set(id, { ...node, hash: nextHash, ...(snapshot ? { snapshot } : {}) });
+  }
+}
+
+/**
+ * Clears a stale flag on behalf of a person who asked for it -- the dashboard's
+ * Re-verify action -- and reports what the evidence said.
+ *
+ * `'cleared'` when the flag is gone (including when it was already gone, so a
+ * caller polling this does not retry forever), `'still-stale'` when the anchored
+ * content genuinely differs from what the claim was made against, `'unknown'`
+ * when there is nothing to compare and therefore nothing to conclude.
+ *
+ * NO LONGER THE ONLY CLEARING PATH, and the docblock that used to sit here said
+ * the opposite: that automatic clearing was refused because it would put N file
+ * reads inside injection and "silently un-mark findings nobody asked about".
+ * `serve` now does exactly that, on the same evidence, for the reason its own
+ * comment gives -- the manual path was reachable only where somebody opens the
+ * dashboard, which is almost nowhere, so the rot path stayed open on most
+ * installs. What survives of that objection is the cost, which `serve` bounds
+ * and states.
+ *
+ * WHAT THIS STILL ADDS over the automatic path: it loads the graph itself, so a
+ * caller holding nothing but a key and a directory can act; it reports the
+ * verdict rather than folding it into a served record; and it runs on demand
+ * rather than only when the finding happens to be retrieved. It re-indexes the
+ * verified anchors for the same reason `serve` does -- otherwise the button
+ * clears the flag and the very next retrieval re-derives a contradiction from a
+ * node hash nobody moved.
+ */
 export function reverify(dir, key) {
   const graph = load(dir);
   const finding = graph.nodes.get(nodeId('finding', key));
@@ -1116,9 +1343,10 @@ export function reverify(dir, key) {
   // holds, and reporting anything else would make a caller retry forever.
   if (!finding.stale) return 'cleared';
 
-  const verdict = claimTimeVerdict(graph, finding);
+  const { verdict, contents } = claimTimeEvidence(graph, finding);
   if (verdict === 'unknown') return 'unknown';
   if (verdict === 'differs') return 'still-stale';
+  reindexVerifiedAnchors(dir, graph, contents);
   clearStale(dir, key, { graph });
   return 'cleared';
 }

--- a/integrations/qwen/hooks/lib/staleness.mjs
+++ b/integrations/qwen/hooks/lib/staleness.mjs
@@ -17,7 +17,13 @@
  * TWO INVALIDATION PATHS, and each covers what the other cannot see:
  *
  *   EAGER  -- our PostToolUse hook saw a write, so the finding is marked at the
- *             moment it went stale, with the exact before/after in hand.
+ *             moment it went stale, with the exact before/after in hand. The
+ *             hook does not call `invalidateOnWrite` directly: it queues the
+ *             evidence through pending.mjs, and the next graph read -- which
+ *             loads the graph anyway -- applies it before serving anything.
+ *             That path is also the only one that catches a write the SESSION
+ *             made, because the lazy check below compares the stored hash
+ *             against disk and `indexFile` has already refreshed it.
  *   LAZY   -- at retrieval, the anchor's stored hash is compared against disk.
  *             This is what catches `git pull`, another editor, a teammate, or a
  *             build step: every change our hooks never observed.
@@ -291,14 +297,69 @@ export function checkAnchor(anchor) {
 }
 
 /**
+ * Characters kept from any single diff line.
+ *
+ * A LINE CAP IS NOT A SIZE CAP, and the gap was measured: with only `maxLines`
+ * in force, `diffLines('X'.repeat(200000), 'Y'.repeat(200000))` returned 2 lines
+ * and 400,005 bytes. Minified bundles, generated sources and single-line JSON
+ * all have that shape, and this output goes STRAIGHT INTO MODEL CONTEXT from
+ * inject.mjs's zero-turn refusal -- so a line bound alone let one pathological
+ * file spend hundreds of thousands of tokens.
+ *
+ * 200 characters is chosen because it is past the width at which a line is read
+ * as a line by anybody, human or model: a hand-written source line is under
+ * ~120 columns, so the cap cannot truncate a diff a reader was going to use,
+ * while the cases it does truncate are ones where the interesting change is not
+ * legible from the raw text anyway.
+ */
+const DIFF_MAX_LINE_CHARS = () => {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_DIFF_MAX_LINE_CHARS);
+  return Number.isFinite(raw) && raw > 0 ? raw : 200;
+};
+
+/**
+ * Total UTF-8 bytes of diff body.
+ *
+ * 4,000 bytes is roughly 1,000 tokens. It is deliberately larger than the
+ * per-file injection budget (`TOKEN_OPTIMIZER_TOUCH_BUDGET`, 500 tokens) and
+ * far smaller than a file, because the two consumers want different things: the
+ * injection surface fits the diff inside its own budget and drops it if it does
+ * not fit, while the zero-turn refusal is replacing a whole file read and can
+ * afford more. One cap that neither consumer has to think about is worth more
+ * than two tuned ones.
+ *
+ * WHAT IT COSTS, PLAINLY: a legitimately large diff now arrives truncated, so a
+ * model looking at a 300-line refactor sees the head of it and a count of what
+ * was elided rather than the whole change. That is the correct direction to
+ * fail -- the alternative was a bounded-looking function that could emit 400 KB.
+ */
+const DIFF_MAX_BYTES = () => {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_DIFF_MAX_BYTES);
+  return Number.isFinite(raw) && raw > 0 ? raw : 4_000;
+};
+
+/**
  * A compact line diff.
  *
  * Deliberately not a full unified diff with hunks and context: the consumer is
  * a model deciding whether an existing conclusion still holds, and for that the
  * changed lines are the signal. Output is capped because an unbounded diff
  * injected alongside a finding would spend more tokens than re-deriving it.
+ *
+ * BOUNDED IN THREE WAYS, and each one is load-bearing: lines, characters per
+ * line, and total bytes. Every truncation is announced in the output, because a
+ * silently shortened diff is worse than a visibly shortened one -- a reader who
+ * cannot tell content was elided believes they saw the whole change.
  */
-export function diffLines(before, after, { maxLines = 40 } = {}) {
+export function diffLines(
+  before,
+  after,
+  {
+    maxLines = 40,
+    maxLineChars = DIFF_MAX_LINE_CHARS(),
+    maxBytes = DIFF_MAX_BYTES(),
+  } = {}
+) {
   const a = String(before).split('\n');
   const b = String(after).split('\n');
 
@@ -314,33 +375,44 @@ export function diffLines(before, after, { maxLines = 40 } = {}) {
   const added = b.slice(head, b.length - tail);
 
   const out = [];
-  for (const line of removed.slice(0, maxLines / 2)) out.push('- ' + line);
-  if (removed.length > maxLines / 2) out.push(`  ... ${removed.length - maxLines / 2} more removed`);
-  for (const line of added.slice(0, maxLines / 2)) out.push('+ ' + line);
-  if (added.length > maxLines / 2) out.push(`  ... ${added.length - maxLines / 2} more added`);
+  let bytes = 0;
+  let dropped = 0;
+
+  // Per line first, so ONE enormous line cannot consume the whole budget and
+  // leave every other changed line unrepresented.
+  const clamp = (line) => {
+    const text = String(line);
+    if (text.length <= maxLineChars) return text;
+    return `${text.slice(0, maxLineChars)} [+${text.length - maxLineChars} chars cut]`;
+  };
+
+  // Bytes, not characters: the cap exists to bound what is sent, and a
+  // multi-byte source file would otherwise pass a character check while
+  // emitting several times the budget.
+  const push = (line) => {
+    const text = clamp(line);
+    const size = Buffer.byteLength(text, 'utf8') + 1;
+    if (bytes + size > maxBytes) {
+      dropped++;
+      return;
+    }
+    out.push(text);
+    bytes += size;
+  };
+
+  for (const line of removed.slice(0, maxLines / 2)) push('- ' + line);
+  if (removed.length > maxLines / 2) push(`  ... ${removed.length - maxLines / 2} more removed`);
+  for (const line of added.slice(0, maxLines / 2)) push('+ ' + line);
+  if (added.length > maxLines / 2) push(`  ... ${added.length - maxLines / 2} more added`);
+
+  // Announced OUTSIDE the budget, deliberately: the one line a reader most
+  // needs is the one saying the rest is missing, and dropping it to stay under
+  // a self-imposed cap would hand back a diff that lies about being complete.
+  if (dropped) out.push(`  ... ${dropped} more changed line(s) cut at the size limit`);
 
   return out.join('\n');
 }
 
-/**
- * Prepares findings for delivery, verifying each one lazily against disk.
- *
- * This is the only function that should ever hand a finding to a model, because
- * it is the one that enforces the rule: a stale finding leaves here carrying
- * `stale: true` AND a diff, or it does not leave at all.
- */
-export function serve(graph, findings) {
-  const served = [];
-
-  // RETIRED FINDINGS STOP HERE, unconditionally.
-  //
-  // findingsFor and sessionIndex already filter them, so this is redundant on
-  // every current path -- deliberately. This function's own contract is that it
-  // is the only thing that hands a finding to a model, which makes it the right
-  // place for the guarantee to live: a future caller that reaches into the
-  // graph directly cannot accidentally serve a claim a human explicitly
-  // withdrew. A withheld claim reappearing is not a bug anyone would notice
-  // quickly.
 /**
  * Types whose truth is a claim ABOUT the anchor's contents.
  *
@@ -363,6 +435,26 @@ export function serve(graph, findings) {
  * to ignore -- taking the rare true positive with it.
  */
 const CONTENT_DEPENDENT = new Set(['finding', 'map']);
+
+/**
+ * Prepares findings for delivery, verifying each one lazily against disk.
+ *
+ * This is the only function that should ever hand a finding to a model, because
+ * it is the one that enforces the rule: a stale finding leaves here carrying
+ * `stale: true` AND a diff, or it does not leave at all.
+ */
+export function serve(graph, findings) {
+  const served = [];
+
+  // RETIRED FINDINGS STOP HERE, unconditionally.
+  //
+  // findingsFor and sessionIndex already filter them, so this is redundant on
+  // every current path -- deliberately. This function's own contract is that it
+  // is the only thing that hands a finding to a model, which makes it the right
+  // place for the guarantee to live: a future caller that reaches into the
+  // graph directly cannot accidentally serve a claim a human explicitly
+  // withdrew. A withheld claim reappearing is not a bug anyone would notice
+  // quickly.
 
   for (const finding of findings.filter((f) => !f.retired)) {
     // A claim that does not depend on the anchor's contents cannot be
@@ -505,6 +597,15 @@ export function invalidateOnWrite(dir, graph, rawPath, beforeText, afterText) {
     for (const edge of byTarget.get(node.id) || []) {
       const finding = graph.nodes.get(edge.from);
       if (!finding || finding.kind !== 'finding') continue;
+      // THE SAME TYPE GATE `serve` APPLIES, and it has to be here too now that
+      // this path actually runs. `serve` ignores a stale flag on a type whose
+      // truth is not a claim about the anchor's contents -- but the flag is
+      // STORED, and disclose.mjs skips a stale finding outright while
+      // utility.mjs penalises one by 160. So writing it onto a `failure` or a
+      // `command` would suppress that claim everywhere except the one reader
+      // that knows to ignore it, which is exactly the harm measured in the
+      // comment on CONTENT_DEPENDENT above.
+      if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) continue;
 
       putNode(dir, {
         ...finding,

--- a/integrations/qwen/hooks/lib/staleness.mjs
+++ b/integrations/qwen/hooks/lib/staleness.mjs
@@ -495,6 +495,54 @@ function disputeOf(graph, finding) {
 }
 
 /**
+ * Whether THIS finding's own claim-time evidence still matches its anchors --
+ * the reader `harvest-write.mjs`'s `derivation` record was written for.
+ * Nothing consumed that record until now: a grep for it found only the writer
+ * and its own tests, which made "checkable rather than merely attributed" a
+ * claim with no code behind it.
+ *
+ * DISTINCT FROM `stale`/`checkAnchor`, DELIBERATELY, not a duplicate of it.
+ * `checkAnchor` compares disk against the anchor NODE's CURRENT stored hash,
+ * which is refreshed by `indexFile` every time ANYTHING touches that file --
+ * so it answers "has this file changed since the last time anyone indexed
+ * it", not "has it changed since THIS finding was derived from it". Those
+ * differ in a real case: file F changes, and a LATER, unrelated write
+ * (another finding, another session) re-indexes F, updating the node's
+ * stored hash to match the new content again. `checkAnchor` now reports
+ * "fresh" -- disk matches the node's current hash -- while this finding's own
+ * frozen `derivation.anchors[id]` snapshot, taken when IT was written, no
+ * longer matches. The bytes this claim was actually derived from are gone,
+ * and `stale` alone would never say so.
+ *
+ * Returns `{}` when there is nothing to check (no `derivation.anchors`
+ * recorded -- true of every finding written before this existed), so a
+ * caller can tell "not checked" from "checked and holds" by whether
+ * `derivationHolds` is present at all.
+ */
+function derivationCheck(graph, finding) {
+  const recorded = finding.derivation && finding.derivation.anchors;
+  if (!recorded || typeof recorded !== 'object') return {};
+  const ids = Object.keys(recorded);
+  if (!ids.length) return {};
+
+  const changed = [];
+  for (const id of ids) {
+    const node = graph.nodes.get(id);
+    const currentHash = node && typeof node.hash === 'string' ? node.hash : null;
+    // An anchor that no longer resolves at all cannot be confirmed either --
+    // treated the same as a changed hash, never as "still holds" by default.
+    if (currentHash === null || currentHash !== recorded[id]) {
+      changed.push(node && typeof node.key === 'string' ? node.key : id);
+    }
+  }
+
+  if (!changed.length) return { derivationHolds: true };
+  // Bounded: a finding with many anchors should not spend unbounded budget
+  // naming every one that moved.
+  return { derivationHolds: false, derivationChanged: changed.slice(0, 5) };
+}
+
+/**
  * Prepares findings for delivery, verifying each one lazily against disk.
  *
  * This is the only function that should ever hand a finding to a model, because
@@ -611,6 +659,9 @@ export function serve(graph, findings) {
       stale,
       ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
       ...dispute,
+      // Independent of `stale` above: see `derivationCheck`'s own comment for
+      // the case it catches that node-level staleness can miss.
+      ...derivationCheck(graph, finding),
     });
   }
   return served;

--- a/integrations/qwen/hooks/lib/staleness.mjs
+++ b/integrations/qwen/hooks/lib/staleness.mjs
@@ -518,6 +518,21 @@ function disputeOf(graph, finding) {
  * recorded -- true of every finding written before this existed), so a
  * caller can tell "not checked" from "checked and holds" by whether
  * `derivationHolds` is present at all.
+ *
+ * `derivationHolds: true` MEANS "MATCHES THE ANCHOR NODE'S LAST-INDEXED
+ * HASH", NOT "MATCHES DISK RIGHT NOW" -- and that distinction is stored in
+ * `derivationCheckedAgainst: 'index'` rather than left for a `wiki_query`
+ * consumer to infer from a field name alone. Two ways to close this gap were
+ * considered: recompute a live hash from disk here, or document precisely
+ * what is actually compared. `stale` (via `checkAnchor`, above) ALREADY owns
+ * the disk comparison -- re-reading the same file a second time on the same
+ * serve path, for the same anchor, from a second mechanism, is worse than
+ * one honest name. So: documented, not duplicated. A file changed on disk
+ * but never re-indexed by anything is still caught, correctly, by `stale`;
+ * `derivationHolds` answers a narrower, complementary question -- whether
+ * the LAST INDEXED state agrees with what this specific finding recorded --
+ * which is exactly the re-indexed-by-something-else case above that `stale`
+ * cannot see.
  */
 function derivationCheck(graph, finding) {
   const recorded = finding.derivation && finding.derivation.anchors;
@@ -536,10 +551,12 @@ function derivationCheck(graph, finding) {
     }
   }
 
-  if (!changed.length) return { derivationHolds: true };
+  // Declared on BOTH branches, not only the ambiguous one: a consumer should
+  // not have to already know the answer to know what was checked.
+  if (!changed.length) return { derivationHolds: true, derivationCheckedAgainst: 'index' };
   // Bounded: a finding with many anchors should not spend unbounded budget
   // naming every one that moved.
-  return { derivationHolds: false, derivationChanged: changed.slice(0, 5) };
+  return { derivationHolds: false, derivationChanged: changed.slice(0, 5), derivationCheckedAgainst: 'index' };
 }
 
 /**

--- a/integrations/qwen/hooks/lib/staleness.mjs
+++ b/integrations/qwen/hooks/lib/staleness.mjs
@@ -54,6 +54,7 @@ import { readFileSync, statSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { dirname, join } from 'node:path';
 import { putNode, putEdge, contentHash, nodeId } from './wiki.mjs';
+import { hasOutstandingContradiction } from './curate.mjs';
 import { extractSymbols, spanText, symbolKey, extractImports } from './symbols.mjs';
 import { canonicalPath, resolvableCandidates, isFsSafePath } from './paths.mjs';
 
@@ -454,6 +455,46 @@ export function diffLines(
 const CONTENT_DEPENDENT = new Set(['finding', 'map']);
 
 /**
+ * What, if anything, currently disagrees with this finding.
+ *
+ * DISCLOSED AT SERVE TIME, because that is the only moment the disagreement can
+ * do any good. `WIKI_GRAPH.md`'s whole argument for making `contradicts` an edge
+ * rather than an overwrite is that a reader "sees both claims and the
+ * disagreement between them" -- so handing a finding to a model while something
+ * in the graph disputes it, without saying so, throws away the reason the edge
+ * was recorded instead of an overwrite.
+ *
+ * `hasOutstandingContradiction` is the gate: it is the one definition of "an
+ * open dispute", shared with the confidence-promotion gate, so the two can never
+ * disagree about what counts. The loop only NAMES the other side, and it names a
+ * key rather than quoting a claim because the reader can call `wiki_query` with
+ * a key -- and because the injection path pays for every character it renders.
+ *
+ * SEPARATE FROM STALENESS on purpose. A finding can be disputed without being
+ * stale (nothing touched its anchor; another finding simply says otherwise) and
+ * stale without being disputed, so this adds its own fields rather than
+ * borrowing the stale ones, and the renderer discloses each on its own terms.
+ */
+function disputeOf(graph, finding) {
+  if (!hasOutstandingContradiction(graph, finding.key)) return {};
+
+  const keys = [];
+  for (const edge of graph.edges) {
+    if (edge.edge !== 'contradicts') continue;
+    const otherId =
+      edge.from === finding.id ? edge.to : edge.to === finding.id ? edge.from : null;
+    if (!otherId) continue;
+    const other = graph.nodes.get(otherId);
+    // An edge end that resolves to nothing names nothing. The dispute is still
+    // disclosed -- the gate above already established it -- but without a key
+    // the reader cannot be pointed anywhere, and inventing one would be worse.
+    if (other && typeof other.key === 'string' && !keys.includes(other.key)) keys.push(other.key);
+  }
+
+  return { contradicted: true, ...(keys.length ? { contradictedBy: keys.join(', ') } : {}) };
+}
+
+/**
  * Prepares findings for delivery, verifying each one lazily against disk.
  *
  * This is the only function that should ever hand a finding to a model, because
@@ -474,10 +515,17 @@ export function serve(graph, findings) {
   // quickly.
 
   for (const finding of findings.filter((f) => !f.retired)) {
+    // A DISPUTE TRAVELS WITH EVERY TYPE, which is why it is computed before the
+    // content-dependence branch below. A `command` or `rule` finding cannot be
+    // invalidated by an anchor's contents, but another finding can still
+    // disagree with it, and this early return is the path that would have
+    // quietly dropped that.
+    const dispute = disputeOf(graph, finding);
+
     // A claim that does not depend on the anchor's contents cannot be
     // invalidated by them. It is served as-is rather than discounted.
     if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) {
-      served.push({ ...finding });
+      served.push({ ...finding, ...dispute });
       continue;
     }
 
@@ -562,6 +610,7 @@ export function serve(graph, findings) {
       ...finding,
       stale,
       ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
+      ...dispute,
     });
   }
   return served;

--- a/integrations/qwen/hooks/lib/waste.mjs
+++ b/integrations/qwen/hooks/lib/waste.mjs
@@ -151,6 +151,11 @@ function reDerivation(events, graph) {
       const id = nodeId('file', canonicalPath(row.anchor));
       if (!graph.nodes.has(id)) continue;
 
+      // READ-ONLY serve: no `dir` is threaded here, so this cannot clear a stale
+      // flag whose evidence is gone. That is deliberate -- this function takes a
+      // graph, not the directory it came from, and widening its signature to give
+      // an analysis path a write capability buys nothing: the injection path runs
+      // on every tool call and clears the same findings.
       const findings = serve(graph, findingsFor(graph, id, { limit: 3 }))
         .filter((f) => !f.stale && (f.confidence ?? 0) >= 0.7);
       if (!findings.length) continue;

--- a/integrations/qwen/hooks/lib/wiki.mjs
+++ b/integrations/qwen/hooks/lib/wiki.mjs
@@ -64,18 +64,37 @@ export const SUPPORTED_VERSIONS = [1];
  * Identity today because GRAPH_VERSION is 1 and no shape has changed. It exists
  * now so the first change that DOES need it has somewhere to go other than an
  * equality check that silently deletes user data.
+ *
+ * CONTRACT for the first non-identity step:
+ *  - It must be IDEMPOTENT. `upcast(upcast(r))` must equal `upcast(r)`, because
+ *    compaction upcasts a record to key it and `load` upcasts the same record
+ *    again on every subsequent read. A step that is not idempotent applies twice
+ *    to anything compaction has touched.
+ *  - It must NOT be relied on to restamp `v`. Nothing in this file writes an
+ *    upcast record back to disk under a version it did not come from; the
+ *    version stamp on disk is always the one that wrote the bytes. See the
+ *    per-branch comments in `compactIfWasteful`.
  */
 export function upcast(record) {
   return record;
 }
 
-/** True when this reader can interpret the record at all. */
-function readable(record) {
+/**
+ * True when this reader can interpret the record at all.
+ *
+ * `versions` is a PARAMETER so the range semantics are testable independently of
+ * today's constants. With `SUPPORTED_VERSIONS = [1]` and `GRAPH_VERSION = 1` a
+ * range check and the old equality check are extensionally identical, so a test
+ * pinned to the live constants cannot tell them apart -- and cannot fail if
+ * someone reverts this to an equality. Exercised against `[1, 2]`, it can.
+ */
+export function readable(record, versions = SUPPORTED_VERSIONS) {
   const version = record.v ?? 0;
   // Forward-incompatible records are skipped: a v-from-the-future was written by
-  // a newer client and we cannot know its shape. Ignoring the future is safe;
-  // ignoring the past is data loss.
-  return SUPPORTED_VERSIONS.includes(version);
+  // a newer client and we cannot know its shape. Ignoring the future is safe for
+  // a READER -- but see `compactIfWasteful`, where "ignore" would mean "delete",
+  // because compaction rewrites the files it reads.
+  return versions.includes(version);
 }
 
 /** Node kinds. `file` and `symbol` are first-class so staleness can propagate. */
@@ -434,9 +453,20 @@ function compactIfWasteful(dir) {
     const nodes = new Map();
     const edges = new Map();
     const snaps = new Map();
-    for (const rec of readSnapshots(dir)) {
+    // KEPT VERBATIM THROUGH THE REBUILD, exactly as the main log keeps what it
+    // cannot parse. These lines are not evictable by the snapshot budget below
+    // because their size cannot be attributed to an id we understand -- and
+    // preserving bytes we may not need is strictly better than deleting bytes a
+    // newer client does. They stop accumulating as soon as the client that
+    // wrote them compacts, since it can read and dedupe them.
+    const sidecar = readSnapshots(dir);
+    const rawSnaps = sidecar.unreadable;
+    for (const rec of sidecar.records) {
       if (typeof rec.snapshot === 'string' && rec.snapshot) {
-        snaps.set(rec.id, { at: rec.at || 0, snapshot: rec.snapshot });
+        // `v` IS CARRIED, not restamped. Writing GRAPH_VERSION over a record
+        // from another version mislabels bytes this reader did not produce, and
+        // the label is the only thing a future reader has to go on.
+        snaps.set(rec.id, { at: rec.at || 0, snapshot: rec.snapshot, v: rec.v ?? GRAPH_VERSION });
       }
     }
     for (const line of readFileSync(path, 'utf8').split('\n')) {
@@ -458,27 +488,40 @@ function compactIfWasteful(dir) {
         edges.set('raw:' + edges.size, line);
         continue;
       }
-      // Upcast IN MEMORY only, to key and classify the record. What gets written
-      // back below is the ORIGINAL `line`: compaction reclaims superseded
-      // records, it does not migrate surviving ones, so the on-disk version is
-      // whatever wrote it and `load` upcasts it again on every read.
-      record = upcast(record);
-      if (record.t === 'n') {
+      // TWO OBJECTS, ON PURPOSE. `record` is exactly what the bytes on disk say;
+      // `view` is the in-memory current-shape reading of it, used only to KEY and
+      // CLASSIFY. Nothing derived from `view` is ever serialized, because
+      // compaction reclaims superseded records -- it does not migrate surviving
+      // ones -- so every version stamp it writes is the one that wrote the bytes.
+      //
+      // An earlier revision of this comment claimed "the ORIGINAL line is written
+      // back" for the whole block. That was FALSE for the inline-snapshot branch,
+      // which re-serializes. It re-serialized the upcast object while carrying
+      // the old `v`, so the first non-identity `upcast` would have written
+      // new-shape bytes under an old label and every later `load` would have
+      // upcast them a second time. Hence: strip from `record`, never from `view`.
+      const view = upcast(record);
+      if (view.t === 'n') {
         // MIGRATION. Graphs written before snapshots were split still carry
         // them inline, and those are exactly the graphs that are slow. Moving
         // them out here means one compaction fixes an existing install.
+        //
+        // THE ONLY RE-SERIALIZING BRANCH in this loop. It writes the original
+        // record minus its snapshot, so the surviving bytes keep their own shape
+        // and their own `v`, and the snapshot moved to the sidecar carries the
+        // same `v` as the node it came out of.
         if (typeof record.snapshot === 'string' && record.snapshot) {
           const { snapshot, ...rest } = record;
-          nodes.set(record.id, JSON.stringify(rest));
-          snaps.set(record.id, { at: record.at || 0, snapshot });
+          nodes.set(view.id, JSON.stringify(rest));
+          snaps.set(view.id, { at: record.at || 0, snapshot, v: record.v ?? GRAPH_VERSION });
         } else {
-          nodes.set(record.id, line);
+          nodes.set(view.id, line);
         }
-      } else if (record.t === 's') {
+      } else if (view.t === 's') {
         if (typeof record.snapshot === 'string' && record.snapshot) {
-          snaps.set(record.id, { at: record.at || 0, snapshot: record.snapshot });
+          snaps.set(view.id, { at: record.at || 0, snapshot: record.snapshot, v: record.v ?? GRAPH_VERSION });
         }
-      } else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
+      } else if (view.t === 'e') edges.set(`${view.from}|${view.edge}|${view.to}`, line);
       else edges.set('raw:' + edges.size, line);
     }
 
@@ -541,10 +584,20 @@ function compactIfWasteful(dir) {
     renameSync(tmp, path);
     // The surviving snapshots are rewritten to their own file, which is also
     // what migrates a graph that still had them inline.
-    const snapOut =
-      [...keep.entries()]
-        .map(([id, v]) => JSON.stringify({ t: 's', v: GRAPH_VERSION, id, snapshot: v.snapshot, at: v.at }))
-        .join('\n') + (keep.size ? '\n' : '');
+    //
+    // UNREADABLE LINES FIRST AND VERBATIM. This rebuild replaces the file, so
+    // anything omitted here is deleted permanently -- which made the missing
+    // counterpart to the main log's `raw:` bucket a real data-loss path, not a
+    // theoretical one. Each survivor also keeps ITS OWN `v` rather than being
+    // restamped to GRAPH_VERSION, so no record is relabelled as something this
+    // reader wrote.
+    const snapLines = [
+      ...rawSnaps,
+      ...[...keep.entries()].map(([id, s]) =>
+        JSON.stringify({ t: 's', v: s.v ?? GRAPH_VERSION, id, snapshot: s.snapshot, at: s.at })
+      ),
+    ];
+    const snapOut = snapLines.join('\n') + (snapLines.length ? '\n' : '');
     const snapTmp = snapshotsPath(dir) + '.compact';
     writeFileSync(snapTmp, snapOut, { mode: 0o600 });
     renameSync(snapTmp, snapshotsPath(dir));
@@ -689,9 +742,26 @@ function appendSnapshot(dir, record) {
   }
 }
 
-/** Every snapshot record, latest wins. Read only when a caller asks. */
+/**
+ * Every snapshot record, latest wins. Read only when a caller asks.
+ *
+ * `unreadable` collects the RAW LINES this reader rejected, and it is the reason
+ * this function reports them at all rather than just dropping them. `load` has
+ * no use for them -- a reader that cannot interpret a record must ignore it --
+ * but `compactIfWasteful` REBUILDS this file from what it read, so for the
+ * compactor "ignore" and "delete permanently" are the same operation. The main
+ * log already keeps what it cannot parse (the `raw:` bucket); the sidecar had no
+ * equivalent, which made it the one asymmetric, destructive path in an otherwise
+ * append-only store.
+ *
+ * This is not hypothetical here: hooks-core is vendored into eleven client
+ * directories that update independently, so a stale client compacting a graph a
+ * newer client has already written to is the expected steady state, not an edge
+ * case.
+ */
 function readSnapshots(dir) {
-  const out = [];
+  /** @type {object[]} */ const out = [];
+  /** @type {string[]} */ const unreadable = [];
   try {
     for (const line of readFileSync(snapshotsPath(dir), 'utf8').split('\n')) {
       if (!line) continue;
@@ -699,19 +769,23 @@ function readSnapshots(dir) {
         const rec = JSON.parse(line);
         // THE SAME RANGE AS THE MAIN LOG, deliberately. An equality check here
         // was the quietest of the three: a bump would have made every stored
-        // snapshot unreadable, and the very next compaction -- which rebuilds
-        // this file from what it could read -- would have deleted them for
-        // good. That is the one place in this store where a read filter turns
-        // into a permanent write.
-        if (readable(rec) && rec.id) out.push(upcast(rec));
+        // snapshot unreadable, and the very next compaction would have deleted
+        // them for good.
+        if (!readable(rec)) {
+          unreadable.push(line);
+          continue;
+        }
+        if (rec.id) out.push(upcast(rec));
       } catch {
-        /* a torn line costs one snapshot */
+        // A torn line costs one snapshot -- and it is NOT preserved, because a
+        // half-written line is not a record from another version, it is
+        // garbage. Distinguishing the two is the whole point of parsing first.
       }
     }
   } catch {
     /* no sidecar yet */
   }
-  return out;
+  return { records: out, unreadable };
 }
 
 /**
@@ -777,7 +851,9 @@ export function load(dir, { snapshots = false } = {}) {
   // Re-attached after the sweep, so a snapshot record may appear before or
   // after the node it belongs to.
   if (pending) {
-    for (const rec of readSnapshots(dir)) pending.set(rec.id, rec.snapshot);
+    // A reader has no use for the lines it could not interpret; only the
+    // compactor does, because only the compactor rewrites the file.
+    for (const rec of readSnapshots(dir).records) pending.set(rec.id, rec.snapshot);
     for (const [id, snapshot] of pending) {
       const node = nodes.get(id);
       if (node) nodes.set(id, { ...node, snapshot });

--- a/integrations/qwen/hooks/lib/wiki.mjs
+++ b/integrations/qwen/hooks/lib/wiki.mjs
@@ -28,17 +28,55 @@ import { canonicalPath, isFsSafePath } from './paths.mjs';
 /**
  * Schema version stamped on every record.
  *
- * There is exactly ONE version and no migration code, because nothing has been
- * released: a graph written by an older commit of an unreleased branch is a
- * development artifact, not user data, and carrying migration paths for it costs
- * real complexity to protect something nobody has. A record from any other
- * version is skipped rather than interpreted, so a stale dev graph degrades to
- * "rebuilds from use" instead of silently mixing incompatible identities.
+ * THIS PACKAGE IS RELEASED. It ships on npm, so every graph on disk is user
+ * data. An earlier version of this comment claimed nothing had been released
+ * and used that to justify having no migration path at all -- and the reader
+ * below compared for EQUALITY, so the first bump would have discarded every
+ * existing graph in silence. That justification is gone and so is the equality:
+ * `SUPPORTED_VERSIONS` is the range this reader accepts, and `upcast` is where a
+ * shape change is absorbed in memory.
  *
- * When this does ship, a bump here is where migration would be added -- with
- * users to protect, that trade reverses.
+ * A bump here is taken only when a record's SHAPE actually changes, and it comes
+ * with a new `upcast` step and an entry in `SUPPORTED_VERSIONS` in the same
+ * change. Adding a field that older readers can ignore is not a shape change.
  */
 export const GRAPH_VERSION = 1;
+
+/**
+ * Versions this reader accepts, oldest first.
+ *
+ * A RANGE, NOT AN EQUALITY. The equality check this replaces would have
+ * discarded every existing graph the moment anyone bumped the version -- and the
+ * header once justified that with "nothing has been released", which stopped
+ * being true at v5.7.0 on npm.
+ *
+ * Nothing on disk is ever rewritten to migrate: `upcast` runs in memory during
+ * the fold, so there is no migration pass to fail halfway and no race with the
+ * concurrent sessions this store is designed for. A mixed-version log is safe
+ * precisely because the original records are never mutated, and the existing
+ * compaction retires old ones naturally as it rewrites snapshots.
+ */
+export const SUPPORTED_VERSIONS = [1];
+
+/**
+ * Brings one record up to the current version. Pure, and one step per version.
+ *
+ * Identity today because GRAPH_VERSION is 1 and no shape has changed. It exists
+ * now so the first change that DOES need it has somewhere to go other than an
+ * equality check that silently deletes user data.
+ */
+export function upcast(record) {
+  return record;
+}
+
+/** True when this reader can interpret the record at all. */
+function readable(record) {
+  const version = record.v ?? 0;
+  // Forward-incompatible records are skipped: a v-from-the-future was written by
+  // a newer client and we cannot know its shape. Ignoring the future is safe;
+  // ignoring the past is data loss.
+  return SUPPORTED_VERSIONS.includes(version);
+}
 
 /** Node kinds. `file` and `symbol` are first-class so staleness can propagate. */
 export const NODE_KINDS = ['file', 'symbol', 'task', 'finding'];
@@ -409,13 +447,22 @@ function compactIfWasteful(dir) {
       } catch {
         continue;
       }
-      // A record from another schema is KEPT VERBATIM rather than reinterpreted.
-      // load() skips it, but discarding it here would make compaction a silent
-      // migration that deletes data a future version might understand.
-      if ((record.v ?? 0) !== GRAPH_VERSION) {
+      // A record this reader cannot interpret is KEPT VERBATIM rather than
+      // reinterpreted. load() skips it, but discarding it here would make
+      // compaction a silent migration that deletes data a future version might
+      // understand. THE RANGE MATTERS HERE TOO: with an equality check, a bump
+      // would have parked every existing v1 record in `raw`, undeduplicated, so
+      // compaction would stop reclaiming anything and inline snapshots would
+      // never migrate out -- the same loss by a second route.
+      if (!readable(record)) {
         edges.set('raw:' + edges.size, line);
         continue;
       }
+      // Upcast IN MEMORY only, to key and classify the record. What gets written
+      // back below is the ORIGINAL `line`: compaction reclaims superseded
+      // records, it does not migrate surviving ones, so the on-disk version is
+      // whatever wrote it and `load` upcasts it again on every read.
+      record = upcast(record);
       if (record.t === 'n') {
         // MIGRATION. Graphs written before snapshots were split still carry
         // them inline, and those are exactly the graphs that are slow. Moving
@@ -650,7 +697,13 @@ function readSnapshots(dir) {
       if (!line) continue;
       try {
         const rec = JSON.parse(line);
-        if ((rec.v ?? 0) === GRAPH_VERSION && rec.id) out.push(rec);
+        // THE SAME RANGE AS THE MAIN LOG, deliberately. An equality check here
+        // was the quietest of the three: a bump would have made every stored
+        // snapshot unreadable, and the very next compaction -- which rebuilds
+        // this file from what it could read -- would have deleted them for
+        // good. That is the one place in this store where a read filter turns
+        // into a permanent write.
+        if (readable(rec) && rec.id) out.push(upcast(rec));
       } catch {
         /* a torn line costs one snapshot */
       }
@@ -691,7 +744,12 @@ export function load(dir, { snapshots = false } = {}) {
       if (!snapshots) continue;
       try {
         const rec = JSON.parse(line);
-        if ((rec.v ?? 0) === GRAPH_VERSION) pending.set(rec.id, rec.snapshot);
+        // Inline snapshots from an older graph: same range, same reason. These
+        // are precisely the records most likely to predate a bump.
+        if (readable(rec)) {
+          const snap = upcast(rec);
+          pending.set(snap.id, snap.snapshot);
+        }
       } catch {
         /* a torn line costs one snapshot, not the graph */
       }
@@ -703,10 +761,14 @@ export function load(dir, { snapshots = false } = {}) {
     } catch {
       continue;
     }
-    // A record from another schema is skipped, not interpreted: its ids and
-    // hashes were derived differently, so honouring it produces confident
-    // nonsense rather than a visible error.
-    if ((record.v ?? 0) !== GRAPH_VERSION) continue;
+    // A record this reader cannot interpret is skipped, not guessed at: a
+    // version from the FUTURE derived its ids and hashes in a way we do not
+    // know, so honouring it produces confident nonsense rather than a visible
+    // error. A record from the PAST is upcast, never skipped -- skipping it is
+    // data loss, and this comparison used to be an equality, which made the
+    // first version bump a silent delete of every graph on disk.
+    if (!readable(record)) continue;
+    record = upcast(record);
     if (record.t === 'n') nodes.set(record.id, record);
     else if (record.t === 'e') edges.push(record);
   }

--- a/integrations/qwen/hooks/lib/wiki.mjs
+++ b/integrations/qwen/hooks/lib/wiki.mjs
@@ -775,7 +775,17 @@ function readSnapshots(dir) {
           unreadable.push(line);
           continue;
         }
+        // A RECORD WITH NO `id` IS KEPT VERBATIM, NOT DROPPED SILENTLY. It
+        // cannot be attributed to a node, so it is useless to `load` -- but this
+        // used to put it in neither bucket, and `compactIfWasteful` rebuilds the
+        // sidecar from `records` plus `unreadable`, so a line in neither was
+        // deleted permanently by the next compaction. That is the same shape as
+        // the Critical this reader's version check already fixed, and the same
+        // asymmetry: for the compactor, "ignore" and "destroy" are one operation.
+        // Unreachable today because every writer sets `id`; a reader is not the
+        // right place to rely on that.
         if (rec.id) out.push(upcast(rec));
+        else unreadable.push(line);
       } catch {
         // A torn line costs one snapshot -- and it is NOT preserved, because a
         // half-written line is not a record from another version, it is

--- a/integrations/qwen/hooks/post-tool.mjs
+++ b/integrations/qwen/hooks/post-tool.mjs
@@ -8,7 +8,7 @@ process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.
-process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write';
+process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write,wiki_query';
 try {
   const { run } = await import('./lib/adapter.mjs');
   await run('qwen', 'post-tool');

--- a/integrations/qwen/hooks/post-tool.mjs
+++ b/integrations/qwen/hooks/post-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/qwen/hooks/pre-tool.mjs
+++ b/integrations/qwen/hooks/pre-tool.mjs
@@ -8,7 +8,7 @@ process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.
-process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write';
+process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write,wiki_query';
 try {
   const { run } = await import('./lib/adapter.mjs');
   await run('qwen', 'pre-tool');

--- a/integrations/qwen/hooks/pre-tool.mjs
+++ b/integrations/qwen/hooks/pre-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/qwen/hooks/session-start.mjs
+++ b/integrations/qwen/hooks/session-start.mjs
@@ -8,7 +8,7 @@ process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.
-process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write';
+process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write,wiki_query';
 try {
   const { run } = await import('./lib/adapter.mjs');
   await run('qwen', 'session-start');

--- a/integrations/qwen/hooks/session-start.mjs
+++ b/integrations/qwen/hooks/session-start.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/qwen/hooks/stop.mjs
+++ b/integrations/qwen/hooks/stop.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/qwen/hooks/stop.mjs
+++ b/integrations/qwen/hooks/stop.mjs
@@ -8,7 +8,7 @@ process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.
-process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write';
+process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write,wiki_query';
 try {
   const { run } = await import('./lib/adapter.mjs');
   await run('qwen', 'stop');

--- a/integrations/windsurf/hooks/lib/adapter.mjs
+++ b/integrations/windsurf/hooks/lib/adapter.mjs
@@ -68,6 +68,7 @@ import {
   standingRules,
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
+import { observedWrite, queueInvalidation } from './pending.mjs';
 import { isArchived } from './transcript.mjs';
 import { isFsSafePath } from './paths.mjs';
 import {
@@ -881,6 +882,35 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Causal tracing is fail-open like every other hook optimization.
+    }
+
+    // EAGER INVALIDATION, finally connected. `invalidateOnWrite` has existed,
+    // been tested and been described in staleness.mjs's own header since
+    // staleness landed, and its only reference in shipped code was a COMMENT in
+    // the PreToolUse router -- so the path that header calls load-bearing had
+    // never run once in production. It matters most for exactly this event: the
+    // lazy check compares the anchor's stored hash against disk, and the
+    // capture below re-points that hash at the bytes this write just produced,
+    // so a write the session performed ITSELF is invisible to lazy staleness.
+    //
+    // QUEUED, NOT APPLIED. Applying needs the graph, and loading a megabyte of
+    // JSONL on the return path of every write is what this shape exists to
+    // avoid. The next graph read drains it before serving anything.
+    try {
+      if (mutationSucceeded(clientName, raw)) {
+        const evidence = observedWrite(payload, raw);
+        if (evidence) {
+          // THE SAME DIRECTORY THE GRAPH ITSELF USES. `observeAndInject` keys
+          // every write on `wikiDir(projectRootFor(path, payload.cwd))`, and a
+          // queue written anywhere else is a queue nothing ever drains.
+          queueInvalidation(
+            wikiDir(projectRootFor(evidence.path, payload.cwd)),
+            evidence
+          );
+        }
+      }
+    } catch {
+      // Bookkeeping for a call that already completed. Never let it cost one.
     }
   }
 

--- a/integrations/windsurf/hooks/lib/adapter.mjs
+++ b/integrations/windsurf/hooks/lib/adapter.mjs
@@ -64,6 +64,7 @@ import {
   forTouch,
   noteActClasses,
   relevantFindingIdsForContext,
+  sessionContext,
   sessionIndex,
   standingRules,
 } from './inject.mjs';
@@ -690,8 +691,23 @@ async function runHook(clientName, event, invocation) {
       rememberOptimizerTools(state, toolEvidence);
       saveState(sessionId, state);
     }
-    const parts = [
-      policyText(client.canDeny, toolEvidence.names, toolEvidence.proven),
+    // ASSEMBLED IN CACHE ORDER, not in whatever order this function happens to
+    // discover the blocks. Everything emitted here sits near the FRONT of the
+    // prompt prefix, and a prefix cache invalidates from the first differing
+    // byte onward -- so the block that changes most often has to sit LAST, or it
+    // re-prices every block behind it on every session. `sessionContext` sorts
+    // by the declared volatility; inject.mjs records how each number was
+    // assigned and why.
+    const blocks = [
+      {
+        id: 'policy',
+        volatility: 0,
+        text: policyText(
+          client.canDeny,
+          toolEvidence.names,
+          toolEvidence.proven
+        ),
+      },
     ];
     const cwd = raw.cwd || raw.working_directory || process.cwd();
     const root = projectRootFor(join(cwd, '__session__'), cwd);
@@ -705,7 +721,7 @@ async function runHook(clientName, event, invocation) {
         const graph = load(dir);
         const episode = episodeMeta({ client: clientName, raw });
         const rules = standingRules(dir, graph, { episode });
-        if (rules) parts.push(rules);
+        if (rules) blocks.push({ id: 'standing', volatility: 1, text: rules });
         const relevantFindingIds = relevantFindingIdsForContext(
           graph,
           sessionTaskContext(raw)
@@ -714,12 +730,12 @@ async function runHook(clientName, event, invocation) {
           episode,
           relevantFindingIds,
         });
-        if (index) parts.push(index);
+        if (index) blocks.push({ id: 'index', volatility: 2, text: index });
       } catch {
         // Retrieval is optional context; the policy must still reach the model.
       }
     }
-    const output = contextOutput(client, eventName, parts.join('\n\n'));
+    const output = contextOutput(client, eventName, sessionContext(blocks));
     if (output) emit(output);
     process.exit(0);
   }

--- a/integrations/windsurf/hooks/lib/adapter.mjs
+++ b/integrations/windsurf/hooks/lib/adapter.mjs
@@ -68,7 +68,7 @@ import {
   standingRules,
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
-import { observedWrite, queueInvalidation } from './pending.mjs';
+import { observedWrites, queueInvalidation } from './pending.mjs';
 import { isArchived } from './transcript.mjs';
 import { isFsSafePath } from './paths.mjs';
 import {
@@ -898,8 +898,7 @@ async function runHook(clientName, event, invocation) {
     // avoid. The next graph read drains it before serving anything.
     try {
       if (mutationSucceeded(clientName, raw)) {
-        const evidence = observedWrite(payload, raw);
-        if (evidence) {
+        for (const evidence of observedWrites(payload, raw)) {
           // THE SAME DIRECTORY THE GRAPH ITSELF USES. `observeAndInject` keys
           // every write on `wikiDir(projectRootFor(path, payload.cwd))`, and a
           // queue written anywhere else is a queue nothing ever drains.

--- a/integrations/windsurf/hooks/lib/capabilities.mjs
+++ b/integrations/windsurf/hooks/lib/capabilities.mjs
@@ -38,6 +38,10 @@ export const HOOK_MCP_TOOLS = Object.freeze([
   'optimize_session',
   'get_optimization_report',
   'wiki_write',
+  // The read side of the graph. The session index tells the model to "call
+  // wiki_query with a key for detail", so the hook needs positive evidence that
+  // the name it is advertising is actually registered in this host.
+  'wiki_query',
 ]);
 
 const HOOK_MCP_TOOL_SET = new Set(HOOK_MCP_TOOLS);

--- a/integrations/windsurf/hooks/lib/curate.mjs
+++ b/integrations/windsurf/hooks/lib/curate.mjs
@@ -22,7 +22,7 @@
  */
 
 import { randomBytes } from 'node:crypto';
-import { putNode, putNodeWithEdges, load, nodeId } from './wiki.mjs';
+import { putNode, putEdge, putNodeWithEdges, load, nodeId } from './wiki.mjs';
 import { indexFile } from './staleness.mjs';
 import { symbolKey } from './symbols.mjs';
 import { canonicalPath } from './paths.mjs';
@@ -178,6 +178,79 @@ export function retire(dir, key) {
   if (!existing) return false;
   putNode(dir, { ...existing, kind: 'finding', key, retired: true });
   return true;
+}
+
+/**
+ * Records that one finding disagrees with another.
+ *
+ * AN EDGE, NOT AN OVERWRITE -- the design is explicit about why: "when a belief
+ * changes, the graph should record THAT it changed and why, not quietly present
+ * the new one as though it had always been true." `contradicts` has been in
+ * EDGE_KINDS since the schema existed and was written by nothing, while
+ * `audit()` already READ it.
+ *
+ * The contradicted finding is deliberately NOT retired, and its claim is
+ * deliberately preserved. A reader needs to see both claims and the
+ * disagreement between them; retiring one silently picks a winner, and putNode
+ * does not merge -- it writes the whole record from what it is handed, so
+ * annotating the target without spreading it back in would blank the very claim
+ * this edge exists to keep visible. That is the overwrite by another name.
+ *
+ * THE EDGE IS WRITTEN FIRST, and the order is the guarantee. These are two
+ * appends and `append` fails open, so either can be the one that lands. Edge
+ * without annotation is a complete, readable disagreement missing only its
+ * reason. Annotation without edge is a finding that says "something contradicts
+ * me" with no contradictor -- a claim of proof with no proof, and invisible to
+ * `audit()` and to `hasOutstandingContradiction`, both of which read the edge.
+ */
+export function contradict(dir, { key, byKey, reason }) {
+  const graph = load(dir);
+  const target = findingByKey(graph, key);
+  const source = findingByKey(graph, byKey);
+  // Both ends must exist, or the edge is unresolvable and the disagreement is
+  // recorded against nothing -- the same un-invalidatable shape anchors prevent.
+  if (!target || !source) return false;
+  // A finding cannot disagree with itself. The self-edge resolves, so the guard
+  // above waves it through, and the result is a node permanently blocked from
+  // confidence promotion by a dispute no person can ever resolve: there is no
+  // second claim to choose between.
+  if (target.id === source.id) return false;
+
+  putEdge(dir, source.id, 'contradicts', target.id);
+  putNode(dir, {
+    ...target,
+    kind: 'finding',
+    key,
+    contradictedAt: Date.now(),
+    contradictionReason: String(reason || '').slice(0, 400),
+  });
+  return true;
+}
+
+/**
+ * Whether anything currently disagrees with this finding.
+ *
+ * Gates confidence promotion. Plan 2's per-finding utility measures whether a
+ * finding SUPPRESSES READS, and a confidently wrong finding suppresses reads
+ * better than a hedged true one -- so utility must never raise confidence on
+ * its own, and this is the check that stops it.
+ *
+ * SYMMETRIC, deliberately: BOTH ends of a `contradicts` edge are outstanding
+ * until a person resolves the disagreement. The named hazard in the design is
+ * presenting "the new one as though it had always been true", so gating only
+ * the older claim would leave the newer one -- which is just as likely to be
+ * the wrong one, since nothing here adjudicates -- free to be promoted on
+ * measured utility alone. That is the exact failure this gate exists to stop.
+ * It also matches `audit()`, the reader that has always been here: it puts both
+ * `from` and `to` in its `contradicted` bucket, because "until one looks, BOTH
+ * are being served".
+ */
+export function hasOutstandingContradiction(graph, key) {
+  const node = findingByKey(graph, key);
+  if (!node) return false;
+  return graph.edges.some(
+    (e) => e.edge === 'contradicts' && (e.to === node.id || e.from === node.id)
+  );
 }
 
 /**

--- a/integrations/windsurf/hooks/lib/curate.mjs
+++ b/integrations/windsurf/hooks/lib/curate.mjs
@@ -124,7 +124,17 @@ export function correct(
   const replacementKey = `${key}-c${Date.now().toString(36)}`;
 
   const edges = [{ edge: 'supersedes', to: originalId }];
-  // The correction inherits the original's anchors, so it can go stale too.
+  // The correction inherits the original's anchors, so it can go stale too --
+  // but it inherits NOTHING ELSE, and that is deliberate rather than incidental.
+  // The node written below is built field by field from `existing` instead of
+  // spreading it, which is what keeps the staleness fields (`stale`,
+  // `staleReason`, `diff`) off the successor: a correction is re-derived
+  // against the current code by definition, so being born carrying its
+  // predecessor's invalidation would discount it the moment it existed --
+  // `disclose.mjs` skips a stale finding outright and `utility.mjs` penalises
+  // one by 160. Any future edit here that reaches for `...existing` to pick up
+  // one more field re-introduces that, since `putNode` writes what it is handed
+  // wholesale; `tests/hooks/stale-clearing.test.mjs` is the guard.
   for (const edge of graph.edges) {
     if (edge.edge === 'derived_from' && edge.from === originalId) {
       edges.push({ edge: 'derived_from', to: edge.to });
@@ -244,13 +254,38 @@ export function contradict(dir, { key, byKey, reason }) {
  * It also matches `audit()`, the reader that has always been here: it puts both
  * `from` and `to` in its `contradicted` bucket, because "until one looks, BOTH
  * are being served".
+ *
+ * A RETIRED COUNTERPART DOES NOT COUNT, and that sentence quoted just above is
+ * the reason. This read edges ONLY, so retiring one end of a contradiction left
+ * the survivor gated against confidence promotion forever and served with a
+ * DISPUTED note naming a key `serve` refuses to hand anybody -- `serve`,
+ * `activeFindings`, `findingsFor` and `sessionIndex` all drop a retired
+ * finding. A retired claim is served to NOBODY, so "BOTH are being served" is
+ * false and the premise of the gate is gone: only one claim is in play, and
+ * there is nothing left to choose between. Retiring one end IS the person
+ * looking that this gate was waiting for -- so the edge counts as open only
+ * while NEITHER end is retired, answered the same way from both directions.
+ *
+ * AN UNRESOLVABLE END STILL COUNTS. An edge whose other side names no node
+ * proves nothing about whether that claim was withdrawn, and the conservative
+ * reading -- still disputed -- is the one that cannot promote a claim nobody
+ * adjudicated.
  */
 export function hasOutstandingContradiction(graph, key) {
   const node = findingByKey(graph, key);
-  if (!node) return false;
-  return graph.edges.some(
-    (e) => e.edge === 'contradicts' && (e.to === node.id || e.from === node.id)
-  );
+  // A withdrawn claim is not in a dispute either: a dispute needs two claims in
+  // play, and this one has been taken out of play. Without this the RETIRED end
+  // still reported an open disagreement, which is the same defect from the other
+  // side -- and the answer has to agree from both directions, since the gate is
+  // symmetric on purpose.
+  if (!node || node.retired) return false;
+  return graph.edges.some((e) => {
+    if (e.edge !== 'contradicts') return false;
+    const otherId = e.from === node.id ? e.to : e.to === node.id ? e.from : null;
+    if (!otherId) return false;
+    const other = graph.nodes.get(otherId);
+    return !other || !other.retired;
+  });
 }
 
 /**
@@ -334,11 +369,24 @@ export function audit(graph) {
       .map((e) => e.from)
   );
 
+  // THE SAME DEFINITION OF AN OPEN DISPUTE as hasOutstandingContradiction, and
+  // it has to be: that function's own comment claims it "matches audit()", and
+  // two rankings that disagree about what needs a human is worse than one that
+  // is wrong. A retired counterpart is a resolved dispute -- the retired claim
+  // is served to nobody -- so the survivor is not one of two claims in play and
+  // does not belong in the bucket of things needing a person to look.
+  //
+  // One pass, not a call per finding: this is a dashboard read over the whole
+  // graph, and the obvious rewrite is O(findings x edges).
   const contradicted = new Set();
   for (const edge of graph.edges) {
     if (edge.edge !== 'contradicts') continue;
-    contradicted.add(edge.from);
-    contradicted.add(edge.to);
+    const from = graph.nodes.get(edge.from);
+    const to = graph.nodes.get(edge.to);
+    // An end that resolves to nothing cannot be shown retired, so it still
+    // counts against the other end.
+    if (!to || !to.retired) contradicted.add(edge.from);
+    if (!from || !from.retired) contradicted.add(edge.to);
   }
 
   return {

--- a/integrations/windsurf/hooks/lib/curate.mjs
+++ b/integrations/windsurf/hooks/lib/curate.mjs
@@ -70,6 +70,38 @@ export function originWeight(origin) {
   return 1;
 }
 
+/**
+ * The claim-time anchor hashes, for a finding being written right now.
+ *
+ * THE CHECKABLE HALF OF PROVENANCE, and until now only `harvest-write.mjs`
+ * wrote it -- so the asymmetry ran exactly the wrong way. `reverify` and the
+ * automatic clear in `serve` both compare disk against these frozen hashes, and
+ * a finding without them can never have a stale flag cleared by anything. That
+ * meant HUMAN-asserted findings, the ones somebody deliberately created or
+ * corrected, were the only ones condemned to stay stale forever once marked,
+ * while machine-harvested claims could recover. The hashes are simply the anchor
+ * nodes' hashes at this moment, and every writer has them in hand.
+ *
+ * DELIBERATELY NOT THE WHOLE RECORD `derivationFor` BUILDS. That one joins the
+ * evidence log to find FILE-surface operations behind the claim; curation
+ * performs no such join, so `operations` is empty and `operationsComplete` says
+ * so. An empty list declared incomplete is honest -- "nothing recorded here, and
+ * do not read that as nothing happened" -- where an empty list declared complete
+ * would assert a fact nobody established.
+ *
+ * An anchor with no stored hash contributes no entry, and a finding whose
+ * anchors all lack one gets a record with no hashes -- which `claimTimeVerdict`
+ * reads as `unknown` and refuses to clear on, which is the correct reading.
+ */
+function claimTimeDerivation(graph, resolved) {
+  const anchors = {};
+  for (const id of resolved) {
+    const node = graph.nodes.get(id);
+    if (node && typeof node.hash === 'string') anchors[id] = node.hash;
+  }
+  return { at: Date.now(), anchors, operations: [], operationsComplete: false };
+}
+
 function findingByKey(graph, key) {
   return graph.nodes.get(nodeId('finding', key)) || null;
 }
@@ -124,6 +156,11 @@ export function correct(
   const replacementKey = `${key}-c${Date.now().toString(36)}`;
 
   const edges = [{ edge: 'supersedes', to: originalId }];
+  // Collected alongside the edges so the correction carries its own claim-time
+  // hashes: it is a NEW claim, re-derived against whatever the code says now, so
+  // its evidence is the anchors' current state -- not the predecessor's, which is
+  // precisely what went stale.
+  const inherited = [];
   // The correction inherits the original's anchors, so it can go stale too --
   // but it inherits NOTHING ELSE, and that is deliberate rather than incidental.
   // The node written below is built field by field from `existing` instead of
@@ -138,6 +175,7 @@ export function correct(
   for (const edge of graph.edges) {
     if (edge.edge === 'derived_from' && edge.from === originalId) {
       edges.push({ edge: 'derived_from', to: edge.to });
+      inherited.push(edge.to);
     }
   }
 
@@ -171,6 +209,11 @@ export function correct(
       // branches, and an unrecognised value already degrades to the neutral
       // ranking weight rather than doing damage.
       origin: typeof origin === 'string' && origin ? origin : ORIGIN_HUMAN,
+      // Without this a correction could never have a stale flag cleared: both
+      // clearing paths compare disk against these hashes, and a finding with
+      // none is `unknown` forever. A hand-written correction being the least
+      // recoverable record in the graph was the wrong way round.
+      derivation: claimTimeDerivation(graph, inherited),
     },
     edges
   );
@@ -339,7 +382,18 @@ export function create(dir, { claim, anchors, type = 'finding', confidence = 0.9
   // path. No process death required; one transient EBUSY is enough.
   const id = putNodeWithEdges(
     dir,
-    { kind: 'finding', key, claim, confidence, type, origin: ORIGIN_HUMAN },
+    {
+      kind: 'finding',
+      key,
+      claim,
+      confidence,
+      type,
+      origin: ORIGIN_HUMAN,
+      // Read AFTER the indexFile loop above, so the hashes are the ones the
+      // person's claim was actually made against rather than whatever the graph
+      // held before this call touched it.
+      derivation: claimTimeDerivation(loadGraph(dir), resolved),
+    },
     resolved.map((target) => ({ edge: 'derived_from', to: target }))
   );
   if (!id) return null;

--- a/integrations/windsurf/hooks/lib/decide.mjs
+++ b/integrations/windsurf/hooks/lib/decide.mjs
@@ -542,19 +542,92 @@ const TOOL_ALIASES = new Map(
     run_shell_command: 'Bash',
     run_terminal_cmd: 'Bash',
     terminal: 'Bash',
+
+    // THIS PROJECT'S OWN TOOLS, which the table did not list for as long as it
+    // existed. `plugin/hooks/hooks.json`'s PostToolUse matcher named
+    // `mcp__.*__(?:smart_edit|smart_write)` and Codex's AfterTool matcher named
+    // the bare `smart_edit|smart_write`, so both hooks fired -- and then
+    // `normalizeTool` returned null and the hook exited before a single line of
+    // accounting ran. Staleness, mutation counting and harvest pressure were all
+    // blind on exactly the path enforcement pushes the model toward, which is the
+    // worst place to be blind: the more effective the routing, the less the
+    // optimizer saw.
+    //
+    // These names are the CANONICAL operation, not a licence to redirect. A call
+    // that is already the replacement is excluded from routing by
+    // `isReplacementTool` below.
+    smart_read: 'Read',
+    smart_grep: 'Grep',
+    smart_glob: 'Glob',
+    smart_edit: 'Edit',
+    smart_write: 'Write',
+
+    // Claude Code's notebook editor. Same shape of gap: a real mutation of a
+    // real file on disk that arrived as null and so never reached
+    // `pending.mjs`'s MUTATING set, leaving every notebook write invisible to
+    // invalidation.
+    notebookedit: 'Edit',
+    notebook_edit: 'Edit',
   })
 );
 
-/** Maps a client's tool name onto the canonical one, or null if unhandled. */
+/**
+ * The optimizer's own replacement tools, by canonical trailing segment.
+ *
+ * Kept separate from the alias table because the two answer different questions.
+ * The table answers "what operation is this", which post-tool accounting needs.
+ * This set answers "is this call ALREADY the thing we would have recommended",
+ * which routing needs -- and conflating them is the loop hazard: `smart_edit`
+ * resolves to `Edit`, the Edit branch recommends `smart_edit`, and the model is
+ * told to call the tool it just called.
+ */
+const REPLACEMENT_TOOLS = new Set([
+  'smart_read',
+  'smart_grep',
+  'smart_glob',
+  'smart_edit',
+  'smart_write',
+]);
+
+/**
+ * The tool name with an `mcp__<server>__` prefix removed, if it had one.
+ *
+ * Server segments contain underscores freely (`plugin_token-optimizer_token-optimizer`)
+ * and so do tool names (`smart_edit`), so the split is taken at the LAST `__`
+ * after the `mcp__` sentinel. Both halves must be non-empty: `mcp__edit` names
+ * no server and is not a name any host emits, and treating it as `edit` would
+ * coerce an unrecognised string into a built-in.
+ */
+function withoutMcpPrefix(name) {
+  const match = /^mcp__(.+)__(.+)$/.exec(name);
+  return match ? match[2] : name;
+}
+
+/** Whether this call IS one of the optimizer's replacements, however spelled. */
+export function isReplacementTool(name) {
+  if (!name) return false;
+  return REPLACEMENT_TOOLS.has(withoutMcpPrefix(String(name)).toLowerCase());
+}
+
+/**
+ * Maps a client's tool name onto the canonical one, or null if unhandled.
+ *
+ * PERMISSIVE IN ONE DIRECTION ONLY. An MCP-prefixed name is resolved by its
+ * trailing segment, but only against the same table every other client is held
+ * to -- so `mcp__vendor__deploy_to_prod` stays null. Coercing an unrecognised
+ * MCP tool into a built-in would change a routing verdict for a tool nobody has
+ * considered, which is a far worse failure than not accounting for it.
+ */
 export function normalizeTool(name) {
   if (!name) return null;
+  const candidate = withoutMcpPrefix(String(name));
   if (
     ['Read', 'Grep', 'Glob', 'Edit', 'MultiEdit', 'Write', 'Bash'].includes(
-      name
+      candidate
     )
   )
-    return name;
-  return TOOL_ALIASES.get(String(name).toLowerCase()) || null;
+    return candidate;
+  return TOOL_ALIASES.get(candidate.toLowerCase()) || null;
 }
 
 /**
@@ -614,6 +687,13 @@ export function normalizePayload(raw) {
     transcript_path: raw.transcript_path ?? raw.transcriptPath ?? null,
     cwd,
     tool_name: normalizeTool(raw.tool_name ?? raw.toolName ?? raw.tool),
+    // WHETHER THIS CALL IS ALREADY THE REPLACEMENT, carried alongside the
+    // canonical name rather than inferred from it -- because it cannot be
+    // inferred from it. `smart_edit` and `Edit` both normalise to `Edit`, and
+    // routing has to treat them as opposites while accounting treats them as
+    // the same. Absent by default (`false`), so a payload assembled by hand in
+    // a test or by a caller that predates this field is a normal built-in call.
+    replacement: isReplacementTool(raw.tool_name ?? raw.toolName ?? raw.tool),
     tool_input: {
       ...input,
       // CANONICALISED HERE, once. Every consumer downstream -- the `seen` map
@@ -673,6 +753,19 @@ function replacementAvailable(availableTools, name) {
 }
 
 export function decide(payload, state, availableTools = undefined) {
+  // THE LOOP HAZARD, and the reason this guard is at the top rather than inside
+  // any one branch. Resolving `smart_edit` to `Edit` is what makes post-tool
+  // accounting work; it must not also make the Edit branch answer a smart_edit
+  // call with "call smart_edit instead". This is not theoretical on a matcher
+  // level either: Qwen's PreToolUse matcher is the unanchored regex
+  // `edit|write_file|run_shell_command`, and `edit` matches inside
+  // `mcp__x__smart_edit`, so that client really does hand the router calls to
+  // its own replacements.
+  //
+  // A tool that IS the replacement is never routed. There is nothing better to
+  // recommend, and every branch below would recommend itself.
+  if (payload.replacement) return null;
+
   const tool = payload.tool_name;
   const input = payload.tool_input || {};
   const threshold = largeFileBytes();
@@ -873,6 +966,12 @@ export function remember(payload, state) {
  */
 export function readCostBytes(payload) {
   if (payload.tool_name !== 'Read') return 0;
+  // A REPLACEMENT DID NOT SPEND THE WHOLE FILE. `smart_read` normalises to
+  // `Read` so the graph sees the touch, but it returns a diff -- charging the
+  // full file size here would feed the holdout comparison a cost that was never
+  // paid, on the arm the optimizer is trying to show is cheaper. Better to
+  // record nothing than to record a number in the wrong direction.
+  if (payload.replacement) return 0;
   const path = payload.tool_input?.file_path;
   if (!path || isBinaryPath(path)) return 0;
   const size = fileSize(path);

--- a/integrations/windsurf/hooks/lib/disclose.mjs
+++ b/integrations/windsurf/hooks/lib/disclose.mjs
@@ -294,6 +294,11 @@ export function verdictFor(graph, { anchors = [], question, minConfidence = 0.7 
     const id = nodeId('file', canonicalPath(anchor));
     if (!graph.nodes.has(id)) continue;
 
+    // READ-ONLY serve: no `dir` is threaded here, so this cannot clear a stale
+    // flag whose evidence is gone. That is deliberate -- this function takes a
+    // graph, not the directory it came from, and widening its signature to give
+    // an analysis path a write capability buys nothing: the injection path runs
+    // on every tool call and clears the same findings.
     const findings = serve(graph, findingsFor(graph, id, { limit: 4 }));
     for (const finding of findings) {
       if (finding.stale) continue;

--- a/integrations/windsurf/hooks/lib/harvest-write.mjs
+++ b/integrations/windsurf/hooks/lib/harvest-write.mjs
@@ -34,7 +34,7 @@ import { randomBytes } from 'node:crypto';
 import { realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
-import { readEvidence } from './metrics.mjs';
+import { readEvidence, evidenceTruncated } from './metrics.mjs';
 
 /**
  * The types that may cross a project boundary.
@@ -431,53 +431,84 @@ function resolveAnchor(dir, anchor, projectRoot) {
 /**
  * Which task actually produced this finding, when nothing said so directly.
  *
- * Session id was the only signal `answers` had, and a session id is exactly
- * what a caller may not have (`wiki_write`'s `sessionId` is optional and
- * nothing populates it today; the detached harvest worker's is gated behind
- * an opt-in). But the graph does not need to be TOLD which task this is: the
- * structural harvest already writes `task -[derived_from]-> file` for every
- * tool call, unconditionally, on every install. So the task is DERIVABLE --
- * it is whichever task node has a `derived_from` edge to one of the SAME
- * anchors this finding resolved to.
+ * ROUND 2's version scanned the WHOLE graph for any task sharing any anchor,
+ * broken by recency. An adversarial review constructed four cases where that
+ * attributes a finding to the WRONG task:
  *
- * "Most recent task, full stop" was rejected on purpose: a task that never
- * touched these files could still be the newest node in the graph (a
- * different file, a different concern, in a later session), and attaching
- * provenance to it would be a WRONG edge, not a missing one -- worse than no
- * edge, because a reader trusts it. So candidates are filtered to tasks that
- * touched at least one of these anchors FIRST, and only ties among THOSE are
- * broken by recency.
+ *   1. STALE PRIOR SESSION -- a session that reasons from injected memory and
+ *      writes a finding about `foo.ts` without touching it this session gets
+ *      attributed to whatever task last touched `foo.ts`, possibly days old,
+ *      possibly someone else's work.
+ *   2. CONCURRENT SESSION -- two windows on one repository; the other
+ *      session's task wins if its touch is a millisecond later.
+ *   3. OVERLAP, NOT COVERAGE -- a finding anchored to [a, b]; a task that
+ *      touched only `b` could still win over one that touched both.
+ *   4. THE TIE-BREAK CONTRADICTED ITS OWN COMMENT -- `Number(edge.at) || 0`
+ *      with strict `>` means the FIRST edge in log order wins on a tie,
+ *      which is the OLDER task, not "more recently" as documented.
  *
- * The tie-break is the edge's own `at`, not the task node's `at`. A task that
- * touched this file once, long ago, and then stayed active on unrelated files
- * for hours has a late node timestamp that says nothing about this anchor;
- * the edge timestamp says exactly when THIS task touched THIS anchor, which
- * is the question being asked. Among tasks sharing an anchor, the one whose
- * most recent touch to any shared anchor is latest wins -- recency of the
- * relevant work, not recency of the task in general.
+ * THE FIX IS NARROWER THAN A BETTER RANKING: SCOPE, THEN REQUIRE COVERAGE.
+ * A task only ever belongs to the session that created it -- `harvest()` and
+ * `linkCoOccurrence()` (wiki.mjs, inject.mjs) both key a task node by
+ * `sessionId`, always, so there is exactly ONE task node for "the current
+ * session" and it is `nodeId('task', sessionId)`. Restricting to that ONE
+ * node structurally eliminates cases 1 and 2 -- a prior or concurrent
+ * session's task has a DIFFERENT sessionId and therefore a different node
+ * id, so it is never even looked at, regardless of timing. No caller can
+ * supply a wrong sessionId and get someone ELSE's task; they can only fail
+ * to get a match.
+ *
+ * COVERAGE, NOT OVERLAP, fixes case 3: the session's task must have a
+ * `derived_from` edge to EVERY one of this finding's anchors, not merely one.
+ * A partial touch is not attribution.
+ *
+ * With the candidate set reduced to at most one node, there is nothing left
+ * to break a tie between -- case 4's comparator is not "fixed", it is
+ * deleted, because the scenario it was written for (two DIFFERENT tasks both
+ * legitimately eligible) cannot occur under this scoping: two task nodes can
+ * never share a key, and only the current session's key is ever considered.
+ * An edge's `at` therefore plays NO role here: presence of a `derived_from`
+ * edge from the session's task to an anchor is what "touched it" means, with
+ * or without a timestamp on that edge -- there is no ranking left for a
+ * missing timestamp to lose.
+ *
+ * `sessionId` absent means there is no identity to scope by, which means no
+ * candidate -- not "fall back to guessing". Absence is the correct answer
+ * when the graph cannot support attribution.
  */
-function taskForAnchors(graph, anchorIds) {
-  if (!anchorIds || !anchorIds.length) return null;
-  const anchors = new Set(anchorIds);
-  let best = null;
-  for (const edge of graph.edges) {
-    if (edge.edge !== 'derived_from' || !anchors.has(edge.to)) continue;
-    const from = graph.nodes.get(edge.from);
-    // `derived_from` is also how a FINDING cites its own anchors, so without
-    // this a finding that already cited the same file would be mistaken for
-    // the task that produced it.
-    if (!from || from.kind !== 'task') continue;
-    const at = Number(edge.at) || 0;
-    if (!best || at > best.at) best = { taskId: edge.from, at };
+function taskForAnchors(graph, anchorIds, sessionId) {
+  if (!sessionId || !anchorIds || !anchorIds.length) return null;
+  const taskTarget = nodeId('task', sessionId);
+  const task = graph.nodes.get(taskTarget);
+  if (!task || task.kind !== 'task') return null;
+
+  for (const anchor of anchorIds) {
+    const covered = graph.edges.some((edge) =>
+      edge.edge === 'derived_from' && edge.from === taskTarget && edge.to === anchor
+    );
+    // ONE missing anchor refuses the whole attribution. A finding cited three
+    // files; this session's task touched two of them -- that is evidence the
+    // task did SOME related work, not evidence it produced THIS finding.
+    if (!covered) return null;
   }
-  return best ? best.taskId : null;
+  return taskTarget;
 }
 
 /**
  * A file path the way `recordToolOutcome` (metrics.mjs) already truncates and
- * stores it on a `tool-outcome` event's `anchor` field, so a derivation record
- * can join against that log without a second, divergent notion of "the same
- * anchor".
+ * stores it on a FILE-surface `tool-outcome` event's `anchor` field, so a
+ * derivation record can join against that log without a second, divergent
+ * notion of "the same anchor".
+ *
+ * COMMAND-surface events are DECLARED OUT OF SCOPE, not silently missed:
+ * `adapter.mjs` stores the COMMAND TEXT in `anchor` for those
+ * (`String(command).slice(0, 120)`), so a build or test run can never share
+ * an anchor string with a canonical file path -- there is no join key in
+ * common, and inventing a command-to-file heuristic (which files did a given
+ * `npm test` invocation cover?) is not something this record can answer
+ * honestly. `operationsScope` on the returned record says so explicitly,
+ * rather than letting an empty `operations` array look like "no build or
+ * test ever ran" when the truth is "this join cannot see it".
  */
 function anchorLabel(rawAnchor) {
   const path = String(rawAnchor).split('#')[0];
@@ -497,7 +528,8 @@ const MAX_DERIVATION_OPERATIONS = 5;
  * that comparison be reconstructed for a specific claim rather than only for
  * the anchor in general: the hash each anchor carried at the moment this
  * finding was derived from it, plus what evidence exists that any work
- * actually happened against it.
+ * actually happened against it. `derivationCheck` (staleness.mjs) is the
+ * reader that actually performs that comparison at serve time.
  *
  * DELIBERATELY NOT DUPLICATING THE EDGES. `derived_from` already records
  * WHICH anchors this finding cites; restating that here would be a second,
@@ -506,14 +538,23 @@ const MAX_DERIVATION_OPERATIONS = 5;
  *
  * DELIBERATELY NOT A REPLAY LOG. Recording enough to mechanically re-run a
  * derivation is a separate subsystem with real storage cost. This stores only
- * what the evidence log already has: `tool-outcome` events matching these
- * anchors, each reduced to the fields that were actually captured. An event
- * that carries no exit code or output contributes none -- nothing here is
- * invented to fill a shape the pipeline does not evidence yet. If a future
- * capture pass adds `exit`/`output` to those events, this starts carrying them
- * with no change to this function.
+ * what the evidence log already has: FILE-surface `tool-outcome` events
+ * matching these anchors, each reduced to the fields that were actually
+ * captured. An event that carries no exit code or output contributes none --
+ * nothing here is invented to fill a shape the pipeline does not evidence
+ * yet. If a future capture pass adds `exit`/`output` to those events, this
+ * starts carrying them with no change to this function.
+ *
+ * INCOMPLETENESS IS MARKED, NOT IMPLIED. An empty `operations` array is
+ * genuinely ambiguous on its own -- it is the same shape whether nothing
+ * happened, or something happened but fell outside what this join can see.
+ * `operationsComplete` distinguishes them: false when the evidence log itself
+ * may have dropped older matches (`evidenceIncomplete`, from
+ * `metrics.evidenceTruncated`) OR when more matches existed than the cap
+ * kept. A reader can then tell "no operations happened" from "operations
+ * existed but are not recorded here" instead of guessing.
  */
-function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
+function derivationFor(graph, resolvedAnchors, evidence, evidenceIncomplete, anchorSpecs) {
   const anchorHashes = {};
   for (const id of resolvedAnchors) {
     const node = graph.nodes.get(id);
@@ -521,8 +562,10 @@ function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
   }
 
   const labels = new Set((anchorSpecs || []).map(anchorLabel));
-  const operations = evidence
-    .filter((event) => event.kind === 'tool-outcome' && labels.has(event.anchor))
+  const matching = evidence.filter(
+    (event) => event.kind === 'tool-outcome' && labels.has(event.anchor)
+  );
+  const operations = [...matching]
     .sort((a, b) => (Number(b.at) || 0) - (Number(a.at) || 0))
     .slice(0, MAX_DERIVATION_OPERATIONS)
     .map((event) => {
@@ -540,7 +583,16 @@ function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
       return op;
     });
 
-  return { at: Date.now(), anchors: anchorHashes, operations };
+  return {
+    at: Date.now(),
+    anchors: anchorHashes,
+    operations,
+    // FILE touches only -- see `anchorLabel`. Declared here, in the record
+    // itself, not only in this function's comment, so a reader who never
+    // opens this source file still learns builds and test runs are excluded.
+    operationsScope: 'file',
+    operationsComplete: !evidenceIncomplete && matching.length <= operations.length,
+  };
 }
 
 /**
@@ -588,6 +640,9 @@ export function writeHarvested(
   // it can hold thousands of lines, so re-reading it per finding would turn a
   // batch of N findings into N passes over the same bytes.
   const evidence = readEvidence(dir);
+  // Cheap: one stat call, checked once per batch rather than once per
+  // finding's derivation record.
+  const evidenceIncomplete = evidenceTruncated(dir);
 
   const written = [];
   for (const finding of findings) {
@@ -647,14 +702,16 @@ export function writeHarvested(
     // An explicit `taskId` is authoritative when a caller supplies one --
     // it OVERRIDES traversal rather than merely seeding it, so a caller that
     // knows better is never second-guessed by inference. Absent one, the task
-    // is DERIVED from the graph itself: `taskForAnchors` finds the task that
-    // actually touched these anchors, which needs no session id from anyone.
-    // Either way, held to the same discipline as the anchors above: a target
-    // that does not resolve to an existing task node produces no edge rather
-    // than a dangling one.
+    // is DERIVED from the graph itself: `taskForAnchors` finds the CURRENT
+    // session's task (scoped by `sessionId`, the same identity this write
+    // already carries for provenance) and requires it to have touched EVERY
+    // one of this finding's anchors, not merely one -- see that function's
+    // own comment for the four attacks this closes. Either way, held to the
+    // same discipline as the anchors above: a target that does not resolve to
+    // an existing task node produces no edge rather than a dangling one.
     const answersTarget = taskId
       ? nodeId('task', taskId)
-      : taskForAnchors(currentGraph, resolved);
+      : taskForAnchors(currentGraph, resolved, sessionId);
     if (answersTarget && currentGraph.nodes.has(answersTarget)) {
       edges.push({ edge: 'answers', to: answersTarget });
     }
@@ -707,7 +764,7 @@ export function writeHarvested(
         // `render()`/`renderSessionIndex()` in inject.mjs or `wiki_read`'s
         // `toFinding()` projection, neither of which reads this field, so it
         // is not part of the automatic per-touch injection `fit()` prices.
-        derivation: derivationFor(currentGraph, resolved, evidence, finding.anchors || []),
+        derivation: derivationFor(currentGraph, resolved, evidence, evidenceIncomplete, finding.anchors || []),
       },
       edges
     );

--- a/integrations/windsurf/hooks/lib/harvest-write.mjs
+++ b/integrations/windsurf/hooks/lib/harvest-write.mjs
@@ -452,11 +452,13 @@ function resolveAnchor(dir, anchor, projectRoot) {
  * `linkCoOccurrence()` (wiki.mjs, inject.mjs) both key a task node by
  * `sessionId`, always, so there is exactly ONE task node for "the current
  * session" and it is `nodeId('task', sessionId)`. Restricting to that ONE
- * node structurally eliminates cases 1 and 2 -- a prior or concurrent
- * session's task has a DIFFERENT sessionId and therefore a different node
- * id, so it is never even looked at, regardless of timing. No caller can
- * supply a wrong sessionId and get someone ELSE's task; they can only fail
- * to get a match.
+ * node structurally eliminates cases 1 and 2 PROVIDED the identity itself is
+ * trustworthy: an UNRELATED sessionId (typo'd, invented, or simply absent)
+ * cannot resolve to someone else's task, because a different key is a
+ * different node id, full stop, regardless of timing. That is NOT the same
+ * guarantee as "no caller can get someone else's task" -- see the note on
+ * `authoritativeSessionId` below for the residual this leaves when the
+ * identity is real but comes from an untrusted caller.
  *
  * COVERAGE, NOT OVERLAP, fixes case 3: the session's task must have a
  * `derived_from` edge to EVERY one of this finding's anchors, not merely one.
@@ -472,17 +474,41 @@ function resolveAnchor(dir, anchor, projectRoot) {
  * or without a timestamp on that edge -- there is no ranking left for a
  * missing timestamp to lose.
  *
- * `sessionId` absent means there is no identity to scope by, which means no
- * candidate -- not "fall back to guessing". Absence is the correct answer
- * when the graph cannot support attribution.
+ * NO IDENTITY MEANS NO CANDIDATE -- not "fall back to guessing". Absence is
+ * the correct answer when the graph cannot support attribution.
+ *
+ * ROUND 4: THE IDENTITY ITSELF MUST BE AUTHORITATIVE, not merely present.
+ * Scoping to `nodeId('task', sessionId)` only refuses an UNRELATED session;
+ * it does nothing against a FOREIGN BUT REAL one. `wiki_write`'s `sessionId`
+ * is a plain MCP tool argument the calling model supplies, unverified -- a
+ * model that names some OTHER, prior session whose task genuinely covered
+ * these anchors gets an `answers` edge to that stale task, because coverage
+ * cannot tell "this session" from "a session that really did touch these
+ * files, named by a string nothing cross-checked". Session id is not
+ * evidence unless the CALLER'S OWN CHANNEL is trustworthy, which is true of
+ * `plugin/hooks/harvest-worker.mjs` (Claude Code's own hook payload) and not
+ * true of a tool-call argument. So this parameter is named for what it must
+ * be, `authoritativeSessionId`, and every caller is a promise: pass this only
+ * when you did not just read it out of untrusted input. `wiki_write` passes
+ * NONE, which means its calls never traverse -- see `writeHarvested`'s own
+ * comment at the call site for what that costs and why it is accepted rather
+ * than worked around.
+ *
+ * COVERAGE IS CHECKED AGAINST RESOLVED ANCHORS, not the caller's original
+ * list. `writeHarvested` already drops any anchor `resolveAnchor` could not
+ * resolve before this function ever runs, so "every anchor" here means every
+ * anchor that survived that filter -- self-consistent with the
+ * `derived_from` edges the same resolved list produces, but worth stating:
+ * an anchor that failed to resolve cannot raise or lower the bar for the
+ * anchors that did.
  */
-function taskForAnchors(graph, anchorIds, sessionId) {
-  if (!sessionId || !anchorIds || !anchorIds.length) return null;
-  const taskTarget = nodeId('task', sessionId);
+function taskForAnchors(graph, resolvedAnchorIds, authoritativeSessionId) {
+  if (!authoritativeSessionId || !resolvedAnchorIds || !resolvedAnchorIds.length) return null;
+  const taskTarget = nodeId('task', authoritativeSessionId);
   const task = graph.nodes.get(taskTarget);
   if (!task || task.kind !== 'task') return null;
 
-  for (const anchor of anchorIds) {
+  for (const anchor of resolvedAnchorIds) {
     const covered = graph.edges.some((edge) =>
       edge.edge === 'derived_from' && edge.from === taskTarget && edge.to === anchor
     );
@@ -604,7 +630,19 @@ function derivationFor(graph, resolvedAnchors, evidence, evidenceIncomplete, anc
 export function writeHarvested(
   dir,
   findings,
-  { sessionId = null, origin = ORIGIN_HARVESTED, projectRoot = null, taskId = null } = {}
+  {
+    sessionId = null,
+    origin = ORIGIN_HARVESTED,
+    projectRoot = null,
+    taskId = null,
+    // Distinct from `sessionId`, which is stored on every finding for
+    // provenance/display regardless of trust. This one gates the `answers`
+    // traversal fallback specifically, and every caller passing it is
+    // asserting the identity came from a channel it does not control --
+    // Claude Code's own hook payload, not a tool-call argument a model
+    // typed. See `taskForAnchors`'s comment for the attack this closes.
+    authoritativeSessionId = null,
+  } = {}
 ) {
   if (!Array.isArray(findings) || !findings.length) return [];
 
@@ -702,16 +740,29 @@ export function writeHarvested(
     // An explicit `taskId` is authoritative when a caller supplies one --
     // it OVERRIDES traversal rather than merely seeding it, so a caller that
     // knows better is never second-guessed by inference. Absent one, the task
-    // is DERIVED from the graph itself: `taskForAnchors` finds the CURRENT
-    // session's task (scoped by `sessionId`, the same identity this write
-    // already carries for provenance) and requires it to have touched EVERY
-    // one of this finding's anchors, not merely one -- see that function's
-    // own comment for the four attacks this closes. Either way, held to the
-    // same discipline as the anchors above: a target that does not resolve to
-    // an existing task node produces no edge rather than a dangling one.
+    // is DERIVED from the graph itself, but ONLY when `authoritativeSessionId`
+    // is present: `taskForAnchors` scopes to that exact session's task and
+    // requires it to have touched EVERY one of this finding's anchors, not
+    // merely one -- see that function's own comment for why the identity
+    // itself must be trustworthy, not merely present.
+    //
+    // THE CONSEQUENCE, STATED PLAINLY: `wiki_write` never supplies
+    // `authoritativeSessionId` (its `sessionId` is a model-typed MCP
+    // argument nothing cross-checks), so its calls never traverse and
+    // `answers` never fires on that path. `plugin/hooks/harvest-worker.mjs`
+    // does supply it (Claude Code's own hook payload), so `answers` fires
+    // there -- opt-in gated. `answers` therefore does NOT fire on a default
+    // install today. Recovering default liveness needs an authoritative
+    // identity on a default-install path, which is what Plan 2's
+    // `hooks-core/derive.mjs` (running in the Stop hook, where the session id
+    // is real) is for -- not a weaker check here.
+    //
+    // Either way, held to the same discipline as the anchors above: a target
+    // that does not resolve to an existing task node produces no edge rather
+    // than a dangling one.
     const answersTarget = taskId
       ? nodeId('task', taskId)
-      : taskForAnchors(currentGraph, resolved, sessionId);
+      : taskForAnchors(currentGraph, resolved, authoritativeSessionId);
     if (answersTarget && currentGraph.nodes.has(answersTarget)) {
       edges.push({ edge: 'answers', to: answersTarget });
     }

--- a/integrations/windsurf/hooks/lib/harvest-write.mjs
+++ b/integrations/windsurf/hooks/lib/harvest-write.mjs
@@ -436,7 +436,7 @@ function resolveAnchor(dir, anchor, projectRoot) {
 export function writeHarvested(
   dir,
   findings,
-  { sessionId = null, origin = ORIGIN_HARVESTED, projectRoot = null } = {}
+  { sessionId = null, origin = ORIGIN_HARVESTED, projectRoot = null, taskId = null } = {}
 ) {
   if (!Array.isArray(findings) || !findings.length) return [];
 
@@ -516,6 +516,21 @@ export function writeHarvested(
     // collision vanishingly unlikely while keeping the timestamp readable.
     const provenance = provenanceFor(finding);
     const key = `${prefixFor(provenance)}-${Date.now().toString(36)}-${written.length}-${randomBytes(4).toString("hex")}`;
+
+    const edges = resolved.map((target) => ({ edge: 'derived_from', to: target }));
+    // `answers` closes the loop back to the task that produced the finding, so
+    // provenance can be traversed rather than inferred: "which session
+    // established this, and from what". Declared in EDGE_KINDS and written by
+    // nothing until now. Held to the same discipline as the anchors above: a
+    // taskId that does not resolve to an existing task node produces no edge
+    // rather than a dangling one.
+    if (taskId) {
+      const taskTarget = nodeId('task', taskId);
+      if (currentGraph.nodes.has(taskTarget)) {
+        edges.push({ edge: 'answers', to: taskTarget });
+      }
+    }
+
     // ONE APPEND for the finding and every anchor it resolved. This runs in a
     // detached worker, so "the process survives to finish the loop" is not a
     // safe assumption: a node written without its edges is an active finding
@@ -557,7 +572,7 @@ export function writeHarvested(
           : undefined,
         sessionId,
       },
-      resolved.map((target) => ({ edge: 'derived_from', to: target }))
+      edges
     );
     // A failed write returns null. Reporting the key anyway would tell the
     // caller a claim was stored that no later session can retrieve.

--- a/integrations/windsurf/hooks/lib/harvest-write.mjs
+++ b/integrations/windsurf/hooks/lib/harvest-write.mjs
@@ -34,6 +34,7 @@ import { randomBytes } from 'node:crypto';
 import { realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
+import { readEvidence } from './metrics.mjs';
 
 /**
  * The types that may cross a project boundary.
@@ -428,6 +429,121 @@ function resolveAnchor(dir, anchor, projectRoot) {
 }
 
 /**
+ * Which task actually produced this finding, when nothing said so directly.
+ *
+ * Session id was the only signal `answers` had, and a session id is exactly
+ * what a caller may not have (`wiki_write`'s `sessionId` is optional and
+ * nothing populates it today; the detached harvest worker's is gated behind
+ * an opt-in). But the graph does not need to be TOLD which task this is: the
+ * structural harvest already writes `task -[derived_from]-> file` for every
+ * tool call, unconditionally, on every install. So the task is DERIVABLE --
+ * it is whichever task node has a `derived_from` edge to one of the SAME
+ * anchors this finding resolved to.
+ *
+ * "Most recent task, full stop" was rejected on purpose: a task that never
+ * touched these files could still be the newest node in the graph (a
+ * different file, a different concern, in a later session), and attaching
+ * provenance to it would be a WRONG edge, not a missing one -- worse than no
+ * edge, because a reader trusts it. So candidates are filtered to tasks that
+ * touched at least one of these anchors FIRST, and only ties among THOSE are
+ * broken by recency.
+ *
+ * The tie-break is the edge's own `at`, not the task node's `at`. A task that
+ * touched this file once, long ago, and then stayed active on unrelated files
+ * for hours has a late node timestamp that says nothing about this anchor;
+ * the edge timestamp says exactly when THIS task touched THIS anchor, which
+ * is the question being asked. Among tasks sharing an anchor, the one whose
+ * most recent touch to any shared anchor is latest wins -- recency of the
+ * relevant work, not recency of the task in general.
+ */
+function taskForAnchors(graph, anchorIds) {
+  if (!anchorIds || !anchorIds.length) return null;
+  const anchors = new Set(anchorIds);
+  let best = null;
+  for (const edge of graph.edges) {
+    if (edge.edge !== 'derived_from' || !anchors.has(edge.to)) continue;
+    const from = graph.nodes.get(edge.from);
+    // `derived_from` is also how a FINDING cites its own anchors, so without
+    // this a finding that already cited the same file would be mistaken for
+    // the task that produced it.
+    if (!from || from.kind !== 'task') continue;
+    const at = Number(edge.at) || 0;
+    if (!best || at > best.at) best = { taskId: edge.from, at };
+  }
+  return best ? best.taskId : null;
+}
+
+/**
+ * A file path the way `recordToolOutcome` (metrics.mjs) already truncates and
+ * stores it on a `tool-outcome` event's `anchor` field, so a derivation record
+ * can join against that log without a second, divergent notion of "the same
+ * anchor".
+ */
+function anchorLabel(rawAnchor) {
+  const path = String(rawAnchor).split('#')[0];
+  return canonicalPath(path).slice(0, 120);
+}
+
+/** How many recorded operations a single finding's derivation may cite. */
+const MAX_DERIVATION_OPERATIONS = 5;
+
+/**
+ * The checkable half of provenance: not just where a finding came from, but
+ * whether that derivation still holds.
+ *
+ * Citation-style provenance (a session or task id) answers "where". It never
+ * answers "does this still apply" -- that is what staleness already computes,
+ * by comparing an anchor's STORED hash against disk. This record is what lets
+ * that comparison be reconstructed for a specific claim rather than only for
+ * the anchor in general: the hash each anchor carried at the moment this
+ * finding was derived from it, plus what evidence exists that any work
+ * actually happened against it.
+ *
+ * DELIBERATELY NOT DUPLICATING THE EDGES. `derived_from` already records
+ * WHICH anchors this finding cites; restating that here would be a second,
+ * driftable copy of the same fact. What is new here, and only here, is the
+ * HASH each anchor carried at claim time -- edges carry no such thing.
+ *
+ * DELIBERATELY NOT A REPLAY LOG. Recording enough to mechanically re-run a
+ * derivation is a separate subsystem with real storage cost. This stores only
+ * what the evidence log already has: `tool-outcome` events matching these
+ * anchors, each reduced to the fields that were actually captured. An event
+ * that carries no exit code or output contributes none -- nothing here is
+ * invented to fill a shape the pipeline does not evidence yet. If a future
+ * capture pass adds `exit`/`output` to those events, this starts carrying them
+ * with no change to this function.
+ */
+function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
+  const anchorHashes = {};
+  for (const id of resolvedAnchors) {
+    const node = graph.nodes.get(id);
+    if (node && typeof node.hash === 'string') anchorHashes[id] = node.hash;
+  }
+
+  const labels = new Set((anchorSpecs || []).map(anchorLabel));
+  const operations = evidence
+    .filter((event) => event.kind === 'tool-outcome' && labels.has(event.anchor))
+    .sort((a, b) => (Number(b.at) || 0) - (Number(a.at) || 0))
+    .slice(0, MAX_DERIVATION_OPERATIONS)
+    .map((event) => {
+      const op = {};
+      if (typeof event.toolName === 'string' && event.toolName)
+        op.tool = event.toolName.slice(0, 60);
+      if (typeof event.success === 'boolean') op.success = event.success;
+      if (typeof event.at === 'number') op.at = event.at;
+      // Forward-compatible, not fabricated: neither field exists on a
+      // `tool-outcome` event in this pipeline today, so every operation
+      // omits them until a capture pass actually evidences one.
+      if (typeof event.exit === 'number') op.exit = event.exit;
+      if (typeof event.output === 'string' && event.output)
+        op.output = event.output.slice(0, 200);
+      return op;
+    });
+
+  return { at: Date.now(), anchors: anchorHashes, operations };
+}
+
+/**
  * Writes validated findings, returning the keys actually stored.
  *
  * `findings` is the output of `harvest.validate()`, so type/claim/confidence
@@ -467,6 +583,11 @@ export function writeHarvested(
       : batch;
   const prefixFor = (p) =>
     p === ORIGIN_AGENT ? 'agent' : p === ORIGIN_HUMAN ? 'human' : 'harvested';
+
+  // Read once: every finding in this batch shares the same evidence log, and
+  // it can hold thousands of lines, so re-reading it per finding would turn a
+  // batch of N findings into N passes over the same bytes.
+  const evidence = readEvidence(dir);
 
   const written = [];
   for (const finding of findings) {
@@ -521,14 +642,21 @@ export function writeHarvested(
     // `answers` closes the loop back to the task that produced the finding, so
     // provenance can be traversed rather than inferred: "which session
     // established this, and from what". Declared in EDGE_KINDS and written by
-    // nothing until now. Held to the same discipline as the anchors above: a
-    // taskId that does not resolve to an existing task node produces no edge
-    // rather than a dangling one.
-    if (taskId) {
-      const taskTarget = nodeId('task', taskId);
-      if (currentGraph.nodes.has(taskTarget)) {
-        edges.push({ edge: 'answers', to: taskTarget });
-      }
+    // nothing until now.
+    //
+    // An explicit `taskId` is authoritative when a caller supplies one --
+    // it OVERRIDES traversal rather than merely seeding it, so a caller that
+    // knows better is never second-guessed by inference. Absent one, the task
+    // is DERIVED from the graph itself: `taskForAnchors` finds the task that
+    // actually touched these anchors, which needs no session id from anyone.
+    // Either way, held to the same discipline as the anchors above: a target
+    // that does not resolve to an existing task node produces no edge rather
+    // than a dangling one.
+    const answersTarget = taskId
+      ? nodeId('task', taskId)
+      : taskForAnchors(currentGraph, resolved);
+    if (answersTarget && currentGraph.nodes.has(answersTarget)) {
+      edges.push({ edge: 'answers', to: answersTarget });
     }
 
     // ONE APPEND for the finding and every anchor it resolved. This runs in a
@@ -571,6 +699,15 @@ export function writeHarvested(
           ? finding.quote
           : undefined,
         sessionId,
+        // THE CHECKABLE HALF OF PROVENANCE. Citation-style (this `sessionId`,
+        // the `answers` edge above) says WHERE a claim came from; it never
+        // says whether that derivation still applies. `derivationFor` reaches
+        // through `wiki_query`'s `node`/`get`/`search` operations only (those
+        // return a finding's stored fields wholesale) -- never through
+        // `render()`/`renderSessionIndex()` in inject.mjs or `wiki_read`'s
+        // `toFinding()` projection, neither of which reads this field, so it
+        // is not part of the automatic per-touch injection `fit()` prices.
+        derivation: derivationFor(currentGraph, resolved, evidence, finding.anchors || []),
       },
       edges
     );

--- a/integrations/windsurf/hooks/lib/inject.mjs
+++ b/integrations/windsurf/hooks/lib/inject.mjs
@@ -26,6 +26,7 @@ import {
 } from './wiki.mjs';
 import { basename } from 'node:path';
 import { serve, diffLines } from './staleness.mjs';
+import { drainInvalidations } from './pending.mjs';
 import { inHoldout, record, indexBudget } from './metrics.mjs';
 import { canonicalPath, resolvableCandidates } from './paths.mjs';
 import { annotatedSkeleton } from './skeleton.mjs';
@@ -142,6 +143,31 @@ function render(finding) {
 }
 
 /**
+ * Applies anything the post-tool hook queued, BEFORE anything is served.
+ *
+ * THIS IS WHERE EAGER STALENESS LANDS. `invalidateOnWrite` needs a graph, and
+ * loading one on the return path of every write is what pending.mjs exists to
+ * avoid -- so the hook queues and the next graph read applies. These two
+ * functions are that read: they already hold a freshly loaded graph, and they
+ * are the last thing to run before a finding reaches a model.
+ *
+ * RE-READ ONLY WHEN SOMETHING WAS ACTUALLY MARKED. The drain writes the stale
+ * flag to disk; it cannot mutate the caller's already-parsed graph, so serving
+ * from that copy would deliver the very "stale finding as fresh" this exists to
+ * prevent. A second load costs a parse, and it is paid once per observed write
+ * rather than once per tool call -- when nothing is queued this is one stat.
+ */
+function withPendingApplied(dir, graph) {
+  try {
+    return drainInvalidations(dir, graph) > 0 ? load(dir) : graph;
+  } catch {
+    // The lazy path still covers everything this would have caught early, and
+    // a hook must never fail because bookkeeping did.
+    return graph;
+  }
+}
+
+/**
  * What the model sees when it touches a file.
  *
  * Returns null when there is nothing to say, or when this touch fell into the
@@ -154,6 +180,7 @@ export function forTouch(
   rawPath,
   { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
+  graph = withPendingApplied(dir, graph);
   // Canonical, so a touch finds findings anchored under any other spelling.
   const filePath = canonicalPath(rawPath);
   const anchorId = nodeId('file', filePath);
@@ -322,6 +349,7 @@ export function forCommand(
   { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
   if (!command) return null;
+  graph = withPendingApplied(dir, graph);
 
   const candidates = [];
   for (const node of graph.nodes.values()) {

--- a/integrations/windsurf/hooks/lib/inject.mjs
+++ b/integrations/windsurf/hooks/lib/inject.mjs
@@ -33,6 +33,7 @@ import { annotatedSkeleton } from './skeleton.mjs';
 import { substitutionBudget } from './metrics.mjs';
 import { assessFindings } from './utility.mjs';
 import { quarantineSharedSource } from './harvest-write.mjs';
+import { cacheOrdered } from './cache.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
@@ -1152,6 +1153,53 @@ export function standingRules(dir, graph, { budget = standingBudget(), episode =
   // which is worse than saying there are more: a model that knows the list is
   // truncated can ask, one that does not will assume it is complete.
   return `${HEADING}${lines.join('\n')}${truncated}`;
+}
+
+/**
+ * SessionStart context, assembled in cache order: stable first, volatile last.
+ *
+ * WHY THE ORDER IS A CORRECTNESS PROPERTY AND NOT A STYLE CHOICE. Everything
+ * here lands near the FRONT of the prompt prefix, and a prefix cache is
+ * invalidated from the first differing byte onward. A block whose text changes
+ * between sessions therefore prices everything positioned after it: put the
+ * freshest block first and the whole remainder of the prefix is re-written
+ * every session; put it last and the invalidation is confined to its own tail.
+ * cache.mjs measures exactly this cost in the user's files -- this is the same
+ * discipline applied to our own output, which is the half nobody else has to
+ * think about because nobody else writes into the prefix.
+ *
+ * `cacheOrdered` existed for precisely this and had no caller, so the order was
+ * whatever order the call sites happened to push in. It was accidentally right;
+ * it is now enforced, which is the difference that matters the next time a
+ * block is added.
+ *
+ * VOLATILITY IS ASSIGNED FROM HOW OFTEN THE TEXT ACTUALLY DIFFERS BETWEEN
+ * SESSIONS, not from how important the block is:
+ *
+ *   0  policy -- the optimization notice and project briefing. Deliberately
+ *      cache-safe by construction: the routing facts are number-free and the
+ *      briefing passes through `stableText`, which DROPS any line that would
+ *      vary. It changes when the tool inventory or configuration changes.
+ *   1  standing -- pinned facts and human-verified corrections, rendered in
+ *      full. Changes only when a person pins, retires or corrects something.
+ *   2  index -- the bounded wiki index, selected per session from the task
+ *      text, and carrying [STALE]/[DISPUTED] markers that flip as the code
+ *      moves. Different on most sessions.
+ *   3  restoration -- present only when resuming from a compaction, and derived
+ *      from the anchors of the session that was just discarded. Never twice the
+ *      same.
+ *
+ * A block with no text is dropped rather than joined, so an absent block cannot
+ * open the assembly with a blank line.
+ */
+export function sessionContext(blocks) {
+  return cacheOrdered(
+    (Array.isArray(blocks) ? blocks : []).filter(
+      (block) => block && typeof block.text === 'string' && block.text.trim()
+    )
+  )
+    .map((block) => block.text)
+    .join('\n\n');
 }
 
 /**

--- a/integrations/windsurf/hooks/lib/inject.mjs
+++ b/integrations/windsurf/hooks/lib/inject.mjs
@@ -122,8 +122,29 @@ function fit(findings, budget) {
   return { kept, spent };
 }
 
+/**
+ * Discloses an open disagreement, on the same line as the claim it is about.
+ *
+ * BOTH HALVES, like the stale renderer below: the strong form names the other
+ * finding so the reader can fetch it, and the form without a key says only what
+ * is actually known. `serve` is what establishes the dispute; this only phrases
+ * it, and it phrases it in one short line because `fit` prices `render` against
+ * the injection budget -- a disagreement is worth a pointer, not both claims in
+ * full.
+ *
+ * NO DISMISSAL VOCABULARY, for the reason measured on the stale wording: an
+ * instruction to discount suppressed findings that were correct. This states
+ * that another claim exists and where to find it, and lets the reader decide.
+ */
+function disputeNote(finding) {
+  if (!finding.contradicted) return '';
+  return finding.contradictedBy
+    ? `\n  DISPUTED by ${finding.contradictedBy} -- wiki_query that key for the other claim`
+    : '\n  DISPUTED by another finding in this graph';
+}
+
 function render(finding) {
-  const head = `- [${finding.type || 'finding'}] ${finding.claim}`;
+  const head = `- [${finding.type || 'finding'}] ${finding.claim}${disputeNote(finding)}`;
   if (!finding.stale) return head;
 
   // A stale finding NEVER renders as though it were current. But the strength
@@ -997,7 +1018,15 @@ function renderSessionIndex(total, findings) {
       : finding.stale
         ? ' [possibly stale; verify before use]'
         : '';
-    return `- ${finding.key}${freshness}: ${finding.claim.slice(0, 90)}`;
+    // The session index is the first thing a session reads, so a disputed
+    // finding must not be listed there as settled either. Compressed to a
+    // marker and a key, matching the freshness markers beside it.
+    const dispute = finding.contradicted
+      ? finding.contradictedBy
+        ? ` [DISPUTED by ${finding.contradictedBy}]`
+        : ' [DISPUTED]'
+      : '';
+    return `- ${finding.key}${freshness}${dispute}: ${finding.claim.slice(0, 90)}`;
   });
   return `# Project wiki (${total} findings, ${findings.length} listed)
 

--- a/integrations/windsurf/hooks/lib/inject.mjs
+++ b/integrations/windsurf/hooks/lib/inject.mjs
@@ -139,9 +139,26 @@ function fit(findings, budget) {
  */
 function disputeNote(finding) {
   if (!finding.contradicted) return '';
-  return finding.contradictedBy
+  const head = finding.contradictedBy
     ? `\n  DISPUTED by ${finding.contradictedBy} -- wiki_query that key for the other claim`
     : '\n  DISPUTED by another finding in this graph';
+  // THE REASON A PERSON TYPED, rendered here because this is the fullest of the
+  // three dispute surfaces and the only one with room for a sentence. `contradict`
+  // has always stored up to 400 characters of human explanation and, until this
+  // line, nothing read it: the pointer told a reader where to look and withheld
+  // the one thing that would tell them whether looking was worth a tool call.
+  //
+  // TRUNCATED AT 140, because `fit` prices this string against the injection
+  // budget and a 400-character paragraph beside a one-line claim inverts the
+  // proportions. The compressed surfaces -- the session index and restore.mjs's
+  // "Likely next" list -- deliberately keep marker-and-key only; they are one
+  // line per finding by design, and `wiki_query` returns the reason in full.
+  if (typeof finding.contradictionReason !== 'string' || !finding.contradictionReason.trim()) {
+    return head;
+  }
+  const reason = finding.contradictionReason.trim();
+  const shown = reason.length > 140 ? `${reason.slice(0, 140)}...` : reason;
+  return `${head}\n  Reason given: ${shown}`;
 }
 
 /**

--- a/integrations/windsurf/hooks/lib/inject.mjs
+++ b/integrations/windsurf/hooks/lib/inject.mjs
@@ -276,7 +276,10 @@ export function forTouch(
   // others, so the comparison becomes within-file and the dominant source of
   // variance drops out. A session-pinned arm would destroy that.
   const holdout = inHoldout(filePath);
-  const served = serve(graph, candidates);
+  // `dir` so an eager flag whose evidence is gone is cleared here rather than
+  // waiting for somebody to open the dashboard. Same evidence test as the manual
+  // path -- see `serve`.
+  const served = serve(graph, candidates, { dir });
   const assessed = assessFindings(dir, served, {
     episodeId: episode.episodeId || sessionId,
     relevanceFor: () => 1,
@@ -463,7 +466,7 @@ export function forCommand(
   // only thing an uncapped list buys is the I/O.
   const considered = candidates.slice(0, MAX_COMMAND_CANDIDATES);
 
-  const served = serve(graph, considered);
+  const served = serve(graph, considered, { dir });
   const assessed = assessFindings(dir, served, {
     episodeId: episode.episodeId || sessionId,
     relevanceFor: (finding) => explicit(finding) ? 1 : 0.6,
@@ -990,7 +993,7 @@ export function sessionIndex(dir, graph, { episode = {}, relevantFindingIds = []
   // `serve` is the only path allowed to hand a finding to a model. In
   // particular, activating this previously-unwired index must not create a new
   // path that labels an invalidated content claim as current.
-  const served = serve(graph, selected);
+  const served = serve(graph, selected, { dir });
   if (!served.length) return null;
   // A stale marker is longer than the fresh preview used for candidate
   // selection. Trim from the lowest-ranked end until the ACTUAL message fits.

--- a/integrations/windsurf/hooks/lib/inject.mjs
+++ b/integrations/windsurf/hooks/lib/inject.mjs
@@ -156,9 +156,9 @@ function disputeNote(finding) {
 function derivationNote(finding) {
   if (finding.derivationHolds !== false) return '';
   const changed = Array.isArray(finding.derivationChanged) ? finding.derivationChanged : [];
-  return changed.length
-    ? `\n  DERIVATION CHANGED -- ${changed.join(', ')} no longer match what this claim was derived from`
-    : '\n  DERIVATION CHANGED since this claim was recorded';
+  if (!changed.length) return '\n  DERIVATION CHANGED since this claim was recorded';
+  const verb = changed.length === 1 ? 'no longer matches' : 'no longer match';
+  return `\n  DERIVATION CHANGED -- ${changed.join(', ')} ${verb} what this claim was derived from`;
 }
 
 function render(finding) {

--- a/integrations/windsurf/hooks/lib/inject.mjs
+++ b/integrations/windsurf/hooks/lib/inject.mjs
@@ -143,8 +143,26 @@ function disputeNote(finding) {
     : '\n  DISPUTED by another finding in this graph';
 }
 
+/**
+ * Discloses `derivationCheck`'s verdict (staleness.mjs) -- distinct from
+ * `disputeNote` (another finding disagrees) and from the STALE block below
+ * (the anchor NODE's current hash does not match disk). This is about
+ * whether the bytes THIS claim was actually derived from are still the bytes
+ * an anchor holds; see `derivationCheck`'s comment for the case that catches
+ * that the other two can miss. Silent when it holds -- the common case pays
+ * nothing -- and silent when it was never checked at all (an older finding
+ * with no `derivation` record).
+ */
+function derivationNote(finding) {
+  if (finding.derivationHolds !== false) return '';
+  const changed = Array.isArray(finding.derivationChanged) ? finding.derivationChanged : [];
+  return changed.length
+    ? `\n  DERIVATION CHANGED -- ${changed.join(', ')} no longer match what this claim was derived from`
+    : '\n  DERIVATION CHANGED since this claim was recorded';
+}
+
 function render(finding) {
-  const head = `- [${finding.type || 'finding'}] ${finding.claim}${disputeNote(finding)}`;
+  const head = `- [${finding.type || 'finding'}] ${finding.claim}${disputeNote(finding)}${derivationNote(finding)}`;
   if (!finding.stale) return head;
 
   // A stale finding NEVER renders as though it were current. But the strength

--- a/integrations/windsurf/hooks/lib/inject.mjs
+++ b/integrations/windsurf/hooks/lib/inject.mjs
@@ -157,9 +157,28 @@ function render(finding) {
  * prevent. A second load costs a parse, and it is paid once per observed write
  * rather than once per tool call -- when nothing is queued this is one stat.
  */
+/**
+ * Per process, per graph directory: did the drain change anything?
+ *
+ * THE SECOND CALLER IS WHY THIS EXISTS. SessionStart calls `standingRules` and
+ * then `sessionIndex` with the SAME graph object it loaded once. Without this
+ * memo the first call drains, marks, and re-reads privately -- and the second
+ * call finds an empty queue, marks nothing, and therefore serves from the
+ * caller's pre-drain copy, advertising as current the very finding the first
+ * call had just marked. Draining is not idempotent from the caller's point of
+ * view; remembering the ANSWER is what makes it so.
+ *
+ * A hook process handles one lifecycle event, so this map holds one or two
+ * entries and dies with the process.
+ */
+const drainedDirs = new Map();
+
 function withPendingApplied(dir, graph) {
   try {
-    return drainInvalidations(dir, graph) > 0 ? load(dir) : graph;
+    if (drainedDirs.has(dir)) return drainedDirs.get(dir) ? load(dir) : graph;
+    const marked = drainInvalidations(dir, graph) > 0;
+    drainedDirs.set(dir, marked);
+    return marked ? load(dir) : graph;
   } catch {
     // The lazy path still covers everything this would have caught early, and
     // a hook must never fail because bookkeeping did.
@@ -862,6 +881,12 @@ export function relevantFindingIdsForContext(graph, context, { limit = 8 } = {})
  * shrinks toward the floor. See metrics.indexBudget.
  */
 export function sessionIndex(dir, graph, { episode = {}, relevantFindingIds = [] } = {}) {
+  // DRAINED HERE TOO, and this is the worst place to be wrong. The session index
+  // is the FIRST thing a session sees and it arrives with no other context to
+  // correct it, so advertising a finding the graph already knows is stale is a
+  // false claim made at maximum leverage. The graph is loaded either way, so the
+  // only cost is the stat that finds no queue.
+  graph = withPendingApplied(dir, graph);
   const budget = indexBudget(dir);
   const relevant = new Set(relevantFindingIds);
   // Some SessionStart payloads have no task signal. Fail closed for situational
@@ -988,6 +1013,9 @@ ${lines.join('\n')}`;
  * is wallpaper, and the model stops reading the thing it always sees.
  */
 export function standingRules(dir, graph, { budget = standingBudget(), episode = {} } = {}) {
+  // Same reason as sessionIndex: always-on text, delivered before the first
+  // tool call, with nothing following it that could qualify what it said.
+  graph = withPendingApplied(dir, graph);
   const rules = [...graph.nodes.values()].filter(
     (n) =>
       n.kind === 'finding' &&

--- a/integrations/windsurf/hooks/lib/inject.mjs
+++ b/integrations/windsurf/hooks/lib/inject.mjs
@@ -143,6 +143,40 @@ function render(finding) {
 }
 
 /**
+ * Graph directories where a drain has already marked something in THIS process.
+ *
+ * THE SECOND CALLER IS WHY THIS EXISTS. SessionStart calls `standingRules` and
+ * then `sessionIndex` with the SAME graph object it loaded once. Without this,
+ * the first call drains, marks, and re-reads privately -- and the second call
+ * finds an empty queue, marks nothing, and therefore serves from the caller's
+ * pre-drain copy, advertising as current the very finding the first call had
+ * just marked. Draining is idempotent; its EFFECT on a caller's parsed graph is
+ * not, so what is remembered here is "a re-read is owed", nothing else.
+ *
+ * ONLY THE POSITIVE CASE IS REMEMBERED, and that is a correctness decision
+ * rather than a tuning one. Remembering "nothing was queued" would mean a queue
+ * arriving LATER in the same process is silently skipped and deferred to some
+ * future session. That cannot happen today, because `queueInvalidation` runs in
+ * the post-tool branch before any injection -- but that is an unguarded
+ * ordering dependency, and it stops being true the moment someone adds a call
+ * site. A repeated empty drain costs one `existsSync` on a file that is not
+ * there, which is a price worth paying to not have an invariant that depends on
+ * nobody reordering anything.
+ *
+ * KEYED CANONICALLY. Two spellings of one directory -- a trailing separator, a
+ * `..` segment, a lower-cased drive letter -- would otherwise be two entries,
+ * which reintroduces exactly the pre-drain-copy bug above. This is the same
+ * defect shape Task 2 on this branch shipped for real, where a tool resolved its
+ * graph from a raw cwd while the hooks resolved theirs through `projectRootFor`
+ * and the two halves of a metric landed in different directories. Path identity
+ * is why `canonicalKey` lives inside `nodeId` rather than at its call sites.
+ *
+ * A hook process handles one lifecycle event, so this set holds one or two
+ * entries and dies with the process.
+ */
+const drainedDirs = new Set();
+
+/**
  * Applies anything the post-tool hook queued, BEFORE anything is served.
  *
  * THIS IS WHERE EAGER STALENESS LANDS. `invalidateOnWrite` needs a graph, and
@@ -157,28 +191,14 @@ function render(finding) {
  * prevent. A second load costs a parse, and it is paid once per observed write
  * rather than once per tool call -- when nothing is queued this is one stat.
  */
-/**
- * Per process, per graph directory: did the drain change anything?
- *
- * THE SECOND CALLER IS WHY THIS EXISTS. SessionStart calls `standingRules` and
- * then `sessionIndex` with the SAME graph object it loaded once. Without this
- * memo the first call drains, marks, and re-reads privately -- and the second
- * call finds an empty queue, marks nothing, and therefore serves from the
- * caller's pre-drain copy, advertising as current the very finding the first
- * call had just marked. Draining is not idempotent from the caller's point of
- * view; remembering the ANSWER is what makes it so.
- *
- * A hook process handles one lifecycle event, so this map holds one or two
- * entries and dies with the process.
- */
-const drainedDirs = new Map();
-
 function withPendingApplied(dir, graph) {
   try {
-    if (drainedDirs.has(dir)) return drainedDirs.get(dir) ? load(dir) : graph;
-    const marked = drainInvalidations(dir, graph) > 0;
-    drainedDirs.set(dir, marked);
-    return marked ? load(dir) : graph;
+    const key = canonicalPath(dir);
+    // The drain runs EVERY time. It is one stat when there is nothing to do,
+    // and running it unconditionally is what keeps the memo from encoding an
+    // assumption about which hook branch ran first.
+    if (drainInvalidations(dir, graph) > 0) drainedDirs.add(key);
+    return drainedDirs.has(key) ? load(dir) : graph;
   } catch {
     // The lazy path still covers everything this would have caught early, and
     // a hook must never fail because bookkeeping did.

--- a/integrations/windsurf/hooks/lib/lexical.mjs
+++ b/integrations/windsurf/hooks/lib/lexical.mjs
@@ -1,0 +1,73 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/lexical.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * BM25 over findings. Pure, dependency-free, deterministic.
+ *
+ * WHY THIS REPLACES `includes()`. The dashboard filtered findings by substring,
+ * which cannot RANK -- and every consumer of retrieval here is under a hard
+ * token budget, so the budget kept whatever happened to match rather than what
+ * matched best. Ranking is the whole value at a budget.
+ *
+ * WHY BM25 AND NOT EMBEDDINGS. Deliberate, per docs/WIKI_GRAPH.md: deterministic,
+ * instant, explainable, and it cannot drift or need a rebuild. The known cost is
+ * recall on findings with no lexical overlap; Plan 2's recall probe measures that
+ * rather than assuming it away.
+ */
+
+/** Non-word split, lowercased. Short tokens are kept: `fs`, `id`, `os` matter here. */
+export function tokenize(text) {
+  return String(text || '')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+}
+
+/**
+ * Classic BM25. `k1` controls term-frequency saturation, `b` length normalisation.
+ * Defaults are the standard ones and are exposed so the recall probe can sweep them.
+ */
+export function rank(query, findings, { limit = 20, k1 = 1.2, b = 0.75 } = {}) {
+  const terms = tokenize(query);
+  if (!terms.length || !Array.isArray(findings) || !findings.length) return [];
+
+  // A finding's searchable text is its claim AND its key: the key is how the
+  // session index refers to it, so a model quoting a key must find it.
+  const docs = findings.map((finding) => ({
+    finding,
+    tokens: tokenize(`${finding.key || ''} ${finding.claim || ''}`),
+  }));
+
+  const avgLen = docs.reduce((sum, d) => sum + d.tokens.length, 0) / docs.length;
+  const N = docs.length;
+
+  const docFreq = new Map();
+  for (const { tokens } of docs) {
+    for (const term of new Set(tokens)) {
+      docFreq.set(term, (docFreq.get(term) || 0) + 1);
+    }
+  }
+
+  const scored = [];
+  for (const { finding, tokens } of docs) {
+    const counts = new Map();
+    for (const token of tokens) counts.set(token, (counts.get(token) || 0) + 1);
+
+    let score = 0;
+    for (const term of terms) {
+      const tf = counts.get(term);
+      if (!tf) continue;
+      const df = docFreq.get(term) || 0;
+      // Standard BM25 IDF, floored at zero so a term present in every document
+      // contributes nothing rather than a negative score.
+      const idf = Math.max(0, Math.log(1 + (N - df + 0.5) / (df + 0.5)));
+      const norm = tf + k1 * (1 - b + (b * tokens.length) / (avgLen || 1));
+      score += idf * ((tf * (k1 + 1)) / (norm || 1));
+    }
+
+    // Zero means no term matched. Omitted rather than returned, so a caller
+    // under a token budget never spends it on an irrelevant finding.
+    if (score > 0) scored.push({ finding, score });
+  }
+
+  return scored.sort((a, b2) => b2.score - a.score).slice(0, limit);
+}

--- a/integrations/windsurf/hooks/lib/lexical.mjs
+++ b/integrations/windsurf/hooks/lib/lexical.mjs
@@ -14,12 +14,54 @@
  * rather than assuming it away.
  */
 
-/** Non-word split, lowercased. Short tokens are kept: `fs`, `id`, `os` matter here. */
-export function tokenize(text) {
-  return String(text || '')
-    .toLowerCase()
-    .split(/[^a-z0-9]+/)
+/**
+ * Splits an identifier's alphanumeric run into its camelCase / letter-digit
+ * parts, e.g. `skipLibCheck` -> ['skip', 'Lib', 'Check'], `TS2345` ->
+ * ['TS', '2345']. Returns a single-element array when there is no internal
+ * boundary (e.g. `retry` -> ['retry']) so callers can skip emitting a
+ * redundant duplicate of the whole token.
+ */
+function splitIdentifierParts(word) {
+  return word
+    .replace(/([a-z])([A-Z])/g, '$1\0$2')
+    .replace(/([A-Za-z])([0-9])/g, '$1\0$2')
+    .replace(/([0-9])([A-Za-z])/g, '$1\0$2')
+    .split('\0')
     .filter(Boolean);
+}
+
+/**
+ * Non-word split, lowercased. Short tokens are kept: `fs`, `id`, `os` matter
+ * here.
+ *
+ * Emits sub-tokens for compound identifiers, in addition to the whole token.
+ * Delimited identifiers (`smart_read`, `wiki.mjs`, the flag in
+ * `--skipLibCheck`) already round-trip fine: the delimiter splits them, and
+ * because query and claim pass through this same function, a query typed
+ * with the same delimiters matches. The silent gap was CONCATENATED
+ * identifiers with no delimiter at all -- `skipLibCheck` collapsed to the
+ * single token `skiplibcheck`, so a query for "skip lib check" (or "TS 2345"
+ * against `TS2345`) never intersected it. No error, just an absent result --
+ * and findings are about code, where run-together identifiers are the
+ * common case. So every alphanumeric run keeps its whole-token form (a query
+ * for the concatenated form still matches) and ALSO contributes its
+ * camelCase / letter-digit parts (a query for the separated form now
+ * matches too). A lone incidental character -- e.g. the `c` split out of a
+ * Windows path `C:\Users\...` -- needs no special-casing: it is a real
+ * token like any other, and BM25's IDF already discounts a term that shows
+ * up in nearly every finding.
+ */
+export function tokenize(text) {
+  const words = String(text || '').match(/[A-Za-z0-9]+/g) || [];
+  const tokens = [];
+  for (const word of words) {
+    tokens.push(word.toLowerCase());
+    const parts = splitIdentifierParts(word);
+    if (parts.length > 1) {
+      for (const part of parts) tokens.push(part.toLowerCase());
+    }
+  }
+  return tokens;
 }
 
 /**
@@ -57,9 +99,15 @@ export function rank(query, findings, { limit = 20, k1 = 1.2, b = 0.75 } = {}) {
       const tf = counts.get(term);
       if (!tf) continue;
       const df = docFreq.get(term) || 0;
-      // Standard BM25 IDF, floored at zero so a term present in every document
-      // contributes nothing rather than a negative score.
-      const idf = Math.max(0, Math.log(1 + (N - df + 0.5) / (df + 0.5)));
+      // Smoothed BM25 idf: log(1 + (N - df + 0.5) / (df + 0.5)). Unlike the
+      // classic unsmoothed idf (log((N - df + 0.5) / (df + 0.5))), which goes
+      // negative once a term appears in most documents, this smoothed form
+      // is strictly positive for every df in [1, N]: even at df === N the
+      // ratio inside the log is (N + 1) / (N + 0.5), which is always
+      // strictly greater than 1, so log(1 + that) is always > 0. No floor
+      // is needed here, and none is applied -- there is no negative case
+      // for this formula to guard against.
+      const idf = Math.log(1 + (N - df + 0.5) / (df + 0.5));
       const norm = tf + k1 * (1 - b + (b * tokens.length) / (avgLen || 1));
       score += idf * ((tf * (k1 + 1)) / (norm || 1));
     }

--- a/integrations/windsurf/hooks/lib/lexical.mjs
+++ b/integrations/windsurf/hooks/lib/lexical.mjs
@@ -65,6 +65,43 @@ export function tokenize(text) {
 }
 
 /**
+ * Effective term-frequency credit for a document that has NO exact token
+ * match for a query term but DOES have a token that starts with it (e.g.
+ * query `custom` against a document containing `customer`). Deliberately
+ * less than one exact occurrence (`1`), and it is a flat credit rather than
+ * one that grows with the number of prefix-matching tokens in the document,
+ * so a prefix hit can never outscore an exact hit of the same term:
+ *
+ *   BM25's per-term contribution is `idf * tf * (k1 + 1) / (tf + K)`, where
+ *   `K = k1 * (1 - b + b * L / avgL)` depends only on document length, not
+ *   on which term or how it matched. As a function of `tf` alone, with `K`
+ *   fixed, `f(tf) = tf / (tf + K)` is non-decreasing for every `tf >= 0` and
+ *   `k1 >= 0` (its derivative `K / (tf + K)^2` is never negative). So for
+ *   ANY document length, and any number of prefix-only occurrences, using
+ *   `PREFIX_TF < 1` in place of `tf` scores no higher than an actual exact
+ *   occurrence (`tf = 1`) would in that same document -- there is no
+ *   PREFIX_TF-independent way to accumulate more evidence than one real hit
+ *   by matching only a prefix. This is also why the count of prefix matches
+ *   is otherwise irrelevant here: it never feeds back into the score.
+ *
+ * PREFIX MATCHING IS NOT SUBSTRING MATCHING. It restores recall for a
+ * fragment typed at the START of a word -- `custom` now finds `customer` --
+ * which is the common case (a user typing the first few letters of a term
+ * they remember). It does NOT restore the old `.includes()` filter's ability
+ * to find a term in the MIDDLE of a word: a query for `tomer` still will not
+ * find `customer`. That recall gap is accepted, not silently reintroduced.
+ */
+const PREFIX_TF = 0.5;
+
+/**
+ * Below this length, a query term is not eligible for prefix matching: a
+ * one- or two-character prefix (`a`, `re`) is a substring of a large
+ * fraction of any real vocabulary, so it would match nearly every document
+ * and IDF alone would not discount it enough to keep the results relevant.
+ */
+const PREFIX_MIN_TERM_LENGTH = 3;
+
+/**
  * Classic BM25. `k1` controls term-frequency saturation, `b` length normalisation.
  * Defaults are the standard ones and are exposed so the recall probe can sweep them.
  */
@@ -96,7 +133,21 @@ export function rank(query, findings, { limit = 20, k1 = 1.2, b = 0.75 } = {}) {
 
     let score = 0;
     for (const term of terms) {
-      const tf = counts.get(term);
+      let tf = counts.get(term) || 0;
+
+      // No exact occurrence: fall back to a prefix match, which is weaker
+      // evidence and so credited at a flat PREFIX_TF rather than a real
+      // count (see PREFIX_TF's comment for why that ordering is safe). Only
+      // considered when nothing already matched exactly and the term is
+      // long enough that "starts with" is a meaningful signal.
+      if (tf === 0 && term.length >= PREFIX_MIN_TERM_LENGTH) {
+        for (const token of counts.keys()) {
+          if (token !== term && token.startsWith(term)) {
+            tf = PREFIX_TF;
+            break;
+          }
+        }
+      }
       if (!tf) continue;
       const df = docFreq.get(term) || 0;
       // Smoothed BM25 idf: log(1 + (N - df + 0.5) / (df + 0.5)). Unlike the

--- a/integrations/windsurf/hooks/lib/metrics.mjs
+++ b/integrations/windsurf/hooks/lib/metrics.mjs
@@ -455,6 +455,23 @@ export function readBalance(dir) {
   return out;
 }
 
+/**
+ * True when `readEvidence` could not have read the whole log -- the file
+ * exceeds the byte cap, so anything written before the tail it kept is
+ * silently absent from what it returned. A caller that builds a per-claim
+ * record from `readEvidence` (the wiki graph's derivation record) needs this
+ * to say "operations existed but are not recorded here" rather than let an
+ * empty result read as "nothing happened".
+ */
+export function evidenceTruncated(dir) {
+  const path = evidencePath(dir);
+  try {
+    return statSync(path).size > MAX_BYTES;
+  } catch {
+    return false;
+  }
+}
+
 /** Every causal evidence record inside the byte cap, deduplicated by id. */
 export function readEvidence(dir) {
   const path = evidencePath(dir);

--- a/integrations/windsurf/hooks/lib/observability.mjs
+++ b/integrations/windsurf/hooks/lib/observability.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 /**
  * Privacy-safe, cross-client lifecycle diagnostics.
  *

--- a/integrations/windsurf/hooks/lib/pending.mjs
+++ b/integrations/windsurf/hooks/lib/pending.mjs
@@ -39,7 +39,7 @@ import {
   statSync,
 } from 'node:fs';
 import { join } from 'node:path';
-import { invalidateOnWrite } from './staleness.mjs';
+import { invalidateChangedAnchors, invalidateOnWrite } from './staleness.mjs';
 import { canonicalPath, isFsSafePath, resolvableCandidates } from './paths.mjs';
 
 const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
@@ -190,31 +190,85 @@ function hasEditEvidence(payload, raw) {
 }
 
 /**
- * The evidence a completed mutation left behind, or null when there is none.
+ * Canonical tool names that mean bytes on disk changed.
  *
- * Separate from `queueInvalidation` so the caller can be a hook branch that
- * knows nothing about diffs, and so the reconstruction above is testable
- * without a filesystem queue.
+ * THE NORMALISED SET, not any client's own vocabulary. `normalizePayload` has
+ * already mapped `replace`, `write_file`, `apply_patch`, `str_replace`,
+ * `search_replace` and the rest onto these three through decide.mjs's alias
+ * table -- and a tool that table cannot map arrives as null and exits the hook
+ * before this module is reached at all. So matching here is both complete for
+ * every client the adapter serves and impossible to spell wrong.
+ *
+ * `NotebookEdit` is absent because `normalizeTool` maps it to null, and the MCP
+ * `smart_edit`/`smart_write` tools are absent for the same reason. Both are gaps
+ * in that alias table rather than in this file, and widening it changes routing
+ * verdicts for every client -- so they are reported, not papered over here.
  */
-export function observedWrite(payload, raw) {
-  // CHEAP CHECK FIRST, because this runs after every tool call on every client.
-  // Reading the file is the expensive part, and there is no point paying for it
-  // on a Read, a Bash or a write whose before side cannot be reconstructed.
-  if (!hasEditEvidence(payload, raw)) return null;
+const MUTATING = new Set(['Edit', 'MultiEdit', 'Write']);
+
+/** Files an apply_patch-style program declares it is about to change. */
+function patchTargets(payload) {
+  const command = payload?.tool_input?.command;
+  if (typeof command !== 'string') return [];
+  const out = [];
+  for (const match of command.matchAll(
+    /^\*\*\* (?:Add|Update|Delete) File:\s*(.+)$/gm
+  )) {
+    const candidate = match[1].trim().replace(/^['"]|['"]$/g, '');
+    // Bounded: one patch naming a thousand files must not append a thousand
+    // queue records on a hook path.
+    if (candidate && out.length < 20) out.push(candidate);
+  }
+  return out;
+}
+
+/**
+ * Everything a completed mutation left behind that is worth queueing.
+ *
+ * TWO GRADES OF EVIDENCE, and the distinction is the point:
+ *
+ *   { path, before, after }  a reconstructable edit. The drain builds a real
+ *                            diff and marks only the symbols that moved.
+ *   { path }                 a whole-file write, or a patch program. No before
+ *                            side exists anywhere in the payload, so the drain
+ *                            compares stored hashes against disk instead.
+ *
+ * The second grade is what closes the biggest hole. A whole-file write is the
+ * commonest write shape there is, and before it was added those writes fell
+ * through to a lazy path that CANNOT see the session's own writes at all --
+ * `indexFile` refreshes the anchor before the lazy check ever looks at it. They
+ * were uncovered, not degraded.
+ *
+ * Returns an array, because one apply_patch program changes several files.
+ */
+export function observedWrites(payload, raw) {
+  if (!MUTATING.has(String(payload?.tool_name || ''))) return [];
 
   const path = writtenPath(payload, raw);
-  if (!path) return null;
+  if (path) {
+    // The expensive branch is guarded: reading the file only pays off when the
+    // payload can actually yield a before side.
+    if (hasEditEvidence(payload, raw)) {
+      const after = afterText(path);
+      if (after !== null && after.length <= MAX_SIDE_CHARS) {
+        const before = beforeText(payload, raw, after);
+        // Identical bytes: a formatter no-op, or a rewrite of the same content.
+        // Nothing changed, so nothing is stale.
+        if (before === after) return [];
+        if (before !== null && before.length <= MAX_SIDE_CHARS)
+          return [{ path, before, after }];
+      }
+    }
+    // Hash grade. Deliberately NOT `{ path, before: '', after }`: an empty
+    // before side makes every symbol in the file look changed, and the eager
+    // mark is a stored flag no later check ever clears.
+    return [{ path }];
+  }
 
-  const after = afterText(path);
-  if (after === null || after.length > MAX_SIDE_CHARS) return null;
-
-  const before = beforeText(payload, raw, after);
-  if (before === null || before.length > MAX_SIDE_CHARS) return null;
-  // Nothing changed: a formatter no-op, or a write of identical bytes. Queuing
-  // it would mark findings stale against an empty diff.
-  if (before === after) return null;
-
-  return { path, before, after };
+  // Codex and code-mode clients carry the whole patch as program text with no
+  // file_path field at all, which is why this recorded nothing for them. The
+  // hash grade needs only the path, so the patch headers are enough.
+  return patchTargets(payload).map((target) => ({ path: target }));
 }
 
 /**
@@ -226,9 +280,14 @@ export function observedWrite(payload, raw) {
 export function queueInvalidation(dir, { path, before, after, at } = {}) {
   try {
     if (typeof path !== 'string' || !path.trim()) return false;
-    if (typeof before !== 'string' || typeof after !== 'string') return false;
-    if (before.length > MAX_SIDE_CHARS || after.length > MAX_SIDE_CHARS)
-      return false;
+    // BOTH SIDES OR NEITHER. A record carrying only one of them cannot produce
+    // a diff and must not pretend to, so it is written as a path-only record
+    // and the drain resolves it by comparing hashes.
+    const diffable =
+      typeof before === 'string' &&
+      typeof after === 'string' &&
+      before.length <= MAX_SIDE_CHARS &&
+      after.length <= MAX_SIDE_CHARS;
 
     const file = queuePath(dir);
     try {
@@ -240,7 +299,11 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
     mkdirSync(dir, { recursive: true });
     appendFileSync(
       file,
-      `${JSON.stringify({ path: canonicalPath(path), before, after, at: at ?? Date.now() })}\n`,
+      `${JSON.stringify({
+        path: canonicalPath(path),
+        ...(diffable ? { before, after } : {}),
+        at: at ?? Date.now(),
+      })}\n`,
       'utf8'
     );
     return true;
@@ -284,16 +347,16 @@ export function drainInvalidations(dir, graph) {
   let marked = 0;
   for (const record of records) {
     if (!record || typeof record.path !== 'string' || !record.path) continue;
-    if (typeof record.before !== 'string' || typeof record.after !== 'string')
-      continue;
+    const diffable =
+      typeof record.before === 'string' && typeof record.after === 'string';
     try {
-      const result = invalidateOnWrite(
-        dir,
-        graph,
-        record.path,
-        record.before,
-        record.after
-      );
+      // TWO GRADES, ONE QUEUE. A record carrying both sides gets a real diff and
+      // symbol-precise marking; one carrying only a path gets the hash
+      // comparison -- the same comparison the lazy path makes, and one that is
+      // only meaningful HERE, before `indexFile` refreshes the anchor.
+      const result = diffable
+        ? invalidateOnWrite(dir, graph, record.path, record.before, record.after)
+        : invalidateChangedAnchors(dir, graph, record.path);
       marked += Array.isArray(result) ? result.length : 0;
     } catch {
       // One bad record must not stop the rest, and must not stop the tool call.

--- a/integrations/windsurf/hooks/lib/pending.mjs
+++ b/integrations/windsurf/hooks/lib/pending.mjs
@@ -1,0 +1,311 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/pending.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * The eager-invalidation queue: the missing half of staleness.mjs's header.
+ *
+ * That header describes TWO invalidation paths and says eager exists because
+ * lazy "would silently serve stale findings as fresh whenever a change came
+ * from outside the agent". `invalidateOnWrite` had been written, tested and
+ * documented -- and its only reference in shipped code was a COMMENT in the
+ * PreToolUse router. Staleness was lazy-only in production, and the router's
+ * own comment ("a write the hook observes is invalidated eagerly by
+ * `invalidateOnWrite`") described something that never happened.
+ *
+ * WHY THAT MATTERS MORE THAN IT SOUNDS. The lazy check compares the anchor's
+ * stored hash against disk -- and both the router and the adapter call
+ * `indexFile` on every file they observe, which re-points that hash at the new
+ * bytes. So for a write the session performed ITSELF, the lazy check is
+ * self-defeating: by the next retrieval the anchor already agrees with disk and
+ * the finding derived from the old content is served clean. Lazy catches the
+ * changes we never saw; only eager catches the ones we did.
+ *
+ * WHY A QUEUE AND NOT A DIRECT CALL. `invalidateOnWrite` needs the graph, and
+ * the graph is a megabyte of JSONL. Loading it on the return path of every
+ * write is the cost this shape exists to avoid. So the post-tool hook, which
+ * already holds the write's evidence, appends one record here and exits; the
+ * next graph read -- `forTouch`/`forCommand`, which load the graph anyway --
+ * drains it BEFORE serving anything.
+ *
+ * The guarantee is unchanged. What must never happen is SERVING a stale finding
+ * as fresh, and serve time is where that is enforced.
+ */
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { invalidateOnWrite } from './staleness.mjs';
+import { canonicalPath, isFsSafePath, resolvableCandidates } from './paths.mjs';
+
+const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
+
+/**
+ * Largest before/after side kept in a queue record.
+ *
+ * Matched to the graph's own snapshot limit for the same reason it has one: past
+ * this size the text is a bundle, a lockfile or a generated asset, and copying
+ * it into a queue file would mirror the repository into the graph directory one
+ * write at a time. Past the cap the write is simply not queued -- the lazy path
+ * still governs it, which is exactly the status quo for that file.
+ */
+const MAX_SIDE_CHARS = 262_144;
+
+/**
+ * Largest queue file appended to.
+ *
+ * A queue only grows while nothing drains it, which means the retrieval feature
+ * is off or every read has failed. Neither is a reason to keep writing: bounded
+ * here so a long unattended session cannot turn one directory into a log of
+ * every file it touched.
+ */
+const MAX_QUEUE_BYTES = 8 * 1024 * 1024;
+
+/** The tool payload fields that name the file a mutation landed on. */
+function writtenPath(payload, raw) {
+  const input = payload?.tool_input || {};
+  const response = raw?.tool_response || raw?.toolResponse || {};
+  for (const candidate of [
+    input.file_path,
+    input.path,
+    input.notebook_path,
+    response.filePath,
+    response.file_path,
+  ]) {
+    if (typeof candidate === 'string' && candidate.trim()) return candidate;
+  }
+  return null;
+}
+
+/** First string among several possible spellings of the same field. */
+function firstString(...values) {
+  for (const value of values) if (typeof value === 'string') return value;
+  return null;
+}
+
+/**
+ * The text before the write, reconstructed from a completed edit.
+ *
+ * PREFERENCE ORDER IS ABOUT EXACTNESS, not convenience. Claude Code's Edit
+ * response carries the whole pre-edit file (`originalFile`), which needs no
+ * reasoning at all. Failing that, an edit is a known substitution, so reverting
+ * `new_string` back to `old_string` in the post-write text reproduces the
+ * before side exactly -- but only when the substitution is unambiguous, which
+ * is why a `new_string` that now appears more than once is refused rather than
+ * guessed at.
+ *
+ * NULL MEANS "DO NOT QUEUE", and that is deliberate. An unknown before side
+ * could be passed as '' -- and `invalidateOnWrite` would then see every symbol
+ * in the file as changed and mark every finding anchored anywhere in it, which
+ * is the exact over-marking its own comments call worse than the file-level
+ * staleness symbols were introduced to avoid. A missed eager invalidation costs
+ * what today already costs; a wrong one permanently discounts correct findings.
+ */
+function beforeText(payload, raw, after) {
+  const input = payload?.tool_input || {};
+  const response = raw?.tool_response || raw?.toolResponse || {};
+
+  const original = firstString(
+    response.originalFile,
+    response.original_file,
+    response.originalContent,
+    response.original_content
+  );
+  if (original !== null) return original;
+
+  // MultiEdit applies its edits in order, so reverting walks them backwards.
+  const edits = Array.isArray(input.edits) ? input.edits : null;
+  if (edits) {
+    let text = after;
+    for (const edit of [...edits].reverse()) {
+      const reverted = revert(text, edit);
+      if (reverted === null) return null;
+      text = reverted;
+    }
+    return text;
+  }
+
+  return revert(after, input);
+}
+
+/** Undoes one old->new substitution, or null when it cannot be done exactly. */
+function revert(text, edit) {
+  const oldString = firstString(edit?.old_string, edit?.oldString);
+  const newString = firstString(edit?.new_string, edit?.newString);
+  if (oldString === null || newString === null || newString === '') return null;
+
+  const all = edit?.replace_all === true || edit?.replaceAll === true;
+  if (all) return text.split(newString).join(oldString);
+
+  const at = text.indexOf(newString);
+  if (at < 0) return null;
+  // Ambiguous: more than one candidate for the occurrence that was written, and
+  // reverting the wrong one fabricates a before side that never existed.
+  if (text.indexOf(newString, at + newString.length) >= 0) return null;
+  return text.slice(0, at) + oldString + text.slice(at + newString.length);
+}
+
+/** The post-write text, read from disk because that is what the write produced. */
+function afterText(path) {
+  if (!isFsSafePath(path)) return null;
+  for (const candidate of resolvableCandidates(path)) {
+    try {
+      if (statSync(candidate).size > MAX_SIDE_CHARS) return null;
+      return readFileSync(candidate, 'utf8');
+    } catch {
+      // Wrong spelling, or gone again already. Try the next one.
+    }
+  }
+  return null;
+}
+
+/**
+ * Does this payload carry enough to reconstruct a before side at all?
+ *
+ * Named tool lists were the alternative and were rejected: every client calls
+ * its editor something different (`Edit`, `replace`, `write_to_file`,
+ * `apply_patch`), and a list would silently exclude the ones nobody thought of
+ * while still charging a file read for every Read that matched by accident.
+ * Asking about the EVIDENCE instead covers any client that carries an edit in
+ * one of these shapes and costs nothing on the calls that do not.
+ */
+function hasEditEvidence(payload, raw) {
+  const input = payload?.tool_input || {};
+  const response = raw?.tool_response || raw?.toolResponse || {};
+  if (
+    firstString(
+      response.originalFile,
+      response.original_file,
+      response.originalContent,
+      response.original_content
+    ) !== null
+  )
+    return true;
+  if (Array.isArray(input.edits) && input.edits.length > 0) return true;
+  return firstString(input.old_string, input.oldString) !== null;
+}
+
+/**
+ * The evidence a completed mutation left behind, or null when there is none.
+ *
+ * Separate from `queueInvalidation` so the caller can be a hook branch that
+ * knows nothing about diffs, and so the reconstruction above is testable
+ * without a filesystem queue.
+ */
+export function observedWrite(payload, raw) {
+  // CHEAP CHECK FIRST, because this runs after every tool call on every client.
+  // Reading the file is the expensive part, and there is no point paying for it
+  // on a Read, a Bash or a write whose before side cannot be reconstructed.
+  if (!hasEditEvidence(payload, raw)) return null;
+
+  const path = writtenPath(payload, raw);
+  if (!path) return null;
+
+  const after = afterText(path);
+  if (after === null || after.length > MAX_SIDE_CHARS) return null;
+
+  const before = beforeText(payload, raw, after);
+  if (before === null || before.length > MAX_SIDE_CHARS) return null;
+  // Nothing changed: a formatter no-op, or a write of identical bytes. Queuing
+  // it would mark findings stale against an empty diff.
+  if (before === after) return null;
+
+  return { path, before, after };
+}
+
+/**
+ * Appends one pending write.
+ *
+ * NEVER THROWS. This runs on a hook's return path, and a queue that cannot be
+ * written degrades to the lazy path rather than costing the user a tool call.
+ */
+export function queueInvalidation(dir, { path, before, after, at } = {}) {
+  try {
+    if (typeof path !== 'string' || !path.trim()) return false;
+    if (typeof before !== 'string' || typeof after !== 'string') return false;
+    if (before.length > MAX_SIDE_CHARS || after.length > MAX_SIDE_CHARS)
+      return false;
+
+    const file = queuePath(dir);
+    try {
+      if (statSync(file).size > MAX_QUEUE_BYTES) return false;
+    } catch {
+      // No queue yet, which is the normal case.
+    }
+
+    mkdirSync(dir, { recursive: true });
+    appendFileSync(
+      file,
+      `${JSON.stringify({ path: canonicalPath(path), before, after, at: at ?? Date.now() })}\n`,
+      'utf8'
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Applies every queued invalidation and clears the queue.
+ *
+ * Returns the number of findings marked, so the caller knows whether its
+ * in-memory graph is now behind the file on disk and needs re-reading.
+ *
+ * CLEARED AFTER APPLYING AND UNCONDITIONALLY: a record that cannot be applied
+ * must not be retried on every tool call for the rest of the session, and the
+ * cost of dropping one is a single missed eager mark that the lazy path still
+ * has a chance at.
+ */
+export function drainInvalidations(dir, graph) {
+  let records;
+  try {
+    const file = queuePath(dir);
+    if (!existsSync(file)) return 0;
+    records = readFileSync(file, 'utf8')
+      .split('\n')
+      .filter((line) => line.trim())
+      .map((line) => {
+        try {
+          return JSON.parse(line);
+        } catch {
+          // A torn append costs one record, not the queue.
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch {
+    return 0;
+  }
+
+  let marked = 0;
+  for (const record of records) {
+    if (!record || typeof record.path !== 'string' || !record.path) continue;
+    if (typeof record.before !== 'string' || typeof record.after !== 'string')
+      continue;
+    try {
+      const result = invalidateOnWrite(
+        dir,
+        graph,
+        record.path,
+        record.before,
+        record.after
+      );
+      marked += Array.isArray(result) ? result.length : 0;
+    } catch {
+      // One bad record must not stop the rest, and must not stop the tool call.
+    }
+  }
+
+  try {
+    rmSync(queuePath(dir), { force: true });
+  } catch {
+    // Held open by a concurrent hook. The next drain re-applies these records,
+    // which is safe: marking an already-marked finding is idempotent.
+  }
+
+  return marked;
+}

--- a/integrations/windsurf/hooks/lib/pending.mjs
+++ b/integrations/windsurf/hooks/lib/pending.mjs
@@ -199,10 +199,11 @@ function hasEditEvidence(payload, raw) {
  * before this module is reached at all. So matching here is both complete for
  * every client the adapter serves and impossible to spell wrong.
  *
- * `NotebookEdit` is absent because `normalizeTool` maps it to null, and the MCP
- * `smart_edit`/`smart_write` tools are absent for the same reason. Both are gaps
- * in that alias table rather than in this file, and widening it changes routing
- * verdicts for every client -- so they are reported, not papered over here.
+ * `NotebookEdit` and the MCP `smart_edit`/`smart_write` tools were absent for as
+ * long as `normalizeTool` mapped them to null. That was a gap in the alias table
+ * rather than in this file, and it has since been closed there: all three now
+ * arrive as `Edit` or `Write` and are matched by the set below without it having
+ * to learn a fourth name.
  */
 const MUTATING = new Set(['Edit', 'MultiEdit', 'Write']);
 

--- a/integrations/windsurf/hooks/lib/pending.mjs
+++ b/integrations/windsurf/hooks/lib/pending.mjs
@@ -35,6 +35,7 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  renameSync,
   rmSync,
   statSync,
 } from 'node:fs';
@@ -43,6 +44,15 @@ import { invalidateChangedAnchors, invalidateOnWrite } from './staleness.mjs';
 import { canonicalPath, isFsSafePath, resolvableCandidates } from './paths.mjs';
 
 const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
+/**
+ * Where a drain moves the queue before reading it.
+ *
+ * PER PROCESS, not one shared name: two hooks draining the same graph directory
+ * at once would otherwise race for the same claim file, and the loser would
+ * either clobber the winner's records or delete them mid-read. A pid makes the
+ * claim private to the drainer that won the rename.
+ */
+const claimPath = (dir) => join(dir, `pending-invalidation.claim.${process.pid}.jsonl`);
 
 /**
  * Largest before/after side kept in a queue record.
@@ -319,17 +329,47 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
  * Returns the number of findings marked, so the caller knows whether its
  * in-memory graph is now behind the file on disk and needs re-reading.
  *
- * CLEARED AFTER APPLYING AND UNCONDITIONALLY: a record that cannot be applied
- * must not be retried on every tool call for the rest of the session, and the
- * cost of dropping one is a single missed eager mark that the lazy path still
- * has a chance at.
+ * CLAIMED BY RENAME, THEN READ, THEN DELETED -- and the order is the whole
+ * point. This used to read the queue and then `rmSync` the same path, so a
+ * post-tool hook appending between the read and the unlink had its record
+ * deleted having never been read. Parallel tool calls in one assistant turn are
+ * the ordinary way that happens, not an exotic race. `renameSync` makes the
+ * claim atomic: whatever the drainer took is exactly what it deletes, and a
+ * record appended a microsecond later lands on a fresh queue that the next drain
+ * will find.
+ *
+ * A LOST RECORD IS A PERMANENTLY MISSED INVALIDATION, which is why this is worth
+ * a rename. The comment here used to price it as "a single missed eager mark that
+ * the lazy path still has a chance at", and that premise is false: this module's
+ * own header states it. The lazy path compares the anchor's stored hash against
+ * disk, and `indexFile` re-points that hash at the bytes the session just wrote,
+ * so for the session's OWN writes lazy is structurally blind rather than merely
+ * late. Nothing else was ever going to catch a dropped record.
+ *
+ * A RECORD THAT CANNOT BE APPLIED IS STILL DROPPED, deliberately and
+ * unconditionally: retrying a permanently unapplicable record on every tool call
+ * for the rest of the session costs more than it can ever recover, and the claim
+ * file is deleted whether the loop marked anything or threw.
+ *
+ * FAIL-OPEN THROUGHOUT. A rename that loses a race, or fails for any other
+ * reason, returns 0 and leaves the queue for the next drain; it never throws
+ * into a hook.
  */
 export function drainInvalidations(dir, graph) {
   let records;
+  let claim;
   try {
     const file = queuePath(dir);
     if (!existsSync(file)) return 0;
-    records = readFileSync(file, 'utf8')
+    claim = claimPath(dir);
+    // A LEFTOVER CLAIM FROM A KILLED DRAIN IS OVERWRITTEN, not merged: rename
+    // onto an existing path replaces it. The pid in the name means the only way
+    // to hit that is this same pid having died mid-drain, whose records were
+    // already being applied when it went -- and re-applying is idempotent, so
+    // losing them is the cheaper of the two errors. Not doing the rename at all
+    // would strand the live queue forever.
+    renameSync(file, claim);
+    records = readFileSync(claim, 'utf8')
       .split('\n')
       .filter((line) => line.trim())
       .map((line) => {
@@ -342,6 +382,18 @@ export function drainInvalidations(dir, graph) {
       })
       .filter(Boolean);
   } catch {
+    // The rename lost a race, or the claim could not be read. Nothing is deleted
+    // unread and the hook proceeds. If the claim was taken and then could not be
+    // read, it is put back under the queue name so the next drain still sees it:
+    // a claim file nobody looks at again is the same lost record this rename
+    // exists to prevent.
+    try {
+      if (claim && existsSync(claim) && !existsSync(queuePath(dir))) {
+        renameSync(claim, queuePath(dir));
+      }
+    } catch {
+      // Best effort only. A hook must not fail because bookkeeping did.
+    }
     return 0;
   }
 
@@ -365,10 +417,13 @@ export function drainInvalidations(dir, graph) {
   }
 
   try {
-    rmSync(queuePath(dir), { force: true });
+    // THE CLAIM, NOT THE QUEUE. Deleting `queuePath` here is what dropped a
+    // concurrently appended record; this path holds exactly the bytes that were
+    // just read, so nothing unread can be inside it.
+    rmSync(claim, { force: true });
   } catch {
-    // Held open by a concurrent hook. The next drain re-applies these records,
-    // which is safe: marking an already-marked finding is idempotent.
+    // Held open by something else. The claim is not read again -- the next drain
+    // looks at the queue -- so this costs a stray file, never a record.
   }
 
   return marked;

--- a/integrations/windsurf/hooks/lib/restore.mjs
+++ b/integrations/windsurf/hooks/lib/restore.mjs
@@ -142,7 +142,7 @@ export function restorationPlan(dir, graph, context = {}) {
     for (const id of predicted) {
       const node = graph.nodes.get(id);
       if (!node) continue;
-      const findings = serve(graph, findingsFor(graph, id, { limit: 2 }));
+      const findings = serve(graph, findingsFor(graph, id, { limit: 2 }), { dir });
       for (const finding of findings) {
         // `! STALE` only where a diff actually exists to back it; see the
         // renderer in inject.mjs for the measurement behind this.

--- a/integrations/windsurf/hooks/lib/restore.mjs
+++ b/integrations/windsurf/hooks/lib/restore.mjs
@@ -158,7 +158,16 @@ export function restorationPlan(dir, graph, context = {}) {
             ? '! STALE '
             : '~ '
           : '';
-        lines.push(`${node.key}: ${mark}${finding.claim}`);
+        // A DISPUTE DISCLOSED ELSEWHERE AND SILENT HERE reads as "the dispute
+        // went away". `serve` already attached the fields; the only question is
+        // the wording, and this list is the most compressed surface in the
+        // system, so it gets the marker and the key and nothing else.
+        const disputed = finding.contradicted
+          ? finding.contradictedBy
+            ? ` (disputed by ${finding.contradictedBy})`
+            : ' (disputed)'
+          : '';
+        lines.push(`${node.key}: ${mark}${finding.claim}${disputed}`);
       }
     }
     section('Likely next', lines, total * split.forward);

--- a/integrations/windsurf/hooks/lib/skeleton.mjs
+++ b/integrations/windsurf/hooks/lib/skeleton.mjs
@@ -126,6 +126,11 @@ export function annotatedSkeleton(graph, rawPath, source, { budget = 1200, git =
 
   // Findings anchored to this file or the symbols inside it, served through the
   // one function that enforces the stale-plus-diff rule.
+  // READ-ONLY serve: no `dir` is threaded here, so this cannot clear a stale
+  // flag whose evidence is gone. That is deliberate -- this function takes a
+  // graph, not the directory it came from, and widening its signature to give
+  // an analysis path a write capability buys nothing: the injection path runs
+  // on every tool call and clears the same findings.
   const served = serve(graph, findingsFor(graph, nodeId('file', path), { limit: 40 }));
 
   // Index findings by the symbol they anchor to, so each one sits beside the

--- a/integrations/windsurf/hooks/lib/staleness.mjs
+++ b/integrations/windsurf/hooks/lib/staleness.mjs
@@ -31,6 +31,23 @@
  * Eager alone would silently serve stale findings as fresh whenever a change
  * came from outside the agent, which is the single failure mode the design
  * calls worse than no graph.
+ *
+ * AND LAZY ALONE IS BLIND TO THE AGENT'S OWN WRITES -- not degraded, BLIND.
+ * `indexFile` re-points an anchor's stored hash at the bytes it was just handed,
+ * and it is called on every file either hook observes: pretooluse-router.mjs
+ * (two call sites) and adapter.mjs (one). The lazy check then compares that
+ * refreshed hash against the same disk it came from and finds them equal. So
+ * for a file the session edited ITSELF, the lazy path cannot detect the change
+ * at all, and the finding derived from the pre-edit content is served CLEAN.
+ *
+ * Which means that until the eager path was connected, staleness for a file the
+ * agent edited did not work AT ALL: eager was dead code and lazy was defeated
+ * by re-indexing. Every account of this defect, including the one in this
+ * module's own git history, called it "lazy-only, therefore degraded". It was
+ * not degraded. `stale-before-reindex.test.mjs` states in its header that this
+ * case is covered by `invalidateOnWrite`, and `invalidateOnWrite` had never run
+ * once in production. The two paths are not redundant and never were: each is
+ * the ONLY cover for a whole class of change.
  */
 
 import { readFileSync, statSync } from 'node:fs';
@@ -622,6 +639,119 @@ export function invalidateOnWrite(dir, graph, rawPath, beforeText, afterText) {
   // Re-index so the anchors carry the new hashes; otherwise the lazy path would
   // report the same change again on every future retrieval.
   indexFile(dir, path, afterText);
+  return marked;
+}
+
+/**
+ * The eager path for a write with NO before/after pair: compare stored hashes
+ * against disk, and mark what actually moved.
+ *
+ * WHY THIS EXISTS AS A SECOND SHAPE. A whole-file `Write` replaces the file, so
+ * the payload carries the after side and nothing at all of the before -- and a
+ * whole-file write is the commonest write shape there is. `invalidateOnWrite`
+ * cannot serve it: passing '' as the before side makes every symbol in the file
+ * look changed, marks every finding anchored anywhere in it, and the eager mark
+ * is a stored flag no later check ever clears. False-stale is expensive and
+ * permanent, so it is not an acceptable price for coverage.
+ *
+ * But the hash comparison is available, and it is exactly the comparison the
+ * lazy path makes. The difference is WHEN: this runs at the top of injection,
+ * before `indexFile` refreshes the anchor, so the stored hash is still the
+ * pre-write one and the comparison is meaningful. That is the whole trick --
+ * lazy is not wrong, it is merely too late.
+ *
+ * SYMBOL-LEVEL, and from ONE read. Re-locating each symbol by name and
+ * comparing its own span hash is what keeps this from degenerating into
+ * file-level marking: editing one function must not stale a finding about
+ * another, which is the property symbol nodes exist to provide.
+ *
+ * WEAKER EVIDENCE, STATED AS SUCH. There is no before text, so no diff can be
+ * built -- the finding is marked with the two hashes and `serve` reports the
+ * evidence gap through `staleEvidence: false`, which the renderer turns into
+ * "no diff could be rebuilt" rather than promising a diff and showing nothing.
+ * A stale finding with weak evidence is far better than one served as fresh,
+ * but the reader has to be able to tell which one they are holding.
+ */
+export function invalidateChangedAnchors(dir, graph, rawPath) {
+  const path = canonicalPath(rawPath);
+  const marked = [];
+
+  // ONE read for the file and every symbol in it. checkAnchor would have been
+  // the obvious reuse and it reads per anchor, which on a file with fifty
+  // symbols is fifty-one reads of the same bytes on a hook path.
+  let source = null;
+  try {
+    source = readAnySpelling(path);
+  } catch {
+    // Deleted, or unreadable from this checkout. Handled below as a change,
+    // because a finding about a file that is no longer there is exactly the
+    // kind that must not be served as fresh.
+  }
+
+  const changed = [];
+  const fileNode = graph.nodes.get(nodeId('file', path));
+  const fileDigest = source === null ? null : hash(source);
+  if (fileNode && fileDigest !== fileNode.hash) {
+    changed.push({ node: fileNode, from: fileNode.hash, to: fileDigest });
+  }
+
+  const current = new Map(
+    source === null
+      ? []
+      : extractSymbols(path, source).map((s) => [s.name, hash(spanText(source, s))])
+  );
+  for (const node of graph.nodes.values()) {
+    if (node.kind !== 'symbol' || node.file !== path) continue;
+    const digest = current.has(node.name) ? current.get(node.name) : null;
+    if (digest !== node.hash) changed.push({ node, from: node.hash, to: digest });
+  }
+
+  if (changed.length) {
+    // Indexed once by target, for the reason invalidateOnWrite indexes: the
+    // nested alternative is O(nodes x edges) inside a hook.
+    const byTarget = new Map();
+    for (const edge of graph.edges) {
+      if (edge.edge !== 'derived_from') continue;
+      if (!byTarget.has(edge.to)) byTarget.set(edge.to, []);
+      byTarget.get(edge.to).push(edge);
+    }
+
+    for (const { node, from, to } of changed) {
+      for (const edge of byTarget.get(node.id) || []) {
+        const finding = graph.nodes.get(edge.from);
+        if (!finding || finding.kind !== 'finding') continue;
+        // The same type gate serve() applies, for the same reason it is applied
+        // in invalidateOnWrite: the flag is STORED, and disclose.mjs skips a
+        // stale finding while utility.mjs penalises one by 160.
+        if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) continue;
+        // ALREADY MARKED IS LEFT ALONE. Whatever marked it first had a diff or
+        // a more specific reason; overwriting that with a hash pair trades real
+        // evidence for less.
+        if (finding.stale) continue;
+
+        putNode(dir, {
+          ...finding,
+          kind: 'finding',
+          key: finding.key,
+          stale: true,
+          staleReason:
+            to === null
+              ? `the ${node.kind} it depends on is no longer present (was ${from})`
+              : `content hash changed during this session (${from} -> ${to}), observed without a before/after pair`,
+          // EXPLICITLY EMPTY, not absent. serve() reports `staleEvidence` from
+          // whether a diff survived, and the renderer says "no diff could be
+          // rebuilt" -- so the reader can tell "changed, diff unknown" from
+          // "changed, here is what changed".
+          diff: '',
+        });
+        marked.push(finding.key);
+      }
+    }
+  }
+
+  // Re-index for the same reason the diff path does: otherwise every future
+  // retrieval re-reports a change that has already been accounted for.
+  if (source !== null) indexFile(dir, path, source);
   return marked;
 }
 

--- a/integrations/windsurf/hooks/lib/staleness.mjs
+++ b/integrations/windsurf/hooks/lib/staleness.mjs
@@ -574,8 +574,20 @@ function derivationCheck(graph, finding) {
  * This is the only function that should ever hand a finding to a model, because
  * it is the one that enforces the rule: a stale finding leaves here carrying
  * `stale: true` AND a diff, or it does not leave at all.
+ *
+ * AND IT CLEARS A STORED FLAG WHOSE EVIDENCE IS GONE, when given a `dir` to
+ * write to. Clearing used to be reachable only by a person pressing Re-verify in
+ * the dashboard, which left the rot path fully open on every install where
+ * nobody opens the dashboard -- and that is most of them. The evidence test is
+ * what makes clearing safe, and it does not care who triggered it: the same
+ * `claimTimeVerdict` runs here as in `reverify`, so this cannot clear anything
+ * the button would not.
+ *
+ * `dir` IS OPTIONAL, AND OMITTING IT MAKES THIS READ-ONLY. Several callers hold
+ * a graph without the directory it came from, and a serve that silently did
+ * nothing would be worse than one that plainly cannot write.
  */
-export function serve(graph, findings) {
+export function serve(graph, findings, { dir = null } = {}) {
   const served = [];
 
   // RETIRED FINDINGS STOP HERE, unconditionally.
@@ -603,8 +615,42 @@ export function serve(graph, findings) {
       continue;
     }
 
+    // AUTOMATIC CLEARING, on the same evidence the manual path demands.
+    //
+    // ONLY THE STORED FLAG IS TOUCHED. The lazy loop below is left to run
+    // exactly as before and can independently mark this finding stale again on
+    // its own comparison -- disk against the anchor NODE's hash -- which answers
+    // a different question and is not this function's to overrule. Eager and
+    // lazy stay two mechanisms, as the module header insists.
+    //
+    // AND THE FIELDS GO WITH THE FLAG. `putNode` does not merge and neither does
+    // this spread: serving `{ ...finding, stale: false }` would hand back a
+    // finding that reads fresh while still carrying `staleReason` and `diff`
+    // from the record -- stale and fresh at once, which is worse than either.
+    // So the cleared record, not the stored one, is what the rest of this
+    // iteration reads and spreads.
+    //
+    // BOUNDED, and the bound is the point: this runs only for a finding whose
+    // flag is already STORED, only when a `derivation` record exists to check
+    // against, and it reads each of that finding's anchors at most once. A
+    // finding that is not flagged pays nothing. The lazy loop below already
+    // reads every anchor of every content-dependent finding served, so the worst
+    // case is twice the anchor reads on the already-stale subset alone.
+    //
+    // NOT ON THE NON-CONTENT-DEPENDENT EARLY RETURN ABOVE, deliberately. Both
+    // eager paths refuse to flag those types at all, so a flag there can only
+    // come from an older graph -- and reading anchors for a type whose truth
+    // does not depend on them is exactly the cost `CONTENT_DEPENDENT` exists to
+    // avoid.
+    let record = finding;
+    if (dir && finding.stale && claimTimeVerdict(graph, finding) === 'match') {
+      clearStale(dir, finding.key, { graph });
+      const { stale: _s, staleReason: _r, diff: _d, staleEvidence: _e, ...cleared } = finding;
+      record = cleared;
+    }
+
     const anchors = graph.edges
-      .filter((e) => e.edge === 'derived_from' && e.from === finding.id)
+      .filter((e) => e.edge === 'derived_from' && e.from === record.id)
       .map((e) => graph.nodes.get(e.to))
       .filter(Boolean);
 
@@ -629,10 +675,10 @@ export function serve(graph, findings) {
     // A finding already marked stale eagerly, whose diff was captured at write
     // time, keeps that diff -- the eager path saw the change we can no longer
     // reconstruct from disk alone.
-    if (!stale && finding.stale) {
+    if (!stale && record.stale) {
       stale = true;
-      diff = finding.diff || '';
-      reason = finding.staleReason || 'marked stale when the change was observed';
+      diff = record.diff || '';
+      reason = record.staleReason || 'marked stale when the change was observed';
     }
 
     if (stale && !diff) {
@@ -681,13 +727,19 @@ export function serve(graph, findings) {
     }
 
     served.push({
-      ...finding,
+      ...record,
       stale,
       ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
+      // BOTH OTHER DISCLOSURES SURVIVE A MID-SERVE CLEAR. `dispute` was computed
+      // above the content-dependence branch and is applied here untouched, and
+      // the derivation verdict is recomputed from the record -- which still
+      // carries its `derivation`, since clearing removes only the staleness
+      // fields. A finding whose flag was just cleared is still disclosed as
+      // disputed, and still reports whether its derivation holds.
       ...dispute,
       // Independent of `stale` above: see `derivationCheck`'s own comment for
       // the case it catches that node-level staleness can miss.
-      ...derivationCheck(graph, finding),
+      ...derivationCheck(graph, record),
     });
   }
   return served;
@@ -939,8 +991,21 @@ function anchorHashNow(anchor) {
  * Exposing it to a hook, a tool argument or an HTTP action would be a way to
  * turn a stale finding fresh on request, which is exactly what must not exist.
  */
-export function clearStale(dir, key) {
-  const node = load(dir).nodes.get(nodeId('finding', key));
+export function clearStale(dir, key, { graph = null } = {}) {
+  // A CALLER THAT ALREADY HOLDS THE GRAPH PASSES IT, and this is not
+  // micro-optimisation: `load` re-parses the entire append-only log, so clearing
+  // inside `serve`'s loop re-read and re-folded the whole graph once PER cleared
+  // finding. Measured on 40 findings all stale and all revertible -- the shape a
+  // mass revert produces -- that was 185 ms against 25 ms, a 7x regression on
+  // the injection path, all of it graph loading rather than the hashing this
+  // feature is actually for. With the graph passed through it is back in line.
+  //
+  // No new race: this store is last-write-wins with no compare-and-set anywhere,
+  // and every other caller that spreads a node back -- `pin`, `retire`,
+  // `contradict`, `correct` -- writes from a graph it loaded earlier too. Both
+  // callers here already DECIDED on this snapshot, so re-reading it purely for
+  // the write narrowed no window that was ever closed.
+  const node = (graph || load(dir)).nodes.get(nodeId('finding', key));
   if (!node || node.kind !== 'finding') return false;
   const { stale, staleReason, diff, staleEvidence, ...rest } = node;
   // Nothing to clear is a success, not a write: an unconditional putNode here
@@ -989,14 +1054,33 @@ export function clearStale(dir, key) {
  * silently un-mark findings nobody asked about. Staleness is disclosed to a
  * reader who then decides; clearing is an explicit act.
  */
-export function reverify(dir, key) {
-  const graph = load(dir);
-  const finding = graph.nodes.get(nodeId('finding', key));
-  if (!finding || finding.kind !== 'finding') return 'unknown';
-  // Idempotent: the postcondition -- no stale flag on this finding -- already
-  // holds, and reporting anything else would make a caller retry forever.
-  if (!finding.stale) return 'cleared';
-
+/**
+ * THE ONE EVIDENCE TEST. Does this finding's anchored content still hash to what
+ * the claim was actually made against?
+ *
+ * `'match'` -- every anchor on disk re-hashes to the value frozen into this
+ * finding's own `derivation.anchors` at claim time. The content IS what the
+ * claim was derived from: a revert, or a write that never moved the anchored
+ * bytes.
+ * `'differs'` -- at least one anchor does not, INCLUDING an anchor whose content
+ * is gone. Deleted is a difference, not a missing measurement.
+ * `'unknown'` -- there is nothing to compare: no `derivation.anchors`, no
+ * anchors, an anchor with no recorded hash, or one that no longer resolves.
+ *
+ * SHARED BY BOTH CLEARING PATHS ON PURPOSE, and that sharing is the guarantee
+ * rather than a convenience. `reverify` (a person pressing Re-verify) and
+ * `serve` (automatic, on every retrieval) call THIS function and nothing else,
+ * so the automatic path cannot clear anything the button would not, and neither
+ * can drift from the other. Two copies of this comparison would be two policies,
+ * and the weaker one would win wherever it ran more often -- which is the
+ * automatic one.
+ *
+ * NOT `checkAnchor`, for the reason `anchorHashNow` above spells out: that
+ * compares disk against the anchor NODE's stored hash, which both eager paths
+ * re-point at the very bytes that caused the mark, so it answers "fresh" for
+ * exactly the finding it just marked stale.
+ */
+function claimTimeVerdict(graph, finding) {
   const recorded = finding.derivation && finding.derivation.anchors;
   if (!recorded || typeof recorded !== 'object') return 'unknown';
 
@@ -1019,10 +1103,23 @@ export function reverify(dir, key) {
     if (node.kind !== 'file' && node.kind !== 'symbol') return 'unknown';
     // null means the content is gone -- deleted file, vanished symbol. That is a
     // difference, not an absence of evidence.
-    if (anchorHashNow(node) !== expected) return 'still-stale';
+    if (anchorHashNow(node) !== expected) return 'differs';
   }
+  return 'match';
+}
 
-  clearStale(dir, key);
+export function reverify(dir, key) {
+  const graph = load(dir);
+  const finding = graph.nodes.get(nodeId('finding', key));
+  if (!finding || finding.kind !== 'finding') return 'unknown';
+  // Idempotent: the postcondition -- no stale flag on this finding -- already
+  // holds, and reporting anything else would make a caller retry forever.
+  if (!finding.stale) return 'cleared';
+
+  const verdict = claimTimeVerdict(graph, finding);
+  if (verdict === 'unknown') return 'unknown';
+  if (verdict === 'differs') return 'still-stale';
+  clearStale(dir, key, { graph });
   return 'cleared';
 }
 

--- a/integrations/windsurf/hooks/lib/staleness.mjs
+++ b/integrations/windsurf/hooks/lib/staleness.mjs
@@ -53,7 +53,7 @@
 import { readFileSync, statSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { dirname, join } from 'node:path';
-import { putNode, putEdge, contentHash, nodeId } from './wiki.mjs';
+import { putNode, putEdge, contentHash, nodeId, load } from './wiki.mjs';
 import { hasOutstandingContradiction } from './curate.mjs';
 import { extractSymbols, spanText, symbolKey, extractImports } from './symbols.mjs';
 import { canonicalPath, resolvableCandidates, isFsSafePath } from './paths.mjs';
@@ -488,7 +488,16 @@ function disputeOf(graph, finding) {
     // An edge end that resolves to nothing names nothing. The dispute is still
     // disclosed -- the gate above already established it -- but without a key
     // the reader cannot be pointed anywhere, and inventing one would be worse.
-    if (other && typeof other.key === 'string' && !keys.includes(other.key)) keys.push(other.key);
+    //
+    // A RETIRED END IS NOT NAMED EITHER, for a sharper reason: the disclosure
+    // tells the reader to `wiki_query` that key, and `serve` refuses to return
+    // a retired finding at all. Naming it points them at a claim they cannot
+    // fetch. `hasOutstandingContradiction` above already declines to open the
+    // gate when EVERY disputant is retired; this is the same rule applied to
+    // each name, so a live disputant is still reported alongside a withdrawn one.
+    if (other && !other.retired && typeof other.key === 'string' && !keys.includes(other.key)) {
+      keys.push(other.key);
+    }
   }
 
   return { contradicted: true, ...(keys.length ? { contradictedBy: keys.join(', ') } : {}) };
@@ -870,6 +879,151 @@ export function invalidateChangedAnchors(dir, graph, rawPath) {
   // retrieval re-reports a change that has already been accounted for.
   if (source !== null) indexFile(dir, path, source);
   return marked;
+}
+
+/**
+ * The current content hash of an anchor, read from disk.
+ *
+ * DELIBERATELY NOT `checkAnchor`, and the difference is the whole of this
+ * clearing rule. `checkAnchor` compares disk against the anchor NODE's stored
+ * hash, and both eager paths call `indexFile` immediately after marking --
+ * which re-points that hash at the very bytes that caused the mark. So
+ * `checkAnchor` answers "fresh" for exactly the finding it just marked stale,
+ * and a clearing rule built on it would clear every flag it was handed,
+ * unconditionally. This returns a bare hash instead, so the caller can compare
+ * it against the FROZEN claim-time hash rather than against a value the marking
+ * path itself moved.
+ *
+ * Returns null when no content can be read at all -- a deleted file, or a
+ * symbol that no longer exists. A caller must treat that as "changed", never as
+ * "unknown": a claim about content that is gone certainly does not match the
+ * content it was made against.
+ */
+function anchorHashNow(anchor) {
+  const path = anchor.kind === 'symbol' ? anchor.file : anchor.key;
+  let source;
+  try {
+    source = readAnySpelling(path);
+  } catch {
+    return null;
+  }
+  if (anchor.kind !== 'symbol') return hash(source);
+
+  // By NAME, like checkAnchor: line numbers shift whenever anything above is
+  // edited, and re-locating by line would report a symbol as moved when only an
+  // unrelated insert happened above it.
+  const current = extractSymbols(path, source).find((s) => s.name === anchor.name);
+  if (!current) return null;
+  return hash(spanText(source, current));
+}
+
+/**
+ * Removes the staleness fields from a finding. Returns whether one was found.
+ *
+ * THE WHOLE NODE IS REWRITTEN, because `putNode` does not merge: it writes a
+ * full record from what it is handed and `load` replaces the node wholesale.
+ * Writing `{ kind, key, stale: false }` would blank the claim, the confidence
+ * and the provenance -- an overwrite by another name, and the same trap
+ * `contradict` documents. So the fields are destructured AWAY and everything
+ * else is spread back: no deletion primitive is needed, and the append-only rule
+ * is respected.
+ *
+ * `staleEvidence` is stripped as well, even though no writer stores it. It is
+ * added by `serve` to the object it hands out, so anything that ever writes a
+ * served finding back would carry it in -- at which point a cleared finding
+ * would still be advertising the quality of the evidence for a flag it no longer
+ * has.
+ *
+ * A PRIMITIVE, NOT A ROUTE. Nothing outside this module calls it: the only
+ * shipping caller is `reverify` below, which establishes the evidence first.
+ * Exposing it to a hook, a tool argument or an HTTP action would be a way to
+ * turn a stale finding fresh on request, which is exactly what must not exist.
+ */
+export function clearStale(dir, key) {
+  const node = load(dir).nodes.get(nodeId('finding', key));
+  if (!node || node.kind !== 'finding') return false;
+  const { stale, staleReason, diff, staleEvidence, ...rest } = node;
+  // Nothing to clear is a success, not a write: an unconditional putNode here
+  // would append a duplicate record to the log on every no-op call.
+  if (stale === undefined && staleReason === undefined
+    && diff === undefined && staleEvidence === undefined) return true;
+  putNode(dir, { ...rest, kind: 'finding', key: node.key });
+  return true;
+}
+
+/**
+ * Clears a stale flag when, and only when, the evidence for it is gone.
+ *
+ * WHY THIS HAS TO EXIST. Nothing in this codebase ever cleared a `stale` flag.
+ * That was harmless while eager invalidation was dead code; it fires now, so
+ * every finding on an edited file becomes permanently stale -- and permanently
+ * discounted, since `disclose.mjs` skips a stale finding outright and
+ * `utility.mjs` penalises one by 160. The graph degrades toward all-stale, and
+ * the eager path is over-eager on top of that: `invalidateOnWrite` marks every
+ * finding anchored to a FILE node on any observed write to that file, whether or
+ * not the bytes moved.
+ *
+ * WHAT COUNTS AS EVIDENCE, AND WHY IT IS NOT NEGOTIABLE. The only trustworthy
+ * record of what a claim was made against is `derivation.anchors` -- the hash
+ * each anchor carried at the moment the finding was written, frozen into the
+ * finding itself by `harvest-write.mjs`. Disk is re-hashed here and compared
+ * against that. If every anchor matches, the content IS what the claim was
+ * derived from: a revert, or a write that never moved the anchored bytes. The
+ * flag comes off. Anything else leaves it exactly as it was.
+ *
+ * IT IS NOT A LAUNDERING ROUTE, and that is a property of the comparison rather
+ * than of who is allowed to call it. A caller cannot make a finding fresh by
+ * asking; they can only make it fresh by putting the content back. There is no
+ * argument, no force flag and no second path -- and `clearStale` above, the one
+ * function that clears without checking, has no caller but this one.
+ *
+ * NO RECORD MEANS UNKNOWN, NEVER CLEAR. A finding with no `derivation.anchors`
+ * -- every one written before that record existed, and every hand-curated one --
+ * has nothing to compare disk against. That is an absence of evidence, and
+ * resolving it to "clear it" would hand back the laundering route through the
+ * side door. It reports `unknown` and changes nothing; re-recording the claim
+ * against the current code (`curate.correct`) is the way forward for those.
+ *
+ * DELIBERATELY NOT AUTOMATIC. This reads every anchor off disk, so running it on
+ * the serve path would put N file reads inside injection -- and, worse, it would
+ * silently un-mark findings nobody asked about. Staleness is disclosed to a
+ * reader who then decides; clearing is an explicit act.
+ */
+export function reverify(dir, key) {
+  const graph = load(dir);
+  const finding = graph.nodes.get(nodeId('finding', key));
+  if (!finding || finding.kind !== 'finding') return 'unknown';
+  // Idempotent: the postcondition -- no stale flag on this finding -- already
+  // holds, and reporting anything else would make a caller retry forever.
+  if (!finding.stale) return 'cleared';
+
+  const recorded = finding.derivation && finding.derivation.anchors;
+  if (!recorded || typeof recorded !== 'object') return 'unknown';
+
+  const anchorIds = new Set(
+    graph.edges
+      .filter((e) => e.edge === 'derived_from' && e.from === finding.id)
+      .map((e) => e.to)
+  );
+  // An unanchored finding cannot be checked against anything, which is the
+  // un-invalidatable shape the anchor discipline exists to refuse. It is equally
+  // un-VERIFIABLE, so it is reported as such rather than cleared.
+  if (!anchorIds.size) return 'unknown';
+
+  for (const id of anchorIds) {
+    const expected = recorded[id];
+    const node = graph.nodes.get(id);
+    // An anchor this finding never recorded a hash for, or one that no longer
+    // resolves to a node: nothing to compare, so nothing is concluded.
+    if (typeof expected !== 'string' || !expected || !node) return 'unknown';
+    if (node.kind !== 'file' && node.kind !== 'symbol') return 'unknown';
+    // null means the content is gone -- deleted file, vanished symbol. That is a
+    // difference, not an absence of evidence.
+    if (anchorHashNow(node) !== expected) return 'still-stale';
+  }
+
+  clearStale(dir, key);
+  return 'cleared';
 }
 
 export { contentHash };

--- a/integrations/windsurf/hooks/lib/staleness.mjs
+++ b/integrations/windsurf/hooks/lib/staleness.mjs
@@ -368,6 +368,12 @@ const DIFF_MAX_BYTES = () => {
  * line, and total bytes. Every truncation is announced in the output, because a
  * silently shortened diff is worse than a visibly shortened one -- a reader who
  * cannot tell content was elided believes they saw the whole change.
+ *
+ * `maxLines` BOUNDS THE BODY, MARKERS INCLUDED: at most `maxLines` lines of
+ * removed lines, added lines and "... N more" elision markers between them, plus
+ * at most one final notice when the byte cap dropped lines -- so `maxLines + 1`
+ * lines in total, and no more. That last line is outside the budget on purpose,
+ * for the reason stated where it is pushed.
  */
 export function diffLines(
   before,
@@ -418,10 +424,24 @@ export function diffLines(
     bytes += size;
   };
 
-  for (const line of removed.slice(0, maxLines / 2)) push('- ' + line);
-  if (removed.length > maxLines / 2) push(`  ... ${removed.length - maxLines / 2} more removed`);
-  for (const line of added.slice(0, maxLines / 2)) push('+ ' + line);
-  if (added.length > maxLines / 2) push(`  ... ${added.length - maxLines / 2} more added`);
+  // THE ELISION MARKER IS PAID FOR OUT OF THE SIDE'S OWN QUOTA, so `maxLines`
+  // bounds the whole body rather than only the content in it. It did not: at the
+  // default 40 the body could reach 42 lines -- 20 removed, 20 added and two
+  // "... N more" markers -- and the out-of-budget notice below made 43, against
+  // a documented bound of 40 and a test asserting 41. Three numbers, no two the
+  // same. A side that has to elide now shows one fewer content line and spends
+  // that line on saying so, which is the trade a reader wants anyway: knowing
+  // that 300 lines were cut matters more than the 20th of the 20 shown.
+  const half = Math.floor(maxLines / 2);
+  const emit = (lines, prefix, label) => {
+    const elides = lines.length > half;
+    const shown = elides ? Math.max(0, half - 1) : half;
+    for (const line of lines.slice(0, shown)) push(prefix + line);
+    if (elides) push(`  ... ${lines.length - shown} more ${label}`);
+  };
+
+  emit(removed, '- ', 'removed');
+  emit(added, '+ ', 'added');
 
   // Announced OUTSIDE the budget, deliberately: the one line a reader most
   // needs is the one saying the rest is missing, and dropping it to stay under
@@ -479,6 +499,15 @@ function disputeOf(graph, finding) {
   if (!hasOutstandingContradiction(graph, finding.key)) return {};
 
   const keys = [];
+  // AND THE REASON A PERSON TYPED, which had no reader anywhere. `contradict`
+  // stores `contradictionReason` -- up to 400 characters of human explanation --
+  // on the CONTRADICTED end only, and nothing outside its own test ever read it:
+  // this disclosure named the other key and stopped, `audit` counts ends, and the
+  // dashboard detail view renders neither. So the one field on the edge that says
+  // WHY was written on every contradiction and seen by nobody. It is collected
+  // from whichever end holds it, so both sides of a dispute disclose the same
+  // reason rather than only the claim that lost.
+  let reason = typeof finding.contradictionReason === 'string' ? finding.contradictionReason : '';
   for (const edge of graph.edges) {
     if (edge.edge !== 'contradicts') continue;
     const otherId =
@@ -497,10 +526,30 @@ function disputeOf(graph, finding) {
     // each name, so a live disputant is still reported alongside a withdrawn one.
     if (other && !other.retired && typeof other.key === 'string' && !keys.includes(other.key)) {
       keys.push(other.key);
+      // A RETIRED END'S REASON IS NOT BORROWED EITHER, which is why this sits
+      // inside the same guard as the key: `hasOutstandingContradiction` can be
+      // open on one live disputant while another is withdrawn, and quoting the
+      // withdrawn one's explanation would attribute the live dispute to a claim
+      // the reader cannot fetch.
+      if (!reason && typeof other.contradictionReason === 'string') {
+        reason = other.contradictionReason;
+      }
     }
   }
 
-  return { contradicted: true, ...(keys.length ? { contradictedBy: keys.join(', ') } : {}) };
+  return {
+    contradicted: true,
+    ...(keys.length ? { contradictedBy: keys.join(', ') } : {}),
+    // Trimmed here rather than at the renderer: an empty string is not a reason,
+    // and a consumer checking `if (reason)` should not have to trim first.
+    //
+    // SET UNCONDITIONALLY, INCLUDING TO `undefined`. `serve` spreads the stored
+    // record before this object, so omitting the key would let a whitespace-only
+    // stored reason through untouched and make the served value differ from the
+    // one this function decided on. The disclosure is authoritative or it is not
+    // a disclosure.
+    contradictionReason: reason.trim() || undefined,
+  };
 }
 
 /**
@@ -580,8 +629,15 @@ function derivationCheck(graph, finding) {
  * the dashboard, which left the rot path fully open on every install where
  * nobody opens the dashboard -- and that is most of them. The evidence test is
  * what makes clearing safe, and it does not care who triggered it: the same
- * `claimTimeVerdict` runs here as in `reverify`, so this cannot clear anything
+ * `claimTimeEvidence` runs here as in `reverify`, so this cannot clear anything
  * the button would not.
+ *
+ * A CLEAR ALSO RE-INDEXES THE ANCHORS IT VERIFIED. The three disclosures this
+ * function emits -- `stale`, `derivationHolds`, and the dispute -- are computed
+ * from three different comparisons, and clearing the flag without moving the
+ * anchor's stored hash made the first two contradict the clear on the revert
+ * path. `reindexVerifiedAnchors` explains the reproduction and why re-pointing
+ * the index is the fix rather than suppressing the disclosures.
  *
  * `dir` IS OPTIONAL, AND OMITTING IT MAKES THIS READ-ONLY. Several callers hold
  * a graph without the directory it came from, and a serve that silently did
@@ -617,11 +673,17 @@ export function serve(graph, findings, { dir = null } = {}) {
 
     // AUTOMATIC CLEARING, on the same evidence the manual path demands.
     //
-    // ONLY THE STORED FLAG IS TOUCHED. The lazy loop below is left to run
-    // exactly as before and can independently mark this finding stale again on
-    // its own comparison -- disk against the anchor NODE's hash -- which answers
-    // a different question and is not this function's to overrule. Eager and
-    // lazy stay two mechanisms, as the module header insists.
+    // THE FLAG AND THE INDEX MOVE TOGETHER. Clearing the flag alone made this
+    // function contradict itself on the revert path: the lazy loop below
+    // compares disk against the anchor NODE's hash, which the eager path
+    // re-pointed at the post-edit bytes, so a reverted file read as `stale:
+    // true, staleReason: 'file changed'` and `derivationHolds: false` inside the
+    // very object whose flag had just been cleared for matching its claim-time
+    // content. `reindexVerifiedAnchors` writes the verified bytes' hash back to
+    // the anchor, so all three disclosures are finally reading the same content
+    // and cannot disagree. Eager and lazy stay two mechanisms, as the module
+    // header insists -- what changed is that the index no longer holds a hash
+    // that matches no version of the file that exists.
     //
     // AND THE FIELDS GO WITH THE FLAG. `putNode` does not merge and neither does
     // this spread: serving `{ ...finding, stale: false }` would hand back a
@@ -630,12 +692,37 @@ export function serve(graph, findings, { dir = null } = {}) {
     // So the cleared record, not the stored one, is what the rest of this
     // iteration reads and spreads.
     //
-    // BOUNDED, and the bound is the point: this runs only for a finding whose
-    // flag is already STORED, only when a `derivation` record exists to check
-    // against, and it reads each of that finding's anchors at most once. A
-    // finding that is not flagged pays nothing. The lazy loop below already
+    // BOUNDED PER CALL, and the bound is the point: this runs only for a finding
+    // whose flag is already STORED, only when a `derivation` record exists to
+    // check against, and it reads each of that finding's anchors at most once.
+    // A finding that is not flagged pays nothing. The lazy loop below already
     // reads every anchor of every content-dependent finding served, so the worst
     // case is twice the anchor reads on the already-stale subset alone.
+    //
+    // AND THE PER-SESSION SHAPE, stated because the per-call bound alone reads
+    // as cheaper than it is. Measured on a synthetic 40-stale-finding graph, the
+    // serve path went 158 ms -> 217 ms (+37%), and for a GENUINELY stale finding
+    // that cost recurs on every call for the whole session: the verdict is
+    // `'differs'` forever, nothing is cleared, and the reads are repaid with
+    // nothing. What keeps it survivable in practice is not this bound but two
+    // others -- `findingsFor`'s result limit and inject.mjs's `alreadyInjected`
+    // gate, which together put it near 40 ms on the first touch of a hot file
+    // and zero on the touches after.
+    //
+    // THE REVERT CASE PAYS ONCE, AND THAT IS MEASURED, not argued. Same 40
+    // findings, all revertible, medians of 9 across three process launches: the
+    // read-only serve is 23-29 ms, the first clearing serve is 141-173 ms (the
+    // anchor reads plus one node append per cleared finding AND per re-pointed
+    // anchor), and the SECOND clearing serve is 21-28 ms -- back to the
+    // read-only baseline, because the flag is off and the index agrees, so this
+    // gate no longer fires. What the re-index changed is not that cost -- the
+    // gate stopped firing once the flag came off before, too -- but that every
+    // serve after the clear used to re-derive `stale: true` and
+    // `derivationHolds: false` from an index nobody had moved. The extra ~120 ms
+    // buys silence that is actually correct.
+    // On the genuinely-stale set the recurring cost is
+    // real and unchanged in kind: 26-45 ms read-only against 53-105 ms with
+    // clearing on, every call, clearing nothing.
     //
     // NOT ON THE NON-CONTENT-DEPENDENT EARLY RETURN ABOVE, deliberately. Both
     // eager paths refuse to flag those types at all, so a flag there can only
@@ -643,10 +730,14 @@ export function serve(graph, findings, { dir = null } = {}) {
     // does not depend on them is exactly the cost `CONTENT_DEPENDENT` exists to
     // avoid.
     let record = finding;
-    if (dir && finding.stale && claimTimeVerdict(graph, finding) === 'match') {
-      clearStale(dir, finding.key, { graph });
-      const { stale: _s, staleReason: _r, diff: _d, staleEvidence: _e, ...cleared } = finding;
-      record = cleared;
+    if (dir && finding.stale) {
+      const evidence = claimTimeEvidence(graph, finding);
+      if (evidence.verdict === 'match') {
+        reindexVerifiedAnchors(dir, graph, evidence.contents);
+        clearStale(dir, finding.key, { graph });
+        const { stale: _s, staleReason: _r, diff: _d, staleEvidence: _e, ...cleared } = finding;
+        record = cleared;
+      }
     }
 
     const anchors = graph.edges
@@ -736,6 +827,14 @@ export function serve(graph, findings, { dir = null } = {}) {
       // carries its `derivation`, since clearing removes only the staleness
       // fields. A finding whose flag was just cleared is still disclosed as
       // disputed, and still reports whether its derivation holds.
+      //
+      // AND THEY NO LONGER CONTRADICT THE CLEAR. Surviving is not the same as
+      // agreeing: for a whole serve this returned `stale: true, staleReason:
+      // 'file changed'` and `derivationHolds: false` on a finding it had just
+      // cleared, because the clear was decided against disk while these two read
+      // the anchor node's hash, and the eager path had moved it. All three now
+      // read the same content because the clear re-points the anchor; see
+      // `reindexVerifiedAnchors`.
       ...dispute,
       // Independent of `stale` above: see `derivationCheck`'s own comment for
       // the case it catches that node-level staleness can miss.
@@ -934,6 +1033,34 @@ export function invalidateChangedAnchors(dir, graph, rawPath) {
 }
 
 /**
+ * The current content of an anchor, read from disk: the whole file for a file
+ * anchor, the located span for a symbol one. Null when nothing can be read.
+ *
+ * SPLIT OUT FROM `anchorHashNow` SO THE BYTES SURVIVE THE COMPARISON. The
+ * clearing path hashes this to reach a verdict and, on `'match'`, re-indexes the
+ * anchor from the same bytes -- see `reindexVerifiedAnchors`. Returning only a
+ * hash forced a second read of a file that had just been read, for content
+ * already known to be identical.
+ */
+function anchorContentNow(anchor) {
+  const path = anchor.kind === 'symbol' ? anchor.file : anchor.key;
+  let source;
+  try {
+    source = readAnySpelling(path);
+  } catch {
+    return null;
+  }
+  if (anchor.kind !== 'symbol') return source;
+
+  // By NAME, like checkAnchor: line numbers shift whenever anything above is
+  // edited, and re-locating by line would report a symbol as moved when only an
+  // unrelated insert happened above it.
+  const current = extractSymbols(path, source).find((s) => s.name === anchor.name);
+  if (!current) return null;
+  return spanText(source, current);
+}
+
+/**
  * The current content hash of an anchor, read from disk.
  *
  * DELIBERATELY NOT `checkAnchor`, and the difference is the whole of this
@@ -952,21 +1079,8 @@ export function invalidateChangedAnchors(dir, graph, rawPath) {
  * content it was made against.
  */
 function anchorHashNow(anchor) {
-  const path = anchor.kind === 'symbol' ? anchor.file : anchor.key;
-  let source;
-  try {
-    source = readAnySpelling(path);
-  } catch {
-    return null;
-  }
-  if (anchor.kind !== 'symbol') return hash(source);
-
-  // By NAME, like checkAnchor: line numbers shift whenever anything above is
-  // edited, and re-locating by line would report a symbol as moved when only an
-  // unrelated insert happened above it.
-  const current = extractSymbols(path, source).find((s) => s.name === anchor.name);
-  if (!current) return null;
-  return hash(spanText(source, current));
+  const content = anchorContentNow(anchor);
+  return content === null ? null : hash(content);
 }
 
 /**
@@ -1005,21 +1119,51 @@ export function clearStale(dir, key, { graph = null } = {}) {
   // `contradict`, `correct` -- writes from a graph it loaded earlier too. Both
   // callers here already DECIDED on this snapshot, so re-reading it purely for
   // the write narrowed no window that was ever closed.
-  const node = (graph || load(dir)).nodes.get(nodeId('finding', key));
+  const id = nodeId('finding', key);
+  const node = (graph || load(dir)).nodes.get(id);
   if (!node || node.kind !== 'finding') return false;
   const { stale, staleReason, diff, staleEvidence, ...rest } = node;
   // Nothing to clear is a success, not a write: an unconditional putNode here
   // would append a duplicate record to the log on every no-op call.
   if (stale === undefined && staleReason === undefined
     && diff === undefined && staleEvidence === undefined) return true;
-  putNode(dir, { ...rest, kind: 'finding', key: node.key });
+  const cleared = { ...rest, kind: 'finding', key: node.key };
+  putNode(dir, cleared);
+  // AND THE CALLER'S GRAPH IS UPDATED, because the guard above reads THAT graph,
+  // not disk. Without this, a second `serve` on the same in-memory graph object
+  // -- two touched files anchored to one finding, or a lifecycle branch that
+  // serves twice from a graph it loaded once, as SessionStart does -- still saw
+  // `stale: true`, re-ran the evidence test, and appended a byte-identical clear
+  // record. The store is append-only, so that is permanent log growth for no
+  // change in state, and the "nothing to clear is a success, not a write"
+  // guarantee directly above was only true of the first call.
+  if (graph) graph.nodes.set(id, { ...cleared, id });
   return true;
 }
 
 /**
- * Clears a stale flag when, and only when, the evidence for it is gone.
+ * THE ONE EVIDENCE TEST, plus the bytes it read. Does this finding's anchored
+ * content still hash to what the claim was actually made against?
  *
- * WHY THIS HAS TO EXIST. Nothing in this codebase ever cleared a `stale` flag.
+ * `verdict` is one of:
+ *   `'match'`   -- every anchor on disk re-hashes to the value frozen into this
+ *                  finding's own `derivation.anchors` at claim time. The content
+ *                  IS what the claim was derived from: a revert, or a write that
+ *                  never moved the anchored bytes.
+ *   `'differs'` -- at least one anchor does not, INCLUDING an anchor whose
+ *                  content is gone. Deleted is a difference, not a missing
+ *                  measurement.
+ *   `'unknown'` -- there is nothing to compare: no `derivation.anchors`, no
+ *                  anchors, an anchor with no recorded hash, or one that no
+ *                  longer resolves.
+ *
+ * `contents` carries the disk bytes read to reach a `'match'`, keyed by anchor
+ * id, so the caller can re-index those anchors without reading them again. It is
+ * empty for the other two verdicts, which read no further than the first
+ * disagreement.
+ *
+ * WHY CLEARING HAS TO EXIST AT ALL. Nothing in this codebase ever cleared a
+ * `stale` flag.
  * That was harmless while eager invalidation was dead code; it fires now, so
  * every finding on an edited file becomes permanently stale -- and permanently
  * discounted, since `disclose.mjs` skips a stale finding outright and
@@ -1049,24 +1193,6 @@ export function clearStale(dir, key, { graph = null } = {}) {
  * side door. It reports `unknown` and changes nothing; re-recording the claim
  * against the current code (`curate.correct`) is the way forward for those.
  *
- * DELIBERATELY NOT AUTOMATIC. This reads every anchor off disk, so running it on
- * the serve path would put N file reads inside injection -- and, worse, it would
- * silently un-mark findings nobody asked about. Staleness is disclosed to a
- * reader who then decides; clearing is an explicit act.
- */
-/**
- * THE ONE EVIDENCE TEST. Does this finding's anchored content still hash to what
- * the claim was actually made against?
- *
- * `'match'` -- every anchor on disk re-hashes to the value frozen into this
- * finding's own `derivation.anchors` at claim time. The content IS what the
- * claim was derived from: a revert, or a write that never moved the anchored
- * bytes.
- * `'differs'` -- at least one anchor does not, INCLUDING an anchor whose content
- * is gone. Deleted is a difference, not a missing measurement.
- * `'unknown'` -- there is nothing to compare: no `derivation.anchors`, no
- * anchors, an anchor with no recorded hash, or one that no longer resolves.
- *
  * SHARED BY BOTH CLEARING PATHS ON PURPOSE, and that sharing is the guarantee
  * rather than a convenience. `reverify` (a person pressing Re-verify) and
  * `serve` (automatic, on every retrieval) call THIS function and nothing else,
@@ -1080,9 +1206,10 @@ export function clearStale(dir, key, { graph = null } = {}) {
  * re-point at the very bytes that caused the mark, so it answers "fresh" for
  * exactly the finding it just marked stale.
  */
-function claimTimeVerdict(graph, finding) {
+function claimTimeEvidence(graph, finding) {
+  const none = { verdict: 'unknown', contents: new Map() };
   const recorded = finding.derivation && finding.derivation.anchors;
-  if (!recorded || typeof recorded !== 'object') return 'unknown';
+  if (!recorded || typeof recorded !== 'object') return none;
 
   const anchorIds = new Set(
     graph.edges
@@ -1092,22 +1219,122 @@ function claimTimeVerdict(graph, finding) {
   // An unanchored finding cannot be checked against anything, which is the
   // un-invalidatable shape the anchor discipline exists to refuse. It is equally
   // un-VERIFIABLE, so it is reported as such rather than cleared.
-  if (!anchorIds.size) return 'unknown';
+  if (!anchorIds.size) return none;
 
+  const contents = new Map();
   for (const id of anchorIds) {
     const expected = recorded[id];
     const node = graph.nodes.get(id);
     // An anchor this finding never recorded a hash for, or one that no longer
     // resolves to a node: nothing to compare, so nothing is concluded.
-    if (typeof expected !== 'string' || !expected || !node) return 'unknown';
-    if (node.kind !== 'file' && node.kind !== 'symbol') return 'unknown';
+    if (typeof expected !== 'string' || !expected || !node) return none;
+    if (node.kind !== 'file' && node.kind !== 'symbol') return none;
     // null means the content is gone -- deleted file, vanished symbol. That is a
     // difference, not an absence of evidence.
-    if (anchorHashNow(node) !== expected) return 'differs';
+    const content = anchorContentNow(node);
+    if (content === null || hash(content) !== expected) {
+      return { verdict: 'differs', contents: new Map() };
+    }
+    contents.set(id, content);
   }
-  return 'match';
+  return { verdict: 'match', contents };
 }
 
+/** The verdict alone, for callers that do not re-index. */
+function claimTimeVerdict(graph, finding) {
+  return claimTimeEvidence(graph, finding).verdict;
+}
+
+/**
+ * Re-points every verified anchor at the content the evidence test just read.
+ *
+ * WHY A CLEAR IS NOT ENOUGH ON ITS OWN, reproduced end to end: index a file at
+ * H1, write a finding whose `derivation.anchors` records H1, edit and re-index so
+ * the node holds H2, let the eager path mark the finding, then REVERT the edit on
+ * disk. `claimTimeVerdict` now says `'match'` -- disk is H1, which is exactly
+ * what the claim was derived from -- and the flag comes off. But the node still
+ * holds H2, so the same `serve` call went on to emit `stale: true` with
+ * `staleReason: 'file changed'` from the lazy loop (disk H1 against node H2) and
+ * `derivationHolds: false` from `derivationCheck` (index H2 against claim H1).
+ * The model was shown DERIVATION CHANGED and STALE at the exact moment this
+ * module's own evidence test had concluded the derivation holds -- on every
+ * serve, until something unrelated happened to re-index the anchor.
+ *
+ * THE FIX IS TO MOVE THE INDEX, NOT TO SILENCE THE DISCLOSURES. Suppressing the
+ * lazy check and the derivation verdict for a cleared finding would leave the
+ * graph holding a hash that matches no version of the file that exists, so every
+ * OTHER finding on that anchor keeps reading stale, and the next reader has to be
+ * told which disclosures to disbelieve. The node hash is simply out of date, the
+ * bytes are already in hand from the comparison that just succeeded, and writing
+ * them makes all three disclosures agree because they are finally reading the
+ * same content.
+ *
+ * COSTS NO READ. `contents` comes from `claimTimeEvidence`, which read each
+ * anchor to reach `'match'`. The write is one node record per anchor whose hash
+ * actually moved, and it happens once per revert rather than once per serve: with
+ * the index re-pointed, the flag stays off and the gate in `serve` does not fire
+ * again.
+ *
+ * THE IN-MEMORY GRAPH IS UPDATED TOO, because the caller is mid-serve and is
+ * about to read these same nodes through the lazy loop and `derivationCheck`.
+ * Writing only to disk would fix the next process and leave this one contradicting
+ * itself, which is the whole defect.
+ *
+ * Line numbers are deliberately left alone on a symbol anchor: `checkAnchor` and
+ * `anchorContentNow` both re-locate by NAME, so a stored line is informational,
+ * and the body being byte-identical is what was just established.
+ */
+function reindexVerifiedAnchors(dir, graph, contents) {
+  for (const [id, content] of contents) {
+    const node = graph.nodes.get(id);
+    if (!node) continue;
+    const nextHash = hash(content);
+    // Already agrees: no record, no write. The common case once a revert has
+    // been accounted for.
+    if (node.hash === nextHash) continue;
+    const limit = node.kind === 'symbol' ? symbolSnapshotLimit() : snapshotLimit();
+    // Same bound as `indexFile`: past the cap the hash still drives staleness and
+    // only the reconstructed diff degrades.
+    const snapshot = content.length <= limit ? content : undefined;
+    const { hash: _h, snapshot: _s, ...rest } = node;
+    try {
+      putNode(dir, { ...rest, kind: node.kind, key: node.key, hash: nextHash, snapshot });
+    } catch {
+      // Fail open: a graph that could not be written is a disclosure that stays
+      // as it was, never a broken tool call. The in-memory copy is left alone to
+      // match, so this serve keeps agreeing with the store.
+      continue;
+    }
+    graph.nodes.set(id, { ...node, hash: nextHash, ...(snapshot ? { snapshot } : {}) });
+  }
+}
+
+/**
+ * Clears a stale flag on behalf of a person who asked for it -- the dashboard's
+ * Re-verify action -- and reports what the evidence said.
+ *
+ * `'cleared'` when the flag is gone (including when it was already gone, so a
+ * caller polling this does not retry forever), `'still-stale'` when the anchored
+ * content genuinely differs from what the claim was made against, `'unknown'`
+ * when there is nothing to compare and therefore nothing to conclude.
+ *
+ * NO LONGER THE ONLY CLEARING PATH, and the docblock that used to sit here said
+ * the opposite: that automatic clearing was refused because it would put N file
+ * reads inside injection and "silently un-mark findings nobody asked about".
+ * `serve` now does exactly that, on the same evidence, for the reason its own
+ * comment gives -- the manual path was reachable only where somebody opens the
+ * dashboard, which is almost nowhere, so the rot path stayed open on most
+ * installs. What survives of that objection is the cost, which `serve` bounds
+ * and states.
+ *
+ * WHAT THIS STILL ADDS over the automatic path: it loads the graph itself, so a
+ * caller holding nothing but a key and a directory can act; it reports the
+ * verdict rather than folding it into a served record; and it runs on demand
+ * rather than only when the finding happens to be retrieved. It re-indexes the
+ * verified anchors for the same reason `serve` does -- otherwise the button
+ * clears the flag and the very next retrieval re-derives a contradiction from a
+ * node hash nobody moved.
+ */
 export function reverify(dir, key) {
   const graph = load(dir);
   const finding = graph.nodes.get(nodeId('finding', key));
@@ -1116,9 +1343,10 @@ export function reverify(dir, key) {
   // holds, and reporting anything else would make a caller retry forever.
   if (!finding.stale) return 'cleared';
 
-  const verdict = claimTimeVerdict(graph, finding);
+  const { verdict, contents } = claimTimeEvidence(graph, finding);
   if (verdict === 'unknown') return 'unknown';
   if (verdict === 'differs') return 'still-stale';
+  reindexVerifiedAnchors(dir, graph, contents);
   clearStale(dir, key, { graph });
   return 'cleared';
 }

--- a/integrations/windsurf/hooks/lib/staleness.mjs
+++ b/integrations/windsurf/hooks/lib/staleness.mjs
@@ -17,7 +17,13 @@
  * TWO INVALIDATION PATHS, and each covers what the other cannot see:
  *
  *   EAGER  -- our PostToolUse hook saw a write, so the finding is marked at the
- *             moment it went stale, with the exact before/after in hand.
+ *             moment it went stale, with the exact before/after in hand. The
+ *             hook does not call `invalidateOnWrite` directly: it queues the
+ *             evidence through pending.mjs, and the next graph read -- which
+ *             loads the graph anyway -- applies it before serving anything.
+ *             That path is also the only one that catches a write the SESSION
+ *             made, because the lazy check below compares the stored hash
+ *             against disk and `indexFile` has already refreshed it.
  *   LAZY   -- at retrieval, the anchor's stored hash is compared against disk.
  *             This is what catches `git pull`, another editor, a teammate, or a
  *             build step: every change our hooks never observed.
@@ -291,14 +297,69 @@ export function checkAnchor(anchor) {
 }
 
 /**
+ * Characters kept from any single diff line.
+ *
+ * A LINE CAP IS NOT A SIZE CAP, and the gap was measured: with only `maxLines`
+ * in force, `diffLines('X'.repeat(200000), 'Y'.repeat(200000))` returned 2 lines
+ * and 400,005 bytes. Minified bundles, generated sources and single-line JSON
+ * all have that shape, and this output goes STRAIGHT INTO MODEL CONTEXT from
+ * inject.mjs's zero-turn refusal -- so a line bound alone let one pathological
+ * file spend hundreds of thousands of tokens.
+ *
+ * 200 characters is chosen because it is past the width at which a line is read
+ * as a line by anybody, human or model: a hand-written source line is under
+ * ~120 columns, so the cap cannot truncate a diff a reader was going to use,
+ * while the cases it does truncate are ones where the interesting change is not
+ * legible from the raw text anyway.
+ */
+const DIFF_MAX_LINE_CHARS = () => {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_DIFF_MAX_LINE_CHARS);
+  return Number.isFinite(raw) && raw > 0 ? raw : 200;
+};
+
+/**
+ * Total UTF-8 bytes of diff body.
+ *
+ * 4,000 bytes is roughly 1,000 tokens. It is deliberately larger than the
+ * per-file injection budget (`TOKEN_OPTIMIZER_TOUCH_BUDGET`, 500 tokens) and
+ * far smaller than a file, because the two consumers want different things: the
+ * injection surface fits the diff inside its own budget and drops it if it does
+ * not fit, while the zero-turn refusal is replacing a whole file read and can
+ * afford more. One cap that neither consumer has to think about is worth more
+ * than two tuned ones.
+ *
+ * WHAT IT COSTS, PLAINLY: a legitimately large diff now arrives truncated, so a
+ * model looking at a 300-line refactor sees the head of it and a count of what
+ * was elided rather than the whole change. That is the correct direction to
+ * fail -- the alternative was a bounded-looking function that could emit 400 KB.
+ */
+const DIFF_MAX_BYTES = () => {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_DIFF_MAX_BYTES);
+  return Number.isFinite(raw) && raw > 0 ? raw : 4_000;
+};
+
+/**
  * A compact line diff.
  *
  * Deliberately not a full unified diff with hunks and context: the consumer is
  * a model deciding whether an existing conclusion still holds, and for that the
  * changed lines are the signal. Output is capped because an unbounded diff
  * injected alongside a finding would spend more tokens than re-deriving it.
+ *
+ * BOUNDED IN THREE WAYS, and each one is load-bearing: lines, characters per
+ * line, and total bytes. Every truncation is announced in the output, because a
+ * silently shortened diff is worse than a visibly shortened one -- a reader who
+ * cannot tell content was elided believes they saw the whole change.
  */
-export function diffLines(before, after, { maxLines = 40 } = {}) {
+export function diffLines(
+  before,
+  after,
+  {
+    maxLines = 40,
+    maxLineChars = DIFF_MAX_LINE_CHARS(),
+    maxBytes = DIFF_MAX_BYTES(),
+  } = {}
+) {
   const a = String(before).split('\n');
   const b = String(after).split('\n');
 
@@ -314,33 +375,44 @@ export function diffLines(before, after, { maxLines = 40 } = {}) {
   const added = b.slice(head, b.length - tail);
 
   const out = [];
-  for (const line of removed.slice(0, maxLines / 2)) out.push('- ' + line);
-  if (removed.length > maxLines / 2) out.push(`  ... ${removed.length - maxLines / 2} more removed`);
-  for (const line of added.slice(0, maxLines / 2)) out.push('+ ' + line);
-  if (added.length > maxLines / 2) out.push(`  ... ${added.length - maxLines / 2} more added`);
+  let bytes = 0;
+  let dropped = 0;
+
+  // Per line first, so ONE enormous line cannot consume the whole budget and
+  // leave every other changed line unrepresented.
+  const clamp = (line) => {
+    const text = String(line);
+    if (text.length <= maxLineChars) return text;
+    return `${text.slice(0, maxLineChars)} [+${text.length - maxLineChars} chars cut]`;
+  };
+
+  // Bytes, not characters: the cap exists to bound what is sent, and a
+  // multi-byte source file would otherwise pass a character check while
+  // emitting several times the budget.
+  const push = (line) => {
+    const text = clamp(line);
+    const size = Buffer.byteLength(text, 'utf8') + 1;
+    if (bytes + size > maxBytes) {
+      dropped++;
+      return;
+    }
+    out.push(text);
+    bytes += size;
+  };
+
+  for (const line of removed.slice(0, maxLines / 2)) push('- ' + line);
+  if (removed.length > maxLines / 2) push(`  ... ${removed.length - maxLines / 2} more removed`);
+  for (const line of added.slice(0, maxLines / 2)) push('+ ' + line);
+  if (added.length > maxLines / 2) push(`  ... ${added.length - maxLines / 2} more added`);
+
+  // Announced OUTSIDE the budget, deliberately: the one line a reader most
+  // needs is the one saying the rest is missing, and dropping it to stay under
+  // a self-imposed cap would hand back a diff that lies about being complete.
+  if (dropped) out.push(`  ... ${dropped} more changed line(s) cut at the size limit`);
 
   return out.join('\n');
 }
 
-/**
- * Prepares findings for delivery, verifying each one lazily against disk.
- *
- * This is the only function that should ever hand a finding to a model, because
- * it is the one that enforces the rule: a stale finding leaves here carrying
- * `stale: true` AND a diff, or it does not leave at all.
- */
-export function serve(graph, findings) {
-  const served = [];
-
-  // RETIRED FINDINGS STOP HERE, unconditionally.
-  //
-  // findingsFor and sessionIndex already filter them, so this is redundant on
-  // every current path -- deliberately. This function's own contract is that it
-  // is the only thing that hands a finding to a model, which makes it the right
-  // place for the guarantee to live: a future caller that reaches into the
-  // graph directly cannot accidentally serve a claim a human explicitly
-  // withdrew. A withheld claim reappearing is not a bug anyone would notice
-  // quickly.
 /**
  * Types whose truth is a claim ABOUT the anchor's contents.
  *
@@ -363,6 +435,26 @@ export function serve(graph, findings) {
  * to ignore -- taking the rare true positive with it.
  */
 const CONTENT_DEPENDENT = new Set(['finding', 'map']);
+
+/**
+ * Prepares findings for delivery, verifying each one lazily against disk.
+ *
+ * This is the only function that should ever hand a finding to a model, because
+ * it is the one that enforces the rule: a stale finding leaves here carrying
+ * `stale: true` AND a diff, or it does not leave at all.
+ */
+export function serve(graph, findings) {
+  const served = [];
+
+  // RETIRED FINDINGS STOP HERE, unconditionally.
+  //
+  // findingsFor and sessionIndex already filter them, so this is redundant on
+  // every current path -- deliberately. This function's own contract is that it
+  // is the only thing that hands a finding to a model, which makes it the right
+  // place for the guarantee to live: a future caller that reaches into the
+  // graph directly cannot accidentally serve a claim a human explicitly
+  // withdrew. A withheld claim reappearing is not a bug anyone would notice
+  // quickly.
 
   for (const finding of findings.filter((f) => !f.retired)) {
     // A claim that does not depend on the anchor's contents cannot be
@@ -505,6 +597,15 @@ export function invalidateOnWrite(dir, graph, rawPath, beforeText, afterText) {
     for (const edge of byTarget.get(node.id) || []) {
       const finding = graph.nodes.get(edge.from);
       if (!finding || finding.kind !== 'finding') continue;
+      // THE SAME TYPE GATE `serve` APPLIES, and it has to be here too now that
+      // this path actually runs. `serve` ignores a stale flag on a type whose
+      // truth is not a claim about the anchor's contents -- but the flag is
+      // STORED, and disclose.mjs skips a stale finding outright while
+      // utility.mjs penalises one by 160. So writing it onto a `failure` or a
+      // `command` would suppress that claim everywhere except the one reader
+      // that knows to ignore it, which is exactly the harm measured in the
+      // comment on CONTENT_DEPENDENT above.
+      if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) continue;
 
       putNode(dir, {
         ...finding,

--- a/integrations/windsurf/hooks/lib/staleness.mjs
+++ b/integrations/windsurf/hooks/lib/staleness.mjs
@@ -495,6 +495,54 @@ function disputeOf(graph, finding) {
 }
 
 /**
+ * Whether THIS finding's own claim-time evidence still matches its anchors --
+ * the reader `harvest-write.mjs`'s `derivation` record was written for.
+ * Nothing consumed that record until now: a grep for it found only the writer
+ * and its own tests, which made "checkable rather than merely attributed" a
+ * claim with no code behind it.
+ *
+ * DISTINCT FROM `stale`/`checkAnchor`, DELIBERATELY, not a duplicate of it.
+ * `checkAnchor` compares disk against the anchor NODE's CURRENT stored hash,
+ * which is refreshed by `indexFile` every time ANYTHING touches that file --
+ * so it answers "has this file changed since the last time anyone indexed
+ * it", not "has it changed since THIS finding was derived from it". Those
+ * differ in a real case: file F changes, and a LATER, unrelated write
+ * (another finding, another session) re-indexes F, updating the node's
+ * stored hash to match the new content again. `checkAnchor` now reports
+ * "fresh" -- disk matches the node's current hash -- while this finding's own
+ * frozen `derivation.anchors[id]` snapshot, taken when IT was written, no
+ * longer matches. The bytes this claim was actually derived from are gone,
+ * and `stale` alone would never say so.
+ *
+ * Returns `{}` when there is nothing to check (no `derivation.anchors`
+ * recorded -- true of every finding written before this existed), so a
+ * caller can tell "not checked" from "checked and holds" by whether
+ * `derivationHolds` is present at all.
+ */
+function derivationCheck(graph, finding) {
+  const recorded = finding.derivation && finding.derivation.anchors;
+  if (!recorded || typeof recorded !== 'object') return {};
+  const ids = Object.keys(recorded);
+  if (!ids.length) return {};
+
+  const changed = [];
+  for (const id of ids) {
+    const node = graph.nodes.get(id);
+    const currentHash = node && typeof node.hash === 'string' ? node.hash : null;
+    // An anchor that no longer resolves at all cannot be confirmed either --
+    // treated the same as a changed hash, never as "still holds" by default.
+    if (currentHash === null || currentHash !== recorded[id]) {
+      changed.push(node && typeof node.key === 'string' ? node.key : id);
+    }
+  }
+
+  if (!changed.length) return { derivationHolds: true };
+  // Bounded: a finding with many anchors should not spend unbounded budget
+  // naming every one that moved.
+  return { derivationHolds: false, derivationChanged: changed.slice(0, 5) };
+}
+
+/**
  * Prepares findings for delivery, verifying each one lazily against disk.
  *
  * This is the only function that should ever hand a finding to a model, because
@@ -611,6 +659,9 @@ export function serve(graph, findings) {
       stale,
       ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
       ...dispute,
+      // Independent of `stale` above: see `derivationCheck`'s own comment for
+      // the case it catches that node-level staleness can miss.
+      ...derivationCheck(graph, finding),
     });
   }
   return served;

--- a/integrations/windsurf/hooks/lib/staleness.mjs
+++ b/integrations/windsurf/hooks/lib/staleness.mjs
@@ -518,6 +518,21 @@ function disputeOf(graph, finding) {
  * recorded -- true of every finding written before this existed), so a
  * caller can tell "not checked" from "checked and holds" by whether
  * `derivationHolds` is present at all.
+ *
+ * `derivationHolds: true` MEANS "MATCHES THE ANCHOR NODE'S LAST-INDEXED
+ * HASH", NOT "MATCHES DISK RIGHT NOW" -- and that distinction is stored in
+ * `derivationCheckedAgainst: 'index'` rather than left for a `wiki_query`
+ * consumer to infer from a field name alone. Two ways to close this gap were
+ * considered: recompute a live hash from disk here, or document precisely
+ * what is actually compared. `stale` (via `checkAnchor`, above) ALREADY owns
+ * the disk comparison -- re-reading the same file a second time on the same
+ * serve path, for the same anchor, from a second mechanism, is worse than
+ * one honest name. So: documented, not duplicated. A file changed on disk
+ * but never re-indexed by anything is still caught, correctly, by `stale`;
+ * `derivationHolds` answers a narrower, complementary question -- whether
+ * the LAST INDEXED state agrees with what this specific finding recorded --
+ * which is exactly the re-indexed-by-something-else case above that `stale`
+ * cannot see.
  */
 function derivationCheck(graph, finding) {
   const recorded = finding.derivation && finding.derivation.anchors;
@@ -536,10 +551,12 @@ function derivationCheck(graph, finding) {
     }
   }
 
-  if (!changed.length) return { derivationHolds: true };
+  // Declared on BOTH branches, not only the ambiguous one: a consumer should
+  // not have to already know the answer to know what was checked.
+  if (!changed.length) return { derivationHolds: true, derivationCheckedAgainst: 'index' };
   // Bounded: a finding with many anchors should not spend unbounded budget
   // naming every one that moved.
-  return { derivationHolds: false, derivationChanged: changed.slice(0, 5) };
+  return { derivationHolds: false, derivationChanged: changed.slice(0, 5), derivationCheckedAgainst: 'index' };
 }
 
 /**

--- a/integrations/windsurf/hooks/lib/staleness.mjs
+++ b/integrations/windsurf/hooks/lib/staleness.mjs
@@ -54,6 +54,7 @@ import { readFileSync, statSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { dirname, join } from 'node:path';
 import { putNode, putEdge, contentHash, nodeId } from './wiki.mjs';
+import { hasOutstandingContradiction } from './curate.mjs';
 import { extractSymbols, spanText, symbolKey, extractImports } from './symbols.mjs';
 import { canonicalPath, resolvableCandidates, isFsSafePath } from './paths.mjs';
 
@@ -454,6 +455,46 @@ export function diffLines(
 const CONTENT_DEPENDENT = new Set(['finding', 'map']);
 
 /**
+ * What, if anything, currently disagrees with this finding.
+ *
+ * DISCLOSED AT SERVE TIME, because that is the only moment the disagreement can
+ * do any good. `WIKI_GRAPH.md`'s whole argument for making `contradicts` an edge
+ * rather than an overwrite is that a reader "sees both claims and the
+ * disagreement between them" -- so handing a finding to a model while something
+ * in the graph disputes it, without saying so, throws away the reason the edge
+ * was recorded instead of an overwrite.
+ *
+ * `hasOutstandingContradiction` is the gate: it is the one definition of "an
+ * open dispute", shared with the confidence-promotion gate, so the two can never
+ * disagree about what counts. The loop only NAMES the other side, and it names a
+ * key rather than quoting a claim because the reader can call `wiki_query` with
+ * a key -- and because the injection path pays for every character it renders.
+ *
+ * SEPARATE FROM STALENESS on purpose. A finding can be disputed without being
+ * stale (nothing touched its anchor; another finding simply says otherwise) and
+ * stale without being disputed, so this adds its own fields rather than
+ * borrowing the stale ones, and the renderer discloses each on its own terms.
+ */
+function disputeOf(graph, finding) {
+  if (!hasOutstandingContradiction(graph, finding.key)) return {};
+
+  const keys = [];
+  for (const edge of graph.edges) {
+    if (edge.edge !== 'contradicts') continue;
+    const otherId =
+      edge.from === finding.id ? edge.to : edge.to === finding.id ? edge.from : null;
+    if (!otherId) continue;
+    const other = graph.nodes.get(otherId);
+    // An edge end that resolves to nothing names nothing. The dispute is still
+    // disclosed -- the gate above already established it -- but without a key
+    // the reader cannot be pointed anywhere, and inventing one would be worse.
+    if (other && typeof other.key === 'string' && !keys.includes(other.key)) keys.push(other.key);
+  }
+
+  return { contradicted: true, ...(keys.length ? { contradictedBy: keys.join(', ') } : {}) };
+}
+
+/**
  * Prepares findings for delivery, verifying each one lazily against disk.
  *
  * This is the only function that should ever hand a finding to a model, because
@@ -474,10 +515,17 @@ export function serve(graph, findings) {
   // quickly.
 
   for (const finding of findings.filter((f) => !f.retired)) {
+    // A DISPUTE TRAVELS WITH EVERY TYPE, which is why it is computed before the
+    // content-dependence branch below. A `command` or `rule` finding cannot be
+    // invalidated by an anchor's contents, but another finding can still
+    // disagree with it, and this early return is the path that would have
+    // quietly dropped that.
+    const dispute = disputeOf(graph, finding);
+
     // A claim that does not depend on the anchor's contents cannot be
     // invalidated by them. It is served as-is rather than discounted.
     if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) {
-      served.push({ ...finding });
+      served.push({ ...finding, ...dispute });
       continue;
     }
 
@@ -562,6 +610,7 @@ export function serve(graph, findings) {
       ...finding,
       stale,
       ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
+      ...dispute,
     });
   }
   return served;

--- a/integrations/windsurf/hooks/lib/waste.mjs
+++ b/integrations/windsurf/hooks/lib/waste.mjs
@@ -151,6 +151,11 @@ function reDerivation(events, graph) {
       const id = nodeId('file', canonicalPath(row.anchor));
       if (!graph.nodes.has(id)) continue;
 
+      // READ-ONLY serve: no `dir` is threaded here, so this cannot clear a stale
+      // flag whose evidence is gone. That is deliberate -- this function takes a
+      // graph, not the directory it came from, and widening its signature to give
+      // an analysis path a write capability buys nothing: the injection path runs
+      // on every tool call and clears the same findings.
       const findings = serve(graph, findingsFor(graph, id, { limit: 3 }))
         .filter((f) => !f.stale && (f.confidence ?? 0) >= 0.7);
       if (!findings.length) continue;

--- a/integrations/windsurf/hooks/lib/wiki.mjs
+++ b/integrations/windsurf/hooks/lib/wiki.mjs
@@ -64,18 +64,37 @@ export const SUPPORTED_VERSIONS = [1];
  * Identity today because GRAPH_VERSION is 1 and no shape has changed. It exists
  * now so the first change that DOES need it has somewhere to go other than an
  * equality check that silently deletes user data.
+ *
+ * CONTRACT for the first non-identity step:
+ *  - It must be IDEMPOTENT. `upcast(upcast(r))` must equal `upcast(r)`, because
+ *    compaction upcasts a record to key it and `load` upcasts the same record
+ *    again on every subsequent read. A step that is not idempotent applies twice
+ *    to anything compaction has touched.
+ *  - It must NOT be relied on to restamp `v`. Nothing in this file writes an
+ *    upcast record back to disk under a version it did not come from; the
+ *    version stamp on disk is always the one that wrote the bytes. See the
+ *    per-branch comments in `compactIfWasteful`.
  */
 export function upcast(record) {
   return record;
 }
 
-/** True when this reader can interpret the record at all. */
-function readable(record) {
+/**
+ * True when this reader can interpret the record at all.
+ *
+ * `versions` is a PARAMETER so the range semantics are testable independently of
+ * today's constants. With `SUPPORTED_VERSIONS = [1]` and `GRAPH_VERSION = 1` a
+ * range check and the old equality check are extensionally identical, so a test
+ * pinned to the live constants cannot tell them apart -- and cannot fail if
+ * someone reverts this to an equality. Exercised against `[1, 2]`, it can.
+ */
+export function readable(record, versions = SUPPORTED_VERSIONS) {
   const version = record.v ?? 0;
   // Forward-incompatible records are skipped: a v-from-the-future was written by
-  // a newer client and we cannot know its shape. Ignoring the future is safe;
-  // ignoring the past is data loss.
-  return SUPPORTED_VERSIONS.includes(version);
+  // a newer client and we cannot know its shape. Ignoring the future is safe for
+  // a READER -- but see `compactIfWasteful`, where "ignore" would mean "delete",
+  // because compaction rewrites the files it reads.
+  return versions.includes(version);
 }
 
 /** Node kinds. `file` and `symbol` are first-class so staleness can propagate. */
@@ -434,9 +453,20 @@ function compactIfWasteful(dir) {
     const nodes = new Map();
     const edges = new Map();
     const snaps = new Map();
-    for (const rec of readSnapshots(dir)) {
+    // KEPT VERBATIM THROUGH THE REBUILD, exactly as the main log keeps what it
+    // cannot parse. These lines are not evictable by the snapshot budget below
+    // because their size cannot be attributed to an id we understand -- and
+    // preserving bytes we may not need is strictly better than deleting bytes a
+    // newer client does. They stop accumulating as soon as the client that
+    // wrote them compacts, since it can read and dedupe them.
+    const sidecar = readSnapshots(dir);
+    const rawSnaps = sidecar.unreadable;
+    for (const rec of sidecar.records) {
       if (typeof rec.snapshot === 'string' && rec.snapshot) {
-        snaps.set(rec.id, { at: rec.at || 0, snapshot: rec.snapshot });
+        // `v` IS CARRIED, not restamped. Writing GRAPH_VERSION over a record
+        // from another version mislabels bytes this reader did not produce, and
+        // the label is the only thing a future reader has to go on.
+        snaps.set(rec.id, { at: rec.at || 0, snapshot: rec.snapshot, v: rec.v ?? GRAPH_VERSION });
       }
     }
     for (const line of readFileSync(path, 'utf8').split('\n')) {
@@ -458,27 +488,40 @@ function compactIfWasteful(dir) {
         edges.set('raw:' + edges.size, line);
         continue;
       }
-      // Upcast IN MEMORY only, to key and classify the record. What gets written
-      // back below is the ORIGINAL `line`: compaction reclaims superseded
-      // records, it does not migrate surviving ones, so the on-disk version is
-      // whatever wrote it and `load` upcasts it again on every read.
-      record = upcast(record);
-      if (record.t === 'n') {
+      // TWO OBJECTS, ON PURPOSE. `record` is exactly what the bytes on disk say;
+      // `view` is the in-memory current-shape reading of it, used only to KEY and
+      // CLASSIFY. Nothing derived from `view` is ever serialized, because
+      // compaction reclaims superseded records -- it does not migrate surviving
+      // ones -- so every version stamp it writes is the one that wrote the bytes.
+      //
+      // An earlier revision of this comment claimed "the ORIGINAL line is written
+      // back" for the whole block. That was FALSE for the inline-snapshot branch,
+      // which re-serializes. It re-serialized the upcast object while carrying
+      // the old `v`, so the first non-identity `upcast` would have written
+      // new-shape bytes under an old label and every later `load` would have
+      // upcast them a second time. Hence: strip from `record`, never from `view`.
+      const view = upcast(record);
+      if (view.t === 'n') {
         // MIGRATION. Graphs written before snapshots were split still carry
         // them inline, and those are exactly the graphs that are slow. Moving
         // them out here means one compaction fixes an existing install.
+        //
+        // THE ONLY RE-SERIALIZING BRANCH in this loop. It writes the original
+        // record minus its snapshot, so the surviving bytes keep their own shape
+        // and their own `v`, and the snapshot moved to the sidecar carries the
+        // same `v` as the node it came out of.
         if (typeof record.snapshot === 'string' && record.snapshot) {
           const { snapshot, ...rest } = record;
-          nodes.set(record.id, JSON.stringify(rest));
-          snaps.set(record.id, { at: record.at || 0, snapshot });
+          nodes.set(view.id, JSON.stringify(rest));
+          snaps.set(view.id, { at: record.at || 0, snapshot, v: record.v ?? GRAPH_VERSION });
         } else {
-          nodes.set(record.id, line);
+          nodes.set(view.id, line);
         }
-      } else if (record.t === 's') {
+      } else if (view.t === 's') {
         if (typeof record.snapshot === 'string' && record.snapshot) {
-          snaps.set(record.id, { at: record.at || 0, snapshot: record.snapshot });
+          snaps.set(view.id, { at: record.at || 0, snapshot: record.snapshot, v: record.v ?? GRAPH_VERSION });
         }
-      } else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
+      } else if (view.t === 'e') edges.set(`${view.from}|${view.edge}|${view.to}`, line);
       else edges.set('raw:' + edges.size, line);
     }
 
@@ -541,10 +584,20 @@ function compactIfWasteful(dir) {
     renameSync(tmp, path);
     // The surviving snapshots are rewritten to their own file, which is also
     // what migrates a graph that still had them inline.
-    const snapOut =
-      [...keep.entries()]
-        .map(([id, v]) => JSON.stringify({ t: 's', v: GRAPH_VERSION, id, snapshot: v.snapshot, at: v.at }))
-        .join('\n') + (keep.size ? '\n' : '');
+    //
+    // UNREADABLE LINES FIRST AND VERBATIM. This rebuild replaces the file, so
+    // anything omitted here is deleted permanently -- which made the missing
+    // counterpart to the main log's `raw:` bucket a real data-loss path, not a
+    // theoretical one. Each survivor also keeps ITS OWN `v` rather than being
+    // restamped to GRAPH_VERSION, so no record is relabelled as something this
+    // reader wrote.
+    const snapLines = [
+      ...rawSnaps,
+      ...[...keep.entries()].map(([id, s]) =>
+        JSON.stringify({ t: 's', v: s.v ?? GRAPH_VERSION, id, snapshot: s.snapshot, at: s.at })
+      ),
+    ];
+    const snapOut = snapLines.join('\n') + (snapLines.length ? '\n' : '');
     const snapTmp = snapshotsPath(dir) + '.compact';
     writeFileSync(snapTmp, snapOut, { mode: 0o600 });
     renameSync(snapTmp, snapshotsPath(dir));
@@ -689,9 +742,26 @@ function appendSnapshot(dir, record) {
   }
 }
 
-/** Every snapshot record, latest wins. Read only when a caller asks. */
+/**
+ * Every snapshot record, latest wins. Read only when a caller asks.
+ *
+ * `unreadable` collects the RAW LINES this reader rejected, and it is the reason
+ * this function reports them at all rather than just dropping them. `load` has
+ * no use for them -- a reader that cannot interpret a record must ignore it --
+ * but `compactIfWasteful` REBUILDS this file from what it read, so for the
+ * compactor "ignore" and "delete permanently" are the same operation. The main
+ * log already keeps what it cannot parse (the `raw:` bucket); the sidecar had no
+ * equivalent, which made it the one asymmetric, destructive path in an otherwise
+ * append-only store.
+ *
+ * This is not hypothetical here: hooks-core is vendored into eleven client
+ * directories that update independently, so a stale client compacting a graph a
+ * newer client has already written to is the expected steady state, not an edge
+ * case.
+ */
 function readSnapshots(dir) {
-  const out = [];
+  /** @type {object[]} */ const out = [];
+  /** @type {string[]} */ const unreadable = [];
   try {
     for (const line of readFileSync(snapshotsPath(dir), 'utf8').split('\n')) {
       if (!line) continue;
@@ -699,19 +769,23 @@ function readSnapshots(dir) {
         const rec = JSON.parse(line);
         // THE SAME RANGE AS THE MAIN LOG, deliberately. An equality check here
         // was the quietest of the three: a bump would have made every stored
-        // snapshot unreadable, and the very next compaction -- which rebuilds
-        // this file from what it could read -- would have deleted them for
-        // good. That is the one place in this store where a read filter turns
-        // into a permanent write.
-        if (readable(rec) && rec.id) out.push(upcast(rec));
+        // snapshot unreadable, and the very next compaction would have deleted
+        // them for good.
+        if (!readable(rec)) {
+          unreadable.push(line);
+          continue;
+        }
+        if (rec.id) out.push(upcast(rec));
       } catch {
-        /* a torn line costs one snapshot */
+        // A torn line costs one snapshot -- and it is NOT preserved, because a
+        // half-written line is not a record from another version, it is
+        // garbage. Distinguishing the two is the whole point of parsing first.
       }
     }
   } catch {
     /* no sidecar yet */
   }
-  return out;
+  return { records: out, unreadable };
 }
 
 /**
@@ -777,7 +851,9 @@ export function load(dir, { snapshots = false } = {}) {
   // Re-attached after the sweep, so a snapshot record may appear before or
   // after the node it belongs to.
   if (pending) {
-    for (const rec of readSnapshots(dir)) pending.set(rec.id, rec.snapshot);
+    // A reader has no use for the lines it could not interpret; only the
+    // compactor does, because only the compactor rewrites the file.
+    for (const rec of readSnapshots(dir).records) pending.set(rec.id, rec.snapshot);
     for (const [id, snapshot] of pending) {
       const node = nodes.get(id);
       if (node) nodes.set(id, { ...node, snapshot });

--- a/integrations/windsurf/hooks/lib/wiki.mjs
+++ b/integrations/windsurf/hooks/lib/wiki.mjs
@@ -28,17 +28,55 @@ import { canonicalPath, isFsSafePath } from './paths.mjs';
 /**
  * Schema version stamped on every record.
  *
- * There is exactly ONE version and no migration code, because nothing has been
- * released: a graph written by an older commit of an unreleased branch is a
- * development artifact, not user data, and carrying migration paths for it costs
- * real complexity to protect something nobody has. A record from any other
- * version is skipped rather than interpreted, so a stale dev graph degrades to
- * "rebuilds from use" instead of silently mixing incompatible identities.
+ * THIS PACKAGE IS RELEASED. It ships on npm, so every graph on disk is user
+ * data. An earlier version of this comment claimed nothing had been released
+ * and used that to justify having no migration path at all -- and the reader
+ * below compared for EQUALITY, so the first bump would have discarded every
+ * existing graph in silence. That justification is gone and so is the equality:
+ * `SUPPORTED_VERSIONS` is the range this reader accepts, and `upcast` is where a
+ * shape change is absorbed in memory.
  *
- * When this does ship, a bump here is where migration would be added -- with
- * users to protect, that trade reverses.
+ * A bump here is taken only when a record's SHAPE actually changes, and it comes
+ * with a new `upcast` step and an entry in `SUPPORTED_VERSIONS` in the same
+ * change. Adding a field that older readers can ignore is not a shape change.
  */
 export const GRAPH_VERSION = 1;
+
+/**
+ * Versions this reader accepts, oldest first.
+ *
+ * A RANGE, NOT AN EQUALITY. The equality check this replaces would have
+ * discarded every existing graph the moment anyone bumped the version -- and the
+ * header once justified that with "nothing has been released", which stopped
+ * being true at v5.7.0 on npm.
+ *
+ * Nothing on disk is ever rewritten to migrate: `upcast` runs in memory during
+ * the fold, so there is no migration pass to fail halfway and no race with the
+ * concurrent sessions this store is designed for. A mixed-version log is safe
+ * precisely because the original records are never mutated, and the existing
+ * compaction retires old ones naturally as it rewrites snapshots.
+ */
+export const SUPPORTED_VERSIONS = [1];
+
+/**
+ * Brings one record up to the current version. Pure, and one step per version.
+ *
+ * Identity today because GRAPH_VERSION is 1 and no shape has changed. It exists
+ * now so the first change that DOES need it has somewhere to go other than an
+ * equality check that silently deletes user data.
+ */
+export function upcast(record) {
+  return record;
+}
+
+/** True when this reader can interpret the record at all. */
+function readable(record) {
+  const version = record.v ?? 0;
+  // Forward-incompatible records are skipped: a v-from-the-future was written by
+  // a newer client and we cannot know its shape. Ignoring the future is safe;
+  // ignoring the past is data loss.
+  return SUPPORTED_VERSIONS.includes(version);
+}
 
 /** Node kinds. `file` and `symbol` are first-class so staleness can propagate. */
 export const NODE_KINDS = ['file', 'symbol', 'task', 'finding'];
@@ -409,13 +447,22 @@ function compactIfWasteful(dir) {
       } catch {
         continue;
       }
-      // A record from another schema is KEPT VERBATIM rather than reinterpreted.
-      // load() skips it, but discarding it here would make compaction a silent
-      // migration that deletes data a future version might understand.
-      if ((record.v ?? 0) !== GRAPH_VERSION) {
+      // A record this reader cannot interpret is KEPT VERBATIM rather than
+      // reinterpreted. load() skips it, but discarding it here would make
+      // compaction a silent migration that deletes data a future version might
+      // understand. THE RANGE MATTERS HERE TOO: with an equality check, a bump
+      // would have parked every existing v1 record in `raw`, undeduplicated, so
+      // compaction would stop reclaiming anything and inline snapshots would
+      // never migrate out -- the same loss by a second route.
+      if (!readable(record)) {
         edges.set('raw:' + edges.size, line);
         continue;
       }
+      // Upcast IN MEMORY only, to key and classify the record. What gets written
+      // back below is the ORIGINAL `line`: compaction reclaims superseded
+      // records, it does not migrate surviving ones, so the on-disk version is
+      // whatever wrote it and `load` upcasts it again on every read.
+      record = upcast(record);
       if (record.t === 'n') {
         // MIGRATION. Graphs written before snapshots were split still carry
         // them inline, and those are exactly the graphs that are slow. Moving
@@ -650,7 +697,13 @@ function readSnapshots(dir) {
       if (!line) continue;
       try {
         const rec = JSON.parse(line);
-        if ((rec.v ?? 0) === GRAPH_VERSION && rec.id) out.push(rec);
+        // THE SAME RANGE AS THE MAIN LOG, deliberately. An equality check here
+        // was the quietest of the three: a bump would have made every stored
+        // snapshot unreadable, and the very next compaction -- which rebuilds
+        // this file from what it could read -- would have deleted them for
+        // good. That is the one place in this store where a read filter turns
+        // into a permanent write.
+        if (readable(rec) && rec.id) out.push(upcast(rec));
       } catch {
         /* a torn line costs one snapshot */
       }
@@ -691,7 +744,12 @@ export function load(dir, { snapshots = false } = {}) {
       if (!snapshots) continue;
       try {
         const rec = JSON.parse(line);
-        if ((rec.v ?? 0) === GRAPH_VERSION) pending.set(rec.id, rec.snapshot);
+        // Inline snapshots from an older graph: same range, same reason. These
+        // are precisely the records most likely to predate a bump.
+        if (readable(rec)) {
+          const snap = upcast(rec);
+          pending.set(snap.id, snap.snapshot);
+        }
       } catch {
         /* a torn line costs one snapshot, not the graph */
       }
@@ -703,10 +761,14 @@ export function load(dir, { snapshots = false } = {}) {
     } catch {
       continue;
     }
-    // A record from another schema is skipped, not interpreted: its ids and
-    // hashes were derived differently, so honouring it produces confident
-    // nonsense rather than a visible error.
-    if ((record.v ?? 0) !== GRAPH_VERSION) continue;
+    // A record this reader cannot interpret is skipped, not guessed at: a
+    // version from the FUTURE derived its ids and hashes in a way we do not
+    // know, so honouring it produces confident nonsense rather than a visible
+    // error. A record from the PAST is upcast, never skipped -- skipping it is
+    // data loss, and this comparison used to be an equality, which made the
+    // first version bump a silent delete of every graph on disk.
+    if (!readable(record)) continue;
+    record = upcast(record);
     if (record.t === 'n') nodes.set(record.id, record);
     else if (record.t === 'e') edges.push(record);
   }

--- a/integrations/windsurf/hooks/lib/wiki.mjs
+++ b/integrations/windsurf/hooks/lib/wiki.mjs
@@ -775,7 +775,17 @@ function readSnapshots(dir) {
           unreadable.push(line);
           continue;
         }
+        // A RECORD WITH NO `id` IS KEPT VERBATIM, NOT DROPPED SILENTLY. It
+        // cannot be attributed to a node, so it is useless to `load` -- but this
+        // used to put it in neither bucket, and `compactIfWasteful` rebuilds the
+        // sidecar from `records` plus `unreadable`, so a line in neither was
+        // deleted permanently by the next compaction. That is the same shape as
+        // the Critical this reader's version check already fixed, and the same
+        // asymmetry: for the compactor, "ignore" and "destroy" are one operation.
+        // Unreachable today because every writer sets `id`; a reader is not the
+        // right place to rely on that.
         if (rec.id) out.push(upcast(rec));
+        else unreadable.push(line);
       } catch {
         // A torn line costs one snapshot -- and it is NOT preserved, because a
         // half-written line is not a record from another version, it is

--- a/integrations/windsurf/hooks/post-tool.mjs
+++ b/integrations/windsurf/hooks/post-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/integrations/windsurf/hooks/post-tool.mjs
+++ b/integrations/windsurf/hooks/post-tool.mjs
@@ -8,7 +8,7 @@ process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.
-process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write';
+process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write,wiki_query';
 try {
   const { run } = await import('./lib/adapter.mjs');
   await run('windsurf', 'post-tool');

--- a/integrations/windsurf/hooks/pre-tool.mjs
+++ b/integrations/windsurf/hooks/pre-tool.mjs
@@ -8,7 +8,7 @@ process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.
-process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write';
+process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write,wiki_query';
 try {
   const { run } = await import('./lib/adapter.mjs');
   await run('windsurf', 'pre-tool');

--- a/integrations/windsurf/hooks/pre-tool.mjs
+++ b/integrations/windsurf/hooks/pre-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/plugin/hooks/harvest-worker.mjs
+++ b/plugin/hooks/harvest-worker.mjs
@@ -102,6 +102,11 @@ async function main() {
     // through PreToolUse/PostToolUse has no such node yet; `writeHarvested`
     // resolves that case to no edge rather than a dangling one.
     taskId: sessionId || null,
+    // AUTHORITATIVE, not just present: this `sessionId` came from Claude
+    // Code's own Stop-hook payload (see stop-harvest.mjs), not a model-typed
+    // tool argument, so it is safe to use for the traversal fallback if the
+    // explicit `taskId` above does not resolve.
+    authoritativeSessionId: sessionId || null,
   });
 
   record(dir, {
@@ -148,6 +153,8 @@ async function main() {
         origin: ORIGIN_HARVESTED,
         projectRoot,
         taskId: sessionId || null,
+        // Same hook-payload identity as above, same reason.
+        authoritativeSessionId: sessionId || null,
       });
 
       record(dir, {

--- a/plugin/hooks/harvest-worker.mjs
+++ b/plugin/hooks/harvest-worker.mjs
@@ -95,6 +95,13 @@ async function main() {
   const written = writeHarvested(dir, findings, {
     sessionId: sessionId || null,
     projectRoot,
+    // Task nodes are keyed by session id (structural capture creates one on
+    // the first touched file, `harvest()` in lib/wiki.mjs) so this is the
+    // shape `writeHarvested` needs to point the `answers` edge back at the
+    // task this harvest belongs to. A session that never touched a file
+    // through PreToolUse/PostToolUse has no such node yet; `writeHarvested`
+    // resolves that case to no edge rather than a dangling one.
+    taskId: sessionId || null,
   });
 
   record(dir, {
@@ -140,6 +147,7 @@ async function main() {
         sessionId: sessionId || null,
         origin: ORIGIN_HARVESTED,
         projectRoot,
+        taskId: sessionId || null,
       });
 
       record(dir, {

--- a/plugin/hooks/harvest-worker.mjs
+++ b/plugin/hooks/harvest-worker.mjs
@@ -131,7 +131,7 @@ async function main() {
       // The same restriction the finding path above applies, for the same reason: a model that
       // invents a plausible path must not be able to anchor a lesson to it. `turns` is the
       // archived transcript for this session, so its rendered digest is the honest file list.
-      const { lessons, rejected } = validateLessons(rawLessons, turns, {
+      const { lessons } = validateLessons(rawLessons, turns, {
         knownFiles: filesIn(feedback),
       });
 
@@ -148,22 +148,24 @@ async function main() {
         anchors: l.anchors.length ? l.anchors : [projectRoot],
       }));
 
-      const writtenLessons = writeHarvested(dir, anchored, {
+      // The write itself is the durable record: writeHarvested anchors each
+      // lesson into the graph, which is what lessons.mjs's real consumers
+      // query. A metrics event of kind 'lessons' used to sit here as well,
+      // but nothing ever read it -- not netTokens (only 'harvest' feeds
+      // harvestTokens), not report()/buildReport() (no kind filter matches
+      // 'lessons'), and no audit render exists to show it to a human. That is
+      // the inverse of the `query` defect and the same shape as
+      // `tokensFullFile` before it: a produced-and-never-consumed event,
+      // which is a cost with no benefit. Deleted rather than wired, per the
+      // reachability allowlist's own rule -- write it again the day
+      // something needs to read it.
+      writeHarvested(dir, anchored, {
         sessionId: sessionId || null,
         origin: ORIGIN_HARVESTED,
         projectRoot,
         taskId: sessionId || null,
         // Same hook-payload identity as above, same reason.
         authoritativeSessionId: sessionId || null,
-      });
-
-      record(dir, {
-        kind: 'lessons',
-        sessionId: sessionId || null,
-        tokens: estimateTokens(feedback),
-        lessons: writtenLessons.length,
-        rejected: rejected.length,
-        at: Date.now(),
       });
     }
   } catch {

--- a/plugin/hooks/lib/adapter.mjs
+++ b/plugin/hooks/lib/adapter.mjs
@@ -68,6 +68,7 @@ import {
   standingRules,
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
+import { observedWrite, queueInvalidation } from './pending.mjs';
 import { isArchived } from './transcript.mjs';
 import { isFsSafePath } from './paths.mjs';
 import {
@@ -881,6 +882,35 @@ async function runHook(clientName, event, invocation) {
       });
     } catch {
       // Causal tracing is fail-open like every other hook optimization.
+    }
+
+    // EAGER INVALIDATION, finally connected. `invalidateOnWrite` has existed,
+    // been tested and been described in staleness.mjs's own header since
+    // staleness landed, and its only reference in shipped code was a COMMENT in
+    // the PreToolUse router -- so the path that header calls load-bearing had
+    // never run once in production. It matters most for exactly this event: the
+    // lazy check compares the anchor's stored hash against disk, and the
+    // capture below re-points that hash at the bytes this write just produced,
+    // so a write the session performed ITSELF is invisible to lazy staleness.
+    //
+    // QUEUED, NOT APPLIED. Applying needs the graph, and loading a megabyte of
+    // JSONL on the return path of every write is what this shape exists to
+    // avoid. The next graph read drains it before serving anything.
+    try {
+      if (mutationSucceeded(clientName, raw)) {
+        const evidence = observedWrite(payload, raw);
+        if (evidence) {
+          // THE SAME DIRECTORY THE GRAPH ITSELF USES. `observeAndInject` keys
+          // every write on `wikiDir(projectRootFor(path, payload.cwd))`, and a
+          // queue written anywhere else is a queue nothing ever drains.
+          queueInvalidation(
+            wikiDir(projectRootFor(evidence.path, payload.cwd)),
+            evidence
+          );
+        }
+      }
+    } catch {
+      // Bookkeeping for a call that already completed. Never let it cost one.
     }
   }
 

--- a/plugin/hooks/lib/adapter.mjs
+++ b/plugin/hooks/lib/adapter.mjs
@@ -64,6 +64,7 @@ import {
   forTouch,
   noteActClasses,
   relevantFindingIdsForContext,
+  sessionContext,
   sessionIndex,
   standingRules,
 } from './inject.mjs';
@@ -690,8 +691,23 @@ async function runHook(clientName, event, invocation) {
       rememberOptimizerTools(state, toolEvidence);
       saveState(sessionId, state);
     }
-    const parts = [
-      policyText(client.canDeny, toolEvidence.names, toolEvidence.proven),
+    // ASSEMBLED IN CACHE ORDER, not in whatever order this function happens to
+    // discover the blocks. Everything emitted here sits near the FRONT of the
+    // prompt prefix, and a prefix cache invalidates from the first differing
+    // byte onward -- so the block that changes most often has to sit LAST, or it
+    // re-prices every block behind it on every session. `sessionContext` sorts
+    // by the declared volatility; inject.mjs records how each number was
+    // assigned and why.
+    const blocks = [
+      {
+        id: 'policy',
+        volatility: 0,
+        text: policyText(
+          client.canDeny,
+          toolEvidence.names,
+          toolEvidence.proven
+        ),
+      },
     ];
     const cwd = raw.cwd || raw.working_directory || process.cwd();
     const root = projectRootFor(join(cwd, '__session__'), cwd);
@@ -705,7 +721,7 @@ async function runHook(clientName, event, invocation) {
         const graph = load(dir);
         const episode = episodeMeta({ client: clientName, raw });
         const rules = standingRules(dir, graph, { episode });
-        if (rules) parts.push(rules);
+        if (rules) blocks.push({ id: 'standing', volatility: 1, text: rules });
         const relevantFindingIds = relevantFindingIdsForContext(
           graph,
           sessionTaskContext(raw)
@@ -714,12 +730,12 @@ async function runHook(clientName, event, invocation) {
           episode,
           relevantFindingIds,
         });
-        if (index) parts.push(index);
+        if (index) blocks.push({ id: 'index', volatility: 2, text: index });
       } catch {
         // Retrieval is optional context; the policy must still reach the model.
       }
     }
-    const output = contextOutput(client, eventName, parts.join('\n\n'));
+    const output = contextOutput(client, eventName, sessionContext(blocks));
     if (output) emit(output);
     process.exit(0);
   }

--- a/plugin/hooks/lib/adapter.mjs
+++ b/plugin/hooks/lib/adapter.mjs
@@ -68,7 +68,7 @@ import {
   standingRules,
 } from './inject.mjs';
 import { indexFile } from './staleness.mjs';
-import { observedWrite, queueInvalidation } from './pending.mjs';
+import { observedWrites, queueInvalidation } from './pending.mjs';
 import { isArchived } from './transcript.mjs';
 import { isFsSafePath } from './paths.mjs';
 import {
@@ -898,8 +898,7 @@ async function runHook(clientName, event, invocation) {
     // avoid. The next graph read drains it before serving anything.
     try {
       if (mutationSucceeded(clientName, raw)) {
-        const evidence = observedWrite(payload, raw);
-        if (evidence) {
+        for (const evidence of observedWrites(payload, raw)) {
           // THE SAME DIRECTORY THE GRAPH ITSELF USES. `observeAndInject` keys
           // every write on `wikiDir(projectRootFor(path, payload.cwd))`, and a
           // queue written anywhere else is a queue nothing ever drains.

--- a/plugin/hooks/lib/capabilities.mjs
+++ b/plugin/hooks/lib/capabilities.mjs
@@ -38,6 +38,10 @@ export const HOOK_MCP_TOOLS = Object.freeze([
   'optimize_session',
   'get_optimization_report',
   'wiki_write',
+  // The read side of the graph. The session index tells the model to "call
+  // wiki_query with a key for detail", so the hook needs positive evidence that
+  // the name it is advertising is actually registered in this host.
+  'wiki_query',
 ]);
 
 const HOOK_MCP_TOOL_SET = new Set(HOOK_MCP_TOOLS);

--- a/plugin/hooks/lib/curate.mjs
+++ b/plugin/hooks/lib/curate.mjs
@@ -22,7 +22,7 @@
  */
 
 import { randomBytes } from 'node:crypto';
-import { putNode, putNodeWithEdges, load, nodeId } from './wiki.mjs';
+import { putNode, putEdge, putNodeWithEdges, load, nodeId } from './wiki.mjs';
 import { indexFile } from './staleness.mjs';
 import { symbolKey } from './symbols.mjs';
 import { canonicalPath } from './paths.mjs';
@@ -178,6 +178,79 @@ export function retire(dir, key) {
   if (!existing) return false;
   putNode(dir, { ...existing, kind: 'finding', key, retired: true });
   return true;
+}
+
+/**
+ * Records that one finding disagrees with another.
+ *
+ * AN EDGE, NOT AN OVERWRITE -- the design is explicit about why: "when a belief
+ * changes, the graph should record THAT it changed and why, not quietly present
+ * the new one as though it had always been true." `contradicts` has been in
+ * EDGE_KINDS since the schema existed and was written by nothing, while
+ * `audit()` already READ it.
+ *
+ * The contradicted finding is deliberately NOT retired, and its claim is
+ * deliberately preserved. A reader needs to see both claims and the
+ * disagreement between them; retiring one silently picks a winner, and putNode
+ * does not merge -- it writes the whole record from what it is handed, so
+ * annotating the target without spreading it back in would blank the very claim
+ * this edge exists to keep visible. That is the overwrite by another name.
+ *
+ * THE EDGE IS WRITTEN FIRST, and the order is the guarantee. These are two
+ * appends and `append` fails open, so either can be the one that lands. Edge
+ * without annotation is a complete, readable disagreement missing only its
+ * reason. Annotation without edge is a finding that says "something contradicts
+ * me" with no contradictor -- a claim of proof with no proof, and invisible to
+ * `audit()` and to `hasOutstandingContradiction`, both of which read the edge.
+ */
+export function contradict(dir, { key, byKey, reason }) {
+  const graph = load(dir);
+  const target = findingByKey(graph, key);
+  const source = findingByKey(graph, byKey);
+  // Both ends must exist, or the edge is unresolvable and the disagreement is
+  // recorded against nothing -- the same un-invalidatable shape anchors prevent.
+  if (!target || !source) return false;
+  // A finding cannot disagree with itself. The self-edge resolves, so the guard
+  // above waves it through, and the result is a node permanently blocked from
+  // confidence promotion by a dispute no person can ever resolve: there is no
+  // second claim to choose between.
+  if (target.id === source.id) return false;
+
+  putEdge(dir, source.id, 'contradicts', target.id);
+  putNode(dir, {
+    ...target,
+    kind: 'finding',
+    key,
+    contradictedAt: Date.now(),
+    contradictionReason: String(reason || '').slice(0, 400),
+  });
+  return true;
+}
+
+/**
+ * Whether anything currently disagrees with this finding.
+ *
+ * Gates confidence promotion. Plan 2's per-finding utility measures whether a
+ * finding SUPPRESSES READS, and a confidently wrong finding suppresses reads
+ * better than a hedged true one -- so utility must never raise confidence on
+ * its own, and this is the check that stops it.
+ *
+ * SYMMETRIC, deliberately: BOTH ends of a `contradicts` edge are outstanding
+ * until a person resolves the disagreement. The named hazard in the design is
+ * presenting "the new one as though it had always been true", so gating only
+ * the older claim would leave the newer one -- which is just as likely to be
+ * the wrong one, since nothing here adjudicates -- free to be promoted on
+ * measured utility alone. That is the exact failure this gate exists to stop.
+ * It also matches `audit()`, the reader that has always been here: it puts both
+ * `from` and `to` in its `contradicted` bucket, because "until one looks, BOTH
+ * are being served".
+ */
+export function hasOutstandingContradiction(graph, key) {
+  const node = findingByKey(graph, key);
+  if (!node) return false;
+  return graph.edges.some(
+    (e) => e.edge === 'contradicts' && (e.to === node.id || e.from === node.id)
+  );
 }
 
 /**

--- a/plugin/hooks/lib/curate.mjs
+++ b/plugin/hooks/lib/curate.mjs
@@ -124,7 +124,17 @@ export function correct(
   const replacementKey = `${key}-c${Date.now().toString(36)}`;
 
   const edges = [{ edge: 'supersedes', to: originalId }];
-  // The correction inherits the original's anchors, so it can go stale too.
+  // The correction inherits the original's anchors, so it can go stale too --
+  // but it inherits NOTHING ELSE, and that is deliberate rather than incidental.
+  // The node written below is built field by field from `existing` instead of
+  // spreading it, which is what keeps the staleness fields (`stale`,
+  // `staleReason`, `diff`) off the successor: a correction is re-derived
+  // against the current code by definition, so being born carrying its
+  // predecessor's invalidation would discount it the moment it existed --
+  // `disclose.mjs` skips a stale finding outright and `utility.mjs` penalises
+  // one by 160. Any future edit here that reaches for `...existing` to pick up
+  // one more field re-introduces that, since `putNode` writes what it is handed
+  // wholesale; `tests/hooks/stale-clearing.test.mjs` is the guard.
   for (const edge of graph.edges) {
     if (edge.edge === 'derived_from' && edge.from === originalId) {
       edges.push({ edge: 'derived_from', to: edge.to });
@@ -244,13 +254,38 @@ export function contradict(dir, { key, byKey, reason }) {
  * It also matches `audit()`, the reader that has always been here: it puts both
  * `from` and `to` in its `contradicted` bucket, because "until one looks, BOTH
  * are being served".
+ *
+ * A RETIRED COUNTERPART DOES NOT COUNT, and that sentence quoted just above is
+ * the reason. This read edges ONLY, so retiring one end of a contradiction left
+ * the survivor gated against confidence promotion forever and served with a
+ * DISPUTED note naming a key `serve` refuses to hand anybody -- `serve`,
+ * `activeFindings`, `findingsFor` and `sessionIndex` all drop a retired
+ * finding. A retired claim is served to NOBODY, so "BOTH are being served" is
+ * false and the premise of the gate is gone: only one claim is in play, and
+ * there is nothing left to choose between. Retiring one end IS the person
+ * looking that this gate was waiting for -- so the edge counts as open only
+ * while NEITHER end is retired, answered the same way from both directions.
+ *
+ * AN UNRESOLVABLE END STILL COUNTS. An edge whose other side names no node
+ * proves nothing about whether that claim was withdrawn, and the conservative
+ * reading -- still disputed -- is the one that cannot promote a claim nobody
+ * adjudicated.
  */
 export function hasOutstandingContradiction(graph, key) {
   const node = findingByKey(graph, key);
-  if (!node) return false;
-  return graph.edges.some(
-    (e) => e.edge === 'contradicts' && (e.to === node.id || e.from === node.id)
-  );
+  // A withdrawn claim is not in a dispute either: a dispute needs two claims in
+  // play, and this one has been taken out of play. Without this the RETIRED end
+  // still reported an open disagreement, which is the same defect from the other
+  // side -- and the answer has to agree from both directions, since the gate is
+  // symmetric on purpose.
+  if (!node || node.retired) return false;
+  return graph.edges.some((e) => {
+    if (e.edge !== 'contradicts') return false;
+    const otherId = e.from === node.id ? e.to : e.to === node.id ? e.from : null;
+    if (!otherId) return false;
+    const other = graph.nodes.get(otherId);
+    return !other || !other.retired;
+  });
 }
 
 /**
@@ -334,11 +369,24 @@ export function audit(graph) {
       .map((e) => e.from)
   );
 
+  // THE SAME DEFINITION OF AN OPEN DISPUTE as hasOutstandingContradiction, and
+  // it has to be: that function's own comment claims it "matches audit()", and
+  // two rankings that disagree about what needs a human is worse than one that
+  // is wrong. A retired counterpart is a resolved dispute -- the retired claim
+  // is served to nobody -- so the survivor is not one of two claims in play and
+  // does not belong in the bucket of things needing a person to look.
+  //
+  // One pass, not a call per finding: this is a dashboard read over the whole
+  // graph, and the obvious rewrite is O(findings x edges).
   const contradicted = new Set();
   for (const edge of graph.edges) {
     if (edge.edge !== 'contradicts') continue;
-    contradicted.add(edge.from);
-    contradicted.add(edge.to);
+    const from = graph.nodes.get(edge.from);
+    const to = graph.nodes.get(edge.to);
+    // An end that resolves to nothing cannot be shown retired, so it still
+    // counts against the other end.
+    if (!to || !to.retired) contradicted.add(edge.from);
+    if (!from || !from.retired) contradicted.add(edge.to);
   }
 
   return {

--- a/plugin/hooks/lib/curate.mjs
+++ b/plugin/hooks/lib/curate.mjs
@@ -70,6 +70,38 @@ export function originWeight(origin) {
   return 1;
 }
 
+/**
+ * The claim-time anchor hashes, for a finding being written right now.
+ *
+ * THE CHECKABLE HALF OF PROVENANCE, and until now only `harvest-write.mjs`
+ * wrote it -- so the asymmetry ran exactly the wrong way. `reverify` and the
+ * automatic clear in `serve` both compare disk against these frozen hashes, and
+ * a finding without them can never have a stale flag cleared by anything. That
+ * meant HUMAN-asserted findings, the ones somebody deliberately created or
+ * corrected, were the only ones condemned to stay stale forever once marked,
+ * while machine-harvested claims could recover. The hashes are simply the anchor
+ * nodes' hashes at this moment, and every writer has them in hand.
+ *
+ * DELIBERATELY NOT THE WHOLE RECORD `derivationFor` BUILDS. That one joins the
+ * evidence log to find FILE-surface operations behind the claim; curation
+ * performs no such join, so `operations` is empty and `operationsComplete` says
+ * so. An empty list declared incomplete is honest -- "nothing recorded here, and
+ * do not read that as nothing happened" -- where an empty list declared complete
+ * would assert a fact nobody established.
+ *
+ * An anchor with no stored hash contributes no entry, and a finding whose
+ * anchors all lack one gets a record with no hashes -- which `claimTimeVerdict`
+ * reads as `unknown` and refuses to clear on, which is the correct reading.
+ */
+function claimTimeDerivation(graph, resolved) {
+  const anchors = {};
+  for (const id of resolved) {
+    const node = graph.nodes.get(id);
+    if (node && typeof node.hash === 'string') anchors[id] = node.hash;
+  }
+  return { at: Date.now(), anchors, operations: [], operationsComplete: false };
+}
+
 function findingByKey(graph, key) {
   return graph.nodes.get(nodeId('finding', key)) || null;
 }
@@ -124,6 +156,11 @@ export function correct(
   const replacementKey = `${key}-c${Date.now().toString(36)}`;
 
   const edges = [{ edge: 'supersedes', to: originalId }];
+  // Collected alongside the edges so the correction carries its own claim-time
+  // hashes: it is a NEW claim, re-derived against whatever the code says now, so
+  // its evidence is the anchors' current state -- not the predecessor's, which is
+  // precisely what went stale.
+  const inherited = [];
   // The correction inherits the original's anchors, so it can go stale too --
   // but it inherits NOTHING ELSE, and that is deliberate rather than incidental.
   // The node written below is built field by field from `existing` instead of
@@ -138,6 +175,7 @@ export function correct(
   for (const edge of graph.edges) {
     if (edge.edge === 'derived_from' && edge.from === originalId) {
       edges.push({ edge: 'derived_from', to: edge.to });
+      inherited.push(edge.to);
     }
   }
 
@@ -171,6 +209,11 @@ export function correct(
       // branches, and an unrecognised value already degrades to the neutral
       // ranking weight rather than doing damage.
       origin: typeof origin === 'string' && origin ? origin : ORIGIN_HUMAN,
+      // Without this a correction could never have a stale flag cleared: both
+      // clearing paths compare disk against these hashes, and a finding with
+      // none is `unknown` forever. A hand-written correction being the least
+      // recoverable record in the graph was the wrong way round.
+      derivation: claimTimeDerivation(graph, inherited),
     },
     edges
   );
@@ -339,7 +382,18 @@ export function create(dir, { claim, anchors, type = 'finding', confidence = 0.9
   // path. No process death required; one transient EBUSY is enough.
   const id = putNodeWithEdges(
     dir,
-    { kind: 'finding', key, claim, confidence, type, origin: ORIGIN_HUMAN },
+    {
+      kind: 'finding',
+      key,
+      claim,
+      confidence,
+      type,
+      origin: ORIGIN_HUMAN,
+      // Read AFTER the indexFile loop above, so the hashes are the ones the
+      // person's claim was actually made against rather than whatever the graph
+      // held before this call touched it.
+      derivation: claimTimeDerivation(loadGraph(dir), resolved),
+    },
     resolved.map((target) => ({ edge: 'derived_from', to: target }))
   );
   if (!id) return null;

--- a/plugin/hooks/lib/decide.mjs
+++ b/plugin/hooks/lib/decide.mjs
@@ -542,19 +542,92 @@ const TOOL_ALIASES = new Map(
     run_shell_command: 'Bash',
     run_terminal_cmd: 'Bash',
     terminal: 'Bash',
+
+    // THIS PROJECT'S OWN TOOLS, which the table did not list for as long as it
+    // existed. `plugin/hooks/hooks.json`'s PostToolUse matcher named
+    // `mcp__.*__(?:smart_edit|smart_write)` and Codex's AfterTool matcher named
+    // the bare `smart_edit|smart_write`, so both hooks fired -- and then
+    // `normalizeTool` returned null and the hook exited before a single line of
+    // accounting ran. Staleness, mutation counting and harvest pressure were all
+    // blind on exactly the path enforcement pushes the model toward, which is the
+    // worst place to be blind: the more effective the routing, the less the
+    // optimizer saw.
+    //
+    // These names are the CANONICAL operation, not a licence to redirect. A call
+    // that is already the replacement is excluded from routing by
+    // `isReplacementTool` below.
+    smart_read: 'Read',
+    smart_grep: 'Grep',
+    smart_glob: 'Glob',
+    smart_edit: 'Edit',
+    smart_write: 'Write',
+
+    // Claude Code's notebook editor. Same shape of gap: a real mutation of a
+    // real file on disk that arrived as null and so never reached
+    // `pending.mjs`'s MUTATING set, leaving every notebook write invisible to
+    // invalidation.
+    notebookedit: 'Edit',
+    notebook_edit: 'Edit',
   })
 );
 
-/** Maps a client's tool name onto the canonical one, or null if unhandled. */
+/**
+ * The optimizer's own replacement tools, by canonical trailing segment.
+ *
+ * Kept separate from the alias table because the two answer different questions.
+ * The table answers "what operation is this", which post-tool accounting needs.
+ * This set answers "is this call ALREADY the thing we would have recommended",
+ * which routing needs -- and conflating them is the loop hazard: `smart_edit`
+ * resolves to `Edit`, the Edit branch recommends `smart_edit`, and the model is
+ * told to call the tool it just called.
+ */
+const REPLACEMENT_TOOLS = new Set([
+  'smart_read',
+  'smart_grep',
+  'smart_glob',
+  'smart_edit',
+  'smart_write',
+]);
+
+/**
+ * The tool name with an `mcp__<server>__` prefix removed, if it had one.
+ *
+ * Server segments contain underscores freely (`plugin_token-optimizer_token-optimizer`)
+ * and so do tool names (`smart_edit`), so the split is taken at the LAST `__`
+ * after the `mcp__` sentinel. Both halves must be non-empty: `mcp__edit` names
+ * no server and is not a name any host emits, and treating it as `edit` would
+ * coerce an unrecognised string into a built-in.
+ */
+function withoutMcpPrefix(name) {
+  const match = /^mcp__(.+)__(.+)$/.exec(name);
+  return match ? match[2] : name;
+}
+
+/** Whether this call IS one of the optimizer's replacements, however spelled. */
+export function isReplacementTool(name) {
+  if (!name) return false;
+  return REPLACEMENT_TOOLS.has(withoutMcpPrefix(String(name)).toLowerCase());
+}
+
+/**
+ * Maps a client's tool name onto the canonical one, or null if unhandled.
+ *
+ * PERMISSIVE IN ONE DIRECTION ONLY. An MCP-prefixed name is resolved by its
+ * trailing segment, but only against the same table every other client is held
+ * to -- so `mcp__vendor__deploy_to_prod` stays null. Coercing an unrecognised
+ * MCP tool into a built-in would change a routing verdict for a tool nobody has
+ * considered, which is a far worse failure than not accounting for it.
+ */
 export function normalizeTool(name) {
   if (!name) return null;
+  const candidate = withoutMcpPrefix(String(name));
   if (
     ['Read', 'Grep', 'Glob', 'Edit', 'MultiEdit', 'Write', 'Bash'].includes(
-      name
+      candidate
     )
   )
-    return name;
-  return TOOL_ALIASES.get(String(name).toLowerCase()) || null;
+    return candidate;
+  return TOOL_ALIASES.get(candidate.toLowerCase()) || null;
 }
 
 /**
@@ -614,6 +687,13 @@ export function normalizePayload(raw) {
     transcript_path: raw.transcript_path ?? raw.transcriptPath ?? null,
     cwd,
     tool_name: normalizeTool(raw.tool_name ?? raw.toolName ?? raw.tool),
+    // WHETHER THIS CALL IS ALREADY THE REPLACEMENT, carried alongside the
+    // canonical name rather than inferred from it -- because it cannot be
+    // inferred from it. `smart_edit` and `Edit` both normalise to `Edit`, and
+    // routing has to treat them as opposites while accounting treats them as
+    // the same. Absent by default (`false`), so a payload assembled by hand in
+    // a test or by a caller that predates this field is a normal built-in call.
+    replacement: isReplacementTool(raw.tool_name ?? raw.toolName ?? raw.tool),
     tool_input: {
       ...input,
       // CANONICALISED HERE, once. Every consumer downstream -- the `seen` map
@@ -673,6 +753,19 @@ function replacementAvailable(availableTools, name) {
 }
 
 export function decide(payload, state, availableTools = undefined) {
+  // THE LOOP HAZARD, and the reason this guard is at the top rather than inside
+  // any one branch. Resolving `smart_edit` to `Edit` is what makes post-tool
+  // accounting work; it must not also make the Edit branch answer a smart_edit
+  // call with "call smart_edit instead". This is not theoretical on a matcher
+  // level either: Qwen's PreToolUse matcher is the unanchored regex
+  // `edit|write_file|run_shell_command`, and `edit` matches inside
+  // `mcp__x__smart_edit`, so that client really does hand the router calls to
+  // its own replacements.
+  //
+  // A tool that IS the replacement is never routed. There is nothing better to
+  // recommend, and every branch below would recommend itself.
+  if (payload.replacement) return null;
+
   const tool = payload.tool_name;
   const input = payload.tool_input || {};
   const threshold = largeFileBytes();
@@ -873,6 +966,12 @@ export function remember(payload, state) {
  */
 export function readCostBytes(payload) {
   if (payload.tool_name !== 'Read') return 0;
+  // A REPLACEMENT DID NOT SPEND THE WHOLE FILE. `smart_read` normalises to
+  // `Read` so the graph sees the touch, but it returns a diff -- charging the
+  // full file size here would feed the holdout comparison a cost that was never
+  // paid, on the arm the optimizer is trying to show is cheaper. Better to
+  // record nothing than to record a number in the wrong direction.
+  if (payload.replacement) return 0;
   const path = payload.tool_input?.file_path;
   if (!path || isBinaryPath(path)) return 0;
   const size = fileSize(path);

--- a/plugin/hooks/lib/disclose.mjs
+++ b/plugin/hooks/lib/disclose.mjs
@@ -294,6 +294,11 @@ export function verdictFor(graph, { anchors = [], question, minConfidence = 0.7 
     const id = nodeId('file', canonicalPath(anchor));
     if (!graph.nodes.has(id)) continue;
 
+    // READ-ONLY serve: no `dir` is threaded here, so this cannot clear a stale
+    // flag whose evidence is gone. That is deliberate -- this function takes a
+    // graph, not the directory it came from, and widening its signature to give
+    // an analysis path a write capability buys nothing: the injection path runs
+    // on every tool call and clears the same findings.
     const findings = serve(graph, findingsFor(graph, id, { limit: 4 }));
     for (const finding of findings) {
       if (finding.stale) continue;

--- a/plugin/hooks/lib/harvest-write.mjs
+++ b/plugin/hooks/lib/harvest-write.mjs
@@ -34,7 +34,7 @@ import { randomBytes } from 'node:crypto';
 import { realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
-import { readEvidence } from './metrics.mjs';
+import { readEvidence, evidenceTruncated } from './metrics.mjs';
 
 /**
  * The types that may cross a project boundary.
@@ -431,53 +431,84 @@ function resolveAnchor(dir, anchor, projectRoot) {
 /**
  * Which task actually produced this finding, when nothing said so directly.
  *
- * Session id was the only signal `answers` had, and a session id is exactly
- * what a caller may not have (`wiki_write`'s `sessionId` is optional and
- * nothing populates it today; the detached harvest worker's is gated behind
- * an opt-in). But the graph does not need to be TOLD which task this is: the
- * structural harvest already writes `task -[derived_from]-> file` for every
- * tool call, unconditionally, on every install. So the task is DERIVABLE --
- * it is whichever task node has a `derived_from` edge to one of the SAME
- * anchors this finding resolved to.
+ * ROUND 2's version scanned the WHOLE graph for any task sharing any anchor,
+ * broken by recency. An adversarial review constructed four cases where that
+ * attributes a finding to the WRONG task:
  *
- * "Most recent task, full stop" was rejected on purpose: a task that never
- * touched these files could still be the newest node in the graph (a
- * different file, a different concern, in a later session), and attaching
- * provenance to it would be a WRONG edge, not a missing one -- worse than no
- * edge, because a reader trusts it. So candidates are filtered to tasks that
- * touched at least one of these anchors FIRST, and only ties among THOSE are
- * broken by recency.
+ *   1. STALE PRIOR SESSION -- a session that reasons from injected memory and
+ *      writes a finding about `foo.ts` without touching it this session gets
+ *      attributed to whatever task last touched `foo.ts`, possibly days old,
+ *      possibly someone else's work.
+ *   2. CONCURRENT SESSION -- two windows on one repository; the other
+ *      session's task wins if its touch is a millisecond later.
+ *   3. OVERLAP, NOT COVERAGE -- a finding anchored to [a, b]; a task that
+ *      touched only `b` could still win over one that touched both.
+ *   4. THE TIE-BREAK CONTRADICTED ITS OWN COMMENT -- `Number(edge.at) || 0`
+ *      with strict `>` means the FIRST edge in log order wins on a tie,
+ *      which is the OLDER task, not "more recently" as documented.
  *
- * The tie-break is the edge's own `at`, not the task node's `at`. A task that
- * touched this file once, long ago, and then stayed active on unrelated files
- * for hours has a late node timestamp that says nothing about this anchor;
- * the edge timestamp says exactly when THIS task touched THIS anchor, which
- * is the question being asked. Among tasks sharing an anchor, the one whose
- * most recent touch to any shared anchor is latest wins -- recency of the
- * relevant work, not recency of the task in general.
+ * THE FIX IS NARROWER THAN A BETTER RANKING: SCOPE, THEN REQUIRE COVERAGE.
+ * A task only ever belongs to the session that created it -- `harvest()` and
+ * `linkCoOccurrence()` (wiki.mjs, inject.mjs) both key a task node by
+ * `sessionId`, always, so there is exactly ONE task node for "the current
+ * session" and it is `nodeId('task', sessionId)`. Restricting to that ONE
+ * node structurally eliminates cases 1 and 2 -- a prior or concurrent
+ * session's task has a DIFFERENT sessionId and therefore a different node
+ * id, so it is never even looked at, regardless of timing. No caller can
+ * supply a wrong sessionId and get someone ELSE's task; they can only fail
+ * to get a match.
+ *
+ * COVERAGE, NOT OVERLAP, fixes case 3: the session's task must have a
+ * `derived_from` edge to EVERY one of this finding's anchors, not merely one.
+ * A partial touch is not attribution.
+ *
+ * With the candidate set reduced to at most one node, there is nothing left
+ * to break a tie between -- case 4's comparator is not "fixed", it is
+ * deleted, because the scenario it was written for (two DIFFERENT tasks both
+ * legitimately eligible) cannot occur under this scoping: two task nodes can
+ * never share a key, and only the current session's key is ever considered.
+ * An edge's `at` therefore plays NO role here: presence of a `derived_from`
+ * edge from the session's task to an anchor is what "touched it" means, with
+ * or without a timestamp on that edge -- there is no ranking left for a
+ * missing timestamp to lose.
+ *
+ * `sessionId` absent means there is no identity to scope by, which means no
+ * candidate -- not "fall back to guessing". Absence is the correct answer
+ * when the graph cannot support attribution.
  */
-function taskForAnchors(graph, anchorIds) {
-  if (!anchorIds || !anchorIds.length) return null;
-  const anchors = new Set(anchorIds);
-  let best = null;
-  for (const edge of graph.edges) {
-    if (edge.edge !== 'derived_from' || !anchors.has(edge.to)) continue;
-    const from = graph.nodes.get(edge.from);
-    // `derived_from` is also how a FINDING cites its own anchors, so without
-    // this a finding that already cited the same file would be mistaken for
-    // the task that produced it.
-    if (!from || from.kind !== 'task') continue;
-    const at = Number(edge.at) || 0;
-    if (!best || at > best.at) best = { taskId: edge.from, at };
+function taskForAnchors(graph, anchorIds, sessionId) {
+  if (!sessionId || !anchorIds || !anchorIds.length) return null;
+  const taskTarget = nodeId('task', sessionId);
+  const task = graph.nodes.get(taskTarget);
+  if (!task || task.kind !== 'task') return null;
+
+  for (const anchor of anchorIds) {
+    const covered = graph.edges.some((edge) =>
+      edge.edge === 'derived_from' && edge.from === taskTarget && edge.to === anchor
+    );
+    // ONE missing anchor refuses the whole attribution. A finding cited three
+    // files; this session's task touched two of them -- that is evidence the
+    // task did SOME related work, not evidence it produced THIS finding.
+    if (!covered) return null;
   }
-  return best ? best.taskId : null;
+  return taskTarget;
 }
 
 /**
  * A file path the way `recordToolOutcome` (metrics.mjs) already truncates and
- * stores it on a `tool-outcome` event's `anchor` field, so a derivation record
- * can join against that log without a second, divergent notion of "the same
- * anchor".
+ * stores it on a FILE-surface `tool-outcome` event's `anchor` field, so a
+ * derivation record can join against that log without a second, divergent
+ * notion of "the same anchor".
+ *
+ * COMMAND-surface events are DECLARED OUT OF SCOPE, not silently missed:
+ * `adapter.mjs` stores the COMMAND TEXT in `anchor` for those
+ * (`String(command).slice(0, 120)`), so a build or test run can never share
+ * an anchor string with a canonical file path -- there is no join key in
+ * common, and inventing a command-to-file heuristic (which files did a given
+ * `npm test` invocation cover?) is not something this record can answer
+ * honestly. `operationsScope` on the returned record says so explicitly,
+ * rather than letting an empty `operations` array look like "no build or
+ * test ever ran" when the truth is "this join cannot see it".
  */
 function anchorLabel(rawAnchor) {
   const path = String(rawAnchor).split('#')[0];
@@ -497,7 +528,8 @@ const MAX_DERIVATION_OPERATIONS = 5;
  * that comparison be reconstructed for a specific claim rather than only for
  * the anchor in general: the hash each anchor carried at the moment this
  * finding was derived from it, plus what evidence exists that any work
- * actually happened against it.
+ * actually happened against it. `derivationCheck` (staleness.mjs) is the
+ * reader that actually performs that comparison at serve time.
  *
  * DELIBERATELY NOT DUPLICATING THE EDGES. `derived_from` already records
  * WHICH anchors this finding cites; restating that here would be a second,
@@ -506,14 +538,23 @@ const MAX_DERIVATION_OPERATIONS = 5;
  *
  * DELIBERATELY NOT A REPLAY LOG. Recording enough to mechanically re-run a
  * derivation is a separate subsystem with real storage cost. This stores only
- * what the evidence log already has: `tool-outcome` events matching these
- * anchors, each reduced to the fields that were actually captured. An event
- * that carries no exit code or output contributes none -- nothing here is
- * invented to fill a shape the pipeline does not evidence yet. If a future
- * capture pass adds `exit`/`output` to those events, this starts carrying them
- * with no change to this function.
+ * what the evidence log already has: FILE-surface `tool-outcome` events
+ * matching these anchors, each reduced to the fields that were actually
+ * captured. An event that carries no exit code or output contributes none --
+ * nothing here is invented to fill a shape the pipeline does not evidence
+ * yet. If a future capture pass adds `exit`/`output` to those events, this
+ * starts carrying them with no change to this function.
+ *
+ * INCOMPLETENESS IS MARKED, NOT IMPLIED. An empty `operations` array is
+ * genuinely ambiguous on its own -- it is the same shape whether nothing
+ * happened, or something happened but fell outside what this join can see.
+ * `operationsComplete` distinguishes them: false when the evidence log itself
+ * may have dropped older matches (`evidenceIncomplete`, from
+ * `metrics.evidenceTruncated`) OR when more matches existed than the cap
+ * kept. A reader can then tell "no operations happened" from "operations
+ * existed but are not recorded here" instead of guessing.
  */
-function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
+function derivationFor(graph, resolvedAnchors, evidence, evidenceIncomplete, anchorSpecs) {
   const anchorHashes = {};
   for (const id of resolvedAnchors) {
     const node = graph.nodes.get(id);
@@ -521,8 +562,10 @@ function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
   }
 
   const labels = new Set((anchorSpecs || []).map(anchorLabel));
-  const operations = evidence
-    .filter((event) => event.kind === 'tool-outcome' && labels.has(event.anchor))
+  const matching = evidence.filter(
+    (event) => event.kind === 'tool-outcome' && labels.has(event.anchor)
+  );
+  const operations = [...matching]
     .sort((a, b) => (Number(b.at) || 0) - (Number(a.at) || 0))
     .slice(0, MAX_DERIVATION_OPERATIONS)
     .map((event) => {
@@ -540,7 +583,16 @@ function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
       return op;
     });
 
-  return { at: Date.now(), anchors: anchorHashes, operations };
+  return {
+    at: Date.now(),
+    anchors: anchorHashes,
+    operations,
+    // FILE touches only -- see `anchorLabel`. Declared here, in the record
+    // itself, not only in this function's comment, so a reader who never
+    // opens this source file still learns builds and test runs are excluded.
+    operationsScope: 'file',
+    operationsComplete: !evidenceIncomplete && matching.length <= operations.length,
+  };
 }
 
 /**
@@ -588,6 +640,9 @@ export function writeHarvested(
   // it can hold thousands of lines, so re-reading it per finding would turn a
   // batch of N findings into N passes over the same bytes.
   const evidence = readEvidence(dir);
+  // Cheap: one stat call, checked once per batch rather than once per
+  // finding's derivation record.
+  const evidenceIncomplete = evidenceTruncated(dir);
 
   const written = [];
   for (const finding of findings) {
@@ -647,14 +702,16 @@ export function writeHarvested(
     // An explicit `taskId` is authoritative when a caller supplies one --
     // it OVERRIDES traversal rather than merely seeding it, so a caller that
     // knows better is never second-guessed by inference. Absent one, the task
-    // is DERIVED from the graph itself: `taskForAnchors` finds the task that
-    // actually touched these anchors, which needs no session id from anyone.
-    // Either way, held to the same discipline as the anchors above: a target
-    // that does not resolve to an existing task node produces no edge rather
-    // than a dangling one.
+    // is DERIVED from the graph itself: `taskForAnchors` finds the CURRENT
+    // session's task (scoped by `sessionId`, the same identity this write
+    // already carries for provenance) and requires it to have touched EVERY
+    // one of this finding's anchors, not merely one -- see that function's
+    // own comment for the four attacks this closes. Either way, held to the
+    // same discipline as the anchors above: a target that does not resolve to
+    // an existing task node produces no edge rather than a dangling one.
     const answersTarget = taskId
       ? nodeId('task', taskId)
-      : taskForAnchors(currentGraph, resolved);
+      : taskForAnchors(currentGraph, resolved, sessionId);
     if (answersTarget && currentGraph.nodes.has(answersTarget)) {
       edges.push({ edge: 'answers', to: answersTarget });
     }
@@ -707,7 +764,7 @@ export function writeHarvested(
         // `render()`/`renderSessionIndex()` in inject.mjs or `wiki_read`'s
         // `toFinding()` projection, neither of which reads this field, so it
         // is not part of the automatic per-touch injection `fit()` prices.
-        derivation: derivationFor(currentGraph, resolved, evidence, finding.anchors || []),
+        derivation: derivationFor(currentGraph, resolved, evidence, evidenceIncomplete, finding.anchors || []),
       },
       edges
     );

--- a/plugin/hooks/lib/harvest-write.mjs
+++ b/plugin/hooks/lib/harvest-write.mjs
@@ -452,11 +452,13 @@ function resolveAnchor(dir, anchor, projectRoot) {
  * `linkCoOccurrence()` (wiki.mjs, inject.mjs) both key a task node by
  * `sessionId`, always, so there is exactly ONE task node for "the current
  * session" and it is `nodeId('task', sessionId)`. Restricting to that ONE
- * node structurally eliminates cases 1 and 2 -- a prior or concurrent
- * session's task has a DIFFERENT sessionId and therefore a different node
- * id, so it is never even looked at, regardless of timing. No caller can
- * supply a wrong sessionId and get someone ELSE's task; they can only fail
- * to get a match.
+ * node structurally eliminates cases 1 and 2 PROVIDED the identity itself is
+ * trustworthy: an UNRELATED sessionId (typo'd, invented, or simply absent)
+ * cannot resolve to someone else's task, because a different key is a
+ * different node id, full stop, regardless of timing. That is NOT the same
+ * guarantee as "no caller can get someone else's task" -- see the note on
+ * `authoritativeSessionId` below for the residual this leaves when the
+ * identity is real but comes from an untrusted caller.
  *
  * COVERAGE, NOT OVERLAP, fixes case 3: the session's task must have a
  * `derived_from` edge to EVERY one of this finding's anchors, not merely one.
@@ -472,17 +474,41 @@ function resolveAnchor(dir, anchor, projectRoot) {
  * or without a timestamp on that edge -- there is no ranking left for a
  * missing timestamp to lose.
  *
- * `sessionId` absent means there is no identity to scope by, which means no
- * candidate -- not "fall back to guessing". Absence is the correct answer
- * when the graph cannot support attribution.
+ * NO IDENTITY MEANS NO CANDIDATE -- not "fall back to guessing". Absence is
+ * the correct answer when the graph cannot support attribution.
+ *
+ * ROUND 4: THE IDENTITY ITSELF MUST BE AUTHORITATIVE, not merely present.
+ * Scoping to `nodeId('task', sessionId)` only refuses an UNRELATED session;
+ * it does nothing against a FOREIGN BUT REAL one. `wiki_write`'s `sessionId`
+ * is a plain MCP tool argument the calling model supplies, unverified -- a
+ * model that names some OTHER, prior session whose task genuinely covered
+ * these anchors gets an `answers` edge to that stale task, because coverage
+ * cannot tell "this session" from "a session that really did touch these
+ * files, named by a string nothing cross-checked". Session id is not
+ * evidence unless the CALLER'S OWN CHANNEL is trustworthy, which is true of
+ * `plugin/hooks/harvest-worker.mjs` (Claude Code's own hook payload) and not
+ * true of a tool-call argument. So this parameter is named for what it must
+ * be, `authoritativeSessionId`, and every caller is a promise: pass this only
+ * when you did not just read it out of untrusted input. `wiki_write` passes
+ * NONE, which means its calls never traverse -- see `writeHarvested`'s own
+ * comment at the call site for what that costs and why it is accepted rather
+ * than worked around.
+ *
+ * COVERAGE IS CHECKED AGAINST RESOLVED ANCHORS, not the caller's original
+ * list. `writeHarvested` already drops any anchor `resolveAnchor` could not
+ * resolve before this function ever runs, so "every anchor" here means every
+ * anchor that survived that filter -- self-consistent with the
+ * `derived_from` edges the same resolved list produces, but worth stating:
+ * an anchor that failed to resolve cannot raise or lower the bar for the
+ * anchors that did.
  */
-function taskForAnchors(graph, anchorIds, sessionId) {
-  if (!sessionId || !anchorIds || !anchorIds.length) return null;
-  const taskTarget = nodeId('task', sessionId);
+function taskForAnchors(graph, resolvedAnchorIds, authoritativeSessionId) {
+  if (!authoritativeSessionId || !resolvedAnchorIds || !resolvedAnchorIds.length) return null;
+  const taskTarget = nodeId('task', authoritativeSessionId);
   const task = graph.nodes.get(taskTarget);
   if (!task || task.kind !== 'task') return null;
 
-  for (const anchor of anchorIds) {
+  for (const anchor of resolvedAnchorIds) {
     const covered = graph.edges.some((edge) =>
       edge.edge === 'derived_from' && edge.from === taskTarget && edge.to === anchor
     );
@@ -604,7 +630,19 @@ function derivationFor(graph, resolvedAnchors, evidence, evidenceIncomplete, anc
 export function writeHarvested(
   dir,
   findings,
-  { sessionId = null, origin = ORIGIN_HARVESTED, projectRoot = null, taskId = null } = {}
+  {
+    sessionId = null,
+    origin = ORIGIN_HARVESTED,
+    projectRoot = null,
+    taskId = null,
+    // Distinct from `sessionId`, which is stored on every finding for
+    // provenance/display regardless of trust. This one gates the `answers`
+    // traversal fallback specifically, and every caller passing it is
+    // asserting the identity came from a channel it does not control --
+    // Claude Code's own hook payload, not a tool-call argument a model
+    // typed. See `taskForAnchors`'s comment for the attack this closes.
+    authoritativeSessionId = null,
+  } = {}
 ) {
   if (!Array.isArray(findings) || !findings.length) return [];
 
@@ -702,16 +740,29 @@ export function writeHarvested(
     // An explicit `taskId` is authoritative when a caller supplies one --
     // it OVERRIDES traversal rather than merely seeding it, so a caller that
     // knows better is never second-guessed by inference. Absent one, the task
-    // is DERIVED from the graph itself: `taskForAnchors` finds the CURRENT
-    // session's task (scoped by `sessionId`, the same identity this write
-    // already carries for provenance) and requires it to have touched EVERY
-    // one of this finding's anchors, not merely one -- see that function's
-    // own comment for the four attacks this closes. Either way, held to the
-    // same discipline as the anchors above: a target that does not resolve to
-    // an existing task node produces no edge rather than a dangling one.
+    // is DERIVED from the graph itself, but ONLY when `authoritativeSessionId`
+    // is present: `taskForAnchors` scopes to that exact session's task and
+    // requires it to have touched EVERY one of this finding's anchors, not
+    // merely one -- see that function's own comment for why the identity
+    // itself must be trustworthy, not merely present.
+    //
+    // THE CONSEQUENCE, STATED PLAINLY: `wiki_write` never supplies
+    // `authoritativeSessionId` (its `sessionId` is a model-typed MCP
+    // argument nothing cross-checks), so its calls never traverse and
+    // `answers` never fires on that path. `plugin/hooks/harvest-worker.mjs`
+    // does supply it (Claude Code's own hook payload), so `answers` fires
+    // there -- opt-in gated. `answers` therefore does NOT fire on a default
+    // install today. Recovering default liveness needs an authoritative
+    // identity on a default-install path, which is what Plan 2's
+    // `hooks-core/derive.mjs` (running in the Stop hook, where the session id
+    // is real) is for -- not a weaker check here.
+    //
+    // Either way, held to the same discipline as the anchors above: a target
+    // that does not resolve to an existing task node produces no edge rather
+    // than a dangling one.
     const answersTarget = taskId
       ? nodeId('task', taskId)
-      : taskForAnchors(currentGraph, resolved, sessionId);
+      : taskForAnchors(currentGraph, resolved, authoritativeSessionId);
     if (answersTarget && currentGraph.nodes.has(answersTarget)) {
       edges.push({ edge: 'answers', to: answersTarget });
     }

--- a/plugin/hooks/lib/harvest-write.mjs
+++ b/plugin/hooks/lib/harvest-write.mjs
@@ -436,7 +436,7 @@ function resolveAnchor(dir, anchor, projectRoot) {
 export function writeHarvested(
   dir,
   findings,
-  { sessionId = null, origin = ORIGIN_HARVESTED, projectRoot = null } = {}
+  { sessionId = null, origin = ORIGIN_HARVESTED, projectRoot = null, taskId = null } = {}
 ) {
   if (!Array.isArray(findings) || !findings.length) return [];
 
@@ -516,6 +516,21 @@ export function writeHarvested(
     // collision vanishingly unlikely while keeping the timestamp readable.
     const provenance = provenanceFor(finding);
     const key = `${prefixFor(provenance)}-${Date.now().toString(36)}-${written.length}-${randomBytes(4).toString("hex")}`;
+
+    const edges = resolved.map((target) => ({ edge: 'derived_from', to: target }));
+    // `answers` closes the loop back to the task that produced the finding, so
+    // provenance can be traversed rather than inferred: "which session
+    // established this, and from what". Declared in EDGE_KINDS and written by
+    // nothing until now. Held to the same discipline as the anchors above: a
+    // taskId that does not resolve to an existing task node produces no edge
+    // rather than a dangling one.
+    if (taskId) {
+      const taskTarget = nodeId('task', taskId);
+      if (currentGraph.nodes.has(taskTarget)) {
+        edges.push({ edge: 'answers', to: taskTarget });
+      }
+    }
+
     // ONE APPEND for the finding and every anchor it resolved. This runs in a
     // detached worker, so "the process survives to finish the loop" is not a
     // safe assumption: a node written without its edges is an active finding
@@ -557,7 +572,7 @@ export function writeHarvested(
           : undefined,
         sessionId,
       },
-      resolved.map((target) => ({ edge: 'derived_from', to: target }))
+      edges
     );
     // A failed write returns null. Reporting the key anyway would tell the
     // caller a claim was stored that no later session can retrieve.

--- a/plugin/hooks/lib/harvest-write.mjs
+++ b/plugin/hooks/lib/harvest-write.mjs
@@ -34,6 +34,7 @@ import { randomBytes } from 'node:crypto';
 import { realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { ORIGIN_HARVESTED, ORIGIN_AGENT, ORIGIN_HUMAN } from './curate.mjs';
+import { readEvidence } from './metrics.mjs';
 
 /**
  * The types that may cross a project boundary.
@@ -428,6 +429,121 @@ function resolveAnchor(dir, anchor, projectRoot) {
 }
 
 /**
+ * Which task actually produced this finding, when nothing said so directly.
+ *
+ * Session id was the only signal `answers` had, and a session id is exactly
+ * what a caller may not have (`wiki_write`'s `sessionId` is optional and
+ * nothing populates it today; the detached harvest worker's is gated behind
+ * an opt-in). But the graph does not need to be TOLD which task this is: the
+ * structural harvest already writes `task -[derived_from]-> file` for every
+ * tool call, unconditionally, on every install. So the task is DERIVABLE --
+ * it is whichever task node has a `derived_from` edge to one of the SAME
+ * anchors this finding resolved to.
+ *
+ * "Most recent task, full stop" was rejected on purpose: a task that never
+ * touched these files could still be the newest node in the graph (a
+ * different file, a different concern, in a later session), and attaching
+ * provenance to it would be a WRONG edge, not a missing one -- worse than no
+ * edge, because a reader trusts it. So candidates are filtered to tasks that
+ * touched at least one of these anchors FIRST, and only ties among THOSE are
+ * broken by recency.
+ *
+ * The tie-break is the edge's own `at`, not the task node's `at`. A task that
+ * touched this file once, long ago, and then stayed active on unrelated files
+ * for hours has a late node timestamp that says nothing about this anchor;
+ * the edge timestamp says exactly when THIS task touched THIS anchor, which
+ * is the question being asked. Among tasks sharing an anchor, the one whose
+ * most recent touch to any shared anchor is latest wins -- recency of the
+ * relevant work, not recency of the task in general.
+ */
+function taskForAnchors(graph, anchorIds) {
+  if (!anchorIds || !anchorIds.length) return null;
+  const anchors = new Set(anchorIds);
+  let best = null;
+  for (const edge of graph.edges) {
+    if (edge.edge !== 'derived_from' || !anchors.has(edge.to)) continue;
+    const from = graph.nodes.get(edge.from);
+    // `derived_from` is also how a FINDING cites its own anchors, so without
+    // this a finding that already cited the same file would be mistaken for
+    // the task that produced it.
+    if (!from || from.kind !== 'task') continue;
+    const at = Number(edge.at) || 0;
+    if (!best || at > best.at) best = { taskId: edge.from, at };
+  }
+  return best ? best.taskId : null;
+}
+
+/**
+ * A file path the way `recordToolOutcome` (metrics.mjs) already truncates and
+ * stores it on a `tool-outcome` event's `anchor` field, so a derivation record
+ * can join against that log without a second, divergent notion of "the same
+ * anchor".
+ */
+function anchorLabel(rawAnchor) {
+  const path = String(rawAnchor).split('#')[0];
+  return canonicalPath(path).slice(0, 120);
+}
+
+/** How many recorded operations a single finding's derivation may cite. */
+const MAX_DERIVATION_OPERATIONS = 5;
+
+/**
+ * The checkable half of provenance: not just where a finding came from, but
+ * whether that derivation still holds.
+ *
+ * Citation-style provenance (a session or task id) answers "where". It never
+ * answers "does this still apply" -- that is what staleness already computes,
+ * by comparing an anchor's STORED hash against disk. This record is what lets
+ * that comparison be reconstructed for a specific claim rather than only for
+ * the anchor in general: the hash each anchor carried at the moment this
+ * finding was derived from it, plus what evidence exists that any work
+ * actually happened against it.
+ *
+ * DELIBERATELY NOT DUPLICATING THE EDGES. `derived_from` already records
+ * WHICH anchors this finding cites; restating that here would be a second,
+ * driftable copy of the same fact. What is new here, and only here, is the
+ * HASH each anchor carried at claim time -- edges carry no such thing.
+ *
+ * DELIBERATELY NOT A REPLAY LOG. Recording enough to mechanically re-run a
+ * derivation is a separate subsystem with real storage cost. This stores only
+ * what the evidence log already has: `tool-outcome` events matching these
+ * anchors, each reduced to the fields that were actually captured. An event
+ * that carries no exit code or output contributes none -- nothing here is
+ * invented to fill a shape the pipeline does not evidence yet. If a future
+ * capture pass adds `exit`/`output` to those events, this starts carrying them
+ * with no change to this function.
+ */
+function derivationFor(graph, resolvedAnchors, evidence, anchorSpecs) {
+  const anchorHashes = {};
+  for (const id of resolvedAnchors) {
+    const node = graph.nodes.get(id);
+    if (node && typeof node.hash === 'string') anchorHashes[id] = node.hash;
+  }
+
+  const labels = new Set((anchorSpecs || []).map(anchorLabel));
+  const operations = evidence
+    .filter((event) => event.kind === 'tool-outcome' && labels.has(event.anchor))
+    .sort((a, b) => (Number(b.at) || 0) - (Number(a.at) || 0))
+    .slice(0, MAX_DERIVATION_OPERATIONS)
+    .map((event) => {
+      const op = {};
+      if (typeof event.toolName === 'string' && event.toolName)
+        op.tool = event.toolName.slice(0, 60);
+      if (typeof event.success === 'boolean') op.success = event.success;
+      if (typeof event.at === 'number') op.at = event.at;
+      // Forward-compatible, not fabricated: neither field exists on a
+      // `tool-outcome` event in this pipeline today, so every operation
+      // omits them until a capture pass actually evidences one.
+      if (typeof event.exit === 'number') op.exit = event.exit;
+      if (typeof event.output === 'string' && event.output)
+        op.output = event.output.slice(0, 200);
+      return op;
+    });
+
+  return { at: Date.now(), anchors: anchorHashes, operations };
+}
+
+/**
  * Writes validated findings, returning the keys actually stored.
  *
  * `findings` is the output of `harvest.validate()`, so type/claim/confidence
@@ -467,6 +583,11 @@ export function writeHarvested(
       : batch;
   const prefixFor = (p) =>
     p === ORIGIN_AGENT ? 'agent' : p === ORIGIN_HUMAN ? 'human' : 'harvested';
+
+  // Read once: every finding in this batch shares the same evidence log, and
+  // it can hold thousands of lines, so re-reading it per finding would turn a
+  // batch of N findings into N passes over the same bytes.
+  const evidence = readEvidence(dir);
 
   const written = [];
   for (const finding of findings) {
@@ -521,14 +642,21 @@ export function writeHarvested(
     // `answers` closes the loop back to the task that produced the finding, so
     // provenance can be traversed rather than inferred: "which session
     // established this, and from what". Declared in EDGE_KINDS and written by
-    // nothing until now. Held to the same discipline as the anchors above: a
-    // taskId that does not resolve to an existing task node produces no edge
-    // rather than a dangling one.
-    if (taskId) {
-      const taskTarget = nodeId('task', taskId);
-      if (currentGraph.nodes.has(taskTarget)) {
-        edges.push({ edge: 'answers', to: taskTarget });
-      }
+    // nothing until now.
+    //
+    // An explicit `taskId` is authoritative when a caller supplies one --
+    // it OVERRIDES traversal rather than merely seeding it, so a caller that
+    // knows better is never second-guessed by inference. Absent one, the task
+    // is DERIVED from the graph itself: `taskForAnchors` finds the task that
+    // actually touched these anchors, which needs no session id from anyone.
+    // Either way, held to the same discipline as the anchors above: a target
+    // that does not resolve to an existing task node produces no edge rather
+    // than a dangling one.
+    const answersTarget = taskId
+      ? nodeId('task', taskId)
+      : taskForAnchors(currentGraph, resolved);
+    if (answersTarget && currentGraph.nodes.has(answersTarget)) {
+      edges.push({ edge: 'answers', to: answersTarget });
     }
 
     // ONE APPEND for the finding and every anchor it resolved. This runs in a
@@ -571,6 +699,15 @@ export function writeHarvested(
           ? finding.quote
           : undefined,
         sessionId,
+        // THE CHECKABLE HALF OF PROVENANCE. Citation-style (this `sessionId`,
+        // the `answers` edge above) says WHERE a claim came from; it never
+        // says whether that derivation still applies. `derivationFor` reaches
+        // through `wiki_query`'s `node`/`get`/`search` operations only (those
+        // return a finding's stored fields wholesale) -- never through
+        // `render()`/`renderSessionIndex()` in inject.mjs or `wiki_read`'s
+        // `toFinding()` projection, neither of which reads this field, so it
+        // is not part of the automatic per-touch injection `fit()` prices.
+        derivation: derivationFor(currentGraph, resolved, evidence, finding.anchors || []),
       },
       edges
     );

--- a/plugin/hooks/lib/inject.mjs
+++ b/plugin/hooks/lib/inject.mjs
@@ -26,6 +26,7 @@ import {
 } from './wiki.mjs';
 import { basename } from 'node:path';
 import { serve, diffLines } from './staleness.mjs';
+import { drainInvalidations } from './pending.mjs';
 import { inHoldout, record, indexBudget } from './metrics.mjs';
 import { canonicalPath, resolvableCandidates } from './paths.mjs';
 import { annotatedSkeleton } from './skeleton.mjs';
@@ -142,6 +143,31 @@ function render(finding) {
 }
 
 /**
+ * Applies anything the post-tool hook queued, BEFORE anything is served.
+ *
+ * THIS IS WHERE EAGER STALENESS LANDS. `invalidateOnWrite` needs a graph, and
+ * loading one on the return path of every write is what pending.mjs exists to
+ * avoid -- so the hook queues and the next graph read applies. These two
+ * functions are that read: they already hold a freshly loaded graph, and they
+ * are the last thing to run before a finding reaches a model.
+ *
+ * RE-READ ONLY WHEN SOMETHING WAS ACTUALLY MARKED. The drain writes the stale
+ * flag to disk; it cannot mutate the caller's already-parsed graph, so serving
+ * from that copy would deliver the very "stale finding as fresh" this exists to
+ * prevent. A second load costs a parse, and it is paid once per observed write
+ * rather than once per tool call -- when nothing is queued this is one stat.
+ */
+function withPendingApplied(dir, graph) {
+  try {
+    return drainInvalidations(dir, graph) > 0 ? load(dir) : graph;
+  } catch {
+    // The lazy path still covers everything this would have caught early, and
+    // a hook must never fail because bookkeeping did.
+    return graph;
+  }
+}
+
+/**
  * What the model sees when it touches a file.
  *
  * Returns null when there is nothing to say, or when this touch fell into the
@@ -154,6 +180,7 @@ export function forTouch(
   rawPath,
   { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
+  graph = withPendingApplied(dir, graph);
   // Canonical, so a touch finds findings anchored under any other spelling.
   const filePath = canonicalPath(rawPath);
   const anchorId = nodeId('file', filePath);
@@ -322,6 +349,7 @@ export function forCommand(
   { budget = touchBudget(), sessionId, alreadyInjected = new Set(), episode = {} } = {}
 ) {
   if (!command) return null;
+  graph = withPendingApplied(dir, graph);
 
   const candidates = [];
   for (const node of graph.nodes.values()) {

--- a/plugin/hooks/lib/inject.mjs
+++ b/plugin/hooks/lib/inject.mjs
@@ -33,6 +33,7 @@ import { annotatedSkeleton } from './skeleton.mjs';
 import { substitutionBudget } from './metrics.mjs';
 import { assessFindings } from './utility.mjs';
 import { quarantineSharedSource } from './harvest-write.mjs';
+import { cacheOrdered } from './cache.mjs';
 
 // Read per call for the same reason as the holdout fraction in metrics.mjs.
 const touchBudget = () => Number(process.env.TOKEN_OPTIMIZER_TOUCH_BUDGET) || 500;
@@ -1152,6 +1153,53 @@ export function standingRules(dir, graph, { budget = standingBudget(), episode =
   // which is worse than saying there are more: a model that knows the list is
   // truncated can ask, one that does not will assume it is complete.
   return `${HEADING}${lines.join('\n')}${truncated}`;
+}
+
+/**
+ * SessionStart context, assembled in cache order: stable first, volatile last.
+ *
+ * WHY THE ORDER IS A CORRECTNESS PROPERTY AND NOT A STYLE CHOICE. Everything
+ * here lands near the FRONT of the prompt prefix, and a prefix cache is
+ * invalidated from the first differing byte onward. A block whose text changes
+ * between sessions therefore prices everything positioned after it: put the
+ * freshest block first and the whole remainder of the prefix is re-written
+ * every session; put it last and the invalidation is confined to its own tail.
+ * cache.mjs measures exactly this cost in the user's files -- this is the same
+ * discipline applied to our own output, which is the half nobody else has to
+ * think about because nobody else writes into the prefix.
+ *
+ * `cacheOrdered` existed for precisely this and had no caller, so the order was
+ * whatever order the call sites happened to push in. It was accidentally right;
+ * it is now enforced, which is the difference that matters the next time a
+ * block is added.
+ *
+ * VOLATILITY IS ASSIGNED FROM HOW OFTEN THE TEXT ACTUALLY DIFFERS BETWEEN
+ * SESSIONS, not from how important the block is:
+ *
+ *   0  policy -- the optimization notice and project briefing. Deliberately
+ *      cache-safe by construction: the routing facts are number-free and the
+ *      briefing passes through `stableText`, which DROPS any line that would
+ *      vary. It changes when the tool inventory or configuration changes.
+ *   1  standing -- pinned facts and human-verified corrections, rendered in
+ *      full. Changes only when a person pins, retires or corrects something.
+ *   2  index -- the bounded wiki index, selected per session from the task
+ *      text, and carrying [STALE]/[DISPUTED] markers that flip as the code
+ *      moves. Different on most sessions.
+ *   3  restoration -- present only when resuming from a compaction, and derived
+ *      from the anchors of the session that was just discarded. Never twice the
+ *      same.
+ *
+ * A block with no text is dropped rather than joined, so an absent block cannot
+ * open the assembly with a blank line.
+ */
+export function sessionContext(blocks) {
+  return cacheOrdered(
+    (Array.isArray(blocks) ? blocks : []).filter(
+      (block) => block && typeof block.text === 'string' && block.text.trim()
+    )
+  )
+    .map((block) => block.text)
+    .join('\n\n');
 }
 
 /**

--- a/plugin/hooks/lib/inject.mjs
+++ b/plugin/hooks/lib/inject.mjs
@@ -122,8 +122,29 @@ function fit(findings, budget) {
   return { kept, spent };
 }
 
+/**
+ * Discloses an open disagreement, on the same line as the claim it is about.
+ *
+ * BOTH HALVES, like the stale renderer below: the strong form names the other
+ * finding so the reader can fetch it, and the form without a key says only what
+ * is actually known. `serve` is what establishes the dispute; this only phrases
+ * it, and it phrases it in one short line because `fit` prices `render` against
+ * the injection budget -- a disagreement is worth a pointer, not both claims in
+ * full.
+ *
+ * NO DISMISSAL VOCABULARY, for the reason measured on the stale wording: an
+ * instruction to discount suppressed findings that were correct. This states
+ * that another claim exists and where to find it, and lets the reader decide.
+ */
+function disputeNote(finding) {
+  if (!finding.contradicted) return '';
+  return finding.contradictedBy
+    ? `\n  DISPUTED by ${finding.contradictedBy} -- wiki_query that key for the other claim`
+    : '\n  DISPUTED by another finding in this graph';
+}
+
 function render(finding) {
-  const head = `- [${finding.type || 'finding'}] ${finding.claim}`;
+  const head = `- [${finding.type || 'finding'}] ${finding.claim}${disputeNote(finding)}`;
   if (!finding.stale) return head;
 
   // A stale finding NEVER renders as though it were current. But the strength
@@ -997,7 +1018,15 @@ function renderSessionIndex(total, findings) {
       : finding.stale
         ? ' [possibly stale; verify before use]'
         : '';
-    return `- ${finding.key}${freshness}: ${finding.claim.slice(0, 90)}`;
+    // The session index is the first thing a session reads, so a disputed
+    // finding must not be listed there as settled either. Compressed to a
+    // marker and a key, matching the freshness markers beside it.
+    const dispute = finding.contradicted
+      ? finding.contradictedBy
+        ? ` [DISPUTED by ${finding.contradictedBy}]`
+        : ' [DISPUTED]'
+      : '';
+    return `- ${finding.key}${freshness}${dispute}: ${finding.claim.slice(0, 90)}`;
   });
   return `# Project wiki (${total} findings, ${findings.length} listed)
 

--- a/plugin/hooks/lib/inject.mjs
+++ b/plugin/hooks/lib/inject.mjs
@@ -139,9 +139,26 @@ function fit(findings, budget) {
  */
 function disputeNote(finding) {
   if (!finding.contradicted) return '';
-  return finding.contradictedBy
+  const head = finding.contradictedBy
     ? `\n  DISPUTED by ${finding.contradictedBy} -- wiki_query that key for the other claim`
     : '\n  DISPUTED by another finding in this graph';
+  // THE REASON A PERSON TYPED, rendered here because this is the fullest of the
+  // three dispute surfaces and the only one with room for a sentence. `contradict`
+  // has always stored up to 400 characters of human explanation and, until this
+  // line, nothing read it: the pointer told a reader where to look and withheld
+  // the one thing that would tell them whether looking was worth a tool call.
+  //
+  // TRUNCATED AT 140, because `fit` prices this string against the injection
+  // budget and a 400-character paragraph beside a one-line claim inverts the
+  // proportions. The compressed surfaces -- the session index and restore.mjs's
+  // "Likely next" list -- deliberately keep marker-and-key only; they are one
+  // line per finding by design, and `wiki_query` returns the reason in full.
+  if (typeof finding.contradictionReason !== 'string' || !finding.contradictionReason.trim()) {
+    return head;
+  }
+  const reason = finding.contradictionReason.trim();
+  const shown = reason.length > 140 ? `${reason.slice(0, 140)}...` : reason;
+  return `${head}\n  Reason given: ${shown}`;
 }
 
 /**

--- a/plugin/hooks/lib/inject.mjs
+++ b/plugin/hooks/lib/inject.mjs
@@ -276,7 +276,10 @@ export function forTouch(
   // others, so the comparison becomes within-file and the dominant source of
   // variance drops out. A session-pinned arm would destroy that.
   const holdout = inHoldout(filePath);
-  const served = serve(graph, candidates);
+  // `dir` so an eager flag whose evidence is gone is cleared here rather than
+  // waiting for somebody to open the dashboard. Same evidence test as the manual
+  // path -- see `serve`.
+  const served = serve(graph, candidates, { dir });
   const assessed = assessFindings(dir, served, {
     episodeId: episode.episodeId || sessionId,
     relevanceFor: () => 1,
@@ -463,7 +466,7 @@ export function forCommand(
   // only thing an uncapped list buys is the I/O.
   const considered = candidates.slice(0, MAX_COMMAND_CANDIDATES);
 
-  const served = serve(graph, considered);
+  const served = serve(graph, considered, { dir });
   const assessed = assessFindings(dir, served, {
     episodeId: episode.episodeId || sessionId,
     relevanceFor: (finding) => explicit(finding) ? 1 : 0.6,
@@ -990,7 +993,7 @@ export function sessionIndex(dir, graph, { episode = {}, relevantFindingIds = []
   // `serve` is the only path allowed to hand a finding to a model. In
   // particular, activating this previously-unwired index must not create a new
   // path that labels an invalidated content claim as current.
-  const served = serve(graph, selected);
+  const served = serve(graph, selected, { dir });
   if (!served.length) return null;
   // A stale marker is longer than the fresh preview used for candidate
   // selection. Trim from the lowest-ranked end until the ACTUAL message fits.

--- a/plugin/hooks/lib/inject.mjs
+++ b/plugin/hooks/lib/inject.mjs
@@ -156,9 +156,9 @@ function disputeNote(finding) {
 function derivationNote(finding) {
   if (finding.derivationHolds !== false) return '';
   const changed = Array.isArray(finding.derivationChanged) ? finding.derivationChanged : [];
-  return changed.length
-    ? `\n  DERIVATION CHANGED -- ${changed.join(', ')} no longer match what this claim was derived from`
-    : '\n  DERIVATION CHANGED since this claim was recorded';
+  if (!changed.length) return '\n  DERIVATION CHANGED since this claim was recorded';
+  const verb = changed.length === 1 ? 'no longer matches' : 'no longer match';
+  return `\n  DERIVATION CHANGED -- ${changed.join(', ')} ${verb} what this claim was derived from`;
 }
 
 function render(finding) {

--- a/plugin/hooks/lib/inject.mjs
+++ b/plugin/hooks/lib/inject.mjs
@@ -143,8 +143,26 @@ function disputeNote(finding) {
     : '\n  DISPUTED by another finding in this graph';
 }
 
+/**
+ * Discloses `derivationCheck`'s verdict (staleness.mjs) -- distinct from
+ * `disputeNote` (another finding disagrees) and from the STALE block below
+ * (the anchor NODE's current hash does not match disk). This is about
+ * whether the bytes THIS claim was actually derived from are still the bytes
+ * an anchor holds; see `derivationCheck`'s comment for the case that catches
+ * that the other two can miss. Silent when it holds -- the common case pays
+ * nothing -- and silent when it was never checked at all (an older finding
+ * with no `derivation` record).
+ */
+function derivationNote(finding) {
+  if (finding.derivationHolds !== false) return '';
+  const changed = Array.isArray(finding.derivationChanged) ? finding.derivationChanged : [];
+  return changed.length
+    ? `\n  DERIVATION CHANGED -- ${changed.join(', ')} no longer match what this claim was derived from`
+    : '\n  DERIVATION CHANGED since this claim was recorded';
+}
+
 function render(finding) {
-  const head = `- [${finding.type || 'finding'}] ${finding.claim}${disputeNote(finding)}`;
+  const head = `- [${finding.type || 'finding'}] ${finding.claim}${disputeNote(finding)}${derivationNote(finding)}`;
   if (!finding.stale) return head;
 
   // A stale finding NEVER renders as though it were current. But the strength

--- a/plugin/hooks/lib/inject.mjs
+++ b/plugin/hooks/lib/inject.mjs
@@ -157,9 +157,28 @@ function render(finding) {
  * prevent. A second load costs a parse, and it is paid once per observed write
  * rather than once per tool call -- when nothing is queued this is one stat.
  */
+/**
+ * Per process, per graph directory: did the drain change anything?
+ *
+ * THE SECOND CALLER IS WHY THIS EXISTS. SessionStart calls `standingRules` and
+ * then `sessionIndex` with the SAME graph object it loaded once. Without this
+ * memo the first call drains, marks, and re-reads privately -- and the second
+ * call finds an empty queue, marks nothing, and therefore serves from the
+ * caller's pre-drain copy, advertising as current the very finding the first
+ * call had just marked. Draining is not idempotent from the caller's point of
+ * view; remembering the ANSWER is what makes it so.
+ *
+ * A hook process handles one lifecycle event, so this map holds one or two
+ * entries and dies with the process.
+ */
+const drainedDirs = new Map();
+
 function withPendingApplied(dir, graph) {
   try {
-    return drainInvalidations(dir, graph) > 0 ? load(dir) : graph;
+    if (drainedDirs.has(dir)) return drainedDirs.get(dir) ? load(dir) : graph;
+    const marked = drainInvalidations(dir, graph) > 0;
+    drainedDirs.set(dir, marked);
+    return marked ? load(dir) : graph;
   } catch {
     // The lazy path still covers everything this would have caught early, and
     // a hook must never fail because bookkeeping did.
@@ -862,6 +881,12 @@ export function relevantFindingIdsForContext(graph, context, { limit = 8 } = {})
  * shrinks toward the floor. See metrics.indexBudget.
  */
 export function sessionIndex(dir, graph, { episode = {}, relevantFindingIds = [] } = {}) {
+  // DRAINED HERE TOO, and this is the worst place to be wrong. The session index
+  // is the FIRST thing a session sees and it arrives with no other context to
+  // correct it, so advertising a finding the graph already knows is stale is a
+  // false claim made at maximum leverage. The graph is loaded either way, so the
+  // only cost is the stat that finds no queue.
+  graph = withPendingApplied(dir, graph);
   const budget = indexBudget(dir);
   const relevant = new Set(relevantFindingIds);
   // Some SessionStart payloads have no task signal. Fail closed for situational
@@ -988,6 +1013,9 @@ ${lines.join('\n')}`;
  * is wallpaper, and the model stops reading the thing it always sees.
  */
 export function standingRules(dir, graph, { budget = standingBudget(), episode = {} } = {}) {
+  // Same reason as sessionIndex: always-on text, delivered before the first
+  // tool call, with nothing following it that could qualify what it said.
+  graph = withPendingApplied(dir, graph);
   const rules = [...graph.nodes.values()].filter(
     (n) =>
       n.kind === 'finding' &&

--- a/plugin/hooks/lib/inject.mjs
+++ b/plugin/hooks/lib/inject.mjs
@@ -143,6 +143,40 @@ function render(finding) {
 }
 
 /**
+ * Graph directories where a drain has already marked something in THIS process.
+ *
+ * THE SECOND CALLER IS WHY THIS EXISTS. SessionStart calls `standingRules` and
+ * then `sessionIndex` with the SAME graph object it loaded once. Without this,
+ * the first call drains, marks, and re-reads privately -- and the second call
+ * finds an empty queue, marks nothing, and therefore serves from the caller's
+ * pre-drain copy, advertising as current the very finding the first call had
+ * just marked. Draining is idempotent; its EFFECT on a caller's parsed graph is
+ * not, so what is remembered here is "a re-read is owed", nothing else.
+ *
+ * ONLY THE POSITIVE CASE IS REMEMBERED, and that is a correctness decision
+ * rather than a tuning one. Remembering "nothing was queued" would mean a queue
+ * arriving LATER in the same process is silently skipped and deferred to some
+ * future session. That cannot happen today, because `queueInvalidation` runs in
+ * the post-tool branch before any injection -- but that is an unguarded
+ * ordering dependency, and it stops being true the moment someone adds a call
+ * site. A repeated empty drain costs one `existsSync` on a file that is not
+ * there, which is a price worth paying to not have an invariant that depends on
+ * nobody reordering anything.
+ *
+ * KEYED CANONICALLY. Two spellings of one directory -- a trailing separator, a
+ * `..` segment, a lower-cased drive letter -- would otherwise be two entries,
+ * which reintroduces exactly the pre-drain-copy bug above. This is the same
+ * defect shape Task 2 on this branch shipped for real, where a tool resolved its
+ * graph from a raw cwd while the hooks resolved theirs through `projectRootFor`
+ * and the two halves of a metric landed in different directories. Path identity
+ * is why `canonicalKey` lives inside `nodeId` rather than at its call sites.
+ *
+ * A hook process handles one lifecycle event, so this set holds one or two
+ * entries and dies with the process.
+ */
+const drainedDirs = new Set();
+
+/**
  * Applies anything the post-tool hook queued, BEFORE anything is served.
  *
  * THIS IS WHERE EAGER STALENESS LANDS. `invalidateOnWrite` needs a graph, and
@@ -157,28 +191,14 @@ function render(finding) {
  * prevent. A second load costs a parse, and it is paid once per observed write
  * rather than once per tool call -- when nothing is queued this is one stat.
  */
-/**
- * Per process, per graph directory: did the drain change anything?
- *
- * THE SECOND CALLER IS WHY THIS EXISTS. SessionStart calls `standingRules` and
- * then `sessionIndex` with the SAME graph object it loaded once. Without this
- * memo the first call drains, marks, and re-reads privately -- and the second
- * call finds an empty queue, marks nothing, and therefore serves from the
- * caller's pre-drain copy, advertising as current the very finding the first
- * call had just marked. Draining is not idempotent from the caller's point of
- * view; remembering the ANSWER is what makes it so.
- *
- * A hook process handles one lifecycle event, so this map holds one or two
- * entries and dies with the process.
- */
-const drainedDirs = new Map();
-
 function withPendingApplied(dir, graph) {
   try {
-    if (drainedDirs.has(dir)) return drainedDirs.get(dir) ? load(dir) : graph;
-    const marked = drainInvalidations(dir, graph) > 0;
-    drainedDirs.set(dir, marked);
-    return marked ? load(dir) : graph;
+    const key = canonicalPath(dir);
+    // The drain runs EVERY time. It is one stat when there is nothing to do,
+    // and running it unconditionally is what keeps the memo from encoding an
+    // assumption about which hook branch ran first.
+    if (drainInvalidations(dir, graph) > 0) drainedDirs.add(key);
+    return drainedDirs.has(key) ? load(dir) : graph;
   } catch {
     // The lazy path still covers everything this would have caught early, and
     // a hook must never fail because bookkeeping did.

--- a/plugin/hooks/lib/lexical.mjs
+++ b/plugin/hooks/lib/lexical.mjs
@@ -1,0 +1,73 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/lexical.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * BM25 over findings. Pure, dependency-free, deterministic.
+ *
+ * WHY THIS REPLACES `includes()`. The dashboard filtered findings by substring,
+ * which cannot RANK -- and every consumer of retrieval here is under a hard
+ * token budget, so the budget kept whatever happened to match rather than what
+ * matched best. Ranking is the whole value at a budget.
+ *
+ * WHY BM25 AND NOT EMBEDDINGS. Deliberate, per docs/WIKI_GRAPH.md: deterministic,
+ * instant, explainable, and it cannot drift or need a rebuild. The known cost is
+ * recall on findings with no lexical overlap; Plan 2's recall probe measures that
+ * rather than assuming it away.
+ */
+
+/** Non-word split, lowercased. Short tokens are kept: `fs`, `id`, `os` matter here. */
+export function tokenize(text) {
+  return String(text || '')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+}
+
+/**
+ * Classic BM25. `k1` controls term-frequency saturation, `b` length normalisation.
+ * Defaults are the standard ones and are exposed so the recall probe can sweep them.
+ */
+export function rank(query, findings, { limit = 20, k1 = 1.2, b = 0.75 } = {}) {
+  const terms = tokenize(query);
+  if (!terms.length || !Array.isArray(findings) || !findings.length) return [];
+
+  // A finding's searchable text is its claim AND its key: the key is how the
+  // session index refers to it, so a model quoting a key must find it.
+  const docs = findings.map((finding) => ({
+    finding,
+    tokens: tokenize(`${finding.key || ''} ${finding.claim || ''}`),
+  }));
+
+  const avgLen = docs.reduce((sum, d) => sum + d.tokens.length, 0) / docs.length;
+  const N = docs.length;
+
+  const docFreq = new Map();
+  for (const { tokens } of docs) {
+    for (const term of new Set(tokens)) {
+      docFreq.set(term, (docFreq.get(term) || 0) + 1);
+    }
+  }
+
+  const scored = [];
+  for (const { finding, tokens } of docs) {
+    const counts = new Map();
+    for (const token of tokens) counts.set(token, (counts.get(token) || 0) + 1);
+
+    let score = 0;
+    for (const term of terms) {
+      const tf = counts.get(term);
+      if (!tf) continue;
+      const df = docFreq.get(term) || 0;
+      // Standard BM25 IDF, floored at zero so a term present in every document
+      // contributes nothing rather than a negative score.
+      const idf = Math.max(0, Math.log(1 + (N - df + 0.5) / (df + 0.5)));
+      const norm = tf + k1 * (1 - b + (b * tokens.length) / (avgLen || 1));
+      score += idf * ((tf * (k1 + 1)) / (norm || 1));
+    }
+
+    // Zero means no term matched. Omitted rather than returned, so a caller
+    // under a token budget never spends it on an irrelevant finding.
+    if (score > 0) scored.push({ finding, score });
+  }
+
+  return scored.sort((a, b2) => b2.score - a.score).slice(0, limit);
+}

--- a/plugin/hooks/lib/lexical.mjs
+++ b/plugin/hooks/lib/lexical.mjs
@@ -14,12 +14,54 @@
  * rather than assuming it away.
  */
 
-/** Non-word split, lowercased. Short tokens are kept: `fs`, `id`, `os` matter here. */
-export function tokenize(text) {
-  return String(text || '')
-    .toLowerCase()
-    .split(/[^a-z0-9]+/)
+/**
+ * Splits an identifier's alphanumeric run into its camelCase / letter-digit
+ * parts, e.g. `skipLibCheck` -> ['skip', 'Lib', 'Check'], `TS2345` ->
+ * ['TS', '2345']. Returns a single-element array when there is no internal
+ * boundary (e.g. `retry` -> ['retry']) so callers can skip emitting a
+ * redundant duplicate of the whole token.
+ */
+function splitIdentifierParts(word) {
+  return word
+    .replace(/([a-z])([A-Z])/g, '$1\0$2')
+    .replace(/([A-Za-z])([0-9])/g, '$1\0$2')
+    .replace(/([0-9])([A-Za-z])/g, '$1\0$2')
+    .split('\0')
     .filter(Boolean);
+}
+
+/**
+ * Non-word split, lowercased. Short tokens are kept: `fs`, `id`, `os` matter
+ * here.
+ *
+ * Emits sub-tokens for compound identifiers, in addition to the whole token.
+ * Delimited identifiers (`smart_read`, `wiki.mjs`, the flag in
+ * `--skipLibCheck`) already round-trip fine: the delimiter splits them, and
+ * because query and claim pass through this same function, a query typed
+ * with the same delimiters matches. The silent gap was CONCATENATED
+ * identifiers with no delimiter at all -- `skipLibCheck` collapsed to the
+ * single token `skiplibcheck`, so a query for "skip lib check" (or "TS 2345"
+ * against `TS2345`) never intersected it. No error, just an absent result --
+ * and findings are about code, where run-together identifiers are the
+ * common case. So every alphanumeric run keeps its whole-token form (a query
+ * for the concatenated form still matches) and ALSO contributes its
+ * camelCase / letter-digit parts (a query for the separated form now
+ * matches too). A lone incidental character -- e.g. the `c` split out of a
+ * Windows path `C:\Users\...` -- needs no special-casing: it is a real
+ * token like any other, and BM25's IDF already discounts a term that shows
+ * up in nearly every finding.
+ */
+export function tokenize(text) {
+  const words = String(text || '').match(/[A-Za-z0-9]+/g) || [];
+  const tokens = [];
+  for (const word of words) {
+    tokens.push(word.toLowerCase());
+    const parts = splitIdentifierParts(word);
+    if (parts.length > 1) {
+      for (const part of parts) tokens.push(part.toLowerCase());
+    }
+  }
+  return tokens;
 }
 
 /**
@@ -57,9 +99,15 @@ export function rank(query, findings, { limit = 20, k1 = 1.2, b = 0.75 } = {}) {
       const tf = counts.get(term);
       if (!tf) continue;
       const df = docFreq.get(term) || 0;
-      // Standard BM25 IDF, floored at zero so a term present in every document
-      // contributes nothing rather than a negative score.
-      const idf = Math.max(0, Math.log(1 + (N - df + 0.5) / (df + 0.5)));
+      // Smoothed BM25 idf: log(1 + (N - df + 0.5) / (df + 0.5)). Unlike the
+      // classic unsmoothed idf (log((N - df + 0.5) / (df + 0.5))), which goes
+      // negative once a term appears in most documents, this smoothed form
+      // is strictly positive for every df in [1, N]: even at df === N the
+      // ratio inside the log is (N + 1) / (N + 0.5), which is always
+      // strictly greater than 1, so log(1 + that) is always > 0. No floor
+      // is needed here, and none is applied -- there is no negative case
+      // for this formula to guard against.
+      const idf = Math.log(1 + (N - df + 0.5) / (df + 0.5));
       const norm = tf + k1 * (1 - b + (b * tokens.length) / (avgLen || 1));
       score += idf * ((tf * (k1 + 1)) / (norm || 1));
     }

--- a/plugin/hooks/lib/lexical.mjs
+++ b/plugin/hooks/lib/lexical.mjs
@@ -65,6 +65,43 @@ export function tokenize(text) {
 }
 
 /**
+ * Effective term-frequency credit for a document that has NO exact token
+ * match for a query term but DOES have a token that starts with it (e.g.
+ * query `custom` against a document containing `customer`). Deliberately
+ * less than one exact occurrence (`1`), and it is a flat credit rather than
+ * one that grows with the number of prefix-matching tokens in the document,
+ * so a prefix hit can never outscore an exact hit of the same term:
+ *
+ *   BM25's per-term contribution is `idf * tf * (k1 + 1) / (tf + K)`, where
+ *   `K = k1 * (1 - b + b * L / avgL)` depends only on document length, not
+ *   on which term or how it matched. As a function of `tf` alone, with `K`
+ *   fixed, `f(tf) = tf / (tf + K)` is non-decreasing for every `tf >= 0` and
+ *   `k1 >= 0` (its derivative `K / (tf + K)^2` is never negative). So for
+ *   ANY document length, and any number of prefix-only occurrences, using
+ *   `PREFIX_TF < 1` in place of `tf` scores no higher than an actual exact
+ *   occurrence (`tf = 1`) would in that same document -- there is no
+ *   PREFIX_TF-independent way to accumulate more evidence than one real hit
+ *   by matching only a prefix. This is also why the count of prefix matches
+ *   is otherwise irrelevant here: it never feeds back into the score.
+ *
+ * PREFIX MATCHING IS NOT SUBSTRING MATCHING. It restores recall for a
+ * fragment typed at the START of a word -- `custom` now finds `customer` --
+ * which is the common case (a user typing the first few letters of a term
+ * they remember). It does NOT restore the old `.includes()` filter's ability
+ * to find a term in the MIDDLE of a word: a query for `tomer` still will not
+ * find `customer`. That recall gap is accepted, not silently reintroduced.
+ */
+const PREFIX_TF = 0.5;
+
+/**
+ * Below this length, a query term is not eligible for prefix matching: a
+ * one- or two-character prefix (`a`, `re`) is a substring of a large
+ * fraction of any real vocabulary, so it would match nearly every document
+ * and IDF alone would not discount it enough to keep the results relevant.
+ */
+const PREFIX_MIN_TERM_LENGTH = 3;
+
+/**
  * Classic BM25. `k1` controls term-frequency saturation, `b` length normalisation.
  * Defaults are the standard ones and are exposed so the recall probe can sweep them.
  */
@@ -96,7 +133,21 @@ export function rank(query, findings, { limit = 20, k1 = 1.2, b = 0.75 } = {}) {
 
     let score = 0;
     for (const term of terms) {
-      const tf = counts.get(term);
+      let tf = counts.get(term) || 0;
+
+      // No exact occurrence: fall back to a prefix match, which is weaker
+      // evidence and so credited at a flat PREFIX_TF rather than a real
+      // count (see PREFIX_TF's comment for why that ordering is safe). Only
+      // considered when nothing already matched exactly and the term is
+      // long enough that "starts with" is a meaningful signal.
+      if (tf === 0 && term.length >= PREFIX_MIN_TERM_LENGTH) {
+        for (const token of counts.keys()) {
+          if (token !== term && token.startsWith(term)) {
+            tf = PREFIX_TF;
+            break;
+          }
+        }
+      }
       if (!tf) continue;
       const df = docFreq.get(term) || 0;
       // Smoothed BM25 idf: log(1 + (N - df + 0.5) / (df + 0.5)). Unlike the

--- a/plugin/hooks/lib/metrics.mjs
+++ b/plugin/hooks/lib/metrics.mjs
@@ -455,6 +455,23 @@ export function readBalance(dir) {
   return out;
 }
 
+/**
+ * True when `readEvidence` could not have read the whole log -- the file
+ * exceeds the byte cap, so anything written before the tail it kept is
+ * silently absent from what it returned. A caller that builds a per-claim
+ * record from `readEvidence` (the wiki graph's derivation record) needs this
+ * to say "operations existed but are not recorded here" rather than let an
+ * empty result read as "nothing happened".
+ */
+export function evidenceTruncated(dir) {
+  const path = evidencePath(dir);
+  try {
+    return statSync(path).size > MAX_BYTES;
+  } catch {
+    return false;
+  }
+}
+
 /** Every causal evidence record inside the byte cap, deduplicated by id. */
 export function readEvidence(dir) {
   const path = evidencePath(dir);

--- a/plugin/hooks/lib/observability.mjs
+++ b/plugin/hooks/lib/observability.mjs
@@ -1,6 +1,6 @@
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/observability.mjs. Regenerate with `npm run sync:hooks`.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 /**
  * Privacy-safe, cross-client lifecycle diagnostics.
  *

--- a/plugin/hooks/lib/pending.mjs
+++ b/plugin/hooks/lib/pending.mjs
@@ -39,7 +39,7 @@ import {
   statSync,
 } from 'node:fs';
 import { join } from 'node:path';
-import { invalidateOnWrite } from './staleness.mjs';
+import { invalidateChangedAnchors, invalidateOnWrite } from './staleness.mjs';
 import { canonicalPath, isFsSafePath, resolvableCandidates } from './paths.mjs';
 
 const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
@@ -190,31 +190,85 @@ function hasEditEvidence(payload, raw) {
 }
 
 /**
- * The evidence a completed mutation left behind, or null when there is none.
+ * Canonical tool names that mean bytes on disk changed.
  *
- * Separate from `queueInvalidation` so the caller can be a hook branch that
- * knows nothing about diffs, and so the reconstruction above is testable
- * without a filesystem queue.
+ * THE NORMALISED SET, not any client's own vocabulary. `normalizePayload` has
+ * already mapped `replace`, `write_file`, `apply_patch`, `str_replace`,
+ * `search_replace` and the rest onto these three through decide.mjs's alias
+ * table -- and a tool that table cannot map arrives as null and exits the hook
+ * before this module is reached at all. So matching here is both complete for
+ * every client the adapter serves and impossible to spell wrong.
+ *
+ * `NotebookEdit` is absent because `normalizeTool` maps it to null, and the MCP
+ * `smart_edit`/`smart_write` tools are absent for the same reason. Both are gaps
+ * in that alias table rather than in this file, and widening it changes routing
+ * verdicts for every client -- so they are reported, not papered over here.
  */
-export function observedWrite(payload, raw) {
-  // CHEAP CHECK FIRST, because this runs after every tool call on every client.
-  // Reading the file is the expensive part, and there is no point paying for it
-  // on a Read, a Bash or a write whose before side cannot be reconstructed.
-  if (!hasEditEvidence(payload, raw)) return null;
+const MUTATING = new Set(['Edit', 'MultiEdit', 'Write']);
+
+/** Files an apply_patch-style program declares it is about to change. */
+function patchTargets(payload) {
+  const command = payload?.tool_input?.command;
+  if (typeof command !== 'string') return [];
+  const out = [];
+  for (const match of command.matchAll(
+    /^\*\*\* (?:Add|Update|Delete) File:\s*(.+)$/gm
+  )) {
+    const candidate = match[1].trim().replace(/^['"]|['"]$/g, '');
+    // Bounded: one patch naming a thousand files must not append a thousand
+    // queue records on a hook path.
+    if (candidate && out.length < 20) out.push(candidate);
+  }
+  return out;
+}
+
+/**
+ * Everything a completed mutation left behind that is worth queueing.
+ *
+ * TWO GRADES OF EVIDENCE, and the distinction is the point:
+ *
+ *   { path, before, after }  a reconstructable edit. The drain builds a real
+ *                            diff and marks only the symbols that moved.
+ *   { path }                 a whole-file write, or a patch program. No before
+ *                            side exists anywhere in the payload, so the drain
+ *                            compares stored hashes against disk instead.
+ *
+ * The second grade is what closes the biggest hole. A whole-file write is the
+ * commonest write shape there is, and before it was added those writes fell
+ * through to a lazy path that CANNOT see the session's own writes at all --
+ * `indexFile` refreshes the anchor before the lazy check ever looks at it. They
+ * were uncovered, not degraded.
+ *
+ * Returns an array, because one apply_patch program changes several files.
+ */
+export function observedWrites(payload, raw) {
+  if (!MUTATING.has(String(payload?.tool_name || ''))) return [];
 
   const path = writtenPath(payload, raw);
-  if (!path) return null;
+  if (path) {
+    // The expensive branch is guarded: reading the file only pays off when the
+    // payload can actually yield a before side.
+    if (hasEditEvidence(payload, raw)) {
+      const after = afterText(path);
+      if (after !== null && after.length <= MAX_SIDE_CHARS) {
+        const before = beforeText(payload, raw, after);
+        // Identical bytes: a formatter no-op, or a rewrite of the same content.
+        // Nothing changed, so nothing is stale.
+        if (before === after) return [];
+        if (before !== null && before.length <= MAX_SIDE_CHARS)
+          return [{ path, before, after }];
+      }
+    }
+    // Hash grade. Deliberately NOT `{ path, before: '', after }`: an empty
+    // before side makes every symbol in the file look changed, and the eager
+    // mark is a stored flag no later check ever clears.
+    return [{ path }];
+  }
 
-  const after = afterText(path);
-  if (after === null || after.length > MAX_SIDE_CHARS) return null;
-
-  const before = beforeText(payload, raw, after);
-  if (before === null || before.length > MAX_SIDE_CHARS) return null;
-  // Nothing changed: a formatter no-op, or a write of identical bytes. Queuing
-  // it would mark findings stale against an empty diff.
-  if (before === after) return null;
-
-  return { path, before, after };
+  // Codex and code-mode clients carry the whole patch as program text with no
+  // file_path field at all, which is why this recorded nothing for them. The
+  // hash grade needs only the path, so the patch headers are enough.
+  return patchTargets(payload).map((target) => ({ path: target }));
 }
 
 /**
@@ -226,9 +280,14 @@ export function observedWrite(payload, raw) {
 export function queueInvalidation(dir, { path, before, after, at } = {}) {
   try {
     if (typeof path !== 'string' || !path.trim()) return false;
-    if (typeof before !== 'string' || typeof after !== 'string') return false;
-    if (before.length > MAX_SIDE_CHARS || after.length > MAX_SIDE_CHARS)
-      return false;
+    // BOTH SIDES OR NEITHER. A record carrying only one of them cannot produce
+    // a diff and must not pretend to, so it is written as a path-only record
+    // and the drain resolves it by comparing hashes.
+    const diffable =
+      typeof before === 'string' &&
+      typeof after === 'string' &&
+      before.length <= MAX_SIDE_CHARS &&
+      after.length <= MAX_SIDE_CHARS;
 
     const file = queuePath(dir);
     try {
@@ -240,7 +299,11 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
     mkdirSync(dir, { recursive: true });
     appendFileSync(
       file,
-      `${JSON.stringify({ path: canonicalPath(path), before, after, at: at ?? Date.now() })}\n`,
+      `${JSON.stringify({
+        path: canonicalPath(path),
+        ...(diffable ? { before, after } : {}),
+        at: at ?? Date.now(),
+      })}\n`,
       'utf8'
     );
     return true;
@@ -284,16 +347,16 @@ export function drainInvalidations(dir, graph) {
   let marked = 0;
   for (const record of records) {
     if (!record || typeof record.path !== 'string' || !record.path) continue;
-    if (typeof record.before !== 'string' || typeof record.after !== 'string')
-      continue;
+    const diffable =
+      typeof record.before === 'string' && typeof record.after === 'string';
     try {
-      const result = invalidateOnWrite(
-        dir,
-        graph,
-        record.path,
-        record.before,
-        record.after
-      );
+      // TWO GRADES, ONE QUEUE. A record carrying both sides gets a real diff and
+      // symbol-precise marking; one carrying only a path gets the hash
+      // comparison -- the same comparison the lazy path makes, and one that is
+      // only meaningful HERE, before `indexFile` refreshes the anchor.
+      const result = diffable
+        ? invalidateOnWrite(dir, graph, record.path, record.before, record.after)
+        : invalidateChangedAnchors(dir, graph, record.path);
       marked += Array.isArray(result) ? result.length : 0;
     } catch {
       // One bad record must not stop the rest, and must not stop the tool call.

--- a/plugin/hooks/lib/pending.mjs
+++ b/plugin/hooks/lib/pending.mjs
@@ -1,0 +1,311 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/pending.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * The eager-invalidation queue: the missing half of staleness.mjs's header.
+ *
+ * That header describes TWO invalidation paths and says eager exists because
+ * lazy "would silently serve stale findings as fresh whenever a change came
+ * from outside the agent". `invalidateOnWrite` had been written, tested and
+ * documented -- and its only reference in shipped code was a COMMENT in the
+ * PreToolUse router. Staleness was lazy-only in production, and the router's
+ * own comment ("a write the hook observes is invalidated eagerly by
+ * `invalidateOnWrite`") described something that never happened.
+ *
+ * WHY THAT MATTERS MORE THAN IT SOUNDS. The lazy check compares the anchor's
+ * stored hash against disk -- and both the router and the adapter call
+ * `indexFile` on every file they observe, which re-points that hash at the new
+ * bytes. So for a write the session performed ITSELF, the lazy check is
+ * self-defeating: by the next retrieval the anchor already agrees with disk and
+ * the finding derived from the old content is served clean. Lazy catches the
+ * changes we never saw; only eager catches the ones we did.
+ *
+ * WHY A QUEUE AND NOT A DIRECT CALL. `invalidateOnWrite` needs the graph, and
+ * the graph is a megabyte of JSONL. Loading it on the return path of every
+ * write is the cost this shape exists to avoid. So the post-tool hook, which
+ * already holds the write's evidence, appends one record here and exits; the
+ * next graph read -- `forTouch`/`forCommand`, which load the graph anyway --
+ * drains it BEFORE serving anything.
+ *
+ * The guarantee is unchanged. What must never happen is SERVING a stale finding
+ * as fresh, and serve time is where that is enforced.
+ */
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { invalidateOnWrite } from './staleness.mjs';
+import { canonicalPath, isFsSafePath, resolvableCandidates } from './paths.mjs';
+
+const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
+
+/**
+ * Largest before/after side kept in a queue record.
+ *
+ * Matched to the graph's own snapshot limit for the same reason it has one: past
+ * this size the text is a bundle, a lockfile or a generated asset, and copying
+ * it into a queue file would mirror the repository into the graph directory one
+ * write at a time. Past the cap the write is simply not queued -- the lazy path
+ * still governs it, which is exactly the status quo for that file.
+ */
+const MAX_SIDE_CHARS = 262_144;
+
+/**
+ * Largest queue file appended to.
+ *
+ * A queue only grows while nothing drains it, which means the retrieval feature
+ * is off or every read has failed. Neither is a reason to keep writing: bounded
+ * here so a long unattended session cannot turn one directory into a log of
+ * every file it touched.
+ */
+const MAX_QUEUE_BYTES = 8 * 1024 * 1024;
+
+/** The tool payload fields that name the file a mutation landed on. */
+function writtenPath(payload, raw) {
+  const input = payload?.tool_input || {};
+  const response = raw?.tool_response || raw?.toolResponse || {};
+  for (const candidate of [
+    input.file_path,
+    input.path,
+    input.notebook_path,
+    response.filePath,
+    response.file_path,
+  ]) {
+    if (typeof candidate === 'string' && candidate.trim()) return candidate;
+  }
+  return null;
+}
+
+/** First string among several possible spellings of the same field. */
+function firstString(...values) {
+  for (const value of values) if (typeof value === 'string') return value;
+  return null;
+}
+
+/**
+ * The text before the write, reconstructed from a completed edit.
+ *
+ * PREFERENCE ORDER IS ABOUT EXACTNESS, not convenience. Claude Code's Edit
+ * response carries the whole pre-edit file (`originalFile`), which needs no
+ * reasoning at all. Failing that, an edit is a known substitution, so reverting
+ * `new_string` back to `old_string` in the post-write text reproduces the
+ * before side exactly -- but only when the substitution is unambiguous, which
+ * is why a `new_string` that now appears more than once is refused rather than
+ * guessed at.
+ *
+ * NULL MEANS "DO NOT QUEUE", and that is deliberate. An unknown before side
+ * could be passed as '' -- and `invalidateOnWrite` would then see every symbol
+ * in the file as changed and mark every finding anchored anywhere in it, which
+ * is the exact over-marking its own comments call worse than the file-level
+ * staleness symbols were introduced to avoid. A missed eager invalidation costs
+ * what today already costs; a wrong one permanently discounts correct findings.
+ */
+function beforeText(payload, raw, after) {
+  const input = payload?.tool_input || {};
+  const response = raw?.tool_response || raw?.toolResponse || {};
+
+  const original = firstString(
+    response.originalFile,
+    response.original_file,
+    response.originalContent,
+    response.original_content
+  );
+  if (original !== null) return original;
+
+  // MultiEdit applies its edits in order, so reverting walks them backwards.
+  const edits = Array.isArray(input.edits) ? input.edits : null;
+  if (edits) {
+    let text = after;
+    for (const edit of [...edits].reverse()) {
+      const reverted = revert(text, edit);
+      if (reverted === null) return null;
+      text = reverted;
+    }
+    return text;
+  }
+
+  return revert(after, input);
+}
+
+/** Undoes one old->new substitution, or null when it cannot be done exactly. */
+function revert(text, edit) {
+  const oldString = firstString(edit?.old_string, edit?.oldString);
+  const newString = firstString(edit?.new_string, edit?.newString);
+  if (oldString === null || newString === null || newString === '') return null;
+
+  const all = edit?.replace_all === true || edit?.replaceAll === true;
+  if (all) return text.split(newString).join(oldString);
+
+  const at = text.indexOf(newString);
+  if (at < 0) return null;
+  // Ambiguous: more than one candidate for the occurrence that was written, and
+  // reverting the wrong one fabricates a before side that never existed.
+  if (text.indexOf(newString, at + newString.length) >= 0) return null;
+  return text.slice(0, at) + oldString + text.slice(at + newString.length);
+}
+
+/** The post-write text, read from disk because that is what the write produced. */
+function afterText(path) {
+  if (!isFsSafePath(path)) return null;
+  for (const candidate of resolvableCandidates(path)) {
+    try {
+      if (statSync(candidate).size > MAX_SIDE_CHARS) return null;
+      return readFileSync(candidate, 'utf8');
+    } catch {
+      // Wrong spelling, or gone again already. Try the next one.
+    }
+  }
+  return null;
+}
+
+/**
+ * Does this payload carry enough to reconstruct a before side at all?
+ *
+ * Named tool lists were the alternative and were rejected: every client calls
+ * its editor something different (`Edit`, `replace`, `write_to_file`,
+ * `apply_patch`), and a list would silently exclude the ones nobody thought of
+ * while still charging a file read for every Read that matched by accident.
+ * Asking about the EVIDENCE instead covers any client that carries an edit in
+ * one of these shapes and costs nothing on the calls that do not.
+ */
+function hasEditEvidence(payload, raw) {
+  const input = payload?.tool_input || {};
+  const response = raw?.tool_response || raw?.toolResponse || {};
+  if (
+    firstString(
+      response.originalFile,
+      response.original_file,
+      response.originalContent,
+      response.original_content
+    ) !== null
+  )
+    return true;
+  if (Array.isArray(input.edits) && input.edits.length > 0) return true;
+  return firstString(input.old_string, input.oldString) !== null;
+}
+
+/**
+ * The evidence a completed mutation left behind, or null when there is none.
+ *
+ * Separate from `queueInvalidation` so the caller can be a hook branch that
+ * knows nothing about diffs, and so the reconstruction above is testable
+ * without a filesystem queue.
+ */
+export function observedWrite(payload, raw) {
+  // CHEAP CHECK FIRST, because this runs after every tool call on every client.
+  // Reading the file is the expensive part, and there is no point paying for it
+  // on a Read, a Bash or a write whose before side cannot be reconstructed.
+  if (!hasEditEvidence(payload, raw)) return null;
+
+  const path = writtenPath(payload, raw);
+  if (!path) return null;
+
+  const after = afterText(path);
+  if (after === null || after.length > MAX_SIDE_CHARS) return null;
+
+  const before = beforeText(payload, raw, after);
+  if (before === null || before.length > MAX_SIDE_CHARS) return null;
+  // Nothing changed: a formatter no-op, or a write of identical bytes. Queuing
+  // it would mark findings stale against an empty diff.
+  if (before === after) return null;
+
+  return { path, before, after };
+}
+
+/**
+ * Appends one pending write.
+ *
+ * NEVER THROWS. This runs on a hook's return path, and a queue that cannot be
+ * written degrades to the lazy path rather than costing the user a tool call.
+ */
+export function queueInvalidation(dir, { path, before, after, at } = {}) {
+  try {
+    if (typeof path !== 'string' || !path.trim()) return false;
+    if (typeof before !== 'string' || typeof after !== 'string') return false;
+    if (before.length > MAX_SIDE_CHARS || after.length > MAX_SIDE_CHARS)
+      return false;
+
+    const file = queuePath(dir);
+    try {
+      if (statSync(file).size > MAX_QUEUE_BYTES) return false;
+    } catch {
+      // No queue yet, which is the normal case.
+    }
+
+    mkdirSync(dir, { recursive: true });
+    appendFileSync(
+      file,
+      `${JSON.stringify({ path: canonicalPath(path), before, after, at: at ?? Date.now() })}\n`,
+      'utf8'
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Applies every queued invalidation and clears the queue.
+ *
+ * Returns the number of findings marked, so the caller knows whether its
+ * in-memory graph is now behind the file on disk and needs re-reading.
+ *
+ * CLEARED AFTER APPLYING AND UNCONDITIONALLY: a record that cannot be applied
+ * must not be retried on every tool call for the rest of the session, and the
+ * cost of dropping one is a single missed eager mark that the lazy path still
+ * has a chance at.
+ */
+export function drainInvalidations(dir, graph) {
+  let records;
+  try {
+    const file = queuePath(dir);
+    if (!existsSync(file)) return 0;
+    records = readFileSync(file, 'utf8')
+      .split('\n')
+      .filter((line) => line.trim())
+      .map((line) => {
+        try {
+          return JSON.parse(line);
+        } catch {
+          // A torn append costs one record, not the queue.
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch {
+    return 0;
+  }
+
+  let marked = 0;
+  for (const record of records) {
+    if (!record || typeof record.path !== 'string' || !record.path) continue;
+    if (typeof record.before !== 'string' || typeof record.after !== 'string')
+      continue;
+    try {
+      const result = invalidateOnWrite(
+        dir,
+        graph,
+        record.path,
+        record.before,
+        record.after
+      );
+      marked += Array.isArray(result) ? result.length : 0;
+    } catch {
+      // One bad record must not stop the rest, and must not stop the tool call.
+    }
+  }
+
+  try {
+    rmSync(queuePath(dir), { force: true });
+  } catch {
+    // Held open by a concurrent hook. The next drain re-applies these records,
+    // which is safe: marking an already-marked finding is idempotent.
+  }
+
+  return marked;
+}

--- a/plugin/hooks/lib/pending.mjs
+++ b/plugin/hooks/lib/pending.mjs
@@ -199,10 +199,11 @@ function hasEditEvidence(payload, raw) {
  * before this module is reached at all. So matching here is both complete for
  * every client the adapter serves and impossible to spell wrong.
  *
- * `NotebookEdit` is absent because `normalizeTool` maps it to null, and the MCP
- * `smart_edit`/`smart_write` tools are absent for the same reason. Both are gaps
- * in that alias table rather than in this file, and widening it changes routing
- * verdicts for every client -- so they are reported, not papered over here.
+ * `NotebookEdit` and the MCP `smart_edit`/`smart_write` tools were absent for as
+ * long as `normalizeTool` mapped them to null. That was a gap in the alias table
+ * rather than in this file, and it has since been closed there: all three now
+ * arrive as `Edit` or `Write` and are matched by the set below without it having
+ * to learn a fourth name.
  */
 const MUTATING = new Set(['Edit', 'MultiEdit', 'Write']);
 

--- a/plugin/hooks/lib/pending.mjs
+++ b/plugin/hooks/lib/pending.mjs
@@ -35,6 +35,7 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  renameSync,
   rmSync,
   statSync,
 } from 'node:fs';
@@ -43,6 +44,15 @@ import { invalidateChangedAnchors, invalidateOnWrite } from './staleness.mjs';
 import { canonicalPath, isFsSafePath, resolvableCandidates } from './paths.mjs';
 
 const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
+/**
+ * Where a drain moves the queue before reading it.
+ *
+ * PER PROCESS, not one shared name: two hooks draining the same graph directory
+ * at once would otherwise race for the same claim file, and the loser would
+ * either clobber the winner's records or delete them mid-read. A pid makes the
+ * claim private to the drainer that won the rename.
+ */
+const claimPath = (dir) => join(dir, `pending-invalidation.claim.${process.pid}.jsonl`);
 
 /**
  * Largest before/after side kept in a queue record.
@@ -319,17 +329,47 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
  * Returns the number of findings marked, so the caller knows whether its
  * in-memory graph is now behind the file on disk and needs re-reading.
  *
- * CLEARED AFTER APPLYING AND UNCONDITIONALLY: a record that cannot be applied
- * must not be retried on every tool call for the rest of the session, and the
- * cost of dropping one is a single missed eager mark that the lazy path still
- * has a chance at.
+ * CLAIMED BY RENAME, THEN READ, THEN DELETED -- and the order is the whole
+ * point. This used to read the queue and then `rmSync` the same path, so a
+ * post-tool hook appending between the read and the unlink had its record
+ * deleted having never been read. Parallel tool calls in one assistant turn are
+ * the ordinary way that happens, not an exotic race. `renameSync` makes the
+ * claim atomic: whatever the drainer took is exactly what it deletes, and a
+ * record appended a microsecond later lands on a fresh queue that the next drain
+ * will find.
+ *
+ * A LOST RECORD IS A PERMANENTLY MISSED INVALIDATION, which is why this is worth
+ * a rename. The comment here used to price it as "a single missed eager mark that
+ * the lazy path still has a chance at", and that premise is false: this module's
+ * own header states it. The lazy path compares the anchor's stored hash against
+ * disk, and `indexFile` re-points that hash at the bytes the session just wrote,
+ * so for the session's OWN writes lazy is structurally blind rather than merely
+ * late. Nothing else was ever going to catch a dropped record.
+ *
+ * A RECORD THAT CANNOT BE APPLIED IS STILL DROPPED, deliberately and
+ * unconditionally: retrying a permanently unapplicable record on every tool call
+ * for the rest of the session costs more than it can ever recover, and the claim
+ * file is deleted whether the loop marked anything or threw.
+ *
+ * FAIL-OPEN THROUGHOUT. A rename that loses a race, or fails for any other
+ * reason, returns 0 and leaves the queue for the next drain; it never throws
+ * into a hook.
  */
 export function drainInvalidations(dir, graph) {
   let records;
+  let claim;
   try {
     const file = queuePath(dir);
     if (!existsSync(file)) return 0;
-    records = readFileSync(file, 'utf8')
+    claim = claimPath(dir);
+    // A LEFTOVER CLAIM FROM A KILLED DRAIN IS OVERWRITTEN, not merged: rename
+    // onto an existing path replaces it. The pid in the name means the only way
+    // to hit that is this same pid having died mid-drain, whose records were
+    // already being applied when it went -- and re-applying is idempotent, so
+    // losing them is the cheaper of the two errors. Not doing the rename at all
+    // would strand the live queue forever.
+    renameSync(file, claim);
+    records = readFileSync(claim, 'utf8')
       .split('\n')
       .filter((line) => line.trim())
       .map((line) => {
@@ -342,6 +382,18 @@ export function drainInvalidations(dir, graph) {
       })
       .filter(Boolean);
   } catch {
+    // The rename lost a race, or the claim could not be read. Nothing is deleted
+    // unread and the hook proceeds. If the claim was taken and then could not be
+    // read, it is put back under the queue name so the next drain still sees it:
+    // a claim file nobody looks at again is the same lost record this rename
+    // exists to prevent.
+    try {
+      if (claim && existsSync(claim) && !existsSync(queuePath(dir))) {
+        renameSync(claim, queuePath(dir));
+      }
+    } catch {
+      // Best effort only. A hook must not fail because bookkeeping did.
+    }
     return 0;
   }
 
@@ -365,10 +417,13 @@ export function drainInvalidations(dir, graph) {
   }
 
   try {
-    rmSync(queuePath(dir), { force: true });
+    // THE CLAIM, NOT THE QUEUE. Deleting `queuePath` here is what dropped a
+    // concurrently appended record; this path holds exactly the bytes that were
+    // just read, so nothing unread can be inside it.
+    rmSync(claim, { force: true });
   } catch {
-    // Held open by a concurrent hook. The next drain re-applies these records,
-    // which is safe: marking an already-marked finding is idempotent.
+    // Held open by something else. The claim is not read again -- the next drain
+    // looks at the queue -- so this costs a stray file, never a record.
   }
 
   return marked;

--- a/plugin/hooks/lib/restore.mjs
+++ b/plugin/hooks/lib/restore.mjs
@@ -142,7 +142,7 @@ export function restorationPlan(dir, graph, context = {}) {
     for (const id of predicted) {
       const node = graph.nodes.get(id);
       if (!node) continue;
-      const findings = serve(graph, findingsFor(graph, id, { limit: 2 }));
+      const findings = serve(graph, findingsFor(graph, id, { limit: 2 }), { dir });
       for (const finding of findings) {
         // `! STALE` only where a diff actually exists to back it; see the
         // renderer in inject.mjs for the measurement behind this.

--- a/plugin/hooks/lib/restore.mjs
+++ b/plugin/hooks/lib/restore.mjs
@@ -158,7 +158,16 @@ export function restorationPlan(dir, graph, context = {}) {
             ? '! STALE '
             : '~ '
           : '';
-        lines.push(`${node.key}: ${mark}${finding.claim}`);
+        // A DISPUTE DISCLOSED ELSEWHERE AND SILENT HERE reads as "the dispute
+        // went away". `serve` already attached the fields; the only question is
+        // the wording, and this list is the most compressed surface in the
+        // system, so it gets the marker and the key and nothing else.
+        const disputed = finding.contradicted
+          ? finding.contradictedBy
+            ? ` (disputed by ${finding.contradictedBy})`
+            : ' (disputed)'
+          : '';
+        lines.push(`${node.key}: ${mark}${finding.claim}${disputed}`);
       }
     }
     section('Likely next', lines, total * split.forward);

--- a/plugin/hooks/lib/skeleton.mjs
+++ b/plugin/hooks/lib/skeleton.mjs
@@ -126,6 +126,11 @@ export function annotatedSkeleton(graph, rawPath, source, { budget = 1200, git =
 
   // Findings anchored to this file or the symbols inside it, served through the
   // one function that enforces the stale-plus-diff rule.
+  // READ-ONLY serve: no `dir` is threaded here, so this cannot clear a stale
+  // flag whose evidence is gone. That is deliberate -- this function takes a
+  // graph, not the directory it came from, and widening its signature to give
+  // an analysis path a write capability buys nothing: the injection path runs
+  // on every tool call and clears the same findings.
   const served = serve(graph, findingsFor(graph, nodeId('file', path), { limit: 40 }));
 
   // Index findings by the symbol they anchor to, so each one sits beside the

--- a/plugin/hooks/lib/staleness.mjs
+++ b/plugin/hooks/lib/staleness.mjs
@@ -31,6 +31,23 @@
  * Eager alone would silently serve stale findings as fresh whenever a change
  * came from outside the agent, which is the single failure mode the design
  * calls worse than no graph.
+ *
+ * AND LAZY ALONE IS BLIND TO THE AGENT'S OWN WRITES -- not degraded, BLIND.
+ * `indexFile` re-points an anchor's stored hash at the bytes it was just handed,
+ * and it is called on every file either hook observes: pretooluse-router.mjs
+ * (two call sites) and adapter.mjs (one). The lazy check then compares that
+ * refreshed hash against the same disk it came from and finds them equal. So
+ * for a file the session edited ITSELF, the lazy path cannot detect the change
+ * at all, and the finding derived from the pre-edit content is served CLEAN.
+ *
+ * Which means that until the eager path was connected, staleness for a file the
+ * agent edited did not work AT ALL: eager was dead code and lazy was defeated
+ * by re-indexing. Every account of this defect, including the one in this
+ * module's own git history, called it "lazy-only, therefore degraded". It was
+ * not degraded. `stale-before-reindex.test.mjs` states in its header that this
+ * case is covered by `invalidateOnWrite`, and `invalidateOnWrite` had never run
+ * once in production. The two paths are not redundant and never were: each is
+ * the ONLY cover for a whole class of change.
  */
 
 import { readFileSync, statSync } from 'node:fs';
@@ -622,6 +639,119 @@ export function invalidateOnWrite(dir, graph, rawPath, beforeText, afterText) {
   // Re-index so the anchors carry the new hashes; otherwise the lazy path would
   // report the same change again on every future retrieval.
   indexFile(dir, path, afterText);
+  return marked;
+}
+
+/**
+ * The eager path for a write with NO before/after pair: compare stored hashes
+ * against disk, and mark what actually moved.
+ *
+ * WHY THIS EXISTS AS A SECOND SHAPE. A whole-file `Write` replaces the file, so
+ * the payload carries the after side and nothing at all of the before -- and a
+ * whole-file write is the commonest write shape there is. `invalidateOnWrite`
+ * cannot serve it: passing '' as the before side makes every symbol in the file
+ * look changed, marks every finding anchored anywhere in it, and the eager mark
+ * is a stored flag no later check ever clears. False-stale is expensive and
+ * permanent, so it is not an acceptable price for coverage.
+ *
+ * But the hash comparison is available, and it is exactly the comparison the
+ * lazy path makes. The difference is WHEN: this runs at the top of injection,
+ * before `indexFile` refreshes the anchor, so the stored hash is still the
+ * pre-write one and the comparison is meaningful. That is the whole trick --
+ * lazy is not wrong, it is merely too late.
+ *
+ * SYMBOL-LEVEL, and from ONE read. Re-locating each symbol by name and
+ * comparing its own span hash is what keeps this from degenerating into
+ * file-level marking: editing one function must not stale a finding about
+ * another, which is the property symbol nodes exist to provide.
+ *
+ * WEAKER EVIDENCE, STATED AS SUCH. There is no before text, so no diff can be
+ * built -- the finding is marked with the two hashes and `serve` reports the
+ * evidence gap through `staleEvidence: false`, which the renderer turns into
+ * "no diff could be rebuilt" rather than promising a diff and showing nothing.
+ * A stale finding with weak evidence is far better than one served as fresh,
+ * but the reader has to be able to tell which one they are holding.
+ */
+export function invalidateChangedAnchors(dir, graph, rawPath) {
+  const path = canonicalPath(rawPath);
+  const marked = [];
+
+  // ONE read for the file and every symbol in it. checkAnchor would have been
+  // the obvious reuse and it reads per anchor, which on a file with fifty
+  // symbols is fifty-one reads of the same bytes on a hook path.
+  let source = null;
+  try {
+    source = readAnySpelling(path);
+  } catch {
+    // Deleted, or unreadable from this checkout. Handled below as a change,
+    // because a finding about a file that is no longer there is exactly the
+    // kind that must not be served as fresh.
+  }
+
+  const changed = [];
+  const fileNode = graph.nodes.get(nodeId('file', path));
+  const fileDigest = source === null ? null : hash(source);
+  if (fileNode && fileDigest !== fileNode.hash) {
+    changed.push({ node: fileNode, from: fileNode.hash, to: fileDigest });
+  }
+
+  const current = new Map(
+    source === null
+      ? []
+      : extractSymbols(path, source).map((s) => [s.name, hash(spanText(source, s))])
+  );
+  for (const node of graph.nodes.values()) {
+    if (node.kind !== 'symbol' || node.file !== path) continue;
+    const digest = current.has(node.name) ? current.get(node.name) : null;
+    if (digest !== node.hash) changed.push({ node, from: node.hash, to: digest });
+  }
+
+  if (changed.length) {
+    // Indexed once by target, for the reason invalidateOnWrite indexes: the
+    // nested alternative is O(nodes x edges) inside a hook.
+    const byTarget = new Map();
+    for (const edge of graph.edges) {
+      if (edge.edge !== 'derived_from') continue;
+      if (!byTarget.has(edge.to)) byTarget.set(edge.to, []);
+      byTarget.get(edge.to).push(edge);
+    }
+
+    for (const { node, from, to } of changed) {
+      for (const edge of byTarget.get(node.id) || []) {
+        const finding = graph.nodes.get(edge.from);
+        if (!finding || finding.kind !== 'finding') continue;
+        // The same type gate serve() applies, for the same reason it is applied
+        // in invalidateOnWrite: the flag is STORED, and disclose.mjs skips a
+        // stale finding while utility.mjs penalises one by 160.
+        if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) continue;
+        // ALREADY MARKED IS LEFT ALONE. Whatever marked it first had a diff or
+        // a more specific reason; overwriting that with a hash pair trades real
+        // evidence for less.
+        if (finding.stale) continue;
+
+        putNode(dir, {
+          ...finding,
+          kind: 'finding',
+          key: finding.key,
+          stale: true,
+          staleReason:
+            to === null
+              ? `the ${node.kind} it depends on is no longer present (was ${from})`
+              : `content hash changed during this session (${from} -> ${to}), observed without a before/after pair`,
+          // EXPLICITLY EMPTY, not absent. serve() reports `staleEvidence` from
+          // whether a diff survived, and the renderer says "no diff could be
+          // rebuilt" -- so the reader can tell "changed, diff unknown" from
+          // "changed, here is what changed".
+          diff: '',
+        });
+        marked.push(finding.key);
+      }
+    }
+  }
+
+  // Re-index for the same reason the diff path does: otherwise every future
+  // retrieval re-reports a change that has already been accounted for.
+  if (source !== null) indexFile(dir, path, source);
   return marked;
 }
 

--- a/plugin/hooks/lib/staleness.mjs
+++ b/plugin/hooks/lib/staleness.mjs
@@ -574,8 +574,20 @@ function derivationCheck(graph, finding) {
  * This is the only function that should ever hand a finding to a model, because
  * it is the one that enforces the rule: a stale finding leaves here carrying
  * `stale: true` AND a diff, or it does not leave at all.
+ *
+ * AND IT CLEARS A STORED FLAG WHOSE EVIDENCE IS GONE, when given a `dir` to
+ * write to. Clearing used to be reachable only by a person pressing Re-verify in
+ * the dashboard, which left the rot path fully open on every install where
+ * nobody opens the dashboard -- and that is most of them. The evidence test is
+ * what makes clearing safe, and it does not care who triggered it: the same
+ * `claimTimeVerdict` runs here as in `reverify`, so this cannot clear anything
+ * the button would not.
+ *
+ * `dir` IS OPTIONAL, AND OMITTING IT MAKES THIS READ-ONLY. Several callers hold
+ * a graph without the directory it came from, and a serve that silently did
+ * nothing would be worse than one that plainly cannot write.
  */
-export function serve(graph, findings) {
+export function serve(graph, findings, { dir = null } = {}) {
   const served = [];
 
   // RETIRED FINDINGS STOP HERE, unconditionally.
@@ -603,8 +615,42 @@ export function serve(graph, findings) {
       continue;
     }
 
+    // AUTOMATIC CLEARING, on the same evidence the manual path demands.
+    //
+    // ONLY THE STORED FLAG IS TOUCHED. The lazy loop below is left to run
+    // exactly as before and can independently mark this finding stale again on
+    // its own comparison -- disk against the anchor NODE's hash -- which answers
+    // a different question and is not this function's to overrule. Eager and
+    // lazy stay two mechanisms, as the module header insists.
+    //
+    // AND THE FIELDS GO WITH THE FLAG. `putNode` does not merge and neither does
+    // this spread: serving `{ ...finding, stale: false }` would hand back a
+    // finding that reads fresh while still carrying `staleReason` and `diff`
+    // from the record -- stale and fresh at once, which is worse than either.
+    // So the cleared record, not the stored one, is what the rest of this
+    // iteration reads and spreads.
+    //
+    // BOUNDED, and the bound is the point: this runs only for a finding whose
+    // flag is already STORED, only when a `derivation` record exists to check
+    // against, and it reads each of that finding's anchors at most once. A
+    // finding that is not flagged pays nothing. The lazy loop below already
+    // reads every anchor of every content-dependent finding served, so the worst
+    // case is twice the anchor reads on the already-stale subset alone.
+    //
+    // NOT ON THE NON-CONTENT-DEPENDENT EARLY RETURN ABOVE, deliberately. Both
+    // eager paths refuse to flag those types at all, so a flag there can only
+    // come from an older graph -- and reading anchors for a type whose truth
+    // does not depend on them is exactly the cost `CONTENT_DEPENDENT` exists to
+    // avoid.
+    let record = finding;
+    if (dir && finding.stale && claimTimeVerdict(graph, finding) === 'match') {
+      clearStale(dir, finding.key, { graph });
+      const { stale: _s, staleReason: _r, diff: _d, staleEvidence: _e, ...cleared } = finding;
+      record = cleared;
+    }
+
     const anchors = graph.edges
-      .filter((e) => e.edge === 'derived_from' && e.from === finding.id)
+      .filter((e) => e.edge === 'derived_from' && e.from === record.id)
       .map((e) => graph.nodes.get(e.to))
       .filter(Boolean);
 
@@ -629,10 +675,10 @@ export function serve(graph, findings) {
     // A finding already marked stale eagerly, whose diff was captured at write
     // time, keeps that diff -- the eager path saw the change we can no longer
     // reconstruct from disk alone.
-    if (!stale && finding.stale) {
+    if (!stale && record.stale) {
       stale = true;
-      diff = finding.diff || '';
-      reason = finding.staleReason || 'marked stale when the change was observed';
+      diff = record.diff || '';
+      reason = record.staleReason || 'marked stale when the change was observed';
     }
 
     if (stale && !diff) {
@@ -681,13 +727,19 @@ export function serve(graph, findings) {
     }
 
     served.push({
-      ...finding,
+      ...record,
       stale,
       ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
+      // BOTH OTHER DISCLOSURES SURVIVE A MID-SERVE CLEAR. `dispute` was computed
+      // above the content-dependence branch and is applied here untouched, and
+      // the derivation verdict is recomputed from the record -- which still
+      // carries its `derivation`, since clearing removes only the staleness
+      // fields. A finding whose flag was just cleared is still disclosed as
+      // disputed, and still reports whether its derivation holds.
       ...dispute,
       // Independent of `stale` above: see `derivationCheck`'s own comment for
       // the case it catches that node-level staleness can miss.
-      ...derivationCheck(graph, finding),
+      ...derivationCheck(graph, record),
     });
   }
   return served;
@@ -939,8 +991,21 @@ function anchorHashNow(anchor) {
  * Exposing it to a hook, a tool argument or an HTTP action would be a way to
  * turn a stale finding fresh on request, which is exactly what must not exist.
  */
-export function clearStale(dir, key) {
-  const node = load(dir).nodes.get(nodeId('finding', key));
+export function clearStale(dir, key, { graph = null } = {}) {
+  // A CALLER THAT ALREADY HOLDS THE GRAPH PASSES IT, and this is not
+  // micro-optimisation: `load` re-parses the entire append-only log, so clearing
+  // inside `serve`'s loop re-read and re-folded the whole graph once PER cleared
+  // finding. Measured on 40 findings all stale and all revertible -- the shape a
+  // mass revert produces -- that was 185 ms against 25 ms, a 7x regression on
+  // the injection path, all of it graph loading rather than the hashing this
+  // feature is actually for. With the graph passed through it is back in line.
+  //
+  // No new race: this store is last-write-wins with no compare-and-set anywhere,
+  // and every other caller that spreads a node back -- `pin`, `retire`,
+  // `contradict`, `correct` -- writes from a graph it loaded earlier too. Both
+  // callers here already DECIDED on this snapshot, so re-reading it purely for
+  // the write narrowed no window that was ever closed.
+  const node = (graph || load(dir)).nodes.get(nodeId('finding', key));
   if (!node || node.kind !== 'finding') return false;
   const { stale, staleReason, diff, staleEvidence, ...rest } = node;
   // Nothing to clear is a success, not a write: an unconditional putNode here
@@ -989,14 +1054,33 @@ export function clearStale(dir, key) {
  * silently un-mark findings nobody asked about. Staleness is disclosed to a
  * reader who then decides; clearing is an explicit act.
  */
-export function reverify(dir, key) {
-  const graph = load(dir);
-  const finding = graph.nodes.get(nodeId('finding', key));
-  if (!finding || finding.kind !== 'finding') return 'unknown';
-  // Idempotent: the postcondition -- no stale flag on this finding -- already
-  // holds, and reporting anything else would make a caller retry forever.
-  if (!finding.stale) return 'cleared';
-
+/**
+ * THE ONE EVIDENCE TEST. Does this finding's anchored content still hash to what
+ * the claim was actually made against?
+ *
+ * `'match'` -- every anchor on disk re-hashes to the value frozen into this
+ * finding's own `derivation.anchors` at claim time. The content IS what the
+ * claim was derived from: a revert, or a write that never moved the anchored
+ * bytes.
+ * `'differs'` -- at least one anchor does not, INCLUDING an anchor whose content
+ * is gone. Deleted is a difference, not a missing measurement.
+ * `'unknown'` -- there is nothing to compare: no `derivation.anchors`, no
+ * anchors, an anchor with no recorded hash, or one that no longer resolves.
+ *
+ * SHARED BY BOTH CLEARING PATHS ON PURPOSE, and that sharing is the guarantee
+ * rather than a convenience. `reverify` (a person pressing Re-verify) and
+ * `serve` (automatic, on every retrieval) call THIS function and nothing else,
+ * so the automatic path cannot clear anything the button would not, and neither
+ * can drift from the other. Two copies of this comparison would be two policies,
+ * and the weaker one would win wherever it ran more often -- which is the
+ * automatic one.
+ *
+ * NOT `checkAnchor`, for the reason `anchorHashNow` above spells out: that
+ * compares disk against the anchor NODE's stored hash, which both eager paths
+ * re-point at the very bytes that caused the mark, so it answers "fresh" for
+ * exactly the finding it just marked stale.
+ */
+function claimTimeVerdict(graph, finding) {
   const recorded = finding.derivation && finding.derivation.anchors;
   if (!recorded || typeof recorded !== 'object') return 'unknown';
 
@@ -1019,10 +1103,23 @@ export function reverify(dir, key) {
     if (node.kind !== 'file' && node.kind !== 'symbol') return 'unknown';
     // null means the content is gone -- deleted file, vanished symbol. That is a
     // difference, not an absence of evidence.
-    if (anchorHashNow(node) !== expected) return 'still-stale';
+    if (anchorHashNow(node) !== expected) return 'differs';
   }
+  return 'match';
+}
 
-  clearStale(dir, key);
+export function reverify(dir, key) {
+  const graph = load(dir);
+  const finding = graph.nodes.get(nodeId('finding', key));
+  if (!finding || finding.kind !== 'finding') return 'unknown';
+  // Idempotent: the postcondition -- no stale flag on this finding -- already
+  // holds, and reporting anything else would make a caller retry forever.
+  if (!finding.stale) return 'cleared';
+
+  const verdict = claimTimeVerdict(graph, finding);
+  if (verdict === 'unknown') return 'unknown';
+  if (verdict === 'differs') return 'still-stale';
+  clearStale(dir, key, { graph });
   return 'cleared';
 }
 

--- a/plugin/hooks/lib/staleness.mjs
+++ b/plugin/hooks/lib/staleness.mjs
@@ -53,7 +53,7 @@
 import { readFileSync, statSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { dirname, join } from 'node:path';
-import { putNode, putEdge, contentHash, nodeId } from './wiki.mjs';
+import { putNode, putEdge, contentHash, nodeId, load } from './wiki.mjs';
 import { hasOutstandingContradiction } from './curate.mjs';
 import { extractSymbols, spanText, symbolKey, extractImports } from './symbols.mjs';
 import { canonicalPath, resolvableCandidates, isFsSafePath } from './paths.mjs';
@@ -488,7 +488,16 @@ function disputeOf(graph, finding) {
     // An edge end that resolves to nothing names nothing. The dispute is still
     // disclosed -- the gate above already established it -- but without a key
     // the reader cannot be pointed anywhere, and inventing one would be worse.
-    if (other && typeof other.key === 'string' && !keys.includes(other.key)) keys.push(other.key);
+    //
+    // A RETIRED END IS NOT NAMED EITHER, for a sharper reason: the disclosure
+    // tells the reader to `wiki_query` that key, and `serve` refuses to return
+    // a retired finding at all. Naming it points them at a claim they cannot
+    // fetch. `hasOutstandingContradiction` above already declines to open the
+    // gate when EVERY disputant is retired; this is the same rule applied to
+    // each name, so a live disputant is still reported alongside a withdrawn one.
+    if (other && !other.retired && typeof other.key === 'string' && !keys.includes(other.key)) {
+      keys.push(other.key);
+    }
   }
 
   return { contradicted: true, ...(keys.length ? { contradictedBy: keys.join(', ') } : {}) };
@@ -870,6 +879,151 @@ export function invalidateChangedAnchors(dir, graph, rawPath) {
   // retrieval re-reports a change that has already been accounted for.
   if (source !== null) indexFile(dir, path, source);
   return marked;
+}
+
+/**
+ * The current content hash of an anchor, read from disk.
+ *
+ * DELIBERATELY NOT `checkAnchor`, and the difference is the whole of this
+ * clearing rule. `checkAnchor` compares disk against the anchor NODE's stored
+ * hash, and both eager paths call `indexFile` immediately after marking --
+ * which re-points that hash at the very bytes that caused the mark. So
+ * `checkAnchor` answers "fresh" for exactly the finding it just marked stale,
+ * and a clearing rule built on it would clear every flag it was handed,
+ * unconditionally. This returns a bare hash instead, so the caller can compare
+ * it against the FROZEN claim-time hash rather than against a value the marking
+ * path itself moved.
+ *
+ * Returns null when no content can be read at all -- a deleted file, or a
+ * symbol that no longer exists. A caller must treat that as "changed", never as
+ * "unknown": a claim about content that is gone certainly does not match the
+ * content it was made against.
+ */
+function anchorHashNow(anchor) {
+  const path = anchor.kind === 'symbol' ? anchor.file : anchor.key;
+  let source;
+  try {
+    source = readAnySpelling(path);
+  } catch {
+    return null;
+  }
+  if (anchor.kind !== 'symbol') return hash(source);
+
+  // By NAME, like checkAnchor: line numbers shift whenever anything above is
+  // edited, and re-locating by line would report a symbol as moved when only an
+  // unrelated insert happened above it.
+  const current = extractSymbols(path, source).find((s) => s.name === anchor.name);
+  if (!current) return null;
+  return hash(spanText(source, current));
+}
+
+/**
+ * Removes the staleness fields from a finding. Returns whether one was found.
+ *
+ * THE WHOLE NODE IS REWRITTEN, because `putNode` does not merge: it writes a
+ * full record from what it is handed and `load` replaces the node wholesale.
+ * Writing `{ kind, key, stale: false }` would blank the claim, the confidence
+ * and the provenance -- an overwrite by another name, and the same trap
+ * `contradict` documents. So the fields are destructured AWAY and everything
+ * else is spread back: no deletion primitive is needed, and the append-only rule
+ * is respected.
+ *
+ * `staleEvidence` is stripped as well, even though no writer stores it. It is
+ * added by `serve` to the object it hands out, so anything that ever writes a
+ * served finding back would carry it in -- at which point a cleared finding
+ * would still be advertising the quality of the evidence for a flag it no longer
+ * has.
+ *
+ * A PRIMITIVE, NOT A ROUTE. Nothing outside this module calls it: the only
+ * shipping caller is `reverify` below, which establishes the evidence first.
+ * Exposing it to a hook, a tool argument or an HTTP action would be a way to
+ * turn a stale finding fresh on request, which is exactly what must not exist.
+ */
+export function clearStale(dir, key) {
+  const node = load(dir).nodes.get(nodeId('finding', key));
+  if (!node || node.kind !== 'finding') return false;
+  const { stale, staleReason, diff, staleEvidence, ...rest } = node;
+  // Nothing to clear is a success, not a write: an unconditional putNode here
+  // would append a duplicate record to the log on every no-op call.
+  if (stale === undefined && staleReason === undefined
+    && diff === undefined && staleEvidence === undefined) return true;
+  putNode(dir, { ...rest, kind: 'finding', key: node.key });
+  return true;
+}
+
+/**
+ * Clears a stale flag when, and only when, the evidence for it is gone.
+ *
+ * WHY THIS HAS TO EXIST. Nothing in this codebase ever cleared a `stale` flag.
+ * That was harmless while eager invalidation was dead code; it fires now, so
+ * every finding on an edited file becomes permanently stale -- and permanently
+ * discounted, since `disclose.mjs` skips a stale finding outright and
+ * `utility.mjs` penalises one by 160. The graph degrades toward all-stale, and
+ * the eager path is over-eager on top of that: `invalidateOnWrite` marks every
+ * finding anchored to a FILE node on any observed write to that file, whether or
+ * not the bytes moved.
+ *
+ * WHAT COUNTS AS EVIDENCE, AND WHY IT IS NOT NEGOTIABLE. The only trustworthy
+ * record of what a claim was made against is `derivation.anchors` -- the hash
+ * each anchor carried at the moment the finding was written, frozen into the
+ * finding itself by `harvest-write.mjs`. Disk is re-hashed here and compared
+ * against that. If every anchor matches, the content IS what the claim was
+ * derived from: a revert, or a write that never moved the anchored bytes. The
+ * flag comes off. Anything else leaves it exactly as it was.
+ *
+ * IT IS NOT A LAUNDERING ROUTE, and that is a property of the comparison rather
+ * than of who is allowed to call it. A caller cannot make a finding fresh by
+ * asking; they can only make it fresh by putting the content back. There is no
+ * argument, no force flag and no second path -- and `clearStale` above, the one
+ * function that clears without checking, has no caller but this one.
+ *
+ * NO RECORD MEANS UNKNOWN, NEVER CLEAR. A finding with no `derivation.anchors`
+ * -- every one written before that record existed, and every hand-curated one --
+ * has nothing to compare disk against. That is an absence of evidence, and
+ * resolving it to "clear it" would hand back the laundering route through the
+ * side door. It reports `unknown` and changes nothing; re-recording the claim
+ * against the current code (`curate.correct`) is the way forward for those.
+ *
+ * DELIBERATELY NOT AUTOMATIC. This reads every anchor off disk, so running it on
+ * the serve path would put N file reads inside injection -- and, worse, it would
+ * silently un-mark findings nobody asked about. Staleness is disclosed to a
+ * reader who then decides; clearing is an explicit act.
+ */
+export function reverify(dir, key) {
+  const graph = load(dir);
+  const finding = graph.nodes.get(nodeId('finding', key));
+  if (!finding || finding.kind !== 'finding') return 'unknown';
+  // Idempotent: the postcondition -- no stale flag on this finding -- already
+  // holds, and reporting anything else would make a caller retry forever.
+  if (!finding.stale) return 'cleared';
+
+  const recorded = finding.derivation && finding.derivation.anchors;
+  if (!recorded || typeof recorded !== 'object') return 'unknown';
+
+  const anchorIds = new Set(
+    graph.edges
+      .filter((e) => e.edge === 'derived_from' && e.from === finding.id)
+      .map((e) => e.to)
+  );
+  // An unanchored finding cannot be checked against anything, which is the
+  // un-invalidatable shape the anchor discipline exists to refuse. It is equally
+  // un-VERIFIABLE, so it is reported as such rather than cleared.
+  if (!anchorIds.size) return 'unknown';
+
+  for (const id of anchorIds) {
+    const expected = recorded[id];
+    const node = graph.nodes.get(id);
+    // An anchor this finding never recorded a hash for, or one that no longer
+    // resolves to a node: nothing to compare, so nothing is concluded.
+    if (typeof expected !== 'string' || !expected || !node) return 'unknown';
+    if (node.kind !== 'file' && node.kind !== 'symbol') return 'unknown';
+    // null means the content is gone -- deleted file, vanished symbol. That is a
+    // difference, not an absence of evidence.
+    if (anchorHashNow(node) !== expected) return 'still-stale';
+  }
+
+  clearStale(dir, key);
+  return 'cleared';
 }
 
 export { contentHash };

--- a/plugin/hooks/lib/staleness.mjs
+++ b/plugin/hooks/lib/staleness.mjs
@@ -368,6 +368,12 @@ const DIFF_MAX_BYTES = () => {
  * line, and total bytes. Every truncation is announced in the output, because a
  * silently shortened diff is worse than a visibly shortened one -- a reader who
  * cannot tell content was elided believes they saw the whole change.
+ *
+ * `maxLines` BOUNDS THE BODY, MARKERS INCLUDED: at most `maxLines` lines of
+ * removed lines, added lines and "... N more" elision markers between them, plus
+ * at most one final notice when the byte cap dropped lines -- so `maxLines + 1`
+ * lines in total, and no more. That last line is outside the budget on purpose,
+ * for the reason stated where it is pushed.
  */
 export function diffLines(
   before,
@@ -418,10 +424,24 @@ export function diffLines(
     bytes += size;
   };
 
-  for (const line of removed.slice(0, maxLines / 2)) push('- ' + line);
-  if (removed.length > maxLines / 2) push(`  ... ${removed.length - maxLines / 2} more removed`);
-  for (const line of added.slice(0, maxLines / 2)) push('+ ' + line);
-  if (added.length > maxLines / 2) push(`  ... ${added.length - maxLines / 2} more added`);
+  // THE ELISION MARKER IS PAID FOR OUT OF THE SIDE'S OWN QUOTA, so `maxLines`
+  // bounds the whole body rather than only the content in it. It did not: at the
+  // default 40 the body could reach 42 lines -- 20 removed, 20 added and two
+  // "... N more" markers -- and the out-of-budget notice below made 43, against
+  // a documented bound of 40 and a test asserting 41. Three numbers, no two the
+  // same. A side that has to elide now shows one fewer content line and spends
+  // that line on saying so, which is the trade a reader wants anyway: knowing
+  // that 300 lines were cut matters more than the 20th of the 20 shown.
+  const half = Math.floor(maxLines / 2);
+  const emit = (lines, prefix, label) => {
+    const elides = lines.length > half;
+    const shown = elides ? Math.max(0, half - 1) : half;
+    for (const line of lines.slice(0, shown)) push(prefix + line);
+    if (elides) push(`  ... ${lines.length - shown} more ${label}`);
+  };
+
+  emit(removed, '- ', 'removed');
+  emit(added, '+ ', 'added');
 
   // Announced OUTSIDE the budget, deliberately: the one line a reader most
   // needs is the one saying the rest is missing, and dropping it to stay under
@@ -479,6 +499,15 @@ function disputeOf(graph, finding) {
   if (!hasOutstandingContradiction(graph, finding.key)) return {};
 
   const keys = [];
+  // AND THE REASON A PERSON TYPED, which had no reader anywhere. `contradict`
+  // stores `contradictionReason` -- up to 400 characters of human explanation --
+  // on the CONTRADICTED end only, and nothing outside its own test ever read it:
+  // this disclosure named the other key and stopped, `audit` counts ends, and the
+  // dashboard detail view renders neither. So the one field on the edge that says
+  // WHY was written on every contradiction and seen by nobody. It is collected
+  // from whichever end holds it, so both sides of a dispute disclose the same
+  // reason rather than only the claim that lost.
+  let reason = typeof finding.contradictionReason === 'string' ? finding.contradictionReason : '';
   for (const edge of graph.edges) {
     if (edge.edge !== 'contradicts') continue;
     const otherId =
@@ -497,10 +526,30 @@ function disputeOf(graph, finding) {
     // each name, so a live disputant is still reported alongside a withdrawn one.
     if (other && !other.retired && typeof other.key === 'string' && !keys.includes(other.key)) {
       keys.push(other.key);
+      // A RETIRED END'S REASON IS NOT BORROWED EITHER, which is why this sits
+      // inside the same guard as the key: `hasOutstandingContradiction` can be
+      // open on one live disputant while another is withdrawn, and quoting the
+      // withdrawn one's explanation would attribute the live dispute to a claim
+      // the reader cannot fetch.
+      if (!reason && typeof other.contradictionReason === 'string') {
+        reason = other.contradictionReason;
+      }
     }
   }
 
-  return { contradicted: true, ...(keys.length ? { contradictedBy: keys.join(', ') } : {}) };
+  return {
+    contradicted: true,
+    ...(keys.length ? { contradictedBy: keys.join(', ') } : {}),
+    // Trimmed here rather than at the renderer: an empty string is not a reason,
+    // and a consumer checking `if (reason)` should not have to trim first.
+    //
+    // SET UNCONDITIONALLY, INCLUDING TO `undefined`. `serve` spreads the stored
+    // record before this object, so omitting the key would let a whitespace-only
+    // stored reason through untouched and make the served value differ from the
+    // one this function decided on. The disclosure is authoritative or it is not
+    // a disclosure.
+    contradictionReason: reason.trim() || undefined,
+  };
 }
 
 /**
@@ -580,8 +629,15 @@ function derivationCheck(graph, finding) {
  * the dashboard, which left the rot path fully open on every install where
  * nobody opens the dashboard -- and that is most of them. The evidence test is
  * what makes clearing safe, and it does not care who triggered it: the same
- * `claimTimeVerdict` runs here as in `reverify`, so this cannot clear anything
+ * `claimTimeEvidence` runs here as in `reverify`, so this cannot clear anything
  * the button would not.
+ *
+ * A CLEAR ALSO RE-INDEXES THE ANCHORS IT VERIFIED. The three disclosures this
+ * function emits -- `stale`, `derivationHolds`, and the dispute -- are computed
+ * from three different comparisons, and clearing the flag without moving the
+ * anchor's stored hash made the first two contradict the clear on the revert
+ * path. `reindexVerifiedAnchors` explains the reproduction and why re-pointing
+ * the index is the fix rather than suppressing the disclosures.
  *
  * `dir` IS OPTIONAL, AND OMITTING IT MAKES THIS READ-ONLY. Several callers hold
  * a graph without the directory it came from, and a serve that silently did
@@ -617,11 +673,17 @@ export function serve(graph, findings, { dir = null } = {}) {
 
     // AUTOMATIC CLEARING, on the same evidence the manual path demands.
     //
-    // ONLY THE STORED FLAG IS TOUCHED. The lazy loop below is left to run
-    // exactly as before and can independently mark this finding stale again on
-    // its own comparison -- disk against the anchor NODE's hash -- which answers
-    // a different question and is not this function's to overrule. Eager and
-    // lazy stay two mechanisms, as the module header insists.
+    // THE FLAG AND THE INDEX MOVE TOGETHER. Clearing the flag alone made this
+    // function contradict itself on the revert path: the lazy loop below
+    // compares disk against the anchor NODE's hash, which the eager path
+    // re-pointed at the post-edit bytes, so a reverted file read as `stale:
+    // true, staleReason: 'file changed'` and `derivationHolds: false` inside the
+    // very object whose flag had just been cleared for matching its claim-time
+    // content. `reindexVerifiedAnchors` writes the verified bytes' hash back to
+    // the anchor, so all three disclosures are finally reading the same content
+    // and cannot disagree. Eager and lazy stay two mechanisms, as the module
+    // header insists -- what changed is that the index no longer holds a hash
+    // that matches no version of the file that exists.
     //
     // AND THE FIELDS GO WITH THE FLAG. `putNode` does not merge and neither does
     // this spread: serving `{ ...finding, stale: false }` would hand back a
@@ -630,12 +692,37 @@ export function serve(graph, findings, { dir = null } = {}) {
     // So the cleared record, not the stored one, is what the rest of this
     // iteration reads and spreads.
     //
-    // BOUNDED, and the bound is the point: this runs only for a finding whose
-    // flag is already STORED, only when a `derivation` record exists to check
-    // against, and it reads each of that finding's anchors at most once. A
-    // finding that is not flagged pays nothing. The lazy loop below already
+    // BOUNDED PER CALL, and the bound is the point: this runs only for a finding
+    // whose flag is already STORED, only when a `derivation` record exists to
+    // check against, and it reads each of that finding's anchors at most once.
+    // A finding that is not flagged pays nothing. The lazy loop below already
     // reads every anchor of every content-dependent finding served, so the worst
     // case is twice the anchor reads on the already-stale subset alone.
+    //
+    // AND THE PER-SESSION SHAPE, stated because the per-call bound alone reads
+    // as cheaper than it is. Measured on a synthetic 40-stale-finding graph, the
+    // serve path went 158 ms -> 217 ms (+37%), and for a GENUINELY stale finding
+    // that cost recurs on every call for the whole session: the verdict is
+    // `'differs'` forever, nothing is cleared, and the reads are repaid with
+    // nothing. What keeps it survivable in practice is not this bound but two
+    // others -- `findingsFor`'s result limit and inject.mjs's `alreadyInjected`
+    // gate, which together put it near 40 ms on the first touch of a hot file
+    // and zero on the touches after.
+    //
+    // THE REVERT CASE PAYS ONCE, AND THAT IS MEASURED, not argued. Same 40
+    // findings, all revertible, medians of 9 across three process launches: the
+    // read-only serve is 23-29 ms, the first clearing serve is 141-173 ms (the
+    // anchor reads plus one node append per cleared finding AND per re-pointed
+    // anchor), and the SECOND clearing serve is 21-28 ms -- back to the
+    // read-only baseline, because the flag is off and the index agrees, so this
+    // gate no longer fires. What the re-index changed is not that cost -- the
+    // gate stopped firing once the flag came off before, too -- but that every
+    // serve after the clear used to re-derive `stale: true` and
+    // `derivationHolds: false` from an index nobody had moved. The extra ~120 ms
+    // buys silence that is actually correct.
+    // On the genuinely-stale set the recurring cost is
+    // real and unchanged in kind: 26-45 ms read-only against 53-105 ms with
+    // clearing on, every call, clearing nothing.
     //
     // NOT ON THE NON-CONTENT-DEPENDENT EARLY RETURN ABOVE, deliberately. Both
     // eager paths refuse to flag those types at all, so a flag there can only
@@ -643,10 +730,14 @@ export function serve(graph, findings, { dir = null } = {}) {
     // does not depend on them is exactly the cost `CONTENT_DEPENDENT` exists to
     // avoid.
     let record = finding;
-    if (dir && finding.stale && claimTimeVerdict(graph, finding) === 'match') {
-      clearStale(dir, finding.key, { graph });
-      const { stale: _s, staleReason: _r, diff: _d, staleEvidence: _e, ...cleared } = finding;
-      record = cleared;
+    if (dir && finding.stale) {
+      const evidence = claimTimeEvidence(graph, finding);
+      if (evidence.verdict === 'match') {
+        reindexVerifiedAnchors(dir, graph, evidence.contents);
+        clearStale(dir, finding.key, { graph });
+        const { stale: _s, staleReason: _r, diff: _d, staleEvidence: _e, ...cleared } = finding;
+        record = cleared;
+      }
     }
 
     const anchors = graph.edges
@@ -736,6 +827,14 @@ export function serve(graph, findings, { dir = null } = {}) {
       // carries its `derivation`, since clearing removes only the staleness
       // fields. A finding whose flag was just cleared is still disclosed as
       // disputed, and still reports whether its derivation holds.
+      //
+      // AND THEY NO LONGER CONTRADICT THE CLEAR. Surviving is not the same as
+      // agreeing: for a whole serve this returned `stale: true, staleReason:
+      // 'file changed'` and `derivationHolds: false` on a finding it had just
+      // cleared, because the clear was decided against disk while these two read
+      // the anchor node's hash, and the eager path had moved it. All three now
+      // read the same content because the clear re-points the anchor; see
+      // `reindexVerifiedAnchors`.
       ...dispute,
       // Independent of `stale` above: see `derivationCheck`'s own comment for
       // the case it catches that node-level staleness can miss.
@@ -934,6 +1033,34 @@ export function invalidateChangedAnchors(dir, graph, rawPath) {
 }
 
 /**
+ * The current content of an anchor, read from disk: the whole file for a file
+ * anchor, the located span for a symbol one. Null when nothing can be read.
+ *
+ * SPLIT OUT FROM `anchorHashNow` SO THE BYTES SURVIVE THE COMPARISON. The
+ * clearing path hashes this to reach a verdict and, on `'match'`, re-indexes the
+ * anchor from the same bytes -- see `reindexVerifiedAnchors`. Returning only a
+ * hash forced a second read of a file that had just been read, for content
+ * already known to be identical.
+ */
+function anchorContentNow(anchor) {
+  const path = anchor.kind === 'symbol' ? anchor.file : anchor.key;
+  let source;
+  try {
+    source = readAnySpelling(path);
+  } catch {
+    return null;
+  }
+  if (anchor.kind !== 'symbol') return source;
+
+  // By NAME, like checkAnchor: line numbers shift whenever anything above is
+  // edited, and re-locating by line would report a symbol as moved when only an
+  // unrelated insert happened above it.
+  const current = extractSymbols(path, source).find((s) => s.name === anchor.name);
+  if (!current) return null;
+  return spanText(source, current);
+}
+
+/**
  * The current content hash of an anchor, read from disk.
  *
  * DELIBERATELY NOT `checkAnchor`, and the difference is the whole of this
@@ -952,21 +1079,8 @@ export function invalidateChangedAnchors(dir, graph, rawPath) {
  * content it was made against.
  */
 function anchorHashNow(anchor) {
-  const path = anchor.kind === 'symbol' ? anchor.file : anchor.key;
-  let source;
-  try {
-    source = readAnySpelling(path);
-  } catch {
-    return null;
-  }
-  if (anchor.kind !== 'symbol') return hash(source);
-
-  // By NAME, like checkAnchor: line numbers shift whenever anything above is
-  // edited, and re-locating by line would report a symbol as moved when only an
-  // unrelated insert happened above it.
-  const current = extractSymbols(path, source).find((s) => s.name === anchor.name);
-  if (!current) return null;
-  return hash(spanText(source, current));
+  const content = anchorContentNow(anchor);
+  return content === null ? null : hash(content);
 }
 
 /**
@@ -1005,21 +1119,51 @@ export function clearStale(dir, key, { graph = null } = {}) {
   // `contradict`, `correct` -- writes from a graph it loaded earlier too. Both
   // callers here already DECIDED on this snapshot, so re-reading it purely for
   // the write narrowed no window that was ever closed.
-  const node = (graph || load(dir)).nodes.get(nodeId('finding', key));
+  const id = nodeId('finding', key);
+  const node = (graph || load(dir)).nodes.get(id);
   if (!node || node.kind !== 'finding') return false;
   const { stale, staleReason, diff, staleEvidence, ...rest } = node;
   // Nothing to clear is a success, not a write: an unconditional putNode here
   // would append a duplicate record to the log on every no-op call.
   if (stale === undefined && staleReason === undefined
     && diff === undefined && staleEvidence === undefined) return true;
-  putNode(dir, { ...rest, kind: 'finding', key: node.key });
+  const cleared = { ...rest, kind: 'finding', key: node.key };
+  putNode(dir, cleared);
+  // AND THE CALLER'S GRAPH IS UPDATED, because the guard above reads THAT graph,
+  // not disk. Without this, a second `serve` on the same in-memory graph object
+  // -- two touched files anchored to one finding, or a lifecycle branch that
+  // serves twice from a graph it loaded once, as SessionStart does -- still saw
+  // `stale: true`, re-ran the evidence test, and appended a byte-identical clear
+  // record. The store is append-only, so that is permanent log growth for no
+  // change in state, and the "nothing to clear is a success, not a write"
+  // guarantee directly above was only true of the first call.
+  if (graph) graph.nodes.set(id, { ...cleared, id });
   return true;
 }
 
 /**
- * Clears a stale flag when, and only when, the evidence for it is gone.
+ * THE ONE EVIDENCE TEST, plus the bytes it read. Does this finding's anchored
+ * content still hash to what the claim was actually made against?
  *
- * WHY THIS HAS TO EXIST. Nothing in this codebase ever cleared a `stale` flag.
+ * `verdict` is one of:
+ *   `'match'`   -- every anchor on disk re-hashes to the value frozen into this
+ *                  finding's own `derivation.anchors` at claim time. The content
+ *                  IS what the claim was derived from: a revert, or a write that
+ *                  never moved the anchored bytes.
+ *   `'differs'` -- at least one anchor does not, INCLUDING an anchor whose
+ *                  content is gone. Deleted is a difference, not a missing
+ *                  measurement.
+ *   `'unknown'` -- there is nothing to compare: no `derivation.anchors`, no
+ *                  anchors, an anchor with no recorded hash, or one that no
+ *                  longer resolves.
+ *
+ * `contents` carries the disk bytes read to reach a `'match'`, keyed by anchor
+ * id, so the caller can re-index those anchors without reading them again. It is
+ * empty for the other two verdicts, which read no further than the first
+ * disagreement.
+ *
+ * WHY CLEARING HAS TO EXIST AT ALL. Nothing in this codebase ever cleared a
+ * `stale` flag.
  * That was harmless while eager invalidation was dead code; it fires now, so
  * every finding on an edited file becomes permanently stale -- and permanently
  * discounted, since `disclose.mjs` skips a stale finding outright and
@@ -1049,24 +1193,6 @@ export function clearStale(dir, key, { graph = null } = {}) {
  * side door. It reports `unknown` and changes nothing; re-recording the claim
  * against the current code (`curate.correct`) is the way forward for those.
  *
- * DELIBERATELY NOT AUTOMATIC. This reads every anchor off disk, so running it on
- * the serve path would put N file reads inside injection -- and, worse, it would
- * silently un-mark findings nobody asked about. Staleness is disclosed to a
- * reader who then decides; clearing is an explicit act.
- */
-/**
- * THE ONE EVIDENCE TEST. Does this finding's anchored content still hash to what
- * the claim was actually made against?
- *
- * `'match'` -- every anchor on disk re-hashes to the value frozen into this
- * finding's own `derivation.anchors` at claim time. The content IS what the
- * claim was derived from: a revert, or a write that never moved the anchored
- * bytes.
- * `'differs'` -- at least one anchor does not, INCLUDING an anchor whose content
- * is gone. Deleted is a difference, not a missing measurement.
- * `'unknown'` -- there is nothing to compare: no `derivation.anchors`, no
- * anchors, an anchor with no recorded hash, or one that no longer resolves.
- *
  * SHARED BY BOTH CLEARING PATHS ON PURPOSE, and that sharing is the guarantee
  * rather than a convenience. `reverify` (a person pressing Re-verify) and
  * `serve` (automatic, on every retrieval) call THIS function and nothing else,
@@ -1080,9 +1206,10 @@ export function clearStale(dir, key, { graph = null } = {}) {
  * re-point at the very bytes that caused the mark, so it answers "fresh" for
  * exactly the finding it just marked stale.
  */
-function claimTimeVerdict(graph, finding) {
+function claimTimeEvidence(graph, finding) {
+  const none = { verdict: 'unknown', contents: new Map() };
   const recorded = finding.derivation && finding.derivation.anchors;
-  if (!recorded || typeof recorded !== 'object') return 'unknown';
+  if (!recorded || typeof recorded !== 'object') return none;
 
   const anchorIds = new Set(
     graph.edges
@@ -1092,22 +1219,122 @@ function claimTimeVerdict(graph, finding) {
   // An unanchored finding cannot be checked against anything, which is the
   // un-invalidatable shape the anchor discipline exists to refuse. It is equally
   // un-VERIFIABLE, so it is reported as such rather than cleared.
-  if (!anchorIds.size) return 'unknown';
+  if (!anchorIds.size) return none;
 
+  const contents = new Map();
   for (const id of anchorIds) {
     const expected = recorded[id];
     const node = graph.nodes.get(id);
     // An anchor this finding never recorded a hash for, or one that no longer
     // resolves to a node: nothing to compare, so nothing is concluded.
-    if (typeof expected !== 'string' || !expected || !node) return 'unknown';
-    if (node.kind !== 'file' && node.kind !== 'symbol') return 'unknown';
+    if (typeof expected !== 'string' || !expected || !node) return none;
+    if (node.kind !== 'file' && node.kind !== 'symbol') return none;
     // null means the content is gone -- deleted file, vanished symbol. That is a
     // difference, not an absence of evidence.
-    if (anchorHashNow(node) !== expected) return 'differs';
+    const content = anchorContentNow(node);
+    if (content === null || hash(content) !== expected) {
+      return { verdict: 'differs', contents: new Map() };
+    }
+    contents.set(id, content);
   }
-  return 'match';
+  return { verdict: 'match', contents };
 }
 
+/** The verdict alone, for callers that do not re-index. */
+function claimTimeVerdict(graph, finding) {
+  return claimTimeEvidence(graph, finding).verdict;
+}
+
+/**
+ * Re-points every verified anchor at the content the evidence test just read.
+ *
+ * WHY A CLEAR IS NOT ENOUGH ON ITS OWN, reproduced end to end: index a file at
+ * H1, write a finding whose `derivation.anchors` records H1, edit and re-index so
+ * the node holds H2, let the eager path mark the finding, then REVERT the edit on
+ * disk. `claimTimeVerdict` now says `'match'` -- disk is H1, which is exactly
+ * what the claim was derived from -- and the flag comes off. But the node still
+ * holds H2, so the same `serve` call went on to emit `stale: true` with
+ * `staleReason: 'file changed'` from the lazy loop (disk H1 against node H2) and
+ * `derivationHolds: false` from `derivationCheck` (index H2 against claim H1).
+ * The model was shown DERIVATION CHANGED and STALE at the exact moment this
+ * module's own evidence test had concluded the derivation holds -- on every
+ * serve, until something unrelated happened to re-index the anchor.
+ *
+ * THE FIX IS TO MOVE THE INDEX, NOT TO SILENCE THE DISCLOSURES. Suppressing the
+ * lazy check and the derivation verdict for a cleared finding would leave the
+ * graph holding a hash that matches no version of the file that exists, so every
+ * OTHER finding on that anchor keeps reading stale, and the next reader has to be
+ * told which disclosures to disbelieve. The node hash is simply out of date, the
+ * bytes are already in hand from the comparison that just succeeded, and writing
+ * them makes all three disclosures agree because they are finally reading the
+ * same content.
+ *
+ * COSTS NO READ. `contents` comes from `claimTimeEvidence`, which read each
+ * anchor to reach `'match'`. The write is one node record per anchor whose hash
+ * actually moved, and it happens once per revert rather than once per serve: with
+ * the index re-pointed, the flag stays off and the gate in `serve` does not fire
+ * again.
+ *
+ * THE IN-MEMORY GRAPH IS UPDATED TOO, because the caller is mid-serve and is
+ * about to read these same nodes through the lazy loop and `derivationCheck`.
+ * Writing only to disk would fix the next process and leave this one contradicting
+ * itself, which is the whole defect.
+ *
+ * Line numbers are deliberately left alone on a symbol anchor: `checkAnchor` and
+ * `anchorContentNow` both re-locate by NAME, so a stored line is informational,
+ * and the body being byte-identical is what was just established.
+ */
+function reindexVerifiedAnchors(dir, graph, contents) {
+  for (const [id, content] of contents) {
+    const node = graph.nodes.get(id);
+    if (!node) continue;
+    const nextHash = hash(content);
+    // Already agrees: no record, no write. The common case once a revert has
+    // been accounted for.
+    if (node.hash === nextHash) continue;
+    const limit = node.kind === 'symbol' ? symbolSnapshotLimit() : snapshotLimit();
+    // Same bound as `indexFile`: past the cap the hash still drives staleness and
+    // only the reconstructed diff degrades.
+    const snapshot = content.length <= limit ? content : undefined;
+    const { hash: _h, snapshot: _s, ...rest } = node;
+    try {
+      putNode(dir, { ...rest, kind: node.kind, key: node.key, hash: nextHash, snapshot });
+    } catch {
+      // Fail open: a graph that could not be written is a disclosure that stays
+      // as it was, never a broken tool call. The in-memory copy is left alone to
+      // match, so this serve keeps agreeing with the store.
+      continue;
+    }
+    graph.nodes.set(id, { ...node, hash: nextHash, ...(snapshot ? { snapshot } : {}) });
+  }
+}
+
+/**
+ * Clears a stale flag on behalf of a person who asked for it -- the dashboard's
+ * Re-verify action -- and reports what the evidence said.
+ *
+ * `'cleared'` when the flag is gone (including when it was already gone, so a
+ * caller polling this does not retry forever), `'still-stale'` when the anchored
+ * content genuinely differs from what the claim was made against, `'unknown'`
+ * when there is nothing to compare and therefore nothing to conclude.
+ *
+ * NO LONGER THE ONLY CLEARING PATH, and the docblock that used to sit here said
+ * the opposite: that automatic clearing was refused because it would put N file
+ * reads inside injection and "silently un-mark findings nobody asked about".
+ * `serve` now does exactly that, on the same evidence, for the reason its own
+ * comment gives -- the manual path was reachable only where somebody opens the
+ * dashboard, which is almost nowhere, so the rot path stayed open on most
+ * installs. What survives of that objection is the cost, which `serve` bounds
+ * and states.
+ *
+ * WHAT THIS STILL ADDS over the automatic path: it loads the graph itself, so a
+ * caller holding nothing but a key and a directory can act; it reports the
+ * verdict rather than folding it into a served record; and it runs on demand
+ * rather than only when the finding happens to be retrieved. It re-indexes the
+ * verified anchors for the same reason `serve` does -- otherwise the button
+ * clears the flag and the very next retrieval re-derives a contradiction from a
+ * node hash nobody moved.
+ */
 export function reverify(dir, key) {
   const graph = load(dir);
   const finding = graph.nodes.get(nodeId('finding', key));
@@ -1116,9 +1343,10 @@ export function reverify(dir, key) {
   // holds, and reporting anything else would make a caller retry forever.
   if (!finding.stale) return 'cleared';
 
-  const verdict = claimTimeVerdict(graph, finding);
+  const { verdict, contents } = claimTimeEvidence(graph, finding);
   if (verdict === 'unknown') return 'unknown';
   if (verdict === 'differs') return 'still-stale';
+  reindexVerifiedAnchors(dir, graph, contents);
   clearStale(dir, key, { graph });
   return 'cleared';
 }

--- a/plugin/hooks/lib/staleness.mjs
+++ b/plugin/hooks/lib/staleness.mjs
@@ -17,7 +17,13 @@
  * TWO INVALIDATION PATHS, and each covers what the other cannot see:
  *
  *   EAGER  -- our PostToolUse hook saw a write, so the finding is marked at the
- *             moment it went stale, with the exact before/after in hand.
+ *             moment it went stale, with the exact before/after in hand. The
+ *             hook does not call `invalidateOnWrite` directly: it queues the
+ *             evidence through pending.mjs, and the next graph read -- which
+ *             loads the graph anyway -- applies it before serving anything.
+ *             That path is also the only one that catches a write the SESSION
+ *             made, because the lazy check below compares the stored hash
+ *             against disk and `indexFile` has already refreshed it.
  *   LAZY   -- at retrieval, the anchor's stored hash is compared against disk.
  *             This is what catches `git pull`, another editor, a teammate, or a
  *             build step: every change our hooks never observed.
@@ -291,14 +297,69 @@ export function checkAnchor(anchor) {
 }
 
 /**
+ * Characters kept from any single diff line.
+ *
+ * A LINE CAP IS NOT A SIZE CAP, and the gap was measured: with only `maxLines`
+ * in force, `diffLines('X'.repeat(200000), 'Y'.repeat(200000))` returned 2 lines
+ * and 400,005 bytes. Minified bundles, generated sources and single-line JSON
+ * all have that shape, and this output goes STRAIGHT INTO MODEL CONTEXT from
+ * inject.mjs's zero-turn refusal -- so a line bound alone let one pathological
+ * file spend hundreds of thousands of tokens.
+ *
+ * 200 characters is chosen because it is past the width at which a line is read
+ * as a line by anybody, human or model: a hand-written source line is under
+ * ~120 columns, so the cap cannot truncate a diff a reader was going to use,
+ * while the cases it does truncate are ones where the interesting change is not
+ * legible from the raw text anyway.
+ */
+const DIFF_MAX_LINE_CHARS = () => {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_DIFF_MAX_LINE_CHARS);
+  return Number.isFinite(raw) && raw > 0 ? raw : 200;
+};
+
+/**
+ * Total UTF-8 bytes of diff body.
+ *
+ * 4,000 bytes is roughly 1,000 tokens. It is deliberately larger than the
+ * per-file injection budget (`TOKEN_OPTIMIZER_TOUCH_BUDGET`, 500 tokens) and
+ * far smaller than a file, because the two consumers want different things: the
+ * injection surface fits the diff inside its own budget and drops it if it does
+ * not fit, while the zero-turn refusal is replacing a whole file read and can
+ * afford more. One cap that neither consumer has to think about is worth more
+ * than two tuned ones.
+ *
+ * WHAT IT COSTS, PLAINLY: a legitimately large diff now arrives truncated, so a
+ * model looking at a 300-line refactor sees the head of it and a count of what
+ * was elided rather than the whole change. That is the correct direction to
+ * fail -- the alternative was a bounded-looking function that could emit 400 KB.
+ */
+const DIFF_MAX_BYTES = () => {
+  const raw = Number(process.env.TOKEN_OPTIMIZER_DIFF_MAX_BYTES);
+  return Number.isFinite(raw) && raw > 0 ? raw : 4_000;
+};
+
+/**
  * A compact line diff.
  *
  * Deliberately not a full unified diff with hunks and context: the consumer is
  * a model deciding whether an existing conclusion still holds, and for that the
  * changed lines are the signal. Output is capped because an unbounded diff
  * injected alongside a finding would spend more tokens than re-deriving it.
+ *
+ * BOUNDED IN THREE WAYS, and each one is load-bearing: lines, characters per
+ * line, and total bytes. Every truncation is announced in the output, because a
+ * silently shortened diff is worse than a visibly shortened one -- a reader who
+ * cannot tell content was elided believes they saw the whole change.
  */
-export function diffLines(before, after, { maxLines = 40 } = {}) {
+export function diffLines(
+  before,
+  after,
+  {
+    maxLines = 40,
+    maxLineChars = DIFF_MAX_LINE_CHARS(),
+    maxBytes = DIFF_MAX_BYTES(),
+  } = {}
+) {
   const a = String(before).split('\n');
   const b = String(after).split('\n');
 
@@ -314,33 +375,44 @@ export function diffLines(before, after, { maxLines = 40 } = {}) {
   const added = b.slice(head, b.length - tail);
 
   const out = [];
-  for (const line of removed.slice(0, maxLines / 2)) out.push('- ' + line);
-  if (removed.length > maxLines / 2) out.push(`  ... ${removed.length - maxLines / 2} more removed`);
-  for (const line of added.slice(0, maxLines / 2)) out.push('+ ' + line);
-  if (added.length > maxLines / 2) out.push(`  ... ${added.length - maxLines / 2} more added`);
+  let bytes = 0;
+  let dropped = 0;
+
+  // Per line first, so ONE enormous line cannot consume the whole budget and
+  // leave every other changed line unrepresented.
+  const clamp = (line) => {
+    const text = String(line);
+    if (text.length <= maxLineChars) return text;
+    return `${text.slice(0, maxLineChars)} [+${text.length - maxLineChars} chars cut]`;
+  };
+
+  // Bytes, not characters: the cap exists to bound what is sent, and a
+  // multi-byte source file would otherwise pass a character check while
+  // emitting several times the budget.
+  const push = (line) => {
+    const text = clamp(line);
+    const size = Buffer.byteLength(text, 'utf8') + 1;
+    if (bytes + size > maxBytes) {
+      dropped++;
+      return;
+    }
+    out.push(text);
+    bytes += size;
+  };
+
+  for (const line of removed.slice(0, maxLines / 2)) push('- ' + line);
+  if (removed.length > maxLines / 2) push(`  ... ${removed.length - maxLines / 2} more removed`);
+  for (const line of added.slice(0, maxLines / 2)) push('+ ' + line);
+  if (added.length > maxLines / 2) push(`  ... ${added.length - maxLines / 2} more added`);
+
+  // Announced OUTSIDE the budget, deliberately: the one line a reader most
+  // needs is the one saying the rest is missing, and dropping it to stay under
+  // a self-imposed cap would hand back a diff that lies about being complete.
+  if (dropped) out.push(`  ... ${dropped} more changed line(s) cut at the size limit`);
 
   return out.join('\n');
 }
 
-/**
- * Prepares findings for delivery, verifying each one lazily against disk.
- *
- * This is the only function that should ever hand a finding to a model, because
- * it is the one that enforces the rule: a stale finding leaves here carrying
- * `stale: true` AND a diff, or it does not leave at all.
- */
-export function serve(graph, findings) {
-  const served = [];
-
-  // RETIRED FINDINGS STOP HERE, unconditionally.
-  //
-  // findingsFor and sessionIndex already filter them, so this is redundant on
-  // every current path -- deliberately. This function's own contract is that it
-  // is the only thing that hands a finding to a model, which makes it the right
-  // place for the guarantee to live: a future caller that reaches into the
-  // graph directly cannot accidentally serve a claim a human explicitly
-  // withdrew. A withheld claim reappearing is not a bug anyone would notice
-  // quickly.
 /**
  * Types whose truth is a claim ABOUT the anchor's contents.
  *
@@ -363,6 +435,26 @@ export function serve(graph, findings) {
  * to ignore -- taking the rare true positive with it.
  */
 const CONTENT_DEPENDENT = new Set(['finding', 'map']);
+
+/**
+ * Prepares findings for delivery, verifying each one lazily against disk.
+ *
+ * This is the only function that should ever hand a finding to a model, because
+ * it is the one that enforces the rule: a stale finding leaves here carrying
+ * `stale: true` AND a diff, or it does not leave at all.
+ */
+export function serve(graph, findings) {
+  const served = [];
+
+  // RETIRED FINDINGS STOP HERE, unconditionally.
+  //
+  // findingsFor and sessionIndex already filter them, so this is redundant on
+  // every current path -- deliberately. This function's own contract is that it
+  // is the only thing that hands a finding to a model, which makes it the right
+  // place for the guarantee to live: a future caller that reaches into the
+  // graph directly cannot accidentally serve a claim a human explicitly
+  // withdrew. A withheld claim reappearing is not a bug anyone would notice
+  // quickly.
 
   for (const finding of findings.filter((f) => !f.retired)) {
     // A claim that does not depend on the anchor's contents cannot be
@@ -505,6 +597,15 @@ export function invalidateOnWrite(dir, graph, rawPath, beforeText, afterText) {
     for (const edge of byTarget.get(node.id) || []) {
       const finding = graph.nodes.get(edge.from);
       if (!finding || finding.kind !== 'finding') continue;
+      // THE SAME TYPE GATE `serve` APPLIES, and it has to be here too now that
+      // this path actually runs. `serve` ignores a stale flag on a type whose
+      // truth is not a claim about the anchor's contents -- but the flag is
+      // STORED, and disclose.mjs skips a stale finding outright while
+      // utility.mjs penalises one by 160. So writing it onto a `failure` or a
+      // `command` would suppress that claim everywhere except the one reader
+      // that knows to ignore it, which is exactly the harm measured in the
+      // comment on CONTENT_DEPENDENT above.
+      if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) continue;
 
       putNode(dir, {
         ...finding,

--- a/plugin/hooks/lib/staleness.mjs
+++ b/plugin/hooks/lib/staleness.mjs
@@ -495,6 +495,54 @@ function disputeOf(graph, finding) {
 }
 
 /**
+ * Whether THIS finding's own claim-time evidence still matches its anchors --
+ * the reader `harvest-write.mjs`'s `derivation` record was written for.
+ * Nothing consumed that record until now: a grep for it found only the writer
+ * and its own tests, which made "checkable rather than merely attributed" a
+ * claim with no code behind it.
+ *
+ * DISTINCT FROM `stale`/`checkAnchor`, DELIBERATELY, not a duplicate of it.
+ * `checkAnchor` compares disk against the anchor NODE's CURRENT stored hash,
+ * which is refreshed by `indexFile` every time ANYTHING touches that file --
+ * so it answers "has this file changed since the last time anyone indexed
+ * it", not "has it changed since THIS finding was derived from it". Those
+ * differ in a real case: file F changes, and a LATER, unrelated write
+ * (another finding, another session) re-indexes F, updating the node's
+ * stored hash to match the new content again. `checkAnchor` now reports
+ * "fresh" -- disk matches the node's current hash -- while this finding's own
+ * frozen `derivation.anchors[id]` snapshot, taken when IT was written, no
+ * longer matches. The bytes this claim was actually derived from are gone,
+ * and `stale` alone would never say so.
+ *
+ * Returns `{}` when there is nothing to check (no `derivation.anchors`
+ * recorded -- true of every finding written before this existed), so a
+ * caller can tell "not checked" from "checked and holds" by whether
+ * `derivationHolds` is present at all.
+ */
+function derivationCheck(graph, finding) {
+  const recorded = finding.derivation && finding.derivation.anchors;
+  if (!recorded || typeof recorded !== 'object') return {};
+  const ids = Object.keys(recorded);
+  if (!ids.length) return {};
+
+  const changed = [];
+  for (const id of ids) {
+    const node = graph.nodes.get(id);
+    const currentHash = node && typeof node.hash === 'string' ? node.hash : null;
+    // An anchor that no longer resolves at all cannot be confirmed either --
+    // treated the same as a changed hash, never as "still holds" by default.
+    if (currentHash === null || currentHash !== recorded[id]) {
+      changed.push(node && typeof node.key === 'string' ? node.key : id);
+    }
+  }
+
+  if (!changed.length) return { derivationHolds: true };
+  // Bounded: a finding with many anchors should not spend unbounded budget
+  // naming every one that moved.
+  return { derivationHolds: false, derivationChanged: changed.slice(0, 5) };
+}
+
+/**
  * Prepares findings for delivery, verifying each one lazily against disk.
  *
  * This is the only function that should ever hand a finding to a model, because
@@ -611,6 +659,9 @@ export function serve(graph, findings) {
       stale,
       ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
       ...dispute,
+      // Independent of `stale` above: see `derivationCheck`'s own comment for
+      // the case it catches that node-level staleness can miss.
+      ...derivationCheck(graph, finding),
     });
   }
   return served;

--- a/plugin/hooks/lib/staleness.mjs
+++ b/plugin/hooks/lib/staleness.mjs
@@ -518,6 +518,21 @@ function disputeOf(graph, finding) {
  * recorded -- true of every finding written before this existed), so a
  * caller can tell "not checked" from "checked and holds" by whether
  * `derivationHolds` is present at all.
+ *
+ * `derivationHolds: true` MEANS "MATCHES THE ANCHOR NODE'S LAST-INDEXED
+ * HASH", NOT "MATCHES DISK RIGHT NOW" -- and that distinction is stored in
+ * `derivationCheckedAgainst: 'index'` rather than left for a `wiki_query`
+ * consumer to infer from a field name alone. Two ways to close this gap were
+ * considered: recompute a live hash from disk here, or document precisely
+ * what is actually compared. `stale` (via `checkAnchor`, above) ALREADY owns
+ * the disk comparison -- re-reading the same file a second time on the same
+ * serve path, for the same anchor, from a second mechanism, is worse than
+ * one honest name. So: documented, not duplicated. A file changed on disk
+ * but never re-indexed by anything is still caught, correctly, by `stale`;
+ * `derivationHolds` answers a narrower, complementary question -- whether
+ * the LAST INDEXED state agrees with what this specific finding recorded --
+ * which is exactly the re-indexed-by-something-else case above that `stale`
+ * cannot see.
  */
 function derivationCheck(graph, finding) {
   const recorded = finding.derivation && finding.derivation.anchors;
@@ -536,10 +551,12 @@ function derivationCheck(graph, finding) {
     }
   }
 
-  if (!changed.length) return { derivationHolds: true };
+  // Declared on BOTH branches, not only the ambiguous one: a consumer should
+  // not have to already know the answer to know what was checked.
+  if (!changed.length) return { derivationHolds: true, derivationCheckedAgainst: 'index' };
   // Bounded: a finding with many anchors should not spend unbounded budget
   // naming every one that moved.
-  return { derivationHolds: false, derivationChanged: changed.slice(0, 5) };
+  return { derivationHolds: false, derivationChanged: changed.slice(0, 5), derivationCheckedAgainst: 'index' };
 }
 
 /**

--- a/plugin/hooks/lib/staleness.mjs
+++ b/plugin/hooks/lib/staleness.mjs
@@ -54,6 +54,7 @@ import { readFileSync, statSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { dirname, join } from 'node:path';
 import { putNode, putEdge, contentHash, nodeId } from './wiki.mjs';
+import { hasOutstandingContradiction } from './curate.mjs';
 import { extractSymbols, spanText, symbolKey, extractImports } from './symbols.mjs';
 import { canonicalPath, resolvableCandidates, isFsSafePath } from './paths.mjs';
 
@@ -454,6 +455,46 @@ export function diffLines(
 const CONTENT_DEPENDENT = new Set(['finding', 'map']);
 
 /**
+ * What, if anything, currently disagrees with this finding.
+ *
+ * DISCLOSED AT SERVE TIME, because that is the only moment the disagreement can
+ * do any good. `WIKI_GRAPH.md`'s whole argument for making `contradicts` an edge
+ * rather than an overwrite is that a reader "sees both claims and the
+ * disagreement between them" -- so handing a finding to a model while something
+ * in the graph disputes it, without saying so, throws away the reason the edge
+ * was recorded instead of an overwrite.
+ *
+ * `hasOutstandingContradiction` is the gate: it is the one definition of "an
+ * open dispute", shared with the confidence-promotion gate, so the two can never
+ * disagree about what counts. The loop only NAMES the other side, and it names a
+ * key rather than quoting a claim because the reader can call `wiki_query` with
+ * a key -- and because the injection path pays for every character it renders.
+ *
+ * SEPARATE FROM STALENESS on purpose. A finding can be disputed without being
+ * stale (nothing touched its anchor; another finding simply says otherwise) and
+ * stale without being disputed, so this adds its own fields rather than
+ * borrowing the stale ones, and the renderer discloses each on its own terms.
+ */
+function disputeOf(graph, finding) {
+  if (!hasOutstandingContradiction(graph, finding.key)) return {};
+
+  const keys = [];
+  for (const edge of graph.edges) {
+    if (edge.edge !== 'contradicts') continue;
+    const otherId =
+      edge.from === finding.id ? edge.to : edge.to === finding.id ? edge.from : null;
+    if (!otherId) continue;
+    const other = graph.nodes.get(otherId);
+    // An edge end that resolves to nothing names nothing. The dispute is still
+    // disclosed -- the gate above already established it -- but without a key
+    // the reader cannot be pointed anywhere, and inventing one would be worse.
+    if (other && typeof other.key === 'string' && !keys.includes(other.key)) keys.push(other.key);
+  }
+
+  return { contradicted: true, ...(keys.length ? { contradictedBy: keys.join(', ') } : {}) };
+}
+
+/**
  * Prepares findings for delivery, verifying each one lazily against disk.
  *
  * This is the only function that should ever hand a finding to a model, because
@@ -474,10 +515,17 @@ export function serve(graph, findings) {
   // quickly.
 
   for (const finding of findings.filter((f) => !f.retired)) {
+    // A DISPUTE TRAVELS WITH EVERY TYPE, which is why it is computed before the
+    // content-dependence branch below. A `command` or `rule` finding cannot be
+    // invalidated by an anchor's contents, but another finding can still
+    // disagree with it, and this early return is the path that would have
+    // quietly dropped that.
+    const dispute = disputeOf(graph, finding);
+
     // A claim that does not depend on the anchor's contents cannot be
     // invalidated by them. It is served as-is rather than discounted.
     if (!CONTENT_DEPENDENT.has(finding.type || 'finding')) {
-      served.push({ ...finding });
+      served.push({ ...finding, ...dispute });
       continue;
     }
 
@@ -562,6 +610,7 @@ export function serve(graph, findings) {
       ...finding,
       stale,
       ...(stale ? { diff, staleReason: reason, staleEvidence: Boolean(diff) } : {}),
+      ...dispute,
     });
   }
   return served;

--- a/plugin/hooks/lib/waste.mjs
+++ b/plugin/hooks/lib/waste.mjs
@@ -151,6 +151,11 @@ function reDerivation(events, graph) {
       const id = nodeId('file', canonicalPath(row.anchor));
       if (!graph.nodes.has(id)) continue;
 
+      // READ-ONLY serve: no `dir` is threaded here, so this cannot clear a stale
+      // flag whose evidence is gone. That is deliberate -- this function takes a
+      // graph, not the directory it came from, and widening its signature to give
+      // an analysis path a write capability buys nothing: the injection path runs
+      // on every tool call and clears the same findings.
       const findings = serve(graph, findingsFor(graph, id, { limit: 3 }))
         .filter((f) => !f.stale && (f.confidence ?? 0) >= 0.7);
       if (!findings.length) continue;

--- a/plugin/hooks/lib/wiki.mjs
+++ b/plugin/hooks/lib/wiki.mjs
@@ -64,18 +64,37 @@ export const SUPPORTED_VERSIONS = [1];
  * Identity today because GRAPH_VERSION is 1 and no shape has changed. It exists
  * now so the first change that DOES need it has somewhere to go other than an
  * equality check that silently deletes user data.
+ *
+ * CONTRACT for the first non-identity step:
+ *  - It must be IDEMPOTENT. `upcast(upcast(r))` must equal `upcast(r)`, because
+ *    compaction upcasts a record to key it and `load` upcasts the same record
+ *    again on every subsequent read. A step that is not idempotent applies twice
+ *    to anything compaction has touched.
+ *  - It must NOT be relied on to restamp `v`. Nothing in this file writes an
+ *    upcast record back to disk under a version it did not come from; the
+ *    version stamp on disk is always the one that wrote the bytes. See the
+ *    per-branch comments in `compactIfWasteful`.
  */
 export function upcast(record) {
   return record;
 }
 
-/** True when this reader can interpret the record at all. */
-function readable(record) {
+/**
+ * True when this reader can interpret the record at all.
+ *
+ * `versions` is a PARAMETER so the range semantics are testable independently of
+ * today's constants. With `SUPPORTED_VERSIONS = [1]` and `GRAPH_VERSION = 1` a
+ * range check and the old equality check are extensionally identical, so a test
+ * pinned to the live constants cannot tell them apart -- and cannot fail if
+ * someone reverts this to an equality. Exercised against `[1, 2]`, it can.
+ */
+export function readable(record, versions = SUPPORTED_VERSIONS) {
   const version = record.v ?? 0;
   // Forward-incompatible records are skipped: a v-from-the-future was written by
-  // a newer client and we cannot know its shape. Ignoring the future is safe;
-  // ignoring the past is data loss.
-  return SUPPORTED_VERSIONS.includes(version);
+  // a newer client and we cannot know its shape. Ignoring the future is safe for
+  // a READER -- but see `compactIfWasteful`, where "ignore" would mean "delete",
+  // because compaction rewrites the files it reads.
+  return versions.includes(version);
 }
 
 /** Node kinds. `file` and `symbol` are first-class so staleness can propagate. */
@@ -434,9 +453,20 @@ function compactIfWasteful(dir) {
     const nodes = new Map();
     const edges = new Map();
     const snaps = new Map();
-    for (const rec of readSnapshots(dir)) {
+    // KEPT VERBATIM THROUGH THE REBUILD, exactly as the main log keeps what it
+    // cannot parse. These lines are not evictable by the snapshot budget below
+    // because their size cannot be attributed to an id we understand -- and
+    // preserving bytes we may not need is strictly better than deleting bytes a
+    // newer client does. They stop accumulating as soon as the client that
+    // wrote them compacts, since it can read and dedupe them.
+    const sidecar = readSnapshots(dir);
+    const rawSnaps = sidecar.unreadable;
+    for (const rec of sidecar.records) {
       if (typeof rec.snapshot === 'string' && rec.snapshot) {
-        snaps.set(rec.id, { at: rec.at || 0, snapshot: rec.snapshot });
+        // `v` IS CARRIED, not restamped. Writing GRAPH_VERSION over a record
+        // from another version mislabels bytes this reader did not produce, and
+        // the label is the only thing a future reader has to go on.
+        snaps.set(rec.id, { at: rec.at || 0, snapshot: rec.snapshot, v: rec.v ?? GRAPH_VERSION });
       }
     }
     for (const line of readFileSync(path, 'utf8').split('\n')) {
@@ -458,27 +488,40 @@ function compactIfWasteful(dir) {
         edges.set('raw:' + edges.size, line);
         continue;
       }
-      // Upcast IN MEMORY only, to key and classify the record. What gets written
-      // back below is the ORIGINAL `line`: compaction reclaims superseded
-      // records, it does not migrate surviving ones, so the on-disk version is
-      // whatever wrote it and `load` upcasts it again on every read.
-      record = upcast(record);
-      if (record.t === 'n') {
+      // TWO OBJECTS, ON PURPOSE. `record` is exactly what the bytes on disk say;
+      // `view` is the in-memory current-shape reading of it, used only to KEY and
+      // CLASSIFY. Nothing derived from `view` is ever serialized, because
+      // compaction reclaims superseded records -- it does not migrate surviving
+      // ones -- so every version stamp it writes is the one that wrote the bytes.
+      //
+      // An earlier revision of this comment claimed "the ORIGINAL line is written
+      // back" for the whole block. That was FALSE for the inline-snapshot branch,
+      // which re-serializes. It re-serialized the upcast object while carrying
+      // the old `v`, so the first non-identity `upcast` would have written
+      // new-shape bytes under an old label and every later `load` would have
+      // upcast them a second time. Hence: strip from `record`, never from `view`.
+      const view = upcast(record);
+      if (view.t === 'n') {
         // MIGRATION. Graphs written before snapshots were split still carry
         // them inline, and those are exactly the graphs that are slow. Moving
         // them out here means one compaction fixes an existing install.
+        //
+        // THE ONLY RE-SERIALIZING BRANCH in this loop. It writes the original
+        // record minus its snapshot, so the surviving bytes keep their own shape
+        // and their own `v`, and the snapshot moved to the sidecar carries the
+        // same `v` as the node it came out of.
         if (typeof record.snapshot === 'string' && record.snapshot) {
           const { snapshot, ...rest } = record;
-          nodes.set(record.id, JSON.stringify(rest));
-          snaps.set(record.id, { at: record.at || 0, snapshot });
+          nodes.set(view.id, JSON.stringify(rest));
+          snaps.set(view.id, { at: record.at || 0, snapshot, v: record.v ?? GRAPH_VERSION });
         } else {
-          nodes.set(record.id, line);
+          nodes.set(view.id, line);
         }
-      } else if (record.t === 's') {
+      } else if (view.t === 's') {
         if (typeof record.snapshot === 'string' && record.snapshot) {
-          snaps.set(record.id, { at: record.at || 0, snapshot: record.snapshot });
+          snaps.set(view.id, { at: record.at || 0, snapshot: record.snapshot, v: record.v ?? GRAPH_VERSION });
         }
-      } else if (record.t === 'e') edges.set(`${record.from}|${record.edge}|${record.to}`, line);
+      } else if (view.t === 'e') edges.set(`${view.from}|${view.edge}|${view.to}`, line);
       else edges.set('raw:' + edges.size, line);
     }
 
@@ -541,10 +584,20 @@ function compactIfWasteful(dir) {
     renameSync(tmp, path);
     // The surviving snapshots are rewritten to their own file, which is also
     // what migrates a graph that still had them inline.
-    const snapOut =
-      [...keep.entries()]
-        .map(([id, v]) => JSON.stringify({ t: 's', v: GRAPH_VERSION, id, snapshot: v.snapshot, at: v.at }))
-        .join('\n') + (keep.size ? '\n' : '');
+    //
+    // UNREADABLE LINES FIRST AND VERBATIM. This rebuild replaces the file, so
+    // anything omitted here is deleted permanently -- which made the missing
+    // counterpart to the main log's `raw:` bucket a real data-loss path, not a
+    // theoretical one. Each survivor also keeps ITS OWN `v` rather than being
+    // restamped to GRAPH_VERSION, so no record is relabelled as something this
+    // reader wrote.
+    const snapLines = [
+      ...rawSnaps,
+      ...[...keep.entries()].map(([id, s]) =>
+        JSON.stringify({ t: 's', v: s.v ?? GRAPH_VERSION, id, snapshot: s.snapshot, at: s.at })
+      ),
+    ];
+    const snapOut = snapLines.join('\n') + (snapLines.length ? '\n' : '');
     const snapTmp = snapshotsPath(dir) + '.compact';
     writeFileSync(snapTmp, snapOut, { mode: 0o600 });
     renameSync(snapTmp, snapshotsPath(dir));
@@ -689,9 +742,26 @@ function appendSnapshot(dir, record) {
   }
 }
 
-/** Every snapshot record, latest wins. Read only when a caller asks. */
+/**
+ * Every snapshot record, latest wins. Read only when a caller asks.
+ *
+ * `unreadable` collects the RAW LINES this reader rejected, and it is the reason
+ * this function reports them at all rather than just dropping them. `load` has
+ * no use for them -- a reader that cannot interpret a record must ignore it --
+ * but `compactIfWasteful` REBUILDS this file from what it read, so for the
+ * compactor "ignore" and "delete permanently" are the same operation. The main
+ * log already keeps what it cannot parse (the `raw:` bucket); the sidecar had no
+ * equivalent, which made it the one asymmetric, destructive path in an otherwise
+ * append-only store.
+ *
+ * This is not hypothetical here: hooks-core is vendored into eleven client
+ * directories that update independently, so a stale client compacting a graph a
+ * newer client has already written to is the expected steady state, not an edge
+ * case.
+ */
 function readSnapshots(dir) {
-  const out = [];
+  /** @type {object[]} */ const out = [];
+  /** @type {string[]} */ const unreadable = [];
   try {
     for (const line of readFileSync(snapshotsPath(dir), 'utf8').split('\n')) {
       if (!line) continue;
@@ -699,19 +769,23 @@ function readSnapshots(dir) {
         const rec = JSON.parse(line);
         // THE SAME RANGE AS THE MAIN LOG, deliberately. An equality check here
         // was the quietest of the three: a bump would have made every stored
-        // snapshot unreadable, and the very next compaction -- which rebuilds
-        // this file from what it could read -- would have deleted them for
-        // good. That is the one place in this store where a read filter turns
-        // into a permanent write.
-        if (readable(rec) && rec.id) out.push(upcast(rec));
+        // snapshot unreadable, and the very next compaction would have deleted
+        // them for good.
+        if (!readable(rec)) {
+          unreadable.push(line);
+          continue;
+        }
+        if (rec.id) out.push(upcast(rec));
       } catch {
-        /* a torn line costs one snapshot */
+        // A torn line costs one snapshot -- and it is NOT preserved, because a
+        // half-written line is not a record from another version, it is
+        // garbage. Distinguishing the two is the whole point of parsing first.
       }
     }
   } catch {
     /* no sidecar yet */
   }
-  return out;
+  return { records: out, unreadable };
 }
 
 /**
@@ -777,7 +851,9 @@ export function load(dir, { snapshots = false } = {}) {
   // Re-attached after the sweep, so a snapshot record may appear before or
   // after the node it belongs to.
   if (pending) {
-    for (const rec of readSnapshots(dir)) pending.set(rec.id, rec.snapshot);
+    // A reader has no use for the lines it could not interpret; only the
+    // compactor does, because only the compactor rewrites the file.
+    for (const rec of readSnapshots(dir).records) pending.set(rec.id, rec.snapshot);
     for (const [id, snapshot] of pending) {
       const node = nodes.get(id);
       if (node) nodes.set(id, { ...node, snapshot });

--- a/plugin/hooks/lib/wiki.mjs
+++ b/plugin/hooks/lib/wiki.mjs
@@ -28,17 +28,55 @@ import { canonicalPath, isFsSafePath } from './paths.mjs';
 /**
  * Schema version stamped on every record.
  *
- * There is exactly ONE version and no migration code, because nothing has been
- * released: a graph written by an older commit of an unreleased branch is a
- * development artifact, not user data, and carrying migration paths for it costs
- * real complexity to protect something nobody has. A record from any other
- * version is skipped rather than interpreted, so a stale dev graph degrades to
- * "rebuilds from use" instead of silently mixing incompatible identities.
+ * THIS PACKAGE IS RELEASED. It ships on npm, so every graph on disk is user
+ * data. An earlier version of this comment claimed nothing had been released
+ * and used that to justify having no migration path at all -- and the reader
+ * below compared for EQUALITY, so the first bump would have discarded every
+ * existing graph in silence. That justification is gone and so is the equality:
+ * `SUPPORTED_VERSIONS` is the range this reader accepts, and `upcast` is where a
+ * shape change is absorbed in memory.
  *
- * When this does ship, a bump here is where migration would be added -- with
- * users to protect, that trade reverses.
+ * A bump here is taken only when a record's SHAPE actually changes, and it comes
+ * with a new `upcast` step and an entry in `SUPPORTED_VERSIONS` in the same
+ * change. Adding a field that older readers can ignore is not a shape change.
  */
 export const GRAPH_VERSION = 1;
+
+/**
+ * Versions this reader accepts, oldest first.
+ *
+ * A RANGE, NOT AN EQUALITY. The equality check this replaces would have
+ * discarded every existing graph the moment anyone bumped the version -- and the
+ * header once justified that with "nothing has been released", which stopped
+ * being true at v5.7.0 on npm.
+ *
+ * Nothing on disk is ever rewritten to migrate: `upcast` runs in memory during
+ * the fold, so there is no migration pass to fail halfway and no race with the
+ * concurrent sessions this store is designed for. A mixed-version log is safe
+ * precisely because the original records are never mutated, and the existing
+ * compaction retires old ones naturally as it rewrites snapshots.
+ */
+export const SUPPORTED_VERSIONS = [1];
+
+/**
+ * Brings one record up to the current version. Pure, and one step per version.
+ *
+ * Identity today because GRAPH_VERSION is 1 and no shape has changed. It exists
+ * now so the first change that DOES need it has somewhere to go other than an
+ * equality check that silently deletes user data.
+ */
+export function upcast(record) {
+  return record;
+}
+
+/** True when this reader can interpret the record at all. */
+function readable(record) {
+  const version = record.v ?? 0;
+  // Forward-incompatible records are skipped: a v-from-the-future was written by
+  // a newer client and we cannot know its shape. Ignoring the future is safe;
+  // ignoring the past is data loss.
+  return SUPPORTED_VERSIONS.includes(version);
+}
 
 /** Node kinds. `file` and `symbol` are first-class so staleness can propagate. */
 export const NODE_KINDS = ['file', 'symbol', 'task', 'finding'];
@@ -409,13 +447,22 @@ function compactIfWasteful(dir) {
       } catch {
         continue;
       }
-      // A record from another schema is KEPT VERBATIM rather than reinterpreted.
-      // load() skips it, but discarding it here would make compaction a silent
-      // migration that deletes data a future version might understand.
-      if ((record.v ?? 0) !== GRAPH_VERSION) {
+      // A record this reader cannot interpret is KEPT VERBATIM rather than
+      // reinterpreted. load() skips it, but discarding it here would make
+      // compaction a silent migration that deletes data a future version might
+      // understand. THE RANGE MATTERS HERE TOO: with an equality check, a bump
+      // would have parked every existing v1 record in `raw`, undeduplicated, so
+      // compaction would stop reclaiming anything and inline snapshots would
+      // never migrate out -- the same loss by a second route.
+      if (!readable(record)) {
         edges.set('raw:' + edges.size, line);
         continue;
       }
+      // Upcast IN MEMORY only, to key and classify the record. What gets written
+      // back below is the ORIGINAL `line`: compaction reclaims superseded
+      // records, it does not migrate surviving ones, so the on-disk version is
+      // whatever wrote it and `load` upcasts it again on every read.
+      record = upcast(record);
       if (record.t === 'n') {
         // MIGRATION. Graphs written before snapshots were split still carry
         // them inline, and those are exactly the graphs that are slow. Moving
@@ -650,7 +697,13 @@ function readSnapshots(dir) {
       if (!line) continue;
       try {
         const rec = JSON.parse(line);
-        if ((rec.v ?? 0) === GRAPH_VERSION && rec.id) out.push(rec);
+        // THE SAME RANGE AS THE MAIN LOG, deliberately. An equality check here
+        // was the quietest of the three: a bump would have made every stored
+        // snapshot unreadable, and the very next compaction -- which rebuilds
+        // this file from what it could read -- would have deleted them for
+        // good. That is the one place in this store where a read filter turns
+        // into a permanent write.
+        if (readable(rec) && rec.id) out.push(upcast(rec));
       } catch {
         /* a torn line costs one snapshot */
       }
@@ -691,7 +744,12 @@ export function load(dir, { snapshots = false } = {}) {
       if (!snapshots) continue;
       try {
         const rec = JSON.parse(line);
-        if ((rec.v ?? 0) === GRAPH_VERSION) pending.set(rec.id, rec.snapshot);
+        // Inline snapshots from an older graph: same range, same reason. These
+        // are precisely the records most likely to predate a bump.
+        if (readable(rec)) {
+          const snap = upcast(rec);
+          pending.set(snap.id, snap.snapshot);
+        }
       } catch {
         /* a torn line costs one snapshot, not the graph */
       }
@@ -703,10 +761,14 @@ export function load(dir, { snapshots = false } = {}) {
     } catch {
       continue;
     }
-    // A record from another schema is skipped, not interpreted: its ids and
-    // hashes were derived differently, so honouring it produces confident
-    // nonsense rather than a visible error.
-    if ((record.v ?? 0) !== GRAPH_VERSION) continue;
+    // A record this reader cannot interpret is skipped, not guessed at: a
+    // version from the FUTURE derived its ids and hashes in a way we do not
+    // know, so honouring it produces confident nonsense rather than a visible
+    // error. A record from the PAST is upcast, never skipped -- skipping it is
+    // data loss, and this comparison used to be an equality, which made the
+    // first version bump a silent delete of every graph on disk.
+    if (!readable(record)) continue;
+    record = upcast(record);
     if (record.t === 'n') nodes.set(record.id, record);
     else if (record.t === 'e') edges.push(record);
   }

--- a/plugin/hooks/lib/wiki.mjs
+++ b/plugin/hooks/lib/wiki.mjs
@@ -775,7 +775,17 @@ function readSnapshots(dir) {
           unreadable.push(line);
           continue;
         }
+        // A RECORD WITH NO `id` IS KEPT VERBATIM, NOT DROPPED SILENTLY. It
+        // cannot be attributed to a node, so it is useless to `load` -- but this
+        // used to put it in neither bucket, and `compactIfWasteful` rebuilds the
+        // sidecar from `records` plus `unreadable`, so a line in neither was
+        // deleted permanently by the next compaction. That is the same shape as
+        // the Critical this reader's version check already fixed, and the same
+        // asymmetry: for the compactor, "ignore" and "destroy" are one operation.
+        // Unreachable today because every writer sets `id`; a reader is not the
+        // right place to rely on that.
         if (rec.id) out.push(upcast(rec));
+        else unreadable.push(line);
       } catch {
         // A torn line costs one snapshot -- and it is NOT preserved, because a
         // half-written line is not a record from another version, it is

--- a/plugin/hooks/post-tool.mjs
+++ b/plugin/hooks/post-tool.mjs
@@ -8,7 +8,7 @@ process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.
-process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write';
+process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write,wiki_query';
 try {
   const { run } = await import('./lib/adapter.mjs');
   await run('claude-code', 'post-tool');

--- a/plugin/hooks/post-tool.mjs
+++ b/plugin/hooks/post-tool.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/plugin/hooks/session-start.mjs
+++ b/plugin/hooks/session-start.mjs
@@ -34,6 +34,7 @@ import {
 import { restorationPlan } from './lib/restore.mjs';
 import {
   relevantFindingIdsForContext,
+  sessionContext,
   sessionIndex,
   standingRules,
 } from './lib/inject.mjs';
@@ -115,7 +116,19 @@ if (payload.session_id && toolEvidence.proven) {
   rememberOptimizerTools(state, toolEvidence);
   saveState(payload.session_id, state);
 }
-const parts = [policyText(true, toolEvidence.names, toolEvidence.proven)];
+// ASSEMBLED IN CACHE ORDER, not in the order the blocks are discovered below.
+// This text sits near the FRONT of the prompt prefix, which a cache invalidates
+// from the first differing byte onward, so the block that changes most often
+// belongs LAST or it re-prices everything behind it every session.
+// `sessionContext` sorts by the declared volatility; the numbers and the
+// evidence for each are recorded in inject.mjs.
+const blocks = [
+  {
+    id: 'policy',
+    volatility: 0,
+    text: policyText(true, toolEvidence.names, toolEvidence.proven),
+  },
+];
 
 // THE ALWAYS-ON HALF OF DELIVERY. Trigger-fired injection answers "this
 // situation is happening now", which cannot cover a rule about how the work is
@@ -134,7 +147,7 @@ try {
     // Skipping the sidecar keeps startup bounded on mature graphs.
     const graph = load(dir);
     const rules = standingRules(dir, graph);
-    if (rules) parts.push(rules);
+    if (rules) blocks.push({ id: 'standing', volatility: 1, text: rules });
     const relevantFindingIds = relevantFindingIdsForContext(
       graph,
       sessionTaskContext(payload)
@@ -143,18 +156,21 @@ try {
       episode: episodeMeta({ client: 'claude-code', raw: payload }),
       relevantFindingIds,
     });
-    if (index) parts.push(index);
+    if (index) blocks.push({ id: 'index', volatility: 2, text: index });
   }
 } catch {
   // The policy notice must still arrive if the graph is unreadable.
 }
 
-// THE SITUATIONAL HALF, LAST. Standing rules govern every turn; restoration
-// speaks only to a session resuming from a compaction, so it reads as the more
-// specific note after the general one.
+// THE SITUATIONAL HALF, LAST -- now stated as a volatility rather than left to
+// the order of these statements. Standing rules govern every turn; a restoration
+// block speaks only to a session resuming from a compaction and is derived from
+// the anchors of the context that was just discarded, so it is never twice the
+// same and is the most expensive thing that could sit ahead of anything else.
 try {
   const restored = await restoration(payload);
-  if (restored) parts.push(restored);
+  if (restored)
+    blocks.push({ id: 'restoration', volatility: 3, text: restored });
 } catch {
   // The policy notice must still arrive if anything above fails.
 }
@@ -162,7 +178,7 @@ try {
 const output = {
     hookSpecificOutput: {
       hookEventName: 'SessionStart',
-      additionalContext: parts.join('\n\n'),
+      additionalContext: sessionContext(blocks),
     },
   };
 const serialized = JSON.stringify(output);

--- a/plugin/hooks/stop.mjs
+++ b/plugin/hooks/stop.mjs
@@ -8,7 +8,7 @@ process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.
-process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write';
+process.env.TOKEN_OPTIMIZER_MCP_CAPABILITIES ??= 'smart_read,smart_write,smart_edit,smart_glob,smart_grep,optimize_session,get_optimization_report,wiki_write,wiki_query';
 try {
   const { run } = await import('./lib/adapter.mjs');
   await run('claude-code', 'stop');

--- a/plugin/hooks/stop.mjs
+++ b/plugin/hooks/stop.mjs
@@ -4,7 +4,7 @@
 // shared core so no client can drift its own thresholds or guidance.
 // Fail open: a defect in the optimizer must never cost the user a tool call.
 // Bootstrap failures are still recorded so fail-open does not become fail-silent.
-process.env.TOKEN_OPTIMIZER_VERSION = '5.7.0';
+process.env.TOKEN_OPTIMIZER_VERSION = '5.7.1';
 // These entry points ship beside an MCP declaration for this same package. Hosts
 // do not expose their registered tool inventory to hook payloads, so make that
 // bundled contract explicit. An explicit empty value still wins and fails open.

--- a/scripts/verify-wiki-interactions.mjs
+++ b/scripts/verify-wiki-interactions.mjs
@@ -153,7 +153,13 @@ async function main() {
       `${retryCount} results`
     );
 
-    await search.fill('zzzz-definitely-no-such-finding');
+    // ONE NONSENSE TOKEN, not a nonsense PHRASE. Search is BM25 now
+    // (hooks-core/lexical.mjs), so a hyphenated phrase tokenizes to its parts
+    // and any one of them scoring is a match -- `zzzz-definitely-no-such-
+    // finding` returned two rows on the word `finding` alone. That is correct
+    // BM25 and correct for a search box; it just is not a no-match query, and
+    // this check needs one to reach the empty state at all.
+    await search.fill('zzzzqqq');
     await page.waitForTimeout(400);
     check(
       'a search with no matches shows an empty list',
@@ -162,6 +168,19 @@ async function main() {
     check(
       'the count still reports honestly when empty',
       (await page.locator('#wiki-count').innerText()).includes('0')
+    );
+
+    // PINNED, because it is the behaviour that silently invalidated the probe
+    // above: any ONE term of a multi-term query scoring is a match. Asserted
+    // rather than left implicit, so a later change back to phrase- or
+    // AND-matching fails here instead of quietly narrowing every search.
+    await search.fill('zzzzqqq finding');
+    await page.waitForTimeout(400);
+    const orCount = await page.locator('#wiki-list li').count();
+    check(
+      'a multi-term search matches on any one term',
+      orCount > 0,
+      `${orCount} results`
     );
 
     // Regex metacharacters must be treated as literal text, not a pattern.

--- a/src/dashboard/public/js/dashboard.js
+++ b/src/dashboard/public/js/dashboard.js
@@ -848,10 +848,10 @@ function renderKpis(s) {
   if (!s) {
     host.innerHTML =
       '<div class="card empty-span"><div class="empty is-compact"><div class="mark">◔</div>' +
-      '<h3>No active session</h3>' +
-      '<p>These fill in while you are working in a supported coding agent. The savings above ' +
+      '<h3>No recent agent activity</h3>' +
+      '<p>These fill in from cross-client lifecycle telemetry while you are working in a supported coding agent. The savings above ' +
       'are kept per project, so they stay accurate between sessions.</p>' +
-      '<p class="next">Start a session, then refresh.</p></div></div>';
+      '<p class="next">Run an agent action, then refresh.</p></div></div>';
     return;
   }
 
@@ -869,7 +869,7 @@ function renderKpis(s) {
             tip: 'Pre-tool actions observed by the cross-client hook protocol during the last 24 hours.',
           },
           {
-            label: 'CLI clients active',
+            label: 'CLI clients observed',
             value: fmt(s.activeClients),
             tip: 'Distinct CLI clients that emitted lifecycle telemetry during the last 24 hours.',
           },

--- a/src/dashboard/public/js/wiki.js
+++ b/src/dashboard/public/js/wiki.js
@@ -1006,6 +1006,11 @@ function showDetail(node) {
         <button class="btn btn-primary" id="detail-correct">Save correction</button>
         <button class="btn" id="detail-pin">${node.pinned ? 'Unpin' : 'Pin'}</button>
         <button class="btn" id="detail-retire">Retire</button>
+        ${
+          node.stale
+            ? '<button class="btn" id="detail-reverify" title="Clears the stale mark only if the code now matches what this claim was derived from">Re-verify</button>'
+            : ''
+        }
         <button class="btn" id="detail-helpful">Helpful</button>
         <button class="btn" id="detail-harmful">Harmful</button>
       </div>
@@ -1045,6 +1050,14 @@ function showDetail(node) {
   el('detail-retire').addEventListener('click', () =>
     curate({ action: 'retire' })
   );
+  // Only rendered for a stale finding, so the listener is conditional too.
+  // Re-verify is not "mark this fresh": the server clears the flag only when the
+  // anchored content re-hashes to what the claim was derived from, and reports
+  // `still-stale` otherwise.
+  const reverifyButton = document.getElementById('detail-reverify');
+  if (reverifyButton) {
+    reverifyButton.addEventListener('click', () => curate({ action: 'reverify' }));
+  }
   const feedback = async (rating) => {
     await api('/api/wiki/evidence/feedback', {
       method: 'POST',

--- a/src/dashboard/public/js/wiki.js
+++ b/src/dashboard/public/js/wiki.js
@@ -1056,7 +1056,9 @@ function showDetail(node) {
   // `still-stale` otherwise.
   const reverifyButton = document.getElementById('detail-reverify');
   if (reverifyButton) {
-    reverifyButton.addEventListener('click', () => curate({ action: 'reverify' }));
+    reverifyButton.addEventListener('click', () =>
+      curate({ action: 'reverify' })
+    );
   }
   const feedback = async (rating) => {
     await api('/api/wiki/evidence/feedback', {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2653,8 +2653,11 @@ async function handleToolCall(request: {
         };
       }
       case 'wiki_query': {
-        // The general read path: by key, by search terms, by anchor, or the
-        // graph's own shape. The SessionStart index has been telling the model
+        // The general read path: one finding by key, a ranked search over claims,
+        // a node with its neighbours, or the graph's own audit.
+        // NOT by anchor -- that operation was removed deliberately and a
+        // test asserts it now answers "unknown operation"; `wiki_read` is the
+        // path that takes files. The SessionStart index has been telling the model
         // to call this for detail since injection landed, so a missing dispatch
         // case here is the difference between an escape hatch and a dead end.
         const result = await wikiQuery(args as WikiQueryOptions);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -25,6 +25,11 @@ import {
   WIKI_READ_TOOL_DEFINITION,
 } from '../tools/intelligence/wiki-read.js';
 import {
+  wikiQuery,
+  WIKI_QUERY_TOOL_DEFINITION,
+  type WikiQueryOptions,
+} from '../tools/intelligence/wiki-query.js';
+import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
@@ -665,6 +670,7 @@ const TOOL_DEFINITIONS = [
   FLEET_TOOL,
   WIKI_WRITE_TOOL_DEFINITION,
   WIKI_READ_TOOL_DEFINITION,
+  WIKI_QUERY_TOOL_DEFINITION,
   ...UCR_TOOL_DEFINITIONS,
   EXPAND_TOOL,
   WASTE_TOOL,
@@ -2642,6 +2648,16 @@ async function handleToolCall(request: {
         // deliberate write path and no deliberate read path, so a subagent -- which
         // never receives the SessionStart briefing -- could not reach it at all.
         const result = await wikiRead(args as any);
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        };
+      }
+      case 'wiki_query': {
+        // The general read path: by key, by search terms, by anchor, or the
+        // graph's own shape. The SessionStart index has been telling the model
+        // to call this for detail since injection landed, so a missing dispatch
+        // case here is the difference between an escape hatch and a dead end.
+        const result = await wikiQuery(args as WikiQueryOptions);
         return {
           content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
         };

--- a/src/server/tool-profile.ts
+++ b/src/server/tool-profile.ts
@@ -10,6 +10,12 @@ export const CORE_TOOL_NAMES = [
   'get_optimization_report',
   'wiki_write',
   'wiki_read',
+  // Advertised in the CORE profile deliberately. An unadvertised tool is not
+  // merely undocumented here -- the CallTool handler refuses any name outside
+  // ADVERTISED_TOOL_NAMES, so leaving wiki_query out would have shipped it
+  // fully implemented, schema-checked, dispatch-wired and unreachable, which is
+  // exactly the defect the injected text has been promising around.
+  'wiki_query',
   'expand',
   'waste_audit',
   'cache_audit',
@@ -135,7 +141,7 @@ export function selectToolDefinitions<T extends { name: string }>(
   }
   if (arm === 'optimizer')
     return selected.filter(
-      (tool) => !['wiki_read', 'wiki_write'].includes(tool.name)
+      (tool) => !['wiki_read', 'wiki_write', 'wiki_query'].includes(tool.name)
     );
   if (arm === 'retrieval')
     return selected.filter((tool) => tool.name !== 'wiki_write');

--- a/src/server/web-server.ts
+++ b/src/server/web-server.ts
@@ -32,7 +32,7 @@ import {
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-const app = express();
+export const app = express();
 // Configurable because 3100 is a popular port and a collision is silent: the
 // second server fails to bind while the FIRST one keeps answering, so anything
 // probing the port gets stale results from a process it did not start. The UI
@@ -60,10 +60,18 @@ const limiter = rateLimit({
 app.use(limiter);
 app.use(cors());
 app.use(express.json());
-app.use(express.static(path.join(__dirname, '..', 'dashboard', 'public')));
+const dashboardPublicDirectory = path.join(
+  __dirname,
+  '..',
+  'dashboard',
+  'public'
+);
+app.use(express.static(dashboardPublicDirectory));
 
-// Helper function to get hooks data path
-function getHooksDataPath(): string {
+// Compatibility storage used only by the legacy Claude hook/session APIs.
+// Current plugin activity is read from the cross-client diagnostic ledger by
+// /api/diagnostics/hooks; it must never depend on this install-specific path.
+function getLegacyClaudeHooksDataPath(): string {
   return path.join(os.homedir(), '.claude-global', 'hooks', 'data');
 }
 
@@ -86,7 +94,7 @@ export { isValidSessionId } from '../utils/session-id.js';
 function resolveSessionLogPath(sessionId: string): string | null {
   if (!isValidSessionId(sessionId)) return null;
 
-  const base = path.resolve(getHooksDataPath());
+  const base = path.resolve(getLegacyClaudeHooksDataPath());
 
   // THE PATH IS BUILT FROM A DIRECTORY ENTRY, NOT FROM THE REQUEST.
   //
@@ -222,11 +230,13 @@ function splitCsvRow(line: string): string[] {
   return cells;
 }
 
-// Helper function to get current session ID
+// Legacy compatibility for callers of /api/session-summary and
+// /api/session-events. The dashboard's current activity cards use the
+// cross-client diagnostic ledger instead.
 function getCurrentSessionId(): string | null {
   try {
     const sessionFilePath = path.join(
-      getHooksDataPath(),
+      getLegacyClaudeHooksDataPath(),
       'current-session.txt'
     );
     if (!fs.existsSync(sessionFilePath)) {
@@ -638,14 +648,17 @@ app.get('/api/health', (_req, res) => {
 registerWikiRoutes(app);
 registerUcrRoutes(app);
 
-// Serve the wiki graph browser.
+// Serve the wiki graph browser through the same static middleware that already
+// serves /wiki.html reliably in globally installed packages. Express sendFile
+// returned a false 404 for this alias on the reported macOS npm installation
+// even though the resolved file existed; redirecting keeps one serving path.
 app.get('/wiki', (_req, res) => {
-  res.sendFile(path.join(__dirname, '..', 'dashboard', 'public', 'wiki.html'));
+  res.redirect(302, '/wiki.html');
 });
 
 // Serve index.html for root route
 app.get('/', (_req, res) => {
-  res.sendFile(path.join(__dirname, '..', 'dashboard', 'public', 'index.html'));
+  res.sendFile(path.join(dashboardPublicDirectory, 'index.html'));
 });
 
 // Start server

--- a/src/server/wiki-routes.ts
+++ b/src/server/wiki-routes.ts
@@ -432,11 +432,26 @@ export function registerWikiRoutes(app: Express): void {
       // this route's pool is `{ node, source }` wrappers (findings are
       // aggregated across every source directory), so each entry is exposed
       // under `key`/`claim` for scoring and unwrapped back to its original
-      // `{ node, source }` shape afterward. The limit is the whole
-      // (kind-filtered) pool, not `offset + limit`, so `total` and the
-      // dashboard's `?offset=` pagination keep behaving exactly as they did
-      // under the old unbounded filter -- only the ordering changes.
-      if (query) {
+      // `{ node, source }` shape afterward. The limit passed to `rank` is
+      // the whole (kind-filtered) pool, not `offset + limit`, so pagination
+      // over the RANKED set is exact -- `?offset=` and `?limit=` slice the
+      // same full ranking on every page, not a truncated one.
+      //
+      // `total` is NOT the old filter's match count, and does not claim to
+      // be: `rank` omits zero-score findings (a query term must actually
+      // match, exactly or by prefix -- see lexical.mjs), so `total` here is
+      // the count of findings BM25 considers relevant, which can be smaller
+      // than what `.includes()` would have counted for the same query.
+      //
+      // Only reached when the query actually tokenizes to at least one term
+      // (`hasQueryTerms` below) -- `tokenize` strips everything but
+      // alphanumeric runs, so a blank, whitespace-only, or punctuation-only
+      // `q=` yields no terms and falls through to the no-query branch below
+      // instead of asking `rank` to score against nothing (which would
+      // return zero results, not "everything," for what a user typing a
+      // stray space in the search box expects to behave like no filter).
+      const hasQueryTerms = query.length > 0 && mods.lexical.tokenize(query).length > 0;
+      if (hasQueryTerms) {
         const scored = mods.lexical.rank(
           query,
           findings.map((entry: any) => ({

--- a/src/server/wiki-routes.ts
+++ b/src/server/wiki-routes.ts
@@ -842,6 +842,26 @@ export function registerWikiRoutes(app: Express): void {
           return res.json({ ok: mods.curate.pin(dir, key, pinned !== false) });
         case 'retire':
           return res.json({ ok: mods.curate.retire(dir, key) });
+        case 'reverify': {
+          // THE ONLY DOOR THAT CLEARS A STALE FLAG, and it cannot be pushed
+          // open. Nothing in the codebase ever cleared one, which was harmless
+          // while eager invalidation was dead code and is a rot path now that it
+          // fires: every finding on an edited file becomes permanently stale.
+          //
+          // `reverify` clears ONLY when disk re-hashes to the frozen claim-time
+          // hashes in the finding's own `derivation` record -- a revert, or a
+          // write that never moved the anchored bytes. There is no force flag and
+          // no second action, so this endpoint cannot launder a stale finding
+          // back to fresh: a caller can only make one fresh by putting the
+          // content back. `clearStale`, the primitive that clears without
+          // checking, is deliberately not reachable from here.
+          //
+          // `unknown` is an ANSWER, not a server error -- no such finding, or
+          // nothing recorded to compare against -- so it is reported as one
+          // rather than as a status a caller would retry until it succeeded.
+          const verdict = mods.staleness.reverify(dir, key);
+          return res.json({ ok: verdict === 'cleared', result: verdict });
+        }
         case 'correct': {
           if (!claim) return res.status(400).json({ error: 'claim required' });
           const replacement = mods.curate.correct(dir, key, claim, {

--- a/src/server/wiki-routes.ts
+++ b/src/server/wiki-routes.ts
@@ -34,6 +34,7 @@ interface GraphModules {
   staleness: any;
   capabilities: any;
   projects: any;
+  lexical: any;
 }
 
 let cached: GraphModules | null = null;
@@ -41,7 +42,7 @@ let cached: GraphModules | null = null;
 async function modules(): Promise<GraphModules | null> {
   if (cached) return cached;
   try {
-    const [wiki, curate, metrics, staleness, capabilities, projects] =
+    const [wiki, curate, metrics, staleness, capabilities, projects, lexical] =
       await Promise.all([
         import(coreUrl('wiki.mjs')),
         import(coreUrl('curate.mjs')),
@@ -49,8 +50,17 @@ async function modules(): Promise<GraphModules | null> {
         import(coreUrl('staleness.mjs')),
         import(coreUrl('capabilities.mjs')),
         import(coreUrl('projects.mjs')),
+        import(coreUrl('lexical.mjs')),
       ]);
-    cached = { wiki, curate, metrics, staleness, capabilities, projects };
+    cached = {
+      wiki,
+      curate,
+      metrics,
+      staleness,
+      capabilities,
+      projects,
+      lexical,
+    };
     return cached;
   } catch {
     return null;
@@ -407,38 +417,54 @@ export function registerWikiRoutes(app: Express): void {
           .map((node: any) => ({ node, source }));
       });
 
-      // Lexical filter, per the design's traversal-plus-lexical retrieval --
-      // there is no embedding index to consult and deliberately so.
-      if (query) {
-        findings = findings.filter(
-          (entry: any) =>
-            String(entry.node.claim || '')
-              .toLowerCase()
-              .includes(query) ||
-            String(entry.node.key || '')
-              .toLowerCase()
-              .includes(query)
-        );
-      }
       if (kind)
         findings = findings.filter(
           (entry: any) => (entry.node.type || 'finding') === kind
         );
 
-      findings.sort((a: any, b: any) => {
-        const weight = (entry: any) => {
-          const f = entry.node;
-          return (
-            (f.confidence ?? 0.5) *
-            // originWeight, not a human-only ternary: the `: 1` branch ranked an
-            // agent finding level with a post-hoc harvested guess, so this sort
-            // and findingsFor disagreed about provenance.
-            mods.curate.originWeight(f.origin) *
-            (f.pinned ? 2 : 1)
-          );
-        };
-        return weight(b) - weight(a);
-      });
+      // Lexical retrieval per the design -- now actually ranked by BM25
+      // (hooks-core/lexical.mjs), the same primitive the wiki_query tool
+      // uses for its `search` operation. The previous substring filter
+      // could not order results, so the caller kept whatever matched rather
+      // than what matched best.
+      //
+      // `rank` scores plain objects by their own `key`/`claim` fields, but
+      // this route's pool is `{ node, source }` wrappers (findings are
+      // aggregated across every source directory), so each entry is exposed
+      // under `key`/`claim` for scoring and unwrapped back to its original
+      // `{ node, source }` shape afterward. The limit is the whole
+      // (kind-filtered) pool, not `offset + limit`, so `total` and the
+      // dashboard's `?offset=` pagination keep behaving exactly as they did
+      // under the old unbounded filter -- only the ordering changes.
+      if (query) {
+        const scored = mods.lexical.rank(
+          query,
+          findings.map((entry: any) => ({
+            key: entry.node.key,
+            claim: entry.node.claim,
+            entry,
+          })),
+          { limit: findings.length }
+        );
+        findings = scored.map(
+          (row: { finding: { entry: unknown } }) => row.finding.entry
+        );
+      } else {
+        findings.sort((a: any, b: any) => {
+          const weight = (entry: any) => {
+            const f = entry.node;
+            return (
+              (f.confidence ?? 0.5) *
+              // originWeight, not a human-only ternary: the `: 1` branch ranked an
+              // agent finding level with a post-hoc harvested guess, so this sort
+              // and findingsFor disagreed about provenance.
+              mods.curate.originWeight(f.origin) *
+              (f.pinned ? 2 : 1)
+            );
+          };
+          return weight(b) - weight(a);
+        });
+      }
 
       return res.json({
         total: findings.length,

--- a/src/server/wiki-routes.ts
+++ b/src/server/wiki-routes.ts
@@ -450,7 +450,8 @@ export function registerWikiRoutes(app: Express): void {
       // instead of asking `rank` to score against nothing (which would
       // return zero results, not "everything," for what a user typing a
       // stray space in the search box expects to behave like no filter).
-      const hasQueryTerms = query.length > 0 && mods.lexical.tokenize(query).length > 0;
+      const hasQueryTerms =
+        query.length > 0 && mods.lexical.tokenize(query).length > 0;
       if (hasQueryTerms) {
         const scored = mods.lexical.rank(
           query,

--- a/src/server/wiki-routes.ts
+++ b/src/server/wiki-routes.ts
@@ -821,7 +821,8 @@ export function registerWikiRoutes(app: Express): void {
     const mods = await modules();
     if (!mods) return res.status(503).json({ error: 'graph unavailable' });
 
-    const { action, key, claim, anchors, confidence, pinned } = req.body || {};
+    const { action, key, claim, anchors, confidence, pinned, byKey, reason } =
+      req.body || {};
     let dir: string;
     try {
       dir = selectedSource(req, mods).dir;
@@ -848,6 +849,21 @@ export function registerWikiRoutes(app: Express): void {
           });
           return replacement
             ? res.json({ ok: true, key: replacement })
+            : res.status(404).json({ error: 'no such finding' });
+        }
+        case 'contradict': {
+          // AN EDGE, NOT AN OVERWRITE, and this is the only door it has: the
+          // schema declared `contradicts` from the start, `audit` read it, and
+          // nothing could write it -- so a belief change could only be recorded
+          // by `correct`, which retires the old claim and picks a winner.
+          // Recording a disagreement is the case where nobody has picked yet.
+          if (!byKey) return res.status(400).json({ error: 'byKey required' });
+          // Both ends must resolve to findings that exist, or the edge points at
+          // nothing and the disagreement is recorded against an id no reader can
+          // follow. curate returns false for that, and for a claim disagreeing
+          // with itself.
+          return mods.curate.contradict(dir, { key, byKey, reason })
+            ? res.json({ ok: true })
             : res.status(404).json({ error: 'no such finding' });
         }
         case 'create': {

--- a/src/tools/intelligence/wiki-query.ts
+++ b/src/tools/intelligence/wiki-query.ts
@@ -29,7 +29,6 @@ function coreUrl(name: string): string {
 export enum WikiQueryOperation {
   Get = 'get',
   Search = 'search',
-  Anchor = 'anchor',
   Node = 'node',
   Audit = 'audit',
   Balance = 'balance',
@@ -58,8 +57,6 @@ export interface WikiQueryOptions {
   query?: string;
   /** `search`: restrict to one finding type. */
   type?: string;
-  /** `anchor`: a file path or `file#symbol`. */
-  anchor?: string;
   /** `node`: a node id. */
   nodeId?: string;
   /** Max rows returned. Default 20, capped at 100. */
@@ -88,7 +85,12 @@ export interface WikiQueryResult {
 export const WIKI_QUERY_TOOL_DEFINITION = {
   name: 'wiki_query',
   description:
-    "Read the project's knowledge graph: fetch a finding by key, search findings, list what is known about a file or symbol, inspect a node, or get the graph's audit, token balance and overall shape. Use this when the session index mentions a finding you want in full, or before re-deriving something about a file you are about to work on.",
+    "Read the project's knowledge graph: fetch a finding by key, search findings by " +
+    "terms, inspect a node and its neighbours, or get the graph's audit, token balance " +
+    'and overall shape. Use it when the session index mentions a finding you want in ' +
+    'full, or to find out what the graph holds at all. NOT for anchored retrieval: to ' +
+    'ask what is known about a particular file or symbol, call wiki_read, which does ' +
+    'exactly that and is the tool the enforcement layer points at.',
   annotations: {
     title: 'Read project knowledge',
     readOnlyHint: true,
@@ -103,7 +105,10 @@ export const WIKI_QUERY_TOOL_DEFINITION = {
         type: 'string',
         enum: WIKI_QUERY_OPERATIONS,
         description:
-          "get = one finding by key. search = findings matching terms. anchor = everything known about a file or 'file#symbol'. node = a node and its neighbours. audit = findings needing attention. balance = what the graph has cost and saved. overview = the graph's shape.",
+          'get = one finding by key. search = findings matching terms. node = a node ' +
+          'and its neighbours. audit = findings needing attention. balance = what the ' +
+          "graph has cost and saved. overview = the graph's shape. For findings about a " +
+          'particular file or symbol, use wiki_read instead.',
       },
       key: { type: 'string', description: 'Finding key, for operation=get.' },
       query: {
@@ -114,10 +119,6 @@ export const WIKI_QUERY_TOOL_DEFINITION = {
         type: 'string',
         enum: WIKI_QUERY_FINDING_TYPES,
         description: 'Restrict search to one finding type.',
-      },
-      anchor: {
-        type: 'string',
-        description: "File path or 'file#symbol', for operation=anchor.",
       },
       nodeId: { type: 'string', description: 'Node id, for operation=node.' },
       limit: {
@@ -141,6 +142,50 @@ export const WIKI_QUERY_TOOL_DEFINITION = {
   },
 };
 
+/**
+ * A node's `snapshot` is a VERBATIM COPY OF A FILE, and it must never reach a
+ * response.
+ *
+ * The original design of this tool trimmed findings to a fixed shape for exactly
+ * this reason, then never called the function that did it -- so the invariant
+ * held only because `load()` happens to be called without `{ snapshots: true }`.
+ * That is one unrelated edit away from posting a private file into a model's
+ * context, and it is not hypothetical from the other direction either: `putNode`
+ * spreads whatever fields it is given onto the record, so a `snapshot` written
+ * inline is returned by `load()` regardless of that flag.
+ *
+ * So the guarantee lives at the boundary instead of in a comment. Every response
+ * leaves through here, and the walk is structural rather than a field list: a
+ * future field nested anywhere inside a served finding, a graph node or a
+ * neighbour is stripped without this function having to know it exists.
+ */
+const SNAPSHOT_FIELDS = new Set(['snapshot', 'snapshots', 'before', 'after']);
+
+function withoutSnapshots<T>(value: T, depth = 0): T {
+  if (depth > 8 || value === null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) {
+    return value.map((item) =>
+      withoutSnapshots(item, depth + 1)
+    ) as unknown as T;
+  }
+  if (value instanceof Map) {
+    // A Map does not survive JSON.stringify anyway, so returning one would be a
+    // silent `{}` on the wire. Refusing to carry it here makes that visible.
+    return undefined as unknown as T;
+  }
+  const out: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
+    if (SNAPSHOT_FIELDS.has(key)) continue;
+    out[key] = withoutSnapshots(item, depth + 1);
+  }
+  return out as unknown as T;
+}
+
+/** The single exit. Nothing returns from wikiQuery except through this. */
+function respond(result: WikiQueryResult): WikiQueryResult {
+  return withoutSnapshots(result);
+}
+
 export async function wikiQuery(
   options: WikiQueryOptions
 ): Promise<WikiQueryResult> {
@@ -159,11 +204,9 @@ export async function wikiQuery(
 
   // The graph belongs to the project the ANCHOR is in, not to wherever the
   // session happens to be running -- the same rule wiki_write follows.
-  const inferredRoot =
-    options.projectRoot ??
-    (options.anchor
-      ? wiki.projectRootFor(String(options.anchor).split('#')[0], process.cwd())
-      : process.cwd());
+  // No anchor to infer from any more -- anchored retrieval belongs to wiki_read.
+  // An explicit projectRoot still wins, so a caller that knows better can name it.
+  const inferredRoot = options.projectRoot ?? process.cwd();
   const dir = options.graphDir ?? wiki.wikiDir(inferredRoot);
   if (!options.graphDir) {
     projects.registerProject({
@@ -179,7 +222,7 @@ export async function wikiQuery(
   metrics.record(dir, {
     kind: 'query',
     operation,
-    key: options.key ?? options.anchor ?? null,
+    key: options.key ?? null,
     sessionId: options.sessionId ?? null,
   });
 
@@ -191,11 +234,15 @@ export async function wikiQuery(
       (f: Record<string, unknown>) => f.key === options.key
     );
     if (!match)
-      return { operation, found: false, note: 'no finding with that key' };
+      return respond({
+        operation,
+        found: false,
+        note: 'no finding with that key',
+      });
     // Served through `serve` so a stale finding arrives WITH the diff that
     // invalidated it. A stale finding served bare is worse than no graph.
     const [served] = staleness.serve(graph, [match]);
-    return { operation, found: true, finding: served };
+    return respond({ operation, found: true, finding: served });
   }
 
   if (operation === WikiQueryOperation.Search) {
@@ -210,22 +257,13 @@ export async function wikiQuery(
       graph,
       ranked.map((r: { finding: unknown }) => r.finding)
     );
-    return { operation, found: served.length > 0, findings: served };
-  }
-
-  if (operation === WikiQueryOperation.Anchor) {
-    const anchor = String(options.anchor ?? '');
-    const id = anchor.includes('#')
-      ? wiki.nodeId('symbol', anchor)
-      : wiki.nodeId('file', anchor);
-    const found = wiki.findingsFor(graph, id, { limit });
-    const served = staleness.serve(graph, found);
-    return { operation, found: served.length > 0, findings: served };
+    return respond({ operation, found: served.length > 0, findings: served });
   }
 
   if (operation === WikiQueryOperation.Node) {
     const node = graph.nodes.get(String(options.nodeId ?? ''));
-    if (!node) return { operation, found: false, note: 'no such node' };
+    if (!node)
+      return respond({ operation, found: false, note: 'no such node' });
     const edges = graph.edges
       .filter(
         (e: { from: string; to: string }) =>
@@ -237,15 +275,15 @@ export async function wikiQuery(
         graph.nodes.get(e.from === node.id ? e.to : e.from)
       )
       .filter(Boolean);
-    return { operation, found: true, node, neighbours };
+    return respond({ operation, found: true, node, neighbours });
   }
 
   if (operation === WikiQueryOperation.Audit) {
-    return { operation, found: true, audit: curate.audit(graph) };
+    return respond({ operation, found: true, audit: curate.audit(graph) });
   }
 
   if (operation === WikiQueryOperation.Balance) {
-    return { operation, found: true, balance: metrics.report(dir) };
+    return respond({ operation, found: true, balance: metrics.report(dir) });
   }
 
   if (operation === WikiQueryOperation.Overview) {
@@ -267,7 +305,7 @@ export async function wikiQuery(
       .slice(0, 10)
       .map(([key, findings]) => ({ key, findings }));
     const findings = curate.activeFindings(graph);
-    return {
+    return respond({
       operation,
       found: true,
       overview: {
@@ -276,8 +314,12 @@ export async function wikiQuery(
         stale: findings.filter((f: Record<string, unknown>) => f.stale).length,
         total: findings.length,
       },
-    };
+    });
   }
 
-  return { operation, found: false, note: `unknown operation: ${operation}` };
+  return respond({
+    operation,
+    found: false,
+    note: `unknown operation: ${operation}`,
+  });
 }

--- a/src/tools/intelligence/wiki-query.ts
+++ b/src/tools/intelligence/wiki-query.ts
@@ -1,0 +1,283 @@
+/**
+ * wiki_query — reading the graph, which nothing could do.
+ *
+ * The SessionStart index has told the model to "call wiki_query with a key for
+ * detail" in twelve shipped copies of the injected text since injection landed.
+ * The tool did not exist. So the design's escape hatch for the hard per-touch
+ * budget -- "everything else reachable through wiki_query" -- was not reachable
+ * at all, and anything the 500-token cap dropped was simply gone.
+ *
+ * IT ALSO FIXES A DEAD METRIC. `indexBudget` earns the session index its token
+ * allowance from `queries / listed`, and nothing in the product had ever written
+ * a `query` event -- only the test suite. So the ratio was 0 for every project
+ * on earth, and the budget ratcheted to its floor and stayed there. Recording
+ * the event here is the numerator.
+ */
+
+import path from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { dirname } from 'path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+function coreUrl(name: string): string {
+  return pathToFileURL(path.join(here, '..', '..', '..', 'hooks-core', name))
+    .href;
+}
+
+/** Closed set, so a typo cannot compile. */
+export enum WikiQueryOperation {
+  Get = 'get',
+  Search = 'search',
+  Anchor = 'anchor',
+  Node = 'node',
+  Audit = 'audit',
+  Balance = 'balance',
+  Overview = 'overview',
+}
+
+/** The operation names as they cross the wire, derived from the enum. */
+export const WIKI_QUERY_OPERATIONS: string[] =
+  Object.values(WikiQueryOperation);
+
+/** Finding types a search may be restricted to. Mirrors wiki_write's set. */
+export const WIKI_QUERY_FINDING_TYPES = [
+  'finding',
+  'decision',
+  'failure',
+  'command',
+  'map',
+  'feedback',
+];
+
+export interface WikiQueryOptions {
+  operation: WikiQueryOperation | `${WikiQueryOperation}`;
+  /** `get`: the finding key. */
+  key?: string;
+  /** `search`: the search terms. */
+  query?: string;
+  /** `search`: restrict to one finding type. */
+  type?: string;
+  /** `anchor`: a file path or `file#symbol`. */
+  anchor?: string;
+  /** `node`: a node id. */
+  nodeId?: string;
+  /** Max rows returned. Default 20, capped at 100. */
+  limit?: number;
+  /** Explicit graph directory. Tests use it; callers normally omit it. */
+  graphDir?: string;
+  /** Explicit project root, when the caller knows better than inference. */
+  projectRoot?: string;
+  /** Recorded with the query event so hit rate can be attributed to a session. */
+  sessionId?: string;
+}
+
+export interface WikiQueryResult {
+  operation: string;
+  found: boolean;
+  finding?: unknown;
+  findings?: unknown[];
+  node?: unknown;
+  neighbours?: unknown[];
+  audit?: unknown;
+  balance?: unknown;
+  overview?: unknown;
+  note?: string;
+}
+
+export const WIKI_QUERY_TOOL_DEFINITION = {
+  name: 'wiki_query',
+  description:
+    "Read the project's knowledge graph: fetch a finding by key, search findings, list what is known about a file or symbol, inspect a node, or get the graph's audit, token balance and overall shape. Use this when the session index mentions a finding you want in full, or before re-deriving something about a file you are about to work on.",
+  annotations: {
+    title: 'Read project knowledge',
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  inputSchema: {
+    type: 'object',
+    properties: {
+      operation: {
+        type: 'string',
+        enum: WIKI_QUERY_OPERATIONS,
+        description:
+          "get = one finding by key. search = findings matching terms. anchor = everything known about a file or 'file#symbol'. node = a node and its neighbours. audit = findings needing attention. balance = what the graph has cost and saved. overview = the graph's shape.",
+      },
+      key: { type: 'string', description: 'Finding key, for operation=get.' },
+      query: {
+        type: 'string',
+        description: 'Search terms, for operation=search.',
+      },
+      type: {
+        type: 'string',
+        enum: WIKI_QUERY_FINDING_TYPES,
+        description: 'Restrict search to one finding type.',
+      },
+      anchor: {
+        type: 'string',
+        description: "File path or 'file#symbol', for operation=anchor.",
+      },
+      nodeId: { type: 'string', description: 'Node id, for operation=node.' },
+      limit: {
+        type: 'number',
+        description: 'Max rows. Default 20, capped at 100.',
+      },
+      graphDir: {
+        type: 'string',
+        description: 'Explicit graph directory. Normally omitted.',
+      },
+      projectRoot: {
+        type: 'string',
+        description: 'Explicit project root. Normally omitted.',
+      },
+      sessionId: {
+        type: 'string',
+        description: 'Session id, recorded with the query event.',
+      },
+    },
+    required: ['operation'],
+  },
+};
+
+export async function wikiQuery(
+  options: WikiQueryOptions
+): Promise<WikiQueryResult> {
+  const operation = String(options?.operation ?? '');
+  const limit = Math.min(100, Math.max(1, Number(options?.limit) || 20));
+
+  const [wiki, curate, metrics, staleness, lexical, projects] =
+    await Promise.all([
+      import(coreUrl('wiki.mjs')),
+      import(coreUrl('curate.mjs')),
+      import(coreUrl('metrics.mjs')),
+      import(coreUrl('staleness.mjs')),
+      import(coreUrl('lexical.mjs')),
+      import(coreUrl('projects.mjs')),
+    ]);
+
+  // The graph belongs to the project the ANCHOR is in, not to wherever the
+  // session happens to be running -- the same rule wiki_write follows.
+  const inferredRoot =
+    options.projectRoot ??
+    (options.anchor
+      ? wiki.projectRootFor(String(options.anchor).split('#')[0], process.cwd())
+      : process.cwd());
+  const dir = options.graphDir ?? wiki.wikiDir(inferredRoot);
+  if (!options.graphDir) {
+    projects.registerProject({
+      root: inferredRoot,
+      graphDir: dir,
+      client: 'mcp',
+    });
+  }
+
+  // Recorded BEFORE the work, so a query that then fails still counts as the
+  // model having asked. The metric is about the index leading somewhere, not
+  // about whether the answer existed.
+  metrics.record(dir, {
+    kind: 'query',
+    operation,
+    key: options.key ?? options.anchor ?? null,
+    sessionId: options.sessionId ?? null,
+  });
+
+  const graph = wiki.load(dir);
+
+  if (operation === WikiQueryOperation.Get) {
+    const all = curate.activeFindings(graph);
+    const match = all.find(
+      (f: Record<string, unknown>) => f.key === options.key
+    );
+    if (!match)
+      return { operation, found: false, note: 'no finding with that key' };
+    // Served through `serve` so a stale finding arrives WITH the diff that
+    // invalidated it. A stale finding served bare is worse than no graph.
+    const [served] = staleness.serve(graph, [match]);
+    return { operation, found: true, finding: served };
+  }
+
+  if (operation === WikiQueryOperation.Search) {
+    let pool = curate.activeFindings(graph);
+    if (options.type) {
+      pool = pool.filter(
+        (f: Record<string, unknown>) => (f.type ?? 'finding') === options.type
+      );
+    }
+    const ranked = lexical.rank(String(options.query ?? ''), pool, { limit });
+    const served = staleness.serve(
+      graph,
+      ranked.map((r: { finding: unknown }) => r.finding)
+    );
+    return { operation, found: served.length > 0, findings: served };
+  }
+
+  if (operation === WikiQueryOperation.Anchor) {
+    const anchor = String(options.anchor ?? '');
+    const id = anchor.includes('#')
+      ? wiki.nodeId('symbol', anchor)
+      : wiki.nodeId('file', anchor);
+    const found = wiki.findingsFor(graph, id, { limit });
+    const served = staleness.serve(graph, found);
+    return { operation, found: served.length > 0, findings: served };
+  }
+
+  if (operation === WikiQueryOperation.Node) {
+    const node = graph.nodes.get(String(options.nodeId ?? ''));
+    if (!node) return { operation, found: false, note: 'no such node' };
+    const edges = graph.edges
+      .filter(
+        (e: { from: string; to: string }) =>
+          e.from === node.id || e.to === node.id
+      )
+      .slice(0, limit);
+    const neighbours = edges
+      .map((e: { from: string; to: string }) =>
+        graph.nodes.get(e.from === node.id ? e.to : e.from)
+      )
+      .filter(Boolean);
+    return { operation, found: true, node, neighbours };
+  }
+
+  if (operation === WikiQueryOperation.Audit) {
+    return { operation, found: true, audit: curate.audit(graph) };
+  }
+
+  if (operation === WikiQueryOperation.Balance) {
+    return { operation, found: true, balance: metrics.report(dir) };
+  }
+
+  if (operation === WikiQueryOperation.Overview) {
+    const counts: Record<string, number> = {};
+    for (const node of graph.nodes.values()) {
+      counts[node.kind] = (counts[node.kind] || 0) + 1;
+    }
+    // Densest anchors: the files carrying the most findings. This is the part a
+    // constellation of coordinates could never tell a model.
+    const perAnchor = new Map<string, number>();
+    for (const edge of graph.edges) {
+      if (edge.edge !== 'derived_from') continue;
+      const target = graph.nodes.get(edge.to);
+      if (target)
+        perAnchor.set(target.key, (perAnchor.get(target.key) || 0) + 1);
+    }
+    const densest = [...perAnchor.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 10)
+      .map(([key, findings]) => ({ key, findings }));
+    const findings = curate.activeFindings(graph);
+    return {
+      operation,
+      found: true,
+      overview: {
+        counts,
+        densest,
+        stale: findings.filter((f: Record<string, unknown>) => f.stale).length,
+        total: findings.length,
+      },
+    };
+  }
+
+  return { operation, found: false, note: `unknown operation: ${operation}` };
+}

--- a/src/tools/intelligence/wiki-query.ts
+++ b/src/tools/intelligence/wiki-query.ts
@@ -297,11 +297,34 @@ export async function wikiQuery(
         (f: Record<string, unknown>) => (f.type ?? 'finding') === options.type
       );
     }
-    const ranked = lexical.rank(String(options.query ?? ''), pool, { limit });
-    const served = staleness.serve(
-      graph,
-      ranked.map((r: { finding: unknown }) => r.finding)
-    );
+
+    const rawQuery = String(options.query ?? '');
+    // Mirrors the dashboard's /api/wiki/search route (src/server/wiki-routes.ts):
+    // `tokenize` strips everything but alphanumeric runs, so a blank,
+    // whitespace-only, or punctuation-only query yields no terms for `rank`
+    // to score against -- and `rank` returns [] when there is nothing to
+    // score, not "the whole pool." `query` is optional in this tool's
+    // schema, so a model can omit it or send '' the same way a user can
+    // leave the dashboard search box blank; both surfaces must agree that
+    // "no usable query" means "return the pool," not "return nothing,"
+    // otherwise the same input means opposite things depending on which
+    // surface asked.
+    const hasQueryTerms = lexical.tokenize(rawQuery).length > 0;
+    const matches = hasQueryTerms
+      ? lexical
+          .rank(rawQuery, pool, { limit })
+          .map((r: { finding: unknown }) => r.finding)
+      : [...pool]
+          .sort((a: Record<string, unknown>, b: Record<string, unknown>) => {
+            const weight = (f: Record<string, unknown>) =>
+              (typeof f.confidence === 'number' ? f.confidence : 0.5) *
+              curate.originWeight(f.origin) *
+              (f.pinned ? 2 : 1);
+            return weight(b) - weight(a);
+          })
+          .slice(0, limit);
+
+    const served = staleness.serve(graph, matches);
     return respond({ operation, found: served.length > 0, findings: served });
   }
 

--- a/src/tools/intelligence/wiki-query.ts
+++ b/src/tools/intelligence/wiki-query.ts
@@ -286,7 +286,7 @@ export async function wikiQuery(
       });
     // Served through `serve` so a stale finding arrives WITH the diff that
     // invalidated it. A stale finding served bare is worse than no graph.
-    const [served] = staleness.serve(graph, [match]);
+    const [served] = staleness.serve(graph, [match], { dir });
     return respond({ operation, found: true, finding: served });
   }
 
@@ -324,7 +324,7 @@ export async function wikiQuery(
           })
           .slice(0, limit);
 
-    const served = staleness.serve(graph, matches);
+    const served = staleness.serve(graph, matches, { dir });
     return respond({ operation, found: served.length > 0, findings: served });
   }
 

--- a/src/tools/intelligence/wiki-query.ts
+++ b/src/tools/intelligence/wiki-query.ts
@@ -161,8 +161,25 @@ export const WIKI_QUERY_TOOL_DEFINITION = {
  */
 const SNAPSHOT_FIELDS = new Set(['snapshot', 'snapshots', 'before', 'after']);
 
+/**
+ * How deep the walk goes before it refuses to carry the subtree.
+ *
+ * Bounded so a cycle cannot hang the response. The bound must FAIL CLOSED: the
+ * first version returned `value` at the cap, which handed back a raw, unstripped
+ * subtree through the one exit this guard exists to seal. Today's responses are
+ * two to four deep so it was unreachable -- but "unreachable in practice" is
+ * exactly the incidental guarantee this function was written to replace.
+ */
+const MAX_DEPTH = 8;
+
+/** What a subtree past the cap is replaced BY. Never the subtree. */
+const DEPTH_LIMIT_MARKER = '[depth limit]';
+
 function withoutSnapshots<T>(value: T, depth = 0): T {
-  if (depth > 8 || value === null || typeof value !== 'object') return value;
+  // FAIL CLOSED, not open: past the cap nothing is carried, because at this
+  // point the walk can no longer promise anything about what is below.
+  if (depth > MAX_DEPTH) return DEPTH_LIMIT_MARKER as unknown as T;
+  if (value === null || typeof value !== 'object') return value;
   if (Array.isArray(value)) {
     return value.map((item) =>
       withoutSnapshots(item, depth + 1)
@@ -192,7 +209,7 @@ export async function wikiQuery(
   const operation = String(options?.operation ?? '');
   const limit = Math.min(100, Math.max(1, Number(options?.limit) || 20));
 
-  const [wiki, curate, metrics, staleness, lexical, projects] =
+  const [wiki, curate, metrics, staleness, lexical, projects, paths] =
     await Promise.all([
       import(coreUrl('wiki.mjs')),
       import(coreUrl('curate.mjs')),
@@ -200,13 +217,41 @@ export async function wikiQuery(
       import(coreUrl('staleness.mjs')),
       import(coreUrl('lexical.mjs')),
       import(coreUrl('projects.mjs')),
+      import(coreUrl('paths.mjs')),
     ]);
 
-  // The graph belongs to the project the ANCHOR is in, not to wherever the
-  // session happens to be running -- the same rule wiki_write follows.
-  // No anchor to infer from any more -- anchored retrieval belongs to wiki_read.
-  // An explicit projectRoot still wins, so a caller that knows better can name it.
-  const inferredRoot = options.projectRoot ?? process.cwd();
+  // THE GRAPH LIVES AT THE REPOSITORY ROOT, and `wikiDir` does no upward walk.
+  //
+  // The raw cwd was wrong, and wrong in the one way that would have made this
+  // whole tool a no-op while looking finished. `indexBudget` divides `queries`
+  // by `listed` PER GRAPH DIRECTORY, and the `index` events that form the
+  // denominator are written by the hooks to
+  // `wikiDir(projectRootFor(join(cwd, '__session__'), cwd))` -- which walks up
+  // for a .git/.hg/.svn marker. So from any cwd below the repository root -- a
+  // monorepo package, a host that spawns the server in a subdirectory, a user
+  // who started it from src/ -- the numerator would land in one graph and the
+  // denominator in another, each zero where the other was counted, and the
+  // budget would stay pinned at its 150-token floor exactly as before.
+  //
+  // Same resolution as the hooks, and the same sentinel filename: the walk wants
+  // a path INSIDE the tree rather than the tree itself. An explicit projectRoot
+  // still wins, so a caller that knows better can name it.
+  //
+  // CANONICAL ON EVERY PATH, including the caller-supplied one. `projectRootFor`
+  // canonicalises what it returns; `wikiDir` does not canonicalise what it is
+  // given. So a caller passing a lower-case drive letter while a hook resolves an
+  // upper-case one would write to two directories for one repository, and the
+  // same for an 8.3 short path or a symlinked spelling. That is the identity bug
+  // this codebase already answered once, by putting `canonicalKey` INSIDE
+  // `nodeId`
+  // rather than trusting each call site to remember.
+  const inferredRoot = paths.canonicalPath(
+    options.projectRoot ??
+      wiki.projectRootFor(
+        path.join(process.cwd(), '__session__'),
+        process.cwd()
+      )
+  );
   const dir = options.graphDir ?? wiki.wikiDir(inferredRoot);
   if (!options.graphDir) {
     projects.registerProject({

--- a/src/tools/intelligence/wiki-write.ts
+++ b/src/tools/intelligence/wiki-write.ts
@@ -61,13 +61,14 @@ export interface WikiWriteOptions {
   /** Conditions that should cause a later reader to distrust or re-check it. */
   invalidators?: string[];
   /**
-   * Recorded for provenance so a claim can be traced to the session, and used
-   * to link the finding back to the task that produced it (the `answers`
-   * edge) -- but only when the SAME session's task actually has a
-   * `derived_from` edge to every one of this claim's anchors; a session id
-   * with no such coverage yields no edge rather than a guessed one. Nothing
-   * populates this automatically today -- the caller must supply the real
-   * session id for either to hold.
+   * Recorded for provenance so a claim can be traced to the session --
+   * stored on the finding, nothing more. It does NOT produce an `answers`
+   * edge: this value is a model-supplied tool argument nothing verifies, so
+   * `writeHarvested` never treats it as authoritative for attribution
+   * (see its `authoritativeSessionId` parameter, which this call omits).
+   * `plugin/hooks/harvest-worker.mjs` is the caller whose session id comes
+   * from a trusted channel (Claude Code's own hook payload) and can supply
+   * that; a tool argument cannot.
    */
   sessionId?: string;
   /** Overrides the project the finding belongs to. Defaults to the anchor's repo. */
@@ -234,22 +235,27 @@ export async function wikiWrite(
         // stores a snapshot, so an unconstrained path would copy any readable
         // file on the machine into the graph.
         projectRoot: project,
-        // NO explicit `taskId` HERE, DELIBERATELY. An earlier version passed
-        // `taskId: options.sessionId`, treating the model's claimed session id
-        // as an AUTHORITATIVE override -- but `writeHarvested`'s explicit-taskId
-        // path resolves it directly with no coverage check, on the theory that
-        // an explicit caller knows better than the graph. That is true of
-        // `plugin/hooks/harvest-worker.mjs`'s `sessionId`, which comes from
-        // Claude Code's own hook payload, but it is NOT true here: `sessionId`
-        // is an optional MCP tool argument the model supplies, unverified,
-        // exactly the kind of caller-asserted value this codebase otherwise
-        // never trusts blindly (anchors are resolved against the graph rather
-        // than accepted as typed). Leaving `taskId` unset routes this through
-        // `writeHarvested`'s traversal fallback instead, which uses the SAME
-        // `sessionId` only to SCOPE which task to check, then still requires
-        // that task to have a `derived_from` edge to EVERY one of this
-        // finding's anchors before an `answers` edge is written. A wrong or
-        // unrelated `sessionId` therefore yields no edge, never a wrong one.
+        // NO explicit `taskId`, AND NO `authoritativeSessionId`, HERE,
+        // DELIBERATELY. An earlier version of this comment claimed that
+        // routing through `writeHarvested`'s session-scoped traversal made a
+        // "wrong or unrelated sessionId yield no edge, never a wrong one" --
+        // that claim was FALSE for a FOREIGN BUT REAL session id. `sessionId`
+        // here is a plain MCP tool argument the model supplies, unverified;
+        // coverage cannot tell "this session" from "some OTHER, real session
+        // whose task genuinely touched these files", so a model naming a
+        // prior session by mistake or by copying a stale value would still
+        // get an `answers` edge -- a confidently wrong one, to the wrong task.
+        //
+        // `writeHarvested` now takes a SEPARATE `authoritativeSessionId`
+        // parameter that gates its traversal fallback, and this call does not
+        // supply it: `sessionId` is stored for provenance/display only, never
+        // used to attribute an `answers` edge. The consequence is real and
+        // accepted, not an oversight: `wiki_write` calls never write an
+        // `answers` edge. `plugin/hooks/harvest-worker.mjs` supplies
+        // `authoritativeSessionId` because ITS `sessionId` comes from Claude
+        // Code's own hook payload, not a tool-call argument -- that is the
+        // difference that makes an identity authoritative, and this function
+        // has no channel that meets it.
       }
     );
 

--- a/src/tools/intelligence/wiki-write.ts
+++ b/src/tools/intelligence/wiki-write.ts
@@ -60,7 +60,13 @@ export interface WikiWriteOptions {
   scope?: 'project' | 'organization' | 'global';
   /** Conditions that should cause a later reader to distrust or re-check it. */
   invalidators?: string[];
-  /** Recorded for provenance so a claim can be traced to the session. */
+  /**
+   * Recorded for provenance so a claim can be traced to the session, and used
+   * to link the finding back to the task that produced it (the `answers`
+   * edge) when a task node with this same id already exists. Nothing
+   * populates this automatically today -- the caller must supply the real
+   * session id for either to hold.
+   */
   sessionId?: string;
   /** Overrides the project the finding belongs to. Defaults to the anchor's repo. */
   projectRoot?: string;
@@ -226,6 +232,14 @@ export async function wikiWrite(
         // stores a snapshot, so an unconstrained path would copy any readable
         // file on the machine into the graph.
         projectRoot: project,
+        // Task nodes are keyed by session id (structural capture creates one
+        // the first time this session's hooks touch a file), so the same
+        // identity that provenance is already recorded under is what
+        // `writeHarvested` needs to point the `answers` edge at the task this
+        // finding came from. Same discipline as everywhere else: a sessionId
+        // that names no existing task node resolves to no edge, not a
+        // dangling one.
+        taskId: options.sessionId ?? null,
       }
     );
 

--- a/src/tools/intelligence/wiki-write.ts
+++ b/src/tools/intelligence/wiki-write.ts
@@ -63,7 +63,9 @@ export interface WikiWriteOptions {
   /**
    * Recorded for provenance so a claim can be traced to the session, and used
    * to link the finding back to the task that produced it (the `answers`
-   * edge) when a task node with this same id already exists. Nothing
+   * edge) -- but only when the SAME session's task actually has a
+   * `derived_from` edge to every one of this claim's anchors; a session id
+   * with no such coverage yields no edge rather than a guessed one. Nothing
    * populates this automatically today -- the caller must supply the real
    * session id for either to hold.
    */
@@ -232,14 +234,22 @@ export async function wikiWrite(
         // stores a snapshot, so an unconstrained path would copy any readable
         // file on the machine into the graph.
         projectRoot: project,
-        // Task nodes are keyed by session id (structural capture creates one
-        // the first time this session's hooks touch a file), so the same
-        // identity that provenance is already recorded under is what
-        // `writeHarvested` needs to point the `answers` edge at the task this
-        // finding came from. Same discipline as everywhere else: a sessionId
-        // that names no existing task node resolves to no edge, not a
-        // dangling one.
-        taskId: options.sessionId ?? null,
+        // NO explicit `taskId` HERE, DELIBERATELY. An earlier version passed
+        // `taskId: options.sessionId`, treating the model's claimed session id
+        // as an AUTHORITATIVE override -- but `writeHarvested`'s explicit-taskId
+        // path resolves it directly with no coverage check, on the theory that
+        // an explicit caller knows better than the graph. That is true of
+        // `plugin/hooks/harvest-worker.mjs`'s `sessionId`, which comes from
+        // Claude Code's own hook payload, but it is NOT true here: `sessionId`
+        // is an optional MCP tool argument the model supplies, unverified,
+        // exactly the kind of caller-asserted value this codebase otherwise
+        // never trusts blindly (anchors are resolved against the graph rather
+        // than accepted as typed). Leaving `taskId` unset routes this through
+        // `writeHarvested`'s traversal fallback instead, which uses the SAME
+        // `sessionId` only to SCOPE which task to check, then still requires
+        // that task to have a `derived_from` edge to EVERY one of this
+        // finding's anchors before an `answers` edge is written. A wrong or
+        // unrelated `sessionId` therefore yields no edge, never a wrong one.
       }
     );
 

--- a/src/validation/tool-schemas.ts
+++ b/src/validation/tool-schemas.ts
@@ -403,6 +403,31 @@ export const WikiWriteSchema = z
 // so the caller gets an explanation rather than a validation rejection.
 export const WikiReadSchema = z.object({}).passthrough();
 
+// wiki_query: reading the knowledge graph. EVERY option must be declared --
+// an option missing here is spread into the handler and silently dropped.
+export const WikiQuerySchema = z.object({
+  operation: z.enum([
+    'get',
+    'search',
+    'anchor',
+    'node',
+    'audit',
+    'balance',
+    'overview',
+  ]),
+  key: z.string().optional(),
+  query: z.string().optional(),
+  type: z
+    .enum(['finding', 'decision', 'failure', 'command', 'map', 'feedback'])
+    .optional(),
+  anchor: z.string().optional(),
+  nodeId: z.string().optional(),
+  limit: z.number().int().positive().max(100).optional(),
+  graphDir: z.string().optional(),
+  projectRoot: z.string().optional(),
+  sessionId: z.string().optional(),
+});
+
 export const ContextPageSchema = z
   .object({
     query: z.string(),
@@ -1000,6 +1025,7 @@ export const toolSchemaMap: Record<string, z.ZodType<any>> = {
   smart_grep: SmartGrepSchema,
   wiki_write: WikiWriteSchema,
   wiki_read: WikiReadSchema,
+  wiki_query: WikiQuerySchema,
   context_page: ContextPageSchema,
   context_receipt_verify: ContextReceiptVerifySchema,
   cognition_record: CognitionRecordSchema,

--- a/src/validation/tool-schemas.ts
+++ b/src/validation/tool-schemas.ts
@@ -406,21 +406,12 @@ export const WikiReadSchema = z.object({}).passthrough();
 // wiki_query: reading the knowledge graph. EVERY option must be declared --
 // an option missing here is spread into the handler and silently dropped.
 export const WikiQuerySchema = z.object({
-  operation: z.enum([
-    'get',
-    'search',
-    'anchor',
-    'node',
-    'audit',
-    'balance',
-    'overview',
-  ]),
+  operation: z.enum(['get', 'search', 'node', 'audit', 'balance', 'overview']),
   key: z.string().optional(),
   query: z.string().optional(),
   type: z
     .enum(['finding', 'decision', 'failure', 'command', 'map', 'feedback'])
     .optional(),
-  anchor: z.string().optional(),
   nodeId: z.string().optional(),
   limit: z.number().int().positive().max(100).optional(),
   graphDir: z.string().optional(),

--- a/tests/hooks/cache.test.mjs
+++ b/tests/hooks/cache.test.mjs
@@ -9,9 +9,10 @@
  * the prefix is stable by construction rather than by hope.
  */
 
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
 import {
   readCacheUsage,
   cacheHealth,
@@ -35,6 +36,8 @@ import {
 } from '../../hooks-core/keepwarm.mjs';
 import { record, readMetrics } from '../../hooks-core/metrics.mjs';
 import { policyText } from '../../hooks-core/adapter.mjs';
+import { sessionContext } from '../../hooks-core/inject.mjs';
+import { putNode } from '../../hooks-core/wiki.mjs';
 
 let workspace;
 let dir;
@@ -568,5 +571,158 @@ describe('a gap between two sessions is not a gap between turns', () => {
     const gaps = gapDistribution(dir);
     expect(gaps.median).toBeGreaterThan(60 * 60_000);
     expect(ttlTier({ prefixTokens: 47_000, gaps })).toBeNull(); // and it correctly declines
+  });
+});
+
+/**
+ * The ordering that makes the economics bite.
+ *
+ * `cacheOrdered` was correct and had zero call sites, so the SessionStart
+ * assembly was ordered by whatever sequence its call sites happened to push in.
+ * These tests are about the ASSEMBLY, not the sort: a unit test of the sort
+ * passed before this was wired and would pass again if the call were deleted.
+ *
+ * The property that actually costs money is the last one -- a change confined to
+ * a volatile block must leave every byte ahead of it identical, because a prefix
+ * cache invalidates from the first difference onward.
+ */
+describe('SessionStart context is assembled in cache order', () => {
+  // The numbers are the contract. An earlier draft of this work used 'high' and
+  // 'low' strings; those subtract to NaN, every comparison returns false, and
+  // Array.prototype.sort leaves the input untouched -- a silent no-op that a
+  // test written against an already-sorted input would have passed.
+  test('volatility is numeric, and a non-numeric taxonomy would be a silent no-op', () => {
+    const numeric = cacheOrdered([
+      { id: 'volatile', volatility: 2 },
+      { id: 'stable', volatility: 0 },
+    ]);
+    expect(numeric.map((b) => b.id)).toEqual(['stable', 'volatile']);
+
+    // Documented, not endorsed: this is what the string version would have done.
+    const strings = cacheOrdered([
+      { id: 'volatile', volatility: 'high' },
+      { id: 'stable', volatility: 'low' },
+    ]);
+    expect(Number('high') - Number('low')).toBeNaN();
+    expect(strings.map((b) => b.id)).toEqual(['volatile', 'stable']);
+  });
+
+  test('sorts the assembled blocks, so insertion order cannot decide the prefix', () => {
+    // Pushed WORST FIRST on purpose. If the assembly merely joined its inputs
+    // this would emit the freshest block at the very front of the prefix, which
+    // is the expensive arrangement.
+    const text = sessionContext([
+      { id: 'restoration', volatility: 3, text: 'RESTORATION' },
+      { id: 'index', volatility: 2, text: 'INDEX' },
+      { id: 'standing', volatility: 1, text: 'STANDING' },
+      { id: 'policy', volatility: 0, text: 'POLICY' },
+    ]);
+    expect(text).toBe('POLICY\n\nSTANDING\n\nINDEX\n\nRESTORATION');
+  });
+
+  test('drops empty blocks instead of opening the prefix with a blank line', () => {
+    // Fail open: an unreadable graph yields no standing block and no index, and
+    // the policy notice must still arrive as the first byte of the prefix.
+    expect(
+      sessionContext([
+        { id: 'index', volatility: 2, text: '' },
+        { id: 'policy', volatility: 0, text: 'POLICY' },
+        { id: 'standing', volatility: 1, text: '   ' },
+        null,
+      ])
+    ).toBe('POLICY');
+    expect(sessionContext([])).toBe('');
+  });
+
+  test('a change to a volatile block leaves the stable prefix byte-identical', () => {
+    // THIS IS THE CLAIM, tested on the bytes the hook actually emits rather than
+    // on the sort. Two sessions over the same graph, differing only in the task
+    // text, select different findings for the wiki index. If the ordering works,
+    // everything ahead of that index -- policy notice, project briefing and
+    // standing rules -- is the same bytes both times, so the cache keeps it.
+    const project = mkdtempSync(join(tmpdir(), 'cache-order-'));
+    const graphDir = join(project, '.token-optimizer', 'wiki');
+    mkdirSync(graphDir, { recursive: true });
+
+    putNode(graphDir, {
+      kind: 'finding',
+      key: 'p1',
+      pinned: true,
+      confidence: 0.9,
+      claim: 'Build against an isolated worktree, never live WIP.',
+    });
+    putNode(graphDir, {
+      kind: 'finding',
+      key: 'runner',
+      type: 'command',
+      trigger: 'jest',
+      confidence: 0.95,
+      claim: 'Run npm test, not npx jest; the jest binary ignores our runner settings.',
+    });
+    putNode(graphDir, {
+      kind: 'finding',
+      key: 'bundler',
+      type: 'command',
+      trigger: 'webpack',
+      confidence: 0.95,
+      claim: 'The webpack bundler emits everything below tools/bundle.',
+    });
+
+    const run = (userPrompt) => {
+      const r = spawnSync(
+        process.execPath,
+        [join(process.cwd(), 'plugin', 'hooks', 'session-start.mjs')],
+        {
+          input: JSON.stringify({ cwd: project, userPrompt }),
+          encoding: 'utf8',
+          timeout: 30_000,
+          env: {
+            ...process.env,
+            TOKEN_OPTIMIZER_WIKI_DIR: graphDir,
+            TOKEN_OPTIMIZER_SHARED_DIR: graphDir,
+            TOKEN_OPTIMIZER_PROJECT_REGISTRY: join(project, 'projects.jsonl'),
+            CLAUDE_PROJECT_DIR: project,
+          },
+        }
+      );
+      expect(r.status).toBe(0);
+      return (
+        JSON.parse(r.stdout || '{}')?.hookSpecificOutput?.additionalContext || ''
+      );
+    };
+
+    // Two prompts with NO overlapping terms, so each selects exactly one of the
+    // two situational findings and the wiki index genuinely differs between them.
+    const first = run('The npx jest runner ignores our settings; fix jest.');
+    const second = run('The webpack bundler emits below the wrong bundle root.');
+
+    const MARKER = '# Project wiki';
+    for (const out of [first, second]) {
+      // Stable-first is an ORDER claim, so assert the order on real output.
+      expect(out.indexOf('# Token optimization is active')).toBe(0);
+      expect(out.indexOf('# Standing rules')).toBeGreaterThan(0);
+      expect(out.indexOf(MARKER)).toBeGreaterThan(out.indexOf('# Standing rules'));
+    }
+
+    // The volatile block genuinely differs, or the prefix claim is vacuous.
+    expect(first.slice(first.indexOf(MARKER))).not.toBe(
+      second.slice(second.indexOf(MARKER))
+    );
+    expect(first).toContain('npx jest');
+    expect(first).not.toContain('webpack bundler');
+    expect(second).toContain('webpack bundler');
+    expect(second).not.toContain('npx jest');
+
+    // And everything ahead of it is the same bytes, which is what the cache
+    // charges for.
+    expect(first.slice(0, first.indexOf(MARKER))).toBe(
+      second.slice(0, second.indexOf(MARKER))
+    );
+
+    try {
+      rmSync(project, { recursive: true, force: true });
+    } catch {
+      /* windows keeps handles open briefly */
+    }
   });
 });

--- a/tests/hooks/contradicts.test.mjs
+++ b/tests/hooks/contradicts.test.mjs
@@ -9,11 +9,13 @@
  * utility while the dispute is open.
  */
 
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { putNodeWithEdges, load, nodeId } from '../../hooks-core/wiki.mjs';
+import { putNode, putEdge, putNodeWithEdges, load, nodeId } from '../../hooks-core/wiki.mjs';
 import { contradict, hasOutstandingContradiction, audit } from '../../hooks-core/curate.mjs';
+import { indexFile, serve } from '../../hooks-core/staleness.mjs';
+import { forTouch, sessionIndex } from '../../hooks-core/inject.mjs';
 
 let dir;
 
@@ -121,5 +123,142 @@ describe('contradicts', () => {
     expect(graph.edges.some((e) => e.edge === 'contradicts')).toBe(false);
     // A self-edge would block promotion forever with no second claim to choose.
     expect(hasOutstandingContradiction(graph, 'old')).toBe(false);
+  });
+});
+
+/**
+ * A dispute is worthless unless the reader is told about it.
+ *
+ * `WIKI_GRAPH.md` argues for an edge rather than an overwrite so that a reader
+ * "sees both claims and the disagreement between them". Recording the edge and
+ * then serving the finding as though nothing disagreed with it throws that away,
+ * so these tests are about the serve and render path rather than the store.
+ */
+describe('disclosing a dispute when a finding is served', () => {
+  let workspace;
+
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), 'contra-ws-'));
+    // Pin the arm: forTouch delivers nothing in the holdout, and the arm is
+    // chosen from the (random) workspace path, so this suite would otherwise be
+    // red about one run in ten for the correct reason.
+    process.env.TOKEN_OPTIMIZER_HOLDOUT = '0';
+  });
+
+  afterEach(() => {
+    delete process.env.TOKEN_OPTIMIZER_HOLDOUT;
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  const write = (name, text) => {
+    const path = join(workspace, name);
+    writeFileSync(path, text);
+    return path;
+  };
+
+  /** An anchored finding, which is what forTouch and staleness both need. */
+  function anchored(key, claim, path, extra = {}) {
+    const id = putNode(dir, {
+      kind: 'finding', key, claim, confidence: 0.9, type: 'finding', ...extra,
+    });
+    putEdge(dir, id, 'derived_from', nodeId('file', path));
+    return id;
+  }
+
+  const findingIn = (list, key) => list.find((f) => f.key === key);
+
+  test('serve names the other claim, at both ends of the disagreement', () => {
+    contradict(dir, { key: 'old', byKey: 'new', reason: 're-derived' });
+    const graph = load(dir);
+    const served = serve(graph, [...graph.nodes.values()].filter((n) => n.kind === 'finding'));
+
+    // A key rather than the claim, because the reader can call wiki_query with
+    // a key and the injection path pays for every character it renders.
+    expect(findingIn(served, 'old').contradicted).toBe(true);
+    expect(findingIn(served, 'old').contradictedBy).toBe('new');
+    expect(findingIn(served, 'new').contradicted).toBe(true);
+    expect(findingIn(served, 'new').contradictedBy).toBe('old');
+  });
+
+  test('serve leaves an undisputed finding unmarked', () => {
+    contradict(dir, { key: 'old', byKey: 'new', reason: 're-derived' });
+    const graph = load(dir);
+    const served = serve(graph, [...graph.nodes.values()].filter((n) => n.kind === 'finding'));
+
+    const other = findingIn(served, 'other');
+    expect(other.contradicted).toBeUndefined();
+    expect(other.contradictedBy).toBeUndefined();
+  });
+
+  test('serve discloses on a type an anchor cannot invalidate', () => {
+    // `command` findings take serve's early return: they are not content
+    // dependent, so no anchor is read and no staleness is computed. Another
+    // finding can still disagree with them, and that path is the one that would
+    // silently drop the disclosure.
+    putNodeWithEdges(dir, {
+      kind: 'finding', key: 'cmd', claim: 'run npm test', confidence: 0.9, type: 'command',
+    });
+    contradict(dir, { key: 'cmd', byKey: 'new', reason: 'npx jest does not work here' });
+
+    const graph = load(dir);
+    const served = serve(graph, [...graph.nodes.values()].filter((n) => n.kind === 'finding'));
+    expect(findingIn(served, 'cmd').contradicted).toBe(true);
+    expect(findingIn(served, 'cmd').contradictedBy).toBe('new');
+  });
+
+  test('the injected text names the disagreement and the key to query', () => {
+    const path = write('a.ts', 'export function f() { return 1; }');
+    indexFile(dir, path);
+    anchored('served', 'f returns 1', path);
+    putNodeWithEdges(dir, {
+      kind: 'finding', key: 'rebuttal', claim: 'f returns 2', confidence: 0.9,
+    });
+    contradict(dir, { key: 'served', byKey: 'rebuttal', reason: 're-derived' });
+
+    const out = forTouch(dir, load(dir), path, { sessionId: 's1' });
+    expect(out).toContain('f returns 1');
+    expect(out).toContain('DISPUTED by rebuttal');
+    // A dispute is not staleness. Nothing touched the anchor, so none of the
+    // staleness vocabulary may appear on the strength of a disagreement.
+    expect(out).not.toContain('STALE');
+    expect(out).not.toContain('recorded earlier');
+  });
+
+  test('a stale finding that is also disputed discloses both, separately', () => {
+    const path = write('b.ts', 'export function g() { return 1; }');
+    indexFile(dir, path);
+    anchored('both', 'g returns 1', path);
+    putNodeWithEdges(dir, {
+      kind: 'finding', key: 'rebuttal2', claim: 'g returns 3', confidence: 0.9,
+    });
+    contradict(dir, { key: 'both', byKey: 'rebuttal2', reason: 'read it again' });
+    // The anchor changes underneath the claim: staleness with evidence, which is
+    // the strong stale form Task 4 guards.
+    writeFileSync(path, 'export function g() { return 2; }');
+
+    // SNAPSHOTS ON. `load` leaves them out by default, and without the stored
+    // `before` there is no diff to rebuild -- which is the softened stale form,
+    // not the strong one this test is about.
+    const graph = load(dir, { snapshots: true });
+    const served = serve(graph, [...graph.nodes.values()].filter((n) => n.kind === 'finding'));
+    const finding = findingIn(served, 'both');
+    expect(finding.stale).toBe(true);
+    expect(finding.staleEvidence).toBe(true);
+    expect(finding.contradicted).toBe(true);
+
+    const out = forTouch(dir, load(dir, { snapshots: true }), path, { sessionId: 's2' });
+    expect(out).toContain('STALE (');
+    expect(out).toContain('What changed:');
+    expect(out).toContain('DISPUTED by rebuttal2');
+  });
+
+  test('the session index lists a disputed finding as disputed', () => {
+    contradict(dir, { key: 'old', byKey: 'new', reason: 're-derived' });
+    const index = sessionIndex(dir, load(dir), { relevantFindingIds: ['old'] });
+
+    // The first thing a session reads must not present a disputed claim as
+    // settled either.
+    expect(index).toContain('[DISPUTED by new]');
+    expect(index).toContain('f returns 1');
   });
 });

--- a/tests/hooks/contradicts.test.mjs
+++ b/tests/hooks/contradicts.test.mjs
@@ -806,8 +806,23 @@ describe('the contradiction reason reaches a reader', () => {
   let dir4;
   let workspace;
   let anchorPath;
+  let priorHoldout;
 
   beforeEach(() => {
+    // PIN THE ARM, the same way `disclosing a dispute when a finding is served`
+    // above does. `forTouch` returns null for an anchor in the measurement
+    // holdout -- a withheld baseline is the point of the holdout, not a failure
+    // -- and the arm is drawn from a hash of the (random) workspace path, so a
+    // suite asserting on injected text without pinning is red a fraction of runs
+    // for the CORRECT reason. Observed: two failures in four full-suite runs,
+    // `expect(null).toContain('DISPUTED by claim-b')`.
+    //
+    // THE PRIOR VALUE IS RESTORED RATHER THAN DELETED, matching
+    // command-injection.test.mjs: another suite in the same worker may have set
+    // it, and `afterEach` runs even when the test threw, which is the `finally`
+    // this needs.
+    priorHoldout = process.env.TOKEN_OPTIMIZER_HOLDOUT;
+    process.env.TOKEN_OPTIMIZER_HOLDOUT = '0';
     dir4 = mkdtempSync(join(tmpdir(), 'contra-reason-'));
     workspace = mkdtempSync(join(tmpdir(), 'contra-reason-ws-'));
     anchorPath = canonicalPath(join(workspace, 'k.ts'));
@@ -823,6 +838,8 @@ describe('the contradiction reason reaches a reader', () => {
   });
 
   afterEach(() => {
+    if (priorHoldout === undefined) delete process.env.TOKEN_OPTIMIZER_HOLDOUT;
+    else process.env.TOKEN_OPTIMIZER_HOLDOUT = priorHoldout;
     rmSync(dir4, { recursive: true, force: true });
     rmSync(workspace, { recursive: true, force: true });
   });

--- a/tests/hooks/contradicts.test.mjs
+++ b/tests/hooks/contradicts.test.mjs
@@ -364,67 +364,136 @@ describe('answers', () => {
 });
 
 /**
- * `answers` inferred from the graph itself, with no session id anywhere.
+ * `answers` inferred from the graph itself, session-scoped and requiring
+ * full coverage.
  *
- * Neither real caller (`plugin/hooks/harvest-worker.mjs`, `wiki_write`) can be
- * relied on to supply a session id that resolves to a task node -- one is
- * opt-in gated, the other's `sessionId` is optional and nothing populates it.
- * But the structural harvest writes `task -[derived_from]-> file` on every
- * tool call, unconditionally, so the task is DERIVABLE: it is whichever task
- * actually touched the SAME anchors this finding resolved to, not simply the
- * newest task node in the graph.
+ * An adversarial review of an earlier version (scanning the whole graph for
+ * ANY task sharing ANY anchor, tie broken by recency) constructed four cases
+ * where that attributes a finding to the WRONG task: a stale prior session, a
+ * concurrent session that touched the anchor a millisecond later, a task that
+ * covered only SOME of the finding's anchors, and a tie-break comparator that
+ * contradicted its own documented direction. The fix scopes candidates to
+ * `nodeId('task', sessionId)` -- the ONE task node this session's own
+ * structural harvest could have written -- and requires it to cover EVERY
+ * anchor. That is at most one candidate, so there is nothing left to break a
+ * tie between; see `taskForAnchors`'s own comment in harvest-write.mjs for why
+ * the old tie-break machinery was deleted rather than "fixed".
  */
 describe('answers inferred by anchor traversal', () => {
-  /** Forces the next Date.now() to differ, so edge `at` order is not a coin flip. */
-  function tick() {
-    const start = Date.now();
-    while (Date.now() === start) { /* spin until the clock moves */ }
-  }
-
-  it('picks the task that touched the anchor over a more recently active task that did not', () => {
+  it('attributes to the current session’s task when it covers every one of the finding’s anchors', () => {
     const dir3 = mkdtempSync(join(tmpdir(), 'ans-trav-'));
-    const file = join(dir3, 'a.ts');
-    writeFileSync(file, 'export const a = 1;');
-    indexFile(dir3, file, 'export const a = 1;');
+    const fileA = join(dir3, 'a1.ts');
+    const fileB = join(dir3, 'a2.ts');
+    writeFileSync(fileA, 'export const a1 = 1;');
+    writeFileSync(fileB, 'export const a2 = 1;');
+    indexFile(dir3, fileA, 'export const a1 = 1;');
+    indexFile(dir3, fileB, 'export const a2 = 1;');
 
-    putNode(dir3, { kind: 'task', key: 'right-task' });
-    putEdge(dir3, nodeId('task', 'right-task'), 'derived_from', nodeId('file', file));
-
-    tick();
-    // Created and touched something LATER, but never this anchor. A "most
-    // recent task" rule would pick this one, which is exactly the wrong
-    // provenance the traversal exists to avoid.
-    putNode(dir3, { kind: 'task', key: 'decoy-task' });
+    putNode(dir3, { kind: 'task', key: 'session-a' });
+    putEdge(dir3, nodeId('task', 'session-a'), 'derived_from', nodeId('file', fileA));
+    putEdge(dir3, nodeId('task', 'session-a'), 'derived_from', nodeId('file', fileB));
 
     writeHarvested(
       dir3,
-      [{ type: 'finding', claim: 'a is 1 by default', anchors: [file], confidence: 0.8 }],
-      { sessionId: 's1', projectRoot: dir3 }
+      [{ type: 'finding', claim: 'a1 and a2 both default to 1', anchors: [fileA, fileB], confidence: 0.8 }],
+      { sessionId: 'session-a', projectRoot: dir3 }
     );
 
     const graph = load(dir3);
     const edge = graph.edges.find((e) => e.edge === 'answers');
     expect(edge).toBeDefined();
-    expect(edge.to).toBe(nodeId('task', 'right-task'));
+    expect(edge.to).toBe(nodeId('task', 'session-a'));
+    rmSync(dir3, { recursive: true, force: true });
+  });
+
+  it('writes no edge when the current session’s task covers only some of the anchors (overlap, not coverage)', () => {
+    const dir3 = mkdtempSync(join(tmpdir(), 'ans-trav-'));
+    const fileA = join(dir3, 'b1.ts');
+    const fileB = join(dir3, 'b2.ts');
+    writeFileSync(fileA, 'export const b1 = 1;');
+    writeFileSync(fileB, 'export const b2 = 1;');
+    indexFile(dir3, fileA, 'export const b1 = 1;');
+    indexFile(dir3, fileB, 'export const b2 = 1;');
+
+    putNode(dir3, { kind: 'task', key: 'session-b' });
+    // Touched ONLY fileA. A finding about both files is not this task's work.
+    putEdge(dir3, nodeId('task', 'session-b'), 'derived_from', nodeId('file', fileA));
+
+    writeHarvested(
+      dir3,
+      [{ type: 'finding', claim: 'b1 and b2 both default to 1', anchors: [fileA, fileB], confidence: 0.8 }],
+      { sessionId: 'session-b', projectRoot: dir3 }
+    );
+
+    const graph = load(dir3);
+    expect(graph.edges.some((e) => e.edge === 'answers')).toBe(false);
+    rmSync(dir3, { recursive: true, force: true });
+  });
+
+  it('ignores a DIFFERENT (stale, prior) session’s task even when it fully covers the anchor', () => {
+    const dir3 = mkdtempSync(join(tmpdir(), 'ans-trav-'));
+    const file = join(dir3, 'c.ts');
+    writeFileSync(file, 'export const c = 1;');
+    indexFile(dir3, file, 'export const c = 1;');
+
+    // An OLDER session that genuinely touched this file, days or weeks ago in
+    // spirit -- nothing about it is wrong except that it is not THIS session.
+    putNode(dir3, { kind: 'task', key: 'old-session' });
+    putEdge(dir3, nodeId('task', 'old-session'), 'derived_from', nodeId('file', file));
+
+    // THIS session never touched the file at all -- it reasoned from injected
+    // memory and wrote a finding about it anyway.
+    writeHarvested(
+      dir3,
+      [{ type: 'finding', claim: 'c is 1 by default', anchors: [file], confidence: 0.8 }],
+      { sessionId: 'new-session', projectRoot: dir3 }
+    );
+
+    const graph = load(dir3);
+    expect(graph.edges.some((e) => e.edge === 'answers')).toBe(false);
+    rmSync(dir3, { recursive: true, force: true });
+  });
+
+  it('ignores a CONCURRENT session’s task, even one that touched the anchor a moment later', () => {
+    const dir3 = mkdtempSync(join(tmpdir(), 'ans-trav-'));
+    const file = join(dir3, 'd.ts');
+    writeFileSync(file, 'export const d = 1;');
+    indexFile(dir3, file, 'export const d = 1;');
+
+    // A second window on the same repository, touching the SAME file at
+    // whatever moment `putEdge` happens to run -- no `tick()` here on
+    // purpose: the point is that timing must not matter at all, not that this
+    // session loses a race.
+    putNode(dir3, { kind: 'task', key: 'other-window' });
+    putEdge(dir3, nodeId('task', 'other-window'), 'derived_from', nodeId('file', file));
+
+    writeHarvested(
+      dir3,
+      [{ type: 'finding', claim: 'd is 1 by default', anchors: [file], confidence: 0.8 }],
+      { sessionId: 'this-window', projectRoot: dir3 }
+    );
+
+    const graph = load(dir3);
+    expect(graph.edges.some((e) => e.edge === 'answers')).toBe(false);
     rmSync(dir3, { recursive: true, force: true });
   });
 
   it('writes no edge when no task shares an anchor with the finding', () => {
     const dir3 = mkdtempSync(join(tmpdir(), 'ans-trav-'));
-    const file = join(dir3, 'b.ts');
+    const file = join(dir3, 'e.ts');
     const other = join(dir3, 'unrelated.ts');
-    writeFileSync(file, 'export const b = 1;');
-    writeFileSync(other, 'export const c = 1;');
-    indexFile(dir3, file, 'export const b = 1;');
-    indexFile(dir3, other, 'export const c = 1;');
+    writeFileSync(file, 'export const e = 1;');
+    writeFileSync(other, 'export const f = 1;');
+    indexFile(dir3, file, 'export const e = 1;');
+    indexFile(dir3, other, 'export const f = 1;');
 
-    putNode(dir3, { kind: 'task', key: 'unrelated-task' });
-    putEdge(dir3, nodeId('task', 'unrelated-task'), 'derived_from', nodeId('file', other));
+    putNode(dir3, { kind: 'task', key: 'session-e' });
+    putEdge(dir3, nodeId('task', 'session-e'), 'derived_from', nodeId('file', other));
 
     writeHarvested(
       dir3,
-      [{ type: 'finding', claim: 'b is 1 by default', anchors: [file], confidence: 0.8 }],
-      { sessionId: 's1', projectRoot: dir3 }
+      [{ type: 'finding', claim: 'e is 1 by default', anchors: [file], confidence: 0.8 }],
+      { sessionId: 'session-e', projectRoot: dir3 }
     );
 
     const graph = load(dir3);
@@ -434,11 +503,12 @@ describe('answers inferred by anchor traversal', () => {
 
   it('lets an explicit taskId override traversal entirely', () => {
     const dir3 = mkdtempSync(join(tmpdir(), 'ans-trav-'));
-    const file = join(dir3, 'c.ts');
-    writeFileSync(file, 'export const c = 1;');
-    indexFile(dir3, file, 'export const c = 1;');
+    const file = join(dir3, 'g.ts');
+    writeFileSync(file, 'export const g = 1;');
+    indexFile(dir3, file, 'export const g = 1;');
 
-    // Traversal would find THIS one -- it actually touched the anchor.
+    // Traversal would find THIS one -- it is this session's task and it
+    // covers the anchor.
     putNode(dir3, { kind: 'task', key: 'inferred-task' });
     putEdge(dir3, nodeId('task', 'inferred-task'), 'derived_from', nodeId('file', file));
     // The caller supplies THIS one instead, and never touched the anchor.
@@ -446,8 +516,8 @@ describe('answers inferred by anchor traversal', () => {
 
     writeHarvested(
       dir3,
-      [{ type: 'finding', claim: 'c is 1 by default', anchors: [file], confidence: 0.8 }],
-      { sessionId: 's1', taskId: 'explicit-task', projectRoot: dir3 }
+      [{ type: 'finding', claim: 'g is 1 by default', anchors: [file], confidence: 0.8 }],
+      { sessionId: 'inferred-task', taskId: 'explicit-task', projectRoot: dir3 }
     );
 
     const graph = load(dir3);
@@ -457,54 +527,26 @@ describe('answers inferred by anchor traversal', () => {
     rmSync(dir3, { recursive: true, force: true });
   });
 
-  it('breaks a tie between two tasks that both touched the anchor by which touched it more recently', () => {
-    const dir3 = mkdtempSync(join(tmpdir(), 'ans-trav-'));
-    const file = join(dir3, 'd.ts');
-    writeFileSync(file, 'export const d = 1;');
-    indexFile(dir3, file, 'export const d = 1;');
-
-    putNode(dir3, { kind: 'task', key: 'older-task' });
-    putEdge(dir3, nodeId('task', 'older-task'), 'derived_from', nodeId('file', file));
-
-    tick();
-
-    putNode(dir3, { kind: 'task', key: 'newer-task' });
-    putEdge(dir3, nodeId('task', 'newer-task'), 'derived_from', nodeId('file', file));
-
-    writeHarvested(
-      dir3,
-      [{ type: 'finding', claim: 'd is 1 by default', anchors: [file], confidence: 0.8 }],
-      { sessionId: 's1', projectRoot: dir3 }
-    );
-
-    const graph = load(dir3);
-    const edge = graph.edges.find((e) => e.edge === 'answers');
-    expect(edge).toBeDefined();
-    expect(edge.to).toBe(nodeId('task', 'newer-task'));
-    rmSync(dir3, { recursive: true, force: true });
-  });
-
   it('does not mistake a prior finding’s own derived_from edge to the anchor for a task', () => {
-    // `derived_from` is also how a FINDING cites its anchors (the edges the
-    // main writeHarvested path always adds). Without a kind check, traversal
-    // would find this edge, see it points at the same anchor, and hand back
-    // the PRIOR FINDING's own node id as though it were the task -- a node
-    // that does exist, so the no-dangling check alone would not catch it.
+    // `derived_from` is also how a FINDING cites its anchors. The lookup is
+    // now a direct `nodeId('task', sessionId)` read, not a scan of every edge
+    // in the graph, so a finding's own edge is never even visited -- covered
+    // here as a construction guarantee, not a runtime filter.
     const dir3 = mkdtempSync(join(tmpdir(), 'ans-trav-'));
-    const file = join(dir3, 'i.ts');
-    writeFileSync(file, 'export const i = 1;');
-    indexFile(dir3, file, 'export const i = 1;');
+    const file = join(dir3, 'h.ts');
+    writeFileSync(file, 'export const h = 1;');
+    indexFile(dir3, file, 'export const h = 1;');
 
     putNodeWithEdges(
       dir3,
-      { kind: 'finding', key: 'prior-finding', claim: 'i was 1 once', confidence: 0.9, type: 'finding' },
+      { kind: 'finding', key: 'prior-finding', claim: 'h was 1 once', confidence: 0.9, type: 'finding' },
       [{ edge: 'derived_from', to: nodeId('file', file) }]
     );
 
     writeHarvested(
       dir3,
-      [{ type: 'finding', claim: 'i is 1 by default', anchors: [file], confidence: 0.8 }],
-      { sessionId: 's1', projectRoot: dir3 }
+      [{ type: 'finding', claim: 'h is 1 by default', anchors: [file], confidence: 0.8 }],
+      { sessionId: 'prior-finding', projectRoot: dir3 }
     );
 
     const graph = load(dir3);
@@ -632,6 +674,84 @@ describe('the derivation record', () => {
     expect(finding.derivation.operations).toHaveLength(5);
     expect(finding.derivation.operations[0].tool).toBe('tool-7');
     expect(finding.derivation.operations[4].tool).toBe('tool-3');
+    // An empty `operations` array is ambiguous by itself; the completeness
+    // flag is what says "more existed than the cap kept" here, versus
+    // "genuinely nothing happened" in the test below.
+    expect(finding.derivation.operationsComplete).toBe(false);
+    rmSync(dir3, { recursive: true, force: true });
+  });
+
+  it('declares its scope as file-surface only, and never joins a command-surface tool-outcome', () => {
+    // `adapter.mjs` stores the COMMAND TEXT in `anchor` for a command-surface
+    // event; `anchorLabel` produces a canonical FILE PATH. There is no join
+    // key in common, so a build or test run can never appear here -- this
+    // asserts that gap is declared, not silently absent.
+    const dir3 = mkdtempSync(join(tmpdir(), 'deriv-'));
+    const file = join(dir3, 'j.ts');
+    writeFileSync(file, 'export const j = 1;');
+
+    record(dir3, {
+      kind: 'tool-outcome',
+      surface: 'command',
+      anchor: 'npm test',
+      toolName: 'Bash',
+      success: true,
+      at: Date.now(),
+    });
+
+    writeHarvested(
+      dir3,
+      [{ type: 'finding', claim: 'j is 1 by default', anchors: [file], confidence: 0.8 }],
+      { sessionId: 's1', projectRoot: dir3 }
+    );
+
+    const graph = load(dir3);
+    const finding = [...graph.nodes.values()].find((n) => n.kind === 'finding');
+    expect(finding.derivation.operationsScope).toBe('file');
+    expect(finding.derivation.operations).toHaveLength(0);
+    // Confirmed empty, not merely absent-looking: nothing was capped and the
+    // log was not truncated, so this IS "no file-surface operations matched".
+    expect(finding.derivation.operationsComplete).toBe(true);
+    rmSync(dir3, { recursive: true, force: true });
+  });
+
+  it('marks operationsComplete false when the evidence log itself may have dropped older matches', () => {
+    // `MAX_BYTES` (metrics.mjs) is read from its env var ONCE, at module
+    // load -- already evaluated for this whole test run -- so overriding the
+    // env var per-test has no effect. Cross the real 2,000,000-byte default
+    // instead, with a single padded event, rather than fight the constant.
+    const dir3 = mkdtempSync(join(tmpdir(), 'deriv-'));
+    const file = join(dir3, 'k.ts');
+    writeFileSync(file, 'export const k = 1;');
+
+    // None of these match this finding's anchor at all -- the point is that
+    // TRUNCATION ALONE, independent of any match, must still mark the record
+    // incomplete: an older matching event could have been evicted before
+    // this join ever saw it.
+    record(dir3, {
+      kind: 'tool-outcome',
+      anchor: canonicalPath(join(dir3, 'padding.ts')).slice(0, 120),
+      toolName: 'Read',
+      success: true,
+      padding: 'x'.repeat(2_100_000),
+    });
+    record(dir3, {
+      kind: 'tool-outcome',
+      anchor: canonicalPath(join(dir3, 'other.ts')).slice(0, 120),
+      toolName: 'Read',
+      success: true,
+    });
+
+    writeHarvested(
+      dir3,
+      [{ type: 'finding', claim: 'k is 1 by default', anchors: [file], confidence: 0.8 }],
+      { sessionId: 's1', projectRoot: dir3 }
+    );
+
+    const graph = load(dir3);
+    const finding = [...graph.nodes.values()].find((n) => n.kind === 'finding');
+    expect(finding.derivation.operations).toHaveLength(0);
+    expect(finding.derivation.operationsComplete).toBe(false);
     rmSync(dir3, { recursive: true, force: true });
   });
 });

--- a/tests/hooks/contradicts.test.mjs
+++ b/tests/hooks/contradicts.test.mjs
@@ -16,6 +16,7 @@ import { putNode, putEdge, putNodeWithEdges, load, nodeId } from '../../hooks-co
 import { contradict, hasOutstandingContradiction, audit } from '../../hooks-core/curate.mjs';
 import { indexFile, serve } from '../../hooks-core/staleness.mjs';
 import { forTouch, sessionIndex } from '../../hooks-core/inject.mjs';
+import { restorationPlan } from '../../hooks-core/restore.mjs';
 
 let dir;
 
@@ -250,6 +251,28 @@ describe('disclosing a dispute when a finding is served', () => {
     expect(out).toContain('STALE (');
     expect(out).toContain('What changed:');
     expect(out).toContain('DISPUTED by rebuttal2');
+  });
+
+  test('the restore brief marks a disputed finding disputed too', () => {
+    // A dispute disclosed on the injection path and silent in a restore reads
+    // as "the dispute went away", so the restore brief goes through the same
+    // fields. `Likely next` is reached through a `related` edge, which is how
+    // co-occurrence recommends a file the session never opened.
+    const touched = write('touched.ts', 'export const a = 1;');
+    const predicted = write('predicted.ts', 'export function h() { return 1; }');
+    indexFile(dir, touched);
+    indexFile(dir, predicted);
+    putEdge(dir, nodeId('file', touched), 'related', nodeId('file', predicted));
+    anchored('restored', 'h returns 1', predicted);
+    putNodeWithEdges(dir, {
+      kind: 'finding', key: 'rebuttal3', claim: 'h returns 4', confidence: 0.9,
+    });
+    contradict(dir, { key: 'restored', byKey: 'rebuttal3', reason: 'read it again' });
+
+    const brief = restorationPlan(dir, load(dir), { recentAnchors: [touched] }).text;
+    expect(brief).toContain('## Likely next');
+    expect(brief).toContain('h returns 1');
+    expect(brief).toContain('(disputed by rebuttal3)');
   });
 
   test('the session index lists a disputed finding as disputed', () => {

--- a/tests/hooks/contradicts.test.mjs
+++ b/tests/hooks/contradicts.test.mjs
@@ -1,0 +1,125 @@
+/**
+ * The `contradicts` edge: recorded disagreement instead of a silent overwrite.
+ *
+ * `EDGE_KINDS` has declared this edge since the schema existed, `WIKI_GRAPH.md`
+ * gives it a paragraph as the design's departure from RAG, and `audit()` already
+ * read it. Nothing wrote it. The properties under test are the ones that make it
+ * worth being an edge at all: BOTH claims survive, the disagreement is
+ * addressable from either end, and neither end can be promoted on measured
+ * utility while the dispute is open.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { putNodeWithEdges, load, nodeId } from '../../hooks-core/wiki.mjs';
+import { contradict, hasOutstandingContradiction, audit } from '../../hooks-core/curate.mjs';
+
+let dir;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'contra-'));
+  putNodeWithEdges(dir, {
+    kind: 'finding', key: 'old', claim: 'f returns 1', confidence: 0.9, origin: 'harvested',
+  });
+  putNodeWithEdges(dir, {
+    kind: 'finding', key: 'new', claim: 'f returns 2', confidence: 0.9, origin: 'human',
+  });
+  // A third finding involved in nothing. Without it, a `hasOutstandingContradiction`
+  // that simply returned true would pass every assertion below.
+  putNodeWithEdges(dir, {
+    kind: 'finding', key: 'other', claim: 'g returns 3', confidence: 0.9, origin: 'harvested',
+  });
+});
+
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+const findingByKey = (graph, key) =>
+  [...graph.nodes.values()].find((n) => n.kind === 'finding' && n.key === key);
+
+describe('contradicts', () => {
+  test('records a disagreement as a directed edge rather than an overwrite', () => {
+    expect(contradict(dir, { key: 'old', byKey: 'new', reason: 're-derived' })).toBe(true);
+
+    const graph = load(dir);
+    const edges = graph.edges.filter((e) => e.edge === 'contradicts');
+    expect(edges).toHaveLength(1);
+    // Direction carries meaning: the contradictOR is the source. Reversed, the
+    // graph says the established claim disputes the new one.
+    expect(edges[0].from).toBe(nodeId('finding', 'new'));
+    expect(edges[0].to).toBe(nodeId('finding', 'old'));
+  });
+
+  test('leaves the contradicted finding present, not retired', () => {
+    contradict(dir, { key: 'old', byKey: 'new', reason: 're-derived' });
+    const old = findingByKey(load(dir), 'old');
+    expect(old).toBeDefined();
+    expect(old.retired).toBeFalsy();
+  });
+
+  test('leaves BOTH claims readable -- the whole reason this is an edge', () => {
+    contradict(dir, { key: 'old', byKey: 'new', reason: 're-derived' });
+    const graph = load(dir);
+
+    // putNode does not merge: it writes the record it is handed and `load`
+    // replaces the node wholesale. Annotating the target without spreading it
+    // back in blanks the claim, which is the overwrite this edge exists to
+    // avoid -- and it would still look "present, not retired" to the test above.
+    const old = findingByKey(graph, 'old');
+    expect(old.claim).toBe('f returns 1');
+    expect(old.confidence).toBe(0.9);
+    expect(old.origin).toBe('harvested');
+    expect(findingByKey(graph, 'new').claim).toBe('f returns 2');
+  });
+
+  test('records WHY the belief changed, capped', () => {
+    contradict(dir, { key: 'old', byKey: 'new', reason: 'x'.repeat(600) });
+    const old = findingByKey(load(dir), 'old');
+    expect(old.contradictionReason).toBe('x'.repeat(400));
+    expect(typeof old.contradictedAt).toBe('number');
+  });
+
+  test('surfaces both ends to audit, which needs a person to resolve them', () => {
+    contradict(dir, { key: 'old', byKey: 'new', reason: 're-derived' });
+    const keys = audit(load(dir)).contradicted.map((f) => f.key).sort();
+    expect(keys).toEqual(['new', 'old']);
+  });
+
+  test('reports an outstanding contradiction at BOTH ends, which blocks promotion', () => {
+    contradict(dir, { key: 'old', byKey: 'new', reason: 're-derived' });
+    const graph = load(dir);
+    expect(hasOutstandingContradiction(graph, 'old')).toBe(true);
+    // The design's named hazard is presenting "the new one as though it had
+    // always been true". Gating only the older claim leaves the newer one --
+    // which nothing here has adjudicated -- free to be promoted on measured
+    // utility alone, which is exactly what this gate exists to stop.
+    expect(hasOutstandingContradiction(graph, 'new')).toBe(true);
+    // And it is not simply true for everything.
+    expect(hasOutstandingContradiction(graph, 'other')).toBe(false);
+  });
+
+  test('reports no contradiction before one is recorded, or for an unknown key', () => {
+    const graph = load(dir);
+    expect(hasOutstandingContradiction(graph, 'old')).toBe(false);
+    expect(hasOutstandingContradiction(graph, 'nope')).toBe(false);
+  });
+
+  test('refuses a contradiction against a key that does not exist', () => {
+    expect(contradict(dir, { key: 'nope', byKey: 'new', reason: 'x' })).toBe(false);
+    expect(contradict(dir, { key: 'old', byKey: 'nope', reason: 'x' })).toBe(false);
+    // Nothing written: an edge pointing at an id nothing created is an
+    // un-invalidatable claim, and the annotation alone would assert a dispute
+    // with no disputant.
+    const graph = load(dir);
+    expect(graph.edges.some((e) => e.edge === 'contradicts')).toBe(false);
+    expect(findingByKey(graph, 'old').contradictedAt).toBeUndefined();
+  });
+
+  test('refuses a finding disagreeing with itself', () => {
+    expect(contradict(dir, { key: 'old', byKey: 'old', reason: 'x' })).toBe(false);
+    const graph = load(dir);
+    expect(graph.edges.some((e) => e.edge === 'contradicts')).toBe(false);
+    // A self-edge would block promotion forever with no second claim to choose.
+    expect(hasOutstandingContradiction(graph, 'old')).toBe(false);
+  });
+});

--- a/tests/hooks/contradicts.test.mjs
+++ b/tests/hooks/contradicts.test.mjs
@@ -18,6 +18,8 @@ import { indexFile, serve } from '../../hooks-core/staleness.mjs';
 import { forTouch, sessionIndex } from '../../hooks-core/inject.mjs';
 import { restorationPlan } from '../../hooks-core/restore.mjs';
 import { writeHarvested } from '../../hooks-core/harvest-write.mjs';
+import { canonicalPath } from '../../hooks-core/paths.mjs';
+import { record } from '../../hooks-core/metrics.mjs';
 
 let dir;
 
@@ -358,5 +360,278 @@ describe('answers', () => {
     const graph = load(dir2);
     expect(graph.edges.some((e) => e.edge === 'answers')).toBe(false);
     rmSync(dir2, { recursive: true, force: true });
+  });
+});
+
+/**
+ * `answers` inferred from the graph itself, with no session id anywhere.
+ *
+ * Neither real caller (`plugin/hooks/harvest-worker.mjs`, `wiki_write`) can be
+ * relied on to supply a session id that resolves to a task node -- one is
+ * opt-in gated, the other's `sessionId` is optional and nothing populates it.
+ * But the structural harvest writes `task -[derived_from]-> file` on every
+ * tool call, unconditionally, so the task is DERIVABLE: it is whichever task
+ * actually touched the SAME anchors this finding resolved to, not simply the
+ * newest task node in the graph.
+ */
+describe('answers inferred by anchor traversal', () => {
+  /** Forces the next Date.now() to differ, so edge `at` order is not a coin flip. */
+  function tick() {
+    const start = Date.now();
+    while (Date.now() === start) { /* spin until the clock moves */ }
+  }
+
+  it('picks the task that touched the anchor over a more recently active task that did not', () => {
+    const dir3 = mkdtempSync(join(tmpdir(), 'ans-trav-'));
+    const file = join(dir3, 'a.ts');
+    writeFileSync(file, 'export const a = 1;');
+    indexFile(dir3, file, 'export const a = 1;');
+
+    putNode(dir3, { kind: 'task', key: 'right-task' });
+    putEdge(dir3, nodeId('task', 'right-task'), 'derived_from', nodeId('file', file));
+
+    tick();
+    // Created and touched something LATER, but never this anchor. A "most
+    // recent task" rule would pick this one, which is exactly the wrong
+    // provenance the traversal exists to avoid.
+    putNode(dir3, { kind: 'task', key: 'decoy-task' });
+
+    writeHarvested(
+      dir3,
+      [{ type: 'finding', claim: 'a is 1 by default', anchors: [file], confidence: 0.8 }],
+      { sessionId: 's1', projectRoot: dir3 }
+    );
+
+    const graph = load(dir3);
+    const edge = graph.edges.find((e) => e.edge === 'answers');
+    expect(edge).toBeDefined();
+    expect(edge.to).toBe(nodeId('task', 'right-task'));
+    rmSync(dir3, { recursive: true, force: true });
+  });
+
+  it('writes no edge when no task shares an anchor with the finding', () => {
+    const dir3 = mkdtempSync(join(tmpdir(), 'ans-trav-'));
+    const file = join(dir3, 'b.ts');
+    const other = join(dir3, 'unrelated.ts');
+    writeFileSync(file, 'export const b = 1;');
+    writeFileSync(other, 'export const c = 1;');
+    indexFile(dir3, file, 'export const b = 1;');
+    indexFile(dir3, other, 'export const c = 1;');
+
+    putNode(dir3, { kind: 'task', key: 'unrelated-task' });
+    putEdge(dir3, nodeId('task', 'unrelated-task'), 'derived_from', nodeId('file', other));
+
+    writeHarvested(
+      dir3,
+      [{ type: 'finding', claim: 'b is 1 by default', anchors: [file], confidence: 0.8 }],
+      { sessionId: 's1', projectRoot: dir3 }
+    );
+
+    const graph = load(dir3);
+    expect(graph.edges.some((e) => e.edge === 'answers')).toBe(false);
+    rmSync(dir3, { recursive: true, force: true });
+  });
+
+  it('lets an explicit taskId override traversal entirely', () => {
+    const dir3 = mkdtempSync(join(tmpdir(), 'ans-trav-'));
+    const file = join(dir3, 'c.ts');
+    writeFileSync(file, 'export const c = 1;');
+    indexFile(dir3, file, 'export const c = 1;');
+
+    // Traversal would find THIS one -- it actually touched the anchor.
+    putNode(dir3, { kind: 'task', key: 'inferred-task' });
+    putEdge(dir3, nodeId('task', 'inferred-task'), 'derived_from', nodeId('file', file));
+    // The caller supplies THIS one instead, and never touched the anchor.
+    putNode(dir3, { kind: 'task', key: 'explicit-task' });
+
+    writeHarvested(
+      dir3,
+      [{ type: 'finding', claim: 'c is 1 by default', anchors: [file], confidence: 0.8 }],
+      { sessionId: 's1', taskId: 'explicit-task', projectRoot: dir3 }
+    );
+
+    const graph = load(dir3);
+    const edge = graph.edges.find((e) => e.edge === 'answers');
+    expect(edge).toBeDefined();
+    expect(edge.to).toBe(nodeId('task', 'explicit-task'));
+    rmSync(dir3, { recursive: true, force: true });
+  });
+
+  it('breaks a tie between two tasks that both touched the anchor by which touched it more recently', () => {
+    const dir3 = mkdtempSync(join(tmpdir(), 'ans-trav-'));
+    const file = join(dir3, 'd.ts');
+    writeFileSync(file, 'export const d = 1;');
+    indexFile(dir3, file, 'export const d = 1;');
+
+    putNode(dir3, { kind: 'task', key: 'older-task' });
+    putEdge(dir3, nodeId('task', 'older-task'), 'derived_from', nodeId('file', file));
+
+    tick();
+
+    putNode(dir3, { kind: 'task', key: 'newer-task' });
+    putEdge(dir3, nodeId('task', 'newer-task'), 'derived_from', nodeId('file', file));
+
+    writeHarvested(
+      dir3,
+      [{ type: 'finding', claim: 'd is 1 by default', anchors: [file], confidence: 0.8 }],
+      { sessionId: 's1', projectRoot: dir3 }
+    );
+
+    const graph = load(dir3);
+    const edge = graph.edges.find((e) => e.edge === 'answers');
+    expect(edge).toBeDefined();
+    expect(edge.to).toBe(nodeId('task', 'newer-task'));
+    rmSync(dir3, { recursive: true, force: true });
+  });
+
+  it('does not mistake a prior finding’s own derived_from edge to the anchor for a task', () => {
+    // `derived_from` is also how a FINDING cites its anchors (the edges the
+    // main writeHarvested path always adds). Without a kind check, traversal
+    // would find this edge, see it points at the same anchor, and hand back
+    // the PRIOR FINDING's own node id as though it were the task -- a node
+    // that does exist, so the no-dangling check alone would not catch it.
+    const dir3 = mkdtempSync(join(tmpdir(), 'ans-trav-'));
+    const file = join(dir3, 'i.ts');
+    writeFileSync(file, 'export const i = 1;');
+    indexFile(dir3, file, 'export const i = 1;');
+
+    putNodeWithEdges(
+      dir3,
+      { kind: 'finding', key: 'prior-finding', claim: 'i was 1 once', confidence: 0.9, type: 'finding' },
+      [{ edge: 'derived_from', to: nodeId('file', file) }]
+    );
+
+    writeHarvested(
+      dir3,
+      [{ type: 'finding', claim: 'i is 1 by default', anchors: [file], confidence: 0.8 }],
+      { sessionId: 's1', projectRoot: dir3 }
+    );
+
+    const graph = load(dir3);
+    expect(graph.edges.some((e) => e.edge === 'answers')).toBe(false);
+    rmSync(dir3, { recursive: true, force: true });
+  });
+});
+
+/**
+ * The derivation record: the checkable half of provenance.
+ *
+ * A session or task id says WHERE a claim came from. It never says whether
+ * that derivation still applies -- so alongside `answers`, every newly
+ * written finding also gets a small, bounded `derivation` record: the hash
+ * each anchor carried at claim time (new information; the `derived_from`
+ * edges already say WHICH anchors, so this does not restate that), and
+ * whatever matching `tool-outcome` evidence exists, reduced to only the
+ * fields that evidence actually carries.
+ */
+describe('the derivation record', () => {
+  it('records the hash each anchor carried at claim time', () => {
+    const dir3 = mkdtempSync(join(tmpdir(), 'deriv-'));
+    const file = join(dir3, 'e.ts');
+    writeFileSync(file, 'export const e = 1;');
+
+    writeHarvested(
+      dir3,
+      [{ type: 'finding', claim: 'e is 1 by default', anchors: [file], confidence: 0.8 }],
+      { sessionId: 's1', projectRoot: dir3 }
+    );
+
+    const graph = load(dir3);
+    const fileNode = graph.nodes.get(nodeId('file', file));
+    const finding = [...graph.nodes.values()].find((n) => n.kind === 'finding');
+    expect(finding.derivation).toBeDefined();
+    expect(finding.derivation.anchors[nodeId('file', file)]).toBe(fileNode.hash);
+    rmSync(dir3, { recursive: true, force: true });
+  });
+
+  it('includes only the fields a matching tool-outcome event actually evidences', () => {
+    const dir3 = mkdtempSync(join(tmpdir(), 'deriv-'));
+    const file = join(dir3, 'f.ts');
+    writeFileSync(file, 'export const f = 1;');
+
+    record(dir3, {
+      kind: 'tool-outcome',
+      anchor: canonicalPath(file).slice(0, 120),
+      toolName: 'Read',
+      success: true,
+      at: Date.now(),
+    });
+
+    writeHarvested(
+      dir3,
+      [{ type: 'finding', claim: 'f is 1 by default', anchors: [file], confidence: 0.8 }],
+      { sessionId: 's1', projectRoot: dir3 }
+    );
+
+    const graph = load(dir3);
+    const finding = [...graph.nodes.values()].find((n) => n.kind === 'finding');
+    expect(finding.derivation.operations).toHaveLength(1);
+    const op = finding.derivation.operations[0];
+    expect(op.tool).toBe('Read');
+    expect(op.success).toBe(true);
+    // Not fabricated: this pipeline's tool-outcome events carry no exit code
+    // or output today, so neither key is present rather than invented.
+    expect(op.exit).toBeUndefined();
+    expect(op.output).toBeUndefined();
+    rmSync(dir3, { recursive: true, force: true });
+  });
+
+  it('ignores a tool-outcome event anchored to a different file', () => {
+    const dir3 = mkdtempSync(join(tmpdir(), 'deriv-'));
+    const file = join(dir3, 'g.ts');
+    const other = join(dir3, 'other.ts');
+    writeFileSync(file, 'export const g = 1;');
+
+    record(dir3, {
+      kind: 'tool-outcome',
+      anchor: canonicalPath(other).slice(0, 120),
+      toolName: 'Read',
+      success: true,
+      at: Date.now(),
+    });
+
+    writeHarvested(
+      dir3,
+      [{ type: 'finding', claim: 'g is 1 by default', anchors: [file], confidence: 0.8 }],
+      { sessionId: 's1', projectRoot: dir3 }
+    );
+
+    const graph = load(dir3);
+    const finding = [...graph.nodes.values()].find((n) => n.kind === 'finding');
+    expect(finding.derivation.operations).toHaveLength(0);
+    rmSync(dir3, { recursive: true, force: true });
+  });
+
+  it('bounds the number of operations recorded, keeping the most recent', () => {
+    const dir3 = mkdtempSync(join(tmpdir(), 'deriv-'));
+    const file = join(dir3, 'h.ts');
+    writeFileSync(file, 'export const h = 1;');
+    const label = canonicalPath(file).slice(0, 120);
+
+    const base = Date.now() - 1000;
+    for (let i = 0; i < 8; i++) {
+      record(dir3, {
+        kind: 'tool-outcome',
+        anchor: label,
+        toolName: `tool-${i}`,
+        success: true,
+        at: base + i,
+      });
+    }
+
+    writeHarvested(
+      dir3,
+      [{ type: 'finding', claim: 'h is 1 by default', anchors: [file], confidence: 0.8 }],
+      { sessionId: 's1', projectRoot: dir3 }
+    );
+
+    const graph = load(dir3);
+    const finding = [...graph.nodes.values()].find((n) => n.kind === 'finding');
+    // Capped -- this is not a replay log -- and the most RECENT of the 8,
+    // not the first 5 written.
+    expect(finding.derivation.operations).toHaveLength(5);
+    expect(finding.derivation.operations[0].tool).toBe('tool-7');
+    expect(finding.derivation.operations[4].tool).toBe('tool-3');
+    rmSync(dir3, { recursive: true, force: true });
   });
 });

--- a/tests/hooks/contradicts.test.mjs
+++ b/tests/hooks/contradicts.test.mjs
@@ -787,3 +787,89 @@ describe('the derivation record', () => {
     rmSync(dir3, { recursive: true, force: true });
   });
 });
+
+/**
+ * THE REASON A PERSON TYPED HAD NO READER.
+ *
+ * `contradict` stores `contradictionReason` -- up to 400 characters of human
+ * explanation -- on every call, and until this it was read by nothing outside
+ * this file's own "records WHY the belief changed" test. The dispute disclosure
+ * named the other key and stopped; `audit` counts ends; the dashboard detail view
+ * renders neither `contradictionReason` nor `contradictedAt`. Someone typed why
+ * one claim contradicts another and it was seen by nobody.
+ *
+ * NOTE ON THE GUARD THAT DID NOT CATCH THIS. The reachability check scans
+ * EXPORTS, so an unread RECORD FIELD is invisible to it -- correct code that
+ * nothing calls, in the one shape the guard cannot see.
+ */
+describe('the contradiction reason reaches a reader', () => {
+  let dir4;
+  let workspace;
+  let anchorPath;
+
+  beforeEach(() => {
+    dir4 = mkdtempSync(join(tmpdir(), 'contra-reason-'));
+    workspace = mkdtempSync(join(tmpdir(), 'contra-reason-ws-'));
+    anchorPath = canonicalPath(join(workspace, 'k.ts'));
+    writeFileSync(anchorPath, 'export function k() { return 1; }');
+    indexFile(dir4, anchorPath);
+    const id = putNode(dir4, {
+      kind: 'finding', key: 'claim-a', claim: 'k returns 1', confidence: 0.9, type: 'finding',
+    });
+    putEdge(dir4, id, 'derived_from', nodeId('file', anchorPath));
+    putNodeWithEdges(dir4, {
+      kind: 'finding', key: 'claim-b', claim: 'k returns 2', confidence: 0.9,
+    });
+  });
+
+  afterEach(() => {
+    rmSync(dir4, { recursive: true, force: true });
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  const servedFindings = () => {
+    const graph = load(dir4);
+    return serve(graph, [...graph.nodes.values()].filter((n) => n.kind === 'finding'));
+  };
+
+  test('serve carries it, at BOTH ends of the disagreement', () => {
+    contradict(dir4, { key: 'claim-a', byKey: 'claim-b', reason: 'read the tests, it returns 2' });
+    const served = servedFindings();
+    // `contradict` annotates only the contradicted end, so a disclosure reading
+    // its own record alone would tell one side of the dispute why and leave the
+    // other side pointing at a key with no explanation.
+    expect(served.find((f) => f.key === 'claim-a').contradictionReason)
+      .toBe('read the tests, it returns 2');
+    expect(served.find((f) => f.key === 'claim-b').contradictionReason)
+      .toBe('read the tests, it returns 2');
+  });
+
+  test('the injection disclosure renders it beside the key', () => {
+    contradict(dir4, { key: 'claim-a', byKey: 'claim-b', reason: 'read the tests, it returns 2' });
+    const out = forTouch(dir4, load(dir4), anchorPath, { sessionId: 'reason-1' });
+    expect(out).toContain('DISPUTED by claim-b');
+    expect(out).toContain('Reason given: read the tests, it returns 2');
+  });
+
+  test('an empty reason renders nothing, rather than an empty label', () => {
+    contradict(dir4, { key: 'claim-a', byKey: 'claim-b', reason: '   ' });
+    const served = servedFindings().find((f) => f.key === 'claim-a');
+    expect(served.contradicted).toBe(true);
+    expect(served.contradictionReason).toBeUndefined();
+    const out = forTouch(dir4, load(dir4), anchorPath, { sessionId: 'reason-2' });
+    expect(out).toContain('DISPUTED by claim-b');
+    expect(out).not.toContain('Reason given:');
+  });
+
+  test('a long reason is truncated where it is rendered, not where it is stored', () => {
+    const reason = 'x'.repeat(400);
+    contradict(dir4, { key: 'claim-a', byKey: 'claim-b', reason });
+    // Stored and served in full: `wiki_query` is a detail view and pays no
+    // injection budget.
+    expect(servedFindings().find((f) => f.key === 'claim-a').contradictionReason).toBe(reason);
+    // Rendered short, because `fit` prices this string against the budget.
+    const out = forTouch(dir4, load(dir4), anchorPath, { sessionId: 'reason-3' });
+    expect(out).toContain(`Reason given: ${'x'.repeat(140)}...`);
+    expect(out).not.toContain('x'.repeat(141));
+  });
+});

--- a/tests/hooks/contradicts.test.mjs
+++ b/tests/hooks/contradicts.test.mjs
@@ -17,6 +17,7 @@ import { contradict, hasOutstandingContradiction, audit } from '../../hooks-core
 import { indexFile, serve } from '../../hooks-core/staleness.mjs';
 import { forTouch, sessionIndex } from '../../hooks-core/inject.mjs';
 import { restorationPlan } from '../../hooks-core/restore.mjs';
+import { writeHarvested } from '../../hooks-core/harvest-write.mjs';
 
 let dir;
 
@@ -283,5 +284,79 @@ describe('disclosing a dispute when a finding is served', () => {
     // settled either.
     expect(index).toContain('[DISPUTED by new]');
     expect(index).toContain('f returns 1');
+  });
+});
+
+/**
+ * The `answers` edge: a finding back to the task that produced it.
+ *
+ * The last of `EDGE_KINDS` with no write site. Its whole point is provenance
+ * traversal -- "which session established this, and from what" -- so what is
+ * under test is that the edge appears when a real task node exists, and is
+ * refused rather than left dangling when it does not.
+ */
+describe('answers', () => {
+  it('links a finding to the task that produced it', () => {
+    const dir2 = mkdtempSync(join(tmpdir(), 'ans-'));
+    const file = join(dir2, 'x.ts');
+    writeFileSync(file, 'export const x = 1;');
+    indexFile(dir2, file, 'export const x = 1;');
+    putNodeWithEdges(dir2, { kind: 'task', key: 'task-1', prompt: 'why is x 1' });
+
+    writeHarvested(
+      dir2,
+      [{ type: 'finding', claim: 'x is 1 by default', anchors: [file], confidence: 0.8 }],
+      { sessionId: 's1', taskId: 'task-1', projectRoot: dir2 }
+    );
+
+    const graph = load(dir2);
+    const edge = graph.edges.find((e) => e.edge === 'answers');
+    expect(edge).toBeDefined();
+    expect(edge.to).toBe(nodeId('task', 'task-1'));
+    rmSync(dir2, { recursive: true, force: true });
+  });
+
+  it('writes no edge when the supplied taskId resolves to no existing task node', () => {
+    // A taskId that names nothing must not become a dangling edge -- the same
+    // discipline `resolveAnchor` already holds anchors to above.
+    const dir2 = mkdtempSync(join(tmpdir(), 'ans-'));
+    const file = join(dir2, 'y.ts');
+    writeFileSync(file, 'export const y = 1;');
+    indexFile(dir2, file, 'export const y = 1;');
+    // Deliberately no task node created for 'ghost-task'.
+
+    writeHarvested(
+      dir2,
+      [{ type: 'finding', claim: 'y is 1 by default', anchors: [file], confidence: 0.8 }],
+      { sessionId: 's1', taskId: 'ghost-task', projectRoot: dir2 }
+    );
+
+    const graph = load(dir2);
+    expect(graph.edges.some((e) => e.edge === 'answers')).toBe(false);
+    // The finding itself must still be written -- an unresolved taskId refuses
+    // only the edge, not the whole write.
+    expect([...graph.nodes.values()].some((n) => n.kind === 'finding')).toBe(true);
+    rmSync(dir2, { recursive: true, force: true });
+  });
+
+  it('writes no answers edge when no taskId is supplied at all', () => {
+    const dir2 = mkdtempSync(join(tmpdir(), 'ans-'));
+    const file = join(dir2, 'z.ts');
+    writeFileSync(file, 'export const z = 1;');
+    indexFile(dir2, file, 'export const z = 1;');
+    // A task node keyed by the SESSION id, present on purpose: omitting
+    // `taskId` must not silently fall back to `sessionId` and resolve against
+    // it anyway.
+    putNodeWithEdges(dir2, { kind: 'task', key: 's1' });
+
+    writeHarvested(
+      dir2,
+      [{ type: 'finding', claim: 'z is 1 by default', anchors: [file], confidence: 0.8 }],
+      { sessionId: 's1', projectRoot: dir2 }
+    );
+
+    const graph = load(dir2);
+    expect(graph.edges.some((e) => e.edge === 'answers')).toBe(false);
+    rmSync(dir2, { recursive: true, force: true });
   });
 });

--- a/tests/hooks/contradicts.test.mjs
+++ b/tests/hooks/contradicts.test.mjs
@@ -396,7 +396,7 @@ describe('answers inferred by anchor traversal', () => {
     writeHarvested(
       dir3,
       [{ type: 'finding', claim: 'a1 and a2 both default to 1', anchors: [fileA, fileB], confidence: 0.8 }],
-      { sessionId: 'session-a', projectRoot: dir3 }
+      { sessionId: 'session-a', authoritativeSessionId: 'session-a', projectRoot: dir3 }
     );
 
     const graph = load(dir3);
@@ -422,7 +422,7 @@ describe('answers inferred by anchor traversal', () => {
     writeHarvested(
       dir3,
       [{ type: 'finding', claim: 'b1 and b2 both default to 1', anchors: [fileA, fileB], confidence: 0.8 }],
-      { sessionId: 'session-b', projectRoot: dir3 }
+      { sessionId: 'session-b', authoritativeSessionId: 'session-b', projectRoot: dir3 }
     );
 
     const graph = load(dir3);
@@ -446,7 +446,7 @@ describe('answers inferred by anchor traversal', () => {
     writeHarvested(
       dir3,
       [{ type: 'finding', claim: 'c is 1 by default', anchors: [file], confidence: 0.8 }],
-      { sessionId: 'new-session', projectRoot: dir3 }
+      { sessionId: 'new-session', authoritativeSessionId: 'new-session', projectRoot: dir3 }
     );
 
     const graph = load(dir3);
@@ -470,7 +470,7 @@ describe('answers inferred by anchor traversal', () => {
     writeHarvested(
       dir3,
       [{ type: 'finding', claim: 'd is 1 by default', anchors: [file], confidence: 0.8 }],
-      { sessionId: 'this-window', projectRoot: dir3 }
+      { sessionId: 'this-window', authoritativeSessionId: 'this-window', projectRoot: dir3 }
     );
 
     const graph = load(dir3);
@@ -493,7 +493,7 @@ describe('answers inferred by anchor traversal', () => {
     writeHarvested(
       dir3,
       [{ type: 'finding', claim: 'e is 1 by default', anchors: [file], confidence: 0.8 }],
-      { sessionId: 'session-e', projectRoot: dir3 }
+      { sessionId: 'session-e', authoritativeSessionId: 'session-e', projectRoot: dir3 }
     );
 
     const graph = load(dir3);
@@ -517,7 +517,7 @@ describe('answers inferred by anchor traversal', () => {
     writeHarvested(
       dir3,
       [{ type: 'finding', claim: 'g is 1 by default', anchors: [file], confidence: 0.8 }],
-      { sessionId: 'inferred-task', taskId: 'explicit-task', projectRoot: dir3 }
+      { sessionId: 'inferred-task', authoritativeSessionId: 'inferred-task', taskId: 'explicit-task', projectRoot: dir3 }
     );
 
     const graph = load(dir3);
@@ -546,7 +546,39 @@ describe('answers inferred by anchor traversal', () => {
     writeHarvested(
       dir3,
       [{ type: 'finding', claim: 'h is 1 by default', anchors: [file], confidence: 0.8 }],
-      { sessionId: 'prior-finding', projectRoot: dir3 }
+      { sessionId: 'prior-finding', authoritativeSessionId: 'prior-finding', projectRoot: dir3 }
+    );
+
+    const graph = load(dir3);
+    expect(graph.edges.some((e) => e.edge === 'answers')).toBe(false);
+    rmSync(dir3, { recursive: true, force: true });
+  });
+
+  it('writes no edge from a plain sessionId alone, even when a real FOREIGN session fully covers the anchor', () => {
+    // Round 3's fix closed "unrelated or invented sessionId" and "a
+    // concurrent session's task wins a timing race". It did NOT close this:
+    // a caller (`wiki_write`) can supply a REAL, foreign session's id --
+    // named by mistake, or copied from a stale value -- and coverage cannot
+    // tell that session apart from the current one, because that OTHER
+    // session genuinely did touch these files. `sessionId` alone is not
+    // evidence; only `authoritativeSessionId` (never supplied by an
+    // unverified caller) may gate the traversal.
+    const dir3 = mkdtempSync(join(tmpdir(), 'ans-trav-'));
+    const file = join(dir3, 'i.ts');
+    writeFileSync(file, 'export const i = 1;');
+    indexFile(dir3, file, 'export const i = 1;');
+
+    // A genuinely real PRIOR session whose task actually covers the anchor.
+    putNode(dir3, { kind: 'task', key: 'foreign-real-session' });
+    putEdge(dir3, nodeId('task', 'foreign-real-session'), 'derived_from', nodeId('file', file));
+
+    // The caller names that session as `sessionId` -- exactly the shape an
+    // unverified MCP tool argument would take -- but supplies no
+    // `authoritativeSessionId`.
+    writeHarvested(
+      dir3,
+      [{ type: 'finding', claim: 'i is 1 by default', anchors: [file], confidence: 0.8 }],
+      { sessionId: 'foreign-real-session', projectRoot: dir3 }
     );
 
     const graph = load(dir3);

--- a/tests/hooks/lessons.test.mjs
+++ b/tests/hooks/lessons.test.mjs
@@ -18,8 +18,16 @@ import { ORIGIN_HUMAN, ORIGIN_HARVESTED } from '../../hooks-core/curate.mjs';
 import { writeHarvested } from '../../hooks-core/harvest-write.mjs';
 import { standingRules, safeTrigger } from '../../hooks-core/inject.mjs';
 import { wikiDir, load, putNode } from '../../hooks-core/wiki.mjs';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
-import { join } from 'path';
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+} from 'fs';
+import { join, relative } from 'path';
 import { tmpdir } from 'os';
 
 const TURNS = [
@@ -367,6 +375,65 @@ describe('a lesson is only stored if its trigger can ever fire', () => {
     expect(safeTrigger(good)).toBeInstanceOf(RegExp);
     const out = validateLessons(lesson(good), []);
     expect(out.rejected.filter((r) => r.reason === 'bad-trigger-regex')).toHaveLength(0);
+  });
+});
+
+describe('the lessons metrics event that nothing read', () => {
+  // harvest-worker.mjs used to call `record(dir, { kind: 'lessons', ... })` after every feedback
+  // pass. Nothing read it: netTokens only pulls from BALANCE_KINDS, which has no 'lessons' entry,
+  // so the cost never reached harvestTokens; report()/buildReport() filter on 'inject', 'harvest',
+  // 'standing', 'index' and 'query' but never 'lessons'; and no audit render surfaced it to a
+  // human. That is the inverse of the `query` defect (a reader with no producer) and the same
+  // shape as `tokensFullFile` before it (written and unread until someone noticed) -- a
+  // produced-and-never-consumed event, which is a cost with no benefit.
+  //
+  // The lesson CONTENT was never at risk: `writeHarvested` persists each lesson into the graph
+  // directly, and that is what lessons.mjs's real consumers (standingRules, the injector) query.
+  // Only the redundant metrics counter is gone.
+  //
+  // This is a source scan rather than a run of main(), because main() is a script entry point
+  // read from argv and driven by a real model call through extract() -- not an exported function
+  // a unit test can invoke without standing up that call. The property under test does not need
+  // it: no file that ships in the live hook path may emit this event kind at all.
+  const REPO = process.cwd();
+
+  function walk(dir, out = []) {
+    let entries;
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return out;
+    }
+    for (const entry of entries) {
+      const full = join(dir, entry);
+      let st;
+      try {
+        st = statSync(full);
+      } catch {
+        continue;
+      }
+      if (st.isDirectory()) {
+        // `lib` holds generated copies of hooks-core; scanning them is redundant with scanning
+        // the source they were generated from, and would double-report a single real offender.
+        if (['node_modules', 'dist', 'lib', '.git'].includes(entry)) continue;
+        walk(full, out);
+      } else if (/\.(mjs|js)$/.test(entry)) {
+        out.push(full);
+      }
+    }
+    return out;
+  }
+
+  it('is written by no file in the live hook path', () => {
+    const files = ['hooks-core', 'plugin/hooks'].flatMap((root) => walk(join(REPO, root)));
+    expect(files.length).toBeGreaterThan(10); // a scan matching nothing would pass vacuously
+
+    const offenders = files
+      .map((file) => ({ file, text: readFileSync(file, 'utf8') }))
+      .filter(({ text }) => /kind:\s*['"]lessons['"]/.test(text))
+      .map(({ file }) => relative(REPO, file));
+
+    expect(offenders).toEqual([]);
   });
 });
 

--- a/tests/hooks/lexical.test.mjs
+++ b/tests/hooks/lexical.test.mjs
@@ -1,0 +1,34 @@
+import { describe, it, expect } from '@jest/globals';
+import { tokenize, rank } from '../../hooks-core/lexical.mjs';
+
+const FINDINGS = [
+  { key: 'a', claim: 'the retry backoff is capped at thirty seconds' },
+  { key: 'b', claim: 'retry retry retry' },
+  { key: 'c', claim: 'the parser rejects a trailing comma' },
+];
+
+describe('lexical', () => {
+  it('splits on non-word characters and lowercases', () => {
+    expect(tokenize('Retry-Backoff, capped!')).toEqual(['retry', 'backoff', 'capped']);
+  });
+
+  it('ranks a specific match above a repetitive one', () => {
+    // This is the whole reason BM25 replaces substring matching: 'b' contains
+    // the term more often, 'a' is the better answer. Saturation must win.
+    const ranked = rank('retry backoff', FINDINGS);
+    expect(ranked[0].finding.key).toBe('a');
+  });
+
+  it('omits findings with no matching term rather than scoring them zero', () => {
+    const keys = rank('retry backoff', FINDINGS).map((r) => r.finding.key);
+    expect(keys).not.toContain('c');
+  });
+
+  it('respects limit', () => {
+    expect(rank('retry', FINDINGS, { limit: 1 })).toHaveLength(1);
+  });
+
+  it('returns nothing for an empty query rather than everything', () => {
+    expect(rank('   ', FINDINGS)).toEqual([]);
+  });
+});

--- a/tests/hooks/lexical.test.mjs
+++ b/tests/hooks/lexical.test.mjs
@@ -1,34 +1,155 @@
 import { describe, it, expect } from '@jest/globals';
 import { tokenize, rank } from '../../hooks-core/lexical.mjs';
 
+// Ordered so the correct BM25 winner ("a") is NOT first in input order --
+// it is listed last. This defeats two confounds a k1 sweep cannot catch,
+// because neither varies with k1:
+//   (1) a naive occurrence-count scorer: "retry" appears in "b" three times
+//       and in "a" once, so counting matches (with no idf, no saturation)
+//       ranks "b" first;
+//   (2) a substring/includes() filter that matches without ranking and
+//       returns hits in original array order: since "b" precedes "a" here,
+//       a no-sort passthrough also surfaces "b" first.
+// Only real BM25 -- which rewards "a" for matching a SECOND distinct term
+// ("backoff") and saturates "b"s triple repeat of one term -- returns "a"
+// first. See the per-test discrimination notes below and the fix report.
 const FINDINGS = [
-  { key: 'a', claim: 'the retry backoff is capped at thirty seconds' },
-  { key: 'b', claim: 'retry retry retry' },
   { key: 'c', claim: 'the parser rejects a trailing comma' },
+  { key: 'b', claim: 'retry retry retry' },
+  { key: 'a', claim: 'the retry backoff is capped at thirty seconds' },
+];
+
+// A second fixture where correct ranking requires reordering ALL THREE
+// matches relative to their input order, not just swapping two. Input
+// order is [short, padded, target]; the correct answer ("target", which
+// matches every query term once) is listed LAST, and the worst-by-real-BM25
+// match that still exists ("padded", a single term repeated eight times) is
+// listed BEFORE it.
+const REORDER_FINDINGS = [
+  { key: 'short', claim: 'timeout' },
+  { key: 'padded', claim: 'timeout timeout timeout timeout timeout timeout timeout timeout' },
+  { key: 'target', claim: 'the connection timeout and retry policy are both configurable' },
 ];
 
 describe('lexical', () => {
-  it('splits on non-word characters and lowercases', () => {
-    expect(tokenize('Retry-Backoff, capped!')).toEqual(['retry', 'backoff', 'capped']);
+  describe('tokenize', () => {
+    it('splits on non-word characters and lowercases', () => {
+      expect(tokenize('Retry-Backoff, capped!')).toEqual(['retry', 'backoff', 'capped']);
+    });
+
+    it('keeps the whole token and adds camelCase parts for a concatenated flag', () => {
+      // --skipLibCheck has no delimiter between "skip", "Lib" and "Check" --
+      // that concatenation is the silent recall gap this covers. The "--" is
+      // stripped as a non-word boundary same as before; the remaining run is
+      // kept whole (so a query for the concatenated form still matches) AND
+      // split into parts (so a query for the separated form matches too).
+      expect(tokenize('--skipLibCheck')).toEqual(['skiplibcheck', 'skip', 'lib', 'check']);
+    });
+
+    it('keeps the whole token and adds letter/digit parts for an error code', () => {
+      expect(tokenize('TS2345')).toEqual(['ts2345', 'ts', '2345']);
+    });
+
+    it('splits a camelCase identifier into parts without dropping the whole token', () => {
+      expect(tokenize('handleRequestTimeout')).toEqual([
+        'handlerequesttimeout',
+        'handle',
+        'request',
+        'timeout',
+      ]);
+    });
+
+    it('does not duplicate a token that has no internal camelCase or digit boundary', () => {
+      // A single already-delimited word (no case or letter/digit transition
+      // inside it) must appear exactly once, not once as the "whole token"
+      // and again as its only "part".
+      expect(tokenize('retry')).toEqual(['retry']);
+    });
   });
 
-  it('ranks a specific match above a repetitive one', () => {
-    // This is the whole reason BM25 replaces substring matching: 'b' contains
-    // the term more often, 'a' is the better answer. Saturation must win.
-    const ranked = rank('retry backoff', FINDINGS);
-    expect(ranked[0].finding.key).toBe('a');
-  });
+  describe('rank', () => {
+    it('ranks a specific match above a repetitive one -- and would not under either confound this replaces', () => {
+      // This is the whole reason BM25 replaces substring matching: "b"
+      // contains the term more often, "a" is the better answer. Saturation
+      // must win. Discrimination, given FINDINGS above lists "a" last:
+      //   (a) naive count-sort (raw term occurrences, sorted desc): "b" has
+      //       count 3 ("retry" x3), "a" has count 2 ("retry" + "backoff") --
+      //       returns ["b", "a"]. This test's expectation of ["a", "b"]
+      //       FAILS under it.
+      //   (b) no-sort passthrough (matches kept, original array order):
+      //       "b" precedes "a" in FINDINGS -- returns ["b", "a"]. FAILS.
+      // Real BM25 returns ["a", "b"]: PASSES.
+      const ranked = rank('retry backoff', FINDINGS);
+      expect(ranked.map((r) => r.finding.key)).toEqual(['a', 'b']);
+    });
 
-  it('omits findings with no matching term rather than scoring them zero', () => {
-    const keys = rank('retry backoff', FINDINGS).map((r) => r.finding.key);
-    expect(keys).not.toContain('c');
-  });
+    it('omits findings with no matching term rather than scoring them zero', () => {
+      // Discrimination: (a) naive count-sort and (b) no-sort passthrough
+      // both also omit a total non-match, so this assertion alone does not
+      // discriminate against either confound -- it is a correctness check,
+      // not a ranking one. The preceding and following tests carry that.
+      const keys = rank('retry backoff', FINDINGS).map((r) => r.finding.key);
+      expect(keys).not.toContain('c');
+    });
 
-  it('respects limit', () => {
-    expect(rank('retry', FINDINGS, { limit: 1 })).toHaveLength(1);
-  });
+    it('reorders all three matches relative to their input order when ranking requires it', () => {
+      // Input order is [short, padded, target]. Discrimination:
+      //   (a) naive count-sort: "padded" has the highest raw term count
+      //       ("timeout" x8), so it sorts first -- returns
+      //       ["padded", "target", "short"]. FAILS (expected "target" first).
+      //   (b) no-sort passthrough: all three match at least one term, so
+      //       nothing is filtered out and input order passes through
+      //       unchanged -- returns ["short", "padded", "target"], the exact
+      //       reverse of correct. FAILS.
+      // Real BM25 rewards "target" for matching all three distinct terms
+      // once each and saturates "padded"s eightfold repeat of a single
+      // term: returns ["target", "padded", "short"]. PASSES.
+      const ranked = rank('timeout retry policy', REORDER_FINDINGS);
+      expect(ranked.map((r) => r.finding.key)).toEqual(['target', 'padded', 'short']);
+    });
 
-  it('returns nothing for an empty query rather than everything', () => {
-    expect(rank('   ', FINDINGS)).toEqual([]);
+    it('keeps the correctly-ranked top results under a limit, not just the first K by input order', () => {
+      // Same fixture and discrimination as above, truncated to limit: 2.
+      //   (a) naive count-sort top 2: ["padded", "target"]. FAILS.
+      //   (b) no-sort passthrough top 2: ["short", "padded"]. FAILS.
+      // Real BM25 top 2: ["target", "padded"]. PASSES.
+      const ranked = rank('timeout retry policy', REORDER_FINDINGS, { limit: 2 });
+      expect(ranked.map((r) => r.finding.key)).toEqual(['target', 'padded']);
+    });
+
+    it('respects limit', () => {
+      expect(rank('retry', FINDINGS, { limit: 1 })).toHaveLength(1);
+    });
+
+    it('returns nothing for an empty query rather than everything', () => {
+      expect(rank('   ', FINDINGS)).toEqual([]);
+    });
+
+    it('finds a concatenated flag by its whole run-together form and by its split camelCase words', () => {
+      const findings = [
+        { key: 'ci', claim: 'CI fails because tsc reports skipLibCheck is required for the build to pass' },
+        { key: 'unrelated', claim: 'the retry backoff is capped at thirty seconds' },
+      ];
+      expect(rank('skiplibcheck', findings).map((r) => r.finding.key)).toEqual(['ci']);
+      expect(rank('skip lib check', findings).map((r) => r.finding.key)).toEqual(['ci']);
+    });
+
+    it('finds an error code by its whole run-together form and by its split letter/digit parts', () => {
+      const findings = [
+        { key: 'err', claim: 'the build fails with TS2345 because the argument type is wrong' },
+        { key: 'unrelated', claim: 'the retry backoff is capped at thirty seconds' },
+      ];
+      expect(rank('ts2345', findings).map((r) => r.finding.key)).toEqual(['err']);
+      expect(rank('ts 2345', findings).map((r) => r.finding.key)).toEqual(['err']);
+    });
+
+    it('finds a camelCase identifier by its whole run-together form and by its split words', () => {
+      const findings = [
+        { key: 'handler', claim: 'handleRequestTimeout retries after the socket closes early' },
+        { key: 'unrelated', claim: 'the retry backoff is capped at thirty seconds' },
+      ];
+      expect(rank('handlerequesttimeout', findings).map((r) => r.finding.key)).toEqual(['handler']);
+      expect(rank('handle request timeout', findings).map((r) => r.finding.key)).toEqual(['handler']);
+    });
   });
 });

--- a/tests/hooks/lexical.test.mjs
+++ b/tests/hooks/lexical.test.mjs
@@ -151,5 +151,53 @@ describe('lexical', () => {
       expect(rank('handlerequesttimeout', findings).map((r) => r.finding.key)).toEqual(['handler']);
       expect(rank('handle request timeout', findings).map((r) => r.finding.key)).toEqual(['handler']);
     });
+
+    describe('prefix matching (fragment recall)', () => {
+      // The exact demonstrated regression: `.includes('custom')` used to
+      // match a claim containing "customer"; pure token-exact BM25 does
+      // not, because "custom" and "customer" are different tokens and share
+      // no camelCase/letter-digit sub-token either. This is the case fixed.
+      it('finds a claim containing a longer word starting with the query term', () => {
+        const findings = [
+          { key: 'target', claim: 'customer data leak in the export pipeline' },
+          { key: 'unrelated', claim: 'the retry backoff is capped at thirty seconds' },
+        ];
+        expect(rank('custom', findings).map((r) => r.finding.key)).toEqual(['target']);
+      });
+
+      it('never lets a prefix-only match outscore an exact match of the same term, no matter how many prefix hits exist', () => {
+        // "exact" has one real occurrence of "custom". "prefix-only" has
+        // five occurrences of "customer" and none of "custom" itself -- if
+        // prefix credit scaled with count instead of being a flat, sub-one
+        // credit, five prefix hits could outweigh one real hit. It must not:
+        // "exact" ranks first.
+        const findings = [
+          { key: 'prefix-only', claim: 'customer customer customer customer customer' },
+          { key: 'exact', claim: 'custom configuration is required' },
+        ];
+        const ranked = rank('custom', findings);
+        expect(ranked.map((r) => r.finding.key)).toEqual(['exact', 'prefix-only']);
+      });
+
+      it('does not prefix-match a query term shorter than three characters', () => {
+        // "cu" is a real prefix of "customer" too, but a two-character
+        // fragment is a substring of most vocabularies -- eligible terms
+        // start at three characters.
+        const findings = [{ key: 'target', claim: 'customer data leak' }];
+        expect(rank('cu', findings)).toEqual([]);
+      });
+
+      it('composes with sub-token emission: a fragment of the whole run-together identifier still prefix-matches', () => {
+        // "skipl" is not one of the emitted sub-tokens ("skiplibcheck",
+        // "skip", "lib", "check") for skipLibCheck, but it IS a prefix of
+        // the whole run-together token "skiplibcheck" that tokenize()
+        // always keeps alongside the split parts.
+        const findings = [
+          { key: 'ci', claim: 'CI fails because tsc reports skipLibCheck is required for the build to pass' },
+          { key: 'unrelated', claim: 'the retry backoff is capped at thirty seconds' },
+        ];
+        expect(rank('skipl', findings).map((r) => r.finding.key)).toEqual(['ci']);
+      });
+    });
   });
 });

--- a/tests/hooks/observability.test.mjs
+++ b/tests/hooks/observability.test.mjs
@@ -194,7 +194,19 @@ describe('cross-client hook observability', () => {
       child.once('exit', (code) => resolve({ code, elapsed: Date.now() - started }));
     });
     expect(result.code).toBe(0);
-    expect(result.elapsed).toBeLessThan(2500);
+    // NO WALL-CLOCK BOUND. This used to assert `result.elapsed < 2500`: a
+    // wall-clock measurement of a spawned Node process, taken inside a suite that
+    // runs its files in parallel workers, against a budget whose slack over the
+    // 1,500 ms stdin wait is process startup. That is the identified source of
+    // this suite's intermittent failure, and it was never the thing under test.
+    //
+    // The gate that actually proves "fails open BEFORE the host timeout" is the
+    // RECORDED REASON below, and it is not a clock reading. `stdin_timeout` can
+    // only be written by the 1,500 ms stdin wait; had the child instead run past
+    // the 3,000 ms deadline configured above, `finish` would have stamped
+    // `internal_deadline_exceeded` and this test would fail no matter how the
+    // machine was loaded. Ordering is asserted by which mechanism won, not by how
+    // long the winner took.
 
     const file = readdirSync(join(workspace, 'timeout-logs')).find((name) =>
       name.endsWith('.jsonl')

--- a/tests/hooks/observability.test.mjs
+++ b/tests/hooks/observability.test.mjs
@@ -12,6 +12,9 @@ import {
 } from '../../hooks-core/observability.mjs';
 
 const ROOT = process.cwd();
+const PACKAGE_VERSION = JSON.parse(
+  readFileSync(join(ROOT, 'package.json'), 'utf8')
+).version;
 let workspace;
 let previous;
 
@@ -229,7 +232,7 @@ describe('cross-client hook observability', () => {
     const [event] = readEventsFrom(join(workspace, 'claude-logs'));
     expect(event).toMatchObject({
       schemaVersion: 2,
-      serviceVersion: '5.7.0',
+      serviceVersion: PACKAGE_VERSION,
       client: 'claude-code',
       hookEvent: 'pre-tool',
       outcome: 'timeout',
@@ -287,7 +290,7 @@ describe('cross-client hook observability', () => {
       expect(event).toMatchObject({
       schemaVersion: 2,
         service: 'token-optimizer',
-        serviceVersion: '5.7.0',
+        serviceVersion: PACKAGE_VERSION,
         client,
         hookEvent: 'pre-tool',
         outcome: 'success',

--- a/tests/hooks/pending-invalidation.test.mjs
+++ b/tests/hooks/pending-invalidation.test.mjs
@@ -1,0 +1,299 @@
+/**
+ * EAGER STALENESS, THROUGH THE HOOKS THAT ACTUALLY SHIP.
+ *
+ * `invalidateOnWrite` had 27 lines of documentation, its own tests, and one
+ * reference in shipped code: a COMMENT in the PreToolUse router saying it ran.
+ * It did not. staleness.mjs's header describes two invalidation paths and only
+ * one of them existed in production.
+ *
+ * SO THIS SUITE SPAWNS THE REAL ENTRY POINTS. A test that calls
+ * `queueInvalidation` and `drainInvalidations` itself proves nothing about the
+ * defect being fixed here -- that defect was precisely a correct function with
+ * passing tests and no caller, and three tasks on this branch have already
+ * shipped code whose tests passed while the product path went unexercised. The
+ * assertions that matter drive `plugin/hooks/post-tool.mjs` with a real Claude
+ * Code PostToolUse payload and then `plugin/hooks/pretooluse-router.mjs` with a
+ * real Read, and check that the finding comes back MARKED.
+ *
+ * WHY THE SESSION'S OWN WRITES ARE THE HARD CASE. Lazy staleness compares the
+ * anchor's stored hash against disk -- and both hooks call `indexFile` on every
+ * file they observe, which re-points that hash at the bytes just written. So a
+ * write the agent performed itself is invisible to the lazy check by the time
+ * the next retrieval happens, and the finding derived from the OLD content is
+ * served clean. That is the gap eager invalidation exists to close, and it is
+ * what the last test in the first block measures.
+ */
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals';
+import { spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { load, nodeId, putNodeWithEdges } from '../../hooks-core/wiki.mjs';
+import { indexFile } from '../../hooks-core/staleness.mjs';
+import {
+  drainInvalidations,
+  observedWrite,
+  queueInvalidation,
+} from '../../hooks-core/pending.mjs';
+
+const ROOT = process.cwd();
+const POST_TOOL = join(ROOT, 'plugin', 'hooks', 'post-tool.mjs');
+const PRE_TOOL = join(ROOT, 'plugin', 'hooks', 'pretooluse-router.mjs');
+
+const BEFORE = 'export function parse(x) {\n  return x.trim();\n}\n';
+const AFTER = 'export function parse(x) {\n  return JSON.parse(x);\n}\n';
+const CLAIM = 'parse() trims its input before returning';
+
+let project;
+let wiki;
+let stateDir;
+let file;
+
+beforeEach(() => {
+  project = mkdtempSync(join(tmpdir(), 'pending-proj-'));
+  // A repository marker, so projectRootFor lands on this tree rather than
+  // walking out of the temp directory.
+  mkdirSync(join(project, '.git'), { recursive: true });
+  wiki = mkdtempSync(join(tmpdir(), 'pending-wiki-'));
+  // PER TEST. Injection is once-per-session per finding and session state lives
+  // in a fixed directory keyed by session id, so a shared state directory makes
+  // the second RUN of a passing assertion see the finding suppressed.
+  stateDir = mkdtempSync(join(tmpdir(), 'pending-state-'));
+
+  file = join(project, 'parser.ts');
+  writeFileSync(file, BEFORE);
+  indexFile(wiki, file, BEFORE);
+  putNodeWithEdges(
+    wiki,
+    {
+      kind: 'finding',
+      key: 'parse-trims',
+      claim: CLAIM,
+      type: 'finding',
+      confidence: 0.95,
+      origin: 'human',
+    },
+    [{ edge: 'derived_from', to: nodeId('file', file) }]
+  );
+});
+
+afterEach(() => {
+  for (const dir of [project, wiki, stateDir]) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* windows can hold a handle briefly */
+    }
+  }
+});
+
+/**
+ * Drives one shipped hook exactly as Claude Code does.
+ *
+ * HOLDOUT PINNED OFF: `forTouch` takes part in a 10% measurement holdout, so an
+ * unpinned run would fail roughly one time in ten -- and a suite that fails one
+ * run in ten teaches people to re-run it rather than read it.
+ */
+function hook(entry, payload, { session, arm } = {}) {
+  const result = spawnSync(process.execPath, [entry], {
+    input: JSON.stringify({ cwd: project, session_id: session, ...payload }),
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      TOKEN_OPTIMIZER_WIKI_DIR: wiki,
+      TOKEN_OPTIMIZER_SHARED_DIR: wiki,
+      TOKEN_OPTIMIZER_STATE_DIR: stateDir,
+      TOKEN_OPTIMIZER_HOLDOUT: '0',
+      ...(arm ? { TOKEN_OPTIMIZER_EXPERIMENT_ARM: arm } : {}),
+    },
+    timeout: 30_000,
+  });
+  expect(result.status).toBe(0);
+  let parsed = {};
+  try {
+    parsed = JSON.parse(result.stdout || '{}');
+  } catch {
+    throw new Error(
+      `hook did not emit JSON: ${result.stdout}\n${result.stderr}`
+    );
+  }
+  return parsed.hookSpecificOutput?.additionalContext ?? '';
+}
+
+/** The PostToolUse payload Claude Code sends after a completed Edit. */
+const editPayload = (response = {}) => ({
+  hook_event_name: 'PostToolUse',
+  tool_name: 'Edit',
+  tool_input: {
+    file_path: file,
+    old_string: 'return x.trim();',
+    new_string: 'return JSON.parse(x);',
+  },
+  tool_response: {
+    filePath: file,
+    oldString: 'return x.trim();',
+    newString: 'return JSON.parse(x);',
+    userModified: false,
+    ...response,
+  },
+});
+
+const readPayload = () => ({
+  hook_event_name: 'PreToolUse',
+  tool_name: 'Read',
+  tool_input: { file_path: file },
+});
+
+const finding = () => load(wiki).nodes.get(nodeId('finding', 'parse-trims'));
+
+describe('a write the hooks observed', () => {
+  test('marks the dependent finding, driven through the real PostToolUse hook', () => {
+    // The edit has landed: this is the state the hook is invoked in.
+    writeFileSync(file, AFTER);
+
+    hook(POST_TOOL, editPayload({ originalFile: BEFORE }), {
+      session: 'eager-original',
+    });
+
+    const marked = finding();
+    expect(marked.stale).toBe(true);
+    // MARKED WITH EVIDENCE, which is the invariant staleness.mjs opens with: a
+    // stale finding is served, marked, and accompanied by the diff.
+    expect(marked.diff).toContain('JSON.parse');
+  });
+
+  test('reconstructs the before side when the host sends no original file', () => {
+    // Not every client puts the pre-edit file in its response. An edit is a
+    // known substitution, so reverting new_string to old_string in the text on
+    // disk reproduces the before side exactly.
+    writeFileSync(file, AFTER);
+
+    hook(POST_TOOL, editPayload(), { session: 'eager-reconstructed' });
+
+    expect(finding().stale).toBe(true);
+  });
+
+  test('is served MARKED on the next read, not as current', () => {
+    // THE ASSERTION THIS WHOLE TASK EXISTS FOR. Without the eager path the
+    // sequence below serves the claim clean: the post-tool capture re-indexes
+    // the anchor, so by this read the stored hash agrees with disk and lazy
+    // staleness has nothing left to notice.
+    writeFileSync(file, AFTER);
+    hook(POST_TOOL, editPayload({ originalFile: BEFORE }), {
+      session: 'eager-serve',
+    });
+
+    // A different session, because once-per-session-per-finding would suppress
+    // a second delivery inside the same one.
+    const context = hook(PRE_TOOL, readPayload(), {
+      session: 'eager-serve-read',
+    });
+
+    expect(context).toContain(CLAIM);
+    expect(context).toContain('STALE');
+    expect(context).toContain('JSON.parse');
+  });
+});
+
+describe('the queue defers the graph load rather than paying for it', () => {
+  test('survives the write hook and is applied by the next graph read', () => {
+    writeFileSync(file, AFTER);
+    // The `optimizer` arm has routing on and retrieval off, so nothing in this
+    // process reads the graph -- which is exactly the shape the queue exists
+    // for: the write hook records what it saw and does not load a megabyte of
+    // JSONL on the return path of the call.
+    hook(POST_TOOL, editPayload({ originalFile: BEFORE }), {
+      session: 'deferred',
+      arm: 'optimizer',
+    });
+
+    expect(existsSync(join(wiki, 'pending-invalidation.jsonl'))).toBe(true);
+    expect(finding().stale).toBeUndefined();
+
+    const context = hook(PRE_TOOL, readPayload(), { session: 'deferred-read' });
+
+    expect(context).toContain('STALE');
+    expect(finding().stale).toBe(true);
+    // Drained means drained: a record left behind would be re-applied on every
+    // tool call for the rest of the session.
+    expect(existsSync(join(wiki, 'pending-invalidation.jsonl'))).toBe(false);
+  });
+
+  test('a read queues nothing, so the hot path pays a field check and stops', () => {
+    hook(
+      POST_TOOL,
+      { hook_event_name: 'PostToolUse', ...readPayload() },
+      { session: 'read-only' }
+    );
+
+    expect(existsSync(join(wiki, 'pending-invalidation.jsonl'))).toBe(false);
+    expect(finding().stale).toBeUndefined();
+  });
+});
+
+describe('what is deliberately NOT queued', () => {
+  test('a write whose before side cannot be established', () => {
+    // Passing an unknown before side as '' would make invalidateOnWrite see
+    // every symbol in the file as changed and mark every finding anchored
+    // anywhere in it -- the over-marking its own comments call worse than the
+    // file-level staleness symbols were introduced to avoid.
+    writeFileSync(file, AFTER);
+    expect(
+      observedWrite(
+        { tool_input: { file_path: file, content: AFTER } },
+        { tool_response: { filePath: file, type: 'update' } }
+      )
+    ).toBeNull();
+  });
+
+  test('an edit whose new text now appears more than once', () => {
+    // Ambiguous: reverting the wrong occurrence fabricates a before side that
+    // never existed on disk.
+    // `retries = 1;` is now on both lines, so nothing in the payload says which
+    // of them this edit produced.
+    writeFileSync(file, 'retries = 1;\nretries = 1;\n');
+    expect(
+      observedWrite(
+        {
+          tool_input: { file_path: file, old_string: 'retries = 2;', new_string: 'retries = 1;' },
+        },
+        {}
+      )
+    ).toBeNull();
+  });
+
+  test('a rewrite that changed nothing', () => {
+    writeFileSync(file, BEFORE);
+    expect(
+      observedWrite(
+        { tool_input: { file_path: file, old_string: 'x', new_string: 'x' } },
+        { tool_response: { originalFile: BEFORE } }
+      )
+    ).toBeNull();
+  });
+});
+
+describe('the drain runs on a hook path, so it cannot throw or repeat', () => {
+  test('draining twice does not re-apply', () => {
+    queueInvalidation(wiki, { path: file, before: BEFORE, after: AFTER });
+    expect(drainInvalidations(wiki, load(wiki))).toBeGreaterThan(0);
+    expect(drainInvalidations(wiki, load(wiki))).toBe(0);
+  });
+
+  test('a malformed record is skipped rather than thrown on', () => {
+    queueInvalidation(wiki, { path: null, before: null, after: null });
+    writeFileSync(join(wiki, 'pending-invalidation.jsonl'), 'not json\n{"path":\n');
+    expect(() => drainInvalidations(wiki, load(wiki))).not.toThrow();
+    expect(existsSync(join(wiki, 'pending-invalidation.jsonl'))).toBe(false);
+  });
+
+  test('a queue that does not exist is not an error', () => {
+    expect(drainInvalidations(wiki, load(wiki))).toBe(0);
+  });
+});

--- a/tests/hooks/pending-invalidation.test.mjs
+++ b/tests/hooks/pending-invalidation.test.mjs
@@ -485,3 +485,79 @@ describe('the drain runs on a hook path, so it cannot throw or repeat', () => {
     expect(drainInvalidations(wiki, load(wiki))).toBe(0);
   });
 });
+
+/**
+ * A RECORD QUEUED WHILE THE DRAIN IS RUNNING MUST SURVIVE IT.
+ *
+ * The drain used to `readFileSync` the queue and then `rmSync` the SAME path. A
+ * post-tool hook appending between those two points had its record deleted
+ * having never been read -- and parallel tool calls inside one assistant turn are
+ * the ordinary way that happens, not an exotic race.
+ *
+ * AND A LOST RECORD IS PERMANENT, not degraded. The comment justifying the
+ * unconditional clear priced it as "a single missed eager mark that the lazy path
+ * still has a chance at". This suite's own header is the refutation: the lazy
+ * path compares the anchor's stored hash against disk, `indexFile` re-points that
+ * hash at the bytes the session just wrote, so for the session's own writes lazy
+ * is blind rather than late. Nothing else was ever going to catch it.
+ *
+ * THE INTERLEAVING IS DETERMINISTIC, not timed. `drainInvalidations` hands the
+ * caller's graph to `invalidateOnWrite`, so a graph whose `nodes` accessor queues
+ * a second record places that append exactly mid-drain, every run.
+ */
+describe('a concurrently queued record is not deleted unread', () => {
+  const queueFile = () => join(wiki, 'pending-invalidation.jsonl');
+
+  /** A graph that appends a second write to the queue the moment the drain reads it. */
+  const graphThatQueuesMidDrain = (onFirstAccess) => {
+    const graph = load(wiki);
+    let fired = false;
+    return {
+      get nodes() {
+        if (!fired) {
+          fired = true;
+          onFirstAccess();
+        }
+        return graph.nodes;
+      },
+      get edges() {
+        return graph.edges;
+      },
+    };
+  };
+
+  test('the record appended mid-drain is still there for the next drain', () => {
+    const second = join(project, 'other.ts');
+    writeFileSync(second, BEFORE);
+    indexFile(wiki, second, BEFORE);
+    putNodeWithEdges(
+      wiki,
+      { kind: 'finding', key: 'other-trims', claim: CLAIM, type: 'finding', confidence: 0.9 },
+      [{ edge: 'derived_from', to: nodeId('file', second) }]
+    );
+
+    queueInvalidation(wiki, { path: file, before: BEFORE, after: AFTER });
+    const graph = graphThatQueuesMidDrain(() => {
+      writeFileSync(second, AFTER);
+      queueInvalidation(wiki, { path: second, before: BEFORE, after: AFTER });
+    });
+
+    expect(drainInvalidations(wiki, graph)).toBeGreaterThan(0);
+    // The first drain took a CLAIM, so the concurrent append landed on a fresh
+    // queue rather than inside the file that was about to be deleted.
+    expect(existsSync(queueFile())).toBe(true);
+
+    // And it is applied, which is the point: the mark exists rather than being
+    // left to a lazy path that cannot see this write at all.
+    expect(drainInvalidations(wiki, load(wiki))).toBeGreaterThan(0);
+    expect(load(wiki).nodes.get(nodeId('finding', 'other-trims')).stale).toBe(true);
+  });
+
+  test('the claim file is not left behind for the next drain to re-apply', () => {
+    queueInvalidation(wiki, { path: file, before: BEFORE, after: AFTER });
+    expect(drainInvalidations(wiki, load(wiki))).toBeGreaterThan(0);
+    // Nothing to re-apply, and no queue: the claim was deleted, not the queue.
+    expect(existsSync(queueFile())).toBe(false);
+    expect(drainInvalidations(wiki, load(wiki))).toBe(0);
+  });
+});

--- a/tests/hooks/pending-invalidation.test.mjs
+++ b/tests/hooks/pending-invalidation.test.mjs
@@ -41,10 +41,11 @@ import {
   rmSync,
   writeFileSync,
 } from 'node:fs';
-import { join } from 'node:path';
+import { join, sep } from 'node:path';
 import { tmpdir } from 'node:os';
 import { load, nodeId, putNodeWithEdges } from '../../hooks-core/wiki.mjs';
 import { indexFile } from '../../hooks-core/staleness.mjs';
+import { forTouch } from '../../hooks-core/inject.mjs';
 import {
   drainInvalidations,
   observedWrites,
@@ -387,6 +388,81 @@ describe('SessionStart drains before it advertises anything', () => {
       session: 'ss-start',
     });
 
+    expect(finding().stale).toBe(true);
+  });
+});
+
+describe('the in-process drain memo, which no spawned hook can exercise', () => {
+  // WHY THESE CALL forTouch DIRECTLY. The memo is per PROCESS: it exists so a
+  // SECOND caller inside one hook invocation does not serve from a graph copy
+  // parsed before the drain. A spawned hook is one caller by construction, so
+  // the hazard is invisible from outside the process. forTouch is still the real
+  // product function the routers call -- what is skipped here is the spawn, not
+  // the code under test. The end-to-end proofs live in the blocks above.
+  //
+  // The holdout is pinned off per call: forTouch takes part in a 10% withheld
+  // arm, which would otherwise fail this roughly one run in ten.
+  const PRIOR = process.env.TOKEN_OPTIMIZER_HOLDOUT;
+  beforeEach(() => {
+    process.env.TOKEN_OPTIMIZER_HOLDOUT = '0';
+  });
+  afterEach(() => {
+    if (PRIOR === undefined) delete process.env.TOKEN_OPTIMIZER_HOLDOUT;
+    else process.env.TOKEN_OPTIMIZER_HOLDOUT = PRIOR;
+  });
+
+  // ONE GRAPH OBJECT, SHARED, which is the whole point: SessionStart parses the
+  // graph once and hands the SAME object to standingRules and then sessionIndex.
+  // Handing each caller a fresh load would hide the hazard entirely, because a
+  // fresh load is already post-drain.
+  const touch = (dir, graph) =>
+    forTouch(dir, graph, file, {
+      sessionId: `memo-${Math.random()}`,
+      alreadyInjected: new Set(),
+    }) || '';
+
+  test('two spellings of one directory share the memo', () => {
+    // A raw-string key would make these two directories, so the second caller
+    // would find an empty queue, mark nothing, and serve from the pre-drain copy
+    // it was handed -- the exact bug the memo exists to prevent.
+    const parsedBeforeAnyDrain = load(wiki);
+    queueInvalidation(wiki, { path: file, before: BEFORE, after: AFTER });
+    writeFileSync(file, AFTER);
+
+    const first = touch(wiki, parsedBeforeAnyDrain);
+    expect(first).toContain(CLAIM);
+    expect(first).toContain('STALE');
+
+    // The same directory, spelled three other ways: a trailing separator, a
+    // redundant `..` segment, and forward slashes where the platform uses
+    // backslashes. Each is handed the SAME pre-drain graph as the first caller.
+    for (const spelling of [
+      `${wiki}${sep}`,
+      `${wiki}${sep}sub${sep}..`,
+      wiki.split(sep).join('/'),
+    ]) {
+      const again = touch(spelling, parsedBeforeAnyDrain);
+      expect(again).toContain(CLAIM);
+      // Re-read because the memo was found, not served from the stale copy.
+      expect(again).toContain('STALE');
+    }
+  });
+
+  test('a queue arriving after an empty drain is still applied', () => {
+    // Memoising the NEGATIVE result would defer this invalidation to a future
+    // session. Nothing enforces that queueing precedes injection except the
+    // current shape of one hook branch.
+    const clean = touch(wiki, load(wiki));
+    expect(clean).toContain(CLAIM);
+    expect(clean).not.toContain('STALE');
+    expect(finding().stale).toBeUndefined();
+
+    queueInvalidation(wiki, { path: file, before: BEFORE, after: AFTER });
+    writeFileSync(file, AFTER);
+
+    const marked = touch(wiki, load(wiki));
+    expect(marked).toContain('STALE');
+    // The drain RAN, rather than being skipped by a remembered negative.
     expect(finding().stale).toBe(true);
   });
 });

--- a/tests/hooks/pending-invalidation.test.mjs
+++ b/tests/hooks/pending-invalidation.test.mjs
@@ -15,13 +15,22 @@
  * Code PostToolUse payload and then `plugin/hooks/pretooluse-router.mjs` with a
  * real Read, and check that the finding comes back MARKED.
  *
- * WHY THE SESSION'S OWN WRITES ARE THE HARD CASE. Lazy staleness compares the
- * anchor's stored hash against disk -- and both hooks call `indexFile` on every
- * file they observe, which re-points that hash at the bytes just written. So a
- * write the agent performed itself is invisible to the lazy check by the time
- * the next retrieval happens, and the finding derived from the OLD content is
- * served clean. That is the gap eager invalidation exists to close, and it is
- * what the last test in the first block measures.
+ * WHY THE SESSION'S OWN WRITES WERE NOT MERELY DEGRADED BUT UNCOVERED. Lazy
+ * staleness compares the anchor's stored hash against disk -- and both hooks
+ * call `indexFile` on every file they observe, which re-points that hash at the
+ * bytes just written (pretooluse-router.mjs twice, adapter.mjs once). So the
+ * lazy check compares a refreshed hash against the disk it came from and finds
+ * them equal: a write the agent performed ITSELF cannot be detected at all, and
+ * the finding derived from the pre-edit content is served CLEAN.
+ *
+ * So before the eager path was connected, staleness for a file the agent edited
+ * did not work AT ALL -- eager was dead code and lazy was defeated by
+ * re-indexing. Not "lazy-only, therefore degraded". Blind.
+ *
+ * TWO GRADES OF EVIDENCE ARE TESTED. A reconstructable edit yields a real diff;
+ * a whole-file write yields a hash comparison and no diff, and the ordering that
+ * makes that comparison meaningful -- drain before re-index -- is asserted end
+ * to end rather than argued from reading the call sites.
  */
 import { afterEach, beforeEach, describe, expect, test } from '@jest/globals';
 import { spawnSync } from 'node:child_process';
@@ -38,13 +47,14 @@ import { load, nodeId, putNodeWithEdges } from '../../hooks-core/wiki.mjs';
 import { indexFile } from '../../hooks-core/staleness.mjs';
 import {
   drainInvalidations,
-  observedWrite,
+  observedWrites,
   queueInvalidation,
 } from '../../hooks-core/pending.mjs';
 
 const ROOT = process.cwd();
 const POST_TOOL = join(ROOT, 'plugin', 'hooks', 'post-tool.mjs');
 const PRE_TOOL = join(ROOT, 'plugin', 'hooks', 'pretooluse-router.mjs');
+const SESSION_START = join(ROOT, 'plugin', 'hooks', 'session-start.mjs');
 
 const BEFORE = 'export function parse(x) {\n  return x.trim();\n}\n';
 const AFTER = 'export function parse(x) {\n  return JSON.parse(x);\n}\n';
@@ -150,6 +160,18 @@ const readPayload = () => ({
   tool_input: { file_path: file },
 });
 
+/** A whole-file write: the after side is on disk, the before side is nowhere. */
+const writePayload = () => ({
+  hook_event_name: 'PostToolUse',
+  tool_name: 'Write',
+  tool_input: { file_path: file, content: AFTER },
+  tool_response: { filePath: file, type: 'update' },
+});
+
+/** An apply_patch program, which names its targets and carries no file_path. */
+const PATCH = () =>
+  ['*** Begin Patch', `*** Update File: ${file}`, '-a', '+b', '*** End Patch'].join('\n');
+
 const finding = () => load(wiki).nodes.get(nodeId('finding', 'parse-trims'));
 
 describe('a write the hooks observed', () => {
@@ -237,45 +259,135 @@ describe('the queue defers the graph load rather than paying for it', () => {
   });
 });
 
-describe('what is deliberately NOT queued', () => {
-  test('a write whose before side cannot be established', () => {
+describe('the grade of evidence a payload can actually support', () => {
+  test('a whole-file write yields a path-only record, never a fabricated before', () => {
     // Passing an unknown before side as '' would make invalidateOnWrite see
     // every symbol in the file as changed and mark every finding anchored
-    // anywhere in it -- the over-marking its own comments call worse than the
-    // file-level staleness symbols were introduced to avoid.
+    // anywhere in it -- and the eager mark is a stored flag nothing clears.
     writeFileSync(file, AFTER);
     expect(
-      observedWrite(
-        { tool_input: { file_path: file, content: AFTER } },
+      observedWrites(
+        { tool_name: 'Write', tool_input: { file_path: file, content: AFTER } },
         { tool_response: { filePath: file, type: 'update' } }
       )
-    ).toBeNull();
+    ).toEqual([{ path: file }]);
   });
 
-  test('an edit whose new text now appears more than once', () => {
+  test('an edit whose new text now appears more than once falls back to hashes', () => {
     // Ambiguous: reverting the wrong occurrence fabricates a before side that
-    // never existed on disk.
-    // `retries = 1;` is now on both lines, so nothing in the payload says which
-    // of them this edit produced.
+    // never existed on disk. The path is still worth queueing.
     writeFileSync(file, 'retries = 1;\nretries = 1;\n');
     expect(
-      observedWrite(
+      observedWrites(
         {
+          tool_name: 'Edit',
           tool_input: { file_path: file, old_string: 'retries = 2;', new_string: 'retries = 1;' },
         },
         {}
       )
-    ).toBeNull();
+    ).toEqual([{ path: file }]);
   });
 
-  test('a rewrite that changed nothing', () => {
+  test('a rewrite that changed nothing yields no record at all', () => {
     writeFileSync(file, BEFORE);
     expect(
-      observedWrite(
-        { tool_input: { file_path: file, old_string: 'x', new_string: 'x' } },
+      observedWrites(
+        { tool_name: 'Edit', tool_input: { file_path: file, old_string: 'x', new_string: 'x' } },
         { tool_response: { originalFile: BEFORE } }
       )
-    ).toBeNull();
+    ).toEqual([]);
+  });
+
+  test('a read yields nothing, however readable the file is', () => {
+    expect(
+      observedWrites({ tool_name: 'Read', tool_input: { file_path: file } }, {})
+    ).toEqual([]);
+  });
+
+  test('a patch program with no file_path still yields its targets', () => {
+    // Codex and code-mode clients carry the whole patch as program text. The
+    // hash grade needs only the path, so those clients are covered too.
+    expect(
+      observedWrites(
+        {
+          tool_name: 'Edit',
+          tool_input: { command: PATCH() },
+        },
+        {}
+      )
+    ).toEqual([{ path: file }]);
+  });
+});
+
+describe('a whole-file write, which has no before side anywhere', () => {
+  test('the anchor is still PRE-write when the drain runs -- verified, not reasoned', () => {
+    // THE ORDERING THIS GRADE DEPENDS ON, asserted end to end rather than
+    // argued from reading the call sites. If `indexFile` ran before the drain,
+    // the stored hash would already agree with disk and nothing below would be
+    // marked -- which is exactly how the lazy path fails on the session's own
+    // writes.
+    //
+    // 1. a read, which refreshes the anchor to the PRE-write bytes
+    hook(PRE_TOOL, readPayload(), { session: 'order' });
+    // 2. the write lands
+    writeFileSync(file, AFTER);
+    // 3. the write hook, with a payload that carries no before side at all
+    hook(POST_TOOL, writePayload(), { session: 'order' });
+
+    const marked = finding();
+    expect(marked.stale).toBe(true);
+    expect(marked.staleReason).toMatch(/content hash changed/);
+    // NO DIFF, and that is honest rather than a shortfall: none is derivable.
+    expect(marked.diff).toBe('');
+  });
+
+  test('is served as changed-with-no-diff, distinguishable from a real diff', () => {
+    hook(PRE_TOOL, readPayload(), { session: 'order-serve' });
+    writeFileSync(file, AFTER);
+    hook(POST_TOOL, writePayload(), { session: 'order-serve' });
+
+    const context = hook(PRE_TOOL, readPayload(), {
+      session: 'order-serve-read',
+    });
+
+    expect(context).toContain(CLAIM);
+    // The reader can tell "changed, diff unknown" from "changed, here it is".
+    expect(context).toContain('no diff could be rebuilt');
+    expect(context).toContain('content hash changed');
+    expect(context).not.toContain('What changed:');
+  });
+
+  test('marks nothing when the bytes did not actually change', () => {
+    // The negative control. A path-only record is a QUESTION, not an
+    // assertion -- if the hash still matches, the finding stays clean. Without
+    // this, coverage would have been bought with false-stale, and the eager
+    // mark is permanent until the finding is re-recorded.
+    hook(PRE_TOOL, readPayload(), { session: 'unchanged' });
+    hook(POST_TOOL, writePayload(), { session: 'unchanged' });
+
+    expect(finding().stale).toBeUndefined();
+    const context = hook(PRE_TOOL, readPayload(), { session: 'unchanged-read' });
+    expect(context).toContain(CLAIM);
+    expect(context).not.toContain('recorded earlier');
+  });
+});
+
+describe('SessionStart drains before it advertises anything', () => {
+  test('a queue left by the last session is applied before the index is built', () => {
+    // The worst moment to be wrong: the session index is the first thing a
+    // session sees and nothing follows it that could qualify the claim.
+    writeFileSync(file, AFTER);
+    hook(POST_TOOL, editPayload({ originalFile: BEFORE }), {
+      session: 'ss-write',
+      arm: 'optimizer',
+    });
+    expect(finding().stale).toBeUndefined();
+
+    hook(SESSION_START, { hook_event_name: 'SessionStart' }, {
+      session: 'ss-start',
+    });
+
+    expect(finding().stale).toBe(true);
   });
 });
 

--- a/tests/hooks/reachability.test.mjs
+++ b/tests/hooks/reachability.test.mjs
@@ -88,8 +88,11 @@ const ALLOWED = new Map([
   // The guard blocks anything new joining this list.
   // ------------------------------------------------------------------
 
-  // WIRED ELSEWHERE -- leaves this list when that PR merges.
-  ['forTouch', 'WIRED by the injection PR: just-in-time delivery, imported by nothing before it.'],
+  // The forTouch entry lived here and said "WIRED by the injection PR ... leaves
+  // this list when that PR merges". The PR merged -- adapter.mjs and the
+  // PreToolUse router both call it -- and the entry stayed for however long
+  // after, which is what the assertion at the bottom of this file now prevents:
+  // an excuse that outlives its defect reads as a live one.
 
   // THE FORECAST IS WIRED, so nothing from it is listed here any more.
   // logForecast and calibrate are called by forecastPanel; forecastPanel and
@@ -116,10 +119,27 @@ const ALLOWED = new Map([
   ['recordRefresh', 'UNWIRED: records that a keep-warm refresh happened; pairs with recordRefreshOutcome, and neither is reached.'],
   ['manifestSize', 'UNWIRED: measures the installation manifest. Verified orphaned, and untested as well.'],
 
+  // THE contradicts EDGE, half wired. `audit()` has read this edge since the
+  // schema existed and nothing wrote it; `contradict` is now the writer, so the
+  // reader has a producer -- and the producer does not yet have a caller. Both
+  // call sites are NAMED, because "we might use it later" is the reason this
+  // list rejects: `contradict` belongs in the `/api/wiki/curate` action switch
+  // beside pin/retire/correct (src/server/wiki-routes.ts, outside the
+  // hooks-core-only scope of the change that added it), and
+  // `hasOutstandingContradiction` is the gate on Plan 2's utility-to-confidence
+  // promotion, which is the only path that can promote anything today. The
+  // assertion at the bottom of this file forces both entries out the moment
+  // those land.
+  ['contradict', 'UNWIRED: writes the contradicts edge; belongs in the /api/wiki/curate action switch, outside this change.'],
+  ['hasOutstandingContradiction', 'UNWIRED: gates confidence promotion on an open dispute; the promotion path it guards lands with Plan 2 utility.'],
+
   // ------------------------------------------------------------------
-  // GENUINE PUBLIC API.
+  // The policyText entry lived here as "GENUINE PUBLIC API", and it was stale
+  // in the same way forTouch was: adapter.mjs and the SessionStart hook both
+  // call it, so it was never an orphan needing an excuse. Being public API and
+  // having an in-repo caller are independent, and only the second is what this
+  // list is for.
   // ------------------------------------------------------------------
-  ['policyText', 'PUBLIC API: shared client briefing, consumed by every non-Claude adapter.'],
 ]);
 
 function walk(dir, out = []) {
@@ -276,11 +296,19 @@ describe('every exported function in the live hook path is reachable', () => {
   it('keeps the allowlist honest', () => {
     // An entry that no longer exists is a stale excuse, and a reason that says
     // nothing is not a reason.
-    const names = new Set(exports.map((e) => e.name));
+    const declaredAt = new Map(exports.map((e) => [e.name, e.file]));
     for (const [name, reason] of ALLOWED) {
       expect(typeof reason).toBe('string');
       expect(reason.length).toBeGreaterThan(20);
-      expect(names.has(name) || /constant|API/i.test(reason)).toBe(true);
+      expect(declaredAt.has(name) || /constant|API/i.test(reason)).toBe(true);
+
+      // AND THE LIST ONLY SHRINKS. An entry for a function that shipped code
+      // now calls is exactly as stale as one for a function that no longer
+      // exists, and nothing removed it -- so the excuse outlives the defect it
+      // described and the list grows monotonically, which is how "the guard
+      // blocks anything new joining this list" stops being true.
+      const file = declaredAt.get(name);
+      if (file) expect([name, usedInShippedCode(name, file)]).toEqual([name, false]);
     }
   });
 });

--- a/tests/hooks/reachability.test.mjs
+++ b/tests/hooks/reachability.test.mjs
@@ -114,7 +114,6 @@ const ALLOWED = new Map([
   ['recordRefreshOutcome', 'UNWIRED: records whether a keep-warm refresh was worth it; the deciding half runs without it.'],
 
   // SINGLETONS still to be traced.
-  ['cacheOrdered', 'UNWIRED: confines cache invalidation to the tail. A real optimisation with no caller.'],
   ['renderStanding', 'UNWIRED: renders the standing-context audit. auditStanding IS reachable, so only the report is orphaned.'],
   ['recordRefresh', 'UNWIRED: records that a keep-warm refresh happened; pairs with recordRefreshOutcome, and neither is reached.'],
   ['manifestSize', 'UNWIRED: measures the installation manifest. Verified orphaned, and untested as well.'],

--- a/tests/hooks/reachability.test.mjs
+++ b/tests/hooks/reachability.test.mjs
@@ -112,7 +112,6 @@ const ALLOWED = new Map([
 
   // SINGLETONS still to be traced.
   ['cacheOrdered', 'UNWIRED: confines cache invalidation to the tail. A real optimisation with no caller.'],
-  ['invalidateOnWrite', 'UNWIRED: the eager staleness path; invalidation currently happens only lazily, on the next touch.'],
   ['renderStanding', 'UNWIRED: renders the standing-context audit. auditStanding IS reachable, so only the report is orphaned.'],
   ['recordRefresh', 'UNWIRED: records that a keep-warm refresh happened; pairs with recordRefreshOutcome, and neither is reached.'],
   ['manifestSize', 'UNWIRED: measures the installation manifest. Verified orphaned, and untested as well.'],

--- a/tests/hooks/reachability.test.mjs
+++ b/tests/hooks/reachability.test.mjs
@@ -119,20 +119,6 @@ const ALLOWED = new Map([
   ['recordRefresh', 'UNWIRED: records that a keep-warm refresh happened; pairs with recordRefreshOutcome, and neither is reached.'],
   ['manifestSize', 'UNWIRED: measures the installation manifest. Verified orphaned, and untested as well.'],
 
-  // THE contradicts EDGE, half wired. `audit()` has read this edge since the
-  // schema existed and nothing wrote it; `contradict` is now the writer, so the
-  // reader has a producer -- and the producer does not yet have a caller. Both
-  // call sites are NAMED, because "we might use it later" is the reason this
-  // list rejects: `contradict` belongs in the `/api/wiki/curate` action switch
-  // beside pin/retire/correct (src/server/wiki-routes.ts, outside the
-  // hooks-core-only scope of the change that added it), and
-  // `hasOutstandingContradiction` is the gate on Plan 2's utility-to-confidence
-  // promotion, which is the only path that can promote anything today. The
-  // assertion at the bottom of this file forces both entries out the moment
-  // those land.
-  ['contradict', 'UNWIRED: writes the contradicts edge; belongs in the /api/wiki/curate action switch, outside this change.'],
-  ['hasOutstandingContradiction', 'UNWIRED: gates confidence promotion on an open dispute; the promotion path it guards lands with Plan 2 utility.'],
-
   // ------------------------------------------------------------------
   // The policyText entry lived here as "GENUINE PUBLIC API", and it was stale
   // in the same way forTouch was: adapter.mjs and the SessionStart hook both

--- a/tests/hooks/schema-compat.test.mjs
+++ b/tests/hooks/schema-compat.test.mjs
@@ -1,0 +1,115 @@
+/**
+ * The reader accepts a RANGE of schema versions, not one exact version.
+ *
+ * `load()` used to skip any record whose `v !== GRAPH_VERSION`, justified by a
+ * header comment claiming nothing had been released. The package ships on npm,
+ * so that justification was false AND load-bearing: the first version bump
+ * would have silently zeroed every existing user graph. `compactIfWasteful`
+ * carried the same comparison, giving a second route to the same loss.
+ *
+ * These tests are the net. They must keep failing if anyone reintroduces an
+ * equality check, and they deliberately assert that GRAPH_VERSION is still 1 --
+ * this work changed no record shape, so it takes no bump.
+ */
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { load, putNode, SUPPORTED_VERSIONS, upcast, GRAPH_VERSION } from '../../hooks-core/wiki.mjs';
+
+let dir;
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'schema-')); });
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+describe('schema compatibility', () => {
+  it('loads a v1 log with every node intact -- the regression that would have caught silent zeroing', () => {
+    writeFileSync(
+      join(dir, 'graph.jsonl'),
+      [
+        JSON.stringify({ t: 'n', v: 1, id: 'file:aaa', kind: 'file', key: '/x/a.ts', at: 1 }),
+        JSON.stringify({ t: 'n', v: 1, id: 'finding:bbb', kind: 'finding', key: 'k1', claim: 'c', at: 2 }),
+        JSON.stringify({ t: 'e', v: 1, from: 'finding:bbb', edge: 'derived_from', to: 'file:aaa', at: 3 }),
+      ].join('\n') + '\n'
+    );
+    const graph = load(dir);
+    expect(graph.nodes.size).toBe(2);
+    expect(graph.edges).toHaveLength(1);
+  });
+
+  it('still skips a record from a FUTURE version, because ignoring the future is safe', () => {
+    writeFileSync(
+      join(dir, 'graph.jsonl'),
+      JSON.stringify({ t: 'n', v: 9999, id: 'file:zzz', kind: 'file', key: '/x/z.ts', at: 1 }) + '\n'
+    );
+    expect(load(dir).nodes.size).toBe(0);
+  });
+
+  it('does not bump the version, because no record shape changed in this work', () => {
+    expect(GRAPH_VERSION).toBe(1);
+    expect(SUPPORTED_VERSIONS).toContain(1);
+  });
+
+  it('upcast is identity for a current-version record', () => {
+    const record = { t: 'n', v: GRAPH_VERSION, id: 'x', kind: 'file', key: '/a', at: 1 };
+    expect(upcast(record)).toEqual(record);
+  });
+
+  it('compaction preserves records of every supported version', () => {
+    // The second data-loss route: compactIfWasteful carried the same version
+    // filter as load, so a bump would drop old records while compacting.
+    //
+    // DEVIATION FROM THE BRIEF, which assumed `load(dir, { snapshots: true })`
+    // triggers compaction. It does not -- `compactIfWasteful` is called only
+    // from `appendAll`, inside the write lock, and only once the pair of logs
+    // exceeds the floor. So the real route is taken: a low floor plus appends,
+    // exactly as tests/hooks/graph-compaction.test.mjs does it. The assertion
+    // is unchanged -- the record count must survive the rewrite -- and the run
+    // asserts compaction actually happened rather than assuming it.
+    process.env.TOKEN_OPTIMIZER_GRAPH_COMPACT_BYTES = '20000';
+    try {
+      writeFileSync(
+        join(dir, 'graph.jsonl'),
+        Array.from({ length: 50 }, (_, i) =>
+          JSON.stringify({
+            t: 'n',
+            v: 1,
+            id: `file:${i}`,
+            kind: 'file',
+            key: `/x/${i}.ts`,
+            at: i,
+            // Padding, so 50 records clear the compaction floor without needing
+            // thousands of them.
+            pad: 'p'.repeat(500),
+          })
+        ).join('\n') + '\n'
+      );
+      const before = load(dir).nodes.size;
+      expect(before).toBe(50);
+
+      // Churn one id repeatedly: every append re-enters the lock and so gives
+      // compactIfWasteful its chance, and the superseded copies are what make
+      // the rewrite worth doing.
+      const APPENDS = 40;
+      for (let i = 0; i < APPENDS; i++) {
+        putNode(dir, { kind: 'file', key: '/src/churn.ts', hash: 'h' + i, pad: 'p'.repeat(500) });
+      }
+
+      // COMPACTION REALLY RAN, asserted rather than assumed. The marker is
+      // written only on the last line of a completed compaction, and the log
+      // holds fewer lines than the 50 + 40 that were appended to it, so records
+      // were genuinely reclaimed rather than merely accumulated.
+      expect(existsSync(join(dir, 'graph.compact.json'))).toBe(true);
+      const lines = readFileSync(join(dir, 'graph.jsonl'), 'utf8').split('\n').filter(Boolean).length;
+      expect(lines).toBeLessThan(50 + APPENDS);
+
+      const after = load(dir);
+      // Every pre-existing record survived, plus the one churned id.
+      expect(after.nodes.size).toBe(before + 1);
+      for (let i = 0; i < 50; i++) {
+        expect(after.nodes.has(`file:${i}`)).toBe(true);
+      }
+    } finally {
+      delete process.env.TOKEN_OPTIMIZER_GRAPH_COMPACT_BYTES;
+    }
+  });
+});

--- a/tests/hooks/schema-compat.test.mjs
+++ b/tests/hooks/schema-compat.test.mjs
@@ -7,15 +7,27 @@
  * would have silently zeroed every existing user graph. `compactIfWasteful`
  * carried the same comparison, giving a second route to the same loss.
  *
- * These tests are the net. They must keep failing if anyone reintroduces an
- * equality check, and they deliberately assert that GRAPH_VERSION is still 1 --
- * this work changed no record shape, so it takes no bump.
+ * These tests are the net, and the net has to work WITHOUT a hand-edited
+ * constant. With SUPPORTED_VERSIONS = [1] and GRAPH_VERSION = 1,
+ * `versions.includes(v)` and `v === GRAPH_VERSION` are extensionally identical,
+ * so any test pinned to the live constants passes under either -- it proves only
+ * that two currently-equivalent expressions are equivalent. That is why
+ * `readable` takes its version range as a PARAMETER: exercised against [1, 2] it
+ * distinguishes a range from an equality, and those cases cannot pass if anyone
+ * reverts the predicate.
+ *
+ * For the same reason nothing here asserts `GRAPH_VERSION === 1`. That assertion
+ * would force whoever eventually bumps the version to edit this file -- the file
+ * holding the net -- at exactly the moment they are most likely to weaken it.
+ * The invariants asserted instead are the ones that must survive a bump: the
+ * current version is supported, and support for the OLDEST version is never
+ * dropped.
  */
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, appendFileSync, readFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { load, putNode, SUPPORTED_VERSIONS, upcast, GRAPH_VERSION } from '../../hooks-core/wiki.mjs';
+import { load, putNode, readable, SUPPORTED_VERSIONS, upcast, GRAPH_VERSION } from '../../hooks-core/wiki.mjs';
 
 let dir;
 beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'schema-')); });
@@ -44,9 +56,53 @@ describe('schema compatibility', () => {
     expect(load(dir).nodes.size).toBe(0);
   });
 
-  it('does not bump the version, because no record shape changed in this work', () => {
-    expect(GRAPH_VERSION).toBe(1);
-    expect(SUPPORTED_VERSIONS).toContain(1);
+  it('supports the current version and never drops the oldest -- the invariants that survive a bump', () => {
+    // NOT `expect(GRAPH_VERSION).toBe(1)`. Pinning the constant here would make
+    // a legitimate future bump fail in the very file that guards against the
+    // damage a bump can do, inviting whoever does it to edit the net.
+    expect(SUPPORTED_VERSIONS).toContain(GRAPH_VERSION);
+    // v1 is what is on every user's disk today. A change may ADD versions to
+    // this range; dropping the oldest is the data loss this whole file exists
+    // to prevent.
+    expect(SUPPORTED_VERSIONS[0]).toBe(1);
+    expect(SUPPORTED_VERSIONS.every((v) => Number.isInteger(v) && v > 0)).toBe(true);
+  });
+
+  describe('readable is a RANGE check, not an equality check', () => {
+    // These are the cases that cannot pass under `v === GRAPH_VERSION`, and they
+    // do not depend on today's values of GRAPH_VERSION or SUPPORTED_VERSIONS.
+    // With GRAPH_VERSION === 1, an equality check rejects v2 -- so the middle
+    // case below fails the moment anyone reverts the predicate.
+    it('accepts an OLDER version in range', () => {
+      expect(readable({ v: 1 }, [1, 2])).toBe(true);
+    });
+
+    it('accepts the NEWEST version in range', () => {
+      expect(readable({ v: 2 }, [1, 2])).toBe(true);
+    });
+
+    it('rejects a version beyond the range, because the future is unknowable', () => {
+      expect(readable({ v: 3 }, [1, 2])).toBe(false);
+    });
+
+    it('treats a missing v as version 0, which no range supports', () => {
+      expect(readable({}, [1, 2])).toBe(false);
+    });
+
+    it('accepts every version it claims to support', () => {
+      for (const v of SUPPORTED_VERSIONS) expect(readable({ v })).toBe(true);
+    });
+  });
+
+  it('upcast is idempotent, because compaction upcasts and then load upcasts again', () => {
+    // The contract for the first non-identity step. A record keyed by an upcast
+    // in compactIfWasteful is read back and upcast a SECOND time by every later
+    // load, so a step that is not idempotent applies twice to anything
+    // compaction has touched.
+    for (const v of SUPPORTED_VERSIONS) {
+      const record = { t: 'n', v, id: 'file:a', kind: 'file', key: '/a.ts', at: 1 };
+      expect(upcast(upcast(record))).toEqual(upcast(record));
+    }
   });
 
   it('upcast is identity for a current-version record', () => {
@@ -111,5 +167,101 @@ describe('schema compatibility', () => {
     } finally {
       delete process.env.TOKEN_OPTIMIZER_GRAPH_COMPACT_BYTES;
     }
+  });
+
+  /**
+   * THE ASYMMETRY THAT MADE THE SIDECAR DESTRUCTIVE.
+   *
+   * graph.jsonl keeps every line it cannot interpret (the `raw:` bucket), so an
+   * unreadable record there survives a compaction. snapshots.jsonl had no
+   * equivalent: compaction REBUILT it from only what it could read, so for the
+   * sidecar "skip the record" and "delete the record forever" were the same
+   * operation.
+   *
+   * Note the direction. This is the FORWARD case -- a version from the future --
+   * which a reader is right to ignore. A rewriter is not: ignoring the future
+   * while replacing the file is data loss. And it is the expected case here,
+   * because hooks-core is vendored into eleven client directories that update
+   * independently, so a stale client compacting after a newer one has written is
+   * ordinary operation.
+   */
+  describe('compaction preserves sidecar snapshots it cannot read', () => {
+    /**
+     * Drives a real compaction: low floor, then appends that re-enter the lock.
+     *
+     * compactIfWasteful is reachable ONLY from appendAll, inside the write lock,
+     * and only once graph.jsonl + snapshots.jsonl together clear both the floor
+     * and twice the recorded baseline -- so the floor has to sit well under what
+     * these appends produce (~700 bytes each across the pair).
+     */
+    function compact(appends = 40) {
+      process.env.TOKEN_OPTIMIZER_GRAPH_COMPACT_BYTES = '4000';
+      try {
+        for (let i = 0; i < appends; i++) {
+          putNode(dir, { kind: 'file', key: '/src/churn.ts', hash: 'h' + i, snapshot: 's'.repeat(500) });
+        }
+        // Asserted, not assumed: the marker is written only by a compaction that
+        // ran to completion.
+        expect(existsSync(join(dir, 'graph.compact.json'))).toBe(true);
+      } finally {
+        delete process.env.TOKEN_OPTIMIZER_GRAPH_COMPACT_BYTES;
+      }
+    }
+
+    const sidecarLines = () =>
+      readFileSync(join(dir, 'snapshots.jsonl'), 'utf8')
+        .split('\n')
+        .filter(Boolean)
+        .map((line) => JSON.parse(line));
+
+    it('keeps a FUTURE-version snapshot record verbatim through a rebuild', () => {
+      const future = { t: 's', v: 9999, id: 'file:future', snapshot: 'FUTURE-PAYLOAD', at: 1, extra: 'a field this reader knows nothing about' };
+      writeFileSync(join(dir, 'snapshots.jsonl'), JSON.stringify(future) + '\n');
+      // Sanity: this reader genuinely cannot interpret it, so its survival is
+      // not an accident of it being readable after all.
+      expect(readable(future)).toBe(false);
+
+      compact();
+
+      const survivor = sidecarLines().find((rec) => rec.id === 'file:future');
+      expect(survivor).toBeDefined();
+      // VERBATIM: the payload, the version stamp and the unknown field all
+      // survive. A rebuild that re-serialized it would drop `extra`.
+      expect(survivor).toEqual(future);
+    });
+
+    it('does not restamp a surviving snapshot with the current version', () => {
+      // Compaction must never relabel bytes it did not write. Restamping was the
+      // other half of this defect: every survivor was written back as
+      // `v: GRAPH_VERSION` regardless of what produced it.
+      const future = { t: 's', v: 9999, id: 'file:future', snapshot: 'p', at: 1 };
+      writeFileSync(join(dir, 'snapshots.jsonl'), JSON.stringify(future) + '\n');
+
+      compact();
+
+      const survivor = sidecarLines().find((rec) => rec.id === 'file:future');
+      expect(survivor).toBeDefined();
+      expect(survivor.v).toBe(9999);
+      expect(survivor.v).not.toBe(GRAPH_VERSION);
+    });
+
+    it('keeps readable snapshots too, so preserving the unreadable costs nothing', () => {
+      // The fix must not trade one loss for another: the ordinary path still
+      // has to work, and a readable record still carries its own version.
+      putNode(dir, { kind: 'file', key: '/src/keep.ts', hash: 'h', snapshot: 'KEEP-ME' });
+      const unreadable = { t: 's', v: 9999, id: 'file:future', snapshot: 'p', at: 1 };
+      appendFileSync(join(dir, 'snapshots.jsonl'), JSON.stringify(unreadable) + '\n');
+
+      compact();
+
+      const ids = sidecarLines().map((rec) => rec.id);
+      expect(ids).toContain('file:future');
+      // The churned node's snapshot is the one compaction is meant to keep.
+      const readableSurvivors = sidecarLines().filter((rec) => rec.v === GRAPH_VERSION);
+      expect(readableSurvivors.length).toBeGreaterThan(0);
+      // And a reader still sees only what it can interpret.
+      const graph = load(dir, { snapshots: true });
+      expect(graph.nodes.has('file:future')).toBe(false);
+    });
   });
 });

--- a/tests/hooks/schema-compat.test.mjs
+++ b/tests/hooks/schema-compat.test.mjs
@@ -230,6 +230,29 @@ describe('schema compatibility', () => {
       expect(survivor).toEqual(future);
     });
 
+    it('keeps a READABLE snapshot record that has no id, rather than dropping it', () => {
+      /**
+       * THE SAME SHAPE, ONE BRANCH FURTHER IN. The version check above sorts
+       * records into `records` and `unreadable`, and both survive a rebuild. A
+       * record that passed the version check but carried no `id` went into
+       * NEITHER: `if (rec.id) out.push(...)` and nothing else, so the next
+       * compaction deleted it permanently. Unreachable today because every
+       * writer sets `id` -- which is exactly the argument that was wrong the
+       * last time, and the reader is not the right place to depend on it.
+       */
+      const idless = { t: 's', v: GRAPH_VERSION, snapshot: 'ORPHAN-PAYLOAD', at: 1 };
+      // Readable, unlike the future-version case: this record clears the version
+      // gate and is dropped for a different reason entirely.
+      expect(readable(idless)).toBe(true);
+      writeFileSync(join(dir, 'snapshots.jsonl'), JSON.stringify(idless) + '\n');
+
+      compact();
+
+      const survivor = sidecarLines().find((rec) => rec.snapshot === 'ORPHAN-PAYLOAD');
+      expect(survivor).toBeDefined();
+      expect(survivor).toEqual(idless);
+    });
+
     it('does not restamp a surviving snapshot with the current version', () => {
       // Compaction must never relabel bytes it did not write. Restamping was the
       // other half of this defect: every survivor was written back as

--- a/tests/hooks/stale-clearing.test.mjs
+++ b/tests/hooks/stale-clearing.test.mjs
@@ -1,0 +1,407 @@
+/**
+ * NOTHING EVER CLEARED A STALE FLAG.
+ *
+ * `stale` is written by two eager paths (`invalidateOnWrite`, with a real diff,
+ * and `invalidateChangedAnchors`, with a hash pair and no diff) and read by
+ * `serve`, `disclose` and `utility`. No code path anywhere removed it. That was
+ * harmless while eager invalidation was dead code; it fires now, so every
+ * finding on an edited file was becoming permanently stale and the graph
+ * degrades toward all-stale.
+ *
+ * THE PROPERTY UNDER TEST IS NOT "A FLAG CAN BE REMOVED" -- that is trivial and
+ * would be satisfied by a laundering route. It is that the flag comes off ONLY
+ * on evidence that the content now matches what the claim was actually made
+ * against: the frozen `derivation.anchors` hashes recorded at claim time.
+ *
+ * WHY NOT `checkAnchor`, WHICH IS THE OBVIOUS REUSE. `checkAnchor` compares disk
+ * against the anchor NODE's stored hash -- and both eager paths call `indexFile`
+ * immediately after marking, which re-points that hash at the bytes that just
+ * caused the mark. So `checkAnchor` reports "fresh" for precisely the finding
+ * that was just marked stale, and a `reverify` built on it would clear every
+ * flag it was ever handed. That is the laundering route, and the
+ * "still differs" tests below are the ones that catch it.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { load, nodeId, putNode, putEdge, putNodeWithEdges } from '../../hooks-core/wiki.mjs';
+import {
+  clearStale,
+  indexFile,
+  invalidateChangedAnchors,
+  invalidateOnWrite,
+  reverify,
+  serve,
+} from '../../hooks-core/staleness.mjs';
+import {
+  audit,
+  contradict,
+  correct,
+  hasOutstandingContradiction,
+  retire,
+} from '../../hooks-core/curate.mjs';
+import { writeHarvested } from '../../hooks-core/harvest-write.mjs';
+import { canonicalPath } from '../../hooks-core/paths.mjs';
+
+const ORIGINAL = 'export function parse(x) {\n  return x.trim();\n}\n';
+const CHANGED = 'export function parse(x) {\n  return String(x).trim();\n}\n';
+
+let dir;
+let workspace;
+let file;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'stale-clear-'));
+  workspace = mkdtempSync(join(tmpdir(), 'stale-clear-ws-'));
+  file = canonicalPath(join(workspace, 'parse.ts'));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+  rmSync(workspace, { recursive: true, force: true });
+});
+
+const findingByKey = (key) => load(dir).nodes.get(nodeId('finding', key));
+
+/**
+ * A finding written the way the product writes one, so it carries the
+ * `derivation.anchors` record `reverify` checks against. Seeding with a bare
+ * `putNodeWithEdges` would produce a finding with no claim-time hashes, which
+ * is a different (and separately tested) case.
+ */
+function seedFinding(claim = 'parse trims its argument') {
+  const keys = writeHarvested(dir, [
+    { claim, type: 'finding', confidence: 0.85, anchors: [file] },
+  ]);
+  expect(keys).toHaveLength(1);
+  return keys[0];
+}
+
+/** The eager path with a before/after pair: a real diff is captured. */
+const markStaleWithDiff = (before, after) =>
+  invalidateOnWrite(dir, load(dir), file, before, after);
+
+/** The eager path with no before side: a hash pair, and `diff: ''`. */
+const markStaleByHash = () => invalidateChangedAnchors(dir, load(dir), file);
+
+describe('reverify clears a stale flag, but only on evidence', () => {
+  test('clears the flag when the anchor returns to its recorded content', () => {
+    writeFileSync(file, ORIGINAL);
+    indexFile(dir, file, ORIGINAL);
+    const key = seedFinding();
+
+    writeFileSync(file, CHANGED);
+    expect(markStaleWithDiff(ORIGINAL, CHANGED)).toEqual([key]);
+    expect(findingByKey(key).stale).toBe(true);
+
+    writeFileSync(file, ORIGINAL); // reverted
+    expect(reverify(dir, key)).toBe('cleared');
+
+    const after = findingByKey(key);
+    expect(after.stale).toBeFalsy();
+    expect(after.diff).toBeFalsy();
+    expect(after.staleReason).toBeFalsy();
+  });
+
+  test('leaves the flag set when the content genuinely still differs', () => {
+    writeFileSync(file, ORIGINAL);
+    indexFile(dir, file, ORIGINAL);
+    const key = seedFinding();
+
+    writeFileSync(file, CHANGED);
+    markStaleWithDiff(ORIGINAL, CHANGED);
+
+    // NOT reverted. The anchor really did change, so the claim stays discounted
+    // until someone re-records it against the new content. This is the
+    // assertion that stops `reverify` becoming a way to launder a stale finding
+    // back to fresh on request.
+    expect(reverify(dir, key)).toBe('still-stale');
+    const after = findingByKey(key);
+    expect(after.stale).toBe(true);
+    expect(after.staleReason).toBe('edited during this session');
+  });
+
+  test('clears a hash-only mark, which carries no diff at all', () => {
+    // The whole-file `Write` shape: `invalidateChangedAnchors` compares stored
+    // hashes against disk and marks with `diff: ''`. Clearing must not assume a
+    // diff exists to remove.
+    writeFileSync(file, ORIGINAL);
+    indexFile(dir, file, ORIGINAL);
+    const key = seedFinding();
+
+    writeFileSync(file, CHANGED);
+    expect(markStaleByHash()).toEqual([key]);
+    expect(findingByKey(key).stale).toBe(true);
+    expect(findingByKey(key).diff).toBe('');
+
+    writeFileSync(file, ORIGINAL);
+    expect(reverify(dir, key)).toBe('cleared');
+    expect(findingByKey(key).stale).toBeFalsy();
+  });
+
+  test('leaves a hash-only mark set when the content still differs', () => {
+    writeFileSync(file, ORIGINAL);
+    indexFile(dir, file, ORIGINAL);
+    const key = seedFinding();
+
+    writeFileSync(file, CHANGED);
+    markStaleByHash();
+
+    expect(reverify(dir, key)).toBe('still-stale');
+    expect(findingByKey(key).stale).toBe(true);
+  });
+
+  test('clears a mark left by a write that changed nothing at all', () => {
+    // `invalidateOnWrite` marks every finding anchored to the FILE node on any
+    // observed write to that file, whether or not the bytes moved. That is a
+    // real over-mark, it is permanent today, and it is exactly the case where
+    // the evidence for clearing is unambiguous.
+    writeFileSync(file, ORIGINAL);
+    indexFile(dir, file, ORIGINAL);
+    const key = seedFinding();
+
+    expect(markStaleWithDiff(ORIGINAL, ORIGINAL)).toEqual([key]);
+    expect(findingByKey(key).stale).toBe(true);
+
+    expect(reverify(dir, key)).toBe('cleared');
+    expect(findingByKey(key).stale).toBeFalsy();
+  });
+
+  test('reports still-stale when the anchored file has been deleted', () => {
+    writeFileSync(file, ORIGINAL);
+    indexFile(dir, file, ORIGINAL);
+    const key = seedFinding();
+
+    writeFileSync(file, CHANGED);
+    markStaleWithDiff(ORIGINAL, CHANGED);
+    rmSync(file);
+
+    // A file that is gone cannot match the content the claim was made against.
+    expect(reverify(dir, key)).toBe('still-stale');
+    expect(findingByKey(key).stale).toBe(true);
+  });
+
+  test('a deleted anchor never matches, even when it was EMPTY at claim time', () => {
+    // Found by mutation, not by reading: making `anchorHashNow` return hash('')
+    // for an unreadable anchor instead of null survived every other test here,
+    // because a deleted file's empty hash differs from any real content. It does
+    // NOT differ when the file was empty when the claim was made -- a stub, a
+    // placeholder, a generated file not yet written -- and then a DELETION would
+    // re-hash to exactly the recorded value and clear the flag. "The file is
+    // gone" must never read as "the content is unchanged".
+    writeFileSync(file, '');
+    indexFile(dir, file, '');
+    const key = seedFinding('parse.ts is still a stub');
+
+    writeFileSync(file, ORIGINAL);
+    markStaleWithDiff('', ORIGINAL);
+    expect(findingByKey(key).stale).toBe(true);
+
+    rmSync(file);
+    expect(reverify(dir, key)).toBe('still-stale');
+    expect(findingByKey(key).stale).toBe(true);
+  });
+
+  test('refuses to clear a finding with no claim-time record to check against', () => {
+    // Findings written before `derivation` existed, and every hand-written one,
+    // carry no frozen anchor hashes. There is nothing to compare disk to, so
+    // there is no evidence -- and "no evidence" must not resolve to "clear it".
+    writeFileSync(file, ORIGINAL);
+    indexFile(dir, file, ORIGINAL);
+    putNodeWithEdges(
+      dir,
+      { kind: 'finding', key: 'legacy', claim: 'parse trims', confidence: 0.9 },
+      [{ edge: 'derived_from', to: nodeId('file', file) }]
+    );
+
+    writeFileSync(file, CHANGED);
+    markStaleWithDiff(ORIGINAL, CHANGED);
+    expect(findingByKey('legacy').stale).toBe(true);
+
+    // Even after a revert: the flag stays, because nothing recorded what this
+    // claim was originally derived from.
+    writeFileSync(file, ORIGINAL);
+    expect(reverify(dir, 'legacy')).toBe('unknown');
+    expect(findingByKey('legacy').stale).toBe(true);
+  });
+
+  test('reports unknown for a key that names no finding, and writes nothing', () => {
+    const before = load(dir).nodes.size;
+    expect(reverify(dir, 'nope')).toBe('unknown');
+    expect(load(dir).nodes.size).toBe(before);
+  });
+
+  test('is idempotent on a finding that is not stale', () => {
+    writeFileSync(file, ORIGINAL);
+    indexFile(dir, file, ORIGINAL);
+    const key = seedFinding();
+
+    expect(findingByKey(key).stale).toBeUndefined();
+    expect(reverify(dir, key)).toBe('cleared');
+    expect(findingByKey(key).stale).toBeFalsy();
+    expect(findingByKey(key).claim).toBe('parse trims its argument');
+  });
+
+  test('a cleared finding is served clean, with no staleness vocabulary left', () => {
+    writeFileSync(file, ORIGINAL);
+    indexFile(dir, file, ORIGINAL);
+    const key = seedFinding();
+
+    writeFileSync(file, CHANGED);
+    markStaleWithDiff(ORIGINAL, CHANGED);
+    writeFileSync(file, ORIGINAL);
+    // The eager mark re-indexed the anchor to CHANGED, so the revert also has
+    // to be re-indexed before the LAZY check agrees -- otherwise `serve` would
+    // recompute staleness from the anchor node and the clear would be invisible.
+    indexFile(dir, file, ORIGINAL);
+    expect(reverify(dir, key)).toBe('cleared');
+
+    const graph = load(dir);
+    const served = serve(graph, [graph.nodes.get(nodeId('finding', key))]);
+    expect(served[0].stale).toBe(false);
+    expect(served[0].staleReason).toBeUndefined();
+    expect(served[0].diff).toBeUndefined();
+  });
+});
+
+describe('clearStale rewrites the whole node', () => {
+  test('preserves every other field when clearing', () => {
+    writeFileSync(file, ORIGINAL);
+    indexFile(dir, file, ORIGINAL);
+    const key = seedFinding();
+    writeFileSync(file, CHANGED);
+    markStaleWithDiff(ORIGINAL, CHANGED);
+
+    const before = findingByKey(key);
+    expect(before.stale).toBe(true);
+    expect(clearStale(dir, key)).toBe(true);
+    const after = findingByKey(key);
+
+    // putNode does NOT merge -- it writes the record it is handed and `load`
+    // replaces the node wholesale. A partial write here would silently blank
+    // the claim, the confidence and the provenance.
+    expect(after.claim).toBe(before.claim);
+    expect(after.confidence).toBe(before.confidence);
+    expect(after.origin).toBe(before.origin);
+    expect(after.type).toBe(before.type);
+    expect(after.derivation).toEqual(before.derivation);
+    expect(after.stale).toBeUndefined();
+    expect(after.staleReason).toBeUndefined();
+    expect(after.diff).toBeUndefined();
+  });
+
+  test('keeps the anchors, so a cleared finding can go stale again', () => {
+    writeFileSync(file, ORIGINAL);
+    indexFile(dir, file, ORIGINAL);
+    const key = seedFinding();
+    writeFileSync(file, CHANGED);
+    markStaleWithDiff(ORIGINAL, CHANGED);
+    clearStale(dir, key);
+
+    const id = nodeId('finding', key);
+    expect(load(dir).edges.some((e) => e.edge === 'derived_from' && e.from === id)).toBe(true);
+
+    // And it really can be marked again -- an un-invalidatable finding would be
+    // a worse outcome than a permanently stale one.
+    writeFileSync(file, CHANGED + '\n// more\n');
+    expect(markStaleWithDiff(CHANGED, CHANGED + '\n// more\n')).toEqual([key]);
+    expect(findingByKey(key).stale).toBe(true);
+  });
+
+  test('returns false for a key that names no finding', () => {
+    expect(clearStale(dir, 'nope')).toBe(false);
+  });
+});
+
+describe('a correction is not born stale', () => {
+  test('does not let a correction inherit its predecessor stale flag', () => {
+    writeFileSync(file, ORIGINAL);
+    indexFile(dir, file, ORIGINAL);
+    const key = seedFinding();
+    writeFileSync(file, CHANGED);
+    markStaleWithDiff(ORIGINAL, CHANGED);
+    expect(findingByKey(key).stale).toBe(true);
+
+    const corrected = correct(dir, key, 're-derived against the new code');
+    expect(typeof corrected).toBe('string');
+
+    const node = findingByKey(corrected);
+    expect(node.stale).toBeFalsy();
+    expect(node.staleReason).toBeFalsy();
+    expect(node.diff).toBeFalsy();
+    // The original keeps its flag AND is retired: the record of what was
+    // believed, and why it stopped being believed, both survive.
+    expect(findingByKey(key).stale).toBe(true);
+    expect(findingByKey(key).retired).toBe(true);
+  });
+});
+
+/**
+ * A RETIRED COUNTERPART IS A RESOLVED DISPUTE.
+ *
+ * `hasOutstandingContradiction` read edges only, so retiring one end of a
+ * contradiction left the survivor gated against confidence promotion forever
+ * and disclosed as DISPUTED by a key `serve` refuses to hand anybody. The gate's
+ * own justification is `audit`'s "until one looks, BOTH are being served" -- a
+ * retired claim is served to nobody, so the premise is gone and retiring one end
+ * IS a person looking.
+ */
+describe('a retired counterpart no longer counts as an open dispute', () => {
+  beforeEach(() => {
+    putNodeWithEdges(dir, { kind: 'finding', key: 'old', claim: 'f returns 1', confidence: 0.9 });
+    putNodeWithEdges(dir, { kind: 'finding', key: 'new', claim: 'f returns 2', confidence: 0.9 });
+    contradict(dir, { key: 'old', byKey: 'new', reason: 're-derived' });
+  });
+
+  test('the gate opens for the survivor once the other end is retired', () => {
+    expect(hasOutstandingContradiction(load(dir), 'old')).toBe(true);
+    expect(retire(dir, 'new')).toBe(true);
+
+    const graph = load(dir);
+    expect(hasOutstandingContradiction(graph, 'old')).toBe(false);
+    // Symmetric, as before: the retired end is not being served either.
+    expect(hasOutstandingContradiction(graph, 'new')).toBe(false);
+  });
+
+  test('a LIVE counterpart still gates, so the test above is not vacuous', () => {
+    const graph = load(dir);
+    expect(hasOutstandingContradiction(graph, 'old')).toBe(true);
+    expect(hasOutstandingContradiction(graph, 'new')).toBe(true);
+  });
+
+  test('serve stops disclosing a dispute whose only disputant is retired', () => {
+    retire(dir, 'new');
+    const graph = load(dir);
+    const served = serve(graph, [graph.nodes.get(nodeId('finding', 'old'))]);
+    expect(served[0].contradicted).toBeUndefined();
+    expect(served[0].contradictedBy).toBeUndefined();
+  });
+
+  test('serve never names a retired disputant alongside a live one', () => {
+    putNodeWithEdges(dir, { kind: 'finding', key: 'third', claim: 'f returns 3', confidence: 0.9 });
+    contradict(dir, { key: 'old', byKey: 'third', reason: 'again' });
+    retire(dir, 'new');
+
+    const graph = load(dir);
+    const served = serve(graph, [graph.nodes.get(nodeId('finding', 'old'))]);
+    expect(served[0].contradicted).toBe(true);
+    // Pointing a reader at a key `serve` refuses to return is worse than saying
+    // nothing: the disclosure tells them to `wiki_query` it and they get nothing.
+    expect(served[0].contradictedBy).toBe('third');
+  });
+
+  test('audit agrees with the gate -- one definition of an open dispute', () => {
+    retire(dir, 'new');
+    expect(audit(load(dir)).contradicted.map((f) => f.key)).toEqual([]);
+  });
+
+  test('an unresolvable counterpart still counts, because it cannot be shown retired', () => {
+    // A `contradicts` edge whose other end resolves to no node at all. Nothing
+    // proves that claim was withdrawn, so the conservative reading stands.
+    const id = putNode(dir, { kind: 'finding', key: 'lonely', claim: 'h returns 1', confidence: 0.9 });
+    putEdge(dir, nodeId('finding', 'ghost'), 'contradicts', id);
+    expect(hasOutstandingContradiction(load(dir), 'lonely')).toBe(true);
+  });
+});

--- a/tests/hooks/stale-clearing.test.mjs
+++ b/tests/hooks/stale-clearing.test.mjs
@@ -23,7 +23,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from '@jest/globals';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { load, nodeId, putNode, putEdge, putNodeWithEdges } from '../../hooks-core/wiki.mjs';
@@ -520,17 +520,37 @@ describe('serve clears a stale flag automatically, on the same evidence', () => 
     expect(findingByKey('legacy2').stale).toBe(true);
   });
 
-  test('the lazy check can still mark a finding whose stored flag was just cleared', () => {
-    // Clearing removes only the STORED flag. The disk-against-node-hash
-    // comparison is a different question and is not overruled: here disk matches
-    // claim time while the anchor node still holds the post-edit hash.
+  test('the lazy check still works after a clear -- on a LATER change', () => {
+    // THIS TEST USED TO ASSERT THE DEFECT. It reverted without re-indexing and
+    // then required `served.stale === true` with `staleReason: 'file changed'` on
+    // the very object whose flag had just been cleared for matching its
+    // claim-time content -- stale and fresh in one response, written down as
+    // intended behaviour. The clear now re-points the anchor, so the two cannot
+    // disagree about the same bytes.
+    //
+    // WHAT IS ACTUALLY WORTH ASSERTING is that clearing did not switch the lazy
+    // path off: a change arriving AFTER the clear, from outside our hooks and
+    // therefore never indexed, is still caught.
     const key = staleFinding();
     writeFileSync(file, ORIGINAL); // reverted, but NOT re-indexed
+    expect(serveOne(key, { dir }).stale).toBe(false);
+    expect(findingByKey(key).stale).toBeUndefined();
 
+    // Now something outside the session edits the file again -- a git pull, a
+    // teammate, a build step. No hook observed it, so nothing re-indexed.
+    writeFileSync(file, CHANGED);
     const served = serveOne(key, { dir });
-    expect(findingByKey(key).stale).toBeUndefined(); // stored flag cleared
-    expect(served.stale).toBe(true);                 // lazy still disagrees
+    expect(served.stale).toBe(true);
     expect(served.staleReason).toBe('file changed');
+    // `derivationHolds: true` ALONGSIDE `stale: true` IS NOT THE CONTRADICTION
+    // this fix was about, and the difference is worth stating. These two answer
+    // different questions: the last indexed state does still agree with what the
+    // claim was made against, and disk has since moved away from both. That is
+    // exactly the complementary pair `derivationCheck` documents. The defect was
+    // the OTHER combination -- a clear decided on claim-time evidence served
+    // beside `derivationHolds: false` claiming that same evidence had moved.
+    expect(served.derivationHolds).toBe(true);
+    expect(served.derivationCheckedAgainst).toBe('index');
   });
 
   test('the injection path clears it, so no dashboard visit is required', () => {
@@ -605,5 +625,170 @@ describe('curate writes claim-time anchor hashes too', () => {
 
     writeFileSync(file, CHANGED);
     expect(reverify(dir, corrected)).toBe('cleared');
+  });
+});
+
+/**
+ * THE THREE DISCLOSURES MUST NOT CONTRADICT EACH OTHER.
+ *
+ * A served finding carries three independent verdicts, each computed from a
+ * different comparison:
+ *
+ *   `stale`/`staleReason`  -- disk against the anchor NODE's stored hash
+ *   `derivationHolds`      -- the anchor node's stored hash against the hash
+ *                             frozen into this finding at claim time
+ *   the clear decision     -- disk against that same claim-time hash
+ *
+ * Two of those three read the node's stored hash, and the EAGER path moves it.
+ * So on the revert path -- index at H1, claim against H1, edit and re-index to
+ * H2, eager-mark, then revert the file to H1 -- the clear fired (disk H1 equals
+ * claim H1) while the same returned object said `stale: true, staleReason: 'file
+ * changed'` and `derivationHolds: false`. The model was shown STALE and
+ * DERIVATION CHANGED at the exact moment the code's own evidence test had
+ * concluded the derivation holds, and it recurred on every serve until something
+ * unrelated re-indexed the anchor.
+ *
+ * EVERY EXISTING TEST OF THIS PATH RE-INDEXED AFTER REVERTING, which is what hid
+ * it: `indexFile(dir, file, ORIGINAL)` moves the node hash back to H1 by hand and
+ * all three agree for a reason the product does not supply. Nothing below calls
+ * `indexFile` after the revert. That omission is the test.
+ */
+describe('a mid-serve clear leaves all three disclosures agreeing', () => {
+  const staleFinding = () => {
+    writeFileSync(file, ORIGINAL);
+    indexFile(dir, file, ORIGINAL);
+    const key = seedFinding();
+    writeFileSync(file, CHANGED);
+    markStaleWithDiff(ORIGINAL, CHANGED);
+    expect(findingByKey(key).stale).toBe(true);
+    return key;
+  };
+
+  const serveOne = (key, opts) => {
+    const graph = load(dir);
+    return serve(graph, [graph.nodes.get(nodeId('finding', key))], opts)[0];
+  };
+
+  const fileHash = () => load(dir).nodes.get(nodeId('file', file)).hash;
+
+  test('the revert path serves fresh, not stale-and-fresh at once', () => {
+    const key = staleFinding();
+    const claimHash = findingByKey(key).derivation.anchors[nodeId('file', file)];
+    // The eager path re-pointed the node at the POST-edit bytes, which is the
+    // whole reason the two derived disclosures disagreed with the clear.
+    expect(fileHash()).not.toBe(claimHash);
+
+    writeFileSync(file, ORIGINAL); // reverted on disk, and NOT re-indexed
+
+    const served = serveOne(key, { dir });
+    // The clear happened...
+    expect(served.stale).toBe(false);
+    expect(findingByKey(key).stale).toBeUndefined();
+    // ...and neither derived disclosure contradicts it.
+    expect(served.staleReason).toBeUndefined();
+    expect(served.diff).toBeUndefined();
+    expect(served.staleEvidence).toBeUndefined();
+    expect(served.derivationHolds).toBe(true);
+    expect(served.derivationChanged).toBeUndefined();
+  });
+
+  test('the anchor is re-indexed from the bytes the evidence test already read', () => {
+    const key = staleFinding();
+    const claimHash = findingByKey(key).derivation.anchors[nodeId('file', file)];
+    writeFileSync(file, ORIGINAL);
+
+    serveOne(key, { dir });
+    // The stored hash is the claim-time hash again, so the NEXT reader -- and
+    // every other finding anchored to this file -- sees the same content this
+    // clear was decided on. Suppressing the disclosures instead would have left
+    // the graph holding a hash matching no version of the file that exists.
+    expect(fileHash()).toBe(claimHash);
+  });
+
+  test('a second serve says the same thing, and pays nothing to say it', () => {
+    const key = staleFinding();
+    writeFileSync(file, ORIGINAL);
+    serveOne(key, { dir });
+
+    const again = serveOne(key, { dir });
+    expect(again.stale).toBe(false);
+    expect(again.staleReason).toBeUndefined();
+    expect(again.derivationHolds).toBe(true);
+  });
+
+  test('a genuine change still disagrees with nothing, and stays stale', () => {
+    // The paired negative: the fix must not make everything agree by making
+    // everything read fresh. Not reverted, so the verdict is `differs`, no
+    // re-index happens, and all three disclosures agree that it is stale.
+    const key = staleFinding();
+    const claimHash = findingByKey(key).derivation.anchors[nodeId('file', file)];
+
+    const served = serveOne(key, { dir });
+    expect(served.stale).toBe(true);
+    expect(findingByKey(key).stale).toBe(true);
+    expect(served.derivationHolds).toBe(false);
+    expect(served.derivationChanged).toEqual([file]);
+    // And the anchor is NOT quietly moved back to the claim-time hash, which
+    // would be the laundering route wearing a re-index for a hat.
+    expect(fileHash()).not.toBe(claimHash);
+  });
+
+  test('reverify agrees with serve, because both re-index what they verified', () => {
+    const key = staleFinding();
+    const claimHash = findingByKey(key).derivation.anchors[nodeId('file', file)];
+    writeFileSync(file, ORIGINAL);
+
+    expect(reverify(dir, key)).toBe('cleared');
+    expect(fileHash()).toBe(claimHash);
+
+    const served = serveOne(key, { dir });
+    expect(served.stale).toBe(false);
+    expect(served.derivationHolds).toBe(true);
+  });
+});
+
+/**
+ * ONE CLEAR IS ONE RECORD.
+ *
+ * `clearStale`'s no-op guard reads the graph its CALLER handed it, not disk. So a
+ * second `serve` over the same in-memory graph object -- two touched files
+ * anchored to one finding, or a lifecycle branch that serves twice from a graph
+ * it loaded once, which is exactly the shape SessionStart has -- still saw
+ * `stale: true`, re-ran the evidence test and appended a byte-identical clear
+ * record. The store is append-only, so that is permanent growth for no change of
+ * state.
+ */
+describe('clearing twice from one graph object writes once', () => {
+  const clearRecordCount = (key) => {
+    const id = nodeId('finding', key);
+    return readFileSync(join(dir, 'graph.jsonl'), 'utf8')
+      .split('\n')
+      .filter((line) => line.includes(`"${id}"`) && line.includes('"t":"n"'))
+      .filter((line) => !JSON.parse(line).stale)
+      .length;
+  };
+
+  test('the second serve on the same graph appends no duplicate', () => {
+    writeFileSync(file, ORIGINAL);
+    indexFile(dir, file, ORIGINAL);
+    const key = seedFinding();
+    writeFileSync(file, CHANGED);
+    markStaleWithDiff(ORIGINAL, CHANGED);
+    writeFileSync(file, ORIGINAL);
+
+    // ONE graph object, served twice -- the SessionStart shape.
+    const graph = load(dir);
+    const findings = () => [graph.nodes.get(nodeId('finding', key))];
+    const before = clearRecordCount(key);
+    serve(graph, findings(), { dir });
+    const afterFirst = clearRecordCount(key);
+    serve(graph, findings(), { dir });
+    const afterSecond = clearRecordCount(key);
+
+    expect(afterFirst).toBe(before + 1);
+    expect(afterSecond).toBe(afterFirst);
+    // And the finding is still cleared -- writing once must not mean clearing
+    // once and then reporting it stale again.
+    expect(findingByKey(key).stale).toBeUndefined();
   });
 });

--- a/tests/hooks/stale-clearing.test.mjs
+++ b/tests/hooks/stale-clearing.test.mjs
@@ -43,6 +43,8 @@ import {
   retire,
 } from '../../hooks-core/curate.mjs';
 import { writeHarvested } from '../../hooks-core/harvest-write.mjs';
+import { create } from '../../hooks-core/curate.mjs';
+import { forTouch } from '../../hooks-core/inject.mjs';
 import { canonicalPath } from '../../hooks-core/paths.mjs';
 
 const ORIGINAL = 'export function parse(x) {\n  return x.trim();\n}\n';
@@ -403,5 +405,205 @@ describe('a retired counterpart no longer counts as an open dispute', () => {
     const id = putNode(dir, { kind: 'finding', key: 'lonely', claim: 'h returns 1', confidence: 0.9 });
     putEdge(dir, nodeId('finding', 'ghost'), 'contradicts', id);
     expect(hasOutstandingContradiction(load(dir), 'lonely')).toBe(true);
+  });
+});
+
+/**
+ * AUTOMATIC CLEARING, ON THE SAME EVIDENCE.
+ *
+ * Clearing reachable only through a dashboard button leaves the rot path fully
+ * open on every install where nobody opens the dashboard -- which is most of
+ * them. The evidence test is what makes clearing safe and it does not care who
+ * triggered it, so `serve` runs the same `claimTimeVerdict` when handed a `dir`.
+ *
+ * THE ASSERTIONS THAT MATTER ARE THE NEGATIVE ONES. An automatic path that
+ * cleared more freely than the button would be a laundering route firing on
+ * every tool call, so each "clears automatically" test below is paired with a
+ * "still differs" test on the identical setup.
+ */
+describe('serve clears a stale flag automatically, on the same evidence', () => {
+  const staleFinding = () => {
+    writeFileSync(file, ORIGINAL);
+    indexFile(dir, file, ORIGINAL);
+    const key = seedFinding();
+    writeFileSync(file, CHANGED);
+    markStaleWithDiff(ORIGINAL, CHANGED);
+    expect(findingByKey(key).stale).toBe(true);
+    return key;
+  };
+
+  const serveOne = (key, opts) => {
+    const graph = load(dir);
+    return serve(graph, [graph.nodes.get(nodeId('finding', key))], opts)[0];
+  };
+
+  test('clears the STORED flag when the content is back to what was claimed', () => {
+    const key = staleFinding();
+    writeFileSync(file, ORIGINAL); // reverted
+    indexFile(dir, file, ORIGINAL); // and observed, so the lazy check agrees too
+
+    const served = serveOne(key, { dir });
+    expect(served.stale).toBe(false);
+    // Gone from the STORE, not merely from this response -- disclose.mjs and
+    // utility.mjs read the stored node, never the served copy.
+    expect(findingByKey(key).stale).toBeUndefined();
+  });
+
+  test('does NOT clear when the content genuinely still differs', () => {
+    const key = staleFinding();
+    // Not reverted. This is the mutation-facing assertion: an automatic path
+    // that cleared unconditionally would fire here on every tool call.
+    const served = serveOne(key, { dir });
+    expect(served.stale).toBe(true);
+    expect(findingByKey(key).stale).toBe(true);
+  });
+
+  test('does not render as both stale and fresh', () => {
+    const key = staleFinding();
+    writeFileSync(file, ORIGINAL);
+    indexFile(dir, file, ORIGINAL);
+
+    const served = serveOne(key, { dir });
+    // `serve` spreads the record, so a cleared flag with staleReason and diff
+    // still attached hands back a finding that reads fresh and stale at once --
+    // and different renderers key off different fields.
+    expect(served.stale).toBe(false);
+    expect(served.staleReason).toBeUndefined();
+    expect(served.diff).toBeUndefined();
+    expect(served.staleEvidence).toBeUndefined();
+  });
+
+  test('keeps the other two disclosures on a finding cleared mid-serve', () => {
+    const key = staleFinding();
+    putNodeWithEdges(dir, {
+      kind: 'finding', key: 'rebuttal', claim: 'parse does not trim', confidence: 0.9,
+    });
+    contradict(dir, { key, byKey: 'rebuttal', reason: 'read it again' });
+    writeFileSync(file, ORIGINAL);
+    indexFile(dir, file, ORIGINAL);
+
+    const served = serveOne(key, { dir });
+    expect(served.stale).toBe(false);
+    // A dispute is not staleness and must survive the clear.
+    expect(served.contradicted).toBe(true);
+    expect(served.contradictedBy).toBe('rebuttal');
+    // And so must the derivation verdict, which is what clearing was decided on.
+    expect(served.derivationHolds).toBe(true);
+    expect(served.derivationCheckedAgainst).toBe('index');
+  });
+
+  test('is read-only without a dir', () => {
+    const key = staleFinding();
+    writeFileSync(file, ORIGINAL);
+    indexFile(dir, file, ORIGINAL);
+
+    // No `dir`: the flag is still reported, and still stored.
+    const served = serveOne(key);
+    expect(served.stale).toBe(true);
+    expect(findingByKey(key).stale).toBe(true);
+  });
+
+  test('refuses to clear automatically with no claim-time record, exactly as reverify does', () => {
+    writeFileSync(file, ORIGINAL);
+    indexFile(dir, file, ORIGINAL);
+    putNodeWithEdges(
+      dir,
+      { kind: 'finding', key: 'legacy2', claim: 'parse trims', confidence: 0.9 },
+      [{ edge: 'derived_from', to: nodeId('file', file) }]
+    );
+    writeFileSync(file, CHANGED);
+    markStaleWithDiff(ORIGINAL, CHANGED);
+    writeFileSync(file, ORIGINAL);
+    indexFile(dir, file, ORIGINAL);
+
+    expect(serveOne('legacy2', { dir }).stale).toBe(true);
+    expect(findingByKey('legacy2').stale).toBe(true);
+  });
+
+  test('the lazy check can still mark a finding whose stored flag was just cleared', () => {
+    // Clearing removes only the STORED flag. The disk-against-node-hash
+    // comparison is a different question and is not overruled: here disk matches
+    // claim time while the anchor node still holds the post-edit hash.
+    const key = staleFinding();
+    writeFileSync(file, ORIGINAL); // reverted, but NOT re-indexed
+
+    const served = serveOne(key, { dir });
+    expect(findingByKey(key).stale).toBeUndefined(); // stored flag cleared
+    expect(served.stale).toBe(true);                 // lazy still disagrees
+    expect(served.staleReason).toBe('file changed');
+  });
+
+  test('the injection path clears it, so no dashboard visit is required', () => {
+    process.env.TOKEN_OPTIMIZER_HOLDOUT = '0';
+    try {
+      const key = staleFinding();
+      writeFileSync(file, ORIGINAL);
+      indexFile(dir, file, ORIGINAL);
+
+      const out = forTouch(dir, load(dir), file, { sessionId: 's1' });
+      expect(out).toContain('parse trims its argument');
+      expect(out).not.toContain('STALE');
+      expect(findingByKey(key).stale).toBeUndefined();
+    } finally {
+      delete process.env.TOKEN_OPTIMIZER_HOLDOUT;
+    }
+  });
+});
+
+/**
+ * Every writer records the claim-time hashes, not just the harvester.
+ *
+ * The asymmetry ran the wrong way: a hand-created or hand-corrected finding had
+ * no `derivation`, so it was the ONLY kind that could never have a stale flag
+ * cleared once marked. Findings that predate the record stay unclearable -- that
+ * is honest, and self-correcting as they are superseded.
+ */
+describe('curate writes claim-time anchor hashes too', () => {
+  test('create records the hashes, so its finding is re-verifiable', () => {
+    writeFileSync(file, ORIGINAL);
+    const key = create(dir, { claim: 'parse trims, asserted by hand', anchors: [file] });
+    expect(typeof key).toBe('string');
+
+    const node = findingByKey(key);
+    expect(node.derivation.anchors[nodeId('file', file)])
+      .toBe(load(dir).nodes.get(nodeId('file', file)).hash);
+    // The operations half is declared incomplete rather than asserted empty:
+    // curation performs no evidence-log join at all.
+    expect(node.derivation.operations).toEqual([]);
+    expect(node.derivation.operationsComplete).toBe(false);
+
+    writeFileSync(file, CHANGED);
+    markStaleWithDiff(ORIGINAL, CHANGED);
+    expect(findingByKey(key).stale).toBe(true);
+    expect(reverify(dir, key)).toBe('still-stale');
+
+    writeFileSync(file, ORIGINAL);
+    expect(reverify(dir, key)).toBe('cleared');
+  });
+
+  test('a correction records hashes against the code it was re-derived from', () => {
+    writeFileSync(file, ORIGINAL);
+    indexFile(dir, file, ORIGINAL);
+    const key = seedFinding();
+    writeFileSync(file, CHANGED);
+    markStaleWithDiff(ORIGINAL, CHANGED);
+
+    // The eager path re-indexed the anchor to CHANGED, which is what a person
+    // correcting the claim now reads -- so the correction's claim-time hash is
+    // CHANGED's, not its predecessor's.
+    const corrected = correct(dir, key, 'parse coerces then trims');
+    const fileHashNow = load(dir).nodes.get(nodeId('file', file)).hash;
+    expect(findingByKey(corrected).derivation.anchors[nodeId('file', file)]).toBe(fileHashNow);
+    expect(findingByKey(corrected).derivation.anchors[nodeId('file', file)])
+      .not.toBe(findingByKey(key).derivation.anchors[nodeId('file', file)]);
+
+    // Move the file away from the correction's own claim time, then back.
+    writeFileSync(file, ORIGINAL);
+    markStaleWithDiff(CHANGED, ORIGINAL);
+    expect(findingByKey(corrected).stale).toBe(true);
+    expect(reverify(dir, corrected)).toBe('still-stale');
+
+    writeFileSync(file, CHANGED);
+    expect(reverify(dir, corrected)).toBe('cleared');
   });
 });

--- a/tests/hooks/staleness.test.mjs
+++ b/tests/hooks/staleness.test.mjs
@@ -335,8 +335,37 @@ describe('diff output is bounded', () => {
     const before = Array.from({ length: 500 }, (_, i) => `line ${i}`).join('\n');
     const after = Array.from({ length: 500 }, (_, i) => `changed ${i}`).join('\n');
     const diff = diffLines(before, after);
-    expect(diff.split('\n').length).toBeLessThanOrEqual(44);
+    // 41, NOT 44, AND THE NUMBER IS THE POINT. Four places described this bound
+    // and no two agreed: the code could emit 43 lines (20 removed, 20 added, two
+    // elision markers, one out-of-budget notice), WIKI_GRAPH.md said 40, another
+    // test said 41 and this one said 44. `maxLines` now bounds the whole body --
+    // elision markers are paid for out of the eliding side's own quota -- so the
+    // ceiling is `maxLines` plus the one notice that is deliberately outside the
+    // budget.
+    expect(diff.split('\n').length).toBeLessThanOrEqual(41);
     expect(diff).toContain('more');
+  });
+
+  test('the worst case -- both sides elided AND lines dropped -- is maxLines + 1', () => {
+    // The shape that produced 43: both sides overflow, so both emit a marker, and
+    // the byte cap drops lines, so the notice is appended too.
+    const before = Array.from({ length: 500 }, (_, i) => `remove ${i} ${'r'.repeat(300)}`).join('\n');
+    const after = Array.from({ length: 500 }, (_, i) => `add ${i} ${'a'.repeat(300)}`).join('\n');
+    const lines = diffLines(before, after).split('\n');
+
+    expect(lines.length).toBeLessThanOrEqual(41);
+    // Vacuous unless all three truncations really fired.
+    expect(lines.filter((l) => l.includes('more removed')).length).toBe(1);
+    expect(lines.filter((l) => l.includes('more added')).length).toBe(1);
+    expect(lines.filter((l) => l.includes('cut at the size limit')).length).toBe(1);
+  });
+
+  test('a smaller maxLines is honoured as a whole-body bound', () => {
+    const before = Array.from({ length: 50 }, (_, i) => `x${i}`).join('\n');
+    const after = Array.from({ length: 50 }, (_, i) => `y${i}`).join('\n');
+    // No byte pressure at this size, so there is no notice: the body alone must
+    // fit, markers included.
+    expect(diffLines(before, after, { maxLines: 6 }).split('\n').length).toBe(6);
   });
 
   test('one enormous line cannot blow the budget', () => {

--- a/tests/hooks/staleness.test.mjs
+++ b/tests/hooks/staleness.test.mjs
@@ -451,6 +451,44 @@ describe('derivationCheck -- whether a claim-time derivation still holds', () =>
     const [out] = serve(graph, [graph.nodes.get(finding)]);
     expect(out.derivationHolds).toBe(false);
   });
+
+  it('declares what it checked against, on both branches, so a wiki_query consumer is not left to infer it', () => {
+    // `derivationHolds: true` means "matches the anchor's last-INDEXED
+    // hash", not "matches disk right now" -- `stale` already owns that
+    // comparison. A consumer reading raw JSON has no way to know which
+    // unless the record says so itself.
+    const holdsPath = write('q1.ts', 'export const q1 = 1;');
+    indexFile(dir, holdsPath);
+    const holdsId = nodeId('file', holdsPath);
+    const holdsHash = load(dir).nodes.get(holdsId).hash;
+    const holdsFinding = putNode(dir, {
+      kind: 'finding', key: 'q1', claim: 'q1 is 1', confidence: 0.9, type: 'finding',
+      derivation: { anchors: { [holdsId]: holdsHash }, operations: [], operationsScope: 'file', operationsComplete: true },
+    });
+    putEdge(dir, holdsFinding, 'derived_from', holdsId);
+
+    const changedPath = write('q2.ts', 'export const q2 = 1;');
+    indexFile(dir, changedPath);
+    const changedId = nodeId('file', changedPath);
+    const changedHash = load(dir).nodes.get(changedId).hash;
+    const changedFinding = putNode(dir, {
+      kind: 'finding', key: 'q2', claim: 'q2 is 1', confidence: 0.9, type: 'finding',
+      derivation: { anchors: { [changedId]: changedHash }, operations: [], operationsScope: 'file', operationsComplete: true },
+    });
+    putEdge(dir, changedFinding, 'derived_from', changedId);
+    writeFileSync(changedPath, 'export const q2 = 2;');
+    indexFile(dir, changedPath);
+
+    const graph = load(dir);
+    const [holdsOut, changedOut] = serve(graph, [
+      graph.nodes.get(holdsFinding),
+      graph.nodes.get(changedFinding),
+    ]);
+    expect(holdsOut.derivationHolds).toBe(true);
+    expect(holdsOut.derivationCheckedAgainst).toBe('index');
+    expect(changedOut.derivationHolds).toBe(false);
+    expect(changedOut.derivationCheckedAgainst).toBe('index');
+  });
 });
 
 /**
@@ -480,9 +518,39 @@ describe('the derivation-changed disclosure in forTouch', () => {
     const out = forTouch(dir, load(dir), path, { sessionId: 's-deriv' });
     expect(out).toContain('q is 1 by default');
     expect(out).toContain('DERIVATION CHANGED');
+    // Singular grammar for exactly one changed anchor -- "a.ts no longer
+    // match" read ungrammatically before this was fixed.
+    expect(out).toContain('no longer matches');
     // Not the staleness vocabulary -- checkAnchor calls this anchor fresh,
     // and the disclosure must not borrow words that assert something else.
     expect(out).not.toContain('STALE (');
+  });
+
+  it('pluralises correctly when MORE THAN ONE anchor no longer matches', () => {
+    const pathA = write('s1.ts', 'export const s1 = 1;');
+    const pathB = write('s2.ts', 'export const s2 = 1;');
+    indexFile(dir, pathA);
+    indexFile(dir, pathB);
+    const idA = nodeId('file', pathA);
+    const idB = nodeId('file', pathB);
+    const hashA = load(dir).nodes.get(idA).hash;
+    const hashB = load(dir).nodes.get(idB).hash;
+
+    const finding = putNode(dir, {
+      kind: 'finding', key: 's1s2', claim: 's1 and s2 both default to 1', confidence: 0.9, type: 'finding',
+      derivation: { anchors: { [idA]: hashA, [idB]: hashB }, operations: [], operationsScope: 'file', operationsComplete: true },
+    });
+    putEdge(dir, finding, 'derived_from', idA);
+    putEdge(dir, finding, 'derived_from', idB);
+
+    writeFileSync(pathA, 'export const s1 = 2;');
+    indexFile(dir, pathA);
+    writeFileSync(pathB, 'export const s2 = 2;');
+    indexFile(dir, pathB);
+
+    const out = forTouch(dir, load(dir), pathA, { sessionId: 's-deriv3' });
+    expect(out).toContain('no longer match ');
+    expect(out).not.toContain('no longer matches');
   });
 
   it('says nothing when the derivation still holds', () => {

--- a/tests/hooks/staleness.test.mjs
+++ b/tests/hooks/staleness.test.mjs
@@ -367,3 +367,138 @@ describe('diff output is bounded', () => {
     expect(diff).not.toContain('a');
   });
 });
+
+/**
+ * `derivationCheck`: the checker `derivation` (harvest-write.mjs) was written
+ * for. A grep found no reader before this -- only the writer and its own
+ * tests -- so "checkable rather than merely attributed" was a claim with no
+ * code behind it. This verifies the comparison it performs, and specifically
+ * the case it exists FOR: a claim's OWN frozen, claim-time hash can stop
+ * matching an anchor even while `checkAnchor`/`stale` -- which compares disk
+ * against the anchor NODE's CURRENT hash, refreshed by every re-index -- still
+ * calls the anchor fresh.
+ */
+describe('derivationCheck -- whether a claim-time derivation still holds', () => {
+  it('reports derivationHolds true when the anchor’s current hash still matches the claim-time hash', () => {
+    const path = write('m.ts', 'export const m = 1;');
+    indexFile(dir, path);
+    const fileId = nodeId('file', path);
+    const claimTimeHash = load(dir).nodes.get(fileId).hash;
+
+    const finding = putNode(dir, {
+      kind: 'finding', key: 'm1', claim: 'm is 1', confidence: 0.9, type: 'finding',
+      derivation: { anchors: { [fileId]: claimTimeHash }, operations: [], operationsScope: 'file', operationsComplete: true },
+    });
+    putEdge(dir, finding, 'derived_from', fileId);
+
+    const graph = load(dir);
+    const [out] = serve(graph, [graph.nodes.get(finding)]);
+    expect(out.derivationHolds).toBe(true);
+    expect(out.derivationChanged).toBeUndefined();
+  });
+
+  it('reports derivationHolds false, naming the anchor, when the CURRENT hash no longer matches the claim-time one -- even though checkAnchor calls the anchor fresh', () => {
+    const path = write('n.ts', 'export const n = 1;');
+    indexFile(dir, path);
+    const fileId = nodeId('file', path);
+    const claimTimeHash = load(dir).nodes.get(fileId).hash;
+
+    const finding = putNode(dir, {
+      kind: 'finding', key: 'n1', claim: 'n is 1', confidence: 0.9, type: 'finding',
+      derivation: { anchors: { [fileId]: claimTimeHash }, operations: [], operationsScope: 'file', operationsComplete: true },
+    });
+    putEdge(dir, finding, 'derived_from', fileId);
+
+    // Someone ELSE re-indexes the file after it changed -- a different
+    // session, a different finding, anything that calls `indexFile` on it
+    // again. The file node's stored hash is refreshed to match disk, so
+    // node-level staleness reports "fresh": disk equals the node's CURRENT
+    // hash. This finding's OWN claim-time snapshot was never updated.
+    writeFileSync(path, 'export const n = 2;');
+    indexFile(dir, path);
+
+    const graph = load(dir);
+    const [out] = serve(graph, [graph.nodes.get(finding)]);
+    // The existing mechanism sees nothing wrong -- this is the exact gap
+    // `derivationCheck` closes, not a case it duplicates.
+    expect(out.stale).toBe(false);
+    expect(out.derivationHolds).toBe(false);
+    // Named by the anchor's stored (canonical) key, not the raw path spelling.
+    expect(out.derivationChanged).toEqual([canonicalPath(path)]);
+  });
+
+  it('is absent (not false) on a finding with no derivation record at all', () => {
+    // Every finding written before this feature existed has no `derivation`
+    // field. `derivationHolds` must be ABSENT for those, not `false` --
+    // `false` would assert a check that never happened.
+    const path = write('o.ts', 'export const o = 1;');
+    indexFile(dir, path);
+    const finding = putNode(dir, { kind: 'finding', key: 'o1', claim: 'o is 1', confidence: 0.9, type: 'finding' });
+    putEdge(dir, finding, 'derived_from', nodeId('file', path));
+
+    const graph = load(dir);
+    const [out] = serve(graph, [graph.nodes.get(finding)]);
+    expect('derivationHolds' in out).toBe(false);
+  });
+
+  it('treats an anchor that no longer resolves at all as changed, not as holding', () => {
+    const finding = putNode(dir, {
+      kind: 'finding', key: 'p1', claim: 'p is 1', confidence: 0.9, type: 'finding',
+      derivation: { anchors: { 'file:doesnotexist': 'some-hash' }, operations: [], operationsScope: 'file', operationsComplete: true },
+    });
+
+    const graph = load(dir);
+    const [out] = serve(graph, [graph.nodes.get(finding)]);
+    expect(out.derivationHolds).toBe(false);
+  });
+});
+
+/**
+ * `derivationNote` (inject.mjs): where `derivationCheck`'s verdict actually
+ * reaches a model. Distinguishable from `disputeNote` (another finding
+ * disagrees) and from the STALE block (the anchor node's current hash does
+ * not match disk) -- silent in the common case, and priced against the
+ * injection budget the same way both of those already are, because it lives
+ * inside `render()`, which `fit()` measures.
+ */
+describe('the derivation-changed disclosure in forTouch', () => {
+  it('names the changed anchor in the injected text when a touched finding’s derivation no longer holds', () => {
+    const path = write('q.ts', 'export const q = 1;');
+    indexFile(dir, path);
+    const fileId = nodeId('file', path);
+    const claimTimeHash = load(dir).nodes.get(fileId).hash;
+
+    const finding = putNode(dir, {
+      kind: 'finding', key: 'q1', claim: 'q is 1 by default', confidence: 0.9, type: 'finding',
+      derivation: { anchors: { [fileId]: claimTimeHash }, operations: [], operationsScope: 'file', operationsComplete: true },
+    });
+    putEdge(dir, finding, 'derived_from', fileId);
+
+    writeFileSync(path, 'export const q = 2;');
+    indexFile(dir, path);
+
+    const out = forTouch(dir, load(dir), path, { sessionId: 's-deriv' });
+    expect(out).toContain('q is 1 by default');
+    expect(out).toContain('DERIVATION CHANGED');
+    // Not the staleness vocabulary -- checkAnchor calls this anchor fresh,
+    // and the disclosure must not borrow words that assert something else.
+    expect(out).not.toContain('STALE (');
+  });
+
+  it('says nothing when the derivation still holds', () => {
+    const path = write('r.ts', 'export const r = 1;');
+    indexFile(dir, path);
+    const fileId = nodeId('file', path);
+    const claimTimeHash = load(dir).nodes.get(fileId).hash;
+
+    putNode(dir, {
+      kind: 'finding', key: 'r1', claim: 'r is 1 by default', confidence: 0.9, type: 'finding',
+      derivation: { anchors: { [fileId]: claimTimeHash }, operations: [], operationsScope: 'file', operationsComplete: true },
+    });
+    putEdge(dir, nodeId('finding', 'r1'), 'derived_from', fileId);
+
+    const out = forTouch(dir, load(dir), path, { sessionId: 's-deriv2' });
+    expect(out).toContain('r is 1 by default');
+    expect(out).not.toContain('DERIVATION CHANGED');
+  });
+});

--- a/tests/hooks/staleness.test.mjs
+++ b/tests/hooks/staleness.test.mjs
@@ -339,6 +339,27 @@ describe('diff output is bounded', () => {
     expect(diff).toContain('more');
   });
 
+  test('one enormous line cannot blow the budget', () => {
+    // MEASURED BEFORE THE FIX: this exact call returned 2 lines and 400,005
+    // bytes. `maxLines` is a LINE bound with no byte bound, and a minified
+    // bundle, a generated file or a single long JSON line all have that shape --
+    // so the "capped" diff put hundreds of kilobytes of verbatim file content
+    // straight into model context through inject.mjs's zero-turn refusal.
+    const diff = diffLines('X'.repeat(200_000), 'Y'.repeat(200_000));
+    expect(Buffer.byteLength(diff, 'utf8')).toBeLessThan(5_000);
+    // AND THE TRUNCATION IS VISIBLE. A silently shortened diff is worse than a
+    // visibly shortened one: a reader who cannot tell content was elided
+    // believes they saw the whole change.
+    expect(diff).toMatch(/chars cut/);
+  });
+
+  test('the total stays bounded even across many long lines', () => {
+    const before = Array.from({ length: 40 }, (_, i) => `a${i}`.repeat(5_000)).join('\n');
+    const after = Array.from({ length: 40 }, (_, i) => `b${i}`.repeat(5_000)).join('\n');
+    const diff = diffLines(before, after);
+    expect(Buffer.byteLength(diff, 'utf8')).toBeLessThan(5_000);
+  });
+
   test('only the changed region is shown', () => {
     const diff = diffLines('a\nb\nc', 'a\nB\nc');
     expect(diff).toContain('- b');

--- a/tests/hooks/tool-normalisation.test.mjs
+++ b/tests/hooks/tool-normalisation.test.mjs
@@ -1,0 +1,225 @@
+/**
+ * Tool-name normalisation, and the loop hazard that comes with widening it.
+ *
+ * `plugin/hooks/hooks.json`'s PostToolUse matcher has always listed
+ * `mcp__.*__(?:smart_edit|smart_write)`, but `normalizeTool` resolved only the
+ * seven built-ins and the alias table -- so an MCP-prefixed name mapped to
+ * null and the hook exited before any accounting ran. The optimizer was blind
+ * to its OWN tools on exactly the path enforcement pushes the model toward:
+ * staleness, mutation counting and harvest pressure all silently skipped.
+ *
+ * Widening the resolver is not free, because the same function feeds the
+ * routing decision. Two properties therefore have to hold together:
+ *
+ *   1. an MCP-prefixed name resolves, so post-tool accounting sees it;
+ *   2. resolving it must NEVER make the router deny the replacement and
+ *      redirect it to itself.
+ *
+ * (2) is not hypothetical. Qwen's PreToolUse matcher is the unanchored regex
+ * `edit|write_file|run_shell_command`, and `edit` matches inside
+ * `mcp__x__smart_edit` -- so on that client the router really is handed
+ * smart_edit calls. Without the guard, smart_edit on a large file normalises
+ * to `Edit` and earns the "call smart_edit instead" verdict.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  normalizeTool,
+  normalizePayload,
+  decide,
+  readCostBytes,
+  isReplacementTool,
+  touchedFiles,
+} from '../../hooks-core/decide.mjs';
+import { observedWrites } from '../../hooks-core/pending.mjs';
+
+let workspace;
+let big;
+
+const AVAILABLE = new Set([
+  'smart_read',
+  'smart_write',
+  'smart_edit',
+  'smart_glob',
+  'smart_grep',
+]);
+
+beforeEach(() => {
+  workspace = mkdtempSync(join(tmpdir(), 'toolnorm-'));
+  big = join(workspace, 'big.ts');
+  writeFileSync(big, 'x'.repeat(200 * 1024));
+});
+afterEach(() => rmSync(workspace, { recursive: true, force: true }));
+
+function payloadFor(toolName, input) {
+  return normalizePayload({
+    session_id: 'session-1',
+    cwd: workspace,
+    tool_name: toolName,
+    tool_input: input,
+  });
+}
+
+describe('normalizeTool', () => {
+  it('resolves an MCP-prefixed tool name by its trailing segment', () => {
+    expect(
+      normalizeTool('mcp__plugin_token-optimizer_token-optimizer__smart_edit')
+    ).toBe('Edit');
+    expect(normalizeTool('mcp__whatever__smart_write')).toBe('Write');
+    expect(normalizeTool('mcp__whatever__smart_read')).toBe('Read');
+    expect(normalizeTool('mcp__whatever__smart_grep')).toBe('Grep');
+    expect(normalizeTool('mcp__whatever__smart_glob')).toBe('Glob');
+  });
+
+  it('resolves the bare replacement names too, as Codex spells them', () => {
+    // integrations/codex/hooks/hooks.json's AfterTool matcher lists
+    // `smart_edit|smart_write` WITHOUT an mcp__ prefix, so the unprefixed
+    // spelling has to resolve or that matcher is decorative on Codex.
+    expect(normalizeTool('smart_edit')).toBe('Edit');
+    expect(normalizeTool('smart_write')).toBe('Write');
+  });
+
+  it('resolves NotebookEdit, which the alias table never listed', () => {
+    expect(normalizeTool('NotebookEdit')).toBe('Edit');
+    expect(normalizeTool('notebook_edit')).toBe('Edit');
+  });
+
+  it('still returns null for a tool it genuinely does not know', () => {
+    // The permissive direction matters: an unknown tool must stay unknown
+    // rather than being coerced into a built-in, which would change a routing
+    // verdict for a tool nobody has considered.
+    expect(normalizeTool('mcp__vendor__deploy_to_prod')).toBeNull();
+    expect(normalizeTool('mcp__vendor__edit_the_database')).toBeNull();
+    expect(normalizeTool('deploy_to_prod')).toBeNull();
+    expect(normalizeTool('')).toBeNull();
+    expect(normalizeTool(undefined)).toBeNull();
+  });
+
+  it('strips only a well-formed mcp__server__ prefix', () => {
+    // A prefix strip that just took the text after the last `__` would resolve
+    // `not_mcp__edit`, which is a name this project has never seen and has no
+    // business coercing into the built-in Edit.
+    expect(normalizeTool('not_mcp__edit')).toBeNull();
+    expect(normalizeTool('mcp__edit')).toBeNull();
+  });
+
+  it('keeps every built-in and pre-existing alias resolving as before', () => {
+    expect(normalizeTool('Read')).toBe('Read');
+    expect(normalizeTool('MultiEdit')).toBe('MultiEdit');
+    expect(normalizeTool('run_shell_command')).toBe('Bash');
+    expect(normalizeTool('apply_patch')).toBe('Edit');
+    expect(normalizeTool('read_file')).toBe('Read');
+  });
+});
+
+describe('the loop hazard', () => {
+  it('does not redirect a large-file smart_edit to smart_edit', () => {
+    // The built-in spelling of the same call IS redirected -- that is the whole
+    // point of enforcement -- so this pair is what proves the guard discriminates
+    // rather than just disabling the Edit branch.
+    const builtin = decide(
+      payloadFor('Edit', { file_path: big, old_string: 'x', new_string: 'y' }),
+      { seen: {} },
+      AVAILABLE
+    );
+    expect(builtin).not.toBeNull();
+    expect(builtin.reason).toMatch(/smart_edit/);
+
+    const replacement = decide(
+      payloadFor('mcp__x__smart_edit', { file_path: big }),
+      { seen: {} },
+      AVAILABLE
+    );
+    expect(replacement).toBeNull();
+  });
+
+  it('does not redirect any of the other replacements to themselves', () => {
+    const cases = [
+      ['mcp__x__smart_read', { file_path: big }],
+      ['mcp__x__smart_grep', { pattern: 'foo' }],
+      ['mcp__x__smart_glob', { pattern: '**/*.ts' }],
+      ['mcp__x__smart_write', { file_path: big, content: 'y'.repeat(200000) }],
+      ['smart_edit', { file_path: big }],
+      ['smart_write', { file_path: big, content: 'y'.repeat(200000) }],
+    ];
+    for (const [tool, input] of cases) {
+      expect(decide(payloadFor(tool, input), { seen: {} }, AVAILABLE)).toBeNull();
+    }
+  });
+
+  it('does not redirect a smart_read of a file already read this session', () => {
+    // The re-read branch fires on `state.seen`, not on size, so it is a second
+    // independent way the same call could have been told to call itself.
+    const payload = payloadFor('mcp__x__smart_read', { file_path: big });
+    const state = { seen: { [payload.tool_input.file_path]: true } };
+    expect(decide(payload, state, AVAILABLE)).toBeNull();
+  });
+
+  it('still redirects a built-in Read the guard must not have disabled', () => {
+    const payload = payloadFor('Read', { file_path: big });
+    const state = { seen: {} };
+    const verdict = decide(payload, state, AVAILABLE);
+    expect(verdict).not.toBeNull();
+    expect(verdict.reason).toMatch(/smart_read/);
+  });
+});
+
+describe('the normalised name reaches post-tool accounting', () => {
+  it('marks a replacement call as a replacement on the payload', () => {
+    expect(payloadFor('mcp__x__smart_edit', { file_path: big }).replacement)
+      .toBe(true);
+    expect(payloadFor('Edit', { file_path: big }).replacement).toBe(false);
+  });
+
+  it('gives NotebookEdit a canonical mutating name', () => {
+    // pending.mjs's MUTATING set matches on the canonical name, so a notebook
+    // edit only reaches invalidation once this resolves.
+    expect(payloadFor('NotebookEdit', { file_path: big }).tool_name).toBe(
+      'Edit'
+    );
+  });
+
+  it('reaches invalidation for a real NotebookEdit without being routed', () => {
+    // Claude Code spells the target `notebook_path`, which normalizePayload
+    // deliberately does NOT fold into the canonical `file_path` -- so the Edit
+    // branch finds no path and the call is allowed, while touchedFiles and
+    // pending.writtenPath (which both already read notebook_path) finally get
+    // a payload to work with because the NAME now resolves.
+    const payload = payloadFor('NotebookEdit', {
+      notebook_path: big,
+      new_source: 'z',
+    });
+    expect(payload.tool_name).toBe('Edit');
+    expect(decide(payload, { seen: {} }, AVAILABLE)).toBeNull();
+    // touchedFiles canonicalises separators, so compare on the leaf.
+    expect(touchedFiles(payload).map((item) => item.path)).toEqual([
+      expect.stringMatching(/big\.ts$/),
+    ]);
+    expect(observedWrites(payload, {}).map((e) => e.path)).toContain(big);
+  });
+});
+
+describe('what the newly-resolving names must NOT be counted as', () => {
+  it('does not charge a smart_read the whole file it did not send', () => {
+    // recordRead prices this at bytes/4 tokens and feeds it to the holdout
+    // comparison as downstream read cost. smart_read returns a diff, so
+    // charging the full file would inflate the very arm the optimizer claims
+    // is cheaper -- a measurement error pointing the flattering way.
+    expect(readCostBytes(payloadFor('Read', { file_path: big }))).toBe(
+      200 * 1024
+    );
+    expect(
+      readCostBytes(payloadFor('mcp__x__smart_read', { file_path: big }))
+    ).toBe(0);
+  });
+
+  it('recognises a replacement however the host spells it', () => {
+    expect(isReplacementTool('mcp__x__smart_edit')).toBe(true);
+    expect(isReplacementTool('SMART_EDIT')).toBe(true);
+    expect(isReplacementTool('Edit')).toBe(false);
+    expect(isReplacementTool('mcp__vendor__deploy_to_prod')).toBe(false);
+    expect(isReplacementTool(null)).toBe(false);
+  });
+});

--- a/tests/hooks/wiki-query-tool.test.mjs
+++ b/tests/hooks/wiki-query-tool.test.mjs
@@ -300,17 +300,34 @@ describe('wiki_query', () => {
     process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY = join(repo, 'projects.jsonl');
     try {
       // Where the hooks write the denominator.
-      const hookDir = wikiDir(projectRootFor(join(repo, '__session__'), repo));
+      const canonicalRoot = projectRootFor(join(repo, '__session__'), repo);
+      const hookDir = wikiDir(canonicalRoot);
 
       // The same root, spelled the way a caller might hand it over.
+      //
+      // CONCATENATED, NOT `join`ed. `path.join` normalises `packages/..` away
+      // as it builds the string, so the "odd" spelling came back already
+      // canonical and the two spellings below were the same string on a POSIX
+      // host -- the assertion that they differ could only ever hold on Windows,
+      // where the lower-case drive letter survives.
       const SEP = String.fromCharCode(92); // a backslash, unambiguously
-      let odd = join(repo, 'packages', '..').split(SEP).join('/');
+      let odd = `${repo}${SEP}packages${SEP}..`.split(SEP).join('/');
       if (process.platform === 'win32')
         odd = odd.charAt(0).toLowerCase() + odd.slice(1);
       // The two spellings are different STRINGS, which is the whole problem:
       // `indexBudget`, the project registry and the dashboards all key on the
       // graph directory, so two strings for one repository double-count it.
-      expect(wikiDir(odd)).not.toBe(hookDir);
+      expect(odd).not.toBe(canonicalRoot);
+      // ...and on Windows that difference reaches the KEY, because `wikiDir`
+      // joins and `path.join` does not touch a drive letter's case.
+      //
+      // STATED RATHER THAN ASSERTED EVERYWHERE: on a POSIX host there is no
+      // spelling of the same directory that survives `path.join` -- it collapses
+      // `.`, `..` and doubled separators, and a case-sensitive filesystem has no
+      // case variant that names the same directory. So the fork is demonstrated
+      // where the platform can produce one; the GUARANTEE below is asserted on
+      // every platform, and so is the end-to-end event placement further down.
+      if (process.platform === 'win32') expect(wikiDir(odd)).not.toBe(hookDir);
       // Canonicalised, they are one key. This is the guarantee the fix adds.
       expect(wikiDir(canonicalPath(odd))).toBe(hookDir);
 

--- a/tests/hooks/wiki-query-tool.test.mjs
+++ b/tests/hooks/wiki-query-tool.test.mjs
@@ -1,9 +1,8 @@
 /**
  * wiki_query — and, more importantly, whether anything can CALL it.
  *
- * The in-process cases below are the ordinary contract: get, search, anchor, the
- * missing key, and the `query` metric event that earns the session index its
- * budget. They are necessary and they are not sufficient. This repository's
+ * The in-process cases below are the ordinary contract: get, search, the missing
+ * key, and the `query` metric event that earns the session index its budget. They are necessary and they are not sufficient. This repository's
  * defining defect is correct code nothing calls, and every one of those cases
  * would pass on a tool that no MCP client could reach.
  *
@@ -23,14 +22,20 @@ import {
   beforeAll,
   afterAll,
 } from '@jest/globals';
-import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, rmSync, existsSync } from 'node:fs';
 import { spawn } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { putNodeWithEdges, nodeId } from '../../hooks-core/wiki.mjs';
+import {
+  putNodeWithEdges,
+  nodeId,
+  wikiDir,
+  projectRootFor,
+} from '../../hooks-core/wiki.mjs';
 // `readAll` is private to metrics.mjs; `readMetrics` is the exported reader over
 // the same bounded log.
 import { readMetrics } from '../../hooks-core/metrics.mjs';
+import { canonicalPath } from '../../hooks-core/paths.mjs';
 import {
   wikiQuery,
   WIKI_QUERY_TOOL_DEFINITION,
@@ -198,6 +203,158 @@ describe('wiki_query', () => {
     expect(result.finding.stale).toBe(true);
     expect(result.finding).toHaveProperty('staleReason');
     expect(result.finding).toHaveProperty('staleEvidence');
+  });
+
+  it('writes the query event to the REPOSITORY ROOT graph, not to the cwd', async () => {
+    // THIS IS THE WHOLE POINT OF THE TASK, and it is the assertion that would
+    // have passed on a broken tool.
+    //
+    // `indexBudget` divides `queries` by `listed` PER GRAPH DIRECTORY. The
+    // `index` events forming the denominator are written by the hooks to
+    // `wikiDir(projectRootFor(join(cwd, '__session__'), cwd))`, which WALKS UP
+    // for a VCS marker. A tool that used the raw cwd would file its numerator in
+    // a subdirectory's graph where the denominator is zero, and the denominator
+    // would sit in the root's graph where the numerator is zero -- so the budget
+    // would stay pinned at its floor and this task would have changed nothing
+    // while looking finished.
+    //
+    // So this asserts agreement with the HOOKS' OWN FORMULA rather than
+    // restating a path, and resolves from a SUBDIRECTORY, where raw cwd differs
+    // from the repository root.
+    const repo = mkdtempSync(join(tmpdir(), 'wq-repo-'));
+    const nested = join(repo, 'packages', 'thing');
+    mkdirSync(join(repo, '.git'), { recursive: true });
+    mkdirSync(nested, { recursive: true });
+
+    const cwdBefore = process.cwd();
+    const wikiOverride = process.env.TOKEN_OPTIMIZER_WIKI_DIR;
+    const registryBefore = process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY;
+    // An override would resolve every root to one directory and make this test
+    // vacuous; the registry is redirected so the run cannot touch the real one.
+    delete process.env.TOKEN_OPTIMIZER_WIKI_DIR;
+    process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY = join(repo, 'projects.jsonl');
+    try {
+      process.chdir(nested);
+
+      // Exactly what plugin/hooks/session-start.mjs and hooks-core/adapter.mjs
+      // compute for the index events.
+      const hookDir = wikiDir(
+        projectRootFor(join(process.cwd(), '__session__'), process.cwd())
+      );
+      const rawCwdDir = wikiDir(process.cwd());
+      // If these were equal the test could not tell the two behaviours apart.
+      expect(hookDir).not.toBe(rawCwdDir);
+
+      await wikiQuery({ operation: 'get', key: 'nothing-here' });
+
+      const atRoot = readMetrics(hookDir).filter((e) => e.kind === 'query');
+      expect(atRoot).toHaveLength(1);
+      expect(atRoot[0].operation).toBe('get');
+      // ...and nothing in the subdirectory, which is where the raw cwd pointed.
+      expect(readMetrics(rawCwdDir).filter((e) => e.kind === 'query')).toEqual(
+        []
+      );
+    } finally {
+      process.chdir(cwdBefore);
+      if (wikiOverride === undefined)
+        delete process.env.TOKEN_OPTIMIZER_WIKI_DIR;
+      else process.env.TOKEN_OPTIMIZER_WIKI_DIR = wikiOverride;
+      if (registryBefore === undefined)
+        delete process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY;
+      else process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY = registryBefore;
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('canonicalises a caller-supplied root, so two spellings are one graph', async () => {
+    // `projectRootFor` canonicalises what it returns, but `wikiDir` does NOT
+    // canonicalise what it is given -- so an explicit `projectRoot` was the one
+    // path into this function that could still fork a repository into two
+    // graphs. A caller spelling the root differently from the hooks (mixed
+    // separators, a redundant segment, a lower-case drive letter on Windows)
+    // must still land where the hooks' index events go, or `indexBudget` splits
+    // again for a second reason.
+    const repo = mkdtempSync(join(tmpdir(), 'wq-spell-'));
+    mkdirSync(join(repo, '.git'), { recursive: true });
+    mkdirSync(join(repo, 'packages'), { recursive: true });
+    const registryBefore = process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY;
+    const wikiOverride = process.env.TOKEN_OPTIMIZER_WIKI_DIR;
+    delete process.env.TOKEN_OPTIMIZER_WIKI_DIR;
+    process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY = join(repo, 'projects.jsonl');
+    try {
+      // Where the hooks write the denominator.
+      const hookDir = wikiDir(projectRootFor(join(repo, '__session__'), repo));
+
+      // The same root, spelled the way a caller might hand it over.
+      const SEP = String.fromCharCode(92); // a backslash, unambiguously
+      let odd = join(repo, 'packages', '..').split(SEP).join('/');
+      if (process.platform === 'win32')
+        odd = odd.charAt(0).toLowerCase() + odd.slice(1);
+      // The two spellings are different STRINGS, which is the whole problem:
+      // `indexBudget`, the project registry and the dashboards all key on the
+      // graph directory, so two strings for one repository double-count it.
+      expect(wikiDir(odd)).not.toBe(hookDir);
+      // Canonicalised, they are one key. This is the guarantee the fix adds.
+      expect(wikiDir(canonicalPath(odd))).toBe(hookDir);
+
+      await wikiQuery({ operation: 'get', key: 'nothing', projectRoot: odd });
+
+      // And the event is where the hooks write the denominator -- exactly one,
+      // so the odd spelling did not open a second graph beside it.
+      expect(
+        readMetrics(hookDir).filter((e) => e.kind === 'query')
+      ).toHaveLength(1);
+      // HONEST LIMIT, stated rather than asserted around: a stronger check
+      // ("nothing at wikiDir(odd)") cannot fail on this filesystem, because a
+      // case- or separator-variant spelling names the SAME physical directory.
+      // The divergence this fix prevents is in the directory used as a KEY, and
+      // on a case-sensitive filesystem it is a divergence on disk as well.
+    } finally {
+      if (wikiOverride === undefined)
+        delete process.env.TOKEN_OPTIMIZER_WIKI_DIR;
+      else process.env.TOKEN_OPTIMIZER_WIKI_DIR = wikiOverride;
+      if (registryBefore === undefined)
+        delete process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY;
+      else process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY = registryBefore;
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed at the walk depth cap instead of returning the subtree', async () => {
+    // The cap exists so a cycle cannot hang the response, and its first version
+    // returned the raw subtree there -- a leak through the single exit the guard
+    // was written to seal. Nesting past the cap proves it now fails closed.
+    const deep = mkdtempSync(join(tmpdir(), 'wq-deep-'));
+    try {
+      putNodeWithEdges(deep, {
+        kind: 'finding',
+        key: 'buried',
+        claim: 'a claim with something buried far below it',
+        confidence: 0.9,
+        type: 'decision', // not content-dependent, so `serve` passes it through
+        nest: {
+          a: {
+            b: {
+              c: { d: { e: { f: { g: { snapshot: 'DEEP PRIVATE BODY' } } } } },
+            },
+          },
+        },
+      });
+
+      const result = await wikiQuery({
+        operation: 'get',
+        key: 'buried',
+        graphDir: deep,
+      });
+      expect(result.found).toBe(true);
+      const rendered = JSON.stringify(result);
+      // Proves the cap was actually REACHED -- without this the test could pass
+      // on a response that was simply shallower than intended.
+      expect(rendered).toContain('[depth limit]');
+      expect(rendered).not.toContain('DEEP PRIVATE BODY');
+    } finally {
+      rmSync(deep, { recursive: true, force: true });
+    }
   });
 });
 

--- a/tests/hooks/wiki-query-tool.test.mjs
+++ b/tests/hooks/wiki-query-tool.test.mjs
@@ -82,6 +82,23 @@ describe('wiki_query', () => {
     expect(result.findings.map((f) => f.key)).toContain('retry-cap');
   });
 
+  it('returns the pool rather than nothing when query is omitted, blank, or punctuation-only', async () => {
+    // `query` is optional in the schema (a model can call search without
+    // one, same as a user leaving the dashboard search box blank). `rank`
+    // itself returns [] when tokenize(query) has nothing to score --
+    // correct for `rank` alone, but wrong for this tool's contract if left
+    // unguarded: a model omitting `query` would get `found: false` for a
+    // pool that is not actually empty. This mirrors the same guard added to
+    // /api/wiki/search in src/server/wiki-routes.ts, so both search surfaces
+    // agree that "no usable query" means "return the pool," not "return
+    // nothing."
+    for (const query of [undefined, '', '   ', '!!! ,,, ???']) {
+      const result = await wikiQuery({ operation: 'search', query, graphDir: dir });
+      expect(result.found).toBe(true);
+      expect(result.findings.map((f) => f.key)).toContain('retry-cap');
+    }
+  });
+
   it('refuses the anchored retrieval that belongs to wiki_read', async () => {
     // Deliberately NOT supported here. wiki_read already answers "what does the
     // graph know about this file", and two tools with an identical operation

--- a/tests/hooks/wiki-query-tool.test.mjs
+++ b/tests/hooks/wiki-query-tool.test.mjs
@@ -1,0 +1,242 @@
+/**
+ * wiki_query — and, more importantly, whether anything can CALL it.
+ *
+ * The in-process cases below are the ordinary contract: get, search, anchor, the
+ * missing key, and the `query` metric event that earns the session index its
+ * budget. They are necessary and they are not sufficient. This repository's
+ * defining defect is correct code nothing calls, and every one of those cases
+ * would pass on a tool that no MCP client could reach.
+ *
+ * So the last block drives the BUILT server over stdio, exactly as a client
+ * does: tools/list must advertise wiki_query under the default profile, and
+ * tools/call must route it. That is the assertion that would have failed while
+ * `wiki_query` was absent from CORE_TOOL_NAMES -- the handler refuses any name
+ * outside the advertised set, so the tool was schema-checked, dispatch-wired and
+ * still unreachable.
+ */
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  afterAll,
+} from '@jest/globals';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { spawn } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  putNodeWithEdges,
+  nodeId,
+} from '../../hooks-core/wiki.mjs';
+// `readAll` is private to metrics.mjs; `readMetrics` is the exported reader over
+// the same bounded log.
+import { readMetrics } from '../../hooks-core/metrics.mjs';
+import { wikiQuery } from '../../dist/tools/intelligence/wiki-query.js';
+
+let dir;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'wq-'));
+  putNodeWithEdges(dir, { kind: 'file', key: join(dir, 'auth.ts'), hash: 'abc' });
+  putNodeWithEdges(
+    dir,
+    {
+      kind: 'finding',
+      key: 'retry-cap',
+      claim: 'the retry backoff is capped at thirty seconds',
+      confidence: 0.9,
+    },
+    [{ edge: 'derived_from', to: nodeId('file', join(dir, 'auth.ts')) }]
+  );
+});
+
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+describe('wiki_query', () => {
+  it('returns a finding by key', async () => {
+    const result = await wikiQuery({
+      operation: 'get',
+      key: 'retry-cap',
+      graphDir: dir,
+    });
+    expect(result.finding.claim).toContain('thirty seconds');
+  });
+
+  it('finds a finding by search term', async () => {
+    const result = await wikiQuery({
+      operation: 'search',
+      query: 'retry backoff',
+      graphDir: dir,
+    });
+    expect(result.findings.map((f) => f.key)).toContain('retry-cap');
+  });
+
+  it('traverses from a file anchor to its findings', async () => {
+    const result = await wikiQuery({
+      operation: 'anchor',
+      anchor: join(dir, 'auth.ts'),
+      graphDir: dir,
+    });
+    expect(result.findings.map((f) => f.key)).toContain('retry-cap');
+  });
+
+  it('records a query event, which is what earns the session index its budget', async () => {
+    await wikiQuery({ operation: 'get', key: 'retry-cap', graphDir: dir });
+    const events = readMetrics(dir).filter((e) => e.kind === 'query');
+    expect(events).toHaveLength(1);
+    expect(events[0].operation).toBe('get');
+  });
+
+  it('reports a missing key rather than throwing', async () => {
+    const result = await wikiQuery({
+      operation: 'get',
+      key: 'nope',
+      graphDir: dir,
+    });
+    expect(result.found).toBe(false);
+  });
+
+  it('never serves a stale finding bare', async () => {
+    // The anchor was recorded with a hash and never written to disk, so the
+    // finding is stale. It must arrive marked, with the evidence state stated.
+    const result = await wikiQuery({
+      operation: 'get',
+      key: 'retry-cap',
+      graphDir: dir,
+    });
+    expect(result.finding.stale).toBe(true);
+    expect(result.finding).toHaveProperty('staleReason');
+    expect(result.finding).toHaveProperty('staleEvidence');
+  });
+});
+
+/**
+ * The reachability half: the real transport, the real profile gate, the real
+ * dispatch switch. Anything asserted above about `wikiQuery` is a claim about a
+ * function; only this is a claim about a TOOL.
+ */
+describe('wiki_query over the MCP transport a client actually uses', () => {
+  const SERVER = join(process.cwd(), 'dist', 'server', 'index.js');
+  let server;
+  let stdoutBuffer = '';
+  let stderr = '';
+  let nextId = 1;
+  const pending = new Map();
+
+  function call(method, params, timeoutMs = 60_000) {
+    const id = nextId++;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(
+        () =>
+          reject(
+            new Error(
+              `timed out waiting for ${method} (id ${id}); stderr: ${stderr.slice(-800)}`
+            )
+          ),
+        timeoutMs
+      );
+      pending.set(id, (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      });
+      server.stdin.write(
+        `${JSON.stringify({ jsonrpc: '2.0', id, method, params })}\n`
+      );
+    });
+  }
+
+  beforeAll(async () => {
+    expect(existsSync(SERVER)).toBe(true);
+    server = spawn(process.execPath, [SERVER], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, TOKEN_OPTIMIZER_MODE: 'off' },
+    });
+    server.stderr.on('data', (chunk) => {
+      stderr += String(chunk);
+    });
+    server.stdout.on('data', (chunk) => {
+      stdoutBuffer += String(chunk);
+      let index = stdoutBuffer.indexOf('\n');
+      while (index !== -1) {
+        const line = stdoutBuffer.slice(0, index).trim();
+        stdoutBuffer = stdoutBuffer.slice(index + 1);
+        if (line) {
+          let message = null;
+          try {
+            message = JSON.parse(line);
+          } catch {
+            message = null;
+          }
+          const resolver =
+            message && typeof message.id === 'number'
+              ? pending.get(message.id)
+              : undefined;
+          if (resolver) {
+            pending.delete(message.id);
+            resolver(message.result ?? message.error);
+          }
+        }
+        index = stdoutBuffer.indexOf('\n');
+      }
+    });
+
+    await call('initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'wiki-query-reachability', version: '0.0.0' },
+    });
+    server.stdin.write(
+      `${JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' })}\n`
+    );
+  }, 120_000);
+
+  afterAll(() => {
+    if (server && !server.killed) server.kill();
+  });
+
+  it('advertises wiki_query in tools/list under the DEFAULT profile', async () => {
+    const result = await call('tools/list', {});
+    const names = (result?.tools ?? []).map((tool) => tool.name);
+    expect(names).toContain('wiki_query');
+  }, 120_000);
+
+  it('publishes every option the implementation accepts', async () => {
+    const result = await call('tools/list', {});
+    const tool = (result?.tools ?? []).find((t) => t.name === 'wiki_query');
+    expect(tool).toBeDefined();
+    expect(Object.keys(tool.inputSchema.properties).sort()).toEqual(
+      [
+        'anchor',
+        'graphDir',
+        'key',
+        'limit',
+        'nodeId',
+        'operation',
+        'projectRoot',
+        'query',
+        'sessionId',
+        'type',
+      ].sort()
+    );
+  }, 120_000);
+
+  it('routes tools/call to the tool, and the call lands a query event in THAT project graph', async () => {
+    const result = await call('tools/call', {
+      name: 'wiki_query',
+      arguments: { operation: 'get', key: 'retry-cap', graphDir: dir },
+    });
+    const text = result?.content?.[0]?.text;
+    expect(typeof text).toBe('string');
+    const payload = JSON.parse(text);
+    expect(payload.found).toBe(true);
+    expect(payload.finding.claim).toContain('thirty seconds');
+
+    // The event must be in the graph directory the CALL named, not in whichever
+    // directory the server process happens to be running from.
+    const events = readMetrics(dir).filter((e) => e.kind === 'query');
+    expect(events.map((e) => e.operation)).toContain('get');
+    expect(events.map((e) => e.key)).toContain('retry-cap');
+  }, 120_000);
+});

--- a/tests/hooks/wiki-query-tool.test.mjs
+++ b/tests/hooks/wiki-query-tool.test.mjs
@@ -27,19 +27,23 @@ import { mkdtempSync, rmSync, existsSync } from 'node:fs';
 import { spawn } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import {
-  putNodeWithEdges,
-  nodeId,
-} from '../../hooks-core/wiki.mjs';
+import { putNodeWithEdges, nodeId } from '../../hooks-core/wiki.mjs';
 // `readAll` is private to metrics.mjs; `readMetrics` is the exported reader over
 // the same bounded log.
 import { readMetrics } from '../../hooks-core/metrics.mjs';
-import { wikiQuery } from '../../dist/tools/intelligence/wiki-query.js';
+import {
+  wikiQuery,
+  WIKI_QUERY_TOOL_DEFINITION,
+} from '../../dist/tools/intelligence/wiki-query.js';
 
 let dir;
 beforeEach(() => {
   dir = mkdtempSync(join(tmpdir(), 'wq-'));
-  putNodeWithEdges(dir, { kind: 'file', key: join(dir, 'auth.ts'), hash: 'abc' });
+  putNodeWithEdges(dir, {
+    kind: 'file',
+    key: join(dir, 'auth.ts'),
+    hash: 'abc',
+  });
   putNodeWithEdges(
     dir,
     {
@@ -73,13 +77,20 @@ describe('wiki_query', () => {
     expect(result.findings.map((f) => f.key)).toContain('retry-cap');
   });
 
-  it('traverses from a file anchor to its findings', async () => {
-    const result = await wikiQuery({
-      operation: 'anchor',
-      anchor: join(dir, 'auth.ts'),
-      graphDir: dir,
-    });
-    expect(result.findings.map((f) => f.key)).toContain('retry-cap');
+  it('refuses the anchored retrieval that belongs to wiki_read', async () => {
+    // Deliberately NOT supported here. wiki_read already answers "what does the
+    // graph know about this file", and two tools with an identical operation
+    // cost the model tokens choosing between them. If anchored retrieval ever
+    // reappears in this tool, this fails and the duplication is visible.
+    const result = await wikiQuery({ operation: 'anchor', graphDir: dir });
+    expect(result.found).toBe(false);
+    expect(result.note).toMatch(/unknown operation/);
+    expect(
+      WIKI_QUERY_TOOL_DEFINITION.inputSchema.properties
+    ).not.toHaveProperty('anchor');
+    expect(
+      WIKI_QUERY_TOOL_DEFINITION.inputSchema.properties.operation.enum
+    ).not.toContain('anchor');
   });
 
   it('records a query event, which is what earns the session index its budget', async () => {
@@ -96,6 +107,84 @@ describe('wiki_query', () => {
       graphDir: dir,
     });
     expect(result.found).toBe(false);
+  });
+
+  it('never lets a file snapshot reach the response', async () => {
+    // A `snapshot` is a verbatim copy of a file. `putNode` spreads whatever
+    // fields it is handed onto the record, so one written inline comes back from
+    // `load()` whether or not snapshots were requested -- which is why the guard
+    // is at the response boundary and not a comment about how load is called.
+    const leaky = mkdtempSync(join(tmpdir(), 'wq-leak-'));
+    try {
+      putNodeWithEdges(leaky, {
+        kind: 'file',
+        key: join(leaky, 'secret.ts'),
+        hash: 'abc',
+        snapshot: 'PRIVATE FILE CONTENTS THAT MUST NOT BE SERVED',
+      });
+      putNodeWithEdges(
+        leaky,
+        {
+          kind: 'finding',
+          key: 'leaky',
+          claim: 'a claim carrying a snapshot it should not carry',
+          confidence: 0.9,
+          snapshot: 'PRIVATE FILE CONTENTS THAT MUST NOT BE SERVED',
+        },
+        [
+          {
+            edge: 'derived_from',
+            to: nodeId('file', join(leaky, 'secret.ts')),
+          },
+        ]
+      );
+
+      const got = await wikiQuery({
+        operation: 'get',
+        key: 'leaky',
+        graphDir: leaky,
+      });
+      expect(got.found).toBe(true);
+      expect(got.finding).not.toHaveProperty('snapshot');
+      // WHAT THIS TEST FOUND, and it is worth stating rather than asserting
+      // around: the snapshot does not only escape as a `snapshot` field. When a
+      // finding is stale, `staleness.serve` renders the snapshot into `diff`.
+      // That one is DELIBERATE and required -- a stale finding must arrive with
+      // the change that invalidated it -- and it is bounded to 40 lines by
+      // `diffLines`, which a raw snapshot is not. So the invariant is: the only
+      // snapshot-derived text a response may carry is that bounded diff.
+      const { diff, ...rest } = got.finding;
+      expect(JSON.stringify(rest)).not.toContain('PRIVATE FILE CONTENTS');
+      expect(String(diff).split('\n').length).toBeLessThanOrEqual(41);
+
+      // The `node` operation returns a raw graph node and its neighbours, which
+      // is the widest exposure of the two.
+      const node = await wikiQuery({
+        operation: 'node',
+        nodeId: nodeId('file', join(leaky, 'secret.ts')),
+        graphDir: leaky,
+      });
+      expect(node.found).toBe(true);
+      expect(node.node).not.toHaveProperty('snapshot');
+      for (const neighbour of node.neighbours)
+        expect(neighbour).not.toHaveProperty('snapshot');
+      expect(JSON.stringify(node)).not.toContain('PRIVATE FILE CONTENTS');
+
+      const searched = await wikiQuery({
+        operation: 'search',
+        query: 'claim carrying snapshot',
+        graphDir: leaky,
+      });
+      for (const finding of searched.findings) {
+        expect(finding).not.toHaveProperty('snapshot');
+        const { diff: served, ...body } = finding;
+        expect(JSON.stringify(body)).not.toContain('PRIVATE FILE CONTENTS');
+        if (served !== undefined)
+          expect(String(served).split('\n').length).toBeLessThanOrEqual(41);
+      }
+    } finally {
+      rmSync(leaky, { recursive: true, force: true });
+    }
   });
 
   it('never serves a stale finding bare', async () => {
@@ -208,7 +297,6 @@ describe('wiki_query over the MCP transport a client actually uses', () => {
     expect(tool).toBeDefined();
     expect(Object.keys(tool.inputSchema.properties).sort()).toEqual(
       [
-        'anchor',
         'graphDir',
         'key',
         'limit',

--- a/tests/integration/mcp-tool-profiles.test.ts
+++ b/tests/integration/mcp-tool-profiles.test.ts
@@ -217,7 +217,7 @@ describe('MCP tool profiles over the real stdio transport', () => {
     );
   });
 
-  it('keeps the complete 103-tool catalog behind the full profile', async () => {
+  it('keeps the complete 104-tool catalog behind the full profile', async () => {
     const [core, full] = await Promise.all([runServer(), runServer('full')]);
     expect(full.status).toBe(0);
 
@@ -225,7 +225,7 @@ describe('MCP tool profiles over the real stdio transport', () => {
       ?.tools as ListedTool[];
     const fullTools = full.responses.find((message) => message.id === 2)?.result
       ?.tools as ListedTool[];
-    expect(fullTools).toHaveLength(103);
+    expect(fullTools).toHaveLength(104);
     expect(fullTools.map((tool) => tool.name)).toContain('cache_benchmark');
     expect(JSON.stringify(coreTools).length).toBeLessThan(
       JSON.stringify(fullTools).length * 0.35

--- a/tests/unit/dashboard-web-server.test.ts
+++ b/tests/unit/dashboard-web-server.test.ts
@@ -1,0 +1,100 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+} from '@jest/globals';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { AddressInfo } from 'node:net';
+import type { Server } from 'node:http';
+import { app } from '../../src/server/web-server.js';
+
+let server: Server;
+let baseUrl: string;
+let temporaryDirectory: string | null = null;
+const originalLogDirectory = process.env.TOKEN_OPTIMIZER_LOG_DIR;
+
+beforeAll(async () => {
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, '127.0.0.1', () => {
+      const address = server.address() as AddressInfo;
+      baseUrl = `http://127.0.0.1:${address.port}`;
+      resolve();
+    });
+  });
+});
+
+afterEach(() => {
+  if (originalLogDirectory === undefined)
+    delete process.env.TOKEN_OPTIMIZER_LOG_DIR;
+  else process.env.TOKEN_OPTIMIZER_LOG_DIR = originalLogDirectory;
+
+  if (temporaryDirectory) {
+    rmSync(temporaryDirectory, { recursive: true, force: true });
+    temporaryDirectory = null;
+  }
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+describe('dashboard web routes', () => {
+  it('serves the extensionless wiki route through the working static asset path', async () => {
+    const alias = await fetch(`${baseUrl}/wiki`, { redirect: 'manual' });
+
+    expect(alias.status).toBe(302);
+    expect(alias.headers.get('location')).toBe('/wiki.html');
+
+    const page = await fetch(new URL(alias.headers.get('location')!, baseUrl));
+    expect(page.status).toBe(200);
+    expect(await page.text()).toContain(
+      '<title>What it knows &middot; Token Optimizer</title>'
+    );
+  });
+
+  it('reports Claude Code plugin activity from the cross-client ledger', async () => {
+    temporaryDirectory = mkdtempSync(
+      join(tmpdir(), 'token-optimizer-dashboard-')
+    );
+    const logDirectory = join(temporaryDirectory, 'logs');
+    mkdirSync(logDirectory);
+    process.env.TOKEN_OPTIMIZER_LOG_DIR = logDirectory;
+    writeFileSync(
+      join(logDirectory, 'hook-events-2026-08-25.jsonl'),
+      `${JSON.stringify({
+        schemaVersion: 2,
+        timestamp: new Date().toISOString(),
+        event: 'hook.completed',
+        invocationId: 'claude-plugin-invocation',
+        client: 'claude-code',
+        hookEvent: 'pre-tool',
+        toolName: 'Read',
+        outcome: 'success',
+        durationMs: 12,
+      })}\n`,
+      'utf8'
+    );
+
+    const response = await fetch(
+      `${baseUrl}/api/diagnostics/hooks?hours=1&limit=10`
+    );
+    const report = (await response.json()) as {
+      summary: {
+        available: boolean;
+        actions: number;
+        byClient: Record<string, { total: number }>;
+      };
+    };
+
+    expect(response.status).toBe(200);
+    expect(report.summary).toMatchObject({ available: true, actions: 1 });
+    expect(report.summary.byClient['claude-code']).toMatchObject({ total: 1 });
+  });
+});

--- a/tests/unit/wiki-routes-search.test.ts
+++ b/tests/unit/wiki-routes-search.test.ts
@@ -184,4 +184,58 @@ describe('/api/wiki/search (the route itself)', () => {
       'low-confidence',
     ]);
   });
+
+  /**
+   * Demonstrated regression: `q=%20` is truthy, so `if (query)` alone sent
+   * it into the BM25 branch, `tokenize(' ')` produced no terms, and `rank`
+   * returned nothing -- a blank search box went from showing (nearly)
+   * everything, under the old `.includes(' ')` filter, to showing nothing.
+   * A query that tokenizes to zero terms must fall through to the same
+   * no-query branch as an actually-empty `q=`, not a distinct "search that
+   * matches nothing" branch.
+   */
+  it.each([
+    ['a single space', ' '],
+    ['punctuation only', '!!! ,,, ???'],
+  ])('treats a query that tokenizes to nothing (%s) the same as no query at all', async (_label, q) => {
+    const scope = registerIsolatedProject();
+    if (!tempGraphDir) throw new Error('fixture graph directory missing');
+
+    putNodeWithEdges(tempGraphDir, {
+      kind: 'finding',
+      key: 'low-confidence',
+      claim: 'an unrelated finding about caching',
+      confidence: 0.3,
+    });
+    putNodeWithEdges(tempGraphDir, {
+      kind: 'finding',
+      key: 'high-confidence',
+      claim: 'a different finding about retries',
+      confidence: 0.95,
+    });
+
+    const blankResponse = await fetch(
+      `${baseUrl}/api/wiki/search?${new URLSearchParams({ q, scope, limit: '50' })}`
+    );
+    const noQueryResponse = await fetch(
+      `${baseUrl}/api/wiki/search?${new URLSearchParams({ scope, limit: '50' })}`
+    );
+    expect(blankResponse.status).toBe(200);
+    const blankBody = (await blankResponse.json()) as {
+      total: number;
+      items: Array<{ key: string }>;
+    };
+    const noQueryBody = (await noQueryResponse.json()) as {
+      total: number;
+      items: Array<{ key: string }>;
+    };
+
+    // Not empty, and identical to the no-query response: both surfaces of
+    // "nothing meaningful to search for" must agree.
+    expect(blankBody.items.map((item) => item.key)).toEqual([
+      'high-confidence',
+      'low-confidence',
+    ]);
+    expect(blankBody).toEqual(noQueryBody);
+  });
 });

--- a/tests/unit/wiki-routes-search.test.ts
+++ b/tests/unit/wiki-routes-search.test.ts
@@ -1,0 +1,187 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+} from '@jest/globals';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import type { AddressInfo } from 'node:net';
+import type { Server } from 'node:http';
+import { app } from '../../src/server/web-server.js';
+import { putNodeWithEdges } from '../../hooks-core/wiki.mjs';
+import { registerProject } from '../../hooks-core/projects.mjs';
+
+const lexical = await import(
+  pathToFileURL(join(process.cwd(), 'hooks-core', 'lexical.mjs')).href
+);
+
+describe('lexical.rank (the primitive the route now calls)', () => {
+  it('ranks a specific claim above a repetitive one', () => {
+    const findings = [
+      { key: 'a', claim: 'the retry backoff is capped at thirty seconds' },
+      { key: 'b', claim: 'retry retry retry' },
+    ];
+    const ranked = lexical.rank('retry backoff', findings);
+    expect(ranked[0].finding.key).toBe('a');
+  });
+});
+
+/**
+ * The test above only proves Task 1's `rank` primitive works -- it never
+ * touches `src/server/wiki-routes.ts`. A route that still filtered with
+ * `.includes()` under the hood would pass it just as well. These tests drive
+ * the actual HTTP route so a regression back to the substring filter fails
+ * here specifically.
+ */
+describe('/api/wiki/search (the route itself)', () => {
+  let server: Server;
+  let baseUrl: string;
+  let originalRegistry: string | undefined;
+  let tempRoot: string | null = null;
+  let tempGraphDir: string | null = null;
+
+  beforeAll(async () => {
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, '127.0.0.1', () => {
+        const address = server.address() as AddressInfo;
+        baseUrl = `http://127.0.0.1:${address.port}`;
+        resolve();
+      });
+    });
+  });
+
+  afterEach(() => {
+    if (originalRegistry === undefined)
+      delete process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY;
+    else process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY = originalRegistry;
+    if (tempRoot) {
+      rmSync(tempRoot, { recursive: true, force: true });
+      tempRoot = null;
+    }
+    if (tempGraphDir) {
+      rmSync(tempGraphDir, { recursive: true, force: true });
+      tempGraphDir = null;
+    }
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  });
+
+  /**
+   * Registers an isolated project (its own fake ".git" root, its own graph
+   * directory, and its own project registry file) so the request never reads
+   * or writes the real machine-wide registry or the real "current project"
+   * graph rooted at this process's cwd.
+   */
+  function registerIsolatedProject(): string {
+    tempRoot = mkdtempSync(join(tmpdir(), 'wiki-routes-search-root-'));
+    mkdirSync(join(tempRoot, '.git'));
+    tempGraphDir = mkdtempSync(join(tmpdir(), 'wiki-routes-search-graph-'));
+
+    originalRegistry = process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY;
+    process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY = join(
+      mkdtempSync(join(tmpdir(), 'wiki-routes-search-registry-')),
+      'projects.jsonl'
+    );
+
+    const project = registerProject({
+      root: tempRoot,
+      graphDir: tempGraphDir,
+      client: 'test',
+    });
+    if (!project) throw new Error('registerProject failed to register the fixture');
+    return project.id;
+  }
+
+  it('ranks by BM25, not substring order, and orders results by relevance not confidence', async () => {
+    const scope = registerIsolatedProject();
+    if (!tempGraphDir) throw new Error('fixture graph directory missing');
+
+    // "b" is given a much higher confidence than "a". Under the OLD code the
+    // route filtered by substring and then ALWAYS sorted by
+    // confidence*origin*pinned, regardless of whether a query was present --
+    // so "b" would have outranked "a" once both had passed the substring
+    // filter. Under the NEW code, a query present means BM25 relevance
+    // decides order and the confidence sort is skipped entirely.
+    //
+    // The query "retry backoff" also could never match "retry retry retry"
+    // under the OLD literal-substring filter (that exact phrase never
+    // appears in the claim), whereas BM25 matches on the individual terms
+    // "retry" and "backoff" -- so its presence in the results at all is
+    // itself proof the route stopped using `.includes()`.
+    putNodeWithEdges(tempGraphDir, {
+      kind: 'finding',
+      key: 'a',
+      claim: 'the retry backoff is capped at thirty seconds',
+      confidence: 0.4,
+    });
+    putNodeWithEdges(tempGraphDir, {
+      kind: 'finding',
+      key: 'b',
+      claim: 'retry retry retry',
+      confidence: 0.99,
+    });
+
+    const response = await fetch(
+      `${baseUrl}/api/wiki/search?${new URLSearchParams({
+        q: 'retry backoff',
+        scope,
+        limit: '50',
+      })}`
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      total: number;
+      offset: number;
+      items: Array<{ key: string }>;
+    };
+
+    // Both findings score > 0 under BM25 (term-level matching), so both are
+    // returned -- the old substring filter would have returned only "a".
+    expect(body.items.map((item) => item.key)).toEqual(['a', 'b']);
+    expect(body.total).toBe(2);
+    expect(body.offset).toBe(0);
+  });
+
+  it('keeps the confidence*origin*pinned sort when there is no query', async () => {
+    const scope = registerIsolatedProject();
+    if (!tempGraphDir) throw new Error('fixture graph directory missing');
+
+    putNodeWithEdges(tempGraphDir, {
+      kind: 'finding',
+      key: 'low-confidence',
+      claim: 'an unrelated finding about caching',
+      confidence: 0.3,
+    });
+    putNodeWithEdges(tempGraphDir, {
+      kind: 'finding',
+      key: 'high-confidence',
+      claim: 'a different finding about retries',
+      confidence: 0.95,
+    });
+
+    const response = await fetch(
+      `${baseUrl}/api/wiki/search?${new URLSearchParams({
+        scope,
+        limit: '50',
+      })}`
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      items: Array<{ key: string }>;
+    };
+
+    expect(body.items.map((item) => item.key)).toEqual([
+      'high-confidence',
+      'low-confidence',
+    ]);
+  });
+});

--- a/tests/unit/wiki-routes-search.test.ts
+++ b/tests/unit/wiki-routes-search.test.ts
@@ -13,7 +13,7 @@ import { pathToFileURL } from 'node:url';
 import type { AddressInfo } from 'node:net';
 import type { Server } from 'node:http';
 import { app } from '../../src/server/web-server.js';
-import { putNodeWithEdges } from '../../hooks-core/wiki.mjs';
+import { putNodeWithEdges, load, nodeId } from '../../hooks-core/wiki.mjs';
 import { registerProject } from '../../hooks-core/projects.mjs';
 
 const lexical = await import(
@@ -32,6 +32,77 @@ describe('lexical.rank (the primitive the route now calls)', () => {
 });
 
 /**
+ * ONE SERVER AND ONE ISOLATED PROJECT FOR THE WHOLE FILE.
+ *
+ * Hoisted out of the search describe when the curate tests below arrived: they
+ * need exactly this harness -- a real Express app on a real port, and a project
+ * whose graph is a temp directory rather than this repo's own -- and standing up
+ * a second copy of it in a second file is how two harnesses drift apart.
+ */
+
+let server: Server;
+let baseUrl: string;
+let originalRegistry: string | undefined;
+let tempRoot: string | null = null;
+let tempGraphDir: string | null = null;
+
+beforeAll(async () => {
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, '127.0.0.1', () => {
+      const address = server.address() as AddressInfo;
+      baseUrl = `http://127.0.0.1:${address.port}`;
+      resolve();
+    });
+  });
+});
+
+afterEach(() => {
+  if (originalRegistry === undefined)
+    delete process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY;
+  else process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY = originalRegistry;
+  if (tempRoot) {
+    rmSync(tempRoot, { recursive: true, force: true });
+    tempRoot = null;
+  }
+  if (tempGraphDir) {
+    rmSync(tempGraphDir, { recursive: true, force: true });
+    tempGraphDir = null;
+  }
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+/**
+ * Registers an isolated project (its own fake ".git" root, its own graph
+ * directory, and its own project registry file) so the request never reads
+ * or writes the real machine-wide registry or the real "current project"
+ * graph rooted at this process's cwd.
+ */
+function registerIsolatedProject(): string {
+  tempRoot = mkdtempSync(join(tmpdir(), 'wiki-routes-search-root-'));
+  mkdirSync(join(tempRoot, '.git'));
+  tempGraphDir = mkdtempSync(join(tmpdir(), 'wiki-routes-search-graph-'));
+
+  originalRegistry = process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY;
+  process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY = join(
+    mkdtempSync(join(tmpdir(), 'wiki-routes-search-registry-')),
+    'projects.jsonl'
+  );
+
+  const project = registerProject({
+    root: tempRoot,
+    graphDir: tempGraphDir,
+    client: 'test',
+  });
+  if (!project) throw new Error('registerProject failed to register the fixture');
+  return project.id;
+}
+
+/**
  * The test above only proves Task 1's `rank` primitive works -- it never
  * touches `src/server/wiki-routes.ts`. A route that still filtered with
  * `.includes()` under the hood would pass it just as well. These tests drive
@@ -39,68 +110,6 @@ describe('lexical.rank (the primitive the route now calls)', () => {
  * here specifically.
  */
 describe('/api/wiki/search (the route itself)', () => {
-  let server: Server;
-  let baseUrl: string;
-  let originalRegistry: string | undefined;
-  let tempRoot: string | null = null;
-  let tempGraphDir: string | null = null;
-
-  beforeAll(async () => {
-    await new Promise<void>((resolve) => {
-      server = app.listen(0, '127.0.0.1', () => {
-        const address = server.address() as AddressInfo;
-        baseUrl = `http://127.0.0.1:${address.port}`;
-        resolve();
-      });
-    });
-  });
-
-  afterEach(() => {
-    if (originalRegistry === undefined)
-      delete process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY;
-    else process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY = originalRegistry;
-    if (tempRoot) {
-      rmSync(tempRoot, { recursive: true, force: true });
-      tempRoot = null;
-    }
-    if (tempGraphDir) {
-      rmSync(tempGraphDir, { recursive: true, force: true });
-      tempGraphDir = null;
-    }
-  });
-
-  afterAll(async () => {
-    await new Promise<void>((resolve, reject) => {
-      server.close((error) => (error ? reject(error) : resolve()));
-    });
-  });
-
-  /**
-   * Registers an isolated project (its own fake ".git" root, its own graph
-   * directory, and its own project registry file) so the request never reads
-   * or writes the real machine-wide registry or the real "current project"
-   * graph rooted at this process's cwd.
-   */
-  function registerIsolatedProject(): string {
-    tempRoot = mkdtempSync(join(tmpdir(), 'wiki-routes-search-root-'));
-    mkdirSync(join(tempRoot, '.git'));
-    tempGraphDir = mkdtempSync(join(tmpdir(), 'wiki-routes-search-graph-'));
-
-    originalRegistry = process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY;
-    process.env.TOKEN_OPTIMIZER_PROJECT_REGISTRY = join(
-      mkdtempSync(join(tmpdir(), 'wiki-routes-search-registry-')),
-      'projects.jsonl'
-    );
-
-    const project = registerProject({
-      root: tempRoot,
-      graphDir: tempGraphDir,
-      client: 'test',
-    });
-    if (!project) throw new Error('registerProject failed to register the fixture');
-    return project.id;
-  }
-
   it('ranks by BM25, not substring order, and orders results by relevance not confidence', async () => {
     const scope = registerIsolatedProject();
     if (!tempGraphDir) throw new Error('fixture graph directory missing');
@@ -237,5 +246,99 @@ describe('/api/wiki/search (the route itself)', () => {
       'low-confidence',
     ]);
     expect(blankBody).toEqual(noQueryBody);
+  });
+});
+
+/**
+ * The curate route's contradict action.
+ *
+ * `contradict` writes the one edge kind the schema declared and nothing could
+ * write, and this switch case is its only door: without it the function is
+ * correct, tested, and reachable by nothing -- the defect shape this branch
+ * exists to close, arriving from the other side. The reachability guard proves
+ * the case EXISTS; only a request proves it works.
+ */
+describe('/api/wiki/curate (contradict)', () => {
+  /** The dashboard's own header, which rejectsCrossSite requires of any POST. */
+  const curate = (body: Record<string, unknown>, scope: string) =>
+    fetch(`${baseUrl}/api/wiki/curate`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-token-optimizer': 'dashboard',
+      },
+      body: JSON.stringify({ ...body, projectId: scope }),
+    });
+
+  function seedPair(graphDir: string) {
+    putNodeWithEdges(graphDir, {
+      kind: 'finding',
+      key: 'old',
+      claim: 'f returns 1',
+      confidence: 0.9,
+    });
+    putNodeWithEdges(graphDir, {
+      kind: 'finding',
+      key: 'new',
+      claim: 'f returns 2',
+      confidence: 0.9,
+    });
+  }
+
+  it('records the disagreement as an edge in the graph', async () => {
+    const scope = registerIsolatedProject();
+    if (!tempGraphDir) throw new Error('fixture graph directory missing');
+    seedPair(tempGraphDir);
+
+    const response = await curate(
+      { action: 'contradict', key: 'old', byKey: 'new', reason: 're-derived' },
+      scope
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+
+    // THE GRAPH, not the response body. A route that answered ok and wrote
+    // nothing would pass on the status alone, and the direction matters: the
+    // contradictOR is the source, so a route that swapped key and byKey would
+    // record the established claim disputing the new one.
+    const graph = load(tempGraphDir);
+    const edges = graph.edges.filter((e: { edge: string }) => e.edge === 'contradicts');
+    expect(edges).toHaveLength(1);
+    expect(edges[0].from).toBe(nodeId('finding', 'new'));
+    expect(edges[0].to).toBe(nodeId('finding', 'old'));
+    // Neither claim is retired: the whole point of an edge over an overwrite.
+    expect(graph.nodes.get(nodeId('finding', 'old')).retired).toBeFalsy();
+    expect(graph.nodes.get(nodeId('finding', 'old')).claim).toBe('f returns 1');
+  });
+
+  it('refuses a request with no byKey, and writes nothing', async () => {
+    const scope = registerIsolatedProject();
+    if (!tempGraphDir) throw new Error('fixture graph directory missing');
+    seedPair(tempGraphDir);
+
+    const response = await curate({ action: 'contradict', key: 'old' }, scope);
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: 'byKey required' });
+    expect(
+      load(tempGraphDir).edges.some((e: { edge: string }) => e.edge === 'contradicts')
+    ).toBe(false);
+  });
+
+  it('reports 404 when an end of the disagreement does not resolve', async () => {
+    const scope = registerIsolatedProject();
+    if (!tempGraphDir) throw new Error('fixture graph directory missing');
+    seedPair(tempGraphDir);
+
+    const response = await curate(
+      { action: 'contradict', key: 'nope', byKey: 'new', reason: 'x' },
+      scope
+    );
+    // An edge to an id nothing created is an un-invalidatable claim, so curate
+    // refuses it and the route must not report success for a write it did not do.
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: 'no such finding' });
+    expect(
+      load(tempGraphDir).edges.some((e: { edge: string }) => e.edge === 'contradicts')
+    ).toBe(false);
   });
 });

--- a/tests/unit/wiki-write-contract.test.ts
+++ b/tests/unit/wiki-write-contract.test.ts
@@ -1,15 +1,36 @@
-import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import {
   WIKI_WRITE_TOOL_DEFINITION,
   wikiWrite,
 } from '../../src/tools/intelligence/wiki-write.js';
+import { putNodeWithEdges, load, nodeId } from '../../hooks-core/wiki.mjs';
 
 let workspace: string;
 let anchor: string;
 let priorWikiDir: string | undefined;
+
+/**
+ * `wikiWrite` loads five hooks-core modules with one `Promise.all` of
+ * dynamic `import()`s (see wiki-write.ts). Under Jest's `--experimental-vm-modules`
+ * loader, linking several BRAND NEW ESM modules concurrently for the first
+ * time races and throws `request for 'node:<builtin>' is not in cache` --
+ * reproducible in isolation, nothing to do with this task's change, and
+ * specific to Jest's VM-module linker (plain Node has no such race). Once
+ * each module has been linked once, a later concurrent `Promise.all` of the
+ * same modules hits Jest's cache and is fine -- so importing them here,
+ * sequentially, before any test calls `wikiWrite`, is what lets its happy
+ * path be exercised under this test runner at all.
+ */
+beforeAll(async () => {
+  const here = join(process.cwd(), 'hooks-core');
+  for (const name of ['wiki.mjs', 'harvest-write.mjs', 'curate.mjs', 'metrics.mjs', 'projects.mjs']) {
+    await import(pathToFileURL(join(here, name)).href);
+  }
+});
 
 beforeEach(() => {
   workspace = mkdtempSync(join(tmpdir(), 'wiki-write-contract-'));
@@ -46,4 +67,77 @@ describe('active-model semantic finding contract', () => {
     expect(result.error).toMatch(/evidence is required/i);
   });
 
+});
+
+/**
+ * The `answers` edge, on the default install path.
+ *
+ * `wiki_write` runs on every install with no opt-in gate, unlike the detached
+ * harvest. So this is the path where the edge is most likely to be observed
+ * in practice -- provided the caller actually supplies the real session id,
+ * which nothing here does automatically. These tests exercise the wiring
+ * itself: a real sessionId resolves, an unresolvable one does not dangle, and
+ * omitting it does not fall back to some other identity.
+ */
+describe('wiki_write links a finding to the task that produced it', () => {
+  it('writes the answers edge when sessionId names an existing task node', async () => {
+    const dir = process.env.TOKEN_OPTIMIZER_WIKI_DIR as string;
+    putNodeWithEdges(dir, { kind: 'task', key: 'session-1' });
+
+    const result = await wikiWrite({
+      claim: 'The verifier requires the project runner.',
+      anchors: [anchor],
+      evidence: 'Ran the suite directly and it failed with a clear error.',
+      applicability: 'When running project verification.',
+      confidenceLabel: 'probable',
+      projectRoot: workspace,
+      sessionId: 'session-1',
+    } as never);
+    expect(result.success).toBe(true);
+
+    const graph = load(dir);
+    const edge = graph.edges.find((e) => e.edge === 'answers');
+    expect(edge).toBeDefined();
+    expect(edge?.to).toBe(nodeId('task', 'session-1'));
+  });
+
+  it('writes no answers edge when sessionId names no existing task node', async () => {
+    const dir = process.env.TOKEN_OPTIMIZER_WIKI_DIR as string;
+    // Deliberately no task node created for 'ghost-session'.
+
+    const result = await wikiWrite({
+      claim: 'The verifier requires the project runner.',
+      anchors: [anchor],
+      evidence: 'Ran the suite directly and it failed with a clear error.',
+      applicability: 'When running project verification.',
+      confidenceLabel: 'probable',
+      projectRoot: workspace,
+      sessionId: 'ghost-session',
+    } as never);
+    expect(result.success).toBe(true);
+
+    const graph = load(dir);
+    expect(graph.edges.some((e) => e.edge === 'answers')).toBe(false);
+  });
+
+  it('writes no answers edge when no sessionId is supplied at all', async () => {
+    const dir = process.env.TOKEN_OPTIMIZER_WIKI_DIR as string;
+    // A sentinel task node that a wrong fallback (e.g. defaulting to some
+    // other identity instead of leaving taskId unset) could accidentally
+    // resolve against.
+    putNodeWithEdges(dir, { kind: 'task', key: 'sentinel-task' });
+
+    const result = await wikiWrite({
+      claim: 'The verifier requires the project runner.',
+      anchors: [anchor],
+      evidence: 'Ran the suite directly and it failed with a clear error.',
+      applicability: 'When running project verification.',
+      confidenceLabel: 'probable',
+      projectRoot: workspace,
+    } as never);
+    expect(result.success).toBe(true);
+
+    const graph = load(dir);
+    expect(graph.edges.some((e) => e.edge === 'answers')).toBe(false);
+  });
 });

--- a/tests/unit/wiki-write-contract.test.ts
+++ b/tests/unit/wiki-write-contract.test.ts
@@ -7,7 +7,7 @@ import {
   WIKI_WRITE_TOOL_DEFINITION,
   wikiWrite,
 } from '../../src/tools/intelligence/wiki-write.js';
-import { putNodeWithEdges, load, nodeId } from '../../hooks-core/wiki.mjs';
+import { putNode, putNodeWithEdges, putEdge, load, nodeId } from '../../hooks-core/wiki.mjs';
 
 let workspace: string;
 let anchor: string;
@@ -73,16 +73,22 @@ describe('active-model semantic finding contract', () => {
  * The `answers` edge, on the default install path.
  *
  * `wiki_write` runs on every install with no opt-in gate, unlike the detached
- * harvest. So this is the path where the edge is most likely to be observed
- * in practice -- provided the caller actually supplies the real session id,
- * which nothing here does automatically. These tests exercise the wiring
- * itself: a real sessionId resolves, an unresolvable one does not dangle, and
- * omitting it does not fall back to some other identity.
+ * harvest. `wikiWrite` passes NO explicit `taskId` (round 3 removed the
+ * earlier `taskId: options.sessionId` synthesis -- a model-supplied
+ * `sessionId` is an unverified claim, unlike the harvest worker's, which
+ * comes from trusted hook infrastructure, so it should be checked against
+ * the graph rather than trusted outright). That routes every call through
+ * `writeHarvested`'s traversal fallback, which requires the SAME session's
+ * task to have a `derived_from` edge to EVERY one of the finding's anchors
+ * before writing an edge -- these tests exercise that: full coverage
+ * resolves, no task at all does not dangle, and omitting `sessionId`
+ * supplies no identity to check against, so there is no candidate.
  */
 describe('wiki_write links a finding to the task that produced it', () => {
-  it('writes the answers edge when sessionId names an existing task node', async () => {
+  it('writes the answers edge when the session’s task fully covers the finding’s anchor', async () => {
     const dir = process.env.TOKEN_OPTIMIZER_WIKI_DIR as string;
-    putNodeWithEdges(dir, { kind: 'task', key: 'session-1' });
+    putNode(dir, { kind: 'task', key: 'session-1' });
+    putEdge(dir, nodeId('task', 'session-1'), 'derived_from', nodeId('file', anchor));
 
     const result = await wikiWrite({
       claim: 'The verifier requires the project runner.',
@@ -99,6 +105,27 @@ describe('wiki_write links a finding to the task that produced it', () => {
     const edge = graph.edges.find((e) => e.edge === 'answers');
     expect(edge).toBeDefined();
     expect(edge?.to).toBe(nodeId('task', 'session-1'));
+  });
+
+  it('writes no answers edge when the session’s task exists but never touched the anchor', async () => {
+    const dir = process.env.TOKEN_OPTIMIZER_WIKI_DIR as string;
+    // The task node exists, matching the sessionId, but has no coverage --
+    // existence alone is not attribution.
+    putNodeWithEdges(dir, { kind: 'task', key: 'session-2' });
+
+    const result = await wikiWrite({
+      claim: 'The verifier requires the project runner.',
+      anchors: [anchor],
+      evidence: 'Ran the suite directly and it failed with a clear error.',
+      applicability: 'When running project verification.',
+      confidenceLabel: 'probable',
+      projectRoot: workspace,
+      sessionId: 'session-2',
+    } as never);
+    expect(result.success).toBe(true);
+
+    const graph = load(dir);
+    expect(graph.edges.some((e) => e.edge === 'answers')).toBe(false);
   });
 
   it('writes no answers edge when sessionId names no existing task node', async () => {
@@ -122,9 +149,9 @@ describe('wiki_write links a finding to the task that produced it', () => {
 
   it('writes no answers edge when no sessionId is supplied at all', async () => {
     const dir = process.env.TOKEN_OPTIMIZER_WIKI_DIR as string;
-    // A sentinel task node that a wrong fallback (e.g. defaulting to some
-    // other identity instead of leaving taskId unset) could accidentally
-    // resolve against.
+    // A sentinel task node -- present to prove the absence of `sessionId`
+    // supplies no identity to check against, not merely that this one
+    // particular node fails to match.
     putNodeWithEdges(dir, { kind: 'task', key: 'sentinel-task' });
 
     const result = await wikiWrite({

--- a/tests/unit/wiki-write-contract.test.ts
+++ b/tests/unit/wiki-write-contract.test.ts
@@ -70,23 +70,36 @@ describe('active-model semantic finding contract', () => {
 });
 
 /**
- * The `answers` edge, on the default install path.
+ * `wiki_write` never writes an `answers` edge, and that is a deliberate,
+ * documented consequence rather than a gap.
  *
- * `wiki_write` runs on every install with no opt-in gate, unlike the detached
- * harvest. `wikiWrite` passes NO explicit `taskId` (round 3 removed the
- * earlier `taskId: options.sessionId` synthesis -- a model-supplied
- * `sessionId` is an unverified claim, unlike the harvest worker's, which
- * comes from trusted hook infrastructure, so it should be checked against
- * the graph rather than trusted outright). That routes every call through
- * `writeHarvested`'s traversal fallback, which requires the SAME session's
- * task to have a `derived_from` edge to EVERY one of the finding's anchors
- * before writing an edge -- these tests exercise that: full coverage
- * resolves, no task at all does not dangle, and omitting `sessionId`
- * supplies no identity to check against, so there is no candidate.
+ * ROUND 3 removed `wikiWrite`'s `taskId: options.sessionId` synthesis and
+ * routed it through `writeHarvested`'s traversal fallback instead, keyed by
+ * `sessionId`. ROUND 4's adversarial review found that was still not enough:
+ * `sessionId` is a plain MCP tool argument the calling model supplies,
+ * unverified, so a model naming a REAL foreign session -- one whose task
+ * genuinely covered these anchors -- would still get a confidently wrong
+ * `answers` edge, because coverage cannot distinguish "this session" from
+ * "some other session that really did touch these files". `writeHarvested`
+ * now takes a separate `authoritativeSessionId` parameter that gates the
+ * traversal fallback, and `wikiWrite` supplies NEITHER `taskId` NOR
+ * `authoritativeSessionId` -- only `sessionId`, stored for provenance and
+ * never used for attribution. So every `wiki_write` call takes the "no
+ * candidate" path regardless of what the graph holds, on purpose: a wrong
+ * provenance edge is worse than none, and `sessionId` here is not evidence.
+ *
+ * These tests assert the CONSEQUENCE directly: even a task that fully covers
+ * the anchor, keyed by exactly the `sessionId` supplied, produces no edge.
+ * `plugin/hooks/harvest-worker.mjs` is where `authoritativeSessionId` is
+ * actually supplied (Claude Code's own hook payload) and where `answers` can
+ * fire -- covered in `tests/hooks/contradicts.test.mjs`, not here.
  */
-describe('wiki_write links a finding to the task that produced it', () => {
-  it('writes the answers edge when the session’s task fully covers the finding’s anchor', async () => {
+describe('wiki_write never attributes an answers edge to an unverified sessionId', () => {
+  it('writes no answers edge even when the named session’s task fully covers the anchor', async () => {
     const dir = process.env.TOKEN_OPTIMIZER_WIKI_DIR as string;
+    // A REAL task, fully covering the anchor -- traversal alone (round 3)
+    // would have matched this. The point is that it must not, because
+    // `wiki_write` supplies no `authoritativeSessionId`.
     putNode(dir, { kind: 'task', key: 'session-1' });
     putEdge(dir, nodeId('task', 'session-1'), 'derived_from', nodeId('file', anchor));
 
@@ -102,15 +115,11 @@ describe('wiki_write links a finding to the task that produced it', () => {
     expect(result.success).toBe(true);
 
     const graph = load(dir);
-    const edge = graph.edges.find((e) => e.edge === 'answers');
-    expect(edge).toBeDefined();
-    expect(edge?.to).toBe(nodeId('task', 'session-1'));
+    expect(graph.edges.some((e) => e.edge === 'answers')).toBe(false);
   });
 
   it('writes no answers edge when the session’s task exists but never touched the anchor', async () => {
     const dir = process.env.TOKEN_OPTIMIZER_WIKI_DIR as string;
-    // The task node exists, matching the sessionId, but has no coverage --
-    // existence alone is not attribution.
     putNodeWithEdges(dir, { kind: 'task', key: 'session-2' });
 
     const result = await wikiWrite({
@@ -149,9 +158,6 @@ describe('wiki_write links a finding to the task that produced it', () => {
 
   it('writes no answers edge when no sessionId is supplied at all', async () => {
     const dir = process.env.TOKEN_OPTIMIZER_WIKI_DIR as string;
-    // A sentinel task node -- present to prove the absence of `sessionId`
-    // supplies no identity to check against, not merely that this one
-    // particular node fails to match.
     putNodeWithEdges(dir, { kind: 'task', key: 'sentinel-task' });
 
     const result = await wikiWrite({


### PR DESCRIPTION
Part 1 of 3 toward #204. Closes specific instances of this repository's signature defect — capabilities declared, documented, tested, and connected to nothing — and hardens the guard that was supposed to catch them.

**#204 stays open.** Plans 2 (production and measurement) and 3 (the detector and its allowlist) follow as their own PRs. Several outcomes here are contingent on Plan 2, and that is stated below rather than implied away.

## Why this exists

`tests/hooks/reachability.test.mjs` already existed to catch correct-but-uncalled code. It had found ~21 instances; four were wired and **sixteen were moved to an allowlist labelled `TRIAGE BACKLOG`** — in a file whose own documentation says that a capability with no consumer should be deleted and written again the day it is needed. An accurate written description of a defect had felt like resolution.

The guard also had holes. During this work, five were found by *using* it rather than reading it:

1. comments count as call sites — `invalidateOnWrite` had 1 raw reference and 0 code references, and the reference was prose
2. exported consts are invisible — `contradicts` and `answers` sat in `EDGE_KINDS` with zero write sites
3. an `import` specifier counts as a use — proven by mutation: dropping the `cacheOrdered` call while keeping its import left the guard green
4. unread record *fields* are invisible — `contradictionReason` was written on every call and read by nothing, guard green throughout
5. tests asserting on holdout-consulting entry points must pin the arm or fail intermittently; the convention is copy-pasted in three variants and nothing enforces it

All five are documented in Plan 3, which is where they get fixed.

## What shipped

| | Before | After |
|---|---|---|
| Allowlist backlog | 16 | **7** |
| Declared edge kinds with no writer | 2 | **0** |
| Dead event kinds | 2 | **0** |
| `wiki_query` | absent, yet named in 12 shipped copies of injected prompt text | live, six operations, reachable end to end |
| Staleness on the agent's own edits | did not work at all | queued at write, drained before serve |
| BM25 | claimed in docs, substring in code | real, shared by the tool and the dashboard |
| Schema version bump | would have zeroed every graph by four routes | range reader + in-memory upcast |

**Retrieval.** Real BM25 in `hooks-core/lexical.mjs`, shared by `wiki_query` and `/api/wiki/search`. Sub-tokens on camelCase and letter/digit boundaries, plus prefix matching for terms of 3+ characters, so `custom` finds `customer` and `skip` finds `skipLibCheck`. **Infix does not match** — `tomer` will not find `customer`.

**The tool.** `wiki_query` with `get`, `search`, `node`, `audit`, `balance`, `overview`. No `anchor` operation: `wiki_read` already owns anchored retrieval. Every call records a `query` event, which is the numerator `indexBudget` needs.

**Staleness — the most consequential fix.** The old description of two invalidation paths was wrong in a way that mattered: eager was dead code *and* the lazy path cannot see the session's own writes, because `indexFile` refreshes a file node's hash to the bytes just read. **For a file the agent itself edited, staleness did not work at all.** Writes are now queued by the post-tool hook and applied at the next graph read, with two evidence grades — a symbol-precise diff where the edit is reconstructable, a hash comparison otherwise, and the served text says which.

**What the graph records.** `contradicts` is written and disclosed when a finding is served, naming the disputing key and its reason. A `derivation` record stores claim-time anchor hashes; `derivationCheck` reports whether they still hold and carries `derivationCheckedAgainst: 'index'` because it compares the last-indexed hash, **not disk**. Stale flags now clear on evidence — a revert, or an edit that left the anchored symbol untouched — automatically at serve time, never on request.

**Schema safety.** `load()` accepts a version range and upcasts in memory; nothing on disk is rewritten. A bump would previously have destroyed graphs by four routes, one of which — `readSnapshots` feeding `compactIfWasteful`'s rebuild — was a permanent delete rather than a read-time skip. `GRAPH_VERSION` stays at 1 because no record shape changed.

**`diffLines` is now bounded in bytes**, not only lines. Two 200,000-character single-line inputs previously produced 2 lines and 400,005 bytes, and that diff feeds the injection path.

## Honest limitations

- **`answers` fires nowhere on a default install.** It is correctly attributed — session-scoped, requiring full anchor coverage — but its only live producer is the semantic harvest, which is credential-gated. Plan 2's `derive.mjs` runs in the Stop hook with an authoritative session id and is the intended default producer.
- **Findings still do not accrue without a credential.** This repository's own graph, re-measured: 2,965 symbol / 904 file / 128 task nodes and **one finding**. The structural layer doubled during this work; findings did not move. `derive.mjs` needs no credential and is the answer.
- **`indexBudget` cannot be demonstrated yet.** The numerator now exists; `sessionIndex` returns null with nothing to list, so on a findings-free graph the denominator is zero too.
- **`cacheOrdered`'s measured token delta is zero.** Insertion order already matched, so what ships is the invariant that it cannot drift — not a saving. It must not be reported as one.
- **The auto-clear costs ~30–60 ms per call on genuinely-stale findings**, clearing nothing, bounded only by `findingsFor`'s limit and the `alreadyInjected` gate.

## Review notes

Every task carried an adversarial pass whose only job was to refute the claim. **It found something real on every task**, including two that demolished claims I had made: that the derivation record was "checkable" when nothing read it, and that provenance was correctly attributed when four cases could attribute a finding to the wrong task. Seven defects were found in the plan rather than the implementation, and one fix wave introduced a flake that was diagnosed and closed.

Worth a reviewer's attention first: `hooks-core/pending.mjs` and the version-range reader in `wiki.mjs`, being the two places where a bug loses data rather than degrading a feature. `serve()` now writes to the graph on a verified-match, which the final review confirmed is not arm-differential — both experiment arms run the identical mutation.

## Follow-ups to file

1. **Unescaped injected text.** A stored `claim` or `contradictionReason` can contain a newline and forge lines inside the injected block. Pre-existing class, newly widened; there is no escaping convention on this branch.
2. **Orphan claim files.** A drainer killed between rename and read strands a pid-named claim and loses those records unread.
3. **`contradictedAt` has no reader** — stored provenance, currently unused.
4. **Content-addressed anchors** (`contentAnchor`, deleted here rather than left dormant) — cross-project findings, deserves its own design pass.

## Verification

182 suites, 2,248 tests, 5 skipped, 0 failed — run ten times across two parties to rule out intermittency. `tsc --noEmit` clean. `npm run lint` 0 errors. `npm run validate` passes. `npm run sync:hooks:check` in sync across eleven vendored directories.

Thirty rulings taken during execution are recorded with their cost-if-wrong in the plan ledger.
🤖 Generated with [Claude Code](https://claude.com/claude-code)

