### PR TITLE
fix(pending): adopt a claim stranded by a killed drainer

### DIFF
--- a/hooks-core/pending.mjs
+++ b/hooks-core/pending.mjs
@@ -32,6 +32,7 @@ import {
   appendFileSync,
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   renameSync,
   rmSync,
@@ -51,6 +52,126 @@ const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
  * claim private to the drainer that won the rename.
  */
 const claimPath = (dir) => join(dir, `pending-invalidation.claim.${process.pid}.jsonl`);
+
+/** Matches any drainer's claim file and captures the pid that owns it. */
+const CLAIM_NAME = /^pending-invalidation\.claim\.(\d+)\.jsonl$/;
+
+/**
+ * After this long, a claim is treated as stranded whatever its pid says.
+ *
+ * PID REUSE IS THE REASON. A drainer killed mid-claim leaves a file named after
+ * a pid the operating system is free to hand to something else, and once it
+ * does, a liveness check answers "alive" forever and the records inside are
+ * never recovered. An hour is several orders of magnitude longer than a drain,
+ * which takes milliseconds, so nothing legitimate is still holding one.
+ */
+const STRANDED_AFTER_MS = 60 * 60 * 1000;
+
+/**
+ * Claim files adopted in a single drain.
+ *
+ * A hook runs on the critical path of a tool call. If a directory has somehow
+ * accumulated hundreds of strays, recovering them all at once would turn one
+ * tool call into a long job -- and the rest are still there for the next drain,
+ * because adoption deletes only what it has read.
+ */
+const MAX_ADOPTED = 20;
+
+/** Is this pid a live process? */
+function isPidAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    // Signal 0 performs the permission and existence checks without delivering
+    // anything.
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // EPERM means the process exists and belongs to somebody else, which is
+    // still alive. Anything else -- ESRCH above all -- means it is gone.
+    return error?.code === 'EPERM';
+  }
+}
+
+/** Parses a queue or claim file into records, tolerating a torn last line. */
+function readRecords(path) {
+  return readFileSync(path, 'utf8')
+    .split('\n')
+    .filter((line) => line.trim())
+    .map((line) => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        // A torn append costs one record, not the queue.
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+/**
+ * Recovers claim files whose drainer died before it could read them.
+ *
+ * THE RESIDUAL THIS CLOSES. Claiming the queue by renaming it to a per-pid file
+ * fixed the original defect -- a concurrent append deleted unread -- but a
+ * drainer killed BETWEEN the rename and the read strands its claim, and the
+ * records inside are lost. The lazy staleness path cannot find them later
+ * either: `indexFile` refreshes an anchor's hash to the bytes just read, so for
+ * a file the session itself edited there is nothing left to compare against.
+ * Those invalidations were permanently missed, and the stray files accumulated
+ * with nothing reading them.
+ *
+ * SAFE BECAUSE RE-APPLICATION IS IDEMPOTENT. Marking a finding stale twice is
+ * marking it stale, so the cost of adopting a claim whose owner turns out to be
+ * alive is a repeated write, while the cost of not adopting is a permanently
+ * missed invalidation. The asymmetry is why the age fallback above is allowed
+ * to be wrong in the permissive direction.
+ *
+ * OUR OWN PID IS ALWAYS ADOPTED. A file under this process's own name can only
+ * be a previous drain in this process that died, and the old behaviour was to
+ * overwrite it with the next rename -- losing exactly the records this function
+ * exists to recover.
+ */
+function adoptStrandedClaims(dir) {
+  const records = [];
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return records;
+  }
+
+  let adopted = 0;
+  for (const entry of entries) {
+    if (adopted >= MAX_ADOPTED) break;
+    const match = CLAIM_NAME.exec(entry);
+    if (!match) continue;
+
+    const pid = Number(match[1]);
+    const path = join(dir, entry);
+    if (pid !== process.pid && isPidAlive(pid)) {
+      let age = 0;
+      try {
+        age = Date.now() - statSync(path).mtimeMs;
+      } catch {
+        continue;
+      }
+      if (age < STRANDED_AFTER_MS) continue;
+    }
+
+    try {
+      records.push(...readRecords(path));
+      adopted += 1;
+      // DELETED ONLY AFTER READING, which is the same rule the drain below
+      // follows: nothing is removed until its contents are in hand.
+      rmSync(path, { force: true });
+    } catch {
+      // Unreadable or held open. Left in place for the next drain rather than
+      // deleted, because a file nobody reads again is the lost record this
+      // whole mechanism exists to prevent.
+    }
+  }
+  return records;
+}
 
 /**
  * Largest before/after side kept in a queue record.
@@ -322,6 +443,37 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
 }
 
 /**
+ * Applies queued invalidations to the graph, returning how many were marked.
+ *
+ * EXTRACTED so the three exits from `drainInvalidations` share one path. Two of
+ * them now carry adopted records -- the empty-queue exit and the failed-rename
+ * exit -- and both previously returned 0. Returning early with records already
+ * read out of a file that has since been deleted would lose them for good,
+ * which is the exact defect adoption exists to close.
+ */
+function applyRecords(dir, graph, records) {
+  let marked = 0;
+  for (const record of records) {
+    if (!record || typeof record.path !== 'string' || !record.path) continue;
+    const diffable =
+      typeof record.before === 'string' && typeof record.after === 'string';
+    try {
+      // TWO GRADES, ONE QUEUE. A record carrying both sides gets a real diff and
+      // symbol-precise marking; one carrying only a path gets the hash
+      // comparison -- the same comparison the lazy path makes, and one that is
+      // only meaningful HERE, before `indexFile` refreshes the anchor.
+      const result = diffable
+        ? invalidateOnWrite(dir, graph, record.path, record.before, record.after)
+        : invalidateChangedAnchors(dir, graph, record.path);
+      marked += Array.isArray(result) ? result.length : 0;
+    } catch {
+      // One bad record must not stop the rest, and must not stop the tool call.
+    }
+  }
+  return marked;
+}
+
+/**
  * Applies every queued invalidation and clears the queue.
  *
  * Returns the number of findings marked, so the caller knows whether its
@@ -349,36 +501,39 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
  * for the rest of the session costs more than it can ever recover, and the claim
  * file is deleted whether the loop marked anything or threw.
  *
+ * AND A DRAINER KILLED BETWEEN THE RENAME AND THE READ STRANDS ITS CLAIM, which
+ * the rename alone does not solve. That was the residual left by the fix above:
+ * the records inside such a file are lost unread, the lazy path is structurally
+ * blind to them for the reason stated three paragraphs up, and the stray files
+ * accumulate with nothing reading them. `adoptStrandedClaims` recovers them at
+ * the head of every drain, before the queue is even checked -- because a
+ * stranded claim has nothing to do with whether there is new work now.
+ *
  * FAIL-OPEN THROUGHOUT. A rename that loses a race, or fails for any other
- * reason, returns 0 and leaves the queue for the next drain; it never throws
- * into a hook.
+ * reason, applies whatever was adopted, leaves the queue for the next drain,
+ * and never throws into a hook.
  */
 export function drainInvalidations(dir, graph) {
-  let records;
+  // ADOPTED FIRST, AND UNCONDITIONALLY. A claim left by a drainer that died
+  // between its rename and its read is recovered here -- including one under
+  // this process's own pid, which the rename below used to overwrite.
+  //
+  // BEFORE THE QUEUE IS EVEN CHECKED, because a stranded claim has nothing to
+  // do with whether a queue exists now. Recovering it only when there happened
+  // to be new work would leave it stranded for as long as the project stayed
+  // quiet, which is exactly the state a killed drain tends to leave behind.
+  let records = adoptStrandedClaims(dir);
+
   let claim;
   try {
     const file = queuePath(dir);
-    if (!existsSync(file)) return 0;
+    if (!existsSync(file)) return applyRecords(dir, graph, records);
     claim = claimPath(dir);
-    // A LEFTOVER CLAIM FROM A KILLED DRAIN IS OVERWRITTEN, not merged: rename
-    // onto an existing path replaces it. The pid in the name means the only way
-    // to hit that is this same pid having died mid-drain, whose records were
-    // already being applied when it went -- and re-applying is idempotent, so
-    // losing them is the cheaper of the two errors. Not doing the rename at all
-    // would strand the live queue forever.
+    // The rename can no longer clobber a leftover claim: adoption above has
+    // already read and removed any file under this pid's name, so the only
+    // thing this can replace is a file that no longer exists.
     renameSync(file, claim);
-    records = readFileSync(claim, 'utf8')
-      .split('\n')
-      .filter((line) => line.trim())
-      .map((line) => {
-        try {
-          return JSON.parse(line);
-        } catch {
-          // A torn append costs one record, not the queue.
-          return null;
-        }
-      })
-      .filter(Boolean);
+    records = records.concat(readRecords(claim));
   } catch {
     // The rename lost a race, or the claim could not be read. Nothing is deleted
     // unread and the hook proceeds. If the claim was taken and then could not be
@@ -392,27 +547,13 @@ export function drainInvalidations(dir, graph) {
     } catch {
       // Best effort only. A hook must not fail because bookkeeping did.
     }
-    return 0;
+    // Anything already ADOPTED is still applied. Those records came out of a
+    // file that has already been deleted, so returning here would lose them
+    // for good -- which is the defect this whole function is being fixed for.
+    return applyRecords(dir, graph, records);
   }
 
-  let marked = 0;
-  for (const record of records) {
-    if (!record || typeof record.path !== 'string' || !record.path) continue;
-    const diffable =
-      typeof record.before === 'string' && typeof record.after === 'string';
-    try {
-      // TWO GRADES, ONE QUEUE. A record carrying both sides gets a real diff and
-      // symbol-precise marking; one carrying only a path gets the hash
-      // comparison -- the same comparison the lazy path makes, and one that is
-      // only meaningful HERE, before `indexFile` refreshes the anchor.
-      const result = diffable
-        ? invalidateOnWrite(dir, graph, record.path, record.before, record.after)
-        : invalidateChangedAnchors(dir, graph, record.path);
-      marked += Array.isArray(result) ? result.length : 0;
-    } catch {
-      // One bad record must not stop the rest, and must not stop the tool call.
-    }
-  }
+  const marked = applyRecords(dir, graph, records);
 
   try {
     // THE CLAIM, NOT THE QUEUE. Deleting `queuePath` here is what dropped a

--- a/integrations/cline/hooks/token-optimizer/lib/pending.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/pending.mjs
@@ -34,6 +34,7 @@ import {
   appendFileSync,
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   renameSync,
   rmSync,
@@ -53,6 +54,126 @@ const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
  * claim private to the drainer that won the rename.
  */
 const claimPath = (dir) => join(dir, `pending-invalidation.claim.${process.pid}.jsonl`);
+
+/** Matches any drainer's claim file and captures the pid that owns it. */
+const CLAIM_NAME = /^pending-invalidation\.claim\.(\d+)\.jsonl$/;
+
+/**
+ * After this long, a claim is treated as stranded whatever its pid says.
+ *
+ * PID REUSE IS THE REASON. A drainer killed mid-claim leaves a file named after
+ * a pid the operating system is free to hand to something else, and once it
+ * does, a liveness check answers "alive" forever and the records inside are
+ * never recovered. An hour is several orders of magnitude longer than a drain,
+ * which takes milliseconds, so nothing legitimate is still holding one.
+ */
+const STRANDED_AFTER_MS = 60 * 60 * 1000;
+
+/**
+ * Claim files adopted in a single drain.
+ *
+ * A hook runs on the critical path of a tool call. If a directory has somehow
+ * accumulated hundreds of strays, recovering them all at once would turn one
+ * tool call into a long job -- and the rest are still there for the next drain,
+ * because adoption deletes only what it has read.
+ */
+const MAX_ADOPTED = 20;
+
+/** Is this pid a live process? */
+function isPidAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    // Signal 0 performs the permission and existence checks without delivering
+    // anything.
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // EPERM means the process exists and belongs to somebody else, which is
+    // still alive. Anything else -- ESRCH above all -- means it is gone.
+    return error?.code === 'EPERM';
+  }
+}
+
+/** Parses a queue or claim file into records, tolerating a torn last line. */
+function readRecords(path) {
+  return readFileSync(path, 'utf8')
+    .split('\n')
+    .filter((line) => line.trim())
+    .map((line) => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        // A torn append costs one record, not the queue.
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+/**
+ * Recovers claim files whose drainer died before it could read them.
+ *
+ * THE RESIDUAL THIS CLOSES. Claiming the queue by renaming it to a per-pid file
+ * fixed the original defect -- a concurrent append deleted unread -- but a
+ * drainer killed BETWEEN the rename and the read strands its claim, and the
+ * records inside are lost. The lazy staleness path cannot find them later
+ * either: `indexFile` refreshes an anchor's hash to the bytes just read, so for
+ * a file the session itself edited there is nothing left to compare against.
+ * Those invalidations were permanently missed, and the stray files accumulated
+ * with nothing reading them.
+ *
+ * SAFE BECAUSE RE-APPLICATION IS IDEMPOTENT. Marking a finding stale twice is
+ * marking it stale, so the cost of adopting a claim whose owner turns out to be
+ * alive is a repeated write, while the cost of not adopting is a permanently
+ * missed invalidation. The asymmetry is why the age fallback above is allowed
+ * to be wrong in the permissive direction.
+ *
+ * OUR OWN PID IS ALWAYS ADOPTED. A file under this process's own name can only
+ * be a previous drain in this process that died, and the old behaviour was to
+ * overwrite it with the next rename -- losing exactly the records this function
+ * exists to recover.
+ */
+function adoptStrandedClaims(dir) {
+  const records = [];
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return records;
+  }
+
+  let adopted = 0;
+  for (const entry of entries) {
+    if (adopted >= MAX_ADOPTED) break;
+    const match = CLAIM_NAME.exec(entry);
+    if (!match) continue;
+
+    const pid = Number(match[1]);
+    const path = join(dir, entry);
+    if (pid !== process.pid && isPidAlive(pid)) {
+      let age = 0;
+      try {
+        age = Date.now() - statSync(path).mtimeMs;
+      } catch {
+        continue;
+      }
+      if (age < STRANDED_AFTER_MS) continue;
+    }
+
+    try {
+      records.push(...readRecords(path));
+      adopted += 1;
+      // DELETED ONLY AFTER READING, which is the same rule the drain below
+      // follows: nothing is removed until its contents are in hand.
+      rmSync(path, { force: true });
+    } catch {
+      // Unreadable or held open. Left in place for the next drain rather than
+      // deleted, because a file nobody reads again is the lost record this
+      // whole mechanism exists to prevent.
+    }
+  }
+  return records;
+}
 
 /**
  * Largest before/after side kept in a queue record.
@@ -324,6 +445,37 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
 }
 
 /**
+ * Applies queued invalidations to the graph, returning how many were marked.
+ *
+ * EXTRACTED so the three exits from `drainInvalidations` share one path. Two of
+ * them now carry adopted records -- the empty-queue exit and the failed-rename
+ * exit -- and both previously returned 0. Returning early with records already
+ * read out of a file that has since been deleted would lose them for good,
+ * which is the exact defect adoption exists to close.
+ */
+function applyRecords(dir, graph, records) {
+  let marked = 0;
+  for (const record of records) {
+    if (!record || typeof record.path !== 'string' || !record.path) continue;
+    const diffable =
+      typeof record.before === 'string' && typeof record.after === 'string';
+    try {
+      // TWO GRADES, ONE QUEUE. A record carrying both sides gets a real diff and
+      // symbol-precise marking; one carrying only a path gets the hash
+      // comparison -- the same comparison the lazy path makes, and one that is
+      // only meaningful HERE, before `indexFile` refreshes the anchor.
+      const result = diffable
+        ? invalidateOnWrite(dir, graph, record.path, record.before, record.after)
+        : invalidateChangedAnchors(dir, graph, record.path);
+      marked += Array.isArray(result) ? result.length : 0;
+    } catch {
+      // One bad record must not stop the rest, and must not stop the tool call.
+    }
+  }
+  return marked;
+}
+
+/**
  * Applies every queued invalidation and clears the queue.
  *
  * Returns the number of findings marked, so the caller knows whether its
@@ -351,36 +503,39 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
  * for the rest of the session costs more than it can ever recover, and the claim
  * file is deleted whether the loop marked anything or threw.
  *
+ * AND A DRAINER KILLED BETWEEN THE RENAME AND THE READ STRANDS ITS CLAIM, which
+ * the rename alone does not solve. That was the residual left by the fix above:
+ * the records inside such a file are lost unread, the lazy path is structurally
+ * blind to them for the reason stated three paragraphs up, and the stray files
+ * accumulate with nothing reading them. `adoptStrandedClaims` recovers them at
+ * the head of every drain, before the queue is even checked -- because a
+ * stranded claim has nothing to do with whether there is new work now.
+ *
  * FAIL-OPEN THROUGHOUT. A rename that loses a race, or fails for any other
- * reason, returns 0 and leaves the queue for the next drain; it never throws
- * into a hook.
+ * reason, applies whatever was adopted, leaves the queue for the next drain,
+ * and never throws into a hook.
  */
 export function drainInvalidations(dir, graph) {
-  let records;
+  // ADOPTED FIRST, AND UNCONDITIONALLY. A claim left by a drainer that died
+  // between its rename and its read is recovered here -- including one under
+  // this process's own pid, which the rename below used to overwrite.
+  //
+  // BEFORE THE QUEUE IS EVEN CHECKED, because a stranded claim has nothing to
+  // do with whether a queue exists now. Recovering it only when there happened
+  // to be new work would leave it stranded for as long as the project stayed
+  // quiet, which is exactly the state a killed drain tends to leave behind.
+  let records = adoptStrandedClaims(dir);
+
   let claim;
   try {
     const file = queuePath(dir);
-    if (!existsSync(file)) return 0;
+    if (!existsSync(file)) return applyRecords(dir, graph, records);
     claim = claimPath(dir);
-    // A LEFTOVER CLAIM FROM A KILLED DRAIN IS OVERWRITTEN, not merged: rename
-    // onto an existing path replaces it. The pid in the name means the only way
-    // to hit that is this same pid having died mid-drain, whose records were
-    // already being applied when it went -- and re-applying is idempotent, so
-    // losing them is the cheaper of the two errors. Not doing the rename at all
-    // would strand the live queue forever.
+    // The rename can no longer clobber a leftover claim: adoption above has
+    // already read and removed any file under this pid's name, so the only
+    // thing this can replace is a file that no longer exists.
     renameSync(file, claim);
-    records = readFileSync(claim, 'utf8')
-      .split('\n')
-      .filter((line) => line.trim())
-      .map((line) => {
-        try {
-          return JSON.parse(line);
-        } catch {
-          // A torn append costs one record, not the queue.
-          return null;
-        }
-      })
-      .filter(Boolean);
+    records = records.concat(readRecords(claim));
   } catch {
     // The rename lost a race, or the claim could not be read. Nothing is deleted
     // unread and the hook proceeds. If the claim was taken and then could not be
@@ -394,27 +549,13 @@ export function drainInvalidations(dir, graph) {
     } catch {
       // Best effort only. A hook must not fail because bookkeeping did.
     }
-    return 0;
+    // Anything already ADOPTED is still applied. Those records came out of a
+    // file that has already been deleted, so returning here would lose them
+    // for good -- which is the defect this whole function is being fixed for.
+    return applyRecords(dir, graph, records);
   }
 
-  let marked = 0;
-  for (const record of records) {
-    if (!record || typeof record.path !== 'string' || !record.path) continue;
-    const diffable =
-      typeof record.before === 'string' && typeof record.after === 'string';
-    try {
-      // TWO GRADES, ONE QUEUE. A record carrying both sides gets a real diff and
-      // symbol-precise marking; one carrying only a path gets the hash
-      // comparison -- the same comparison the lazy path makes, and one that is
-      // only meaningful HERE, before `indexFile` refreshes the anchor.
-      const result = diffable
-        ? invalidateOnWrite(dir, graph, record.path, record.before, record.after)
-        : invalidateChangedAnchors(dir, graph, record.path);
-      marked += Array.isArray(result) ? result.length : 0;
-    } catch {
-      // One bad record must not stop the rest, and must not stop the tool call.
-    }
-  }
+  const marked = applyRecords(dir, graph, records);
 
   try {
     // THE CLAIM, NOT THE QUEUE. Deleting `queuePath` here is what dropped a

--- a/integrations/codex/hooks/lib/pending.mjs
+++ b/integrations/codex/hooks/lib/pending.mjs
@@ -34,6 +34,7 @@ import {
   appendFileSync,
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   renameSync,
   rmSync,
@@ -53,6 +54,126 @@ const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
  * claim private to the drainer that won the rename.
  */
 const claimPath = (dir) => join(dir, `pending-invalidation.claim.${process.pid}.jsonl`);
+
+/** Matches any drainer's claim file and captures the pid that owns it. */
+const CLAIM_NAME = /^pending-invalidation\.claim\.(\d+)\.jsonl$/;
+
+/**
+ * After this long, a claim is treated as stranded whatever its pid says.
+ *
+ * PID REUSE IS THE REASON. A drainer killed mid-claim leaves a file named after
+ * a pid the operating system is free to hand to something else, and once it
+ * does, a liveness check answers "alive" forever and the records inside are
+ * never recovered. An hour is several orders of magnitude longer than a drain,
+ * which takes milliseconds, so nothing legitimate is still holding one.
+ */
+const STRANDED_AFTER_MS = 60 * 60 * 1000;
+
+/**
+ * Claim files adopted in a single drain.
+ *
+ * A hook runs on the critical path of a tool call. If a directory has somehow
+ * accumulated hundreds of strays, recovering them all at once would turn one
+ * tool call into a long job -- and the rest are still there for the next drain,
+ * because adoption deletes only what it has read.
+ */
+const MAX_ADOPTED = 20;
+
+/** Is this pid a live process? */
+function isPidAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    // Signal 0 performs the permission and existence checks without delivering
+    // anything.
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // EPERM means the process exists and belongs to somebody else, which is
+    // still alive. Anything else -- ESRCH above all -- means it is gone.
+    return error?.code === 'EPERM';
+  }
+}
+
+/** Parses a queue or claim file into records, tolerating a torn last line. */
+function readRecords(path) {
+  return readFileSync(path, 'utf8')
+    .split('\n')
+    .filter((line) => line.trim())
+    .map((line) => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        // A torn append costs one record, not the queue.
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+/**
+ * Recovers claim files whose drainer died before it could read them.
+ *
+ * THE RESIDUAL THIS CLOSES. Claiming the queue by renaming it to a per-pid file
+ * fixed the original defect -- a concurrent append deleted unread -- but a
+ * drainer killed BETWEEN the rename and the read strands its claim, and the
+ * records inside are lost. The lazy staleness path cannot find them later
+ * either: `indexFile` refreshes an anchor's hash to the bytes just read, so for
+ * a file the session itself edited there is nothing left to compare against.
+ * Those invalidations were permanently missed, and the stray files accumulated
+ * with nothing reading them.
+ *
+ * SAFE BECAUSE RE-APPLICATION IS IDEMPOTENT. Marking a finding stale twice is
+ * marking it stale, so the cost of adopting a claim whose owner turns out to be
+ * alive is a repeated write, while the cost of not adopting is a permanently
+ * missed invalidation. The asymmetry is why the age fallback above is allowed
+ * to be wrong in the permissive direction.
+ *
+ * OUR OWN PID IS ALWAYS ADOPTED. A file under this process's own name can only
+ * be a previous drain in this process that died, and the old behaviour was to
+ * overwrite it with the next rename -- losing exactly the records this function
+ * exists to recover.
+ */
+function adoptStrandedClaims(dir) {
+  const records = [];
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return records;
+  }
+
+  let adopted = 0;
+  for (const entry of entries) {
+    if (adopted >= MAX_ADOPTED) break;
+    const match = CLAIM_NAME.exec(entry);
+    if (!match) continue;
+
+    const pid = Number(match[1]);
+    const path = join(dir, entry);
+    if (pid !== process.pid && isPidAlive(pid)) {
+      let age = 0;
+      try {
+        age = Date.now() - statSync(path).mtimeMs;
+      } catch {
+        continue;
+      }
+      if (age < STRANDED_AFTER_MS) continue;
+    }
+
+    try {
+      records.push(...readRecords(path));
+      adopted += 1;
+      // DELETED ONLY AFTER READING, which is the same rule the drain below
+      // follows: nothing is removed until its contents are in hand.
+      rmSync(path, { force: true });
+    } catch {
+      // Unreadable or held open. Left in place for the next drain rather than
+      // deleted, because a file nobody reads again is the lost record this
+      // whole mechanism exists to prevent.
+    }
+  }
+  return records;
+}
 
 /**
  * Largest before/after side kept in a queue record.
@@ -324,6 +445,37 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
 }
 
 /**
+ * Applies queued invalidations to the graph, returning how many were marked.
+ *
+ * EXTRACTED so the three exits from `drainInvalidations` share one path. Two of
+ * them now carry adopted records -- the empty-queue exit and the failed-rename
+ * exit -- and both previously returned 0. Returning early with records already
+ * read out of a file that has since been deleted would lose them for good,
+ * which is the exact defect adoption exists to close.
+ */
+function applyRecords(dir, graph, records) {
+  let marked = 0;
+  for (const record of records) {
+    if (!record || typeof record.path !== 'string' || !record.path) continue;
+    const diffable =
+      typeof record.before === 'string' && typeof record.after === 'string';
+    try {
+      // TWO GRADES, ONE QUEUE. A record carrying both sides gets a real diff and
+      // symbol-precise marking; one carrying only a path gets the hash
+      // comparison -- the same comparison the lazy path makes, and one that is
+      // only meaningful HERE, before `indexFile` refreshes the anchor.
+      const result = diffable
+        ? invalidateOnWrite(dir, graph, record.path, record.before, record.after)
+        : invalidateChangedAnchors(dir, graph, record.path);
+      marked += Array.isArray(result) ? result.length : 0;
+    } catch {
+      // One bad record must not stop the rest, and must not stop the tool call.
+    }
+  }
+  return marked;
+}
+
+/**
  * Applies every queued invalidation and clears the queue.
  *
  * Returns the number of findings marked, so the caller knows whether its
@@ -351,36 +503,39 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
  * for the rest of the session costs more than it can ever recover, and the claim
  * file is deleted whether the loop marked anything or threw.
  *
+ * AND A DRAINER KILLED BETWEEN THE RENAME AND THE READ STRANDS ITS CLAIM, which
+ * the rename alone does not solve. That was the residual left by the fix above:
+ * the records inside such a file are lost unread, the lazy path is structurally
+ * blind to them for the reason stated three paragraphs up, and the stray files
+ * accumulate with nothing reading them. `adoptStrandedClaims` recovers them at
+ * the head of every drain, before the queue is even checked -- because a
+ * stranded claim has nothing to do with whether there is new work now.
+ *
  * FAIL-OPEN THROUGHOUT. A rename that loses a race, or fails for any other
- * reason, returns 0 and leaves the queue for the next drain; it never throws
- * into a hook.
+ * reason, applies whatever was adopted, leaves the queue for the next drain,
+ * and never throws into a hook.
  */
 export function drainInvalidations(dir, graph) {
-  let records;
+  // ADOPTED FIRST, AND UNCONDITIONALLY. A claim left by a drainer that died
+  // between its rename and its read is recovered here -- including one under
+  // this process's own pid, which the rename below used to overwrite.
+  //
+  // BEFORE THE QUEUE IS EVEN CHECKED, because a stranded claim has nothing to
+  // do with whether a queue exists now. Recovering it only when there happened
+  // to be new work would leave it stranded for as long as the project stayed
+  // quiet, which is exactly the state a killed drain tends to leave behind.
+  let records = adoptStrandedClaims(dir);
+
   let claim;
   try {
     const file = queuePath(dir);
-    if (!existsSync(file)) return 0;
+    if (!existsSync(file)) return applyRecords(dir, graph, records);
     claim = claimPath(dir);
-    // A LEFTOVER CLAIM FROM A KILLED DRAIN IS OVERWRITTEN, not merged: rename
-    // onto an existing path replaces it. The pid in the name means the only way
-    // to hit that is this same pid having died mid-drain, whose records were
-    // already being applied when it went -- and re-applying is idempotent, so
-    // losing them is the cheaper of the two errors. Not doing the rename at all
-    // would strand the live queue forever.
+    // The rename can no longer clobber a leftover claim: adoption above has
+    // already read and removed any file under this pid's name, so the only
+    // thing this can replace is a file that no longer exists.
     renameSync(file, claim);
-    records = readFileSync(claim, 'utf8')
-      .split('\n')
-      .filter((line) => line.trim())
-      .map((line) => {
-        try {
-          return JSON.parse(line);
-        } catch {
-          // A torn append costs one record, not the queue.
-          return null;
-        }
-      })
-      .filter(Boolean);
+    records = records.concat(readRecords(claim));
   } catch {
     // The rename lost a race, or the claim could not be read. Nothing is deleted
     // unread and the hook proceeds. If the claim was taken and then could not be
@@ -394,27 +549,13 @@ export function drainInvalidations(dir, graph) {
     } catch {
       // Best effort only. A hook must not fail because bookkeeping did.
     }
-    return 0;
+    // Anything already ADOPTED is still applied. Those records came out of a
+    // file that has already been deleted, so returning here would lose them
+    // for good -- which is the defect this whole function is being fixed for.
+    return applyRecords(dir, graph, records);
   }
 
-  let marked = 0;
-  for (const record of records) {
-    if (!record || typeof record.path !== 'string' || !record.path) continue;
-    const diffable =
-      typeof record.before === 'string' && typeof record.after === 'string';
-    try {
-      // TWO GRADES, ONE QUEUE. A record carrying both sides gets a real diff and
-      // symbol-precise marking; one carrying only a path gets the hash
-      // comparison -- the same comparison the lazy path makes, and one that is
-      // only meaningful HERE, before `indexFile` refreshes the anchor.
-      const result = diffable
-        ? invalidateOnWrite(dir, graph, record.path, record.before, record.after)
-        : invalidateChangedAnchors(dir, graph, record.path);
-      marked += Array.isArray(result) ? result.length : 0;
-    } catch {
-      // One bad record must not stop the rest, and must not stop the tool call.
-    }
-  }
+  const marked = applyRecords(dir, graph, records);
 
   try {
     // THE CLAIM, NOT THE QUEUE. Deleting `queuePath` here is what dropped a

--- a/integrations/codex/plugin/hooks/lib/pending.mjs
+++ b/integrations/codex/plugin/hooks/lib/pending.mjs
@@ -34,6 +34,7 @@ import {
   appendFileSync,
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   renameSync,
   rmSync,
@@ -53,6 +54,126 @@ const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
  * claim private to the drainer that won the rename.
  */
 const claimPath = (dir) => join(dir, `pending-invalidation.claim.${process.pid}.jsonl`);
+
+/** Matches any drainer's claim file and captures the pid that owns it. */
+const CLAIM_NAME = /^pending-invalidation\.claim\.(\d+)\.jsonl$/;
+
+/**
+ * After this long, a claim is treated as stranded whatever its pid says.
+ *
+ * PID REUSE IS THE REASON. A drainer killed mid-claim leaves a file named after
+ * a pid the operating system is free to hand to something else, and once it
+ * does, a liveness check answers "alive" forever and the records inside are
+ * never recovered. An hour is several orders of magnitude longer than a drain,
+ * which takes milliseconds, so nothing legitimate is still holding one.
+ */
+const STRANDED_AFTER_MS = 60 * 60 * 1000;
+
+/**
+ * Claim files adopted in a single drain.
+ *
+ * A hook runs on the critical path of a tool call. If a directory has somehow
+ * accumulated hundreds of strays, recovering them all at once would turn one
+ * tool call into a long job -- and the rest are still there for the next drain,
+ * because adoption deletes only what it has read.
+ */
+const MAX_ADOPTED = 20;
+
+/** Is this pid a live process? */
+function isPidAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    // Signal 0 performs the permission and existence checks without delivering
+    // anything.
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // EPERM means the process exists and belongs to somebody else, which is
+    // still alive. Anything else -- ESRCH above all -- means it is gone.
+    return error?.code === 'EPERM';
+  }
+}
+
+/** Parses a queue or claim file into records, tolerating a torn last line. */
+function readRecords(path) {
+  return readFileSync(path, 'utf8')
+    .split('\n')
+    .filter((line) => line.trim())
+    .map((line) => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        // A torn append costs one record, not the queue.
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+/**
+ * Recovers claim files whose drainer died before it could read them.
+ *
+ * THE RESIDUAL THIS CLOSES. Claiming the queue by renaming it to a per-pid file
+ * fixed the original defect -- a concurrent append deleted unread -- but a
+ * drainer killed BETWEEN the rename and the read strands its claim, and the
+ * records inside are lost. The lazy staleness path cannot find them later
+ * either: `indexFile` refreshes an anchor's hash to the bytes just read, so for
+ * a file the session itself edited there is nothing left to compare against.
+ * Those invalidations were permanently missed, and the stray files accumulated
+ * with nothing reading them.
+ *
+ * SAFE BECAUSE RE-APPLICATION IS IDEMPOTENT. Marking a finding stale twice is
+ * marking it stale, so the cost of adopting a claim whose owner turns out to be
+ * alive is a repeated write, while the cost of not adopting is a permanently
+ * missed invalidation. The asymmetry is why the age fallback above is allowed
+ * to be wrong in the permissive direction.
+ *
+ * OUR OWN PID IS ALWAYS ADOPTED. A file under this process's own name can only
+ * be a previous drain in this process that died, and the old behaviour was to
+ * overwrite it with the next rename -- losing exactly the records this function
+ * exists to recover.
+ */
+function adoptStrandedClaims(dir) {
+  const records = [];
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return records;
+  }
+
+  let adopted = 0;
+  for (const entry of entries) {
+    if (adopted >= MAX_ADOPTED) break;
+    const match = CLAIM_NAME.exec(entry);
+    if (!match) continue;
+
+    const pid = Number(match[1]);
+    const path = join(dir, entry);
+    if (pid !== process.pid && isPidAlive(pid)) {
+      let age = 0;
+      try {
+        age = Date.now() - statSync(path).mtimeMs;
+      } catch {
+        continue;
+      }
+      if (age < STRANDED_AFTER_MS) continue;
+    }
+
+    try {
+      records.push(...readRecords(path));
+      adopted += 1;
+      // DELETED ONLY AFTER READING, which is the same rule the drain below
+      // follows: nothing is removed until its contents are in hand.
+      rmSync(path, { force: true });
+    } catch {
+      // Unreadable or held open. Left in place for the next drain rather than
+      // deleted, because a file nobody reads again is the lost record this
+      // whole mechanism exists to prevent.
+    }
+  }
+  return records;
+}
 
 /**
  * Largest before/after side kept in a queue record.
@@ -324,6 +445,37 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
 }
 
 /**
+ * Applies queued invalidations to the graph, returning how many were marked.
+ *
+ * EXTRACTED so the three exits from `drainInvalidations` share one path. Two of
+ * them now carry adopted records -- the empty-queue exit and the failed-rename
+ * exit -- and both previously returned 0. Returning early with records already
+ * read out of a file that has since been deleted would lose them for good,
+ * which is the exact defect adoption exists to close.
+ */
+function applyRecords(dir, graph, records) {
+  let marked = 0;
+  for (const record of records) {
+    if (!record || typeof record.path !== 'string' || !record.path) continue;
+    const diffable =
+      typeof record.before === 'string' && typeof record.after === 'string';
+    try {
+      // TWO GRADES, ONE QUEUE. A record carrying both sides gets a real diff and
+      // symbol-precise marking; one carrying only a path gets the hash
+      // comparison -- the same comparison the lazy path makes, and one that is
+      // only meaningful HERE, before `indexFile` refreshes the anchor.
+      const result = diffable
+        ? invalidateOnWrite(dir, graph, record.path, record.before, record.after)
+        : invalidateChangedAnchors(dir, graph, record.path);
+      marked += Array.isArray(result) ? result.length : 0;
+    } catch {
+      // One bad record must not stop the rest, and must not stop the tool call.
+    }
+  }
+  return marked;
+}
+
+/**
  * Applies every queued invalidation and clears the queue.
  *
  * Returns the number of findings marked, so the caller knows whether its
@@ -351,36 +503,39 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
  * for the rest of the session costs more than it can ever recover, and the claim
  * file is deleted whether the loop marked anything or threw.
  *
+ * AND A DRAINER KILLED BETWEEN THE RENAME AND THE READ STRANDS ITS CLAIM, which
+ * the rename alone does not solve. That was the residual left by the fix above:
+ * the records inside such a file are lost unread, the lazy path is structurally
+ * blind to them for the reason stated three paragraphs up, and the stray files
+ * accumulate with nothing reading them. `adoptStrandedClaims` recovers them at
+ * the head of every drain, before the queue is even checked -- because a
+ * stranded claim has nothing to do with whether there is new work now.
+ *
  * FAIL-OPEN THROUGHOUT. A rename that loses a race, or fails for any other
- * reason, returns 0 and leaves the queue for the next drain; it never throws
- * into a hook.
+ * reason, applies whatever was adopted, leaves the queue for the next drain,
+ * and never throws into a hook.
  */
 export function drainInvalidations(dir, graph) {
-  let records;
+  // ADOPTED FIRST, AND UNCONDITIONALLY. A claim left by a drainer that died
+  // between its rename and its read is recovered here -- including one under
+  // this process's own pid, which the rename below used to overwrite.
+  //
+  // BEFORE THE QUEUE IS EVEN CHECKED, because a stranded claim has nothing to
+  // do with whether a queue exists now. Recovering it only when there happened
+  // to be new work would leave it stranded for as long as the project stayed
+  // quiet, which is exactly the state a killed drain tends to leave behind.
+  let records = adoptStrandedClaims(dir);
+
   let claim;
   try {
     const file = queuePath(dir);
-    if (!existsSync(file)) return 0;
+    if (!existsSync(file)) return applyRecords(dir, graph, records);
     claim = claimPath(dir);
-    // A LEFTOVER CLAIM FROM A KILLED DRAIN IS OVERWRITTEN, not merged: rename
-    // onto an existing path replaces it. The pid in the name means the only way
-    // to hit that is this same pid having died mid-drain, whose records were
-    // already being applied when it went -- and re-applying is idempotent, so
-    // losing them is the cheaper of the two errors. Not doing the rename at all
-    // would strand the live queue forever.
+    // The rename can no longer clobber a leftover claim: adoption above has
+    // already read and removed any file under this pid's name, so the only
+    // thing this can replace is a file that no longer exists.
     renameSync(file, claim);
-    records = readFileSync(claim, 'utf8')
-      .split('\n')
-      .filter((line) => line.trim())
-      .map((line) => {
-        try {
-          return JSON.parse(line);
-        } catch {
-          // A torn append costs one record, not the queue.
-          return null;
-        }
-      })
-      .filter(Boolean);
+    records = records.concat(readRecords(claim));
   } catch {
     // The rename lost a race, or the claim could not be read. Nothing is deleted
     // unread and the hook proceeds. If the claim was taken and then could not be
@@ -394,27 +549,13 @@ export function drainInvalidations(dir, graph) {
     } catch {
       // Best effort only. A hook must not fail because bookkeeping did.
     }
-    return 0;
+    // Anything already ADOPTED is still applied. Those records came out of a
+    // file that has already been deleted, so returning here would lose them
+    // for good -- which is the defect this whole function is being fixed for.
+    return applyRecords(dir, graph, records);
   }
 
-  let marked = 0;
-  for (const record of records) {
-    if (!record || typeof record.path !== 'string' || !record.path) continue;
-    const diffable =
-      typeof record.before === 'string' && typeof record.after === 'string';
-    try {
-      // TWO GRADES, ONE QUEUE. A record carrying both sides gets a real diff and
-      // symbol-precise marking; one carrying only a path gets the hash
-      // comparison -- the same comparison the lazy path makes, and one that is
-      // only meaningful HERE, before `indexFile` refreshes the anchor.
-      const result = diffable
-        ? invalidateOnWrite(dir, graph, record.path, record.before, record.after)
-        : invalidateChangedAnchors(dir, graph, record.path);
-      marked += Array.isArray(result) ? result.length : 0;
-    } catch {
-      // One bad record must not stop the rest, and must not stop the tool call.
-    }
-  }
+  const marked = applyRecords(dir, graph, records);
 
   try {
     // THE CLAIM, NOT THE QUEUE. Deleting `queuePath` here is what dropped a

--- a/integrations/copilot/.github/hooks/lib/pending.mjs
+++ b/integrations/copilot/.github/hooks/lib/pending.mjs
@@ -34,6 +34,7 @@ import {
   appendFileSync,
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   renameSync,
   rmSync,
@@ -53,6 +54,126 @@ const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
  * claim private to the drainer that won the rename.
  */
 const claimPath = (dir) => join(dir, `pending-invalidation.claim.${process.pid}.jsonl`);
+
+/** Matches any drainer's claim file and captures the pid that owns it. */
+const CLAIM_NAME = /^pending-invalidation\.claim\.(\d+)\.jsonl$/;
+
+/**
+ * After this long, a claim is treated as stranded whatever its pid says.
+ *
+ * PID REUSE IS THE REASON. A drainer killed mid-claim leaves a file named after
+ * a pid the operating system is free to hand to something else, and once it
+ * does, a liveness check answers "alive" forever and the records inside are
+ * never recovered. An hour is several orders of magnitude longer than a drain,
+ * which takes milliseconds, so nothing legitimate is still holding one.
+ */
+const STRANDED_AFTER_MS = 60 * 60 * 1000;
+
+/**
+ * Claim files adopted in a single drain.
+ *
+ * A hook runs on the critical path of a tool call. If a directory has somehow
+ * accumulated hundreds of strays, recovering them all at once would turn one
+ * tool call into a long job -- and the rest are still there for the next drain,
+ * because adoption deletes only what it has read.
+ */
+const MAX_ADOPTED = 20;
+
+/** Is this pid a live process? */
+function isPidAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    // Signal 0 performs the permission and existence checks without delivering
+    // anything.
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // EPERM means the process exists and belongs to somebody else, which is
+    // still alive. Anything else -- ESRCH above all -- means it is gone.
+    return error?.code === 'EPERM';
+  }
+}
+
+/** Parses a queue or claim file into records, tolerating a torn last line. */
+function readRecords(path) {
+  return readFileSync(path, 'utf8')
+    .split('\n')
+    .filter((line) => line.trim())
+    .map((line) => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        // A torn append costs one record, not the queue.
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+/**
+ * Recovers claim files whose drainer died before it could read them.
+ *
+ * THE RESIDUAL THIS CLOSES. Claiming the queue by renaming it to a per-pid file
+ * fixed the original defect -- a concurrent append deleted unread -- but a
+ * drainer killed BETWEEN the rename and the read strands its claim, and the
+ * records inside are lost. The lazy staleness path cannot find them later
+ * either: `indexFile` refreshes an anchor's hash to the bytes just read, so for
+ * a file the session itself edited there is nothing left to compare against.
+ * Those invalidations were permanently missed, and the stray files accumulated
+ * with nothing reading them.
+ *
+ * SAFE BECAUSE RE-APPLICATION IS IDEMPOTENT. Marking a finding stale twice is
+ * marking it stale, so the cost of adopting a claim whose owner turns out to be
+ * alive is a repeated write, while the cost of not adopting is a permanently
+ * missed invalidation. The asymmetry is why the age fallback above is allowed
+ * to be wrong in the permissive direction.
+ *
+ * OUR OWN PID IS ALWAYS ADOPTED. A file under this process's own name can only
+ * be a previous drain in this process that died, and the old behaviour was to
+ * overwrite it with the next rename -- losing exactly the records this function
+ * exists to recover.
+ */
+function adoptStrandedClaims(dir) {
+  const records = [];
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return records;
+  }
+
+  let adopted = 0;
+  for (const entry of entries) {
+    if (adopted >= MAX_ADOPTED) break;
+    const match = CLAIM_NAME.exec(entry);
+    if (!match) continue;
+
+    const pid = Number(match[1]);
+    const path = join(dir, entry);
+    if (pid !== process.pid && isPidAlive(pid)) {
+      let age = 0;
+      try {
+        age = Date.now() - statSync(path).mtimeMs;
+      } catch {
+        continue;
+      }
+      if (age < STRANDED_AFTER_MS) continue;
+    }
+
+    try {
+      records.push(...readRecords(path));
+      adopted += 1;
+      // DELETED ONLY AFTER READING, which is the same rule the drain below
+      // follows: nothing is removed until its contents are in hand.
+      rmSync(path, { force: true });
+    } catch {
+      // Unreadable or held open. Left in place for the next drain rather than
+      // deleted, because a file nobody reads again is the lost record this
+      // whole mechanism exists to prevent.
+    }
+  }
+  return records;
+}
 
 /**
  * Largest before/after side kept in a queue record.
@@ -324,6 +445,37 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
 }
 
 /**
+ * Applies queued invalidations to the graph, returning how many were marked.
+ *
+ * EXTRACTED so the three exits from `drainInvalidations` share one path. Two of
+ * them now carry adopted records -- the empty-queue exit and the failed-rename
+ * exit -- and both previously returned 0. Returning early with records already
+ * read out of a file that has since been deleted would lose them for good,
+ * which is the exact defect adoption exists to close.
+ */
+function applyRecords(dir, graph, records) {
+  let marked = 0;
+  for (const record of records) {
+    if (!record || typeof record.path !== 'string' || !record.path) continue;
+    const diffable =
+      typeof record.before === 'string' && typeof record.after === 'string';
+    try {
+      // TWO GRADES, ONE QUEUE. A record carrying both sides gets a real diff and
+      // symbol-precise marking; one carrying only a path gets the hash
+      // comparison -- the same comparison the lazy path makes, and one that is
+      // only meaningful HERE, before `indexFile` refreshes the anchor.
+      const result = diffable
+        ? invalidateOnWrite(dir, graph, record.path, record.before, record.after)
+        : invalidateChangedAnchors(dir, graph, record.path);
+      marked += Array.isArray(result) ? result.length : 0;
+    } catch {
+      // One bad record must not stop the rest, and must not stop the tool call.
+    }
+  }
+  return marked;
+}
+
+/**
  * Applies every queued invalidation and clears the queue.
  *
  * Returns the number of findings marked, so the caller knows whether its
@@ -351,36 +503,39 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
  * for the rest of the session costs more than it can ever recover, and the claim
  * file is deleted whether the loop marked anything or threw.
  *
+ * AND A DRAINER KILLED BETWEEN THE RENAME AND THE READ STRANDS ITS CLAIM, which
+ * the rename alone does not solve. That was the residual left by the fix above:
+ * the records inside such a file are lost unread, the lazy path is structurally
+ * blind to them for the reason stated three paragraphs up, and the stray files
+ * accumulate with nothing reading them. `adoptStrandedClaims` recovers them at
+ * the head of every drain, before the queue is even checked -- because a
+ * stranded claim has nothing to do with whether there is new work now.
+ *
  * FAIL-OPEN THROUGHOUT. A rename that loses a race, or fails for any other
- * reason, returns 0 and leaves the queue for the next drain; it never throws
- * into a hook.
+ * reason, applies whatever was adopted, leaves the queue for the next drain,
+ * and never throws into a hook.
  */
 export function drainInvalidations(dir, graph) {
-  let records;
+  // ADOPTED FIRST, AND UNCONDITIONALLY. A claim left by a drainer that died
+  // between its rename and its read is recovered here -- including one under
+  // this process's own pid, which the rename below used to overwrite.
+  //
+  // BEFORE THE QUEUE IS EVEN CHECKED, because a stranded claim has nothing to
+  // do with whether a queue exists now. Recovering it only when there happened
+  // to be new work would leave it stranded for as long as the project stayed
+  // quiet, which is exactly the state a killed drain tends to leave behind.
+  let records = adoptStrandedClaims(dir);
+
   let claim;
   try {
     const file = queuePath(dir);
-    if (!existsSync(file)) return 0;
+    if (!existsSync(file)) return applyRecords(dir, graph, records);
     claim = claimPath(dir);
-    // A LEFTOVER CLAIM FROM A KILLED DRAIN IS OVERWRITTEN, not merged: rename
-    // onto an existing path replaces it. The pid in the name means the only way
-    // to hit that is this same pid having died mid-drain, whose records were
-    // already being applied when it went -- and re-applying is idempotent, so
-    // losing them is the cheaper of the two errors. Not doing the rename at all
-    // would strand the live queue forever.
+    // The rename can no longer clobber a leftover claim: adoption above has
+    // already read and removed any file under this pid's name, so the only
+    // thing this can replace is a file that no longer exists.
     renameSync(file, claim);
-    records = readFileSync(claim, 'utf8')
-      .split('\n')
-      .filter((line) => line.trim())
-      .map((line) => {
-        try {
-          return JSON.parse(line);
-        } catch {
-          // A torn append costs one record, not the queue.
-          return null;
-        }
-      })
-      .filter(Boolean);
+    records = records.concat(readRecords(claim));
   } catch {
     // The rename lost a race, or the claim could not be read. Nothing is deleted
     // unread and the hook proceeds. If the claim was taken and then could not be
@@ -394,27 +549,13 @@ export function drainInvalidations(dir, graph) {
     } catch {
       // Best effort only. A hook must not fail because bookkeeping did.
     }
-    return 0;
+    // Anything already ADOPTED is still applied. Those records came out of a
+    // file that has already been deleted, so returning here would lose them
+    // for good -- which is the defect this whole function is being fixed for.
+    return applyRecords(dir, graph, records);
   }
 
-  let marked = 0;
-  for (const record of records) {
-    if (!record || typeof record.path !== 'string' || !record.path) continue;
-    const diffable =
-      typeof record.before === 'string' && typeof record.after === 'string';
-    try {
-      // TWO GRADES, ONE QUEUE. A record carrying both sides gets a real diff and
-      // symbol-precise marking; one carrying only a path gets the hash
-      // comparison -- the same comparison the lazy path makes, and one that is
-      // only meaningful HERE, before `indexFile` refreshes the anchor.
-      const result = diffable
-        ? invalidateOnWrite(dir, graph, record.path, record.before, record.after)
-        : invalidateChangedAnchors(dir, graph, record.path);
-      marked += Array.isArray(result) ? result.length : 0;
-    } catch {
-      // One bad record must not stop the rest, and must not stop the tool call.
-    }
-  }
+  const marked = applyRecords(dir, graph, records);
 
   try {
     // THE CLAIM, NOT THE QUEUE. Deleting `queuePath` here is what dropped a

--- a/integrations/cursor/hooks/lib/pending.mjs
+++ b/integrations/cursor/hooks/lib/pending.mjs
@@ -34,6 +34,7 @@ import {
   appendFileSync,
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   renameSync,
   rmSync,
@@ -53,6 +54,126 @@ const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
  * claim private to the drainer that won the rename.
  */
 const claimPath = (dir) => join(dir, `pending-invalidation.claim.${process.pid}.jsonl`);
+
+/** Matches any drainer's claim file and captures the pid that owns it. */
+const CLAIM_NAME = /^pending-invalidation\.claim\.(\d+)\.jsonl$/;
+
+/**
+ * After this long, a claim is treated as stranded whatever its pid says.
+ *
+ * PID REUSE IS THE REASON. A drainer killed mid-claim leaves a file named after
+ * a pid the operating system is free to hand to something else, and once it
+ * does, a liveness check answers "alive" forever and the records inside are
+ * never recovered. An hour is several orders of magnitude longer than a drain,
+ * which takes milliseconds, so nothing legitimate is still holding one.
+ */
+const STRANDED_AFTER_MS = 60 * 60 * 1000;
+
+/**
+ * Claim files adopted in a single drain.
+ *
+ * A hook runs on the critical path of a tool call. If a directory has somehow
+ * accumulated hundreds of strays, recovering them all at once would turn one
+ * tool call into a long job -- and the rest are still there for the next drain,
+ * because adoption deletes only what it has read.
+ */
+const MAX_ADOPTED = 20;
+
+/** Is this pid a live process? */
+function isPidAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    // Signal 0 performs the permission and existence checks without delivering
+    // anything.
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // EPERM means the process exists and belongs to somebody else, which is
+    // still alive. Anything else -- ESRCH above all -- means it is gone.
+    return error?.code === 'EPERM';
+  }
+}
+
+/** Parses a queue or claim file into records, tolerating a torn last line. */
+function readRecords(path) {
+  return readFileSync(path, 'utf8')
+    .split('\n')
+    .filter((line) => line.trim())
+    .map((line) => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        // A torn append costs one record, not the queue.
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+/**
+ * Recovers claim files whose drainer died before it could read them.
+ *
+ * THE RESIDUAL THIS CLOSES. Claiming the queue by renaming it to a per-pid file
+ * fixed the original defect -- a concurrent append deleted unread -- but a
+ * drainer killed BETWEEN the rename and the read strands its claim, and the
+ * records inside are lost. The lazy staleness path cannot find them later
+ * either: `indexFile` refreshes an anchor's hash to the bytes just read, so for
+ * a file the session itself edited there is nothing left to compare against.
+ * Those invalidations were permanently missed, and the stray files accumulated
+ * with nothing reading them.
+ *
+ * SAFE BECAUSE RE-APPLICATION IS IDEMPOTENT. Marking a finding stale twice is
+ * marking it stale, so the cost of adopting a claim whose owner turns out to be
+ * alive is a repeated write, while the cost of not adopting is a permanently
+ * missed invalidation. The asymmetry is why the age fallback above is allowed
+ * to be wrong in the permissive direction.
+ *
+ * OUR OWN PID IS ALWAYS ADOPTED. A file under this process's own name can only
+ * be a previous drain in this process that died, and the old behaviour was to
+ * overwrite it with the next rename -- losing exactly the records this function
+ * exists to recover.
+ */
+function adoptStrandedClaims(dir) {
+  const records = [];
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return records;
+  }
+
+  let adopted = 0;
+  for (const entry of entries) {
+    if (adopted >= MAX_ADOPTED) break;
+    const match = CLAIM_NAME.exec(entry);
+    if (!match) continue;
+
+    const pid = Number(match[1]);
+    const path = join(dir, entry);
+    if (pid !== process.pid && isPidAlive(pid)) {
+      let age = 0;
+      try {
+        age = Date.now() - statSync(path).mtimeMs;
+      } catch {
+        continue;
+      }
+      if (age < STRANDED_AFTER_MS) continue;
+    }
+
+    try {
+      records.push(...readRecords(path));
+      adopted += 1;
+      // DELETED ONLY AFTER READING, which is the same rule the drain below
+      // follows: nothing is removed until its contents are in hand.
+      rmSync(path, { force: true });
+    } catch {
+      // Unreadable or held open. Left in place for the next drain rather than
+      // deleted, because a file nobody reads again is the lost record this
+      // whole mechanism exists to prevent.
+    }
+  }
+  return records;
+}
 
 /**
  * Largest before/after side kept in a queue record.
@@ -324,6 +445,37 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
 }
 
 /**
+ * Applies queued invalidations to the graph, returning how many were marked.
+ *
+ * EXTRACTED so the three exits from `drainInvalidations` share one path. Two of
+ * them now carry adopted records -- the empty-queue exit and the failed-rename
+ * exit -- and both previously returned 0. Returning early with records already
+ * read out of a file that has since been deleted would lose them for good,
+ * which is the exact defect adoption exists to close.
+ */
+function applyRecords(dir, graph, records) {
+  let marked = 0;
+  for (const record of records) {
+    if (!record || typeof record.path !== 'string' || !record.path) continue;
+    const diffable =
+      typeof record.before === 'string' && typeof record.after === 'string';
+    try {
+      // TWO GRADES, ONE QUEUE. A record carrying both sides gets a real diff and
+      // symbol-precise marking; one carrying only a path gets the hash
+      // comparison -- the same comparison the lazy path makes, and one that is
+      // only meaningful HERE, before `indexFile` refreshes the anchor.
+      const result = diffable
+        ? invalidateOnWrite(dir, graph, record.path, record.before, record.after)
+        : invalidateChangedAnchors(dir, graph, record.path);
+      marked += Array.isArray(result) ? result.length : 0;
+    } catch {
+      // One bad record must not stop the rest, and must not stop the tool call.
+    }
+  }
+  return marked;
+}
+
+/**
  * Applies every queued invalidation and clears the queue.
  *
  * Returns the number of findings marked, so the caller knows whether its
@@ -351,36 +503,39 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
  * for the rest of the session costs more than it can ever recover, and the claim
  * file is deleted whether the loop marked anything or threw.
  *
+ * AND A DRAINER KILLED BETWEEN THE RENAME AND THE READ STRANDS ITS CLAIM, which
+ * the rename alone does not solve. That was the residual left by the fix above:
+ * the records inside such a file are lost unread, the lazy path is structurally
+ * blind to them for the reason stated three paragraphs up, and the stray files
+ * accumulate with nothing reading them. `adoptStrandedClaims` recovers them at
+ * the head of every drain, before the queue is even checked -- because a
+ * stranded claim has nothing to do with whether there is new work now.
+ *
  * FAIL-OPEN THROUGHOUT. A rename that loses a race, or fails for any other
- * reason, returns 0 and leaves the queue for the next drain; it never throws
- * into a hook.
+ * reason, applies whatever was adopted, leaves the queue for the next drain,
+ * and never throws into a hook.
  */
 export function drainInvalidations(dir, graph) {
-  let records;
+  // ADOPTED FIRST, AND UNCONDITIONALLY. A claim left by a drainer that died
+  // between its rename and its read is recovered here -- including one under
+  // this process's own pid, which the rename below used to overwrite.
+  //
+  // BEFORE THE QUEUE IS EVEN CHECKED, because a stranded claim has nothing to
+  // do with whether a queue exists now. Recovering it only when there happened
+  // to be new work would leave it stranded for as long as the project stayed
+  // quiet, which is exactly the state a killed drain tends to leave behind.
+  let records = adoptStrandedClaims(dir);
+
   let claim;
   try {
     const file = queuePath(dir);
-    if (!existsSync(file)) return 0;
+    if (!existsSync(file)) return applyRecords(dir, graph, records);
     claim = claimPath(dir);
-    // A LEFTOVER CLAIM FROM A KILLED DRAIN IS OVERWRITTEN, not merged: rename
-    // onto an existing path replaces it. The pid in the name means the only way
-    // to hit that is this same pid having died mid-drain, whose records were
-    // already being applied when it went -- and re-applying is idempotent, so
-    // losing them is the cheaper of the two errors. Not doing the rename at all
-    // would strand the live queue forever.
+    // The rename can no longer clobber a leftover claim: adoption above has
+    // already read and removed any file under this pid's name, so the only
+    // thing this can replace is a file that no longer exists.
     renameSync(file, claim);
-    records = readFileSync(claim, 'utf8')
-      .split('\n')
-      .filter((line) => line.trim())
-      .map((line) => {
-        try {
-          return JSON.parse(line);
-        } catch {
-          // A torn append costs one record, not the queue.
-          return null;
-        }
-      })
-      .filter(Boolean);
+    records = records.concat(readRecords(claim));
   } catch {
     // The rename lost a race, or the claim could not be read. Nothing is deleted
     // unread and the hook proceeds. If the claim was taken and then could not be
@@ -394,27 +549,13 @@ export function drainInvalidations(dir, graph) {
     } catch {
       // Best effort only. A hook must not fail because bookkeeping did.
     }
-    return 0;
+    // Anything already ADOPTED is still applied. Those records came out of a
+    // file that has already been deleted, so returning here would lose them
+    // for good -- which is the defect this whole function is being fixed for.
+    return applyRecords(dir, graph, records);
   }
 
-  let marked = 0;
-  for (const record of records) {
-    if (!record || typeof record.path !== 'string' || !record.path) continue;
-    const diffable =
-      typeof record.before === 'string' && typeof record.after === 'string';
-    try {
-      // TWO GRADES, ONE QUEUE. A record carrying both sides gets a real diff and
-      // symbol-precise marking; one carrying only a path gets the hash
-      // comparison -- the same comparison the lazy path makes, and one that is
-      // only meaningful HERE, before `indexFile` refreshes the anchor.
-      const result = diffable
-        ? invalidateOnWrite(dir, graph, record.path, record.before, record.after)
-        : invalidateChangedAnchors(dir, graph, record.path);
-      marked += Array.isArray(result) ? result.length : 0;
-    } catch {
-      // One bad record must not stop the rest, and must not stop the tool call.
-    }
-  }
+  const marked = applyRecords(dir, graph, records);
 
   try {
     // THE CLAIM, NOT THE QUEUE. Deleting `queuePath` here is what dropped a

--- a/integrations/gemini/hooks/lib/pending.mjs
+++ b/integrations/gemini/hooks/lib/pending.mjs
@@ -34,6 +34,7 @@ import {
   appendFileSync,
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   renameSync,
   rmSync,
@@ -53,6 +54,126 @@ const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
  * claim private to the drainer that won the rename.
  */
 const claimPath = (dir) => join(dir, `pending-invalidation.claim.${process.pid}.jsonl`);
+
+/** Matches any drainer's claim file and captures the pid that owns it. */
+const CLAIM_NAME = /^pending-invalidation\.claim\.(\d+)\.jsonl$/;
+
+/**
+ * After this long, a claim is treated as stranded whatever its pid says.
+ *
+ * PID REUSE IS THE REASON. A drainer killed mid-claim leaves a file named after
+ * a pid the operating system is free to hand to something else, and once it
+ * does, a liveness check answers "alive" forever and the records inside are
+ * never recovered. An hour is several orders of magnitude longer than a drain,
+ * which takes milliseconds, so nothing legitimate is still holding one.
+ */
+const STRANDED_AFTER_MS = 60 * 60 * 1000;
+
+/**
+ * Claim files adopted in a single drain.
+ *
+ * A hook runs on the critical path of a tool call. If a directory has somehow
+ * accumulated hundreds of strays, recovering them all at once would turn one
+ * tool call into a long job -- and the rest are still there for the next drain,
+ * because adoption deletes only what it has read.
+ */
+const MAX_ADOPTED = 20;
+
+/** Is this pid a live process? */
+function isPidAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    // Signal 0 performs the permission and existence checks without delivering
+    // anything.
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // EPERM means the process exists and belongs to somebody else, which is
+    // still alive. Anything else -- ESRCH above all -- means it is gone.
+    return error?.code === 'EPERM';
+  }
+}
+
+/** Parses a queue or claim file into records, tolerating a torn last line. */
+function readRecords(path) {
+  return readFileSync(path, 'utf8')
+    .split('\n')
+    .filter((line) => line.trim())
+    .map((line) => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        // A torn append costs one record, not the queue.
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+/**
+ * Recovers claim files whose drainer died before it could read them.
+ *
+ * THE RESIDUAL THIS CLOSES. Claiming the queue by renaming it to a per-pid file
+ * fixed the original defect -- a concurrent append deleted unread -- but a
+ * drainer killed BETWEEN the rename and the read strands its claim, and the
+ * records inside are lost. The lazy staleness path cannot find them later
+ * either: `indexFile` refreshes an anchor's hash to the bytes just read, so for
+ * a file the session itself edited there is nothing left to compare against.
+ * Those invalidations were permanently missed, and the stray files accumulated
+ * with nothing reading them.
+ *
+ * SAFE BECAUSE RE-APPLICATION IS IDEMPOTENT. Marking a finding stale twice is
+ * marking it stale, so the cost of adopting a claim whose owner turns out to be
+ * alive is a repeated write, while the cost of not adopting is a permanently
+ * missed invalidation. The asymmetry is why the age fallback above is allowed
+ * to be wrong in the permissive direction.
+ *
+ * OUR OWN PID IS ALWAYS ADOPTED. A file under this process's own name can only
+ * be a previous drain in this process that died, and the old behaviour was to
+ * overwrite it with the next rename -- losing exactly the records this function
+ * exists to recover.
+ */
+function adoptStrandedClaims(dir) {
+  const records = [];
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return records;
+  }
+
+  let adopted = 0;
+  for (const entry of entries) {
+    if (adopted >= MAX_ADOPTED) break;
+    const match = CLAIM_NAME.exec(entry);
+    if (!match) continue;
+
+    const pid = Number(match[1]);
+    const path = join(dir, entry);
+    if (pid !== process.pid && isPidAlive(pid)) {
+      let age = 0;
+      try {
+        age = Date.now() - statSync(path).mtimeMs;
+      } catch {
+        continue;
+      }
+      if (age < STRANDED_AFTER_MS) continue;
+    }
+
+    try {
+      records.push(...readRecords(path));
+      adopted += 1;
+      // DELETED ONLY AFTER READING, which is the same rule the drain below
+      // follows: nothing is removed until its contents are in hand.
+      rmSync(path, { force: true });
+    } catch {
+      // Unreadable or held open. Left in place for the next drain rather than
+      // deleted, because a file nobody reads again is the lost record this
+      // whole mechanism exists to prevent.
+    }
+  }
+  return records;
+}
 
 /**
  * Largest before/after side kept in a queue record.
@@ -324,6 +445,37 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
 }
 
 /**
+ * Applies queued invalidations to the graph, returning how many were marked.
+ *
+ * EXTRACTED so the three exits from `drainInvalidations` share one path. Two of
+ * them now carry adopted records -- the empty-queue exit and the failed-rename
+ * exit -- and both previously returned 0. Returning early with records already
+ * read out of a file that has since been deleted would lose them for good,
+ * which is the exact defect adoption exists to close.
+ */
+function applyRecords(dir, graph, records) {
+  let marked = 0;
+  for (const record of records) {
+    if (!record || typeof record.path !== 'string' || !record.path) continue;
+    const diffable =
+      typeof record.before === 'string' && typeof record.after === 'string';
+    try {
+      // TWO GRADES, ONE QUEUE. A record carrying both sides gets a real diff and
+      // symbol-precise marking; one carrying only a path gets the hash
+      // comparison -- the same comparison the lazy path makes, and one that is
+      // only meaningful HERE, before `indexFile` refreshes the anchor.
+      const result = diffable
+        ? invalidateOnWrite(dir, graph, record.path, record.before, record.after)
+        : invalidateChangedAnchors(dir, graph, record.path);
+      marked += Array.isArray(result) ? result.length : 0;
+    } catch {
+      // One bad record must not stop the rest, and must not stop the tool call.
+    }
+  }
+  return marked;
+}
+
+/**
  * Applies every queued invalidation and clears the queue.
  *
  * Returns the number of findings marked, so the caller knows whether its
@@ -351,36 +503,39 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
  * for the rest of the session costs more than it can ever recover, and the claim
  * file is deleted whether the loop marked anything or threw.
  *
+ * AND A DRAINER KILLED BETWEEN THE RENAME AND THE READ STRANDS ITS CLAIM, which
+ * the rename alone does not solve. That was the residual left by the fix above:
+ * the records inside such a file are lost unread, the lazy path is structurally
+ * blind to them for the reason stated three paragraphs up, and the stray files
+ * accumulate with nothing reading them. `adoptStrandedClaims` recovers them at
+ * the head of every drain, before the queue is even checked -- because a
+ * stranded claim has nothing to do with whether there is new work now.
+ *
  * FAIL-OPEN THROUGHOUT. A rename that loses a race, or fails for any other
- * reason, returns 0 and leaves the queue for the next drain; it never throws
- * into a hook.
+ * reason, applies whatever was adopted, leaves the queue for the next drain,
+ * and never throws into a hook.
  */
 export function drainInvalidations(dir, graph) {
-  let records;
+  // ADOPTED FIRST, AND UNCONDITIONALLY. A claim left by a drainer that died
+  // between its rename and its read is recovered here -- including one under
+  // this process's own pid, which the rename below used to overwrite.
+  //
+  // BEFORE THE QUEUE IS EVEN CHECKED, because a stranded claim has nothing to
+  // do with whether a queue exists now. Recovering it only when there happened
+  // to be new work would leave it stranded for as long as the project stayed
+  // quiet, which is exactly the state a killed drain tends to leave behind.
+  let records = adoptStrandedClaims(dir);
+
   let claim;
   try {
     const file = queuePath(dir);
-    if (!existsSync(file)) return 0;
+    if (!existsSync(file)) return applyRecords(dir, graph, records);
     claim = claimPath(dir);
-    // A LEFTOVER CLAIM FROM A KILLED DRAIN IS OVERWRITTEN, not merged: rename
-    // onto an existing path replaces it. The pid in the name means the only way
-    // to hit that is this same pid having died mid-drain, whose records were
-    // already being applied when it went -- and re-applying is idempotent, so
-    // losing them is the cheaper of the two errors. Not doing the rename at all
-    // would strand the live queue forever.
+    // The rename can no longer clobber a leftover claim: adoption above has
+    // already read and removed any file under this pid's name, so the only
+    // thing this can replace is a file that no longer exists.
     renameSync(file, claim);
-    records = readFileSync(claim, 'utf8')
-      .split('\n')
-      .filter((line) => line.trim())
-      .map((line) => {
-        try {
-          return JSON.parse(line);
-        } catch {
-          // A torn append costs one record, not the queue.
-          return null;
-        }
-      })
-      .filter(Boolean);
+    records = records.concat(readRecords(claim));
   } catch {
     // The rename lost a race, or the claim could not be read. Nothing is deleted
     // unread and the hook proceeds. If the claim was taken and then could not be
@@ -394,27 +549,13 @@ export function drainInvalidations(dir, graph) {
     } catch {
       // Best effort only. A hook must not fail because bookkeeping did.
     }
-    return 0;
+    // Anything already ADOPTED is still applied. Those records came out of a
+    // file that has already been deleted, so returning here would lose them
+    // for good -- which is the defect this whole function is being fixed for.
+    return applyRecords(dir, graph, records);
   }
 
-  let marked = 0;
-  for (const record of records) {
-    if (!record || typeof record.path !== 'string' || !record.path) continue;
-    const diffable =
-      typeof record.before === 'string' && typeof record.after === 'string';
-    try {
-      // TWO GRADES, ONE QUEUE. A record carrying both sides gets a real diff and
-      // symbol-precise marking; one carrying only a path gets the hash
-      // comparison -- the same comparison the lazy path makes, and one that is
-      // only meaningful HERE, before `indexFile` refreshes the anchor.
-      const result = diffable
-        ? invalidateOnWrite(dir, graph, record.path, record.before, record.after)
-        : invalidateChangedAnchors(dir, graph, record.path);
-      marked += Array.isArray(result) ? result.length : 0;
-    } catch {
-      // One bad record must not stop the rest, and must not stop the tool call.
-    }
-  }
+  const marked = applyRecords(dir, graph, records);
 
   try {
     // THE CLAIM, NOT THE QUEUE. Deleting `queuePath` here is what dropped a

--- a/integrations/kilo/hooks/lib/pending.mjs
+++ b/integrations/kilo/hooks/lib/pending.mjs
@@ -34,6 +34,7 @@ import {
   appendFileSync,
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   renameSync,
   rmSync,
@@ -53,6 +54,126 @@ const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
  * claim private to the drainer that won the rename.
  */
 const claimPath = (dir) => join(dir, `pending-invalidation.claim.${process.pid}.jsonl`);
+
+/** Matches any drainer's claim file and captures the pid that owns it. */
+const CLAIM_NAME = /^pending-invalidation\.claim\.(\d+)\.jsonl$/;
+
+/**
+ * After this long, a claim is treated as stranded whatever its pid says.
+ *
+ * PID REUSE IS THE REASON. A drainer killed mid-claim leaves a file named after
+ * a pid the operating system is free to hand to something else, and once it
+ * does, a liveness check answers "alive" forever and the records inside are
+ * never recovered. An hour is several orders of magnitude longer than a drain,
+ * which takes milliseconds, so nothing legitimate is still holding one.
+ */
+const STRANDED_AFTER_MS = 60 * 60 * 1000;
+
+/**
+ * Claim files adopted in a single drain.
+ *
+ * A hook runs on the critical path of a tool call. If a directory has somehow
+ * accumulated hundreds of strays, recovering them all at once would turn one
+ * tool call into a long job -- and the rest are still there for the next drain,
+ * because adoption deletes only what it has read.
+ */
+const MAX_ADOPTED = 20;
+
+/** Is this pid a live process? */
+function isPidAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    // Signal 0 performs the permission and existence checks without delivering
+    // anything.
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // EPERM means the process exists and belongs to somebody else, which is
+    // still alive. Anything else -- ESRCH above all -- means it is gone.
+    return error?.code === 'EPERM';
+  }
+}
+
+/** Parses a queue or claim file into records, tolerating a torn last line. */
+function readRecords(path) {
+  return readFileSync(path, 'utf8')
+    .split('\n')
+    .filter((line) => line.trim())
+    .map((line) => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        // A torn append costs one record, not the queue.
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+/**
+ * Recovers claim files whose drainer died before it could read them.
+ *
+ * THE RESIDUAL THIS CLOSES. Claiming the queue by renaming it to a per-pid file
+ * fixed the original defect -- a concurrent append deleted unread -- but a
+ * drainer killed BETWEEN the rename and the read strands its claim, and the
+ * records inside are lost. The lazy staleness path cannot find them later
+ * either: `indexFile` refreshes an anchor's hash to the bytes just read, so for
+ * a file the session itself edited there is nothing left to compare against.
+ * Those invalidations were permanently missed, and the stray files accumulated
+ * with nothing reading them.
+ *
+ * SAFE BECAUSE RE-APPLICATION IS IDEMPOTENT. Marking a finding stale twice is
+ * marking it stale, so the cost of adopting a claim whose owner turns out to be
+ * alive is a repeated write, while the cost of not adopting is a permanently
+ * missed invalidation. The asymmetry is why the age fallback above is allowed
+ * to be wrong in the permissive direction.
+ *
+ * OUR OWN PID IS ALWAYS ADOPTED. A file under this process's own name can only
+ * be a previous drain in this process that died, and the old behaviour was to
+ * overwrite it with the next rename -- losing exactly the records this function
+ * exists to recover.
+ */
+function adoptStrandedClaims(dir) {
+  const records = [];
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return records;
+  }
+
+  let adopted = 0;
+  for (const entry of entries) {
+    if (adopted >= MAX_ADOPTED) break;
+    const match = CLAIM_NAME.exec(entry);
+    if (!match) continue;
+
+    const pid = Number(match[1]);
+    const path = join(dir, entry);
+    if (pid !== process.pid && isPidAlive(pid)) {
+      let age = 0;
+      try {
+        age = Date.now() - statSync(path).mtimeMs;
+      } catch {
+        continue;
+      }
+      if (age < STRANDED_AFTER_MS) continue;
+    }
+
+    try {
+      records.push(...readRecords(path));
+      adopted += 1;
+      // DELETED ONLY AFTER READING, which is the same rule the drain below
+      // follows: nothing is removed until its contents are in hand.
+      rmSync(path, { force: true });
+    } catch {
+      // Unreadable or held open. Left in place for the next drain rather than
+      // deleted, because a file nobody reads again is the lost record this
+      // whole mechanism exists to prevent.
+    }
+  }
+  return records;
+}
 
 /**
  * Largest before/after side kept in a queue record.
@@ -324,6 +445,37 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
 }
 
 /**
+ * Applies queued invalidations to the graph, returning how many were marked.
+ *
+ * EXTRACTED so the three exits from `drainInvalidations` share one path. Two of
+ * them now carry adopted records -- the empty-queue exit and the failed-rename
+ * exit -- and both previously returned 0. Returning early with records already
+ * read out of a file that has since been deleted would lose them for good,
+ * which is the exact defect adoption exists to close.
+ */
+function applyRecords(dir, graph, records) {
+  let marked = 0;
+  for (const record of records) {
+    if (!record || typeof record.path !== 'string' || !record.path) continue;
+    const diffable =
+      typeof record.before === 'string' && typeof record.after === 'string';
+    try {
+      // TWO GRADES, ONE QUEUE. A record carrying both sides gets a real diff and
+      // symbol-precise marking; one carrying only a path gets the hash
+      // comparison -- the same comparison the lazy path makes, and one that is
+      // only meaningful HERE, before `indexFile` refreshes the anchor.
+      const result = diffable
+        ? invalidateOnWrite(dir, graph, record.path, record.before, record.after)
+        : invalidateChangedAnchors(dir, graph, record.path);
+      marked += Array.isArray(result) ? result.length : 0;
+    } catch {
+      // One bad record must not stop the rest, and must not stop the tool call.
+    }
+  }
+  return marked;
+}
+
+/**
  * Applies every queued invalidation and clears the queue.
  *
  * Returns the number of findings marked, so the caller knows whether its
@@ -351,36 +503,39 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
  * for the rest of the session costs more than it can ever recover, and the claim
  * file is deleted whether the loop marked anything or threw.
  *
+ * AND A DRAINER KILLED BETWEEN THE RENAME AND THE READ STRANDS ITS CLAIM, which
+ * the rename alone does not solve. That was the residual left by the fix above:
+ * the records inside such a file are lost unread, the lazy path is structurally
+ * blind to them for the reason stated three paragraphs up, and the stray files
+ * accumulate with nothing reading them. `adoptStrandedClaims` recovers them at
+ * the head of every drain, before the queue is even checked -- because a
+ * stranded claim has nothing to do with whether there is new work now.
+ *
  * FAIL-OPEN THROUGHOUT. A rename that loses a race, or fails for any other
- * reason, returns 0 and leaves the queue for the next drain; it never throws
- * into a hook.
+ * reason, applies whatever was adopted, leaves the queue for the next drain,
+ * and never throws into a hook.
  */
 export function drainInvalidations(dir, graph) {
-  let records;
+  // ADOPTED FIRST, AND UNCONDITIONALLY. A claim left by a drainer that died
+  // between its rename and its read is recovered here -- including one under
+  // this process's own pid, which the rename below used to overwrite.
+  //
+  // BEFORE THE QUEUE IS EVEN CHECKED, because a stranded claim has nothing to
+  // do with whether a queue exists now. Recovering it only when there happened
+  // to be new work would leave it stranded for as long as the project stayed
+  // quiet, which is exactly the state a killed drain tends to leave behind.
+  let records = adoptStrandedClaims(dir);
+
   let claim;
   try {
     const file = queuePath(dir);
-    if (!existsSync(file)) return 0;
+    if (!existsSync(file)) return applyRecords(dir, graph, records);
     claim = claimPath(dir);
-    // A LEFTOVER CLAIM FROM A KILLED DRAIN IS OVERWRITTEN, not merged: rename
-    // onto an existing path replaces it. The pid in the name means the only way
-    // to hit that is this same pid having died mid-drain, whose records were
-    // already being applied when it went -- and re-applying is idempotent, so
-    // losing them is the cheaper of the two errors. Not doing the rename at all
-    // would strand the live queue forever.
+    // The rename can no longer clobber a leftover claim: adoption above has
+    // already read and removed any file under this pid's name, so the only
+    // thing this can replace is a file that no longer exists.
     renameSync(file, claim);
-    records = readFileSync(claim, 'utf8')
-      .split('\n')
-      .filter((line) => line.trim())
-      .map((line) => {
-        try {
-          return JSON.parse(line);
-        } catch {
-          // A torn append costs one record, not the queue.
-          return null;
-        }
-      })
-      .filter(Boolean);
+    records = records.concat(readRecords(claim));
   } catch {
     // The rename lost a race, or the claim could not be read. Nothing is deleted
     // unread and the hook proceeds. If the claim was taken and then could not be
@@ -394,27 +549,13 @@ export function drainInvalidations(dir, graph) {
     } catch {
       // Best effort only. A hook must not fail because bookkeeping did.
     }
-    return 0;
+    // Anything already ADOPTED is still applied. Those records came out of a
+    // file that has already been deleted, so returning here would lose them
+    // for good -- which is the defect this whole function is being fixed for.
+    return applyRecords(dir, graph, records);
   }
 
-  let marked = 0;
-  for (const record of records) {
-    if (!record || typeof record.path !== 'string' || !record.path) continue;
-    const diffable =
-      typeof record.before === 'string' && typeof record.after === 'string';
-    try {
-      // TWO GRADES, ONE QUEUE. A record carrying both sides gets a real diff and
-      // symbol-precise marking; one carrying only a path gets the hash
-      // comparison -- the same comparison the lazy path makes, and one that is
-      // only meaningful HERE, before `indexFile` refreshes the anchor.
-      const result = diffable
-        ? invalidateOnWrite(dir, graph, record.path, record.before, record.after)
-        : invalidateChangedAnchors(dir, graph, record.path);
-      marked += Array.isArray(result) ? result.length : 0;
-    } catch {
-      // One bad record must not stop the rest, and must not stop the tool call.
-    }
-  }
+  const marked = applyRecords(dir, graph, records);
 
   try {
     // THE CLAIM, NOT THE QUEUE. Deleting `queuePath` here is what dropped a

--- a/integrations/opencode/hooks/lib/pending.mjs
+++ b/integrations/opencode/hooks/lib/pending.mjs
@@ -34,6 +34,7 @@ import {
   appendFileSync,
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   renameSync,
   rmSync,
@@ -53,6 +54,126 @@ const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
  * claim private to the drainer that won the rename.
  */
 const claimPath = (dir) => join(dir, `pending-invalidation.claim.${process.pid}.jsonl`);
+
+/** Matches any drainer's claim file and captures the pid that owns it. */
+const CLAIM_NAME = /^pending-invalidation\.claim\.(\d+)\.jsonl$/;
+
+/**
+ * After this long, a claim is treated as stranded whatever its pid says.
+ *
+ * PID REUSE IS THE REASON. A drainer killed mid-claim leaves a file named after
+ * a pid the operating system is free to hand to something else, and once it
+ * does, a liveness check answers "alive" forever and the records inside are
+ * never recovered. An hour is several orders of magnitude longer than a drain,
+ * which takes milliseconds, so nothing legitimate is still holding one.
+ */
+const STRANDED_AFTER_MS = 60 * 60 * 1000;
+
+/**
+ * Claim files adopted in a single drain.
+ *
+ * A hook runs on the critical path of a tool call. If a directory has somehow
+ * accumulated hundreds of strays, recovering them all at once would turn one
+ * tool call into a long job -- and the rest are still there for the next drain,
+ * because adoption deletes only what it has read.
+ */
+const MAX_ADOPTED = 20;
+
+/** Is this pid a live process? */
+function isPidAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    // Signal 0 performs the permission and existence checks without delivering
+    // anything.
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // EPERM means the process exists and belongs to somebody else, which is
+    // still alive. Anything else -- ESRCH above all -- means it is gone.
+    return error?.code === 'EPERM';
+  }
+}
+
+/** Parses a queue or claim file into records, tolerating a torn last line. */
+function readRecords(path) {
+  return readFileSync(path, 'utf8')
+    .split('\n')
+    .filter((line) => line.trim())
+    .map((line) => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        // A torn append costs one record, not the queue.
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+/**
+ * Recovers claim files whose drainer died before it could read them.
+ *
+ * THE RESIDUAL THIS CLOSES. Claiming the queue by renaming it to a per-pid file
+ * fixed the original defect -- a concurrent append deleted unread -- but a
+ * drainer killed BETWEEN the rename and the read strands its claim, and the
+ * records inside are lost. The lazy staleness path cannot find them later
+ * either: `indexFile` refreshes an anchor's hash to the bytes just read, so for
+ * a file the session itself edited there is nothing left to compare against.
+ * Those invalidations were permanently missed, and the stray files accumulated
+ * with nothing reading them.
+ *
+ * SAFE BECAUSE RE-APPLICATION IS IDEMPOTENT. Marking a finding stale twice is
+ * marking it stale, so the cost of adopting a claim whose owner turns out to be
+ * alive is a repeated write, while the cost of not adopting is a permanently
+ * missed invalidation. The asymmetry is why the age fallback above is allowed
+ * to be wrong in the permissive direction.
+ *
+ * OUR OWN PID IS ALWAYS ADOPTED. A file under this process's own name can only
+ * be a previous drain in this process that died, and the old behaviour was to
+ * overwrite it with the next rename -- losing exactly the records this function
+ * exists to recover.
+ */
+function adoptStrandedClaims(dir) {
+  const records = [];
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return records;
+  }
+
+  let adopted = 0;
+  for (const entry of entries) {
+    if (adopted >= MAX_ADOPTED) break;
+    const match = CLAIM_NAME.exec(entry);
+    if (!match) continue;
+
+    const pid = Number(match[1]);
+    const path = join(dir, entry);
+    if (pid !== process.pid && isPidAlive(pid)) {
+      let age = 0;
+      try {
+        age = Date.now() - statSync(path).mtimeMs;
+      } catch {
+        continue;
+      }
+      if (age < STRANDED_AFTER_MS) continue;
+    }
+
+    try {
+      records.push(...readRecords(path));
+      adopted += 1;
+      // DELETED ONLY AFTER READING, which is the same rule the drain below
+      // follows: nothing is removed until its contents are in hand.
+      rmSync(path, { force: true });
+    } catch {
+      // Unreadable or held open. Left in place for the next drain rather than
+      // deleted, because a file nobody reads again is the lost record this
+      // whole mechanism exists to prevent.
+    }
+  }
+  return records;
+}
 
 /**
  * Largest before/after side kept in a queue record.
@@ -324,6 +445,37 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
 }
 
 /**
+ * Applies queued invalidations to the graph, returning how many were marked.
+ *
+ * EXTRACTED so the three exits from `drainInvalidations` share one path. Two of
+ * them now carry adopted records -- the empty-queue exit and the failed-rename
+ * exit -- and both previously returned 0. Returning early with records already
+ * read out of a file that has since been deleted would lose them for good,
+ * which is the exact defect adoption exists to close.
+ */
+function applyRecords(dir, graph, records) {
+  let marked = 0;
+  for (const record of records) {
+    if (!record || typeof record.path !== 'string' || !record.path) continue;
+    const diffable =
+      typeof record.before === 'string' && typeof record.after === 'string';
+    try {
+      // TWO GRADES, ONE QUEUE. A record carrying both sides gets a real diff and
+      // symbol-precise marking; one carrying only a path gets the hash
+      // comparison -- the same comparison the lazy path makes, and one that is
+      // only meaningful HERE, before `indexFile` refreshes the anchor.
+      const result = diffable
+        ? invalidateOnWrite(dir, graph, record.path, record.before, record.after)
+        : invalidateChangedAnchors(dir, graph, record.path);
+      marked += Array.isArray(result) ? result.length : 0;
+    } catch {
+      // One bad record must not stop the rest, and must not stop the tool call.
+    }
+  }
+  return marked;
+}
+
+/**
  * Applies every queued invalidation and clears the queue.
  *
  * Returns the number of findings marked, so the caller knows whether its
@@ -351,36 +503,39 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
  * for the rest of the session costs more than it can ever recover, and the claim
  * file is deleted whether the loop marked anything or threw.
  *
+ * AND A DRAINER KILLED BETWEEN THE RENAME AND THE READ STRANDS ITS CLAIM, which
+ * the rename alone does not solve. That was the residual left by the fix above:
+ * the records inside such a file are lost unread, the lazy path is structurally
+ * blind to them for the reason stated three paragraphs up, and the stray files
+ * accumulate with nothing reading them. `adoptStrandedClaims` recovers them at
+ * the head of every drain, before the queue is even checked -- because a
+ * stranded claim has nothing to do with whether there is new work now.
+ *
  * FAIL-OPEN THROUGHOUT. A rename that loses a race, or fails for any other
- * reason, returns 0 and leaves the queue for the next drain; it never throws
- * into a hook.
+ * reason, applies whatever was adopted, leaves the queue for the next drain,
+ * and never throws into a hook.
  */
 export function drainInvalidations(dir, graph) {
-  let records;
+  // ADOPTED FIRST, AND UNCONDITIONALLY. A claim left by a drainer that died
+  // between its rename and its read is recovered here -- including one under
+  // this process's own pid, which the rename below used to overwrite.
+  //
+  // BEFORE THE QUEUE IS EVEN CHECKED, because a stranded claim has nothing to
+  // do with whether a queue exists now. Recovering it only when there happened
+  // to be new work would leave it stranded for as long as the project stayed
+  // quiet, which is exactly the state a killed drain tends to leave behind.
+  let records = adoptStrandedClaims(dir);
+
   let claim;
   try {
     const file = queuePath(dir);
-    if (!existsSync(file)) return 0;
+    if (!existsSync(file)) return applyRecords(dir, graph, records);
     claim = claimPath(dir);
-    // A LEFTOVER CLAIM FROM A KILLED DRAIN IS OVERWRITTEN, not merged: rename
-    // onto an existing path replaces it. The pid in the name means the only way
-    // to hit that is this same pid having died mid-drain, whose records were
-    // already being applied when it went -- and re-applying is idempotent, so
-    // losing them is the cheaper of the two errors. Not doing the rename at all
-    // would strand the live queue forever.
+    // The rename can no longer clobber a leftover claim: adoption above has
+    // already read and removed any file under this pid's name, so the only
+    // thing this can replace is a file that no longer exists.
     renameSync(file, claim);
-    records = readFileSync(claim, 'utf8')
-      .split('\n')
-      .filter((line) => line.trim())
-      .map((line) => {
-        try {
-          return JSON.parse(line);
-        } catch {
-          // A torn append costs one record, not the queue.
-          return null;
-        }
-      })
-      .filter(Boolean);
+    records = records.concat(readRecords(claim));
   } catch {
     // The rename lost a race, or the claim could not be read. Nothing is deleted
     // unread and the hook proceeds. If the claim was taken and then could not be
@@ -394,27 +549,13 @@ export function drainInvalidations(dir, graph) {
     } catch {
       // Best effort only. A hook must not fail because bookkeeping did.
     }
-    return 0;
+    // Anything already ADOPTED is still applied. Those records came out of a
+    // file that has already been deleted, so returning here would lose them
+    // for good -- which is the defect this whole function is being fixed for.
+    return applyRecords(dir, graph, records);
   }
 
-  let marked = 0;
-  for (const record of records) {
-    if (!record || typeof record.path !== 'string' || !record.path) continue;
-    const diffable =
-      typeof record.before === 'string' && typeof record.after === 'string';
-    try {
-      // TWO GRADES, ONE QUEUE. A record carrying both sides gets a real diff and
-      // symbol-precise marking; one carrying only a path gets the hash
-      // comparison -- the same comparison the lazy path makes, and one that is
-      // only meaningful HERE, before `indexFile` refreshes the anchor.
-      const result = diffable
-        ? invalidateOnWrite(dir, graph, record.path, record.before, record.after)
-        : invalidateChangedAnchors(dir, graph, record.path);
-      marked += Array.isArray(result) ? result.length : 0;
-    } catch {
-      // One bad record must not stop the rest, and must not stop the tool call.
-    }
-  }
+  const marked = applyRecords(dir, graph, records);
 
   try {
     // THE CLAIM, NOT THE QUEUE. Deleting `queuePath` here is what dropped a

--- a/integrations/qwen/hooks/lib/pending.mjs
+++ b/integrations/qwen/hooks/lib/pending.mjs
@@ -34,6 +34,7 @@ import {
   appendFileSync,
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   renameSync,
   rmSync,
@@ -53,6 +54,126 @@ const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
  * claim private to the drainer that won the rename.
  */
 const claimPath = (dir) => join(dir, `pending-invalidation.claim.${process.pid}.jsonl`);
+
+/** Matches any drainer's claim file and captures the pid that owns it. */
+const CLAIM_NAME = /^pending-invalidation\.claim\.(\d+)\.jsonl$/;
+
+/**
+ * After this long, a claim is treated as stranded whatever its pid says.
+ *
+ * PID REUSE IS THE REASON. A drainer killed mid-claim leaves a file named after
+ * a pid the operating system is free to hand to something else, and once it
+ * does, a liveness check answers "alive" forever and the records inside are
+ * never recovered. An hour is several orders of magnitude longer than a drain,
+ * which takes milliseconds, so nothing legitimate is still holding one.
+ */
+const STRANDED_AFTER_MS = 60 * 60 * 1000;
+
+/**
+ * Claim files adopted in a single drain.
+ *
+ * A hook runs on the critical path of a tool call. If a directory has somehow
+ * accumulated hundreds of strays, recovering them all at once would turn one
+ * tool call into a long job -- and the rest are still there for the next drain,
+ * because adoption deletes only what it has read.
+ */
+const MAX_ADOPTED = 20;
+
+/** Is this pid a live process? */
+function isPidAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    // Signal 0 performs the permission and existence checks without delivering
+    // anything.
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // EPERM means the process exists and belongs to somebody else, which is
+    // still alive. Anything else -- ESRCH above all -- means it is gone.
+    return error?.code === 'EPERM';
+  }
+}
+
+/** Parses a queue or claim file into records, tolerating a torn last line. */
+function readRecords(path) {
+  return readFileSync(path, 'utf8')
+    .split('\n')
+    .filter((line) => line.trim())
+    .map((line) => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        // A torn append costs one record, not the queue.
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+/**
+ * Recovers claim files whose drainer died before it could read them.
+ *
+ * THE RESIDUAL THIS CLOSES. Claiming the queue by renaming it to a per-pid file
+ * fixed the original defect -- a concurrent append deleted unread -- but a
+ * drainer killed BETWEEN the rename and the read strands its claim, and the
+ * records inside are lost. The lazy staleness path cannot find them later
+ * either: `indexFile` refreshes an anchor's hash to the bytes just read, so for
+ * a file the session itself edited there is nothing left to compare against.
+ * Those invalidations were permanently missed, and the stray files accumulated
+ * with nothing reading them.
+ *
+ * SAFE BECAUSE RE-APPLICATION IS IDEMPOTENT. Marking a finding stale twice is
+ * marking it stale, so the cost of adopting a claim whose owner turns out to be
+ * alive is a repeated write, while the cost of not adopting is a permanently
+ * missed invalidation. The asymmetry is why the age fallback above is allowed
+ * to be wrong in the permissive direction.
+ *
+ * OUR OWN PID IS ALWAYS ADOPTED. A file under this process's own name can only
+ * be a previous drain in this process that died, and the old behaviour was to
+ * overwrite it with the next rename -- losing exactly the records this function
+ * exists to recover.
+ */
+function adoptStrandedClaims(dir) {
+  const records = [];
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return records;
+  }
+
+  let adopted = 0;
+  for (const entry of entries) {
+    if (adopted >= MAX_ADOPTED) break;
+    const match = CLAIM_NAME.exec(entry);
+    if (!match) continue;
+
+    const pid = Number(match[1]);
+    const path = join(dir, entry);
+    if (pid !== process.pid && isPidAlive(pid)) {
+      let age = 0;
+      try {
+        age = Date.now() - statSync(path).mtimeMs;
+      } catch {
+        continue;
+      }
+      if (age < STRANDED_AFTER_MS) continue;
+    }
+
+    try {
+      records.push(...readRecords(path));
+      adopted += 1;
+      // DELETED ONLY AFTER READING, which is the same rule the drain below
+      // follows: nothing is removed until its contents are in hand.
+      rmSync(path, { force: true });
+    } catch {
+      // Unreadable or held open. Left in place for the next drain rather than
+      // deleted, because a file nobody reads again is the lost record this
+      // whole mechanism exists to prevent.
+    }
+  }
+  return records;
+}
 
 /**
  * Largest before/after side kept in a queue record.
@@ -324,6 +445,37 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
 }
 
 /**
+ * Applies queued invalidations to the graph, returning how many were marked.
+ *
+ * EXTRACTED so the three exits from `drainInvalidations` share one path. Two of
+ * them now carry adopted records -- the empty-queue exit and the failed-rename
+ * exit -- and both previously returned 0. Returning early with records already
+ * read out of a file that has since been deleted would lose them for good,
+ * which is the exact defect adoption exists to close.
+ */
+function applyRecords(dir, graph, records) {
+  let marked = 0;
+  for (const record of records) {
+    if (!record || typeof record.path !== 'string' || !record.path) continue;
+    const diffable =
+      typeof record.before === 'string' && typeof record.after === 'string';
+    try {
+      // TWO GRADES, ONE QUEUE. A record carrying both sides gets a real diff and
+      // symbol-precise marking; one carrying only a path gets the hash
+      // comparison -- the same comparison the lazy path makes, and one that is
+      // only meaningful HERE, before `indexFile` refreshes the anchor.
+      const result = diffable
+        ? invalidateOnWrite(dir, graph, record.path, record.before, record.after)
+        : invalidateChangedAnchors(dir, graph, record.path);
+      marked += Array.isArray(result) ? result.length : 0;
+    } catch {
+      // One bad record must not stop the rest, and must not stop the tool call.
+    }
+  }
+  return marked;
+}
+
+/**
  * Applies every queued invalidation and clears the queue.
  *
  * Returns the number of findings marked, so the caller knows whether its
@@ -351,36 +503,39 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
  * for the rest of the session costs more than it can ever recover, and the claim
  * file is deleted whether the loop marked anything or threw.
  *
+ * AND A DRAINER KILLED BETWEEN THE RENAME AND THE READ STRANDS ITS CLAIM, which
+ * the rename alone does not solve. That was the residual left by the fix above:
+ * the records inside such a file are lost unread, the lazy path is structurally
+ * blind to them for the reason stated three paragraphs up, and the stray files
+ * accumulate with nothing reading them. `adoptStrandedClaims` recovers them at
+ * the head of every drain, before the queue is even checked -- because a
+ * stranded claim has nothing to do with whether there is new work now.
+ *
  * FAIL-OPEN THROUGHOUT. A rename that loses a race, or fails for any other
- * reason, returns 0 and leaves the queue for the next drain; it never throws
- * into a hook.
+ * reason, applies whatever was adopted, leaves the queue for the next drain,
+ * and never throws into a hook.
  */
 export function drainInvalidations(dir, graph) {
-  let records;
+  // ADOPTED FIRST, AND UNCONDITIONALLY. A claim left by a drainer that died
+  // between its rename and its read is recovered here -- including one under
+  // this process's own pid, which the rename below used to overwrite.
+  //
+  // BEFORE THE QUEUE IS EVEN CHECKED, because a stranded claim has nothing to
+  // do with whether a queue exists now. Recovering it only when there happened
+  // to be new work would leave it stranded for as long as the project stayed
+  // quiet, which is exactly the state a killed drain tends to leave behind.
+  let records = adoptStrandedClaims(dir);
+
   let claim;
   try {
     const file = queuePath(dir);
-    if (!existsSync(file)) return 0;
+    if (!existsSync(file)) return applyRecords(dir, graph, records);
     claim = claimPath(dir);
-    // A LEFTOVER CLAIM FROM A KILLED DRAIN IS OVERWRITTEN, not merged: rename
-    // onto an existing path replaces it. The pid in the name means the only way
-    // to hit that is this same pid having died mid-drain, whose records were
-    // already being applied when it went -- and re-applying is idempotent, so
-    // losing them is the cheaper of the two errors. Not doing the rename at all
-    // would strand the live queue forever.
+    // The rename can no longer clobber a leftover claim: adoption above has
+    // already read and removed any file under this pid's name, so the only
+    // thing this can replace is a file that no longer exists.
     renameSync(file, claim);
-    records = readFileSync(claim, 'utf8')
-      .split('\n')
-      .filter((line) => line.trim())
-      .map((line) => {
-        try {
-          return JSON.parse(line);
-        } catch {
-          // A torn append costs one record, not the queue.
-          return null;
-        }
-      })
-      .filter(Boolean);
+    records = records.concat(readRecords(claim));
   } catch {
     // The rename lost a race, or the claim could not be read. Nothing is deleted
     // unread and the hook proceeds. If the claim was taken and then could not be
@@ -394,27 +549,13 @@ export function drainInvalidations(dir, graph) {
     } catch {
       // Best effort only. A hook must not fail because bookkeeping did.
     }
-    return 0;
+    // Anything already ADOPTED is still applied. Those records came out of a
+    // file that has already been deleted, so returning here would lose them
+    // for good -- which is the defect this whole function is being fixed for.
+    return applyRecords(dir, graph, records);
   }
 
-  let marked = 0;
-  for (const record of records) {
-    if (!record || typeof record.path !== 'string' || !record.path) continue;
-    const diffable =
-      typeof record.before === 'string' && typeof record.after === 'string';
-    try {
-      // TWO GRADES, ONE QUEUE. A record carrying both sides gets a real diff and
-      // symbol-precise marking; one carrying only a path gets the hash
-      // comparison -- the same comparison the lazy path makes, and one that is
-      // only meaningful HERE, before `indexFile` refreshes the anchor.
-      const result = diffable
-        ? invalidateOnWrite(dir, graph, record.path, record.before, record.after)
-        : invalidateChangedAnchors(dir, graph, record.path);
-      marked += Array.isArray(result) ? result.length : 0;
-    } catch {
-      // One bad record must not stop the rest, and must not stop the tool call.
-    }
-  }
+  const marked = applyRecords(dir, graph, records);
 
   try {
     // THE CLAIM, NOT THE QUEUE. Deleting `queuePath` here is what dropped a

--- a/integrations/windsurf/hooks/lib/pending.mjs
+++ b/integrations/windsurf/hooks/lib/pending.mjs
@@ -34,6 +34,7 @@ import {
   appendFileSync,
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   renameSync,
   rmSync,
@@ -53,6 +54,126 @@ const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
  * claim private to the drainer that won the rename.
  */
 const claimPath = (dir) => join(dir, `pending-invalidation.claim.${process.pid}.jsonl`);
+
+/** Matches any drainer's claim file and captures the pid that owns it. */
+const CLAIM_NAME = /^pending-invalidation\.claim\.(\d+)\.jsonl$/;
+
+/**
+ * After this long, a claim is treated as stranded whatever its pid says.
+ *
+ * PID REUSE IS THE REASON. A drainer killed mid-claim leaves a file named after
+ * a pid the operating system is free to hand to something else, and once it
+ * does, a liveness check answers "alive" forever and the records inside are
+ * never recovered. An hour is several orders of magnitude longer than a drain,
+ * which takes milliseconds, so nothing legitimate is still holding one.
+ */
+const STRANDED_AFTER_MS = 60 * 60 * 1000;
+
+/**
+ * Claim files adopted in a single drain.
+ *
+ * A hook runs on the critical path of a tool call. If a directory has somehow
+ * accumulated hundreds of strays, recovering them all at once would turn one
+ * tool call into a long job -- and the rest are still there for the next drain,
+ * because adoption deletes only what it has read.
+ */
+const MAX_ADOPTED = 20;
+
+/** Is this pid a live process? */
+function isPidAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    // Signal 0 performs the permission and existence checks without delivering
+    // anything.
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // EPERM means the process exists and belongs to somebody else, which is
+    // still alive. Anything else -- ESRCH above all -- means it is gone.
+    return error?.code === 'EPERM';
+  }
+}
+
+/** Parses a queue or claim file into records, tolerating a torn last line. */
+function readRecords(path) {
+  return readFileSync(path, 'utf8')
+    .split('\n')
+    .filter((line) => line.trim())
+    .map((line) => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        // A torn append costs one record, not the queue.
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+/**
+ * Recovers claim files whose drainer died before it could read them.
+ *
+ * THE RESIDUAL THIS CLOSES. Claiming the queue by renaming it to a per-pid file
+ * fixed the original defect -- a concurrent append deleted unread -- but a
+ * drainer killed BETWEEN the rename and the read strands its claim, and the
+ * records inside are lost. The lazy staleness path cannot find them later
+ * either: `indexFile` refreshes an anchor's hash to the bytes just read, so for
+ * a file the session itself edited there is nothing left to compare against.
+ * Those invalidations were permanently missed, and the stray files accumulated
+ * with nothing reading them.
+ *
+ * SAFE BECAUSE RE-APPLICATION IS IDEMPOTENT. Marking a finding stale twice is
+ * marking it stale, so the cost of adopting a claim whose owner turns out to be
+ * alive is a repeated write, while the cost of not adopting is a permanently
+ * missed invalidation. The asymmetry is why the age fallback above is allowed
+ * to be wrong in the permissive direction.
+ *
+ * OUR OWN PID IS ALWAYS ADOPTED. A file under this process's own name can only
+ * be a previous drain in this process that died, and the old behaviour was to
+ * overwrite it with the next rename -- losing exactly the records this function
+ * exists to recover.
+ */
+function adoptStrandedClaims(dir) {
+  const records = [];
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return records;
+  }
+
+  let adopted = 0;
+  for (const entry of entries) {
+    if (adopted >= MAX_ADOPTED) break;
+    const match = CLAIM_NAME.exec(entry);
+    if (!match) continue;
+
+    const pid = Number(match[1]);
+    const path = join(dir, entry);
+    if (pid !== process.pid && isPidAlive(pid)) {
+      let age = 0;
+      try {
+        age = Date.now() - statSync(path).mtimeMs;
+      } catch {
+        continue;
+      }
+      if (age < STRANDED_AFTER_MS) continue;
+    }
+
+    try {
+      records.push(...readRecords(path));
+      adopted += 1;
+      // DELETED ONLY AFTER READING, which is the same rule the drain below
+      // follows: nothing is removed until its contents are in hand.
+      rmSync(path, { force: true });
+    } catch {
+      // Unreadable or held open. Left in place for the next drain rather than
+      // deleted, because a file nobody reads again is the lost record this
+      // whole mechanism exists to prevent.
+    }
+  }
+  return records;
+}
 
 /**
  * Largest before/after side kept in a queue record.
@@ -324,6 +445,37 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
 }
 
 /**
+ * Applies queued invalidations to the graph, returning how many were marked.
+ *
+ * EXTRACTED so the three exits from `drainInvalidations` share one path. Two of
+ * them now carry adopted records -- the empty-queue exit and the failed-rename
+ * exit -- and both previously returned 0. Returning early with records already
+ * read out of a file that has since been deleted would lose them for good,
+ * which is the exact defect adoption exists to close.
+ */
+function applyRecords(dir, graph, records) {
+  let marked = 0;
+  for (const record of records) {
+    if (!record || typeof record.path !== 'string' || !record.path) continue;
+    const diffable =
+      typeof record.before === 'string' && typeof record.after === 'string';
+    try {
+      // TWO GRADES, ONE QUEUE. A record carrying both sides gets a real diff and
+      // symbol-precise marking; one carrying only a path gets the hash
+      // comparison -- the same comparison the lazy path makes, and one that is
+      // only meaningful HERE, before `indexFile` refreshes the anchor.
+      const result = diffable
+        ? invalidateOnWrite(dir, graph, record.path, record.before, record.after)
+        : invalidateChangedAnchors(dir, graph, record.path);
+      marked += Array.isArray(result) ? result.length : 0;
+    } catch {
+      // One bad record must not stop the rest, and must not stop the tool call.
+    }
+  }
+  return marked;
+}
+
+/**
  * Applies every queued invalidation and clears the queue.
  *
  * Returns the number of findings marked, so the caller knows whether its
@@ -351,36 +503,39 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
  * for the rest of the session costs more than it can ever recover, and the claim
  * file is deleted whether the loop marked anything or threw.
  *
+ * AND A DRAINER KILLED BETWEEN THE RENAME AND THE READ STRANDS ITS CLAIM, which
+ * the rename alone does not solve. That was the residual left by the fix above:
+ * the records inside such a file are lost unread, the lazy path is structurally
+ * blind to them for the reason stated three paragraphs up, and the stray files
+ * accumulate with nothing reading them. `adoptStrandedClaims` recovers them at
+ * the head of every drain, before the queue is even checked -- because a
+ * stranded claim has nothing to do with whether there is new work now.
+ *
  * FAIL-OPEN THROUGHOUT. A rename that loses a race, or fails for any other
- * reason, returns 0 and leaves the queue for the next drain; it never throws
- * into a hook.
+ * reason, applies whatever was adopted, leaves the queue for the next drain,
+ * and never throws into a hook.
  */
 export function drainInvalidations(dir, graph) {
-  let records;
+  // ADOPTED FIRST, AND UNCONDITIONALLY. A claim left by a drainer that died
+  // between its rename and its read is recovered here -- including one under
+  // this process's own pid, which the rename below used to overwrite.
+  //
+  // BEFORE THE QUEUE IS EVEN CHECKED, because a stranded claim has nothing to
+  // do with whether a queue exists now. Recovering it only when there happened
+  // to be new work would leave it stranded for as long as the project stayed
+  // quiet, which is exactly the state a killed drain tends to leave behind.
+  let records = adoptStrandedClaims(dir);
+
   let claim;
   try {
     const file = queuePath(dir);
-    if (!existsSync(file)) return 0;
+    if (!existsSync(file)) return applyRecords(dir, graph, records);
     claim = claimPath(dir);
-    // A LEFTOVER CLAIM FROM A KILLED DRAIN IS OVERWRITTEN, not merged: rename
-    // onto an existing path replaces it. The pid in the name means the only way
-    // to hit that is this same pid having died mid-drain, whose records were
-    // already being applied when it went -- and re-applying is idempotent, so
-    // losing them is the cheaper of the two errors. Not doing the rename at all
-    // would strand the live queue forever.
+    // The rename can no longer clobber a leftover claim: adoption above has
+    // already read and removed any file under this pid's name, so the only
+    // thing this can replace is a file that no longer exists.
     renameSync(file, claim);
-    records = readFileSync(claim, 'utf8')
-      .split('\n')
-      .filter((line) => line.trim())
-      .map((line) => {
-        try {
-          return JSON.parse(line);
-        } catch {
-          // A torn append costs one record, not the queue.
-          return null;
-        }
-      })
-      .filter(Boolean);
+    records = records.concat(readRecords(claim));
   } catch {
     // The rename lost a race, or the claim could not be read. Nothing is deleted
     // unread and the hook proceeds. If the claim was taken and then could not be
@@ -394,27 +549,13 @@ export function drainInvalidations(dir, graph) {
     } catch {
       // Best effort only. A hook must not fail because bookkeeping did.
     }
-    return 0;
+    // Anything already ADOPTED is still applied. Those records came out of a
+    // file that has already been deleted, so returning here would lose them
+    // for good -- which is the defect this whole function is being fixed for.
+    return applyRecords(dir, graph, records);
   }
 
-  let marked = 0;
-  for (const record of records) {
-    if (!record || typeof record.path !== 'string' || !record.path) continue;
-    const diffable =
-      typeof record.before === 'string' && typeof record.after === 'string';
-    try {
-      // TWO GRADES, ONE QUEUE. A record carrying both sides gets a real diff and
-      // symbol-precise marking; one carrying only a path gets the hash
-      // comparison -- the same comparison the lazy path makes, and one that is
-      // only meaningful HERE, before `indexFile` refreshes the anchor.
-      const result = diffable
-        ? invalidateOnWrite(dir, graph, record.path, record.before, record.after)
-        : invalidateChangedAnchors(dir, graph, record.path);
-      marked += Array.isArray(result) ? result.length : 0;
-    } catch {
-      // One bad record must not stop the rest, and must not stop the tool call.
-    }
-  }
+  const marked = applyRecords(dir, graph, records);
 
   try {
     // THE CLAIM, NOT THE QUEUE. Deleting `queuePath` here is what dropped a

--- a/plugin/hooks/lib/pending.mjs
+++ b/plugin/hooks/lib/pending.mjs
@@ -34,6 +34,7 @@ import {
   appendFileSync,
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   renameSync,
   rmSync,
@@ -53,6 +54,126 @@ const queuePath = (dir) => join(dir, 'pending-invalidation.jsonl');
  * claim private to the drainer that won the rename.
  */
 const claimPath = (dir) => join(dir, `pending-invalidation.claim.${process.pid}.jsonl`);
+
+/** Matches any drainer's claim file and captures the pid that owns it. */
+const CLAIM_NAME = /^pending-invalidation\.claim\.(\d+)\.jsonl$/;
+
+/**
+ * After this long, a claim is treated as stranded whatever its pid says.
+ *
+ * PID REUSE IS THE REASON. A drainer killed mid-claim leaves a file named after
+ * a pid the operating system is free to hand to something else, and once it
+ * does, a liveness check answers "alive" forever and the records inside are
+ * never recovered. An hour is several orders of magnitude longer than a drain,
+ * which takes milliseconds, so nothing legitimate is still holding one.
+ */
+const STRANDED_AFTER_MS = 60 * 60 * 1000;
+
+/**
+ * Claim files adopted in a single drain.
+ *
+ * A hook runs on the critical path of a tool call. If a directory has somehow
+ * accumulated hundreds of strays, recovering them all at once would turn one
+ * tool call into a long job -- and the rest are still there for the next drain,
+ * because adoption deletes only what it has read.
+ */
+const MAX_ADOPTED = 20;
+
+/** Is this pid a live process? */
+function isPidAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    // Signal 0 performs the permission and existence checks without delivering
+    // anything.
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // EPERM means the process exists and belongs to somebody else, which is
+    // still alive. Anything else -- ESRCH above all -- means it is gone.
+    return error?.code === 'EPERM';
+  }
+}
+
+/** Parses a queue or claim file into records, tolerating a torn last line. */
+function readRecords(path) {
+  return readFileSync(path, 'utf8')
+    .split('\n')
+    .filter((line) => line.trim())
+    .map((line) => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        // A torn append costs one record, not the queue.
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+/**
+ * Recovers claim files whose drainer died before it could read them.
+ *
+ * THE RESIDUAL THIS CLOSES. Claiming the queue by renaming it to a per-pid file
+ * fixed the original defect -- a concurrent append deleted unread -- but a
+ * drainer killed BETWEEN the rename and the read strands its claim, and the
+ * records inside are lost. The lazy staleness path cannot find them later
+ * either: `indexFile` refreshes an anchor's hash to the bytes just read, so for
+ * a file the session itself edited there is nothing left to compare against.
+ * Those invalidations were permanently missed, and the stray files accumulated
+ * with nothing reading them.
+ *
+ * SAFE BECAUSE RE-APPLICATION IS IDEMPOTENT. Marking a finding stale twice is
+ * marking it stale, so the cost of adopting a claim whose owner turns out to be
+ * alive is a repeated write, while the cost of not adopting is a permanently
+ * missed invalidation. The asymmetry is why the age fallback above is allowed
+ * to be wrong in the permissive direction.
+ *
+ * OUR OWN PID IS ALWAYS ADOPTED. A file under this process's own name can only
+ * be a previous drain in this process that died, and the old behaviour was to
+ * overwrite it with the next rename -- losing exactly the records this function
+ * exists to recover.
+ */
+function adoptStrandedClaims(dir) {
+  const records = [];
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return records;
+  }
+
+  let adopted = 0;
+  for (const entry of entries) {
+    if (adopted >= MAX_ADOPTED) break;
+    const match = CLAIM_NAME.exec(entry);
+    if (!match) continue;
+
+    const pid = Number(match[1]);
+    const path = join(dir, entry);
+    if (pid !== process.pid && isPidAlive(pid)) {
+      let age = 0;
+      try {
+        age = Date.now() - statSync(path).mtimeMs;
+      } catch {
+        continue;
+      }
+      if (age < STRANDED_AFTER_MS) continue;
+    }
+
+    try {
+      records.push(...readRecords(path));
+      adopted += 1;
+      // DELETED ONLY AFTER READING, which is the same rule the drain below
+      // follows: nothing is removed until its contents are in hand.
+      rmSync(path, { force: true });
+    } catch {
+      // Unreadable or held open. Left in place for the next drain rather than
+      // deleted, because a file nobody reads again is the lost record this
+      // whole mechanism exists to prevent.
+    }
+  }
+  return records;
+}
 
 /**
  * Largest before/after side kept in a queue record.
@@ -324,6 +445,37 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
 }
 
 /**
+ * Applies queued invalidations to the graph, returning how many were marked.
+ *
+ * EXTRACTED so the three exits from `drainInvalidations` share one path. Two of
+ * them now carry adopted records -- the empty-queue exit and the failed-rename
+ * exit -- and both previously returned 0. Returning early with records already
+ * read out of a file that has since been deleted would lose them for good,
+ * which is the exact defect adoption exists to close.
+ */
+function applyRecords(dir, graph, records) {
+  let marked = 0;
+  for (const record of records) {
+    if (!record || typeof record.path !== 'string' || !record.path) continue;
+    const diffable =
+      typeof record.before === 'string' && typeof record.after === 'string';
+    try {
+      // TWO GRADES, ONE QUEUE. A record carrying both sides gets a real diff and
+      // symbol-precise marking; one carrying only a path gets the hash
+      // comparison -- the same comparison the lazy path makes, and one that is
+      // only meaningful HERE, before `indexFile` refreshes the anchor.
+      const result = diffable
+        ? invalidateOnWrite(dir, graph, record.path, record.before, record.after)
+        : invalidateChangedAnchors(dir, graph, record.path);
+      marked += Array.isArray(result) ? result.length : 0;
+    } catch {
+      // One bad record must not stop the rest, and must not stop the tool call.
+    }
+  }
+  return marked;
+}
+
+/**
  * Applies every queued invalidation and clears the queue.
  *
  * Returns the number of findings marked, so the caller knows whether its
@@ -351,36 +503,39 @@ export function queueInvalidation(dir, { path, before, after, at } = {}) {
  * for the rest of the session costs more than it can ever recover, and the claim
  * file is deleted whether the loop marked anything or threw.
  *
+ * AND A DRAINER KILLED BETWEEN THE RENAME AND THE READ STRANDS ITS CLAIM, which
+ * the rename alone does not solve. That was the residual left by the fix above:
+ * the records inside such a file are lost unread, the lazy path is structurally
+ * blind to them for the reason stated three paragraphs up, and the stray files
+ * accumulate with nothing reading them. `adoptStrandedClaims` recovers them at
+ * the head of every drain, before the queue is even checked -- because a
+ * stranded claim has nothing to do with whether there is new work now.
+ *
  * FAIL-OPEN THROUGHOUT. A rename that loses a race, or fails for any other
- * reason, returns 0 and leaves the queue for the next drain; it never throws
- * into a hook.
+ * reason, applies whatever was adopted, leaves the queue for the next drain,
+ * and never throws into a hook.
  */
 export function drainInvalidations(dir, graph) {
-  let records;
+  // ADOPTED FIRST, AND UNCONDITIONALLY. A claim left by a drainer that died
+  // between its rename and its read is recovered here -- including one under
+  // this process's own pid, which the rename below used to overwrite.
+  //
+  // BEFORE THE QUEUE IS EVEN CHECKED, because a stranded claim has nothing to
+  // do with whether a queue exists now. Recovering it only when there happened
+  // to be new work would leave it stranded for as long as the project stayed
+  // quiet, which is exactly the state a killed drain tends to leave behind.
+  let records = adoptStrandedClaims(dir);
+
   let claim;
   try {
     const file = queuePath(dir);
-    if (!existsSync(file)) return 0;
+    if (!existsSync(file)) return applyRecords(dir, graph, records);
     claim = claimPath(dir);
-    // A LEFTOVER CLAIM FROM A KILLED DRAIN IS OVERWRITTEN, not merged: rename
-    // onto an existing path replaces it. The pid in the name means the only way
-    // to hit that is this same pid having died mid-drain, whose records were
-    // already being applied when it went -- and re-applying is idempotent, so
-    // losing them is the cheaper of the two errors. Not doing the rename at all
-    // would strand the live queue forever.
+    // The rename can no longer clobber a leftover claim: adoption above has
+    // already read and removed any file under this pid's name, so the only
+    // thing this can replace is a file that no longer exists.
     renameSync(file, claim);
-    records = readFileSync(claim, 'utf8')
-      .split('\n')
-      .filter((line) => line.trim())
-      .map((line) => {
-        try {
-          return JSON.parse(line);
-        } catch {
-          // A torn append costs one record, not the queue.
-          return null;
-        }
-      })
-      .filter(Boolean);
+    records = records.concat(readRecords(claim));
   } catch {
     // The rename lost a race, or the claim could not be read. Nothing is deleted
     // unread and the hook proceeds. If the claim was taken and then could not be
@@ -394,27 +549,13 @@ export function drainInvalidations(dir, graph) {
     } catch {
       // Best effort only. A hook must not fail because bookkeeping did.
     }
-    return 0;
+    // Anything already ADOPTED is still applied. Those records came out of a
+    // file that has already been deleted, so returning here would lose them
+    // for good -- which is the defect this whole function is being fixed for.
+    return applyRecords(dir, graph, records);
   }
 
-  let marked = 0;
-  for (const record of records) {
-    if (!record || typeof record.path !== 'string' || !record.path) continue;
-    const diffable =
-      typeof record.before === 'string' && typeof record.after === 'string';
-    try {
-      // TWO GRADES, ONE QUEUE. A record carrying both sides gets a real diff and
-      // symbol-precise marking; one carrying only a path gets the hash
-      // comparison -- the same comparison the lazy path makes, and one that is
-      // only meaningful HERE, before `indexFile` refreshes the anchor.
-      const result = diffable
-        ? invalidateOnWrite(dir, graph, record.path, record.before, record.after)
-        : invalidateChangedAnchors(dir, graph, record.path);
-      marked += Array.isArray(result) ? result.length : 0;
-    } catch {
-      // One bad record must not stop the rest, and must not stop the tool call.
-    }
-  }
+  const marked = applyRecords(dir, graph, records);
 
   try {
     // THE CLAIM, NOT THE QUEUE. Deleting `queuePath` here is what dropped a

--- a/tests/hooks/stranded-claim-is-adopted.test.mjs
+++ b/tests/hooks/stranded-claim-is-adopted.test.mjs
@@ -1,0 +1,232 @@
+/**
+ * A drainer killed mid-claim does not take its records with it.
+ *
+ * `drainInvalidations` claims the pending-invalidation queue by renaming it to a
+ * per-pid file, then reads and deletes that file. The rename closed the original
+ * defect -- a concurrent append deleted unread -- and it left a residual, which
+ * is what this file is about: a drainer killed BETWEEN the rename and the read
+ * strands its claim, and the records inside are lost.
+ *
+ * WHY LOST MEANS LOST. The lazy staleness path cannot pick them up afterwards.
+ * `indexFile` re-points an anchor's stored hash at the bytes the session just
+ * wrote, so for a file the session itself edited there is nothing left to
+ * compare against -- lazy is structurally blind to the session's own writes
+ * rather than merely late. A stranded claim is a permanently missed
+ * invalidation, and the stray files accumulate with nothing reading them.
+ *
+ * The recovery is safe because re-application is idempotent: marking a finding
+ * stale twice is marking it stale. So the cost of adopting a claim whose owner
+ * turns out to be alive is a repeated write, and the cost of not adopting is a
+ * finding served as current when it is not.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { load, nodeId, putNodeWithEdges } from '../../hooks-core/wiki.mjs';
+import { indexFile } from '../../hooks-core/staleness.mjs';
+import { drainInvalidations } from '../../hooks-core/pending.mjs';
+
+const NL = String.fromCharCode(10);
+const BEFORE = 'export function parse(x) {' + NL + '  return x.trim();' + NL + '}' + NL;
+const AFTER = 'export function parse(x) {' + NL + '  return JSON.parse(x);' + NL + '}' + NL;
+const CLAIM_TEXT = 'parse() trims rather than parsing';
+
+let project;
+let wiki;
+let file;
+
+beforeEach(() => {
+  project = mkdtempSync(join(tmpdir(), 'stranded-proj-'));
+  mkdirSync(join(project, '.git'), { recursive: true });
+  wiki = mkdtempSync(join(tmpdir(), 'stranded-wiki-'));
+
+  file = join(project, 'parser.ts');
+  writeFileSync(file, BEFORE);
+  indexFile(wiki, file, BEFORE);
+  putNodeWithEdges(
+    wiki,
+    {
+      kind: 'finding',
+      key: 'parse-trims',
+      claim: CLAIM_TEXT,
+      type: 'finding',
+      confidence: 0.95,
+      origin: 'human',
+    },
+    [{ edge: 'derived_from', to: nodeId('file', file) }]
+  );
+});
+
+afterEach(() => {
+  rmSync(project, { recursive: true, force: true });
+  rmSync(wiki, { recursive: true, force: true });
+});
+
+const finding = () => load(wiki).nodes.get(nodeId('finding', 'parse-trims'));
+const claimFiles = () =>
+  readdirSync(wiki).filter((f) => f.startsWith('pending-invalidation.claim.'));
+
+/**
+ * Writes a claim file exactly as a drainer killed after its rename would leave
+ * one: the queue's bytes, under a pid-suffixed name, never read.
+ */
+function strandClaim(pid, records) {
+  const path = join(wiki, `pending-invalidation.claim.${pid}.jsonl`);
+  writeFileSync(path, records.map((r) => JSON.stringify(r)).join(NL) + NL);
+  return path;
+}
+
+/**
+ * A pid that is certainly not running.
+ *
+ * Spawning and reaping a real process would be exact but slow and racy on a
+ * shared runner. A very high pid is not allocated on any platform this ships
+ * to, and the guard under test only ever asks "is this alive".
+ */
+const DEAD_PID = 999_999;
+
+describe('a claim stranded by a dead drainer', () => {
+  test('is adopted and applied, so the invalidation is not missed', () => {
+    // The edit has landed and the anchor has been re-indexed, which is the
+    // state that makes lazy staleness blind: the stored hash already agrees
+    // with disk.
+    writeFileSync(file, AFTER);
+    const stranded = strandClaim(DEAD_PID, [
+      { path: file, before: BEFORE, after: AFTER },
+    ]);
+    indexFile(wiki, file, AFTER);
+
+    expect(finding().stale).toBeFalsy();
+
+    const marked = drainInvalidations(wiki, load(wiki));
+
+    expect(marked).toBeGreaterThan(0);
+    expect(finding().stale).toBe(true);
+    // And with evidence, which is the invariant staleness.mjs opens with.
+    expect(finding().diff).toContain('JSON.parse');
+    // Read, then removed -- not left to accumulate.
+    expect(existsSync(stranded)).toBe(false);
+  });
+
+  test('is adopted even when there is no queue at all', () => {
+    // THE CASE THAT MADE THE RESIDUAL PERMANENT. The drain used to return
+    // early when no queue existed, so a stranded claim stayed stranded for as
+    // long as the project was quiet -- which is exactly the state a killed
+    // drain leaves behind.
+    writeFileSync(file, AFTER);
+    strandClaim(DEAD_PID, [{ path: file, before: BEFORE, after: AFTER }]);
+    indexFile(wiki, file, AFTER);
+
+    expect(existsSync(join(wiki, 'pending-invalidation.jsonl'))).toBe(false);
+
+    expect(drainInvalidations(wiki, load(wiki))).toBeGreaterThan(0);
+    expect(finding().stale).toBe(true);
+    expect(claimFiles()).toEqual([]);
+  });
+
+  test('a claim under this process own pid is adopted, not overwritten', () => {
+    // The old behaviour renamed the queue straight onto this path, replacing a
+    // leftover from a previous drain in the same process and losing whatever
+    // was inside it.
+    writeFileSync(file, AFTER);
+    strandClaim(process.pid, [{ path: file, before: BEFORE, after: AFTER }]);
+    indexFile(wiki, file, AFTER);
+
+    expect(drainInvalidations(wiki, load(wiki))).toBeGreaterThan(0);
+    expect(finding().stale).toBe(true);
+  });
+
+  test('a hash-only record is adopted too, not just a diffable one', () => {
+    // The queue carries two grades. A record with only a path gets the hash
+    // comparison, which is the grade that is meaningful only before indexFile
+    // refreshes the anchor -- so it is the one with the most to lose.
+    writeFileSync(file, AFTER);
+    strandClaim(DEAD_PID, [{ path: file }]);
+
+    expect(drainInvalidations(wiki, load(wiki))).toBeGreaterThan(0);
+    expect(finding().stale).toBe(true);
+  });
+});
+
+describe('a claim held by a live drainer', () => {
+  test('is left alone, because its owner is still going to read it', () => {
+    // process.pid is this test, which is alive by construction -- but the
+    // same-pid rule adopts our own, so a live FOREIGN pid is what this needs.
+    // process.ppid is the runner that spawned us: alive, and not us.
+    writeFileSync(file, AFTER);
+    const held = strandClaim(process.ppid, [
+      { path: file, before: BEFORE, after: AFTER },
+    ]);
+
+    drainInvalidations(wiki, load(wiki));
+
+    expect(existsSync(held)).toBe(true);
+    expect(finding().stale).toBeFalsy();
+  });
+
+  test('is adopted anyway once it is old enough, because pids get reused', () => {
+    // THE HOLE A LIVENESS CHECK ALONE LEAVES. A killed drainer's pid is free to
+    // be handed to something unrelated, and from that moment the check answers
+    // "alive" forever and the records are never recovered. An age fallback
+    // closes it, and is safe to be wrong about because re-application is
+    // idempotent.
+    writeFileSync(file, AFTER);
+    const held = strandClaim(process.ppid, [
+      { path: file, before: BEFORE, after: AFTER },
+    ]);
+    const longAgo = new Date(Date.now() - 3 * 60 * 60 * 1000);
+    utimesSync(held, longAgo, longAgo);
+    indexFile(wiki, file, AFTER);
+
+    expect(drainInvalidations(wiki, load(wiki))).toBeGreaterThan(0);
+    expect(finding().stale).toBe(true);
+    expect(existsSync(held)).toBe(false);
+  });
+});
+
+describe('adoption does not break the ordinary paths', () => {
+  test('an unrelated file in the graph directory is never touched', () => {
+    // The scan matches on a name shape. A graph directory holds graph.jsonl,
+    // metrics.jsonl and the rest, and deleting one of those would be a far
+    // worse bug than the one being fixed.
+    const bystanders = ['graph.jsonl', 'metrics.jsonl', 'pending-invalidation.claim.jsonl'];
+    for (const name of bystanders) writeFileSync(join(wiki, name), 'keep me' + NL);
+
+    drainInvalidations(wiki, load(wiki));
+
+    for (const name of bystanders) expect(existsSync(join(wiki, name))).toBe(true);
+  });
+
+  test('an empty graph directory drains to zero without throwing', () => {
+    const empty = mkdtempSync(join(tmpdir(), 'stranded-empty-'));
+    try {
+      expect(drainInvalidations(empty, load(empty))).toBe(0);
+    } finally {
+      rmSync(empty, { recursive: true, force: true });
+    }
+  });
+
+  test('a torn line in a stranded claim costs one record, not the file', () => {
+    writeFileSync(file, AFTER);
+    const path = join(wiki, `pending-invalidation.claim.${DEAD_PID}.jsonl`);
+    writeFileSync(
+      path,
+      '{"path":"' + 'not-json' + NL +
+        JSON.stringify({ path: file, before: BEFORE, after: AFTER }) + NL
+    );
+    indexFile(wiki, file, AFTER);
+
+    expect(drainInvalidations(wiki, load(wiki))).toBeGreaterThan(0);
+    expect(finding().stale).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #317.

`drainInvalidations` claims the pending-invalidation queue by renaming it to a per-pid file, then reads and deletes that file. The rename closed the original defect — a concurrent append deleted unread — and left a residual: **a drainer killed between the rename and the read strands its claim**, and the records inside are lost.

## Why lost means lost

The lazy staleness path cannot pick them up afterwards. `indexFile` re-points an anchor's stored hash at the bytes the session just wrote, so for a file the session itself edited there is nothing left to compare against — lazy is **structurally blind** to the session's own writes rather than merely late. A stranded claim is a permanently missed invalidation, and the stray `pending-invalidation.claim.*.jsonl` files accumulate with nothing reading them.

## The fix

`adoptStrandedClaims` runs at the head of every drain and recovers any claim whose owning pid is gone. Safe because **re-application is idempotent** — marking a finding stale twice is marking it stale — so adopting a claim whose owner turns out to be alive costs a repeated write, while not adopting costs a finding served as current when it is not. That asymmetry is what licenses the two judgement calls below.

**Before the queue is checked, and that ordering *is* the fix.** The drain returned early when no queue existed, so a stranded claim stayed stranded for as long as the project was quiet — which is exactly the state a killed drain leaves behind. Both early exits now apply whatever was adopted, because those records came out of a file that has already been deleted; returning would lose them for good.

**A pid liveness check alone is not enough.** A dead drainer's pid is free to be handed to something unrelated, and from that moment the check answers "alive" forever and the records are never recovered. An age fallback closes it at one hour — several orders of magnitude longer than a drain, which takes milliseconds.

**A claim under this process's own pid is always adopted.** The old behaviour renamed the queue straight onto that path, replacing a leftover from an earlier drain in the same process and losing what was inside it. The docblock described those records as *"already being applied when it went"*, which overstated the recovery — corrected, as the issue asked.

**Bounded to twenty files per drain**, because a hook runs on the critical path of a tool call and the rest are still there for the next one.

## Verification

Every claim mutation-tested — break the thing, confirm the test goes red:

| Mutation | Result |
|---|---|
| Adoption removed entirely | **6 of 9 fail** |
| Liveness check inverted (adopt everything) | live-drainer case **fails** |
| Age fallback removed | pid-reuse case **fails** |

Also covered: a hash-only record (the grade with the most to lose, since it is only meaningful before `indexFile` refreshes the anchor), a torn line costing one record rather than the file, an unrelated file in the graph directory left untouched — deleting `graph.jsonl` would be a far worse bug than the one being fixed — and an empty directory draining to zero without throwing.

The existing `pending-invalidation` suite is unchanged and still passes, including the two assertions that pin the original rename fix.

221 suites, 2708 tests, 5 skipped, 0 failed. `tsc --noEmit` clean, `npm run lint` 0 errors, `format:check` clean, `sync:hooks:check` in sync across eleven vendored directories, `validate` passes. Quality Gates steps run locally: `verify:clients`, `verify:certification`, `verify:harvest`, `verify:live-graph`, `verify:ui` 55/55, `verify:interactions` 64/64.

Two source files plus the generated vendored copies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSFxBpREeR7mMkJXYb6wuX
