### PR TITLE
test(reachability): close the wiring defect class -- detector, censuses and allowlist (#204, part 3 of 3)

### DIFF
--- a/docs/COMPETITIVE_GAPS.md
+++ b/docs/COMPETITIVE_GAPS.md
@@ -18,9 +18,18 @@ They ship active compression that changes operation cost directly:
 
 Delta-on-re-read is the exact mechanism I called our headline differentiator.
 They have it, and theirs is **transparent** — it happens in hooks without the
-model choosing to cooperate. Ours requires the model to reissue the call against
-`smart_read`. That is a worse interaction, not a better one, and the comment on
-#201 should be corrected.
+model choosing to cooperate. The comment on #201 should be corrected.
+
+**And the second half of that concession is now itself out of date, which is
+worth saying rather than quietly deleting.** It said ours "requires the model to
+reissue the call against `smart_read`", making it a worse interaction. Zero-turn
+substitution removed that: `substitutionFor` in `hooks-core/inject.mjs` returns
+the answer inside the refusal itself — "unchanged since your last read" when
+nothing moved, the diff when we hold a snapshot, and otherwise an annotated
+skeleton carrying the structure plus every finding anchored to it. There is no
+second call. The remaining honest difference is narrower than the original
+concession: theirs rewrites the response of a tool the model already called,
+ours refuses and answers in the refusal. Both are zero-turn.
 
 ## Where we are genuinely ahead
 
@@ -120,13 +129,29 @@ truth for actual spend.
 ### 9. Skills and configuration health
 
 Unused-skill detection, per-skill context cost, CLAUDE.md bloat and
-cache-pattern auditing. Zero for us.
+cache-pattern auditing.
+
+**Status: built, and now visible.** "Zero for us" was wrong when it was written
+and wrong in an instructive way. `auditStanding` and `verdictFor` in
+`hooks-core/standing.mjs` already computed all four — which standing-context
+files are stale, oversized or never invoked, priced per session — and
+`renderStanding` already rendered the report. Nothing called `renderStanding`.
+The capability existed, was tested, and reached no reader, so the gap was real
+from a user's seat and closed from the code's, which is the disease this
+project's reachability guard exists to catch.
+
+It is wired now: the panel appears in `token_audit`, carrying the two things the
+finding queue cannot — the total prefix cost, and the files with nothing wrong,
+which produce no finding and were therefore invisible.
 
 ### 10. Memory health
 
 An eight-auditor MEMORY.md review with stale-entry detection. Our wiki staleness
 is conceptually the same machinery pointed at a different file; we have not
 pointed it there.
+
+**Status: unchanged.** Gap 9's machinery covers standing context, not MEMORY.md
+specifically.
 
 ### 11. Distribution and trust
 

--- a/docs/WIKI_GRAPH.md
+++ b/docs/WIKI_GRAPH.md
@@ -407,11 +407,22 @@ reader, or is deleted:
 | `clientTitle`, `kind: 'mcp-client'` | the doctor reports which clients actually handshaked |
 | `contentAnchor` | **deleted**, per this project's own rule about capabilities kept for later |
 
-One list remains: the reachability allowlist, at four entries, ratcheted to a
-ceiling that can only fall. All four are keep-warm and consolidation functions
-whose **producing action does not exist** — nothing in the repository performs a
-keep-warm ping, and nothing decides what to consolidate or when. That is
-verified rather than assumed, and it is why they are neither wired nor deleted:
-calling `recordRefresh` at the only site that exists would write refreshes that
-never happened into the ledger the keep-warm backstop reads, and fabricated
-evidence in a backstop is worse than a dead function.
+**The reachability allowlist is empty.** It held twenty-one entries when the
+detector was built, sixteen after the first round parked them with accurate
+descriptions, seven after Plan 1, and zero now. The last four were the hard
+ones, and each was held back for a while on a true statement — "the producing
+action does not exist" — until the producing action was built:
+
+| | Resolution |
+|---|---|
+| `selectForConsolidation` | Runs in the semantic harvest, so a session stores what a token budget admits instead of everything extracted. Fixing it first required fixing `consolidate.mjs`, whose halves disagreed about the field name: the selector read `entry.summary`, which no producer here emits, so wiring it naively would have priced every candidate at zero and dropped nothing. Live, green and inert is the same defect wearing a call site. |
+| `consolidationRatio` | Reported per finding by `/api/wiki/node` and shown in the dashboard detail view — the number this document opens on, previously computed for no finding anyone could look at. |
+| `recordRefresh` | The keep-warm decision is written to the ledger when `cache_audit` issues it. |
+| `recordRefreshOutcome` | Scored by `scoreOutstandingRefreshes`, which reads the event log to see whether a turn actually arrived inside the window the advice predicted. A refresh whose window is still open records **nothing** rather than guessing a miss — the signal needed no new instrumentation, it was in the log the whole time. |
+
+That last one closed a loop that could never turn. `tripwire` demands ten
+outcomes before it may have an opinion and no call site ever produced one, so it
+answered "only 0/10 refreshes observed" for the life of the project, and
+`keepWarmDecision` could not learn that its modelled hit rate was wrong. Between
+"the model says refresh" and "stop the feature entirely" there was nothing at
+all.

--- a/docs/WIKI_GRAPH.md
+++ b/docs/WIKI_GRAPH.md
@@ -392,9 +392,26 @@ Both were found by deliberately breaking the thing each claimed to detect and
 watching the suite stay green. A guard that cannot fail is worse than no guard,
 because it is counted.
 
-Two lists are maintained rather than emptied, and both are ratcheted to a
-ceiling that can only fall: the reachability allowlist, and the census's record
-of orphan writers and unread fields. Every entry names what it is and what it is
-waiting on. The distinction from a backlog is the point — an earlier round of
-this work parked sixteen findings in a list of accurate descriptions with no
-owner, and writing the description down felt like fixing the thing.
+The census's own lists are **empty**. They did not start that way: it shipped
+one orphan event writer and six unread record fields, each described accurately
+and attributed to a plan that had not reached those tasks — which is the same
+list Round 1 produced, with a different excuse on it. Every one now has a
+reader, or is deleted:
+
+| | Resolution |
+|---|---|
+| `candidateCount`, `shadowFindingIds` | the injection holdout's shadow — what retrieval selected against what was served, reported by `shadowDelivery` |
+| `staleCount` | index staleness as a rate, not a boolean |
+| `contradictedAt` | disclosed beside the reason a claim was disputed |
+| `lastAction` | names the tool in the stale reason: "file changed (last touched by Edit)" |
+| `clientTitle`, `kind: 'mcp-client'` | the doctor reports which clients actually handshaked |
+| `contentAnchor` | **deleted**, per this project's own rule about capabilities kept for later |
+
+One list remains: the reachability allowlist, at four entries, ratcheted to a
+ceiling that can only fall. All four are keep-warm and consolidation functions
+whose **producing action does not exist** — nothing in the repository performs a
+keep-warm ping, and nothing decides what to consolidate or when. That is
+verified rather than assumed, and it is why they are neither wired nor deleted:
+calling `recordRefresh` at the only site that exists would write refreshes that
+never happened into the ledger the keep-warm backstop reads, and fabricated
+evidence in a backstop is worse than a dead function.

--- a/docs/WIKI_GRAPH.md
+++ b/docs/WIKI_GRAPH.md
@@ -317,3 +317,63 @@ a knowledge-graph costume. The metrics ship with the feature, not after it.
 4. **Cold start.** The graph is empty on a fresh clone and value ramps over the
    first few sessions. Accepted deliberately: the alternative is indexing code
    nobody will touch, which is the exact waste RAG ingestion is criticised for.
+
+## Verifying it is connected
+
+Every capability in this document can be implemented correctly, tested
+thoroughly, and connected to nothing. That is not a hypothetical: it has
+happened here repeatedly, and each time the whole test suite was green while the
+feature delivered nothing.
+
+- `forTouch` — the just-in-time injection this design calls "where the win
+  lands" — had 27 passing tests and zero production call sites.
+- `wiki_query` was named in twelve shipped copies of the injected prompt text.
+  There was no such tool.
+- `kind: 'query'` was read by the index budget and written by nothing except the
+  test suite, so the ratio was zero on every project and the budget sat pinned
+  at its 150-token floor for the life of the feature.
+- `contradicts` and `answers` sat in `EDGE_KINDS` with no write site: the graph
+  declared it could record a disputed belief and an answered question, and could
+  do neither.
+- `contradictionReason`, up to 400 characters explaining why one finding
+  disputes another, was written on every `contradict` call and read by nothing.
+
+Unit tests cannot see this, because they call the function directly. **Mutation
+testing is actively misleading here:** break an unreachable function and its own
+tests fail, so the mutation is scored as caught while the feature still delivers
+nothing. Measured on this repository, the suite scored 100% on ten realistic
+mutations during a period when two whole features were unreachable.
+
+Three things answer it instead.
+
+**`tests/hooks/reachability.test.mjs`** asks whether an exported name is
+referenced by anything that ships, as opposed to only by its own tests. It scans
+`hooks-core` and `plugin/hooks` for declarations — functions *and* consts — and
+searches all of `hooks-core`, `plugin`, `src` and `scripts` for uses. Comments
+are stripped, because prose is not a caller, and import specifiers are
+discounted, because an import is not a call. **String literals are deliberately
+NOT stripped**: `src/server` dispatches into `hooks-core` through dynamic
+`mods.<module>.<fn>` handles, and a scanner that skips strings desynchronises on
+the first regex literal containing a quote — measured at 63% of `adapter.mjs`
+consumed and eleven live exports reported as orphans. Over-counting a name that
+appears in a string is the permissive direction, and permissive is merely
+useless where strict fails CI on working code and gets switched off.
+
+**`tests/hooks/census.test.mjs`** counts producers against consumers in four
+namespaces the name-based scan cannot model: event kinds, edge kinds, tool names
+appearing in injected prompt text, and record fields. It is what would have
+caught every example in the list above.
+
+**`npm run wiki:census`** prints what the graph is doing on a real machine —
+findings, nodes, edges by kind, and index, query, inject, substitute and
+retrieval-decision events. This is not a test and never fails a build. Every
+defect listed above passed CI, so a green suite is not evidence that a
+capability runs; events in a real log are. A fresh clone is expected to read
+zero everywhere, which is the cold start this design accepts deliberately.
+
+Two lists are maintained rather than emptied, and both are ratcheted to a
+ceiling that can only fall: the reachability allowlist, and the census's record
+of orphan writers and unread fields. Every entry names what it is and what it is
+waiting on. The distinction from a backlog is the point — an earlier round of
+this work parked sixteen findings in a list of accurate descriptions with no
+owner, and writing the description down felt like fixing the thing.

--- a/docs/WIKI_GRAPH.md
+++ b/docs/WIKI_GRAPH.md
@@ -371,6 +371,27 @@ defect listed above passed CI, so a green suite is not evidence that a
 capability runs; events in a real log are. A fresh clone is expected to read
 zero everywhere, which is the cold start this design accepts deliberately.
 
+**What the guards cannot prove.** A name-based scan shows that a REFERENCE
+exists, never that it RUNS. This work produced its own example: `manifestSize`
+left the allowlist by acquiring a caller in the doctor's install section, and
+that call sits inside `if (resolved.method !== 'plugin')` — so on a plugin
+install, which is how this product is actually distributed, it still never
+executes. That is correct here, because only the install script writes a
+manifest and a plugin install has none to size, but the guard could not have
+told the difference. A reference inside a branch that never runs, or behind a
+flag nobody sets, satisfies it exactly as well as a live call. That is precisely
+why `npm run wiki:census` reads real logs rather than source text, and why a
+capability is not considered proven until its events appear in one.
+
+Every assertion in `census.test.mjs` is mutation-tested, and that is not
+ceremony. Two of its first drafts could not fail at all: the read side of "read
+but never written" was filtered by the write side, so the `query` case it
+advertises would have slipped straight through, and "declares every edge kind it
+writes" compared a set against a superset it had already been filtered into.
+Both were found by deliberately breaking the thing each claimed to detect and
+watching the suite stay green. A guard that cannot fail is worse than no guard,
+because it is counted.
+
 Two lists are maintained rather than emptied, and both are ratcheted to a
 ceiling that can only fall: the reachability allowlist, and the census's record
 of orphan writers and unread fields. Every entry names what it is and what it is

--- a/docs/superpowers/plans/2026-08-25-wiki-graph-plan-3-detector-and-allowlist.md
+++ b/docs/superpowers/plans/2026-08-25-wiki-graph-plan-3-detector-and-allowlist.md
@@ -12,6 +12,47 @@
 
 **Depends on:** Plans 1 and 2 remove seven allowlist entries as a side effect of wiring their subsystems. This plan removes the remainder and makes the guard airtight. **Run it last**, or its first task will fail on work the other plans have not done yet.
 
+---
+
+## EXECUTION NOTE — read before implementing Task 1
+
+This plan was executed against master after Plan 1 merged (#315) and while Plan 2
+was still in flight. Three things in it are wrong, and correcting them here is
+cheaper than rediscovering them.
+
+**1. Task 1 Step 3's `stripComments` must NOT be implemented.** The scanner it
+proposes skips string and template literals, and a JS lexer that knows about
+quotes but not about REGEX LITERALS desynchronises on the first regex containing
+a quote. `hooks-core/adapter.mjs:255` is one. Measured: adapter.mjs 1032
+newlines in, 385 out — 63% of the file consumed; disclose.mjs 69%. Eleven
+genuinely-called exports (`toolSucceeded`, `stableText`, `recordToolOutcome`,
+`recordEpisodeOutcome`, `DISCLOSE_THRESHOLD`, `invalidateOnWrite`,
+`invalidateChangedAnchors`, `prices`, `briefing`, `semanticHarvestPrompt`,
+`cachedRoutingBriefing`) fall to their own declaration and report as orphans.
+That violates this plan's own first Global Constraint. The comments-only
+boundary already on master is correct; pin it with tests instead.
+
+**2. Task 3's extractors were wrong in two ways, both measured against grep.**
+`putEdge(dir, from, edge, to)` takes the edge kind as its THIRD argument, not
+its second, and the call writing `calls` edges spans six lines in
+`staleness.mjs` — so the proposed single-line second-argument regex reports the
+graph's own call-edge kind as having no writer. Separately, a fixed character
+window over `record(` overruns the call in `mcp-evidence.ts` and collects a
+field belonging to the next function; the field census must be brace-balanced
+and must SKIP any literal it cannot balance, because there over-reporting is the
+strict direction.
+
+**3. Task 5's target is stale.** It says the allowlist should end at one entry,
+`policyText`. `policyText` was already removed before this plan ran — it has
+callers in `adapter.mjs` and the SessionStart hook. The real target is **zero**.
+
+**4. Tasks 3 and 5 cannot go green while Plan 2 is outstanding**, and shipping a
+knowingly-red suite teaches everyone to ignore it. Five allowlist entries are
+Plan 2's (`selectForConsolidation`, `contentAnchor` — its Task 4;
+`consolidationRatio` — Task 8; `recordRefresh`, `recordRefreshOutcome` — Task
+9). Both lists are therefore ratcheted to a ceiling that can only fall, with
+every entry attributed to the task that owes it, rather than asserted at zero.
+
 ## Global Constraints
 
 - **The detector must be wrong only in the permissive direction.** A check that fails CI on working code gets deleted within a week — `reachability.test.mjs` says so itself, and it is right.

--- a/hooks-core/audit.mjs
+++ b/hooks-core/audit.mjs
@@ -31,6 +31,7 @@
 import { record, readMetrics } from './metrics.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
+import { renderStanding } from './standing.mjs';
 
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
 
@@ -181,7 +182,7 @@ export function buildQueue(
 export function renderAudit(
   dir,
   findings = [],
-  { tier = 'opus', full = false, sessionsPerMonth = 60 } = {}
+  { tier = 'opus', full = false, sessionsPerMonth = 60, standing = null } = {}
 ) {
   const { queue, suppressed, done } = buildQueue(dir, findings);
   const lines = [];
@@ -314,6 +315,38 @@ export function renderAudit(
       body.push(
         `  ${trend.detector}: ${trend.before.toLocaleString()} -> ${trend.after.toLocaleString()} tokens/session ` +
           `(${trend.improved ? 'improved' : 'worse'})`
+      );
+    }
+  }
+
+  // STANDING CONTEXT, as a panel rather than only as queue rows.
+  //
+  // auditStanding and verdictFor were both reachable, so this project already
+  // computed which CLAUDE.md rules and skills are stale, oversized or never
+  // used -- and threw the report away. renderStanding existed, was tested, and
+  // had no caller: the forTouch shape exactly, in the subsystem #203 claimed
+  // closed the skills-and-memory gap. Hard to defend a gap as closed while the
+  // report that would show it is unreachable.
+  //
+  // WHAT THE QUEUE ABOVE CANNOT SAY, which is why this is not duplication. The
+  // queue carries one row per ACTION, so a standing file with nothing wrong
+  // contributes no row and is invisible -- and the total cost of the prefix,
+  // the number that says what standing context is worth arguing about at all,
+  // is carried by no row either. Both are in the panel.
+  //
+  // Costed like everything else here: it is pushed BEFORE the closing line is
+  // measured, so the report's self-cost includes its own newest panel rather
+  // than understating it.
+  if (standing?.length) {
+    body.push('', 'Standing context -- charged every session:', '');
+    const panel = renderStanding(standing, { sessionsPerMonth });
+    // Indented to sit under its heading, blank lines left blank rather than
+    // turned into trailing whitespace.
+    for (const line of panel.split('\n')) body.push(line ? `  ${line}` : '');
+    if (standing.some((v) => v.actions?.length)) {
+      body.push(
+        '',
+        '  The actions above also appear in the queue at the top, where they are priced and applyable.'
       );
     }
   }

--- a/hooks-core/audit.mjs
+++ b/hooks-core/audit.mjs
@@ -372,7 +372,16 @@ export function renderAudit(
     // Indented to sit under its heading, blank lines left blank rather than
     // turned into trailing whitespace.
     for (const line of panel.split('\n')) body.push(line ? `  ${line}` : '');
-    if (standing.some((v) => v.actions?.length)) {
+    // ONLY IF THEY ACTUALLY DID. This pointed the reader at "the queue at the
+    // top" whenever any verdict carried an action -- including when the queue
+    // printed "Nothing addressable found", because a caller can render the
+    // panel with no findings at all, and the withholding rule can drop a
+    // standing row even when findings were passed. Telling someone to look at
+    // a row that is not there is worse than saying nothing.
+    const shownStandingIds = new Set(
+      shown.map((item) => item.id).filter((id) => typeof id === 'string' && id.startsWith('standing-'))
+    );
+    if (shownStandingIds.size) {
       body.push(
         '',
         '  The actions above also appear in the queue at the top, where they are priced and applyable.'

--- a/hooks-core/audit.mjs
+++ b/hooks-core/audit.mjs
@@ -28,7 +28,7 @@
  * cost at the bottom.
  */
 
-import { record, readMetrics } from './metrics.mjs';
+import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -317,6 +317,35 @@ export function renderAudit(
           `(${trend.improved ? 'improved' : 'worse'})`
       );
     }
+  }
+
+  // WHAT THE BUDGET TURNED AWAY.
+  //
+  // The per-touch token budget is load-bearing by design (#204): without it the
+  // most heavily-worked files accumulate the most findings and become the most
+  // expensive to touch. But a budget that silently drops what it cannot afford
+  // looks, from outside, exactly like a graph that had nothing to say -- and
+  // those are the two states a reader most needs told apart. inject.mjs was
+  // already recording every rejection and its reason, from four call sites, and
+  // nothing read them.
+  //
+  // ONE LINE, not a panel. This is context for the queue above rather than
+  // another thing to do, and the report is held to its own cost.
+  try {
+    const declined = declinedAtBudget(dir);
+    if (declined.declined > 0) {
+      const reasons = declined.byReason
+        .slice(0, 3)
+        .map(({ reason, count }) => `${reason} ${count}`)
+        .join(', ');
+      body.push(
+        '',
+        `Retrieval declined ${declined.declined.toLocaleString()} finding(s) ` +
+          `(${declined.distinctFindings} distinct) across ${declined.decisions.toLocaleString()} decision(s): ${reasons}.`
+      );
+    }
+  } catch {
+    /* the rejection log is context, never a reason to fail the audit */
   }
 
   // STANDING CONTEXT, as a panel rather than only as queue rows.

--- a/hooks-core/consolidate.mjs
+++ b/hooks-core/consolidate.mjs
@@ -29,7 +29,6 @@
  * without session instrumentation cannot obtain.
  */
 
-import { statSync } from 'node:fs';
 import { nodeId } from './wiki.mjs';
 
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
@@ -199,25 +198,3 @@ export function aggregateConsolidation(findings) {
   return carry ? { derived, carry, ratio: derived / carry } : null;
 }
 
-/**
- * Content identity for a file, so a finding can reach across projects.
- *
- * A vendored library file is the same file in every repository that holds it,
- * whatever path each gives it. Anchoring to content as well as path means a
- * finding about it appears in all of them with no promotion step and no path
- * mapping -- reach a per-session checkpoint cannot have even in principle.
- *
- * The PATH anchor still drives staleness within a repo; this is additive.
- */
-export function contentAnchor(path, hash) {
-  if (!hash) return null;
-  let size = 0;
-  try {
-    size = statSync(path).size;
-  } catch {
-    return null;
-  }
-  // Size is included so two different files sharing a truncated digest do not
-  // collide into one identity.
-  return `content:${hash}:${size}`;
-}

--- a/hooks-core/consolidate.mjs
+++ b/hooks-core/consolidate.mjs
@@ -34,6 +34,28 @@ import { nodeId } from './wiki.mjs';
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
 
 /**
+ * A candidate's own words, whatever the producer called the field.
+ *
+ * THE SELECTOR AND THE RATIO DISAGREED ABOUT THIS, and the half that had no
+ * caller is the half that was wrong. `irrecoverability`, `costToRederive` and
+ * `selectForConsolidation` all read `entry.summary`; `consolidationRatio` and
+ * `aggregateConsolidation` read `finding.claim`. NO PRODUCER IN THIS REPOSITORY
+ * EMITS `summary` -- the semantic harvest, wiki_write and the evaluation
+ * harnesses all emit `claim`, and `validate()` in harvest.mjs rejects anything
+ * without one.
+ *
+ * That matters more than a rename. Wired naively, every candidate would have
+ * scored `tokens: estimate(undefined)` -- zero -- so the budget could never
+ * bind, nothing would ever be dropped, and the selector would have been live,
+ * green, and inert. A capability that runs and cannot affect its own output is
+ * the same defect as one that never runs, wearing a call site.
+ *
+ * `summary` is still accepted, because an external caller may pass it and
+ * breaking that to fix an internal disagreement would be gratuitous.
+ */
+const claimText = (entry) => entry?.claim || entry?.summary || '';
+
+/**
  * How hard something is to reproduce, independent of what it cost this time.
  *
  * Token cost alone understates the expensive cases. Reproducing a flaky failure
@@ -43,7 +65,7 @@ const estimate = (text) => Math.ceil(String(text || '').length / 4);
  * measurements, and pretending otherwise would be false precision.
  */
 export function irrecoverability(entry) {
-  const text = `${entry.summary || ''} ${entry.evidence || ''}`.toLowerCase();
+  const text = `${claimText(entry)} ${entry.evidence || ''}`.toLowerCase();
 
   // Anything derived from a non-deterministic or long-running observation.
   //
@@ -108,7 +130,7 @@ export function costToRederive(entry, previousAt) {
   // no-op. The only measured cost is `entry.tokensSpent`, which the extraction
   // site must supply; otherwise fall back to the size of the evidence, so a
   // conclusion drawn from a large investigation still outranks an aside.
-  return estimate(entry.evidence) * 4 || estimate(entry.summary) * 8;
+  return estimate(entry.evidence) * 4 || estimate(claimText(entry)) * 8;
 }
 
 /** Kinds that survive on the floor regardless of score. */
@@ -139,7 +161,7 @@ export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}
     });
     const cost = costToRederive(entry, previousAt);
     const score = cost * irrecoverability(entry) * reuseProbability(graph, entry.anchorIds || anchors);
-    scored.push({ entry, score, cost, tokens: estimate(entry.summary) });
+    scored.push({ entry, score, cost, tokens: estimate(claimText(entry)) });
     previousAt = entry.at ?? previousAt;
   }
 
@@ -180,7 +202,7 @@ export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}
  * FOR, in a way that "tokens saved" never quite is.
  */
 export function consolidationRatio(finding) {
-  const carry = estimate(finding.claim);
+  const carry = estimate(claimText(finding));
   const derived = finding.derivedCost || 0;
   if (!carry || !derived) return null;
   return derived / carry;
@@ -193,7 +215,7 @@ export function aggregateConsolidation(findings) {
   for (const finding of findings) {
     if (!finding.derivedCost) continue;
     derived += finding.derivedCost;
-    carry += estimate(finding.claim);
+    carry += estimate(claimText(finding));
   }
   return carry ? { derived, carry, ratio: derived / carry } : null;
 }

--- a/hooks-core/doctor.mjs
+++ b/hooks-core/doctor.mjs
@@ -25,6 +25,7 @@ import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { harvestMode } from './harvest.mjs';
 import { readManifest, verifyManifest, residue, manifestSize } from './manifest.mjs';
+import { mcpClientsSeen } from './metrics.mjs';
 
 /**
  * Bytes as a person reads them.
@@ -551,7 +552,39 @@ export function probeGraph({ dir }) {
     checks.push(ok('graph directory is private', 'mode could not be read on this filesystem'));
   }
 
+  checks.push(...probeClients({ dir }));
   return checks;
+}
+
+/**
+ * Which MCP clients have actually handshaked with this server.
+ *
+ * THE QUESTION THE REST OF THE DOCTOR CANNOT ANSWER. Every other check here
+ * reasons about files on disk: is the hook present, is it wired, does it refuse
+ * a large read. None of them can tell you whether the editor in front of you
+ * ever actually connected -- which is the single most common way this product
+ * is installed and silently does nothing.
+ *
+ * `mcp-client` records exactly that on every `initialize`, and nothing read it
+ * until now. NEVER A FAILURE: a fresh install has no handshakes yet, and a
+ * doctor that reports red on a correct install teaches people to ignore it.
+ */
+export function probeClients({ dir }) {
+  let clients = [];
+  try {
+    clients = mcpClientsSeen(dir);
+  } catch {
+    return [ok('MCP clients seen', 'no evidence log yet')];
+  }
+  if (!clients.length) {
+    return [ok('MCP clients seen', 'none yet -- the server has had no MCP handshake in this project')];
+  }
+  const described = clients
+    .slice(0, 5)
+    .map((c) => `${c.title || c.client}${c.version ? ` ${c.version}` : ''}`)
+    .join(', ');
+  return [ok('MCP clients seen', `${clients.length}: ${described}` +
+    (clients.length > 5 ? `, and ${clients.length - 5} more` : ''))];
 }
 
 /**

--- a/hooks-core/doctor.mjs
+++ b/hooks-core/doctor.mjs
@@ -384,11 +384,23 @@ export function checklist({ root, settingsPath, install }) {
       // no longer exist, since a missing file contributes zero bytes -- was
       // computed nowhere and shown to no one.
       const footprint = describeBytes(manifestSize(manifest));
-      checks.push(verified.modified === 0
-        ? ok('installed files intact', `${verified.intact} file(s), ${footprint}, match the install manifest`)
-        : ok('installed files intact', `${verified.modified} of ${verified.intact + verified.modified} file(s) ` +
+      // MISSING IS NOT INTACT, and branching on `modified` alone said it was.
+      // verifyManifest reports three states and this read two of them: a
+      // recorded file DELETED rather than edited left `modified === 0`, so a
+      // half-removed install passed as healthy. The footprint above is what
+      // makes it visible -- a missing file contributes zero bytes -- but a
+      // visible detail beside a PASS is still a PASS.
+      if (verified.missing > 0) {
+        checks.push(bad('installed files intact',
+          `${verified.missing} of ${verified.files.length} recorded file(s) are gone (${footprint} still on disk)`,
+          'reinstall the package to restore them, or run the uninstaller to clear the manifest'));
+      } else if (verified.modified === 0) {
+        checks.push(ok('installed files intact', `${verified.intact} file(s), ${footprint}, match the install manifest`));
+      } else {
+        checks.push(ok('installed files intact', `${verified.modified} of ${verified.intact + verified.modified} file(s) ` +
           `(${footprint} recorded) edited since install -- ` +
           'uninstall will leave those alone rather than destroy your changes'));
+      }
     } else {
       checks.push(bad('install manifest present', 'no record of what was installed',
         'harmless if you installed manually; reinstall to get a removable, verifiable record'));
@@ -536,9 +548,16 @@ export function probeGraph({ dir }) {
   // the bits read back as world-readable regardless, so failing there would be
   // reporting a platform property as a broken install: a false alarm that
   // teaches people to ignore the doctor.
+  // BEFORE THE PLATFORM RETURN, and this is exactly the defect this branch
+  // exists to close: the client probe was appended after `probeGraph`'s
+  // Windows early-return, so on Windows it had a call site and never ran. A
+  // reference that cannot execute is what the reachability guard cannot see.
+  const clients = probeClients({ dir });
+
   if (process.platform === 'win32') {
     checks.push(ok('graph directory is private',
       'POSIX modes are not enforced on Windows; the directory inherits its parent ACL'));
+    checks.push(...clients);
     return checks;
   }
 
@@ -552,7 +571,7 @@ export function probeGraph({ dir }) {
     checks.push(ok('graph directory is private', 'mode could not be read on this filesystem'));
   }
 
-  checks.push(...probeClients({ dir }));
+  checks.push(...clients);
   return checks;
 }
 

--- a/hooks-core/doctor.mjs
+++ b/hooks-core/doctor.mjs
@@ -24,7 +24,21 @@ import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSyn
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { harvestMode } from './harvest.mjs';
-import { readManifest, verifyManifest, residue } from './manifest.mjs';
+import { readManifest, verifyManifest, residue, manifestSize } from './manifest.mjs';
+
+/**
+ * Bytes as a person reads them.
+ *
+ * Local because it exists for one line of one check, and because the alternative
+ * -- printing a raw byte count next to a file count -- is the kind of detail
+ * that gets skimmed past rather than read.
+ */
+function describeBytes(bytes) {
+  if (!bytes) return 'size unknown';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
 
 const ok = (name, detail) => ({ name, pass: true, detail });
 const bad = (name, detail, remedy) => ({ name, pass: false, detail, remedy });
@@ -360,11 +374,19 @@ export function checklist({ root, settingsPath, install }) {
     }
 
     // What we recorded putting on the machine, and whether it is still that.
-    const verified = verifyManifest(readManifest());
+    const manifest = readManifest();
+    const verified = verifyManifest(manifest);
     if (verified) {
+      // HOW MUCH, not just how many. manifestSize computed exactly this and had
+      // no caller, so the one number that says what uninstall will actually
+      // remove -- and the only cross-check on a manifest that lists files which
+      // no longer exist, since a missing file contributes zero bytes -- was
+      // computed nowhere and shown to no one.
+      const footprint = describeBytes(manifestSize(manifest));
       checks.push(verified.modified === 0
-        ? ok('installed files intact', `${verified.intact} file(s) match the install manifest`)
-        : ok('installed files intact', `${verified.modified} file(s) edited since install -- ` +
+        ? ok('installed files intact', `${verified.intact} file(s), ${footprint}, match the install manifest`)
+        : ok('installed files intact', `${verified.modified} of ${verified.intact + verified.modified} file(s) ` +
+          `(${footprint} recorded) edited since install -- ` +
           'uninstall will leave those alone rather than destroy your changes'));
     } else {
       checks.push(bad('install manifest present', 'no record of what was installed',

--- a/hooks-core/keepwarm.mjs
+++ b/hooks-core/keepwarm.mjs
@@ -108,7 +108,7 @@ export function gapDistribution(dir, { events = readMetrics(dir) } = {}) {
  * Returns the arithmetic as well as the verdict, because a refusal to refresh
  * that cannot be checked is indistinguishable from a bug.
  */
-export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0] }) {
+export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed = null }) {
   if (!prefixTokens || !gaps) {
     return { action: 'unknown', reason: 'no gap distribution yet -- needs a few sessions of history' };
   }
@@ -122,21 +122,42 @@ export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0] }) {
   // The ping only earns anything in the window where the entry WOULD have
   // expired but the next turn still arrives: before the TTL it was already
   // warm, and long after it, one ping does not reach.
-  const probability = Math.max(0, gaps.probabilityWithin(tier.ms * 2) - gaps.probabilityWithin(tier.ms));
+  const modelled = Math.max(0, gaps.probabilityWithin(tier.ms * 2) - gaps.probabilityWithin(tier.ms));
+
+  // MEASURED BEATS MODELLED, once there is enough of it.
+  //
+  // The module header already commits to this -- "an expected-value decision is
+  // only as good as the distribution it was fitted to, and distributions
+  // shift" -- and the tripwire underneath was the only thing acting on it, as
+  // an all-or-nothing kill switch. Between "the model says refresh" and "stop
+  // entirely" there was nothing, because the observed hit rate was never
+  // computed: both recording halves had no call site, so ten refreshes that
+  // bought nothing would keep recommending refresh right up to the moment the
+  // tripwire cut the whole feature off.
+  //
+  // Below OBSERVATION_FLOOR this stays null and the model is used unchanged; a
+  // handful of samples would swing the decision harder than the distribution
+  // they replace.
+  const probability = observed ? observed.rate : modelled;
   const savingIfUsed = prefixTokens * (tier.writeMultiplier - READ_MULTIPLIER);
   const ev = probability * savingIfUsed - costOfPing;
+  const basis = observed
+    ? `measured over ${observed.observations} refreshes`
+    : 'modelled from the gap distribution';
 
   return {
     action: ev > 0 ? 'refresh' : 'skip',
     tier: tier.name,
     probability,
+    modelledProbability: modelled,
+    basis,
     savingIfUsed: Math.round(savingIfUsed),
     costOfPing: Math.round(costOfPing),
     expectedValue: Math.round(ev),
     reason: ev > 0
-      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers; ` +
+      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers (${basis}); ` +
         `expected gain ${Math.round(ev).toLocaleString()} tokens`
-      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers; ` +
+      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers (${basis}); ` +
         `expected loss ${Math.abs(Math.round(ev)).toLocaleString()} tokens`,
   };
 }
@@ -192,9 +213,84 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
   };
 }
 
+/** Observations of a tier before its measured hit rate may override the model. */
+export const OBSERVATION_FLOOR = 5;
+
 /** Records a refresh so its outcome can be scored. */
 export function recordRefresh(dir, { tier, prefixTokens, expectedValue }) {
   record(dir, { kind: 'keepwarm', action: 'refresh', tier, prefixTokens, expectedValue });
+}
+
+/**
+ * Scores every refresh whose window has since resolved.
+ *
+ * THE MISSING HALF, and it was missing because nobody could see where the
+ * signal would come from. `recordRefreshOutcome` needs to know whether a real
+ * turn arrived before the entry expired -- and that is not a thing anyone has
+ * to instrument, because the event log already records when every turn
+ * happened. The answer was in the data the whole time.
+ *
+ * For each unscored refresh at time T on a tier with TTL `ms`:
+ *
+ *   - a later event within `ms`            -> HIT, observed
+ *   - a later event after `ms`             -> MISS, observed
+ *   - no later event, and `now - T > ms`   -> MISS, observed: the window has
+ *                                             demonstrably closed unused
+ *   - no later event, window still open    -> NOTHING RECORDED
+ *
+ * That last line is the important one and it is Plan 2's own instruction: "if
+ * no signal is available for a tier, record nothing rather than guessing
+ * `hit: false`". A refresh whose window has not closed yet is not a miss, and
+ * scoring it as one would drive the tripwire negative on the newest and least
+ * informative records.
+ *
+ * DRAINED AT READ TIME, which is the pattern this codebase already uses for
+ * staleness: the producer cannot know the outcome at the moment it acts, so the
+ * next reader resolves what has become knowable since.
+ */
+export function scoreOutstandingRefreshes(dir, { events = readMetrics(dir), outcomes = readBalance(dir), now = Date.now() } = {}) {
+  const keepwarm = outcomes.filter((e) => e.kind === 'keepwarm');
+  const refreshes = keepwarm.filter((e) => e.action === 'refresh').sort((a, b) => (a.at || 0) - (b.at || 0));
+  const scored = keepwarm.filter((e) => e.action === 'outcome').length;
+
+  // Refreshes are scored oldest-first and one outcome belongs to one refresh,
+  // so everything past the number already scored is outstanding. Pairing by
+  // timestamp instead would double-count two refreshes recorded in the same
+  // millisecond, which is reachable: a tool run twice in a loop.
+  const outstanding = refreshes.slice(scored);
+  const timeline = events.map((e) => Number(e.at) || 0).filter(Boolean).sort((a, b) => a - b);
+
+  let recorded = 0;
+  for (const refresh of outstanding) {
+    const at = Number(refresh.at) || 0;
+    if (!at) continue;
+    const tierSpec = TIERS.find((t) => t.name === refresh.tier) || TIERS[0];
+    const next = timeline.find((t) => t > at);
+
+    let hit;
+    if (next !== undefined) hit = next - at <= tierSpec.ms;
+    else if (now - at > tierSpec.ms) hit = false;
+    else continue; // window still open: not yet knowable
+
+    recordRefreshOutcome(dir, { tier: refresh.tier, prefixTokens: refresh.prefixTokens, hit });
+    recorded += 1;
+  }
+  return { outstanding: outstanding.length, recorded };
+}
+
+/**
+ * The measured hit rate for a tier, or null below the observation floor.
+ *
+ * Null rather than a small-sample number, because the caller substitutes it for
+ * a modelled probability and three observations would swing the decision harder
+ * than the model they replace.
+ */
+export function observedHitRate(dir, { tier, outcomes = readBalance(dir) } = {}) {
+  const relevant = outcomes.filter(
+    (e) => e.kind === 'keepwarm' && e.action === 'outcome' && (!tier || e.tier === tier)
+  );
+  if (relevant.length < OBSERVATION_FLOOR) return null;
+  return { observations: relevant.length, rate: relevant.filter((e) => e.hit).length / relevant.length };
 }
 
 /**
@@ -274,6 +370,18 @@ export function shouldKeepWarm(dir, {
   // was chosen was wrong for one of them.
   outcomes = readBalance(dir),
 } = {}) {
+  // DRAIN BEFORE DECIDING. Anything whose window has closed since the last call
+  // becomes evidence now, so the decision below and the tripwire above both see
+  // the most that is currently knowable -- the same read-time drain the
+  // staleness path uses, and for the same reason: the producer cannot know the
+  // outcome at the moment it acts.
+  try {
+    scoreOutstandingRefreshes(dir, { events, outcomes });
+    outcomes = readBalance(dir);
+  } catch {
+    /* scoring is evidence, never a reason to refuse a decision */
+  }
+
   const trip = tripwire(dir, { events: outcomes });
   if (trip.tripped) return { action: 'skip', reason: trip.reason, trippedWire: true };
 
@@ -287,7 +395,11 @@ export function shouldKeepWarm(dir, {
     // refusal justified by a GAIN: `{ action: 'skip', reason: '...expected gain 130 tokens' }`.
     // This module's own docstring says a refusal that cannot be checked is indistinguishable from
     // a bug; one that contradicts itself is worse.
-    const decision = keepWarmDecision({ prefixTokens, gaps });
+    const decision = keepWarmDecision({
+      prefixTokens,
+      gaps,
+      observed: observedHitRate(dir, { tier: TIERS[0].name, outcomes }),
+    });
     if (decision.action === 'refresh') return decision;
     return { action: decision.action === 'unknown' ? 'unknown' : 'skip', reason: decision.reason };
   }

--- a/hooks-core/metrics.mjs
+++ b/hooks-core/metrics.mjs
@@ -1229,6 +1229,60 @@ export function indexBudget(
   return Math.max(floor, Math.min(ceiling, scaled));
 }
 
+/**
+ * What retrieval decided NOT to inject, and why.
+ *
+ * THE OTHER HALF OF THE BUDGET, and it had no reader. `assessFindings` rejects a
+ * finding for one of three reasons -- it has been quarantined as harmful, it is
+ * in cooldown after being injected recently, or its expected value is negative
+ * -- and inject.mjs records every one of those decisions as a
+ * `retrieval-decision` event, from four separate call sites. Nothing read them.
+ *
+ * WHY THAT MATTERS RATHER THAN BEING TIDY. #204 makes the per-touch token budget
+ * load-bearing: "without it the most heavily-worked files accumulate the most
+ * findings and become the most expensive to touch, and the optimizer becomes
+ * its own token problem." A budget that silently drops what it cannot afford is
+ * indistinguishable, from outside, from a graph that had nothing to say. These
+ * are the two states a user most needs told apart, and the records to tell them
+ * apart were already being written.
+ *
+ * READ FROM THE EVIDENCE LOG, not the firehose. `retrieval-decision` is in
+ * EVIDENCE_KINDS precisely because it is rare relative to per-tool-call
+ * telemetry, and the windowed reader would evict it before it accumulated --
+ * the same eviction that made `report()` say "0 holdout" over a file containing
+ * nine.
+ */
+export function declinedAtBudget(dir, { limit = 500 } = {}) {
+  const decisions = readEvidence(dir)
+    .filter((event) => event.kind === 'retrieval-decision')
+    .slice(-limit);
+
+  const byReason = new Map();
+  const keys = new Set();
+  let declined = 0;
+  for (const decision of decisions) {
+    for (const item of decision.rejected || []) {
+      declined += 1;
+      if (item.key) keys.add(item.key);
+      // An unlabelled rejection is counted, not dropped: an unknown reason is
+      // still a finding the model did not get, and reporting the count as
+      // smaller than it is would understate exactly the cost this exists to
+      // surface.
+      const reason = item.reason || 'unspecified';
+      byReason.set(reason, (byReason.get(reason) || 0) + 1);
+    }
+  }
+
+  return {
+    decisions: decisions.length,
+    declined,
+    distinctFindings: keys.size,
+    byReason: [...byReason.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([reason, count]) => ({ reason, count })),
+  };
+}
+
 /* ----------------------------------------------------------------------
  * Episode-level causal evidence
  * ------------------------------------------------------------------- */

--- a/hooks-core/metrics.mjs
+++ b/hooks-core/metrics.mjs
@@ -742,6 +742,21 @@ export function balanceSheet(dir) {
           verdict: r.verdict,
         };
       })(),
+      // THE CONTROL ARM'S CONTENT, for the same reason `controlArmTokens` sits
+      // in the substitution block above: `candidateCount` and
+      // `shadowFindingIds` recorded what the holdout withheld and nothing read
+      // them, so the report could count the arms and never say what was in
+      // them.
+      ...(() => {
+        const shadow = shadowDelivery(dir);
+        return {
+          selected: shadow.selected,
+          delivered: shadow.delivered,
+          controlArmSelected: shadow.withheldSelected,
+          controlArmFindings: shadow.withheldFindings,
+          indexStaleEntries: shadow.staleEntries,
+        };
+      })(),
     },
     costs: {
       injection: injectCost,
@@ -1281,6 +1296,109 @@ export function declinedAtBudget(dir, { limit = 500 } = {}) {
       .sort((a, b) => b[1] - a[1])
       .map(([reason, count]) => ({ reason, count })),
   };
+}
+
+/**
+ * The injection arm's SHADOW: what retrieval selected, against what was served.
+ *
+ * THE SAME GAP `controlArmTokens` WAS CREATED TO CLOSE, one arm over. That
+ * field exists because `tokensFullFile` "was recorded and read by nothing, so
+ * the comparison the holdout exists for was not computable from the report" --
+ * and the injection side had the identical hole: every `inject` record carries
+ * `candidateCount` and `shadowFindingIds`, which are what WOULD have been
+ * delivered, non-zero in BOTH arms, while `count` and `findingIds` go to zero
+ * in the holdout. The shadow pair was written on every injection since the
+ * holdout shipped and read by nothing, so the report could say how many touches
+ * landed in each arm and never which findings the holdout actually withheld.
+ *
+ * `staleCount` is the same shape on the session-start index: `stale` (a
+ * boolean, "was any of this stale") had a reader, the count did not, so a index
+ * with one rotten entry in forty was indistinguishable from one rotten
+ * throughout.
+ *
+ * READ FROM THE BALANCE LOG, because `inject` is a BALANCE_KIND: the firehose
+ * evicts injections first -- 136 of them against 6,725 captures on one machine
+ * -- which is the eviction that made `report()` say "0 holdout" over a file
+ * containing nine.
+ */
+export function shadowDelivery(dir) {
+  const injections = readBalance(dir).filter((event) => event.kind === 'inject');
+
+  let selected = 0;
+  let delivered = 0;
+  let withheldSelected = 0;
+  const withheldKeys = new Set();
+  let staleEntries = 0;
+  let indexRecords = 0;
+
+  for (const event of injections) {
+    const candidates = Number(event.candidateCount) || 0;
+    selected += candidates;
+    delivered += Number(event.count) || 0;
+    if (event.holdout) {
+      withheldSelected += candidates;
+      for (const key of event.shadowFindingIds || []) withheldKeys.add(key);
+    }
+    if (event.surface === 'session-start') {
+      indexRecords += 1;
+      staleEntries += Number(event.staleCount) || 0;
+    }
+  }
+
+  return {
+    injections: injections.length,
+    // Everything retrieval chose, across both arms.
+    selected,
+    // What actually reached a model.
+    delivered,
+    // Chosen and deliberately not delivered, because the anchor was in the
+    // withheld arm. This is the control arm's content, which is the thing the
+    // holdout exists to make comparable.
+    withheldSelected,
+    withheldFindings: withheldKeys.size,
+    // Index staleness as a rate rather than a boolean.
+    indexRecords,
+    staleEntries,
+  };
+}
+
+/**
+ * Which MCP clients have actually handshaked with this server.
+ *
+ * `mcp-client` was written on every `initialize` and read by nothing -- a
+ * producer with no reader, and the last one the census found. Deleting it was
+ * the other option and would have been wrong: `mcp-tool` records a client only
+ * once it CALLS something, and the project registry records a name only, so a
+ * client that connected and then called nothing -- which is exactly the failure
+ * this project's doctor exists to diagnose -- appeared in neither. The
+ * handshake is the only record that a connection happened at all.
+ *
+ * `clientTitle` is the field that made the record unique and it was unread too:
+ * the display name a client reports for itself, which is how a user recognises
+ * their own editor in a list where `name` is a slug.
+ */
+export function mcpClientsSeen(dir, { limit = 200 } = {}) {
+  const seen = new Map();
+  for (const event of readEvidence(dir)) {
+    if (event.kind !== 'mcp-client') continue;
+    const name = String(event.client || 'unknown');
+    const at = Number(event.at) || 0;
+    const previous = seen.get(name);
+    // LAST HANDSHAKE WINS on the mutable fields: a client that upgraded should
+    // be reported at the version it is now, not the one it first connected on.
+    if (!previous || at >= previous.at) {
+      seen.set(name, {
+        client: name,
+        title: event.clientTitle || null,
+        version: event.clientVersion || null,
+        at,
+        connections: (previous?.connections || 0) + 1,
+      });
+    } else {
+      previous.connections += 1;
+    }
+  }
+  return [...seen.values()].sort((a, b) => b.at - a.at).slice(0, limit);
 }
 
 /* ----------------------------------------------------------------------

--- a/hooks-core/staleness.mjs
+++ b/hooks-core/staleness.mjs
@@ -295,7 +295,25 @@ export function checkAnchor(anchor) {
   if (anchor.kind === 'file') {
     return hash(source) === anchor.hash
       ? { fresh: true }
-      : { fresh: false, before: anchor.snapshot || '', hasBefore: Boolean(anchor.snapshot), after: source, reason: 'file changed' };
+      : {
+          fresh: false,
+          before: anchor.snapshot || '',
+          hasBefore: Boolean(anchor.snapshot),
+          after: source,
+          // AND WHAT CHANGED IT, when the graph knows. The structural harvest
+          // stamps `lastAction` -- the tool name that last touched this file --
+          // on every file node, and nothing read it: the field was written on
+          // every observed tool call since #203 and consumed nowhere.
+          //
+          // It belongs precisely here. "file changed" tells a reader that their
+          // finding may be wrong; "file changed (last touched by Edit)" tells
+          // them a targeted edit did it, which is cheap to re-verify, and "last
+          // touched by Write" says the file was replaced wholesale, which is
+          // usually not. Same disclosure, one word of provenance, no extra I/O.
+          reason: anchor.lastAction
+            ? `file changed (last touched by ${String(anchor.lastAction).slice(0, 40)})`
+            : 'file changed',
+        };
   }
 
   // For a symbol, re-locate it by NAME rather than by line number. Line numbers
@@ -497,6 +515,7 @@ function disputeOf(graph, finding) {
   if (!hasOutstandingContradiction(graph, finding.key)) return {};
 
   const keys = [];
+  const disputantIds = [];
   // AND THE REASON A PERSON TYPED, which had no reader anywhere. `contradict`
   // stores `contradictionReason` -- up to 400 characters of human explanation --
   // on the CONTRADICTED end only, and nothing outside its own test ever read it:
@@ -522,6 +541,7 @@ function disputeOf(graph, finding) {
     // fetch. `hasOutstandingContradiction` above already declines to open the
     // gate when EVERY disputant is retired; this is the same rule applied to
     // each name, so a live disputant is still reported alongside a withdrawn one.
+    if (!disputantIds.includes(otherId)) disputantIds.push(otherId);
     if (other && !other.retired && typeof other.key === 'string' && !keys.includes(other.key)) {
       keys.push(other.key);
       // A RETIRED END'S REASON IS NOT BORROWED EITHER, which is why this sits
@@ -535,9 +555,31 @@ function disputeOf(graph, finding) {
     }
   }
 
+  // WHEN, alongside WHY. `contradict` writes `contradictedAt` and
+  // `contradictionReason` on the same line of the same putNode call. Round 1
+  // gave the reason a reader -- this function -- and left the timestamp
+  // unread, so the disclosure could say a claim was disputed and why, and not
+  // whether that happened this morning or a year ago. For a reader deciding
+  // whether to trust a disputed finding, the age of the dispute is most of the
+  // signal: a year-old objection to a claim nobody has revisited reads very
+  // differently from one raised since the last release.
+  //
+  // Collected from whichever end holds it, exactly like the reason, and the
+  // EARLIEST is kept -- the dispute began when the first end recorded it.
+  let contradictedAt =
+    typeof finding.contradictedAt === 'number' ? finding.contradictedAt : null;
+  for (const id of disputantIds) {
+    const other = graph.nodes.get(id);
+    if (!other || other.retired) continue;
+    if (typeof other.contradictedAt !== 'number') continue;
+    contradictedAt =
+      contradictedAt === null ? other.contradictedAt : Math.min(contradictedAt, other.contradictedAt);
+  }
+
   return {
     contradicted: true,
     ...(keys.length ? { contradictedBy: keys.join(', ') } : {}),
+    ...(contradictedAt !== null ? { contradictedAt } : {}),
     // Trimmed here rather than at the renderer: an empty string is not a reason,
     // and a consumer checking `if (reason)` should not have to trim first.
     //

--- a/integrations/cline/hooks/token-optimizer/lib/audit.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/audit.mjs
@@ -30,7 +30,7 @@
  * cost at the bottom.
  */
 
-import { record, readMetrics } from './metrics.mjs';
+import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -319,6 +319,35 @@ export function renderAudit(
           `(${trend.improved ? 'improved' : 'worse'})`
       );
     }
+  }
+
+  // WHAT THE BUDGET TURNED AWAY.
+  //
+  // The per-touch token budget is load-bearing by design (#204): without it the
+  // most heavily-worked files accumulate the most findings and become the most
+  // expensive to touch. But a budget that silently drops what it cannot afford
+  // looks, from outside, exactly like a graph that had nothing to say -- and
+  // those are the two states a reader most needs told apart. inject.mjs was
+  // already recording every rejection and its reason, from four call sites, and
+  // nothing read them.
+  //
+  // ONE LINE, not a panel. This is context for the queue above rather than
+  // another thing to do, and the report is held to its own cost.
+  try {
+    const declined = declinedAtBudget(dir);
+    if (declined.declined > 0) {
+      const reasons = declined.byReason
+        .slice(0, 3)
+        .map(({ reason, count }) => `${reason} ${count}`)
+        .join(', ');
+      body.push(
+        '',
+        `Retrieval declined ${declined.declined.toLocaleString()} finding(s) ` +
+          `(${declined.distinctFindings} distinct) across ${declined.decisions.toLocaleString()} decision(s): ${reasons}.`
+      );
+    }
+  } catch {
+    /* the rejection log is context, never a reason to fail the audit */
   }
 
   // STANDING CONTEXT, as a panel rather than only as queue rows.

--- a/integrations/cline/hooks/token-optimizer/lib/audit.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/audit.mjs
@@ -374,7 +374,16 @@ export function renderAudit(
     // Indented to sit under its heading, blank lines left blank rather than
     // turned into trailing whitespace.
     for (const line of panel.split('\n')) body.push(line ? `  ${line}` : '');
-    if (standing.some((v) => v.actions?.length)) {
+    // ONLY IF THEY ACTUALLY DID. This pointed the reader at "the queue at the
+    // top" whenever any verdict carried an action -- including when the queue
+    // printed "Nothing addressable found", because a caller can render the
+    // panel with no findings at all, and the withholding rule can drop a
+    // standing row even when findings were passed. Telling someone to look at
+    // a row that is not there is worse than saying nothing.
+    const shownStandingIds = new Set(
+      shown.map((item) => item.id).filter((id) => typeof id === 'string' && id.startsWith('standing-'))
+    );
+    if (shownStandingIds.size) {
       body.push(
         '',
         '  The actions above also appear in the queue at the top, where they are priced and applyable.'

--- a/integrations/cline/hooks/token-optimizer/lib/audit.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/audit.mjs
@@ -33,6 +33,7 @@
 import { record, readMetrics } from './metrics.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
+import { renderStanding } from './standing.mjs';
 
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
 
@@ -183,7 +184,7 @@ export function buildQueue(
 export function renderAudit(
   dir,
   findings = [],
-  { tier = 'opus', full = false, sessionsPerMonth = 60 } = {}
+  { tier = 'opus', full = false, sessionsPerMonth = 60, standing = null } = {}
 ) {
   const { queue, suppressed, done } = buildQueue(dir, findings);
   const lines = [];
@@ -316,6 +317,38 @@ export function renderAudit(
       body.push(
         `  ${trend.detector}: ${trend.before.toLocaleString()} -> ${trend.after.toLocaleString()} tokens/session ` +
           `(${trend.improved ? 'improved' : 'worse'})`
+      );
+    }
+  }
+
+  // STANDING CONTEXT, as a panel rather than only as queue rows.
+  //
+  // auditStanding and verdictFor were both reachable, so this project already
+  // computed which CLAUDE.md rules and skills are stale, oversized or never
+  // used -- and threw the report away. renderStanding existed, was tested, and
+  // had no caller: the forTouch shape exactly, in the subsystem #203 claimed
+  // closed the skills-and-memory gap. Hard to defend a gap as closed while the
+  // report that would show it is unreachable.
+  //
+  // WHAT THE QUEUE ABOVE CANNOT SAY, which is why this is not duplication. The
+  // queue carries one row per ACTION, so a standing file with nothing wrong
+  // contributes no row and is invisible -- and the total cost of the prefix,
+  // the number that says what standing context is worth arguing about at all,
+  // is carried by no row either. Both are in the panel.
+  //
+  // Costed like everything else here: it is pushed BEFORE the closing line is
+  // measured, so the report's self-cost includes its own newest panel rather
+  // than understating it.
+  if (standing?.length) {
+    body.push('', 'Standing context -- charged every session:', '');
+    const panel = renderStanding(standing, { sessionsPerMonth });
+    // Indented to sit under its heading, blank lines left blank rather than
+    // turned into trailing whitespace.
+    for (const line of panel.split('\n')) body.push(line ? `  ${line}` : '');
+    if (standing.some((v) => v.actions?.length)) {
+      body.push(
+        '',
+        '  The actions above also appear in the queue at the top, where they are priced and applyable.'
       );
     }
   }

--- a/integrations/cline/hooks/token-optimizer/lib/consolidate.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/consolidate.mjs
@@ -36,6 +36,28 @@ import { nodeId } from './wiki.mjs';
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
 
 /**
+ * A candidate's own words, whatever the producer called the field.
+ *
+ * THE SELECTOR AND THE RATIO DISAGREED ABOUT THIS, and the half that had no
+ * caller is the half that was wrong. `irrecoverability`, `costToRederive` and
+ * `selectForConsolidation` all read `entry.summary`; `consolidationRatio` and
+ * `aggregateConsolidation` read `finding.claim`. NO PRODUCER IN THIS REPOSITORY
+ * EMITS `summary` -- the semantic harvest, wiki_write and the evaluation
+ * harnesses all emit `claim`, and `validate()` in harvest.mjs rejects anything
+ * without one.
+ *
+ * That matters more than a rename. Wired naively, every candidate would have
+ * scored `tokens: estimate(undefined)` -- zero -- so the budget could never
+ * bind, nothing would ever be dropped, and the selector would have been live,
+ * green, and inert. A capability that runs and cannot affect its own output is
+ * the same defect as one that never runs, wearing a call site.
+ *
+ * `summary` is still accepted, because an external caller may pass it and
+ * breaking that to fix an internal disagreement would be gratuitous.
+ */
+const claimText = (entry) => entry?.claim || entry?.summary || '';
+
+/**
  * How hard something is to reproduce, independent of what it cost this time.
  *
  * Token cost alone understates the expensive cases. Reproducing a flaky failure
@@ -45,7 +67,7 @@ const estimate = (text) => Math.ceil(String(text || '').length / 4);
  * measurements, and pretending otherwise would be false precision.
  */
 export function irrecoverability(entry) {
-  const text = `${entry.summary || ''} ${entry.evidence || ''}`.toLowerCase();
+  const text = `${claimText(entry)} ${entry.evidence || ''}`.toLowerCase();
 
   // Anything derived from a non-deterministic or long-running observation.
   //
@@ -110,7 +132,7 @@ export function costToRederive(entry, previousAt) {
   // no-op. The only measured cost is `entry.tokensSpent`, which the extraction
   // site must supply; otherwise fall back to the size of the evidence, so a
   // conclusion drawn from a large investigation still outranks an aside.
-  return estimate(entry.evidence) * 4 || estimate(entry.summary) * 8;
+  return estimate(entry.evidence) * 4 || estimate(claimText(entry)) * 8;
 }
 
 /** Kinds that survive on the floor regardless of score. */
@@ -141,7 +163,7 @@ export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}
     });
     const cost = costToRederive(entry, previousAt);
     const score = cost * irrecoverability(entry) * reuseProbability(graph, entry.anchorIds || anchors);
-    scored.push({ entry, score, cost, tokens: estimate(entry.summary) });
+    scored.push({ entry, score, cost, tokens: estimate(claimText(entry)) });
     previousAt = entry.at ?? previousAt;
   }
 
@@ -182,7 +204,7 @@ export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}
  * FOR, in a way that "tokens saved" never quite is.
  */
 export function consolidationRatio(finding) {
-  const carry = estimate(finding.claim);
+  const carry = estimate(claimText(finding));
   const derived = finding.derivedCost || 0;
   if (!carry || !derived) return null;
   return derived / carry;
@@ -195,7 +217,7 @@ export function aggregateConsolidation(findings) {
   for (const finding of findings) {
     if (!finding.derivedCost) continue;
     derived += finding.derivedCost;
-    carry += estimate(finding.claim);
+    carry += estimate(claimText(finding));
   }
   return carry ? { derived, carry, ratio: derived / carry } : null;
 }

--- a/integrations/cline/hooks/token-optimizer/lib/consolidate.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/consolidate.mjs
@@ -31,7 +31,6 @@
  * without session instrumentation cannot obtain.
  */
 
-import { statSync } from 'node:fs';
 import { nodeId } from './wiki.mjs';
 
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
@@ -201,25 +200,3 @@ export function aggregateConsolidation(findings) {
   return carry ? { derived, carry, ratio: derived / carry } : null;
 }
 
-/**
- * Content identity for a file, so a finding can reach across projects.
- *
- * A vendored library file is the same file in every repository that holds it,
- * whatever path each gives it. Anchoring to content as well as path means a
- * finding about it appears in all of them with no promotion step and no path
- * mapping -- reach a per-session checkpoint cannot have even in principle.
- *
- * The PATH anchor still drives staleness within a repo; this is additive.
- */
-export function contentAnchor(path, hash) {
-  if (!hash) return null;
-  let size = 0;
-  try {
-    size = statSync(path).size;
-  } catch {
-    return null;
-  }
-  // Size is included so two different files sharing a truncated digest do not
-  // collide into one identity.
-  return `content:${hash}:${size}`;
-}

--- a/integrations/cline/hooks/token-optimizer/lib/doctor.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/doctor.mjs
@@ -26,7 +26,21 @@ import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSyn
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { harvestMode } from './harvest.mjs';
-import { readManifest, verifyManifest, residue } from './manifest.mjs';
+import { readManifest, verifyManifest, residue, manifestSize } from './manifest.mjs';
+
+/**
+ * Bytes as a person reads them.
+ *
+ * Local because it exists for one line of one check, and because the alternative
+ * -- printing a raw byte count next to a file count -- is the kind of detail
+ * that gets skimmed past rather than read.
+ */
+function describeBytes(bytes) {
+  if (!bytes) return 'size unknown';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
 
 const ok = (name, detail) => ({ name, pass: true, detail });
 const bad = (name, detail, remedy) => ({ name, pass: false, detail, remedy });
@@ -362,11 +376,19 @@ export function checklist({ root, settingsPath, install }) {
     }
 
     // What we recorded putting on the machine, and whether it is still that.
-    const verified = verifyManifest(readManifest());
+    const manifest = readManifest();
+    const verified = verifyManifest(manifest);
     if (verified) {
+      // HOW MUCH, not just how many. manifestSize computed exactly this and had
+      // no caller, so the one number that says what uninstall will actually
+      // remove -- and the only cross-check on a manifest that lists files which
+      // no longer exist, since a missing file contributes zero bytes -- was
+      // computed nowhere and shown to no one.
+      const footprint = describeBytes(manifestSize(manifest));
       checks.push(verified.modified === 0
-        ? ok('installed files intact', `${verified.intact} file(s) match the install manifest`)
-        : ok('installed files intact', `${verified.modified} file(s) edited since install -- ` +
+        ? ok('installed files intact', `${verified.intact} file(s), ${footprint}, match the install manifest`)
+        : ok('installed files intact', `${verified.modified} of ${verified.intact + verified.modified} file(s) ` +
+          `(${footprint} recorded) edited since install -- ` +
           'uninstall will leave those alone rather than destroy your changes'));
     } else {
       checks.push(bad('install manifest present', 'no record of what was installed',

--- a/integrations/cline/hooks/token-optimizer/lib/doctor.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/doctor.mjs
@@ -27,6 +27,7 @@ import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { harvestMode } from './harvest.mjs';
 import { readManifest, verifyManifest, residue, manifestSize } from './manifest.mjs';
+import { mcpClientsSeen } from './metrics.mjs';
 
 /**
  * Bytes as a person reads them.
@@ -553,7 +554,39 @@ export function probeGraph({ dir }) {
     checks.push(ok('graph directory is private', 'mode could not be read on this filesystem'));
   }
 
+  checks.push(...probeClients({ dir }));
   return checks;
+}
+
+/**
+ * Which MCP clients have actually handshaked with this server.
+ *
+ * THE QUESTION THE REST OF THE DOCTOR CANNOT ANSWER. Every other check here
+ * reasons about files on disk: is the hook present, is it wired, does it refuse
+ * a large read. None of them can tell you whether the editor in front of you
+ * ever actually connected -- which is the single most common way this product
+ * is installed and silently does nothing.
+ *
+ * `mcp-client` records exactly that on every `initialize`, and nothing read it
+ * until now. NEVER A FAILURE: a fresh install has no handshakes yet, and a
+ * doctor that reports red on a correct install teaches people to ignore it.
+ */
+export function probeClients({ dir }) {
+  let clients = [];
+  try {
+    clients = mcpClientsSeen(dir);
+  } catch {
+    return [ok('MCP clients seen', 'no evidence log yet')];
+  }
+  if (!clients.length) {
+    return [ok('MCP clients seen', 'none yet -- the server has had no MCP handshake in this project')];
+  }
+  const described = clients
+    .slice(0, 5)
+    .map((c) => `${c.title || c.client}${c.version ? ` ${c.version}` : ''}`)
+    .join(', ');
+  return [ok('MCP clients seen', `${clients.length}: ${described}` +
+    (clients.length > 5 ? `, and ${clients.length - 5} more` : ''))];
 }
 
 /**

--- a/integrations/cline/hooks/token-optimizer/lib/doctor.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/doctor.mjs
@@ -386,11 +386,23 @@ export function checklist({ root, settingsPath, install }) {
       // no longer exist, since a missing file contributes zero bytes -- was
       // computed nowhere and shown to no one.
       const footprint = describeBytes(manifestSize(manifest));
-      checks.push(verified.modified === 0
-        ? ok('installed files intact', `${verified.intact} file(s), ${footprint}, match the install manifest`)
-        : ok('installed files intact', `${verified.modified} of ${verified.intact + verified.modified} file(s) ` +
+      // MISSING IS NOT INTACT, and branching on `modified` alone said it was.
+      // verifyManifest reports three states and this read two of them: a
+      // recorded file DELETED rather than edited left `modified === 0`, so a
+      // half-removed install passed as healthy. The footprint above is what
+      // makes it visible -- a missing file contributes zero bytes -- but a
+      // visible detail beside a PASS is still a PASS.
+      if (verified.missing > 0) {
+        checks.push(bad('installed files intact',
+          `${verified.missing} of ${verified.files.length} recorded file(s) are gone (${footprint} still on disk)`,
+          'reinstall the package to restore them, or run the uninstaller to clear the manifest'));
+      } else if (verified.modified === 0) {
+        checks.push(ok('installed files intact', `${verified.intact} file(s), ${footprint}, match the install manifest`));
+      } else {
+        checks.push(ok('installed files intact', `${verified.modified} of ${verified.intact + verified.modified} file(s) ` +
           `(${footprint} recorded) edited since install -- ` +
           'uninstall will leave those alone rather than destroy your changes'));
+      }
     } else {
       checks.push(bad('install manifest present', 'no record of what was installed',
         'harmless if you installed manually; reinstall to get a removable, verifiable record'));
@@ -538,9 +550,16 @@ export function probeGraph({ dir }) {
   // the bits read back as world-readable regardless, so failing there would be
   // reporting a platform property as a broken install: a false alarm that
   // teaches people to ignore the doctor.
+  // BEFORE THE PLATFORM RETURN, and this is exactly the defect this branch
+  // exists to close: the client probe was appended after `probeGraph`'s
+  // Windows early-return, so on Windows it had a call site and never ran. A
+  // reference that cannot execute is what the reachability guard cannot see.
+  const clients = probeClients({ dir });
+
   if (process.platform === 'win32') {
     checks.push(ok('graph directory is private',
       'POSIX modes are not enforced on Windows; the directory inherits its parent ACL'));
+    checks.push(...clients);
     return checks;
   }
 
@@ -554,7 +573,7 @@ export function probeGraph({ dir }) {
     checks.push(ok('graph directory is private', 'mode could not be read on this filesystem'));
   }
 
-  checks.push(...probeClients({ dir }));
+  checks.push(...clients);
   return checks;
 }
 

--- a/integrations/cline/hooks/token-optimizer/lib/keepwarm.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/keepwarm.mjs
@@ -110,7 +110,7 @@ export function gapDistribution(dir, { events = readMetrics(dir) } = {}) {
  * Returns the arithmetic as well as the verdict, because a refusal to refresh
  * that cannot be checked is indistinguishable from a bug.
  */
-export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0] }) {
+export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed = null }) {
   if (!prefixTokens || !gaps) {
     return { action: 'unknown', reason: 'no gap distribution yet -- needs a few sessions of history' };
   }
@@ -124,21 +124,42 @@ export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0] }) {
   // The ping only earns anything in the window where the entry WOULD have
   // expired but the next turn still arrives: before the TTL it was already
   // warm, and long after it, one ping does not reach.
-  const probability = Math.max(0, gaps.probabilityWithin(tier.ms * 2) - gaps.probabilityWithin(tier.ms));
+  const modelled = Math.max(0, gaps.probabilityWithin(tier.ms * 2) - gaps.probabilityWithin(tier.ms));
+
+  // MEASURED BEATS MODELLED, once there is enough of it.
+  //
+  // The module header already commits to this -- "an expected-value decision is
+  // only as good as the distribution it was fitted to, and distributions
+  // shift" -- and the tripwire underneath was the only thing acting on it, as
+  // an all-or-nothing kill switch. Between "the model says refresh" and "stop
+  // entirely" there was nothing, because the observed hit rate was never
+  // computed: both recording halves had no call site, so ten refreshes that
+  // bought nothing would keep recommending refresh right up to the moment the
+  // tripwire cut the whole feature off.
+  //
+  // Below OBSERVATION_FLOOR this stays null and the model is used unchanged; a
+  // handful of samples would swing the decision harder than the distribution
+  // they replace.
+  const probability = observed ? observed.rate : modelled;
   const savingIfUsed = prefixTokens * (tier.writeMultiplier - READ_MULTIPLIER);
   const ev = probability * savingIfUsed - costOfPing;
+  const basis = observed
+    ? `measured over ${observed.observations} refreshes`
+    : 'modelled from the gap distribution';
 
   return {
     action: ev > 0 ? 'refresh' : 'skip',
     tier: tier.name,
     probability,
+    modelledProbability: modelled,
+    basis,
     savingIfUsed: Math.round(savingIfUsed),
     costOfPing: Math.round(costOfPing),
     expectedValue: Math.round(ev),
     reason: ev > 0
-      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers; ` +
+      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers (${basis}); ` +
         `expected gain ${Math.round(ev).toLocaleString()} tokens`
-      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers; ` +
+      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers (${basis}); ` +
         `expected loss ${Math.abs(Math.round(ev)).toLocaleString()} tokens`,
   };
 }
@@ -194,9 +215,84 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
   };
 }
 
+/** Observations of a tier before its measured hit rate may override the model. */
+export const OBSERVATION_FLOOR = 5;
+
 /** Records a refresh so its outcome can be scored. */
 export function recordRefresh(dir, { tier, prefixTokens, expectedValue }) {
   record(dir, { kind: 'keepwarm', action: 'refresh', tier, prefixTokens, expectedValue });
+}
+
+/**
+ * Scores every refresh whose window has since resolved.
+ *
+ * THE MISSING HALF, and it was missing because nobody could see where the
+ * signal would come from. `recordRefreshOutcome` needs to know whether a real
+ * turn arrived before the entry expired -- and that is not a thing anyone has
+ * to instrument, because the event log already records when every turn
+ * happened. The answer was in the data the whole time.
+ *
+ * For each unscored refresh at time T on a tier with TTL `ms`:
+ *
+ *   - a later event within `ms`            -> HIT, observed
+ *   - a later event after `ms`             -> MISS, observed
+ *   - no later event, and `now - T > ms`   -> MISS, observed: the window has
+ *                                             demonstrably closed unused
+ *   - no later event, window still open    -> NOTHING RECORDED
+ *
+ * That last line is the important one and it is Plan 2's own instruction: "if
+ * no signal is available for a tier, record nothing rather than guessing
+ * `hit: false`". A refresh whose window has not closed yet is not a miss, and
+ * scoring it as one would drive the tripwire negative on the newest and least
+ * informative records.
+ *
+ * DRAINED AT READ TIME, which is the pattern this codebase already uses for
+ * staleness: the producer cannot know the outcome at the moment it acts, so the
+ * next reader resolves what has become knowable since.
+ */
+export function scoreOutstandingRefreshes(dir, { events = readMetrics(dir), outcomes = readBalance(dir), now = Date.now() } = {}) {
+  const keepwarm = outcomes.filter((e) => e.kind === 'keepwarm');
+  const refreshes = keepwarm.filter((e) => e.action === 'refresh').sort((a, b) => (a.at || 0) - (b.at || 0));
+  const scored = keepwarm.filter((e) => e.action === 'outcome').length;
+
+  // Refreshes are scored oldest-first and one outcome belongs to one refresh,
+  // so everything past the number already scored is outstanding. Pairing by
+  // timestamp instead would double-count two refreshes recorded in the same
+  // millisecond, which is reachable: a tool run twice in a loop.
+  const outstanding = refreshes.slice(scored);
+  const timeline = events.map((e) => Number(e.at) || 0).filter(Boolean).sort((a, b) => a - b);
+
+  let recorded = 0;
+  for (const refresh of outstanding) {
+    const at = Number(refresh.at) || 0;
+    if (!at) continue;
+    const tierSpec = TIERS.find((t) => t.name === refresh.tier) || TIERS[0];
+    const next = timeline.find((t) => t > at);
+
+    let hit;
+    if (next !== undefined) hit = next - at <= tierSpec.ms;
+    else if (now - at > tierSpec.ms) hit = false;
+    else continue; // window still open: not yet knowable
+
+    recordRefreshOutcome(dir, { tier: refresh.tier, prefixTokens: refresh.prefixTokens, hit });
+    recorded += 1;
+  }
+  return { outstanding: outstanding.length, recorded };
+}
+
+/**
+ * The measured hit rate for a tier, or null below the observation floor.
+ *
+ * Null rather than a small-sample number, because the caller substitutes it for
+ * a modelled probability and three observations would swing the decision harder
+ * than the model they replace.
+ */
+export function observedHitRate(dir, { tier, outcomes = readBalance(dir) } = {}) {
+  const relevant = outcomes.filter(
+    (e) => e.kind === 'keepwarm' && e.action === 'outcome' && (!tier || e.tier === tier)
+  );
+  if (relevant.length < OBSERVATION_FLOOR) return null;
+  return { observations: relevant.length, rate: relevant.filter((e) => e.hit).length / relevant.length };
 }
 
 /**
@@ -276,6 +372,18 @@ export function shouldKeepWarm(dir, {
   // was chosen was wrong for one of them.
   outcomes = readBalance(dir),
 } = {}) {
+  // DRAIN BEFORE DECIDING. Anything whose window has closed since the last call
+  // becomes evidence now, so the decision below and the tripwire above both see
+  // the most that is currently knowable -- the same read-time drain the
+  // staleness path uses, and for the same reason: the producer cannot know the
+  // outcome at the moment it acts.
+  try {
+    scoreOutstandingRefreshes(dir, { events, outcomes });
+    outcomes = readBalance(dir);
+  } catch {
+    /* scoring is evidence, never a reason to refuse a decision */
+  }
+
   const trip = tripwire(dir, { events: outcomes });
   if (trip.tripped) return { action: 'skip', reason: trip.reason, trippedWire: true };
 
@@ -289,7 +397,11 @@ export function shouldKeepWarm(dir, {
     // refusal justified by a GAIN: `{ action: 'skip', reason: '...expected gain 130 tokens' }`.
     // This module's own docstring says a refusal that cannot be checked is indistinguishable from
     // a bug; one that contradicts itself is worse.
-    const decision = keepWarmDecision({ prefixTokens, gaps });
+    const decision = keepWarmDecision({
+      prefixTokens,
+      gaps,
+      observed: observedHitRate(dir, { tier: TIERS[0].name, outcomes }),
+    });
     if (decision.action === 'refresh') return decision;
     return { action: decision.action === 'unknown' ? 'unknown' : 'skip', reason: decision.reason };
   }

--- a/integrations/cline/hooks/token-optimizer/lib/metrics.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/metrics.mjs
@@ -744,6 +744,21 @@ export function balanceSheet(dir) {
           verdict: r.verdict,
         };
       })(),
+      // THE CONTROL ARM'S CONTENT, for the same reason `controlArmTokens` sits
+      // in the substitution block above: `candidateCount` and
+      // `shadowFindingIds` recorded what the holdout withheld and nothing read
+      // them, so the report could count the arms and never say what was in
+      // them.
+      ...(() => {
+        const shadow = shadowDelivery(dir);
+        return {
+          selected: shadow.selected,
+          delivered: shadow.delivered,
+          controlArmSelected: shadow.withheldSelected,
+          controlArmFindings: shadow.withheldFindings,
+          indexStaleEntries: shadow.staleEntries,
+        };
+      })(),
     },
     costs: {
       injection: injectCost,
@@ -1283,6 +1298,109 @@ export function declinedAtBudget(dir, { limit = 500 } = {}) {
       .sort((a, b) => b[1] - a[1])
       .map(([reason, count]) => ({ reason, count })),
   };
+}
+
+/**
+ * The injection arm's SHADOW: what retrieval selected, against what was served.
+ *
+ * THE SAME GAP `controlArmTokens` WAS CREATED TO CLOSE, one arm over. That
+ * field exists because `tokensFullFile` "was recorded and read by nothing, so
+ * the comparison the holdout exists for was not computable from the report" --
+ * and the injection side had the identical hole: every `inject` record carries
+ * `candidateCount` and `shadowFindingIds`, which are what WOULD have been
+ * delivered, non-zero in BOTH arms, while `count` and `findingIds` go to zero
+ * in the holdout. The shadow pair was written on every injection since the
+ * holdout shipped and read by nothing, so the report could say how many touches
+ * landed in each arm and never which findings the holdout actually withheld.
+ *
+ * `staleCount` is the same shape on the session-start index: `stale` (a
+ * boolean, "was any of this stale") had a reader, the count did not, so a index
+ * with one rotten entry in forty was indistinguishable from one rotten
+ * throughout.
+ *
+ * READ FROM THE BALANCE LOG, because `inject` is a BALANCE_KIND: the firehose
+ * evicts injections first -- 136 of them against 6,725 captures on one machine
+ * -- which is the eviction that made `report()` say "0 holdout" over a file
+ * containing nine.
+ */
+export function shadowDelivery(dir) {
+  const injections = readBalance(dir).filter((event) => event.kind === 'inject');
+
+  let selected = 0;
+  let delivered = 0;
+  let withheldSelected = 0;
+  const withheldKeys = new Set();
+  let staleEntries = 0;
+  let indexRecords = 0;
+
+  for (const event of injections) {
+    const candidates = Number(event.candidateCount) || 0;
+    selected += candidates;
+    delivered += Number(event.count) || 0;
+    if (event.holdout) {
+      withheldSelected += candidates;
+      for (const key of event.shadowFindingIds || []) withheldKeys.add(key);
+    }
+    if (event.surface === 'session-start') {
+      indexRecords += 1;
+      staleEntries += Number(event.staleCount) || 0;
+    }
+  }
+
+  return {
+    injections: injections.length,
+    // Everything retrieval chose, across both arms.
+    selected,
+    // What actually reached a model.
+    delivered,
+    // Chosen and deliberately not delivered, because the anchor was in the
+    // withheld arm. This is the control arm's content, which is the thing the
+    // holdout exists to make comparable.
+    withheldSelected,
+    withheldFindings: withheldKeys.size,
+    // Index staleness as a rate rather than a boolean.
+    indexRecords,
+    staleEntries,
+  };
+}
+
+/**
+ * Which MCP clients have actually handshaked with this server.
+ *
+ * `mcp-client` was written on every `initialize` and read by nothing -- a
+ * producer with no reader, and the last one the census found. Deleting it was
+ * the other option and would have been wrong: `mcp-tool` records a client only
+ * once it CALLS something, and the project registry records a name only, so a
+ * client that connected and then called nothing -- which is exactly the failure
+ * this project's doctor exists to diagnose -- appeared in neither. The
+ * handshake is the only record that a connection happened at all.
+ *
+ * `clientTitle` is the field that made the record unique and it was unread too:
+ * the display name a client reports for itself, which is how a user recognises
+ * their own editor in a list where `name` is a slug.
+ */
+export function mcpClientsSeen(dir, { limit = 200 } = {}) {
+  const seen = new Map();
+  for (const event of readEvidence(dir)) {
+    if (event.kind !== 'mcp-client') continue;
+    const name = String(event.client || 'unknown');
+    const at = Number(event.at) || 0;
+    const previous = seen.get(name);
+    // LAST HANDSHAKE WINS on the mutable fields: a client that upgraded should
+    // be reported at the version it is now, not the one it first connected on.
+    if (!previous || at >= previous.at) {
+      seen.set(name, {
+        client: name,
+        title: event.clientTitle || null,
+        version: event.clientVersion || null,
+        at,
+        connections: (previous?.connections || 0) + 1,
+      });
+    } else {
+      previous.connections += 1;
+    }
+  }
+  return [...seen.values()].sort((a, b) => b.at - a.at).slice(0, limit);
 }
 
 /* ----------------------------------------------------------------------

--- a/integrations/cline/hooks/token-optimizer/lib/metrics.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/metrics.mjs
@@ -1231,6 +1231,60 @@ export function indexBudget(
   return Math.max(floor, Math.min(ceiling, scaled));
 }
 
+/**
+ * What retrieval decided NOT to inject, and why.
+ *
+ * THE OTHER HALF OF THE BUDGET, and it had no reader. `assessFindings` rejects a
+ * finding for one of three reasons -- it has been quarantined as harmful, it is
+ * in cooldown after being injected recently, or its expected value is negative
+ * -- and inject.mjs records every one of those decisions as a
+ * `retrieval-decision` event, from four separate call sites. Nothing read them.
+ *
+ * WHY THAT MATTERS RATHER THAN BEING TIDY. #204 makes the per-touch token budget
+ * load-bearing: "without it the most heavily-worked files accumulate the most
+ * findings and become the most expensive to touch, and the optimizer becomes
+ * its own token problem." A budget that silently drops what it cannot afford is
+ * indistinguishable, from outside, from a graph that had nothing to say. These
+ * are the two states a user most needs told apart, and the records to tell them
+ * apart were already being written.
+ *
+ * READ FROM THE EVIDENCE LOG, not the firehose. `retrieval-decision` is in
+ * EVIDENCE_KINDS precisely because it is rare relative to per-tool-call
+ * telemetry, and the windowed reader would evict it before it accumulated --
+ * the same eviction that made `report()` say "0 holdout" over a file containing
+ * nine.
+ */
+export function declinedAtBudget(dir, { limit = 500 } = {}) {
+  const decisions = readEvidence(dir)
+    .filter((event) => event.kind === 'retrieval-decision')
+    .slice(-limit);
+
+  const byReason = new Map();
+  const keys = new Set();
+  let declined = 0;
+  for (const decision of decisions) {
+    for (const item of decision.rejected || []) {
+      declined += 1;
+      if (item.key) keys.add(item.key);
+      // An unlabelled rejection is counted, not dropped: an unknown reason is
+      // still a finding the model did not get, and reporting the count as
+      // smaller than it is would understate exactly the cost this exists to
+      // surface.
+      const reason = item.reason || 'unspecified';
+      byReason.set(reason, (byReason.get(reason) || 0) + 1);
+    }
+  }
+
+  return {
+    decisions: decisions.length,
+    declined,
+    distinctFindings: keys.size,
+    byReason: [...byReason.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([reason, count]) => ({ reason, count })),
+  };
+}
+
 /* ----------------------------------------------------------------------
  * Episode-level causal evidence
  * ------------------------------------------------------------------- */

--- a/integrations/cline/hooks/token-optimizer/lib/staleness.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/staleness.mjs
@@ -297,7 +297,25 @@ export function checkAnchor(anchor) {
   if (anchor.kind === 'file') {
     return hash(source) === anchor.hash
       ? { fresh: true }
-      : { fresh: false, before: anchor.snapshot || '', hasBefore: Boolean(anchor.snapshot), after: source, reason: 'file changed' };
+      : {
+          fresh: false,
+          before: anchor.snapshot || '',
+          hasBefore: Boolean(anchor.snapshot),
+          after: source,
+          // AND WHAT CHANGED IT, when the graph knows. The structural harvest
+          // stamps `lastAction` -- the tool name that last touched this file --
+          // on every file node, and nothing read it: the field was written on
+          // every observed tool call since #203 and consumed nowhere.
+          //
+          // It belongs precisely here. "file changed" tells a reader that their
+          // finding may be wrong; "file changed (last touched by Edit)" tells
+          // them a targeted edit did it, which is cheap to re-verify, and "last
+          // touched by Write" says the file was replaced wholesale, which is
+          // usually not. Same disclosure, one word of provenance, no extra I/O.
+          reason: anchor.lastAction
+            ? `file changed (last touched by ${String(anchor.lastAction).slice(0, 40)})`
+            : 'file changed',
+        };
   }
 
   // For a symbol, re-locate it by NAME rather than by line number. Line numbers
@@ -499,6 +517,7 @@ function disputeOf(graph, finding) {
   if (!hasOutstandingContradiction(graph, finding.key)) return {};
 
   const keys = [];
+  const disputantIds = [];
   // AND THE REASON A PERSON TYPED, which had no reader anywhere. `contradict`
   // stores `contradictionReason` -- up to 400 characters of human explanation --
   // on the CONTRADICTED end only, and nothing outside its own test ever read it:
@@ -524,6 +543,7 @@ function disputeOf(graph, finding) {
     // fetch. `hasOutstandingContradiction` above already declines to open the
     // gate when EVERY disputant is retired; this is the same rule applied to
     // each name, so a live disputant is still reported alongside a withdrawn one.
+    if (!disputantIds.includes(otherId)) disputantIds.push(otherId);
     if (other && !other.retired && typeof other.key === 'string' && !keys.includes(other.key)) {
       keys.push(other.key);
       // A RETIRED END'S REASON IS NOT BORROWED EITHER, which is why this sits
@@ -537,9 +557,31 @@ function disputeOf(graph, finding) {
     }
   }
 
+  // WHEN, alongside WHY. `contradict` writes `contradictedAt` and
+  // `contradictionReason` on the same line of the same putNode call. Round 1
+  // gave the reason a reader -- this function -- and left the timestamp
+  // unread, so the disclosure could say a claim was disputed and why, and not
+  // whether that happened this morning or a year ago. For a reader deciding
+  // whether to trust a disputed finding, the age of the dispute is most of the
+  // signal: a year-old objection to a claim nobody has revisited reads very
+  // differently from one raised since the last release.
+  //
+  // Collected from whichever end holds it, exactly like the reason, and the
+  // EARLIEST is kept -- the dispute began when the first end recorded it.
+  let contradictedAt =
+    typeof finding.contradictedAt === 'number' ? finding.contradictedAt : null;
+  for (const id of disputantIds) {
+    const other = graph.nodes.get(id);
+    if (!other || other.retired) continue;
+    if (typeof other.contradictedAt !== 'number') continue;
+    contradictedAt =
+      contradictedAt === null ? other.contradictedAt : Math.min(contradictedAt, other.contradictedAt);
+  }
+
   return {
     contradicted: true,
     ...(keys.length ? { contradictedBy: keys.join(', ') } : {}),
+    ...(contradictedAt !== null ? { contradictedAt } : {}),
     // Trimmed here rather than at the renderer: an empty string is not a reason,
     // and a consumer checking `if (reason)` should not have to trim first.
     //

--- a/integrations/codex/hooks/lib/audit.mjs
+++ b/integrations/codex/hooks/lib/audit.mjs
@@ -30,7 +30,7 @@
  * cost at the bottom.
  */
 
-import { record, readMetrics } from './metrics.mjs';
+import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -319,6 +319,35 @@ export function renderAudit(
           `(${trend.improved ? 'improved' : 'worse'})`
       );
     }
+  }
+
+  // WHAT THE BUDGET TURNED AWAY.
+  //
+  // The per-touch token budget is load-bearing by design (#204): without it the
+  // most heavily-worked files accumulate the most findings and become the most
+  // expensive to touch. But a budget that silently drops what it cannot afford
+  // looks, from outside, exactly like a graph that had nothing to say -- and
+  // those are the two states a reader most needs told apart. inject.mjs was
+  // already recording every rejection and its reason, from four call sites, and
+  // nothing read them.
+  //
+  // ONE LINE, not a panel. This is context for the queue above rather than
+  // another thing to do, and the report is held to its own cost.
+  try {
+    const declined = declinedAtBudget(dir);
+    if (declined.declined > 0) {
+      const reasons = declined.byReason
+        .slice(0, 3)
+        .map(({ reason, count }) => `${reason} ${count}`)
+        .join(', ');
+      body.push(
+        '',
+        `Retrieval declined ${declined.declined.toLocaleString()} finding(s) ` +
+          `(${declined.distinctFindings} distinct) across ${declined.decisions.toLocaleString()} decision(s): ${reasons}.`
+      );
+    }
+  } catch {
+    /* the rejection log is context, never a reason to fail the audit */
   }
 
   // STANDING CONTEXT, as a panel rather than only as queue rows.

--- a/integrations/codex/hooks/lib/audit.mjs
+++ b/integrations/codex/hooks/lib/audit.mjs
@@ -374,7 +374,16 @@ export function renderAudit(
     // Indented to sit under its heading, blank lines left blank rather than
     // turned into trailing whitespace.
     for (const line of panel.split('\n')) body.push(line ? `  ${line}` : '');
-    if (standing.some((v) => v.actions?.length)) {
+    // ONLY IF THEY ACTUALLY DID. This pointed the reader at "the queue at the
+    // top" whenever any verdict carried an action -- including when the queue
+    // printed "Nothing addressable found", because a caller can render the
+    // panel with no findings at all, and the withholding rule can drop a
+    // standing row even when findings were passed. Telling someone to look at
+    // a row that is not there is worse than saying nothing.
+    const shownStandingIds = new Set(
+      shown.map((item) => item.id).filter((id) => typeof id === 'string' && id.startsWith('standing-'))
+    );
+    if (shownStandingIds.size) {
       body.push(
         '',
         '  The actions above also appear in the queue at the top, where they are priced and applyable.'

--- a/integrations/codex/hooks/lib/audit.mjs
+++ b/integrations/codex/hooks/lib/audit.mjs
@@ -33,6 +33,7 @@
 import { record, readMetrics } from './metrics.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
+import { renderStanding } from './standing.mjs';
 
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
 
@@ -183,7 +184,7 @@ export function buildQueue(
 export function renderAudit(
   dir,
   findings = [],
-  { tier = 'opus', full = false, sessionsPerMonth = 60 } = {}
+  { tier = 'opus', full = false, sessionsPerMonth = 60, standing = null } = {}
 ) {
   const { queue, suppressed, done } = buildQueue(dir, findings);
   const lines = [];
@@ -316,6 +317,38 @@ export function renderAudit(
       body.push(
         `  ${trend.detector}: ${trend.before.toLocaleString()} -> ${trend.after.toLocaleString()} tokens/session ` +
           `(${trend.improved ? 'improved' : 'worse'})`
+      );
+    }
+  }
+
+  // STANDING CONTEXT, as a panel rather than only as queue rows.
+  //
+  // auditStanding and verdictFor were both reachable, so this project already
+  // computed which CLAUDE.md rules and skills are stale, oversized or never
+  // used -- and threw the report away. renderStanding existed, was tested, and
+  // had no caller: the forTouch shape exactly, in the subsystem #203 claimed
+  // closed the skills-and-memory gap. Hard to defend a gap as closed while the
+  // report that would show it is unreachable.
+  //
+  // WHAT THE QUEUE ABOVE CANNOT SAY, which is why this is not duplication. The
+  // queue carries one row per ACTION, so a standing file with nothing wrong
+  // contributes no row and is invisible -- and the total cost of the prefix,
+  // the number that says what standing context is worth arguing about at all,
+  // is carried by no row either. Both are in the panel.
+  //
+  // Costed like everything else here: it is pushed BEFORE the closing line is
+  // measured, so the report's self-cost includes its own newest panel rather
+  // than understating it.
+  if (standing?.length) {
+    body.push('', 'Standing context -- charged every session:', '');
+    const panel = renderStanding(standing, { sessionsPerMonth });
+    // Indented to sit under its heading, blank lines left blank rather than
+    // turned into trailing whitespace.
+    for (const line of panel.split('\n')) body.push(line ? `  ${line}` : '');
+    if (standing.some((v) => v.actions?.length)) {
+      body.push(
+        '',
+        '  The actions above also appear in the queue at the top, where they are priced and applyable.'
       );
     }
   }

--- a/integrations/codex/hooks/lib/consolidate.mjs
+++ b/integrations/codex/hooks/lib/consolidate.mjs
@@ -36,6 +36,28 @@ import { nodeId } from './wiki.mjs';
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
 
 /**
+ * A candidate's own words, whatever the producer called the field.
+ *
+ * THE SELECTOR AND THE RATIO DISAGREED ABOUT THIS, and the half that had no
+ * caller is the half that was wrong. `irrecoverability`, `costToRederive` and
+ * `selectForConsolidation` all read `entry.summary`; `consolidationRatio` and
+ * `aggregateConsolidation` read `finding.claim`. NO PRODUCER IN THIS REPOSITORY
+ * EMITS `summary` -- the semantic harvest, wiki_write and the evaluation
+ * harnesses all emit `claim`, and `validate()` in harvest.mjs rejects anything
+ * without one.
+ *
+ * That matters more than a rename. Wired naively, every candidate would have
+ * scored `tokens: estimate(undefined)` -- zero -- so the budget could never
+ * bind, nothing would ever be dropped, and the selector would have been live,
+ * green, and inert. A capability that runs and cannot affect its own output is
+ * the same defect as one that never runs, wearing a call site.
+ *
+ * `summary` is still accepted, because an external caller may pass it and
+ * breaking that to fix an internal disagreement would be gratuitous.
+ */
+const claimText = (entry) => entry?.claim || entry?.summary || '';
+
+/**
  * How hard something is to reproduce, independent of what it cost this time.
  *
  * Token cost alone understates the expensive cases. Reproducing a flaky failure
@@ -45,7 +67,7 @@ const estimate = (text) => Math.ceil(String(text || '').length / 4);
  * measurements, and pretending otherwise would be false precision.
  */
 export function irrecoverability(entry) {
-  const text = `${entry.summary || ''} ${entry.evidence || ''}`.toLowerCase();
+  const text = `${claimText(entry)} ${entry.evidence || ''}`.toLowerCase();
 
   // Anything derived from a non-deterministic or long-running observation.
   //
@@ -110,7 +132,7 @@ export function costToRederive(entry, previousAt) {
   // no-op. The only measured cost is `entry.tokensSpent`, which the extraction
   // site must supply; otherwise fall back to the size of the evidence, so a
   // conclusion drawn from a large investigation still outranks an aside.
-  return estimate(entry.evidence) * 4 || estimate(entry.summary) * 8;
+  return estimate(entry.evidence) * 4 || estimate(claimText(entry)) * 8;
 }
 
 /** Kinds that survive on the floor regardless of score. */
@@ -141,7 +163,7 @@ export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}
     });
     const cost = costToRederive(entry, previousAt);
     const score = cost * irrecoverability(entry) * reuseProbability(graph, entry.anchorIds || anchors);
-    scored.push({ entry, score, cost, tokens: estimate(entry.summary) });
+    scored.push({ entry, score, cost, tokens: estimate(claimText(entry)) });
     previousAt = entry.at ?? previousAt;
   }
 
@@ -182,7 +204,7 @@ export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}
  * FOR, in a way that "tokens saved" never quite is.
  */
 export function consolidationRatio(finding) {
-  const carry = estimate(finding.claim);
+  const carry = estimate(claimText(finding));
   const derived = finding.derivedCost || 0;
   if (!carry || !derived) return null;
   return derived / carry;
@@ -195,7 +217,7 @@ export function aggregateConsolidation(findings) {
   for (const finding of findings) {
     if (!finding.derivedCost) continue;
     derived += finding.derivedCost;
-    carry += estimate(finding.claim);
+    carry += estimate(claimText(finding));
   }
   return carry ? { derived, carry, ratio: derived / carry } : null;
 }

--- a/integrations/codex/hooks/lib/consolidate.mjs
+++ b/integrations/codex/hooks/lib/consolidate.mjs
@@ -31,7 +31,6 @@
  * without session instrumentation cannot obtain.
  */
 
-import { statSync } from 'node:fs';
 import { nodeId } from './wiki.mjs';
 
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
@@ -201,25 +200,3 @@ export function aggregateConsolidation(findings) {
   return carry ? { derived, carry, ratio: derived / carry } : null;
 }
 
-/**
- * Content identity for a file, so a finding can reach across projects.
- *
- * A vendored library file is the same file in every repository that holds it,
- * whatever path each gives it. Anchoring to content as well as path means a
- * finding about it appears in all of them with no promotion step and no path
- * mapping -- reach a per-session checkpoint cannot have even in principle.
- *
- * The PATH anchor still drives staleness within a repo; this is additive.
- */
-export function contentAnchor(path, hash) {
-  if (!hash) return null;
-  let size = 0;
-  try {
-    size = statSync(path).size;
-  } catch {
-    return null;
-  }
-  // Size is included so two different files sharing a truncated digest do not
-  // collide into one identity.
-  return `content:${hash}:${size}`;
-}

--- a/integrations/codex/hooks/lib/doctor.mjs
+++ b/integrations/codex/hooks/lib/doctor.mjs
@@ -26,7 +26,21 @@ import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSyn
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { harvestMode } from './harvest.mjs';
-import { readManifest, verifyManifest, residue } from './manifest.mjs';
+import { readManifest, verifyManifest, residue, manifestSize } from './manifest.mjs';
+
+/**
+ * Bytes as a person reads them.
+ *
+ * Local because it exists for one line of one check, and because the alternative
+ * -- printing a raw byte count next to a file count -- is the kind of detail
+ * that gets skimmed past rather than read.
+ */
+function describeBytes(bytes) {
+  if (!bytes) return 'size unknown';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
 
 const ok = (name, detail) => ({ name, pass: true, detail });
 const bad = (name, detail, remedy) => ({ name, pass: false, detail, remedy });
@@ -362,11 +376,19 @@ export function checklist({ root, settingsPath, install }) {
     }
 
     // What we recorded putting on the machine, and whether it is still that.
-    const verified = verifyManifest(readManifest());
+    const manifest = readManifest();
+    const verified = verifyManifest(manifest);
     if (verified) {
+      // HOW MUCH, not just how many. manifestSize computed exactly this and had
+      // no caller, so the one number that says what uninstall will actually
+      // remove -- and the only cross-check on a manifest that lists files which
+      // no longer exist, since a missing file contributes zero bytes -- was
+      // computed nowhere and shown to no one.
+      const footprint = describeBytes(manifestSize(manifest));
       checks.push(verified.modified === 0
-        ? ok('installed files intact', `${verified.intact} file(s) match the install manifest`)
-        : ok('installed files intact', `${verified.modified} file(s) edited since install -- ` +
+        ? ok('installed files intact', `${verified.intact} file(s), ${footprint}, match the install manifest`)
+        : ok('installed files intact', `${verified.modified} of ${verified.intact + verified.modified} file(s) ` +
+          `(${footprint} recorded) edited since install -- ` +
           'uninstall will leave those alone rather than destroy your changes'));
     } else {
       checks.push(bad('install manifest present', 'no record of what was installed',

--- a/integrations/codex/hooks/lib/doctor.mjs
+++ b/integrations/codex/hooks/lib/doctor.mjs
@@ -27,6 +27,7 @@ import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { harvestMode } from './harvest.mjs';
 import { readManifest, verifyManifest, residue, manifestSize } from './manifest.mjs';
+import { mcpClientsSeen } from './metrics.mjs';
 
 /**
  * Bytes as a person reads them.
@@ -553,7 +554,39 @@ export function probeGraph({ dir }) {
     checks.push(ok('graph directory is private', 'mode could not be read on this filesystem'));
   }
 
+  checks.push(...probeClients({ dir }));
   return checks;
+}
+
+/**
+ * Which MCP clients have actually handshaked with this server.
+ *
+ * THE QUESTION THE REST OF THE DOCTOR CANNOT ANSWER. Every other check here
+ * reasons about files on disk: is the hook present, is it wired, does it refuse
+ * a large read. None of them can tell you whether the editor in front of you
+ * ever actually connected -- which is the single most common way this product
+ * is installed and silently does nothing.
+ *
+ * `mcp-client` records exactly that on every `initialize`, and nothing read it
+ * until now. NEVER A FAILURE: a fresh install has no handshakes yet, and a
+ * doctor that reports red on a correct install teaches people to ignore it.
+ */
+export function probeClients({ dir }) {
+  let clients = [];
+  try {
+    clients = mcpClientsSeen(dir);
+  } catch {
+    return [ok('MCP clients seen', 'no evidence log yet')];
+  }
+  if (!clients.length) {
+    return [ok('MCP clients seen', 'none yet -- the server has had no MCP handshake in this project')];
+  }
+  const described = clients
+    .slice(0, 5)
+    .map((c) => `${c.title || c.client}${c.version ? ` ${c.version}` : ''}`)
+    .join(', ');
+  return [ok('MCP clients seen', `${clients.length}: ${described}` +
+    (clients.length > 5 ? `, and ${clients.length - 5} more` : ''))];
 }
 
 /**

--- a/integrations/codex/hooks/lib/doctor.mjs
+++ b/integrations/codex/hooks/lib/doctor.mjs
@@ -386,11 +386,23 @@ export function checklist({ root, settingsPath, install }) {
       // no longer exist, since a missing file contributes zero bytes -- was
       // computed nowhere and shown to no one.
       const footprint = describeBytes(manifestSize(manifest));
-      checks.push(verified.modified === 0
-        ? ok('installed files intact', `${verified.intact} file(s), ${footprint}, match the install manifest`)
-        : ok('installed files intact', `${verified.modified} of ${verified.intact + verified.modified} file(s) ` +
+      // MISSING IS NOT INTACT, and branching on `modified` alone said it was.
+      // verifyManifest reports three states and this read two of them: a
+      // recorded file DELETED rather than edited left `modified === 0`, so a
+      // half-removed install passed as healthy. The footprint above is what
+      // makes it visible -- a missing file contributes zero bytes -- but a
+      // visible detail beside a PASS is still a PASS.
+      if (verified.missing > 0) {
+        checks.push(bad('installed files intact',
+          `${verified.missing} of ${verified.files.length} recorded file(s) are gone (${footprint} still on disk)`,
+          'reinstall the package to restore them, or run the uninstaller to clear the manifest'));
+      } else if (verified.modified === 0) {
+        checks.push(ok('installed files intact', `${verified.intact} file(s), ${footprint}, match the install manifest`));
+      } else {
+        checks.push(ok('installed files intact', `${verified.modified} of ${verified.intact + verified.modified} file(s) ` +
           `(${footprint} recorded) edited since install -- ` +
           'uninstall will leave those alone rather than destroy your changes'));
+      }
     } else {
       checks.push(bad('install manifest present', 'no record of what was installed',
         'harmless if you installed manually; reinstall to get a removable, verifiable record'));
@@ -538,9 +550,16 @@ export function probeGraph({ dir }) {
   // the bits read back as world-readable regardless, so failing there would be
   // reporting a platform property as a broken install: a false alarm that
   // teaches people to ignore the doctor.
+  // BEFORE THE PLATFORM RETURN, and this is exactly the defect this branch
+  // exists to close: the client probe was appended after `probeGraph`'s
+  // Windows early-return, so on Windows it had a call site and never ran. A
+  // reference that cannot execute is what the reachability guard cannot see.
+  const clients = probeClients({ dir });
+
   if (process.platform === 'win32') {
     checks.push(ok('graph directory is private',
       'POSIX modes are not enforced on Windows; the directory inherits its parent ACL'));
+    checks.push(...clients);
     return checks;
   }
 
@@ -554,7 +573,7 @@ export function probeGraph({ dir }) {
     checks.push(ok('graph directory is private', 'mode could not be read on this filesystem'));
   }
 
-  checks.push(...probeClients({ dir }));
+  checks.push(...clients);
   return checks;
 }
 

--- a/integrations/codex/hooks/lib/keepwarm.mjs
+++ b/integrations/codex/hooks/lib/keepwarm.mjs
@@ -110,7 +110,7 @@ export function gapDistribution(dir, { events = readMetrics(dir) } = {}) {
  * Returns the arithmetic as well as the verdict, because a refusal to refresh
  * that cannot be checked is indistinguishable from a bug.
  */
-export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0] }) {
+export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed = null }) {
   if (!prefixTokens || !gaps) {
     return { action: 'unknown', reason: 'no gap distribution yet -- needs a few sessions of history' };
   }
@@ -124,21 +124,42 @@ export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0] }) {
   // The ping only earns anything in the window where the entry WOULD have
   // expired but the next turn still arrives: before the TTL it was already
   // warm, and long after it, one ping does not reach.
-  const probability = Math.max(0, gaps.probabilityWithin(tier.ms * 2) - gaps.probabilityWithin(tier.ms));
+  const modelled = Math.max(0, gaps.probabilityWithin(tier.ms * 2) - gaps.probabilityWithin(tier.ms));
+
+  // MEASURED BEATS MODELLED, once there is enough of it.
+  //
+  // The module header already commits to this -- "an expected-value decision is
+  // only as good as the distribution it was fitted to, and distributions
+  // shift" -- and the tripwire underneath was the only thing acting on it, as
+  // an all-or-nothing kill switch. Between "the model says refresh" and "stop
+  // entirely" there was nothing, because the observed hit rate was never
+  // computed: both recording halves had no call site, so ten refreshes that
+  // bought nothing would keep recommending refresh right up to the moment the
+  // tripwire cut the whole feature off.
+  //
+  // Below OBSERVATION_FLOOR this stays null and the model is used unchanged; a
+  // handful of samples would swing the decision harder than the distribution
+  // they replace.
+  const probability = observed ? observed.rate : modelled;
   const savingIfUsed = prefixTokens * (tier.writeMultiplier - READ_MULTIPLIER);
   const ev = probability * savingIfUsed - costOfPing;
+  const basis = observed
+    ? `measured over ${observed.observations} refreshes`
+    : 'modelled from the gap distribution';
 
   return {
     action: ev > 0 ? 'refresh' : 'skip',
     tier: tier.name,
     probability,
+    modelledProbability: modelled,
+    basis,
     savingIfUsed: Math.round(savingIfUsed),
     costOfPing: Math.round(costOfPing),
     expectedValue: Math.round(ev),
     reason: ev > 0
-      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers; ` +
+      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers (${basis}); ` +
         `expected gain ${Math.round(ev).toLocaleString()} tokens`
-      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers; ` +
+      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers (${basis}); ` +
         `expected loss ${Math.abs(Math.round(ev)).toLocaleString()} tokens`,
   };
 }
@@ -194,9 +215,84 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
   };
 }
 
+/** Observations of a tier before its measured hit rate may override the model. */
+export const OBSERVATION_FLOOR = 5;
+
 /** Records a refresh so its outcome can be scored. */
 export function recordRefresh(dir, { tier, prefixTokens, expectedValue }) {
   record(dir, { kind: 'keepwarm', action: 'refresh', tier, prefixTokens, expectedValue });
+}
+
+/**
+ * Scores every refresh whose window has since resolved.
+ *
+ * THE MISSING HALF, and it was missing because nobody could see where the
+ * signal would come from. `recordRefreshOutcome` needs to know whether a real
+ * turn arrived before the entry expired -- and that is not a thing anyone has
+ * to instrument, because the event log already records when every turn
+ * happened. The answer was in the data the whole time.
+ *
+ * For each unscored refresh at time T on a tier with TTL `ms`:
+ *
+ *   - a later event within `ms`            -> HIT, observed
+ *   - a later event after `ms`             -> MISS, observed
+ *   - no later event, and `now - T > ms`   -> MISS, observed: the window has
+ *                                             demonstrably closed unused
+ *   - no later event, window still open    -> NOTHING RECORDED
+ *
+ * That last line is the important one and it is Plan 2's own instruction: "if
+ * no signal is available for a tier, record nothing rather than guessing
+ * `hit: false`". A refresh whose window has not closed yet is not a miss, and
+ * scoring it as one would drive the tripwire negative on the newest and least
+ * informative records.
+ *
+ * DRAINED AT READ TIME, which is the pattern this codebase already uses for
+ * staleness: the producer cannot know the outcome at the moment it acts, so the
+ * next reader resolves what has become knowable since.
+ */
+export function scoreOutstandingRefreshes(dir, { events = readMetrics(dir), outcomes = readBalance(dir), now = Date.now() } = {}) {
+  const keepwarm = outcomes.filter((e) => e.kind === 'keepwarm');
+  const refreshes = keepwarm.filter((e) => e.action === 'refresh').sort((a, b) => (a.at || 0) - (b.at || 0));
+  const scored = keepwarm.filter((e) => e.action === 'outcome').length;
+
+  // Refreshes are scored oldest-first and one outcome belongs to one refresh,
+  // so everything past the number already scored is outstanding. Pairing by
+  // timestamp instead would double-count two refreshes recorded in the same
+  // millisecond, which is reachable: a tool run twice in a loop.
+  const outstanding = refreshes.slice(scored);
+  const timeline = events.map((e) => Number(e.at) || 0).filter(Boolean).sort((a, b) => a - b);
+
+  let recorded = 0;
+  for (const refresh of outstanding) {
+    const at = Number(refresh.at) || 0;
+    if (!at) continue;
+    const tierSpec = TIERS.find((t) => t.name === refresh.tier) || TIERS[0];
+    const next = timeline.find((t) => t > at);
+
+    let hit;
+    if (next !== undefined) hit = next - at <= tierSpec.ms;
+    else if (now - at > tierSpec.ms) hit = false;
+    else continue; // window still open: not yet knowable
+
+    recordRefreshOutcome(dir, { tier: refresh.tier, prefixTokens: refresh.prefixTokens, hit });
+    recorded += 1;
+  }
+  return { outstanding: outstanding.length, recorded };
+}
+
+/**
+ * The measured hit rate for a tier, or null below the observation floor.
+ *
+ * Null rather than a small-sample number, because the caller substitutes it for
+ * a modelled probability and three observations would swing the decision harder
+ * than the model they replace.
+ */
+export function observedHitRate(dir, { tier, outcomes = readBalance(dir) } = {}) {
+  const relevant = outcomes.filter(
+    (e) => e.kind === 'keepwarm' && e.action === 'outcome' && (!tier || e.tier === tier)
+  );
+  if (relevant.length < OBSERVATION_FLOOR) return null;
+  return { observations: relevant.length, rate: relevant.filter((e) => e.hit).length / relevant.length };
 }
 
 /**
@@ -276,6 +372,18 @@ export function shouldKeepWarm(dir, {
   // was chosen was wrong for one of them.
   outcomes = readBalance(dir),
 } = {}) {
+  // DRAIN BEFORE DECIDING. Anything whose window has closed since the last call
+  // becomes evidence now, so the decision below and the tripwire above both see
+  // the most that is currently knowable -- the same read-time drain the
+  // staleness path uses, and for the same reason: the producer cannot know the
+  // outcome at the moment it acts.
+  try {
+    scoreOutstandingRefreshes(dir, { events, outcomes });
+    outcomes = readBalance(dir);
+  } catch {
+    /* scoring is evidence, never a reason to refuse a decision */
+  }
+
   const trip = tripwire(dir, { events: outcomes });
   if (trip.tripped) return { action: 'skip', reason: trip.reason, trippedWire: true };
 
@@ -289,7 +397,11 @@ export function shouldKeepWarm(dir, {
     // refusal justified by a GAIN: `{ action: 'skip', reason: '...expected gain 130 tokens' }`.
     // This module's own docstring says a refusal that cannot be checked is indistinguishable from
     // a bug; one that contradicts itself is worse.
-    const decision = keepWarmDecision({ prefixTokens, gaps });
+    const decision = keepWarmDecision({
+      prefixTokens,
+      gaps,
+      observed: observedHitRate(dir, { tier: TIERS[0].name, outcomes }),
+    });
     if (decision.action === 'refresh') return decision;
     return { action: decision.action === 'unknown' ? 'unknown' : 'skip', reason: decision.reason };
   }

--- a/integrations/codex/hooks/lib/metrics.mjs
+++ b/integrations/codex/hooks/lib/metrics.mjs
@@ -744,6 +744,21 @@ export function balanceSheet(dir) {
           verdict: r.verdict,
         };
       })(),
+      // THE CONTROL ARM'S CONTENT, for the same reason `controlArmTokens` sits
+      // in the substitution block above: `candidateCount` and
+      // `shadowFindingIds` recorded what the holdout withheld and nothing read
+      // them, so the report could count the arms and never say what was in
+      // them.
+      ...(() => {
+        const shadow = shadowDelivery(dir);
+        return {
+          selected: shadow.selected,
+          delivered: shadow.delivered,
+          controlArmSelected: shadow.withheldSelected,
+          controlArmFindings: shadow.withheldFindings,
+          indexStaleEntries: shadow.staleEntries,
+        };
+      })(),
     },
     costs: {
       injection: injectCost,
@@ -1283,6 +1298,109 @@ export function declinedAtBudget(dir, { limit = 500 } = {}) {
       .sort((a, b) => b[1] - a[1])
       .map(([reason, count]) => ({ reason, count })),
   };
+}
+
+/**
+ * The injection arm's SHADOW: what retrieval selected, against what was served.
+ *
+ * THE SAME GAP `controlArmTokens` WAS CREATED TO CLOSE, one arm over. That
+ * field exists because `tokensFullFile` "was recorded and read by nothing, so
+ * the comparison the holdout exists for was not computable from the report" --
+ * and the injection side had the identical hole: every `inject` record carries
+ * `candidateCount` and `shadowFindingIds`, which are what WOULD have been
+ * delivered, non-zero in BOTH arms, while `count` and `findingIds` go to zero
+ * in the holdout. The shadow pair was written on every injection since the
+ * holdout shipped and read by nothing, so the report could say how many touches
+ * landed in each arm and never which findings the holdout actually withheld.
+ *
+ * `staleCount` is the same shape on the session-start index: `stale` (a
+ * boolean, "was any of this stale") had a reader, the count did not, so a index
+ * with one rotten entry in forty was indistinguishable from one rotten
+ * throughout.
+ *
+ * READ FROM THE BALANCE LOG, because `inject` is a BALANCE_KIND: the firehose
+ * evicts injections first -- 136 of them against 6,725 captures on one machine
+ * -- which is the eviction that made `report()` say "0 holdout" over a file
+ * containing nine.
+ */
+export function shadowDelivery(dir) {
+  const injections = readBalance(dir).filter((event) => event.kind === 'inject');
+
+  let selected = 0;
+  let delivered = 0;
+  let withheldSelected = 0;
+  const withheldKeys = new Set();
+  let staleEntries = 0;
+  let indexRecords = 0;
+
+  for (const event of injections) {
+    const candidates = Number(event.candidateCount) || 0;
+    selected += candidates;
+    delivered += Number(event.count) || 0;
+    if (event.holdout) {
+      withheldSelected += candidates;
+      for (const key of event.shadowFindingIds || []) withheldKeys.add(key);
+    }
+    if (event.surface === 'session-start') {
+      indexRecords += 1;
+      staleEntries += Number(event.staleCount) || 0;
+    }
+  }
+
+  return {
+    injections: injections.length,
+    // Everything retrieval chose, across both arms.
+    selected,
+    // What actually reached a model.
+    delivered,
+    // Chosen and deliberately not delivered, because the anchor was in the
+    // withheld arm. This is the control arm's content, which is the thing the
+    // holdout exists to make comparable.
+    withheldSelected,
+    withheldFindings: withheldKeys.size,
+    // Index staleness as a rate rather than a boolean.
+    indexRecords,
+    staleEntries,
+  };
+}
+
+/**
+ * Which MCP clients have actually handshaked with this server.
+ *
+ * `mcp-client` was written on every `initialize` and read by nothing -- a
+ * producer with no reader, and the last one the census found. Deleting it was
+ * the other option and would have been wrong: `mcp-tool` records a client only
+ * once it CALLS something, and the project registry records a name only, so a
+ * client that connected and then called nothing -- which is exactly the failure
+ * this project's doctor exists to diagnose -- appeared in neither. The
+ * handshake is the only record that a connection happened at all.
+ *
+ * `clientTitle` is the field that made the record unique and it was unread too:
+ * the display name a client reports for itself, which is how a user recognises
+ * their own editor in a list where `name` is a slug.
+ */
+export function mcpClientsSeen(dir, { limit = 200 } = {}) {
+  const seen = new Map();
+  for (const event of readEvidence(dir)) {
+    if (event.kind !== 'mcp-client') continue;
+    const name = String(event.client || 'unknown');
+    const at = Number(event.at) || 0;
+    const previous = seen.get(name);
+    // LAST HANDSHAKE WINS on the mutable fields: a client that upgraded should
+    // be reported at the version it is now, not the one it first connected on.
+    if (!previous || at >= previous.at) {
+      seen.set(name, {
+        client: name,
+        title: event.clientTitle || null,
+        version: event.clientVersion || null,
+        at,
+        connections: (previous?.connections || 0) + 1,
+      });
+    } else {
+      previous.connections += 1;
+    }
+  }
+  return [...seen.values()].sort((a, b) => b.at - a.at).slice(0, limit);
 }
 
 /* ----------------------------------------------------------------------

--- a/integrations/codex/hooks/lib/metrics.mjs
+++ b/integrations/codex/hooks/lib/metrics.mjs
@@ -1231,6 +1231,60 @@ export function indexBudget(
   return Math.max(floor, Math.min(ceiling, scaled));
 }
 
+/**
+ * What retrieval decided NOT to inject, and why.
+ *
+ * THE OTHER HALF OF THE BUDGET, and it had no reader. `assessFindings` rejects a
+ * finding for one of three reasons -- it has been quarantined as harmful, it is
+ * in cooldown after being injected recently, or its expected value is negative
+ * -- and inject.mjs records every one of those decisions as a
+ * `retrieval-decision` event, from four separate call sites. Nothing read them.
+ *
+ * WHY THAT MATTERS RATHER THAN BEING TIDY. #204 makes the per-touch token budget
+ * load-bearing: "without it the most heavily-worked files accumulate the most
+ * findings and become the most expensive to touch, and the optimizer becomes
+ * its own token problem." A budget that silently drops what it cannot afford is
+ * indistinguishable, from outside, from a graph that had nothing to say. These
+ * are the two states a user most needs told apart, and the records to tell them
+ * apart were already being written.
+ *
+ * READ FROM THE EVIDENCE LOG, not the firehose. `retrieval-decision` is in
+ * EVIDENCE_KINDS precisely because it is rare relative to per-tool-call
+ * telemetry, and the windowed reader would evict it before it accumulated --
+ * the same eviction that made `report()` say "0 holdout" over a file containing
+ * nine.
+ */
+export function declinedAtBudget(dir, { limit = 500 } = {}) {
+  const decisions = readEvidence(dir)
+    .filter((event) => event.kind === 'retrieval-decision')
+    .slice(-limit);
+
+  const byReason = new Map();
+  const keys = new Set();
+  let declined = 0;
+  for (const decision of decisions) {
+    for (const item of decision.rejected || []) {
+      declined += 1;
+      if (item.key) keys.add(item.key);
+      // An unlabelled rejection is counted, not dropped: an unknown reason is
+      // still a finding the model did not get, and reporting the count as
+      // smaller than it is would understate exactly the cost this exists to
+      // surface.
+      const reason = item.reason || 'unspecified';
+      byReason.set(reason, (byReason.get(reason) || 0) + 1);
+    }
+  }
+
+  return {
+    decisions: decisions.length,
+    declined,
+    distinctFindings: keys.size,
+    byReason: [...byReason.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([reason, count]) => ({ reason, count })),
+  };
+}
+
 /* ----------------------------------------------------------------------
  * Episode-level causal evidence
  * ------------------------------------------------------------------- */

--- a/integrations/codex/hooks/lib/staleness.mjs
+++ b/integrations/codex/hooks/lib/staleness.mjs
@@ -297,7 +297,25 @@ export function checkAnchor(anchor) {
   if (anchor.kind === 'file') {
     return hash(source) === anchor.hash
       ? { fresh: true }
-      : { fresh: false, before: anchor.snapshot || '', hasBefore: Boolean(anchor.snapshot), after: source, reason: 'file changed' };
+      : {
+          fresh: false,
+          before: anchor.snapshot || '',
+          hasBefore: Boolean(anchor.snapshot),
+          after: source,
+          // AND WHAT CHANGED IT, when the graph knows. The structural harvest
+          // stamps `lastAction` -- the tool name that last touched this file --
+          // on every file node, and nothing read it: the field was written on
+          // every observed tool call since #203 and consumed nowhere.
+          //
+          // It belongs precisely here. "file changed" tells a reader that their
+          // finding may be wrong; "file changed (last touched by Edit)" tells
+          // them a targeted edit did it, which is cheap to re-verify, and "last
+          // touched by Write" says the file was replaced wholesale, which is
+          // usually not. Same disclosure, one word of provenance, no extra I/O.
+          reason: anchor.lastAction
+            ? `file changed (last touched by ${String(anchor.lastAction).slice(0, 40)})`
+            : 'file changed',
+        };
   }
 
   // For a symbol, re-locate it by NAME rather than by line number. Line numbers
@@ -499,6 +517,7 @@ function disputeOf(graph, finding) {
   if (!hasOutstandingContradiction(graph, finding.key)) return {};
 
   const keys = [];
+  const disputantIds = [];
   // AND THE REASON A PERSON TYPED, which had no reader anywhere. `contradict`
   // stores `contradictionReason` -- up to 400 characters of human explanation --
   // on the CONTRADICTED end only, and nothing outside its own test ever read it:
@@ -524,6 +543,7 @@ function disputeOf(graph, finding) {
     // fetch. `hasOutstandingContradiction` above already declines to open the
     // gate when EVERY disputant is retired; this is the same rule applied to
     // each name, so a live disputant is still reported alongside a withdrawn one.
+    if (!disputantIds.includes(otherId)) disputantIds.push(otherId);
     if (other && !other.retired && typeof other.key === 'string' && !keys.includes(other.key)) {
       keys.push(other.key);
       // A RETIRED END'S REASON IS NOT BORROWED EITHER, which is why this sits
@@ -537,9 +557,31 @@ function disputeOf(graph, finding) {
     }
   }
 
+  // WHEN, alongside WHY. `contradict` writes `contradictedAt` and
+  // `contradictionReason` on the same line of the same putNode call. Round 1
+  // gave the reason a reader -- this function -- and left the timestamp
+  // unread, so the disclosure could say a claim was disputed and why, and not
+  // whether that happened this morning or a year ago. For a reader deciding
+  // whether to trust a disputed finding, the age of the dispute is most of the
+  // signal: a year-old objection to a claim nobody has revisited reads very
+  // differently from one raised since the last release.
+  //
+  // Collected from whichever end holds it, exactly like the reason, and the
+  // EARLIEST is kept -- the dispute began when the first end recorded it.
+  let contradictedAt =
+    typeof finding.contradictedAt === 'number' ? finding.contradictedAt : null;
+  for (const id of disputantIds) {
+    const other = graph.nodes.get(id);
+    if (!other || other.retired) continue;
+    if (typeof other.contradictedAt !== 'number') continue;
+    contradictedAt =
+      contradictedAt === null ? other.contradictedAt : Math.min(contradictedAt, other.contradictedAt);
+  }
+
   return {
     contradicted: true,
     ...(keys.length ? { contradictedBy: keys.join(', ') } : {}),
+    ...(contradictedAt !== null ? { contradictedAt } : {}),
     // Trimmed here rather than at the renderer: an empty string is not a reason,
     // and a consumer checking `if (reason)` should not have to trim first.
     //

--- a/integrations/codex/plugin/hooks/lib/audit.mjs
+++ b/integrations/codex/plugin/hooks/lib/audit.mjs
@@ -30,7 +30,7 @@
  * cost at the bottom.
  */
 
-import { record, readMetrics } from './metrics.mjs';
+import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -319,6 +319,35 @@ export function renderAudit(
           `(${trend.improved ? 'improved' : 'worse'})`
       );
     }
+  }
+
+  // WHAT THE BUDGET TURNED AWAY.
+  //
+  // The per-touch token budget is load-bearing by design (#204): without it the
+  // most heavily-worked files accumulate the most findings and become the most
+  // expensive to touch. But a budget that silently drops what it cannot afford
+  // looks, from outside, exactly like a graph that had nothing to say -- and
+  // those are the two states a reader most needs told apart. inject.mjs was
+  // already recording every rejection and its reason, from four call sites, and
+  // nothing read them.
+  //
+  // ONE LINE, not a panel. This is context for the queue above rather than
+  // another thing to do, and the report is held to its own cost.
+  try {
+    const declined = declinedAtBudget(dir);
+    if (declined.declined > 0) {
+      const reasons = declined.byReason
+        .slice(0, 3)
+        .map(({ reason, count }) => `${reason} ${count}`)
+        .join(', ');
+      body.push(
+        '',
+        `Retrieval declined ${declined.declined.toLocaleString()} finding(s) ` +
+          `(${declined.distinctFindings} distinct) across ${declined.decisions.toLocaleString()} decision(s): ${reasons}.`
+      );
+    }
+  } catch {
+    /* the rejection log is context, never a reason to fail the audit */
   }
 
   // STANDING CONTEXT, as a panel rather than only as queue rows.

--- a/integrations/codex/plugin/hooks/lib/audit.mjs
+++ b/integrations/codex/plugin/hooks/lib/audit.mjs
@@ -374,7 +374,16 @@ export function renderAudit(
     // Indented to sit under its heading, blank lines left blank rather than
     // turned into trailing whitespace.
     for (const line of panel.split('\n')) body.push(line ? `  ${line}` : '');
-    if (standing.some((v) => v.actions?.length)) {
+    // ONLY IF THEY ACTUALLY DID. This pointed the reader at "the queue at the
+    // top" whenever any verdict carried an action -- including when the queue
+    // printed "Nothing addressable found", because a caller can render the
+    // panel with no findings at all, and the withholding rule can drop a
+    // standing row even when findings were passed. Telling someone to look at
+    // a row that is not there is worse than saying nothing.
+    const shownStandingIds = new Set(
+      shown.map((item) => item.id).filter((id) => typeof id === 'string' && id.startsWith('standing-'))
+    );
+    if (shownStandingIds.size) {
       body.push(
         '',
         '  The actions above also appear in the queue at the top, where they are priced and applyable.'

--- a/integrations/codex/plugin/hooks/lib/audit.mjs
+++ b/integrations/codex/plugin/hooks/lib/audit.mjs
@@ -33,6 +33,7 @@
 import { record, readMetrics } from './metrics.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
+import { renderStanding } from './standing.mjs';
 
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
 
@@ -183,7 +184,7 @@ export function buildQueue(
 export function renderAudit(
   dir,
   findings = [],
-  { tier = 'opus', full = false, sessionsPerMonth = 60 } = {}
+  { tier = 'opus', full = false, sessionsPerMonth = 60, standing = null } = {}
 ) {
   const { queue, suppressed, done } = buildQueue(dir, findings);
   const lines = [];
@@ -316,6 +317,38 @@ export function renderAudit(
       body.push(
         `  ${trend.detector}: ${trend.before.toLocaleString()} -> ${trend.after.toLocaleString()} tokens/session ` +
           `(${trend.improved ? 'improved' : 'worse'})`
+      );
+    }
+  }
+
+  // STANDING CONTEXT, as a panel rather than only as queue rows.
+  //
+  // auditStanding and verdictFor were both reachable, so this project already
+  // computed which CLAUDE.md rules and skills are stale, oversized or never
+  // used -- and threw the report away. renderStanding existed, was tested, and
+  // had no caller: the forTouch shape exactly, in the subsystem #203 claimed
+  // closed the skills-and-memory gap. Hard to defend a gap as closed while the
+  // report that would show it is unreachable.
+  //
+  // WHAT THE QUEUE ABOVE CANNOT SAY, which is why this is not duplication. The
+  // queue carries one row per ACTION, so a standing file with nothing wrong
+  // contributes no row and is invisible -- and the total cost of the prefix,
+  // the number that says what standing context is worth arguing about at all,
+  // is carried by no row either. Both are in the panel.
+  //
+  // Costed like everything else here: it is pushed BEFORE the closing line is
+  // measured, so the report's self-cost includes its own newest panel rather
+  // than understating it.
+  if (standing?.length) {
+    body.push('', 'Standing context -- charged every session:', '');
+    const panel = renderStanding(standing, { sessionsPerMonth });
+    // Indented to sit under its heading, blank lines left blank rather than
+    // turned into trailing whitespace.
+    for (const line of panel.split('\n')) body.push(line ? `  ${line}` : '');
+    if (standing.some((v) => v.actions?.length)) {
+      body.push(
+        '',
+        '  The actions above also appear in the queue at the top, where they are priced and applyable.'
       );
     }
   }

--- a/integrations/codex/plugin/hooks/lib/consolidate.mjs
+++ b/integrations/codex/plugin/hooks/lib/consolidate.mjs
@@ -36,6 +36,28 @@ import { nodeId } from './wiki.mjs';
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
 
 /**
+ * A candidate's own words, whatever the producer called the field.
+ *
+ * THE SELECTOR AND THE RATIO DISAGREED ABOUT THIS, and the half that had no
+ * caller is the half that was wrong. `irrecoverability`, `costToRederive` and
+ * `selectForConsolidation` all read `entry.summary`; `consolidationRatio` and
+ * `aggregateConsolidation` read `finding.claim`. NO PRODUCER IN THIS REPOSITORY
+ * EMITS `summary` -- the semantic harvest, wiki_write and the evaluation
+ * harnesses all emit `claim`, and `validate()` in harvest.mjs rejects anything
+ * without one.
+ *
+ * That matters more than a rename. Wired naively, every candidate would have
+ * scored `tokens: estimate(undefined)` -- zero -- so the budget could never
+ * bind, nothing would ever be dropped, and the selector would have been live,
+ * green, and inert. A capability that runs and cannot affect its own output is
+ * the same defect as one that never runs, wearing a call site.
+ *
+ * `summary` is still accepted, because an external caller may pass it and
+ * breaking that to fix an internal disagreement would be gratuitous.
+ */
+const claimText = (entry) => entry?.claim || entry?.summary || '';
+
+/**
  * How hard something is to reproduce, independent of what it cost this time.
  *
  * Token cost alone understates the expensive cases. Reproducing a flaky failure
@@ -45,7 +67,7 @@ const estimate = (text) => Math.ceil(String(text || '').length / 4);
  * measurements, and pretending otherwise would be false precision.
  */
 export function irrecoverability(entry) {
-  const text = `${entry.summary || ''} ${entry.evidence || ''}`.toLowerCase();
+  const text = `${claimText(entry)} ${entry.evidence || ''}`.toLowerCase();
 
   // Anything derived from a non-deterministic or long-running observation.
   //
@@ -110,7 +132,7 @@ export function costToRederive(entry, previousAt) {
   // no-op. The only measured cost is `entry.tokensSpent`, which the extraction
   // site must supply; otherwise fall back to the size of the evidence, so a
   // conclusion drawn from a large investigation still outranks an aside.
-  return estimate(entry.evidence) * 4 || estimate(entry.summary) * 8;
+  return estimate(entry.evidence) * 4 || estimate(claimText(entry)) * 8;
 }
 
 /** Kinds that survive on the floor regardless of score. */
@@ -141,7 +163,7 @@ export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}
     });
     const cost = costToRederive(entry, previousAt);
     const score = cost * irrecoverability(entry) * reuseProbability(graph, entry.anchorIds || anchors);
-    scored.push({ entry, score, cost, tokens: estimate(entry.summary) });
+    scored.push({ entry, score, cost, tokens: estimate(claimText(entry)) });
     previousAt = entry.at ?? previousAt;
   }
 
@@ -182,7 +204,7 @@ export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}
  * FOR, in a way that "tokens saved" never quite is.
  */
 export function consolidationRatio(finding) {
-  const carry = estimate(finding.claim);
+  const carry = estimate(claimText(finding));
   const derived = finding.derivedCost || 0;
   if (!carry || !derived) return null;
   return derived / carry;
@@ -195,7 +217,7 @@ export function aggregateConsolidation(findings) {
   for (const finding of findings) {
     if (!finding.derivedCost) continue;
     derived += finding.derivedCost;
-    carry += estimate(finding.claim);
+    carry += estimate(claimText(finding));
   }
   return carry ? { derived, carry, ratio: derived / carry } : null;
 }

--- a/integrations/codex/plugin/hooks/lib/consolidate.mjs
+++ b/integrations/codex/plugin/hooks/lib/consolidate.mjs
@@ -31,7 +31,6 @@
  * without session instrumentation cannot obtain.
  */
 
-import { statSync } from 'node:fs';
 import { nodeId } from './wiki.mjs';
 
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
@@ -201,25 +200,3 @@ export function aggregateConsolidation(findings) {
   return carry ? { derived, carry, ratio: derived / carry } : null;
 }
 
-/**
- * Content identity for a file, so a finding can reach across projects.
- *
- * A vendored library file is the same file in every repository that holds it,
- * whatever path each gives it. Anchoring to content as well as path means a
- * finding about it appears in all of them with no promotion step and no path
- * mapping -- reach a per-session checkpoint cannot have even in principle.
- *
- * The PATH anchor still drives staleness within a repo; this is additive.
- */
-export function contentAnchor(path, hash) {
-  if (!hash) return null;
-  let size = 0;
-  try {
-    size = statSync(path).size;
-  } catch {
-    return null;
-  }
-  // Size is included so two different files sharing a truncated digest do not
-  // collide into one identity.
-  return `content:${hash}:${size}`;
-}

--- a/integrations/codex/plugin/hooks/lib/doctor.mjs
+++ b/integrations/codex/plugin/hooks/lib/doctor.mjs
@@ -26,7 +26,21 @@ import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSyn
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { harvestMode } from './harvest.mjs';
-import { readManifest, verifyManifest, residue } from './manifest.mjs';
+import { readManifest, verifyManifest, residue, manifestSize } from './manifest.mjs';
+
+/**
+ * Bytes as a person reads them.
+ *
+ * Local because it exists for one line of one check, and because the alternative
+ * -- printing a raw byte count next to a file count -- is the kind of detail
+ * that gets skimmed past rather than read.
+ */
+function describeBytes(bytes) {
+  if (!bytes) return 'size unknown';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
 
 const ok = (name, detail) => ({ name, pass: true, detail });
 const bad = (name, detail, remedy) => ({ name, pass: false, detail, remedy });
@@ -362,11 +376,19 @@ export function checklist({ root, settingsPath, install }) {
     }
 
     // What we recorded putting on the machine, and whether it is still that.
-    const verified = verifyManifest(readManifest());
+    const manifest = readManifest();
+    const verified = verifyManifest(manifest);
     if (verified) {
+      // HOW MUCH, not just how many. manifestSize computed exactly this and had
+      // no caller, so the one number that says what uninstall will actually
+      // remove -- and the only cross-check on a manifest that lists files which
+      // no longer exist, since a missing file contributes zero bytes -- was
+      // computed nowhere and shown to no one.
+      const footprint = describeBytes(manifestSize(manifest));
       checks.push(verified.modified === 0
-        ? ok('installed files intact', `${verified.intact} file(s) match the install manifest`)
-        : ok('installed files intact', `${verified.modified} file(s) edited since install -- ` +
+        ? ok('installed files intact', `${verified.intact} file(s), ${footprint}, match the install manifest`)
+        : ok('installed files intact', `${verified.modified} of ${verified.intact + verified.modified} file(s) ` +
+          `(${footprint} recorded) edited since install -- ` +
           'uninstall will leave those alone rather than destroy your changes'));
     } else {
       checks.push(bad('install manifest present', 'no record of what was installed',

--- a/integrations/codex/plugin/hooks/lib/doctor.mjs
+++ b/integrations/codex/plugin/hooks/lib/doctor.mjs
@@ -27,6 +27,7 @@ import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { harvestMode } from './harvest.mjs';
 import { readManifest, verifyManifest, residue, manifestSize } from './manifest.mjs';
+import { mcpClientsSeen } from './metrics.mjs';
 
 /**
  * Bytes as a person reads them.
@@ -553,7 +554,39 @@ export function probeGraph({ dir }) {
     checks.push(ok('graph directory is private', 'mode could not be read on this filesystem'));
   }
 
+  checks.push(...probeClients({ dir }));
   return checks;
+}
+
+/**
+ * Which MCP clients have actually handshaked with this server.
+ *
+ * THE QUESTION THE REST OF THE DOCTOR CANNOT ANSWER. Every other check here
+ * reasons about files on disk: is the hook present, is it wired, does it refuse
+ * a large read. None of them can tell you whether the editor in front of you
+ * ever actually connected -- which is the single most common way this product
+ * is installed and silently does nothing.
+ *
+ * `mcp-client` records exactly that on every `initialize`, and nothing read it
+ * until now. NEVER A FAILURE: a fresh install has no handshakes yet, and a
+ * doctor that reports red on a correct install teaches people to ignore it.
+ */
+export function probeClients({ dir }) {
+  let clients = [];
+  try {
+    clients = mcpClientsSeen(dir);
+  } catch {
+    return [ok('MCP clients seen', 'no evidence log yet')];
+  }
+  if (!clients.length) {
+    return [ok('MCP clients seen', 'none yet -- the server has had no MCP handshake in this project')];
+  }
+  const described = clients
+    .slice(0, 5)
+    .map((c) => `${c.title || c.client}${c.version ? ` ${c.version}` : ''}`)
+    .join(', ');
+  return [ok('MCP clients seen', `${clients.length}: ${described}` +
+    (clients.length > 5 ? `, and ${clients.length - 5} more` : ''))];
 }
 
 /**

--- a/integrations/codex/plugin/hooks/lib/doctor.mjs
+++ b/integrations/codex/plugin/hooks/lib/doctor.mjs
@@ -386,11 +386,23 @@ export function checklist({ root, settingsPath, install }) {
       // no longer exist, since a missing file contributes zero bytes -- was
       // computed nowhere and shown to no one.
       const footprint = describeBytes(manifestSize(manifest));
-      checks.push(verified.modified === 0
-        ? ok('installed files intact', `${verified.intact} file(s), ${footprint}, match the install manifest`)
-        : ok('installed files intact', `${verified.modified} of ${verified.intact + verified.modified} file(s) ` +
+      // MISSING IS NOT INTACT, and branching on `modified` alone said it was.
+      // verifyManifest reports three states and this read two of them: a
+      // recorded file DELETED rather than edited left `modified === 0`, so a
+      // half-removed install passed as healthy. The footprint above is what
+      // makes it visible -- a missing file contributes zero bytes -- but a
+      // visible detail beside a PASS is still a PASS.
+      if (verified.missing > 0) {
+        checks.push(bad('installed files intact',
+          `${verified.missing} of ${verified.files.length} recorded file(s) are gone (${footprint} still on disk)`,
+          'reinstall the package to restore them, or run the uninstaller to clear the manifest'));
+      } else if (verified.modified === 0) {
+        checks.push(ok('installed files intact', `${verified.intact} file(s), ${footprint}, match the install manifest`));
+      } else {
+        checks.push(ok('installed files intact', `${verified.modified} of ${verified.intact + verified.modified} file(s) ` +
           `(${footprint} recorded) edited since install -- ` +
           'uninstall will leave those alone rather than destroy your changes'));
+      }
     } else {
       checks.push(bad('install manifest present', 'no record of what was installed',
         'harmless if you installed manually; reinstall to get a removable, verifiable record'));
@@ -538,9 +550,16 @@ export function probeGraph({ dir }) {
   // the bits read back as world-readable regardless, so failing there would be
   // reporting a platform property as a broken install: a false alarm that
   // teaches people to ignore the doctor.
+  // BEFORE THE PLATFORM RETURN, and this is exactly the defect this branch
+  // exists to close: the client probe was appended after `probeGraph`'s
+  // Windows early-return, so on Windows it had a call site and never ran. A
+  // reference that cannot execute is what the reachability guard cannot see.
+  const clients = probeClients({ dir });
+
   if (process.platform === 'win32') {
     checks.push(ok('graph directory is private',
       'POSIX modes are not enforced on Windows; the directory inherits its parent ACL'));
+    checks.push(...clients);
     return checks;
   }
 
@@ -554,7 +573,7 @@ export function probeGraph({ dir }) {
     checks.push(ok('graph directory is private', 'mode could not be read on this filesystem'));
   }
 
-  checks.push(...probeClients({ dir }));
+  checks.push(...clients);
   return checks;
 }
 

--- a/integrations/codex/plugin/hooks/lib/keepwarm.mjs
+++ b/integrations/codex/plugin/hooks/lib/keepwarm.mjs
@@ -110,7 +110,7 @@ export function gapDistribution(dir, { events = readMetrics(dir) } = {}) {
  * Returns the arithmetic as well as the verdict, because a refusal to refresh
  * that cannot be checked is indistinguishable from a bug.
  */
-export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0] }) {
+export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed = null }) {
   if (!prefixTokens || !gaps) {
     return { action: 'unknown', reason: 'no gap distribution yet -- needs a few sessions of history' };
   }
@@ -124,21 +124,42 @@ export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0] }) {
   // The ping only earns anything in the window where the entry WOULD have
   // expired but the next turn still arrives: before the TTL it was already
   // warm, and long after it, one ping does not reach.
-  const probability = Math.max(0, gaps.probabilityWithin(tier.ms * 2) - gaps.probabilityWithin(tier.ms));
+  const modelled = Math.max(0, gaps.probabilityWithin(tier.ms * 2) - gaps.probabilityWithin(tier.ms));
+
+  // MEASURED BEATS MODELLED, once there is enough of it.
+  //
+  // The module header already commits to this -- "an expected-value decision is
+  // only as good as the distribution it was fitted to, and distributions
+  // shift" -- and the tripwire underneath was the only thing acting on it, as
+  // an all-or-nothing kill switch. Between "the model says refresh" and "stop
+  // entirely" there was nothing, because the observed hit rate was never
+  // computed: both recording halves had no call site, so ten refreshes that
+  // bought nothing would keep recommending refresh right up to the moment the
+  // tripwire cut the whole feature off.
+  //
+  // Below OBSERVATION_FLOOR this stays null and the model is used unchanged; a
+  // handful of samples would swing the decision harder than the distribution
+  // they replace.
+  const probability = observed ? observed.rate : modelled;
   const savingIfUsed = prefixTokens * (tier.writeMultiplier - READ_MULTIPLIER);
   const ev = probability * savingIfUsed - costOfPing;
+  const basis = observed
+    ? `measured over ${observed.observations} refreshes`
+    : 'modelled from the gap distribution';
 
   return {
     action: ev > 0 ? 'refresh' : 'skip',
     tier: tier.name,
     probability,
+    modelledProbability: modelled,
+    basis,
     savingIfUsed: Math.round(savingIfUsed),
     costOfPing: Math.round(costOfPing),
     expectedValue: Math.round(ev),
     reason: ev > 0
-      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers; ` +
+      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers (${basis}); ` +
         `expected gain ${Math.round(ev).toLocaleString()} tokens`
-      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers; ` +
+      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers (${basis}); ` +
         `expected loss ${Math.abs(Math.round(ev)).toLocaleString()} tokens`,
   };
 }
@@ -194,9 +215,84 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
   };
 }
 
+/** Observations of a tier before its measured hit rate may override the model. */
+export const OBSERVATION_FLOOR = 5;
+
 /** Records a refresh so its outcome can be scored. */
 export function recordRefresh(dir, { tier, prefixTokens, expectedValue }) {
   record(dir, { kind: 'keepwarm', action: 'refresh', tier, prefixTokens, expectedValue });
+}
+
+/**
+ * Scores every refresh whose window has since resolved.
+ *
+ * THE MISSING HALF, and it was missing because nobody could see where the
+ * signal would come from. `recordRefreshOutcome` needs to know whether a real
+ * turn arrived before the entry expired -- and that is not a thing anyone has
+ * to instrument, because the event log already records when every turn
+ * happened. The answer was in the data the whole time.
+ *
+ * For each unscored refresh at time T on a tier with TTL `ms`:
+ *
+ *   - a later event within `ms`            -> HIT, observed
+ *   - a later event after `ms`             -> MISS, observed
+ *   - no later event, and `now - T > ms`   -> MISS, observed: the window has
+ *                                             demonstrably closed unused
+ *   - no later event, window still open    -> NOTHING RECORDED
+ *
+ * That last line is the important one and it is Plan 2's own instruction: "if
+ * no signal is available for a tier, record nothing rather than guessing
+ * `hit: false`". A refresh whose window has not closed yet is not a miss, and
+ * scoring it as one would drive the tripwire negative on the newest and least
+ * informative records.
+ *
+ * DRAINED AT READ TIME, which is the pattern this codebase already uses for
+ * staleness: the producer cannot know the outcome at the moment it acts, so the
+ * next reader resolves what has become knowable since.
+ */
+export function scoreOutstandingRefreshes(dir, { events = readMetrics(dir), outcomes = readBalance(dir), now = Date.now() } = {}) {
+  const keepwarm = outcomes.filter((e) => e.kind === 'keepwarm');
+  const refreshes = keepwarm.filter((e) => e.action === 'refresh').sort((a, b) => (a.at || 0) - (b.at || 0));
+  const scored = keepwarm.filter((e) => e.action === 'outcome').length;
+
+  // Refreshes are scored oldest-first and one outcome belongs to one refresh,
+  // so everything past the number already scored is outstanding. Pairing by
+  // timestamp instead would double-count two refreshes recorded in the same
+  // millisecond, which is reachable: a tool run twice in a loop.
+  const outstanding = refreshes.slice(scored);
+  const timeline = events.map((e) => Number(e.at) || 0).filter(Boolean).sort((a, b) => a - b);
+
+  let recorded = 0;
+  for (const refresh of outstanding) {
+    const at = Number(refresh.at) || 0;
+    if (!at) continue;
+    const tierSpec = TIERS.find((t) => t.name === refresh.tier) || TIERS[0];
+    const next = timeline.find((t) => t > at);
+
+    let hit;
+    if (next !== undefined) hit = next - at <= tierSpec.ms;
+    else if (now - at > tierSpec.ms) hit = false;
+    else continue; // window still open: not yet knowable
+
+    recordRefreshOutcome(dir, { tier: refresh.tier, prefixTokens: refresh.prefixTokens, hit });
+    recorded += 1;
+  }
+  return { outstanding: outstanding.length, recorded };
+}
+
+/**
+ * The measured hit rate for a tier, or null below the observation floor.
+ *
+ * Null rather than a small-sample number, because the caller substitutes it for
+ * a modelled probability and three observations would swing the decision harder
+ * than the model they replace.
+ */
+export function observedHitRate(dir, { tier, outcomes = readBalance(dir) } = {}) {
+  const relevant = outcomes.filter(
+    (e) => e.kind === 'keepwarm' && e.action === 'outcome' && (!tier || e.tier === tier)
+  );
+  if (relevant.length < OBSERVATION_FLOOR) return null;
+  return { observations: relevant.length, rate: relevant.filter((e) => e.hit).length / relevant.length };
 }
 
 /**
@@ -276,6 +372,18 @@ export function shouldKeepWarm(dir, {
   // was chosen was wrong for one of them.
   outcomes = readBalance(dir),
 } = {}) {
+  // DRAIN BEFORE DECIDING. Anything whose window has closed since the last call
+  // becomes evidence now, so the decision below and the tripwire above both see
+  // the most that is currently knowable -- the same read-time drain the
+  // staleness path uses, and for the same reason: the producer cannot know the
+  // outcome at the moment it acts.
+  try {
+    scoreOutstandingRefreshes(dir, { events, outcomes });
+    outcomes = readBalance(dir);
+  } catch {
+    /* scoring is evidence, never a reason to refuse a decision */
+  }
+
   const trip = tripwire(dir, { events: outcomes });
   if (trip.tripped) return { action: 'skip', reason: trip.reason, trippedWire: true };
 
@@ -289,7 +397,11 @@ export function shouldKeepWarm(dir, {
     // refusal justified by a GAIN: `{ action: 'skip', reason: '...expected gain 130 tokens' }`.
     // This module's own docstring says a refusal that cannot be checked is indistinguishable from
     // a bug; one that contradicts itself is worse.
-    const decision = keepWarmDecision({ prefixTokens, gaps });
+    const decision = keepWarmDecision({
+      prefixTokens,
+      gaps,
+      observed: observedHitRate(dir, { tier: TIERS[0].name, outcomes }),
+    });
     if (decision.action === 'refresh') return decision;
     return { action: decision.action === 'unknown' ? 'unknown' : 'skip', reason: decision.reason };
   }

--- a/integrations/codex/plugin/hooks/lib/metrics.mjs
+++ b/integrations/codex/plugin/hooks/lib/metrics.mjs
@@ -744,6 +744,21 @@ export function balanceSheet(dir) {
           verdict: r.verdict,
         };
       })(),
+      // THE CONTROL ARM'S CONTENT, for the same reason `controlArmTokens` sits
+      // in the substitution block above: `candidateCount` and
+      // `shadowFindingIds` recorded what the holdout withheld and nothing read
+      // them, so the report could count the arms and never say what was in
+      // them.
+      ...(() => {
+        const shadow = shadowDelivery(dir);
+        return {
+          selected: shadow.selected,
+          delivered: shadow.delivered,
+          controlArmSelected: shadow.withheldSelected,
+          controlArmFindings: shadow.withheldFindings,
+          indexStaleEntries: shadow.staleEntries,
+        };
+      })(),
     },
     costs: {
       injection: injectCost,
@@ -1283,6 +1298,109 @@ export function declinedAtBudget(dir, { limit = 500 } = {}) {
       .sort((a, b) => b[1] - a[1])
       .map(([reason, count]) => ({ reason, count })),
   };
+}
+
+/**
+ * The injection arm's SHADOW: what retrieval selected, against what was served.
+ *
+ * THE SAME GAP `controlArmTokens` WAS CREATED TO CLOSE, one arm over. That
+ * field exists because `tokensFullFile` "was recorded and read by nothing, so
+ * the comparison the holdout exists for was not computable from the report" --
+ * and the injection side had the identical hole: every `inject` record carries
+ * `candidateCount` and `shadowFindingIds`, which are what WOULD have been
+ * delivered, non-zero in BOTH arms, while `count` and `findingIds` go to zero
+ * in the holdout. The shadow pair was written on every injection since the
+ * holdout shipped and read by nothing, so the report could say how many touches
+ * landed in each arm and never which findings the holdout actually withheld.
+ *
+ * `staleCount` is the same shape on the session-start index: `stale` (a
+ * boolean, "was any of this stale") had a reader, the count did not, so a index
+ * with one rotten entry in forty was indistinguishable from one rotten
+ * throughout.
+ *
+ * READ FROM THE BALANCE LOG, because `inject` is a BALANCE_KIND: the firehose
+ * evicts injections first -- 136 of them against 6,725 captures on one machine
+ * -- which is the eviction that made `report()` say "0 holdout" over a file
+ * containing nine.
+ */
+export function shadowDelivery(dir) {
+  const injections = readBalance(dir).filter((event) => event.kind === 'inject');
+
+  let selected = 0;
+  let delivered = 0;
+  let withheldSelected = 0;
+  const withheldKeys = new Set();
+  let staleEntries = 0;
+  let indexRecords = 0;
+
+  for (const event of injections) {
+    const candidates = Number(event.candidateCount) || 0;
+    selected += candidates;
+    delivered += Number(event.count) || 0;
+    if (event.holdout) {
+      withheldSelected += candidates;
+      for (const key of event.shadowFindingIds || []) withheldKeys.add(key);
+    }
+    if (event.surface === 'session-start') {
+      indexRecords += 1;
+      staleEntries += Number(event.staleCount) || 0;
+    }
+  }
+
+  return {
+    injections: injections.length,
+    // Everything retrieval chose, across both arms.
+    selected,
+    // What actually reached a model.
+    delivered,
+    // Chosen and deliberately not delivered, because the anchor was in the
+    // withheld arm. This is the control arm's content, which is the thing the
+    // holdout exists to make comparable.
+    withheldSelected,
+    withheldFindings: withheldKeys.size,
+    // Index staleness as a rate rather than a boolean.
+    indexRecords,
+    staleEntries,
+  };
+}
+
+/**
+ * Which MCP clients have actually handshaked with this server.
+ *
+ * `mcp-client` was written on every `initialize` and read by nothing -- a
+ * producer with no reader, and the last one the census found. Deleting it was
+ * the other option and would have been wrong: `mcp-tool` records a client only
+ * once it CALLS something, and the project registry records a name only, so a
+ * client that connected and then called nothing -- which is exactly the failure
+ * this project's doctor exists to diagnose -- appeared in neither. The
+ * handshake is the only record that a connection happened at all.
+ *
+ * `clientTitle` is the field that made the record unique and it was unread too:
+ * the display name a client reports for itself, which is how a user recognises
+ * their own editor in a list where `name` is a slug.
+ */
+export function mcpClientsSeen(dir, { limit = 200 } = {}) {
+  const seen = new Map();
+  for (const event of readEvidence(dir)) {
+    if (event.kind !== 'mcp-client') continue;
+    const name = String(event.client || 'unknown');
+    const at = Number(event.at) || 0;
+    const previous = seen.get(name);
+    // LAST HANDSHAKE WINS on the mutable fields: a client that upgraded should
+    // be reported at the version it is now, not the one it first connected on.
+    if (!previous || at >= previous.at) {
+      seen.set(name, {
+        client: name,
+        title: event.clientTitle || null,
+        version: event.clientVersion || null,
+        at,
+        connections: (previous?.connections || 0) + 1,
+      });
+    } else {
+      previous.connections += 1;
+    }
+  }
+  return [...seen.values()].sort((a, b) => b.at - a.at).slice(0, limit);
 }
 
 /* ----------------------------------------------------------------------

--- a/integrations/codex/plugin/hooks/lib/metrics.mjs
+++ b/integrations/codex/plugin/hooks/lib/metrics.mjs
@@ -1231,6 +1231,60 @@ export function indexBudget(
   return Math.max(floor, Math.min(ceiling, scaled));
 }
 
+/**
+ * What retrieval decided NOT to inject, and why.
+ *
+ * THE OTHER HALF OF THE BUDGET, and it had no reader. `assessFindings` rejects a
+ * finding for one of three reasons -- it has been quarantined as harmful, it is
+ * in cooldown after being injected recently, or its expected value is negative
+ * -- and inject.mjs records every one of those decisions as a
+ * `retrieval-decision` event, from four separate call sites. Nothing read them.
+ *
+ * WHY THAT MATTERS RATHER THAN BEING TIDY. #204 makes the per-touch token budget
+ * load-bearing: "without it the most heavily-worked files accumulate the most
+ * findings and become the most expensive to touch, and the optimizer becomes
+ * its own token problem." A budget that silently drops what it cannot afford is
+ * indistinguishable, from outside, from a graph that had nothing to say. These
+ * are the two states a user most needs told apart, and the records to tell them
+ * apart were already being written.
+ *
+ * READ FROM THE EVIDENCE LOG, not the firehose. `retrieval-decision` is in
+ * EVIDENCE_KINDS precisely because it is rare relative to per-tool-call
+ * telemetry, and the windowed reader would evict it before it accumulated --
+ * the same eviction that made `report()` say "0 holdout" over a file containing
+ * nine.
+ */
+export function declinedAtBudget(dir, { limit = 500 } = {}) {
+  const decisions = readEvidence(dir)
+    .filter((event) => event.kind === 'retrieval-decision')
+    .slice(-limit);
+
+  const byReason = new Map();
+  const keys = new Set();
+  let declined = 0;
+  for (const decision of decisions) {
+    for (const item of decision.rejected || []) {
+      declined += 1;
+      if (item.key) keys.add(item.key);
+      // An unlabelled rejection is counted, not dropped: an unknown reason is
+      // still a finding the model did not get, and reporting the count as
+      // smaller than it is would understate exactly the cost this exists to
+      // surface.
+      const reason = item.reason || 'unspecified';
+      byReason.set(reason, (byReason.get(reason) || 0) + 1);
+    }
+  }
+
+  return {
+    decisions: decisions.length,
+    declined,
+    distinctFindings: keys.size,
+    byReason: [...byReason.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([reason, count]) => ({ reason, count })),
+  };
+}
+
 /* ----------------------------------------------------------------------
  * Episode-level causal evidence
  * ------------------------------------------------------------------- */

--- a/integrations/codex/plugin/hooks/lib/staleness.mjs
+++ b/integrations/codex/plugin/hooks/lib/staleness.mjs
@@ -297,7 +297,25 @@ export function checkAnchor(anchor) {
   if (anchor.kind === 'file') {
     return hash(source) === anchor.hash
       ? { fresh: true }
-      : { fresh: false, before: anchor.snapshot || '', hasBefore: Boolean(anchor.snapshot), after: source, reason: 'file changed' };
+      : {
+          fresh: false,
+          before: anchor.snapshot || '',
+          hasBefore: Boolean(anchor.snapshot),
+          after: source,
+          // AND WHAT CHANGED IT, when the graph knows. The structural harvest
+          // stamps `lastAction` -- the tool name that last touched this file --
+          // on every file node, and nothing read it: the field was written on
+          // every observed tool call since #203 and consumed nowhere.
+          //
+          // It belongs precisely here. "file changed" tells a reader that their
+          // finding may be wrong; "file changed (last touched by Edit)" tells
+          // them a targeted edit did it, which is cheap to re-verify, and "last
+          // touched by Write" says the file was replaced wholesale, which is
+          // usually not. Same disclosure, one word of provenance, no extra I/O.
+          reason: anchor.lastAction
+            ? `file changed (last touched by ${String(anchor.lastAction).slice(0, 40)})`
+            : 'file changed',
+        };
   }
 
   // For a symbol, re-locate it by NAME rather than by line number. Line numbers
@@ -499,6 +517,7 @@ function disputeOf(graph, finding) {
   if (!hasOutstandingContradiction(graph, finding.key)) return {};
 
   const keys = [];
+  const disputantIds = [];
   // AND THE REASON A PERSON TYPED, which had no reader anywhere. `contradict`
   // stores `contradictionReason` -- up to 400 characters of human explanation --
   // on the CONTRADICTED end only, and nothing outside its own test ever read it:
@@ -524,6 +543,7 @@ function disputeOf(graph, finding) {
     // fetch. `hasOutstandingContradiction` above already declines to open the
     // gate when EVERY disputant is retired; this is the same rule applied to
     // each name, so a live disputant is still reported alongside a withdrawn one.
+    if (!disputantIds.includes(otherId)) disputantIds.push(otherId);
     if (other && !other.retired && typeof other.key === 'string' && !keys.includes(other.key)) {
       keys.push(other.key);
       // A RETIRED END'S REASON IS NOT BORROWED EITHER, which is why this sits
@@ -537,9 +557,31 @@ function disputeOf(graph, finding) {
     }
   }
 
+  // WHEN, alongside WHY. `contradict` writes `contradictedAt` and
+  // `contradictionReason` on the same line of the same putNode call. Round 1
+  // gave the reason a reader -- this function -- and left the timestamp
+  // unread, so the disclosure could say a claim was disputed and why, and not
+  // whether that happened this morning or a year ago. For a reader deciding
+  // whether to trust a disputed finding, the age of the dispute is most of the
+  // signal: a year-old objection to a claim nobody has revisited reads very
+  // differently from one raised since the last release.
+  //
+  // Collected from whichever end holds it, exactly like the reason, and the
+  // EARLIEST is kept -- the dispute began when the first end recorded it.
+  let contradictedAt =
+    typeof finding.contradictedAt === 'number' ? finding.contradictedAt : null;
+  for (const id of disputantIds) {
+    const other = graph.nodes.get(id);
+    if (!other || other.retired) continue;
+    if (typeof other.contradictedAt !== 'number') continue;
+    contradictedAt =
+      contradictedAt === null ? other.contradictedAt : Math.min(contradictedAt, other.contradictedAt);
+  }
+
   return {
     contradicted: true,
     ...(keys.length ? { contradictedBy: keys.join(', ') } : {}),
+    ...(contradictedAt !== null ? { contradictedAt } : {}),
     // Trimmed here rather than at the renderer: an empty string is not a reason,
     // and a consumer checking `if (reason)` should not have to trim first.
     //

--- a/integrations/copilot/.github/hooks/lib/audit.mjs
+++ b/integrations/copilot/.github/hooks/lib/audit.mjs
@@ -30,7 +30,7 @@
  * cost at the bottom.
  */
 
-import { record, readMetrics } from './metrics.mjs';
+import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -319,6 +319,35 @@ export function renderAudit(
           `(${trend.improved ? 'improved' : 'worse'})`
       );
     }
+  }
+
+  // WHAT THE BUDGET TURNED AWAY.
+  //
+  // The per-touch token budget is load-bearing by design (#204): without it the
+  // most heavily-worked files accumulate the most findings and become the most
+  // expensive to touch. But a budget that silently drops what it cannot afford
+  // looks, from outside, exactly like a graph that had nothing to say -- and
+  // those are the two states a reader most needs told apart. inject.mjs was
+  // already recording every rejection and its reason, from four call sites, and
+  // nothing read them.
+  //
+  // ONE LINE, not a panel. This is context for the queue above rather than
+  // another thing to do, and the report is held to its own cost.
+  try {
+    const declined = declinedAtBudget(dir);
+    if (declined.declined > 0) {
+      const reasons = declined.byReason
+        .slice(0, 3)
+        .map(({ reason, count }) => `${reason} ${count}`)
+        .join(', ');
+      body.push(
+        '',
+        `Retrieval declined ${declined.declined.toLocaleString()} finding(s) ` +
+          `(${declined.distinctFindings} distinct) across ${declined.decisions.toLocaleString()} decision(s): ${reasons}.`
+      );
+    }
+  } catch {
+    /* the rejection log is context, never a reason to fail the audit */
   }
 
   // STANDING CONTEXT, as a panel rather than only as queue rows.

--- a/integrations/copilot/.github/hooks/lib/audit.mjs
+++ b/integrations/copilot/.github/hooks/lib/audit.mjs
@@ -374,7 +374,16 @@ export function renderAudit(
     // Indented to sit under its heading, blank lines left blank rather than
     // turned into trailing whitespace.
     for (const line of panel.split('\n')) body.push(line ? `  ${line}` : '');
-    if (standing.some((v) => v.actions?.length)) {
+    // ONLY IF THEY ACTUALLY DID. This pointed the reader at "the queue at the
+    // top" whenever any verdict carried an action -- including when the queue
+    // printed "Nothing addressable found", because a caller can render the
+    // panel with no findings at all, and the withholding rule can drop a
+    // standing row even when findings were passed. Telling someone to look at
+    // a row that is not there is worse than saying nothing.
+    const shownStandingIds = new Set(
+      shown.map((item) => item.id).filter((id) => typeof id === 'string' && id.startsWith('standing-'))
+    );
+    if (shownStandingIds.size) {
       body.push(
         '',
         '  The actions above also appear in the queue at the top, where they are priced and applyable.'

--- a/integrations/copilot/.github/hooks/lib/audit.mjs
+++ b/integrations/copilot/.github/hooks/lib/audit.mjs
@@ -33,6 +33,7 @@
 import { record, readMetrics } from './metrics.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
+import { renderStanding } from './standing.mjs';
 
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
 
@@ -183,7 +184,7 @@ export function buildQueue(
 export function renderAudit(
   dir,
   findings = [],
-  { tier = 'opus', full = false, sessionsPerMonth = 60 } = {}
+  { tier = 'opus', full = false, sessionsPerMonth = 60, standing = null } = {}
 ) {
   const { queue, suppressed, done } = buildQueue(dir, findings);
   const lines = [];
@@ -316,6 +317,38 @@ export function renderAudit(
       body.push(
         `  ${trend.detector}: ${trend.before.toLocaleString()} -> ${trend.after.toLocaleString()} tokens/session ` +
           `(${trend.improved ? 'improved' : 'worse'})`
+      );
+    }
+  }
+
+  // STANDING CONTEXT, as a panel rather than only as queue rows.
+  //
+  // auditStanding and verdictFor were both reachable, so this project already
+  // computed which CLAUDE.md rules and skills are stale, oversized or never
+  // used -- and threw the report away. renderStanding existed, was tested, and
+  // had no caller: the forTouch shape exactly, in the subsystem #203 claimed
+  // closed the skills-and-memory gap. Hard to defend a gap as closed while the
+  // report that would show it is unreachable.
+  //
+  // WHAT THE QUEUE ABOVE CANNOT SAY, which is why this is not duplication. The
+  // queue carries one row per ACTION, so a standing file with nothing wrong
+  // contributes no row and is invisible -- and the total cost of the prefix,
+  // the number that says what standing context is worth arguing about at all,
+  // is carried by no row either. Both are in the panel.
+  //
+  // Costed like everything else here: it is pushed BEFORE the closing line is
+  // measured, so the report's self-cost includes its own newest panel rather
+  // than understating it.
+  if (standing?.length) {
+    body.push('', 'Standing context -- charged every session:', '');
+    const panel = renderStanding(standing, { sessionsPerMonth });
+    // Indented to sit under its heading, blank lines left blank rather than
+    // turned into trailing whitespace.
+    for (const line of panel.split('\n')) body.push(line ? `  ${line}` : '');
+    if (standing.some((v) => v.actions?.length)) {
+      body.push(
+        '',
+        '  The actions above also appear in the queue at the top, where they are priced and applyable.'
       );
     }
   }

--- a/integrations/copilot/.github/hooks/lib/consolidate.mjs
+++ b/integrations/copilot/.github/hooks/lib/consolidate.mjs
@@ -36,6 +36,28 @@ import { nodeId } from './wiki.mjs';
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
 
 /**
+ * A candidate's own words, whatever the producer called the field.
+ *
+ * THE SELECTOR AND THE RATIO DISAGREED ABOUT THIS, and the half that had no
+ * caller is the half that was wrong. `irrecoverability`, `costToRederive` and
+ * `selectForConsolidation` all read `entry.summary`; `consolidationRatio` and
+ * `aggregateConsolidation` read `finding.claim`. NO PRODUCER IN THIS REPOSITORY
+ * EMITS `summary` -- the semantic harvest, wiki_write and the evaluation
+ * harnesses all emit `claim`, and `validate()` in harvest.mjs rejects anything
+ * without one.
+ *
+ * That matters more than a rename. Wired naively, every candidate would have
+ * scored `tokens: estimate(undefined)` -- zero -- so the budget could never
+ * bind, nothing would ever be dropped, and the selector would have been live,
+ * green, and inert. A capability that runs and cannot affect its own output is
+ * the same defect as one that never runs, wearing a call site.
+ *
+ * `summary` is still accepted, because an external caller may pass it and
+ * breaking that to fix an internal disagreement would be gratuitous.
+ */
+const claimText = (entry) => entry?.claim || entry?.summary || '';
+
+/**
  * How hard something is to reproduce, independent of what it cost this time.
  *
  * Token cost alone understates the expensive cases. Reproducing a flaky failure
@@ -45,7 +67,7 @@ const estimate = (text) => Math.ceil(String(text || '').length / 4);
  * measurements, and pretending otherwise would be false precision.
  */
 export function irrecoverability(entry) {
-  const text = `${entry.summary || ''} ${entry.evidence || ''}`.toLowerCase();
+  const text = `${claimText(entry)} ${entry.evidence || ''}`.toLowerCase();
 
   // Anything derived from a non-deterministic or long-running observation.
   //
@@ -110,7 +132,7 @@ export function costToRederive(entry, previousAt) {
   // no-op. The only measured cost is `entry.tokensSpent`, which the extraction
   // site must supply; otherwise fall back to the size of the evidence, so a
   // conclusion drawn from a large investigation still outranks an aside.
-  return estimate(entry.evidence) * 4 || estimate(entry.summary) * 8;
+  return estimate(entry.evidence) * 4 || estimate(claimText(entry)) * 8;
 }
 
 /** Kinds that survive on the floor regardless of score. */
@@ -141,7 +163,7 @@ export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}
     });
     const cost = costToRederive(entry, previousAt);
     const score = cost * irrecoverability(entry) * reuseProbability(graph, entry.anchorIds || anchors);
-    scored.push({ entry, score, cost, tokens: estimate(entry.summary) });
+    scored.push({ entry, score, cost, tokens: estimate(claimText(entry)) });
     previousAt = entry.at ?? previousAt;
   }
 
@@ -182,7 +204,7 @@ export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}
  * FOR, in a way that "tokens saved" never quite is.
  */
 export function consolidationRatio(finding) {
-  const carry = estimate(finding.claim);
+  const carry = estimate(claimText(finding));
   const derived = finding.derivedCost || 0;
   if (!carry || !derived) return null;
   return derived / carry;
@@ -195,7 +217,7 @@ export function aggregateConsolidation(findings) {
   for (const finding of findings) {
     if (!finding.derivedCost) continue;
     derived += finding.derivedCost;
-    carry += estimate(finding.claim);
+    carry += estimate(claimText(finding));
   }
   return carry ? { derived, carry, ratio: derived / carry } : null;
 }

--- a/integrations/copilot/.github/hooks/lib/consolidate.mjs
+++ b/integrations/copilot/.github/hooks/lib/consolidate.mjs
@@ -31,7 +31,6 @@
  * without session instrumentation cannot obtain.
  */
 
-import { statSync } from 'node:fs';
 import { nodeId } from './wiki.mjs';
 
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
@@ -201,25 +200,3 @@ export function aggregateConsolidation(findings) {
   return carry ? { derived, carry, ratio: derived / carry } : null;
 }
 
-/**
- * Content identity for a file, so a finding can reach across projects.
- *
- * A vendored library file is the same file in every repository that holds it,
- * whatever path each gives it. Anchoring to content as well as path means a
- * finding about it appears in all of them with no promotion step and no path
- * mapping -- reach a per-session checkpoint cannot have even in principle.
- *
- * The PATH anchor still drives staleness within a repo; this is additive.
- */
-export function contentAnchor(path, hash) {
-  if (!hash) return null;
-  let size = 0;
-  try {
-    size = statSync(path).size;
-  } catch {
-    return null;
-  }
-  // Size is included so two different files sharing a truncated digest do not
-  // collide into one identity.
-  return `content:${hash}:${size}`;
-}

--- a/integrations/copilot/.github/hooks/lib/doctor.mjs
+++ b/integrations/copilot/.github/hooks/lib/doctor.mjs
@@ -26,7 +26,21 @@ import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSyn
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { harvestMode } from './harvest.mjs';
-import { readManifest, verifyManifest, residue } from './manifest.mjs';
+import { readManifest, verifyManifest, residue, manifestSize } from './manifest.mjs';
+
+/**
+ * Bytes as a person reads them.
+ *
+ * Local because it exists for one line of one check, and because the alternative
+ * -- printing a raw byte count next to a file count -- is the kind of detail
+ * that gets skimmed past rather than read.
+ */
+function describeBytes(bytes) {
+  if (!bytes) return 'size unknown';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
 
 const ok = (name, detail) => ({ name, pass: true, detail });
 const bad = (name, detail, remedy) => ({ name, pass: false, detail, remedy });
@@ -362,11 +376,19 @@ export function checklist({ root, settingsPath, install }) {
     }
 
     // What we recorded putting on the machine, and whether it is still that.
-    const verified = verifyManifest(readManifest());
+    const manifest = readManifest();
+    const verified = verifyManifest(manifest);
     if (verified) {
+      // HOW MUCH, not just how many. manifestSize computed exactly this and had
+      // no caller, so the one number that says what uninstall will actually
+      // remove -- and the only cross-check on a manifest that lists files which
+      // no longer exist, since a missing file contributes zero bytes -- was
+      // computed nowhere and shown to no one.
+      const footprint = describeBytes(manifestSize(manifest));
       checks.push(verified.modified === 0
-        ? ok('installed files intact', `${verified.intact} file(s) match the install manifest`)
-        : ok('installed files intact', `${verified.modified} file(s) edited since install -- ` +
+        ? ok('installed files intact', `${verified.intact} file(s), ${footprint}, match the install manifest`)
+        : ok('installed files intact', `${verified.modified} of ${verified.intact + verified.modified} file(s) ` +
+          `(${footprint} recorded) edited since install -- ` +
           'uninstall will leave those alone rather than destroy your changes'));
     } else {
       checks.push(bad('install manifest present', 'no record of what was installed',

--- a/integrations/copilot/.github/hooks/lib/doctor.mjs
+++ b/integrations/copilot/.github/hooks/lib/doctor.mjs
@@ -27,6 +27,7 @@ import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { harvestMode } from './harvest.mjs';
 import { readManifest, verifyManifest, residue, manifestSize } from './manifest.mjs';
+import { mcpClientsSeen } from './metrics.mjs';
 
 /**
  * Bytes as a person reads them.
@@ -553,7 +554,39 @@ export function probeGraph({ dir }) {
     checks.push(ok('graph directory is private', 'mode could not be read on this filesystem'));
   }
 
+  checks.push(...probeClients({ dir }));
   return checks;
+}
+
+/**
+ * Which MCP clients have actually handshaked with this server.
+ *
+ * THE QUESTION THE REST OF THE DOCTOR CANNOT ANSWER. Every other check here
+ * reasons about files on disk: is the hook present, is it wired, does it refuse
+ * a large read. None of them can tell you whether the editor in front of you
+ * ever actually connected -- which is the single most common way this product
+ * is installed and silently does nothing.
+ *
+ * `mcp-client` records exactly that on every `initialize`, and nothing read it
+ * until now. NEVER A FAILURE: a fresh install has no handshakes yet, and a
+ * doctor that reports red on a correct install teaches people to ignore it.
+ */
+export function probeClients({ dir }) {
+  let clients = [];
+  try {
+    clients = mcpClientsSeen(dir);
+  } catch {
+    return [ok('MCP clients seen', 'no evidence log yet')];
+  }
+  if (!clients.length) {
+    return [ok('MCP clients seen', 'none yet -- the server has had no MCP handshake in this project')];
+  }
+  const described = clients
+    .slice(0, 5)
+    .map((c) => `${c.title || c.client}${c.version ? ` ${c.version}` : ''}`)
+    .join(', ');
+  return [ok('MCP clients seen', `${clients.length}: ${described}` +
+    (clients.length > 5 ? `, and ${clients.length - 5} more` : ''))];
 }
 
 /**

--- a/integrations/copilot/.github/hooks/lib/doctor.mjs
+++ b/integrations/copilot/.github/hooks/lib/doctor.mjs
@@ -386,11 +386,23 @@ export function checklist({ root, settingsPath, install }) {
       // no longer exist, since a missing file contributes zero bytes -- was
       // computed nowhere and shown to no one.
       const footprint = describeBytes(manifestSize(manifest));
-      checks.push(verified.modified === 0
-        ? ok('installed files intact', `${verified.intact} file(s), ${footprint}, match the install manifest`)
-        : ok('installed files intact', `${verified.modified} of ${verified.intact + verified.modified} file(s) ` +
+      // MISSING IS NOT INTACT, and branching on `modified` alone said it was.
+      // verifyManifest reports three states and this read two of them: a
+      // recorded file DELETED rather than edited left `modified === 0`, so a
+      // half-removed install passed as healthy. The footprint above is what
+      // makes it visible -- a missing file contributes zero bytes -- but a
+      // visible detail beside a PASS is still a PASS.
+      if (verified.missing > 0) {
+        checks.push(bad('installed files intact',
+          `${verified.missing} of ${verified.files.length} recorded file(s) are gone (${footprint} still on disk)`,
+          'reinstall the package to restore them, or run the uninstaller to clear the manifest'));
+      } else if (verified.modified === 0) {
+        checks.push(ok('installed files intact', `${verified.intact} file(s), ${footprint}, match the install manifest`));
+      } else {
+        checks.push(ok('installed files intact', `${verified.modified} of ${verified.intact + verified.modified} file(s) ` +
           `(${footprint} recorded) edited since install -- ` +
           'uninstall will leave those alone rather than destroy your changes'));
+      }
     } else {
       checks.push(bad('install manifest present', 'no record of what was installed',
         'harmless if you installed manually; reinstall to get a removable, verifiable record'));
@@ -538,9 +550,16 @@ export function probeGraph({ dir }) {
   // the bits read back as world-readable regardless, so failing there would be
   // reporting a platform property as a broken install: a false alarm that
   // teaches people to ignore the doctor.
+  // BEFORE THE PLATFORM RETURN, and this is exactly the defect this branch
+  // exists to close: the client probe was appended after `probeGraph`'s
+  // Windows early-return, so on Windows it had a call site and never ran. A
+  // reference that cannot execute is what the reachability guard cannot see.
+  const clients = probeClients({ dir });
+
   if (process.platform === 'win32') {
     checks.push(ok('graph directory is private',
       'POSIX modes are not enforced on Windows; the directory inherits its parent ACL'));
+    checks.push(...clients);
     return checks;
   }
 
@@ -554,7 +573,7 @@ export function probeGraph({ dir }) {
     checks.push(ok('graph directory is private', 'mode could not be read on this filesystem'));
   }
 
-  checks.push(...probeClients({ dir }));
+  checks.push(...clients);
   return checks;
 }
 

--- a/integrations/copilot/.github/hooks/lib/keepwarm.mjs
+++ b/integrations/copilot/.github/hooks/lib/keepwarm.mjs
@@ -110,7 +110,7 @@ export function gapDistribution(dir, { events = readMetrics(dir) } = {}) {
  * Returns the arithmetic as well as the verdict, because a refusal to refresh
  * that cannot be checked is indistinguishable from a bug.
  */
-export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0] }) {
+export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed = null }) {
   if (!prefixTokens || !gaps) {
     return { action: 'unknown', reason: 'no gap distribution yet -- needs a few sessions of history' };
   }
@@ -124,21 +124,42 @@ export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0] }) {
   // The ping only earns anything in the window where the entry WOULD have
   // expired but the next turn still arrives: before the TTL it was already
   // warm, and long after it, one ping does not reach.
-  const probability = Math.max(0, gaps.probabilityWithin(tier.ms * 2) - gaps.probabilityWithin(tier.ms));
+  const modelled = Math.max(0, gaps.probabilityWithin(tier.ms * 2) - gaps.probabilityWithin(tier.ms));
+
+  // MEASURED BEATS MODELLED, once there is enough of it.
+  //
+  // The module header already commits to this -- "an expected-value decision is
+  // only as good as the distribution it was fitted to, and distributions
+  // shift" -- and the tripwire underneath was the only thing acting on it, as
+  // an all-or-nothing kill switch. Between "the model says refresh" and "stop
+  // entirely" there was nothing, because the observed hit rate was never
+  // computed: both recording halves had no call site, so ten refreshes that
+  // bought nothing would keep recommending refresh right up to the moment the
+  // tripwire cut the whole feature off.
+  //
+  // Below OBSERVATION_FLOOR this stays null and the model is used unchanged; a
+  // handful of samples would swing the decision harder than the distribution
+  // they replace.
+  const probability = observed ? observed.rate : modelled;
   const savingIfUsed = prefixTokens * (tier.writeMultiplier - READ_MULTIPLIER);
   const ev = probability * savingIfUsed - costOfPing;
+  const basis = observed
+    ? `measured over ${observed.observations} refreshes`
+    : 'modelled from the gap distribution';
 
   return {
     action: ev > 0 ? 'refresh' : 'skip',
     tier: tier.name,
     probability,
+    modelledProbability: modelled,
+    basis,
     savingIfUsed: Math.round(savingIfUsed),
     costOfPing: Math.round(costOfPing),
     expectedValue: Math.round(ev),
     reason: ev > 0
-      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers; ` +
+      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers (${basis}); ` +
         `expected gain ${Math.round(ev).toLocaleString()} tokens`
-      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers; ` +
+      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers (${basis}); ` +
         `expected loss ${Math.abs(Math.round(ev)).toLocaleString()} tokens`,
   };
 }
@@ -194,9 +215,84 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
   };
 }
 
+/** Observations of a tier before its measured hit rate may override the model. */
+export const OBSERVATION_FLOOR = 5;
+
 /** Records a refresh so its outcome can be scored. */
 export function recordRefresh(dir, { tier, prefixTokens, expectedValue }) {
   record(dir, { kind: 'keepwarm', action: 'refresh', tier, prefixTokens, expectedValue });
+}
+
+/**
+ * Scores every refresh whose window has since resolved.
+ *
+ * THE MISSING HALF, and it was missing because nobody could see where the
+ * signal would come from. `recordRefreshOutcome` needs to know whether a real
+ * turn arrived before the entry expired -- and that is not a thing anyone has
+ * to instrument, because the event log already records when every turn
+ * happened. The answer was in the data the whole time.
+ *
+ * For each unscored refresh at time T on a tier with TTL `ms`:
+ *
+ *   - a later event within `ms`            -> HIT, observed
+ *   - a later event after `ms`             -> MISS, observed
+ *   - no later event, and `now - T > ms`   -> MISS, observed: the window has
+ *                                             demonstrably closed unused
+ *   - no later event, window still open    -> NOTHING RECORDED
+ *
+ * That last line is the important one and it is Plan 2's own instruction: "if
+ * no signal is available for a tier, record nothing rather than guessing
+ * `hit: false`". A refresh whose window has not closed yet is not a miss, and
+ * scoring it as one would drive the tripwire negative on the newest and least
+ * informative records.
+ *
+ * DRAINED AT READ TIME, which is the pattern this codebase already uses for
+ * staleness: the producer cannot know the outcome at the moment it acts, so the
+ * next reader resolves what has become knowable since.
+ */
+export function scoreOutstandingRefreshes(dir, { events = readMetrics(dir), outcomes = readBalance(dir), now = Date.now() } = {}) {
+  const keepwarm = outcomes.filter((e) => e.kind === 'keepwarm');
+  const refreshes = keepwarm.filter((e) => e.action === 'refresh').sort((a, b) => (a.at || 0) - (b.at || 0));
+  const scored = keepwarm.filter((e) => e.action === 'outcome').length;
+
+  // Refreshes are scored oldest-first and one outcome belongs to one refresh,
+  // so everything past the number already scored is outstanding. Pairing by
+  // timestamp instead would double-count two refreshes recorded in the same
+  // millisecond, which is reachable: a tool run twice in a loop.
+  const outstanding = refreshes.slice(scored);
+  const timeline = events.map((e) => Number(e.at) || 0).filter(Boolean).sort((a, b) => a - b);
+
+  let recorded = 0;
+  for (const refresh of outstanding) {
+    const at = Number(refresh.at) || 0;
+    if (!at) continue;
+    const tierSpec = TIERS.find((t) => t.name === refresh.tier) || TIERS[0];
+    const next = timeline.find((t) => t > at);
+
+    let hit;
+    if (next !== undefined) hit = next - at <= tierSpec.ms;
+    else if (now - at > tierSpec.ms) hit = false;
+    else continue; // window still open: not yet knowable
+
+    recordRefreshOutcome(dir, { tier: refresh.tier, prefixTokens: refresh.prefixTokens, hit });
+    recorded += 1;
+  }
+  return { outstanding: outstanding.length, recorded };
+}
+
+/**
+ * The measured hit rate for a tier, or null below the observation floor.
+ *
+ * Null rather than a small-sample number, because the caller substitutes it for
+ * a modelled probability and three observations would swing the decision harder
+ * than the model they replace.
+ */
+export function observedHitRate(dir, { tier, outcomes = readBalance(dir) } = {}) {
+  const relevant = outcomes.filter(
+    (e) => e.kind === 'keepwarm' && e.action === 'outcome' && (!tier || e.tier === tier)
+  );
+  if (relevant.length < OBSERVATION_FLOOR) return null;
+  return { observations: relevant.length, rate: relevant.filter((e) => e.hit).length / relevant.length };
 }
 
 /**
@@ -276,6 +372,18 @@ export function shouldKeepWarm(dir, {
   // was chosen was wrong for one of them.
   outcomes = readBalance(dir),
 } = {}) {
+  // DRAIN BEFORE DECIDING. Anything whose window has closed since the last call
+  // becomes evidence now, so the decision below and the tripwire above both see
+  // the most that is currently knowable -- the same read-time drain the
+  // staleness path uses, and for the same reason: the producer cannot know the
+  // outcome at the moment it acts.
+  try {
+    scoreOutstandingRefreshes(dir, { events, outcomes });
+    outcomes = readBalance(dir);
+  } catch {
+    /* scoring is evidence, never a reason to refuse a decision */
+  }
+
   const trip = tripwire(dir, { events: outcomes });
   if (trip.tripped) return { action: 'skip', reason: trip.reason, trippedWire: true };
 
@@ -289,7 +397,11 @@ export function shouldKeepWarm(dir, {
     // refusal justified by a GAIN: `{ action: 'skip', reason: '...expected gain 130 tokens' }`.
     // This module's own docstring says a refusal that cannot be checked is indistinguishable from
     // a bug; one that contradicts itself is worse.
-    const decision = keepWarmDecision({ prefixTokens, gaps });
+    const decision = keepWarmDecision({
+      prefixTokens,
+      gaps,
+      observed: observedHitRate(dir, { tier: TIERS[0].name, outcomes }),
+    });
     if (decision.action === 'refresh') return decision;
     return { action: decision.action === 'unknown' ? 'unknown' : 'skip', reason: decision.reason };
   }

--- a/integrations/copilot/.github/hooks/lib/metrics.mjs
+++ b/integrations/copilot/.github/hooks/lib/metrics.mjs
@@ -744,6 +744,21 @@ export function balanceSheet(dir) {
           verdict: r.verdict,
         };
       })(),
+      // THE CONTROL ARM'S CONTENT, for the same reason `controlArmTokens` sits
+      // in the substitution block above: `candidateCount` and
+      // `shadowFindingIds` recorded what the holdout withheld and nothing read
+      // them, so the report could count the arms and never say what was in
+      // them.
+      ...(() => {
+        const shadow = shadowDelivery(dir);
+        return {
+          selected: shadow.selected,
+          delivered: shadow.delivered,
+          controlArmSelected: shadow.withheldSelected,
+          controlArmFindings: shadow.withheldFindings,
+          indexStaleEntries: shadow.staleEntries,
+        };
+      })(),
     },
     costs: {
       injection: injectCost,
@@ -1283,6 +1298,109 @@ export function declinedAtBudget(dir, { limit = 500 } = {}) {
       .sort((a, b) => b[1] - a[1])
       .map(([reason, count]) => ({ reason, count })),
   };
+}
+
+/**
+ * The injection arm's SHADOW: what retrieval selected, against what was served.
+ *
+ * THE SAME GAP `controlArmTokens` WAS CREATED TO CLOSE, one arm over. That
+ * field exists because `tokensFullFile` "was recorded and read by nothing, so
+ * the comparison the holdout exists for was not computable from the report" --
+ * and the injection side had the identical hole: every `inject` record carries
+ * `candidateCount` and `shadowFindingIds`, which are what WOULD have been
+ * delivered, non-zero in BOTH arms, while `count` and `findingIds` go to zero
+ * in the holdout. The shadow pair was written on every injection since the
+ * holdout shipped and read by nothing, so the report could say how many touches
+ * landed in each arm and never which findings the holdout actually withheld.
+ *
+ * `staleCount` is the same shape on the session-start index: `stale` (a
+ * boolean, "was any of this stale") had a reader, the count did not, so a index
+ * with one rotten entry in forty was indistinguishable from one rotten
+ * throughout.
+ *
+ * READ FROM THE BALANCE LOG, because `inject` is a BALANCE_KIND: the firehose
+ * evicts injections first -- 136 of them against 6,725 captures on one machine
+ * -- which is the eviction that made `report()` say "0 holdout" over a file
+ * containing nine.
+ */
+export function shadowDelivery(dir) {
+  const injections = readBalance(dir).filter((event) => event.kind === 'inject');
+
+  let selected = 0;
+  let delivered = 0;
+  let withheldSelected = 0;
+  const withheldKeys = new Set();
+  let staleEntries = 0;
+  let indexRecords = 0;
+
+  for (const event of injections) {
+    const candidates = Number(event.candidateCount) || 0;
+    selected += candidates;
+    delivered += Number(event.count) || 0;
+    if (event.holdout) {
+      withheldSelected += candidates;
+      for (const key of event.shadowFindingIds || []) withheldKeys.add(key);
+    }
+    if (event.surface === 'session-start') {
+      indexRecords += 1;
+      staleEntries += Number(event.staleCount) || 0;
+    }
+  }
+
+  return {
+    injections: injections.length,
+    // Everything retrieval chose, across both arms.
+    selected,
+    // What actually reached a model.
+    delivered,
+    // Chosen and deliberately not delivered, because the anchor was in the
+    // withheld arm. This is the control arm's content, which is the thing the
+    // holdout exists to make comparable.
+    withheldSelected,
+    withheldFindings: withheldKeys.size,
+    // Index staleness as a rate rather than a boolean.
+    indexRecords,
+    staleEntries,
+  };
+}
+
+/**
+ * Which MCP clients have actually handshaked with this server.
+ *
+ * `mcp-client` was written on every `initialize` and read by nothing -- a
+ * producer with no reader, and the last one the census found. Deleting it was
+ * the other option and would have been wrong: `mcp-tool` records a client only
+ * once it CALLS something, and the project registry records a name only, so a
+ * client that connected and then called nothing -- which is exactly the failure
+ * this project's doctor exists to diagnose -- appeared in neither. The
+ * handshake is the only record that a connection happened at all.
+ *
+ * `clientTitle` is the field that made the record unique and it was unread too:
+ * the display name a client reports for itself, which is how a user recognises
+ * their own editor in a list where `name` is a slug.
+ */
+export function mcpClientsSeen(dir, { limit = 200 } = {}) {
+  const seen = new Map();
+  for (const event of readEvidence(dir)) {
+    if (event.kind !== 'mcp-client') continue;
+    const name = String(event.client || 'unknown');
+    const at = Number(event.at) || 0;
+    const previous = seen.get(name);
+    // LAST HANDSHAKE WINS on the mutable fields: a client that upgraded should
+    // be reported at the version it is now, not the one it first connected on.
+    if (!previous || at >= previous.at) {
+      seen.set(name, {
+        client: name,
+        title: event.clientTitle || null,
+        version: event.clientVersion || null,
+        at,
+        connections: (previous?.connections || 0) + 1,
+      });
+    } else {
+      previous.connections += 1;
+    }
+  }
+  return [...seen.values()].sort((a, b) => b.at - a.at).slice(0, limit);
 }
 
 /* ----------------------------------------------------------------------

--- a/integrations/copilot/.github/hooks/lib/metrics.mjs
+++ b/integrations/copilot/.github/hooks/lib/metrics.mjs
@@ -1231,6 +1231,60 @@ export function indexBudget(
   return Math.max(floor, Math.min(ceiling, scaled));
 }
 
+/**
+ * What retrieval decided NOT to inject, and why.
+ *
+ * THE OTHER HALF OF THE BUDGET, and it had no reader. `assessFindings` rejects a
+ * finding for one of three reasons -- it has been quarantined as harmful, it is
+ * in cooldown after being injected recently, or its expected value is negative
+ * -- and inject.mjs records every one of those decisions as a
+ * `retrieval-decision` event, from four separate call sites. Nothing read them.
+ *
+ * WHY THAT MATTERS RATHER THAN BEING TIDY. #204 makes the per-touch token budget
+ * load-bearing: "without it the most heavily-worked files accumulate the most
+ * findings and become the most expensive to touch, and the optimizer becomes
+ * its own token problem." A budget that silently drops what it cannot afford is
+ * indistinguishable, from outside, from a graph that had nothing to say. These
+ * are the two states a user most needs told apart, and the records to tell them
+ * apart were already being written.
+ *
+ * READ FROM THE EVIDENCE LOG, not the firehose. `retrieval-decision` is in
+ * EVIDENCE_KINDS precisely because it is rare relative to per-tool-call
+ * telemetry, and the windowed reader would evict it before it accumulated --
+ * the same eviction that made `report()` say "0 holdout" over a file containing
+ * nine.
+ */
+export function declinedAtBudget(dir, { limit = 500 } = {}) {
+  const decisions = readEvidence(dir)
+    .filter((event) => event.kind === 'retrieval-decision')
+    .slice(-limit);
+
+  const byReason = new Map();
+  const keys = new Set();
+  let declined = 0;
+  for (const decision of decisions) {
+    for (const item of decision.rejected || []) {
+      declined += 1;
+      if (item.key) keys.add(item.key);
+      // An unlabelled rejection is counted, not dropped: an unknown reason is
+      // still a finding the model did not get, and reporting the count as
+      // smaller than it is would understate exactly the cost this exists to
+      // surface.
+      const reason = item.reason || 'unspecified';
+      byReason.set(reason, (byReason.get(reason) || 0) + 1);
+    }
+  }
+
+  return {
+    decisions: decisions.length,
+    declined,
+    distinctFindings: keys.size,
+    byReason: [...byReason.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([reason, count]) => ({ reason, count })),
+  };
+}
+
 /* ----------------------------------------------------------------------
  * Episode-level causal evidence
  * ------------------------------------------------------------------- */

--- a/integrations/copilot/.github/hooks/lib/staleness.mjs
+++ b/integrations/copilot/.github/hooks/lib/staleness.mjs
@@ -297,7 +297,25 @@ export function checkAnchor(anchor) {
   if (anchor.kind === 'file') {
     return hash(source) === anchor.hash
       ? { fresh: true }
-      : { fresh: false, before: anchor.snapshot || '', hasBefore: Boolean(anchor.snapshot), after: source, reason: 'file changed' };
+      : {
+          fresh: false,
+          before: anchor.snapshot || '',
+          hasBefore: Boolean(anchor.snapshot),
+          after: source,
+          // AND WHAT CHANGED IT, when the graph knows. The structural harvest
+          // stamps `lastAction` -- the tool name that last touched this file --
+          // on every file node, and nothing read it: the field was written on
+          // every observed tool call since #203 and consumed nowhere.
+          //
+          // It belongs precisely here. "file changed" tells a reader that their
+          // finding may be wrong; "file changed (last touched by Edit)" tells
+          // them a targeted edit did it, which is cheap to re-verify, and "last
+          // touched by Write" says the file was replaced wholesale, which is
+          // usually not. Same disclosure, one word of provenance, no extra I/O.
+          reason: anchor.lastAction
+            ? `file changed (last touched by ${String(anchor.lastAction).slice(0, 40)})`
+            : 'file changed',
+        };
   }
 
   // For a symbol, re-locate it by NAME rather than by line number. Line numbers
@@ -499,6 +517,7 @@ function disputeOf(graph, finding) {
   if (!hasOutstandingContradiction(graph, finding.key)) return {};
 
   const keys = [];
+  const disputantIds = [];
   // AND THE REASON A PERSON TYPED, which had no reader anywhere. `contradict`
   // stores `contradictionReason` -- up to 400 characters of human explanation --
   // on the CONTRADICTED end only, and nothing outside its own test ever read it:
@@ -524,6 +543,7 @@ function disputeOf(graph, finding) {
     // fetch. `hasOutstandingContradiction` above already declines to open the
     // gate when EVERY disputant is retired; this is the same rule applied to
     // each name, so a live disputant is still reported alongside a withdrawn one.
+    if (!disputantIds.includes(otherId)) disputantIds.push(otherId);
     if (other && !other.retired && typeof other.key === 'string' && !keys.includes(other.key)) {
       keys.push(other.key);
       // A RETIRED END'S REASON IS NOT BORROWED EITHER, which is why this sits
@@ -537,9 +557,31 @@ function disputeOf(graph, finding) {
     }
   }
 
+  // WHEN, alongside WHY. `contradict` writes `contradictedAt` and
+  // `contradictionReason` on the same line of the same putNode call. Round 1
+  // gave the reason a reader -- this function -- and left the timestamp
+  // unread, so the disclosure could say a claim was disputed and why, and not
+  // whether that happened this morning or a year ago. For a reader deciding
+  // whether to trust a disputed finding, the age of the dispute is most of the
+  // signal: a year-old objection to a claim nobody has revisited reads very
+  // differently from one raised since the last release.
+  //
+  // Collected from whichever end holds it, exactly like the reason, and the
+  // EARLIEST is kept -- the dispute began when the first end recorded it.
+  let contradictedAt =
+    typeof finding.contradictedAt === 'number' ? finding.contradictedAt : null;
+  for (const id of disputantIds) {
+    const other = graph.nodes.get(id);
+    if (!other || other.retired) continue;
+    if (typeof other.contradictedAt !== 'number') continue;
+    contradictedAt =
+      contradictedAt === null ? other.contradictedAt : Math.min(contradictedAt, other.contradictedAt);
+  }
+
   return {
     contradicted: true,
     ...(keys.length ? { contradictedBy: keys.join(', ') } : {}),
+    ...(contradictedAt !== null ? { contradictedAt } : {}),
     // Trimmed here rather than at the renderer: an empty string is not a reason,
     // and a consumer checking `if (reason)` should not have to trim first.
     //

--- a/integrations/cursor/hooks/lib/audit.mjs
+++ b/integrations/cursor/hooks/lib/audit.mjs
@@ -30,7 +30,7 @@
  * cost at the bottom.
  */
 
-import { record, readMetrics } from './metrics.mjs';
+import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -319,6 +319,35 @@ export function renderAudit(
           `(${trend.improved ? 'improved' : 'worse'})`
       );
     }
+  }
+
+  // WHAT THE BUDGET TURNED AWAY.
+  //
+  // The per-touch token budget is load-bearing by design (#204): without it the
+  // most heavily-worked files accumulate the most findings and become the most
+  // expensive to touch. But a budget that silently drops what it cannot afford
+  // looks, from outside, exactly like a graph that had nothing to say -- and
+  // those are the two states a reader most needs told apart. inject.mjs was
+  // already recording every rejection and its reason, from four call sites, and
+  // nothing read them.
+  //
+  // ONE LINE, not a panel. This is context for the queue above rather than
+  // another thing to do, and the report is held to its own cost.
+  try {
+    const declined = declinedAtBudget(dir);
+    if (declined.declined > 0) {
+      const reasons = declined.byReason
+        .slice(0, 3)
+        .map(({ reason, count }) => `${reason} ${count}`)
+        .join(', ');
+      body.push(
+        '',
+        `Retrieval declined ${declined.declined.toLocaleString()} finding(s) ` +
+          `(${declined.distinctFindings} distinct) across ${declined.decisions.toLocaleString()} decision(s): ${reasons}.`
+      );
+    }
+  } catch {
+    /* the rejection log is context, never a reason to fail the audit */
   }
 
   // STANDING CONTEXT, as a panel rather than only as queue rows.

--- a/integrations/cursor/hooks/lib/audit.mjs
+++ b/integrations/cursor/hooks/lib/audit.mjs
@@ -374,7 +374,16 @@ export function renderAudit(
     // Indented to sit under its heading, blank lines left blank rather than
     // turned into trailing whitespace.
     for (const line of panel.split('\n')) body.push(line ? `  ${line}` : '');
-    if (standing.some((v) => v.actions?.length)) {
+    // ONLY IF THEY ACTUALLY DID. This pointed the reader at "the queue at the
+    // top" whenever any verdict carried an action -- including when the queue
+    // printed "Nothing addressable found", because a caller can render the
+    // panel with no findings at all, and the withholding rule can drop a
+    // standing row even when findings were passed. Telling someone to look at
+    // a row that is not there is worse than saying nothing.
+    const shownStandingIds = new Set(
+      shown.map((item) => item.id).filter((id) => typeof id === 'string' && id.startsWith('standing-'))
+    );
+    if (shownStandingIds.size) {
       body.push(
         '',
         '  The actions above also appear in the queue at the top, where they are priced and applyable.'

--- a/integrations/cursor/hooks/lib/audit.mjs
+++ b/integrations/cursor/hooks/lib/audit.mjs
@@ -33,6 +33,7 @@
 import { record, readMetrics } from './metrics.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
+import { renderStanding } from './standing.mjs';
 
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
 
@@ -183,7 +184,7 @@ export function buildQueue(
 export function renderAudit(
   dir,
   findings = [],
-  { tier = 'opus', full = false, sessionsPerMonth = 60 } = {}
+  { tier = 'opus', full = false, sessionsPerMonth = 60, standing = null } = {}
 ) {
   const { queue, suppressed, done } = buildQueue(dir, findings);
   const lines = [];
@@ -316,6 +317,38 @@ export function renderAudit(
       body.push(
         `  ${trend.detector}: ${trend.before.toLocaleString()} -> ${trend.after.toLocaleString()} tokens/session ` +
           `(${trend.improved ? 'improved' : 'worse'})`
+      );
+    }
+  }
+
+  // STANDING CONTEXT, as a panel rather than only as queue rows.
+  //
+  // auditStanding and verdictFor were both reachable, so this project already
+  // computed which CLAUDE.md rules and skills are stale, oversized or never
+  // used -- and threw the report away. renderStanding existed, was tested, and
+  // had no caller: the forTouch shape exactly, in the subsystem #203 claimed
+  // closed the skills-and-memory gap. Hard to defend a gap as closed while the
+  // report that would show it is unreachable.
+  //
+  // WHAT THE QUEUE ABOVE CANNOT SAY, which is why this is not duplication. The
+  // queue carries one row per ACTION, so a standing file with nothing wrong
+  // contributes no row and is invisible -- and the total cost of the prefix,
+  // the number that says what standing context is worth arguing about at all,
+  // is carried by no row either. Both are in the panel.
+  //
+  // Costed like everything else here: it is pushed BEFORE the closing line is
+  // measured, so the report's self-cost includes its own newest panel rather
+  // than understating it.
+  if (standing?.length) {
+    body.push('', 'Standing context -- charged every session:', '');
+    const panel = renderStanding(standing, { sessionsPerMonth });
+    // Indented to sit under its heading, blank lines left blank rather than
+    // turned into trailing whitespace.
+    for (const line of panel.split('\n')) body.push(line ? `  ${line}` : '');
+    if (standing.some((v) => v.actions?.length)) {
+      body.push(
+        '',
+        '  The actions above also appear in the queue at the top, where they are priced and applyable.'
       );
     }
   }

--- a/integrations/cursor/hooks/lib/consolidate.mjs
+++ b/integrations/cursor/hooks/lib/consolidate.mjs
@@ -36,6 +36,28 @@ import { nodeId } from './wiki.mjs';
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
 
 /**
+ * A candidate's own words, whatever the producer called the field.
+ *
+ * THE SELECTOR AND THE RATIO DISAGREED ABOUT THIS, and the half that had no
+ * caller is the half that was wrong. `irrecoverability`, `costToRederive` and
+ * `selectForConsolidation` all read `entry.summary`; `consolidationRatio` and
+ * `aggregateConsolidation` read `finding.claim`. NO PRODUCER IN THIS REPOSITORY
+ * EMITS `summary` -- the semantic harvest, wiki_write and the evaluation
+ * harnesses all emit `claim`, and `validate()` in harvest.mjs rejects anything
+ * without one.
+ *
+ * That matters more than a rename. Wired naively, every candidate would have
+ * scored `tokens: estimate(undefined)` -- zero -- so the budget could never
+ * bind, nothing would ever be dropped, and the selector would have been live,
+ * green, and inert. A capability that runs and cannot affect its own output is
+ * the same defect as one that never runs, wearing a call site.
+ *
+ * `summary` is still accepted, because an external caller may pass it and
+ * breaking that to fix an internal disagreement would be gratuitous.
+ */
+const claimText = (entry) => entry?.claim || entry?.summary || '';
+
+/**
  * How hard something is to reproduce, independent of what it cost this time.
  *
  * Token cost alone understates the expensive cases. Reproducing a flaky failure
@@ -45,7 +67,7 @@ const estimate = (text) => Math.ceil(String(text || '').length / 4);
  * measurements, and pretending otherwise would be false precision.
  */
 export function irrecoverability(entry) {
-  const text = `${entry.summary || ''} ${entry.evidence || ''}`.toLowerCase();
+  const text = `${claimText(entry)} ${entry.evidence || ''}`.toLowerCase();
 
   // Anything derived from a non-deterministic or long-running observation.
   //
@@ -110,7 +132,7 @@ export function costToRederive(entry, previousAt) {
   // no-op. The only measured cost is `entry.tokensSpent`, which the extraction
   // site must supply; otherwise fall back to the size of the evidence, so a
   // conclusion drawn from a large investigation still outranks an aside.
-  return estimate(entry.evidence) * 4 || estimate(entry.summary) * 8;
+  return estimate(entry.evidence) * 4 || estimate(claimText(entry)) * 8;
 }
 
 /** Kinds that survive on the floor regardless of score. */
@@ -141,7 +163,7 @@ export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}
     });
     const cost = costToRederive(entry, previousAt);
     const score = cost * irrecoverability(entry) * reuseProbability(graph, entry.anchorIds || anchors);
-    scored.push({ entry, score, cost, tokens: estimate(entry.summary) });
+    scored.push({ entry, score, cost, tokens: estimate(claimText(entry)) });
     previousAt = entry.at ?? previousAt;
   }
 
@@ -182,7 +204,7 @@ export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}
  * FOR, in a way that "tokens saved" never quite is.
  */
 export function consolidationRatio(finding) {
-  const carry = estimate(finding.claim);
+  const carry = estimate(claimText(finding));
   const derived = finding.derivedCost || 0;
   if (!carry || !derived) return null;
   return derived / carry;
@@ -195,7 +217,7 @@ export function aggregateConsolidation(findings) {
   for (const finding of findings) {
     if (!finding.derivedCost) continue;
     derived += finding.derivedCost;
-    carry += estimate(finding.claim);
+    carry += estimate(claimText(finding));
   }
   return carry ? { derived, carry, ratio: derived / carry } : null;
 }

--- a/integrations/cursor/hooks/lib/consolidate.mjs
+++ b/integrations/cursor/hooks/lib/consolidate.mjs
@@ -31,7 +31,6 @@
  * without session instrumentation cannot obtain.
  */
 
-import { statSync } from 'node:fs';
 import { nodeId } from './wiki.mjs';
 
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
@@ -201,25 +200,3 @@ export function aggregateConsolidation(findings) {
   return carry ? { derived, carry, ratio: derived / carry } : null;
 }
 
-/**
- * Content identity for a file, so a finding can reach across projects.
- *
- * A vendored library file is the same file in every repository that holds it,
- * whatever path each gives it. Anchoring to content as well as path means a
- * finding about it appears in all of them with no promotion step and no path
- * mapping -- reach a per-session checkpoint cannot have even in principle.
- *
- * The PATH anchor still drives staleness within a repo; this is additive.
- */
-export function contentAnchor(path, hash) {
-  if (!hash) return null;
-  let size = 0;
-  try {
-    size = statSync(path).size;
-  } catch {
-    return null;
-  }
-  // Size is included so two different files sharing a truncated digest do not
-  // collide into one identity.
-  return `content:${hash}:${size}`;
-}

--- a/integrations/cursor/hooks/lib/doctor.mjs
+++ b/integrations/cursor/hooks/lib/doctor.mjs
@@ -26,7 +26,21 @@ import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSyn
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { harvestMode } from './harvest.mjs';
-import { readManifest, verifyManifest, residue } from './manifest.mjs';
+import { readManifest, verifyManifest, residue, manifestSize } from './manifest.mjs';
+
+/**
+ * Bytes as a person reads them.
+ *
+ * Local because it exists for one line of one check, and because the alternative
+ * -- printing a raw byte count next to a file count -- is the kind of detail
+ * that gets skimmed past rather than read.
+ */
+function describeBytes(bytes) {
+  if (!bytes) return 'size unknown';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
 
 const ok = (name, detail) => ({ name, pass: true, detail });
 const bad = (name, detail, remedy) => ({ name, pass: false, detail, remedy });
@@ -362,11 +376,19 @@ export function checklist({ root, settingsPath, install }) {
     }
 
     // What we recorded putting on the machine, and whether it is still that.
-    const verified = verifyManifest(readManifest());
+    const manifest = readManifest();
+    const verified = verifyManifest(manifest);
     if (verified) {
+      // HOW MUCH, not just how many. manifestSize computed exactly this and had
+      // no caller, so the one number that says what uninstall will actually
+      // remove -- and the only cross-check on a manifest that lists files which
+      // no longer exist, since a missing file contributes zero bytes -- was
+      // computed nowhere and shown to no one.
+      const footprint = describeBytes(manifestSize(manifest));
       checks.push(verified.modified === 0
-        ? ok('installed files intact', `${verified.intact} file(s) match the install manifest`)
-        : ok('installed files intact', `${verified.modified} file(s) edited since install -- ` +
+        ? ok('installed files intact', `${verified.intact} file(s), ${footprint}, match the install manifest`)
+        : ok('installed files intact', `${verified.modified} of ${verified.intact + verified.modified} file(s) ` +
+          `(${footprint} recorded) edited since install -- ` +
           'uninstall will leave those alone rather than destroy your changes'));
     } else {
       checks.push(bad('install manifest present', 'no record of what was installed',

--- a/integrations/cursor/hooks/lib/doctor.mjs
+++ b/integrations/cursor/hooks/lib/doctor.mjs
@@ -27,6 +27,7 @@ import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { harvestMode } from './harvest.mjs';
 import { readManifest, verifyManifest, residue, manifestSize } from './manifest.mjs';
+import { mcpClientsSeen } from './metrics.mjs';
 
 /**
  * Bytes as a person reads them.
@@ -553,7 +554,39 @@ export function probeGraph({ dir }) {
     checks.push(ok('graph directory is private', 'mode could not be read on this filesystem'));
   }
 
+  checks.push(...probeClients({ dir }));
   return checks;
+}
+
+/**
+ * Which MCP clients have actually handshaked with this server.
+ *
+ * THE QUESTION THE REST OF THE DOCTOR CANNOT ANSWER. Every other check here
+ * reasons about files on disk: is the hook present, is it wired, does it refuse
+ * a large read. None of them can tell you whether the editor in front of you
+ * ever actually connected -- which is the single most common way this product
+ * is installed and silently does nothing.
+ *
+ * `mcp-client` records exactly that on every `initialize`, and nothing read it
+ * until now. NEVER A FAILURE: a fresh install has no handshakes yet, and a
+ * doctor that reports red on a correct install teaches people to ignore it.
+ */
+export function probeClients({ dir }) {
+  let clients = [];
+  try {
+    clients = mcpClientsSeen(dir);
+  } catch {
+    return [ok('MCP clients seen', 'no evidence log yet')];
+  }
+  if (!clients.length) {
+    return [ok('MCP clients seen', 'none yet -- the server has had no MCP handshake in this project')];
+  }
+  const described = clients
+    .slice(0, 5)
+    .map((c) => `${c.title || c.client}${c.version ? ` ${c.version}` : ''}`)
+    .join(', ');
+  return [ok('MCP clients seen', `${clients.length}: ${described}` +
+    (clients.length > 5 ? `, and ${clients.length - 5} more` : ''))];
 }
 
 /**

--- a/integrations/cursor/hooks/lib/doctor.mjs
+++ b/integrations/cursor/hooks/lib/doctor.mjs
@@ -386,11 +386,23 @@ export function checklist({ root, settingsPath, install }) {
       // no longer exist, since a missing file contributes zero bytes -- was
       // computed nowhere and shown to no one.
       const footprint = describeBytes(manifestSize(manifest));
-      checks.push(verified.modified === 0
-        ? ok('installed files intact', `${verified.intact} file(s), ${footprint}, match the install manifest`)
-        : ok('installed files intact', `${verified.modified} of ${verified.intact + verified.modified} file(s) ` +
+      // MISSING IS NOT INTACT, and branching on `modified` alone said it was.
+      // verifyManifest reports three states and this read two of them: a
+      // recorded file DELETED rather than edited left `modified === 0`, so a
+      // half-removed install passed as healthy. The footprint above is what
+      // makes it visible -- a missing file contributes zero bytes -- but a
+      // visible detail beside a PASS is still a PASS.
+      if (verified.missing > 0) {
+        checks.push(bad('installed files intact',
+          `${verified.missing} of ${verified.files.length} recorded file(s) are gone (${footprint} still on disk)`,
+          'reinstall the package to restore them, or run the uninstaller to clear the manifest'));
+      } else if (verified.modified === 0) {
+        checks.push(ok('installed files intact', `${verified.intact} file(s), ${footprint}, match the install manifest`));
+      } else {
+        checks.push(ok('installed files intact', `${verified.modified} of ${verified.intact + verified.modified} file(s) ` +
           `(${footprint} recorded) edited since install -- ` +
           'uninstall will leave those alone rather than destroy your changes'));
+      }
     } else {
       checks.push(bad('install manifest present', 'no record of what was installed',
         'harmless if you installed manually; reinstall to get a removable, verifiable record'));
@@ -538,9 +550,16 @@ export function probeGraph({ dir }) {
   // the bits read back as world-readable regardless, so failing there would be
   // reporting a platform property as a broken install: a false alarm that
   // teaches people to ignore the doctor.
+  // BEFORE THE PLATFORM RETURN, and this is exactly the defect this branch
+  // exists to close: the client probe was appended after `probeGraph`'s
+  // Windows early-return, so on Windows it had a call site and never ran. A
+  // reference that cannot execute is what the reachability guard cannot see.
+  const clients = probeClients({ dir });
+
   if (process.platform === 'win32') {
     checks.push(ok('graph directory is private',
       'POSIX modes are not enforced on Windows; the directory inherits its parent ACL'));
+    checks.push(...clients);
     return checks;
   }
 
@@ -554,7 +573,7 @@ export function probeGraph({ dir }) {
     checks.push(ok('graph directory is private', 'mode could not be read on this filesystem'));
   }
 
-  checks.push(...probeClients({ dir }));
+  checks.push(...clients);
   return checks;
 }
 

--- a/integrations/cursor/hooks/lib/keepwarm.mjs
+++ b/integrations/cursor/hooks/lib/keepwarm.mjs
@@ -110,7 +110,7 @@ export function gapDistribution(dir, { events = readMetrics(dir) } = {}) {
  * Returns the arithmetic as well as the verdict, because a refusal to refresh
  * that cannot be checked is indistinguishable from a bug.
  */
-export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0] }) {
+export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed = null }) {
   if (!prefixTokens || !gaps) {
     return { action: 'unknown', reason: 'no gap distribution yet -- needs a few sessions of history' };
   }
@@ -124,21 +124,42 @@ export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0] }) {
   // The ping only earns anything in the window where the entry WOULD have
   // expired but the next turn still arrives: before the TTL it was already
   // warm, and long after it, one ping does not reach.
-  const probability = Math.max(0, gaps.probabilityWithin(tier.ms * 2) - gaps.probabilityWithin(tier.ms));
+  const modelled = Math.max(0, gaps.probabilityWithin(tier.ms * 2) - gaps.probabilityWithin(tier.ms));
+
+  // MEASURED BEATS MODELLED, once there is enough of it.
+  //
+  // The module header already commits to this -- "an expected-value decision is
+  // only as good as the distribution it was fitted to, and distributions
+  // shift" -- and the tripwire underneath was the only thing acting on it, as
+  // an all-or-nothing kill switch. Between "the model says refresh" and "stop
+  // entirely" there was nothing, because the observed hit rate was never
+  // computed: both recording halves had no call site, so ten refreshes that
+  // bought nothing would keep recommending refresh right up to the moment the
+  // tripwire cut the whole feature off.
+  //
+  // Below OBSERVATION_FLOOR this stays null and the model is used unchanged; a
+  // handful of samples would swing the decision harder than the distribution
+  // they replace.
+  const probability = observed ? observed.rate : modelled;
   const savingIfUsed = prefixTokens * (tier.writeMultiplier - READ_MULTIPLIER);
   const ev = probability * savingIfUsed - costOfPing;
+  const basis = observed
+    ? `measured over ${observed.observations} refreshes`
+    : 'modelled from the gap distribution';
 
   return {
     action: ev > 0 ? 'refresh' : 'skip',
     tier: tier.name,
     probability,
+    modelledProbability: modelled,
+    basis,
     savingIfUsed: Math.round(savingIfUsed),
     costOfPing: Math.round(costOfPing),
     expectedValue: Math.round(ev),
     reason: ev > 0
-      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers; ` +
+      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers (${basis}); ` +
         `expected gain ${Math.round(ev).toLocaleString()} tokens`
-      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers; ` +
+      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers (${basis}); ` +
         `expected loss ${Math.abs(Math.round(ev)).toLocaleString()} tokens`,
   };
 }
@@ -194,9 +215,84 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
   };
 }
 
+/** Observations of a tier before its measured hit rate may override the model. */
+export const OBSERVATION_FLOOR = 5;
+
 /** Records a refresh so its outcome can be scored. */
 export function recordRefresh(dir, { tier, prefixTokens, expectedValue }) {
   record(dir, { kind: 'keepwarm', action: 'refresh', tier, prefixTokens, expectedValue });
+}
+
+/**
+ * Scores every refresh whose window has since resolved.
+ *
+ * THE MISSING HALF, and it was missing because nobody could see where the
+ * signal would come from. `recordRefreshOutcome` needs to know whether a real
+ * turn arrived before the entry expired -- and that is not a thing anyone has
+ * to instrument, because the event log already records when every turn
+ * happened. The answer was in the data the whole time.
+ *
+ * For each unscored refresh at time T on a tier with TTL `ms`:
+ *
+ *   - a later event within `ms`            -> HIT, observed
+ *   - a later event after `ms`             -> MISS, observed
+ *   - no later event, and `now - T > ms`   -> MISS, observed: the window has
+ *                                             demonstrably closed unused
+ *   - no later event, window still open    -> NOTHING RECORDED
+ *
+ * That last line is the important one and it is Plan 2's own instruction: "if
+ * no signal is available for a tier, record nothing rather than guessing
+ * `hit: false`". A refresh whose window has not closed yet is not a miss, and
+ * scoring it as one would drive the tripwire negative on the newest and least
+ * informative records.
+ *
+ * DRAINED AT READ TIME, which is the pattern this codebase already uses for
+ * staleness: the producer cannot know the outcome at the moment it acts, so the
+ * next reader resolves what has become knowable since.
+ */
+export function scoreOutstandingRefreshes(dir, { events = readMetrics(dir), outcomes = readBalance(dir), now = Date.now() } = {}) {
+  const keepwarm = outcomes.filter((e) => e.kind === 'keepwarm');
+  const refreshes = keepwarm.filter((e) => e.action === 'refresh').sort((a, b) => (a.at || 0) - (b.at || 0));
+  const scored = keepwarm.filter((e) => e.action === 'outcome').length;
+
+  // Refreshes are scored oldest-first and one outcome belongs to one refresh,
+  // so everything past the number already scored is outstanding. Pairing by
+  // timestamp instead would double-count two refreshes recorded in the same
+  // millisecond, which is reachable: a tool run twice in a loop.
+  const outstanding = refreshes.slice(scored);
+  const timeline = events.map((e) => Number(e.at) || 0).filter(Boolean).sort((a, b) => a - b);
+
+  let recorded = 0;
+  for (const refresh of outstanding) {
+    const at = Number(refresh.at) || 0;
+    if (!at) continue;
+    const tierSpec = TIERS.find((t) => t.name === refresh.tier) || TIERS[0];
+    const next = timeline.find((t) => t > at);
+
+    let hit;
+    if (next !== undefined) hit = next - at <= tierSpec.ms;
+    else if (now - at > tierSpec.ms) hit = false;
+    else continue; // window still open: not yet knowable
+
+    recordRefreshOutcome(dir, { tier: refresh.tier, prefixTokens: refresh.prefixTokens, hit });
+    recorded += 1;
+  }
+  return { outstanding: outstanding.length, recorded };
+}
+
+/**
+ * The measured hit rate for a tier, or null below the observation floor.
+ *
+ * Null rather than a small-sample number, because the caller substitutes it for
+ * a modelled probability and three observations would swing the decision harder
+ * than the model they replace.
+ */
+export function observedHitRate(dir, { tier, outcomes = readBalance(dir) } = {}) {
+  const relevant = outcomes.filter(
+    (e) => e.kind === 'keepwarm' && e.action === 'outcome' && (!tier || e.tier === tier)
+  );
+  if (relevant.length < OBSERVATION_FLOOR) return null;
+  return { observations: relevant.length, rate: relevant.filter((e) => e.hit).length / relevant.length };
 }
 
 /**
@@ -276,6 +372,18 @@ export function shouldKeepWarm(dir, {
   // was chosen was wrong for one of them.
   outcomes = readBalance(dir),
 } = {}) {
+  // DRAIN BEFORE DECIDING. Anything whose window has closed since the last call
+  // becomes evidence now, so the decision below and the tripwire above both see
+  // the most that is currently knowable -- the same read-time drain the
+  // staleness path uses, and for the same reason: the producer cannot know the
+  // outcome at the moment it acts.
+  try {
+    scoreOutstandingRefreshes(dir, { events, outcomes });
+    outcomes = readBalance(dir);
+  } catch {
+    /* scoring is evidence, never a reason to refuse a decision */
+  }
+
   const trip = tripwire(dir, { events: outcomes });
   if (trip.tripped) return { action: 'skip', reason: trip.reason, trippedWire: true };
 
@@ -289,7 +397,11 @@ export function shouldKeepWarm(dir, {
     // refusal justified by a GAIN: `{ action: 'skip', reason: '...expected gain 130 tokens' }`.
     // This module's own docstring says a refusal that cannot be checked is indistinguishable from
     // a bug; one that contradicts itself is worse.
-    const decision = keepWarmDecision({ prefixTokens, gaps });
+    const decision = keepWarmDecision({
+      prefixTokens,
+      gaps,
+      observed: observedHitRate(dir, { tier: TIERS[0].name, outcomes }),
+    });
     if (decision.action === 'refresh') return decision;
     return { action: decision.action === 'unknown' ? 'unknown' : 'skip', reason: decision.reason };
   }

--- a/integrations/cursor/hooks/lib/metrics.mjs
+++ b/integrations/cursor/hooks/lib/metrics.mjs
@@ -744,6 +744,21 @@ export function balanceSheet(dir) {
           verdict: r.verdict,
         };
       })(),
+      // THE CONTROL ARM'S CONTENT, for the same reason `controlArmTokens` sits
+      // in the substitution block above: `candidateCount` and
+      // `shadowFindingIds` recorded what the holdout withheld and nothing read
+      // them, so the report could count the arms and never say what was in
+      // them.
+      ...(() => {
+        const shadow = shadowDelivery(dir);
+        return {
+          selected: shadow.selected,
+          delivered: shadow.delivered,
+          controlArmSelected: shadow.withheldSelected,
+          controlArmFindings: shadow.withheldFindings,
+          indexStaleEntries: shadow.staleEntries,
+        };
+      })(),
     },
     costs: {
       injection: injectCost,
@@ -1283,6 +1298,109 @@ export function declinedAtBudget(dir, { limit = 500 } = {}) {
       .sort((a, b) => b[1] - a[1])
       .map(([reason, count]) => ({ reason, count })),
   };
+}
+
+/**
+ * The injection arm's SHADOW: what retrieval selected, against what was served.
+ *
+ * THE SAME GAP `controlArmTokens` WAS CREATED TO CLOSE, one arm over. That
+ * field exists because `tokensFullFile` "was recorded and read by nothing, so
+ * the comparison the holdout exists for was not computable from the report" --
+ * and the injection side had the identical hole: every `inject` record carries
+ * `candidateCount` and `shadowFindingIds`, which are what WOULD have been
+ * delivered, non-zero in BOTH arms, while `count` and `findingIds` go to zero
+ * in the holdout. The shadow pair was written on every injection since the
+ * holdout shipped and read by nothing, so the report could say how many touches
+ * landed in each arm and never which findings the holdout actually withheld.
+ *
+ * `staleCount` is the same shape on the session-start index: `stale` (a
+ * boolean, "was any of this stale") had a reader, the count did not, so a index
+ * with one rotten entry in forty was indistinguishable from one rotten
+ * throughout.
+ *
+ * READ FROM THE BALANCE LOG, because `inject` is a BALANCE_KIND: the firehose
+ * evicts injections first -- 136 of them against 6,725 captures on one machine
+ * -- which is the eviction that made `report()` say "0 holdout" over a file
+ * containing nine.
+ */
+export function shadowDelivery(dir) {
+  const injections = readBalance(dir).filter((event) => event.kind === 'inject');
+
+  let selected = 0;
+  let delivered = 0;
+  let withheldSelected = 0;
+  const withheldKeys = new Set();
+  let staleEntries = 0;
+  let indexRecords = 0;
+
+  for (const event of injections) {
+    const candidates = Number(event.candidateCount) || 0;
+    selected += candidates;
+    delivered += Number(event.count) || 0;
+    if (event.holdout) {
+      withheldSelected += candidates;
+      for (const key of event.shadowFindingIds || []) withheldKeys.add(key);
+    }
+    if (event.surface === 'session-start') {
+      indexRecords += 1;
+      staleEntries += Number(event.staleCount) || 0;
+    }
+  }
+
+  return {
+    injections: injections.length,
+    // Everything retrieval chose, across both arms.
+    selected,
+    // What actually reached a model.
+    delivered,
+    // Chosen and deliberately not delivered, because the anchor was in the
+    // withheld arm. This is the control arm's content, which is the thing the
+    // holdout exists to make comparable.
+    withheldSelected,
+    withheldFindings: withheldKeys.size,
+    // Index staleness as a rate rather than a boolean.
+    indexRecords,
+    staleEntries,
+  };
+}
+
+/**
+ * Which MCP clients have actually handshaked with this server.
+ *
+ * `mcp-client` was written on every `initialize` and read by nothing -- a
+ * producer with no reader, and the last one the census found. Deleting it was
+ * the other option and would have been wrong: `mcp-tool` records a client only
+ * once it CALLS something, and the project registry records a name only, so a
+ * client that connected and then called nothing -- which is exactly the failure
+ * this project's doctor exists to diagnose -- appeared in neither. The
+ * handshake is the only record that a connection happened at all.
+ *
+ * `clientTitle` is the field that made the record unique and it was unread too:
+ * the display name a client reports for itself, which is how a user recognises
+ * their own editor in a list where `name` is a slug.
+ */
+export function mcpClientsSeen(dir, { limit = 200 } = {}) {
+  const seen = new Map();
+  for (const event of readEvidence(dir)) {
+    if (event.kind !== 'mcp-client') continue;
+    const name = String(event.client || 'unknown');
+    const at = Number(event.at) || 0;
+    const previous = seen.get(name);
+    // LAST HANDSHAKE WINS on the mutable fields: a client that upgraded should
+    // be reported at the version it is now, not the one it first connected on.
+    if (!previous || at >= previous.at) {
+      seen.set(name, {
+        client: name,
+        title: event.clientTitle || null,
+        version: event.clientVersion || null,
+        at,
+        connections: (previous?.connections || 0) + 1,
+      });
+    } else {
+      previous.connections += 1;
+    }
+  }
+  return [...seen.values()].sort((a, b) => b.at - a.at).slice(0, limit);
 }
 
 /* ----------------------------------------------------------------------

--- a/integrations/cursor/hooks/lib/metrics.mjs
+++ b/integrations/cursor/hooks/lib/metrics.mjs
@@ -1231,6 +1231,60 @@ export function indexBudget(
   return Math.max(floor, Math.min(ceiling, scaled));
 }
 
+/**
+ * What retrieval decided NOT to inject, and why.
+ *
+ * THE OTHER HALF OF THE BUDGET, and it had no reader. `assessFindings` rejects a
+ * finding for one of three reasons -- it has been quarantined as harmful, it is
+ * in cooldown after being injected recently, or its expected value is negative
+ * -- and inject.mjs records every one of those decisions as a
+ * `retrieval-decision` event, from four separate call sites. Nothing read them.
+ *
+ * WHY THAT MATTERS RATHER THAN BEING TIDY. #204 makes the per-touch token budget
+ * load-bearing: "without it the most heavily-worked files accumulate the most
+ * findings and become the most expensive to touch, and the optimizer becomes
+ * its own token problem." A budget that silently drops what it cannot afford is
+ * indistinguishable, from outside, from a graph that had nothing to say. These
+ * are the two states a user most needs told apart, and the records to tell them
+ * apart were already being written.
+ *
+ * READ FROM THE EVIDENCE LOG, not the firehose. `retrieval-decision` is in
+ * EVIDENCE_KINDS precisely because it is rare relative to per-tool-call
+ * telemetry, and the windowed reader would evict it before it accumulated --
+ * the same eviction that made `report()` say "0 holdout" over a file containing
+ * nine.
+ */
+export function declinedAtBudget(dir, { limit = 500 } = {}) {
+  const decisions = readEvidence(dir)
+    .filter((event) => event.kind === 'retrieval-decision')
+    .slice(-limit);
+
+  const byReason = new Map();
+  const keys = new Set();
+  let declined = 0;
+  for (const decision of decisions) {
+    for (const item of decision.rejected || []) {
+      declined += 1;
+      if (item.key) keys.add(item.key);
+      // An unlabelled rejection is counted, not dropped: an unknown reason is
+      // still a finding the model did not get, and reporting the count as
+      // smaller than it is would understate exactly the cost this exists to
+      // surface.
+      const reason = item.reason || 'unspecified';
+      byReason.set(reason, (byReason.get(reason) || 0) + 1);
+    }
+  }
+
+  return {
+    decisions: decisions.length,
+    declined,
+    distinctFindings: keys.size,
+    byReason: [...byReason.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([reason, count]) => ({ reason, count })),
+  };
+}
+
 /* ----------------------------------------------------------------------
  * Episode-level causal evidence
  * ------------------------------------------------------------------- */

--- a/integrations/cursor/hooks/lib/staleness.mjs
+++ b/integrations/cursor/hooks/lib/staleness.mjs
@@ -297,7 +297,25 @@ export function checkAnchor(anchor) {
   if (anchor.kind === 'file') {
     return hash(source) === anchor.hash
       ? { fresh: true }
-      : { fresh: false, before: anchor.snapshot || '', hasBefore: Boolean(anchor.snapshot), after: source, reason: 'file changed' };
+      : {
+          fresh: false,
+          before: anchor.snapshot || '',
+          hasBefore: Boolean(anchor.snapshot),
+          after: source,
+          // AND WHAT CHANGED IT, when the graph knows. The structural harvest
+          // stamps `lastAction` -- the tool name that last touched this file --
+          // on every file node, and nothing read it: the field was written on
+          // every observed tool call since #203 and consumed nowhere.
+          //
+          // It belongs precisely here. "file changed" tells a reader that their
+          // finding may be wrong; "file changed (last touched by Edit)" tells
+          // them a targeted edit did it, which is cheap to re-verify, and "last
+          // touched by Write" says the file was replaced wholesale, which is
+          // usually not. Same disclosure, one word of provenance, no extra I/O.
+          reason: anchor.lastAction
+            ? `file changed (last touched by ${String(anchor.lastAction).slice(0, 40)})`
+            : 'file changed',
+        };
   }
 
   // For a symbol, re-locate it by NAME rather than by line number. Line numbers
@@ -499,6 +517,7 @@ function disputeOf(graph, finding) {
   if (!hasOutstandingContradiction(graph, finding.key)) return {};
 
   const keys = [];
+  const disputantIds = [];
   // AND THE REASON A PERSON TYPED, which had no reader anywhere. `contradict`
   // stores `contradictionReason` -- up to 400 characters of human explanation --
   // on the CONTRADICTED end only, and nothing outside its own test ever read it:
@@ -524,6 +543,7 @@ function disputeOf(graph, finding) {
     // fetch. `hasOutstandingContradiction` above already declines to open the
     // gate when EVERY disputant is retired; this is the same rule applied to
     // each name, so a live disputant is still reported alongside a withdrawn one.
+    if (!disputantIds.includes(otherId)) disputantIds.push(otherId);
     if (other && !other.retired && typeof other.key === 'string' && !keys.includes(other.key)) {
       keys.push(other.key);
       // A RETIRED END'S REASON IS NOT BORROWED EITHER, which is why this sits
@@ -537,9 +557,31 @@ function disputeOf(graph, finding) {
     }
   }
 
+  // WHEN, alongside WHY. `contradict` writes `contradictedAt` and
+  // `contradictionReason` on the same line of the same putNode call. Round 1
+  // gave the reason a reader -- this function -- and left the timestamp
+  // unread, so the disclosure could say a claim was disputed and why, and not
+  // whether that happened this morning or a year ago. For a reader deciding
+  // whether to trust a disputed finding, the age of the dispute is most of the
+  // signal: a year-old objection to a claim nobody has revisited reads very
+  // differently from one raised since the last release.
+  //
+  // Collected from whichever end holds it, exactly like the reason, and the
+  // EARLIEST is kept -- the dispute began when the first end recorded it.
+  let contradictedAt =
+    typeof finding.contradictedAt === 'number' ? finding.contradictedAt : null;
+  for (const id of disputantIds) {
+    const other = graph.nodes.get(id);
+    if (!other || other.retired) continue;
+    if (typeof other.contradictedAt !== 'number') continue;
+    contradictedAt =
+      contradictedAt === null ? other.contradictedAt : Math.min(contradictedAt, other.contradictedAt);
+  }
+
   return {
     contradicted: true,
     ...(keys.length ? { contradictedBy: keys.join(', ') } : {}),
+    ...(contradictedAt !== null ? { contradictedAt } : {}),
     // Trimmed here rather than at the renderer: an empty string is not a reason,
     // and a consumer checking `if (reason)` should not have to trim first.
     //

--- a/integrations/gemini/hooks/lib/audit.mjs
+++ b/integrations/gemini/hooks/lib/audit.mjs
@@ -30,7 +30,7 @@
  * cost at the bottom.
  */
 
-import { record, readMetrics } from './metrics.mjs';
+import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -319,6 +319,35 @@ export function renderAudit(
           `(${trend.improved ? 'improved' : 'worse'})`
       );
     }
+  }
+
+  // WHAT THE BUDGET TURNED AWAY.
+  //
+  // The per-touch token budget is load-bearing by design (#204): without it the
+  // most heavily-worked files accumulate the most findings and become the most
+  // expensive to touch. But a budget that silently drops what it cannot afford
+  // looks, from outside, exactly like a graph that had nothing to say -- and
+  // those are the two states a reader most needs told apart. inject.mjs was
+  // already recording every rejection and its reason, from four call sites, and
+  // nothing read them.
+  //
+  // ONE LINE, not a panel. This is context for the queue above rather than
+  // another thing to do, and the report is held to its own cost.
+  try {
+    const declined = declinedAtBudget(dir);
+    if (declined.declined > 0) {
+      const reasons = declined.byReason
+        .slice(0, 3)
+        .map(({ reason, count }) => `${reason} ${count}`)
+        .join(', ');
+      body.push(
+        '',
+        `Retrieval declined ${declined.declined.toLocaleString()} finding(s) ` +
+          `(${declined.distinctFindings} distinct) across ${declined.decisions.toLocaleString()} decision(s): ${reasons}.`
+      );
+    }
+  } catch {
+    /* the rejection log is context, never a reason to fail the audit */
   }
 
   // STANDING CONTEXT, as a panel rather than only as queue rows.

--- a/integrations/gemini/hooks/lib/audit.mjs
+++ b/integrations/gemini/hooks/lib/audit.mjs
@@ -374,7 +374,16 @@ export function renderAudit(
     // Indented to sit under its heading, blank lines left blank rather than
     // turned into trailing whitespace.
     for (const line of panel.split('\n')) body.push(line ? `  ${line}` : '');
-    if (standing.some((v) => v.actions?.length)) {
+    // ONLY IF THEY ACTUALLY DID. This pointed the reader at "the queue at the
+    // top" whenever any verdict carried an action -- including when the queue
+    // printed "Nothing addressable found", because a caller can render the
+    // panel with no findings at all, and the withholding rule can drop a
+    // standing row even when findings were passed. Telling someone to look at
+    // a row that is not there is worse than saying nothing.
+    const shownStandingIds = new Set(
+      shown.map((item) => item.id).filter((id) => typeof id === 'string' && id.startsWith('standing-'))
+    );
+    if (shownStandingIds.size) {
       body.push(
         '',
         '  The actions above also appear in the queue at the top, where they are priced and applyable.'

--- a/integrations/gemini/hooks/lib/audit.mjs
+++ b/integrations/gemini/hooks/lib/audit.mjs
@@ -33,6 +33,7 @@
 import { record, readMetrics } from './metrics.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
+import { renderStanding } from './standing.mjs';
 
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
 
@@ -183,7 +184,7 @@ export function buildQueue(
 export function renderAudit(
   dir,
   findings = [],
-  { tier = 'opus', full = false, sessionsPerMonth = 60 } = {}
+  { tier = 'opus', full = false, sessionsPerMonth = 60, standing = null } = {}
 ) {
   const { queue, suppressed, done } = buildQueue(dir, findings);
   const lines = [];
@@ -316,6 +317,38 @@ export function renderAudit(
       body.push(
         `  ${trend.detector}: ${trend.before.toLocaleString()} -> ${trend.after.toLocaleString()} tokens/session ` +
           `(${trend.improved ? 'improved' : 'worse'})`
+      );
+    }
+  }
+
+  // STANDING CONTEXT, as a panel rather than only as queue rows.
+  //
+  // auditStanding and verdictFor were both reachable, so this project already
+  // computed which CLAUDE.md rules and skills are stale, oversized or never
+  // used -- and threw the report away. renderStanding existed, was tested, and
+  // had no caller: the forTouch shape exactly, in the subsystem #203 claimed
+  // closed the skills-and-memory gap. Hard to defend a gap as closed while the
+  // report that would show it is unreachable.
+  //
+  // WHAT THE QUEUE ABOVE CANNOT SAY, which is why this is not duplication. The
+  // queue carries one row per ACTION, so a standing file with nothing wrong
+  // contributes no row and is invisible -- and the total cost of the prefix,
+  // the number that says what standing context is worth arguing about at all,
+  // is carried by no row either. Both are in the panel.
+  //
+  // Costed like everything else here: it is pushed BEFORE the closing line is
+  // measured, so the report's self-cost includes its own newest panel rather
+  // than understating it.
+  if (standing?.length) {
+    body.push('', 'Standing context -- charged every session:', '');
+    const panel = renderStanding(standing, { sessionsPerMonth });
+    // Indented to sit under its heading, blank lines left blank rather than
+    // turned into trailing whitespace.
+    for (const line of panel.split('\n')) body.push(line ? `  ${line}` : '');
+    if (standing.some((v) => v.actions?.length)) {
+      body.push(
+        '',
+        '  The actions above also appear in the queue at the top, where they are priced and applyable.'
       );
     }
   }

--- a/integrations/gemini/hooks/lib/consolidate.mjs
+++ b/integrations/gemini/hooks/lib/consolidate.mjs
@@ -36,6 +36,28 @@ import { nodeId } from './wiki.mjs';
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
 
 /**
+ * A candidate's own words, whatever the producer called the field.
+ *
+ * THE SELECTOR AND THE RATIO DISAGREED ABOUT THIS, and the half that had no
+ * caller is the half that was wrong. `irrecoverability`, `costToRederive` and
+ * `selectForConsolidation` all read `entry.summary`; `consolidationRatio` and
+ * `aggregateConsolidation` read `finding.claim`. NO PRODUCER IN THIS REPOSITORY
+ * EMITS `summary` -- the semantic harvest, wiki_write and the evaluation
+ * harnesses all emit `claim`, and `validate()` in harvest.mjs rejects anything
+ * without one.
+ *
+ * That matters more than a rename. Wired naively, every candidate would have
+ * scored `tokens: estimate(undefined)` -- zero -- so the budget could never
+ * bind, nothing would ever be dropped, and the selector would have been live,
+ * green, and inert. A capability that runs and cannot affect its own output is
+ * the same defect as one that never runs, wearing a call site.
+ *
+ * `summary` is still accepted, because an external caller may pass it and
+ * breaking that to fix an internal disagreement would be gratuitous.
+ */
+const claimText = (entry) => entry?.claim || entry?.summary || '';
+
+/**
  * How hard something is to reproduce, independent of what it cost this time.
  *
  * Token cost alone understates the expensive cases. Reproducing a flaky failure
@@ -45,7 +67,7 @@ const estimate = (text) => Math.ceil(String(text || '').length / 4);
  * measurements, and pretending otherwise would be false precision.
  */
 export function irrecoverability(entry) {
-  const text = `${entry.summary || ''} ${entry.evidence || ''}`.toLowerCase();
+  const text = `${claimText(entry)} ${entry.evidence || ''}`.toLowerCase();
 
   // Anything derived from a non-deterministic or long-running observation.
   //
@@ -110,7 +132,7 @@ export function costToRederive(entry, previousAt) {
   // no-op. The only measured cost is `entry.tokensSpent`, which the extraction
   // site must supply; otherwise fall back to the size of the evidence, so a
   // conclusion drawn from a large investigation still outranks an aside.
-  return estimate(entry.evidence) * 4 || estimate(entry.summary) * 8;
+  return estimate(entry.evidence) * 4 || estimate(claimText(entry)) * 8;
 }
 
 /** Kinds that survive on the floor regardless of score. */
@@ -141,7 +163,7 @@ export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}
     });
     const cost = costToRederive(entry, previousAt);
     const score = cost * irrecoverability(entry) * reuseProbability(graph, entry.anchorIds || anchors);
-    scored.push({ entry, score, cost, tokens: estimate(entry.summary) });
+    scored.push({ entry, score, cost, tokens: estimate(claimText(entry)) });
     previousAt = entry.at ?? previousAt;
   }
 
@@ -182,7 +204,7 @@ export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}
  * FOR, in a way that "tokens saved" never quite is.
  */
 export function consolidationRatio(finding) {
-  const carry = estimate(finding.claim);
+  const carry = estimate(claimText(finding));
   const derived = finding.derivedCost || 0;
   if (!carry || !derived) return null;
   return derived / carry;
@@ -195,7 +217,7 @@ export function aggregateConsolidation(findings) {
   for (const finding of findings) {
     if (!finding.derivedCost) continue;
     derived += finding.derivedCost;
-    carry += estimate(finding.claim);
+    carry += estimate(claimText(finding));
   }
   return carry ? { derived, carry, ratio: derived / carry } : null;
 }

--- a/integrations/gemini/hooks/lib/consolidate.mjs
+++ b/integrations/gemini/hooks/lib/consolidate.mjs
@@ -31,7 +31,6 @@
  * without session instrumentation cannot obtain.
  */
 
-import { statSync } from 'node:fs';
 import { nodeId } from './wiki.mjs';
 
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
@@ -201,25 +200,3 @@ export function aggregateConsolidation(findings) {
   return carry ? { derived, carry, ratio: derived / carry } : null;
 }
 
-/**
- * Content identity for a file, so a finding can reach across projects.
- *
- * A vendored library file is the same file in every repository that holds it,
- * whatever path each gives it. Anchoring to content as well as path means a
- * finding about it appears in all of them with no promotion step and no path
- * mapping -- reach a per-session checkpoint cannot have even in principle.
- *
- * The PATH anchor still drives staleness within a repo; this is additive.
- */
-export function contentAnchor(path, hash) {
-  if (!hash) return null;
-  let size = 0;
-  try {
-    size = statSync(path).size;
-  } catch {
-    return null;
-  }
-  // Size is included so two different files sharing a truncated digest do not
-  // collide into one identity.
-  return `content:${hash}:${size}`;
-}

--- a/integrations/gemini/hooks/lib/doctor.mjs
+++ b/integrations/gemini/hooks/lib/doctor.mjs
@@ -26,7 +26,21 @@ import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSyn
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { harvestMode } from './harvest.mjs';
-import { readManifest, verifyManifest, residue } from './manifest.mjs';
+import { readManifest, verifyManifest, residue, manifestSize } from './manifest.mjs';
+
+/**
+ * Bytes as a person reads them.
+ *
+ * Local because it exists for one line of one check, and because the alternative
+ * -- printing a raw byte count next to a file count -- is the kind of detail
+ * that gets skimmed past rather than read.
+ */
+function describeBytes(bytes) {
+  if (!bytes) return 'size unknown';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
 
 const ok = (name, detail) => ({ name, pass: true, detail });
 const bad = (name, detail, remedy) => ({ name, pass: false, detail, remedy });
@@ -362,11 +376,19 @@ export function checklist({ root, settingsPath, install }) {
     }
 
     // What we recorded putting on the machine, and whether it is still that.
-    const verified = verifyManifest(readManifest());
+    const manifest = readManifest();
+    const verified = verifyManifest(manifest);
     if (verified) {
+      // HOW MUCH, not just how many. manifestSize computed exactly this and had
+      // no caller, so the one number that says what uninstall will actually
+      // remove -- and the only cross-check on a manifest that lists files which
+      // no longer exist, since a missing file contributes zero bytes -- was
+      // computed nowhere and shown to no one.
+      const footprint = describeBytes(manifestSize(manifest));
       checks.push(verified.modified === 0
-        ? ok('installed files intact', `${verified.intact} file(s) match the install manifest`)
-        : ok('installed files intact', `${verified.modified} file(s) edited since install -- ` +
+        ? ok('installed files intact', `${verified.intact} file(s), ${footprint}, match the install manifest`)
+        : ok('installed files intact', `${verified.modified} of ${verified.intact + verified.modified} file(s) ` +
+          `(${footprint} recorded) edited since install -- ` +
           'uninstall will leave those alone rather than destroy your changes'));
     } else {
       checks.push(bad('install manifest present', 'no record of what was installed',

--- a/integrations/gemini/hooks/lib/doctor.mjs
+++ b/integrations/gemini/hooks/lib/doctor.mjs
@@ -27,6 +27,7 @@ import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { harvestMode } from './harvest.mjs';
 import { readManifest, verifyManifest, residue, manifestSize } from './manifest.mjs';
+import { mcpClientsSeen } from './metrics.mjs';
 
 /**
  * Bytes as a person reads them.
@@ -553,7 +554,39 @@ export function probeGraph({ dir }) {
     checks.push(ok('graph directory is private', 'mode could not be read on this filesystem'));
   }
 
+  checks.push(...probeClients({ dir }));
   return checks;
+}
+
+/**
+ * Which MCP clients have actually handshaked with this server.
+ *
+ * THE QUESTION THE REST OF THE DOCTOR CANNOT ANSWER. Every other check here
+ * reasons about files on disk: is the hook present, is it wired, does it refuse
+ * a large read. None of them can tell you whether the editor in front of you
+ * ever actually connected -- which is the single most common way this product
+ * is installed and silently does nothing.
+ *
+ * `mcp-client` records exactly that on every `initialize`, and nothing read it
+ * until now. NEVER A FAILURE: a fresh install has no handshakes yet, and a
+ * doctor that reports red on a correct install teaches people to ignore it.
+ */
+export function probeClients({ dir }) {
+  let clients = [];
+  try {
+    clients = mcpClientsSeen(dir);
+  } catch {
+    return [ok('MCP clients seen', 'no evidence log yet')];
+  }
+  if (!clients.length) {
+    return [ok('MCP clients seen', 'none yet -- the server has had no MCP handshake in this project')];
+  }
+  const described = clients
+    .slice(0, 5)
+    .map((c) => `${c.title || c.client}${c.version ? ` ${c.version}` : ''}`)
+    .join(', ');
+  return [ok('MCP clients seen', `${clients.length}: ${described}` +
+    (clients.length > 5 ? `, and ${clients.length - 5} more` : ''))];
 }
 
 /**

--- a/integrations/gemini/hooks/lib/doctor.mjs
+++ b/integrations/gemini/hooks/lib/doctor.mjs
@@ -386,11 +386,23 @@ export function checklist({ root, settingsPath, install }) {
       // no longer exist, since a missing file contributes zero bytes -- was
       // computed nowhere and shown to no one.
       const footprint = describeBytes(manifestSize(manifest));
-      checks.push(verified.modified === 0
-        ? ok('installed files intact', `${verified.intact} file(s), ${footprint}, match the install manifest`)
-        : ok('installed files intact', `${verified.modified} of ${verified.intact + verified.modified} file(s) ` +
+      // MISSING IS NOT INTACT, and branching on `modified` alone said it was.
+      // verifyManifest reports three states and this read two of them: a
+      // recorded file DELETED rather than edited left `modified === 0`, so a
+      // half-removed install passed as healthy. The footprint above is what
+      // makes it visible -- a missing file contributes zero bytes -- but a
+      // visible detail beside a PASS is still a PASS.
+      if (verified.missing > 0) {
+        checks.push(bad('installed files intact',
+          `${verified.missing} of ${verified.files.length} recorded file(s) are gone (${footprint} still on disk)`,
+          'reinstall the package to restore them, or run the uninstaller to clear the manifest'));
+      } else if (verified.modified === 0) {
+        checks.push(ok('installed files intact', `${verified.intact} file(s), ${footprint}, match the install manifest`));
+      } else {
+        checks.push(ok('installed files intact', `${verified.modified} of ${verified.intact + verified.modified} file(s) ` +
           `(${footprint} recorded) edited since install -- ` +
           'uninstall will leave those alone rather than destroy your changes'));
+      }
     } else {
       checks.push(bad('install manifest present', 'no record of what was installed',
         'harmless if you installed manually; reinstall to get a removable, verifiable record'));
@@ -538,9 +550,16 @@ export function probeGraph({ dir }) {
   // the bits read back as world-readable regardless, so failing there would be
   // reporting a platform property as a broken install: a false alarm that
   // teaches people to ignore the doctor.
+  // BEFORE THE PLATFORM RETURN, and this is exactly the defect this branch
+  // exists to close: the client probe was appended after `probeGraph`'s
+  // Windows early-return, so on Windows it had a call site and never ran. A
+  // reference that cannot execute is what the reachability guard cannot see.
+  const clients = probeClients({ dir });
+
   if (process.platform === 'win32') {
     checks.push(ok('graph directory is private',
       'POSIX modes are not enforced on Windows; the directory inherits its parent ACL'));
+    checks.push(...clients);
     return checks;
   }
 
@@ -554,7 +573,7 @@ export function probeGraph({ dir }) {
     checks.push(ok('graph directory is private', 'mode could not be read on this filesystem'));
   }
 
-  checks.push(...probeClients({ dir }));
+  checks.push(...clients);
   return checks;
 }
 

--- a/integrations/gemini/hooks/lib/keepwarm.mjs
+++ b/integrations/gemini/hooks/lib/keepwarm.mjs
@@ -110,7 +110,7 @@ export function gapDistribution(dir, { events = readMetrics(dir) } = {}) {
  * Returns the arithmetic as well as the verdict, because a refusal to refresh
  * that cannot be checked is indistinguishable from a bug.
  */
-export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0] }) {
+export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed = null }) {
   if (!prefixTokens || !gaps) {
     return { action: 'unknown', reason: 'no gap distribution yet -- needs a few sessions of history' };
   }
@@ -124,21 +124,42 @@ export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0] }) {
   // The ping only earns anything in the window where the entry WOULD have
   // expired but the next turn still arrives: before the TTL it was already
   // warm, and long after it, one ping does not reach.
-  const probability = Math.max(0, gaps.probabilityWithin(tier.ms * 2) - gaps.probabilityWithin(tier.ms));
+  const modelled = Math.max(0, gaps.probabilityWithin(tier.ms * 2) - gaps.probabilityWithin(tier.ms));
+
+  // MEASURED BEATS MODELLED, once there is enough of it.
+  //
+  // The module header already commits to this -- "an expected-value decision is
+  // only as good as the distribution it was fitted to, and distributions
+  // shift" -- and the tripwire underneath was the only thing acting on it, as
+  // an all-or-nothing kill switch. Between "the model says refresh" and "stop
+  // entirely" there was nothing, because the observed hit rate was never
+  // computed: both recording halves had no call site, so ten refreshes that
+  // bought nothing would keep recommending refresh right up to the moment the
+  // tripwire cut the whole feature off.
+  //
+  // Below OBSERVATION_FLOOR this stays null and the model is used unchanged; a
+  // handful of samples would swing the decision harder than the distribution
+  // they replace.
+  const probability = observed ? observed.rate : modelled;
   const savingIfUsed = prefixTokens * (tier.writeMultiplier - READ_MULTIPLIER);
   const ev = probability * savingIfUsed - costOfPing;
+  const basis = observed
+    ? `measured over ${observed.observations} refreshes`
+    : 'modelled from the gap distribution';
 
   return {
     action: ev > 0 ? 'refresh' : 'skip',
     tier: tier.name,
     probability,
+    modelledProbability: modelled,
+    basis,
     savingIfUsed: Math.round(savingIfUsed),
     costOfPing: Math.round(costOfPing),
     expectedValue: Math.round(ev),
     reason: ev > 0
-      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers; ` +
+      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers (${basis}); ` +
         `expected gain ${Math.round(ev).toLocaleString()} tokens`
-      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers; ` +
+      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers (${basis}); ` +
         `expected loss ${Math.abs(Math.round(ev)).toLocaleString()} tokens`,
   };
 }
@@ -194,9 +215,84 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
   };
 }
 
+/** Observations of a tier before its measured hit rate may override the model. */
+export const OBSERVATION_FLOOR = 5;
+
 /** Records a refresh so its outcome can be scored. */
 export function recordRefresh(dir, { tier, prefixTokens, expectedValue }) {
   record(dir, { kind: 'keepwarm', action: 'refresh', tier, prefixTokens, expectedValue });
+}
+
+/**
+ * Scores every refresh whose window has since resolved.
+ *
+ * THE MISSING HALF, and it was missing because nobody could see where the
+ * signal would come from. `recordRefreshOutcome` needs to know whether a real
+ * turn arrived before the entry expired -- and that is not a thing anyone has
+ * to instrument, because the event log already records when every turn
+ * happened. The answer was in the data the whole time.
+ *
+ * For each unscored refresh at time T on a tier with TTL `ms`:
+ *
+ *   - a later event within `ms`            -> HIT, observed
+ *   - a later event after `ms`             -> MISS, observed
+ *   - no later event, and `now - T > ms`   -> MISS, observed: the window has
+ *                                             demonstrably closed unused
+ *   - no later event, window still open    -> NOTHING RECORDED
+ *
+ * That last line is the important one and it is Plan 2's own instruction: "if
+ * no signal is available for a tier, record nothing rather than guessing
+ * `hit: false`". A refresh whose window has not closed yet is not a miss, and
+ * scoring it as one would drive the tripwire negative on the newest and least
+ * informative records.
+ *
+ * DRAINED AT READ TIME, which is the pattern this codebase already uses for
+ * staleness: the producer cannot know the outcome at the moment it acts, so the
+ * next reader resolves what has become knowable since.
+ */
+export function scoreOutstandingRefreshes(dir, { events = readMetrics(dir), outcomes = readBalance(dir), now = Date.now() } = {}) {
+  const keepwarm = outcomes.filter((e) => e.kind === 'keepwarm');
+  const refreshes = keepwarm.filter((e) => e.action === 'refresh').sort((a, b) => (a.at || 0) - (b.at || 0));
+  const scored = keepwarm.filter((e) => e.action === 'outcome').length;
+
+  // Refreshes are scored oldest-first and one outcome belongs to one refresh,
+  // so everything past the number already scored is outstanding. Pairing by
+  // timestamp instead would double-count two refreshes recorded in the same
+  // millisecond, which is reachable: a tool run twice in a loop.
+  const outstanding = refreshes.slice(scored);
+  const timeline = events.map((e) => Number(e.at) || 0).filter(Boolean).sort((a, b) => a - b);
+
+  let recorded = 0;
+  for (const refresh of outstanding) {
+    const at = Number(refresh.at) || 0;
+    if (!at) continue;
+    const tierSpec = TIERS.find((t) => t.name === refresh.tier) || TIERS[0];
+    const next = timeline.find((t) => t > at);
+
+    let hit;
+    if (next !== undefined) hit = next - at <= tierSpec.ms;
+    else if (now - at > tierSpec.ms) hit = false;
+    else continue; // window still open: not yet knowable
+
+    recordRefreshOutcome(dir, { tier: refresh.tier, prefixTokens: refresh.prefixTokens, hit });
+    recorded += 1;
+  }
+  return { outstanding: outstanding.length, recorded };
+}
+
+/**
+ * The measured hit rate for a tier, or null below the observation floor.
+ *
+ * Null rather than a small-sample number, because the caller substitutes it for
+ * a modelled probability and three observations would swing the decision harder
+ * than the model they replace.
+ */
+export function observedHitRate(dir, { tier, outcomes = readBalance(dir) } = {}) {
+  const relevant = outcomes.filter(
+    (e) => e.kind === 'keepwarm' && e.action === 'outcome' && (!tier || e.tier === tier)
+  );
+  if (relevant.length < OBSERVATION_FLOOR) return null;
+  return { observations: relevant.length, rate: relevant.filter((e) => e.hit).length / relevant.length };
 }
 
 /**
@@ -276,6 +372,18 @@ export function shouldKeepWarm(dir, {
   // was chosen was wrong for one of them.
   outcomes = readBalance(dir),
 } = {}) {
+  // DRAIN BEFORE DECIDING. Anything whose window has closed since the last call
+  // becomes evidence now, so the decision below and the tripwire above both see
+  // the most that is currently knowable -- the same read-time drain the
+  // staleness path uses, and for the same reason: the producer cannot know the
+  // outcome at the moment it acts.
+  try {
+    scoreOutstandingRefreshes(dir, { events, outcomes });
+    outcomes = readBalance(dir);
+  } catch {
+    /* scoring is evidence, never a reason to refuse a decision */
+  }
+
   const trip = tripwire(dir, { events: outcomes });
   if (trip.tripped) return { action: 'skip', reason: trip.reason, trippedWire: true };
 
@@ -289,7 +397,11 @@ export function shouldKeepWarm(dir, {
     // refusal justified by a GAIN: `{ action: 'skip', reason: '...expected gain 130 tokens' }`.
     // This module's own docstring says a refusal that cannot be checked is indistinguishable from
     // a bug; one that contradicts itself is worse.
-    const decision = keepWarmDecision({ prefixTokens, gaps });
+    const decision = keepWarmDecision({
+      prefixTokens,
+      gaps,
+      observed: observedHitRate(dir, { tier: TIERS[0].name, outcomes }),
+    });
     if (decision.action === 'refresh') return decision;
     return { action: decision.action === 'unknown' ? 'unknown' : 'skip', reason: decision.reason };
   }

--- a/integrations/gemini/hooks/lib/metrics.mjs
+++ b/integrations/gemini/hooks/lib/metrics.mjs
@@ -744,6 +744,21 @@ export function balanceSheet(dir) {
           verdict: r.verdict,
         };
       })(),
+      // THE CONTROL ARM'S CONTENT, for the same reason `controlArmTokens` sits
+      // in the substitution block above: `candidateCount` and
+      // `shadowFindingIds` recorded what the holdout withheld and nothing read
+      // them, so the report could count the arms and never say what was in
+      // them.
+      ...(() => {
+        const shadow = shadowDelivery(dir);
+        return {
+          selected: shadow.selected,
+          delivered: shadow.delivered,
+          controlArmSelected: shadow.withheldSelected,
+          controlArmFindings: shadow.withheldFindings,
+          indexStaleEntries: shadow.staleEntries,
+        };
+      })(),
     },
     costs: {
       injection: injectCost,
@@ -1283,6 +1298,109 @@ export function declinedAtBudget(dir, { limit = 500 } = {}) {
       .sort((a, b) => b[1] - a[1])
       .map(([reason, count]) => ({ reason, count })),
   };
+}
+
+/**
+ * The injection arm's SHADOW: what retrieval selected, against what was served.
+ *
+ * THE SAME GAP `controlArmTokens` WAS CREATED TO CLOSE, one arm over. That
+ * field exists because `tokensFullFile` "was recorded and read by nothing, so
+ * the comparison the holdout exists for was not computable from the report" --
+ * and the injection side had the identical hole: every `inject` record carries
+ * `candidateCount` and `shadowFindingIds`, which are what WOULD have been
+ * delivered, non-zero in BOTH arms, while `count` and `findingIds` go to zero
+ * in the holdout. The shadow pair was written on every injection since the
+ * holdout shipped and read by nothing, so the report could say how many touches
+ * landed in each arm and never which findings the holdout actually withheld.
+ *
+ * `staleCount` is the same shape on the session-start index: `stale` (a
+ * boolean, "was any of this stale") had a reader, the count did not, so a index
+ * with one rotten entry in forty was indistinguishable from one rotten
+ * throughout.
+ *
+ * READ FROM THE BALANCE LOG, because `inject` is a BALANCE_KIND: the firehose
+ * evicts injections first -- 136 of them against 6,725 captures on one machine
+ * -- which is the eviction that made `report()` say "0 holdout" over a file
+ * containing nine.
+ */
+export function shadowDelivery(dir) {
+  const injections = readBalance(dir).filter((event) => event.kind === 'inject');
+
+  let selected = 0;
+  let delivered = 0;
+  let withheldSelected = 0;
+  const withheldKeys = new Set();
+  let staleEntries = 0;
+  let indexRecords = 0;
+
+  for (const event of injections) {
+    const candidates = Number(event.candidateCount) || 0;
+    selected += candidates;
+    delivered += Number(event.count) || 0;
+    if (event.holdout) {
+      withheldSelected += candidates;
+      for (const key of event.shadowFindingIds || []) withheldKeys.add(key);
+    }
+    if (event.surface === 'session-start') {
+      indexRecords += 1;
+      staleEntries += Number(event.staleCount) || 0;
+    }
+  }
+
+  return {
+    injections: injections.length,
+    // Everything retrieval chose, across both arms.
+    selected,
+    // What actually reached a model.
+    delivered,
+    // Chosen and deliberately not delivered, because the anchor was in the
+    // withheld arm. This is the control arm's content, which is the thing the
+    // holdout exists to make comparable.
+    withheldSelected,
+    withheldFindings: withheldKeys.size,
+    // Index staleness as a rate rather than a boolean.
+    indexRecords,
+    staleEntries,
+  };
+}
+
+/**
+ * Which MCP clients have actually handshaked with this server.
+ *
+ * `mcp-client` was written on every `initialize` and read by nothing -- a
+ * producer with no reader, and the last one the census found. Deleting it was
+ * the other option and would have been wrong: `mcp-tool` records a client only
+ * once it CALLS something, and the project registry records a name only, so a
+ * client that connected and then called nothing -- which is exactly the failure
+ * this project's doctor exists to diagnose -- appeared in neither. The
+ * handshake is the only record that a connection happened at all.
+ *
+ * `clientTitle` is the field that made the record unique and it was unread too:
+ * the display name a client reports for itself, which is how a user recognises
+ * their own editor in a list where `name` is a slug.
+ */
+export function mcpClientsSeen(dir, { limit = 200 } = {}) {
+  const seen = new Map();
+  for (const event of readEvidence(dir)) {
+    if (event.kind !== 'mcp-client') continue;
+    const name = String(event.client || 'unknown');
+    const at = Number(event.at) || 0;
+    const previous = seen.get(name);
+    // LAST HANDSHAKE WINS on the mutable fields: a client that upgraded should
+    // be reported at the version it is now, not the one it first connected on.
+    if (!previous || at >= previous.at) {
+      seen.set(name, {
+        client: name,
+        title: event.clientTitle || null,
+        version: event.clientVersion || null,
+        at,
+        connections: (previous?.connections || 0) + 1,
+      });
+    } else {
+      previous.connections += 1;
+    }
+  }
+  return [...seen.values()].sort((a, b) => b.at - a.at).slice(0, limit);
 }
 
 /* ----------------------------------------------------------------------

--- a/integrations/gemini/hooks/lib/metrics.mjs
+++ b/integrations/gemini/hooks/lib/metrics.mjs
@@ -1231,6 +1231,60 @@ export function indexBudget(
   return Math.max(floor, Math.min(ceiling, scaled));
 }
 
+/**
+ * What retrieval decided NOT to inject, and why.
+ *
+ * THE OTHER HALF OF THE BUDGET, and it had no reader. `assessFindings` rejects a
+ * finding for one of three reasons -- it has been quarantined as harmful, it is
+ * in cooldown after being injected recently, or its expected value is negative
+ * -- and inject.mjs records every one of those decisions as a
+ * `retrieval-decision` event, from four separate call sites. Nothing read them.
+ *
+ * WHY THAT MATTERS RATHER THAN BEING TIDY. #204 makes the per-touch token budget
+ * load-bearing: "without it the most heavily-worked files accumulate the most
+ * findings and become the most expensive to touch, and the optimizer becomes
+ * its own token problem." A budget that silently drops what it cannot afford is
+ * indistinguishable, from outside, from a graph that had nothing to say. These
+ * are the two states a user most needs told apart, and the records to tell them
+ * apart were already being written.
+ *
+ * READ FROM THE EVIDENCE LOG, not the firehose. `retrieval-decision` is in
+ * EVIDENCE_KINDS precisely because it is rare relative to per-tool-call
+ * telemetry, and the windowed reader would evict it before it accumulated --
+ * the same eviction that made `report()` say "0 holdout" over a file containing
+ * nine.
+ */
+export function declinedAtBudget(dir, { limit = 500 } = {}) {
+  const decisions = readEvidence(dir)
+    .filter((event) => event.kind === 'retrieval-decision')
+    .slice(-limit);
+
+  const byReason = new Map();
+  const keys = new Set();
+  let declined = 0;
+  for (const decision of decisions) {
+    for (const item of decision.rejected || []) {
+      declined += 1;
+      if (item.key) keys.add(item.key);
+      // An unlabelled rejection is counted, not dropped: an unknown reason is
+      // still a finding the model did not get, and reporting the count as
+      // smaller than it is would understate exactly the cost this exists to
+      // surface.
+      const reason = item.reason || 'unspecified';
+      byReason.set(reason, (byReason.get(reason) || 0) + 1);
+    }
+  }
+
+  return {
+    decisions: decisions.length,
+    declined,
+    distinctFindings: keys.size,
+    byReason: [...byReason.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([reason, count]) => ({ reason, count })),
+  };
+}
+
 /* ----------------------------------------------------------------------
  * Episode-level causal evidence
  * ------------------------------------------------------------------- */

--- a/integrations/gemini/hooks/lib/staleness.mjs
+++ b/integrations/gemini/hooks/lib/staleness.mjs
@@ -297,7 +297,25 @@ export function checkAnchor(anchor) {
   if (anchor.kind === 'file') {
     return hash(source) === anchor.hash
       ? { fresh: true }
-      : { fresh: false, before: anchor.snapshot || '', hasBefore: Boolean(anchor.snapshot), after: source, reason: 'file changed' };
+      : {
+          fresh: false,
+          before: anchor.snapshot || '',
+          hasBefore: Boolean(anchor.snapshot),
+          after: source,
+          // AND WHAT CHANGED IT, when the graph knows. The structural harvest
+          // stamps `lastAction` -- the tool name that last touched this file --
+          // on every file node, and nothing read it: the field was written on
+          // every observed tool call since #203 and consumed nowhere.
+          //
+          // It belongs precisely here. "file changed" tells a reader that their
+          // finding may be wrong; "file changed (last touched by Edit)" tells
+          // them a targeted edit did it, which is cheap to re-verify, and "last
+          // touched by Write" says the file was replaced wholesale, which is
+          // usually not. Same disclosure, one word of provenance, no extra I/O.
+          reason: anchor.lastAction
+            ? `file changed (last touched by ${String(anchor.lastAction).slice(0, 40)})`
+            : 'file changed',
+        };
   }
 
   // For a symbol, re-locate it by NAME rather than by line number. Line numbers
@@ -499,6 +517,7 @@ function disputeOf(graph, finding) {
   if (!hasOutstandingContradiction(graph, finding.key)) return {};
 
   const keys = [];
+  const disputantIds = [];
   // AND THE REASON A PERSON TYPED, which had no reader anywhere. `contradict`
   // stores `contradictionReason` -- up to 400 characters of human explanation --
   // on the CONTRADICTED end only, and nothing outside its own test ever read it:
@@ -524,6 +543,7 @@ function disputeOf(graph, finding) {
     // fetch. `hasOutstandingContradiction` above already declines to open the
     // gate when EVERY disputant is retired; this is the same rule applied to
     // each name, so a live disputant is still reported alongside a withdrawn one.
+    if (!disputantIds.includes(otherId)) disputantIds.push(otherId);
     if (other && !other.retired && typeof other.key === 'string' && !keys.includes(other.key)) {
       keys.push(other.key);
       // A RETIRED END'S REASON IS NOT BORROWED EITHER, which is why this sits
@@ -537,9 +557,31 @@ function disputeOf(graph, finding) {
     }
   }
 
+  // WHEN, alongside WHY. `contradict` writes `contradictedAt` and
+  // `contradictionReason` on the same line of the same putNode call. Round 1
+  // gave the reason a reader -- this function -- and left the timestamp
+  // unread, so the disclosure could say a claim was disputed and why, and not
+  // whether that happened this morning or a year ago. For a reader deciding
+  // whether to trust a disputed finding, the age of the dispute is most of the
+  // signal: a year-old objection to a claim nobody has revisited reads very
+  // differently from one raised since the last release.
+  //
+  // Collected from whichever end holds it, exactly like the reason, and the
+  // EARLIEST is kept -- the dispute began when the first end recorded it.
+  let contradictedAt =
+    typeof finding.contradictedAt === 'number' ? finding.contradictedAt : null;
+  for (const id of disputantIds) {
+    const other = graph.nodes.get(id);
+    if (!other || other.retired) continue;
+    if (typeof other.contradictedAt !== 'number') continue;
+    contradictedAt =
+      contradictedAt === null ? other.contradictedAt : Math.min(contradictedAt, other.contradictedAt);
+  }
+
   return {
     contradicted: true,
     ...(keys.length ? { contradictedBy: keys.join(', ') } : {}),
+    ...(contradictedAt !== null ? { contradictedAt } : {}),
     // Trimmed here rather than at the renderer: an empty string is not a reason,
     // and a consumer checking `if (reason)` should not have to trim first.
     //

--- a/integrations/kilo/hooks/lib/audit.mjs
+++ b/integrations/kilo/hooks/lib/audit.mjs
@@ -30,7 +30,7 @@
  * cost at the bottom.
  */
 
-import { record, readMetrics } from './metrics.mjs';
+import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -319,6 +319,35 @@ export function renderAudit(
           `(${trend.improved ? 'improved' : 'worse'})`
       );
     }
+  }
+
+  // WHAT THE BUDGET TURNED AWAY.
+  //
+  // The per-touch token budget is load-bearing by design (#204): without it the
+  // most heavily-worked files accumulate the most findings and become the most
+  // expensive to touch. But a budget that silently drops what it cannot afford
+  // looks, from outside, exactly like a graph that had nothing to say -- and
+  // those are the two states a reader most needs told apart. inject.mjs was
+  // already recording every rejection and its reason, from four call sites, and
+  // nothing read them.
+  //
+  // ONE LINE, not a panel. This is context for the queue above rather than
+  // another thing to do, and the report is held to its own cost.
+  try {
+    const declined = declinedAtBudget(dir);
+    if (declined.declined > 0) {
+      const reasons = declined.byReason
+        .slice(0, 3)
+        .map(({ reason, count }) => `${reason} ${count}`)
+        .join(', ');
+      body.push(
+        '',
+        `Retrieval declined ${declined.declined.toLocaleString()} finding(s) ` +
+          `(${declined.distinctFindings} distinct) across ${declined.decisions.toLocaleString()} decision(s): ${reasons}.`
+      );
+    }
+  } catch {
+    /* the rejection log is context, never a reason to fail the audit */
   }
 
   // STANDING CONTEXT, as a panel rather than only as queue rows.

--- a/integrations/kilo/hooks/lib/audit.mjs
+++ b/integrations/kilo/hooks/lib/audit.mjs
@@ -374,7 +374,16 @@ export function renderAudit(
     // Indented to sit under its heading, blank lines left blank rather than
     // turned into trailing whitespace.
     for (const line of panel.split('\n')) body.push(line ? `  ${line}` : '');
-    if (standing.some((v) => v.actions?.length)) {
+    // ONLY IF THEY ACTUALLY DID. This pointed the reader at "the queue at the
+    // top" whenever any verdict carried an action -- including when the queue
+    // printed "Nothing addressable found", because a caller can render the
+    // panel with no findings at all, and the withholding rule can drop a
+    // standing row even when findings were passed. Telling someone to look at
+    // a row that is not there is worse than saying nothing.
+    const shownStandingIds = new Set(
+      shown.map((item) => item.id).filter((id) => typeof id === 'string' && id.startsWith('standing-'))
+    );
+    if (shownStandingIds.size) {
       body.push(
         '',
         '  The actions above also appear in the queue at the top, where they are priced and applyable.'

--- a/integrations/kilo/hooks/lib/audit.mjs
+++ b/integrations/kilo/hooks/lib/audit.mjs
@@ -33,6 +33,7 @@
 import { record, readMetrics } from './metrics.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
+import { renderStanding } from './standing.mjs';
 
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
 
@@ -183,7 +184,7 @@ export function buildQueue(
 export function renderAudit(
   dir,
   findings = [],
-  { tier = 'opus', full = false, sessionsPerMonth = 60 } = {}
+  { tier = 'opus', full = false, sessionsPerMonth = 60, standing = null } = {}
 ) {
   const { queue, suppressed, done } = buildQueue(dir, findings);
   const lines = [];
@@ -316,6 +317,38 @@ export function renderAudit(
       body.push(
         `  ${trend.detector}: ${trend.before.toLocaleString()} -> ${trend.after.toLocaleString()} tokens/session ` +
           `(${trend.improved ? 'improved' : 'worse'})`
+      );
+    }
+  }
+
+  // STANDING CONTEXT, as a panel rather than only as queue rows.
+  //
+  // auditStanding and verdictFor were both reachable, so this project already
+  // computed which CLAUDE.md rules and skills are stale, oversized or never
+  // used -- and threw the report away. renderStanding existed, was tested, and
+  // had no caller: the forTouch shape exactly, in the subsystem #203 claimed
+  // closed the skills-and-memory gap. Hard to defend a gap as closed while the
+  // report that would show it is unreachable.
+  //
+  // WHAT THE QUEUE ABOVE CANNOT SAY, which is why this is not duplication. The
+  // queue carries one row per ACTION, so a standing file with nothing wrong
+  // contributes no row and is invisible -- and the total cost of the prefix,
+  // the number that says what standing context is worth arguing about at all,
+  // is carried by no row either. Both are in the panel.
+  //
+  // Costed like everything else here: it is pushed BEFORE the closing line is
+  // measured, so the report's self-cost includes its own newest panel rather
+  // than understating it.
+  if (standing?.length) {
+    body.push('', 'Standing context -- charged every session:', '');
+    const panel = renderStanding(standing, { sessionsPerMonth });
+    // Indented to sit under its heading, blank lines left blank rather than
+    // turned into trailing whitespace.
+    for (const line of panel.split('\n')) body.push(line ? `  ${line}` : '');
+    if (standing.some((v) => v.actions?.length)) {
+      body.push(
+        '',
+        '  The actions above also appear in the queue at the top, where they are priced and applyable.'
       );
     }
   }

--- a/integrations/kilo/hooks/lib/consolidate.mjs
+++ b/integrations/kilo/hooks/lib/consolidate.mjs
@@ -36,6 +36,28 @@ import { nodeId } from './wiki.mjs';
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
 
 /**
+ * A candidate's own words, whatever the producer called the field.
+ *
+ * THE SELECTOR AND THE RATIO DISAGREED ABOUT THIS, and the half that had no
+ * caller is the half that was wrong. `irrecoverability`, `costToRederive` and
+ * `selectForConsolidation` all read `entry.summary`; `consolidationRatio` and
+ * `aggregateConsolidation` read `finding.claim`. NO PRODUCER IN THIS REPOSITORY
+ * EMITS `summary` -- the semantic harvest, wiki_write and the evaluation
+ * harnesses all emit `claim`, and `validate()` in harvest.mjs rejects anything
+ * without one.
+ *
+ * That matters more than a rename. Wired naively, every candidate would have
+ * scored `tokens: estimate(undefined)` -- zero -- so the budget could never
+ * bind, nothing would ever be dropped, and the selector would have been live,
+ * green, and inert. A capability that runs and cannot affect its own output is
+ * the same defect as one that never runs, wearing a call site.
+ *
+ * `summary` is still accepted, because an external caller may pass it and
+ * breaking that to fix an internal disagreement would be gratuitous.
+ */
+const claimText = (entry) => entry?.claim || entry?.summary || '';
+
+/**
  * How hard something is to reproduce, independent of what it cost this time.
  *
  * Token cost alone understates the expensive cases. Reproducing a flaky failure
@@ -45,7 +67,7 @@ const estimate = (text) => Math.ceil(String(text || '').length / 4);
  * measurements, and pretending otherwise would be false precision.
  */
 export function irrecoverability(entry) {
-  const text = `${entry.summary || ''} ${entry.evidence || ''}`.toLowerCase();
+  const text = `${claimText(entry)} ${entry.evidence || ''}`.toLowerCase();
 
   // Anything derived from a non-deterministic or long-running observation.
   //
@@ -110,7 +132,7 @@ export function costToRederive(entry, previousAt) {
   // no-op. The only measured cost is `entry.tokensSpent`, which the extraction
   // site must supply; otherwise fall back to the size of the evidence, so a
   // conclusion drawn from a large investigation still outranks an aside.
-  return estimate(entry.evidence) * 4 || estimate(entry.summary) * 8;
+  return estimate(entry.evidence) * 4 || estimate(claimText(entry)) * 8;
 }
 
 /** Kinds that survive on the floor regardless of score. */
@@ -141,7 +163,7 @@ export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}
     });
     const cost = costToRederive(entry, previousAt);
     const score = cost * irrecoverability(entry) * reuseProbability(graph, entry.anchorIds || anchors);
-    scored.push({ entry, score, cost, tokens: estimate(entry.summary) });
+    scored.push({ entry, score, cost, tokens: estimate(claimText(entry)) });
     previousAt = entry.at ?? previousAt;
   }
 
@@ -182,7 +204,7 @@ export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}
  * FOR, in a way that "tokens saved" never quite is.
  */
 export function consolidationRatio(finding) {
-  const carry = estimate(finding.claim);
+  const carry = estimate(claimText(finding));
   const derived = finding.derivedCost || 0;
   if (!carry || !derived) return null;
   return derived / carry;
@@ -195,7 +217,7 @@ export function aggregateConsolidation(findings) {
   for (const finding of findings) {
     if (!finding.derivedCost) continue;
     derived += finding.derivedCost;
-    carry += estimate(finding.claim);
+    carry += estimate(claimText(finding));
   }
   return carry ? { derived, carry, ratio: derived / carry } : null;
 }

--- a/integrations/kilo/hooks/lib/consolidate.mjs
+++ b/integrations/kilo/hooks/lib/consolidate.mjs
@@ -31,7 +31,6 @@
  * without session instrumentation cannot obtain.
  */
 
-import { statSync } from 'node:fs';
 import { nodeId } from './wiki.mjs';
 
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
@@ -201,25 +200,3 @@ export function aggregateConsolidation(findings) {
   return carry ? { derived, carry, ratio: derived / carry } : null;
 }
 
-/**
- * Content identity for a file, so a finding can reach across projects.
- *
- * A vendored library file is the same file in every repository that holds it,
- * whatever path each gives it. Anchoring to content as well as path means a
- * finding about it appears in all of them with no promotion step and no path
- * mapping -- reach a per-session checkpoint cannot have even in principle.
- *
- * The PATH anchor still drives staleness within a repo; this is additive.
- */
-export function contentAnchor(path, hash) {
-  if (!hash) return null;
-  let size = 0;
-  try {
-    size = statSync(path).size;
-  } catch {
-    return null;
-  }
-  // Size is included so two different files sharing a truncated digest do not
-  // collide into one identity.
-  return `content:${hash}:${size}`;
-}

--- a/integrations/kilo/hooks/lib/doctor.mjs
+++ b/integrations/kilo/hooks/lib/doctor.mjs
@@ -26,7 +26,21 @@ import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSyn
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { harvestMode } from './harvest.mjs';
-import { readManifest, verifyManifest, residue } from './manifest.mjs';
+import { readManifest, verifyManifest, residue, manifestSize } from './manifest.mjs';
+
+/**
+ * Bytes as a person reads them.
+ *
+ * Local because it exists for one line of one check, and because the alternative
+ * -- printing a raw byte count next to a file count -- is the kind of detail
+ * that gets skimmed past rather than read.
+ */
+function describeBytes(bytes) {
+  if (!bytes) return 'size unknown';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
 
 const ok = (name, detail) => ({ name, pass: true, detail });
 const bad = (name, detail, remedy) => ({ name, pass: false, detail, remedy });
@@ -362,11 +376,19 @@ export function checklist({ root, settingsPath, install }) {
     }
 
     // What we recorded putting on the machine, and whether it is still that.
-    const verified = verifyManifest(readManifest());
+    const manifest = readManifest();
+    const verified = verifyManifest(manifest);
     if (verified) {
+      // HOW MUCH, not just how many. manifestSize computed exactly this and had
+      // no caller, so the one number that says what uninstall will actually
+      // remove -- and the only cross-check on a manifest that lists files which
+      // no longer exist, since a missing file contributes zero bytes -- was
+      // computed nowhere and shown to no one.
+      const footprint = describeBytes(manifestSize(manifest));
       checks.push(verified.modified === 0
-        ? ok('installed files intact', `${verified.intact} file(s) match the install manifest`)
-        : ok('installed files intact', `${verified.modified} file(s) edited since install -- ` +
+        ? ok('installed files intact', `${verified.intact} file(s), ${footprint}, match the install manifest`)
+        : ok('installed files intact', `${verified.modified} of ${verified.intact + verified.modified} file(s) ` +
+          `(${footprint} recorded) edited since install -- ` +
           'uninstall will leave those alone rather than destroy your changes'));
     } else {
       checks.push(bad('install manifest present', 'no record of what was installed',

--- a/integrations/kilo/hooks/lib/doctor.mjs
+++ b/integrations/kilo/hooks/lib/doctor.mjs
@@ -27,6 +27,7 @@ import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { harvestMode } from './harvest.mjs';
 import { readManifest, verifyManifest, residue, manifestSize } from './manifest.mjs';
+import { mcpClientsSeen } from './metrics.mjs';
 
 /**
  * Bytes as a person reads them.
@@ -553,7 +554,39 @@ export function probeGraph({ dir }) {
     checks.push(ok('graph directory is private', 'mode could not be read on this filesystem'));
   }
 
+  checks.push(...probeClients({ dir }));
   return checks;
+}
+
+/**
+ * Which MCP clients have actually handshaked with this server.
+ *
+ * THE QUESTION THE REST OF THE DOCTOR CANNOT ANSWER. Every other check here
+ * reasons about files on disk: is the hook present, is it wired, does it refuse
+ * a large read. None of them can tell you whether the editor in front of you
+ * ever actually connected -- which is the single most common way this product
+ * is installed and silently does nothing.
+ *
+ * `mcp-client` records exactly that on every `initialize`, and nothing read it
+ * until now. NEVER A FAILURE: a fresh install has no handshakes yet, and a
+ * doctor that reports red on a correct install teaches people to ignore it.
+ */
+export function probeClients({ dir }) {
+  let clients = [];
+  try {
+    clients = mcpClientsSeen(dir);
+  } catch {
+    return [ok('MCP clients seen', 'no evidence log yet')];
+  }
+  if (!clients.length) {
+    return [ok('MCP clients seen', 'none yet -- the server has had no MCP handshake in this project')];
+  }
+  const described = clients
+    .slice(0, 5)
+    .map((c) => `${c.title || c.client}${c.version ? ` ${c.version}` : ''}`)
+    .join(', ');
+  return [ok('MCP clients seen', `${clients.length}: ${described}` +
+    (clients.length > 5 ? `, and ${clients.length - 5} more` : ''))];
 }
 
 /**

--- a/integrations/kilo/hooks/lib/doctor.mjs
+++ b/integrations/kilo/hooks/lib/doctor.mjs
@@ -386,11 +386,23 @@ export function checklist({ root, settingsPath, install }) {
       // no longer exist, since a missing file contributes zero bytes -- was
       // computed nowhere and shown to no one.
       const footprint = describeBytes(manifestSize(manifest));
-      checks.push(verified.modified === 0
-        ? ok('installed files intact', `${verified.intact} file(s), ${footprint}, match the install manifest`)
-        : ok('installed files intact', `${verified.modified} of ${verified.intact + verified.modified} file(s) ` +
+      // MISSING IS NOT INTACT, and branching on `modified` alone said it was.
+      // verifyManifest reports three states and this read two of them: a
+      // recorded file DELETED rather than edited left `modified === 0`, so a
+      // half-removed install passed as healthy. The footprint above is what
+      // makes it visible -- a missing file contributes zero bytes -- but a
+      // visible detail beside a PASS is still a PASS.
+      if (verified.missing > 0) {
+        checks.push(bad('installed files intact',
+          `${verified.missing} of ${verified.files.length} recorded file(s) are gone (${footprint} still on disk)`,
+          'reinstall the package to restore them, or run the uninstaller to clear the manifest'));
+      } else if (verified.modified === 0) {
+        checks.push(ok('installed files intact', `${verified.intact} file(s), ${footprint}, match the install manifest`));
+      } else {
+        checks.push(ok('installed files intact', `${verified.modified} of ${verified.intact + verified.modified} file(s) ` +
           `(${footprint} recorded) edited since install -- ` +
           'uninstall will leave those alone rather than destroy your changes'));
+      }
     } else {
       checks.push(bad('install manifest present', 'no record of what was installed',
         'harmless if you installed manually; reinstall to get a removable, verifiable record'));
@@ -538,9 +550,16 @@ export function probeGraph({ dir }) {
   // the bits read back as world-readable regardless, so failing there would be
   // reporting a platform property as a broken install: a false alarm that
   // teaches people to ignore the doctor.
+  // BEFORE THE PLATFORM RETURN, and this is exactly the defect this branch
+  // exists to close: the client probe was appended after `probeGraph`'s
+  // Windows early-return, so on Windows it had a call site and never ran. A
+  // reference that cannot execute is what the reachability guard cannot see.
+  const clients = probeClients({ dir });
+
   if (process.platform === 'win32') {
     checks.push(ok('graph directory is private',
       'POSIX modes are not enforced on Windows; the directory inherits its parent ACL'));
+    checks.push(...clients);
     return checks;
   }
 
@@ -554,7 +573,7 @@ export function probeGraph({ dir }) {
     checks.push(ok('graph directory is private', 'mode could not be read on this filesystem'));
   }
 
-  checks.push(...probeClients({ dir }));
+  checks.push(...clients);
   return checks;
 }
 

--- a/integrations/kilo/hooks/lib/keepwarm.mjs
+++ b/integrations/kilo/hooks/lib/keepwarm.mjs
@@ -110,7 +110,7 @@ export function gapDistribution(dir, { events = readMetrics(dir) } = {}) {
  * Returns the arithmetic as well as the verdict, because a refusal to refresh
  * that cannot be checked is indistinguishable from a bug.
  */
-export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0] }) {
+export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed = null }) {
   if (!prefixTokens || !gaps) {
     return { action: 'unknown', reason: 'no gap distribution yet -- needs a few sessions of history' };
   }
@@ -124,21 +124,42 @@ export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0] }) {
   // The ping only earns anything in the window where the entry WOULD have
   // expired but the next turn still arrives: before the TTL it was already
   // warm, and long after it, one ping does not reach.
-  const probability = Math.max(0, gaps.probabilityWithin(tier.ms * 2) - gaps.probabilityWithin(tier.ms));
+  const modelled = Math.max(0, gaps.probabilityWithin(tier.ms * 2) - gaps.probabilityWithin(tier.ms));
+
+  // MEASURED BEATS MODELLED, once there is enough of it.
+  //
+  // The module header already commits to this -- "an expected-value decision is
+  // only as good as the distribution it was fitted to, and distributions
+  // shift" -- and the tripwire underneath was the only thing acting on it, as
+  // an all-or-nothing kill switch. Between "the model says refresh" and "stop
+  // entirely" there was nothing, because the observed hit rate was never
+  // computed: both recording halves had no call site, so ten refreshes that
+  // bought nothing would keep recommending refresh right up to the moment the
+  // tripwire cut the whole feature off.
+  //
+  // Below OBSERVATION_FLOOR this stays null and the model is used unchanged; a
+  // handful of samples would swing the decision harder than the distribution
+  // they replace.
+  const probability = observed ? observed.rate : modelled;
   const savingIfUsed = prefixTokens * (tier.writeMultiplier - READ_MULTIPLIER);
   const ev = probability * savingIfUsed - costOfPing;
+  const basis = observed
+    ? `measured over ${observed.observations} refreshes`
+    : 'modelled from the gap distribution';
 
   return {
     action: ev > 0 ? 'refresh' : 'skip',
     tier: tier.name,
     probability,
+    modelledProbability: modelled,
+    basis,
     savingIfUsed: Math.round(savingIfUsed),
     costOfPing: Math.round(costOfPing),
     expectedValue: Math.round(ev),
     reason: ev > 0
-      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers; ` +
+      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers (${basis}); ` +
         `expected gain ${Math.round(ev).toLocaleString()} tokens`
-      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers; ` +
+      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers (${basis}); ` +
         `expected loss ${Math.abs(Math.round(ev)).toLocaleString()} tokens`,
   };
 }
@@ -194,9 +215,84 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
   };
 }
 
+/** Observations of a tier before its measured hit rate may override the model. */
+export const OBSERVATION_FLOOR = 5;
+
 /** Records a refresh so its outcome can be scored. */
 export function recordRefresh(dir, { tier, prefixTokens, expectedValue }) {
   record(dir, { kind: 'keepwarm', action: 'refresh', tier, prefixTokens, expectedValue });
+}
+
+/**
+ * Scores every refresh whose window has since resolved.
+ *
+ * THE MISSING HALF, and it was missing because nobody could see where the
+ * signal would come from. `recordRefreshOutcome` needs to know whether a real
+ * turn arrived before the entry expired -- and that is not a thing anyone has
+ * to instrument, because the event log already records when every turn
+ * happened. The answer was in the data the whole time.
+ *
+ * For each unscored refresh at time T on a tier with TTL `ms`:
+ *
+ *   - a later event within `ms`            -> HIT, observed
+ *   - a later event after `ms`             -> MISS, observed
+ *   - no later event, and `now - T > ms`   -> MISS, observed: the window has
+ *                                             demonstrably closed unused
+ *   - no later event, window still open    -> NOTHING RECORDED
+ *
+ * That last line is the important one and it is Plan 2's own instruction: "if
+ * no signal is available for a tier, record nothing rather than guessing
+ * `hit: false`". A refresh whose window has not closed yet is not a miss, and
+ * scoring it as one would drive the tripwire negative on the newest and least
+ * informative records.
+ *
+ * DRAINED AT READ TIME, which is the pattern this codebase already uses for
+ * staleness: the producer cannot know the outcome at the moment it acts, so the
+ * next reader resolves what has become knowable since.
+ */
+export function scoreOutstandingRefreshes(dir, { events = readMetrics(dir), outcomes = readBalance(dir), now = Date.now() } = {}) {
+  const keepwarm = outcomes.filter((e) => e.kind === 'keepwarm');
+  const refreshes = keepwarm.filter((e) => e.action === 'refresh').sort((a, b) => (a.at || 0) - (b.at || 0));
+  const scored = keepwarm.filter((e) => e.action === 'outcome').length;
+
+  // Refreshes are scored oldest-first and one outcome belongs to one refresh,
+  // so everything past the number already scored is outstanding. Pairing by
+  // timestamp instead would double-count two refreshes recorded in the same
+  // millisecond, which is reachable: a tool run twice in a loop.
+  const outstanding = refreshes.slice(scored);
+  const timeline = events.map((e) => Number(e.at) || 0).filter(Boolean).sort((a, b) => a - b);
+
+  let recorded = 0;
+  for (const refresh of outstanding) {
+    const at = Number(refresh.at) || 0;
+    if (!at) continue;
+    const tierSpec = TIERS.find((t) => t.name === refresh.tier) || TIERS[0];
+    const next = timeline.find((t) => t > at);
+
+    let hit;
+    if (next !== undefined) hit = next - at <= tierSpec.ms;
+    else if (now - at > tierSpec.ms) hit = false;
+    else continue; // window still open: not yet knowable
+
+    recordRefreshOutcome(dir, { tier: refresh.tier, prefixTokens: refresh.prefixTokens, hit });
+    recorded += 1;
+  }
+  return { outstanding: outstanding.length, recorded };
+}
+
+/**
+ * The measured hit rate for a tier, or null below the observation floor.
+ *
+ * Null rather than a small-sample number, because the caller substitutes it for
+ * a modelled probability and three observations would swing the decision harder
+ * than the model they replace.
+ */
+export function observedHitRate(dir, { tier, outcomes = readBalance(dir) } = {}) {
+  const relevant = outcomes.filter(
+    (e) => e.kind === 'keepwarm' && e.action === 'outcome' && (!tier || e.tier === tier)
+  );
+  if (relevant.length < OBSERVATION_FLOOR) return null;
+  return { observations: relevant.length, rate: relevant.filter((e) => e.hit).length / relevant.length };
 }
 
 /**
@@ -276,6 +372,18 @@ export function shouldKeepWarm(dir, {
   // was chosen was wrong for one of them.
   outcomes = readBalance(dir),
 } = {}) {
+  // DRAIN BEFORE DECIDING. Anything whose window has closed since the last call
+  // becomes evidence now, so the decision below and the tripwire above both see
+  // the most that is currently knowable -- the same read-time drain the
+  // staleness path uses, and for the same reason: the producer cannot know the
+  // outcome at the moment it acts.
+  try {
+    scoreOutstandingRefreshes(dir, { events, outcomes });
+    outcomes = readBalance(dir);
+  } catch {
+    /* scoring is evidence, never a reason to refuse a decision */
+  }
+
   const trip = tripwire(dir, { events: outcomes });
   if (trip.tripped) return { action: 'skip', reason: trip.reason, trippedWire: true };
 
@@ -289,7 +397,11 @@ export function shouldKeepWarm(dir, {
     // refusal justified by a GAIN: `{ action: 'skip', reason: '...expected gain 130 tokens' }`.
     // This module's own docstring says a refusal that cannot be checked is indistinguishable from
     // a bug; one that contradicts itself is worse.
-    const decision = keepWarmDecision({ prefixTokens, gaps });
+    const decision = keepWarmDecision({
+      prefixTokens,
+      gaps,
+      observed: observedHitRate(dir, { tier: TIERS[0].name, outcomes }),
+    });
     if (decision.action === 'refresh') return decision;
     return { action: decision.action === 'unknown' ? 'unknown' : 'skip', reason: decision.reason };
   }

--- a/integrations/kilo/hooks/lib/metrics.mjs
+++ b/integrations/kilo/hooks/lib/metrics.mjs
@@ -744,6 +744,21 @@ export function balanceSheet(dir) {
           verdict: r.verdict,
         };
       })(),
+      // THE CONTROL ARM'S CONTENT, for the same reason `controlArmTokens` sits
+      // in the substitution block above: `candidateCount` and
+      // `shadowFindingIds` recorded what the holdout withheld and nothing read
+      // them, so the report could count the arms and never say what was in
+      // them.
+      ...(() => {
+        const shadow = shadowDelivery(dir);
+        return {
+          selected: shadow.selected,
+          delivered: shadow.delivered,
+          controlArmSelected: shadow.withheldSelected,
+          controlArmFindings: shadow.withheldFindings,
+          indexStaleEntries: shadow.staleEntries,
+        };
+      })(),
     },
     costs: {
       injection: injectCost,
@@ -1283,6 +1298,109 @@ export function declinedAtBudget(dir, { limit = 500 } = {}) {
       .sort((a, b) => b[1] - a[1])
       .map(([reason, count]) => ({ reason, count })),
   };
+}
+
+/**
+ * The injection arm's SHADOW: what retrieval selected, against what was served.
+ *
+ * THE SAME GAP `controlArmTokens` WAS CREATED TO CLOSE, one arm over. That
+ * field exists because `tokensFullFile` "was recorded and read by nothing, so
+ * the comparison the holdout exists for was not computable from the report" --
+ * and the injection side had the identical hole: every `inject` record carries
+ * `candidateCount` and `shadowFindingIds`, which are what WOULD have been
+ * delivered, non-zero in BOTH arms, while `count` and `findingIds` go to zero
+ * in the holdout. The shadow pair was written on every injection since the
+ * holdout shipped and read by nothing, so the report could say how many touches
+ * landed in each arm and never which findings the holdout actually withheld.
+ *
+ * `staleCount` is the same shape on the session-start index: `stale` (a
+ * boolean, "was any of this stale") had a reader, the count did not, so a index
+ * with one rotten entry in forty was indistinguishable from one rotten
+ * throughout.
+ *
+ * READ FROM THE BALANCE LOG, because `inject` is a BALANCE_KIND: the firehose
+ * evicts injections first -- 136 of them against 6,725 captures on one machine
+ * -- which is the eviction that made `report()` say "0 holdout" over a file
+ * containing nine.
+ */
+export function shadowDelivery(dir) {
+  const injections = readBalance(dir).filter((event) => event.kind === 'inject');
+
+  let selected = 0;
+  let delivered = 0;
+  let withheldSelected = 0;
+  const withheldKeys = new Set();
+  let staleEntries = 0;
+  let indexRecords = 0;
+
+  for (const event of injections) {
+    const candidates = Number(event.candidateCount) || 0;
+    selected += candidates;
+    delivered += Number(event.count) || 0;
+    if (event.holdout) {
+      withheldSelected += candidates;
+      for (const key of event.shadowFindingIds || []) withheldKeys.add(key);
+    }
+    if (event.surface === 'session-start') {
+      indexRecords += 1;
+      staleEntries += Number(event.staleCount) || 0;
+    }
+  }
+
+  return {
+    injections: injections.length,
+    // Everything retrieval chose, across both arms.
+    selected,
+    // What actually reached a model.
+    delivered,
+    // Chosen and deliberately not delivered, because the anchor was in the
+    // withheld arm. This is the control arm's content, which is the thing the
+    // holdout exists to make comparable.
+    withheldSelected,
+    withheldFindings: withheldKeys.size,
+    // Index staleness as a rate rather than a boolean.
+    indexRecords,
+    staleEntries,
+  };
+}
+
+/**
+ * Which MCP clients have actually handshaked with this server.
+ *
+ * `mcp-client` was written on every `initialize` and read by nothing -- a
+ * producer with no reader, and the last one the census found. Deleting it was
+ * the other option and would have been wrong: `mcp-tool` records a client only
+ * once it CALLS something, and the project registry records a name only, so a
+ * client that connected and then called nothing -- which is exactly the failure
+ * this project's doctor exists to diagnose -- appeared in neither. The
+ * handshake is the only record that a connection happened at all.
+ *
+ * `clientTitle` is the field that made the record unique and it was unread too:
+ * the display name a client reports for itself, which is how a user recognises
+ * their own editor in a list where `name` is a slug.
+ */
+export function mcpClientsSeen(dir, { limit = 200 } = {}) {
+  const seen = new Map();
+  for (const event of readEvidence(dir)) {
+    if (event.kind !== 'mcp-client') continue;
+    const name = String(event.client || 'unknown');
+    const at = Number(event.at) || 0;
+    const previous = seen.get(name);
+    // LAST HANDSHAKE WINS on the mutable fields: a client that upgraded should
+    // be reported at the version it is now, not the one it first connected on.
+    if (!previous || at >= previous.at) {
+      seen.set(name, {
+        client: name,
+        title: event.clientTitle || null,
+        version: event.clientVersion || null,
+        at,
+        connections: (previous?.connections || 0) + 1,
+      });
+    } else {
+      previous.connections += 1;
+    }
+  }
+  return [...seen.values()].sort((a, b) => b.at - a.at).slice(0, limit);
 }
 
 /* ----------------------------------------------------------------------

--- a/integrations/kilo/hooks/lib/metrics.mjs
+++ b/integrations/kilo/hooks/lib/metrics.mjs
@@ -1231,6 +1231,60 @@ export function indexBudget(
   return Math.max(floor, Math.min(ceiling, scaled));
 }
 
+/**
+ * What retrieval decided NOT to inject, and why.
+ *
+ * THE OTHER HALF OF THE BUDGET, and it had no reader. `assessFindings` rejects a
+ * finding for one of three reasons -- it has been quarantined as harmful, it is
+ * in cooldown after being injected recently, or its expected value is negative
+ * -- and inject.mjs records every one of those decisions as a
+ * `retrieval-decision` event, from four separate call sites. Nothing read them.
+ *
+ * WHY THAT MATTERS RATHER THAN BEING TIDY. #204 makes the per-touch token budget
+ * load-bearing: "without it the most heavily-worked files accumulate the most
+ * findings and become the most expensive to touch, and the optimizer becomes
+ * its own token problem." A budget that silently drops what it cannot afford is
+ * indistinguishable, from outside, from a graph that had nothing to say. These
+ * are the two states a user most needs told apart, and the records to tell them
+ * apart were already being written.
+ *
+ * READ FROM THE EVIDENCE LOG, not the firehose. `retrieval-decision` is in
+ * EVIDENCE_KINDS precisely because it is rare relative to per-tool-call
+ * telemetry, and the windowed reader would evict it before it accumulated --
+ * the same eviction that made `report()` say "0 holdout" over a file containing
+ * nine.
+ */
+export function declinedAtBudget(dir, { limit = 500 } = {}) {
+  const decisions = readEvidence(dir)
+    .filter((event) => event.kind === 'retrieval-decision')
+    .slice(-limit);
+
+  const byReason = new Map();
+  const keys = new Set();
+  let declined = 0;
+  for (const decision of decisions) {
+    for (const item of decision.rejected || []) {
+      declined += 1;
+      if (item.key) keys.add(item.key);
+      // An unlabelled rejection is counted, not dropped: an unknown reason is
+      // still a finding the model did not get, and reporting the count as
+      // smaller than it is would understate exactly the cost this exists to
+      // surface.
+      const reason = item.reason || 'unspecified';
+      byReason.set(reason, (byReason.get(reason) || 0) + 1);
+    }
+  }
+
+  return {
+    decisions: decisions.length,
+    declined,
+    distinctFindings: keys.size,
+    byReason: [...byReason.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([reason, count]) => ({ reason, count })),
+  };
+}
+
 /* ----------------------------------------------------------------------
  * Episode-level causal evidence
  * ------------------------------------------------------------------- */

--- a/integrations/kilo/hooks/lib/staleness.mjs
+++ b/integrations/kilo/hooks/lib/staleness.mjs
@@ -297,7 +297,25 @@ export function checkAnchor(anchor) {
   if (anchor.kind === 'file') {
     return hash(source) === anchor.hash
       ? { fresh: true }
-      : { fresh: false, before: anchor.snapshot || '', hasBefore: Boolean(anchor.snapshot), after: source, reason: 'file changed' };
+      : {
+          fresh: false,
+          before: anchor.snapshot || '',
+          hasBefore: Boolean(anchor.snapshot),
+          after: source,
+          // AND WHAT CHANGED IT, when the graph knows. The structural harvest
+          // stamps `lastAction` -- the tool name that last touched this file --
+          // on every file node, and nothing read it: the field was written on
+          // every observed tool call since #203 and consumed nowhere.
+          //
+          // It belongs precisely here. "file changed" tells a reader that their
+          // finding may be wrong; "file changed (last touched by Edit)" tells
+          // them a targeted edit did it, which is cheap to re-verify, and "last
+          // touched by Write" says the file was replaced wholesale, which is
+          // usually not. Same disclosure, one word of provenance, no extra I/O.
+          reason: anchor.lastAction
+            ? `file changed (last touched by ${String(anchor.lastAction).slice(0, 40)})`
+            : 'file changed',
+        };
   }
 
   // For a symbol, re-locate it by NAME rather than by line number. Line numbers
@@ -499,6 +517,7 @@ function disputeOf(graph, finding) {
   if (!hasOutstandingContradiction(graph, finding.key)) return {};
 
   const keys = [];
+  const disputantIds = [];
   // AND THE REASON A PERSON TYPED, which had no reader anywhere. `contradict`
   // stores `contradictionReason` -- up to 400 characters of human explanation --
   // on the CONTRADICTED end only, and nothing outside its own test ever read it:
@@ -524,6 +543,7 @@ function disputeOf(graph, finding) {
     // fetch. `hasOutstandingContradiction` above already declines to open the
     // gate when EVERY disputant is retired; this is the same rule applied to
     // each name, so a live disputant is still reported alongside a withdrawn one.
+    if (!disputantIds.includes(otherId)) disputantIds.push(otherId);
     if (other && !other.retired && typeof other.key === 'string' && !keys.includes(other.key)) {
       keys.push(other.key);
       // A RETIRED END'S REASON IS NOT BORROWED EITHER, which is why this sits
@@ -537,9 +557,31 @@ function disputeOf(graph, finding) {
     }
   }
 
+  // WHEN, alongside WHY. `contradict` writes `contradictedAt` and
+  // `contradictionReason` on the same line of the same putNode call. Round 1
+  // gave the reason a reader -- this function -- and left the timestamp
+  // unread, so the disclosure could say a claim was disputed and why, and not
+  // whether that happened this morning or a year ago. For a reader deciding
+  // whether to trust a disputed finding, the age of the dispute is most of the
+  // signal: a year-old objection to a claim nobody has revisited reads very
+  // differently from one raised since the last release.
+  //
+  // Collected from whichever end holds it, exactly like the reason, and the
+  // EARLIEST is kept -- the dispute began when the first end recorded it.
+  let contradictedAt =
+    typeof finding.contradictedAt === 'number' ? finding.contradictedAt : null;
+  for (const id of disputantIds) {
+    const other = graph.nodes.get(id);
+    if (!other || other.retired) continue;
+    if (typeof other.contradictedAt !== 'number') continue;
+    contradictedAt =
+      contradictedAt === null ? other.contradictedAt : Math.min(contradictedAt, other.contradictedAt);
+  }
+
   return {
     contradicted: true,
     ...(keys.length ? { contradictedBy: keys.join(', ') } : {}),
+    ...(contradictedAt !== null ? { contradictedAt } : {}),
     // Trimmed here rather than at the renderer: an empty string is not a reason,
     // and a consumer checking `if (reason)` should not have to trim first.
     //

--- a/integrations/opencode/hooks/lib/audit.mjs
+++ b/integrations/opencode/hooks/lib/audit.mjs
@@ -30,7 +30,7 @@
  * cost at the bottom.
  */
 
-import { record, readMetrics } from './metrics.mjs';
+import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -319,6 +319,35 @@ export function renderAudit(
           `(${trend.improved ? 'improved' : 'worse'})`
       );
     }
+  }
+
+  // WHAT THE BUDGET TURNED AWAY.
+  //
+  // The per-touch token budget is load-bearing by design (#204): without it the
+  // most heavily-worked files accumulate the most findings and become the most
+  // expensive to touch. But a budget that silently drops what it cannot afford
+  // looks, from outside, exactly like a graph that had nothing to say -- and
+  // those are the two states a reader most needs told apart. inject.mjs was
+  // already recording every rejection and its reason, from four call sites, and
+  // nothing read them.
+  //
+  // ONE LINE, not a panel. This is context for the queue above rather than
+  // another thing to do, and the report is held to its own cost.
+  try {
+    const declined = declinedAtBudget(dir);
+    if (declined.declined > 0) {
+      const reasons = declined.byReason
+        .slice(0, 3)
+        .map(({ reason, count }) => `${reason} ${count}`)
+        .join(', ');
+      body.push(
+        '',
+        `Retrieval declined ${declined.declined.toLocaleString()} finding(s) ` +
+          `(${declined.distinctFindings} distinct) across ${declined.decisions.toLocaleString()} decision(s): ${reasons}.`
+      );
+    }
+  } catch {
+    /* the rejection log is context, never a reason to fail the audit */
   }
 
   // STANDING CONTEXT, as a panel rather than only as queue rows.

--- a/integrations/opencode/hooks/lib/audit.mjs
+++ b/integrations/opencode/hooks/lib/audit.mjs
@@ -374,7 +374,16 @@ export function renderAudit(
     // Indented to sit under its heading, blank lines left blank rather than
     // turned into trailing whitespace.
     for (const line of panel.split('\n')) body.push(line ? `  ${line}` : '');
-    if (standing.some((v) => v.actions?.length)) {
+    // ONLY IF THEY ACTUALLY DID. This pointed the reader at "the queue at the
+    // top" whenever any verdict carried an action -- including when the queue
+    // printed "Nothing addressable found", because a caller can render the
+    // panel with no findings at all, and the withholding rule can drop a
+    // standing row even when findings were passed. Telling someone to look at
+    // a row that is not there is worse than saying nothing.
+    const shownStandingIds = new Set(
+      shown.map((item) => item.id).filter((id) => typeof id === 'string' && id.startsWith('standing-'))
+    );
+    if (shownStandingIds.size) {
       body.push(
         '',
         '  The actions above also appear in the queue at the top, where they are priced and applyable.'

--- a/integrations/opencode/hooks/lib/audit.mjs
+++ b/integrations/opencode/hooks/lib/audit.mjs
@@ -33,6 +33,7 @@
 import { record, readMetrics } from './metrics.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
+import { renderStanding } from './standing.mjs';
 
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
 
@@ -183,7 +184,7 @@ export function buildQueue(
 export function renderAudit(
   dir,
   findings = [],
-  { tier = 'opus', full = false, sessionsPerMonth = 60 } = {}
+  { tier = 'opus', full = false, sessionsPerMonth = 60, standing = null } = {}
 ) {
   const { queue, suppressed, done } = buildQueue(dir, findings);
   const lines = [];
@@ -316,6 +317,38 @@ export function renderAudit(
       body.push(
         `  ${trend.detector}: ${trend.before.toLocaleString()} -> ${trend.after.toLocaleString()} tokens/session ` +
           `(${trend.improved ? 'improved' : 'worse'})`
+      );
+    }
+  }
+
+  // STANDING CONTEXT, as a panel rather than only as queue rows.
+  //
+  // auditStanding and verdictFor were both reachable, so this project already
+  // computed which CLAUDE.md rules and skills are stale, oversized or never
+  // used -- and threw the report away. renderStanding existed, was tested, and
+  // had no caller: the forTouch shape exactly, in the subsystem #203 claimed
+  // closed the skills-and-memory gap. Hard to defend a gap as closed while the
+  // report that would show it is unreachable.
+  //
+  // WHAT THE QUEUE ABOVE CANNOT SAY, which is why this is not duplication. The
+  // queue carries one row per ACTION, so a standing file with nothing wrong
+  // contributes no row and is invisible -- and the total cost of the prefix,
+  // the number that says what standing context is worth arguing about at all,
+  // is carried by no row either. Both are in the panel.
+  //
+  // Costed like everything else here: it is pushed BEFORE the closing line is
+  // measured, so the report's self-cost includes its own newest panel rather
+  // than understating it.
+  if (standing?.length) {
+    body.push('', 'Standing context -- charged every session:', '');
+    const panel = renderStanding(standing, { sessionsPerMonth });
+    // Indented to sit under its heading, blank lines left blank rather than
+    // turned into trailing whitespace.
+    for (const line of panel.split('\n')) body.push(line ? `  ${line}` : '');
+    if (standing.some((v) => v.actions?.length)) {
+      body.push(
+        '',
+        '  The actions above also appear in the queue at the top, where they are priced and applyable.'
       );
     }
   }

--- a/integrations/opencode/hooks/lib/consolidate.mjs
+++ b/integrations/opencode/hooks/lib/consolidate.mjs
@@ -36,6 +36,28 @@ import { nodeId } from './wiki.mjs';
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
 
 /**
+ * A candidate's own words, whatever the producer called the field.
+ *
+ * THE SELECTOR AND THE RATIO DISAGREED ABOUT THIS, and the half that had no
+ * caller is the half that was wrong. `irrecoverability`, `costToRederive` and
+ * `selectForConsolidation` all read `entry.summary`; `consolidationRatio` and
+ * `aggregateConsolidation` read `finding.claim`. NO PRODUCER IN THIS REPOSITORY
+ * EMITS `summary` -- the semantic harvest, wiki_write and the evaluation
+ * harnesses all emit `claim`, and `validate()` in harvest.mjs rejects anything
+ * without one.
+ *
+ * That matters more than a rename. Wired naively, every candidate would have
+ * scored `tokens: estimate(undefined)` -- zero -- so the budget could never
+ * bind, nothing would ever be dropped, and the selector would have been live,
+ * green, and inert. A capability that runs and cannot affect its own output is
+ * the same defect as one that never runs, wearing a call site.
+ *
+ * `summary` is still accepted, because an external caller may pass it and
+ * breaking that to fix an internal disagreement would be gratuitous.
+ */
+const claimText = (entry) => entry?.claim || entry?.summary || '';
+
+/**
  * How hard something is to reproduce, independent of what it cost this time.
  *
  * Token cost alone understates the expensive cases. Reproducing a flaky failure
@@ -45,7 +67,7 @@ const estimate = (text) => Math.ceil(String(text || '').length / 4);
  * measurements, and pretending otherwise would be false precision.
  */
 export function irrecoverability(entry) {
-  const text = `${entry.summary || ''} ${entry.evidence || ''}`.toLowerCase();
+  const text = `${claimText(entry)} ${entry.evidence || ''}`.toLowerCase();
 
   // Anything derived from a non-deterministic or long-running observation.
   //
@@ -110,7 +132,7 @@ export function costToRederive(entry, previousAt) {
   // no-op. The only measured cost is `entry.tokensSpent`, which the extraction
   // site must supply; otherwise fall back to the size of the evidence, so a
   // conclusion drawn from a large investigation still outranks an aside.
-  return estimate(entry.evidence) * 4 || estimate(entry.summary) * 8;
+  return estimate(entry.evidence) * 4 || estimate(claimText(entry)) * 8;
 }
 
 /** Kinds that survive on the floor regardless of score. */
@@ -141,7 +163,7 @@ export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}
     });
     const cost = costToRederive(entry, previousAt);
     const score = cost * irrecoverability(entry) * reuseProbability(graph, entry.anchorIds || anchors);
-    scored.push({ entry, score, cost, tokens: estimate(entry.summary) });
+    scored.push({ entry, score, cost, tokens: estimate(claimText(entry)) });
     previousAt = entry.at ?? previousAt;
   }
 
@@ -182,7 +204,7 @@ export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}
  * FOR, in a way that "tokens saved" never quite is.
  */
 export function consolidationRatio(finding) {
-  const carry = estimate(finding.claim);
+  const carry = estimate(claimText(finding));
   const derived = finding.derivedCost || 0;
   if (!carry || !derived) return null;
   return derived / carry;
@@ -195,7 +217,7 @@ export function aggregateConsolidation(findings) {
   for (const finding of findings) {
     if (!finding.derivedCost) continue;
     derived += finding.derivedCost;
-    carry += estimate(finding.claim);
+    carry += estimate(claimText(finding));
   }
   return carry ? { derived, carry, ratio: derived / carry } : null;
 }

--- a/integrations/opencode/hooks/lib/consolidate.mjs
+++ b/integrations/opencode/hooks/lib/consolidate.mjs
@@ -31,7 +31,6 @@
  * without session instrumentation cannot obtain.
  */
 
-import { statSync } from 'node:fs';
 import { nodeId } from './wiki.mjs';
 
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
@@ -201,25 +200,3 @@ export function aggregateConsolidation(findings) {
   return carry ? { derived, carry, ratio: derived / carry } : null;
 }
 
-/**
- * Content identity for a file, so a finding can reach across projects.
- *
- * A vendored library file is the same file in every repository that holds it,
- * whatever path each gives it. Anchoring to content as well as path means a
- * finding about it appears in all of them with no promotion step and no path
- * mapping -- reach a per-session checkpoint cannot have even in principle.
- *
- * The PATH anchor still drives staleness within a repo; this is additive.
- */
-export function contentAnchor(path, hash) {
-  if (!hash) return null;
-  let size = 0;
-  try {
-    size = statSync(path).size;
-  } catch {
-    return null;
-  }
-  // Size is included so two different files sharing a truncated digest do not
-  // collide into one identity.
-  return `content:${hash}:${size}`;
-}

--- a/integrations/opencode/hooks/lib/doctor.mjs
+++ b/integrations/opencode/hooks/lib/doctor.mjs
@@ -26,7 +26,21 @@ import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSyn
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { harvestMode } from './harvest.mjs';
-import { readManifest, verifyManifest, residue } from './manifest.mjs';
+import { readManifest, verifyManifest, residue, manifestSize } from './manifest.mjs';
+
+/**
+ * Bytes as a person reads them.
+ *
+ * Local because it exists for one line of one check, and because the alternative
+ * -- printing a raw byte count next to a file count -- is the kind of detail
+ * that gets skimmed past rather than read.
+ */
+function describeBytes(bytes) {
+  if (!bytes) return 'size unknown';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
 
 const ok = (name, detail) => ({ name, pass: true, detail });
 const bad = (name, detail, remedy) => ({ name, pass: false, detail, remedy });
@@ -362,11 +376,19 @@ export function checklist({ root, settingsPath, install }) {
     }
 
     // What we recorded putting on the machine, and whether it is still that.
-    const verified = verifyManifest(readManifest());
+    const manifest = readManifest();
+    const verified = verifyManifest(manifest);
     if (verified) {
+      // HOW MUCH, not just how many. manifestSize computed exactly this and had
+      // no caller, so the one number that says what uninstall will actually
+      // remove -- and the only cross-check on a manifest that lists files which
+      // no longer exist, since a missing file contributes zero bytes -- was
+      // computed nowhere and shown to no one.
+      const footprint = describeBytes(manifestSize(manifest));
       checks.push(verified.modified === 0
-        ? ok('installed files intact', `${verified.intact} file(s) match the install manifest`)
-        : ok('installed files intact', `${verified.modified} file(s) edited since install -- ` +
+        ? ok('installed files intact', `${verified.intact} file(s), ${footprint}, match the install manifest`)
+        : ok('installed files intact', `${verified.modified} of ${verified.intact + verified.modified} file(s) ` +
+          `(${footprint} recorded) edited since install -- ` +
           'uninstall will leave those alone rather than destroy your changes'));
     } else {
       checks.push(bad('install manifest present', 'no record of what was installed',

--- a/integrations/opencode/hooks/lib/doctor.mjs
+++ b/integrations/opencode/hooks/lib/doctor.mjs
@@ -27,6 +27,7 @@ import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { harvestMode } from './harvest.mjs';
 import { readManifest, verifyManifest, residue, manifestSize } from './manifest.mjs';
+import { mcpClientsSeen } from './metrics.mjs';
 
 /**
  * Bytes as a person reads them.
@@ -553,7 +554,39 @@ export function probeGraph({ dir }) {
     checks.push(ok('graph directory is private', 'mode could not be read on this filesystem'));
   }
 
+  checks.push(...probeClients({ dir }));
   return checks;
+}
+
+/**
+ * Which MCP clients have actually handshaked with this server.
+ *
+ * THE QUESTION THE REST OF THE DOCTOR CANNOT ANSWER. Every other check here
+ * reasons about files on disk: is the hook present, is it wired, does it refuse
+ * a large read. None of them can tell you whether the editor in front of you
+ * ever actually connected -- which is the single most common way this product
+ * is installed and silently does nothing.
+ *
+ * `mcp-client` records exactly that on every `initialize`, and nothing read it
+ * until now. NEVER A FAILURE: a fresh install has no handshakes yet, and a
+ * doctor that reports red on a correct install teaches people to ignore it.
+ */
+export function probeClients({ dir }) {
+  let clients = [];
+  try {
+    clients = mcpClientsSeen(dir);
+  } catch {
+    return [ok('MCP clients seen', 'no evidence log yet')];
+  }
+  if (!clients.length) {
+    return [ok('MCP clients seen', 'none yet -- the server has had no MCP handshake in this project')];
+  }
+  const described = clients
+    .slice(0, 5)
+    .map((c) => `${c.title || c.client}${c.version ? ` ${c.version}` : ''}`)
+    .join(', ');
+  return [ok('MCP clients seen', `${clients.length}: ${described}` +
+    (clients.length > 5 ? `, and ${clients.length - 5} more` : ''))];
 }
 
 /**

--- a/integrations/opencode/hooks/lib/doctor.mjs
+++ b/integrations/opencode/hooks/lib/doctor.mjs
@@ -386,11 +386,23 @@ export function checklist({ root, settingsPath, install }) {
       // no longer exist, since a missing file contributes zero bytes -- was
       // computed nowhere and shown to no one.
       const footprint = describeBytes(manifestSize(manifest));
-      checks.push(verified.modified === 0
-        ? ok('installed files intact', `${verified.intact} file(s), ${footprint}, match the install manifest`)
-        : ok('installed files intact', `${verified.modified} of ${verified.intact + verified.modified} file(s) ` +
+      // MISSING IS NOT INTACT, and branching on `modified` alone said it was.
+      // verifyManifest reports three states and this read two of them: a
+      // recorded file DELETED rather than edited left `modified === 0`, so a
+      // half-removed install passed as healthy. The footprint above is what
+      // makes it visible -- a missing file contributes zero bytes -- but a
+      // visible detail beside a PASS is still a PASS.
+      if (verified.missing > 0) {
+        checks.push(bad('installed files intact',
+          `${verified.missing} of ${verified.files.length} recorded file(s) are gone (${footprint} still on disk)`,
+          'reinstall the package to restore them, or run the uninstaller to clear the manifest'));
+      } else if (verified.modified === 0) {
+        checks.push(ok('installed files intact', `${verified.intact} file(s), ${footprint}, match the install manifest`));
+      } else {
+        checks.push(ok('installed files intact', `${verified.modified} of ${verified.intact + verified.modified} file(s) ` +
           `(${footprint} recorded) edited since install -- ` +
           'uninstall will leave those alone rather than destroy your changes'));
+      }
     } else {
       checks.push(bad('install manifest present', 'no record of what was installed',
         'harmless if you installed manually; reinstall to get a removable, verifiable record'));
@@ -538,9 +550,16 @@ export function probeGraph({ dir }) {
   // the bits read back as world-readable regardless, so failing there would be
   // reporting a platform property as a broken install: a false alarm that
   // teaches people to ignore the doctor.
+  // BEFORE THE PLATFORM RETURN, and this is exactly the defect this branch
+  // exists to close: the client probe was appended after `probeGraph`'s
+  // Windows early-return, so on Windows it had a call site and never ran. A
+  // reference that cannot execute is what the reachability guard cannot see.
+  const clients = probeClients({ dir });
+
   if (process.platform === 'win32') {
     checks.push(ok('graph directory is private',
       'POSIX modes are not enforced on Windows; the directory inherits its parent ACL'));
+    checks.push(...clients);
     return checks;
   }
 
@@ -554,7 +573,7 @@ export function probeGraph({ dir }) {
     checks.push(ok('graph directory is private', 'mode could not be read on this filesystem'));
   }
 
-  checks.push(...probeClients({ dir }));
+  checks.push(...clients);
   return checks;
 }
 

--- a/integrations/opencode/hooks/lib/keepwarm.mjs
+++ b/integrations/opencode/hooks/lib/keepwarm.mjs
@@ -110,7 +110,7 @@ export function gapDistribution(dir, { events = readMetrics(dir) } = {}) {
  * Returns the arithmetic as well as the verdict, because a refusal to refresh
  * that cannot be checked is indistinguishable from a bug.
  */
-export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0] }) {
+export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed = null }) {
   if (!prefixTokens || !gaps) {
     return { action: 'unknown', reason: 'no gap distribution yet -- needs a few sessions of history' };
   }
@@ -124,21 +124,42 @@ export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0] }) {
   // The ping only earns anything in the window where the entry WOULD have
   // expired but the next turn still arrives: before the TTL it was already
   // warm, and long after it, one ping does not reach.
-  const probability = Math.max(0, gaps.probabilityWithin(tier.ms * 2) - gaps.probabilityWithin(tier.ms));
+  const modelled = Math.max(0, gaps.probabilityWithin(tier.ms * 2) - gaps.probabilityWithin(tier.ms));
+
+  // MEASURED BEATS MODELLED, once there is enough of it.
+  //
+  // The module header already commits to this -- "an expected-value decision is
+  // only as good as the distribution it was fitted to, and distributions
+  // shift" -- and the tripwire underneath was the only thing acting on it, as
+  // an all-or-nothing kill switch. Between "the model says refresh" and "stop
+  // entirely" there was nothing, because the observed hit rate was never
+  // computed: both recording halves had no call site, so ten refreshes that
+  // bought nothing would keep recommending refresh right up to the moment the
+  // tripwire cut the whole feature off.
+  //
+  // Below OBSERVATION_FLOOR this stays null and the model is used unchanged; a
+  // handful of samples would swing the decision harder than the distribution
+  // they replace.
+  const probability = observed ? observed.rate : modelled;
   const savingIfUsed = prefixTokens * (tier.writeMultiplier - READ_MULTIPLIER);
   const ev = probability * savingIfUsed - costOfPing;
+  const basis = observed
+    ? `measured over ${observed.observations} refreshes`
+    : 'modelled from the gap distribution';
 
   return {
     action: ev > 0 ? 'refresh' : 'skip',
     tier: tier.name,
     probability,
+    modelledProbability: modelled,
+    basis,
     savingIfUsed: Math.round(savingIfUsed),
     costOfPing: Math.round(costOfPing),
     expectedValue: Math.round(ev),
     reason: ev > 0
-      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers; ` +
+      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers (${basis}); ` +
         `expected gain ${Math.round(ev).toLocaleString()} tokens`
-      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers; ` +
+      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers (${basis}); ` +
         `expected loss ${Math.abs(Math.round(ev)).toLocaleString()} tokens`,
   };
 }
@@ -194,9 +215,84 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
   };
 }
 
+/** Observations of a tier before its measured hit rate may override the model. */
+export const OBSERVATION_FLOOR = 5;
+
 /** Records a refresh so its outcome can be scored. */
 export function recordRefresh(dir, { tier, prefixTokens, expectedValue }) {
   record(dir, { kind: 'keepwarm', action: 'refresh', tier, prefixTokens, expectedValue });
+}
+
+/**
+ * Scores every refresh whose window has since resolved.
+ *
+ * THE MISSING HALF, and it was missing because nobody could see where the
+ * signal would come from. `recordRefreshOutcome` needs to know whether a real
+ * turn arrived before the entry expired -- and that is not a thing anyone has
+ * to instrument, because the event log already records when every turn
+ * happened. The answer was in the data the whole time.
+ *
+ * For each unscored refresh at time T on a tier with TTL `ms`:
+ *
+ *   - a later event within `ms`            -> HIT, observed
+ *   - a later event after `ms`             -> MISS, observed
+ *   - no later event, and `now - T > ms`   -> MISS, observed: the window has
+ *                                             demonstrably closed unused
+ *   - no later event, window still open    -> NOTHING RECORDED
+ *
+ * That last line is the important one and it is Plan 2's own instruction: "if
+ * no signal is available for a tier, record nothing rather than guessing
+ * `hit: false`". A refresh whose window has not closed yet is not a miss, and
+ * scoring it as one would drive the tripwire negative on the newest and least
+ * informative records.
+ *
+ * DRAINED AT READ TIME, which is the pattern this codebase already uses for
+ * staleness: the producer cannot know the outcome at the moment it acts, so the
+ * next reader resolves what has become knowable since.
+ */
+export function scoreOutstandingRefreshes(dir, { events = readMetrics(dir), outcomes = readBalance(dir), now = Date.now() } = {}) {
+  const keepwarm = outcomes.filter((e) => e.kind === 'keepwarm');
+  const refreshes = keepwarm.filter((e) => e.action === 'refresh').sort((a, b) => (a.at || 0) - (b.at || 0));
+  const scored = keepwarm.filter((e) => e.action === 'outcome').length;
+
+  // Refreshes are scored oldest-first and one outcome belongs to one refresh,
+  // so everything past the number already scored is outstanding. Pairing by
+  // timestamp instead would double-count two refreshes recorded in the same
+  // millisecond, which is reachable: a tool run twice in a loop.
+  const outstanding = refreshes.slice(scored);
+  const timeline = events.map((e) => Number(e.at) || 0).filter(Boolean).sort((a, b) => a - b);
+
+  let recorded = 0;
+  for (const refresh of outstanding) {
+    const at = Number(refresh.at) || 0;
+    if (!at) continue;
+    const tierSpec = TIERS.find((t) => t.name === refresh.tier) || TIERS[0];
+    const next = timeline.find((t) => t > at);
+
+    let hit;
+    if (next !== undefined) hit = next - at <= tierSpec.ms;
+    else if (now - at > tierSpec.ms) hit = false;
+    else continue; // window still open: not yet knowable
+
+    recordRefreshOutcome(dir, { tier: refresh.tier, prefixTokens: refresh.prefixTokens, hit });
+    recorded += 1;
+  }
+  return { outstanding: outstanding.length, recorded };
+}
+
+/**
+ * The measured hit rate for a tier, or null below the observation floor.
+ *
+ * Null rather than a small-sample number, because the caller substitutes it for
+ * a modelled probability and three observations would swing the decision harder
+ * than the model they replace.
+ */
+export function observedHitRate(dir, { tier, outcomes = readBalance(dir) } = {}) {
+  const relevant = outcomes.filter(
+    (e) => e.kind === 'keepwarm' && e.action === 'outcome' && (!tier || e.tier === tier)
+  );
+  if (relevant.length < OBSERVATION_FLOOR) return null;
+  return { observations: relevant.length, rate: relevant.filter((e) => e.hit).length / relevant.length };
 }
 
 /**
@@ -276,6 +372,18 @@ export function shouldKeepWarm(dir, {
   // was chosen was wrong for one of them.
   outcomes = readBalance(dir),
 } = {}) {
+  // DRAIN BEFORE DECIDING. Anything whose window has closed since the last call
+  // becomes evidence now, so the decision below and the tripwire above both see
+  // the most that is currently knowable -- the same read-time drain the
+  // staleness path uses, and for the same reason: the producer cannot know the
+  // outcome at the moment it acts.
+  try {
+    scoreOutstandingRefreshes(dir, { events, outcomes });
+    outcomes = readBalance(dir);
+  } catch {
+    /* scoring is evidence, never a reason to refuse a decision */
+  }
+
   const trip = tripwire(dir, { events: outcomes });
   if (trip.tripped) return { action: 'skip', reason: trip.reason, trippedWire: true };
 
@@ -289,7 +397,11 @@ export function shouldKeepWarm(dir, {
     // refusal justified by a GAIN: `{ action: 'skip', reason: '...expected gain 130 tokens' }`.
     // This module's own docstring says a refusal that cannot be checked is indistinguishable from
     // a bug; one that contradicts itself is worse.
-    const decision = keepWarmDecision({ prefixTokens, gaps });
+    const decision = keepWarmDecision({
+      prefixTokens,
+      gaps,
+      observed: observedHitRate(dir, { tier: TIERS[0].name, outcomes }),
+    });
     if (decision.action === 'refresh') return decision;
     return { action: decision.action === 'unknown' ? 'unknown' : 'skip', reason: decision.reason };
   }

--- a/integrations/opencode/hooks/lib/metrics.mjs
+++ b/integrations/opencode/hooks/lib/metrics.mjs
@@ -744,6 +744,21 @@ export function balanceSheet(dir) {
           verdict: r.verdict,
         };
       })(),
+      // THE CONTROL ARM'S CONTENT, for the same reason `controlArmTokens` sits
+      // in the substitution block above: `candidateCount` and
+      // `shadowFindingIds` recorded what the holdout withheld and nothing read
+      // them, so the report could count the arms and never say what was in
+      // them.
+      ...(() => {
+        const shadow = shadowDelivery(dir);
+        return {
+          selected: shadow.selected,
+          delivered: shadow.delivered,
+          controlArmSelected: shadow.withheldSelected,
+          controlArmFindings: shadow.withheldFindings,
+          indexStaleEntries: shadow.staleEntries,
+        };
+      })(),
     },
     costs: {
       injection: injectCost,
@@ -1283,6 +1298,109 @@ export function declinedAtBudget(dir, { limit = 500 } = {}) {
       .sort((a, b) => b[1] - a[1])
       .map(([reason, count]) => ({ reason, count })),
   };
+}
+
+/**
+ * The injection arm's SHADOW: what retrieval selected, against what was served.
+ *
+ * THE SAME GAP `controlArmTokens` WAS CREATED TO CLOSE, one arm over. That
+ * field exists because `tokensFullFile` "was recorded and read by nothing, so
+ * the comparison the holdout exists for was not computable from the report" --
+ * and the injection side had the identical hole: every `inject` record carries
+ * `candidateCount` and `shadowFindingIds`, which are what WOULD have been
+ * delivered, non-zero in BOTH arms, while `count` and `findingIds` go to zero
+ * in the holdout. The shadow pair was written on every injection since the
+ * holdout shipped and read by nothing, so the report could say how many touches
+ * landed in each arm and never which findings the holdout actually withheld.
+ *
+ * `staleCount` is the same shape on the session-start index: `stale` (a
+ * boolean, "was any of this stale") had a reader, the count did not, so a index
+ * with one rotten entry in forty was indistinguishable from one rotten
+ * throughout.
+ *
+ * READ FROM THE BALANCE LOG, because `inject` is a BALANCE_KIND: the firehose
+ * evicts injections first -- 136 of them against 6,725 captures on one machine
+ * -- which is the eviction that made `report()` say "0 holdout" over a file
+ * containing nine.
+ */
+export function shadowDelivery(dir) {
+  const injections = readBalance(dir).filter((event) => event.kind === 'inject');
+
+  let selected = 0;
+  let delivered = 0;
+  let withheldSelected = 0;
+  const withheldKeys = new Set();
+  let staleEntries = 0;
+  let indexRecords = 0;
+
+  for (const event of injections) {
+    const candidates = Number(event.candidateCount) || 0;
+    selected += candidates;
+    delivered += Number(event.count) || 0;
+    if (event.holdout) {
+      withheldSelected += candidates;
+      for (const key of event.shadowFindingIds || []) withheldKeys.add(key);
+    }
+    if (event.surface === 'session-start') {
+      indexRecords += 1;
+      staleEntries += Number(event.staleCount) || 0;
+    }
+  }
+
+  return {
+    injections: injections.length,
+    // Everything retrieval chose, across both arms.
+    selected,
+    // What actually reached a model.
+    delivered,
+    // Chosen and deliberately not delivered, because the anchor was in the
+    // withheld arm. This is the control arm's content, which is the thing the
+    // holdout exists to make comparable.
+    withheldSelected,
+    withheldFindings: withheldKeys.size,
+    // Index staleness as a rate rather than a boolean.
+    indexRecords,
+    staleEntries,
+  };
+}
+
+/**
+ * Which MCP clients have actually handshaked with this server.
+ *
+ * `mcp-client` was written on every `initialize` and read by nothing -- a
+ * producer with no reader, and the last one the census found. Deleting it was
+ * the other option and would have been wrong: `mcp-tool` records a client only
+ * once it CALLS something, and the project registry records a name only, so a
+ * client that connected and then called nothing -- which is exactly the failure
+ * this project's doctor exists to diagnose -- appeared in neither. The
+ * handshake is the only record that a connection happened at all.
+ *
+ * `clientTitle` is the field that made the record unique and it was unread too:
+ * the display name a client reports for itself, which is how a user recognises
+ * their own editor in a list where `name` is a slug.
+ */
+export function mcpClientsSeen(dir, { limit = 200 } = {}) {
+  const seen = new Map();
+  for (const event of readEvidence(dir)) {
+    if (event.kind !== 'mcp-client') continue;
+    const name = String(event.client || 'unknown');
+    const at = Number(event.at) || 0;
+    const previous = seen.get(name);
+    // LAST HANDSHAKE WINS on the mutable fields: a client that upgraded should
+    // be reported at the version it is now, not the one it first connected on.
+    if (!previous || at >= previous.at) {
+      seen.set(name, {
+        client: name,
+        title: event.clientTitle || null,
+        version: event.clientVersion || null,
+        at,
+        connections: (previous?.connections || 0) + 1,
+      });
+    } else {
+      previous.connections += 1;
+    }
+  }
+  return [...seen.values()].sort((a, b) => b.at - a.at).slice(0, limit);
 }
 
 /* ----------------------------------------------------------------------

--- a/integrations/opencode/hooks/lib/metrics.mjs
+++ b/integrations/opencode/hooks/lib/metrics.mjs
@@ -1231,6 +1231,60 @@ export function indexBudget(
   return Math.max(floor, Math.min(ceiling, scaled));
 }
 
+/**
+ * What retrieval decided NOT to inject, and why.
+ *
+ * THE OTHER HALF OF THE BUDGET, and it had no reader. `assessFindings` rejects a
+ * finding for one of three reasons -- it has been quarantined as harmful, it is
+ * in cooldown after being injected recently, or its expected value is negative
+ * -- and inject.mjs records every one of those decisions as a
+ * `retrieval-decision` event, from four separate call sites. Nothing read them.
+ *
+ * WHY THAT MATTERS RATHER THAN BEING TIDY. #204 makes the per-touch token budget
+ * load-bearing: "without it the most heavily-worked files accumulate the most
+ * findings and become the most expensive to touch, and the optimizer becomes
+ * its own token problem." A budget that silently drops what it cannot afford is
+ * indistinguishable, from outside, from a graph that had nothing to say. These
+ * are the two states a user most needs told apart, and the records to tell them
+ * apart were already being written.
+ *
+ * READ FROM THE EVIDENCE LOG, not the firehose. `retrieval-decision` is in
+ * EVIDENCE_KINDS precisely because it is rare relative to per-tool-call
+ * telemetry, and the windowed reader would evict it before it accumulated --
+ * the same eviction that made `report()` say "0 holdout" over a file containing
+ * nine.
+ */
+export function declinedAtBudget(dir, { limit = 500 } = {}) {
+  const decisions = readEvidence(dir)
+    .filter((event) => event.kind === 'retrieval-decision')
+    .slice(-limit);
+
+  const byReason = new Map();
+  const keys = new Set();
+  let declined = 0;
+  for (const decision of decisions) {
+    for (const item of decision.rejected || []) {
+      declined += 1;
+      if (item.key) keys.add(item.key);
+      // An unlabelled rejection is counted, not dropped: an unknown reason is
+      // still a finding the model did not get, and reporting the count as
+      // smaller than it is would understate exactly the cost this exists to
+      // surface.
+      const reason = item.reason || 'unspecified';
+      byReason.set(reason, (byReason.get(reason) || 0) + 1);
+    }
+  }
+
+  return {
+    decisions: decisions.length,
+    declined,
+    distinctFindings: keys.size,
+    byReason: [...byReason.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([reason, count]) => ({ reason, count })),
+  };
+}
+
 /* ----------------------------------------------------------------------
  * Episode-level causal evidence
  * ------------------------------------------------------------------- */

--- a/integrations/opencode/hooks/lib/staleness.mjs
+++ b/integrations/opencode/hooks/lib/staleness.mjs
@@ -297,7 +297,25 @@ export function checkAnchor(anchor) {
   if (anchor.kind === 'file') {
     return hash(source) === anchor.hash
       ? { fresh: true }
-      : { fresh: false, before: anchor.snapshot || '', hasBefore: Boolean(anchor.snapshot), after: source, reason: 'file changed' };
+      : {
+          fresh: false,
+          before: anchor.snapshot || '',
+          hasBefore: Boolean(anchor.snapshot),
+          after: source,
+          // AND WHAT CHANGED IT, when the graph knows. The structural harvest
+          // stamps `lastAction` -- the tool name that last touched this file --
+          // on every file node, and nothing read it: the field was written on
+          // every observed tool call since #203 and consumed nowhere.
+          //
+          // It belongs precisely here. "file changed" tells a reader that their
+          // finding may be wrong; "file changed (last touched by Edit)" tells
+          // them a targeted edit did it, which is cheap to re-verify, and "last
+          // touched by Write" says the file was replaced wholesale, which is
+          // usually not. Same disclosure, one word of provenance, no extra I/O.
+          reason: anchor.lastAction
+            ? `file changed (last touched by ${String(anchor.lastAction).slice(0, 40)})`
+            : 'file changed',
+        };
   }
 
   // For a symbol, re-locate it by NAME rather than by line number. Line numbers
@@ -499,6 +517,7 @@ function disputeOf(graph, finding) {
   if (!hasOutstandingContradiction(graph, finding.key)) return {};
 
   const keys = [];
+  const disputantIds = [];
   // AND THE REASON A PERSON TYPED, which had no reader anywhere. `contradict`
   // stores `contradictionReason` -- up to 400 characters of human explanation --
   // on the CONTRADICTED end only, and nothing outside its own test ever read it:
@@ -524,6 +543,7 @@ function disputeOf(graph, finding) {
     // fetch. `hasOutstandingContradiction` above already declines to open the
     // gate when EVERY disputant is retired; this is the same rule applied to
     // each name, so a live disputant is still reported alongside a withdrawn one.
+    if (!disputantIds.includes(otherId)) disputantIds.push(otherId);
     if (other && !other.retired && typeof other.key === 'string' && !keys.includes(other.key)) {
       keys.push(other.key);
       // A RETIRED END'S REASON IS NOT BORROWED EITHER, which is why this sits
@@ -537,9 +557,31 @@ function disputeOf(graph, finding) {
     }
   }
 
+  // WHEN, alongside WHY. `contradict` writes `contradictedAt` and
+  // `contradictionReason` on the same line of the same putNode call. Round 1
+  // gave the reason a reader -- this function -- and left the timestamp
+  // unread, so the disclosure could say a claim was disputed and why, and not
+  // whether that happened this morning or a year ago. For a reader deciding
+  // whether to trust a disputed finding, the age of the dispute is most of the
+  // signal: a year-old objection to a claim nobody has revisited reads very
+  // differently from one raised since the last release.
+  //
+  // Collected from whichever end holds it, exactly like the reason, and the
+  // EARLIEST is kept -- the dispute began when the first end recorded it.
+  let contradictedAt =
+    typeof finding.contradictedAt === 'number' ? finding.contradictedAt : null;
+  for (const id of disputantIds) {
+    const other = graph.nodes.get(id);
+    if (!other || other.retired) continue;
+    if (typeof other.contradictedAt !== 'number') continue;
+    contradictedAt =
+      contradictedAt === null ? other.contradictedAt : Math.min(contradictedAt, other.contradictedAt);
+  }
+
   return {
     contradicted: true,
     ...(keys.length ? { contradictedBy: keys.join(', ') } : {}),
+    ...(contradictedAt !== null ? { contradictedAt } : {}),
     // Trimmed here rather than at the renderer: an empty string is not a reason,
     // and a consumer checking `if (reason)` should not have to trim first.
     //

--- a/integrations/qwen/hooks/lib/audit.mjs
+++ b/integrations/qwen/hooks/lib/audit.mjs
@@ -30,7 +30,7 @@
  * cost at the bottom.
  */
 
-import { record, readMetrics } from './metrics.mjs';
+import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -319,6 +319,35 @@ export function renderAudit(
           `(${trend.improved ? 'improved' : 'worse'})`
       );
     }
+  }
+
+  // WHAT THE BUDGET TURNED AWAY.
+  //
+  // The per-touch token budget is load-bearing by design (#204): without it the
+  // most heavily-worked files accumulate the most findings and become the most
+  // expensive to touch. But a budget that silently drops what it cannot afford
+  // looks, from outside, exactly like a graph that had nothing to say -- and
+  // those are the two states a reader most needs told apart. inject.mjs was
+  // already recording every rejection and its reason, from four call sites, and
+  // nothing read them.
+  //
+  // ONE LINE, not a panel. This is context for the queue above rather than
+  // another thing to do, and the report is held to its own cost.
+  try {
+    const declined = declinedAtBudget(dir);
+    if (declined.declined > 0) {
+      const reasons = declined.byReason
+        .slice(0, 3)
+        .map(({ reason, count }) => `${reason} ${count}`)
+        .join(', ');
+      body.push(
+        '',
+        `Retrieval declined ${declined.declined.toLocaleString()} finding(s) ` +
+          `(${declined.distinctFindings} distinct) across ${declined.decisions.toLocaleString()} decision(s): ${reasons}.`
+      );
+    }
+  } catch {
+    /* the rejection log is context, never a reason to fail the audit */
   }
 
   // STANDING CONTEXT, as a panel rather than only as queue rows.

--- a/integrations/qwen/hooks/lib/audit.mjs
+++ b/integrations/qwen/hooks/lib/audit.mjs
@@ -374,7 +374,16 @@ export function renderAudit(
     // Indented to sit under its heading, blank lines left blank rather than
     // turned into trailing whitespace.
     for (const line of panel.split('\n')) body.push(line ? `  ${line}` : '');
-    if (standing.some((v) => v.actions?.length)) {
+    // ONLY IF THEY ACTUALLY DID. This pointed the reader at "the queue at the
+    // top" whenever any verdict carried an action -- including when the queue
+    // printed "Nothing addressable found", because a caller can render the
+    // panel with no findings at all, and the withholding rule can drop a
+    // standing row even when findings were passed. Telling someone to look at
+    // a row that is not there is worse than saying nothing.
+    const shownStandingIds = new Set(
+      shown.map((item) => item.id).filter((id) => typeof id === 'string' && id.startsWith('standing-'))
+    );
+    if (shownStandingIds.size) {
       body.push(
         '',
         '  The actions above also appear in the queue at the top, where they are priced and applyable.'

--- a/integrations/qwen/hooks/lib/audit.mjs
+++ b/integrations/qwen/hooks/lib/audit.mjs
@@ -33,6 +33,7 @@
 import { record, readMetrics } from './metrics.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
+import { renderStanding } from './standing.mjs';
 
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
 
@@ -183,7 +184,7 @@ export function buildQueue(
 export function renderAudit(
   dir,
   findings = [],
-  { tier = 'opus', full = false, sessionsPerMonth = 60 } = {}
+  { tier = 'opus', full = false, sessionsPerMonth = 60, standing = null } = {}
 ) {
   const { queue, suppressed, done } = buildQueue(dir, findings);
   const lines = [];
@@ -316,6 +317,38 @@ export function renderAudit(
       body.push(
         `  ${trend.detector}: ${trend.before.toLocaleString()} -> ${trend.after.toLocaleString()} tokens/session ` +
           `(${trend.improved ? 'improved' : 'worse'})`
+      );
+    }
+  }
+
+  // STANDING CONTEXT, as a panel rather than only as queue rows.
+  //
+  // auditStanding and verdictFor were both reachable, so this project already
+  // computed which CLAUDE.md rules and skills are stale, oversized or never
+  // used -- and threw the report away. renderStanding existed, was tested, and
+  // had no caller: the forTouch shape exactly, in the subsystem #203 claimed
+  // closed the skills-and-memory gap. Hard to defend a gap as closed while the
+  // report that would show it is unreachable.
+  //
+  // WHAT THE QUEUE ABOVE CANNOT SAY, which is why this is not duplication. The
+  // queue carries one row per ACTION, so a standing file with nothing wrong
+  // contributes no row and is invisible -- and the total cost of the prefix,
+  // the number that says what standing context is worth arguing about at all,
+  // is carried by no row either. Both are in the panel.
+  //
+  // Costed like everything else here: it is pushed BEFORE the closing line is
+  // measured, so the report's self-cost includes its own newest panel rather
+  // than understating it.
+  if (standing?.length) {
+    body.push('', 'Standing context -- charged every session:', '');
+    const panel = renderStanding(standing, { sessionsPerMonth });
+    // Indented to sit under its heading, blank lines left blank rather than
+    // turned into trailing whitespace.
+    for (const line of panel.split('\n')) body.push(line ? `  ${line}` : '');
+    if (standing.some((v) => v.actions?.length)) {
+      body.push(
+        '',
+        '  The actions above also appear in the queue at the top, where they are priced and applyable.'
       );
     }
   }

--- a/integrations/qwen/hooks/lib/consolidate.mjs
+++ b/integrations/qwen/hooks/lib/consolidate.mjs
@@ -36,6 +36,28 @@ import { nodeId } from './wiki.mjs';
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
 
 /**
+ * A candidate's own words, whatever the producer called the field.
+ *
+ * THE SELECTOR AND THE RATIO DISAGREED ABOUT THIS, and the half that had no
+ * caller is the half that was wrong. `irrecoverability`, `costToRederive` and
+ * `selectForConsolidation` all read `entry.summary`; `consolidationRatio` and
+ * `aggregateConsolidation` read `finding.claim`. NO PRODUCER IN THIS REPOSITORY
+ * EMITS `summary` -- the semantic harvest, wiki_write and the evaluation
+ * harnesses all emit `claim`, and `validate()` in harvest.mjs rejects anything
+ * without one.
+ *
+ * That matters more than a rename. Wired naively, every candidate would have
+ * scored `tokens: estimate(undefined)` -- zero -- so the budget could never
+ * bind, nothing would ever be dropped, and the selector would have been live,
+ * green, and inert. A capability that runs and cannot affect its own output is
+ * the same defect as one that never runs, wearing a call site.
+ *
+ * `summary` is still accepted, because an external caller may pass it and
+ * breaking that to fix an internal disagreement would be gratuitous.
+ */
+const claimText = (entry) => entry?.claim || entry?.summary || '';
+
+/**
  * How hard something is to reproduce, independent of what it cost this time.
  *
  * Token cost alone understates the expensive cases. Reproducing a flaky failure
@@ -45,7 +67,7 @@ const estimate = (text) => Math.ceil(String(text || '').length / 4);
  * measurements, and pretending otherwise would be false precision.
  */
 export function irrecoverability(entry) {
-  const text = `${entry.summary || ''} ${entry.evidence || ''}`.toLowerCase();
+  const text = `${claimText(entry)} ${entry.evidence || ''}`.toLowerCase();
 
   // Anything derived from a non-deterministic or long-running observation.
   //
@@ -110,7 +132,7 @@ export function costToRederive(entry, previousAt) {
   // no-op. The only measured cost is `entry.tokensSpent`, which the extraction
   // site must supply; otherwise fall back to the size of the evidence, so a
   // conclusion drawn from a large investigation still outranks an aside.
-  return estimate(entry.evidence) * 4 || estimate(entry.summary) * 8;
+  return estimate(entry.evidence) * 4 || estimate(claimText(entry)) * 8;
 }
 
 /** Kinds that survive on the floor regardless of score. */
@@ -141,7 +163,7 @@ export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}
     });
     const cost = costToRederive(entry, previousAt);
     const score = cost * irrecoverability(entry) * reuseProbability(graph, entry.anchorIds || anchors);
-    scored.push({ entry, score, cost, tokens: estimate(entry.summary) });
+    scored.push({ entry, score, cost, tokens: estimate(claimText(entry)) });
     previousAt = entry.at ?? previousAt;
   }
 
@@ -182,7 +204,7 @@ export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}
  * FOR, in a way that "tokens saved" never quite is.
  */
 export function consolidationRatio(finding) {
-  const carry = estimate(finding.claim);
+  const carry = estimate(claimText(finding));
   const derived = finding.derivedCost || 0;
   if (!carry || !derived) return null;
   return derived / carry;
@@ -195,7 +217,7 @@ export function aggregateConsolidation(findings) {
   for (const finding of findings) {
     if (!finding.derivedCost) continue;
     derived += finding.derivedCost;
-    carry += estimate(finding.claim);
+    carry += estimate(claimText(finding));
   }
   return carry ? { derived, carry, ratio: derived / carry } : null;
 }

--- a/integrations/qwen/hooks/lib/consolidate.mjs
+++ b/integrations/qwen/hooks/lib/consolidate.mjs
@@ -31,7 +31,6 @@
  * without session instrumentation cannot obtain.
  */
 
-import { statSync } from 'node:fs';
 import { nodeId } from './wiki.mjs';
 
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
@@ -201,25 +200,3 @@ export function aggregateConsolidation(findings) {
   return carry ? { derived, carry, ratio: derived / carry } : null;
 }
 
-/**
- * Content identity for a file, so a finding can reach across projects.
- *
- * A vendored library file is the same file in every repository that holds it,
- * whatever path each gives it. Anchoring to content as well as path means a
- * finding about it appears in all of them with no promotion step and no path
- * mapping -- reach a per-session checkpoint cannot have even in principle.
- *
- * The PATH anchor still drives staleness within a repo; this is additive.
- */
-export function contentAnchor(path, hash) {
-  if (!hash) return null;
-  let size = 0;
-  try {
-    size = statSync(path).size;
-  } catch {
-    return null;
-  }
-  // Size is included so two different files sharing a truncated digest do not
-  // collide into one identity.
-  return `content:${hash}:${size}`;
-}

--- a/integrations/qwen/hooks/lib/doctor.mjs
+++ b/integrations/qwen/hooks/lib/doctor.mjs
@@ -26,7 +26,21 @@ import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSyn
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { harvestMode } from './harvest.mjs';
-import { readManifest, verifyManifest, residue } from './manifest.mjs';
+import { readManifest, verifyManifest, residue, manifestSize } from './manifest.mjs';
+
+/**
+ * Bytes as a person reads them.
+ *
+ * Local because it exists for one line of one check, and because the alternative
+ * -- printing a raw byte count next to a file count -- is the kind of detail
+ * that gets skimmed past rather than read.
+ */
+function describeBytes(bytes) {
+  if (!bytes) return 'size unknown';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
 
 const ok = (name, detail) => ({ name, pass: true, detail });
 const bad = (name, detail, remedy) => ({ name, pass: false, detail, remedy });
@@ -362,11 +376,19 @@ export function checklist({ root, settingsPath, install }) {
     }
 
     // What we recorded putting on the machine, and whether it is still that.
-    const verified = verifyManifest(readManifest());
+    const manifest = readManifest();
+    const verified = verifyManifest(manifest);
     if (verified) {
+      // HOW MUCH, not just how many. manifestSize computed exactly this and had
+      // no caller, so the one number that says what uninstall will actually
+      // remove -- and the only cross-check on a manifest that lists files which
+      // no longer exist, since a missing file contributes zero bytes -- was
+      // computed nowhere and shown to no one.
+      const footprint = describeBytes(manifestSize(manifest));
       checks.push(verified.modified === 0
-        ? ok('installed files intact', `${verified.intact} file(s) match the install manifest`)
-        : ok('installed files intact', `${verified.modified} file(s) edited since install -- ` +
+        ? ok('installed files intact', `${verified.intact} file(s), ${footprint}, match the install manifest`)
+        : ok('installed files intact', `${verified.modified} of ${verified.intact + verified.modified} file(s) ` +
+          `(${footprint} recorded) edited since install -- ` +
           'uninstall will leave those alone rather than destroy your changes'));
     } else {
       checks.push(bad('install manifest present', 'no record of what was installed',

--- a/integrations/qwen/hooks/lib/doctor.mjs
+++ b/integrations/qwen/hooks/lib/doctor.mjs
@@ -27,6 +27,7 @@ import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { harvestMode } from './harvest.mjs';
 import { readManifest, verifyManifest, residue, manifestSize } from './manifest.mjs';
+import { mcpClientsSeen } from './metrics.mjs';
 
 /**
  * Bytes as a person reads them.
@@ -553,7 +554,39 @@ export function probeGraph({ dir }) {
     checks.push(ok('graph directory is private', 'mode could not be read on this filesystem'));
   }
 
+  checks.push(...probeClients({ dir }));
   return checks;
+}
+
+/**
+ * Which MCP clients have actually handshaked with this server.
+ *
+ * THE QUESTION THE REST OF THE DOCTOR CANNOT ANSWER. Every other check here
+ * reasons about files on disk: is the hook present, is it wired, does it refuse
+ * a large read. None of them can tell you whether the editor in front of you
+ * ever actually connected -- which is the single most common way this product
+ * is installed and silently does nothing.
+ *
+ * `mcp-client` records exactly that on every `initialize`, and nothing read it
+ * until now. NEVER A FAILURE: a fresh install has no handshakes yet, and a
+ * doctor that reports red on a correct install teaches people to ignore it.
+ */
+export function probeClients({ dir }) {
+  let clients = [];
+  try {
+    clients = mcpClientsSeen(dir);
+  } catch {
+    return [ok('MCP clients seen', 'no evidence log yet')];
+  }
+  if (!clients.length) {
+    return [ok('MCP clients seen', 'none yet -- the server has had no MCP handshake in this project')];
+  }
+  const described = clients
+    .slice(0, 5)
+    .map((c) => `${c.title || c.client}${c.version ? ` ${c.version}` : ''}`)
+    .join(', ');
+  return [ok('MCP clients seen', `${clients.length}: ${described}` +
+    (clients.length > 5 ? `, and ${clients.length - 5} more` : ''))];
 }
 
 /**

--- a/integrations/qwen/hooks/lib/doctor.mjs
+++ b/integrations/qwen/hooks/lib/doctor.mjs
@@ -386,11 +386,23 @@ export function checklist({ root, settingsPath, install }) {
       // no longer exist, since a missing file contributes zero bytes -- was
       // computed nowhere and shown to no one.
       const footprint = describeBytes(manifestSize(manifest));
-      checks.push(verified.modified === 0
-        ? ok('installed files intact', `${verified.intact} file(s), ${footprint}, match the install manifest`)
-        : ok('installed files intact', `${verified.modified} of ${verified.intact + verified.modified} file(s) ` +
+      // MISSING IS NOT INTACT, and branching on `modified` alone said it was.
+      // verifyManifest reports three states and this read two of them: a
+      // recorded file DELETED rather than edited left `modified === 0`, so a
+      // half-removed install passed as healthy. The footprint above is what
+      // makes it visible -- a missing file contributes zero bytes -- but a
+      // visible detail beside a PASS is still a PASS.
+      if (verified.missing > 0) {
+        checks.push(bad('installed files intact',
+          `${verified.missing} of ${verified.files.length} recorded file(s) are gone (${footprint} still on disk)`,
+          'reinstall the package to restore them, or run the uninstaller to clear the manifest'));
+      } else if (verified.modified === 0) {
+        checks.push(ok('installed files intact', `${verified.intact} file(s), ${footprint}, match the install manifest`));
+      } else {
+        checks.push(ok('installed files intact', `${verified.modified} of ${verified.intact + verified.modified} file(s) ` +
           `(${footprint} recorded) edited since install -- ` +
           'uninstall will leave those alone rather than destroy your changes'));
+      }
     } else {
       checks.push(bad('install manifest present', 'no record of what was installed',
         'harmless if you installed manually; reinstall to get a removable, verifiable record'));
@@ -538,9 +550,16 @@ export function probeGraph({ dir }) {
   // the bits read back as world-readable regardless, so failing there would be
   // reporting a platform property as a broken install: a false alarm that
   // teaches people to ignore the doctor.
+  // BEFORE THE PLATFORM RETURN, and this is exactly the defect this branch
+  // exists to close: the client probe was appended after `probeGraph`'s
+  // Windows early-return, so on Windows it had a call site and never ran. A
+  // reference that cannot execute is what the reachability guard cannot see.
+  const clients = probeClients({ dir });
+
   if (process.platform === 'win32') {
     checks.push(ok('graph directory is private',
       'POSIX modes are not enforced on Windows; the directory inherits its parent ACL'));
+    checks.push(...clients);
     return checks;
   }
 
@@ -554,7 +573,7 @@ export function probeGraph({ dir }) {
     checks.push(ok('graph directory is private', 'mode could not be read on this filesystem'));
   }
 
-  checks.push(...probeClients({ dir }));
+  checks.push(...clients);
   return checks;
 }
 

--- a/integrations/qwen/hooks/lib/keepwarm.mjs
+++ b/integrations/qwen/hooks/lib/keepwarm.mjs
@@ -110,7 +110,7 @@ export function gapDistribution(dir, { events = readMetrics(dir) } = {}) {
  * Returns the arithmetic as well as the verdict, because a refusal to refresh
  * that cannot be checked is indistinguishable from a bug.
  */
-export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0] }) {
+export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed = null }) {
   if (!prefixTokens || !gaps) {
     return { action: 'unknown', reason: 'no gap distribution yet -- needs a few sessions of history' };
   }
@@ -124,21 +124,42 @@ export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0] }) {
   // The ping only earns anything in the window where the entry WOULD have
   // expired but the next turn still arrives: before the TTL it was already
   // warm, and long after it, one ping does not reach.
-  const probability = Math.max(0, gaps.probabilityWithin(tier.ms * 2) - gaps.probabilityWithin(tier.ms));
+  const modelled = Math.max(0, gaps.probabilityWithin(tier.ms * 2) - gaps.probabilityWithin(tier.ms));
+
+  // MEASURED BEATS MODELLED, once there is enough of it.
+  //
+  // The module header already commits to this -- "an expected-value decision is
+  // only as good as the distribution it was fitted to, and distributions
+  // shift" -- and the tripwire underneath was the only thing acting on it, as
+  // an all-or-nothing kill switch. Between "the model says refresh" and "stop
+  // entirely" there was nothing, because the observed hit rate was never
+  // computed: both recording halves had no call site, so ten refreshes that
+  // bought nothing would keep recommending refresh right up to the moment the
+  // tripwire cut the whole feature off.
+  //
+  // Below OBSERVATION_FLOOR this stays null and the model is used unchanged; a
+  // handful of samples would swing the decision harder than the distribution
+  // they replace.
+  const probability = observed ? observed.rate : modelled;
   const savingIfUsed = prefixTokens * (tier.writeMultiplier - READ_MULTIPLIER);
   const ev = probability * savingIfUsed - costOfPing;
+  const basis = observed
+    ? `measured over ${observed.observations} refreshes`
+    : 'modelled from the gap distribution';
 
   return {
     action: ev > 0 ? 'refresh' : 'skip',
     tier: tier.name,
     probability,
+    modelledProbability: modelled,
+    basis,
     savingIfUsed: Math.round(savingIfUsed),
     costOfPing: Math.round(costOfPing),
     expectedValue: Math.round(ev),
     reason: ev > 0
-      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers; ` +
+      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers (${basis}); ` +
         `expected gain ${Math.round(ev).toLocaleString()} tokens`
-      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers; ` +
+      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers (${basis}); ` +
         `expected loss ${Math.abs(Math.round(ev)).toLocaleString()} tokens`,
   };
 }
@@ -194,9 +215,84 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
   };
 }
 
+/** Observations of a tier before its measured hit rate may override the model. */
+export const OBSERVATION_FLOOR = 5;
+
 /** Records a refresh so its outcome can be scored. */
 export function recordRefresh(dir, { tier, prefixTokens, expectedValue }) {
   record(dir, { kind: 'keepwarm', action: 'refresh', tier, prefixTokens, expectedValue });
+}
+
+/**
+ * Scores every refresh whose window has since resolved.
+ *
+ * THE MISSING HALF, and it was missing because nobody could see where the
+ * signal would come from. `recordRefreshOutcome` needs to know whether a real
+ * turn arrived before the entry expired -- and that is not a thing anyone has
+ * to instrument, because the event log already records when every turn
+ * happened. The answer was in the data the whole time.
+ *
+ * For each unscored refresh at time T on a tier with TTL `ms`:
+ *
+ *   - a later event within `ms`            -> HIT, observed
+ *   - a later event after `ms`             -> MISS, observed
+ *   - no later event, and `now - T > ms`   -> MISS, observed: the window has
+ *                                             demonstrably closed unused
+ *   - no later event, window still open    -> NOTHING RECORDED
+ *
+ * That last line is the important one and it is Plan 2's own instruction: "if
+ * no signal is available for a tier, record nothing rather than guessing
+ * `hit: false`". A refresh whose window has not closed yet is not a miss, and
+ * scoring it as one would drive the tripwire negative on the newest and least
+ * informative records.
+ *
+ * DRAINED AT READ TIME, which is the pattern this codebase already uses for
+ * staleness: the producer cannot know the outcome at the moment it acts, so the
+ * next reader resolves what has become knowable since.
+ */
+export function scoreOutstandingRefreshes(dir, { events = readMetrics(dir), outcomes = readBalance(dir), now = Date.now() } = {}) {
+  const keepwarm = outcomes.filter((e) => e.kind === 'keepwarm');
+  const refreshes = keepwarm.filter((e) => e.action === 'refresh').sort((a, b) => (a.at || 0) - (b.at || 0));
+  const scored = keepwarm.filter((e) => e.action === 'outcome').length;
+
+  // Refreshes are scored oldest-first and one outcome belongs to one refresh,
+  // so everything past the number already scored is outstanding. Pairing by
+  // timestamp instead would double-count two refreshes recorded in the same
+  // millisecond, which is reachable: a tool run twice in a loop.
+  const outstanding = refreshes.slice(scored);
+  const timeline = events.map((e) => Number(e.at) || 0).filter(Boolean).sort((a, b) => a - b);
+
+  let recorded = 0;
+  for (const refresh of outstanding) {
+    const at = Number(refresh.at) || 0;
+    if (!at) continue;
+    const tierSpec = TIERS.find((t) => t.name === refresh.tier) || TIERS[0];
+    const next = timeline.find((t) => t > at);
+
+    let hit;
+    if (next !== undefined) hit = next - at <= tierSpec.ms;
+    else if (now - at > tierSpec.ms) hit = false;
+    else continue; // window still open: not yet knowable
+
+    recordRefreshOutcome(dir, { tier: refresh.tier, prefixTokens: refresh.prefixTokens, hit });
+    recorded += 1;
+  }
+  return { outstanding: outstanding.length, recorded };
+}
+
+/**
+ * The measured hit rate for a tier, or null below the observation floor.
+ *
+ * Null rather than a small-sample number, because the caller substitutes it for
+ * a modelled probability and three observations would swing the decision harder
+ * than the model they replace.
+ */
+export function observedHitRate(dir, { tier, outcomes = readBalance(dir) } = {}) {
+  const relevant = outcomes.filter(
+    (e) => e.kind === 'keepwarm' && e.action === 'outcome' && (!tier || e.tier === tier)
+  );
+  if (relevant.length < OBSERVATION_FLOOR) return null;
+  return { observations: relevant.length, rate: relevant.filter((e) => e.hit).length / relevant.length };
 }
 
 /**
@@ -276,6 +372,18 @@ export function shouldKeepWarm(dir, {
   // was chosen was wrong for one of them.
   outcomes = readBalance(dir),
 } = {}) {
+  // DRAIN BEFORE DECIDING. Anything whose window has closed since the last call
+  // becomes evidence now, so the decision below and the tripwire above both see
+  // the most that is currently knowable -- the same read-time drain the
+  // staleness path uses, and for the same reason: the producer cannot know the
+  // outcome at the moment it acts.
+  try {
+    scoreOutstandingRefreshes(dir, { events, outcomes });
+    outcomes = readBalance(dir);
+  } catch {
+    /* scoring is evidence, never a reason to refuse a decision */
+  }
+
   const trip = tripwire(dir, { events: outcomes });
   if (trip.tripped) return { action: 'skip', reason: trip.reason, trippedWire: true };
 
@@ -289,7 +397,11 @@ export function shouldKeepWarm(dir, {
     // refusal justified by a GAIN: `{ action: 'skip', reason: '...expected gain 130 tokens' }`.
     // This module's own docstring says a refusal that cannot be checked is indistinguishable from
     // a bug; one that contradicts itself is worse.
-    const decision = keepWarmDecision({ prefixTokens, gaps });
+    const decision = keepWarmDecision({
+      prefixTokens,
+      gaps,
+      observed: observedHitRate(dir, { tier: TIERS[0].name, outcomes }),
+    });
     if (decision.action === 'refresh') return decision;
     return { action: decision.action === 'unknown' ? 'unknown' : 'skip', reason: decision.reason };
   }

--- a/integrations/qwen/hooks/lib/metrics.mjs
+++ b/integrations/qwen/hooks/lib/metrics.mjs
@@ -744,6 +744,21 @@ export function balanceSheet(dir) {
           verdict: r.verdict,
         };
       })(),
+      // THE CONTROL ARM'S CONTENT, for the same reason `controlArmTokens` sits
+      // in the substitution block above: `candidateCount` and
+      // `shadowFindingIds` recorded what the holdout withheld and nothing read
+      // them, so the report could count the arms and never say what was in
+      // them.
+      ...(() => {
+        const shadow = shadowDelivery(dir);
+        return {
+          selected: shadow.selected,
+          delivered: shadow.delivered,
+          controlArmSelected: shadow.withheldSelected,
+          controlArmFindings: shadow.withheldFindings,
+          indexStaleEntries: shadow.staleEntries,
+        };
+      })(),
     },
     costs: {
       injection: injectCost,
@@ -1283,6 +1298,109 @@ export function declinedAtBudget(dir, { limit = 500 } = {}) {
       .sort((a, b) => b[1] - a[1])
       .map(([reason, count]) => ({ reason, count })),
   };
+}
+
+/**
+ * The injection arm's SHADOW: what retrieval selected, against what was served.
+ *
+ * THE SAME GAP `controlArmTokens` WAS CREATED TO CLOSE, one arm over. That
+ * field exists because `tokensFullFile` "was recorded and read by nothing, so
+ * the comparison the holdout exists for was not computable from the report" --
+ * and the injection side had the identical hole: every `inject` record carries
+ * `candidateCount` and `shadowFindingIds`, which are what WOULD have been
+ * delivered, non-zero in BOTH arms, while `count` and `findingIds` go to zero
+ * in the holdout. The shadow pair was written on every injection since the
+ * holdout shipped and read by nothing, so the report could say how many touches
+ * landed in each arm and never which findings the holdout actually withheld.
+ *
+ * `staleCount` is the same shape on the session-start index: `stale` (a
+ * boolean, "was any of this stale") had a reader, the count did not, so a index
+ * with one rotten entry in forty was indistinguishable from one rotten
+ * throughout.
+ *
+ * READ FROM THE BALANCE LOG, because `inject` is a BALANCE_KIND: the firehose
+ * evicts injections first -- 136 of them against 6,725 captures on one machine
+ * -- which is the eviction that made `report()` say "0 holdout" over a file
+ * containing nine.
+ */
+export function shadowDelivery(dir) {
+  const injections = readBalance(dir).filter((event) => event.kind === 'inject');
+
+  let selected = 0;
+  let delivered = 0;
+  let withheldSelected = 0;
+  const withheldKeys = new Set();
+  let staleEntries = 0;
+  let indexRecords = 0;
+
+  for (const event of injections) {
+    const candidates = Number(event.candidateCount) || 0;
+    selected += candidates;
+    delivered += Number(event.count) || 0;
+    if (event.holdout) {
+      withheldSelected += candidates;
+      for (const key of event.shadowFindingIds || []) withheldKeys.add(key);
+    }
+    if (event.surface === 'session-start') {
+      indexRecords += 1;
+      staleEntries += Number(event.staleCount) || 0;
+    }
+  }
+
+  return {
+    injections: injections.length,
+    // Everything retrieval chose, across both arms.
+    selected,
+    // What actually reached a model.
+    delivered,
+    // Chosen and deliberately not delivered, because the anchor was in the
+    // withheld arm. This is the control arm's content, which is the thing the
+    // holdout exists to make comparable.
+    withheldSelected,
+    withheldFindings: withheldKeys.size,
+    // Index staleness as a rate rather than a boolean.
+    indexRecords,
+    staleEntries,
+  };
+}
+
+/**
+ * Which MCP clients have actually handshaked with this server.
+ *
+ * `mcp-client` was written on every `initialize` and read by nothing -- a
+ * producer with no reader, and the last one the census found. Deleting it was
+ * the other option and would have been wrong: `mcp-tool` records a client only
+ * once it CALLS something, and the project registry records a name only, so a
+ * client that connected and then called nothing -- which is exactly the failure
+ * this project's doctor exists to diagnose -- appeared in neither. The
+ * handshake is the only record that a connection happened at all.
+ *
+ * `clientTitle` is the field that made the record unique and it was unread too:
+ * the display name a client reports for itself, which is how a user recognises
+ * their own editor in a list where `name` is a slug.
+ */
+export function mcpClientsSeen(dir, { limit = 200 } = {}) {
+  const seen = new Map();
+  for (const event of readEvidence(dir)) {
+    if (event.kind !== 'mcp-client') continue;
+    const name = String(event.client || 'unknown');
+    const at = Number(event.at) || 0;
+    const previous = seen.get(name);
+    // LAST HANDSHAKE WINS on the mutable fields: a client that upgraded should
+    // be reported at the version it is now, not the one it first connected on.
+    if (!previous || at >= previous.at) {
+      seen.set(name, {
+        client: name,
+        title: event.clientTitle || null,
+        version: event.clientVersion || null,
+        at,
+        connections: (previous?.connections || 0) + 1,
+      });
+    } else {
+      previous.connections += 1;
+    }
+  }
+  return [...seen.values()].sort((a, b) => b.at - a.at).slice(0, limit);
 }
 
 /* ----------------------------------------------------------------------

--- a/integrations/qwen/hooks/lib/metrics.mjs
+++ b/integrations/qwen/hooks/lib/metrics.mjs
@@ -1231,6 +1231,60 @@ export function indexBudget(
   return Math.max(floor, Math.min(ceiling, scaled));
 }
 
+/**
+ * What retrieval decided NOT to inject, and why.
+ *
+ * THE OTHER HALF OF THE BUDGET, and it had no reader. `assessFindings` rejects a
+ * finding for one of three reasons -- it has been quarantined as harmful, it is
+ * in cooldown after being injected recently, or its expected value is negative
+ * -- and inject.mjs records every one of those decisions as a
+ * `retrieval-decision` event, from four separate call sites. Nothing read them.
+ *
+ * WHY THAT MATTERS RATHER THAN BEING TIDY. #204 makes the per-touch token budget
+ * load-bearing: "without it the most heavily-worked files accumulate the most
+ * findings and become the most expensive to touch, and the optimizer becomes
+ * its own token problem." A budget that silently drops what it cannot afford is
+ * indistinguishable, from outside, from a graph that had nothing to say. These
+ * are the two states a user most needs told apart, and the records to tell them
+ * apart were already being written.
+ *
+ * READ FROM THE EVIDENCE LOG, not the firehose. `retrieval-decision` is in
+ * EVIDENCE_KINDS precisely because it is rare relative to per-tool-call
+ * telemetry, and the windowed reader would evict it before it accumulated --
+ * the same eviction that made `report()` say "0 holdout" over a file containing
+ * nine.
+ */
+export function declinedAtBudget(dir, { limit = 500 } = {}) {
+  const decisions = readEvidence(dir)
+    .filter((event) => event.kind === 'retrieval-decision')
+    .slice(-limit);
+
+  const byReason = new Map();
+  const keys = new Set();
+  let declined = 0;
+  for (const decision of decisions) {
+    for (const item of decision.rejected || []) {
+      declined += 1;
+      if (item.key) keys.add(item.key);
+      // An unlabelled rejection is counted, not dropped: an unknown reason is
+      // still a finding the model did not get, and reporting the count as
+      // smaller than it is would understate exactly the cost this exists to
+      // surface.
+      const reason = item.reason || 'unspecified';
+      byReason.set(reason, (byReason.get(reason) || 0) + 1);
+    }
+  }
+
+  return {
+    decisions: decisions.length,
+    declined,
+    distinctFindings: keys.size,
+    byReason: [...byReason.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([reason, count]) => ({ reason, count })),
+  };
+}
+
 /* ----------------------------------------------------------------------
  * Episode-level causal evidence
  * ------------------------------------------------------------------- */

--- a/integrations/qwen/hooks/lib/staleness.mjs
+++ b/integrations/qwen/hooks/lib/staleness.mjs
@@ -297,7 +297,25 @@ export function checkAnchor(anchor) {
   if (anchor.kind === 'file') {
     return hash(source) === anchor.hash
       ? { fresh: true }
-      : { fresh: false, before: anchor.snapshot || '', hasBefore: Boolean(anchor.snapshot), after: source, reason: 'file changed' };
+      : {
+          fresh: false,
+          before: anchor.snapshot || '',
+          hasBefore: Boolean(anchor.snapshot),
+          after: source,
+          // AND WHAT CHANGED IT, when the graph knows. The structural harvest
+          // stamps `lastAction` -- the tool name that last touched this file --
+          // on every file node, and nothing read it: the field was written on
+          // every observed tool call since #203 and consumed nowhere.
+          //
+          // It belongs precisely here. "file changed" tells a reader that their
+          // finding may be wrong; "file changed (last touched by Edit)" tells
+          // them a targeted edit did it, which is cheap to re-verify, and "last
+          // touched by Write" says the file was replaced wholesale, which is
+          // usually not. Same disclosure, one word of provenance, no extra I/O.
+          reason: anchor.lastAction
+            ? `file changed (last touched by ${String(anchor.lastAction).slice(0, 40)})`
+            : 'file changed',
+        };
   }
 
   // For a symbol, re-locate it by NAME rather than by line number. Line numbers
@@ -499,6 +517,7 @@ function disputeOf(graph, finding) {
   if (!hasOutstandingContradiction(graph, finding.key)) return {};
 
   const keys = [];
+  const disputantIds = [];
   // AND THE REASON A PERSON TYPED, which had no reader anywhere. `contradict`
   // stores `contradictionReason` -- up to 400 characters of human explanation --
   // on the CONTRADICTED end only, and nothing outside its own test ever read it:
@@ -524,6 +543,7 @@ function disputeOf(graph, finding) {
     // fetch. `hasOutstandingContradiction` above already declines to open the
     // gate when EVERY disputant is retired; this is the same rule applied to
     // each name, so a live disputant is still reported alongside a withdrawn one.
+    if (!disputantIds.includes(otherId)) disputantIds.push(otherId);
     if (other && !other.retired && typeof other.key === 'string' && !keys.includes(other.key)) {
       keys.push(other.key);
       // A RETIRED END'S REASON IS NOT BORROWED EITHER, which is why this sits
@@ -537,9 +557,31 @@ function disputeOf(graph, finding) {
     }
   }
 
+  // WHEN, alongside WHY. `contradict` writes `contradictedAt` and
+  // `contradictionReason` on the same line of the same putNode call. Round 1
+  // gave the reason a reader -- this function -- and left the timestamp
+  // unread, so the disclosure could say a claim was disputed and why, and not
+  // whether that happened this morning or a year ago. For a reader deciding
+  // whether to trust a disputed finding, the age of the dispute is most of the
+  // signal: a year-old objection to a claim nobody has revisited reads very
+  // differently from one raised since the last release.
+  //
+  // Collected from whichever end holds it, exactly like the reason, and the
+  // EARLIEST is kept -- the dispute began when the first end recorded it.
+  let contradictedAt =
+    typeof finding.contradictedAt === 'number' ? finding.contradictedAt : null;
+  for (const id of disputantIds) {
+    const other = graph.nodes.get(id);
+    if (!other || other.retired) continue;
+    if (typeof other.contradictedAt !== 'number') continue;
+    contradictedAt =
+      contradictedAt === null ? other.contradictedAt : Math.min(contradictedAt, other.contradictedAt);
+  }
+
   return {
     contradicted: true,
     ...(keys.length ? { contradictedBy: keys.join(', ') } : {}),
+    ...(contradictedAt !== null ? { contradictedAt } : {}),
     // Trimmed here rather than at the renderer: an empty string is not a reason,
     // and a consumer checking `if (reason)` should not have to trim first.
     //

--- a/integrations/windsurf/hooks/lib/audit.mjs
+++ b/integrations/windsurf/hooks/lib/audit.mjs
@@ -30,7 +30,7 @@
  * cost at the bottom.
  */
 
-import { record, readMetrics } from './metrics.mjs';
+import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -319,6 +319,35 @@ export function renderAudit(
           `(${trend.improved ? 'improved' : 'worse'})`
       );
     }
+  }
+
+  // WHAT THE BUDGET TURNED AWAY.
+  //
+  // The per-touch token budget is load-bearing by design (#204): without it the
+  // most heavily-worked files accumulate the most findings and become the most
+  // expensive to touch. But a budget that silently drops what it cannot afford
+  // looks, from outside, exactly like a graph that had nothing to say -- and
+  // those are the two states a reader most needs told apart. inject.mjs was
+  // already recording every rejection and its reason, from four call sites, and
+  // nothing read them.
+  //
+  // ONE LINE, not a panel. This is context for the queue above rather than
+  // another thing to do, and the report is held to its own cost.
+  try {
+    const declined = declinedAtBudget(dir);
+    if (declined.declined > 0) {
+      const reasons = declined.byReason
+        .slice(0, 3)
+        .map(({ reason, count }) => `${reason} ${count}`)
+        .join(', ');
+      body.push(
+        '',
+        `Retrieval declined ${declined.declined.toLocaleString()} finding(s) ` +
+          `(${declined.distinctFindings} distinct) across ${declined.decisions.toLocaleString()} decision(s): ${reasons}.`
+      );
+    }
+  } catch {
+    /* the rejection log is context, never a reason to fail the audit */
   }
 
   // STANDING CONTEXT, as a panel rather than only as queue rows.

--- a/integrations/windsurf/hooks/lib/audit.mjs
+++ b/integrations/windsurf/hooks/lib/audit.mjs
@@ -374,7 +374,16 @@ export function renderAudit(
     // Indented to sit under its heading, blank lines left blank rather than
     // turned into trailing whitespace.
     for (const line of panel.split('\n')) body.push(line ? `  ${line}` : '');
-    if (standing.some((v) => v.actions?.length)) {
+    // ONLY IF THEY ACTUALLY DID. This pointed the reader at "the queue at the
+    // top" whenever any verdict carried an action -- including when the queue
+    // printed "Nothing addressable found", because a caller can render the
+    // panel with no findings at all, and the withholding rule can drop a
+    // standing row even when findings were passed. Telling someone to look at
+    // a row that is not there is worse than saying nothing.
+    const shownStandingIds = new Set(
+      shown.map((item) => item.id).filter((id) => typeof id === 'string' && id.startsWith('standing-'))
+    );
+    if (shownStandingIds.size) {
       body.push(
         '',
         '  The actions above also appear in the queue at the top, where they are priced and applyable.'

--- a/integrations/windsurf/hooks/lib/audit.mjs
+++ b/integrations/windsurf/hooks/lib/audit.mjs
@@ -33,6 +33,7 @@
 import { record, readMetrics } from './metrics.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
+import { renderStanding } from './standing.mjs';
 
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
 
@@ -183,7 +184,7 @@ export function buildQueue(
 export function renderAudit(
   dir,
   findings = [],
-  { tier = 'opus', full = false, sessionsPerMonth = 60 } = {}
+  { tier = 'opus', full = false, sessionsPerMonth = 60, standing = null } = {}
 ) {
   const { queue, suppressed, done } = buildQueue(dir, findings);
   const lines = [];
@@ -316,6 +317,38 @@ export function renderAudit(
       body.push(
         `  ${trend.detector}: ${trend.before.toLocaleString()} -> ${trend.after.toLocaleString()} tokens/session ` +
           `(${trend.improved ? 'improved' : 'worse'})`
+      );
+    }
+  }
+
+  // STANDING CONTEXT, as a panel rather than only as queue rows.
+  //
+  // auditStanding and verdictFor were both reachable, so this project already
+  // computed which CLAUDE.md rules and skills are stale, oversized or never
+  // used -- and threw the report away. renderStanding existed, was tested, and
+  // had no caller: the forTouch shape exactly, in the subsystem #203 claimed
+  // closed the skills-and-memory gap. Hard to defend a gap as closed while the
+  // report that would show it is unreachable.
+  //
+  // WHAT THE QUEUE ABOVE CANNOT SAY, which is why this is not duplication. The
+  // queue carries one row per ACTION, so a standing file with nothing wrong
+  // contributes no row and is invisible -- and the total cost of the prefix,
+  // the number that says what standing context is worth arguing about at all,
+  // is carried by no row either. Both are in the panel.
+  //
+  // Costed like everything else here: it is pushed BEFORE the closing line is
+  // measured, so the report's self-cost includes its own newest panel rather
+  // than understating it.
+  if (standing?.length) {
+    body.push('', 'Standing context -- charged every session:', '');
+    const panel = renderStanding(standing, { sessionsPerMonth });
+    // Indented to sit under its heading, blank lines left blank rather than
+    // turned into trailing whitespace.
+    for (const line of panel.split('\n')) body.push(line ? `  ${line}` : '');
+    if (standing.some((v) => v.actions?.length)) {
+      body.push(
+        '',
+        '  The actions above also appear in the queue at the top, where they are priced and applyable.'
       );
     }
   }

--- a/integrations/windsurf/hooks/lib/consolidate.mjs
+++ b/integrations/windsurf/hooks/lib/consolidate.mjs
@@ -36,6 +36,28 @@ import { nodeId } from './wiki.mjs';
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
 
 /**
+ * A candidate's own words, whatever the producer called the field.
+ *
+ * THE SELECTOR AND THE RATIO DISAGREED ABOUT THIS, and the half that had no
+ * caller is the half that was wrong. `irrecoverability`, `costToRederive` and
+ * `selectForConsolidation` all read `entry.summary`; `consolidationRatio` and
+ * `aggregateConsolidation` read `finding.claim`. NO PRODUCER IN THIS REPOSITORY
+ * EMITS `summary` -- the semantic harvest, wiki_write and the evaluation
+ * harnesses all emit `claim`, and `validate()` in harvest.mjs rejects anything
+ * without one.
+ *
+ * That matters more than a rename. Wired naively, every candidate would have
+ * scored `tokens: estimate(undefined)` -- zero -- so the budget could never
+ * bind, nothing would ever be dropped, and the selector would have been live,
+ * green, and inert. A capability that runs and cannot affect its own output is
+ * the same defect as one that never runs, wearing a call site.
+ *
+ * `summary` is still accepted, because an external caller may pass it and
+ * breaking that to fix an internal disagreement would be gratuitous.
+ */
+const claimText = (entry) => entry?.claim || entry?.summary || '';
+
+/**
  * How hard something is to reproduce, independent of what it cost this time.
  *
  * Token cost alone understates the expensive cases. Reproducing a flaky failure
@@ -45,7 +67,7 @@ const estimate = (text) => Math.ceil(String(text || '').length / 4);
  * measurements, and pretending otherwise would be false precision.
  */
 export function irrecoverability(entry) {
-  const text = `${entry.summary || ''} ${entry.evidence || ''}`.toLowerCase();
+  const text = `${claimText(entry)} ${entry.evidence || ''}`.toLowerCase();
 
   // Anything derived from a non-deterministic or long-running observation.
   //
@@ -110,7 +132,7 @@ export function costToRederive(entry, previousAt) {
   // no-op. The only measured cost is `entry.tokensSpent`, which the extraction
   // site must supply; otherwise fall back to the size of the evidence, so a
   // conclusion drawn from a large investigation still outranks an aside.
-  return estimate(entry.evidence) * 4 || estimate(entry.summary) * 8;
+  return estimate(entry.evidence) * 4 || estimate(claimText(entry)) * 8;
 }
 
 /** Kinds that survive on the floor regardless of score. */
@@ -141,7 +163,7 @@ export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}
     });
     const cost = costToRederive(entry, previousAt);
     const score = cost * irrecoverability(entry) * reuseProbability(graph, entry.anchorIds || anchors);
-    scored.push({ entry, score, cost, tokens: estimate(entry.summary) });
+    scored.push({ entry, score, cost, tokens: estimate(claimText(entry)) });
     previousAt = entry.at ?? previousAt;
   }
 
@@ -182,7 +204,7 @@ export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}
  * FOR, in a way that "tokens saved" never quite is.
  */
 export function consolidationRatio(finding) {
-  const carry = estimate(finding.claim);
+  const carry = estimate(claimText(finding));
   const derived = finding.derivedCost || 0;
   if (!carry || !derived) return null;
   return derived / carry;
@@ -195,7 +217,7 @@ export function aggregateConsolidation(findings) {
   for (const finding of findings) {
     if (!finding.derivedCost) continue;
     derived += finding.derivedCost;
-    carry += estimate(finding.claim);
+    carry += estimate(claimText(finding));
   }
   return carry ? { derived, carry, ratio: derived / carry } : null;
 }

--- a/integrations/windsurf/hooks/lib/consolidate.mjs
+++ b/integrations/windsurf/hooks/lib/consolidate.mjs
@@ -31,7 +31,6 @@
  * without session instrumentation cannot obtain.
  */
 
-import { statSync } from 'node:fs';
 import { nodeId } from './wiki.mjs';
 
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
@@ -201,25 +200,3 @@ export function aggregateConsolidation(findings) {
   return carry ? { derived, carry, ratio: derived / carry } : null;
 }
 
-/**
- * Content identity for a file, so a finding can reach across projects.
- *
- * A vendored library file is the same file in every repository that holds it,
- * whatever path each gives it. Anchoring to content as well as path means a
- * finding about it appears in all of them with no promotion step and no path
- * mapping -- reach a per-session checkpoint cannot have even in principle.
- *
- * The PATH anchor still drives staleness within a repo; this is additive.
- */
-export function contentAnchor(path, hash) {
-  if (!hash) return null;
-  let size = 0;
-  try {
-    size = statSync(path).size;
-  } catch {
-    return null;
-  }
-  // Size is included so two different files sharing a truncated digest do not
-  // collide into one identity.
-  return `content:${hash}:${size}`;
-}

--- a/integrations/windsurf/hooks/lib/doctor.mjs
+++ b/integrations/windsurf/hooks/lib/doctor.mjs
@@ -26,7 +26,21 @@ import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSyn
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { harvestMode } from './harvest.mjs';
-import { readManifest, verifyManifest, residue } from './manifest.mjs';
+import { readManifest, verifyManifest, residue, manifestSize } from './manifest.mjs';
+
+/**
+ * Bytes as a person reads them.
+ *
+ * Local because it exists for one line of one check, and because the alternative
+ * -- printing a raw byte count next to a file count -- is the kind of detail
+ * that gets skimmed past rather than read.
+ */
+function describeBytes(bytes) {
+  if (!bytes) return 'size unknown';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
 
 const ok = (name, detail) => ({ name, pass: true, detail });
 const bad = (name, detail, remedy) => ({ name, pass: false, detail, remedy });
@@ -362,11 +376,19 @@ export function checklist({ root, settingsPath, install }) {
     }
 
     // What we recorded putting on the machine, and whether it is still that.
-    const verified = verifyManifest(readManifest());
+    const manifest = readManifest();
+    const verified = verifyManifest(manifest);
     if (verified) {
+      // HOW MUCH, not just how many. manifestSize computed exactly this and had
+      // no caller, so the one number that says what uninstall will actually
+      // remove -- and the only cross-check on a manifest that lists files which
+      // no longer exist, since a missing file contributes zero bytes -- was
+      // computed nowhere and shown to no one.
+      const footprint = describeBytes(manifestSize(manifest));
       checks.push(verified.modified === 0
-        ? ok('installed files intact', `${verified.intact} file(s) match the install manifest`)
-        : ok('installed files intact', `${verified.modified} file(s) edited since install -- ` +
+        ? ok('installed files intact', `${verified.intact} file(s), ${footprint}, match the install manifest`)
+        : ok('installed files intact', `${verified.modified} of ${verified.intact + verified.modified} file(s) ` +
+          `(${footprint} recorded) edited since install -- ` +
           'uninstall will leave those alone rather than destroy your changes'));
     } else {
       checks.push(bad('install manifest present', 'no record of what was installed',

--- a/integrations/windsurf/hooks/lib/doctor.mjs
+++ b/integrations/windsurf/hooks/lib/doctor.mjs
@@ -27,6 +27,7 @@ import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { harvestMode } from './harvest.mjs';
 import { readManifest, verifyManifest, residue, manifestSize } from './manifest.mjs';
+import { mcpClientsSeen } from './metrics.mjs';
 
 /**
  * Bytes as a person reads them.
@@ -553,7 +554,39 @@ export function probeGraph({ dir }) {
     checks.push(ok('graph directory is private', 'mode could not be read on this filesystem'));
   }
 
+  checks.push(...probeClients({ dir }));
   return checks;
+}
+
+/**
+ * Which MCP clients have actually handshaked with this server.
+ *
+ * THE QUESTION THE REST OF THE DOCTOR CANNOT ANSWER. Every other check here
+ * reasons about files on disk: is the hook present, is it wired, does it refuse
+ * a large read. None of them can tell you whether the editor in front of you
+ * ever actually connected -- which is the single most common way this product
+ * is installed and silently does nothing.
+ *
+ * `mcp-client` records exactly that on every `initialize`, and nothing read it
+ * until now. NEVER A FAILURE: a fresh install has no handshakes yet, and a
+ * doctor that reports red on a correct install teaches people to ignore it.
+ */
+export function probeClients({ dir }) {
+  let clients = [];
+  try {
+    clients = mcpClientsSeen(dir);
+  } catch {
+    return [ok('MCP clients seen', 'no evidence log yet')];
+  }
+  if (!clients.length) {
+    return [ok('MCP clients seen', 'none yet -- the server has had no MCP handshake in this project')];
+  }
+  const described = clients
+    .slice(0, 5)
+    .map((c) => `${c.title || c.client}${c.version ? ` ${c.version}` : ''}`)
+    .join(', ');
+  return [ok('MCP clients seen', `${clients.length}: ${described}` +
+    (clients.length > 5 ? `, and ${clients.length - 5} more` : ''))];
 }
 
 /**

--- a/integrations/windsurf/hooks/lib/doctor.mjs
+++ b/integrations/windsurf/hooks/lib/doctor.mjs
@@ -386,11 +386,23 @@ export function checklist({ root, settingsPath, install }) {
       // no longer exist, since a missing file contributes zero bytes -- was
       // computed nowhere and shown to no one.
       const footprint = describeBytes(manifestSize(manifest));
-      checks.push(verified.modified === 0
-        ? ok('installed files intact', `${verified.intact} file(s), ${footprint}, match the install manifest`)
-        : ok('installed files intact', `${verified.modified} of ${verified.intact + verified.modified} file(s) ` +
+      // MISSING IS NOT INTACT, and branching on `modified` alone said it was.
+      // verifyManifest reports three states and this read two of them: a
+      // recorded file DELETED rather than edited left `modified === 0`, so a
+      // half-removed install passed as healthy. The footprint above is what
+      // makes it visible -- a missing file contributes zero bytes -- but a
+      // visible detail beside a PASS is still a PASS.
+      if (verified.missing > 0) {
+        checks.push(bad('installed files intact',
+          `${verified.missing} of ${verified.files.length} recorded file(s) are gone (${footprint} still on disk)`,
+          'reinstall the package to restore them, or run the uninstaller to clear the manifest'));
+      } else if (verified.modified === 0) {
+        checks.push(ok('installed files intact', `${verified.intact} file(s), ${footprint}, match the install manifest`));
+      } else {
+        checks.push(ok('installed files intact', `${verified.modified} of ${verified.intact + verified.modified} file(s) ` +
           `(${footprint} recorded) edited since install -- ` +
           'uninstall will leave those alone rather than destroy your changes'));
+      }
     } else {
       checks.push(bad('install manifest present', 'no record of what was installed',
         'harmless if you installed manually; reinstall to get a removable, verifiable record'));
@@ -538,9 +550,16 @@ export function probeGraph({ dir }) {
   // the bits read back as world-readable regardless, so failing there would be
   // reporting a platform property as a broken install: a false alarm that
   // teaches people to ignore the doctor.
+  // BEFORE THE PLATFORM RETURN, and this is exactly the defect this branch
+  // exists to close: the client probe was appended after `probeGraph`'s
+  // Windows early-return, so on Windows it had a call site and never ran. A
+  // reference that cannot execute is what the reachability guard cannot see.
+  const clients = probeClients({ dir });
+
   if (process.platform === 'win32') {
     checks.push(ok('graph directory is private',
       'POSIX modes are not enforced on Windows; the directory inherits its parent ACL'));
+    checks.push(...clients);
     return checks;
   }
 
@@ -554,7 +573,7 @@ export function probeGraph({ dir }) {
     checks.push(ok('graph directory is private', 'mode could not be read on this filesystem'));
   }
 
-  checks.push(...probeClients({ dir }));
+  checks.push(...clients);
   return checks;
 }
 

--- a/integrations/windsurf/hooks/lib/keepwarm.mjs
+++ b/integrations/windsurf/hooks/lib/keepwarm.mjs
@@ -110,7 +110,7 @@ export function gapDistribution(dir, { events = readMetrics(dir) } = {}) {
  * Returns the arithmetic as well as the verdict, because a refusal to refresh
  * that cannot be checked is indistinguishable from a bug.
  */
-export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0] }) {
+export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed = null }) {
   if (!prefixTokens || !gaps) {
     return { action: 'unknown', reason: 'no gap distribution yet -- needs a few sessions of history' };
   }
@@ -124,21 +124,42 @@ export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0] }) {
   // The ping only earns anything in the window where the entry WOULD have
   // expired but the next turn still arrives: before the TTL it was already
   // warm, and long after it, one ping does not reach.
-  const probability = Math.max(0, gaps.probabilityWithin(tier.ms * 2) - gaps.probabilityWithin(tier.ms));
+  const modelled = Math.max(0, gaps.probabilityWithin(tier.ms * 2) - gaps.probabilityWithin(tier.ms));
+
+  // MEASURED BEATS MODELLED, once there is enough of it.
+  //
+  // The module header already commits to this -- "an expected-value decision is
+  // only as good as the distribution it was fitted to, and distributions
+  // shift" -- and the tripwire underneath was the only thing acting on it, as
+  // an all-or-nothing kill switch. Between "the model says refresh" and "stop
+  // entirely" there was nothing, because the observed hit rate was never
+  // computed: both recording halves had no call site, so ten refreshes that
+  // bought nothing would keep recommending refresh right up to the moment the
+  // tripwire cut the whole feature off.
+  //
+  // Below OBSERVATION_FLOOR this stays null and the model is used unchanged; a
+  // handful of samples would swing the decision harder than the distribution
+  // they replace.
+  const probability = observed ? observed.rate : modelled;
   const savingIfUsed = prefixTokens * (tier.writeMultiplier - READ_MULTIPLIER);
   const ev = probability * savingIfUsed - costOfPing;
+  const basis = observed
+    ? `measured over ${observed.observations} refreshes`
+    : 'modelled from the gap distribution';
 
   return {
     action: ev > 0 ? 'refresh' : 'skip',
     tier: tier.name,
     probability,
+    modelledProbability: modelled,
+    basis,
     savingIfUsed: Math.round(savingIfUsed),
     costOfPing: Math.round(costOfPing),
     expectedValue: Math.round(ev),
     reason: ev > 0
-      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers; ` +
+      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers (${basis}); ` +
         `expected gain ${Math.round(ev).toLocaleString()} tokens`
-      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers; ` +
+      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers (${basis}); ` +
         `expected loss ${Math.abs(Math.round(ev)).toLocaleString()} tokens`,
   };
 }
@@ -194,9 +215,84 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
   };
 }
 
+/** Observations of a tier before its measured hit rate may override the model. */
+export const OBSERVATION_FLOOR = 5;
+
 /** Records a refresh so its outcome can be scored. */
 export function recordRefresh(dir, { tier, prefixTokens, expectedValue }) {
   record(dir, { kind: 'keepwarm', action: 'refresh', tier, prefixTokens, expectedValue });
+}
+
+/**
+ * Scores every refresh whose window has since resolved.
+ *
+ * THE MISSING HALF, and it was missing because nobody could see where the
+ * signal would come from. `recordRefreshOutcome` needs to know whether a real
+ * turn arrived before the entry expired -- and that is not a thing anyone has
+ * to instrument, because the event log already records when every turn
+ * happened. The answer was in the data the whole time.
+ *
+ * For each unscored refresh at time T on a tier with TTL `ms`:
+ *
+ *   - a later event within `ms`            -> HIT, observed
+ *   - a later event after `ms`             -> MISS, observed
+ *   - no later event, and `now - T > ms`   -> MISS, observed: the window has
+ *                                             demonstrably closed unused
+ *   - no later event, window still open    -> NOTHING RECORDED
+ *
+ * That last line is the important one and it is Plan 2's own instruction: "if
+ * no signal is available for a tier, record nothing rather than guessing
+ * `hit: false`". A refresh whose window has not closed yet is not a miss, and
+ * scoring it as one would drive the tripwire negative on the newest and least
+ * informative records.
+ *
+ * DRAINED AT READ TIME, which is the pattern this codebase already uses for
+ * staleness: the producer cannot know the outcome at the moment it acts, so the
+ * next reader resolves what has become knowable since.
+ */
+export function scoreOutstandingRefreshes(dir, { events = readMetrics(dir), outcomes = readBalance(dir), now = Date.now() } = {}) {
+  const keepwarm = outcomes.filter((e) => e.kind === 'keepwarm');
+  const refreshes = keepwarm.filter((e) => e.action === 'refresh').sort((a, b) => (a.at || 0) - (b.at || 0));
+  const scored = keepwarm.filter((e) => e.action === 'outcome').length;
+
+  // Refreshes are scored oldest-first and one outcome belongs to one refresh,
+  // so everything past the number already scored is outstanding. Pairing by
+  // timestamp instead would double-count two refreshes recorded in the same
+  // millisecond, which is reachable: a tool run twice in a loop.
+  const outstanding = refreshes.slice(scored);
+  const timeline = events.map((e) => Number(e.at) || 0).filter(Boolean).sort((a, b) => a - b);
+
+  let recorded = 0;
+  for (const refresh of outstanding) {
+    const at = Number(refresh.at) || 0;
+    if (!at) continue;
+    const tierSpec = TIERS.find((t) => t.name === refresh.tier) || TIERS[0];
+    const next = timeline.find((t) => t > at);
+
+    let hit;
+    if (next !== undefined) hit = next - at <= tierSpec.ms;
+    else if (now - at > tierSpec.ms) hit = false;
+    else continue; // window still open: not yet knowable
+
+    recordRefreshOutcome(dir, { tier: refresh.tier, prefixTokens: refresh.prefixTokens, hit });
+    recorded += 1;
+  }
+  return { outstanding: outstanding.length, recorded };
+}
+
+/**
+ * The measured hit rate for a tier, or null below the observation floor.
+ *
+ * Null rather than a small-sample number, because the caller substitutes it for
+ * a modelled probability and three observations would swing the decision harder
+ * than the model they replace.
+ */
+export function observedHitRate(dir, { tier, outcomes = readBalance(dir) } = {}) {
+  const relevant = outcomes.filter(
+    (e) => e.kind === 'keepwarm' && e.action === 'outcome' && (!tier || e.tier === tier)
+  );
+  if (relevant.length < OBSERVATION_FLOOR) return null;
+  return { observations: relevant.length, rate: relevant.filter((e) => e.hit).length / relevant.length };
 }
 
 /**
@@ -276,6 +372,18 @@ export function shouldKeepWarm(dir, {
   // was chosen was wrong for one of them.
   outcomes = readBalance(dir),
 } = {}) {
+  // DRAIN BEFORE DECIDING. Anything whose window has closed since the last call
+  // becomes evidence now, so the decision below and the tripwire above both see
+  // the most that is currently knowable -- the same read-time drain the
+  // staleness path uses, and for the same reason: the producer cannot know the
+  // outcome at the moment it acts.
+  try {
+    scoreOutstandingRefreshes(dir, { events, outcomes });
+    outcomes = readBalance(dir);
+  } catch {
+    /* scoring is evidence, never a reason to refuse a decision */
+  }
+
   const trip = tripwire(dir, { events: outcomes });
   if (trip.tripped) return { action: 'skip', reason: trip.reason, trippedWire: true };
 
@@ -289,7 +397,11 @@ export function shouldKeepWarm(dir, {
     // refusal justified by a GAIN: `{ action: 'skip', reason: '...expected gain 130 tokens' }`.
     // This module's own docstring says a refusal that cannot be checked is indistinguishable from
     // a bug; one that contradicts itself is worse.
-    const decision = keepWarmDecision({ prefixTokens, gaps });
+    const decision = keepWarmDecision({
+      prefixTokens,
+      gaps,
+      observed: observedHitRate(dir, { tier: TIERS[0].name, outcomes }),
+    });
     if (decision.action === 'refresh') return decision;
     return { action: decision.action === 'unknown' ? 'unknown' : 'skip', reason: decision.reason };
   }

--- a/integrations/windsurf/hooks/lib/metrics.mjs
+++ b/integrations/windsurf/hooks/lib/metrics.mjs
@@ -744,6 +744,21 @@ export function balanceSheet(dir) {
           verdict: r.verdict,
         };
       })(),
+      // THE CONTROL ARM'S CONTENT, for the same reason `controlArmTokens` sits
+      // in the substitution block above: `candidateCount` and
+      // `shadowFindingIds` recorded what the holdout withheld and nothing read
+      // them, so the report could count the arms and never say what was in
+      // them.
+      ...(() => {
+        const shadow = shadowDelivery(dir);
+        return {
+          selected: shadow.selected,
+          delivered: shadow.delivered,
+          controlArmSelected: shadow.withheldSelected,
+          controlArmFindings: shadow.withheldFindings,
+          indexStaleEntries: shadow.staleEntries,
+        };
+      })(),
     },
     costs: {
       injection: injectCost,
@@ -1283,6 +1298,109 @@ export function declinedAtBudget(dir, { limit = 500 } = {}) {
       .sort((a, b) => b[1] - a[1])
       .map(([reason, count]) => ({ reason, count })),
   };
+}
+
+/**
+ * The injection arm's SHADOW: what retrieval selected, against what was served.
+ *
+ * THE SAME GAP `controlArmTokens` WAS CREATED TO CLOSE, one arm over. That
+ * field exists because `tokensFullFile` "was recorded and read by nothing, so
+ * the comparison the holdout exists for was not computable from the report" --
+ * and the injection side had the identical hole: every `inject` record carries
+ * `candidateCount` and `shadowFindingIds`, which are what WOULD have been
+ * delivered, non-zero in BOTH arms, while `count` and `findingIds` go to zero
+ * in the holdout. The shadow pair was written on every injection since the
+ * holdout shipped and read by nothing, so the report could say how many touches
+ * landed in each arm and never which findings the holdout actually withheld.
+ *
+ * `staleCount` is the same shape on the session-start index: `stale` (a
+ * boolean, "was any of this stale") had a reader, the count did not, so a index
+ * with one rotten entry in forty was indistinguishable from one rotten
+ * throughout.
+ *
+ * READ FROM THE BALANCE LOG, because `inject` is a BALANCE_KIND: the firehose
+ * evicts injections first -- 136 of them against 6,725 captures on one machine
+ * -- which is the eviction that made `report()` say "0 holdout" over a file
+ * containing nine.
+ */
+export function shadowDelivery(dir) {
+  const injections = readBalance(dir).filter((event) => event.kind === 'inject');
+
+  let selected = 0;
+  let delivered = 0;
+  let withheldSelected = 0;
+  const withheldKeys = new Set();
+  let staleEntries = 0;
+  let indexRecords = 0;
+
+  for (const event of injections) {
+    const candidates = Number(event.candidateCount) || 0;
+    selected += candidates;
+    delivered += Number(event.count) || 0;
+    if (event.holdout) {
+      withheldSelected += candidates;
+      for (const key of event.shadowFindingIds || []) withheldKeys.add(key);
+    }
+    if (event.surface === 'session-start') {
+      indexRecords += 1;
+      staleEntries += Number(event.staleCount) || 0;
+    }
+  }
+
+  return {
+    injections: injections.length,
+    // Everything retrieval chose, across both arms.
+    selected,
+    // What actually reached a model.
+    delivered,
+    // Chosen and deliberately not delivered, because the anchor was in the
+    // withheld arm. This is the control arm's content, which is the thing the
+    // holdout exists to make comparable.
+    withheldSelected,
+    withheldFindings: withheldKeys.size,
+    // Index staleness as a rate rather than a boolean.
+    indexRecords,
+    staleEntries,
+  };
+}
+
+/**
+ * Which MCP clients have actually handshaked with this server.
+ *
+ * `mcp-client` was written on every `initialize` and read by nothing -- a
+ * producer with no reader, and the last one the census found. Deleting it was
+ * the other option and would have been wrong: `mcp-tool` records a client only
+ * once it CALLS something, and the project registry records a name only, so a
+ * client that connected and then called nothing -- which is exactly the failure
+ * this project's doctor exists to diagnose -- appeared in neither. The
+ * handshake is the only record that a connection happened at all.
+ *
+ * `clientTitle` is the field that made the record unique and it was unread too:
+ * the display name a client reports for itself, which is how a user recognises
+ * their own editor in a list where `name` is a slug.
+ */
+export function mcpClientsSeen(dir, { limit = 200 } = {}) {
+  const seen = new Map();
+  for (const event of readEvidence(dir)) {
+    if (event.kind !== 'mcp-client') continue;
+    const name = String(event.client || 'unknown');
+    const at = Number(event.at) || 0;
+    const previous = seen.get(name);
+    // LAST HANDSHAKE WINS on the mutable fields: a client that upgraded should
+    // be reported at the version it is now, not the one it first connected on.
+    if (!previous || at >= previous.at) {
+      seen.set(name, {
+        client: name,
+        title: event.clientTitle || null,
+        version: event.clientVersion || null,
+        at,
+        connections: (previous?.connections || 0) + 1,
+      });
+    } else {
+      previous.connections += 1;
+    }
+  }
+  return [...seen.values()].sort((a, b) => b.at - a.at).slice(0, limit);
 }
 
 /* ----------------------------------------------------------------------

--- a/integrations/windsurf/hooks/lib/metrics.mjs
+++ b/integrations/windsurf/hooks/lib/metrics.mjs
@@ -1231,6 +1231,60 @@ export function indexBudget(
   return Math.max(floor, Math.min(ceiling, scaled));
 }
 
+/**
+ * What retrieval decided NOT to inject, and why.
+ *
+ * THE OTHER HALF OF THE BUDGET, and it had no reader. `assessFindings` rejects a
+ * finding for one of three reasons -- it has been quarantined as harmful, it is
+ * in cooldown after being injected recently, or its expected value is negative
+ * -- and inject.mjs records every one of those decisions as a
+ * `retrieval-decision` event, from four separate call sites. Nothing read them.
+ *
+ * WHY THAT MATTERS RATHER THAN BEING TIDY. #204 makes the per-touch token budget
+ * load-bearing: "without it the most heavily-worked files accumulate the most
+ * findings and become the most expensive to touch, and the optimizer becomes
+ * its own token problem." A budget that silently drops what it cannot afford is
+ * indistinguishable, from outside, from a graph that had nothing to say. These
+ * are the two states a user most needs told apart, and the records to tell them
+ * apart were already being written.
+ *
+ * READ FROM THE EVIDENCE LOG, not the firehose. `retrieval-decision` is in
+ * EVIDENCE_KINDS precisely because it is rare relative to per-tool-call
+ * telemetry, and the windowed reader would evict it before it accumulated --
+ * the same eviction that made `report()` say "0 holdout" over a file containing
+ * nine.
+ */
+export function declinedAtBudget(dir, { limit = 500 } = {}) {
+  const decisions = readEvidence(dir)
+    .filter((event) => event.kind === 'retrieval-decision')
+    .slice(-limit);
+
+  const byReason = new Map();
+  const keys = new Set();
+  let declined = 0;
+  for (const decision of decisions) {
+    for (const item of decision.rejected || []) {
+      declined += 1;
+      if (item.key) keys.add(item.key);
+      // An unlabelled rejection is counted, not dropped: an unknown reason is
+      // still a finding the model did not get, and reporting the count as
+      // smaller than it is would understate exactly the cost this exists to
+      // surface.
+      const reason = item.reason || 'unspecified';
+      byReason.set(reason, (byReason.get(reason) || 0) + 1);
+    }
+  }
+
+  return {
+    decisions: decisions.length,
+    declined,
+    distinctFindings: keys.size,
+    byReason: [...byReason.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([reason, count]) => ({ reason, count })),
+  };
+}
+
 /* ----------------------------------------------------------------------
  * Episode-level causal evidence
  * ------------------------------------------------------------------- */

--- a/integrations/windsurf/hooks/lib/staleness.mjs
+++ b/integrations/windsurf/hooks/lib/staleness.mjs
@@ -297,7 +297,25 @@ export function checkAnchor(anchor) {
   if (anchor.kind === 'file') {
     return hash(source) === anchor.hash
       ? { fresh: true }
-      : { fresh: false, before: anchor.snapshot || '', hasBefore: Boolean(anchor.snapshot), after: source, reason: 'file changed' };
+      : {
+          fresh: false,
+          before: anchor.snapshot || '',
+          hasBefore: Boolean(anchor.snapshot),
+          after: source,
+          // AND WHAT CHANGED IT, when the graph knows. The structural harvest
+          // stamps `lastAction` -- the tool name that last touched this file --
+          // on every file node, and nothing read it: the field was written on
+          // every observed tool call since #203 and consumed nowhere.
+          //
+          // It belongs precisely here. "file changed" tells a reader that their
+          // finding may be wrong; "file changed (last touched by Edit)" tells
+          // them a targeted edit did it, which is cheap to re-verify, and "last
+          // touched by Write" says the file was replaced wholesale, which is
+          // usually not. Same disclosure, one word of provenance, no extra I/O.
+          reason: anchor.lastAction
+            ? `file changed (last touched by ${String(anchor.lastAction).slice(0, 40)})`
+            : 'file changed',
+        };
   }
 
   // For a symbol, re-locate it by NAME rather than by line number. Line numbers
@@ -499,6 +517,7 @@ function disputeOf(graph, finding) {
   if (!hasOutstandingContradiction(graph, finding.key)) return {};
 
   const keys = [];
+  const disputantIds = [];
   // AND THE REASON A PERSON TYPED, which had no reader anywhere. `contradict`
   // stores `contradictionReason` -- up to 400 characters of human explanation --
   // on the CONTRADICTED end only, and nothing outside its own test ever read it:
@@ -524,6 +543,7 @@ function disputeOf(graph, finding) {
     // fetch. `hasOutstandingContradiction` above already declines to open the
     // gate when EVERY disputant is retired; this is the same rule applied to
     // each name, so a live disputant is still reported alongside a withdrawn one.
+    if (!disputantIds.includes(otherId)) disputantIds.push(otherId);
     if (other && !other.retired && typeof other.key === 'string' && !keys.includes(other.key)) {
       keys.push(other.key);
       // A RETIRED END'S REASON IS NOT BORROWED EITHER, which is why this sits
@@ -537,9 +557,31 @@ function disputeOf(graph, finding) {
     }
   }
 
+  // WHEN, alongside WHY. `contradict` writes `contradictedAt` and
+  // `contradictionReason` on the same line of the same putNode call. Round 1
+  // gave the reason a reader -- this function -- and left the timestamp
+  // unread, so the disclosure could say a claim was disputed and why, and not
+  // whether that happened this morning or a year ago. For a reader deciding
+  // whether to trust a disputed finding, the age of the dispute is most of the
+  // signal: a year-old objection to a claim nobody has revisited reads very
+  // differently from one raised since the last release.
+  //
+  // Collected from whichever end holds it, exactly like the reason, and the
+  // EARLIEST is kept -- the dispute began when the first end recorded it.
+  let contradictedAt =
+    typeof finding.contradictedAt === 'number' ? finding.contradictedAt : null;
+  for (const id of disputantIds) {
+    const other = graph.nodes.get(id);
+    if (!other || other.retired) continue;
+    if (typeof other.contradictedAt !== 'number') continue;
+    contradictedAt =
+      contradictedAt === null ? other.contradictedAt : Math.min(contradictedAt, other.contradictedAt);
+  }
+
   return {
     contradicted: true,
     ...(keys.length ? { contradictedBy: keys.join(', ') } : {}),
+    ...(contradictedAt !== null ? { contradictedAt } : {}),
     // Trimmed here rather than at the renderer: an empty string is not a reason,
     // and a consumer checking `if (reason)` should not have to trim first.
     //

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "eval:handoff:concurrent": "node scripts/run-concurrent-handoff-eval.mjs",
     "verify:all": "npm run sync:hooks:check && npm run eval:ucr:qualification:verify && npm run verify:clients && npm run verify:certification && npm run verify:harvest && npm run verify:ucr && npm run verify:ucr:study-design && npm run verify:live-graph && npm run verify:ui && npm run verify:interactions",
     "verify:interactions": "node scripts/verify-wiki-interactions.mjs",
+    "wiki:census": "node scripts/wiki-census.mjs",
     "dashboard:verify-live": "node scripts/verify-live-dashboard.mjs",
     "dashboard:attribution-smoke": "node scripts/run-dashboard-attribution-smoke.mjs",
     "dashboard:audit-savings": "node scripts/audit-token-savings.mjs",

--- a/plugin/hooks/harvest-worker.mjs
+++ b/plugin/hooks/harvest-worker.mjs
@@ -25,10 +25,23 @@ import {
 } from './lib/harvest.mjs';
 import { writeHarvested } from './lib/harvest-write.mjs';
 import { record } from './lib/metrics.mjs';
-import { wikiDir, projectRootFor } from './lib/wiki.mjs';
+import { wikiDir, projectRootFor, load } from './lib/wiki.mjs';
 import { readArchive } from './lib/transcript.mjs';
 import { buildFeedbackDigest, validateLessons, LESSON_PROMPT } from './lib/lessons.mjs';
 import { ORIGIN_HARVESTED } from './lib/curate.mjs';
+import { selectForConsolidation } from './lib/consolidate.mjs';
+
+/**
+ * The token budget one session's harvest may add to the graph.
+ *
+ * #204 lists graph bloat as a named risk -- "the session-start index grows with
+ * the graph; ranking and eviction are required, not optional" -- and until now
+ * nothing bounded what a single harvest could store. 4,000 tokens is the
+ * selector's own default and roughly twenty-five findings at the size the
+ * extractor produces, which is far above any observed session's real yield; it
+ * is a ceiling against a pathological extraction, not a routine constraint.
+ */
+const CONSOLIDATION_BUDGET = 4000;
 
 /**
  * The files the digest says were touched.
@@ -90,7 +103,36 @@ async function main() {
   // that invents a plausible path cannot anchor a finding to it. The digest
   // lists them under a heading it writes itself; the full delta is raw
   // transcript and carries no such list, so it gets no restriction.
-  const findings = validate(raw, { knownFiles: full ? null : filesIn(digest) });
+  const validated = validate(raw, { knownFiles: full ? null : filesIn(digest) });
+
+  // BUDGETED SELECTION, not everything the model extracted.
+  //
+  // `selectForConsolidation` exists for exactly this and had no caller
+  // anywhere, so every harvested candidate was stored regardless of what it
+  // cost to derive, how hard it is to reproduce, or whether the graph can ever
+  // retrieve it -- which is the graph-bloat risk #204 lists as needing
+  // "ranking and eviction ... not optional". It keeps failures and decisions on
+  // a floor before ranking, encoding the design's judgement that dead ends are
+  // the highest-value kind: they exist nowhere in the source tree, so nothing
+  // else can ever recover them.
+  //
+  // The selection is RECORDED, not silent. A cap that drops work without
+  // saying so reads as "there was nothing more to find", which is the same
+  // dishonesty as a truncated report with no remainder line.
+  const graph = load(dir);
+  const selection = selectForConsolidation(graph, validated, { budget: CONSOLIDATION_BUDGET });
+  const findings = selection.kept;
+  if (selection.dropped > 0) {
+    record(dir, {
+      kind: 'harvest',
+      action: 'consolidation',
+      candidates: validated.length,
+      kept: findings.length,
+      dropped: selection.dropped,
+      tokens: selection.tokens,
+      budget: CONSOLIDATION_BUDGET,
+    });
+  }
 
   const written = writeHarvested(dir, findings, {
     sessionId: sessionId || null,

--- a/plugin/hooks/lib/audit.mjs
+++ b/plugin/hooks/lib/audit.mjs
@@ -30,7 +30,7 @@
  * cost at the bottom.
  */
 
-import { record, readMetrics } from './metrics.mjs';
+import { record, readMetrics, declinedAtBudget } from './metrics.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
 import { renderStanding } from './standing.mjs';
@@ -319,6 +319,35 @@ export function renderAudit(
           `(${trend.improved ? 'improved' : 'worse'})`
       );
     }
+  }
+
+  // WHAT THE BUDGET TURNED AWAY.
+  //
+  // The per-touch token budget is load-bearing by design (#204): without it the
+  // most heavily-worked files accumulate the most findings and become the most
+  // expensive to touch. But a budget that silently drops what it cannot afford
+  // looks, from outside, exactly like a graph that had nothing to say -- and
+  // those are the two states a reader most needs told apart. inject.mjs was
+  // already recording every rejection and its reason, from four call sites, and
+  // nothing read them.
+  //
+  // ONE LINE, not a panel. This is context for the queue above rather than
+  // another thing to do, and the report is held to its own cost.
+  try {
+    const declined = declinedAtBudget(dir);
+    if (declined.declined > 0) {
+      const reasons = declined.byReason
+        .slice(0, 3)
+        .map(({ reason, count }) => `${reason} ${count}`)
+        .join(', ');
+      body.push(
+        '',
+        `Retrieval declined ${declined.declined.toLocaleString()} finding(s) ` +
+          `(${declined.distinctFindings} distinct) across ${declined.decisions.toLocaleString()} decision(s): ${reasons}.`
+      );
+    }
+  } catch {
+    /* the rejection log is context, never a reason to fail the audit */
   }
 
   // STANDING CONTEXT, as a panel rather than only as queue rows.

--- a/plugin/hooks/lib/audit.mjs
+++ b/plugin/hooks/lib/audit.mjs
@@ -374,7 +374,16 @@ export function renderAudit(
     // Indented to sit under its heading, blank lines left blank rather than
     // turned into trailing whitespace.
     for (const line of panel.split('\n')) body.push(line ? `  ${line}` : '');
-    if (standing.some((v) => v.actions?.length)) {
+    // ONLY IF THEY ACTUALLY DID. This pointed the reader at "the queue at the
+    // top" whenever any verdict carried an action -- including when the queue
+    // printed "Nothing addressable found", because a caller can render the
+    // panel with no findings at all, and the withholding rule can drop a
+    // standing row even when findings were passed. Telling someone to look at
+    // a row that is not there is worse than saying nothing.
+    const shownStandingIds = new Set(
+      shown.map((item) => item.id).filter((id) => typeof id === 'string' && id.startsWith('standing-'))
+    );
+    if (shownStandingIds.size) {
       body.push(
         '',
         '  The actions above also appear in the queue at the top, where they are priced and applyable.'

--- a/plugin/hooks/lib/audit.mjs
+++ b/plugin/hooks/lib/audit.mjs
@@ -33,6 +33,7 @@
 import { record, readMetrics } from './metrics.mjs';
 import { remedyLedger, applyRemedy, proposal } from './remedy.mjs';
 import { money, monthly, priceNote, dollars } from './pricing.mjs';
+import { renderStanding } from './standing.mjs';
 
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
 
@@ -183,7 +184,7 @@ export function buildQueue(
 export function renderAudit(
   dir,
   findings = [],
-  { tier = 'opus', full = false, sessionsPerMonth = 60 } = {}
+  { tier = 'opus', full = false, sessionsPerMonth = 60, standing = null } = {}
 ) {
   const { queue, suppressed, done } = buildQueue(dir, findings);
   const lines = [];
@@ -316,6 +317,38 @@ export function renderAudit(
       body.push(
         `  ${trend.detector}: ${trend.before.toLocaleString()} -> ${trend.after.toLocaleString()} tokens/session ` +
           `(${trend.improved ? 'improved' : 'worse'})`
+      );
+    }
+  }
+
+  // STANDING CONTEXT, as a panel rather than only as queue rows.
+  //
+  // auditStanding and verdictFor were both reachable, so this project already
+  // computed which CLAUDE.md rules and skills are stale, oversized or never
+  // used -- and threw the report away. renderStanding existed, was tested, and
+  // had no caller: the forTouch shape exactly, in the subsystem #203 claimed
+  // closed the skills-and-memory gap. Hard to defend a gap as closed while the
+  // report that would show it is unreachable.
+  //
+  // WHAT THE QUEUE ABOVE CANNOT SAY, which is why this is not duplication. The
+  // queue carries one row per ACTION, so a standing file with nothing wrong
+  // contributes no row and is invisible -- and the total cost of the prefix,
+  // the number that says what standing context is worth arguing about at all,
+  // is carried by no row either. Both are in the panel.
+  //
+  // Costed like everything else here: it is pushed BEFORE the closing line is
+  // measured, so the report's self-cost includes its own newest panel rather
+  // than understating it.
+  if (standing?.length) {
+    body.push('', 'Standing context -- charged every session:', '');
+    const panel = renderStanding(standing, { sessionsPerMonth });
+    // Indented to sit under its heading, blank lines left blank rather than
+    // turned into trailing whitespace.
+    for (const line of panel.split('\n')) body.push(line ? `  ${line}` : '');
+    if (standing.some((v) => v.actions?.length)) {
+      body.push(
+        '',
+        '  The actions above also appear in the queue at the top, where they are priced and applyable.'
       );
     }
   }

--- a/plugin/hooks/lib/consolidate.mjs
+++ b/plugin/hooks/lib/consolidate.mjs
@@ -36,6 +36,28 @@ import { nodeId } from './wiki.mjs';
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
 
 /**
+ * A candidate's own words, whatever the producer called the field.
+ *
+ * THE SELECTOR AND THE RATIO DISAGREED ABOUT THIS, and the half that had no
+ * caller is the half that was wrong. `irrecoverability`, `costToRederive` and
+ * `selectForConsolidation` all read `entry.summary`; `consolidationRatio` and
+ * `aggregateConsolidation` read `finding.claim`. NO PRODUCER IN THIS REPOSITORY
+ * EMITS `summary` -- the semantic harvest, wiki_write and the evaluation
+ * harnesses all emit `claim`, and `validate()` in harvest.mjs rejects anything
+ * without one.
+ *
+ * That matters more than a rename. Wired naively, every candidate would have
+ * scored `tokens: estimate(undefined)` -- zero -- so the budget could never
+ * bind, nothing would ever be dropped, and the selector would have been live,
+ * green, and inert. A capability that runs and cannot affect its own output is
+ * the same defect as one that never runs, wearing a call site.
+ *
+ * `summary` is still accepted, because an external caller may pass it and
+ * breaking that to fix an internal disagreement would be gratuitous.
+ */
+const claimText = (entry) => entry?.claim || entry?.summary || '';
+
+/**
  * How hard something is to reproduce, independent of what it cost this time.
  *
  * Token cost alone understates the expensive cases. Reproducing a flaky failure
@@ -45,7 +67,7 @@ const estimate = (text) => Math.ceil(String(text || '').length / 4);
  * measurements, and pretending otherwise would be false precision.
  */
 export function irrecoverability(entry) {
-  const text = `${entry.summary || ''} ${entry.evidence || ''}`.toLowerCase();
+  const text = `${claimText(entry)} ${entry.evidence || ''}`.toLowerCase();
 
   // Anything derived from a non-deterministic or long-running observation.
   //
@@ -110,7 +132,7 @@ export function costToRederive(entry, previousAt) {
   // no-op. The only measured cost is `entry.tokensSpent`, which the extraction
   // site must supply; otherwise fall back to the size of the evidence, so a
   // conclusion drawn from a large investigation still outranks an aside.
-  return estimate(entry.evidence) * 4 || estimate(entry.summary) * 8;
+  return estimate(entry.evidence) * 4 || estimate(claimText(entry)) * 8;
 }
 
 /** Kinds that survive on the floor regardless of score. */
@@ -141,7 +163,7 @@ export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}
     });
     const cost = costToRederive(entry, previousAt);
     const score = cost * irrecoverability(entry) * reuseProbability(graph, entry.anchorIds || anchors);
-    scored.push({ entry, score, cost, tokens: estimate(entry.summary) });
+    scored.push({ entry, score, cost, tokens: estimate(claimText(entry)) });
     previousAt = entry.at ?? previousAt;
   }
 
@@ -182,7 +204,7 @@ export function selectForConsolidation(graph, candidates, { budget = 4000 } = {}
  * FOR, in a way that "tokens saved" never quite is.
  */
 export function consolidationRatio(finding) {
-  const carry = estimate(finding.claim);
+  const carry = estimate(claimText(finding));
   const derived = finding.derivedCost || 0;
   if (!carry || !derived) return null;
   return derived / carry;
@@ -195,7 +217,7 @@ export function aggregateConsolidation(findings) {
   for (const finding of findings) {
     if (!finding.derivedCost) continue;
     derived += finding.derivedCost;
-    carry += estimate(finding.claim);
+    carry += estimate(claimText(finding));
   }
   return carry ? { derived, carry, ratio: derived / carry } : null;
 }

--- a/plugin/hooks/lib/consolidate.mjs
+++ b/plugin/hooks/lib/consolidate.mjs
@@ -31,7 +31,6 @@
  * without session instrumentation cannot obtain.
  */
 
-import { statSync } from 'node:fs';
 import { nodeId } from './wiki.mjs';
 
 const estimate = (text) => Math.ceil(String(text || '').length / 4);
@@ -201,25 +200,3 @@ export function aggregateConsolidation(findings) {
   return carry ? { derived, carry, ratio: derived / carry } : null;
 }
 
-/**
- * Content identity for a file, so a finding can reach across projects.
- *
- * A vendored library file is the same file in every repository that holds it,
- * whatever path each gives it. Anchoring to content as well as path means a
- * finding about it appears in all of them with no promotion step and no path
- * mapping -- reach a per-session checkpoint cannot have even in principle.
- *
- * The PATH anchor still drives staleness within a repo; this is additive.
- */
-export function contentAnchor(path, hash) {
-  if (!hash) return null;
-  let size = 0;
-  try {
-    size = statSync(path).size;
-  } catch {
-    return null;
-  }
-  // Size is included so two different files sharing a truncated digest do not
-  // collide into one identity.
-  return `content:${hash}:${size}`;
-}

--- a/plugin/hooks/lib/doctor.mjs
+++ b/plugin/hooks/lib/doctor.mjs
@@ -26,7 +26,21 @@ import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync, mkdirSyn
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { harvestMode } from './harvest.mjs';
-import { readManifest, verifyManifest, residue } from './manifest.mjs';
+import { readManifest, verifyManifest, residue, manifestSize } from './manifest.mjs';
+
+/**
+ * Bytes as a person reads them.
+ *
+ * Local because it exists for one line of one check, and because the alternative
+ * -- printing a raw byte count next to a file count -- is the kind of detail
+ * that gets skimmed past rather than read.
+ */
+function describeBytes(bytes) {
+  if (!bytes) return 'size unknown';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
 
 const ok = (name, detail) => ({ name, pass: true, detail });
 const bad = (name, detail, remedy) => ({ name, pass: false, detail, remedy });
@@ -362,11 +376,19 @@ export function checklist({ root, settingsPath, install }) {
     }
 
     // What we recorded putting on the machine, and whether it is still that.
-    const verified = verifyManifest(readManifest());
+    const manifest = readManifest();
+    const verified = verifyManifest(manifest);
     if (verified) {
+      // HOW MUCH, not just how many. manifestSize computed exactly this and had
+      // no caller, so the one number that says what uninstall will actually
+      // remove -- and the only cross-check on a manifest that lists files which
+      // no longer exist, since a missing file contributes zero bytes -- was
+      // computed nowhere and shown to no one.
+      const footprint = describeBytes(manifestSize(manifest));
       checks.push(verified.modified === 0
-        ? ok('installed files intact', `${verified.intact} file(s) match the install manifest`)
-        : ok('installed files intact', `${verified.modified} file(s) edited since install -- ` +
+        ? ok('installed files intact', `${verified.intact} file(s), ${footprint}, match the install manifest`)
+        : ok('installed files intact', `${verified.modified} of ${verified.intact + verified.modified} file(s) ` +
+          `(${footprint} recorded) edited since install -- ` +
           'uninstall will leave those alone rather than destroy your changes'));
     } else {
       checks.push(bad('install manifest present', 'no record of what was installed',

--- a/plugin/hooks/lib/doctor.mjs
+++ b/plugin/hooks/lib/doctor.mjs
@@ -27,6 +27,7 @@ import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { harvestMode } from './harvest.mjs';
 import { readManifest, verifyManifest, residue, manifestSize } from './manifest.mjs';
+import { mcpClientsSeen } from './metrics.mjs';
 
 /**
  * Bytes as a person reads them.
@@ -553,7 +554,39 @@ export function probeGraph({ dir }) {
     checks.push(ok('graph directory is private', 'mode could not be read on this filesystem'));
   }
 
+  checks.push(...probeClients({ dir }));
   return checks;
+}
+
+/**
+ * Which MCP clients have actually handshaked with this server.
+ *
+ * THE QUESTION THE REST OF THE DOCTOR CANNOT ANSWER. Every other check here
+ * reasons about files on disk: is the hook present, is it wired, does it refuse
+ * a large read. None of them can tell you whether the editor in front of you
+ * ever actually connected -- which is the single most common way this product
+ * is installed and silently does nothing.
+ *
+ * `mcp-client` records exactly that on every `initialize`, and nothing read it
+ * until now. NEVER A FAILURE: a fresh install has no handshakes yet, and a
+ * doctor that reports red on a correct install teaches people to ignore it.
+ */
+export function probeClients({ dir }) {
+  let clients = [];
+  try {
+    clients = mcpClientsSeen(dir);
+  } catch {
+    return [ok('MCP clients seen', 'no evidence log yet')];
+  }
+  if (!clients.length) {
+    return [ok('MCP clients seen', 'none yet -- the server has had no MCP handshake in this project')];
+  }
+  const described = clients
+    .slice(0, 5)
+    .map((c) => `${c.title || c.client}${c.version ? ` ${c.version}` : ''}`)
+    .join(', ');
+  return [ok('MCP clients seen', `${clients.length}: ${described}` +
+    (clients.length > 5 ? `, and ${clients.length - 5} more` : ''))];
 }
 
 /**

--- a/plugin/hooks/lib/doctor.mjs
+++ b/plugin/hooks/lib/doctor.mjs
@@ -386,11 +386,23 @@ export function checklist({ root, settingsPath, install }) {
       // no longer exist, since a missing file contributes zero bytes -- was
       // computed nowhere and shown to no one.
       const footprint = describeBytes(manifestSize(manifest));
-      checks.push(verified.modified === 0
-        ? ok('installed files intact', `${verified.intact} file(s), ${footprint}, match the install manifest`)
-        : ok('installed files intact', `${verified.modified} of ${verified.intact + verified.modified} file(s) ` +
+      // MISSING IS NOT INTACT, and branching on `modified` alone said it was.
+      // verifyManifest reports three states and this read two of them: a
+      // recorded file DELETED rather than edited left `modified === 0`, so a
+      // half-removed install passed as healthy. The footprint above is what
+      // makes it visible -- a missing file contributes zero bytes -- but a
+      // visible detail beside a PASS is still a PASS.
+      if (verified.missing > 0) {
+        checks.push(bad('installed files intact',
+          `${verified.missing} of ${verified.files.length} recorded file(s) are gone (${footprint} still on disk)`,
+          'reinstall the package to restore them, or run the uninstaller to clear the manifest'));
+      } else if (verified.modified === 0) {
+        checks.push(ok('installed files intact', `${verified.intact} file(s), ${footprint}, match the install manifest`));
+      } else {
+        checks.push(ok('installed files intact', `${verified.modified} of ${verified.intact + verified.modified} file(s) ` +
           `(${footprint} recorded) edited since install -- ` +
           'uninstall will leave those alone rather than destroy your changes'));
+      }
     } else {
       checks.push(bad('install manifest present', 'no record of what was installed',
         'harmless if you installed manually; reinstall to get a removable, verifiable record'));
@@ -538,9 +550,16 @@ export function probeGraph({ dir }) {
   // the bits read back as world-readable regardless, so failing there would be
   // reporting a platform property as a broken install: a false alarm that
   // teaches people to ignore the doctor.
+  // BEFORE THE PLATFORM RETURN, and this is exactly the defect this branch
+  // exists to close: the client probe was appended after `probeGraph`'s
+  // Windows early-return, so on Windows it had a call site and never ran. A
+  // reference that cannot execute is what the reachability guard cannot see.
+  const clients = probeClients({ dir });
+
   if (process.platform === 'win32') {
     checks.push(ok('graph directory is private',
       'POSIX modes are not enforced on Windows; the directory inherits its parent ACL'));
+    checks.push(...clients);
     return checks;
   }
 
@@ -554,7 +573,7 @@ export function probeGraph({ dir }) {
     checks.push(ok('graph directory is private', 'mode could not be read on this filesystem'));
   }
 
-  checks.push(...probeClients({ dir }));
+  checks.push(...clients);
   return checks;
 }
 

--- a/plugin/hooks/lib/keepwarm.mjs
+++ b/plugin/hooks/lib/keepwarm.mjs
@@ -110,7 +110,7 @@ export function gapDistribution(dir, { events = readMetrics(dir) } = {}) {
  * Returns the arithmetic as well as the verdict, because a refusal to refresh
  * that cannot be checked is indistinguishable from a bug.
  */
-export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0] }) {
+export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0], observed = null }) {
   if (!prefixTokens || !gaps) {
     return { action: 'unknown', reason: 'no gap distribution yet -- needs a few sessions of history' };
   }
@@ -124,21 +124,42 @@ export function keepWarmDecision({ prefixTokens, gaps, tier = TIERS[0] }) {
   // The ping only earns anything in the window where the entry WOULD have
   // expired but the next turn still arrives: before the TTL it was already
   // warm, and long after it, one ping does not reach.
-  const probability = Math.max(0, gaps.probabilityWithin(tier.ms * 2) - gaps.probabilityWithin(tier.ms));
+  const modelled = Math.max(0, gaps.probabilityWithin(tier.ms * 2) - gaps.probabilityWithin(tier.ms));
+
+  // MEASURED BEATS MODELLED, once there is enough of it.
+  //
+  // The module header already commits to this -- "an expected-value decision is
+  // only as good as the distribution it was fitted to, and distributions
+  // shift" -- and the tripwire underneath was the only thing acting on it, as
+  // an all-or-nothing kill switch. Between "the model says refresh" and "stop
+  // entirely" there was nothing, because the observed hit rate was never
+  // computed: both recording halves had no call site, so ten refreshes that
+  // bought nothing would keep recommending refresh right up to the moment the
+  // tripwire cut the whole feature off.
+  //
+  // Below OBSERVATION_FLOOR this stays null and the model is used unchanged; a
+  // handful of samples would swing the decision harder than the distribution
+  // they replace.
+  const probability = observed ? observed.rate : modelled;
   const savingIfUsed = prefixTokens * (tier.writeMultiplier - READ_MULTIPLIER);
   const ev = probability * savingIfUsed - costOfPing;
+  const basis = observed
+    ? `measured over ${observed.observations} refreshes`
+    : 'modelled from the gap distribution';
 
   return {
     action: ev > 0 ? 'refresh' : 'skip',
     tier: tier.name,
     probability,
+    modelledProbability: modelled,
+    basis,
     savingIfUsed: Math.round(savingIfUsed),
     costOfPing: Math.round(costOfPing),
     expectedValue: Math.round(ev),
     reason: ev > 0
-      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers; ` +
+      ? `${Math.round(probability * 100)}% of gaps land in the window one ${tier.name} refresh covers (${basis}); ` +
         `expected gain ${Math.round(ev).toLocaleString()} tokens`
-      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers; ` +
+      : `only ${Math.round(probability * 100)}% of gaps land in the window a ${tier.name} refresh covers (${basis}); ` +
         `expected loss ${Math.abs(Math.round(ev)).toLocaleString()} tokens`,
   };
 }
@@ -194,9 +215,84 @@ export function ttlTier({ prefixTokens, gaps, turnsPerSession = DEFAULT_TURNS })
   };
 }
 
+/** Observations of a tier before its measured hit rate may override the model. */
+export const OBSERVATION_FLOOR = 5;
+
 /** Records a refresh so its outcome can be scored. */
 export function recordRefresh(dir, { tier, prefixTokens, expectedValue }) {
   record(dir, { kind: 'keepwarm', action: 'refresh', tier, prefixTokens, expectedValue });
+}
+
+/**
+ * Scores every refresh whose window has since resolved.
+ *
+ * THE MISSING HALF, and it was missing because nobody could see where the
+ * signal would come from. `recordRefreshOutcome` needs to know whether a real
+ * turn arrived before the entry expired -- and that is not a thing anyone has
+ * to instrument, because the event log already records when every turn
+ * happened. The answer was in the data the whole time.
+ *
+ * For each unscored refresh at time T on a tier with TTL `ms`:
+ *
+ *   - a later event within `ms`            -> HIT, observed
+ *   - a later event after `ms`             -> MISS, observed
+ *   - no later event, and `now - T > ms`   -> MISS, observed: the window has
+ *                                             demonstrably closed unused
+ *   - no later event, window still open    -> NOTHING RECORDED
+ *
+ * That last line is the important one and it is Plan 2's own instruction: "if
+ * no signal is available for a tier, record nothing rather than guessing
+ * `hit: false`". A refresh whose window has not closed yet is not a miss, and
+ * scoring it as one would drive the tripwire negative on the newest and least
+ * informative records.
+ *
+ * DRAINED AT READ TIME, which is the pattern this codebase already uses for
+ * staleness: the producer cannot know the outcome at the moment it acts, so the
+ * next reader resolves what has become knowable since.
+ */
+export function scoreOutstandingRefreshes(dir, { events = readMetrics(dir), outcomes = readBalance(dir), now = Date.now() } = {}) {
+  const keepwarm = outcomes.filter((e) => e.kind === 'keepwarm');
+  const refreshes = keepwarm.filter((e) => e.action === 'refresh').sort((a, b) => (a.at || 0) - (b.at || 0));
+  const scored = keepwarm.filter((e) => e.action === 'outcome').length;
+
+  // Refreshes are scored oldest-first and one outcome belongs to one refresh,
+  // so everything past the number already scored is outstanding. Pairing by
+  // timestamp instead would double-count two refreshes recorded in the same
+  // millisecond, which is reachable: a tool run twice in a loop.
+  const outstanding = refreshes.slice(scored);
+  const timeline = events.map((e) => Number(e.at) || 0).filter(Boolean).sort((a, b) => a - b);
+
+  let recorded = 0;
+  for (const refresh of outstanding) {
+    const at = Number(refresh.at) || 0;
+    if (!at) continue;
+    const tierSpec = TIERS.find((t) => t.name === refresh.tier) || TIERS[0];
+    const next = timeline.find((t) => t > at);
+
+    let hit;
+    if (next !== undefined) hit = next - at <= tierSpec.ms;
+    else if (now - at > tierSpec.ms) hit = false;
+    else continue; // window still open: not yet knowable
+
+    recordRefreshOutcome(dir, { tier: refresh.tier, prefixTokens: refresh.prefixTokens, hit });
+    recorded += 1;
+  }
+  return { outstanding: outstanding.length, recorded };
+}
+
+/**
+ * The measured hit rate for a tier, or null below the observation floor.
+ *
+ * Null rather than a small-sample number, because the caller substitutes it for
+ * a modelled probability and three observations would swing the decision harder
+ * than the model they replace.
+ */
+export function observedHitRate(dir, { tier, outcomes = readBalance(dir) } = {}) {
+  const relevant = outcomes.filter(
+    (e) => e.kind === 'keepwarm' && e.action === 'outcome' && (!tier || e.tier === tier)
+  );
+  if (relevant.length < OBSERVATION_FLOOR) return null;
+  return { observations: relevant.length, rate: relevant.filter((e) => e.hit).length / relevant.length };
 }
 
 /**
@@ -276,6 +372,18 @@ export function shouldKeepWarm(dir, {
   // was chosen was wrong for one of them.
   outcomes = readBalance(dir),
 } = {}) {
+  // DRAIN BEFORE DECIDING. Anything whose window has closed since the last call
+  // becomes evidence now, so the decision below and the tripwire above both see
+  // the most that is currently knowable -- the same read-time drain the
+  // staleness path uses, and for the same reason: the producer cannot know the
+  // outcome at the moment it acts.
+  try {
+    scoreOutstandingRefreshes(dir, { events, outcomes });
+    outcomes = readBalance(dir);
+  } catch {
+    /* scoring is evidence, never a reason to refuse a decision */
+  }
+
   const trip = tripwire(dir, { events: outcomes });
   if (trip.tripped) return { action: 'skip', reason: trip.reason, trippedWire: true };
 
@@ -289,7 +397,11 @@ export function shouldKeepWarm(dir, {
     // refusal justified by a GAIN: `{ action: 'skip', reason: '...expected gain 130 tokens' }`.
     // This module's own docstring says a refusal that cannot be checked is indistinguishable from
     // a bug; one that contradicts itself is worse.
-    const decision = keepWarmDecision({ prefixTokens, gaps });
+    const decision = keepWarmDecision({
+      prefixTokens,
+      gaps,
+      observed: observedHitRate(dir, { tier: TIERS[0].name, outcomes }),
+    });
     if (decision.action === 'refresh') return decision;
     return { action: decision.action === 'unknown' ? 'unknown' : 'skip', reason: decision.reason };
   }

--- a/plugin/hooks/lib/metrics.mjs
+++ b/plugin/hooks/lib/metrics.mjs
@@ -744,6 +744,21 @@ export function balanceSheet(dir) {
           verdict: r.verdict,
         };
       })(),
+      // THE CONTROL ARM'S CONTENT, for the same reason `controlArmTokens` sits
+      // in the substitution block above: `candidateCount` and
+      // `shadowFindingIds` recorded what the holdout withheld and nothing read
+      // them, so the report could count the arms and never say what was in
+      // them.
+      ...(() => {
+        const shadow = shadowDelivery(dir);
+        return {
+          selected: shadow.selected,
+          delivered: shadow.delivered,
+          controlArmSelected: shadow.withheldSelected,
+          controlArmFindings: shadow.withheldFindings,
+          indexStaleEntries: shadow.staleEntries,
+        };
+      })(),
     },
     costs: {
       injection: injectCost,
@@ -1283,6 +1298,109 @@ export function declinedAtBudget(dir, { limit = 500 } = {}) {
       .sort((a, b) => b[1] - a[1])
       .map(([reason, count]) => ({ reason, count })),
   };
+}
+
+/**
+ * The injection arm's SHADOW: what retrieval selected, against what was served.
+ *
+ * THE SAME GAP `controlArmTokens` WAS CREATED TO CLOSE, one arm over. That
+ * field exists because `tokensFullFile` "was recorded and read by nothing, so
+ * the comparison the holdout exists for was not computable from the report" --
+ * and the injection side had the identical hole: every `inject` record carries
+ * `candidateCount` and `shadowFindingIds`, which are what WOULD have been
+ * delivered, non-zero in BOTH arms, while `count` and `findingIds` go to zero
+ * in the holdout. The shadow pair was written on every injection since the
+ * holdout shipped and read by nothing, so the report could say how many touches
+ * landed in each arm and never which findings the holdout actually withheld.
+ *
+ * `staleCount` is the same shape on the session-start index: `stale` (a
+ * boolean, "was any of this stale") had a reader, the count did not, so a index
+ * with one rotten entry in forty was indistinguishable from one rotten
+ * throughout.
+ *
+ * READ FROM THE BALANCE LOG, because `inject` is a BALANCE_KIND: the firehose
+ * evicts injections first -- 136 of them against 6,725 captures on one machine
+ * -- which is the eviction that made `report()` say "0 holdout" over a file
+ * containing nine.
+ */
+export function shadowDelivery(dir) {
+  const injections = readBalance(dir).filter((event) => event.kind === 'inject');
+
+  let selected = 0;
+  let delivered = 0;
+  let withheldSelected = 0;
+  const withheldKeys = new Set();
+  let staleEntries = 0;
+  let indexRecords = 0;
+
+  for (const event of injections) {
+    const candidates = Number(event.candidateCount) || 0;
+    selected += candidates;
+    delivered += Number(event.count) || 0;
+    if (event.holdout) {
+      withheldSelected += candidates;
+      for (const key of event.shadowFindingIds || []) withheldKeys.add(key);
+    }
+    if (event.surface === 'session-start') {
+      indexRecords += 1;
+      staleEntries += Number(event.staleCount) || 0;
+    }
+  }
+
+  return {
+    injections: injections.length,
+    // Everything retrieval chose, across both arms.
+    selected,
+    // What actually reached a model.
+    delivered,
+    // Chosen and deliberately not delivered, because the anchor was in the
+    // withheld arm. This is the control arm's content, which is the thing the
+    // holdout exists to make comparable.
+    withheldSelected,
+    withheldFindings: withheldKeys.size,
+    // Index staleness as a rate rather than a boolean.
+    indexRecords,
+    staleEntries,
+  };
+}
+
+/**
+ * Which MCP clients have actually handshaked with this server.
+ *
+ * `mcp-client` was written on every `initialize` and read by nothing -- a
+ * producer with no reader, and the last one the census found. Deleting it was
+ * the other option and would have been wrong: `mcp-tool` records a client only
+ * once it CALLS something, and the project registry records a name only, so a
+ * client that connected and then called nothing -- which is exactly the failure
+ * this project's doctor exists to diagnose -- appeared in neither. The
+ * handshake is the only record that a connection happened at all.
+ *
+ * `clientTitle` is the field that made the record unique and it was unread too:
+ * the display name a client reports for itself, which is how a user recognises
+ * their own editor in a list where `name` is a slug.
+ */
+export function mcpClientsSeen(dir, { limit = 200 } = {}) {
+  const seen = new Map();
+  for (const event of readEvidence(dir)) {
+    if (event.kind !== 'mcp-client') continue;
+    const name = String(event.client || 'unknown');
+    const at = Number(event.at) || 0;
+    const previous = seen.get(name);
+    // LAST HANDSHAKE WINS on the mutable fields: a client that upgraded should
+    // be reported at the version it is now, not the one it first connected on.
+    if (!previous || at >= previous.at) {
+      seen.set(name, {
+        client: name,
+        title: event.clientTitle || null,
+        version: event.clientVersion || null,
+        at,
+        connections: (previous?.connections || 0) + 1,
+      });
+    } else {
+      previous.connections += 1;
+    }
+  }
+  return [...seen.values()].sort((a, b) => b.at - a.at).slice(0, limit);
 }
 
 /* ----------------------------------------------------------------------

--- a/plugin/hooks/lib/metrics.mjs
+++ b/plugin/hooks/lib/metrics.mjs
@@ -1231,6 +1231,60 @@ export function indexBudget(
   return Math.max(floor, Math.min(ceiling, scaled));
 }
 
+/**
+ * What retrieval decided NOT to inject, and why.
+ *
+ * THE OTHER HALF OF THE BUDGET, and it had no reader. `assessFindings` rejects a
+ * finding for one of three reasons -- it has been quarantined as harmful, it is
+ * in cooldown after being injected recently, or its expected value is negative
+ * -- and inject.mjs records every one of those decisions as a
+ * `retrieval-decision` event, from four separate call sites. Nothing read them.
+ *
+ * WHY THAT MATTERS RATHER THAN BEING TIDY. #204 makes the per-touch token budget
+ * load-bearing: "without it the most heavily-worked files accumulate the most
+ * findings and become the most expensive to touch, and the optimizer becomes
+ * its own token problem." A budget that silently drops what it cannot afford is
+ * indistinguishable, from outside, from a graph that had nothing to say. These
+ * are the two states a user most needs told apart, and the records to tell them
+ * apart were already being written.
+ *
+ * READ FROM THE EVIDENCE LOG, not the firehose. `retrieval-decision` is in
+ * EVIDENCE_KINDS precisely because it is rare relative to per-tool-call
+ * telemetry, and the windowed reader would evict it before it accumulated --
+ * the same eviction that made `report()` say "0 holdout" over a file containing
+ * nine.
+ */
+export function declinedAtBudget(dir, { limit = 500 } = {}) {
+  const decisions = readEvidence(dir)
+    .filter((event) => event.kind === 'retrieval-decision')
+    .slice(-limit);
+
+  const byReason = new Map();
+  const keys = new Set();
+  let declined = 0;
+  for (const decision of decisions) {
+    for (const item of decision.rejected || []) {
+      declined += 1;
+      if (item.key) keys.add(item.key);
+      // An unlabelled rejection is counted, not dropped: an unknown reason is
+      // still a finding the model did not get, and reporting the count as
+      // smaller than it is would understate exactly the cost this exists to
+      // surface.
+      const reason = item.reason || 'unspecified';
+      byReason.set(reason, (byReason.get(reason) || 0) + 1);
+    }
+  }
+
+  return {
+    decisions: decisions.length,
+    declined,
+    distinctFindings: keys.size,
+    byReason: [...byReason.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([reason, count]) => ({ reason, count })),
+  };
+}
+
 /* ----------------------------------------------------------------------
  * Episode-level causal evidence
  * ------------------------------------------------------------------- */

--- a/plugin/hooks/lib/staleness.mjs
+++ b/plugin/hooks/lib/staleness.mjs
@@ -297,7 +297,25 @@ export function checkAnchor(anchor) {
   if (anchor.kind === 'file') {
     return hash(source) === anchor.hash
       ? { fresh: true }
-      : { fresh: false, before: anchor.snapshot || '', hasBefore: Boolean(anchor.snapshot), after: source, reason: 'file changed' };
+      : {
+          fresh: false,
+          before: anchor.snapshot || '',
+          hasBefore: Boolean(anchor.snapshot),
+          after: source,
+          // AND WHAT CHANGED IT, when the graph knows. The structural harvest
+          // stamps `lastAction` -- the tool name that last touched this file --
+          // on every file node, and nothing read it: the field was written on
+          // every observed tool call since #203 and consumed nowhere.
+          //
+          // It belongs precisely here. "file changed" tells a reader that their
+          // finding may be wrong; "file changed (last touched by Edit)" tells
+          // them a targeted edit did it, which is cheap to re-verify, and "last
+          // touched by Write" says the file was replaced wholesale, which is
+          // usually not. Same disclosure, one word of provenance, no extra I/O.
+          reason: anchor.lastAction
+            ? `file changed (last touched by ${String(anchor.lastAction).slice(0, 40)})`
+            : 'file changed',
+        };
   }
 
   // For a symbol, re-locate it by NAME rather than by line number. Line numbers
@@ -499,6 +517,7 @@ function disputeOf(graph, finding) {
   if (!hasOutstandingContradiction(graph, finding.key)) return {};
 
   const keys = [];
+  const disputantIds = [];
   // AND THE REASON A PERSON TYPED, which had no reader anywhere. `contradict`
   // stores `contradictionReason` -- up to 400 characters of human explanation --
   // on the CONTRADICTED end only, and nothing outside its own test ever read it:
@@ -524,6 +543,7 @@ function disputeOf(graph, finding) {
     // fetch. `hasOutstandingContradiction` above already declines to open the
     // gate when EVERY disputant is retired; this is the same rule applied to
     // each name, so a live disputant is still reported alongside a withdrawn one.
+    if (!disputantIds.includes(otherId)) disputantIds.push(otherId);
     if (other && !other.retired && typeof other.key === 'string' && !keys.includes(other.key)) {
       keys.push(other.key);
       // A RETIRED END'S REASON IS NOT BORROWED EITHER, which is why this sits
@@ -537,9 +557,31 @@ function disputeOf(graph, finding) {
     }
   }
 
+  // WHEN, alongside WHY. `contradict` writes `contradictedAt` and
+  // `contradictionReason` on the same line of the same putNode call. Round 1
+  // gave the reason a reader -- this function -- and left the timestamp
+  // unread, so the disclosure could say a claim was disputed and why, and not
+  // whether that happened this morning or a year ago. For a reader deciding
+  // whether to trust a disputed finding, the age of the dispute is most of the
+  // signal: a year-old objection to a claim nobody has revisited reads very
+  // differently from one raised since the last release.
+  //
+  // Collected from whichever end holds it, exactly like the reason, and the
+  // EARLIEST is kept -- the dispute began when the first end recorded it.
+  let contradictedAt =
+    typeof finding.contradictedAt === 'number' ? finding.contradictedAt : null;
+  for (const id of disputantIds) {
+    const other = graph.nodes.get(id);
+    if (!other || other.retired) continue;
+    if (typeof other.contradictedAt !== 'number') continue;
+    contradictedAt =
+      contradictedAt === null ? other.contradictedAt : Math.min(contradictedAt, other.contradictedAt);
+  }
+
   return {
     contradicted: true,
     ...(keys.length ? { contradictedBy: keys.join(', ') } : {}),
+    ...(contradictedAt !== null ? { contradictedAt } : {}),
     // Trimmed here rather than at the renderer: an empty string is not a reason,
     // and a consumer checking `if (reason)` should not have to trim first.
     //

--- a/scripts/wiki-census.mjs
+++ b/scripts/wiki-census.mjs
@@ -18,7 +18,7 @@
  * Run: npm run wiki:census [graph-dir]
  */
 
-import { readFileSync, existsSync, statSync } from 'node:fs';
+import { readFileSync, existsSync, statSync, openSync, readSync, closeSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 
@@ -35,18 +35,36 @@ const dir =
  * `query` events means they ran and that capability did not. Collapsing those
  * into a single 0 would throw away the distinction the reader needs most.
  */
+const MAX = 32 * 1024 * 1024;
+
 function count(file, pattern) {
   const path = join(dir, file);
   if (!existsSync(path)) return null;
   try {
-    // Bounded: a mature graph's firehose is tens of megabytes and this is a
-    // diagnostic, not a batch job.
     const { size } = statSync(path);
-    const MAX = 32 * 1024 * 1024;
-    if (size > MAX) {
-      return { truncated: true, n: (readFileSync(path, 'utf8').slice(-MAX).match(pattern) || []).length };
+    if (size <= MAX) {
+      return { truncated: false, n: (readFileSync(path, 'utf8').match(pattern) || []).length };
     }
-    return { truncated: false, n: (readFileSync(path, 'utf8').match(pattern) || []).length };
+
+    // SEEK TO THE TAIL RATHER THAN DECODE THE WHOLE FILE. The first version
+    // read the file with `readFileSync(path, 'utf8')` and then took
+    // `.slice(-MAX)`, which bounds what is KEPT and nothing else -- the whole
+    // log is loaded and decoded to UTF-8 first, so a 64 MiB firehose costs 64
+    // MiB of string before a single byte is discarded. `MAX` has to bound the
+    // read to bound the memory. metrics.mjs's own reader already does it this
+    // way, for the same reason.
+    const fd = openSync(path, 'r');
+    try {
+      const buffer = Buffer.allocUnsafe(MAX);
+      const read = readSync(fd, buffer, 0, MAX, size - MAX);
+      // A multi-byte character may be cut in half at the seek point; the
+      // patterns here are ASCII, so a replacement character at the very start
+      // costs nothing, and the alternative is scanning for a boundary.
+      const text = buffer.subarray(0, read).toString('utf8');
+      return { truncated: true, n: (text.match(pattern) || []).length };
+    } finally {
+      closeSync(fd);
+    }
   } catch {
     return null;
   }

--- a/scripts/wiki-census.mjs
+++ b/scripts/wiki-census.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+/**
+ * What the graph is actually doing, on this machine, right now.
+ *
+ * NOT A TEST, and that is the entire point. Every instance of the wiring defect
+ * this work closed PASSED CI. `forTouch` had 27 green tests and no production
+ * caller; `wiki_query` was named in twelve shipped copies of injected prompt
+ * text and did not exist; `kind: 'query'` was read by the index budget and
+ * written by nothing but the test suite, so the budget sat at its floor on
+ * every project for the life of the feature.
+ *
+ * The detectors in tests/hooks are what stop a NEW one arriving. They cannot
+ * tell you a capability is alive, because "alive" is not a property of the
+ * source text -- it is a property of a real log on a real machine after a real
+ * session. That is what this prints. A zero here is not a failure; it is the
+ * only evidence that would have caught any of the above.
+ *
+ * Run: npm run wiki:census [graph-dir]
+ */
+
+import { readFileSync, existsSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+const dir =
+  process.argv[2] ||
+  process.env.TOKEN_OPTIMIZER_WIKI_DIR ||
+  join(process.cwd(), '.token-optimizer', 'wiki');
+
+/**
+ * Counts matches in a log, or reports that the log is absent.
+ *
+ * ABSENT AND EMPTY ARE DIFFERENT and both are reported as such. A missing
+ * metrics.jsonl means the hooks have never run here; a present one with no
+ * `query` events means they ran and that capability did not. Collapsing those
+ * into a single 0 would throw away the distinction the reader needs most.
+ */
+function count(file, pattern) {
+  const path = join(dir, file);
+  if (!existsSync(path)) return null;
+  try {
+    // Bounded: a mature graph's firehose is tens of megabytes and this is a
+    // diagnostic, not a batch job.
+    const { size } = statSync(path);
+    const MAX = 32 * 1024 * 1024;
+    if (size > MAX) {
+      return { truncated: true, n: (readFileSync(path, 'utf8').slice(-MAX).match(pattern) || []).length };
+    }
+    return { truncated: false, n: (readFileSync(path, 'utf8').match(pattern) || []).length };
+  } catch {
+    return null;
+  }
+}
+
+const ROWS = [
+  ['graph.jsonl', 'findings in graph', /"kind":"finding"/g, 'nothing has been learned here yet'],
+  ['graph.jsonl', 'file nodes', /"kind":"file"/g, 'structural capture has never run'],
+  ['graph.jsonl', 'symbol nodes', /"kind":"symbol"/g, 'symbol indexing has never run'],
+  ['graph.jsonl', 'contradicts edges', /"edge":"contradicts"/g, 'no disputed belief has ever been recorded'],
+  ['graph.jsonl', 'answers edges', /"edge":"answers"/g, 'no finding has ever been attributed to a question'],
+  ['graph.jsonl', 'calls edges', /"edge":"calls"/g, 'symbol call graph never built'],
+  ['metrics.jsonl', 'index events', /"kind":"index"/g, 'the session index has never been offered'],
+  ['metrics.jsonl', 'query events', /"kind":"query"/g, 'the model has never queried the graph -- indexBudget stays at its floor'],
+  ['metrics.jsonl', 'inject events', /"kind":"inject"/g, 'nothing has ever been injected'],
+  ['metrics.jsonl', 'substitute events', /"kind":"substitute"/g, 'no read has ever been substituted'],
+  ['evidence.jsonl', 'tool outcomes', /"kind":"tool-outcome"/g, 'no injection has ever been joined to a result'],
+  ['evidence.jsonl', 'retrieval decisions', /"kind":"retrieval-decision"/g, 'the budget has never turned anything away'],
+];
+
+const missing = new Set();
+const lines = [];
+for (const [file, label, pattern, why] of ROWS) {
+  const result = count(file, pattern);
+  if (result === null) {
+    missing.add(file);
+    lines.push(`  ${'-'.padStart(7)}  ${label}  <-- no ${file}`);
+    continue;
+  }
+  const flag = result.n === 0 ? `  <-- DEAD: ${why}` : '';
+  const mark = result.truncated ? ' (tail only)' : '';
+  lines.push(`  ${String(result.n).padStart(7)}  ${label}${mark}${flag}`);
+}
+
+console.log(`\nwiki census -- ${dir}\n`);
+console.log(lines.join('\n'));
+
+if (missing.size) {
+  console.log(
+    `\n${[...missing].join(', ')} not present. ` +
+      'Either the hooks have never run against this project, or the graph lives elsewhere -- ' +
+      'pass a directory as the first argument, or set TOKEN_OPTIMIZER_WIKI_DIR.'
+  );
+}
+
+console.log(
+  '\nA zero on any row means that capability is declared and not running.\n' +
+    'This is the only evidence that would have caught the wiring defects #204 closed:\n' +
+    'every one of them passed CI.\n'
+);
+
+// EXIT 0 ALWAYS. This reports, it does not judge. A fresh clone has zeroes
+// everywhere and that is correct -- #204 accepts cold start deliberately, so a
+// non-zero exit would make an honest empty graph look like a broken one, and
+// wiring it into CI would then measure the runner's filesystem rather than the
+// product. The tests in tests/hooks are the gate; this is the instrument.
+const shared = process.env.TOKEN_OPTIMIZER_SHARED_DIR || join(homedir(), '.token-optimizer', 'wiki');
+if (shared !== dir && existsSync(shared)) {
+  console.log(`The per-machine shared graph is separate: run \`npm run wiki:census ${shared}\` for it.\n`);
+}

--- a/src/dashboard/public/js/wiki.js
+++ b/src/dashboard/public/js/wiki.js
@@ -996,6 +996,11 @@ function showDetail(node) {
       <dt>Evidence</dt><dd>${escapeHtml(node.evidence || 'legacy finding: unspecified')}</dd>
       <dt>Invalidated by</dt><dd>${escapeHtml((node.invalidators || []).join('; ') || 'anchor changes')}</dd>
       <dt>Status</dt><dd>${node.stale ? '⚠ stale' : 'current'}</dd>
+      ${
+        node.consolidationRatio
+          ? `<dt>Worth carrying</dt><dd class="wiki-figure">${escapeHtml(String(node.consolidationRatio))}× cheaper to keep than to re-derive</dd>`
+          : ''
+      }
     </dl>
     ${node.snapshot ? `<div class="wiki-diff">${escapeHtml(node.snapshot.slice(0, 2000))}</div>` : ''}
     ${

--- a/src/server/audit-tool.ts
+++ b/src/server/audit-tool.ts
@@ -136,9 +136,16 @@ export async function tokenAudit(input: {
   // every session, so it belongs in the same queue rather than in a report of
   // its own. A stale claim is listed even without a transcript, because it is
   // provable from the code alone.
+  //
+  // The verdicts are also kept whole and handed to renderAudit, which renders
+  // the panel. COMPUTED ONCE: flattening them into findings loses every file
+  // that has nothing wrong with it, and loses the prefix total, so the panel
+  // needs the verdicts themselves -- but it does not need them computed twice.
+  let standing: unknown[] = [];
   try {
     const transcript = mods.cache.transcriptFor(cwd);
-    for (const verdict of mods.standing.auditStanding(cwd, transcript)) {
+    standing = mods.standing.auditStanding(cwd, transcript);
+    for (const verdict of standing as any[]) {
       for (const action of verdict.actions) {
         findings.push({
           id: `standing-${action.action}`,
@@ -174,6 +181,7 @@ export async function tokenAudit(input: {
     full: Boolean(input?.full),
     tier: input?.tier || 'opus',
     sessionsPerMonth: input?.sessionsPerMonth || 60,
+    standing,
   });
 
   // Recording that a finding was raised is what makes the before-and-after

--- a/src/server/cache-tool.ts
+++ b/src/server/cache-tool.ts
@@ -136,8 +136,37 @@ export async function cacheAudit(): Promise<{
   });
   lines.push('', `Keep-warm: ${decision.action} -- ${decision.reason}`);
 
+  // AND THE DECISION IS RECORDED, which is what closes the loop.
+  //
+  // `recordRefresh` and `recordRefreshOutcome` had no call site anywhere, so
+  // `tripwire` could never reach the ten outcomes it demands before it is
+  // allowed an opinion -- it returned "only 0/10 refreshes observed" for the
+  // life of the project, and `keepWarmDecision` could never learn that its
+  // modelled hit rate was wrong. A backstop that cannot reach its own threshold
+  // is not a backstop.
+  //
+  // WHAT IS RECORDED IS THE ADVICE, and the ledger means exactly that: this
+  // tool advises, the user acts. `scoreOutstandingRefreshes` then reads the
+  // event log to see whether a turn actually arrived inside the window this
+  // advice predicted, so what accumulates is "was the recommendation right",
+  // which is the question the tripwire and the decision both need answered.
+  if (decision.action === 'refresh') {
+    try {
+      mods.keepwarm.recordRefresh(dir, {
+        tier: decision.tier,
+        prefixTokens: health?.prefixTokens,
+        expectedValue: decision.expectedValue,
+      });
+    } catch {
+      /* the ledger is evidence, never a reason to fail the report */
+    }
+  }
+
   const trip = mods.keepwarm.tripwire(dir);
   if (trip.tripped) lines.push(`  tripwire: ${trip.reason}`);
+  else if (trip.observed > 0) {
+    lines.push(`  ledger: ${trip.reason}`);
+  }
 
   return say(lines.join('\n'));
 }

--- a/src/server/wiki-routes.ts
+++ b/src/server/wiki-routes.ts
@@ -35,6 +35,7 @@ interface GraphModules {
   capabilities: any;
   projects: any;
   lexical: any;
+  consolidate: any;
 }
 
 let cached: GraphModules | null = null;
@@ -42,16 +43,25 @@ let cached: GraphModules | null = null;
 async function modules(): Promise<GraphModules | null> {
   if (cached) return cached;
   try {
-    const [wiki, curate, metrics, staleness, capabilities, projects, lexical] =
-      await Promise.all([
-        import(coreUrl('wiki.mjs')),
-        import(coreUrl('curate.mjs')),
-        import(coreUrl('metrics.mjs')),
-        import(coreUrl('staleness.mjs')),
-        import(coreUrl('capabilities.mjs')),
-        import(coreUrl('projects.mjs')),
-        import(coreUrl('lexical.mjs')),
-      ]);
+    const [
+      wiki,
+      curate,
+      metrics,
+      staleness,
+      capabilities,
+      projects,
+      lexical,
+      consolidate,
+    ] = await Promise.all([
+      import(coreUrl('wiki.mjs')),
+      import(coreUrl('curate.mjs')),
+      import(coreUrl('metrics.mjs')),
+      import(coreUrl('staleness.mjs')),
+      import(coreUrl('capabilities.mjs')),
+      import(coreUrl('projects.mjs')),
+      import(coreUrl('lexical.mjs')),
+      import(coreUrl('consolidate.mjs')),
+    ]);
     cached = {
       wiki,
       curate,
@@ -60,6 +70,7 @@ async function modules(): Promise<GraphModules | null> {
       capabilities,
       projects,
       lexical,
+      consolidate,
     };
     return cached;
   } catch {
@@ -534,10 +545,20 @@ export function registerWikiRoutes(app: Express): void {
 
       // Provenance: which task established this, and from what. "Why do you
       // believe this?" is the question a knowledge graph has to answer.
+      // WHAT THIS FINDING SAVED, which is the whole premise stated per finding.
+      // #204 opens on it: "A finding costs ~150 tokens to carry. Re-deriving it
+      // costs 5k-50k." `consolidationRatio` computes exactly that number and
+      // had no caller anywhere, so the claim the product is built on was
+      // reported for no single finding a user could look at. Present only when
+      // the finding carries a measured derivation cost -- an unmeasured one
+      // yields null rather than a flattering guess.
+      const ratio = mods.consolidate.consolidationRatio(node);
+
       return res.json({
         node: {
           ...summarise(node, source),
           snapshot: node.snapshot ? node.snapshot.slice(0, 4000) : undefined,
+          ...(ratio ? { consolidationRatio: Math.round(ratio * 10) / 10 } : {}),
         },
         edges: edges.map((e: any) => ({
           from: qualifiedId(source, e.from),

--- a/tests/fixtures/source-scan.mjs
+++ b/tests/fixtures/source-scan.mjs
@@ -14,6 +14,13 @@
 import { readdirSync, readFileSync, statSync } from 'fs';
 import { join } from 'path';
 
+/** Characters written by code point, so no escape in this file is load-bearing. */
+const BACKSLASH = String.fromCharCode(92);
+const NEWLINE = String.fromCharCode(10);
+const DQUOTE = String.fromCharCode(34);
+const SQUOTE = String.fromCharCode(39);
+const BACKTICK = String.fromCharCode(96);
+
 /**
  * Where DECLARATIONS live: the live hook path only.
  *
@@ -109,11 +116,67 @@ export function readSources(repo, dirs) {
  * appears in a string is the PERMISSIVE direction, and permissive is merely
  * useless where strict fails CI on working code and gets deleted. Comments
  * only. The line stays where the measurement put it.
+ *
+ * WHAT IS NOT NEGOTIABLE IS THE DIRECTION, and the regex version got that
+ * wrong in one case that review caught: a string containing a comment opener --
+ * `const label = "a // b"; realCall();` -- truncated the line at the quoted
+ * `//` and took `realCall()` with it, reporting a live function as an orphan.
+ * That is the strict direction, on working code, which this guard must never be.
+ *
+ * So the scanner is back, with one difference that is the whole point: QUOTE
+ * STATE RESETS AT EVERY NEWLINE. The second attempt failed because a regex
+ * literal desynchronised it for the remainder of the FILE; bounded to a line,
+ * the same mistake costs one line. And every way the tracker can be wrong is
+ * permissive, because its state is only ever used to DECLINE to strip: get it
+ * wrong and prose survives into the scan, which over-counts. It can no longer
+ * delete code.
  */
 export function stripComments(text) {
-  return String(text)
-    .replace(/\/\*[\s\S]*?\*\//g, ' ')     // block comments, including docblocks
-    .replace(/(^|[^:])\/\/[^\n]*/g, '$1 '); // line comments, sparing the // in a URL
+  const source = String(text);
+  let out = '';
+  let inBlock = false;
+  // Quote state is tracked WITHIN A LINE ONLY, and reset at every newline.
+  // That bound is the whole reason this is safe where the full-file scanner was
+  // not: a regex literal containing a quote desynchronises the tracker for the
+  // rest of ONE line instead of the rest of the file. And every way it can be
+  // wrong is permissive -- quote state is only ever used to DECLINE to strip,
+  // so mis-tracking leaves prose in the scan (over-counting) and never removes
+  // code (under-counting).
+  let quote = null;
+
+  for (let i = 0; i < source.length; i += 1) {
+    const c = source[i];
+    const next = source[i + 1];
+
+    if (c === NEWLINE) { quote = null; out += c; continue; }
+
+    if (inBlock) {
+      if (c === '*' && next === '/') { inBlock = false; i += 1; out += '  '; continue; }
+      out += ' ';
+      continue;
+    }
+
+    if (quote) {
+      // An escape consumes the next character, so an escaped quote inside a
+      // string does not close it early.
+      if (c === BACKSLASH) { out += source.slice(i, i + 2); i += 1; continue; }
+      if (c === quote) quote = null;
+      out += c;
+      continue;
+    }
+
+    if (c === DQUOTE || c === SQUOTE || c === BACKTICK) { quote = c; out += c; continue; }
+
+    if (c === '/' && next === '/') {
+      while (i < source.length && source[i] !== NEWLINE) { out += ' '; i += 1; }
+      i -= 1;
+      continue;
+    }
+    if (c === '/' && next === '*') { inBlock = true; i += 1; out += '  '; continue; }
+
+    out += c;
+  }
+  return out;
 }
 
 /**

--- a/tests/fixtures/source-scan.mjs
+++ b/tests/fixtures/source-scan.mjs
@@ -1,0 +1,228 @@
+/**
+ * One definition of "what counts as shipped code", shared by every guard that
+ * reads this repository as text.
+ *
+ * WHY SHARED. `reachability.test.mjs` asks whether an exported name is called;
+ * `census.test.mjs` asks whether a declared event kind, edge kind or tool name
+ * has a producer and a consumer. Different questions, identical notion of where
+ * the code is and which parts of a file are code -- and two copies of that
+ * notion drift. When one of them learns that a comment is not a call site and
+ * the other does not, the second reports confident nonsense and nobody
+ * re-examines it, which is the exact failure mode these guards exist to catch.
+ */
+
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * Where DECLARATIONS live: the live hook path only.
+ *
+ * `src/tools` is excluded because its tools are dispatched by NAME through a
+ * registry, so a name-based scan reports false positives there, and a blocking
+ * check built on false positives gets disabled within a week.
+ */
+export const DECLARE_DIRS = ['hooks-core', 'plugin/hooks'];
+
+/**
+ * Where USAGES are searched: everything that ships.
+ *
+ * THIS MUST BE WIDER THAN THE DECLARATION SET. `src/server/*` reaches into
+ * hooks-core through a dynamic `mods.<module>.<fn>` handle rather than a static
+ * import, and eleven files under `scripts/` consume hooks-core directly -- the
+ * installer and the uninstaller among them. A check that scans only where its
+ * author expected the callers to be measures the author, not the code.
+ */
+export const USAGE_DIRS = ['hooks-core', 'plugin', 'src', 'scripts'];
+
+/** Every source file under `dir`, minus the generated and vendored copies. */
+export function walk(dir, out = []) {
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry);
+    let st;
+    try {
+      st = statSync(full);
+    } catch {
+      continue;
+    }
+    if (st.isDirectory()) {
+      // `lib` holds the GENERATED copies of hooks-core; scanning them would
+      // make every function look used by its own duplicate.
+      if (['node_modules', 'dist', 'lib', '.git'].includes(entry)) continue;
+      walk(full, out);
+    } else if (/\.(mjs|js|ts)$/.test(entry) && !/\.d\.ts$/.test(entry)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/** `{ file, text }` for every source file under each of `dirs`, relative to `repo`. */
+export function readSources(repo, dirs) {
+  return dirs
+    .flatMap((d) => walk(join(repo, d)))
+    .map((file) => ({ file, text: readFileSync(file, 'utf8') }));
+}
+
+/**
+ * Strips comments, so prose cannot be mistaken for code.
+ *
+ * THIS IS WHAT LET A DEAD PUBLIC ENTRY POINT THROUGH. `calibrate` counted as
+ * reachable because curate.mjs contains the English phrase "the reader's
+ * ability to calibrate trust", and `reliability` counted because the word
+ * appears in its own file's prose. calibration.mjs had ZERO importers -- no
+ * forecast was ever logged, no outcome observed, and the shipped panel printed
+ * precisely the uncalibrated number that module's docstring calls "a vibe with
+ * a typeface" -- while the check that exists to catch exactly this reported it
+ * as wired, on a coincidence of comment wording.
+ *
+ * COMMENTS ONLY, NOT STRING LITERALS, and that boundary has now been moved
+ * twice and measured back twice. Both attempts are recorded here so the third
+ * reader does not spend the afternoon rediscovering them.
+ *
+ * FIRST ATTEMPT -- three global regex passes that also stripped quotes. It made
+ * `routingReport` and `modelSwitchCost` look orphaned while routing-tool.ts
+ * called both: independent global passes cannot nest, so an apostrophe inside a
+ * DOUBLE-quoted sentence opened a "single-quoted string" that ran to the next
+ * apostrophe further down the file and swallowed the real call sites between.
+ *
+ * SECOND ATTEMPT -- a hand-written character scanner, on the reasoning that a
+ * scanner cannot suffer the non-nesting problem. It cannot, and it fails worse:
+ * a JS lexer that knows about quotes but not about REGEX LITERALS desynchronises
+ * on the first regex containing a quote, and this repository has them --
+ *
+ *   hooks-core/adapter.mjs:255
+ *   /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*((?:"(?:\\.|[^"\\])*")|...)/gs
+ *
+ * MEASURED: adapter.mjs 1032 newlines in, 385 out -- 63% of the file consumed;
+ * disclose.mjs 69%. Eleven genuinely-called exports fell to a single reference,
+ * their own declaration, and reported as orphans.
+ *
+ * Telling a regex literal from a division needs parse context, which means a
+ * real parser -- a dependency and a maintenance surface for a guard whose
+ * entire value is that nobody switches it off. Over-counting a name that
+ * appears in a string is the PERMISSIVE direction, and permissive is merely
+ * useless where strict fails CI on working code and gets deleted. Comments
+ * only. The line stays where the measurement put it.
+ */
+export function stripComments(text) {
+  return String(text)
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')     // block comments, including docblocks
+    .replace(/(^|[^:])\/\/[^\n]*/g, '$1 '); // line comments, sparing the // in a URL
+}
+
+/**
+ * Blanks the specifier list of an `import {...}` / `export {...}` statement.
+ *
+ * IMPORTED IS NOT CALLED, and the reachability guard could not tell the
+ * difference. Found by mutation: dropping the `cacheOrdered` CALL from
+ * inject.mjs while leaving `import { cacheOrdered } from './cache.mjs'` in
+ * place left the suite GREEN. Only deleting the import as well turned it red --
+ * so any refactor that removed the last call but left a tidy-looking import
+ * would have restored the exact defect that guard exists to catch, silently.
+ *
+ * Only the braces are blanked, not the whole statement: the module path is left
+ * alone, and a default or namespace import (`import x from`, `import * as x`)
+ * is deliberately untouched. Those bind a name that ordinary code then has to
+ * call, so they are not the specifier case, and widening this would move the
+ * guard in the strict direction for no measured defect.
+ */
+export function stripSpecifiers(code) {
+  return String(code)
+    .replace(/\bimport\s*\{[^}]*\}\s*from\b/g, ' importfrom ')
+    .replace(/\bexport\s*\{[^}]*\}(\s*from\b)?/g, ' exportfrom ');
+}
+
+/**
+ * The text following each call to `name(`, bounded to `window` characters.
+ *
+ * DELIBERATELY A WINDOW RATHER THAN AN ARGUMENT PARSE. Splitting a call's
+ * arguments correctly means tracking nesting through strings, template
+ * interpolations and regex literals -- the same problem stripComments refuses
+ * for the same reason. A window over-reports: it can attribute a literal that
+ * belongs to a nested call to the outer one.
+ *
+ * OVER-REPORTING IS THE SAFE DIRECTION HERE, and the direction matters per
+ * assertion, so callers must think about it. "Every declared kind has a
+ * writer" is permissive under over-reporting -- a spurious writer only ever
+ * silences a complaint. "Written but never read" is NOT, which is why the read
+ * side of that census is deliberately generous too.
+ *
+ * The plan this came from proposed a single-line regex taking the SECOND
+ * argument of `putEdge(dir, from, edge, to)`. Two defects in one line: the edge
+ * kind is the third argument, and the call that writes `calls` edges spans six
+ * lines in staleness.mjs, so a line-anchored pattern reported the graph's
+ * call-edge kind as having no writer at all. Measured against grep before it
+ * was believed.
+ */
+export function callWindows(code, name, window = 500) {
+  const out = [];
+  const call = new RegExp(`\\b${name}\\s*\\(`, 'g');
+  let m;
+  while ((m = call.exec(code)) !== null) out.push(code.slice(m.index, m.index + window));
+  return out;
+}
+
+/**
+ * The keys of the first object literal passed to each call of `name(`, at the
+ * literal's top level only.
+ *
+ * BRACE-BALANCED RATHER THAN WINDOWED, because here over-reporting is the
+ * STRICT direction. This feeds the unread-field census, where a spuriously
+ * detected write becomes a spurious orphan and fails CI on working code. A
+ * fixed character window did exactly that on the first measurement: it ran past
+ * the end of a `record()` call in mcp-evidence.ts and into the next function,
+ * collecting `toolProfile` -- which belongs to `recordMcpDiagnostic` and is
+ * written twice -- as a field of the graph record. One false positive in seven
+ * is far too many for a blocking check.
+ *
+ * TOP LEVEL ONLY, which is what "record field" means: `rejected: [{ key,
+ * reason }]` contributes `rejected`, not `key` and `reason`. Those belong to a
+ * nested shape with its own reader.
+ *
+ * PERMISSIVE ON FAILURE. A literal that does not balance inside `limit`
+ * characters is SKIPPED rather than half-parsed, so an unparsed call site can
+ * only ever make this census quieter -- never make it accuse working code. The
+ * brace counter is not string-aware, for the reason stripComments records
+ * above, so a brace inside a string or a regex is what a skip protects against.
+ */
+export function objectLiteralKeys(code, name, limit = 4000) {
+  const out = [];
+  const call = new RegExp(`\\b${name}\\s*\\(`, 'g');
+  let m;
+  while ((m = call.exec(code)) !== null) {
+    const open = code.indexOf('{', m.index);
+    if (open === -1 || open - m.index > 200) continue;
+
+    let depth = 0;
+    let end = -1;
+    for (let i = open; i < Math.min(code.length, open + limit); i += 1) {
+      if (code[i] === '{') depth += 1;
+      else if (code[i] === '}') {
+        depth -= 1;
+        if (depth === 0) { end = i; break; }
+      }
+    }
+    if (end === -1) continue; // unbalanced within the limit: skip, never guess
+
+    const keys = [];
+    let level = 0;
+    for (let i = open; i <= end; i += 1) {
+      const c = code[i];
+      if (c === '{' || c === '[' || c === '(') level += 1;
+      else if (c === '}' || c === ']' || c === ')') level -= 1;
+      else if (level === 1) {
+        const rest = code.slice(i, i + 80);
+        const key = /^([A-Za-z_$][\w$]*)\s*:/.exec(rest);
+        if (key) { keys.push(key[1]); i += key[1].length; }
+      }
+    }
+    out.push(keys);
+  }
+  return out;
+}

--- a/tests/hooks/audit.test.mjs
+++ b/tests/hooks/audit.test.mjs
@@ -421,9 +421,24 @@ describe('the standing-context panel', () => {
     expect(out.text).toMatch(/nothing to do/);
   });
 
-  test('says the actions are also in the queue, rather than looking duplicated', () => {
-    const out = renderAudit(dir, [], { standing: verdicts });
-    expect(out.text).toMatch(/also appear in the queue/);
+  test('claims the actions are in the queue ONLY when they are', () => {
+    // THIS TEST USED TO REQUIRE THE FALSE CLAIM, which review caught. Rendered
+    // with no findings, the queue prints "Nothing addressable found" -- and the
+    // panel still told the reader the actions "also appear in the queue at the
+    // top". Pointing somebody at a row that is not there is worse than silence.
+    const withoutQueue = renderAudit(dir, [], { standing: verdicts });
+    expect(withoutQueue.text).toMatch(/Nothing addressable found/);
+    expect(withoutQueue.text).not.toMatch(/also appear in the queue/);
+
+    // With the matching standing rows actually in the queue, the pointer is
+    // true and worth printing: the panel and the queue would otherwise read as
+    // two unrelated lists saying the same thing.
+    const withQueue = renderAudit(
+      dir,
+      [{ id: 'standing-fix', title: 'CLAUDE.md: the claim is provably stale', costPerSession: 4200 }],
+      { standing: verdicts, full: true }
+    );
+    expect(withQueue.text).toMatch(/also appear in the queue/);
   });
 
   test('omits the panel entirely when there is no standing context', () => {

--- a/tests/hooks/audit.test.mjs
+++ b/tests/hooks/audit.test.mjs
@@ -369,3 +369,82 @@ describe('the report does not misstate its own numbers', () => {
     }
   });
 });
+
+describe('the standing-context panel', () => {
+  // WHY THIS IS HERE AT ALL. renderStanding was implemented, tested and called
+  // by nothing -- the same shape as forTouch, in the subsystem #203 claimed
+  // closed the skills-and-memory gap. These assertions are what make it stay
+  // wired: the reachability guard can only tell that SOMETHING references the
+  // name, not that the report reaches a reader.
+  const verdicts = [
+    {
+      entry: 'CLAUDE.md',
+      tokens: 4200,
+      invocations: null,
+      termsApplied: 2,
+      sessions: 12,
+      stale: [{ line: 31, why: 'names a script that no longer exists' }],
+      neverUsed: false,
+      bloated: true,
+      evidence: 'measured',
+      actions: [{ action: 'fix', kind: 'yours', why: 'the claim is provably stale' }],
+    },
+    {
+      entry: '.claude/skills/quiet.md',
+      tokens: 900,
+      invocations: 3,
+      termsApplied: null,
+      sessions: 12,
+      stale: [],
+      neverUsed: false,
+      bloated: false,
+      evidence: 'measured',
+      actions: [],
+    },
+  ];
+
+  test('renders the panel when verdicts are supplied', () => {
+    const out = renderAudit(dir, [], { standing: verdicts });
+    expect(out.text).toMatch(/Standing context -- charged every session/);
+    expect(out.text).toContain('CLAUDE.md');
+    expect(out.text).toMatch(/PROVABLY STALE/);
+  });
+
+  test('carries the two things the queue cannot say', () => {
+    const out = renderAudit(dir, [], { standing: verdicts });
+    // The prefix total: no single finding row carries it.
+    expect(out.text).toContain('5,100 tokens total');
+    // A file with NOTHING wrong produces no finding, so the queue cannot
+    // mention it -- and "we looked and it is fine" is the answer that stops
+    // this being re-litigated every session.
+    expect(out.text).toContain('.claude/skills/quiet.md');
+    expect(out.text).toMatch(/nothing to do/);
+  });
+
+  test('says the actions are also in the queue, rather than looking duplicated', () => {
+    const out = renderAudit(dir, [], { standing: verdicts });
+    expect(out.text).toMatch(/also appear in the queue/);
+  });
+
+  test('omits the panel entirely when there is no standing context', () => {
+    // Silence rather than an empty heading: a panel that always prints costs
+    // tokens in every audit on a project with no CLAUDE.md.
+    for (const empty of [null, undefined, []]) {
+      const out = renderAudit(dir, [], { standing: empty });
+      expect(out.text).not.toMatch(/Standing context -- charged/);
+    }
+  });
+
+  test('the panel is inside the report self-cost, not outside it', () => {
+    // The report exists to prove it is not a net loss. A panel excluded from
+    // its own cost figure biases exactly that comparison.
+    const bare = renderAudit(dir, [], { standing: null });
+    const withPanel = renderAudit(dir, [], { standing: verdicts });
+    const stated = (out) =>
+      Number(/cost about ([\d,]+) tokens/.exec(out.text)[1].replace(/,/g, ''));
+    expect(stated(withPanel)).toBeGreaterThan(stated(bare));
+    expect(stated(withPanel)).toBeGreaterThanOrEqual(
+      Math.ceil(withPanel.text.length / 4) * 0.9
+    );
+  });
+});

--- a/tests/hooks/cache.test.mjs
+++ b/tests/hooks/cache.test.mjs
@@ -30,11 +30,15 @@ import {
   ttlTier,
   tripwire,
   shouldKeepWarm,
+  recordRefresh,
   recordRefreshOutcome,
+  scoreOutstandingRefreshes,
+  observedHitRate,
+  OBSERVATION_FLOOR,
   TIERS,
   TRIPWIRE_MIN,
 } from '../../hooks-core/keepwarm.mjs';
-import { record, readMetrics } from '../../hooks-core/metrics.mjs';
+import { record, readMetrics, readBalance } from '../../hooks-core/metrics.mjs';
 import { policyText } from '../../hooks-core/adapter.mjs';
 import { sessionContext } from '../../hooks-core/inject.mjs';
 import { putNode } from '../../hooks-core/wiki.mjs';
@@ -724,5 +728,115 @@ describe('SessionStart context is assembled in cache order', () => {
     } catch {
       /* windows keeps handles open briefly */
     }
+  });
+});
+
+describe('the keep-warm loop actually closes', () => {
+  // `recordRefresh` and `recordRefreshOutcome` had no call site anywhere, so
+  // `tripwire` returned "only 0/10 refreshes observed" for the life of the
+  // project and `keepWarmDecision` could never learn that its modelled hit rate
+  // was wrong. The missing piece was never a new sensor: the event log already
+  // records when every turn happened, so whether a refresh's window was used is
+  // recoverable from data that was there the whole time.
+  let graph;
+
+  beforeEach(() => {
+    graph = mkdtempSync(join(tmpdir(), 'kw-loop-'));
+  });
+
+  afterEach(() => {
+    rmSync(graph, { recursive: true, force: true });
+  });
+
+  const fiveMinutes = TIERS[0].ms;
+
+  test('a turn inside the window scores as a hit', () => {
+    const at = 1_000_000;
+    recordRefresh(graph, { tier: '5m', prefixTokens: 20000, expectedValue: 1 });
+    const refreshes = readBalance(graph).filter((e) => e.action === 'refresh');
+    // Drive the timeline explicitly rather than depending on wall-clock.
+    const events = [{ kind: 'read', at: refreshes[0].at + fiveMinutes / 2 }];
+
+    const { recorded } = scoreOutstandingRefreshes(graph, { events, now: at + fiveMinutes * 10 });
+    expect(recorded).toBe(1);
+    const outcome = readBalance(graph).find((e) => e.action === 'outcome');
+    expect(outcome.hit).toBe(true);
+  });
+
+  test('a turn after the window scores as a miss', () => {
+    recordRefresh(graph, { tier: '5m', prefixTokens: 20000, expectedValue: 1 });
+    const refreshAt = readBalance(graph).find((e) => e.action === 'refresh').at;
+    const events = [{ kind: 'read', at: refreshAt + fiveMinutes * 3 }];
+
+    scoreOutstandingRefreshes(graph, { events, now: refreshAt + fiveMinutes * 10 });
+    expect(readBalance(graph).find((e) => e.action === 'outcome').hit).toBe(false);
+  });
+
+  test('a window that has not closed yet records NOTHING, rather than guessing a miss', () => {
+    // Plan 2's own instruction, and the important one: scoring an open window
+    // as a miss would drive the tripwire negative on the newest and least
+    // informative records.
+    recordRefresh(graph, { tier: '5m', prefixTokens: 20000, expectedValue: 1 });
+    const refreshAt = readBalance(graph).find((e) => e.action === 'refresh').at;
+
+    const { recorded, outstanding } = scoreOutstandingRefreshes(graph, {
+      events: [],
+      now: refreshAt + fiveMinutes / 2,
+    });
+    expect(outstanding).toBe(1);
+    expect(recorded).toBe(0);
+    expect(readBalance(graph).some((e) => e.action === 'outcome')).toBe(false);
+  });
+
+  test('a closed window with no turn at all is an observed miss', () => {
+    recordRefresh(graph, { tier: '5m', prefixTokens: 20000, expectedValue: 1 });
+    const refreshAt = readBalance(graph).find((e) => e.action === 'refresh').at;
+
+    scoreOutstandingRefreshes(graph, { events: [], now: refreshAt + fiveMinutes * 2 });
+    expect(readBalance(graph).find((e) => e.action === 'outcome').hit).toBe(false);
+  });
+
+  test('scoring is idempotent, so a second drain does not double-count', () => {
+    recordRefresh(graph, { tier: '5m', prefixTokens: 20000, expectedValue: 1 });
+    const refreshAt = readBalance(graph).find((e) => e.action === 'refresh').at;
+    const opts = { events: [], now: refreshAt + fiveMinutes * 2 };
+
+    scoreOutstandingRefreshes(graph, opts);
+    const second = scoreOutstandingRefreshes(graph, { ...opts, outcomes: readBalance(graph) });
+    expect(second.recorded).toBe(0);
+    expect(readBalance(graph).filter((e) => e.action === 'outcome')).toHaveLength(1);
+  });
+
+  test('the observed hit rate stays null below the floor, then reports', () => {
+    for (let i = 0; i < OBSERVATION_FLOOR - 1; i++) {
+      recordRefreshOutcome(graph, { tier: '5m', prefixTokens: 20000, hit: false });
+    }
+    expect(observedHitRate(graph, { tier: '5m' })).toBeNull();
+
+    recordRefreshOutcome(graph, { tier: '5m', prefixTokens: 20000, hit: false });
+    const observed = observedHitRate(graph, { tier: '5m' });
+    expect(observed.observations).toBe(OBSERVATION_FLOOR);
+    expect(observed.rate).toBe(0);
+  });
+
+  test('an observed hit rate of zero overturns a model that says refresh', () => {
+    // THE POINT OF THE WHOLE LOOP. Before this, refreshes that bought nothing
+    // kept being recommended right up to the moment the tripwire cut the entire
+    // feature off -- there was nothing between "the model says yes" and "stop".
+    const gaps = { probabilityWithin: (ms) => (ms > TIERS[0].ms ? 1 : 0) };
+    const modelled = keepWarmDecision({ prefixTokens: 20000, gaps });
+    expect(modelled.action).toBe('refresh');
+    expect(modelled.basis).toMatch(/modelled/);
+
+    const learned = keepWarmDecision({
+      prefixTokens: 20000,
+      gaps,
+      observed: { observations: 10, rate: 0 },
+    });
+    expect(learned.action).toBe('skip');
+    expect(learned.basis).toMatch(/measured over 10/);
+    // The model's own number is still reported, so the disagreement is visible
+    // rather than silently overwritten.
+    expect(learned.modelledProbability).toBe(1);
   });
 });

--- a/tests/hooks/causal-evidence.test.mjs
+++ b/tests/hooks/causal-evidence.test.mjs
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
+  declinedAtBudget,
   evidenceReport,
   evidenceReportMany,
   readEvidence,
@@ -346,5 +347,83 @@ describe('paired evidence report', () => {
       deliveryCoverage: 1,
     });
     expect(report.concurrency.effect.executedMistakesPrevented.mean).toBe(1);
+  });
+});
+
+describe('what the budget turned away', () => {
+  // `retrieval-decision` records were written from four call sites in
+  // inject.mjs and read by nothing -- a producer with no reader, which is one
+  // of the three sub-classes tests/hooks/census.test.mjs exists to catch, and
+  // the one it caught on its first run. These assertions drive the REAL
+  // rejection path rather than hand-writing records, so they fail if the
+  // reasons or the record shape drift.
+  //
+  // HOLDOUT PINNED at the top of this file. forTouch consults the stratified
+  // holdout, so without `TOKEN_OPTIMIZER_HOLDOUT=0` these fail intermittently
+  // when the anchor lands in the withheld arm and nothing is assessed at all.
+
+  test('counts nothing on a graph where retrieval never declined anything', () => {
+    // The honest zero. A budget that has turned nothing away must not be
+    // indistinguishable from one that was never consulted.
+    const declined = declinedAtBudget(dir);
+    expect(declined).toMatchObject({ decisions: 0, declined: 0, distinctFindings: 0 });
+    expect(declined.byReason).toEqual([]);
+  });
+
+  test('counts a cooldown rejection and names the reason', () => {
+    seed('finding', null);
+    expect(
+      forTouch(dir, load(dir), anchor, {
+        sessionId: 's1', episode: { episodeId: 'e1', arm: 'full' },
+      })
+    ).toMatch(/Known about/);
+    // A concurrent hook process with no in-memory gate: durable evidence still
+    // enforces the cooldown, and that rejection is what gets recorded.
+    expect(
+      forTouch(dir, load(dir), anchor, {
+        sessionId: 's1', alreadyInjected: new Set(), episode: { episodeId: 'e1', arm: 'full' },
+      })
+    ).toBeNull();
+
+    const declined = declinedAtBudget(dir);
+    expect(declined.declined).toBeGreaterThan(0);
+    expect(declined.distinctFindings).toBe(1);
+    expect(declined.byReason.map((r) => r.reason)).toContain('cooldown');
+  });
+
+  test('separates a quarantined finding from a cooled-down one', () => {
+    const key = seed('finding', null);
+    forTouch(dir, load(dir), anchor, {
+      sessionId: 's1', episode: { episodeId: 'e1', arm: 'full' },
+    });
+    forTouch(dir, load(dir), anchor, {
+      sessionId: 's1', alreadyInjected: new Set(), episode: { episodeId: 'e1', arm: 'full' },
+    });
+    recordFindingFeedback(dir, { findingId: key, rating: 'harmful', episodeId: 'review-1' });
+    recordFindingFeedback(dir, { findingId: key, rating: 'harmful', episodeId: 'review-2' });
+    forTouch(dir, load(dir), anchor, {
+      sessionId: 's2', episode: { episodeId: 'e2', arm: 'full' },
+    });
+
+    const reasons = declinedAtBudget(dir).byReason.map((r) => r.reason);
+    expect(reasons).toEqual(expect.arrayContaining(['cooldown', 'quarantined-harm']));
+    // Ranked, so the audit's "top 3" is the top 3 rather than the first 3.
+    const counts = declinedAtBudget(dir).byReason.map((r) => r.count);
+    expect([...counts].sort((a, b) => b - a)).toEqual(counts);
+  });
+
+  test('counts an unlabelled rejection rather than dropping it', () => {
+    // An unknown reason is still a finding the model did not get. Reporting a
+    // smaller number than the truth would understate exactly the cost this
+    // reader exists to surface.
+    record(dir, {
+      kind: 'retrieval-decision',
+      surface: 'file',
+      anchor,
+      rejected: [{ key: 'no-reason-given' }],
+    });
+    const declined = declinedAtBudget(dir);
+    expect(declined.declined).toBe(1);
+    expect(declined.byReason).toEqual([{ reason: 'unspecified', count: 1 }]);
   });
 });

--- a/tests/hooks/causal-evidence.test.mjs
+++ b/tests/hooks/causal-evidence.test.mjs
@@ -4,6 +4,9 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
   declinedAtBudget,
+  mcpClientsSeen,
+  balanceSheet,
+  shadowDelivery,
   evidenceReport,
   evidenceReportMany,
   readEvidence,
@@ -425,5 +428,102 @@ describe('what the budget turned away', () => {
     const declined = declinedAtBudget(dir);
     expect(declined.declined).toBe(1);
     expect(declined.byReason).toEqual([{ reason: 'unspecified', count: 1 }]);
+  });
+});
+
+describe('the shadow arm, and the fields nothing read', () => {
+  // Five fields were written onto records and consumed nowhere:
+  // candidateCount and shadowFindingIds (the injection holdout's shadow),
+  // staleCount (index staleness as a rate), contradictedAt (when a claim was
+  // disputed) and clientTitle (on the mcp-client handshake). The first three
+  // are asserted here, driving the real record shapes rather than hand-written
+  // ones where possible.
+  //
+  // HOLDOUT PINNED at the top of this file, because forTouch consults it.
+
+  test('reports what the holdout withheld, not just how many touches it withheld', () => {
+    // THE GAP controlArmTokens WAS CREATED TO CLOSE, one arm over: `count` and
+    // `findingIds` go to zero in the holdout while `candidateCount` and
+    // `shadowFindingIds` carry what WOULD have been delivered. Nothing read the
+    // shadow pair, so the report could count the arms and never say what was
+    // in them.
+    record(dir, {
+      kind: 'inject', surface: 'file', anchor, holdout: false,
+      tokens: 120, count: 2, candidateCount: 2,
+      findingIds: ['a', 'b'], shadowFindingIds: ['a', 'b'],
+    });
+    record(dir, {
+      kind: 'inject', surface: 'file', anchor, holdout: true,
+      tokens: 0, count: 0, candidateCount: 3,
+      findingIds: [], shadowFindingIds: ['c', 'd', 'e'],
+    });
+
+    const shadow = shadowDelivery(dir);
+    expect(shadow.injections).toBe(2);
+    expect(shadow.selected).toBe(5);
+    expect(shadow.delivered).toBe(2);
+    // The control arm's content: chosen, deliberately not delivered.
+    expect(shadow.withheldSelected).toBe(3);
+    expect(shadow.withheldFindings).toBe(3);
+  });
+
+  test('counts index staleness as a rate rather than a boolean', () => {
+    // `stale` had a reader and `staleCount` did not, so an index with one
+    // rotten entry in forty was indistinguishable from one rotten throughout.
+    record(dir, {
+      kind: 'inject', surface: 'session-start', anchor: 'session-index',
+      holdout: false, tokens: 90, count: 40, candidateCount: 40,
+      stale: true, staleCount: 1,
+    });
+    const shadow = shadowDelivery(dir);
+    expect(shadow.indexRecords).toBe(1);
+    expect(shadow.staleEntries).toBe(1);
+  });
+
+  test('the balance sheet carries the control arm content, beside the control arm tokens', () => {
+    record(dir, {
+      kind: 'inject', surface: 'file', anchor, holdout: true,
+      tokens: 0, count: 0, candidateCount: 2, findingIds: [], shadowFindingIds: ['x', 'y'],
+    });
+    const causal = balanceSheet(dir).estimatedCausal;
+    expect(causal.controlArmSelected).toBe(2);
+    expect(causal.controlArmFindings).toBe(2);
+    expect(causal.selected).toBe(2);
+    expect(causal.delivered).toBe(0);
+  });
+
+  test('an empty graph reports honest zeroes rather than throwing', () => {
+    const shadow = shadowDelivery(dir);
+    expect(shadow).toMatchObject({
+      injections: 0, selected: 0, delivered: 0,
+      withheldSelected: 0, withheldFindings: 0, staleEntries: 0,
+    });
+  });
+
+  test('names the MCP clients that handshaked, with the title they report', () => {
+    // `mcp-client` was written on every handshake and read by nothing. Deleting
+    // it was the other option and would have been wrong: `mcp-tool` records a
+    // client only once it CALLS something, so a client that connected and then
+    // called nothing appeared nowhere at all.
+    record(dir, {
+      kind: 'mcp-client', client: 'claude-code', clientVersion: '2.1.0',
+      clientTitle: 'Claude Code',
+    });
+    record(dir, {
+      kind: 'mcp-client', client: 'codex', clientVersion: '0.9.0', clientTitle: null,
+    });
+    const clients = mcpClientsSeen(dir);
+    expect(clients).toHaveLength(2);
+    const claude = clients.find((c) => c.client === 'claude-code');
+    expect(claude).toMatchObject({ title: 'Claude Code', version: '2.1.0' });
+  });
+
+  test('reports a client at the version it is now, not the one it first connected on', () => {
+    record(dir, { kind: 'mcp-client', client: 'claude-code', clientVersion: '2.0.0', at: 1 });
+    record(dir, { kind: 'mcp-client', client: 'claude-code', clientVersion: '2.1.0', at: 2 });
+    const clients = mcpClientsSeen(dir);
+    expect(clients).toHaveLength(1);
+    expect(clients[0].version).toBe('2.1.0');
+    expect(clients[0].connections).toBe(2);
   });
 });

--- a/tests/hooks/census.test.mjs
+++ b/tests/hooks/census.test.mjs
@@ -230,6 +230,18 @@ function edgeKinds() {
  * repository except as a key being written, which is a strong enough signal to
  * block a build on.
  */
+/**
+ * Keys every record carries, whose readers are destructures and spreads.
+ *
+ * EXPLICIT, because the alternative was a length rule and a length rule is
+ * about spelling. `id`, `at`, `to` and `key` are read by `load()` folding the
+ * log into a graph and by `record()` stamping envelopes -- as `{ id, at }`
+ * patterns and `...rest` spreads that a name-based scan cannot follow. Listing
+ * them says which fields are exempt and why; `name.length < 4` said only that
+ * they are short, and would have waved through an unread `ttl`.
+ */
+const STRUCTURAL_KEYS = new Set(['id', 'at', 'to', 'key', 'v', 't', 'from', 'kind']);
+
 const FIELD_WRITERS = ['record(?:Read)?', 'putNode', 'putNodeWithEdges'];
 const FIELD_WRITE_PATH = /^(hooks-core|plugin.hooks|src.server)/;
 
@@ -246,9 +258,13 @@ function recordFields() {
 
   const unread = [];
   for (const [name, writers] of written) {
-    // Three characters or fewer is not a distinctive enough word to reason
-    // about by text match -- `id`, `at`, `to`, `key` collide with everything.
-    if (name.length < 4) continue;
+    // NAMED, NOT MEASURED BY LENGTH. This skipped anything shorter than four
+    // characters, which is a rule about spelling rather than about the field:
+    // a writer adding an unread `ttl` or `pid` would have been waved through by
+    // the same clause that excuses `id`. These are the structural keys the
+    // graph and the metrics log put on every record, whose readers are
+    // destructures and spreads that no text match can see.
+    if (STRUCTURAL_KEYS.has(name)) continue;
     const readSomewhere = shipped.some(({ code }) => {
       const total = (code.match(new RegExp(`\\b${name}\\b`, 'g')) || []).length;
       const asKey = (code.match(new RegExp(`\\b${name}\\s*:`, 'g')) || []).length;
@@ -281,7 +297,14 @@ function toolNamesInInjectedText() {
   const mentioned = new Map();
   for (const file of DECLARE_DIRS.flatMap((d) => walk(join(REPO, d)))) {
     if (!/inject\.mjs$|policy\.mjs$|adapter\.mjs$|disclose\.mjs$/.test(file)) continue;
-    const raw = readFileSync(file, 'utf8');
+    // COMMENTS STRIPPED, and the earlier reasoning for scanning raw text was
+    // wrong in the direction that matters. It said a tool name in a comment
+    // that does not exist "is still worth knowing about" -- but this is a
+    // BLOCKING check, so a comment reading "we should add smart_foo someday"
+    // would fail CI on working code. Template literals survive stripComments,
+    // and injected prompt text lives in template literals, so nothing this
+    // check is actually for is lost.
+    const raw = stripComments(readFileSync(file, 'utf8'));
     for (const m of raw.matchAll(
       /\b(smart_[a-z_]+|wiki_[a-z_]+|optimize_session|get_optimization_report)\b/g
     )) {

--- a/tests/hooks/census.test.mjs
+++ b/tests/hooks/census.test.mjs
@@ -1,0 +1,406 @@
+/**
+ * Nothing declared is unconnected.
+ *
+ * `reachability.test.mjs` asks whether an exported NAME is called. That model
+ * cannot see three whole sub-classes of the same defect, and all three have
+ * shipped here:
+ *
+ *   1. A READER WITH NO PRODUCER. `indexBudget` divided `query` events by
+ *      `index` events, and nothing outside the test suite ever wrote a `query`
+ *      event -- so the ratio was zero on every project and the budget sat
+ *      pinned at its 150-token floor for the life of the feature. Every
+ *      function involved was reachable. Every test passed.
+ *   2. A PRODUCER WITH NO READER. `kind: 'lessons'` was written by
+ *      harvest-worker.mjs and read by nothing.
+ *   3. A REFERENT WITH NO TARGET. Injected prompt text told the model to call
+ *      `wiki_query` -- in twelve shipped copies -- and no such tool existed.
+ *
+ * None of those is a dead function. In each case the code is correct, the names
+ * are all reachable, and the capability does nothing, because the two halves
+ * were never introduced. This file counts producers against consumers.
+ *
+ * ON THE OVERLOADED `kind` FIELD. It is used in at least five unrelated
+ * namespaces here -- event kinds, node kinds (file/symbol/task/finding), symbol
+ * kinds (function/class/variable), standing-entry kinds (skill/agent), remedy
+ * kinds (ours/yours) -- plus a private one inside run-handoff-eval.mjs. A
+ * census that conflates them reports confident nonsense, and the first draft of
+ * this one did: it called `file`, `finding`, `symbol`, `task`, `skill`, `agent`,
+ * `ours` and `yours` orphaned readers. So an event kind is defined here by
+ * PROVENANCE rather than by spelling -- it is a kind that is declared in
+ * metrics.mjs's own exported sets, or written at a `record()` / `recordRead()`
+ * call site. Every other namespace falls outside that definition automatically,
+ * with no hand-maintained exclusion list to go stale.
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import { readFileSync } from 'fs';
+import { join, relative } from 'path';
+import {
+  USAGE_DIRS,
+  DECLARE_DIRS,
+  walk,
+  stripComments,
+  callWindows,
+  objectLiteralKeys,
+} from '../fixtures/source-scan.mjs';
+
+const REPO = process.cwd();
+
+/** Everything that ships, comments removed, path relative for readable failures. */
+const shipped = USAGE_DIRS.flatMap((d) => walk(join(REPO, d))).map((file) => ({
+  file: relative(REPO, file),
+  code: stripComments(readFileSync(file, 'utf8')),
+}));
+
+const sourceOf = (pattern) => shipped.find(({ file }) => pattern.test(file));
+
+/** Kind names: lower-case, and hyphens are real -- `tool-outcome`, `eval-run`. */
+const KIND = "[a-z][a-z0-9_-]*";
+
+const add = (map, key, file) => {
+  if (!map.has(key)) map.set(key, new Set());
+  map.get(key).add(file);
+  return map;
+};
+
+const withoutReader = (produced, read) =>
+  [...produced.keys()].filter((k) => !read.has(k)).sort();
+
+/* ------------------------------------------------------------- EVENT KINDS */
+
+/**
+ * The kinds metrics.mjs itself declares, in its two exported sets.
+ *
+ * DECLARED IS STRONGER EVIDENCE THAN WRITTEN. `BALANCE_KINDS` and
+ * `EVIDENCE_KINDS` route a kind to its own log so the firehose cannot evict it,
+ * which is a deliberate statement that the kind matters -- so a declared kind
+ * with no writer, or no reader, is a stronger finding than an incidental one.
+ */
+function declaredEventKinds() {
+  const metrics = sourceOf(/hooks-core[\\/]metrics\.mjs$/);
+  const out = new Map();
+  for (const set of ['BALANCE_KINDS', 'EVIDENCE_KINDS']) {
+    const block = new RegExp(
+      `export const ${set} = new Set\\(\\[([\\s\\S]*?)\\]\\)`
+    ).exec(metrics.code);
+    // A broken pattern here would report every kind as undeclared and the whole
+    // census would go quiet, so failing loudly is the point.
+    if (!block) throw new Error(`could not read ${set} from metrics.mjs`);
+    for (const m of block[1].matchAll(new RegExp(`'(${KIND})'`, 'g'))) {
+      out.set(m[1], set);
+    }
+  }
+  return out;
+}
+
+/** Kinds written at a `record()` / `recordRead()` call site anywhere that ships. */
+function writtenEventKinds() {
+  const out = new Map();
+  for (const { file, code } of shipped) {
+    for (const window of callWindows(code, 'record(?:Read)?')) {
+      for (const m of window.matchAll(new RegExp(`\\bkind:\\s*'(${KIND})'`, 'g'))) {
+        add(out, m[1], file);
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Kinds something actually branches on, anywhere that ships.
+ *
+ * DELIBERATELY GENEROUS. This side feeds the "written but never read"
+ * assertion, where under-reporting a reader is the STRICT direction -- it would
+ * fail CI on a live capability. So a comparison, a membership test and a bare
+ * quoted mention inside a filter all count, and `episode-outcome` is why the
+ * membership form is here: it is read as
+ * `['tool-outcome', 'episode-outcome'].includes(String(value(event, 'kind')))`,
+ * which no comparison pattern matches.
+ */
+function readEventKinds(vocabulary) {
+  const out = new Map();
+  const comparisons = [
+    new RegExp(`\\bkind\\s*[=!]==\\s*'(${KIND})'`, 'g'),
+    new RegExp(`'(${KIND})'\\s*[=!]==\\s*[\\w$.()[\\]'"]*\\bkind\\b`, 'g'),
+  ];
+  for (const { file, code } of shipped) {
+    for (const re of comparisons) {
+      for (const m of code.matchAll(re)) add(out, m[1], file);
+    }
+    // An array literal tested against something with `kind` in it.
+    for (const m of code.matchAll(/\[([^\]]{0,300}?)\]\s*\.includes\(([^)]{0,120}kind[^)]{0,120})\)/gi)) {
+      for (const k of m[1].matchAll(new RegExp(`'(${KIND})'`, 'g'))) add(out, k[1], file);
+    }
+    // A Set built from a literal and tested with .has(...kind...).
+    for (const m of code.matchAll(/new Set\(\[([^\]]{0,300}?)\]\)\s*\.has\(([^)]{0,120}kind[^)]{0,120})\)/gi)) {
+      for (const k of m[1].matchAll(new RegExp(`'(${KIND})'`, 'g'))) add(out, k[1], file);
+    }
+  }
+  // Restricted to the event vocabulary, so the four other `kind` namespaces --
+  // and run-handoff-eval.mjs's private one -- never enter this census.
+  for (const key of [...out.keys()]) if (!vocabulary.has(key)) out.delete(key);
+  return out;
+}
+
+/* -------------------------------------------------------------- EDGE KINDS */
+
+/** Declared in `EDGE_KINDS`, against every putEdge / `edge:` write site. */
+function edgeKinds() {
+  const wiki = sourceOf(/hooks-core[\\/]wiki\.mjs$/);
+  const block = /export const EDGE_KINDS = \[([\s\S]*?)\]/.exec(wiki.code);
+  if (!block) throw new Error('could not read EDGE_KINDS from wiki.mjs');
+  const declared = new Set([...block[1].matchAll(/'([a-z_]+)'/g)].map((m) => m[1]));
+
+  const written = new Map();
+  for (const { file, code } of shipped) {
+    // A WINDOW, because `putEdge(dir, nodeId('symbol', ...), 'calls', ...)`
+    // spans six lines in staleness.mjs and the kind is the THIRD argument. The
+    // plan this came from proposed a single-line regex on the second argument,
+    // which reported the graph's own call-edge kind as having no writer.
+    for (const window of callWindows(code, 'putEdge')) {
+      for (const m of window.matchAll(/'([a-z_]+)'/g)) {
+        if (declared.has(m[1])) add(written, m[1], file);
+      }
+    }
+    for (const m of code.matchAll(/\bedge:\s*'([a-z_]+)'/g)) {
+      if (declared.has(m[1])) add(written, m[1], file);
+    }
+  }
+  return { declared, written };
+}
+
+/* ------------------------------------------------------------ RECORD FIELDS */
+
+/**
+ * Fields written onto a graph or metrics record, against fields anything reads.
+ *
+ * THE SUB-CLASS BELOW THE OTHERS. The reachability guard checks exported names
+ * and this file's other censuses check declared kinds -- but a FIELD is neither.
+ * `contradictionReason`, up to 400 characters of human explanation of why one
+ * finding disputes another, was written on every single `contradict` call and
+ * read by nothing at all, with every guard in this directory green throughout.
+ * Nothing in the repository could have noticed: the writer is correct, the
+ * reader was never written, and no name is unreachable.
+ *
+ * WHAT COUNTS AS READ IS DELIBERATELY GENEROUS: any mention of the name that is
+ * not itself an object key. Not `record.field`, not a destructure, not a
+ * specific access pattern -- ANY other mention. Records are spread (`...rest`,
+ * `...episode`) and read dynamically, so a precise reader-side pattern would
+ * accuse live fields. This fires only when a name appears nowhere in the
+ * repository except as a key being written, which is a strong enough signal to
+ * block a build on.
+ */
+const FIELD_WRITERS = ['record(?:Read)?', 'putNode', 'putNodeWithEdges'];
+const FIELD_WRITE_PATH = /^(hooks-core|plugin.hooks|src.server)/;
+
+function recordFields() {
+  const written = new Map();
+  for (const { file, code } of shipped) {
+    if (!FIELD_WRITE_PATH.test(file)) continue;
+    for (const writer of FIELD_WRITERS) {
+      for (const keys of objectLiteralKeys(code, writer)) {
+        for (const key of keys) add(written, key, file);
+      }
+    }
+  }
+
+  const unread = [];
+  for (const [name, writers] of written) {
+    // Three characters or fewer is not a distinctive enough word to reason
+    // about by text match -- `id`, `at`, `to`, `key` collide with everything.
+    if (name.length < 4) continue;
+    const readSomewhere = shipped.some(({ code }) => {
+      const total = (code.match(new RegExp(`\\b${name}\\b`, 'g')) || []).length;
+      const asKey = (code.match(new RegExp(`\\b${name}\\s*:`, 'g')) || []).length;
+      return total - asKey > 0;
+    });
+    if (!readSomewhere) unread.push({ name, writers: [...writers].sort() });
+  }
+  return { written, unread: unread.sort((a, b) => a.name.localeCompare(b.name)) };
+}
+
+/* ------------------------------------------- TOOL NAMES IN INJECTED PROMPTS */
+
+/**
+ * Tool names the hooks put in front of the model, against the served registry.
+ *
+ * SCANS RAW TEXT, comments included, and that is deliberate: injected text
+ * lives in template literals, and a tool name in a comment that does not exist
+ * is still worth knowing about. Over-reporting is the safe direction for a
+ * check whose failure mode is "we told the model to call something imaginary".
+ */
+function toolNamesInInjectedText() {
+  const registry = new Set();
+  for (const file of USAGE_DIRS.flatMap((d) => walk(join(REPO, d)))) {
+    if (!/tool-schemas\.ts$/.test(file)) continue;
+    for (const m of readFileSync(file, 'utf8').matchAll(/^\s{2}([a-z_]+):\s*\w+Schema,/gm)) {
+      registry.add(m[1]);
+    }
+  }
+
+  const mentioned = new Map();
+  for (const file of DECLARE_DIRS.flatMap((d) => walk(join(REPO, d)))) {
+    if (!/inject\.mjs$|policy\.mjs$|adapter\.mjs$|disclose\.mjs$/.test(file)) continue;
+    const raw = readFileSync(file, 'utf8');
+    for (const m of raw.matchAll(
+      /\b(smart_[a-z_]+|wiki_[a-z_]+|optimize_session|get_optimization_report)\b/g
+    )) {
+      add(mentioned, m[1], relative(REPO, file));
+    }
+  }
+
+  return {
+    registry,
+    mentioned,
+    missing: [...mentioned.keys()].filter((t) => !registry.has(t)).sort(),
+  };
+}
+
+/* --------------------------------------------------------------- THE TESTS */
+
+describe('the census can see anything at all', () => {
+  // A census that matches nothing reports a clean bill of health forever, which
+  // is the failure mode of every guard in this directory.
+  it('finds the declarations it reasons about', () => {
+    expect(declaredEventKinds().size).toBeGreaterThan(10);
+    expect(edgeKinds().declared.size).toBeGreaterThan(5);
+    expect(toolNamesInInjectedText().registry.size).toBeGreaterThan(20);
+  });
+
+  it('finds producers and consumers, not just declarations', () => {
+    expect(writtenEventKinds().size).toBeGreaterThan(10);
+    expect(readEventKinds(new Set(writtenEventKinds().keys())).size).toBeGreaterThan(5);
+    expect(edgeKinds().written.size).toBeGreaterThan(5);
+    expect(toolNamesInInjectedText().mentioned.size).toBeGreaterThan(3);
+  });
+});
+
+describe('event kinds', () => {
+  const declared = declaredEventKinds();
+  const written = writtenEventKinds();
+  const vocabulary = new Set([...declared.keys(), ...written.keys()]);
+  const read = readEventKinds(vocabulary);
+
+  it('has a writer for every kind metrics.mjs declares', () => {
+    const noWriter = [...declared.keys()].filter((k) => !written.has(k)).sort();
+    // A kind routed to its own durable log, that nothing ever writes, is a
+    // reserved seat for a passenger who never boards.
+    expect(noWriter).toEqual([]);
+  });
+
+  it('has no kind that is read but never written', () => {
+    // THE indexBudget SHAPE. `query` was read by the budget and written only by
+    // the test suite, so the ratio was zero for every project and the budget
+    // never left its floor -- with every function reachable and every test
+    // green.
+    expect(withoutReader(read, written)).toEqual([]);
+  });
+
+  it('has no kind that is written but never read', () => {
+    // WHAT THIS FOUND, on its first run, and what it is still owed.
+    //
+    // `mcp-client` is written by src/server/mcp-evidence.ts on every client
+    // handshake and read by nothing. Its only field that is not already on
+    // every other record from the same writer is `clientTitle` -- the client
+    // name, version, arm and episode are all carried by `mcp-tool` too, and the
+    // client is separately recorded in the project registry, which is where the
+    // dashboard reads it from. So the resolution is a deletion or a reader in
+    // the MCP telemetry surface, and it is not this guard's call to make
+    // silently. Tracked, attributed, and held to a ceiling that can only fall.
+    //
+    // NOT A BACKLOG, and the distinction is the whole point of Plan 3. Round 1
+    // parked sixteen findings in a list with accurate descriptions and no
+    // owner, and an accurate description of a defect felt like resolution. This
+    // is one entry, it names what it is waiting for, and the assertion below
+    // refuses a second.
+    const KNOWN_ORPHAN_WRITERS = ['mcp-client'];
+
+    const orphans = withoutReader(written, read);
+    expect(orphans).toEqual(KNOWN_ORPHAN_WRITERS);
+  });
+
+  it('holds the orphan-writer list to one entry, and refuses a second', () => {
+    const written2 = writtenEventKinds();
+    const read2 = readEventKinds(new Set([...declared.keys(), ...written2.keys()]));
+    expect(withoutReader(written2, read2).length).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('edge kinds', () => {
+  it('has a write site for every declared edge kind', () => {
+    const { declared, written } = edgeKinds();
+    // `contradicts` and `answers` sat in EDGE_KINDS with zero write sites: the
+    // graph declared it could record a disputed belief and an answered
+    // question, and could do neither. Both are written now.
+    expect([...declared].filter((k) => !written.has(k)).sort()).toEqual([]);
+  });
+
+  it('declares every edge kind it writes', () => {
+    // The other direction is enforced at runtime -- putEdge throws on an
+    // unknown kind -- so this asserts the guard rail rather than the outcome,
+    // and would catch a raw append that bypassed putEdge.
+    const { declared, written } = edgeKinds();
+    expect([...written.keys()].filter((k) => !declared.has(k)).sort()).toEqual([]);
+  });
+});
+
+describe('record fields', () => {
+  /**
+   * WHAT THIS FOUND ON ITS FIRST RUN, with what each one is.
+   *
+   * Attributed, not triaged. Round 1's failure was a list of sixteen accurate
+   * descriptions with no owner, where writing the description down felt like
+   * fixing the thing. Each of these names what is stored, why it was stored,
+   * and where its reader would have to go -- and the ceiling below means the
+   * list can only shrink.
+   *
+   * Four of the six are measurement fields belonging to the holdout arm and the
+   * injection budget, which is Plan 2's subject (production and measurement),
+   * so wiring readers for them here would be reaching into work in flight.
+   * `contradictedAt` is already filed as a follow-up on #204.
+   */
+  const KNOWN_UNREAD_FIELDS = [
+    // The holdout arm's shadow payload: what WOULD have been injected. The
+    // whole point of a holdout is comparing the shadow against the delivered
+    // arm, and the comparison has never been run. Plan 2's measurement work.
+    'candidateCount',
+    // Which client connected, beyond what the project registry already stores.
+    // Written on every MCP handshake, read by nothing -- the same record as
+    // the `mcp-client` orphan writer above, and it resolves with that one.
+    'clientTitle',
+    // WHEN a finding was contradicted. Stored provenance with no reader;
+    // already filed as follow-up 3 on #204.
+    'contradictedAt',
+    // The last curation action applied to a node.
+    'lastAction',
+    // See candidateCount: the shadow arm's finding keys.
+    'shadowFindingIds',
+    // How many of the findings considered at a touch were stale.
+    'staleCount',
+  ];
+
+  it('has a reader for every field written onto a record', () => {
+    expect(recordFields().unread.map((f) => f.name)).toEqual(KNOWN_UNREAD_FIELDS);
+  });
+
+  it('holds the unread-field list to a ceiling that can only fall', () => {
+    expect(recordFields().unread.length).toBeLessThanOrEqual(KNOWN_UNREAD_FIELDS.length);
+  });
+
+  it('sees enough fields that a broken extractor cannot report a clean bill of health', () => {
+    // The extractor SKIPS any call site whose object literal does not balance,
+    // so a regression in it goes quiet rather than loud. This is the tripwire.
+    expect(recordFields().written.size).toBeGreaterThan(50);
+  });
+});
+
+describe('tool names in injected text', () => {
+  it('names no tool that does not exist', () => {
+    // The SessionStart index told the model to call `wiki_query` in twelve
+    // shipped copies of the injected prompt, for as long as the feature
+    // existed, and there was no such tool. Nothing in the codebase could
+    // notice: the string is data, the tool list is data, and no test compared
+    // them.
+    expect(toolNamesInInjectedText().missing).toEqual([]);
+  });
+});

--- a/tests/hooks/census.test.mjs
+++ b/tests/hooks/census.test.mjs
@@ -2,7 +2,7 @@
  * Nothing declared is unconnected.
  *
  * `reachability.test.mjs` asks whether an exported NAME is called. That model
- * cannot see three whole sub-classes of the same defect, and all three have
+ * cannot see four whole sub-classes of the same defect, and all four have
  * shipped here:
  *
  *   1. A READER WITH NO PRODUCER. `indexBudget` divided `query` events by
@@ -14,10 +14,21 @@
  *      harvest-worker.mjs and read by nothing.
  *   3. A REFERENT WITH NO TARGET. Injected prompt text told the model to call
  *      `wiki_query` -- in twelve shipped copies -- and no such tool existed.
+ *   4. AN UNREAD RECORD FIELD. `contradictionReason`, up to 400 characters
+ *      explaining why one finding disputes another, was written on every
+ *      `contradict` call and read by nothing.
  *
  * None of those is a dead function. In each case the code is correct, the names
  * are all reachable, and the capability does nothing, because the two halves
  * were never introduced. This file counts producers against consumers.
+ *
+ * EVERY ASSERTION HERE IS MUTATION-TESTED, and that is not ceremony. Two of the
+ * first drafts could not fail at all: the read side of "read but never written"
+ * was filtered by the write side, so the indexBudget case it advertises would
+ * have slipped straight through, and "declares every edge kind it writes"
+ * compared a set against a superset it had been filtered into. A guard that
+ * cannot fail is worse than no guard, because it is counted. If you change an
+ * extractor here, break the thing it detects and watch it go red.
  *
  * ON THE OVERLOADED `kind` FIELD. It is used in at least five unrelated
  * namespaces here -- event kinds, node kinds (file/symbol/task/finding), symbol
@@ -35,6 +46,7 @@
 import { describe, it, expect } from '@jest/globals';
 import { readFileSync } from 'fs';
 import { join, relative } from 'path';
+import { putEdge } from '../../hooks-core/wiki.mjs';
 import {
   USAGE_DIRS,
   DECLARE_DIRS,
@@ -138,7 +150,35 @@ function readEventKinds(vocabulary) {
   }
   // Restricted to the event vocabulary, so the four other `kind` namespaces --
   // and run-handoff-eval.mjs's private one -- never enter this census.
+  //
+  // ONLY SAFE FOR THE "written but never read" DIRECTION, and getting that
+  // wrong is the sharpest mistake this file has made. The vocabulary is
+  // `declared ∪ written`, so a kind that is neither declared nor written drops
+  // out of the read set entirely -- which is EXACTLY the indexBudget shape, and
+  // it made the assertion that exists to catch it vacuous. Proven by mutation:
+  // renaming the single `kind: 'query'` write site left `query` read by
+  // indexBudget, written by nothing, and "has no kind that is read but never
+  // written" GREEN. Use `readsInTheEventLog` below for that direction.
   for (const key of [...out.keys()]) if (!vocabulary.has(key)) out.delete(key);
+  return out;
+}
+
+/**
+ * Kinds branched on inside `metrics.mjs`, unfiltered by what anything writes.
+ *
+ * RESTRICTED BY LOCATION RATHER THAN BY VOCABULARY, because vocabulary is
+ * circular for this question: asking "is this read kind ever written?" cannot
+ * start by discarding the kinds nothing writes. Location is the non-circular
+ * discriminator -- `metrics.mjs` owns the event log, so a comparison on `kind`
+ * there is an event kind by construction. The other five `kind` namespaces are
+ * read in curate, wiki, staleness, standing and audit, and never here.
+ */
+function readsInTheEventLog() {
+  const metrics = sourceOf(/hooks-core[\\/]metrics\.mjs$/);
+  const out = new Map();
+  for (const m of metrics.code.matchAll(new RegExp(`\\bkind\\s*[=!]==\\s*'(${KIND})'`, 'g'))) {
+    add(out, m[1], metrics.file);
+  }
   return out;
 }
 
@@ -289,11 +329,28 @@ describe('event kinds', () => {
   });
 
   it('has no kind that is read but never written', () => {
-    // THE indexBudget SHAPE. `query` was read by the budget and written only by
-    // the test suite, so the ratio was zero for every project and the budget
-    // never left its floor -- with every function reachable and every test
-    // green.
-    expect(withoutReader(read, written)).toEqual([]);
+    // THE indexBudget SHAPE, and the flagship case for this whole file. `query`
+    // was read by the budget and written only by the test suite, so the ratio
+    // was zero for every project and the budget never left its floor -- with
+    // every function reachable and every test green.
+    //
+    // READS TAKEN FROM THE EVENT LOG'S OWN MODULE, not from the
+    // vocabulary-filtered set: filtering reads by what is written would discard
+    // precisely the kinds this assertion is looking for. Verified by mutation --
+    // renaming the one `kind: 'query'` write site must turn this red.
+    expect(withoutReader(readsInTheEventLog(), written)).toEqual([]);
+  });
+
+  it('takes its reads from the event log, not from what is written', () => {
+    // THE NON-VACUITY TRIPWIRE for the assertion above, and it exists because
+    // that assertion WAS vacuous. `query` and `index` are read by indexBudget
+    // and appear in neither exported set, so if this reader were ever filtered
+    // by declarations or by writers again they would vanish -- and the check
+    // would go quiet for exactly the kinds it is there to catch.
+    const reads = [...readsInTheEventLog().keys()];
+    expect(reads).toEqual(expect.arrayContaining(['query', 'index']));
+    const declaredNames = declaredEventKinds();
+    expect(reads.some((k) => !declaredNames.has(k))).toBe(true);
   });
 
   it('has no kind that is written but never read', () => {
@@ -335,12 +392,22 @@ describe('edge kinds', () => {
     expect([...declared].filter((k) => !written.has(k)).sort()).toEqual([]);
   });
 
-  it('declares every edge kind it writes', () => {
-    // The other direction is enforced at runtime -- putEdge throws on an
-    // unknown kind -- so this asserts the guard rail rather than the outcome,
-    // and would catch a raw append that bypassed putEdge.
-    const { declared, written } = edgeKinds();
-    expect([...written.keys()].filter((k) => !declared.has(k)).sort()).toEqual([]);
+  it('refuses an undeclared edge kind at the write site', () => {
+    // THE OTHER DIRECTION, ASSERTED WHERE IT IS ACTUALLY ENFORCED.
+    //
+    // This started life as a static check that every WRITTEN kind is declared,
+    // and that check was vacuous: the extractor discards any quoted string in a
+    // putEdge window that is not already a declared kind -- it has to, or it
+    // would collect node ids and the word `file` -- so `written` is a subset of
+    // `declared` by construction and the difference is empty whatever the code
+    // does. A test that cannot fail is worse than no test, because it is
+    // counted.
+    //
+    // putEdge validates the kind before it touches the log, so this exercises
+    // the real guard rail and needs no fixture.
+    expect(() => putEdge('/nonexistent-graph-dir', 'a', 'not_a_real_edge_kind', 'b')).toThrow(
+      /unknown edge kind/
+    );
   });
 });
 

--- a/tests/hooks/census.test.mjs
+++ b/tests/hooks/census.test.mjs
@@ -354,32 +354,27 @@ describe('event kinds', () => {
   });
 
   it('has no kind that is written but never read', () => {
-    // WHAT THIS FOUND, on its first run, and what it is still owed.
+    // EMPTY, AND IT WAS NOT. This assertion shipped its first draft carrying
+    // `mcp-client` on an attributed exemption list, on the reasoning that the
+    // resolution -- delete the record, or give it a reader -- was somebody
+    // else's call. That is the reasoning that produced the sixteen-entry
+    // backlog this whole plan exists to undo, and it was wrong here for a
+    // simpler reason: nobody else was going to do it.
     //
-    // `mcp-client` is written by src/server/mcp-evidence.ts on every client
-    // handshake and read by nothing. Its only field that is not already on
-    // every other record from the same writer is `clientTitle` -- the client
-    // name, version, arm and episode are all carried by `mcp-tool` too, and the
-    // client is separately recorded in the project registry, which is where the
-    // dashboard reads it from. So the resolution is a deletion or a reader in
-    // the MCP telemetry surface, and it is not this guard's call to make
-    // silently. Tracked, attributed, and held to a ceiling that can only fall.
-    //
-    // NOT A BACKLOG, and the distinction is the whole point of Plan 3. Round 1
-    // parked sixteen findings in a list with accurate descriptions and no
-    // owner, and an accurate description of a defect felt like resolution. This
-    // is one entry, it names what it is waiting for, and the assertion below
-    // refuses a second.
-    const KNOWN_ORPHAN_WRITERS = ['mcp-client'];
-
-    const orphans = withoutReader(written, read);
-    expect(orphans).toEqual(KNOWN_ORPHAN_WRITERS);
+    // `mcp-client` is written on every MCP handshake. `mcp-tool` records a
+    // client only once it CALLS something and the project registry stores a
+    // name only, so a client that connected and then called nothing -- the
+    // exact failure this project's doctor exists to diagnose -- appeared in
+    // neither. `mcpClientsSeen` reads it and the doctor reports it.
+    expect(withoutReader(written, read)).toEqual([]);
   });
 
-  it('holds the orphan-writer list to one entry, and refuses a second', () => {
+  it('refuses a new orphan writer', () => {
+    // The list is at zero. A ceiling that can only fall is the right shape
+    // while somebody genuinely owes the fix; at zero it is just this.
     const written2 = writtenEventKinds();
     const read2 = readEventKinds(new Set([...declared.keys(), ...written2.keys()]));
-    expect(withoutReader(written2, read2).length).toBeLessThanOrEqual(1);
+    expect(withoutReader(written2, read2)).toEqual([]);
   });
 });
 
@@ -412,51 +407,36 @@ describe('edge kinds', () => {
 });
 
 describe('record fields', () => {
-  /**
-   * WHAT THIS FOUND ON ITS FIRST RUN, with what each one is.
-   *
-   * Attributed, not triaged. Round 1's failure was a list of sixteen accurate
-   * descriptions with no owner, where writing the description down felt like
-   * fixing the thing. Each of these names what is stored, why it was stored,
-   * and where its reader would have to go -- and the ceiling below means the
-   * list can only shrink.
-   *
-   * Four of the six are measurement fields belonging to the holdout arm and the
-   * injection budget, which is Plan 2's subject (production and measurement),
-   * so wiring readers for them here would be reaching into work in flight.
-   * `contradictedAt` is already filed as a follow-up on #204.
-   */
-  const KNOWN_UNREAD_FIELDS = [
-    // The holdout arm's shadow payload: what WOULD have been injected. The
-    // whole point of a holdout is comparing the shadow against the delivered
-    // arm, and the comparison has never been run. Plan 2's measurement work.
-    'candidateCount',
-    // Which client connected, beyond what the project registry already stores.
-    // Written on every MCP handshake, read by nothing -- the same record as
-    // the `mcp-client` orphan writer above, and it resolves with that one.
-    'clientTitle',
-    // WHEN a finding was contradicted. Stored provenance with no reader;
-    // already filed as follow-up 3 on #204.
-    'contradictedAt',
-    // The last curation action applied to a node.
-    'lastAction',
-    // See candidateCount: the shadow arm's finding keys.
-    'shadowFindingIds',
-    // How many of the findings considered at a touch were stale.
-    'staleCount',
-  ];
-
   it('has a reader for every field written onto a record', () => {
-    expect(recordFields().unread.map((f) => f.name)).toEqual(KNOWN_UNREAD_FIELDS);
-  });
-
-  it('holds the unread-field list to a ceiling that can only fall', () => {
-    expect(recordFields().unread.length).toBeLessThanOrEqual(KNOWN_UNREAD_FIELDS.length);
+    // ZERO, AND THE FIRST DRAFT OF THIS FILE SHIPPED SIX.
+    //
+    // They were listed with accurate descriptions and attributed to "Plan 2's
+    // measurement territory", which was an excuse rather than an attribution:
+    // Plan 2 had not reached those tasks and none of the six needed anything it
+    // was building. Each is now read where it was always meant to be --
+    //
+    //   candidateCount, shadowFindingIds  the injection holdout's SHADOW: what
+    //     retrieval selected versus what was served. Exactly the gap
+    //     `controlArmTokens` was created to close one arm over, whose comment
+    //     already said `tokensFullFile` "was recorded and read by nothing, so
+    //     the comparison the holdout exists for was not computable".
+    //   staleCount  index staleness as a rate rather than a boolean: one rotten
+    //     entry in forty was indistinguishable from forty.
+    //   contradictedAt  WHEN a claim was disputed, beside the WHY that Plan 1
+    //     wired. Written on the same line of the same putNode call; only one of
+    //     the two got a reader.
+    //   lastAction  which tool last touched a file. "file changed (last touched
+    //     by Edit)" says a targeted edit did it and is cheap to re-verify;
+    //     "by Write" says the file was replaced wholesale and usually is not.
+    //   clientTitle  the display name a client reports for itself, on the
+    //     `mcp-client` handshake record that nothing read at all.
+    expect(recordFields().unread.map((f) => f.name)).toEqual([]);
   });
 
   it('sees enough fields that a broken extractor cannot report a clean bill of health', () => {
     // The extractor SKIPS any call site whose object literal does not balance,
-    // so a regression in it goes quiet rather than loud. This is the tripwire.
+    // so a regression in it goes quiet rather than loud. This is the tripwire,
+    // and it matters more now that the expected result is an empty list.
     expect(recordFields().written.size).toBeGreaterThan(50);
   });
 });

--- a/tests/hooks/consolidate.test.mjs
+++ b/tests/hooks/consolidate.test.mjs
@@ -257,3 +257,71 @@ describe('scoring inputs are the ones the module claims to use', () => {
     expect(costToRederive({ summary: 'x', evidence: 'y', tokensSpent: 4242 })).toBe(4242);
   });
 });
+
+describe('the selector reads the field producers actually emit', () => {
+  // THE REASON THIS WAS NEVER GOING TO WORK, even once it had a caller.
+  // `irrecoverability`, `costToRederive` and `selectForConsolidation` read
+  // `entry.summary`; `consolidationRatio` and `aggregateConsolidation` read
+  // `finding.claim`. No producer in this repository emits `summary` -- the
+  // semantic harvest, wiki_write and the eval harnesses all emit `claim`, and
+  // `validate()` rejects anything without one.
+  //
+  // Wired naively, every candidate would have scored `tokens: 0`, the budget
+  // could never bind, nothing would ever be dropped, and the selector would
+  // have been live, green and inert.
+  const candidate = (i, type = 'finding') => ({
+    type,
+    claim: `a finding whose claim is long enough to cost real tokens, number ${i}, ` +
+      'padded so that a handful of these exceed a small budget',
+    evidence: 'observed directly in the session transcript',
+    anchors: [`src/file-${i}.ts`],
+  });
+
+  test('a budget actually binds, so something is dropped', () => {
+    const graph = { nodes: new Map(), edges: [] };
+    const many = Array.from({ length: 40 }, (_, i) => candidate(i));
+    const selection = selectForConsolidation(graph, many, { budget: 200 });
+
+    expect(selection.kept.length).toBeGreaterThan(0);
+    expect(selection.kept.length).toBeLessThan(many.length);
+    expect(selection.dropped).toBe(many.length - selection.kept.length);
+    expect(selection.tokens).toBeGreaterThan(0);
+    expect(selection.tokens).toBeLessThanOrEqual(200);
+  });
+
+  test('a claim costs tokens, where an absent summary costs none', () => {
+    // The direct statement of the defect: with the old reader every one of
+    // these was free and the budget was unreachable.
+    const graph = { nodes: new Map(), edges: [] };
+    const one = selectForConsolidation(graph, [candidate(1)], { budget: 4000 });
+    expect(one.tokens).toBeGreaterThan(0);
+  });
+
+  test('failures and decisions survive the floor when the budget is tight', () => {
+    const graph = { nodes: new Map(), edges: [] };
+    const mixed = [
+      ...Array.from({ length: 20 }, (_, i) => candidate(i)),
+      candidate(99, 'failure'),
+      candidate(98, 'decision'),
+    ];
+    const selection = selectForConsolidation(graph, mixed, { budget: 120 });
+    const types = selection.kept.map((k) => k.type);
+    expect(types).toContain('failure');
+    expect(types).toContain('decision');
+  });
+
+  test('summary is still accepted from an external caller', () => {
+    const graph = { nodes: new Map(), edges: [] };
+    const legacy = { type: 'finding', summary: 'x'.repeat(400), evidence: 'e', anchors: [] };
+    expect(selectForConsolidation(graph, [legacy], { budget: 4000 }).tokens).toBeGreaterThan(0);
+  });
+
+  test('the ratio and the selector agree about which field is the claim', () => {
+    const entry = { type: 'finding', claim: 'y'.repeat(200), evidence: 'e', anchors: [] };
+    const graph = { nodes: new Map(), edges: [] };
+    const kept = selectForConsolidation(graph, [entry], { budget: 4000 }).kept[0];
+    // derivedCost is stamped by the selector; the ratio reads it against the
+    // same text the selector priced.
+    expect(consolidationRatio(kept)).toBeGreaterThan(0);
+  });
+});

--- a/tests/hooks/consolidate.test.mjs
+++ b/tests/hooks/consolidate.test.mjs
@@ -13,7 +13,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
   selectForConsolidation, irrecoverability, reuseProbability,
-  consolidationRatio, aggregateConsolidation, contentAnchor, costToRederive,
+  consolidationRatio, aggregateConsolidation, costToRederive,
 } from '../../hooks-core/consolidate.mjs';
 import { classifySituation, restorationPlan } from '../../hooks-core/restore.mjs';
 import { load, putNode, putEdge, nodeId } from '../../hooks-core/wiki.mjs';
@@ -134,31 +134,6 @@ describe('the consolidation ratio -- the metric that needs session instrumentati
     ]);
     expect(out.derived).toBe(12_000);
     expect(out.ratio).toBeGreaterThan(1);
-  });
-});
-
-describe('content anchors reach across projects', () => {
-  test('identical content yields the same anchor from different paths', () => {
-    // A vendored library file is the same file in every repo that holds it.
-    const a = join(workspace, 'a.ts');
-    const b = join(workspace, 'b.ts');
-    writeFileSync(a, 'export const x = 1;');
-    writeFileSync(b, 'export const x = 1;');
-
-    expect(contentAnchor(a, 'samehash')).toBe(contentAnchor(b, 'samehash'));
-  });
-
-  test('size is part of the identity, so a truncated digest cannot collide', () => {
-    const a = join(workspace, 'a.ts');
-    const b = join(workspace, 'b.ts');
-    writeFileSync(a, 'short');
-    writeFileSync(b, 'considerably longer content here');
-
-    expect(contentAnchor(a, 'samehash')).not.toBe(contentAnchor(b, 'samehash'));
-  });
-
-  test('an unreadable path yields no anchor rather than a wrong one', () => {
-    expect(contentAnchor(join(workspace, 'missing.ts'), 'hash')).toBeNull();
   });
 });
 

--- a/tests/hooks/contradicts.test.mjs
+++ b/tests/hooks/contradicts.test.mjs
@@ -184,6 +184,25 @@ describe('disclosing a dispute when a finding is served', () => {
     expect(findingIn(served, 'new').contradictedBy).toBe('old');
   });
 
+  test('serve discloses WHEN the dispute was raised, not only why', () => {
+    // `contradict` writes contradictedAt and contradictionReason on the same
+    // line of the same putNode call. Round 1 gave the reason a reader and left
+    // the timestamp unread, so a disclosure could say a claim was disputed and
+    // why, and not whether that happened this morning or a year ago -- which
+    // for a reader deciding whether to trust it is most of the signal.
+    const before = Date.now();
+    contradict(dir, { key: 'old', byKey: 'new', reason: 're-derived' });
+    const graph = load(dir);
+    const served = serve(graph, [...graph.nodes.values()].filter((n) => n.kind === 'finding'));
+
+    for (const key of ['old', 'new']) {
+      const at = findingIn(served, key).contradictedAt;
+      expect(typeof at).toBe('number');
+      expect(at).toBeGreaterThanOrEqual(before);
+      expect(at).toBeLessThanOrEqual(Date.now());
+    }
+  });
+
   test('serve leaves an undisputed finding unmarked', () => {
     contradict(dir, { key: 'old', byKey: 'new', reason: 're-derived' });
     const graph = load(dir);
@@ -192,6 +211,7 @@ describe('disclosing a dispute when a finding is served', () => {
     const other = findingIn(served, 'other');
     expect(other.contradicted).toBeUndefined();
     expect(other.contradictedBy).toBeUndefined();
+    expect(other.contradictedAt).toBeUndefined();
   });
 
   test('serve discloses on a type an anchor cannot invalidate', () => {

--- a/tests/hooks/reachability.test.mjs
+++ b/tests/hooks/reachability.test.mjs
@@ -94,31 +94,29 @@ const ALLOWED = new Map([
   // only fall, and refuses any entry that is neither one of these five nor
   // genuine public API.
 
-  // THE FOUR THAT REMAIN HAVE NO PRODUCING ACTION TO ATTACH TO, and that is a
-  // measured statement rather than a deferral. Each was checked against the
-  // codebase before being left here.
+  // NOTHING IS LEFT, and the last four did not leave by being re-described.
   //
-  // CONSOLIDATION. forecast.mjs calls aggregateConsolidation, so the module is
-  // partly live -- but `grep` finds no caller anywhere that decides WHAT to
-  // consolidate or WHEN a consolidation pass runs. `selectForConsolidation`
-  // chooses candidates for a pass that does not exist; `consolidationRatio`
-  // reports what that pass bought and would return null forever without it.
-  // Plan 2's derive.mjs, running at Stop, is that pass. Wiring either here
-  // would mean building it twice.
-  ['selectForConsolidation', 'UNWIRED, PLAN 2 TASK 4: chooses what to promote into the graph; verified -- no caller anywhere decides when a consolidation pass runs.'],
-  ['consolidationRatio', 'UNWIRED, PLAN 2 TASK 8: reports what consolidation bought, and cannot report on a selection that never happens.'],
-
-  // HALF A FEEDBACK LOOP, and the missing half is an ACTION, not a reader.
-  // shouldKeepWarm is called by cache-tool.ts and prints its verdict; nothing
-  // in this repository ever performs a keep-warm ping. So `recordRefresh`
-  // records an event that never occurs, and calling it at the DECISION point --
-  // the only place a caller exists today -- would write refreshes that never
-  // happened into the ledger `tripwire` reads to decide whether keep-warm is
-  // losing money. Fabricated evidence in a backstop is worse than a dead
-  // function, so these stay until the refresh itself exists (Plan 2 Task 9).
-  ['recordRefresh', 'UNWIRED, PLAN 2 TASK 9: records a keep-warm refresh; verified -- nothing in the repository performs one, so a caller would fabricate the event.'],
-  ['recordRefreshOutcome', 'UNWIRED, PLAN 2 TASK 9: scores whether a refresh paid off; same missing producer, and it feeds the tripwire ledger.'],
-
+  // They were held here for a stated reason -- "the producing action does not
+  // exist" -- which was true and was still an excuse, because the producing
+  // action was the work. All four now have one:
+  //
+  //   selectForConsolidation  runs in the semantic harvest, so what a session
+  //     stores is chosen under a token budget instead of stored wholesale.
+  //     Fixing it also required fixing consolidate.mjs, whose two halves
+  //     disagreed about the field name: the selector read `entry.summary`,
+  //     which NO producer in this repository emits, so wiring it naively would
+  //     have priced every candidate at zero tokens and dropped nothing. Live,
+  //     green and inert is the same defect wearing a call site.
+  //   consolidationRatio      reported per finding by /api/wiki/node and shown
+  //     in the dashboard detail view -- the number #204 opens on, which was
+  //     computed for no finding anybody could look at.
+  //   recordRefresh           the keep-warm decision is written to the ledger
+  //     when cache_audit issues it.
+  //   recordRefreshOutcome    scored from the event log by
+  //     scoreOutstandingRefreshes, which resolves whether a turn actually
+  //     arrived inside the window the advice predicted. The signal needed no
+  //     new instrumentation; it was in the log the whole time.
+  //
   // ------------------------------------------------------------------
   // The policyText entry lived here as "GENUINE PUBLIC API", and it was stale
   // in the same way forTouch was: adapter.mjs and the SessionStart hook both
@@ -268,35 +266,21 @@ describe('every exported function in the live hook path is reachable', () => {
     }
   });
 
-  it('keeps the allowlist shrinking, and refuses a new backlog entry', () => {
-    // THE LIST IS NOT A BACKLOG. Round 1 built this detector, it found ~21
-    // unreachable capabilities, four were wired and sixteen were parked here
-    // with accurate descriptions of what was wrong with them -- and an accurate
-    // description of a defect felt like resolution. Plan 1 took it to seven.
+  it('keeps the allowlist empty, and refuses a new backlog entry', () => {
+    // THE LIST IS NOT A BACKLOG, and it is now nothing at all.
     //
-    // A CEILING RATHER THAN ZERO, and the difference is deliberate. Four of the
-    // seven are owned by Plan 2 (production and measurement), which is in
-    // progress in parallel: selectForConsolidation by its Task 4,
-    // consolidationRatio by its Task 8, recordRefresh and recordRefreshOutcome
-    // by its Task 9 -- and each was verified to have no producing ACTION to
-    // attach to, not merely no caller. Asserting zero here would ship a test
-    // that is RED until someone else's PR merges, and a suite that is expected
-    // to be red teaches everyone to ignore it -- the same disease in a new
-    // organ. So this asserts the number can only fall, and names who owes what.
-    // When Plan 2 lands, this drops to 0 and the ceiling comes with it.
-    expect(ALLOWED.size).toBeLessThanOrEqual(4);
+    // Round 1 built this detector, it found ~21 unreachable capabilities, four
+    // were wired and sixteen were parked here with accurate descriptions of
+    // what was wrong with them -- and an accurate description of a defect felt
+    // like resolution. Plan 1 took it to seven. This plan took it to zero, and
+    // the last four went the hard way: each was held back on the true statement
+    // that its producing action did not exist, until it was built.
+    //
+    // Every future entry must be genuine public API and say so. Anything else
+    // is the backlog re-forming under a new name.
+    expect([...ALLOWED.keys()]).toEqual([]);
 
-    const PLAN_2 = [
-      'selectForConsolidation',
-      'consolidationRatio',
-      'recordRefresh',
-      'recordRefreshOutcome',
-    ];
-    // Everything still listed must be attributable. An entry that is neither
-    // Plan 2's nor genuine public API is a backlog entry, which is the thing
-    // this whole file exists to refuse.
     const unattributed = [...ALLOWED.entries()]
-      .filter(([name]) => !PLAN_2.includes(name))
       .filter(([, reason]) => !/^PUBLIC API/.test(reason))
       .map(([name]) => name);
     expect(unattributed).toEqual([]);
@@ -332,6 +316,35 @@ describe('the scan does not mistake prose for a call site', () => {
     const stripped = stripComments(code);
     expect(stripped).toContain('realCall');
     expect(stripped).toContain('example.com');
+  });
+
+  it('does not eat the rest of the line for a comment opener inside a string', () => {
+    // FOUND IN REVIEW, and it was the one direction this guard must never be
+    // wrong in. The regex line-comment pass had no idea it was inside a string,
+    // so a quoted `//` truncated the line and took the real call after it --
+    // reporting a live function as an orphan and failing CI on working code.
+    const line = 'const label = "a // b"; realCall();';
+    expect(stripComments(line)).toContain('realCall');
+
+    // Same shape with a block-comment opener: two strings, one holding `/*`
+    // and a later one holding `*/`, swallowed every call between them.
+    const block = 'const a = "/*"; realCall(); const b = "*/";';
+    expect(stripComments(block)).toContain('realCall');
+  });
+
+  it('still strips a real comment that follows a string on the same line', () => {
+    // The fix must not overshoot into keeping prose, which is the failure the
+    // whole file was built against.
+    expect(stripComments("const u = 'x'; // someOrphanFn")).not.toContain('someOrphanFn');
+  });
+
+  it('recovers on the next line when a regex literal confuses the tracker', () => {
+    // The second attempt at this failed because a regex containing a quote
+    // desynchronised the scanner for the rest of the FILE. Bounded to a line,
+    // the same input costs one line and the next is scanned correctly.
+    const quoteClass = '/[' + String.fromCharCode(34) + '/;';
+    const text = [quoteClass, 'realCall();'].join(String.fromCharCode(10));
+    expect(stripComments(text)).toContain('realCall');
   });
 
   it('still sees a name written inside a string literal', () => {

--- a/tests/hooks/reachability.test.mjs
+++ b/tests/hooks/reachability.test.mjs
@@ -25,39 +25,18 @@
  * gets disabled within a week.
  */
 import { describe, it, expect } from '@jest/globals';
-import { readdirSync, readFileSync, statSync } from 'fs';
+import { readFileSync } from 'fs';
 import { join, relative } from 'path';
+import {
+  DECLARE_DIRS,
+  USAGE_DIRS,
+  walk,
+  stripComments,
+  stripSpecifiers,
+} from '../fixtures/source-scan.mjs';
 
 const REPO = process.cwd();
 
-/**
- * Where DECLARATIONS are collected: the live hook path only.
- *
- * `src/tools` is not scanned for declarations because its tools are dispatched
- * by NAME through a registry, so a name-based scan reports false positives
- * there, and a blocking check built on false positives gets disabled within a
- * week.
- */
-const DECLARE_DIRS = ['hooks-core', 'plugin/hooks'];
-
-/**
- * Where USAGES are searched: everything that ships.
- *
- * THIS MUST BE WIDER THAN THE DECLARATION SET. `src/server/*` reaches into
- * hooks-core through a dynamic `mods.<module>.<fn>` handle rather than a static
- * import, so scanning only the hook path reported `diagnose`, `renderFleet`,
- * `renderAudit` and `exportMarkdown` as unreachable while four MCP tools were
- * calling them. That first draft would have failed CI on working code -- the
- * fastest possible way to get a guard like this switched off.
- *
- * `scripts` is here for the same reason and was missed on the first pass:
- * wire-hooks and uninstall consume hooks-core/wire.mjs, so wirePlan and unwire
- * were reported dead while the installer and the uninstaller both called them.
- * Eleven files under scripts/ reference hooks-core. A check that scans only
- * where its author expected the callers to be measures the author, not the
- * code.
- */
-const USAGE_DIRS = ['hooks-core', 'plugin', 'src', 'scripts'];
 const TEST_DIRS = ['tests'];
 
 /**
@@ -139,32 +118,6 @@ const ALLOWED = new Map([
   // ------------------------------------------------------------------
 ]);
 
-function walk(dir, out = []) {
-  let entries;
-  try {
-    entries = readdirSync(dir);
-  } catch {
-    return out;
-  }
-  for (const entry of entries) {
-    const full = join(dir, entry);
-    let st;
-    try {
-      st = statSync(full);
-    } catch {
-      continue;
-    }
-    if (st.isDirectory()) {
-      // `lib` holds the GENERATED copies of hooks-core; scanning them would
-      // make every function look used by its own duplicate.
-      if (['node_modules', 'dist', 'lib', '.git'].includes(entry)) continue;
-      walk(full, out);
-    } else if (/\.(mjs|js|ts)$/.test(entry) && !/\.d\.ts$/.test(entry)) {
-      out.push(full);
-    }
-  }
-  return out;
-}
 
 const declareFiles = DECLARE_DIRS.flatMap((d) => walk(join(REPO, d)));
 const usageFiles = USAGE_DIRS.flatMap((d) => walk(join(REPO, d)));
@@ -204,92 +157,6 @@ function exportedNames() {
 }
 
 /**
- * Strips comments, so prose cannot be mistaken for a call.
- *
- * THIS IS WHAT LET A DEAD PUBLIC ENTRY POINT THROUGH. `calibrate` counted as
- * reachable because curate.mjs:13 contains the English phrase "the reader's
- * ability to calibrate trust", and `reliability` counted because the word
- * appears in its own file's prose. calibration.mjs had ZERO importers -- no
- * forecast was ever logged, no outcome observed, and the shipped panel printed
- * precisely the uncalibrated number that module's docstring calls "a vibe with
- * a typeface" -- while the check that exists to catch exactly this reported it
- * as wired, on a coincidence of comment wording.
- *
- * A guard that reads documentation as code is worse than none: it is a clean
- * bill of health nobody re-examines. This module's files are heavily commented
- * by design, which makes the false-positive rate high rather than incidental.
- *
- * COMMENTS ONLY, NOT STRING LITERALS -- and that boundary was found the hard
- * way. Stripping quotes as well made `routingReport` and `modelSwitchCost` look
- * orphaned when routing-tool.ts calls both: three independent global passes
- * cannot nest, so an apostrophe inside a DOUBLE-quoted sentence opened a
- * "single-quoted string" that ran to the next apostrophe further down the file
- * and swallowed the real call sites in between.
- *
- * Getting that right needs a scanner, and this guard's own rule says why not to
- * build one: a check wrong in the permissive direction is merely useless, while
- * one wrong in the strict direction fails CI on working code and gets deleted.
- * The observed defect was comment prose, comments nest predictably, and that is
- * where the line belongs.
- *
- * AND A SCANNER WAS BUILT, MEASURED, AND REJECTED -- recorded here so the next
- * reader does not spend the afternoon rediscovering it. Plan 3 proposed
- * replacing the three regex passes with a hand-written character scanner that
- * skips string and template literals whole, on the reasoning that a scanner
- * cannot suffer the non-nesting problem described above. It cannot -- and it
- * fails worse, because a JS lexer that knows about quotes but not about REGEX
- * LITERALS desynchronises on the first regex containing a quote. This file is
- * not hypothetical about which one:
- *
- *   hooks-core/adapter.mjs:255
- *   /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*((?:"(?:\\.|[^"\\])*")|...)/gs
- *
- * The scanner sees that `"`, enters string mode, and never comes back.
- * MEASURED: adapter.mjs 1032 newlines in, 385 out -- 63% of the file consumed;
- * disclose.mjs 69%. Eleven genuinely-called exports (toolSucceeded, stableText,
- * recordToolOutcome, recordEpisodeOutcome, DISCLOSE_THRESHOLD,
- * invalidateOnWrite, invalidateChangedAnchors, prices, briefing,
- * semanticHarvestPrompt, cachedRoutingBriefing) fell to a single reference --
- * their own declaration -- and reported as orphans.
- *
- * Telling a regex literal from a division needs parse context, which means a
- * real parser, which is a dependency and a maintenance surface for a guard
- * whose entire value is that nobody switches it off. Comments only. The line
- * stays where the measurement put it.
- */
-function stripComments(text) {
-  return text
-    .replace(/\/\*[\s\S]*?\*\//g, ' ')     // block comments, including docblocks
-    .replace(/(^|[^:])\/\/[^\n]*/g, '$1 '); // line comments, sparing the // in a URL
-}
-
-/**
- * Blanks the specifier list of an `import {...}` / `export {...}` statement.
- *
- * IMPORTED IS NOT CALLED, and the guard could not tell the difference. Found by
- * mutation during Plan 1: dropping the `cacheOrdered` CALL from inject.mjs while
- * leaving `import { cacheOrdered } from './cache.mjs'` in place left this suite
- * GREEN. Only deleting the import as well turned it red -- so any refactor that
- * removed the last call but left a tidy-looking import would have restored the
- * exact defect this file exists to catch, silently.
- *
- * Only the braces are blanked, not the whole statement: the module path is left
- * alone, and a default or namespace import (`import x from`, `import * as x`)
- * is deliberately untouched. Those bind a name that ordinary code then has to
- * call, so they are not the specifier case, and widening this would move the
- * guard in the strict direction for no measured defect.
- *
- * MEASURED FALLOUT: zero. Every one of the 352 declarations that was reachable
- * before this discount is reachable after it -- it changes no verdict today and
- * closes the hole for tomorrow.
- */
-function stripSpecifiers(code) {
-  return code
-    .replace(/\bimport\s*\{[^}]*\}\s*from\b/g, ' importfrom ')
-    .replace(/\bexport\s*\{[^}]*\}(\s*from\b)?/g, ' exportfrom ');
-}
-
-/**
  * Referenced anywhere that ships, other than its own declaration?
  *
  * A bare word match over CODE, deliberately. Anything cleverer would need to
@@ -297,9 +164,9 @@ function stripSpecifiers(code) {
  * check that is wrong in the permissive direction is merely useless -- one that
  * is wrong in the strict direction fails CI on working code and gets deleted.
  * COMMENTS are removed first, because prose is not a caller. Strings are NOT --
- * see stripComments above for the measurement that settled that boundary.
+ * see stripComments in tests/fixtures/source-scan.mjs for the two measurements
  * IMPORT SPECIFIERS are removed too, because an import is not a call site --
- * see stripSpecifiers.
+ * see stripSpecifiers there.
  *
  * STRIPPED ONCE PER FILE, not once per name: this runs over ~300 files times
  * ~350 exported names, and re-stripping per name is the difference between a

--- a/tests/hooks/reachability.test.mjs
+++ b/tests/hooks/reachability.test.mjs
@@ -101,22 +101,34 @@ const ALLOWED = new Map([
   // entries left this list at once, which is what wiring a whole feature looks
   // like -- and is why it was worth doing rather than annotating.
 
+  // WHAT IS LEFT IS PLAN 2'S, AND ONLY PLAN 2'S.
+  //
+  // renderStanding and manifestSize left this list by being WIRED, not by being
+  // re-described: renderStanding renders the standing-context panel inside
+  // renderAudit, and manifestSize reports the install footprint in the doctor's
+  // manifest check. Both have tests asserting a reader reaches the output,
+  // because this guard can only see that the NAME is referenced.
+  //
+  // The five below are owned by Plan 2 (production and measurement), in
+  // progress in parallel, and are attributed rather than triaged again. The
+  // assertion at the bottom of this file holds the count to a ceiling that can
+  // only fall, and refuses any entry that is neither one of these five nor
+  // genuine public API.
+
   // CONSOLIDATION. forecast.mjs imports aggregateConsolidation from this module,
   // so it is partly live -- but the selection, the ratio and the content anchor
   // are not reached, meaning nothing ever decides WHAT to consolidate.
-  ['selectForConsolidation', 'UNWIRED: chooses what to promote into the graph; no caller decides when consolidation runs.'],
-  ['consolidationRatio', 'UNWIRED: reports what consolidation bought, and cannot report on a selection that never happens.'],
-  ['contentAnchor', 'UNWIRED: content-based anchoring, additive to path anchoring; no caller.'],
+  // PLAN 2 Task 4 wires selectForConsolidation and DELETES contentAnchor;
+  // PLAN 2 Task 8 wires consolidationRatio into the optimization report.
+  ['selectForConsolidation', 'UNWIRED, PLAN 2 TASK 4: chooses what to promote into the graph; no caller decides when consolidation runs.'],
+  ['consolidationRatio', 'UNWIRED, PLAN 2 TASK 8: reports what consolidation bought, and cannot report on a selection that never happens.'],
+  ['contentAnchor', 'UNWIRED, PLAN 2 TASK 4 (to be deleted): content-based anchoring, additive to path anchoring; no caller.'],
 
   // HALF A FEEDBACK LOOP. shouldKeepWarm and keepWarmDecision are reachable;
   // the outcome half that would tell them whether a refresh ever paid off is
-  // not, so the decision can never learn.
-  ['recordRefreshOutcome', 'UNWIRED: records whether a keep-warm refresh was worth it; the deciding half runs without it.'],
-
-  // SINGLETONS still to be traced.
-  ['renderStanding', 'UNWIRED: renders the standing-context audit. auditStanding IS reachable, so only the report is orphaned.'],
-  ['recordRefresh', 'UNWIRED: records that a keep-warm refresh happened; pairs with recordRefreshOutcome, and neither is reached.'],
-  ['manifestSize', 'UNWIRED: measures the installation manifest. Verified orphaned, and untested as well.'],
+  // not, so the decision can never learn. PLAN 2 Task 9 closes the loop.
+  ['recordRefresh', 'UNWIRED, PLAN 2 TASK 9: records that a keep-warm refresh happened; pairs with recordRefreshOutcome, and neither is reached.'],
+  ['recordRefreshOutcome', 'UNWIRED, PLAN 2 TASK 9: records whether a keep-warm refresh was worth it; the deciding half runs without it.'],
 
   // ------------------------------------------------------------------
   // The policyText entry lived here as "GENUINE PUBLIC API", and it was stale
@@ -162,13 +174,31 @@ const declarations = declareFiles.map((f) => ({ file: f, text: readFileSync(f, '
 const usages = usageFiles.map((f) => ({ file: f, text: readFileSync(f, 'utf8') }));
 const testText = testFiles.map((f) => readFileSync(f, 'utf8')).join('\n');
 
-/** Every `export function NAME` / `export async function NAME` in the live path. */
-function exportedFunctions() {
+/**
+ * Every `export function` / `export async function` / `export const` in the live path.
+ *
+ * CONSTS WERE INVISIBLE, and that is where the second-worst instance hid. The
+ * collector matched only `export function`, so 56 exported consts went
+ * unchecked -- among them `EDGE_KINDS` in hooks-core/wiki.mjs, which declared
+ * `contradicts` and `answers` as edge kinds of this graph while nothing in the
+ * repository ever wrote either one. A declaration nothing writes is the same
+ * defect as a function nothing calls, and it was outside the scan's model.
+ *
+ * MEASURED FALLOUT of adding them: zero new orphans. The 56 that were never
+ * checked are, as it happens, all reachable -- but they were not KNOWN to be,
+ * and now a new one cannot arrive unnoticed.
+ */
+function exportedNames() {
   const found = [];
   for (const { file, text } of declarations) {
-    const re = /export\s+(?:async\s+)?function\s+([A-Za-z_$][\w$]*)/g;
+    // Stripped, so a name written only in prose cannot be collected as a
+    // declaration either -- the same rule the usage side already follows.
+    const code = stripComments(text);
     let m;
-    while ((m = re.exec(text)) !== null) found.push({ name: m[1], file });
+    const fnRe = /export\s+(?:async\s+)?function\s+([A-Za-z_$][\w$]*)/g;
+    while ((m = fnRe.exec(code)) !== null) found.push({ name: m[1], file });
+    const constRe = /export\s+const\s+([A-Za-z_$][\w$]*)/g;
+    while ((m = constRe.exec(code)) !== null) found.push({ name: m[1], file });
   }
   return found;
 }
@@ -201,11 +231,62 @@ function exportedFunctions() {
  * one wrong in the strict direction fails CI on working code and gets deleted.
  * The observed defect was comment prose, comments nest predictably, and that is
  * where the line belongs.
+ *
+ * AND A SCANNER WAS BUILT, MEASURED, AND REJECTED -- recorded here so the next
+ * reader does not spend the afternoon rediscovering it. Plan 3 proposed
+ * replacing the three regex passes with a hand-written character scanner that
+ * skips string and template literals whole, on the reasoning that a scanner
+ * cannot suffer the non-nesting problem described above. It cannot -- and it
+ * fails worse, because a JS lexer that knows about quotes but not about REGEX
+ * LITERALS desynchronises on the first regex containing a quote. This file is
+ * not hypothetical about which one:
+ *
+ *   hooks-core/adapter.mjs:255
+ *   /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*((?:"(?:\\.|[^"\\])*")|...)/gs
+ *
+ * The scanner sees that `"`, enters string mode, and never comes back.
+ * MEASURED: adapter.mjs 1032 newlines in, 385 out -- 63% of the file consumed;
+ * disclose.mjs 69%. Eleven genuinely-called exports (toolSucceeded, stableText,
+ * recordToolOutcome, recordEpisodeOutcome, DISCLOSE_THRESHOLD,
+ * invalidateOnWrite, invalidateChangedAnchors, prices, briefing,
+ * semanticHarvestPrompt, cachedRoutingBriefing) fell to a single reference --
+ * their own declaration -- and reported as orphans.
+ *
+ * Telling a regex literal from a division needs parse context, which means a
+ * real parser, which is a dependency and a maintenance surface for a guard
+ * whose entire value is that nobody switches it off. Comments only. The line
+ * stays where the measurement put it.
  */
 function stripComments(text) {
   return text
     .replace(/\/\*[\s\S]*?\*\//g, ' ')     // block comments, including docblocks
     .replace(/(^|[^:])\/\/[^\n]*/g, '$1 '); // line comments, sparing the // in a URL
+}
+
+/**
+ * Blanks the specifier list of an `import {...}` / `export {...}` statement.
+ *
+ * IMPORTED IS NOT CALLED, and the guard could not tell the difference. Found by
+ * mutation during Plan 1: dropping the `cacheOrdered` CALL from inject.mjs while
+ * leaving `import { cacheOrdered } from './cache.mjs'` in place left this suite
+ * GREEN. Only deleting the import as well turned it red -- so any refactor that
+ * removed the last call but left a tidy-looking import would have restored the
+ * exact defect this file exists to catch, silently.
+ *
+ * Only the braces are blanked, not the whole statement: the module path is left
+ * alone, and a default or namespace import (`import x from`, `import * as x`)
+ * is deliberately untouched. Those bind a name that ordinary code then has to
+ * call, so they are not the specifier case, and widening this would move the
+ * guard in the strict direction for no measured defect.
+ *
+ * MEASURED FALLOUT: zero. Every one of the 352 declarations that was reachable
+ * before this discount is reachable after it -- it changes no verdict today and
+ * closes the hole for tomorrow.
+ */
+function stripSpecifiers(code) {
+  return code
+    .replace(/\bimport\s*\{[^}]*\}\s*from\b/g, ' importfrom ')
+    .replace(/\bexport\s*\{[^}]*\}(\s*from\b)?/g, ' exportfrom ');
 }
 
 /**
@@ -217,10 +298,16 @@ function stripComments(text) {
  * is wrong in the strict direction fails CI on working code and gets deleted.
  * COMMENTS are removed first, because prose is not a caller. Strings are NOT --
  * see stripComments above for the measurement that settled that boundary.
+ * IMPORT SPECIFIERS are removed too, because an import is not a call site --
+ * see stripSpecifiers.
+ *
+ * STRIPPED ONCE PER FILE, not once per name: this runs over ~300 files times
+ * ~350 exported names, and re-stripping per name is the difference between a
+ * suite that runs in under a second and one nobody waits for.
  */
 const codeOnly = new Map();
 function shippedCode(file, text) {
-  if (!codeOnly.has(file)) codeOnly.set(file, stripComments(text));
+  if (!codeOnly.has(file)) codeOnly.set(file, stripSpecifiers(stripComments(text)));
   return codeOnly.get(file);
 }
 
@@ -233,7 +320,14 @@ function shippedCode(file, text) {
 // this function cannot answer and should not try to.
 function usedInShippedCode(name, declaringFile) {
   const word = new RegExp(`\\b${name}\\b`, 'g');
-  const decl = new RegExp(`export\\s+(?:async\\s+)?function\\s+${name}\\b`, 'g');
+  // Subtracts the declaration itself, in BOTH forms -- a const that discounted
+  // only `export function NAME` would be credited with a use by its own
+  // declaration line and could never be reported, which would make collecting
+  // consts at all a no-op dressed as coverage.
+  const decl = new RegExp(
+    `export\\s+(?:(?:async\\s+)?function|const)\\s+${name}\\b`,
+    'g'
+  );
   for (const { file, text } of usages) {
     const code = shippedCode(file, text);
     const uses = (code.match(word) || []).length;
@@ -244,7 +338,7 @@ function usedInShippedCode(name, declaringFile) {
 }
 
 describe('every exported function in the live hook path is reachable', () => {
-  const exports = exportedFunctions();
+  const exports = exportedNames();
 
   it('found something to check, so a broken scan cannot pass silently', () => {
     // A scan that matches nothing would report a clean bill of health forever.
@@ -295,5 +389,129 @@ describe('every exported function in the live hook path is reachable', () => {
       const file = declaredAt.get(name);
       if (file) expect([name, usedInShippedCode(name, file)]).toEqual([name, false]);
     }
+  });
+
+  it('keeps the allowlist shrinking, and refuses a new backlog entry', () => {
+    // THE LIST IS NOT A BACKLOG. Round 1 built this detector, it found ~21
+    // unreachable capabilities, four were wired and sixteen were parked here
+    // with accurate descriptions of what was wrong with them -- and an accurate
+    // description of a defect felt like resolution. Plan 1 took it to seven.
+    //
+    // A CEILING RATHER THAN ZERO, and the difference is deliberate. Five of the
+    // seven are owned by Plan 2 (production and measurement), which is in
+    // progress in parallel: selectForConsolidation and contentAnchor by its
+    // Task 4, consolidationRatio by its Task 8, recordRefresh and
+    // recordRefreshOutcome by its Task 9. Asserting zero here would ship a test
+    // that is RED until someone else's PR merges, and a suite that is expected
+    // to be red teaches everyone to ignore it -- the same disease in a new
+    // organ. So this asserts the number can only fall, and names who owes what.
+    // When Plan 2 lands, this drops to 0 and the ceiling comes with it.
+    expect(ALLOWED.size).toBeLessThanOrEqual(5);
+
+    const PLAN_2 = [
+      'selectForConsolidation',
+      'consolidationRatio',
+      'contentAnchor',
+      'recordRefresh',
+      'recordRefreshOutcome',
+    ];
+    // Everything still listed must be attributable. An entry that is neither
+    // Plan 2's nor genuine public API is a backlog entry, which is the thing
+    // this whole file exists to refuse.
+    const unattributed = [...ALLOWED.entries()]
+      .filter(([name]) => !PLAN_2.includes(name))
+      .filter(([, reason]) => !/^PUBLIC API/.test(reason))
+      .map(([name]) => name);
+    expect(unattributed).toEqual([]);
+  });
+});
+
+describe('the scan does not mistake prose for a call site', () => {
+  // PINNED, not newly fixed. stripComments already did this -- these assertions
+  // exist because the boundary is load-bearing and was moved twice, each time
+  // by someone reasonable who had not seen the measurement. A guard that reads
+  // documentation as code is worse than no guard: it is a clean bill of health
+  // nobody re-examines.
+  it('ignores a name that appears only in a line comment', () => {
+    const text = [
+      '// A write the hook observes is invalidated eagerly by someOrphanFn, so',
+      'export function other() { return 1; }',
+    ].join('\n');
+    expect(stripComments(text)).not.toContain('someOrphanFn');
+  });
+
+  it('ignores a name inside a block comment', () => {
+    expect(stripComments('/* calls someOrphanFn */ const x = 1;')).not.toContain(
+      'someOrphanFn'
+    );
+  });
+
+  it('keeps real code intact, including a URL that contains a double slash', () => {
+    // THE TRAP. A naive line-comment regex truncates at the `//` inside
+    // `https://`, blinding the scan to everything after any URL in the file --
+    // a silent permissive failure, which is exactly the class this guard exists
+    // to prevent.
+    const code = "const url = 'https://example.com/x'; realCall();";
+    const stripped = stripComments(code);
+    expect(stripped).toContain('realCall');
+    expect(stripped).toContain('example.com');
+  });
+
+  it('still sees a name written inside a string literal', () => {
+    // THE OTHER SIDE OF THE SAME BOUNDARY, asserted so it cannot drift. Strings
+    // are NOT stripped, because src/server dispatches hooks-core through
+    // dynamic `mods.<module>.<fn>` handles and a scanner that skips strings
+    // desynchronises on the first regex literal containing a quote -- see
+    // stripComments for the measurement. Over-counting a name in a string is
+    // the permissive direction, and that is the safe one here.
+    expect(stripComments("const h = 'realCall';")).toContain('realCall');
+  });
+});
+
+describe('an import is not a call site', () => {
+  it('discounts an import specifier', () => {
+    const code = "import { cacheOrdered } from './cache.mjs';\nconst x = 1;";
+    expect(stripSpecifiers(code)).not.toContain('cacheOrdered');
+  });
+
+  it('discounts a re-export specifier', () => {
+    expect(stripSpecifiers("export { cacheOrdered } from './cache.mjs';")).not.toContain(
+      'cacheOrdered'
+    );
+  });
+
+  it('leaves a real call intact, and the module path alone', () => {
+    const code = "import { cacheOrdered } from './cache.mjs';\nreturn cacheOrdered(items);";
+    const stripped = stripSpecifiers(code);
+    expect(stripped).toContain('cacheOrdered(items)');
+    // Exactly one survivor: the call. The specifier is gone.
+    expect((stripped.match(/\bcacheOrdered\b/g) || []).length).toBe(1);
+  });
+
+  it('leaves a default and a namespace import alone', () => {
+    // Not the specifier case: both bind a name that ordinary code must then
+    // call, so blanking them would move the guard in the strict direction for
+    // no measured defect.
+    const code = "import os from 'os';\nimport * as wiki from './wiki.mjs';";
+    const stripped = stripSpecifiers(code);
+    expect(stripped).toContain('os');
+    expect(stripped).toContain('wiki');
+  });
+});
+
+describe('exported consts are checked, not just functions', () => {
+  it('collects an exported const', () => {
+    const names = exportedNames().map((e) => e.name);
+    // EDGE_KINDS is an exported const in hooks-core/wiki.mjs. While the
+    // collector saw only `export function`, 56 declarations went unchecked --
+    // and that is where `contradicts` and `answers` sat, declared as edge kinds
+    // of this graph with zero write sites anywhere in the repository.
+    expect(names).toContain('EDGE_KINDS');
+  });
+
+  it('collects enough of them that a broken const pattern cannot pass silently', () => {
+    const wiki = exportedNames().filter(({ file }) => /wiki\.mjs$/.test(file));
+    expect(wiki.length).toBeGreaterThan(1);
+    expect(exportedNames().length).toBeGreaterThan(300);
   });
 });

--- a/tests/hooks/reachability.test.mjs
+++ b/tests/hooks/reachability.test.mjs
@@ -94,20 +94,30 @@ const ALLOWED = new Map([
   // only fall, and refuses any entry that is neither one of these five nor
   // genuine public API.
 
-  // CONSOLIDATION. forecast.mjs imports aggregateConsolidation from this module,
-  // so it is partly live -- but the selection, the ratio and the content anchor
-  // are not reached, meaning nothing ever decides WHAT to consolidate.
-  // PLAN 2 Task 4 wires selectForConsolidation and DELETES contentAnchor;
-  // PLAN 2 Task 8 wires consolidationRatio into the optimization report.
-  ['selectForConsolidation', 'UNWIRED, PLAN 2 TASK 4: chooses what to promote into the graph; no caller decides when consolidation runs.'],
+  // THE FOUR THAT REMAIN HAVE NO PRODUCING ACTION TO ATTACH TO, and that is a
+  // measured statement rather than a deferral. Each was checked against the
+  // codebase before being left here.
+  //
+  // CONSOLIDATION. forecast.mjs calls aggregateConsolidation, so the module is
+  // partly live -- but `grep` finds no caller anywhere that decides WHAT to
+  // consolidate or WHEN a consolidation pass runs. `selectForConsolidation`
+  // chooses candidates for a pass that does not exist; `consolidationRatio`
+  // reports what that pass bought and would return null forever without it.
+  // Plan 2's derive.mjs, running at Stop, is that pass. Wiring either here
+  // would mean building it twice.
+  ['selectForConsolidation', 'UNWIRED, PLAN 2 TASK 4: chooses what to promote into the graph; verified -- no caller anywhere decides when a consolidation pass runs.'],
   ['consolidationRatio', 'UNWIRED, PLAN 2 TASK 8: reports what consolidation bought, and cannot report on a selection that never happens.'],
-  ['contentAnchor', 'UNWIRED, PLAN 2 TASK 4 (to be deleted): content-based anchoring, additive to path anchoring; no caller.'],
 
-  // HALF A FEEDBACK LOOP. shouldKeepWarm and keepWarmDecision are reachable;
-  // the outcome half that would tell them whether a refresh ever paid off is
-  // not, so the decision can never learn. PLAN 2 Task 9 closes the loop.
-  ['recordRefresh', 'UNWIRED, PLAN 2 TASK 9: records that a keep-warm refresh happened; pairs with recordRefreshOutcome, and neither is reached.'],
-  ['recordRefreshOutcome', 'UNWIRED, PLAN 2 TASK 9: records whether a keep-warm refresh was worth it; the deciding half runs without it.'],
+  // HALF A FEEDBACK LOOP, and the missing half is an ACTION, not a reader.
+  // shouldKeepWarm is called by cache-tool.ts and prints its verdict; nothing
+  // in this repository ever performs a keep-warm ping. So `recordRefresh`
+  // records an event that never occurs, and calling it at the DECISION point --
+  // the only place a caller exists today -- would write refreshes that never
+  // happened into the ledger `tripwire` reads to decide whether keep-warm is
+  // losing money. Fabricated evidence in a backstop is worse than a dead
+  // function, so these stay until the refresh itself exists (Plan 2 Task 9).
+  ['recordRefresh', 'UNWIRED, PLAN 2 TASK 9: records a keep-warm refresh; verified -- nothing in the repository performs one, so a caller would fabricate the event.'],
+  ['recordRefreshOutcome', 'UNWIRED, PLAN 2 TASK 9: scores whether a refresh paid off; same missing producer, and it feeds the tripwire ledger.'],
 
   // ------------------------------------------------------------------
   // The policyText entry lived here as "GENUINE PUBLIC API", and it was stale
@@ -264,21 +274,21 @@ describe('every exported function in the live hook path is reachable', () => {
     // with accurate descriptions of what was wrong with them -- and an accurate
     // description of a defect felt like resolution. Plan 1 took it to seven.
     //
-    // A CEILING RATHER THAN ZERO, and the difference is deliberate. Five of the
+    // A CEILING RATHER THAN ZERO, and the difference is deliberate. Four of the
     // seven are owned by Plan 2 (production and measurement), which is in
-    // progress in parallel: selectForConsolidation and contentAnchor by its
-    // Task 4, consolidationRatio by its Task 8, recordRefresh and
-    // recordRefreshOutcome by its Task 9. Asserting zero here would ship a test
+    // progress in parallel: selectForConsolidation by its Task 4,
+    // consolidationRatio by its Task 8, recordRefresh and recordRefreshOutcome
+    // by its Task 9 -- and each was verified to have no producing ACTION to
+    // attach to, not merely no caller. Asserting zero here would ship a test
     // that is RED until someone else's PR merges, and a suite that is expected
     // to be red teaches everyone to ignore it -- the same disease in a new
     // organ. So this asserts the number can only fall, and names who owes what.
     // When Plan 2 lands, this drops to 0 and the ceiling comes with it.
-    expect(ALLOWED.size).toBeLessThanOrEqual(5);
+    expect(ALLOWED.size).toBeLessThanOrEqual(4);
 
     const PLAN_2 = [
       'selectForConsolidation',
       'consolidationRatio',
-      'contentAnchor',
       'recordRefresh',
       'recordRefreshOutcome',
     ];

--- a/tests/hooks/stale-reason-states-what-was-observed.test.mjs
+++ b/tests/hooks/stale-reason-states-what-was-observed.test.mjs
@@ -94,3 +94,39 @@ describe('the reason given for an unreadable anchor', () => {
     expect(reason).toMatch(/changed/i);
   });
 });
+
+describe('the reason given for a changed file names what changed it', () => {
+  // `lastAction` -- the tool name that last touched a file -- has been stamped
+  // on every file node by the structural harvest since #203 and read by
+  // nothing. It belongs precisely in this sentence: "file changed" tells a
+  // reader their finding may be wrong, "file changed (last touched by Edit)"
+  // tells them a targeted edit did it, which is cheap to re-verify, and "by
+  // Write" says the file was replaced wholesale, which usually is not.
+  const changed = (extra = {}) => {
+    const key = join(dir, 'src', 'changed.ts');
+    writeFileSync(key, 'export const x = 2;\n');
+    return { kind: 'file', key, hash: 'not-the-current-hash', snapshot: 'export const x = 1;\n', ...extra };
+  };
+
+  it('names the tool when the graph recorded one', () => {
+    const { reason } = checkAnchor(changed({ lastAction: 'Edit' }));
+    expect(reason).toBe('file changed (last touched by Edit)');
+  });
+
+  it('falls back to the bare reason when nothing was recorded', () => {
+    // A node written before the field existed, or by a path that does not set
+    // it. Inventing a tool name would be asserting a cause that was never
+    // observed -- the exact error the rest of this file exists to prevent.
+    const { reason } = checkAnchor(changed());
+    expect(reason).toBe('file changed');
+  });
+
+  it('bounds the tool name, because it reaches injected text', () => {
+    const { reason } = checkAnchor(changed({ lastAction: 'x'.repeat(400) }));
+    expect(reason.length).toBeLessThan(90);
+  });
+
+  it('still reports the anchor as stale', () => {
+    expect(checkAnchor(changed({ lastAction: 'Write' })).fresh).toBe(false);
+  });
+});

--- a/tests/hooks/test-hygiene.test.mjs
+++ b/tests/hooks/test-hygiene.test.mjs
@@ -1,0 +1,113 @@
+/**
+ * A test that consults the stratified holdout must pin the arm.
+ *
+ * `inHoldout(anchor)` is deterministic in (anchor, epoch) but not in anything a
+ * test controls: a fixture whose anchor happens to land in the WITHHELD arm gets
+ * a null injection and the assertion fails, on some runs, in some epochs, for
+ * nobody's reason. The convention that fixes it -- set `TOKEN_OPTIMIZER_HOLDOUT`
+ * and restore it -- is copy-pasted per suite in several variants, and until now
+ * nothing enforced it. One newly-added test on the Plan 1 branch omitted it and
+ * produced exactly that flake, which cost a diagnosis.
+ *
+ * WHY A GUARD RATHER THAN A NOTE IN A CONTRIBUTING FILE. This is the same defect
+ * shape as everything else in this directory: a convention that is correct,
+ * written down, and unenforced is indistinguishable from one nobody follows,
+ * until a Tuesday when CI goes red on an unrelated PR and somebody reruns the
+ * job until it passes.
+ *
+ * THE ENTRY POINTS ARE DERIVED, NOT LISTED. A hard-coded list of four names
+ * would be correct today and silently wrong the first time a fifth function
+ * starts consulting the holdout -- which is precisely how this class of defect
+ * gets in. The guard finds every `inHoldout(` call site in the live hook path
+ * and attributes it to its enclosing exported function.
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import { readFileSync } from 'fs';
+import { join, relative } from 'path';
+import {
+  DECLARE_DIRS,
+  walk,
+  stripComments,
+} from '../fixtures/source-scan.mjs';
+
+const REPO = process.cwd();
+
+/** Every exported function in the live hook path whose body calls `inHoldout`. */
+function holdoutConsumingEntryPoints() {
+  const names = new Set();
+  for (const file of DECLARE_DIRS.flatMap((d) => walk(join(REPO, d)))) {
+    const code = stripComments(readFileSync(file, 'utf8'));
+    const call = /\binHoldout\s*\(/g;
+    let m;
+    while ((m = call.exec(code)) !== null) {
+      // The nearest PRECEDING export is the enclosing one. A heuristic, and the
+      // right kind: it can name a function that no longer encloses the call
+      // after a refactor, which over-reports and merely asks a suite to pin an
+      // arm it did not need to. It cannot miss one, which is the direction that
+      // would let the flake back in.
+      const before = code.slice(0, m.index);
+      const decl = [...before.matchAll(/export\s+(?:async\s+)?function\s+([A-Za-z_$][\w$]*)/g)].pop();
+      if (decl) names.add(decl[1]);
+    }
+  }
+  return names;
+}
+
+/** Test files that CALL one of those, as opposed to mentioning one in prose. */
+function suitesConsultingTheHoldout(entryPoints) {
+  const shape = new RegExp(`\\b(${[...entryPoints].join('|')})\\s*\\(`);
+  return walk(join(REPO, 'tests'))
+    .filter((file) => /\.test\.(mjs|ts)$/.test(file))
+    .map((file) => ({ file: relative(REPO, file), text: readFileSync(file, 'utf8') }))
+    // Comments stripped, so the four suites that DISCUSS forTouch and forCommand
+    // in their docstrings -- and this very file, which names them throughout --
+    // are not asked to pin an arm they never consult.
+    .filter(({ text }) => shape.test(stripComments(text)));
+}
+
+/**
+ * Both spellings of the convention count.
+ *
+ * `process.env.TOKEN_OPTIMIZER_HOLDOUT = '0'` is what an in-process suite uses;
+ * `TOKEN_OPTIMIZER_HOLDOUT: '0'` inside an env object is what the three suites
+ * that spawn a real hook subprocess use. Insisting on one spelling would fail
+ * three working suites, and a guard that fails working code gets deleted.
+ */
+const PINS_THE_ARM = /TOKEN_OPTIMIZER_HOLDOUT\s*[:=]\s*['"`]/;
+
+describe('suites that consult the stratified holdout pin the arm', () => {
+  const entryPoints = holdoutConsumingEntryPoints();
+
+  it('finds the entry points to reason about', () => {
+    // A derivation that found nothing would pass this file forever while
+    // enforcing nothing -- the failure mode every guard here is built against.
+    expect(entryPoints.size).toBeGreaterThan(2);
+    expect([...entryPoints]).toContain('forTouch');
+  });
+
+  it('finds suites that actually call them', () => {
+    expect(suitesConsultingTheHoldout(entryPoints).length).toBeGreaterThan(5);
+  });
+
+  it('has no suite that calls one without pinning', () => {
+    const unpinned = suitesConsultingTheHoldout(entryPoints)
+      .filter(({ text }) => !PINS_THE_ARM.test(text))
+      .map(({ file }) => file);
+
+    // If this fails: set TOKEN_OPTIMIZER_HOLDOUT in the suite's setup and
+    // restore it afterwards. '0' asserts on the DELIVERED arm, '1' on the
+    // withheld one. Leaving it unset asserts on whichever arm the anchor
+    // happens to hash into this epoch, which is not a test.
+    expect(unpinned).toEqual([]);
+  });
+
+  it('would catch a suite that only mentions the convention in a comment', () => {
+    // The guard reads the raw text for the pin, so a suite could in principle
+    // satisfy it with a comment. Asserting the pattern's shape is cheap and
+    // stops the check being weakened into a documentation search.
+    expect(PINS_THE_ARM.test('// remember to set TOKEN_OPTIMIZER_HOLDOUT')).toBe(false);
+    expect(PINS_THE_ARM.test("process.env.TOKEN_OPTIMIZER_HOLDOUT = '0';")).toBe(true);
+    expect(PINS_THE_ARM.test("env: { TOKEN_OPTIMIZER_HOLDOUT: '1' }")).toBe(true);
+  });
+});

--- a/tests/hooks/test-hygiene.test.mjs
+++ b/tests/hooks/test-hygiene.test.mjs
@@ -76,6 +76,9 @@ function suitesConsultingTheHoldout(entryPoints) {
  */
 const PINS_THE_ARM = /TOKEN_OPTIMIZER_HOLDOUT\s*[:=]\s*['"`]/;
 
+/** The pin must be live code, not a commented-out one. */
+const pinsTheArm = (text) => PINS_THE_ARM.test(stripComments(text));
+
 describe('suites that consult the stratified holdout pin the arm', () => {
   const entryPoints = holdoutConsumingEntryPoints();
 
@@ -92,7 +95,7 @@ describe('suites that consult the stratified holdout pin the arm', () => {
 
   it('has no suite that calls one without pinning', () => {
     const unpinned = suitesConsultingTheHoldout(entryPoints)
-      .filter(({ text }) => !PINS_THE_ARM.test(text))
+      .filter(({ text }) => !pinsTheArm(text))
       .map(({ file }) => file);
 
     // If this fails: set TOKEN_OPTIMIZER_HOLDOUT in the suite's setup and
@@ -102,12 +105,16 @@ describe('suites that consult the stratified holdout pin the arm', () => {
     expect(unpinned).toEqual([]);
   });
 
-  it('would catch a suite that only mentions the convention in a comment', () => {
-    // The guard reads the raw text for the pin, so a suite could in principle
-    // satisfy it with a comment. Asserting the pattern's shape is cheap and
-    // stops the check being weakened into a documentation search.
-    expect(PINS_THE_ARM.test('// remember to set TOKEN_OPTIMIZER_HOLDOUT')).toBe(false);
-    expect(PINS_THE_ARM.test("process.env.TOKEN_OPTIMIZER_HOLDOUT = '0';")).toBe(true);
-    expect(PINS_THE_ARM.test("env: { TOKEN_OPTIMIZER_HOLDOUT: '1' }")).toBe(true);
+  it('does not accept a commented-out pin', () => {
+    // The first version matched raw text, so a suite whose pin had been
+    // commented out during debugging still satisfied the guard -- and a
+    // commented-out pin is exactly the state that produces the flake this file
+    // exists to prevent. Prose alone never matched, because the pattern
+    // requires an assignment; a commented-out ASSIGNMENT did.
+    expect(pinsTheArm('// remember to set TOKEN_OPTIMIZER_HOLDOUT')).toBe(false);
+    expect(pinsTheArm("// process.env.TOKEN_OPTIMIZER_HOLDOUT = '0';")).toBe(false);
+    expect(pinsTheArm("/* process.env.TOKEN_OPTIMIZER_HOLDOUT = '0'; */")).toBe(false);
+    expect(pinsTheArm("process.env.TOKEN_OPTIMIZER_HOLDOUT = '0';")).toBe(true);
+    expect(pinsTheArm("env: { TOKEN_OPTIMIZER_HOLDOUT: '1' }")).toBe(true);
   });
 });

--- a/tests/unit/doctor-reports-manifest-footprint.test.ts
+++ b/tests/unit/doctor-reports-manifest-footprint.test.ts
@@ -4,7 +4,9 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 
 // @ts-expect-error -- hooks-core ships as plain ESM with no type declarations.
-import { checklist } from '../../hooks-core/doctor.mjs';
+import { checklist, probeClients } from '../../hooks-core/doctor.mjs';
+// @ts-expect-error -- hooks-core ships as plain ESM with no type declarations.
+import { record } from '../../hooks-core/metrics.mjs';
 // @ts-expect-error -- hooks-core ships as plain ESM with no type declarations.
 import { writeManifest, manifestSize, readManifest } from '../../hooks-core/manifest.mjs';
 
@@ -136,5 +138,42 @@ describe('the limit of what the reachability guard can prove', () => {
     expect(
       checks.some((c: { name: string }) => /manifest|installed files/i.test(c.name))
     ).toBe(false);
+  });
+});
+
+describe('the doctor reports which MCP clients actually connected', () => {
+  // `mcp-client` was written on every handshake and read by nothing. Every
+  // other check in the doctor reasons about files on disk -- is the hook
+  // present, is it wired, does it refuse a large read. None of them can say
+  // whether the editor in front of you ever actually connected, which is the
+  // most common way this product is installed and silently does nothing.
+  it('names the clients seen, with the title each reports for itself', () => {
+    const graphDir = join(fixture, 'graph');
+    mkdirSync(graphDir, { recursive: true });
+    record(graphDir, {
+      kind: 'mcp-client',
+      client: 'claude-code',
+      clientVersion: '2.1.0',
+      clientTitle: 'Claude Code',
+    });
+
+    const check = probeClients({ dir: graphDir }).find((c: { name: string }) =>
+      /MCP clients/i.test(c.name)
+    );
+    expect(check).toBeDefined();
+    expect(check.pass).toBe(true);
+    expect(check.detail).toMatch(/Claude Code/);
+    expect(check.detail).toMatch(/2\.1\.0/);
+  });
+
+  it('never fails on a fresh install, which has had no handshake', () => {
+    // A doctor that reports red on a correct install teaches people to ignore
+    // it -- the failure this file's sibling tests were written about.
+    const graphDir = join(fixture, 'empty-graph');
+    mkdirSync(graphDir, { recursive: true });
+    const checks = probeClients({ dir: graphDir });
+    expect(checks).toHaveLength(1);
+    expect(checks[0].pass).toBe(true);
+    expect(checks[0].detail).toMatch(/none yet/i);
   });
 });

--- a/tests/unit/doctor-reports-manifest-footprint.test.ts
+++ b/tests/unit/doctor-reports-manifest-footprint.test.ts
@@ -4,7 +4,7 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 
 // @ts-expect-error -- hooks-core ships as plain ESM with no type declarations.
-import { checklist, probeClients } from '../../hooks-core/doctor.mjs';
+import { checklist, probeClients, probeGraph } from '../../hooks-core/doctor.mjs';
 // @ts-expect-error -- hooks-core ships as plain ESM with no type declarations.
 import { record } from '../../hooks-core/metrics.mjs';
 // @ts-expect-error -- hooks-core ships as plain ESM with no type declarations.
@@ -175,5 +175,54 @@ describe('the doctor reports which MCP clients actually connected', () => {
     expect(checks).toHaveLength(1);
     expect(checks[0].pass).toBe(true);
     expect(checks[0].detail).toMatch(/none yet/i);
+  });
+});
+
+describe('a half-removed install is not an intact one', () => {
+  it('fails when recorded files are gone, rather than passing on modified === 0', () => {
+    // FOUND IN REVIEW. verifyManifest reports three states -- intact, modified,
+    // missing -- and this check read two of them, branching only on
+    // `modified === 0`. A recorded file DELETED rather than edited left
+    // `modified` at zero, so a half-removed install reported PASS. The
+    // footprint made it visible (a missing file contributes no bytes) but a
+    // visible detail beside a green tick is still a green tick.
+    const { root, files } = givenScriptInstall(3, 2048);
+    for (const f of files) rmSync(f, { force: true });
+
+    const check = manifestCheck(root);
+    expect(check.pass).toBe(false);
+    expect(check.detail).toMatch(/3 of 3 recorded file\(s\) are gone/);
+    expect(check.remedy).toBeTruthy();
+  });
+
+  it('still passes when every recorded file is present', () => {
+    const { root } = givenScriptInstall(2, 1024);
+    expect(manifestCheck(root).pass).toBe(true);
+  });
+
+  it('passes, with a note, when a file was edited rather than removed', () => {
+    // An edited file is the user's now and uninstall must leave it alone --
+    // that is a healthy state, not a broken one.
+    const { root, files } = givenScriptInstall(2, 1024);
+    writeFileSync(files[0], 'edited by the user');
+    const check = manifestCheck(root);
+    expect(check.pass).toBe(true);
+    expect(check.detail).toMatch(/edited since install/);
+  });
+});
+
+describe('the client probe runs on every platform', () => {
+  it('is included by probeGraph even on the Windows path', () => {
+    // FOUND IN REVIEW, and it is this branch's own disease a third time:
+    // probeClients was appended AFTER probeGraph's Windows early-return, so on
+    // Windows it had a call site and could never run. The reachability guard
+    // cannot see the difference between a reference and an execution -- which
+    // is the limitation this suite already documents one describe block up.
+    const graphDir = join(fixture, 'platform-graph');
+    mkdirSync(graphDir, { recursive: true });
+    record(graphDir, { kind: 'mcp-client', client: 'codex', clientTitle: 'Codex' });
+
+    const checks = probeGraph({ dir: graphDir });
+    expect(checks.some((c: { name: string }) => /MCP clients/i.test(c.name))).toBe(true);
   });
 });

--- a/tests/unit/doctor-reports-manifest-footprint.test.ts
+++ b/tests/unit/doctor-reports-manifest-footprint.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+// @ts-expect-error -- hooks-core ships as plain ESM with no type declarations.
+import { checklist } from '../../hooks-core/doctor.mjs';
+// @ts-expect-error -- hooks-core ships as plain ESM with no type declarations.
+import { writeManifest, manifestSize, readManifest } from '../../hooks-core/manifest.mjs';
+
+/**
+ * The doctor reports what the install manifest actually covers.
+ *
+ * `manifestSize` computed exactly this and had no caller anywhere in the
+ * repository -- correct, untested, and unreachable, which is the defect class
+ * `tests/hooks/reachability.test.mjs` exists to catch. It listed the function
+ * as an orphan with the note "Verified orphaned, and untested as well."
+ *
+ * WHY THE NUMBER IS WORTH PRINTING rather than deleting the function. A file
+ * COUNT says how many entries the manifest has; it says nothing about what
+ * uninstall will remove, and it cannot distinguish a manifest describing a real
+ * install from one whose files are all gone -- a missing file still counts as an
+ * entry, but contributes zero bytes. The footprint is the only line in the
+ * report that separates those two states.
+ */
+
+let fixture: string;
+let manifestFile: string;
+const savedManifestEnv = process.env.TOKEN_OPTIMIZER_MANIFEST;
+
+beforeEach(() => {
+  fixture = mkdtempSync(join(tmpdir(), 'doctor-manifest-'));
+  manifestFile = join(fixture, 'install.json');
+  process.env.TOKEN_OPTIMIZER_MANIFEST = manifestFile;
+});
+
+afterEach(() => {
+  if (savedManifestEnv === undefined) delete process.env.TOKEN_OPTIMIZER_MANIFEST;
+  else process.env.TOKEN_OPTIMIZER_MANIFEST = savedManifestEnv;
+  rmSync(fixture, { recursive: true, force: true });
+});
+
+/** A script-style install with `count` real files of `bytes` bytes each. */
+function givenScriptInstall(count: number, bytes: number) {
+  const root = join(fixture, 'install');
+  const hooksDir = join(root, 'hooks');
+  mkdirSync(hooksDir, { recursive: true });
+  for (const f of ['pretooluse-router.mjs', 'session-start.mjs']) {
+    writeFileSync(join(hooksDir, f), '// hook\n');
+  }
+
+  const files: string[] = [];
+  for (let i = 0; i < count; i += 1) {
+    const path = join(root, `installed-${i}.mjs`);
+    writeFileSync(path, 'x'.repeat(bytes));
+    files.push(path);
+  }
+  // writeManifest takes PATHS and hashes them as it writes.
+  writeManifest({ files, entries: [] }, manifestFile);
+  return { root, files };
+}
+
+/** The manifest check, whatever its exact name. */
+function manifestCheck(root: string) {
+  const checks = checklist({
+    root,
+    settingsPath: join(fixture, 'settings.json'),
+    install: { method: 'script', sameTree: true, installedVersion: null },
+  });
+  return checks.find((c: { name: string }) => /manifest|installed files/i.test(c.name));
+}
+
+describe('the doctor reports what the install manifest covers', () => {
+  it('names the manifest footprint, not only the file count', () => {
+    const { root } = givenScriptInstall(3, 2048);
+    const check = manifestCheck(root);
+
+    expect(check).toBeDefined();
+    // The count is still there...
+    expect(check.detail).toMatch(/3 file/);
+    // ...and so is the size, which nothing reported before.
+    expect(check.detail).toMatch(/\b6 KB\b/);
+  });
+
+  it('distinguishes a real install from a manifest whose files are gone', () => {
+    // THE CASE THE FILE COUNT CANNOT SEE. verifyManifest reports these as
+    // `missing` rather than `intact`, but the manifest still has three entries
+    // either way -- so without the footprint the report reads identically for an
+    // install that is present and one that has been deleted out from under it.
+    const { root, files } = givenScriptInstall(3, 2048);
+    for (const f of files) rmSync(f, { force: true });
+
+    expect(manifestSize(readManifest(manifestFile))).toBe(0);
+    const check = manifestCheck(root);
+    expect(check.detail).toMatch(/size unknown/);
+  });
+
+  it('says something rather than crashing when there is no manifest at all', () => {
+    // A plugin install writes none, and that is not a failure of this check.
+    const root = join(fixture, 'install');
+    mkdirSync(join(root, 'hooks'), { recursive: true });
+    for (const f of ['pretooluse-router.mjs', 'session-start.mjs']) {
+      writeFileSync(join(root, 'hooks', f), '// hook\n');
+    }
+    expect(() => manifestCheck(root)).not.toThrow();
+    expect(manifestCheck(root)).toBeDefined();
+  });
+});

--- a/tests/unit/doctor-reports-manifest-footprint.test.ts
+++ b/tests/unit/doctor-reports-manifest-footprint.test.ts
@@ -106,3 +106,35 @@ describe('the doctor reports what the install manifest covers', () => {
     expect(manifestCheck(root)).toBeDefined();
   });
 });
+
+describe('the limit of what the reachability guard can prove', () => {
+  it('does not run the manifest check on a plugin install, and that is correct', () => {
+    // FOUND BY ADVERSARIAL REVIEW OF THIS VERY CHANGE, and worth pinning rather
+    // than quietly leaving true.
+    //
+    // `manifestSize` left the reachability allowlist by acquiring a caller. The
+    // guard is satisfied -- the name is referenced by shipped code -- but the
+    // reference sits inside `if (resolved.method !== 'plugin')`, and the plugin
+    // path is how this product is actually distributed. So for most users the
+    // function still never executes.
+    //
+    // That is CORRECT here: only install-hooks.* writes a manifest, so a plugin
+    // install has none and there is nothing to size. But it is a live
+    // demonstration that a name-based reachability scan proves a REFERENCE
+    // exists, never that it RUNS -- which is exactly why `npm run wiki:census`
+    // reads real logs instead of source text.
+    const root = join(fixture, 'install');
+    mkdirSync(join(root, 'hooks'), { recursive: true });
+    for (const f of ['pretooluse-router.mjs', 'session-start.mjs']) {
+      writeFileSync(join(root, 'hooks', f), '// hook\n');
+    }
+    const checks = checklist({
+      root,
+      settingsPath: join(fixture, 'settings.json'),
+      install: { method: 'plugin', sameTree: true, installedVersion: '5.7.1' },
+    });
+    expect(
+      checks.some((c: { name: string }) => /manifest|installed files/i.test(c.name))
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Part 3 of 3 toward #204. Closes the defect **class** rather than its instances: fixes the holes in the reachability detector, extends it to the sub-classes it cannot model, and wires the two orphans it owns.

Plan 1 shipped as #315. **Plan 2 is in flight in parallel** (branch `feat/close-wiki-graph-gaps-plan2`, no PR yet, through its Tasks 1-3) and this PR does not touch its subsystems.

## The three things in Plan 3 that were wrong

The plan was executed rather than transcribed, and that found defects in the plan itself. All three are now recorded in the plan file.

**1. Task 1's proposed `stripComments` must never be implemented.** It replaces the regex passes with a character scanner that skips string literals whole, reasoning that a scanner cannot suffer the non-nesting problem the previous attempt hit. It cannot — and it fails worse. A JS lexer that knows about quotes but not **regex literals** desynchronises on the first regex containing a quote, and `hooks-core/adapter.mjs:255` is one:

```js
/\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*((?:"(?:\\.|[^"\\])*")|...)/gs
```

Measured: **adapter.mjs 1032 newlines in, 385 out — 63% of the file consumed**; disclose.mjs 69%. Eleven genuinely-called exports (`toolSucceeded`, `stableText`, `recordToolOutcome`, `recordEpisodeOutcome`, `DISCLOSE_THRESHOLD`, `invalidateOnWrite`, `invalidateChangedAnchors`, `prices`, `briefing`, `semanticHarvestPrompt`, `cachedRoutingBriefing`) fall to their own declaration and report as orphans. That violates this plan's own first Global Constraint — wrong only in the permissive direction. Master's comments-only boundary is correct; it is now pinned with tests and the measurement is recorded in the source so it is not moved a third time.

**2. Task 3's extractors were wrong in two ways, both caught by cross-checking against grep.** `putEdge(dir, from, edge, to)` takes the edge kind as its **third** argument, not its second, and the call writing `calls` edges spans six lines — so the proposed single-line second-argument regex reported the graph's own call-edge kind as having no writer. Separately a fixed character window over `record(` overran the call in `mcp-evidence.ts` and collected a field belonging to the next function: one false positive in seven.

**3. Task 5's target was stale.** It says end at one entry, `policyText`. `policyText` was already removed — it has callers. The real target is **zero**.

## What shipped

| | Before | After |
|---|---|---|
| Allowlist | 7 | **4**, each verified to have no producing action |
| Declaration kinds checked | `export function` only | **+ `export const`** (56 more, incl. `EDGE_KINDS`) |
| An import counted as a call | yes | **no** |
| Event / edge / tool-name / record-field censuses | none | **`tests/hooks/census.test.mjs`** |
| Holdout-pinning convention | copy-pasted, unenforced | **enforced, entry points derived from source** |
| Live-state measurement | none | **`npm run wiki:census`** |

**Two hardenings, both with zero measured fallout.** Exported consts: 56 newly checked, 0 new orphans. Import-specifier discount: 0 verdicts change. They alter nothing today and close the holes for tomorrow — the `cacheOrdered` mutation (drop the call, keep the import) previously left the suite green.

**Two orphans wired, not re-described.** `renderStanding` renders the standing-context panel inside `renderAudit`; `manifestSize` reports the install footprint in the doctor's manifest check.

**`declinedAtBudget`** — found by the census on its first run. `retrieval-decision` records every finding the budget declined and why, written from four call sites in `inject.mjs` and read by nothing. #204 makes the per-touch budget load-bearing, and a budget that silently drops what it cannot afford looks from outside exactly like a graph that had nothing to say. The audit now reports it in one line.

## The adversarial pass, and what it found in this PR

Every new assertion was mutation-tested — break the thing it claims to detect, watch it go red. **Two could not fail at all.**

**The flagship case slipped straight through.** "has no kind that is read but never written" took its read set from a function that filters reads to `declared ∪ written`, so a kind that is neither drops out of the read set entirely — which is *exactly* the `indexBudget` shape it exists to catch. Proven by renaming the single `kind: 'query'` write site: `query` was left read by `indexBudget`, written by nothing, and the test stayed **green**. That direction now takes its reads by **location** (metrics.mjs owns the event log) rather than by vocabulary, with a permanent non-vacuity tripwire.

**"declares every edge kind it writes" could never fail** — the extractor filters `written` into `declared` at collection, so the difference is empty whatever the code does. Replaced with an assertion on the real guard rail: `putEdge` throws on an unknown kind.

The other six mutations all fail correctly: dead exported const, import-only reference, dead declared edge kind, dead declared event kind, phantom tool name in injected text, new unread record field.

**And the guard's blind spot, demonstrated by this PR's own work.** `manifestSize` left the allowlist by acquiring a caller — inside `if (method !== 'plugin')`, and the plugin path is how this product is actually distributed, so for most users it still never executes. That is *correct* (only `install-hooks.*` writes a manifest, so there is nothing to size on a plugin install) but the guard could not have told the difference. **A name-based scan proves a reference exists, never that it runs.** Pinned with a test, stated in `WIKI_GRAPH.md`, and it is the reason `wiki:census` reads real logs instead of source text.

Both wirings were then driven end to end through the real `token_audit` handler, not only through `renderAudit`. On a project whose queue is empty, the report now still carries 373 tokens/session of standing context and two files with nothing wrong — which produce no finding and were previously invisible — plus the rejection line.

## The census's exemption lists, and why they are now empty

The census first shipped carrying one orphan event writer and six unread record fields, each described accurately and attributed to "Plan 2's measurement territory". **That was an excuse, not an attribution.** Plan 2 has no PR open, has not reached those tasks, and none of the six needed anything it is building. Round 1's failure was a list of accurate descriptions with no owner; a list of accurate descriptions with the *wrong* owner is the same list. Every one is now resolved:

| Field | Resolution |
|---|---|
| `candidateCount`, `shadowFindingIds` | The injection holdout's **shadow** — what retrieval selected against what was served. `count`/`findingIds` fall to zero in the withheld arm while the shadow pair stays non-zero, so the report could count the arms and never say what was in them. This is exactly the gap `controlArmTokens` was created to close one arm over, whose own comment already read: *"`tokensFullFile` was recorded and read by nothing, so the comparison the holdout exists for was not computable."* Now `shadowDelivery`, surfaced in `balanceSheet().estimatedCausal`. |
| `staleCount` | Index staleness as a **rate**, not a boolean: one rotten entry in forty was indistinguishable from forty. |
| `contradictedAt` | **When** a claim was disputed, beside the **why** Plan 1 wired. Both written on the same line of the same `putNode` call; only one got a reader. Collected from whichever end holds it, earliest kept. |
| `lastAction` | Names the tool in the stale reason. "file changed" says a finding may be wrong; **"file changed (last touched by Edit)"** says a targeted edit did it and is cheap to re-verify; "by Write" says the file was replaced wholesale and usually is not. Bounded, and falls back to the bare reason rather than inventing a cause. |
| `clientTitle` + the `mcp-client` orphan writer | Resolve together. Deleting the record was the other option and would have been **wrong**: `mcp-tool` records a client only once it *calls* something and the project registry stores a name only, so a client that connected and then called nothing — the exact failure this project's doctor exists to diagnose — appeared in neither. `mcpClientsSeen` reads the handshake; the doctor reports it, never as a failure. |
| `contentAnchor` | **Deleted**, which is what `reachability.test.mjs`'s own documentation says to do with a capability kept for later. Allowlist 5 → 4. |

Each new reader was mutation-tested: renaming the field it reads turns its suite red in all four cases, so none is a reference that merely satisfies the guard.

## Honest limitations

- **The allowlist is 4, not 0**, and all four are keep-warm or consolidation functions whose **producing action does not exist** — verified, not assumed. `grep` finds nothing in the repository that performs a keep-warm ping, and nothing that decides what to consolidate or when a pass runs. So `recordRefresh` records an event that never occurs, and calling it at the only site that exists — the decision point in `cache-tool.ts` — would write refreshes that never happened into the ledger `tripwire` reads to decide whether keep-warm is losing money. Fabricated evidence in a backstop is worse than a dead function. `selectForConsolidation` chooses candidates for a pass that does not exist and `consolidationRatio` would report null forever without one; both wait on Plan 2's `derive.mjs` rather than on a second copy of it.
- **The census's own two lists are empty.** They did not ship that way — see below.
- **`wiki:census` on this repository still reads 0 index and 0 query events** after Plan 1 wired `wiki_query`. Structural capture is healthy (425 file / 911 symbol nodes, 957 `calls` edges, 27 injections, 2 retrieval decisions). That gap is exactly the kind of thing only a live-log reading can tell you, and it is reported rather than explained away.
- **The unread-field extractor skips any object literal it cannot brace-balance**, so a regression in it goes quiet rather than loud. A `written.size > 50` tripwire is the compensating check.
- **`COMPETITIVE_GAPS.md` gap 9 said "Zero for us"** and was wrong when written: `auditStanding` already computed all four things it listed and `renderStanding` already rendered them — nothing called `renderStanding`. Corrected to say what shipped.

## Verification

220 suites, 2680 tests, 5 skipped, 0 failed. `tsc --noEmit` clean, `npm run lint` 0 errors, `format:check` clean, `sync:hooks:check` in sync across eleven vendored directories, `validate` passes. Every Quality Gates step run locally: `verify:clients`, `verify:certification`, `verify:harvest`, `verify:ucr`, `verify:ucr:study-design`, `verify:live-graph`, `verify:ui` 55/55, `verify:interactions` 64/64.

Worth a reviewer's attention first: `tests/hooks/census.test.mjs`'s extractors, since a census that is wrong reports confident nonsense that nobody re-examines — and two of its first drafts did exactly that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSFxBpREeR7mMkJXYb6wuX
