### PR TITLE
fix(harvest): run the semantic harvest on the shared stop path

### DIFF
--- a/hooks-core/adapter.mjs
+++ b/hooks-core/adapter.mjs
@@ -86,6 +86,7 @@ import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 import { evaluateUcrGuards } from './ucr-guard.mjs';
 import { beginHookInvocation, noteHookOutput } from './observability.mjs';
 import { registerProject } from './projects.mjs';
+import { runStopHarvest } from './stop-harvest.mjs';
 
 /**
  * Per-client capability.
@@ -790,10 +791,33 @@ async function runHook(clientName, event, invocation) {
       state.harvestedEdits = Number(state.edits || 0);
       saveState(sessionId, state, agentScope);
     }
+    // THE OUT-OF-BAND HARVEST, which no client was running.
+    //
+    // The in-band `prompt` above asks the MODEL to call `wiki_write`, and the
+    // session pays for summarising itself -- the exact cost the design says the
+    // harvest exists to avoid ("out-of-band, so the session doing the work never
+    // pays for the harvest"). The out-of-band half lived in a Claude Code hook
+    // that #300 unregistered, and nothing replaced it, so on every client the
+    // transcript was never archived, the worker never spawned, refusals were
+    // never detected, and the notice explaining why no findings exist was never
+    // shown. Awaited because it must finish before the exit below; it spawns a
+    // DETACHED worker and returns immediately, so Stop is not delayed by a model
+    // call.
+    let harvestNotice = null;
+    try {
+      harvestNotice = await runStopHarvest(raw);
+    } catch {
+      // The harvest is a side effect of ending a session. It must never stop
+      // one from ending.
+    }
+
     if (prompt && client.stopStyle === 'followup') {
-      emit({ followup_message: prompt });
+      emit({ followup_message: prompt, ...(harvestNotice ? { systemMessage: harvestNotice } : {}) });
     } else {
-      emit(prompt ? { decision: client.stopDecision, reason: prompt } : {});
+      emit({
+        ...(prompt ? { decision: client.stopDecision, reason: prompt } : {}),
+        ...(harvestNotice ? { systemMessage: harvestNotice } : {}),
+      });
     }
     process.exit(0);
   }

--- a/hooks-core/adapter.mjs
+++ b/hooks-core/adapter.mjs
@@ -760,8 +760,11 @@ async function runHook(clientName, event, invocation) {
     const toolEvidence = optimizerToolsForHook(raw, state);
     rememberOptimizerTools(state, toolEvidence);
     const episode = episodeMeta({ client: clientName, raw });
+    // Hoisted out of the try below, because the harvest needs the same resolved
+    // directory and resolving it twice is how two halves of one hook end up
+    // reasoning about different projects.
+    const cwd = raw.cwd || raw.working_directory || process.cwd();
     try {
-      const cwd = raw.cwd || raw.working_directory || process.cwd();
       const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
       recordEpisodeOutcome(dir, {
         ...episode,
@@ -805,7 +808,21 @@ async function runHook(clientName, event, invocation) {
     // call.
     let harvestNotice = null;
     try {
-      harvestNotice = await runStopHarvest(raw);
+      // NORMALIZED, NOT RAW. The identifiers were resolved a few lines up
+      // through every alias a host might use -- `sessionId`,
+      // `conversation_id`, `working_directory` -- and handing `raw` straight
+      // over threw that away: runStopHarvest reads `session_id` and `cwd`
+      // only, so on a client that sends an alias the session id came back
+      // undefined and the archive root fell back to `process.cwd()`. That
+      // shares the once-per-session notice and the debounce marker across
+      // every session, and files the transcript under whatever directory the
+      // hook happened to start in.
+      harvestNotice = await runStopHarvest({
+        ...raw,
+        session_id: sessionId,
+        cwd,
+        transcript_path: raw.transcript_path ?? raw.transcriptPath ?? null,
+      });
     } catch {
       // The harvest is a side effect of ending a session. It must never stop
       // one from ending.

--- a/hooks-core/harvest-worker.mjs
+++ b/hooks-core/harvest-worker.mjs
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+/**
+ * The out-of-band half of the semantic harvest.
+ *
+ * Spawned detached by the Stop adapter so the session that did the work never
+ * pays for the model call that summarises it. Everything here is best-effort:
+ * a harvest that fails must be indistinguishable from a session with nothing
+ * to learn, because the alternative -- a hook that can break a turn -- is worse
+ * than no findings at all.
+ *
+ * The cost of the extraction is recorded either way. Without it the metrics
+ * report a benefit with no matching expense, and `netTokens` would flatter the
+ * feature by exactly the amount it spends.
+ */
+
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  harvestEnabled,
+  buildDigest,
+  buildFullDelta,
+  extract,
+  validate,
+  estimateTokens,
+} from './harvest.mjs';
+import { writeHarvested } from './harvest-write.mjs';
+import { record } from './metrics.mjs';
+import { wikiDir, projectRootFor, load } from './wiki.mjs';
+import { readArchive } from './transcript.mjs';
+import { buildFeedbackDigest, validateLessons, LESSON_PROMPT } from './lessons.mjs';
+import { ORIGIN_HARVESTED } from './curate.mjs';
+import { selectForConsolidation } from './consolidate.mjs';
+
+/**
+ * The token budget one session's harvest may add to the graph.
+ *
+ * #204 lists graph bloat as a named risk -- "the session-start index grows with
+ * the graph; ranking and eviction are required, not optional" -- and until now
+ * nothing bounded what a single harvest could store. 4,000 tokens is the
+ * selector's own default and roughly twenty-five findings at the size the
+ * extractor produces, which is far above any observed session's real yield; it
+ * is a ceiling against a pathological extraction, not a routine constraint.
+ */
+const CONSOLIDATION_BUDGET = 4000;
+
+/**
+ * The files the digest says were touched.
+ *
+ * `buildDigest` emits them under a `## Files touched` heading and returns a
+ * string, so this reads back the list it just wrote rather than walking the
+ * transcript a second time. Returns null when the section is absent, which
+ * `validate` treats as "no restriction" rather than "no files".
+ */
+function filesIn(digest) {
+  const start = digest.indexOf('## Files touched');
+  if (start === -1) return null;
+
+  const rest = digest.slice(start + '## Files touched'.length);
+  const end = rest.indexOf('\n##');
+  const block = (end === -1 ? rest : rest.slice(0, end)).split('\n');
+
+  const files = new Set();
+  for (const line of block) {
+    const value = line.trim();
+    if (value) files.add(value);
+  }
+  return files.size ? files : null;
+}
+
+async function main() {
+  const [transcript, sessionId, cwd] = process.argv.slice(2);
+  if (!transcript || !existsSync(transcript) || !harvestEnabled()) return;
+
+  // THE GRAPH AND THE CONTAINMENT BOUNDARY BOTH COME FROM THE REPOSITORY ROOT,
+  // NOT THE SESSION'S CWD. `wikiDir` only joins the path it is handed, so a
+  // session started in a subdirectory selected `<subdir>/.token-optimizer/wiki`
+  // -- a second graph, invisible to every other hook, which all resolve the root
+  // first. It also made the subdirectory the containment root for the write, so
+  // a finding anchored anywhere else in the same repository was refused for
+  // sitting "outside" the project.
+  //
+  // `__session__` is a synthetic leaf so the walk starts at `cwd` itself rather
+  // than its parent; `projectRootFor` takes a FILE path. This is the same idiom
+  // the adapter, the session-start hook and the Stop adapter already use.
+  //
+  // A cwd with no VCS ancestor resolves to the machine-level unrooted bucket,
+  // which `resolveAnchor` expects and handles: it swaps in home as the
+  // containment root for that case, so passing the resolved root here is what
+  // lets unrooted anchors work at all.
+  const sessionCwd = cwd || process.cwd();
+  const projectRoot = projectRootFor(join(sessionCwd, '__session__'), sessionCwd);
+  const dir = wikiDir(projectRoot);
+
+  // Default sends a structured digest with no file contents. The full delta is
+  // opt-in because the default has to be defensible without reading the docs.
+  const full = process.env.TOKEN_OPTIMIZER_HARVEST_FULL === 'true';
+  const digest = full ? buildFullDelta(transcript) : buildDigest(transcript);
+  if (!digest) return;
+
+  const raw = await extract(digest);
+
+  // Anchors are held to the files this session actually touched, so a model
+  // that invents a plausible path cannot anchor a finding to it. The digest
+  // lists them under a heading it writes itself; the full delta is raw
+  // transcript and carries no such list, so it gets no restriction.
+  const validated = validate(raw, { knownFiles: full ? null : filesIn(digest) });
+
+  // BUDGETED SELECTION, not everything the model extracted.
+  //
+  // `selectForConsolidation` exists for exactly this and had no caller
+  // anywhere, so every harvested candidate was stored regardless of what it
+  // cost to derive, how hard it is to reproduce, or whether the graph can ever
+  // retrieve it -- which is the graph-bloat risk #204 lists as needing
+  // "ranking and eviction ... not optional". It keeps failures and decisions on
+  // a floor before ranking, encoding the design's judgement that dead ends are
+  // the highest-value kind: they exist nowhere in the source tree, so nothing
+  // else can ever recover them.
+  //
+  // The selection is RECORDED, not silent. A cap that drops work without
+  // saying so reads as "there was nothing more to find", which is the same
+  // dishonesty as a truncated report with no remainder line.
+  const graph = load(dir);
+  const selection = selectForConsolidation(graph, validated, { budget: CONSOLIDATION_BUDGET });
+  const findings = selection.kept;
+  if (selection.dropped > 0) {
+    record(dir, {
+      kind: 'harvest',
+      action: 'consolidation',
+      candidates: validated.length,
+      kept: findings.length,
+      dropped: selection.dropped,
+      tokens: selection.tokens,
+      budget: CONSOLIDATION_BUDGET,
+    });
+  }
+
+  const written = writeHarvested(dir, findings, {
+    sessionId: sessionId || null,
+    projectRoot,
+    // Task nodes are keyed by session id (structural capture creates one on
+    // the first touched file, `harvest()` in lib/wiki.mjs) so this is the
+    // shape `writeHarvested` needs to point the `answers` edge back at the
+    // task this harvest belongs to. A session that never touched a file
+    // through PreToolUse/PostToolUse has no such node yet; `writeHarvested`
+    // resolves that case to no edge rather than a dangling one.
+    taskId: sessionId || null,
+    // AUTHORITATIVE, not just present: this `sessionId` came from Claude
+    // Code's own Stop-hook payload (see stop-harvest.mjs), not a model-typed
+    // tool argument, so it is safe to use for the traversal fallback if the
+    // explicit `taskId` above does not resolve.
+    authoritativeSessionId: sessionId || null,
+  });
+
+  record(dir, {
+    kind: 'harvest',
+    sessionId: sessionId || null,
+    tokens: estimateTokens(digest),
+    findings: written.length,
+    at: Date.now(),
+  });
+
+  // THE FEEDBACK LOOP. A separate extraction with a separate prompt, because
+  // the two are looking for different things: the harvest above wants what was
+  // LEARNED about the code, this wants where the user said the agent was WRONG.
+  // Asked for both at once a model returns a summary and the corrections get
+  // lost in it -- and corrections are the only turns carrying information the
+  // code itself could never supply.
+  try {
+    const turns = readArchive(dir, sessionId || 'unknown');
+    const feedback = buildFeedbackDigest(turns);
+    if (feedback) {
+      const rawLessons = await extract(feedback, { prompt: LESSON_PROMPT });
+      // The same restriction the finding path above applies, for the same reason: a model that
+      // invents a plausible path must not be able to anchor a lesson to it. `turns` is the
+      // archived transcript for this session, so its rendered digest is the honest file list.
+      const { lessons } = validateLessons(rawLessons, turns, {
+        knownFiles: filesIn(feedback),
+      });
+
+      // Anchors are optional on a lesson -- "always run npm test" is about no
+      // file -- so each is anchored to the project root when it names nothing,
+      // which keeps the store's rule that an unanchored finding is refused.
+      //
+      // The RESOLVED root, matching the containment root this write is checked
+      // against. The session's cwd would be refused outright once that root is
+      // the unrooted bucket, because `resolveAnchor` then narrows containment to
+      // home and a VCS-less working directory need not sit under it.
+      const anchored = lessons.map((l) => ({
+        ...l,
+        anchors: l.anchors.length ? l.anchors : [projectRoot],
+      }));
+
+      // The write itself is the durable record: writeHarvested anchors each
+      // lesson into the graph, which is what lessons.mjs's real consumers
+      // query. A metrics event of kind 'lessons' used to sit here as well,
+      // but nothing ever read it -- not netTokens (only 'harvest' feeds
+      // harvestTokens), not report()/buildReport() (no kind filter matches
+      // 'lessons'), and no audit render exists to show it to a human. That is
+      // the inverse of the `query` defect and the same shape as
+      // `tokensFullFile` before it: a produced-and-never-consumed event,
+      // which is a cost with no benefit. Deleted rather than wired, per the
+      // reachability allowlist's own rule -- write it again the day
+      // something needs to read it.
+      writeHarvested(dir, anchored, {
+        sessionId: sessionId || null,
+        origin: ORIGIN_HARVESTED,
+        projectRoot,
+        taskId: sessionId || null,
+        // Same hook-payload identity as above, same reason.
+        authoritativeSessionId: sessionId || null,
+      });
+    }
+  } catch {
+    // A failed feedback pass must be indistinguishable from a session with
+    // nothing to correct.
+  }
+}
+
+main()
+  .catch(() => {})
+  .finally(() => {
+    // NEVER process.exit() SYNCHRONOUSLY HERE.
+    //
+    // It crashed this worker on Windows every single time the feedback pass
+    // ran -- libuv asserts `!(handle->flags & UV_HANDLE_CLOSING)` when the
+    // process exits while the sockets from the model call are still closing,
+    // giving exit code 0xC0000409. Reproduced 5 runs out of 5, and silently,
+    // because this worker is spawned detached and nothing reads its status.
+    // Deferring by one tick is NOT enough; the handles are still closing then.
+    //
+    // So the normal path just lets the loop drain, which it does promptly.
+    //
+    // THE RECORDED CODE IS PRESERVED, not overwritten with 0. Assigning 0
+    // unconditionally would turn a harvest that had already recorded a failure
+    // into one that reports success -- and this worker is detached, so that
+    // status is the only signal a supervisor could ever act on.
+    const code = process.exitCode ?? 0;
+    process.exitCode = code;
+
+    // The watchdog keeps the original guarantee: a detached worker must never
+    // linger holding a keep-alive socket open. It is UNREF'D, so it cannot
+    // itself keep the process alive -- it only fires if something else already
+    // has, which is exactly the case worth killing.
+    const watchdog = setTimeout(() => process.exit(code), 5000);
+    watchdog.unref();
+  });

--- a/hooks-core/stop-harvest.mjs
+++ b/hooks-core/stop-harvest.mjs
@@ -351,6 +351,11 @@ export async function runStopHarvest(payload = {}) {
       env: { ...process.env },
     }
   );
+  // AN 'error' EVENT WITH NO LISTENER IS A THROW. `spawn` reports a failed
+  // start asynchronously, so an unlistened error does not return a code -- Node
+  // raises it, and here that would abort the Stop response itself. A harvest
+  // that cannot start must degrade to no harvest, never to a broken Stop.
+  child.on('error', () => {});
   child.unref();
   return null;
 }

--- a/hooks-core/stop-harvest.mjs
+++ b/hooks-core/stop-harvest.mjs
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /**
  * Claude Code Stop adapter -- run the semantic harvest the design specifies.
  *
@@ -38,11 +37,11 @@ import {
 import { dirname, join } from 'node:path';
 import { tmpdir, homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
-import { mode, MODE_OFF } from './lib/policy.mjs';
-import { harvestEnabled, harvestMode } from './lib/harvest.mjs';
-import { archive } from './lib/transcript.mjs';
-import { wikiDir, projectRootFor, sharedDir, load } from './lib/wiki.mjs';
-import { detectRefusals, recordRefusal } from './lib/harvest-write.mjs';
+import { mode, MODE_OFF } from './policy.mjs';
+import { harvestEnabled, harvestMode } from './harvest.mjs';
+import { archive } from './transcript.mjs';
+import { wikiDir, projectRootFor, sharedDir, load } from './wiki.mjs';
+import { detectRefusals, recordRefusal } from './harvest-write.mjs';
 
 /** What to tell the user, per reason the harvest is not running. */
 const OFF_REASON = {
@@ -229,22 +228,35 @@ function dueForHarvest(sessionId) {
   return true;
 }
 
-async function main() {
-  if (mode() === MODE_OFF) return;
+/**
+ * The Stop-time harvest, for every client rather than one.
+ *
+ * WHY THIS IS A FUNCTION AND NOT A HOOK. It was a hook -- a Claude Code entry
+ * point named `stop-harvest.mjs` -- and #300 unregistered it. Nothing replaced
+ * it, so four capabilities went silently: the transcript archive, the harvest
+ * worker spawn, refusal detection, and the notice that says why no findings
+ * exist. Every client routes Stop through the shared adapter, and the adapter
+ * did none of these, so on a full session with a valid credential
+ * `harvestMode()` reported `remote` and nothing happened.
+ *
+ * NOTHING OBSERVED THAT IT DID NOT RUN, which is why it survived a year. There
+ * is no `kind:'harvest'` event to be absent from a report, no error, and a
+ * harvest that ran and found nothing looks exactly like one that never
+ * started. The reachability guard could not see it either: this file's own
+ * imports gave `archive`, `detectRefusals` and `recordRefusal` call sites, and
+ * a name-based scan proves a reference exists, never that it runs.
+ *
+ * Returns a notice for the caller to emit, or null. It does NOT write to
+ * stdout: the adapter emits exactly one JSON object per hook invocation, and a
+ * second writer racing it is how a Stop payload gets corrupted.
+ *
+ * @returns {Promise<string|null>} a once-per-session message, or null.
+ */
+export async function runStopHarvest(payload = {}) {
+  if (mode() === MODE_OFF) return null;
 
-  const chunks = [];
-  process.stdin.setEncoding('utf8');
-  for await (const chunk of process.stdin) chunks.push(chunk);
-
-  let payload;
-  try {
-    payload = JSON.parse(chunks.join(''));
-  } catch {
-    return;
-  }
-
-  const transcript = payload.transcript_path;
-  if (!transcript || !existsSync(transcript)) return;
+  const transcript = payload.transcript_path ?? payload.transcriptPath ?? null;
+  if (!transcript || !existsSync(transcript)) return null;
 
   // ARCHIVE FIRST, AND UNCONDITIONALLY. This is a local file copy: it costs no
   // model call, spends no money, and sends nothing anywhere, so it must not sit
@@ -298,32 +310,29 @@ async function main() {
     // what still works. A user who reads this should know exactly what they are
     // and are not getting, and what to do about it.
     const message = OFF_REASON[harvestMode()];
-    if (message && !alreadyNotified(payload.session_id)) {
-      // AWAIT THE WRITE. The finally below used to call process.exit(0), which
-      // discards anything still buffered -- so on a pipe that had filled, the
-      // one notice explaining why no findings exist was the thing most likely
-      // to be dropped. Resolve on the callback, or on drain when the write is
-      // buffered, before returning.
-      await new Promise((resolve) => {
-        const flushed = process.stdout.write(
-          JSON.stringify({ systemMessage: message }),
-          () => resolve()
-        );
-        if (!flushed) process.stdout.once('drain', resolve);
-      });
-    }
-    return;
+    // RETURNED, NOT WRITTEN. This used to write its own JSON to stdout and
+    // race whatever the hook emitted; the adapter now folds this into the one
+    // object it sends, so the notice cannot be dropped by a full pipe or
+    // truncated by an exit -- which is what used to happen to the single line
+    // explaining why no findings exist.
+    if (message && !alreadyNotified(payload.session_id)) return message;
+    return null;
   }
 
+  // SIBLING IN THE SHARED CORE. The worker used to live beside the hook entry
+  // in `plugin/hooks/`, which is why only Claude Code could ever have spawned
+  // it -- it was vendored to no other client. It now sits in the core that
+  // every client receives an identical copy of, so this resolves in all
+  // eleven.
   const worker = join(HERE, 'harvest-worker.mjs');
-  if (!existsSync(worker)) return;
+  if (!existsSync(worker)) return null;
 
   // DEBOUNCE. Stop fires at the end of every assistant turn, so a talkative
   // session would spawn a model call per turn -- each re-reading an overlapping
   // transcript and re-extracting most of the same findings. The marker is
   // touched only when a harvest is actually started, so a skipped turn does not
   // push the next one further away.
-  if (!dueForHarvest(payload.session_id)) return;
+  if (!dueForHarvest(payload.session_id)) return null;
 
   // Detached and fully released: the harvest must outlive this hook without
   // holding Stop open for a model round-trip.
@@ -343,14 +352,5 @@ async function main() {
     }
   );
   child.unref();
+  return null;
 }
-
-// Stop must complete whatever happens here -- but exitCode rather than exit(),
-// so a buffered stdout notice is flushed on natural termination instead of being
-// truncated. The detached worker is already unref'd, so nothing holds the loop
-// open once main resolves.
-main()
-  .catch(() => {})
-  .finally(() => {
-    process.exitCode = 0;
-  });

--- a/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
@@ -762,8 +762,11 @@ async function runHook(clientName, event, invocation) {
     const toolEvidence = optimizerToolsForHook(raw, state);
     rememberOptimizerTools(state, toolEvidence);
     const episode = episodeMeta({ client: clientName, raw });
+    // Hoisted out of the try below, because the harvest needs the same resolved
+    // directory and resolving it twice is how two halves of one hook end up
+    // reasoning about different projects.
+    const cwd = raw.cwd || raw.working_directory || process.cwd();
     try {
-      const cwd = raw.cwd || raw.working_directory || process.cwd();
       const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
       recordEpisodeOutcome(dir, {
         ...episode,
@@ -807,7 +810,21 @@ async function runHook(clientName, event, invocation) {
     // call.
     let harvestNotice = null;
     try {
-      harvestNotice = await runStopHarvest(raw);
+      // NORMALIZED, NOT RAW. The identifiers were resolved a few lines up
+      // through every alias a host might use -- `sessionId`,
+      // `conversation_id`, `working_directory` -- and handing `raw` straight
+      // over threw that away: runStopHarvest reads `session_id` and `cwd`
+      // only, so on a client that sends an alias the session id came back
+      // undefined and the archive root fell back to `process.cwd()`. That
+      // shares the once-per-session notice and the debounce marker across
+      // every session, and files the transcript under whatever directory the
+      // hook happened to start in.
+      harvestNotice = await runStopHarvest({
+        ...raw,
+        session_id: sessionId,
+        cwd,
+        transcript_path: raw.transcript_path ?? raw.transcriptPath ?? null,
+      });
     } catch {
       // The harvest is a side effect of ending a session. It must never stop
       // one from ending.

--- a/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/adapter.mjs
@@ -88,6 +88,7 @@ import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 import { evaluateUcrGuards } from './ucr-guard.mjs';
 import { beginHookInvocation, noteHookOutput } from './observability.mjs';
 import { registerProject } from './projects.mjs';
+import { runStopHarvest } from './stop-harvest.mjs';
 
 /**
  * Per-client capability.
@@ -792,10 +793,33 @@ async function runHook(clientName, event, invocation) {
       state.harvestedEdits = Number(state.edits || 0);
       saveState(sessionId, state, agentScope);
     }
+    // THE OUT-OF-BAND HARVEST, which no client was running.
+    //
+    // The in-band `prompt` above asks the MODEL to call `wiki_write`, and the
+    // session pays for summarising itself -- the exact cost the design says the
+    // harvest exists to avoid ("out-of-band, so the session doing the work never
+    // pays for the harvest"). The out-of-band half lived in a Claude Code hook
+    // that #300 unregistered, and nothing replaced it, so on every client the
+    // transcript was never archived, the worker never spawned, refusals were
+    // never detected, and the notice explaining why no findings exist was never
+    // shown. Awaited because it must finish before the exit below; it spawns a
+    // DETACHED worker and returns immediately, so Stop is not delayed by a model
+    // call.
+    let harvestNotice = null;
+    try {
+      harvestNotice = await runStopHarvest(raw);
+    } catch {
+      // The harvest is a side effect of ending a session. It must never stop
+      // one from ending.
+    }
+
     if (prompt && client.stopStyle === 'followup') {
-      emit({ followup_message: prompt });
+      emit({ followup_message: prompt, ...(harvestNotice ? { systemMessage: harvestNotice } : {}) });
     } else {
-      emit(prompt ? { decision: client.stopDecision, reason: prompt } : {});
+      emit({
+        ...(prompt ? { decision: client.stopDecision, reason: prompt } : {}),
+        ...(harvestNotice ? { systemMessage: harvestNotice } : {}),
+      });
     }
     process.exit(0);
   }

--- a/integrations/cline/hooks/token-optimizer/lib/harvest-worker.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/harvest-worker.mjs
@@ -1,0 +1,248 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/harvest-worker.mjs. Regenerate with `npm run sync:hooks`.
+#!/usr/bin/env node
+/**
+ * The out-of-band half of the semantic harvest.
+ *
+ * Spawned detached by the Stop adapter so the session that did the work never
+ * pays for the model call that summarises it. Everything here is best-effort:
+ * a harvest that fails must be indistinguishable from a session with nothing
+ * to learn, because the alternative -- a hook that can break a turn -- is worse
+ * than no findings at all.
+ *
+ * The cost of the extraction is recorded either way. Without it the metrics
+ * report a benefit with no matching expense, and `netTokens` would flatter the
+ * feature by exactly the amount it spends.
+ */
+
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  harvestEnabled,
+  buildDigest,
+  buildFullDelta,
+  extract,
+  validate,
+  estimateTokens,
+} from './harvest.mjs';
+import { writeHarvested } from './harvest-write.mjs';
+import { record } from './metrics.mjs';
+import { wikiDir, projectRootFor, load } from './wiki.mjs';
+import { readArchive } from './transcript.mjs';
+import { buildFeedbackDigest, validateLessons, LESSON_PROMPT } from './lessons.mjs';
+import { ORIGIN_HARVESTED } from './curate.mjs';
+import { selectForConsolidation } from './consolidate.mjs';
+
+/**
+ * The token budget one session's harvest may add to the graph.
+ *
+ * #204 lists graph bloat as a named risk -- "the session-start index grows with
+ * the graph; ranking and eviction are required, not optional" -- and until now
+ * nothing bounded what a single harvest could store. 4,000 tokens is the
+ * selector's own default and roughly twenty-five findings at the size the
+ * extractor produces, which is far above any observed session's real yield; it
+ * is a ceiling against a pathological extraction, not a routine constraint.
+ */
+const CONSOLIDATION_BUDGET = 4000;
+
+/**
+ * The files the digest says were touched.
+ *
+ * `buildDigest` emits them under a `## Files touched` heading and returns a
+ * string, so this reads back the list it just wrote rather than walking the
+ * transcript a second time. Returns null when the section is absent, which
+ * `validate` treats as "no restriction" rather than "no files".
+ */
+function filesIn(digest) {
+  const start = digest.indexOf('## Files touched');
+  if (start === -1) return null;
+
+  const rest = digest.slice(start + '## Files touched'.length);
+  const end = rest.indexOf('\n##');
+  const block = (end === -1 ? rest : rest.slice(0, end)).split('\n');
+
+  const files = new Set();
+  for (const line of block) {
+    const value = line.trim();
+    if (value) files.add(value);
+  }
+  return files.size ? files : null;
+}
+
+async function main() {
+  const [transcript, sessionId, cwd] = process.argv.slice(2);
+  if (!transcript || !existsSync(transcript) || !harvestEnabled()) return;
+
+  // THE GRAPH AND THE CONTAINMENT BOUNDARY BOTH COME FROM THE REPOSITORY ROOT,
+  // NOT THE SESSION'S CWD. `wikiDir` only joins the path it is handed, so a
+  // session started in a subdirectory selected `<subdir>/.token-optimizer/wiki`
+  // -- a second graph, invisible to every other hook, which all resolve the root
+  // first. It also made the subdirectory the containment root for the write, so
+  // a finding anchored anywhere else in the same repository was refused for
+  // sitting "outside" the project.
+  //
+  // `__session__` is a synthetic leaf so the walk starts at `cwd` itself rather
+  // than its parent; `projectRootFor` takes a FILE path. This is the same idiom
+  // the adapter, the session-start hook and the Stop adapter already use.
+  //
+  // A cwd with no VCS ancestor resolves to the machine-level unrooted bucket,
+  // which `resolveAnchor` expects and handles: it swaps in home as the
+  // containment root for that case, so passing the resolved root here is what
+  // lets unrooted anchors work at all.
+  const sessionCwd = cwd || process.cwd();
+  const projectRoot = projectRootFor(join(sessionCwd, '__session__'), sessionCwd);
+  const dir = wikiDir(projectRoot);
+
+  // Default sends a structured digest with no file contents. The full delta is
+  // opt-in because the default has to be defensible without reading the docs.
+  const full = process.env.TOKEN_OPTIMIZER_HARVEST_FULL === 'true';
+  const digest = full ? buildFullDelta(transcript) : buildDigest(transcript);
+  if (!digest) return;
+
+  const raw = await extract(digest);
+
+  // Anchors are held to the files this session actually touched, so a model
+  // that invents a plausible path cannot anchor a finding to it. The digest
+  // lists them under a heading it writes itself; the full delta is raw
+  // transcript and carries no such list, so it gets no restriction.
+  const validated = validate(raw, { knownFiles: full ? null : filesIn(digest) });
+
+  // BUDGETED SELECTION, not everything the model extracted.
+  //
+  // `selectForConsolidation` exists for exactly this and had no caller
+  // anywhere, so every harvested candidate was stored regardless of what it
+  // cost to derive, how hard it is to reproduce, or whether the graph can ever
+  // retrieve it -- which is the graph-bloat risk #204 lists as needing
+  // "ranking and eviction ... not optional". It keeps failures and decisions on
+  // a floor before ranking, encoding the design's judgement that dead ends are
+  // the highest-value kind: they exist nowhere in the source tree, so nothing
+  // else can ever recover them.
+  //
+  // The selection is RECORDED, not silent. A cap that drops work without
+  // saying so reads as "there was nothing more to find", which is the same
+  // dishonesty as a truncated report with no remainder line.
+  const graph = load(dir);
+  const selection = selectForConsolidation(graph, validated, { budget: CONSOLIDATION_BUDGET });
+  const findings = selection.kept;
+  if (selection.dropped > 0) {
+    record(dir, {
+      kind: 'harvest',
+      action: 'consolidation',
+      candidates: validated.length,
+      kept: findings.length,
+      dropped: selection.dropped,
+      tokens: selection.tokens,
+      budget: CONSOLIDATION_BUDGET,
+    });
+  }
+
+  const written = writeHarvested(dir, findings, {
+    sessionId: sessionId || null,
+    projectRoot,
+    // Task nodes are keyed by session id (structural capture creates one on
+    // the first touched file, `harvest()` in lib/wiki.mjs) so this is the
+    // shape `writeHarvested` needs to point the `answers` edge back at the
+    // task this harvest belongs to. A session that never touched a file
+    // through PreToolUse/PostToolUse has no such node yet; `writeHarvested`
+    // resolves that case to no edge rather than a dangling one.
+    taskId: sessionId || null,
+    // AUTHORITATIVE, not just present: this `sessionId` came from Claude
+    // Code's own Stop-hook payload (see stop-harvest.mjs), not a model-typed
+    // tool argument, so it is safe to use for the traversal fallback if the
+    // explicit `taskId` above does not resolve.
+    authoritativeSessionId: sessionId || null,
+  });
+
+  record(dir, {
+    kind: 'harvest',
+    sessionId: sessionId || null,
+    tokens: estimateTokens(digest),
+    findings: written.length,
+    at: Date.now(),
+  });
+
+  // THE FEEDBACK LOOP. A separate extraction with a separate prompt, because
+  // the two are looking for different things: the harvest above wants what was
+  // LEARNED about the code, this wants where the user said the agent was WRONG.
+  // Asked for both at once a model returns a summary and the corrections get
+  // lost in it -- and corrections are the only turns carrying information the
+  // code itself could never supply.
+  try {
+    const turns = readArchive(dir, sessionId || 'unknown');
+    const feedback = buildFeedbackDigest(turns);
+    if (feedback) {
+      const rawLessons = await extract(feedback, { prompt: LESSON_PROMPT });
+      // The same restriction the finding path above applies, for the same reason: a model that
+      // invents a plausible path must not be able to anchor a lesson to it. `turns` is the
+      // archived transcript for this session, so its rendered digest is the honest file list.
+      const { lessons } = validateLessons(rawLessons, turns, {
+        knownFiles: filesIn(feedback),
+      });
+
+      // Anchors are optional on a lesson -- "always run npm test" is about no
+      // file -- so each is anchored to the project root when it names nothing,
+      // which keeps the store's rule that an unanchored finding is refused.
+      //
+      // The RESOLVED root, matching the containment root this write is checked
+      // against. The session's cwd would be refused outright once that root is
+      // the unrooted bucket, because `resolveAnchor` then narrows containment to
+      // home and a VCS-less working directory need not sit under it.
+      const anchored = lessons.map((l) => ({
+        ...l,
+        anchors: l.anchors.length ? l.anchors : [projectRoot],
+      }));
+
+      // The write itself is the durable record: writeHarvested anchors each
+      // lesson into the graph, which is what lessons.mjs's real consumers
+      // query. A metrics event of kind 'lessons' used to sit here as well,
+      // but nothing ever read it -- not netTokens (only 'harvest' feeds
+      // harvestTokens), not report()/buildReport() (no kind filter matches
+      // 'lessons'), and no audit render exists to show it to a human. That is
+      // the inverse of the `query` defect and the same shape as
+      // `tokensFullFile` before it: a produced-and-never-consumed event,
+      // which is a cost with no benefit. Deleted rather than wired, per the
+      // reachability allowlist's own rule -- write it again the day
+      // something needs to read it.
+      writeHarvested(dir, anchored, {
+        sessionId: sessionId || null,
+        origin: ORIGIN_HARVESTED,
+        projectRoot,
+        taskId: sessionId || null,
+        // Same hook-payload identity as above, same reason.
+        authoritativeSessionId: sessionId || null,
+      });
+    }
+  } catch {
+    // A failed feedback pass must be indistinguishable from a session with
+    // nothing to correct.
+  }
+}
+
+main()
+  .catch(() => {})
+  .finally(() => {
+    // NEVER process.exit() SYNCHRONOUSLY HERE.
+    //
+    // It crashed this worker on Windows every single time the feedback pass
+    // ran -- libuv asserts `!(handle->flags & UV_HANDLE_CLOSING)` when the
+    // process exits while the sockets from the model call are still closing,
+    // giving exit code 0xC0000409. Reproduced 5 runs out of 5, and silently,
+    // because this worker is spawned detached and nothing reads its status.
+    // Deferring by one tick is NOT enough; the handles are still closing then.
+    //
+    // So the normal path just lets the loop drain, which it does promptly.
+    //
+    // THE RECORDED CODE IS PRESERVED, not overwritten with 0. Assigning 0
+    // unconditionally would turn a harvest that had already recorded a failure
+    // into one that reports success -- and this worker is detached, so that
+    // status is the only signal a supervisor could ever act on.
+    const code = process.exitCode ?? 0;
+    process.exitCode = code;
+
+    // The watchdog keeps the original guarantee: a detached worker must never
+    // linger holding a keep-alive socket open. It is UNREF'D, so it cannot
+    // itself keep the process alive -- it only fires if something else already
+    // has, which is exactly the case worth killing.
+    const watchdog = setTimeout(() => process.exit(code), 5000);
+    watchdog.unref();
+  });

--- a/integrations/cline/hooks/token-optimizer/lib/harvest-worker.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/harvest-worker.mjs
@@ -1,6 +1,6 @@
+#!/usr/bin/env node
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/harvest-worker.mjs. Regenerate with `npm run sync:hooks`.
-#!/usr/bin/env node
 /**
  * The out-of-band half of the semantic harvest.
  *

--- a/integrations/cline/hooks/token-optimizer/lib/stop-harvest.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/stop-harvest.mjs
@@ -353,6 +353,11 @@ export async function runStopHarvest(payload = {}) {
       env: { ...process.env },
     }
   );
+  // AN 'error' EVENT WITH NO LISTENER IS A THROW. `spawn` reports a failed
+  // start asynchronously, so an unlistened error does not return a code -- Node
+  // raises it, and here that would abort the Stop response itself. A harvest
+  // that cannot start must degrade to no harvest, never to a broken Stop.
+  child.on('error', () => {});
   child.unref();
   return null;
 }

--- a/integrations/cline/hooks/token-optimizer/lib/stop-harvest.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/stop-harvest.mjs
@@ -1,0 +1,358 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/stop-harvest.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Claude Code Stop adapter -- run the semantic harvest the design specifies.
+ *
+ * The wiki design says findings are extracted "at Stop and PreCompact" by a
+ * cheap model, out of band. The extractor (`lib/harvest.mjs`) was implemented
+ * and then imported by nothing: no hook invoked it, and Stop carried no
+ * token-optimizer entry at all. The consequence was not a crash but a graph
+ * that could serve findings and never acquired any -- 122 file / 132 symbol /
+ * 61 task nodes and zero findings on a real project after a full session, with
+ * injection, staleness and the metrics all wired and idle behind it.
+ *
+ * OUT OF BAND IS THE POINT. The extraction is a model call; doing it inline
+ * would make the session that did the work pay for summarising itself, which is
+ * the cost this whole subsystem exists to avoid. So this spawns a detached
+ * worker and returns immediately. Stop is never delayed.
+ *
+ * IT ALSO REPORTS WHEN IT CANNOT RUN. Harvest requires an API key, and without
+ * one `harvestEnabled()` returns false and the module skips silently. Silence
+ * was how this stayed invisible: nothing in doctor, audit or waste mentions
+ * harvest, so a user sees a graph filling with structural nodes and no findings
+ * and has no way to learn why. Saying so once per session is the difference
+ * between a disabled feature and a broken one.
+ */
+
+import { spawn } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  chmodSync,
+  readFileSync,
+  openSync,
+  writeSync,
+  closeSync,
+  lstatSync,
+  constants,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir, homedir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { mode, MODE_OFF } from './policy.mjs';
+import { harvestEnabled, harvestMode } from './harvest.mjs';
+import { archive } from './transcript.mjs';
+import { wikiDir, projectRootFor, sharedDir, load } from './wiki.mjs';
+import { detectRefusals, recordRefusal } from './harvest-write.mjs';
+
+/** What to tell the user, per reason the harvest is not running. */
+const OFF_REASON = {
+  'off:mode': null, // The whole optimizer is off; saying more would be noise.
+  'off:not-opted-in':
+    'token-optimizer: automatic finding-extraction is OFF. It costs a model call and ' +
+    'sends a digest (paths, commands, prompts, conclusions -- never file contents) off ' +
+    'this machine, so it is opt-in: set TOKEN_OPTIMIZER_HARVEST=1 with an API key, or ' +
+    'point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model to run it free and private. ' +
+    'Meanwhile lifecycle-based structural graph capture keeps working. Durable semantic MCP ' +
+    'writes require a writer schema that is actually registered in the current CLI session.',
+  'off:no-key':
+    'token-optimizer: finding-extraction is opted in but has no credential. Set ' +
+    'TOKEN_OPTIMIZER_API_KEY, or point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model ' +
+    'to run it without one.',
+};
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * A session id reduced to something that cannot leave the marker directory.
+ *
+ * The id arrives in the hook payload, so it is external input, and it was being
+ * interpolated straight into a path: a value containing separators or `..` would
+ * have placed (and later read) the marker anywhere on disk. Everything outside a
+ * conservative allowlist becomes an underscore, which keeps ordinary uuids
+ * readable while making traversal unrepresentable rather than merely unlikely.
+ */
+function markerName(sessionId) {
+  const safe = String(sessionId || 'unknown').replace(/[^A-Za-z0-9._-]/g, '_');
+  // A name of only dots would still resolve to a directory entry.
+  const cleaned = /^[.]+$/.test(safe) ? 'unknown' : safe;
+  return `harvest-notice-${cleaned.slice(0, 64)}`;
+}
+
+/**
+ * A private, per-user directory for this hook's markers.
+ *
+ * os.tmpdir() is per-user on Windows but resolves to a SHARED, world-writable
+ * /tmp on POSIX. The marker name is derived from the session id, so it is
+ * predictable enough for another local user to pre-create -- as a symlink, or
+ * as a file they own -- and writeFileSync would then follow it and write
+ * through with this user's privileges.
+ *
+ * The state here is a debounce timestamp and a "said it once" flag, so the fix
+ * is not to guard a shared location but to stop using one. XDG_STATE_HOME is
+ * the standard place for state that should persist across runs but is not
+ * precious, and it is inside the user's own home on every POSIX system.
+ */
+function stateDir() {
+  const home = homedir();
+  const base =
+    process.platform === 'win32'
+      ? process.env.LOCALAPPDATA || tmpdir()
+      : process.env.XDG_STATE_HOME ||
+        (home ? join(home, '.local', 'state') : tmpdir());
+
+  const dir = join(base, 'token-optimizer');
+  try {
+    // 0o700 AND an explicit chmod, for the reason the graph store documents:
+    // `recursive` applies the mode only to directories it actually creates, and
+    // the umask masks it further, so neither alone guarantees the result.
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    try {
+      chmodSync(dir, 0o700);
+    } catch {
+      // Not POSIX, or not ours to chmod.
+    }
+  } catch {
+    /* best effort */
+  }
+  return dir;
+}
+
+/** Where the once-per-session notice is remembered, so Stop does not nag. */
+function noticePath(sessionId) {
+  return join(stateDir(), markerName(sessionId));
+}
+
+/**
+ * True when the path is absent, or is a regular file this user owns.
+ *
+ * lstat rather than stat: stat FOLLOWS the link and would happily report on the
+ * target, which is the thing being defended against.
+ */
+function ownedRegularFile(path) {
+  let info;
+  try {
+    info = lstatSync(path);
+  } catch {
+    return true; // Absent. The O_NOFOLLOW open below settles the race.
+  }
+  if (!info.isFile()) return false;
+  // getuid is undefined on Windows, where stateDir() is already per-user.
+  if (typeof process.getuid === 'function' && info.uid !== process.getuid())
+    return false;
+  return true;
+}
+
+/**
+ * Writes a marker, refusing to follow a symlink.
+ *
+ * O_NOFOLLOW makes the refusal ATOMIC rather than a check-then-use window: a
+ * link swapped in after ownedRegularFile() returns fails the open instead of
+ * being written through. The flag does not exist on Windows, where it is
+ * undefined and falls back to 0 -- acceptable, because the directory is
+ * per-user there to begin with.
+ */
+function writeMarker(path, contents) {
+  if (!ownedRegularFile(path)) return false;
+  const NOFOLLOW = constants.O_NOFOLLOW || 0;
+  let fd;
+  try {
+    fd = openSync(
+      path,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | NOFOLLOW,
+      0o600
+    );
+    writeSync(fd, contents);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* already closed */
+      }
+    }
+  }
+}
+
+/** Reads a marker, ignoring anything that is not a regular file we own. */
+function readMarker(path) {
+  if (!ownedRegularFile(path)) return null;
+  try {
+    return readFileSync(path, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function alreadyNotified(sessionId) {
+  const path = noticePath(sessionId);
+  // Anything already at this path -- our marker, or something planted -- means
+  // stay quiet. Repeating the notice is the worse failure, and refusing to
+  // write over a foreign file is the point.
+  if (existsSync(path)) return true;
+  return !writeMarker(path, String(Date.now()));
+}
+
+/** Minimum gap between harvests of one session. */
+const HARVEST_INTERVAL_MS =
+  Number(process.env.TOKEN_OPTIMIZER_HARVEST_INTERVAL_MS) > 0
+    ? Number(process.env.TOKEN_OPTIMIZER_HARVEST_INTERVAL_MS)
+    : 10 * 60 * 1000;
+
+/**
+ * True when this session has not been harvested recently, and records that it
+ * is about to be.
+ *
+ * Deliberately marks only when a harvest actually starts: touching it on every
+ * Stop would let a run of skipped turns keep pushing the next harvest away.
+ */
+function dueForHarvest(sessionId) {
+  const marker = join(stateDir(), `harvest-last-${markerName(sessionId)}`);
+
+  const last = Number(readMarker(marker));
+  // > 0 matters: readMarker returns null when the marker is missing or is not
+  // ours, and Number(null) is 0, which is finite -- so without this an absent
+  // marker would read as a harvest at the epoch.
+  if (
+    Number.isFinite(last) &&
+    last > 0 &&
+    Date.now() - last < HARVEST_INTERVAL_MS
+  ) {
+    return false;
+  }
+
+  // If the marker cannot be written the debounce degrades to off rather than
+  // blocking the harvest entirely.
+  writeMarker(marker, String(Date.now()));
+  return true;
+}
+
+/**
+ * The Stop-time harvest, for every client rather than one.
+ *
+ * WHY THIS IS A FUNCTION AND NOT A HOOK. It was a hook -- a Claude Code entry
+ * point named `stop-harvest.mjs` -- and #300 unregistered it. Nothing replaced
+ * it, so four capabilities went silently: the transcript archive, the harvest
+ * worker spawn, refusal detection, and the notice that says why no findings
+ * exist. Every client routes Stop through the shared adapter, and the adapter
+ * did none of these, so on a full session with a valid credential
+ * `harvestMode()` reported `remote` and nothing happened.
+ *
+ * NOTHING OBSERVED THAT IT DID NOT RUN, which is why it survived a year. There
+ * is no `kind:'harvest'` event to be absent from a report, no error, and a
+ * harvest that ran and found nothing looks exactly like one that never
+ * started. The reachability guard could not see it either: this file's own
+ * imports gave `archive`, `detectRefusals` and `recordRefusal` call sites, and
+ * a name-based scan proves a reference exists, never that it runs.
+ *
+ * Returns a notice for the caller to emit, or null. It does NOT write to
+ * stdout: the adapter emits exactly one JSON object per hook invocation, and a
+ * second writer racing it is how a Stop payload gets corrupted.
+ *
+ * @returns {Promise<string|null>} a once-per-session message, or null.
+ */
+export async function runStopHarvest(payload = {}) {
+  if (mode() === MODE_OFF) return null;
+
+  const transcript = payload.transcript_path ?? payload.transcriptPath ?? null;
+  if (!transcript || !existsSync(transcript)) return null;
+
+  // ARCHIVE FIRST, AND UNCONDITIONALLY. This is a local file copy: it costs no
+  // model call, spends no money, and sends nothing anywhere, so it must not sit
+  // behind the opt-in that exists to gate cost and disclosure. Gating it there
+  // would mean the record of what the user actually said is kept only for the
+  // users who opted into a paid feature, which is exactly backwards.
+  //
+  // It also has to happen before the early return below, or a session with
+  // harvesting off would archive nothing at all.
+  try {
+    archive(
+      wikiDir(
+        projectRootFor(
+          join(payload.cwd || process.cwd(), '__session__'),
+          payload.cwd
+        )
+      ),
+      transcript,
+      {
+        sessionId: payload.session_id,
+      }
+    );
+  } catch {
+    // The archive is a convenience. Failing to write it must not affect Stop.
+  }
+
+  // CLOSE THE REFUSAL LOOP, and do it OUTSIDE the harvest opt-in. Reading the
+  // transcript this process already holds costs no model call and sends nothing
+  // anywhere, so gating it behind the paid feature would leave a mis-scoped
+  // lesson costing tokens forever for everyone who did not opt in.
+  //
+  // The model states plainly when a cross-project lesson does not transfer --
+  // "that figure is another repo's baseline and it doesn't transfer" -- and until
+  // now nothing read it, so the same lesson was delivered again next session.
+  try {
+    const shared = sharedDir();
+    const lessons = [...load(shared).nodes.values()].filter(
+      (n) => n.kind === 'finding' && !n.retired && n.claim
+    );
+    if (lessons.length) {
+      const text = readFileSync(transcript, 'utf8');
+      for (const key of detectRefusals(lessons, text))
+        recordRefusal(shared, key);
+    }
+  } catch {
+    // Feedback is a refinement; a failure here must not affect Stop.
+  }
+
+  if (!harvestEnabled()) {
+    // Say it once, name the reason and the variable that changes it, and state
+    // what still works. A user who reads this should know exactly what they are
+    // and are not getting, and what to do about it.
+    const message = OFF_REASON[harvestMode()];
+    // RETURNED, NOT WRITTEN. This used to write its own JSON to stdout and
+    // race whatever the hook emitted; the adapter now folds this into the one
+    // object it sends, so the notice cannot be dropped by a full pipe or
+    // truncated by an exit -- which is what used to happen to the single line
+    // explaining why no findings exist.
+    if (message && !alreadyNotified(payload.session_id)) return message;
+    return null;
+  }
+
+  // SIBLING IN THE SHARED CORE. The worker used to live beside the hook entry
+  // in `plugin/hooks/`, which is why only Claude Code could ever have spawned
+  // it -- it was vendored to no other client. It now sits in the core that
+  // every client receives an identical copy of, so this resolves in all
+  // eleven.
+  const worker = join(HERE, 'harvest-worker.mjs');
+  if (!existsSync(worker)) return null;
+
+  // DEBOUNCE. Stop fires at the end of every assistant turn, so a talkative
+  // session would spawn a model call per turn -- each re-reading an overlapping
+  // transcript and re-extracting most of the same findings. The marker is
+  // touched only when a harvest is actually started, so a skipped turn does not
+  // push the next one further away.
+  if (!dueForHarvest(payload.session_id)) return null;
+
+  // Detached and fully released: the harvest must outlive this hook without
+  // holding Stop open for a model round-trip.
+  const child = spawn(
+    process.execPath,
+    [
+      worker,
+      transcript,
+      String(payload.session_id || ''),
+      String(payload.cwd || process.cwd()),
+    ],
+    {
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: true,
+      env: { ...process.env },
+    }
+  );
+  child.unref();
+  return null;
+}

--- a/integrations/codex/hooks/lib/adapter.mjs
+++ b/integrations/codex/hooks/lib/adapter.mjs
@@ -762,8 +762,11 @@ async function runHook(clientName, event, invocation) {
     const toolEvidence = optimizerToolsForHook(raw, state);
     rememberOptimizerTools(state, toolEvidence);
     const episode = episodeMeta({ client: clientName, raw });
+    // Hoisted out of the try below, because the harvest needs the same resolved
+    // directory and resolving it twice is how two halves of one hook end up
+    // reasoning about different projects.
+    const cwd = raw.cwd || raw.working_directory || process.cwd();
     try {
-      const cwd = raw.cwd || raw.working_directory || process.cwd();
       const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
       recordEpisodeOutcome(dir, {
         ...episode,
@@ -807,7 +810,21 @@ async function runHook(clientName, event, invocation) {
     // call.
     let harvestNotice = null;
     try {
-      harvestNotice = await runStopHarvest(raw);
+      // NORMALIZED, NOT RAW. The identifiers were resolved a few lines up
+      // through every alias a host might use -- `sessionId`,
+      // `conversation_id`, `working_directory` -- and handing `raw` straight
+      // over threw that away: runStopHarvest reads `session_id` and `cwd`
+      // only, so on a client that sends an alias the session id came back
+      // undefined and the archive root fell back to `process.cwd()`. That
+      // shares the once-per-session notice and the debounce marker across
+      // every session, and files the transcript under whatever directory the
+      // hook happened to start in.
+      harvestNotice = await runStopHarvest({
+        ...raw,
+        session_id: sessionId,
+        cwd,
+        transcript_path: raw.transcript_path ?? raw.transcriptPath ?? null,
+      });
     } catch {
       // The harvest is a side effect of ending a session. It must never stop
       // one from ending.

--- a/integrations/codex/hooks/lib/adapter.mjs
+++ b/integrations/codex/hooks/lib/adapter.mjs
@@ -88,6 +88,7 @@ import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 import { evaluateUcrGuards } from './ucr-guard.mjs';
 import { beginHookInvocation, noteHookOutput } from './observability.mjs';
 import { registerProject } from './projects.mjs';
+import { runStopHarvest } from './stop-harvest.mjs';
 
 /**
  * Per-client capability.
@@ -792,10 +793,33 @@ async function runHook(clientName, event, invocation) {
       state.harvestedEdits = Number(state.edits || 0);
       saveState(sessionId, state, agentScope);
     }
+    // THE OUT-OF-BAND HARVEST, which no client was running.
+    //
+    // The in-band `prompt` above asks the MODEL to call `wiki_write`, and the
+    // session pays for summarising itself -- the exact cost the design says the
+    // harvest exists to avoid ("out-of-band, so the session doing the work never
+    // pays for the harvest"). The out-of-band half lived in a Claude Code hook
+    // that #300 unregistered, and nothing replaced it, so on every client the
+    // transcript was never archived, the worker never spawned, refusals were
+    // never detected, and the notice explaining why no findings exist was never
+    // shown. Awaited because it must finish before the exit below; it spawns a
+    // DETACHED worker and returns immediately, so Stop is not delayed by a model
+    // call.
+    let harvestNotice = null;
+    try {
+      harvestNotice = await runStopHarvest(raw);
+    } catch {
+      // The harvest is a side effect of ending a session. It must never stop
+      // one from ending.
+    }
+
     if (prompt && client.stopStyle === 'followup') {
-      emit({ followup_message: prompt });
+      emit({ followup_message: prompt, ...(harvestNotice ? { systemMessage: harvestNotice } : {}) });
     } else {
-      emit(prompt ? { decision: client.stopDecision, reason: prompt } : {});
+      emit({
+        ...(prompt ? { decision: client.stopDecision, reason: prompt } : {}),
+        ...(harvestNotice ? { systemMessage: harvestNotice } : {}),
+      });
     }
     process.exit(0);
   }

--- a/integrations/codex/hooks/lib/harvest-worker.mjs
+++ b/integrations/codex/hooks/lib/harvest-worker.mjs
@@ -1,0 +1,248 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/harvest-worker.mjs. Regenerate with `npm run sync:hooks`.
+#!/usr/bin/env node
+/**
+ * The out-of-band half of the semantic harvest.
+ *
+ * Spawned detached by the Stop adapter so the session that did the work never
+ * pays for the model call that summarises it. Everything here is best-effort:
+ * a harvest that fails must be indistinguishable from a session with nothing
+ * to learn, because the alternative -- a hook that can break a turn -- is worse
+ * than no findings at all.
+ *
+ * The cost of the extraction is recorded either way. Without it the metrics
+ * report a benefit with no matching expense, and `netTokens` would flatter the
+ * feature by exactly the amount it spends.
+ */
+
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  harvestEnabled,
+  buildDigest,
+  buildFullDelta,
+  extract,
+  validate,
+  estimateTokens,
+} from './harvest.mjs';
+import { writeHarvested } from './harvest-write.mjs';
+import { record } from './metrics.mjs';
+import { wikiDir, projectRootFor, load } from './wiki.mjs';
+import { readArchive } from './transcript.mjs';
+import { buildFeedbackDigest, validateLessons, LESSON_PROMPT } from './lessons.mjs';
+import { ORIGIN_HARVESTED } from './curate.mjs';
+import { selectForConsolidation } from './consolidate.mjs';
+
+/**
+ * The token budget one session's harvest may add to the graph.
+ *
+ * #204 lists graph bloat as a named risk -- "the session-start index grows with
+ * the graph; ranking and eviction are required, not optional" -- and until now
+ * nothing bounded what a single harvest could store. 4,000 tokens is the
+ * selector's own default and roughly twenty-five findings at the size the
+ * extractor produces, which is far above any observed session's real yield; it
+ * is a ceiling against a pathological extraction, not a routine constraint.
+ */
+const CONSOLIDATION_BUDGET = 4000;
+
+/**
+ * The files the digest says were touched.
+ *
+ * `buildDigest` emits them under a `## Files touched` heading and returns a
+ * string, so this reads back the list it just wrote rather than walking the
+ * transcript a second time. Returns null when the section is absent, which
+ * `validate` treats as "no restriction" rather than "no files".
+ */
+function filesIn(digest) {
+  const start = digest.indexOf('## Files touched');
+  if (start === -1) return null;
+
+  const rest = digest.slice(start + '## Files touched'.length);
+  const end = rest.indexOf('\n##');
+  const block = (end === -1 ? rest : rest.slice(0, end)).split('\n');
+
+  const files = new Set();
+  for (const line of block) {
+    const value = line.trim();
+    if (value) files.add(value);
+  }
+  return files.size ? files : null;
+}
+
+async function main() {
+  const [transcript, sessionId, cwd] = process.argv.slice(2);
+  if (!transcript || !existsSync(transcript) || !harvestEnabled()) return;
+
+  // THE GRAPH AND THE CONTAINMENT BOUNDARY BOTH COME FROM THE REPOSITORY ROOT,
+  // NOT THE SESSION'S CWD. `wikiDir` only joins the path it is handed, so a
+  // session started in a subdirectory selected `<subdir>/.token-optimizer/wiki`
+  // -- a second graph, invisible to every other hook, which all resolve the root
+  // first. It also made the subdirectory the containment root for the write, so
+  // a finding anchored anywhere else in the same repository was refused for
+  // sitting "outside" the project.
+  //
+  // `__session__` is a synthetic leaf so the walk starts at `cwd` itself rather
+  // than its parent; `projectRootFor` takes a FILE path. This is the same idiom
+  // the adapter, the session-start hook and the Stop adapter already use.
+  //
+  // A cwd with no VCS ancestor resolves to the machine-level unrooted bucket,
+  // which `resolveAnchor` expects and handles: it swaps in home as the
+  // containment root for that case, so passing the resolved root here is what
+  // lets unrooted anchors work at all.
+  const sessionCwd = cwd || process.cwd();
+  const projectRoot = projectRootFor(join(sessionCwd, '__session__'), sessionCwd);
+  const dir = wikiDir(projectRoot);
+
+  // Default sends a structured digest with no file contents. The full delta is
+  // opt-in because the default has to be defensible without reading the docs.
+  const full = process.env.TOKEN_OPTIMIZER_HARVEST_FULL === 'true';
+  const digest = full ? buildFullDelta(transcript) : buildDigest(transcript);
+  if (!digest) return;
+
+  const raw = await extract(digest);
+
+  // Anchors are held to the files this session actually touched, so a model
+  // that invents a plausible path cannot anchor a finding to it. The digest
+  // lists them under a heading it writes itself; the full delta is raw
+  // transcript and carries no such list, so it gets no restriction.
+  const validated = validate(raw, { knownFiles: full ? null : filesIn(digest) });
+
+  // BUDGETED SELECTION, not everything the model extracted.
+  //
+  // `selectForConsolidation` exists for exactly this and had no caller
+  // anywhere, so every harvested candidate was stored regardless of what it
+  // cost to derive, how hard it is to reproduce, or whether the graph can ever
+  // retrieve it -- which is the graph-bloat risk #204 lists as needing
+  // "ranking and eviction ... not optional". It keeps failures and decisions on
+  // a floor before ranking, encoding the design's judgement that dead ends are
+  // the highest-value kind: they exist nowhere in the source tree, so nothing
+  // else can ever recover them.
+  //
+  // The selection is RECORDED, not silent. A cap that drops work without
+  // saying so reads as "there was nothing more to find", which is the same
+  // dishonesty as a truncated report with no remainder line.
+  const graph = load(dir);
+  const selection = selectForConsolidation(graph, validated, { budget: CONSOLIDATION_BUDGET });
+  const findings = selection.kept;
+  if (selection.dropped > 0) {
+    record(dir, {
+      kind: 'harvest',
+      action: 'consolidation',
+      candidates: validated.length,
+      kept: findings.length,
+      dropped: selection.dropped,
+      tokens: selection.tokens,
+      budget: CONSOLIDATION_BUDGET,
+    });
+  }
+
+  const written = writeHarvested(dir, findings, {
+    sessionId: sessionId || null,
+    projectRoot,
+    // Task nodes are keyed by session id (structural capture creates one on
+    // the first touched file, `harvest()` in lib/wiki.mjs) so this is the
+    // shape `writeHarvested` needs to point the `answers` edge back at the
+    // task this harvest belongs to. A session that never touched a file
+    // through PreToolUse/PostToolUse has no such node yet; `writeHarvested`
+    // resolves that case to no edge rather than a dangling one.
+    taskId: sessionId || null,
+    // AUTHORITATIVE, not just present: this `sessionId` came from Claude
+    // Code's own Stop-hook payload (see stop-harvest.mjs), not a model-typed
+    // tool argument, so it is safe to use for the traversal fallback if the
+    // explicit `taskId` above does not resolve.
+    authoritativeSessionId: sessionId || null,
+  });
+
+  record(dir, {
+    kind: 'harvest',
+    sessionId: sessionId || null,
+    tokens: estimateTokens(digest),
+    findings: written.length,
+    at: Date.now(),
+  });
+
+  // THE FEEDBACK LOOP. A separate extraction with a separate prompt, because
+  // the two are looking for different things: the harvest above wants what was
+  // LEARNED about the code, this wants where the user said the agent was WRONG.
+  // Asked for both at once a model returns a summary and the corrections get
+  // lost in it -- and corrections are the only turns carrying information the
+  // code itself could never supply.
+  try {
+    const turns = readArchive(dir, sessionId || 'unknown');
+    const feedback = buildFeedbackDigest(turns);
+    if (feedback) {
+      const rawLessons = await extract(feedback, { prompt: LESSON_PROMPT });
+      // The same restriction the finding path above applies, for the same reason: a model that
+      // invents a plausible path must not be able to anchor a lesson to it. `turns` is the
+      // archived transcript for this session, so its rendered digest is the honest file list.
+      const { lessons } = validateLessons(rawLessons, turns, {
+        knownFiles: filesIn(feedback),
+      });
+
+      // Anchors are optional on a lesson -- "always run npm test" is about no
+      // file -- so each is anchored to the project root when it names nothing,
+      // which keeps the store's rule that an unanchored finding is refused.
+      //
+      // The RESOLVED root, matching the containment root this write is checked
+      // against. The session's cwd would be refused outright once that root is
+      // the unrooted bucket, because `resolveAnchor` then narrows containment to
+      // home and a VCS-less working directory need not sit under it.
+      const anchored = lessons.map((l) => ({
+        ...l,
+        anchors: l.anchors.length ? l.anchors : [projectRoot],
+      }));
+
+      // The write itself is the durable record: writeHarvested anchors each
+      // lesson into the graph, which is what lessons.mjs's real consumers
+      // query. A metrics event of kind 'lessons' used to sit here as well,
+      // but nothing ever read it -- not netTokens (only 'harvest' feeds
+      // harvestTokens), not report()/buildReport() (no kind filter matches
+      // 'lessons'), and no audit render exists to show it to a human. That is
+      // the inverse of the `query` defect and the same shape as
+      // `tokensFullFile` before it: a produced-and-never-consumed event,
+      // which is a cost with no benefit. Deleted rather than wired, per the
+      // reachability allowlist's own rule -- write it again the day
+      // something needs to read it.
+      writeHarvested(dir, anchored, {
+        sessionId: sessionId || null,
+        origin: ORIGIN_HARVESTED,
+        projectRoot,
+        taskId: sessionId || null,
+        // Same hook-payload identity as above, same reason.
+        authoritativeSessionId: sessionId || null,
+      });
+    }
+  } catch {
+    // A failed feedback pass must be indistinguishable from a session with
+    // nothing to correct.
+  }
+}
+
+main()
+  .catch(() => {})
+  .finally(() => {
+    // NEVER process.exit() SYNCHRONOUSLY HERE.
+    //
+    // It crashed this worker on Windows every single time the feedback pass
+    // ran -- libuv asserts `!(handle->flags & UV_HANDLE_CLOSING)` when the
+    // process exits while the sockets from the model call are still closing,
+    // giving exit code 0xC0000409. Reproduced 5 runs out of 5, and silently,
+    // because this worker is spawned detached and nothing reads its status.
+    // Deferring by one tick is NOT enough; the handles are still closing then.
+    //
+    // So the normal path just lets the loop drain, which it does promptly.
+    //
+    // THE RECORDED CODE IS PRESERVED, not overwritten with 0. Assigning 0
+    // unconditionally would turn a harvest that had already recorded a failure
+    // into one that reports success -- and this worker is detached, so that
+    // status is the only signal a supervisor could ever act on.
+    const code = process.exitCode ?? 0;
+    process.exitCode = code;
+
+    // The watchdog keeps the original guarantee: a detached worker must never
+    // linger holding a keep-alive socket open. It is UNREF'D, so it cannot
+    // itself keep the process alive -- it only fires if something else already
+    // has, which is exactly the case worth killing.
+    const watchdog = setTimeout(() => process.exit(code), 5000);
+    watchdog.unref();
+  });

--- a/integrations/codex/hooks/lib/harvest-worker.mjs
+++ b/integrations/codex/hooks/lib/harvest-worker.mjs
@@ -1,6 +1,6 @@
+#!/usr/bin/env node
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/harvest-worker.mjs. Regenerate with `npm run sync:hooks`.
-#!/usr/bin/env node
 /**
  * The out-of-band half of the semantic harvest.
  *

--- a/integrations/codex/hooks/lib/stop-harvest.mjs
+++ b/integrations/codex/hooks/lib/stop-harvest.mjs
@@ -353,6 +353,11 @@ export async function runStopHarvest(payload = {}) {
       env: { ...process.env },
     }
   );
+  // AN 'error' EVENT WITH NO LISTENER IS A THROW. `spawn` reports a failed
+  // start asynchronously, so an unlistened error does not return a code -- Node
+  // raises it, and here that would abort the Stop response itself. A harvest
+  // that cannot start must degrade to no harvest, never to a broken Stop.
+  child.on('error', () => {});
   child.unref();
   return null;
 }

--- a/integrations/codex/hooks/lib/stop-harvest.mjs
+++ b/integrations/codex/hooks/lib/stop-harvest.mjs
@@ -1,0 +1,358 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/stop-harvest.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Claude Code Stop adapter -- run the semantic harvest the design specifies.
+ *
+ * The wiki design says findings are extracted "at Stop and PreCompact" by a
+ * cheap model, out of band. The extractor (`lib/harvest.mjs`) was implemented
+ * and then imported by nothing: no hook invoked it, and Stop carried no
+ * token-optimizer entry at all. The consequence was not a crash but a graph
+ * that could serve findings and never acquired any -- 122 file / 132 symbol /
+ * 61 task nodes and zero findings on a real project after a full session, with
+ * injection, staleness and the metrics all wired and idle behind it.
+ *
+ * OUT OF BAND IS THE POINT. The extraction is a model call; doing it inline
+ * would make the session that did the work pay for summarising itself, which is
+ * the cost this whole subsystem exists to avoid. So this spawns a detached
+ * worker and returns immediately. Stop is never delayed.
+ *
+ * IT ALSO REPORTS WHEN IT CANNOT RUN. Harvest requires an API key, and without
+ * one `harvestEnabled()` returns false and the module skips silently. Silence
+ * was how this stayed invisible: nothing in doctor, audit or waste mentions
+ * harvest, so a user sees a graph filling with structural nodes and no findings
+ * and has no way to learn why. Saying so once per session is the difference
+ * between a disabled feature and a broken one.
+ */
+
+import { spawn } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  chmodSync,
+  readFileSync,
+  openSync,
+  writeSync,
+  closeSync,
+  lstatSync,
+  constants,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir, homedir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { mode, MODE_OFF } from './policy.mjs';
+import { harvestEnabled, harvestMode } from './harvest.mjs';
+import { archive } from './transcript.mjs';
+import { wikiDir, projectRootFor, sharedDir, load } from './wiki.mjs';
+import { detectRefusals, recordRefusal } from './harvest-write.mjs';
+
+/** What to tell the user, per reason the harvest is not running. */
+const OFF_REASON = {
+  'off:mode': null, // The whole optimizer is off; saying more would be noise.
+  'off:not-opted-in':
+    'token-optimizer: automatic finding-extraction is OFF. It costs a model call and ' +
+    'sends a digest (paths, commands, prompts, conclusions -- never file contents) off ' +
+    'this machine, so it is opt-in: set TOKEN_OPTIMIZER_HARVEST=1 with an API key, or ' +
+    'point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model to run it free and private. ' +
+    'Meanwhile lifecycle-based structural graph capture keeps working. Durable semantic MCP ' +
+    'writes require a writer schema that is actually registered in the current CLI session.',
+  'off:no-key':
+    'token-optimizer: finding-extraction is opted in but has no credential. Set ' +
+    'TOKEN_OPTIMIZER_API_KEY, or point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model ' +
+    'to run it without one.',
+};
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * A session id reduced to something that cannot leave the marker directory.
+ *
+ * The id arrives in the hook payload, so it is external input, and it was being
+ * interpolated straight into a path: a value containing separators or `..` would
+ * have placed (and later read) the marker anywhere on disk. Everything outside a
+ * conservative allowlist becomes an underscore, which keeps ordinary uuids
+ * readable while making traversal unrepresentable rather than merely unlikely.
+ */
+function markerName(sessionId) {
+  const safe = String(sessionId || 'unknown').replace(/[^A-Za-z0-9._-]/g, '_');
+  // A name of only dots would still resolve to a directory entry.
+  const cleaned = /^[.]+$/.test(safe) ? 'unknown' : safe;
+  return `harvest-notice-${cleaned.slice(0, 64)}`;
+}
+
+/**
+ * A private, per-user directory for this hook's markers.
+ *
+ * os.tmpdir() is per-user on Windows but resolves to a SHARED, world-writable
+ * /tmp on POSIX. The marker name is derived from the session id, so it is
+ * predictable enough for another local user to pre-create -- as a symlink, or
+ * as a file they own -- and writeFileSync would then follow it and write
+ * through with this user's privileges.
+ *
+ * The state here is a debounce timestamp and a "said it once" flag, so the fix
+ * is not to guard a shared location but to stop using one. XDG_STATE_HOME is
+ * the standard place for state that should persist across runs but is not
+ * precious, and it is inside the user's own home on every POSIX system.
+ */
+function stateDir() {
+  const home = homedir();
+  const base =
+    process.platform === 'win32'
+      ? process.env.LOCALAPPDATA || tmpdir()
+      : process.env.XDG_STATE_HOME ||
+        (home ? join(home, '.local', 'state') : tmpdir());
+
+  const dir = join(base, 'token-optimizer');
+  try {
+    // 0o700 AND an explicit chmod, for the reason the graph store documents:
+    // `recursive` applies the mode only to directories it actually creates, and
+    // the umask masks it further, so neither alone guarantees the result.
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    try {
+      chmodSync(dir, 0o700);
+    } catch {
+      // Not POSIX, or not ours to chmod.
+    }
+  } catch {
+    /* best effort */
+  }
+  return dir;
+}
+
+/** Where the once-per-session notice is remembered, so Stop does not nag. */
+function noticePath(sessionId) {
+  return join(stateDir(), markerName(sessionId));
+}
+
+/**
+ * True when the path is absent, or is a regular file this user owns.
+ *
+ * lstat rather than stat: stat FOLLOWS the link and would happily report on the
+ * target, which is the thing being defended against.
+ */
+function ownedRegularFile(path) {
+  let info;
+  try {
+    info = lstatSync(path);
+  } catch {
+    return true; // Absent. The O_NOFOLLOW open below settles the race.
+  }
+  if (!info.isFile()) return false;
+  // getuid is undefined on Windows, where stateDir() is already per-user.
+  if (typeof process.getuid === 'function' && info.uid !== process.getuid())
+    return false;
+  return true;
+}
+
+/**
+ * Writes a marker, refusing to follow a symlink.
+ *
+ * O_NOFOLLOW makes the refusal ATOMIC rather than a check-then-use window: a
+ * link swapped in after ownedRegularFile() returns fails the open instead of
+ * being written through. The flag does not exist on Windows, where it is
+ * undefined and falls back to 0 -- acceptable, because the directory is
+ * per-user there to begin with.
+ */
+function writeMarker(path, contents) {
+  if (!ownedRegularFile(path)) return false;
+  const NOFOLLOW = constants.O_NOFOLLOW || 0;
+  let fd;
+  try {
+    fd = openSync(
+      path,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | NOFOLLOW,
+      0o600
+    );
+    writeSync(fd, contents);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* already closed */
+      }
+    }
+  }
+}
+
+/** Reads a marker, ignoring anything that is not a regular file we own. */
+function readMarker(path) {
+  if (!ownedRegularFile(path)) return null;
+  try {
+    return readFileSync(path, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function alreadyNotified(sessionId) {
+  const path = noticePath(sessionId);
+  // Anything already at this path -- our marker, or something planted -- means
+  // stay quiet. Repeating the notice is the worse failure, and refusing to
+  // write over a foreign file is the point.
+  if (existsSync(path)) return true;
+  return !writeMarker(path, String(Date.now()));
+}
+
+/** Minimum gap between harvests of one session. */
+const HARVEST_INTERVAL_MS =
+  Number(process.env.TOKEN_OPTIMIZER_HARVEST_INTERVAL_MS) > 0
+    ? Number(process.env.TOKEN_OPTIMIZER_HARVEST_INTERVAL_MS)
+    : 10 * 60 * 1000;
+
+/**
+ * True when this session has not been harvested recently, and records that it
+ * is about to be.
+ *
+ * Deliberately marks only when a harvest actually starts: touching it on every
+ * Stop would let a run of skipped turns keep pushing the next harvest away.
+ */
+function dueForHarvest(sessionId) {
+  const marker = join(stateDir(), `harvest-last-${markerName(sessionId)}`);
+
+  const last = Number(readMarker(marker));
+  // > 0 matters: readMarker returns null when the marker is missing or is not
+  // ours, and Number(null) is 0, which is finite -- so without this an absent
+  // marker would read as a harvest at the epoch.
+  if (
+    Number.isFinite(last) &&
+    last > 0 &&
+    Date.now() - last < HARVEST_INTERVAL_MS
+  ) {
+    return false;
+  }
+
+  // If the marker cannot be written the debounce degrades to off rather than
+  // blocking the harvest entirely.
+  writeMarker(marker, String(Date.now()));
+  return true;
+}
+
+/**
+ * The Stop-time harvest, for every client rather than one.
+ *
+ * WHY THIS IS A FUNCTION AND NOT A HOOK. It was a hook -- a Claude Code entry
+ * point named `stop-harvest.mjs` -- and #300 unregistered it. Nothing replaced
+ * it, so four capabilities went silently: the transcript archive, the harvest
+ * worker spawn, refusal detection, and the notice that says why no findings
+ * exist. Every client routes Stop through the shared adapter, and the adapter
+ * did none of these, so on a full session with a valid credential
+ * `harvestMode()` reported `remote` and nothing happened.
+ *
+ * NOTHING OBSERVED THAT IT DID NOT RUN, which is why it survived a year. There
+ * is no `kind:'harvest'` event to be absent from a report, no error, and a
+ * harvest that ran and found nothing looks exactly like one that never
+ * started. The reachability guard could not see it either: this file's own
+ * imports gave `archive`, `detectRefusals` and `recordRefusal` call sites, and
+ * a name-based scan proves a reference exists, never that it runs.
+ *
+ * Returns a notice for the caller to emit, or null. It does NOT write to
+ * stdout: the adapter emits exactly one JSON object per hook invocation, and a
+ * second writer racing it is how a Stop payload gets corrupted.
+ *
+ * @returns {Promise<string|null>} a once-per-session message, or null.
+ */
+export async function runStopHarvest(payload = {}) {
+  if (mode() === MODE_OFF) return null;
+
+  const transcript = payload.transcript_path ?? payload.transcriptPath ?? null;
+  if (!transcript || !existsSync(transcript)) return null;
+
+  // ARCHIVE FIRST, AND UNCONDITIONALLY. This is a local file copy: it costs no
+  // model call, spends no money, and sends nothing anywhere, so it must not sit
+  // behind the opt-in that exists to gate cost and disclosure. Gating it there
+  // would mean the record of what the user actually said is kept only for the
+  // users who opted into a paid feature, which is exactly backwards.
+  //
+  // It also has to happen before the early return below, or a session with
+  // harvesting off would archive nothing at all.
+  try {
+    archive(
+      wikiDir(
+        projectRootFor(
+          join(payload.cwd || process.cwd(), '__session__'),
+          payload.cwd
+        )
+      ),
+      transcript,
+      {
+        sessionId: payload.session_id,
+      }
+    );
+  } catch {
+    // The archive is a convenience. Failing to write it must not affect Stop.
+  }
+
+  // CLOSE THE REFUSAL LOOP, and do it OUTSIDE the harvest opt-in. Reading the
+  // transcript this process already holds costs no model call and sends nothing
+  // anywhere, so gating it behind the paid feature would leave a mis-scoped
+  // lesson costing tokens forever for everyone who did not opt in.
+  //
+  // The model states plainly when a cross-project lesson does not transfer --
+  // "that figure is another repo's baseline and it doesn't transfer" -- and until
+  // now nothing read it, so the same lesson was delivered again next session.
+  try {
+    const shared = sharedDir();
+    const lessons = [...load(shared).nodes.values()].filter(
+      (n) => n.kind === 'finding' && !n.retired && n.claim
+    );
+    if (lessons.length) {
+      const text = readFileSync(transcript, 'utf8');
+      for (const key of detectRefusals(lessons, text))
+        recordRefusal(shared, key);
+    }
+  } catch {
+    // Feedback is a refinement; a failure here must not affect Stop.
+  }
+
+  if (!harvestEnabled()) {
+    // Say it once, name the reason and the variable that changes it, and state
+    // what still works. A user who reads this should know exactly what they are
+    // and are not getting, and what to do about it.
+    const message = OFF_REASON[harvestMode()];
+    // RETURNED, NOT WRITTEN. This used to write its own JSON to stdout and
+    // race whatever the hook emitted; the adapter now folds this into the one
+    // object it sends, so the notice cannot be dropped by a full pipe or
+    // truncated by an exit -- which is what used to happen to the single line
+    // explaining why no findings exist.
+    if (message && !alreadyNotified(payload.session_id)) return message;
+    return null;
+  }
+
+  // SIBLING IN THE SHARED CORE. The worker used to live beside the hook entry
+  // in `plugin/hooks/`, which is why only Claude Code could ever have spawned
+  // it -- it was vendored to no other client. It now sits in the core that
+  // every client receives an identical copy of, so this resolves in all
+  // eleven.
+  const worker = join(HERE, 'harvest-worker.mjs');
+  if (!existsSync(worker)) return null;
+
+  // DEBOUNCE. Stop fires at the end of every assistant turn, so a talkative
+  // session would spawn a model call per turn -- each re-reading an overlapping
+  // transcript and re-extracting most of the same findings. The marker is
+  // touched only when a harvest is actually started, so a skipped turn does not
+  // push the next one further away.
+  if (!dueForHarvest(payload.session_id)) return null;
+
+  // Detached and fully released: the harvest must outlive this hook without
+  // holding Stop open for a model round-trip.
+  const child = spawn(
+    process.execPath,
+    [
+      worker,
+      transcript,
+      String(payload.session_id || ''),
+      String(payload.cwd || process.cwd()),
+    ],
+    {
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: true,
+      env: { ...process.env },
+    }
+  );
+  child.unref();
+  return null;
+}

--- a/integrations/codex/plugin/hooks/lib/adapter.mjs
+++ b/integrations/codex/plugin/hooks/lib/adapter.mjs
@@ -762,8 +762,11 @@ async function runHook(clientName, event, invocation) {
     const toolEvidence = optimizerToolsForHook(raw, state);
     rememberOptimizerTools(state, toolEvidence);
     const episode = episodeMeta({ client: clientName, raw });
+    // Hoisted out of the try below, because the harvest needs the same resolved
+    // directory and resolving it twice is how two halves of one hook end up
+    // reasoning about different projects.
+    const cwd = raw.cwd || raw.working_directory || process.cwd();
     try {
-      const cwd = raw.cwd || raw.working_directory || process.cwd();
       const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
       recordEpisodeOutcome(dir, {
         ...episode,
@@ -807,7 +810,21 @@ async function runHook(clientName, event, invocation) {
     // call.
     let harvestNotice = null;
     try {
-      harvestNotice = await runStopHarvest(raw);
+      // NORMALIZED, NOT RAW. The identifiers were resolved a few lines up
+      // through every alias a host might use -- `sessionId`,
+      // `conversation_id`, `working_directory` -- and handing `raw` straight
+      // over threw that away: runStopHarvest reads `session_id` and `cwd`
+      // only, so on a client that sends an alias the session id came back
+      // undefined and the archive root fell back to `process.cwd()`. That
+      // shares the once-per-session notice and the debounce marker across
+      // every session, and files the transcript under whatever directory the
+      // hook happened to start in.
+      harvestNotice = await runStopHarvest({
+        ...raw,
+        session_id: sessionId,
+        cwd,
+        transcript_path: raw.transcript_path ?? raw.transcriptPath ?? null,
+      });
     } catch {
       // The harvest is a side effect of ending a session. It must never stop
       // one from ending.

--- a/integrations/codex/plugin/hooks/lib/adapter.mjs
+++ b/integrations/codex/plugin/hooks/lib/adapter.mjs
@@ -88,6 +88,7 @@ import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 import { evaluateUcrGuards } from './ucr-guard.mjs';
 import { beginHookInvocation, noteHookOutput } from './observability.mjs';
 import { registerProject } from './projects.mjs';
+import { runStopHarvest } from './stop-harvest.mjs';
 
 /**
  * Per-client capability.
@@ -792,10 +793,33 @@ async function runHook(clientName, event, invocation) {
       state.harvestedEdits = Number(state.edits || 0);
       saveState(sessionId, state, agentScope);
     }
+    // THE OUT-OF-BAND HARVEST, which no client was running.
+    //
+    // The in-band `prompt` above asks the MODEL to call `wiki_write`, and the
+    // session pays for summarising itself -- the exact cost the design says the
+    // harvest exists to avoid ("out-of-band, so the session doing the work never
+    // pays for the harvest"). The out-of-band half lived in a Claude Code hook
+    // that #300 unregistered, and nothing replaced it, so on every client the
+    // transcript was never archived, the worker never spawned, refusals were
+    // never detected, and the notice explaining why no findings exist was never
+    // shown. Awaited because it must finish before the exit below; it spawns a
+    // DETACHED worker and returns immediately, so Stop is not delayed by a model
+    // call.
+    let harvestNotice = null;
+    try {
+      harvestNotice = await runStopHarvest(raw);
+    } catch {
+      // The harvest is a side effect of ending a session. It must never stop
+      // one from ending.
+    }
+
     if (prompt && client.stopStyle === 'followup') {
-      emit({ followup_message: prompt });
+      emit({ followup_message: prompt, ...(harvestNotice ? { systemMessage: harvestNotice } : {}) });
     } else {
-      emit(prompt ? { decision: client.stopDecision, reason: prompt } : {});
+      emit({
+        ...(prompt ? { decision: client.stopDecision, reason: prompt } : {}),
+        ...(harvestNotice ? { systemMessage: harvestNotice } : {}),
+      });
     }
     process.exit(0);
   }

--- a/integrations/codex/plugin/hooks/lib/harvest-worker.mjs
+++ b/integrations/codex/plugin/hooks/lib/harvest-worker.mjs
@@ -1,0 +1,248 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/harvest-worker.mjs. Regenerate with `npm run sync:hooks`.
+#!/usr/bin/env node
+/**
+ * The out-of-band half of the semantic harvest.
+ *
+ * Spawned detached by the Stop adapter so the session that did the work never
+ * pays for the model call that summarises it. Everything here is best-effort:
+ * a harvest that fails must be indistinguishable from a session with nothing
+ * to learn, because the alternative -- a hook that can break a turn -- is worse
+ * than no findings at all.
+ *
+ * The cost of the extraction is recorded either way. Without it the metrics
+ * report a benefit with no matching expense, and `netTokens` would flatter the
+ * feature by exactly the amount it spends.
+ */
+
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  harvestEnabled,
+  buildDigest,
+  buildFullDelta,
+  extract,
+  validate,
+  estimateTokens,
+} from './harvest.mjs';
+import { writeHarvested } from './harvest-write.mjs';
+import { record } from './metrics.mjs';
+import { wikiDir, projectRootFor, load } from './wiki.mjs';
+import { readArchive } from './transcript.mjs';
+import { buildFeedbackDigest, validateLessons, LESSON_PROMPT } from './lessons.mjs';
+import { ORIGIN_HARVESTED } from './curate.mjs';
+import { selectForConsolidation } from './consolidate.mjs';
+
+/**
+ * The token budget one session's harvest may add to the graph.
+ *
+ * #204 lists graph bloat as a named risk -- "the session-start index grows with
+ * the graph; ranking and eviction are required, not optional" -- and until now
+ * nothing bounded what a single harvest could store. 4,000 tokens is the
+ * selector's own default and roughly twenty-five findings at the size the
+ * extractor produces, which is far above any observed session's real yield; it
+ * is a ceiling against a pathological extraction, not a routine constraint.
+ */
+const CONSOLIDATION_BUDGET = 4000;
+
+/**
+ * The files the digest says were touched.
+ *
+ * `buildDigest` emits them under a `## Files touched` heading and returns a
+ * string, so this reads back the list it just wrote rather than walking the
+ * transcript a second time. Returns null when the section is absent, which
+ * `validate` treats as "no restriction" rather than "no files".
+ */
+function filesIn(digest) {
+  const start = digest.indexOf('## Files touched');
+  if (start === -1) return null;
+
+  const rest = digest.slice(start + '## Files touched'.length);
+  const end = rest.indexOf('\n##');
+  const block = (end === -1 ? rest : rest.slice(0, end)).split('\n');
+
+  const files = new Set();
+  for (const line of block) {
+    const value = line.trim();
+    if (value) files.add(value);
+  }
+  return files.size ? files : null;
+}
+
+async function main() {
+  const [transcript, sessionId, cwd] = process.argv.slice(2);
+  if (!transcript || !existsSync(transcript) || !harvestEnabled()) return;
+
+  // THE GRAPH AND THE CONTAINMENT BOUNDARY BOTH COME FROM THE REPOSITORY ROOT,
+  // NOT THE SESSION'S CWD. `wikiDir` only joins the path it is handed, so a
+  // session started in a subdirectory selected `<subdir>/.token-optimizer/wiki`
+  // -- a second graph, invisible to every other hook, which all resolve the root
+  // first. It also made the subdirectory the containment root for the write, so
+  // a finding anchored anywhere else in the same repository was refused for
+  // sitting "outside" the project.
+  //
+  // `__session__` is a synthetic leaf so the walk starts at `cwd` itself rather
+  // than its parent; `projectRootFor` takes a FILE path. This is the same idiom
+  // the adapter, the session-start hook and the Stop adapter already use.
+  //
+  // A cwd with no VCS ancestor resolves to the machine-level unrooted bucket,
+  // which `resolveAnchor` expects and handles: it swaps in home as the
+  // containment root for that case, so passing the resolved root here is what
+  // lets unrooted anchors work at all.
+  const sessionCwd = cwd || process.cwd();
+  const projectRoot = projectRootFor(join(sessionCwd, '__session__'), sessionCwd);
+  const dir = wikiDir(projectRoot);
+
+  // Default sends a structured digest with no file contents. The full delta is
+  // opt-in because the default has to be defensible without reading the docs.
+  const full = process.env.TOKEN_OPTIMIZER_HARVEST_FULL === 'true';
+  const digest = full ? buildFullDelta(transcript) : buildDigest(transcript);
+  if (!digest) return;
+
+  const raw = await extract(digest);
+
+  // Anchors are held to the files this session actually touched, so a model
+  // that invents a plausible path cannot anchor a finding to it. The digest
+  // lists them under a heading it writes itself; the full delta is raw
+  // transcript and carries no such list, so it gets no restriction.
+  const validated = validate(raw, { knownFiles: full ? null : filesIn(digest) });
+
+  // BUDGETED SELECTION, not everything the model extracted.
+  //
+  // `selectForConsolidation` exists for exactly this and had no caller
+  // anywhere, so every harvested candidate was stored regardless of what it
+  // cost to derive, how hard it is to reproduce, or whether the graph can ever
+  // retrieve it -- which is the graph-bloat risk #204 lists as needing
+  // "ranking and eviction ... not optional". It keeps failures and decisions on
+  // a floor before ranking, encoding the design's judgement that dead ends are
+  // the highest-value kind: they exist nowhere in the source tree, so nothing
+  // else can ever recover them.
+  //
+  // The selection is RECORDED, not silent. A cap that drops work without
+  // saying so reads as "there was nothing more to find", which is the same
+  // dishonesty as a truncated report with no remainder line.
+  const graph = load(dir);
+  const selection = selectForConsolidation(graph, validated, { budget: CONSOLIDATION_BUDGET });
+  const findings = selection.kept;
+  if (selection.dropped > 0) {
+    record(dir, {
+      kind: 'harvest',
+      action: 'consolidation',
+      candidates: validated.length,
+      kept: findings.length,
+      dropped: selection.dropped,
+      tokens: selection.tokens,
+      budget: CONSOLIDATION_BUDGET,
+    });
+  }
+
+  const written = writeHarvested(dir, findings, {
+    sessionId: sessionId || null,
+    projectRoot,
+    // Task nodes are keyed by session id (structural capture creates one on
+    // the first touched file, `harvest()` in lib/wiki.mjs) so this is the
+    // shape `writeHarvested` needs to point the `answers` edge back at the
+    // task this harvest belongs to. A session that never touched a file
+    // through PreToolUse/PostToolUse has no such node yet; `writeHarvested`
+    // resolves that case to no edge rather than a dangling one.
+    taskId: sessionId || null,
+    // AUTHORITATIVE, not just present: this `sessionId` came from Claude
+    // Code's own Stop-hook payload (see stop-harvest.mjs), not a model-typed
+    // tool argument, so it is safe to use for the traversal fallback if the
+    // explicit `taskId` above does not resolve.
+    authoritativeSessionId: sessionId || null,
+  });
+
+  record(dir, {
+    kind: 'harvest',
+    sessionId: sessionId || null,
+    tokens: estimateTokens(digest),
+    findings: written.length,
+    at: Date.now(),
+  });
+
+  // THE FEEDBACK LOOP. A separate extraction with a separate prompt, because
+  // the two are looking for different things: the harvest above wants what was
+  // LEARNED about the code, this wants where the user said the agent was WRONG.
+  // Asked for both at once a model returns a summary and the corrections get
+  // lost in it -- and corrections are the only turns carrying information the
+  // code itself could never supply.
+  try {
+    const turns = readArchive(dir, sessionId || 'unknown');
+    const feedback = buildFeedbackDigest(turns);
+    if (feedback) {
+      const rawLessons = await extract(feedback, { prompt: LESSON_PROMPT });
+      // The same restriction the finding path above applies, for the same reason: a model that
+      // invents a plausible path must not be able to anchor a lesson to it. `turns` is the
+      // archived transcript for this session, so its rendered digest is the honest file list.
+      const { lessons } = validateLessons(rawLessons, turns, {
+        knownFiles: filesIn(feedback),
+      });
+
+      // Anchors are optional on a lesson -- "always run npm test" is about no
+      // file -- so each is anchored to the project root when it names nothing,
+      // which keeps the store's rule that an unanchored finding is refused.
+      //
+      // The RESOLVED root, matching the containment root this write is checked
+      // against. The session's cwd would be refused outright once that root is
+      // the unrooted bucket, because `resolveAnchor` then narrows containment to
+      // home and a VCS-less working directory need not sit under it.
+      const anchored = lessons.map((l) => ({
+        ...l,
+        anchors: l.anchors.length ? l.anchors : [projectRoot],
+      }));
+
+      // The write itself is the durable record: writeHarvested anchors each
+      // lesson into the graph, which is what lessons.mjs's real consumers
+      // query. A metrics event of kind 'lessons' used to sit here as well,
+      // but nothing ever read it -- not netTokens (only 'harvest' feeds
+      // harvestTokens), not report()/buildReport() (no kind filter matches
+      // 'lessons'), and no audit render exists to show it to a human. That is
+      // the inverse of the `query` defect and the same shape as
+      // `tokensFullFile` before it: a produced-and-never-consumed event,
+      // which is a cost with no benefit. Deleted rather than wired, per the
+      // reachability allowlist's own rule -- write it again the day
+      // something needs to read it.
+      writeHarvested(dir, anchored, {
+        sessionId: sessionId || null,
+        origin: ORIGIN_HARVESTED,
+        projectRoot,
+        taskId: sessionId || null,
+        // Same hook-payload identity as above, same reason.
+        authoritativeSessionId: sessionId || null,
+      });
+    }
+  } catch {
+    // A failed feedback pass must be indistinguishable from a session with
+    // nothing to correct.
+  }
+}
+
+main()
+  .catch(() => {})
+  .finally(() => {
+    // NEVER process.exit() SYNCHRONOUSLY HERE.
+    //
+    // It crashed this worker on Windows every single time the feedback pass
+    // ran -- libuv asserts `!(handle->flags & UV_HANDLE_CLOSING)` when the
+    // process exits while the sockets from the model call are still closing,
+    // giving exit code 0xC0000409. Reproduced 5 runs out of 5, and silently,
+    // because this worker is spawned detached and nothing reads its status.
+    // Deferring by one tick is NOT enough; the handles are still closing then.
+    //
+    // So the normal path just lets the loop drain, which it does promptly.
+    //
+    // THE RECORDED CODE IS PRESERVED, not overwritten with 0. Assigning 0
+    // unconditionally would turn a harvest that had already recorded a failure
+    // into one that reports success -- and this worker is detached, so that
+    // status is the only signal a supervisor could ever act on.
+    const code = process.exitCode ?? 0;
+    process.exitCode = code;
+
+    // The watchdog keeps the original guarantee: a detached worker must never
+    // linger holding a keep-alive socket open. It is UNREF'D, so it cannot
+    // itself keep the process alive -- it only fires if something else already
+    // has, which is exactly the case worth killing.
+    const watchdog = setTimeout(() => process.exit(code), 5000);
+    watchdog.unref();
+  });

--- a/integrations/codex/plugin/hooks/lib/harvest-worker.mjs
+++ b/integrations/codex/plugin/hooks/lib/harvest-worker.mjs
@@ -1,6 +1,6 @@
+#!/usr/bin/env node
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/harvest-worker.mjs. Regenerate with `npm run sync:hooks`.
-#!/usr/bin/env node
 /**
  * The out-of-band half of the semantic harvest.
  *

--- a/integrations/codex/plugin/hooks/lib/stop-harvest.mjs
+++ b/integrations/codex/plugin/hooks/lib/stop-harvest.mjs
@@ -353,6 +353,11 @@ export async function runStopHarvest(payload = {}) {
       env: { ...process.env },
     }
   );
+  // AN 'error' EVENT WITH NO LISTENER IS A THROW. `spawn` reports a failed
+  // start asynchronously, so an unlistened error does not return a code -- Node
+  // raises it, and here that would abort the Stop response itself. A harvest
+  // that cannot start must degrade to no harvest, never to a broken Stop.
+  child.on('error', () => {});
   child.unref();
   return null;
 }

--- a/integrations/codex/plugin/hooks/lib/stop-harvest.mjs
+++ b/integrations/codex/plugin/hooks/lib/stop-harvest.mjs
@@ -1,0 +1,358 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/stop-harvest.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Claude Code Stop adapter -- run the semantic harvest the design specifies.
+ *
+ * The wiki design says findings are extracted "at Stop and PreCompact" by a
+ * cheap model, out of band. The extractor (`lib/harvest.mjs`) was implemented
+ * and then imported by nothing: no hook invoked it, and Stop carried no
+ * token-optimizer entry at all. The consequence was not a crash but a graph
+ * that could serve findings and never acquired any -- 122 file / 132 symbol /
+ * 61 task nodes and zero findings on a real project after a full session, with
+ * injection, staleness and the metrics all wired and idle behind it.
+ *
+ * OUT OF BAND IS THE POINT. The extraction is a model call; doing it inline
+ * would make the session that did the work pay for summarising itself, which is
+ * the cost this whole subsystem exists to avoid. So this spawns a detached
+ * worker and returns immediately. Stop is never delayed.
+ *
+ * IT ALSO REPORTS WHEN IT CANNOT RUN. Harvest requires an API key, and without
+ * one `harvestEnabled()` returns false and the module skips silently. Silence
+ * was how this stayed invisible: nothing in doctor, audit or waste mentions
+ * harvest, so a user sees a graph filling with structural nodes and no findings
+ * and has no way to learn why. Saying so once per session is the difference
+ * between a disabled feature and a broken one.
+ */
+
+import { spawn } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  chmodSync,
+  readFileSync,
+  openSync,
+  writeSync,
+  closeSync,
+  lstatSync,
+  constants,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir, homedir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { mode, MODE_OFF } from './policy.mjs';
+import { harvestEnabled, harvestMode } from './harvest.mjs';
+import { archive } from './transcript.mjs';
+import { wikiDir, projectRootFor, sharedDir, load } from './wiki.mjs';
+import { detectRefusals, recordRefusal } from './harvest-write.mjs';
+
+/** What to tell the user, per reason the harvest is not running. */
+const OFF_REASON = {
+  'off:mode': null, // The whole optimizer is off; saying more would be noise.
+  'off:not-opted-in':
+    'token-optimizer: automatic finding-extraction is OFF. It costs a model call and ' +
+    'sends a digest (paths, commands, prompts, conclusions -- never file contents) off ' +
+    'this machine, so it is opt-in: set TOKEN_OPTIMIZER_HARVEST=1 with an API key, or ' +
+    'point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model to run it free and private. ' +
+    'Meanwhile lifecycle-based structural graph capture keeps working. Durable semantic MCP ' +
+    'writes require a writer schema that is actually registered in the current CLI session.',
+  'off:no-key':
+    'token-optimizer: finding-extraction is opted in but has no credential. Set ' +
+    'TOKEN_OPTIMIZER_API_KEY, or point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model ' +
+    'to run it without one.',
+};
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * A session id reduced to something that cannot leave the marker directory.
+ *
+ * The id arrives in the hook payload, so it is external input, and it was being
+ * interpolated straight into a path: a value containing separators or `..` would
+ * have placed (and later read) the marker anywhere on disk. Everything outside a
+ * conservative allowlist becomes an underscore, which keeps ordinary uuids
+ * readable while making traversal unrepresentable rather than merely unlikely.
+ */
+function markerName(sessionId) {
+  const safe = String(sessionId || 'unknown').replace(/[^A-Za-z0-9._-]/g, '_');
+  // A name of only dots would still resolve to a directory entry.
+  const cleaned = /^[.]+$/.test(safe) ? 'unknown' : safe;
+  return `harvest-notice-${cleaned.slice(0, 64)}`;
+}
+
+/**
+ * A private, per-user directory for this hook's markers.
+ *
+ * os.tmpdir() is per-user on Windows but resolves to a SHARED, world-writable
+ * /tmp on POSIX. The marker name is derived from the session id, so it is
+ * predictable enough for another local user to pre-create -- as a symlink, or
+ * as a file they own -- and writeFileSync would then follow it and write
+ * through with this user's privileges.
+ *
+ * The state here is a debounce timestamp and a "said it once" flag, so the fix
+ * is not to guard a shared location but to stop using one. XDG_STATE_HOME is
+ * the standard place for state that should persist across runs but is not
+ * precious, and it is inside the user's own home on every POSIX system.
+ */
+function stateDir() {
+  const home = homedir();
+  const base =
+    process.platform === 'win32'
+      ? process.env.LOCALAPPDATA || tmpdir()
+      : process.env.XDG_STATE_HOME ||
+        (home ? join(home, '.local', 'state') : tmpdir());
+
+  const dir = join(base, 'token-optimizer');
+  try {
+    // 0o700 AND an explicit chmod, for the reason the graph store documents:
+    // `recursive` applies the mode only to directories it actually creates, and
+    // the umask masks it further, so neither alone guarantees the result.
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    try {
+      chmodSync(dir, 0o700);
+    } catch {
+      // Not POSIX, or not ours to chmod.
+    }
+  } catch {
+    /* best effort */
+  }
+  return dir;
+}
+
+/** Where the once-per-session notice is remembered, so Stop does not nag. */
+function noticePath(sessionId) {
+  return join(stateDir(), markerName(sessionId));
+}
+
+/**
+ * True when the path is absent, or is a regular file this user owns.
+ *
+ * lstat rather than stat: stat FOLLOWS the link and would happily report on the
+ * target, which is the thing being defended against.
+ */
+function ownedRegularFile(path) {
+  let info;
+  try {
+    info = lstatSync(path);
+  } catch {
+    return true; // Absent. The O_NOFOLLOW open below settles the race.
+  }
+  if (!info.isFile()) return false;
+  // getuid is undefined on Windows, where stateDir() is already per-user.
+  if (typeof process.getuid === 'function' && info.uid !== process.getuid())
+    return false;
+  return true;
+}
+
+/**
+ * Writes a marker, refusing to follow a symlink.
+ *
+ * O_NOFOLLOW makes the refusal ATOMIC rather than a check-then-use window: a
+ * link swapped in after ownedRegularFile() returns fails the open instead of
+ * being written through. The flag does not exist on Windows, where it is
+ * undefined and falls back to 0 -- acceptable, because the directory is
+ * per-user there to begin with.
+ */
+function writeMarker(path, contents) {
+  if (!ownedRegularFile(path)) return false;
+  const NOFOLLOW = constants.O_NOFOLLOW || 0;
+  let fd;
+  try {
+    fd = openSync(
+      path,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | NOFOLLOW,
+      0o600
+    );
+    writeSync(fd, contents);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* already closed */
+      }
+    }
+  }
+}
+
+/** Reads a marker, ignoring anything that is not a regular file we own. */
+function readMarker(path) {
+  if (!ownedRegularFile(path)) return null;
+  try {
+    return readFileSync(path, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function alreadyNotified(sessionId) {
+  const path = noticePath(sessionId);
+  // Anything already at this path -- our marker, or something planted -- means
+  // stay quiet. Repeating the notice is the worse failure, and refusing to
+  // write over a foreign file is the point.
+  if (existsSync(path)) return true;
+  return !writeMarker(path, String(Date.now()));
+}
+
+/** Minimum gap between harvests of one session. */
+const HARVEST_INTERVAL_MS =
+  Number(process.env.TOKEN_OPTIMIZER_HARVEST_INTERVAL_MS) > 0
+    ? Number(process.env.TOKEN_OPTIMIZER_HARVEST_INTERVAL_MS)
+    : 10 * 60 * 1000;
+
+/**
+ * True when this session has not been harvested recently, and records that it
+ * is about to be.
+ *
+ * Deliberately marks only when a harvest actually starts: touching it on every
+ * Stop would let a run of skipped turns keep pushing the next harvest away.
+ */
+function dueForHarvest(sessionId) {
+  const marker = join(stateDir(), `harvest-last-${markerName(sessionId)}`);
+
+  const last = Number(readMarker(marker));
+  // > 0 matters: readMarker returns null when the marker is missing or is not
+  // ours, and Number(null) is 0, which is finite -- so without this an absent
+  // marker would read as a harvest at the epoch.
+  if (
+    Number.isFinite(last) &&
+    last > 0 &&
+    Date.now() - last < HARVEST_INTERVAL_MS
+  ) {
+    return false;
+  }
+
+  // If the marker cannot be written the debounce degrades to off rather than
+  // blocking the harvest entirely.
+  writeMarker(marker, String(Date.now()));
+  return true;
+}
+
+/**
+ * The Stop-time harvest, for every client rather than one.
+ *
+ * WHY THIS IS A FUNCTION AND NOT A HOOK. It was a hook -- a Claude Code entry
+ * point named `stop-harvest.mjs` -- and #300 unregistered it. Nothing replaced
+ * it, so four capabilities went silently: the transcript archive, the harvest
+ * worker spawn, refusal detection, and the notice that says why no findings
+ * exist. Every client routes Stop through the shared adapter, and the adapter
+ * did none of these, so on a full session with a valid credential
+ * `harvestMode()` reported `remote` and nothing happened.
+ *
+ * NOTHING OBSERVED THAT IT DID NOT RUN, which is why it survived a year. There
+ * is no `kind:'harvest'` event to be absent from a report, no error, and a
+ * harvest that ran and found nothing looks exactly like one that never
+ * started. The reachability guard could not see it either: this file's own
+ * imports gave `archive`, `detectRefusals` and `recordRefusal` call sites, and
+ * a name-based scan proves a reference exists, never that it runs.
+ *
+ * Returns a notice for the caller to emit, or null. It does NOT write to
+ * stdout: the adapter emits exactly one JSON object per hook invocation, and a
+ * second writer racing it is how a Stop payload gets corrupted.
+ *
+ * @returns {Promise<string|null>} a once-per-session message, or null.
+ */
+export async function runStopHarvest(payload = {}) {
+  if (mode() === MODE_OFF) return null;
+
+  const transcript = payload.transcript_path ?? payload.transcriptPath ?? null;
+  if (!transcript || !existsSync(transcript)) return null;
+
+  // ARCHIVE FIRST, AND UNCONDITIONALLY. This is a local file copy: it costs no
+  // model call, spends no money, and sends nothing anywhere, so it must not sit
+  // behind the opt-in that exists to gate cost and disclosure. Gating it there
+  // would mean the record of what the user actually said is kept only for the
+  // users who opted into a paid feature, which is exactly backwards.
+  //
+  // It also has to happen before the early return below, or a session with
+  // harvesting off would archive nothing at all.
+  try {
+    archive(
+      wikiDir(
+        projectRootFor(
+          join(payload.cwd || process.cwd(), '__session__'),
+          payload.cwd
+        )
+      ),
+      transcript,
+      {
+        sessionId: payload.session_id,
+      }
+    );
+  } catch {
+    // The archive is a convenience. Failing to write it must not affect Stop.
+  }
+
+  // CLOSE THE REFUSAL LOOP, and do it OUTSIDE the harvest opt-in. Reading the
+  // transcript this process already holds costs no model call and sends nothing
+  // anywhere, so gating it behind the paid feature would leave a mis-scoped
+  // lesson costing tokens forever for everyone who did not opt in.
+  //
+  // The model states plainly when a cross-project lesson does not transfer --
+  // "that figure is another repo's baseline and it doesn't transfer" -- and until
+  // now nothing read it, so the same lesson was delivered again next session.
+  try {
+    const shared = sharedDir();
+    const lessons = [...load(shared).nodes.values()].filter(
+      (n) => n.kind === 'finding' && !n.retired && n.claim
+    );
+    if (lessons.length) {
+      const text = readFileSync(transcript, 'utf8');
+      for (const key of detectRefusals(lessons, text))
+        recordRefusal(shared, key);
+    }
+  } catch {
+    // Feedback is a refinement; a failure here must not affect Stop.
+  }
+
+  if (!harvestEnabled()) {
+    // Say it once, name the reason and the variable that changes it, and state
+    // what still works. A user who reads this should know exactly what they are
+    // and are not getting, and what to do about it.
+    const message = OFF_REASON[harvestMode()];
+    // RETURNED, NOT WRITTEN. This used to write its own JSON to stdout and
+    // race whatever the hook emitted; the adapter now folds this into the one
+    // object it sends, so the notice cannot be dropped by a full pipe or
+    // truncated by an exit -- which is what used to happen to the single line
+    // explaining why no findings exist.
+    if (message && !alreadyNotified(payload.session_id)) return message;
+    return null;
+  }
+
+  // SIBLING IN THE SHARED CORE. The worker used to live beside the hook entry
+  // in `plugin/hooks/`, which is why only Claude Code could ever have spawned
+  // it -- it was vendored to no other client. It now sits in the core that
+  // every client receives an identical copy of, so this resolves in all
+  // eleven.
+  const worker = join(HERE, 'harvest-worker.mjs');
+  if (!existsSync(worker)) return null;
+
+  // DEBOUNCE. Stop fires at the end of every assistant turn, so a talkative
+  // session would spawn a model call per turn -- each re-reading an overlapping
+  // transcript and re-extracting most of the same findings. The marker is
+  // touched only when a harvest is actually started, so a skipped turn does not
+  // push the next one further away.
+  if (!dueForHarvest(payload.session_id)) return null;
+
+  // Detached and fully released: the harvest must outlive this hook without
+  // holding Stop open for a model round-trip.
+  const child = spawn(
+    process.execPath,
+    [
+      worker,
+      transcript,
+      String(payload.session_id || ''),
+      String(payload.cwd || process.cwd()),
+    ],
+    {
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: true,
+      env: { ...process.env },
+    }
+  );
+  child.unref();
+  return null;
+}

--- a/integrations/copilot/.github/hooks/lib/adapter.mjs
+++ b/integrations/copilot/.github/hooks/lib/adapter.mjs
@@ -762,8 +762,11 @@ async function runHook(clientName, event, invocation) {
     const toolEvidence = optimizerToolsForHook(raw, state);
     rememberOptimizerTools(state, toolEvidence);
     const episode = episodeMeta({ client: clientName, raw });
+    // Hoisted out of the try below, because the harvest needs the same resolved
+    // directory and resolving it twice is how two halves of one hook end up
+    // reasoning about different projects.
+    const cwd = raw.cwd || raw.working_directory || process.cwd();
     try {
-      const cwd = raw.cwd || raw.working_directory || process.cwd();
       const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
       recordEpisodeOutcome(dir, {
         ...episode,
@@ -807,7 +810,21 @@ async function runHook(clientName, event, invocation) {
     // call.
     let harvestNotice = null;
     try {
-      harvestNotice = await runStopHarvest(raw);
+      // NORMALIZED, NOT RAW. The identifiers were resolved a few lines up
+      // through every alias a host might use -- `sessionId`,
+      // `conversation_id`, `working_directory` -- and handing `raw` straight
+      // over threw that away: runStopHarvest reads `session_id` and `cwd`
+      // only, so on a client that sends an alias the session id came back
+      // undefined and the archive root fell back to `process.cwd()`. That
+      // shares the once-per-session notice and the debounce marker across
+      // every session, and files the transcript under whatever directory the
+      // hook happened to start in.
+      harvestNotice = await runStopHarvest({
+        ...raw,
+        session_id: sessionId,
+        cwd,
+        transcript_path: raw.transcript_path ?? raw.transcriptPath ?? null,
+      });
     } catch {
       // The harvest is a side effect of ending a session. It must never stop
       // one from ending.

--- a/integrations/copilot/.github/hooks/lib/adapter.mjs
+++ b/integrations/copilot/.github/hooks/lib/adapter.mjs
@@ -88,6 +88,7 @@ import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 import { evaluateUcrGuards } from './ucr-guard.mjs';
 import { beginHookInvocation, noteHookOutput } from './observability.mjs';
 import { registerProject } from './projects.mjs';
+import { runStopHarvest } from './stop-harvest.mjs';
 
 /**
  * Per-client capability.
@@ -792,10 +793,33 @@ async function runHook(clientName, event, invocation) {
       state.harvestedEdits = Number(state.edits || 0);
       saveState(sessionId, state, agentScope);
     }
+    // THE OUT-OF-BAND HARVEST, which no client was running.
+    //
+    // The in-band `prompt` above asks the MODEL to call `wiki_write`, and the
+    // session pays for summarising itself -- the exact cost the design says the
+    // harvest exists to avoid ("out-of-band, so the session doing the work never
+    // pays for the harvest"). The out-of-band half lived in a Claude Code hook
+    // that #300 unregistered, and nothing replaced it, so on every client the
+    // transcript was never archived, the worker never spawned, refusals were
+    // never detected, and the notice explaining why no findings exist was never
+    // shown. Awaited because it must finish before the exit below; it spawns a
+    // DETACHED worker and returns immediately, so Stop is not delayed by a model
+    // call.
+    let harvestNotice = null;
+    try {
+      harvestNotice = await runStopHarvest(raw);
+    } catch {
+      // The harvest is a side effect of ending a session. It must never stop
+      // one from ending.
+    }
+
     if (prompt && client.stopStyle === 'followup') {
-      emit({ followup_message: prompt });
+      emit({ followup_message: prompt, ...(harvestNotice ? { systemMessage: harvestNotice } : {}) });
     } else {
-      emit(prompt ? { decision: client.stopDecision, reason: prompt } : {});
+      emit({
+        ...(prompt ? { decision: client.stopDecision, reason: prompt } : {}),
+        ...(harvestNotice ? { systemMessage: harvestNotice } : {}),
+      });
     }
     process.exit(0);
   }

--- a/integrations/copilot/.github/hooks/lib/harvest-worker.mjs
+++ b/integrations/copilot/.github/hooks/lib/harvest-worker.mjs
@@ -1,0 +1,248 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/harvest-worker.mjs. Regenerate with `npm run sync:hooks`.
+#!/usr/bin/env node
+/**
+ * The out-of-band half of the semantic harvest.
+ *
+ * Spawned detached by the Stop adapter so the session that did the work never
+ * pays for the model call that summarises it. Everything here is best-effort:
+ * a harvest that fails must be indistinguishable from a session with nothing
+ * to learn, because the alternative -- a hook that can break a turn -- is worse
+ * than no findings at all.
+ *
+ * The cost of the extraction is recorded either way. Without it the metrics
+ * report a benefit with no matching expense, and `netTokens` would flatter the
+ * feature by exactly the amount it spends.
+ */
+
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  harvestEnabled,
+  buildDigest,
+  buildFullDelta,
+  extract,
+  validate,
+  estimateTokens,
+} from './harvest.mjs';
+import { writeHarvested } from './harvest-write.mjs';
+import { record } from './metrics.mjs';
+import { wikiDir, projectRootFor, load } from './wiki.mjs';
+import { readArchive } from './transcript.mjs';
+import { buildFeedbackDigest, validateLessons, LESSON_PROMPT } from './lessons.mjs';
+import { ORIGIN_HARVESTED } from './curate.mjs';
+import { selectForConsolidation } from './consolidate.mjs';
+
+/**
+ * The token budget one session's harvest may add to the graph.
+ *
+ * #204 lists graph bloat as a named risk -- "the session-start index grows with
+ * the graph; ranking and eviction are required, not optional" -- and until now
+ * nothing bounded what a single harvest could store. 4,000 tokens is the
+ * selector's own default and roughly twenty-five findings at the size the
+ * extractor produces, which is far above any observed session's real yield; it
+ * is a ceiling against a pathological extraction, not a routine constraint.
+ */
+const CONSOLIDATION_BUDGET = 4000;
+
+/**
+ * The files the digest says were touched.
+ *
+ * `buildDigest` emits them under a `## Files touched` heading and returns a
+ * string, so this reads back the list it just wrote rather than walking the
+ * transcript a second time. Returns null when the section is absent, which
+ * `validate` treats as "no restriction" rather than "no files".
+ */
+function filesIn(digest) {
+  const start = digest.indexOf('## Files touched');
+  if (start === -1) return null;
+
+  const rest = digest.slice(start + '## Files touched'.length);
+  const end = rest.indexOf('\n##');
+  const block = (end === -1 ? rest : rest.slice(0, end)).split('\n');
+
+  const files = new Set();
+  for (const line of block) {
+    const value = line.trim();
+    if (value) files.add(value);
+  }
+  return files.size ? files : null;
+}
+
+async function main() {
+  const [transcript, sessionId, cwd] = process.argv.slice(2);
+  if (!transcript || !existsSync(transcript) || !harvestEnabled()) return;
+
+  // THE GRAPH AND THE CONTAINMENT BOUNDARY BOTH COME FROM THE REPOSITORY ROOT,
+  // NOT THE SESSION'S CWD. `wikiDir` only joins the path it is handed, so a
+  // session started in a subdirectory selected `<subdir>/.token-optimizer/wiki`
+  // -- a second graph, invisible to every other hook, which all resolve the root
+  // first. It also made the subdirectory the containment root for the write, so
+  // a finding anchored anywhere else in the same repository was refused for
+  // sitting "outside" the project.
+  //
+  // `__session__` is a synthetic leaf so the walk starts at `cwd` itself rather
+  // than its parent; `projectRootFor` takes a FILE path. This is the same idiom
+  // the adapter, the session-start hook and the Stop adapter already use.
+  //
+  // A cwd with no VCS ancestor resolves to the machine-level unrooted bucket,
+  // which `resolveAnchor` expects and handles: it swaps in home as the
+  // containment root for that case, so passing the resolved root here is what
+  // lets unrooted anchors work at all.
+  const sessionCwd = cwd || process.cwd();
+  const projectRoot = projectRootFor(join(sessionCwd, '__session__'), sessionCwd);
+  const dir = wikiDir(projectRoot);
+
+  // Default sends a structured digest with no file contents. The full delta is
+  // opt-in because the default has to be defensible without reading the docs.
+  const full = process.env.TOKEN_OPTIMIZER_HARVEST_FULL === 'true';
+  const digest = full ? buildFullDelta(transcript) : buildDigest(transcript);
+  if (!digest) return;
+
+  const raw = await extract(digest);
+
+  // Anchors are held to the files this session actually touched, so a model
+  // that invents a plausible path cannot anchor a finding to it. The digest
+  // lists them under a heading it writes itself; the full delta is raw
+  // transcript and carries no such list, so it gets no restriction.
+  const validated = validate(raw, { knownFiles: full ? null : filesIn(digest) });
+
+  // BUDGETED SELECTION, not everything the model extracted.
+  //
+  // `selectForConsolidation` exists for exactly this and had no caller
+  // anywhere, so every harvested candidate was stored regardless of what it
+  // cost to derive, how hard it is to reproduce, or whether the graph can ever
+  // retrieve it -- which is the graph-bloat risk #204 lists as needing
+  // "ranking and eviction ... not optional". It keeps failures and decisions on
+  // a floor before ranking, encoding the design's judgement that dead ends are
+  // the highest-value kind: they exist nowhere in the source tree, so nothing
+  // else can ever recover them.
+  //
+  // The selection is RECORDED, not silent. A cap that drops work without
+  // saying so reads as "there was nothing more to find", which is the same
+  // dishonesty as a truncated report with no remainder line.
+  const graph = load(dir);
+  const selection = selectForConsolidation(graph, validated, { budget: CONSOLIDATION_BUDGET });
+  const findings = selection.kept;
+  if (selection.dropped > 0) {
+    record(dir, {
+      kind: 'harvest',
+      action: 'consolidation',
+      candidates: validated.length,
+      kept: findings.length,
+      dropped: selection.dropped,
+      tokens: selection.tokens,
+      budget: CONSOLIDATION_BUDGET,
+    });
+  }
+
+  const written = writeHarvested(dir, findings, {
+    sessionId: sessionId || null,
+    projectRoot,
+    // Task nodes are keyed by session id (structural capture creates one on
+    // the first touched file, `harvest()` in lib/wiki.mjs) so this is the
+    // shape `writeHarvested` needs to point the `answers` edge back at the
+    // task this harvest belongs to. A session that never touched a file
+    // through PreToolUse/PostToolUse has no such node yet; `writeHarvested`
+    // resolves that case to no edge rather than a dangling one.
+    taskId: sessionId || null,
+    // AUTHORITATIVE, not just present: this `sessionId` came from Claude
+    // Code's own Stop-hook payload (see stop-harvest.mjs), not a model-typed
+    // tool argument, so it is safe to use for the traversal fallback if the
+    // explicit `taskId` above does not resolve.
+    authoritativeSessionId: sessionId || null,
+  });
+
+  record(dir, {
+    kind: 'harvest',
+    sessionId: sessionId || null,
+    tokens: estimateTokens(digest),
+    findings: written.length,
+    at: Date.now(),
+  });
+
+  // THE FEEDBACK LOOP. A separate extraction with a separate prompt, because
+  // the two are looking for different things: the harvest above wants what was
+  // LEARNED about the code, this wants where the user said the agent was WRONG.
+  // Asked for both at once a model returns a summary and the corrections get
+  // lost in it -- and corrections are the only turns carrying information the
+  // code itself could never supply.
+  try {
+    const turns = readArchive(dir, sessionId || 'unknown');
+    const feedback = buildFeedbackDigest(turns);
+    if (feedback) {
+      const rawLessons = await extract(feedback, { prompt: LESSON_PROMPT });
+      // The same restriction the finding path above applies, for the same reason: a model that
+      // invents a plausible path must not be able to anchor a lesson to it. `turns` is the
+      // archived transcript for this session, so its rendered digest is the honest file list.
+      const { lessons } = validateLessons(rawLessons, turns, {
+        knownFiles: filesIn(feedback),
+      });
+
+      // Anchors are optional on a lesson -- "always run npm test" is about no
+      // file -- so each is anchored to the project root when it names nothing,
+      // which keeps the store's rule that an unanchored finding is refused.
+      //
+      // The RESOLVED root, matching the containment root this write is checked
+      // against. The session's cwd would be refused outright once that root is
+      // the unrooted bucket, because `resolveAnchor` then narrows containment to
+      // home and a VCS-less working directory need not sit under it.
+      const anchored = lessons.map((l) => ({
+        ...l,
+        anchors: l.anchors.length ? l.anchors : [projectRoot],
+      }));
+
+      // The write itself is the durable record: writeHarvested anchors each
+      // lesson into the graph, which is what lessons.mjs's real consumers
+      // query. A metrics event of kind 'lessons' used to sit here as well,
+      // but nothing ever read it -- not netTokens (only 'harvest' feeds
+      // harvestTokens), not report()/buildReport() (no kind filter matches
+      // 'lessons'), and no audit render exists to show it to a human. That is
+      // the inverse of the `query` defect and the same shape as
+      // `tokensFullFile` before it: a produced-and-never-consumed event,
+      // which is a cost with no benefit. Deleted rather than wired, per the
+      // reachability allowlist's own rule -- write it again the day
+      // something needs to read it.
+      writeHarvested(dir, anchored, {
+        sessionId: sessionId || null,
+        origin: ORIGIN_HARVESTED,
+        projectRoot,
+        taskId: sessionId || null,
+        // Same hook-payload identity as above, same reason.
+        authoritativeSessionId: sessionId || null,
+      });
+    }
+  } catch {
+    // A failed feedback pass must be indistinguishable from a session with
+    // nothing to correct.
+  }
+}
+
+main()
+  .catch(() => {})
+  .finally(() => {
+    // NEVER process.exit() SYNCHRONOUSLY HERE.
+    //
+    // It crashed this worker on Windows every single time the feedback pass
+    // ran -- libuv asserts `!(handle->flags & UV_HANDLE_CLOSING)` when the
+    // process exits while the sockets from the model call are still closing,
+    // giving exit code 0xC0000409. Reproduced 5 runs out of 5, and silently,
+    // because this worker is spawned detached and nothing reads its status.
+    // Deferring by one tick is NOT enough; the handles are still closing then.
+    //
+    // So the normal path just lets the loop drain, which it does promptly.
+    //
+    // THE RECORDED CODE IS PRESERVED, not overwritten with 0. Assigning 0
+    // unconditionally would turn a harvest that had already recorded a failure
+    // into one that reports success -- and this worker is detached, so that
+    // status is the only signal a supervisor could ever act on.
+    const code = process.exitCode ?? 0;
+    process.exitCode = code;
+
+    // The watchdog keeps the original guarantee: a detached worker must never
+    // linger holding a keep-alive socket open. It is UNREF'D, so it cannot
+    // itself keep the process alive -- it only fires if something else already
+    // has, which is exactly the case worth killing.
+    const watchdog = setTimeout(() => process.exit(code), 5000);
+    watchdog.unref();
+  });

--- a/integrations/copilot/.github/hooks/lib/harvest-worker.mjs
+++ b/integrations/copilot/.github/hooks/lib/harvest-worker.mjs
@@ -1,6 +1,6 @@
+#!/usr/bin/env node
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/harvest-worker.mjs. Regenerate with `npm run sync:hooks`.
-#!/usr/bin/env node
 /**
  * The out-of-band half of the semantic harvest.
  *

--- a/integrations/copilot/.github/hooks/lib/stop-harvest.mjs
+++ b/integrations/copilot/.github/hooks/lib/stop-harvest.mjs
@@ -353,6 +353,11 @@ export async function runStopHarvest(payload = {}) {
       env: { ...process.env },
     }
   );
+  // AN 'error' EVENT WITH NO LISTENER IS A THROW. `spawn` reports a failed
+  // start asynchronously, so an unlistened error does not return a code -- Node
+  // raises it, and here that would abort the Stop response itself. A harvest
+  // that cannot start must degrade to no harvest, never to a broken Stop.
+  child.on('error', () => {});
   child.unref();
   return null;
 }

--- a/integrations/copilot/.github/hooks/lib/stop-harvest.mjs
+++ b/integrations/copilot/.github/hooks/lib/stop-harvest.mjs
@@ -1,0 +1,358 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/stop-harvest.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Claude Code Stop adapter -- run the semantic harvest the design specifies.
+ *
+ * The wiki design says findings are extracted "at Stop and PreCompact" by a
+ * cheap model, out of band. The extractor (`lib/harvest.mjs`) was implemented
+ * and then imported by nothing: no hook invoked it, and Stop carried no
+ * token-optimizer entry at all. The consequence was not a crash but a graph
+ * that could serve findings and never acquired any -- 122 file / 132 symbol /
+ * 61 task nodes and zero findings on a real project after a full session, with
+ * injection, staleness and the metrics all wired and idle behind it.
+ *
+ * OUT OF BAND IS THE POINT. The extraction is a model call; doing it inline
+ * would make the session that did the work pay for summarising itself, which is
+ * the cost this whole subsystem exists to avoid. So this spawns a detached
+ * worker and returns immediately. Stop is never delayed.
+ *
+ * IT ALSO REPORTS WHEN IT CANNOT RUN. Harvest requires an API key, and without
+ * one `harvestEnabled()` returns false and the module skips silently. Silence
+ * was how this stayed invisible: nothing in doctor, audit or waste mentions
+ * harvest, so a user sees a graph filling with structural nodes and no findings
+ * and has no way to learn why. Saying so once per session is the difference
+ * between a disabled feature and a broken one.
+ */
+
+import { spawn } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  chmodSync,
+  readFileSync,
+  openSync,
+  writeSync,
+  closeSync,
+  lstatSync,
+  constants,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir, homedir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { mode, MODE_OFF } from './policy.mjs';
+import { harvestEnabled, harvestMode } from './harvest.mjs';
+import { archive } from './transcript.mjs';
+import { wikiDir, projectRootFor, sharedDir, load } from './wiki.mjs';
+import { detectRefusals, recordRefusal } from './harvest-write.mjs';
+
+/** What to tell the user, per reason the harvest is not running. */
+const OFF_REASON = {
+  'off:mode': null, // The whole optimizer is off; saying more would be noise.
+  'off:not-opted-in':
+    'token-optimizer: automatic finding-extraction is OFF. It costs a model call and ' +
+    'sends a digest (paths, commands, prompts, conclusions -- never file contents) off ' +
+    'this machine, so it is opt-in: set TOKEN_OPTIMIZER_HARVEST=1 with an API key, or ' +
+    'point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model to run it free and private. ' +
+    'Meanwhile lifecycle-based structural graph capture keeps working. Durable semantic MCP ' +
+    'writes require a writer schema that is actually registered in the current CLI session.',
+  'off:no-key':
+    'token-optimizer: finding-extraction is opted in but has no credential. Set ' +
+    'TOKEN_OPTIMIZER_API_KEY, or point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model ' +
+    'to run it without one.',
+};
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * A session id reduced to something that cannot leave the marker directory.
+ *
+ * The id arrives in the hook payload, so it is external input, and it was being
+ * interpolated straight into a path: a value containing separators or `..` would
+ * have placed (and later read) the marker anywhere on disk. Everything outside a
+ * conservative allowlist becomes an underscore, which keeps ordinary uuids
+ * readable while making traversal unrepresentable rather than merely unlikely.
+ */
+function markerName(sessionId) {
+  const safe = String(sessionId || 'unknown').replace(/[^A-Za-z0-9._-]/g, '_');
+  // A name of only dots would still resolve to a directory entry.
+  const cleaned = /^[.]+$/.test(safe) ? 'unknown' : safe;
+  return `harvest-notice-${cleaned.slice(0, 64)}`;
+}
+
+/**
+ * A private, per-user directory for this hook's markers.
+ *
+ * os.tmpdir() is per-user on Windows but resolves to a SHARED, world-writable
+ * /tmp on POSIX. The marker name is derived from the session id, so it is
+ * predictable enough for another local user to pre-create -- as a symlink, or
+ * as a file they own -- and writeFileSync would then follow it and write
+ * through with this user's privileges.
+ *
+ * The state here is a debounce timestamp and a "said it once" flag, so the fix
+ * is not to guard a shared location but to stop using one. XDG_STATE_HOME is
+ * the standard place for state that should persist across runs but is not
+ * precious, and it is inside the user's own home on every POSIX system.
+ */
+function stateDir() {
+  const home = homedir();
+  const base =
+    process.platform === 'win32'
+      ? process.env.LOCALAPPDATA || tmpdir()
+      : process.env.XDG_STATE_HOME ||
+        (home ? join(home, '.local', 'state') : tmpdir());
+
+  const dir = join(base, 'token-optimizer');
+  try {
+    // 0o700 AND an explicit chmod, for the reason the graph store documents:
+    // `recursive` applies the mode only to directories it actually creates, and
+    // the umask masks it further, so neither alone guarantees the result.
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    try {
+      chmodSync(dir, 0o700);
+    } catch {
+      // Not POSIX, or not ours to chmod.
+    }
+  } catch {
+    /* best effort */
+  }
+  return dir;
+}
+
+/** Where the once-per-session notice is remembered, so Stop does not nag. */
+function noticePath(sessionId) {
+  return join(stateDir(), markerName(sessionId));
+}
+
+/**
+ * True when the path is absent, or is a regular file this user owns.
+ *
+ * lstat rather than stat: stat FOLLOWS the link and would happily report on the
+ * target, which is the thing being defended against.
+ */
+function ownedRegularFile(path) {
+  let info;
+  try {
+    info = lstatSync(path);
+  } catch {
+    return true; // Absent. The O_NOFOLLOW open below settles the race.
+  }
+  if (!info.isFile()) return false;
+  // getuid is undefined on Windows, where stateDir() is already per-user.
+  if (typeof process.getuid === 'function' && info.uid !== process.getuid())
+    return false;
+  return true;
+}
+
+/**
+ * Writes a marker, refusing to follow a symlink.
+ *
+ * O_NOFOLLOW makes the refusal ATOMIC rather than a check-then-use window: a
+ * link swapped in after ownedRegularFile() returns fails the open instead of
+ * being written through. The flag does not exist on Windows, where it is
+ * undefined and falls back to 0 -- acceptable, because the directory is
+ * per-user there to begin with.
+ */
+function writeMarker(path, contents) {
+  if (!ownedRegularFile(path)) return false;
+  const NOFOLLOW = constants.O_NOFOLLOW || 0;
+  let fd;
+  try {
+    fd = openSync(
+      path,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | NOFOLLOW,
+      0o600
+    );
+    writeSync(fd, contents);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* already closed */
+      }
+    }
+  }
+}
+
+/** Reads a marker, ignoring anything that is not a regular file we own. */
+function readMarker(path) {
+  if (!ownedRegularFile(path)) return null;
+  try {
+    return readFileSync(path, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function alreadyNotified(sessionId) {
+  const path = noticePath(sessionId);
+  // Anything already at this path -- our marker, or something planted -- means
+  // stay quiet. Repeating the notice is the worse failure, and refusing to
+  // write over a foreign file is the point.
+  if (existsSync(path)) return true;
+  return !writeMarker(path, String(Date.now()));
+}
+
+/** Minimum gap between harvests of one session. */
+const HARVEST_INTERVAL_MS =
+  Number(process.env.TOKEN_OPTIMIZER_HARVEST_INTERVAL_MS) > 0
+    ? Number(process.env.TOKEN_OPTIMIZER_HARVEST_INTERVAL_MS)
+    : 10 * 60 * 1000;
+
+/**
+ * True when this session has not been harvested recently, and records that it
+ * is about to be.
+ *
+ * Deliberately marks only when a harvest actually starts: touching it on every
+ * Stop would let a run of skipped turns keep pushing the next harvest away.
+ */
+function dueForHarvest(sessionId) {
+  const marker = join(stateDir(), `harvest-last-${markerName(sessionId)}`);
+
+  const last = Number(readMarker(marker));
+  // > 0 matters: readMarker returns null when the marker is missing or is not
+  // ours, and Number(null) is 0, which is finite -- so without this an absent
+  // marker would read as a harvest at the epoch.
+  if (
+    Number.isFinite(last) &&
+    last > 0 &&
+    Date.now() - last < HARVEST_INTERVAL_MS
+  ) {
+    return false;
+  }
+
+  // If the marker cannot be written the debounce degrades to off rather than
+  // blocking the harvest entirely.
+  writeMarker(marker, String(Date.now()));
+  return true;
+}
+
+/**
+ * The Stop-time harvest, for every client rather than one.
+ *
+ * WHY THIS IS A FUNCTION AND NOT A HOOK. It was a hook -- a Claude Code entry
+ * point named `stop-harvest.mjs` -- and #300 unregistered it. Nothing replaced
+ * it, so four capabilities went silently: the transcript archive, the harvest
+ * worker spawn, refusal detection, and the notice that says why no findings
+ * exist. Every client routes Stop through the shared adapter, and the adapter
+ * did none of these, so on a full session with a valid credential
+ * `harvestMode()` reported `remote` and nothing happened.
+ *
+ * NOTHING OBSERVED THAT IT DID NOT RUN, which is why it survived a year. There
+ * is no `kind:'harvest'` event to be absent from a report, no error, and a
+ * harvest that ran and found nothing looks exactly like one that never
+ * started. The reachability guard could not see it either: this file's own
+ * imports gave `archive`, `detectRefusals` and `recordRefusal` call sites, and
+ * a name-based scan proves a reference exists, never that it runs.
+ *
+ * Returns a notice for the caller to emit, or null. It does NOT write to
+ * stdout: the adapter emits exactly one JSON object per hook invocation, and a
+ * second writer racing it is how a Stop payload gets corrupted.
+ *
+ * @returns {Promise<string|null>} a once-per-session message, or null.
+ */
+export async function runStopHarvest(payload = {}) {
+  if (mode() === MODE_OFF) return null;
+
+  const transcript = payload.transcript_path ?? payload.transcriptPath ?? null;
+  if (!transcript || !existsSync(transcript)) return null;
+
+  // ARCHIVE FIRST, AND UNCONDITIONALLY. This is a local file copy: it costs no
+  // model call, spends no money, and sends nothing anywhere, so it must not sit
+  // behind the opt-in that exists to gate cost and disclosure. Gating it there
+  // would mean the record of what the user actually said is kept only for the
+  // users who opted into a paid feature, which is exactly backwards.
+  //
+  // It also has to happen before the early return below, or a session with
+  // harvesting off would archive nothing at all.
+  try {
+    archive(
+      wikiDir(
+        projectRootFor(
+          join(payload.cwd || process.cwd(), '__session__'),
+          payload.cwd
+        )
+      ),
+      transcript,
+      {
+        sessionId: payload.session_id,
+      }
+    );
+  } catch {
+    // The archive is a convenience. Failing to write it must not affect Stop.
+  }
+
+  // CLOSE THE REFUSAL LOOP, and do it OUTSIDE the harvest opt-in. Reading the
+  // transcript this process already holds costs no model call and sends nothing
+  // anywhere, so gating it behind the paid feature would leave a mis-scoped
+  // lesson costing tokens forever for everyone who did not opt in.
+  //
+  // The model states plainly when a cross-project lesson does not transfer --
+  // "that figure is another repo's baseline and it doesn't transfer" -- and until
+  // now nothing read it, so the same lesson was delivered again next session.
+  try {
+    const shared = sharedDir();
+    const lessons = [...load(shared).nodes.values()].filter(
+      (n) => n.kind === 'finding' && !n.retired && n.claim
+    );
+    if (lessons.length) {
+      const text = readFileSync(transcript, 'utf8');
+      for (const key of detectRefusals(lessons, text))
+        recordRefusal(shared, key);
+    }
+  } catch {
+    // Feedback is a refinement; a failure here must not affect Stop.
+  }
+
+  if (!harvestEnabled()) {
+    // Say it once, name the reason and the variable that changes it, and state
+    // what still works. A user who reads this should know exactly what they are
+    // and are not getting, and what to do about it.
+    const message = OFF_REASON[harvestMode()];
+    // RETURNED, NOT WRITTEN. This used to write its own JSON to stdout and
+    // race whatever the hook emitted; the adapter now folds this into the one
+    // object it sends, so the notice cannot be dropped by a full pipe or
+    // truncated by an exit -- which is what used to happen to the single line
+    // explaining why no findings exist.
+    if (message && !alreadyNotified(payload.session_id)) return message;
+    return null;
+  }
+
+  // SIBLING IN THE SHARED CORE. The worker used to live beside the hook entry
+  // in `plugin/hooks/`, which is why only Claude Code could ever have spawned
+  // it -- it was vendored to no other client. It now sits in the core that
+  // every client receives an identical copy of, so this resolves in all
+  // eleven.
+  const worker = join(HERE, 'harvest-worker.mjs');
+  if (!existsSync(worker)) return null;
+
+  // DEBOUNCE. Stop fires at the end of every assistant turn, so a talkative
+  // session would spawn a model call per turn -- each re-reading an overlapping
+  // transcript and re-extracting most of the same findings. The marker is
+  // touched only when a harvest is actually started, so a skipped turn does not
+  // push the next one further away.
+  if (!dueForHarvest(payload.session_id)) return null;
+
+  // Detached and fully released: the harvest must outlive this hook without
+  // holding Stop open for a model round-trip.
+  const child = spawn(
+    process.execPath,
+    [
+      worker,
+      transcript,
+      String(payload.session_id || ''),
+      String(payload.cwd || process.cwd()),
+    ],
+    {
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: true,
+      env: { ...process.env },
+    }
+  );
+  child.unref();
+  return null;
+}

--- a/integrations/cursor/hooks/lib/adapter.mjs
+++ b/integrations/cursor/hooks/lib/adapter.mjs
@@ -762,8 +762,11 @@ async function runHook(clientName, event, invocation) {
     const toolEvidence = optimizerToolsForHook(raw, state);
     rememberOptimizerTools(state, toolEvidence);
     const episode = episodeMeta({ client: clientName, raw });
+    // Hoisted out of the try below, because the harvest needs the same resolved
+    // directory and resolving it twice is how two halves of one hook end up
+    // reasoning about different projects.
+    const cwd = raw.cwd || raw.working_directory || process.cwd();
     try {
-      const cwd = raw.cwd || raw.working_directory || process.cwd();
       const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
       recordEpisodeOutcome(dir, {
         ...episode,
@@ -807,7 +810,21 @@ async function runHook(clientName, event, invocation) {
     // call.
     let harvestNotice = null;
     try {
-      harvestNotice = await runStopHarvest(raw);
+      // NORMALIZED, NOT RAW. The identifiers were resolved a few lines up
+      // through every alias a host might use -- `sessionId`,
+      // `conversation_id`, `working_directory` -- and handing `raw` straight
+      // over threw that away: runStopHarvest reads `session_id` and `cwd`
+      // only, so on a client that sends an alias the session id came back
+      // undefined and the archive root fell back to `process.cwd()`. That
+      // shares the once-per-session notice and the debounce marker across
+      // every session, and files the transcript under whatever directory the
+      // hook happened to start in.
+      harvestNotice = await runStopHarvest({
+        ...raw,
+        session_id: sessionId,
+        cwd,
+        transcript_path: raw.transcript_path ?? raw.transcriptPath ?? null,
+      });
     } catch {
       // The harvest is a side effect of ending a session. It must never stop
       // one from ending.

--- a/integrations/cursor/hooks/lib/adapter.mjs
+++ b/integrations/cursor/hooks/lib/adapter.mjs
@@ -88,6 +88,7 @@ import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 import { evaluateUcrGuards } from './ucr-guard.mjs';
 import { beginHookInvocation, noteHookOutput } from './observability.mjs';
 import { registerProject } from './projects.mjs';
+import { runStopHarvest } from './stop-harvest.mjs';
 
 /**
  * Per-client capability.
@@ -792,10 +793,33 @@ async function runHook(clientName, event, invocation) {
       state.harvestedEdits = Number(state.edits || 0);
       saveState(sessionId, state, agentScope);
     }
+    // THE OUT-OF-BAND HARVEST, which no client was running.
+    //
+    // The in-band `prompt` above asks the MODEL to call `wiki_write`, and the
+    // session pays for summarising itself -- the exact cost the design says the
+    // harvest exists to avoid ("out-of-band, so the session doing the work never
+    // pays for the harvest"). The out-of-band half lived in a Claude Code hook
+    // that #300 unregistered, and nothing replaced it, so on every client the
+    // transcript was never archived, the worker never spawned, refusals were
+    // never detected, and the notice explaining why no findings exist was never
+    // shown. Awaited because it must finish before the exit below; it spawns a
+    // DETACHED worker and returns immediately, so Stop is not delayed by a model
+    // call.
+    let harvestNotice = null;
+    try {
+      harvestNotice = await runStopHarvest(raw);
+    } catch {
+      // The harvest is a side effect of ending a session. It must never stop
+      // one from ending.
+    }
+
     if (prompt && client.stopStyle === 'followup') {
-      emit({ followup_message: prompt });
+      emit({ followup_message: prompt, ...(harvestNotice ? { systemMessage: harvestNotice } : {}) });
     } else {
-      emit(prompt ? { decision: client.stopDecision, reason: prompt } : {});
+      emit({
+        ...(prompt ? { decision: client.stopDecision, reason: prompt } : {}),
+        ...(harvestNotice ? { systemMessage: harvestNotice } : {}),
+      });
     }
     process.exit(0);
   }

--- a/integrations/cursor/hooks/lib/harvest-worker.mjs
+++ b/integrations/cursor/hooks/lib/harvest-worker.mjs
@@ -1,0 +1,248 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/harvest-worker.mjs. Regenerate with `npm run sync:hooks`.
+#!/usr/bin/env node
+/**
+ * The out-of-band half of the semantic harvest.
+ *
+ * Spawned detached by the Stop adapter so the session that did the work never
+ * pays for the model call that summarises it. Everything here is best-effort:
+ * a harvest that fails must be indistinguishable from a session with nothing
+ * to learn, because the alternative -- a hook that can break a turn -- is worse
+ * than no findings at all.
+ *
+ * The cost of the extraction is recorded either way. Without it the metrics
+ * report a benefit with no matching expense, and `netTokens` would flatter the
+ * feature by exactly the amount it spends.
+ */
+
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  harvestEnabled,
+  buildDigest,
+  buildFullDelta,
+  extract,
+  validate,
+  estimateTokens,
+} from './harvest.mjs';
+import { writeHarvested } from './harvest-write.mjs';
+import { record } from './metrics.mjs';
+import { wikiDir, projectRootFor, load } from './wiki.mjs';
+import { readArchive } from './transcript.mjs';
+import { buildFeedbackDigest, validateLessons, LESSON_PROMPT } from './lessons.mjs';
+import { ORIGIN_HARVESTED } from './curate.mjs';
+import { selectForConsolidation } from './consolidate.mjs';
+
+/**
+ * The token budget one session's harvest may add to the graph.
+ *
+ * #204 lists graph bloat as a named risk -- "the session-start index grows with
+ * the graph; ranking and eviction are required, not optional" -- and until now
+ * nothing bounded what a single harvest could store. 4,000 tokens is the
+ * selector's own default and roughly twenty-five findings at the size the
+ * extractor produces, which is far above any observed session's real yield; it
+ * is a ceiling against a pathological extraction, not a routine constraint.
+ */
+const CONSOLIDATION_BUDGET = 4000;
+
+/**
+ * The files the digest says were touched.
+ *
+ * `buildDigest` emits them under a `## Files touched` heading and returns a
+ * string, so this reads back the list it just wrote rather than walking the
+ * transcript a second time. Returns null when the section is absent, which
+ * `validate` treats as "no restriction" rather than "no files".
+ */
+function filesIn(digest) {
+  const start = digest.indexOf('## Files touched');
+  if (start === -1) return null;
+
+  const rest = digest.slice(start + '## Files touched'.length);
+  const end = rest.indexOf('\n##');
+  const block = (end === -1 ? rest : rest.slice(0, end)).split('\n');
+
+  const files = new Set();
+  for (const line of block) {
+    const value = line.trim();
+    if (value) files.add(value);
+  }
+  return files.size ? files : null;
+}
+
+async function main() {
+  const [transcript, sessionId, cwd] = process.argv.slice(2);
+  if (!transcript || !existsSync(transcript) || !harvestEnabled()) return;
+
+  // THE GRAPH AND THE CONTAINMENT BOUNDARY BOTH COME FROM THE REPOSITORY ROOT,
+  // NOT THE SESSION'S CWD. `wikiDir` only joins the path it is handed, so a
+  // session started in a subdirectory selected `<subdir>/.token-optimizer/wiki`
+  // -- a second graph, invisible to every other hook, which all resolve the root
+  // first. It also made the subdirectory the containment root for the write, so
+  // a finding anchored anywhere else in the same repository was refused for
+  // sitting "outside" the project.
+  //
+  // `__session__` is a synthetic leaf so the walk starts at `cwd` itself rather
+  // than its parent; `projectRootFor` takes a FILE path. This is the same idiom
+  // the adapter, the session-start hook and the Stop adapter already use.
+  //
+  // A cwd with no VCS ancestor resolves to the machine-level unrooted bucket,
+  // which `resolveAnchor` expects and handles: it swaps in home as the
+  // containment root for that case, so passing the resolved root here is what
+  // lets unrooted anchors work at all.
+  const sessionCwd = cwd || process.cwd();
+  const projectRoot = projectRootFor(join(sessionCwd, '__session__'), sessionCwd);
+  const dir = wikiDir(projectRoot);
+
+  // Default sends a structured digest with no file contents. The full delta is
+  // opt-in because the default has to be defensible without reading the docs.
+  const full = process.env.TOKEN_OPTIMIZER_HARVEST_FULL === 'true';
+  const digest = full ? buildFullDelta(transcript) : buildDigest(transcript);
+  if (!digest) return;
+
+  const raw = await extract(digest);
+
+  // Anchors are held to the files this session actually touched, so a model
+  // that invents a plausible path cannot anchor a finding to it. The digest
+  // lists them under a heading it writes itself; the full delta is raw
+  // transcript and carries no such list, so it gets no restriction.
+  const validated = validate(raw, { knownFiles: full ? null : filesIn(digest) });
+
+  // BUDGETED SELECTION, not everything the model extracted.
+  //
+  // `selectForConsolidation` exists for exactly this and had no caller
+  // anywhere, so every harvested candidate was stored regardless of what it
+  // cost to derive, how hard it is to reproduce, or whether the graph can ever
+  // retrieve it -- which is the graph-bloat risk #204 lists as needing
+  // "ranking and eviction ... not optional". It keeps failures and decisions on
+  // a floor before ranking, encoding the design's judgement that dead ends are
+  // the highest-value kind: they exist nowhere in the source tree, so nothing
+  // else can ever recover them.
+  //
+  // The selection is RECORDED, not silent. A cap that drops work without
+  // saying so reads as "there was nothing more to find", which is the same
+  // dishonesty as a truncated report with no remainder line.
+  const graph = load(dir);
+  const selection = selectForConsolidation(graph, validated, { budget: CONSOLIDATION_BUDGET });
+  const findings = selection.kept;
+  if (selection.dropped > 0) {
+    record(dir, {
+      kind: 'harvest',
+      action: 'consolidation',
+      candidates: validated.length,
+      kept: findings.length,
+      dropped: selection.dropped,
+      tokens: selection.tokens,
+      budget: CONSOLIDATION_BUDGET,
+    });
+  }
+
+  const written = writeHarvested(dir, findings, {
+    sessionId: sessionId || null,
+    projectRoot,
+    // Task nodes are keyed by session id (structural capture creates one on
+    // the first touched file, `harvest()` in lib/wiki.mjs) so this is the
+    // shape `writeHarvested` needs to point the `answers` edge back at the
+    // task this harvest belongs to. A session that never touched a file
+    // through PreToolUse/PostToolUse has no such node yet; `writeHarvested`
+    // resolves that case to no edge rather than a dangling one.
+    taskId: sessionId || null,
+    // AUTHORITATIVE, not just present: this `sessionId` came from Claude
+    // Code's own Stop-hook payload (see stop-harvest.mjs), not a model-typed
+    // tool argument, so it is safe to use for the traversal fallback if the
+    // explicit `taskId` above does not resolve.
+    authoritativeSessionId: sessionId || null,
+  });
+
+  record(dir, {
+    kind: 'harvest',
+    sessionId: sessionId || null,
+    tokens: estimateTokens(digest),
+    findings: written.length,
+    at: Date.now(),
+  });
+
+  // THE FEEDBACK LOOP. A separate extraction with a separate prompt, because
+  // the two are looking for different things: the harvest above wants what was
+  // LEARNED about the code, this wants where the user said the agent was WRONG.
+  // Asked for both at once a model returns a summary and the corrections get
+  // lost in it -- and corrections are the only turns carrying information the
+  // code itself could never supply.
+  try {
+    const turns = readArchive(dir, sessionId || 'unknown');
+    const feedback = buildFeedbackDigest(turns);
+    if (feedback) {
+      const rawLessons = await extract(feedback, { prompt: LESSON_PROMPT });
+      // The same restriction the finding path above applies, for the same reason: a model that
+      // invents a plausible path must not be able to anchor a lesson to it. `turns` is the
+      // archived transcript for this session, so its rendered digest is the honest file list.
+      const { lessons } = validateLessons(rawLessons, turns, {
+        knownFiles: filesIn(feedback),
+      });
+
+      // Anchors are optional on a lesson -- "always run npm test" is about no
+      // file -- so each is anchored to the project root when it names nothing,
+      // which keeps the store's rule that an unanchored finding is refused.
+      //
+      // The RESOLVED root, matching the containment root this write is checked
+      // against. The session's cwd would be refused outright once that root is
+      // the unrooted bucket, because `resolveAnchor` then narrows containment to
+      // home and a VCS-less working directory need not sit under it.
+      const anchored = lessons.map((l) => ({
+        ...l,
+        anchors: l.anchors.length ? l.anchors : [projectRoot],
+      }));
+
+      // The write itself is the durable record: writeHarvested anchors each
+      // lesson into the graph, which is what lessons.mjs's real consumers
+      // query. A metrics event of kind 'lessons' used to sit here as well,
+      // but nothing ever read it -- not netTokens (only 'harvest' feeds
+      // harvestTokens), not report()/buildReport() (no kind filter matches
+      // 'lessons'), and no audit render exists to show it to a human. That is
+      // the inverse of the `query` defect and the same shape as
+      // `tokensFullFile` before it: a produced-and-never-consumed event,
+      // which is a cost with no benefit. Deleted rather than wired, per the
+      // reachability allowlist's own rule -- write it again the day
+      // something needs to read it.
+      writeHarvested(dir, anchored, {
+        sessionId: sessionId || null,
+        origin: ORIGIN_HARVESTED,
+        projectRoot,
+        taskId: sessionId || null,
+        // Same hook-payload identity as above, same reason.
+        authoritativeSessionId: sessionId || null,
+      });
+    }
+  } catch {
+    // A failed feedback pass must be indistinguishable from a session with
+    // nothing to correct.
+  }
+}
+
+main()
+  .catch(() => {})
+  .finally(() => {
+    // NEVER process.exit() SYNCHRONOUSLY HERE.
+    //
+    // It crashed this worker on Windows every single time the feedback pass
+    // ran -- libuv asserts `!(handle->flags & UV_HANDLE_CLOSING)` when the
+    // process exits while the sockets from the model call are still closing,
+    // giving exit code 0xC0000409. Reproduced 5 runs out of 5, and silently,
+    // because this worker is spawned detached and nothing reads its status.
+    // Deferring by one tick is NOT enough; the handles are still closing then.
+    //
+    // So the normal path just lets the loop drain, which it does promptly.
+    //
+    // THE RECORDED CODE IS PRESERVED, not overwritten with 0. Assigning 0
+    // unconditionally would turn a harvest that had already recorded a failure
+    // into one that reports success -- and this worker is detached, so that
+    // status is the only signal a supervisor could ever act on.
+    const code = process.exitCode ?? 0;
+    process.exitCode = code;
+
+    // The watchdog keeps the original guarantee: a detached worker must never
+    // linger holding a keep-alive socket open. It is UNREF'D, so it cannot
+    // itself keep the process alive -- it only fires if something else already
+    // has, which is exactly the case worth killing.
+    const watchdog = setTimeout(() => process.exit(code), 5000);
+    watchdog.unref();
+  });

--- a/integrations/cursor/hooks/lib/harvest-worker.mjs
+++ b/integrations/cursor/hooks/lib/harvest-worker.mjs
@@ -1,6 +1,6 @@
+#!/usr/bin/env node
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/harvest-worker.mjs. Regenerate with `npm run sync:hooks`.
-#!/usr/bin/env node
 /**
  * The out-of-band half of the semantic harvest.
  *

--- a/integrations/cursor/hooks/lib/stop-harvest.mjs
+++ b/integrations/cursor/hooks/lib/stop-harvest.mjs
@@ -353,6 +353,11 @@ export async function runStopHarvest(payload = {}) {
       env: { ...process.env },
     }
   );
+  // AN 'error' EVENT WITH NO LISTENER IS A THROW. `spawn` reports a failed
+  // start asynchronously, so an unlistened error does not return a code -- Node
+  // raises it, and here that would abort the Stop response itself. A harvest
+  // that cannot start must degrade to no harvest, never to a broken Stop.
+  child.on('error', () => {});
   child.unref();
   return null;
 }

--- a/integrations/cursor/hooks/lib/stop-harvest.mjs
+++ b/integrations/cursor/hooks/lib/stop-harvest.mjs
@@ -1,0 +1,358 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/stop-harvest.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Claude Code Stop adapter -- run the semantic harvest the design specifies.
+ *
+ * The wiki design says findings are extracted "at Stop and PreCompact" by a
+ * cheap model, out of band. The extractor (`lib/harvest.mjs`) was implemented
+ * and then imported by nothing: no hook invoked it, and Stop carried no
+ * token-optimizer entry at all. The consequence was not a crash but a graph
+ * that could serve findings and never acquired any -- 122 file / 132 symbol /
+ * 61 task nodes and zero findings on a real project after a full session, with
+ * injection, staleness and the metrics all wired and idle behind it.
+ *
+ * OUT OF BAND IS THE POINT. The extraction is a model call; doing it inline
+ * would make the session that did the work pay for summarising itself, which is
+ * the cost this whole subsystem exists to avoid. So this spawns a detached
+ * worker and returns immediately. Stop is never delayed.
+ *
+ * IT ALSO REPORTS WHEN IT CANNOT RUN. Harvest requires an API key, and without
+ * one `harvestEnabled()` returns false and the module skips silently. Silence
+ * was how this stayed invisible: nothing in doctor, audit or waste mentions
+ * harvest, so a user sees a graph filling with structural nodes and no findings
+ * and has no way to learn why. Saying so once per session is the difference
+ * between a disabled feature and a broken one.
+ */
+
+import { spawn } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  chmodSync,
+  readFileSync,
+  openSync,
+  writeSync,
+  closeSync,
+  lstatSync,
+  constants,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir, homedir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { mode, MODE_OFF } from './policy.mjs';
+import { harvestEnabled, harvestMode } from './harvest.mjs';
+import { archive } from './transcript.mjs';
+import { wikiDir, projectRootFor, sharedDir, load } from './wiki.mjs';
+import { detectRefusals, recordRefusal } from './harvest-write.mjs';
+
+/** What to tell the user, per reason the harvest is not running. */
+const OFF_REASON = {
+  'off:mode': null, // The whole optimizer is off; saying more would be noise.
+  'off:not-opted-in':
+    'token-optimizer: automatic finding-extraction is OFF. It costs a model call and ' +
+    'sends a digest (paths, commands, prompts, conclusions -- never file contents) off ' +
+    'this machine, so it is opt-in: set TOKEN_OPTIMIZER_HARVEST=1 with an API key, or ' +
+    'point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model to run it free and private. ' +
+    'Meanwhile lifecycle-based structural graph capture keeps working. Durable semantic MCP ' +
+    'writes require a writer schema that is actually registered in the current CLI session.',
+  'off:no-key':
+    'token-optimizer: finding-extraction is opted in but has no credential. Set ' +
+    'TOKEN_OPTIMIZER_API_KEY, or point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model ' +
+    'to run it without one.',
+};
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * A session id reduced to something that cannot leave the marker directory.
+ *
+ * The id arrives in the hook payload, so it is external input, and it was being
+ * interpolated straight into a path: a value containing separators or `..` would
+ * have placed (and later read) the marker anywhere on disk. Everything outside a
+ * conservative allowlist becomes an underscore, which keeps ordinary uuids
+ * readable while making traversal unrepresentable rather than merely unlikely.
+ */
+function markerName(sessionId) {
+  const safe = String(sessionId || 'unknown').replace(/[^A-Za-z0-9._-]/g, '_');
+  // A name of only dots would still resolve to a directory entry.
+  const cleaned = /^[.]+$/.test(safe) ? 'unknown' : safe;
+  return `harvest-notice-${cleaned.slice(0, 64)}`;
+}
+
+/**
+ * A private, per-user directory for this hook's markers.
+ *
+ * os.tmpdir() is per-user on Windows but resolves to a SHARED, world-writable
+ * /tmp on POSIX. The marker name is derived from the session id, so it is
+ * predictable enough for another local user to pre-create -- as a symlink, or
+ * as a file they own -- and writeFileSync would then follow it and write
+ * through with this user's privileges.
+ *
+ * The state here is a debounce timestamp and a "said it once" flag, so the fix
+ * is not to guard a shared location but to stop using one. XDG_STATE_HOME is
+ * the standard place for state that should persist across runs but is not
+ * precious, and it is inside the user's own home on every POSIX system.
+ */
+function stateDir() {
+  const home = homedir();
+  const base =
+    process.platform === 'win32'
+      ? process.env.LOCALAPPDATA || tmpdir()
+      : process.env.XDG_STATE_HOME ||
+        (home ? join(home, '.local', 'state') : tmpdir());
+
+  const dir = join(base, 'token-optimizer');
+  try {
+    // 0o700 AND an explicit chmod, for the reason the graph store documents:
+    // `recursive` applies the mode only to directories it actually creates, and
+    // the umask masks it further, so neither alone guarantees the result.
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    try {
+      chmodSync(dir, 0o700);
+    } catch {
+      // Not POSIX, or not ours to chmod.
+    }
+  } catch {
+    /* best effort */
+  }
+  return dir;
+}
+
+/** Where the once-per-session notice is remembered, so Stop does not nag. */
+function noticePath(sessionId) {
+  return join(stateDir(), markerName(sessionId));
+}
+
+/**
+ * True when the path is absent, or is a regular file this user owns.
+ *
+ * lstat rather than stat: stat FOLLOWS the link and would happily report on the
+ * target, which is the thing being defended against.
+ */
+function ownedRegularFile(path) {
+  let info;
+  try {
+    info = lstatSync(path);
+  } catch {
+    return true; // Absent. The O_NOFOLLOW open below settles the race.
+  }
+  if (!info.isFile()) return false;
+  // getuid is undefined on Windows, where stateDir() is already per-user.
+  if (typeof process.getuid === 'function' && info.uid !== process.getuid())
+    return false;
+  return true;
+}
+
+/**
+ * Writes a marker, refusing to follow a symlink.
+ *
+ * O_NOFOLLOW makes the refusal ATOMIC rather than a check-then-use window: a
+ * link swapped in after ownedRegularFile() returns fails the open instead of
+ * being written through. The flag does not exist on Windows, where it is
+ * undefined and falls back to 0 -- acceptable, because the directory is
+ * per-user there to begin with.
+ */
+function writeMarker(path, contents) {
+  if (!ownedRegularFile(path)) return false;
+  const NOFOLLOW = constants.O_NOFOLLOW || 0;
+  let fd;
+  try {
+    fd = openSync(
+      path,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | NOFOLLOW,
+      0o600
+    );
+    writeSync(fd, contents);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* already closed */
+      }
+    }
+  }
+}
+
+/** Reads a marker, ignoring anything that is not a regular file we own. */
+function readMarker(path) {
+  if (!ownedRegularFile(path)) return null;
+  try {
+    return readFileSync(path, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function alreadyNotified(sessionId) {
+  const path = noticePath(sessionId);
+  // Anything already at this path -- our marker, or something planted -- means
+  // stay quiet. Repeating the notice is the worse failure, and refusing to
+  // write over a foreign file is the point.
+  if (existsSync(path)) return true;
+  return !writeMarker(path, String(Date.now()));
+}
+
+/** Minimum gap between harvests of one session. */
+const HARVEST_INTERVAL_MS =
+  Number(process.env.TOKEN_OPTIMIZER_HARVEST_INTERVAL_MS) > 0
+    ? Number(process.env.TOKEN_OPTIMIZER_HARVEST_INTERVAL_MS)
+    : 10 * 60 * 1000;
+
+/**
+ * True when this session has not been harvested recently, and records that it
+ * is about to be.
+ *
+ * Deliberately marks only when a harvest actually starts: touching it on every
+ * Stop would let a run of skipped turns keep pushing the next harvest away.
+ */
+function dueForHarvest(sessionId) {
+  const marker = join(stateDir(), `harvest-last-${markerName(sessionId)}`);
+
+  const last = Number(readMarker(marker));
+  // > 0 matters: readMarker returns null when the marker is missing or is not
+  // ours, and Number(null) is 0, which is finite -- so without this an absent
+  // marker would read as a harvest at the epoch.
+  if (
+    Number.isFinite(last) &&
+    last > 0 &&
+    Date.now() - last < HARVEST_INTERVAL_MS
+  ) {
+    return false;
+  }
+
+  // If the marker cannot be written the debounce degrades to off rather than
+  // blocking the harvest entirely.
+  writeMarker(marker, String(Date.now()));
+  return true;
+}
+
+/**
+ * The Stop-time harvest, for every client rather than one.
+ *
+ * WHY THIS IS A FUNCTION AND NOT A HOOK. It was a hook -- a Claude Code entry
+ * point named `stop-harvest.mjs` -- and #300 unregistered it. Nothing replaced
+ * it, so four capabilities went silently: the transcript archive, the harvest
+ * worker spawn, refusal detection, and the notice that says why no findings
+ * exist. Every client routes Stop through the shared adapter, and the adapter
+ * did none of these, so on a full session with a valid credential
+ * `harvestMode()` reported `remote` and nothing happened.
+ *
+ * NOTHING OBSERVED THAT IT DID NOT RUN, which is why it survived a year. There
+ * is no `kind:'harvest'` event to be absent from a report, no error, and a
+ * harvest that ran and found nothing looks exactly like one that never
+ * started. The reachability guard could not see it either: this file's own
+ * imports gave `archive`, `detectRefusals` and `recordRefusal` call sites, and
+ * a name-based scan proves a reference exists, never that it runs.
+ *
+ * Returns a notice for the caller to emit, or null. It does NOT write to
+ * stdout: the adapter emits exactly one JSON object per hook invocation, and a
+ * second writer racing it is how a Stop payload gets corrupted.
+ *
+ * @returns {Promise<string|null>} a once-per-session message, or null.
+ */
+export async function runStopHarvest(payload = {}) {
+  if (mode() === MODE_OFF) return null;
+
+  const transcript = payload.transcript_path ?? payload.transcriptPath ?? null;
+  if (!transcript || !existsSync(transcript)) return null;
+
+  // ARCHIVE FIRST, AND UNCONDITIONALLY. This is a local file copy: it costs no
+  // model call, spends no money, and sends nothing anywhere, so it must not sit
+  // behind the opt-in that exists to gate cost and disclosure. Gating it there
+  // would mean the record of what the user actually said is kept only for the
+  // users who opted into a paid feature, which is exactly backwards.
+  //
+  // It also has to happen before the early return below, or a session with
+  // harvesting off would archive nothing at all.
+  try {
+    archive(
+      wikiDir(
+        projectRootFor(
+          join(payload.cwd || process.cwd(), '__session__'),
+          payload.cwd
+        )
+      ),
+      transcript,
+      {
+        sessionId: payload.session_id,
+      }
+    );
+  } catch {
+    // The archive is a convenience. Failing to write it must not affect Stop.
+  }
+
+  // CLOSE THE REFUSAL LOOP, and do it OUTSIDE the harvest opt-in. Reading the
+  // transcript this process already holds costs no model call and sends nothing
+  // anywhere, so gating it behind the paid feature would leave a mis-scoped
+  // lesson costing tokens forever for everyone who did not opt in.
+  //
+  // The model states plainly when a cross-project lesson does not transfer --
+  // "that figure is another repo's baseline and it doesn't transfer" -- and until
+  // now nothing read it, so the same lesson was delivered again next session.
+  try {
+    const shared = sharedDir();
+    const lessons = [...load(shared).nodes.values()].filter(
+      (n) => n.kind === 'finding' && !n.retired && n.claim
+    );
+    if (lessons.length) {
+      const text = readFileSync(transcript, 'utf8');
+      for (const key of detectRefusals(lessons, text))
+        recordRefusal(shared, key);
+    }
+  } catch {
+    // Feedback is a refinement; a failure here must not affect Stop.
+  }
+
+  if (!harvestEnabled()) {
+    // Say it once, name the reason and the variable that changes it, and state
+    // what still works. A user who reads this should know exactly what they are
+    // and are not getting, and what to do about it.
+    const message = OFF_REASON[harvestMode()];
+    // RETURNED, NOT WRITTEN. This used to write its own JSON to stdout and
+    // race whatever the hook emitted; the adapter now folds this into the one
+    // object it sends, so the notice cannot be dropped by a full pipe or
+    // truncated by an exit -- which is what used to happen to the single line
+    // explaining why no findings exist.
+    if (message && !alreadyNotified(payload.session_id)) return message;
+    return null;
+  }
+
+  // SIBLING IN THE SHARED CORE. The worker used to live beside the hook entry
+  // in `plugin/hooks/`, which is why only Claude Code could ever have spawned
+  // it -- it was vendored to no other client. It now sits in the core that
+  // every client receives an identical copy of, so this resolves in all
+  // eleven.
+  const worker = join(HERE, 'harvest-worker.mjs');
+  if (!existsSync(worker)) return null;
+
+  // DEBOUNCE. Stop fires at the end of every assistant turn, so a talkative
+  // session would spawn a model call per turn -- each re-reading an overlapping
+  // transcript and re-extracting most of the same findings. The marker is
+  // touched only when a harvest is actually started, so a skipped turn does not
+  // push the next one further away.
+  if (!dueForHarvest(payload.session_id)) return null;
+
+  // Detached and fully released: the harvest must outlive this hook without
+  // holding Stop open for a model round-trip.
+  const child = spawn(
+    process.execPath,
+    [
+      worker,
+      transcript,
+      String(payload.session_id || ''),
+      String(payload.cwd || process.cwd()),
+    ],
+    {
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: true,
+      env: { ...process.env },
+    }
+  );
+  child.unref();
+  return null;
+}

--- a/integrations/gemini/hooks/lib/adapter.mjs
+++ b/integrations/gemini/hooks/lib/adapter.mjs
@@ -762,8 +762,11 @@ async function runHook(clientName, event, invocation) {
     const toolEvidence = optimizerToolsForHook(raw, state);
     rememberOptimizerTools(state, toolEvidence);
     const episode = episodeMeta({ client: clientName, raw });
+    // Hoisted out of the try below, because the harvest needs the same resolved
+    // directory and resolving it twice is how two halves of one hook end up
+    // reasoning about different projects.
+    const cwd = raw.cwd || raw.working_directory || process.cwd();
     try {
-      const cwd = raw.cwd || raw.working_directory || process.cwd();
       const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
       recordEpisodeOutcome(dir, {
         ...episode,
@@ -807,7 +810,21 @@ async function runHook(clientName, event, invocation) {
     // call.
     let harvestNotice = null;
     try {
-      harvestNotice = await runStopHarvest(raw);
+      // NORMALIZED, NOT RAW. The identifiers were resolved a few lines up
+      // through every alias a host might use -- `sessionId`,
+      // `conversation_id`, `working_directory` -- and handing `raw` straight
+      // over threw that away: runStopHarvest reads `session_id` and `cwd`
+      // only, so on a client that sends an alias the session id came back
+      // undefined and the archive root fell back to `process.cwd()`. That
+      // shares the once-per-session notice and the debounce marker across
+      // every session, and files the transcript under whatever directory the
+      // hook happened to start in.
+      harvestNotice = await runStopHarvest({
+        ...raw,
+        session_id: sessionId,
+        cwd,
+        transcript_path: raw.transcript_path ?? raw.transcriptPath ?? null,
+      });
     } catch {
       // The harvest is a side effect of ending a session. It must never stop
       // one from ending.

--- a/integrations/gemini/hooks/lib/adapter.mjs
+++ b/integrations/gemini/hooks/lib/adapter.mjs
@@ -88,6 +88,7 @@ import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 import { evaluateUcrGuards } from './ucr-guard.mjs';
 import { beginHookInvocation, noteHookOutput } from './observability.mjs';
 import { registerProject } from './projects.mjs';
+import { runStopHarvest } from './stop-harvest.mjs';
 
 /**
  * Per-client capability.
@@ -792,10 +793,33 @@ async function runHook(clientName, event, invocation) {
       state.harvestedEdits = Number(state.edits || 0);
       saveState(sessionId, state, agentScope);
     }
+    // THE OUT-OF-BAND HARVEST, which no client was running.
+    //
+    // The in-band `prompt` above asks the MODEL to call `wiki_write`, and the
+    // session pays for summarising itself -- the exact cost the design says the
+    // harvest exists to avoid ("out-of-band, so the session doing the work never
+    // pays for the harvest"). The out-of-band half lived in a Claude Code hook
+    // that #300 unregistered, and nothing replaced it, so on every client the
+    // transcript was never archived, the worker never spawned, refusals were
+    // never detected, and the notice explaining why no findings exist was never
+    // shown. Awaited because it must finish before the exit below; it spawns a
+    // DETACHED worker and returns immediately, so Stop is not delayed by a model
+    // call.
+    let harvestNotice = null;
+    try {
+      harvestNotice = await runStopHarvest(raw);
+    } catch {
+      // The harvest is a side effect of ending a session. It must never stop
+      // one from ending.
+    }
+
     if (prompt && client.stopStyle === 'followup') {
-      emit({ followup_message: prompt });
+      emit({ followup_message: prompt, ...(harvestNotice ? { systemMessage: harvestNotice } : {}) });
     } else {
-      emit(prompt ? { decision: client.stopDecision, reason: prompt } : {});
+      emit({
+        ...(prompt ? { decision: client.stopDecision, reason: prompt } : {}),
+        ...(harvestNotice ? { systemMessage: harvestNotice } : {}),
+      });
     }
     process.exit(0);
   }

--- a/integrations/gemini/hooks/lib/harvest-worker.mjs
+++ b/integrations/gemini/hooks/lib/harvest-worker.mjs
@@ -1,0 +1,248 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/harvest-worker.mjs. Regenerate with `npm run sync:hooks`.
+#!/usr/bin/env node
+/**
+ * The out-of-band half of the semantic harvest.
+ *
+ * Spawned detached by the Stop adapter so the session that did the work never
+ * pays for the model call that summarises it. Everything here is best-effort:
+ * a harvest that fails must be indistinguishable from a session with nothing
+ * to learn, because the alternative -- a hook that can break a turn -- is worse
+ * than no findings at all.
+ *
+ * The cost of the extraction is recorded either way. Without it the metrics
+ * report a benefit with no matching expense, and `netTokens` would flatter the
+ * feature by exactly the amount it spends.
+ */
+
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  harvestEnabled,
+  buildDigest,
+  buildFullDelta,
+  extract,
+  validate,
+  estimateTokens,
+} from './harvest.mjs';
+import { writeHarvested } from './harvest-write.mjs';
+import { record } from './metrics.mjs';
+import { wikiDir, projectRootFor, load } from './wiki.mjs';
+import { readArchive } from './transcript.mjs';
+import { buildFeedbackDigest, validateLessons, LESSON_PROMPT } from './lessons.mjs';
+import { ORIGIN_HARVESTED } from './curate.mjs';
+import { selectForConsolidation } from './consolidate.mjs';
+
+/**
+ * The token budget one session's harvest may add to the graph.
+ *
+ * #204 lists graph bloat as a named risk -- "the session-start index grows with
+ * the graph; ranking and eviction are required, not optional" -- and until now
+ * nothing bounded what a single harvest could store. 4,000 tokens is the
+ * selector's own default and roughly twenty-five findings at the size the
+ * extractor produces, which is far above any observed session's real yield; it
+ * is a ceiling against a pathological extraction, not a routine constraint.
+ */
+const CONSOLIDATION_BUDGET = 4000;
+
+/**
+ * The files the digest says were touched.
+ *
+ * `buildDigest` emits them under a `## Files touched` heading and returns a
+ * string, so this reads back the list it just wrote rather than walking the
+ * transcript a second time. Returns null when the section is absent, which
+ * `validate` treats as "no restriction" rather than "no files".
+ */
+function filesIn(digest) {
+  const start = digest.indexOf('## Files touched');
+  if (start === -1) return null;
+
+  const rest = digest.slice(start + '## Files touched'.length);
+  const end = rest.indexOf('\n##');
+  const block = (end === -1 ? rest : rest.slice(0, end)).split('\n');
+
+  const files = new Set();
+  for (const line of block) {
+    const value = line.trim();
+    if (value) files.add(value);
+  }
+  return files.size ? files : null;
+}
+
+async function main() {
+  const [transcript, sessionId, cwd] = process.argv.slice(2);
+  if (!transcript || !existsSync(transcript) || !harvestEnabled()) return;
+
+  // THE GRAPH AND THE CONTAINMENT BOUNDARY BOTH COME FROM THE REPOSITORY ROOT,
+  // NOT THE SESSION'S CWD. `wikiDir` only joins the path it is handed, so a
+  // session started in a subdirectory selected `<subdir>/.token-optimizer/wiki`
+  // -- a second graph, invisible to every other hook, which all resolve the root
+  // first. It also made the subdirectory the containment root for the write, so
+  // a finding anchored anywhere else in the same repository was refused for
+  // sitting "outside" the project.
+  //
+  // `__session__` is a synthetic leaf so the walk starts at `cwd` itself rather
+  // than its parent; `projectRootFor` takes a FILE path. This is the same idiom
+  // the adapter, the session-start hook and the Stop adapter already use.
+  //
+  // A cwd with no VCS ancestor resolves to the machine-level unrooted bucket,
+  // which `resolveAnchor` expects and handles: it swaps in home as the
+  // containment root for that case, so passing the resolved root here is what
+  // lets unrooted anchors work at all.
+  const sessionCwd = cwd || process.cwd();
+  const projectRoot = projectRootFor(join(sessionCwd, '__session__'), sessionCwd);
+  const dir = wikiDir(projectRoot);
+
+  // Default sends a structured digest with no file contents. The full delta is
+  // opt-in because the default has to be defensible without reading the docs.
+  const full = process.env.TOKEN_OPTIMIZER_HARVEST_FULL === 'true';
+  const digest = full ? buildFullDelta(transcript) : buildDigest(transcript);
+  if (!digest) return;
+
+  const raw = await extract(digest);
+
+  // Anchors are held to the files this session actually touched, so a model
+  // that invents a plausible path cannot anchor a finding to it. The digest
+  // lists them under a heading it writes itself; the full delta is raw
+  // transcript and carries no such list, so it gets no restriction.
+  const validated = validate(raw, { knownFiles: full ? null : filesIn(digest) });
+
+  // BUDGETED SELECTION, not everything the model extracted.
+  //
+  // `selectForConsolidation` exists for exactly this and had no caller
+  // anywhere, so every harvested candidate was stored regardless of what it
+  // cost to derive, how hard it is to reproduce, or whether the graph can ever
+  // retrieve it -- which is the graph-bloat risk #204 lists as needing
+  // "ranking and eviction ... not optional". It keeps failures and decisions on
+  // a floor before ranking, encoding the design's judgement that dead ends are
+  // the highest-value kind: they exist nowhere in the source tree, so nothing
+  // else can ever recover them.
+  //
+  // The selection is RECORDED, not silent. A cap that drops work without
+  // saying so reads as "there was nothing more to find", which is the same
+  // dishonesty as a truncated report with no remainder line.
+  const graph = load(dir);
+  const selection = selectForConsolidation(graph, validated, { budget: CONSOLIDATION_BUDGET });
+  const findings = selection.kept;
+  if (selection.dropped > 0) {
+    record(dir, {
+      kind: 'harvest',
+      action: 'consolidation',
+      candidates: validated.length,
+      kept: findings.length,
+      dropped: selection.dropped,
+      tokens: selection.tokens,
+      budget: CONSOLIDATION_BUDGET,
+    });
+  }
+
+  const written = writeHarvested(dir, findings, {
+    sessionId: sessionId || null,
+    projectRoot,
+    // Task nodes are keyed by session id (structural capture creates one on
+    // the first touched file, `harvest()` in lib/wiki.mjs) so this is the
+    // shape `writeHarvested` needs to point the `answers` edge back at the
+    // task this harvest belongs to. A session that never touched a file
+    // through PreToolUse/PostToolUse has no such node yet; `writeHarvested`
+    // resolves that case to no edge rather than a dangling one.
+    taskId: sessionId || null,
+    // AUTHORITATIVE, not just present: this `sessionId` came from Claude
+    // Code's own Stop-hook payload (see stop-harvest.mjs), not a model-typed
+    // tool argument, so it is safe to use for the traversal fallback if the
+    // explicit `taskId` above does not resolve.
+    authoritativeSessionId: sessionId || null,
+  });
+
+  record(dir, {
+    kind: 'harvest',
+    sessionId: sessionId || null,
+    tokens: estimateTokens(digest),
+    findings: written.length,
+    at: Date.now(),
+  });
+
+  // THE FEEDBACK LOOP. A separate extraction with a separate prompt, because
+  // the two are looking for different things: the harvest above wants what was
+  // LEARNED about the code, this wants where the user said the agent was WRONG.
+  // Asked for both at once a model returns a summary and the corrections get
+  // lost in it -- and corrections are the only turns carrying information the
+  // code itself could never supply.
+  try {
+    const turns = readArchive(dir, sessionId || 'unknown');
+    const feedback = buildFeedbackDigest(turns);
+    if (feedback) {
+      const rawLessons = await extract(feedback, { prompt: LESSON_PROMPT });
+      // The same restriction the finding path above applies, for the same reason: a model that
+      // invents a plausible path must not be able to anchor a lesson to it. `turns` is the
+      // archived transcript for this session, so its rendered digest is the honest file list.
+      const { lessons } = validateLessons(rawLessons, turns, {
+        knownFiles: filesIn(feedback),
+      });
+
+      // Anchors are optional on a lesson -- "always run npm test" is about no
+      // file -- so each is anchored to the project root when it names nothing,
+      // which keeps the store's rule that an unanchored finding is refused.
+      //
+      // The RESOLVED root, matching the containment root this write is checked
+      // against. The session's cwd would be refused outright once that root is
+      // the unrooted bucket, because `resolveAnchor` then narrows containment to
+      // home and a VCS-less working directory need not sit under it.
+      const anchored = lessons.map((l) => ({
+        ...l,
+        anchors: l.anchors.length ? l.anchors : [projectRoot],
+      }));
+
+      // The write itself is the durable record: writeHarvested anchors each
+      // lesson into the graph, which is what lessons.mjs's real consumers
+      // query. A metrics event of kind 'lessons' used to sit here as well,
+      // but nothing ever read it -- not netTokens (only 'harvest' feeds
+      // harvestTokens), not report()/buildReport() (no kind filter matches
+      // 'lessons'), and no audit render exists to show it to a human. That is
+      // the inverse of the `query` defect and the same shape as
+      // `tokensFullFile` before it: a produced-and-never-consumed event,
+      // which is a cost with no benefit. Deleted rather than wired, per the
+      // reachability allowlist's own rule -- write it again the day
+      // something needs to read it.
+      writeHarvested(dir, anchored, {
+        sessionId: sessionId || null,
+        origin: ORIGIN_HARVESTED,
+        projectRoot,
+        taskId: sessionId || null,
+        // Same hook-payload identity as above, same reason.
+        authoritativeSessionId: sessionId || null,
+      });
+    }
+  } catch {
+    // A failed feedback pass must be indistinguishable from a session with
+    // nothing to correct.
+  }
+}
+
+main()
+  .catch(() => {})
+  .finally(() => {
+    // NEVER process.exit() SYNCHRONOUSLY HERE.
+    //
+    // It crashed this worker on Windows every single time the feedback pass
+    // ran -- libuv asserts `!(handle->flags & UV_HANDLE_CLOSING)` when the
+    // process exits while the sockets from the model call are still closing,
+    // giving exit code 0xC0000409. Reproduced 5 runs out of 5, and silently,
+    // because this worker is spawned detached and nothing reads its status.
+    // Deferring by one tick is NOT enough; the handles are still closing then.
+    //
+    // So the normal path just lets the loop drain, which it does promptly.
+    //
+    // THE RECORDED CODE IS PRESERVED, not overwritten with 0. Assigning 0
+    // unconditionally would turn a harvest that had already recorded a failure
+    // into one that reports success -- and this worker is detached, so that
+    // status is the only signal a supervisor could ever act on.
+    const code = process.exitCode ?? 0;
+    process.exitCode = code;
+
+    // The watchdog keeps the original guarantee: a detached worker must never
+    // linger holding a keep-alive socket open. It is UNREF'D, so it cannot
+    // itself keep the process alive -- it only fires if something else already
+    // has, which is exactly the case worth killing.
+    const watchdog = setTimeout(() => process.exit(code), 5000);
+    watchdog.unref();
+  });

--- a/integrations/gemini/hooks/lib/harvest-worker.mjs
+++ b/integrations/gemini/hooks/lib/harvest-worker.mjs
@@ -1,6 +1,6 @@
+#!/usr/bin/env node
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/harvest-worker.mjs. Regenerate with `npm run sync:hooks`.
-#!/usr/bin/env node
 /**
  * The out-of-band half of the semantic harvest.
  *

--- a/integrations/gemini/hooks/lib/stop-harvest.mjs
+++ b/integrations/gemini/hooks/lib/stop-harvest.mjs
@@ -353,6 +353,11 @@ export async function runStopHarvest(payload = {}) {
       env: { ...process.env },
     }
   );
+  // AN 'error' EVENT WITH NO LISTENER IS A THROW. `spawn` reports a failed
+  // start asynchronously, so an unlistened error does not return a code -- Node
+  // raises it, and here that would abort the Stop response itself. A harvest
+  // that cannot start must degrade to no harvest, never to a broken Stop.
+  child.on('error', () => {});
   child.unref();
   return null;
 }

--- a/integrations/gemini/hooks/lib/stop-harvest.mjs
+++ b/integrations/gemini/hooks/lib/stop-harvest.mjs
@@ -1,0 +1,358 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/stop-harvest.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Claude Code Stop adapter -- run the semantic harvest the design specifies.
+ *
+ * The wiki design says findings are extracted "at Stop and PreCompact" by a
+ * cheap model, out of band. The extractor (`lib/harvest.mjs`) was implemented
+ * and then imported by nothing: no hook invoked it, and Stop carried no
+ * token-optimizer entry at all. The consequence was not a crash but a graph
+ * that could serve findings and never acquired any -- 122 file / 132 symbol /
+ * 61 task nodes and zero findings on a real project after a full session, with
+ * injection, staleness and the metrics all wired and idle behind it.
+ *
+ * OUT OF BAND IS THE POINT. The extraction is a model call; doing it inline
+ * would make the session that did the work pay for summarising itself, which is
+ * the cost this whole subsystem exists to avoid. So this spawns a detached
+ * worker and returns immediately. Stop is never delayed.
+ *
+ * IT ALSO REPORTS WHEN IT CANNOT RUN. Harvest requires an API key, and without
+ * one `harvestEnabled()` returns false and the module skips silently. Silence
+ * was how this stayed invisible: nothing in doctor, audit or waste mentions
+ * harvest, so a user sees a graph filling with structural nodes and no findings
+ * and has no way to learn why. Saying so once per session is the difference
+ * between a disabled feature and a broken one.
+ */
+
+import { spawn } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  chmodSync,
+  readFileSync,
+  openSync,
+  writeSync,
+  closeSync,
+  lstatSync,
+  constants,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir, homedir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { mode, MODE_OFF } from './policy.mjs';
+import { harvestEnabled, harvestMode } from './harvest.mjs';
+import { archive } from './transcript.mjs';
+import { wikiDir, projectRootFor, sharedDir, load } from './wiki.mjs';
+import { detectRefusals, recordRefusal } from './harvest-write.mjs';
+
+/** What to tell the user, per reason the harvest is not running. */
+const OFF_REASON = {
+  'off:mode': null, // The whole optimizer is off; saying more would be noise.
+  'off:not-opted-in':
+    'token-optimizer: automatic finding-extraction is OFF. It costs a model call and ' +
+    'sends a digest (paths, commands, prompts, conclusions -- never file contents) off ' +
+    'this machine, so it is opt-in: set TOKEN_OPTIMIZER_HARVEST=1 with an API key, or ' +
+    'point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model to run it free and private. ' +
+    'Meanwhile lifecycle-based structural graph capture keeps working. Durable semantic MCP ' +
+    'writes require a writer schema that is actually registered in the current CLI session.',
+  'off:no-key':
+    'token-optimizer: finding-extraction is opted in but has no credential. Set ' +
+    'TOKEN_OPTIMIZER_API_KEY, or point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model ' +
+    'to run it without one.',
+};
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * A session id reduced to something that cannot leave the marker directory.
+ *
+ * The id arrives in the hook payload, so it is external input, and it was being
+ * interpolated straight into a path: a value containing separators or `..` would
+ * have placed (and later read) the marker anywhere on disk. Everything outside a
+ * conservative allowlist becomes an underscore, which keeps ordinary uuids
+ * readable while making traversal unrepresentable rather than merely unlikely.
+ */
+function markerName(sessionId) {
+  const safe = String(sessionId || 'unknown').replace(/[^A-Za-z0-9._-]/g, '_');
+  // A name of only dots would still resolve to a directory entry.
+  const cleaned = /^[.]+$/.test(safe) ? 'unknown' : safe;
+  return `harvest-notice-${cleaned.slice(0, 64)}`;
+}
+
+/**
+ * A private, per-user directory for this hook's markers.
+ *
+ * os.tmpdir() is per-user on Windows but resolves to a SHARED, world-writable
+ * /tmp on POSIX. The marker name is derived from the session id, so it is
+ * predictable enough for another local user to pre-create -- as a symlink, or
+ * as a file they own -- and writeFileSync would then follow it and write
+ * through with this user's privileges.
+ *
+ * The state here is a debounce timestamp and a "said it once" flag, so the fix
+ * is not to guard a shared location but to stop using one. XDG_STATE_HOME is
+ * the standard place for state that should persist across runs but is not
+ * precious, and it is inside the user's own home on every POSIX system.
+ */
+function stateDir() {
+  const home = homedir();
+  const base =
+    process.platform === 'win32'
+      ? process.env.LOCALAPPDATA || tmpdir()
+      : process.env.XDG_STATE_HOME ||
+        (home ? join(home, '.local', 'state') : tmpdir());
+
+  const dir = join(base, 'token-optimizer');
+  try {
+    // 0o700 AND an explicit chmod, for the reason the graph store documents:
+    // `recursive` applies the mode only to directories it actually creates, and
+    // the umask masks it further, so neither alone guarantees the result.
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    try {
+      chmodSync(dir, 0o700);
+    } catch {
+      // Not POSIX, or not ours to chmod.
+    }
+  } catch {
+    /* best effort */
+  }
+  return dir;
+}
+
+/** Where the once-per-session notice is remembered, so Stop does not nag. */
+function noticePath(sessionId) {
+  return join(stateDir(), markerName(sessionId));
+}
+
+/**
+ * True when the path is absent, or is a regular file this user owns.
+ *
+ * lstat rather than stat: stat FOLLOWS the link and would happily report on the
+ * target, which is the thing being defended against.
+ */
+function ownedRegularFile(path) {
+  let info;
+  try {
+    info = lstatSync(path);
+  } catch {
+    return true; // Absent. The O_NOFOLLOW open below settles the race.
+  }
+  if (!info.isFile()) return false;
+  // getuid is undefined on Windows, where stateDir() is already per-user.
+  if (typeof process.getuid === 'function' && info.uid !== process.getuid())
+    return false;
+  return true;
+}
+
+/**
+ * Writes a marker, refusing to follow a symlink.
+ *
+ * O_NOFOLLOW makes the refusal ATOMIC rather than a check-then-use window: a
+ * link swapped in after ownedRegularFile() returns fails the open instead of
+ * being written through. The flag does not exist on Windows, where it is
+ * undefined and falls back to 0 -- acceptable, because the directory is
+ * per-user there to begin with.
+ */
+function writeMarker(path, contents) {
+  if (!ownedRegularFile(path)) return false;
+  const NOFOLLOW = constants.O_NOFOLLOW || 0;
+  let fd;
+  try {
+    fd = openSync(
+      path,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | NOFOLLOW,
+      0o600
+    );
+    writeSync(fd, contents);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* already closed */
+      }
+    }
+  }
+}
+
+/** Reads a marker, ignoring anything that is not a regular file we own. */
+function readMarker(path) {
+  if (!ownedRegularFile(path)) return null;
+  try {
+    return readFileSync(path, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function alreadyNotified(sessionId) {
+  const path = noticePath(sessionId);
+  // Anything already at this path -- our marker, or something planted -- means
+  // stay quiet. Repeating the notice is the worse failure, and refusing to
+  // write over a foreign file is the point.
+  if (existsSync(path)) return true;
+  return !writeMarker(path, String(Date.now()));
+}
+
+/** Minimum gap between harvests of one session. */
+const HARVEST_INTERVAL_MS =
+  Number(process.env.TOKEN_OPTIMIZER_HARVEST_INTERVAL_MS) > 0
+    ? Number(process.env.TOKEN_OPTIMIZER_HARVEST_INTERVAL_MS)
+    : 10 * 60 * 1000;
+
+/**
+ * True when this session has not been harvested recently, and records that it
+ * is about to be.
+ *
+ * Deliberately marks only when a harvest actually starts: touching it on every
+ * Stop would let a run of skipped turns keep pushing the next harvest away.
+ */
+function dueForHarvest(sessionId) {
+  const marker = join(stateDir(), `harvest-last-${markerName(sessionId)}`);
+
+  const last = Number(readMarker(marker));
+  // > 0 matters: readMarker returns null when the marker is missing or is not
+  // ours, and Number(null) is 0, which is finite -- so without this an absent
+  // marker would read as a harvest at the epoch.
+  if (
+    Number.isFinite(last) &&
+    last > 0 &&
+    Date.now() - last < HARVEST_INTERVAL_MS
+  ) {
+    return false;
+  }
+
+  // If the marker cannot be written the debounce degrades to off rather than
+  // blocking the harvest entirely.
+  writeMarker(marker, String(Date.now()));
+  return true;
+}
+
+/**
+ * The Stop-time harvest, for every client rather than one.
+ *
+ * WHY THIS IS A FUNCTION AND NOT A HOOK. It was a hook -- a Claude Code entry
+ * point named `stop-harvest.mjs` -- and #300 unregistered it. Nothing replaced
+ * it, so four capabilities went silently: the transcript archive, the harvest
+ * worker spawn, refusal detection, and the notice that says why no findings
+ * exist. Every client routes Stop through the shared adapter, and the adapter
+ * did none of these, so on a full session with a valid credential
+ * `harvestMode()` reported `remote` and nothing happened.
+ *
+ * NOTHING OBSERVED THAT IT DID NOT RUN, which is why it survived a year. There
+ * is no `kind:'harvest'` event to be absent from a report, no error, and a
+ * harvest that ran and found nothing looks exactly like one that never
+ * started. The reachability guard could not see it either: this file's own
+ * imports gave `archive`, `detectRefusals` and `recordRefusal` call sites, and
+ * a name-based scan proves a reference exists, never that it runs.
+ *
+ * Returns a notice for the caller to emit, or null. It does NOT write to
+ * stdout: the adapter emits exactly one JSON object per hook invocation, and a
+ * second writer racing it is how a Stop payload gets corrupted.
+ *
+ * @returns {Promise<string|null>} a once-per-session message, or null.
+ */
+export async function runStopHarvest(payload = {}) {
+  if (mode() === MODE_OFF) return null;
+
+  const transcript = payload.transcript_path ?? payload.transcriptPath ?? null;
+  if (!transcript || !existsSync(transcript)) return null;
+
+  // ARCHIVE FIRST, AND UNCONDITIONALLY. This is a local file copy: it costs no
+  // model call, spends no money, and sends nothing anywhere, so it must not sit
+  // behind the opt-in that exists to gate cost and disclosure. Gating it there
+  // would mean the record of what the user actually said is kept only for the
+  // users who opted into a paid feature, which is exactly backwards.
+  //
+  // It also has to happen before the early return below, or a session with
+  // harvesting off would archive nothing at all.
+  try {
+    archive(
+      wikiDir(
+        projectRootFor(
+          join(payload.cwd || process.cwd(), '__session__'),
+          payload.cwd
+        )
+      ),
+      transcript,
+      {
+        sessionId: payload.session_id,
+      }
+    );
+  } catch {
+    // The archive is a convenience. Failing to write it must not affect Stop.
+  }
+
+  // CLOSE THE REFUSAL LOOP, and do it OUTSIDE the harvest opt-in. Reading the
+  // transcript this process already holds costs no model call and sends nothing
+  // anywhere, so gating it behind the paid feature would leave a mis-scoped
+  // lesson costing tokens forever for everyone who did not opt in.
+  //
+  // The model states plainly when a cross-project lesson does not transfer --
+  // "that figure is another repo's baseline and it doesn't transfer" -- and until
+  // now nothing read it, so the same lesson was delivered again next session.
+  try {
+    const shared = sharedDir();
+    const lessons = [...load(shared).nodes.values()].filter(
+      (n) => n.kind === 'finding' && !n.retired && n.claim
+    );
+    if (lessons.length) {
+      const text = readFileSync(transcript, 'utf8');
+      for (const key of detectRefusals(lessons, text))
+        recordRefusal(shared, key);
+    }
+  } catch {
+    // Feedback is a refinement; a failure here must not affect Stop.
+  }
+
+  if (!harvestEnabled()) {
+    // Say it once, name the reason and the variable that changes it, and state
+    // what still works. A user who reads this should know exactly what they are
+    // and are not getting, and what to do about it.
+    const message = OFF_REASON[harvestMode()];
+    // RETURNED, NOT WRITTEN. This used to write its own JSON to stdout and
+    // race whatever the hook emitted; the adapter now folds this into the one
+    // object it sends, so the notice cannot be dropped by a full pipe or
+    // truncated by an exit -- which is what used to happen to the single line
+    // explaining why no findings exist.
+    if (message && !alreadyNotified(payload.session_id)) return message;
+    return null;
+  }
+
+  // SIBLING IN THE SHARED CORE. The worker used to live beside the hook entry
+  // in `plugin/hooks/`, which is why only Claude Code could ever have spawned
+  // it -- it was vendored to no other client. It now sits in the core that
+  // every client receives an identical copy of, so this resolves in all
+  // eleven.
+  const worker = join(HERE, 'harvest-worker.mjs');
+  if (!existsSync(worker)) return null;
+
+  // DEBOUNCE. Stop fires at the end of every assistant turn, so a talkative
+  // session would spawn a model call per turn -- each re-reading an overlapping
+  // transcript and re-extracting most of the same findings. The marker is
+  // touched only when a harvest is actually started, so a skipped turn does not
+  // push the next one further away.
+  if (!dueForHarvest(payload.session_id)) return null;
+
+  // Detached and fully released: the harvest must outlive this hook without
+  // holding Stop open for a model round-trip.
+  const child = spawn(
+    process.execPath,
+    [
+      worker,
+      transcript,
+      String(payload.session_id || ''),
+      String(payload.cwd || process.cwd()),
+    ],
+    {
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: true,
+      env: { ...process.env },
+    }
+  );
+  child.unref();
+  return null;
+}

--- a/integrations/kilo/hooks/lib/adapter.mjs
+++ b/integrations/kilo/hooks/lib/adapter.mjs
@@ -762,8 +762,11 @@ async function runHook(clientName, event, invocation) {
     const toolEvidence = optimizerToolsForHook(raw, state);
     rememberOptimizerTools(state, toolEvidence);
     const episode = episodeMeta({ client: clientName, raw });
+    // Hoisted out of the try below, because the harvest needs the same resolved
+    // directory and resolving it twice is how two halves of one hook end up
+    // reasoning about different projects.
+    const cwd = raw.cwd || raw.working_directory || process.cwd();
     try {
-      const cwd = raw.cwd || raw.working_directory || process.cwd();
       const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
       recordEpisodeOutcome(dir, {
         ...episode,
@@ -807,7 +810,21 @@ async function runHook(clientName, event, invocation) {
     // call.
     let harvestNotice = null;
     try {
-      harvestNotice = await runStopHarvest(raw);
+      // NORMALIZED, NOT RAW. The identifiers were resolved a few lines up
+      // through every alias a host might use -- `sessionId`,
+      // `conversation_id`, `working_directory` -- and handing `raw` straight
+      // over threw that away: runStopHarvest reads `session_id` and `cwd`
+      // only, so on a client that sends an alias the session id came back
+      // undefined and the archive root fell back to `process.cwd()`. That
+      // shares the once-per-session notice and the debounce marker across
+      // every session, and files the transcript under whatever directory the
+      // hook happened to start in.
+      harvestNotice = await runStopHarvest({
+        ...raw,
+        session_id: sessionId,
+        cwd,
+        transcript_path: raw.transcript_path ?? raw.transcriptPath ?? null,
+      });
     } catch {
       // The harvest is a side effect of ending a session. It must never stop
       // one from ending.

--- a/integrations/kilo/hooks/lib/adapter.mjs
+++ b/integrations/kilo/hooks/lib/adapter.mjs
@@ -88,6 +88,7 @@ import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 import { evaluateUcrGuards } from './ucr-guard.mjs';
 import { beginHookInvocation, noteHookOutput } from './observability.mjs';
 import { registerProject } from './projects.mjs';
+import { runStopHarvest } from './stop-harvest.mjs';
 
 /**
  * Per-client capability.
@@ -792,10 +793,33 @@ async function runHook(clientName, event, invocation) {
       state.harvestedEdits = Number(state.edits || 0);
       saveState(sessionId, state, agentScope);
     }
+    // THE OUT-OF-BAND HARVEST, which no client was running.
+    //
+    // The in-band `prompt` above asks the MODEL to call `wiki_write`, and the
+    // session pays for summarising itself -- the exact cost the design says the
+    // harvest exists to avoid ("out-of-band, so the session doing the work never
+    // pays for the harvest"). The out-of-band half lived in a Claude Code hook
+    // that #300 unregistered, and nothing replaced it, so on every client the
+    // transcript was never archived, the worker never spawned, refusals were
+    // never detected, and the notice explaining why no findings exist was never
+    // shown. Awaited because it must finish before the exit below; it spawns a
+    // DETACHED worker and returns immediately, so Stop is not delayed by a model
+    // call.
+    let harvestNotice = null;
+    try {
+      harvestNotice = await runStopHarvest(raw);
+    } catch {
+      // The harvest is a side effect of ending a session. It must never stop
+      // one from ending.
+    }
+
     if (prompt && client.stopStyle === 'followup') {
-      emit({ followup_message: prompt });
+      emit({ followup_message: prompt, ...(harvestNotice ? { systemMessage: harvestNotice } : {}) });
     } else {
-      emit(prompt ? { decision: client.stopDecision, reason: prompt } : {});
+      emit({
+        ...(prompt ? { decision: client.stopDecision, reason: prompt } : {}),
+        ...(harvestNotice ? { systemMessage: harvestNotice } : {}),
+      });
     }
     process.exit(0);
   }

--- a/integrations/kilo/hooks/lib/harvest-worker.mjs
+++ b/integrations/kilo/hooks/lib/harvest-worker.mjs
@@ -1,0 +1,248 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/harvest-worker.mjs. Regenerate with `npm run sync:hooks`.
+#!/usr/bin/env node
+/**
+ * The out-of-band half of the semantic harvest.
+ *
+ * Spawned detached by the Stop adapter so the session that did the work never
+ * pays for the model call that summarises it. Everything here is best-effort:
+ * a harvest that fails must be indistinguishable from a session with nothing
+ * to learn, because the alternative -- a hook that can break a turn -- is worse
+ * than no findings at all.
+ *
+ * The cost of the extraction is recorded either way. Without it the metrics
+ * report a benefit with no matching expense, and `netTokens` would flatter the
+ * feature by exactly the amount it spends.
+ */
+
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  harvestEnabled,
+  buildDigest,
+  buildFullDelta,
+  extract,
+  validate,
+  estimateTokens,
+} from './harvest.mjs';
+import { writeHarvested } from './harvest-write.mjs';
+import { record } from './metrics.mjs';
+import { wikiDir, projectRootFor, load } from './wiki.mjs';
+import { readArchive } from './transcript.mjs';
+import { buildFeedbackDigest, validateLessons, LESSON_PROMPT } from './lessons.mjs';
+import { ORIGIN_HARVESTED } from './curate.mjs';
+import { selectForConsolidation } from './consolidate.mjs';
+
+/**
+ * The token budget one session's harvest may add to the graph.
+ *
+ * #204 lists graph bloat as a named risk -- "the session-start index grows with
+ * the graph; ranking and eviction are required, not optional" -- and until now
+ * nothing bounded what a single harvest could store. 4,000 tokens is the
+ * selector's own default and roughly twenty-five findings at the size the
+ * extractor produces, which is far above any observed session's real yield; it
+ * is a ceiling against a pathological extraction, not a routine constraint.
+ */
+const CONSOLIDATION_BUDGET = 4000;
+
+/**
+ * The files the digest says were touched.
+ *
+ * `buildDigest` emits them under a `## Files touched` heading and returns a
+ * string, so this reads back the list it just wrote rather than walking the
+ * transcript a second time. Returns null when the section is absent, which
+ * `validate` treats as "no restriction" rather than "no files".
+ */
+function filesIn(digest) {
+  const start = digest.indexOf('## Files touched');
+  if (start === -1) return null;
+
+  const rest = digest.slice(start + '## Files touched'.length);
+  const end = rest.indexOf('\n##');
+  const block = (end === -1 ? rest : rest.slice(0, end)).split('\n');
+
+  const files = new Set();
+  for (const line of block) {
+    const value = line.trim();
+    if (value) files.add(value);
+  }
+  return files.size ? files : null;
+}
+
+async function main() {
+  const [transcript, sessionId, cwd] = process.argv.slice(2);
+  if (!transcript || !existsSync(transcript) || !harvestEnabled()) return;
+
+  // THE GRAPH AND THE CONTAINMENT BOUNDARY BOTH COME FROM THE REPOSITORY ROOT,
+  // NOT THE SESSION'S CWD. `wikiDir` only joins the path it is handed, so a
+  // session started in a subdirectory selected `<subdir>/.token-optimizer/wiki`
+  // -- a second graph, invisible to every other hook, which all resolve the root
+  // first. It also made the subdirectory the containment root for the write, so
+  // a finding anchored anywhere else in the same repository was refused for
+  // sitting "outside" the project.
+  //
+  // `__session__` is a synthetic leaf so the walk starts at `cwd` itself rather
+  // than its parent; `projectRootFor` takes a FILE path. This is the same idiom
+  // the adapter, the session-start hook and the Stop adapter already use.
+  //
+  // A cwd with no VCS ancestor resolves to the machine-level unrooted bucket,
+  // which `resolveAnchor` expects and handles: it swaps in home as the
+  // containment root for that case, so passing the resolved root here is what
+  // lets unrooted anchors work at all.
+  const sessionCwd = cwd || process.cwd();
+  const projectRoot = projectRootFor(join(sessionCwd, '__session__'), sessionCwd);
+  const dir = wikiDir(projectRoot);
+
+  // Default sends a structured digest with no file contents. The full delta is
+  // opt-in because the default has to be defensible without reading the docs.
+  const full = process.env.TOKEN_OPTIMIZER_HARVEST_FULL === 'true';
+  const digest = full ? buildFullDelta(transcript) : buildDigest(transcript);
+  if (!digest) return;
+
+  const raw = await extract(digest);
+
+  // Anchors are held to the files this session actually touched, so a model
+  // that invents a plausible path cannot anchor a finding to it. The digest
+  // lists them under a heading it writes itself; the full delta is raw
+  // transcript and carries no such list, so it gets no restriction.
+  const validated = validate(raw, { knownFiles: full ? null : filesIn(digest) });
+
+  // BUDGETED SELECTION, not everything the model extracted.
+  //
+  // `selectForConsolidation` exists for exactly this and had no caller
+  // anywhere, so every harvested candidate was stored regardless of what it
+  // cost to derive, how hard it is to reproduce, or whether the graph can ever
+  // retrieve it -- which is the graph-bloat risk #204 lists as needing
+  // "ranking and eviction ... not optional". It keeps failures and decisions on
+  // a floor before ranking, encoding the design's judgement that dead ends are
+  // the highest-value kind: they exist nowhere in the source tree, so nothing
+  // else can ever recover them.
+  //
+  // The selection is RECORDED, not silent. A cap that drops work without
+  // saying so reads as "there was nothing more to find", which is the same
+  // dishonesty as a truncated report with no remainder line.
+  const graph = load(dir);
+  const selection = selectForConsolidation(graph, validated, { budget: CONSOLIDATION_BUDGET });
+  const findings = selection.kept;
+  if (selection.dropped > 0) {
+    record(dir, {
+      kind: 'harvest',
+      action: 'consolidation',
+      candidates: validated.length,
+      kept: findings.length,
+      dropped: selection.dropped,
+      tokens: selection.tokens,
+      budget: CONSOLIDATION_BUDGET,
+    });
+  }
+
+  const written = writeHarvested(dir, findings, {
+    sessionId: sessionId || null,
+    projectRoot,
+    // Task nodes are keyed by session id (structural capture creates one on
+    // the first touched file, `harvest()` in lib/wiki.mjs) so this is the
+    // shape `writeHarvested` needs to point the `answers` edge back at the
+    // task this harvest belongs to. A session that never touched a file
+    // through PreToolUse/PostToolUse has no such node yet; `writeHarvested`
+    // resolves that case to no edge rather than a dangling one.
+    taskId: sessionId || null,
+    // AUTHORITATIVE, not just present: this `sessionId` came from Claude
+    // Code's own Stop-hook payload (see stop-harvest.mjs), not a model-typed
+    // tool argument, so it is safe to use for the traversal fallback if the
+    // explicit `taskId` above does not resolve.
+    authoritativeSessionId: sessionId || null,
+  });
+
+  record(dir, {
+    kind: 'harvest',
+    sessionId: sessionId || null,
+    tokens: estimateTokens(digest),
+    findings: written.length,
+    at: Date.now(),
+  });
+
+  // THE FEEDBACK LOOP. A separate extraction with a separate prompt, because
+  // the two are looking for different things: the harvest above wants what was
+  // LEARNED about the code, this wants where the user said the agent was WRONG.
+  // Asked for both at once a model returns a summary and the corrections get
+  // lost in it -- and corrections are the only turns carrying information the
+  // code itself could never supply.
+  try {
+    const turns = readArchive(dir, sessionId || 'unknown');
+    const feedback = buildFeedbackDigest(turns);
+    if (feedback) {
+      const rawLessons = await extract(feedback, { prompt: LESSON_PROMPT });
+      // The same restriction the finding path above applies, for the same reason: a model that
+      // invents a plausible path must not be able to anchor a lesson to it. `turns` is the
+      // archived transcript for this session, so its rendered digest is the honest file list.
+      const { lessons } = validateLessons(rawLessons, turns, {
+        knownFiles: filesIn(feedback),
+      });
+
+      // Anchors are optional on a lesson -- "always run npm test" is about no
+      // file -- so each is anchored to the project root when it names nothing,
+      // which keeps the store's rule that an unanchored finding is refused.
+      //
+      // The RESOLVED root, matching the containment root this write is checked
+      // against. The session's cwd would be refused outright once that root is
+      // the unrooted bucket, because `resolveAnchor` then narrows containment to
+      // home and a VCS-less working directory need not sit under it.
+      const anchored = lessons.map((l) => ({
+        ...l,
+        anchors: l.anchors.length ? l.anchors : [projectRoot],
+      }));
+
+      // The write itself is the durable record: writeHarvested anchors each
+      // lesson into the graph, which is what lessons.mjs's real consumers
+      // query. A metrics event of kind 'lessons' used to sit here as well,
+      // but nothing ever read it -- not netTokens (only 'harvest' feeds
+      // harvestTokens), not report()/buildReport() (no kind filter matches
+      // 'lessons'), and no audit render exists to show it to a human. That is
+      // the inverse of the `query` defect and the same shape as
+      // `tokensFullFile` before it: a produced-and-never-consumed event,
+      // which is a cost with no benefit. Deleted rather than wired, per the
+      // reachability allowlist's own rule -- write it again the day
+      // something needs to read it.
+      writeHarvested(dir, anchored, {
+        sessionId: sessionId || null,
+        origin: ORIGIN_HARVESTED,
+        projectRoot,
+        taskId: sessionId || null,
+        // Same hook-payload identity as above, same reason.
+        authoritativeSessionId: sessionId || null,
+      });
+    }
+  } catch {
+    // A failed feedback pass must be indistinguishable from a session with
+    // nothing to correct.
+  }
+}
+
+main()
+  .catch(() => {})
+  .finally(() => {
+    // NEVER process.exit() SYNCHRONOUSLY HERE.
+    //
+    // It crashed this worker on Windows every single time the feedback pass
+    // ran -- libuv asserts `!(handle->flags & UV_HANDLE_CLOSING)` when the
+    // process exits while the sockets from the model call are still closing,
+    // giving exit code 0xC0000409. Reproduced 5 runs out of 5, and silently,
+    // because this worker is spawned detached and nothing reads its status.
+    // Deferring by one tick is NOT enough; the handles are still closing then.
+    //
+    // So the normal path just lets the loop drain, which it does promptly.
+    //
+    // THE RECORDED CODE IS PRESERVED, not overwritten with 0. Assigning 0
+    // unconditionally would turn a harvest that had already recorded a failure
+    // into one that reports success -- and this worker is detached, so that
+    // status is the only signal a supervisor could ever act on.
+    const code = process.exitCode ?? 0;
+    process.exitCode = code;
+
+    // The watchdog keeps the original guarantee: a detached worker must never
+    // linger holding a keep-alive socket open. It is UNREF'D, so it cannot
+    // itself keep the process alive -- it only fires if something else already
+    // has, which is exactly the case worth killing.
+    const watchdog = setTimeout(() => process.exit(code), 5000);
+    watchdog.unref();
+  });

--- a/integrations/kilo/hooks/lib/harvest-worker.mjs
+++ b/integrations/kilo/hooks/lib/harvest-worker.mjs
@@ -1,6 +1,6 @@
+#!/usr/bin/env node
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/harvest-worker.mjs. Regenerate with `npm run sync:hooks`.
-#!/usr/bin/env node
 /**
  * The out-of-band half of the semantic harvest.
  *

--- a/integrations/kilo/hooks/lib/stop-harvest.mjs
+++ b/integrations/kilo/hooks/lib/stop-harvest.mjs
@@ -353,6 +353,11 @@ export async function runStopHarvest(payload = {}) {
       env: { ...process.env },
     }
   );
+  // AN 'error' EVENT WITH NO LISTENER IS A THROW. `spawn` reports a failed
+  // start asynchronously, so an unlistened error does not return a code -- Node
+  // raises it, and here that would abort the Stop response itself. A harvest
+  // that cannot start must degrade to no harvest, never to a broken Stop.
+  child.on('error', () => {});
   child.unref();
   return null;
 }

--- a/integrations/kilo/hooks/lib/stop-harvest.mjs
+++ b/integrations/kilo/hooks/lib/stop-harvest.mjs
@@ -1,0 +1,358 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/stop-harvest.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Claude Code Stop adapter -- run the semantic harvest the design specifies.
+ *
+ * The wiki design says findings are extracted "at Stop and PreCompact" by a
+ * cheap model, out of band. The extractor (`lib/harvest.mjs`) was implemented
+ * and then imported by nothing: no hook invoked it, and Stop carried no
+ * token-optimizer entry at all. The consequence was not a crash but a graph
+ * that could serve findings and never acquired any -- 122 file / 132 symbol /
+ * 61 task nodes and zero findings on a real project after a full session, with
+ * injection, staleness and the metrics all wired and idle behind it.
+ *
+ * OUT OF BAND IS THE POINT. The extraction is a model call; doing it inline
+ * would make the session that did the work pay for summarising itself, which is
+ * the cost this whole subsystem exists to avoid. So this spawns a detached
+ * worker and returns immediately. Stop is never delayed.
+ *
+ * IT ALSO REPORTS WHEN IT CANNOT RUN. Harvest requires an API key, and without
+ * one `harvestEnabled()` returns false and the module skips silently. Silence
+ * was how this stayed invisible: nothing in doctor, audit or waste mentions
+ * harvest, so a user sees a graph filling with structural nodes and no findings
+ * and has no way to learn why. Saying so once per session is the difference
+ * between a disabled feature and a broken one.
+ */
+
+import { spawn } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  chmodSync,
+  readFileSync,
+  openSync,
+  writeSync,
+  closeSync,
+  lstatSync,
+  constants,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir, homedir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { mode, MODE_OFF } from './policy.mjs';
+import { harvestEnabled, harvestMode } from './harvest.mjs';
+import { archive } from './transcript.mjs';
+import { wikiDir, projectRootFor, sharedDir, load } from './wiki.mjs';
+import { detectRefusals, recordRefusal } from './harvest-write.mjs';
+
+/** What to tell the user, per reason the harvest is not running. */
+const OFF_REASON = {
+  'off:mode': null, // The whole optimizer is off; saying more would be noise.
+  'off:not-opted-in':
+    'token-optimizer: automatic finding-extraction is OFF. It costs a model call and ' +
+    'sends a digest (paths, commands, prompts, conclusions -- never file contents) off ' +
+    'this machine, so it is opt-in: set TOKEN_OPTIMIZER_HARVEST=1 with an API key, or ' +
+    'point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model to run it free and private. ' +
+    'Meanwhile lifecycle-based structural graph capture keeps working. Durable semantic MCP ' +
+    'writes require a writer schema that is actually registered in the current CLI session.',
+  'off:no-key':
+    'token-optimizer: finding-extraction is opted in but has no credential. Set ' +
+    'TOKEN_OPTIMIZER_API_KEY, or point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model ' +
+    'to run it without one.',
+};
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * A session id reduced to something that cannot leave the marker directory.
+ *
+ * The id arrives in the hook payload, so it is external input, and it was being
+ * interpolated straight into a path: a value containing separators or `..` would
+ * have placed (and later read) the marker anywhere on disk. Everything outside a
+ * conservative allowlist becomes an underscore, which keeps ordinary uuids
+ * readable while making traversal unrepresentable rather than merely unlikely.
+ */
+function markerName(sessionId) {
+  const safe = String(sessionId || 'unknown').replace(/[^A-Za-z0-9._-]/g, '_');
+  // A name of only dots would still resolve to a directory entry.
+  const cleaned = /^[.]+$/.test(safe) ? 'unknown' : safe;
+  return `harvest-notice-${cleaned.slice(0, 64)}`;
+}
+
+/**
+ * A private, per-user directory for this hook's markers.
+ *
+ * os.tmpdir() is per-user on Windows but resolves to a SHARED, world-writable
+ * /tmp on POSIX. The marker name is derived from the session id, so it is
+ * predictable enough for another local user to pre-create -- as a symlink, or
+ * as a file they own -- and writeFileSync would then follow it and write
+ * through with this user's privileges.
+ *
+ * The state here is a debounce timestamp and a "said it once" flag, so the fix
+ * is not to guard a shared location but to stop using one. XDG_STATE_HOME is
+ * the standard place for state that should persist across runs but is not
+ * precious, and it is inside the user's own home on every POSIX system.
+ */
+function stateDir() {
+  const home = homedir();
+  const base =
+    process.platform === 'win32'
+      ? process.env.LOCALAPPDATA || tmpdir()
+      : process.env.XDG_STATE_HOME ||
+        (home ? join(home, '.local', 'state') : tmpdir());
+
+  const dir = join(base, 'token-optimizer');
+  try {
+    // 0o700 AND an explicit chmod, for the reason the graph store documents:
+    // `recursive` applies the mode only to directories it actually creates, and
+    // the umask masks it further, so neither alone guarantees the result.
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    try {
+      chmodSync(dir, 0o700);
+    } catch {
+      // Not POSIX, or not ours to chmod.
+    }
+  } catch {
+    /* best effort */
+  }
+  return dir;
+}
+
+/** Where the once-per-session notice is remembered, so Stop does not nag. */
+function noticePath(sessionId) {
+  return join(stateDir(), markerName(sessionId));
+}
+
+/**
+ * True when the path is absent, or is a regular file this user owns.
+ *
+ * lstat rather than stat: stat FOLLOWS the link and would happily report on the
+ * target, which is the thing being defended against.
+ */
+function ownedRegularFile(path) {
+  let info;
+  try {
+    info = lstatSync(path);
+  } catch {
+    return true; // Absent. The O_NOFOLLOW open below settles the race.
+  }
+  if (!info.isFile()) return false;
+  // getuid is undefined on Windows, where stateDir() is already per-user.
+  if (typeof process.getuid === 'function' && info.uid !== process.getuid())
+    return false;
+  return true;
+}
+
+/**
+ * Writes a marker, refusing to follow a symlink.
+ *
+ * O_NOFOLLOW makes the refusal ATOMIC rather than a check-then-use window: a
+ * link swapped in after ownedRegularFile() returns fails the open instead of
+ * being written through. The flag does not exist on Windows, where it is
+ * undefined and falls back to 0 -- acceptable, because the directory is
+ * per-user there to begin with.
+ */
+function writeMarker(path, contents) {
+  if (!ownedRegularFile(path)) return false;
+  const NOFOLLOW = constants.O_NOFOLLOW || 0;
+  let fd;
+  try {
+    fd = openSync(
+      path,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | NOFOLLOW,
+      0o600
+    );
+    writeSync(fd, contents);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* already closed */
+      }
+    }
+  }
+}
+
+/** Reads a marker, ignoring anything that is not a regular file we own. */
+function readMarker(path) {
+  if (!ownedRegularFile(path)) return null;
+  try {
+    return readFileSync(path, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function alreadyNotified(sessionId) {
+  const path = noticePath(sessionId);
+  // Anything already at this path -- our marker, or something planted -- means
+  // stay quiet. Repeating the notice is the worse failure, and refusing to
+  // write over a foreign file is the point.
+  if (existsSync(path)) return true;
+  return !writeMarker(path, String(Date.now()));
+}
+
+/** Minimum gap between harvests of one session. */
+const HARVEST_INTERVAL_MS =
+  Number(process.env.TOKEN_OPTIMIZER_HARVEST_INTERVAL_MS) > 0
+    ? Number(process.env.TOKEN_OPTIMIZER_HARVEST_INTERVAL_MS)
+    : 10 * 60 * 1000;
+
+/**
+ * True when this session has not been harvested recently, and records that it
+ * is about to be.
+ *
+ * Deliberately marks only when a harvest actually starts: touching it on every
+ * Stop would let a run of skipped turns keep pushing the next harvest away.
+ */
+function dueForHarvest(sessionId) {
+  const marker = join(stateDir(), `harvest-last-${markerName(sessionId)}`);
+
+  const last = Number(readMarker(marker));
+  // > 0 matters: readMarker returns null when the marker is missing or is not
+  // ours, and Number(null) is 0, which is finite -- so without this an absent
+  // marker would read as a harvest at the epoch.
+  if (
+    Number.isFinite(last) &&
+    last > 0 &&
+    Date.now() - last < HARVEST_INTERVAL_MS
+  ) {
+    return false;
+  }
+
+  // If the marker cannot be written the debounce degrades to off rather than
+  // blocking the harvest entirely.
+  writeMarker(marker, String(Date.now()));
+  return true;
+}
+
+/**
+ * The Stop-time harvest, for every client rather than one.
+ *
+ * WHY THIS IS A FUNCTION AND NOT A HOOK. It was a hook -- a Claude Code entry
+ * point named `stop-harvest.mjs` -- and #300 unregistered it. Nothing replaced
+ * it, so four capabilities went silently: the transcript archive, the harvest
+ * worker spawn, refusal detection, and the notice that says why no findings
+ * exist. Every client routes Stop through the shared adapter, and the adapter
+ * did none of these, so on a full session with a valid credential
+ * `harvestMode()` reported `remote` and nothing happened.
+ *
+ * NOTHING OBSERVED THAT IT DID NOT RUN, which is why it survived a year. There
+ * is no `kind:'harvest'` event to be absent from a report, no error, and a
+ * harvest that ran and found nothing looks exactly like one that never
+ * started. The reachability guard could not see it either: this file's own
+ * imports gave `archive`, `detectRefusals` and `recordRefusal` call sites, and
+ * a name-based scan proves a reference exists, never that it runs.
+ *
+ * Returns a notice for the caller to emit, or null. It does NOT write to
+ * stdout: the adapter emits exactly one JSON object per hook invocation, and a
+ * second writer racing it is how a Stop payload gets corrupted.
+ *
+ * @returns {Promise<string|null>} a once-per-session message, or null.
+ */
+export async function runStopHarvest(payload = {}) {
+  if (mode() === MODE_OFF) return null;
+
+  const transcript = payload.transcript_path ?? payload.transcriptPath ?? null;
+  if (!transcript || !existsSync(transcript)) return null;
+
+  // ARCHIVE FIRST, AND UNCONDITIONALLY. This is a local file copy: it costs no
+  // model call, spends no money, and sends nothing anywhere, so it must not sit
+  // behind the opt-in that exists to gate cost and disclosure. Gating it there
+  // would mean the record of what the user actually said is kept only for the
+  // users who opted into a paid feature, which is exactly backwards.
+  //
+  // It also has to happen before the early return below, or a session with
+  // harvesting off would archive nothing at all.
+  try {
+    archive(
+      wikiDir(
+        projectRootFor(
+          join(payload.cwd || process.cwd(), '__session__'),
+          payload.cwd
+        )
+      ),
+      transcript,
+      {
+        sessionId: payload.session_id,
+      }
+    );
+  } catch {
+    // The archive is a convenience. Failing to write it must not affect Stop.
+  }
+
+  // CLOSE THE REFUSAL LOOP, and do it OUTSIDE the harvest opt-in. Reading the
+  // transcript this process already holds costs no model call and sends nothing
+  // anywhere, so gating it behind the paid feature would leave a mis-scoped
+  // lesson costing tokens forever for everyone who did not opt in.
+  //
+  // The model states plainly when a cross-project lesson does not transfer --
+  // "that figure is another repo's baseline and it doesn't transfer" -- and until
+  // now nothing read it, so the same lesson was delivered again next session.
+  try {
+    const shared = sharedDir();
+    const lessons = [...load(shared).nodes.values()].filter(
+      (n) => n.kind === 'finding' && !n.retired && n.claim
+    );
+    if (lessons.length) {
+      const text = readFileSync(transcript, 'utf8');
+      for (const key of detectRefusals(lessons, text))
+        recordRefusal(shared, key);
+    }
+  } catch {
+    // Feedback is a refinement; a failure here must not affect Stop.
+  }
+
+  if (!harvestEnabled()) {
+    // Say it once, name the reason and the variable that changes it, and state
+    // what still works. A user who reads this should know exactly what they are
+    // and are not getting, and what to do about it.
+    const message = OFF_REASON[harvestMode()];
+    // RETURNED, NOT WRITTEN. This used to write its own JSON to stdout and
+    // race whatever the hook emitted; the adapter now folds this into the one
+    // object it sends, so the notice cannot be dropped by a full pipe or
+    // truncated by an exit -- which is what used to happen to the single line
+    // explaining why no findings exist.
+    if (message && !alreadyNotified(payload.session_id)) return message;
+    return null;
+  }
+
+  // SIBLING IN THE SHARED CORE. The worker used to live beside the hook entry
+  // in `plugin/hooks/`, which is why only Claude Code could ever have spawned
+  // it -- it was vendored to no other client. It now sits in the core that
+  // every client receives an identical copy of, so this resolves in all
+  // eleven.
+  const worker = join(HERE, 'harvest-worker.mjs');
+  if (!existsSync(worker)) return null;
+
+  // DEBOUNCE. Stop fires at the end of every assistant turn, so a talkative
+  // session would spawn a model call per turn -- each re-reading an overlapping
+  // transcript and re-extracting most of the same findings. The marker is
+  // touched only when a harvest is actually started, so a skipped turn does not
+  // push the next one further away.
+  if (!dueForHarvest(payload.session_id)) return null;
+
+  // Detached and fully released: the harvest must outlive this hook without
+  // holding Stop open for a model round-trip.
+  const child = spawn(
+    process.execPath,
+    [
+      worker,
+      transcript,
+      String(payload.session_id || ''),
+      String(payload.cwd || process.cwd()),
+    ],
+    {
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: true,
+      env: { ...process.env },
+    }
+  );
+  child.unref();
+  return null;
+}

--- a/integrations/opencode/hooks/lib/adapter.mjs
+++ b/integrations/opencode/hooks/lib/adapter.mjs
@@ -762,8 +762,11 @@ async function runHook(clientName, event, invocation) {
     const toolEvidence = optimizerToolsForHook(raw, state);
     rememberOptimizerTools(state, toolEvidence);
     const episode = episodeMeta({ client: clientName, raw });
+    // Hoisted out of the try below, because the harvest needs the same resolved
+    // directory and resolving it twice is how two halves of one hook end up
+    // reasoning about different projects.
+    const cwd = raw.cwd || raw.working_directory || process.cwd();
     try {
-      const cwd = raw.cwd || raw.working_directory || process.cwd();
       const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
       recordEpisodeOutcome(dir, {
         ...episode,
@@ -807,7 +810,21 @@ async function runHook(clientName, event, invocation) {
     // call.
     let harvestNotice = null;
     try {
-      harvestNotice = await runStopHarvest(raw);
+      // NORMALIZED, NOT RAW. The identifiers were resolved a few lines up
+      // through every alias a host might use -- `sessionId`,
+      // `conversation_id`, `working_directory` -- and handing `raw` straight
+      // over threw that away: runStopHarvest reads `session_id` and `cwd`
+      // only, so on a client that sends an alias the session id came back
+      // undefined and the archive root fell back to `process.cwd()`. That
+      // shares the once-per-session notice and the debounce marker across
+      // every session, and files the transcript under whatever directory the
+      // hook happened to start in.
+      harvestNotice = await runStopHarvest({
+        ...raw,
+        session_id: sessionId,
+        cwd,
+        transcript_path: raw.transcript_path ?? raw.transcriptPath ?? null,
+      });
     } catch {
       // The harvest is a side effect of ending a session. It must never stop
       // one from ending.

--- a/integrations/opencode/hooks/lib/adapter.mjs
+++ b/integrations/opencode/hooks/lib/adapter.mjs
@@ -88,6 +88,7 @@ import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 import { evaluateUcrGuards } from './ucr-guard.mjs';
 import { beginHookInvocation, noteHookOutput } from './observability.mjs';
 import { registerProject } from './projects.mjs';
+import { runStopHarvest } from './stop-harvest.mjs';
 
 /**
  * Per-client capability.
@@ -792,10 +793,33 @@ async function runHook(clientName, event, invocation) {
       state.harvestedEdits = Number(state.edits || 0);
       saveState(sessionId, state, agentScope);
     }
+    // THE OUT-OF-BAND HARVEST, which no client was running.
+    //
+    // The in-band `prompt` above asks the MODEL to call `wiki_write`, and the
+    // session pays for summarising itself -- the exact cost the design says the
+    // harvest exists to avoid ("out-of-band, so the session doing the work never
+    // pays for the harvest"). The out-of-band half lived in a Claude Code hook
+    // that #300 unregistered, and nothing replaced it, so on every client the
+    // transcript was never archived, the worker never spawned, refusals were
+    // never detected, and the notice explaining why no findings exist was never
+    // shown. Awaited because it must finish before the exit below; it spawns a
+    // DETACHED worker and returns immediately, so Stop is not delayed by a model
+    // call.
+    let harvestNotice = null;
+    try {
+      harvestNotice = await runStopHarvest(raw);
+    } catch {
+      // The harvest is a side effect of ending a session. It must never stop
+      // one from ending.
+    }
+
     if (prompt && client.stopStyle === 'followup') {
-      emit({ followup_message: prompt });
+      emit({ followup_message: prompt, ...(harvestNotice ? { systemMessage: harvestNotice } : {}) });
     } else {
-      emit(prompt ? { decision: client.stopDecision, reason: prompt } : {});
+      emit({
+        ...(prompt ? { decision: client.stopDecision, reason: prompt } : {}),
+        ...(harvestNotice ? { systemMessage: harvestNotice } : {}),
+      });
     }
     process.exit(0);
   }

--- a/integrations/opencode/hooks/lib/harvest-worker.mjs
+++ b/integrations/opencode/hooks/lib/harvest-worker.mjs
@@ -1,0 +1,248 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/harvest-worker.mjs. Regenerate with `npm run sync:hooks`.
+#!/usr/bin/env node
+/**
+ * The out-of-band half of the semantic harvest.
+ *
+ * Spawned detached by the Stop adapter so the session that did the work never
+ * pays for the model call that summarises it. Everything here is best-effort:
+ * a harvest that fails must be indistinguishable from a session with nothing
+ * to learn, because the alternative -- a hook that can break a turn -- is worse
+ * than no findings at all.
+ *
+ * The cost of the extraction is recorded either way. Without it the metrics
+ * report a benefit with no matching expense, and `netTokens` would flatter the
+ * feature by exactly the amount it spends.
+ */
+
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  harvestEnabled,
+  buildDigest,
+  buildFullDelta,
+  extract,
+  validate,
+  estimateTokens,
+} from './harvest.mjs';
+import { writeHarvested } from './harvest-write.mjs';
+import { record } from './metrics.mjs';
+import { wikiDir, projectRootFor, load } from './wiki.mjs';
+import { readArchive } from './transcript.mjs';
+import { buildFeedbackDigest, validateLessons, LESSON_PROMPT } from './lessons.mjs';
+import { ORIGIN_HARVESTED } from './curate.mjs';
+import { selectForConsolidation } from './consolidate.mjs';
+
+/**
+ * The token budget one session's harvest may add to the graph.
+ *
+ * #204 lists graph bloat as a named risk -- "the session-start index grows with
+ * the graph; ranking and eviction are required, not optional" -- and until now
+ * nothing bounded what a single harvest could store. 4,000 tokens is the
+ * selector's own default and roughly twenty-five findings at the size the
+ * extractor produces, which is far above any observed session's real yield; it
+ * is a ceiling against a pathological extraction, not a routine constraint.
+ */
+const CONSOLIDATION_BUDGET = 4000;
+
+/**
+ * The files the digest says were touched.
+ *
+ * `buildDigest` emits them under a `## Files touched` heading and returns a
+ * string, so this reads back the list it just wrote rather than walking the
+ * transcript a second time. Returns null when the section is absent, which
+ * `validate` treats as "no restriction" rather than "no files".
+ */
+function filesIn(digest) {
+  const start = digest.indexOf('## Files touched');
+  if (start === -1) return null;
+
+  const rest = digest.slice(start + '## Files touched'.length);
+  const end = rest.indexOf('\n##');
+  const block = (end === -1 ? rest : rest.slice(0, end)).split('\n');
+
+  const files = new Set();
+  for (const line of block) {
+    const value = line.trim();
+    if (value) files.add(value);
+  }
+  return files.size ? files : null;
+}
+
+async function main() {
+  const [transcript, sessionId, cwd] = process.argv.slice(2);
+  if (!transcript || !existsSync(transcript) || !harvestEnabled()) return;
+
+  // THE GRAPH AND THE CONTAINMENT BOUNDARY BOTH COME FROM THE REPOSITORY ROOT,
+  // NOT THE SESSION'S CWD. `wikiDir` only joins the path it is handed, so a
+  // session started in a subdirectory selected `<subdir>/.token-optimizer/wiki`
+  // -- a second graph, invisible to every other hook, which all resolve the root
+  // first. It also made the subdirectory the containment root for the write, so
+  // a finding anchored anywhere else in the same repository was refused for
+  // sitting "outside" the project.
+  //
+  // `__session__` is a synthetic leaf so the walk starts at `cwd` itself rather
+  // than its parent; `projectRootFor` takes a FILE path. This is the same idiom
+  // the adapter, the session-start hook and the Stop adapter already use.
+  //
+  // A cwd with no VCS ancestor resolves to the machine-level unrooted bucket,
+  // which `resolveAnchor` expects and handles: it swaps in home as the
+  // containment root for that case, so passing the resolved root here is what
+  // lets unrooted anchors work at all.
+  const sessionCwd = cwd || process.cwd();
+  const projectRoot = projectRootFor(join(sessionCwd, '__session__'), sessionCwd);
+  const dir = wikiDir(projectRoot);
+
+  // Default sends a structured digest with no file contents. The full delta is
+  // opt-in because the default has to be defensible without reading the docs.
+  const full = process.env.TOKEN_OPTIMIZER_HARVEST_FULL === 'true';
+  const digest = full ? buildFullDelta(transcript) : buildDigest(transcript);
+  if (!digest) return;
+
+  const raw = await extract(digest);
+
+  // Anchors are held to the files this session actually touched, so a model
+  // that invents a plausible path cannot anchor a finding to it. The digest
+  // lists them under a heading it writes itself; the full delta is raw
+  // transcript and carries no such list, so it gets no restriction.
+  const validated = validate(raw, { knownFiles: full ? null : filesIn(digest) });
+
+  // BUDGETED SELECTION, not everything the model extracted.
+  //
+  // `selectForConsolidation` exists for exactly this and had no caller
+  // anywhere, so every harvested candidate was stored regardless of what it
+  // cost to derive, how hard it is to reproduce, or whether the graph can ever
+  // retrieve it -- which is the graph-bloat risk #204 lists as needing
+  // "ranking and eviction ... not optional". It keeps failures and decisions on
+  // a floor before ranking, encoding the design's judgement that dead ends are
+  // the highest-value kind: they exist nowhere in the source tree, so nothing
+  // else can ever recover them.
+  //
+  // The selection is RECORDED, not silent. A cap that drops work without
+  // saying so reads as "there was nothing more to find", which is the same
+  // dishonesty as a truncated report with no remainder line.
+  const graph = load(dir);
+  const selection = selectForConsolidation(graph, validated, { budget: CONSOLIDATION_BUDGET });
+  const findings = selection.kept;
+  if (selection.dropped > 0) {
+    record(dir, {
+      kind: 'harvest',
+      action: 'consolidation',
+      candidates: validated.length,
+      kept: findings.length,
+      dropped: selection.dropped,
+      tokens: selection.tokens,
+      budget: CONSOLIDATION_BUDGET,
+    });
+  }
+
+  const written = writeHarvested(dir, findings, {
+    sessionId: sessionId || null,
+    projectRoot,
+    // Task nodes are keyed by session id (structural capture creates one on
+    // the first touched file, `harvest()` in lib/wiki.mjs) so this is the
+    // shape `writeHarvested` needs to point the `answers` edge back at the
+    // task this harvest belongs to. A session that never touched a file
+    // through PreToolUse/PostToolUse has no such node yet; `writeHarvested`
+    // resolves that case to no edge rather than a dangling one.
+    taskId: sessionId || null,
+    // AUTHORITATIVE, not just present: this `sessionId` came from Claude
+    // Code's own Stop-hook payload (see stop-harvest.mjs), not a model-typed
+    // tool argument, so it is safe to use for the traversal fallback if the
+    // explicit `taskId` above does not resolve.
+    authoritativeSessionId: sessionId || null,
+  });
+
+  record(dir, {
+    kind: 'harvest',
+    sessionId: sessionId || null,
+    tokens: estimateTokens(digest),
+    findings: written.length,
+    at: Date.now(),
+  });
+
+  // THE FEEDBACK LOOP. A separate extraction with a separate prompt, because
+  // the two are looking for different things: the harvest above wants what was
+  // LEARNED about the code, this wants where the user said the agent was WRONG.
+  // Asked for both at once a model returns a summary and the corrections get
+  // lost in it -- and corrections are the only turns carrying information the
+  // code itself could never supply.
+  try {
+    const turns = readArchive(dir, sessionId || 'unknown');
+    const feedback = buildFeedbackDigest(turns);
+    if (feedback) {
+      const rawLessons = await extract(feedback, { prompt: LESSON_PROMPT });
+      // The same restriction the finding path above applies, for the same reason: a model that
+      // invents a plausible path must not be able to anchor a lesson to it. `turns` is the
+      // archived transcript for this session, so its rendered digest is the honest file list.
+      const { lessons } = validateLessons(rawLessons, turns, {
+        knownFiles: filesIn(feedback),
+      });
+
+      // Anchors are optional on a lesson -- "always run npm test" is about no
+      // file -- so each is anchored to the project root when it names nothing,
+      // which keeps the store's rule that an unanchored finding is refused.
+      //
+      // The RESOLVED root, matching the containment root this write is checked
+      // against. The session's cwd would be refused outright once that root is
+      // the unrooted bucket, because `resolveAnchor` then narrows containment to
+      // home and a VCS-less working directory need not sit under it.
+      const anchored = lessons.map((l) => ({
+        ...l,
+        anchors: l.anchors.length ? l.anchors : [projectRoot],
+      }));
+
+      // The write itself is the durable record: writeHarvested anchors each
+      // lesson into the graph, which is what lessons.mjs's real consumers
+      // query. A metrics event of kind 'lessons' used to sit here as well,
+      // but nothing ever read it -- not netTokens (only 'harvest' feeds
+      // harvestTokens), not report()/buildReport() (no kind filter matches
+      // 'lessons'), and no audit render exists to show it to a human. That is
+      // the inverse of the `query` defect and the same shape as
+      // `tokensFullFile` before it: a produced-and-never-consumed event,
+      // which is a cost with no benefit. Deleted rather than wired, per the
+      // reachability allowlist's own rule -- write it again the day
+      // something needs to read it.
+      writeHarvested(dir, anchored, {
+        sessionId: sessionId || null,
+        origin: ORIGIN_HARVESTED,
+        projectRoot,
+        taskId: sessionId || null,
+        // Same hook-payload identity as above, same reason.
+        authoritativeSessionId: sessionId || null,
+      });
+    }
+  } catch {
+    // A failed feedback pass must be indistinguishable from a session with
+    // nothing to correct.
+  }
+}
+
+main()
+  .catch(() => {})
+  .finally(() => {
+    // NEVER process.exit() SYNCHRONOUSLY HERE.
+    //
+    // It crashed this worker on Windows every single time the feedback pass
+    // ran -- libuv asserts `!(handle->flags & UV_HANDLE_CLOSING)` when the
+    // process exits while the sockets from the model call are still closing,
+    // giving exit code 0xC0000409. Reproduced 5 runs out of 5, and silently,
+    // because this worker is spawned detached and nothing reads its status.
+    // Deferring by one tick is NOT enough; the handles are still closing then.
+    //
+    // So the normal path just lets the loop drain, which it does promptly.
+    //
+    // THE RECORDED CODE IS PRESERVED, not overwritten with 0. Assigning 0
+    // unconditionally would turn a harvest that had already recorded a failure
+    // into one that reports success -- and this worker is detached, so that
+    // status is the only signal a supervisor could ever act on.
+    const code = process.exitCode ?? 0;
+    process.exitCode = code;
+
+    // The watchdog keeps the original guarantee: a detached worker must never
+    // linger holding a keep-alive socket open. It is UNREF'D, so it cannot
+    // itself keep the process alive -- it only fires if something else already
+    // has, which is exactly the case worth killing.
+    const watchdog = setTimeout(() => process.exit(code), 5000);
+    watchdog.unref();
+  });

--- a/integrations/opencode/hooks/lib/harvest-worker.mjs
+++ b/integrations/opencode/hooks/lib/harvest-worker.mjs
@@ -1,6 +1,6 @@
+#!/usr/bin/env node
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/harvest-worker.mjs. Regenerate with `npm run sync:hooks`.
-#!/usr/bin/env node
 /**
  * The out-of-band half of the semantic harvest.
  *

--- a/integrations/opencode/hooks/lib/stop-harvest.mjs
+++ b/integrations/opencode/hooks/lib/stop-harvest.mjs
@@ -353,6 +353,11 @@ export async function runStopHarvest(payload = {}) {
       env: { ...process.env },
     }
   );
+  // AN 'error' EVENT WITH NO LISTENER IS A THROW. `spawn` reports a failed
+  // start asynchronously, so an unlistened error does not return a code -- Node
+  // raises it, and here that would abort the Stop response itself. A harvest
+  // that cannot start must degrade to no harvest, never to a broken Stop.
+  child.on('error', () => {});
   child.unref();
   return null;
 }

--- a/integrations/opencode/hooks/lib/stop-harvest.mjs
+++ b/integrations/opencode/hooks/lib/stop-harvest.mjs
@@ -1,0 +1,358 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/stop-harvest.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Claude Code Stop adapter -- run the semantic harvest the design specifies.
+ *
+ * The wiki design says findings are extracted "at Stop and PreCompact" by a
+ * cheap model, out of band. The extractor (`lib/harvest.mjs`) was implemented
+ * and then imported by nothing: no hook invoked it, and Stop carried no
+ * token-optimizer entry at all. The consequence was not a crash but a graph
+ * that could serve findings and never acquired any -- 122 file / 132 symbol /
+ * 61 task nodes and zero findings on a real project after a full session, with
+ * injection, staleness and the metrics all wired and idle behind it.
+ *
+ * OUT OF BAND IS THE POINT. The extraction is a model call; doing it inline
+ * would make the session that did the work pay for summarising itself, which is
+ * the cost this whole subsystem exists to avoid. So this spawns a detached
+ * worker and returns immediately. Stop is never delayed.
+ *
+ * IT ALSO REPORTS WHEN IT CANNOT RUN. Harvest requires an API key, and without
+ * one `harvestEnabled()` returns false and the module skips silently. Silence
+ * was how this stayed invisible: nothing in doctor, audit or waste mentions
+ * harvest, so a user sees a graph filling with structural nodes and no findings
+ * and has no way to learn why. Saying so once per session is the difference
+ * between a disabled feature and a broken one.
+ */
+
+import { spawn } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  chmodSync,
+  readFileSync,
+  openSync,
+  writeSync,
+  closeSync,
+  lstatSync,
+  constants,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir, homedir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { mode, MODE_OFF } from './policy.mjs';
+import { harvestEnabled, harvestMode } from './harvest.mjs';
+import { archive } from './transcript.mjs';
+import { wikiDir, projectRootFor, sharedDir, load } from './wiki.mjs';
+import { detectRefusals, recordRefusal } from './harvest-write.mjs';
+
+/** What to tell the user, per reason the harvest is not running. */
+const OFF_REASON = {
+  'off:mode': null, // The whole optimizer is off; saying more would be noise.
+  'off:not-opted-in':
+    'token-optimizer: automatic finding-extraction is OFF. It costs a model call and ' +
+    'sends a digest (paths, commands, prompts, conclusions -- never file contents) off ' +
+    'this machine, so it is opt-in: set TOKEN_OPTIMIZER_HARVEST=1 with an API key, or ' +
+    'point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model to run it free and private. ' +
+    'Meanwhile lifecycle-based structural graph capture keeps working. Durable semantic MCP ' +
+    'writes require a writer schema that is actually registered in the current CLI session.',
+  'off:no-key':
+    'token-optimizer: finding-extraction is opted in but has no credential. Set ' +
+    'TOKEN_OPTIMIZER_API_KEY, or point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model ' +
+    'to run it without one.',
+};
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * A session id reduced to something that cannot leave the marker directory.
+ *
+ * The id arrives in the hook payload, so it is external input, and it was being
+ * interpolated straight into a path: a value containing separators or `..` would
+ * have placed (and later read) the marker anywhere on disk. Everything outside a
+ * conservative allowlist becomes an underscore, which keeps ordinary uuids
+ * readable while making traversal unrepresentable rather than merely unlikely.
+ */
+function markerName(sessionId) {
+  const safe = String(sessionId || 'unknown').replace(/[^A-Za-z0-9._-]/g, '_');
+  // A name of only dots would still resolve to a directory entry.
+  const cleaned = /^[.]+$/.test(safe) ? 'unknown' : safe;
+  return `harvest-notice-${cleaned.slice(0, 64)}`;
+}
+
+/**
+ * A private, per-user directory for this hook's markers.
+ *
+ * os.tmpdir() is per-user on Windows but resolves to a SHARED, world-writable
+ * /tmp on POSIX. The marker name is derived from the session id, so it is
+ * predictable enough for another local user to pre-create -- as a symlink, or
+ * as a file they own -- and writeFileSync would then follow it and write
+ * through with this user's privileges.
+ *
+ * The state here is a debounce timestamp and a "said it once" flag, so the fix
+ * is not to guard a shared location but to stop using one. XDG_STATE_HOME is
+ * the standard place for state that should persist across runs but is not
+ * precious, and it is inside the user's own home on every POSIX system.
+ */
+function stateDir() {
+  const home = homedir();
+  const base =
+    process.platform === 'win32'
+      ? process.env.LOCALAPPDATA || tmpdir()
+      : process.env.XDG_STATE_HOME ||
+        (home ? join(home, '.local', 'state') : tmpdir());
+
+  const dir = join(base, 'token-optimizer');
+  try {
+    // 0o700 AND an explicit chmod, for the reason the graph store documents:
+    // `recursive` applies the mode only to directories it actually creates, and
+    // the umask masks it further, so neither alone guarantees the result.
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    try {
+      chmodSync(dir, 0o700);
+    } catch {
+      // Not POSIX, or not ours to chmod.
+    }
+  } catch {
+    /* best effort */
+  }
+  return dir;
+}
+
+/** Where the once-per-session notice is remembered, so Stop does not nag. */
+function noticePath(sessionId) {
+  return join(stateDir(), markerName(sessionId));
+}
+
+/**
+ * True when the path is absent, or is a regular file this user owns.
+ *
+ * lstat rather than stat: stat FOLLOWS the link and would happily report on the
+ * target, which is the thing being defended against.
+ */
+function ownedRegularFile(path) {
+  let info;
+  try {
+    info = lstatSync(path);
+  } catch {
+    return true; // Absent. The O_NOFOLLOW open below settles the race.
+  }
+  if (!info.isFile()) return false;
+  // getuid is undefined on Windows, where stateDir() is already per-user.
+  if (typeof process.getuid === 'function' && info.uid !== process.getuid())
+    return false;
+  return true;
+}
+
+/**
+ * Writes a marker, refusing to follow a symlink.
+ *
+ * O_NOFOLLOW makes the refusal ATOMIC rather than a check-then-use window: a
+ * link swapped in after ownedRegularFile() returns fails the open instead of
+ * being written through. The flag does not exist on Windows, where it is
+ * undefined and falls back to 0 -- acceptable, because the directory is
+ * per-user there to begin with.
+ */
+function writeMarker(path, contents) {
+  if (!ownedRegularFile(path)) return false;
+  const NOFOLLOW = constants.O_NOFOLLOW || 0;
+  let fd;
+  try {
+    fd = openSync(
+      path,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | NOFOLLOW,
+      0o600
+    );
+    writeSync(fd, contents);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* already closed */
+      }
+    }
+  }
+}
+
+/** Reads a marker, ignoring anything that is not a regular file we own. */
+function readMarker(path) {
+  if (!ownedRegularFile(path)) return null;
+  try {
+    return readFileSync(path, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function alreadyNotified(sessionId) {
+  const path = noticePath(sessionId);
+  // Anything already at this path -- our marker, or something planted -- means
+  // stay quiet. Repeating the notice is the worse failure, and refusing to
+  // write over a foreign file is the point.
+  if (existsSync(path)) return true;
+  return !writeMarker(path, String(Date.now()));
+}
+
+/** Minimum gap between harvests of one session. */
+const HARVEST_INTERVAL_MS =
+  Number(process.env.TOKEN_OPTIMIZER_HARVEST_INTERVAL_MS) > 0
+    ? Number(process.env.TOKEN_OPTIMIZER_HARVEST_INTERVAL_MS)
+    : 10 * 60 * 1000;
+
+/**
+ * True when this session has not been harvested recently, and records that it
+ * is about to be.
+ *
+ * Deliberately marks only when a harvest actually starts: touching it on every
+ * Stop would let a run of skipped turns keep pushing the next harvest away.
+ */
+function dueForHarvest(sessionId) {
+  const marker = join(stateDir(), `harvest-last-${markerName(sessionId)}`);
+
+  const last = Number(readMarker(marker));
+  // > 0 matters: readMarker returns null when the marker is missing or is not
+  // ours, and Number(null) is 0, which is finite -- so without this an absent
+  // marker would read as a harvest at the epoch.
+  if (
+    Number.isFinite(last) &&
+    last > 0 &&
+    Date.now() - last < HARVEST_INTERVAL_MS
+  ) {
+    return false;
+  }
+
+  // If the marker cannot be written the debounce degrades to off rather than
+  // blocking the harvest entirely.
+  writeMarker(marker, String(Date.now()));
+  return true;
+}
+
+/**
+ * The Stop-time harvest, for every client rather than one.
+ *
+ * WHY THIS IS A FUNCTION AND NOT A HOOK. It was a hook -- a Claude Code entry
+ * point named `stop-harvest.mjs` -- and #300 unregistered it. Nothing replaced
+ * it, so four capabilities went silently: the transcript archive, the harvest
+ * worker spawn, refusal detection, and the notice that says why no findings
+ * exist. Every client routes Stop through the shared adapter, and the adapter
+ * did none of these, so on a full session with a valid credential
+ * `harvestMode()` reported `remote` and nothing happened.
+ *
+ * NOTHING OBSERVED THAT IT DID NOT RUN, which is why it survived a year. There
+ * is no `kind:'harvest'` event to be absent from a report, no error, and a
+ * harvest that ran and found nothing looks exactly like one that never
+ * started. The reachability guard could not see it either: this file's own
+ * imports gave `archive`, `detectRefusals` and `recordRefusal` call sites, and
+ * a name-based scan proves a reference exists, never that it runs.
+ *
+ * Returns a notice for the caller to emit, or null. It does NOT write to
+ * stdout: the adapter emits exactly one JSON object per hook invocation, and a
+ * second writer racing it is how a Stop payload gets corrupted.
+ *
+ * @returns {Promise<string|null>} a once-per-session message, or null.
+ */
+export async function runStopHarvest(payload = {}) {
+  if (mode() === MODE_OFF) return null;
+
+  const transcript = payload.transcript_path ?? payload.transcriptPath ?? null;
+  if (!transcript || !existsSync(transcript)) return null;
+
+  // ARCHIVE FIRST, AND UNCONDITIONALLY. This is a local file copy: it costs no
+  // model call, spends no money, and sends nothing anywhere, so it must not sit
+  // behind the opt-in that exists to gate cost and disclosure. Gating it there
+  // would mean the record of what the user actually said is kept only for the
+  // users who opted into a paid feature, which is exactly backwards.
+  //
+  // It also has to happen before the early return below, or a session with
+  // harvesting off would archive nothing at all.
+  try {
+    archive(
+      wikiDir(
+        projectRootFor(
+          join(payload.cwd || process.cwd(), '__session__'),
+          payload.cwd
+        )
+      ),
+      transcript,
+      {
+        sessionId: payload.session_id,
+      }
+    );
+  } catch {
+    // The archive is a convenience. Failing to write it must not affect Stop.
+  }
+
+  // CLOSE THE REFUSAL LOOP, and do it OUTSIDE the harvest opt-in. Reading the
+  // transcript this process already holds costs no model call and sends nothing
+  // anywhere, so gating it behind the paid feature would leave a mis-scoped
+  // lesson costing tokens forever for everyone who did not opt in.
+  //
+  // The model states plainly when a cross-project lesson does not transfer --
+  // "that figure is another repo's baseline and it doesn't transfer" -- and until
+  // now nothing read it, so the same lesson was delivered again next session.
+  try {
+    const shared = sharedDir();
+    const lessons = [...load(shared).nodes.values()].filter(
+      (n) => n.kind === 'finding' && !n.retired && n.claim
+    );
+    if (lessons.length) {
+      const text = readFileSync(transcript, 'utf8');
+      for (const key of detectRefusals(lessons, text))
+        recordRefusal(shared, key);
+    }
+  } catch {
+    // Feedback is a refinement; a failure here must not affect Stop.
+  }
+
+  if (!harvestEnabled()) {
+    // Say it once, name the reason and the variable that changes it, and state
+    // what still works. A user who reads this should know exactly what they are
+    // and are not getting, and what to do about it.
+    const message = OFF_REASON[harvestMode()];
+    // RETURNED, NOT WRITTEN. This used to write its own JSON to stdout and
+    // race whatever the hook emitted; the adapter now folds this into the one
+    // object it sends, so the notice cannot be dropped by a full pipe or
+    // truncated by an exit -- which is what used to happen to the single line
+    // explaining why no findings exist.
+    if (message && !alreadyNotified(payload.session_id)) return message;
+    return null;
+  }
+
+  // SIBLING IN THE SHARED CORE. The worker used to live beside the hook entry
+  // in `plugin/hooks/`, which is why only Claude Code could ever have spawned
+  // it -- it was vendored to no other client. It now sits in the core that
+  // every client receives an identical copy of, so this resolves in all
+  // eleven.
+  const worker = join(HERE, 'harvest-worker.mjs');
+  if (!existsSync(worker)) return null;
+
+  // DEBOUNCE. Stop fires at the end of every assistant turn, so a talkative
+  // session would spawn a model call per turn -- each re-reading an overlapping
+  // transcript and re-extracting most of the same findings. The marker is
+  // touched only when a harvest is actually started, so a skipped turn does not
+  // push the next one further away.
+  if (!dueForHarvest(payload.session_id)) return null;
+
+  // Detached and fully released: the harvest must outlive this hook without
+  // holding Stop open for a model round-trip.
+  const child = spawn(
+    process.execPath,
+    [
+      worker,
+      transcript,
+      String(payload.session_id || ''),
+      String(payload.cwd || process.cwd()),
+    ],
+    {
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: true,
+      env: { ...process.env },
+    }
+  );
+  child.unref();
+  return null;
+}

--- a/integrations/qwen/hooks/lib/adapter.mjs
+++ b/integrations/qwen/hooks/lib/adapter.mjs
@@ -762,8 +762,11 @@ async function runHook(clientName, event, invocation) {
     const toolEvidence = optimizerToolsForHook(raw, state);
     rememberOptimizerTools(state, toolEvidence);
     const episode = episodeMeta({ client: clientName, raw });
+    // Hoisted out of the try below, because the harvest needs the same resolved
+    // directory and resolving it twice is how two halves of one hook end up
+    // reasoning about different projects.
+    const cwd = raw.cwd || raw.working_directory || process.cwd();
     try {
-      const cwd = raw.cwd || raw.working_directory || process.cwd();
       const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
       recordEpisodeOutcome(dir, {
         ...episode,
@@ -807,7 +810,21 @@ async function runHook(clientName, event, invocation) {
     // call.
     let harvestNotice = null;
     try {
-      harvestNotice = await runStopHarvest(raw);
+      // NORMALIZED, NOT RAW. The identifiers were resolved a few lines up
+      // through every alias a host might use -- `sessionId`,
+      // `conversation_id`, `working_directory` -- and handing `raw` straight
+      // over threw that away: runStopHarvest reads `session_id` and `cwd`
+      // only, so on a client that sends an alias the session id came back
+      // undefined and the archive root fell back to `process.cwd()`. That
+      // shares the once-per-session notice and the debounce marker across
+      // every session, and files the transcript under whatever directory the
+      // hook happened to start in.
+      harvestNotice = await runStopHarvest({
+        ...raw,
+        session_id: sessionId,
+        cwd,
+        transcript_path: raw.transcript_path ?? raw.transcriptPath ?? null,
+      });
     } catch {
       // The harvest is a side effect of ending a session. It must never stop
       // one from ending.

--- a/integrations/qwen/hooks/lib/adapter.mjs
+++ b/integrations/qwen/hooks/lib/adapter.mjs
@@ -88,6 +88,7 @@ import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 import { evaluateUcrGuards } from './ucr-guard.mjs';
 import { beginHookInvocation, noteHookOutput } from './observability.mjs';
 import { registerProject } from './projects.mjs';
+import { runStopHarvest } from './stop-harvest.mjs';
 
 /**
  * Per-client capability.
@@ -792,10 +793,33 @@ async function runHook(clientName, event, invocation) {
       state.harvestedEdits = Number(state.edits || 0);
       saveState(sessionId, state, agentScope);
     }
+    // THE OUT-OF-BAND HARVEST, which no client was running.
+    //
+    // The in-band `prompt` above asks the MODEL to call `wiki_write`, and the
+    // session pays for summarising itself -- the exact cost the design says the
+    // harvest exists to avoid ("out-of-band, so the session doing the work never
+    // pays for the harvest"). The out-of-band half lived in a Claude Code hook
+    // that #300 unregistered, and nothing replaced it, so on every client the
+    // transcript was never archived, the worker never spawned, refusals were
+    // never detected, and the notice explaining why no findings exist was never
+    // shown. Awaited because it must finish before the exit below; it spawns a
+    // DETACHED worker and returns immediately, so Stop is not delayed by a model
+    // call.
+    let harvestNotice = null;
+    try {
+      harvestNotice = await runStopHarvest(raw);
+    } catch {
+      // The harvest is a side effect of ending a session. It must never stop
+      // one from ending.
+    }
+
     if (prompt && client.stopStyle === 'followup') {
-      emit({ followup_message: prompt });
+      emit({ followup_message: prompt, ...(harvestNotice ? { systemMessage: harvestNotice } : {}) });
     } else {
-      emit(prompt ? { decision: client.stopDecision, reason: prompt } : {});
+      emit({
+        ...(prompt ? { decision: client.stopDecision, reason: prompt } : {}),
+        ...(harvestNotice ? { systemMessage: harvestNotice } : {}),
+      });
     }
     process.exit(0);
   }

--- a/integrations/qwen/hooks/lib/harvest-worker.mjs
+++ b/integrations/qwen/hooks/lib/harvest-worker.mjs
@@ -1,0 +1,248 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/harvest-worker.mjs. Regenerate with `npm run sync:hooks`.
+#!/usr/bin/env node
+/**
+ * The out-of-band half of the semantic harvest.
+ *
+ * Spawned detached by the Stop adapter so the session that did the work never
+ * pays for the model call that summarises it. Everything here is best-effort:
+ * a harvest that fails must be indistinguishable from a session with nothing
+ * to learn, because the alternative -- a hook that can break a turn -- is worse
+ * than no findings at all.
+ *
+ * The cost of the extraction is recorded either way. Without it the metrics
+ * report a benefit with no matching expense, and `netTokens` would flatter the
+ * feature by exactly the amount it spends.
+ */
+
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  harvestEnabled,
+  buildDigest,
+  buildFullDelta,
+  extract,
+  validate,
+  estimateTokens,
+} from './harvest.mjs';
+import { writeHarvested } from './harvest-write.mjs';
+import { record } from './metrics.mjs';
+import { wikiDir, projectRootFor, load } from './wiki.mjs';
+import { readArchive } from './transcript.mjs';
+import { buildFeedbackDigest, validateLessons, LESSON_PROMPT } from './lessons.mjs';
+import { ORIGIN_HARVESTED } from './curate.mjs';
+import { selectForConsolidation } from './consolidate.mjs';
+
+/**
+ * The token budget one session's harvest may add to the graph.
+ *
+ * #204 lists graph bloat as a named risk -- "the session-start index grows with
+ * the graph; ranking and eviction are required, not optional" -- and until now
+ * nothing bounded what a single harvest could store. 4,000 tokens is the
+ * selector's own default and roughly twenty-five findings at the size the
+ * extractor produces, which is far above any observed session's real yield; it
+ * is a ceiling against a pathological extraction, not a routine constraint.
+ */
+const CONSOLIDATION_BUDGET = 4000;
+
+/**
+ * The files the digest says were touched.
+ *
+ * `buildDigest` emits them under a `## Files touched` heading and returns a
+ * string, so this reads back the list it just wrote rather than walking the
+ * transcript a second time. Returns null when the section is absent, which
+ * `validate` treats as "no restriction" rather than "no files".
+ */
+function filesIn(digest) {
+  const start = digest.indexOf('## Files touched');
+  if (start === -1) return null;
+
+  const rest = digest.slice(start + '## Files touched'.length);
+  const end = rest.indexOf('\n##');
+  const block = (end === -1 ? rest : rest.slice(0, end)).split('\n');
+
+  const files = new Set();
+  for (const line of block) {
+    const value = line.trim();
+    if (value) files.add(value);
+  }
+  return files.size ? files : null;
+}
+
+async function main() {
+  const [transcript, sessionId, cwd] = process.argv.slice(2);
+  if (!transcript || !existsSync(transcript) || !harvestEnabled()) return;
+
+  // THE GRAPH AND THE CONTAINMENT BOUNDARY BOTH COME FROM THE REPOSITORY ROOT,
+  // NOT THE SESSION'S CWD. `wikiDir` only joins the path it is handed, so a
+  // session started in a subdirectory selected `<subdir>/.token-optimizer/wiki`
+  // -- a second graph, invisible to every other hook, which all resolve the root
+  // first. It also made the subdirectory the containment root for the write, so
+  // a finding anchored anywhere else in the same repository was refused for
+  // sitting "outside" the project.
+  //
+  // `__session__` is a synthetic leaf so the walk starts at `cwd` itself rather
+  // than its parent; `projectRootFor` takes a FILE path. This is the same idiom
+  // the adapter, the session-start hook and the Stop adapter already use.
+  //
+  // A cwd with no VCS ancestor resolves to the machine-level unrooted bucket,
+  // which `resolveAnchor` expects and handles: it swaps in home as the
+  // containment root for that case, so passing the resolved root here is what
+  // lets unrooted anchors work at all.
+  const sessionCwd = cwd || process.cwd();
+  const projectRoot = projectRootFor(join(sessionCwd, '__session__'), sessionCwd);
+  const dir = wikiDir(projectRoot);
+
+  // Default sends a structured digest with no file contents. The full delta is
+  // opt-in because the default has to be defensible without reading the docs.
+  const full = process.env.TOKEN_OPTIMIZER_HARVEST_FULL === 'true';
+  const digest = full ? buildFullDelta(transcript) : buildDigest(transcript);
+  if (!digest) return;
+
+  const raw = await extract(digest);
+
+  // Anchors are held to the files this session actually touched, so a model
+  // that invents a plausible path cannot anchor a finding to it. The digest
+  // lists them under a heading it writes itself; the full delta is raw
+  // transcript and carries no such list, so it gets no restriction.
+  const validated = validate(raw, { knownFiles: full ? null : filesIn(digest) });
+
+  // BUDGETED SELECTION, not everything the model extracted.
+  //
+  // `selectForConsolidation` exists for exactly this and had no caller
+  // anywhere, so every harvested candidate was stored regardless of what it
+  // cost to derive, how hard it is to reproduce, or whether the graph can ever
+  // retrieve it -- which is the graph-bloat risk #204 lists as needing
+  // "ranking and eviction ... not optional". It keeps failures and decisions on
+  // a floor before ranking, encoding the design's judgement that dead ends are
+  // the highest-value kind: they exist nowhere in the source tree, so nothing
+  // else can ever recover them.
+  //
+  // The selection is RECORDED, not silent. A cap that drops work without
+  // saying so reads as "there was nothing more to find", which is the same
+  // dishonesty as a truncated report with no remainder line.
+  const graph = load(dir);
+  const selection = selectForConsolidation(graph, validated, { budget: CONSOLIDATION_BUDGET });
+  const findings = selection.kept;
+  if (selection.dropped > 0) {
+    record(dir, {
+      kind: 'harvest',
+      action: 'consolidation',
+      candidates: validated.length,
+      kept: findings.length,
+      dropped: selection.dropped,
+      tokens: selection.tokens,
+      budget: CONSOLIDATION_BUDGET,
+    });
+  }
+
+  const written = writeHarvested(dir, findings, {
+    sessionId: sessionId || null,
+    projectRoot,
+    // Task nodes are keyed by session id (structural capture creates one on
+    // the first touched file, `harvest()` in lib/wiki.mjs) so this is the
+    // shape `writeHarvested` needs to point the `answers` edge back at the
+    // task this harvest belongs to. A session that never touched a file
+    // through PreToolUse/PostToolUse has no such node yet; `writeHarvested`
+    // resolves that case to no edge rather than a dangling one.
+    taskId: sessionId || null,
+    // AUTHORITATIVE, not just present: this `sessionId` came from Claude
+    // Code's own Stop-hook payload (see stop-harvest.mjs), not a model-typed
+    // tool argument, so it is safe to use for the traversal fallback if the
+    // explicit `taskId` above does not resolve.
+    authoritativeSessionId: sessionId || null,
+  });
+
+  record(dir, {
+    kind: 'harvest',
+    sessionId: sessionId || null,
+    tokens: estimateTokens(digest),
+    findings: written.length,
+    at: Date.now(),
+  });
+
+  // THE FEEDBACK LOOP. A separate extraction with a separate prompt, because
+  // the two are looking for different things: the harvest above wants what was
+  // LEARNED about the code, this wants where the user said the agent was WRONG.
+  // Asked for both at once a model returns a summary and the corrections get
+  // lost in it -- and corrections are the only turns carrying information the
+  // code itself could never supply.
+  try {
+    const turns = readArchive(dir, sessionId || 'unknown');
+    const feedback = buildFeedbackDigest(turns);
+    if (feedback) {
+      const rawLessons = await extract(feedback, { prompt: LESSON_PROMPT });
+      // The same restriction the finding path above applies, for the same reason: a model that
+      // invents a plausible path must not be able to anchor a lesson to it. `turns` is the
+      // archived transcript for this session, so its rendered digest is the honest file list.
+      const { lessons } = validateLessons(rawLessons, turns, {
+        knownFiles: filesIn(feedback),
+      });
+
+      // Anchors are optional on a lesson -- "always run npm test" is about no
+      // file -- so each is anchored to the project root when it names nothing,
+      // which keeps the store's rule that an unanchored finding is refused.
+      //
+      // The RESOLVED root, matching the containment root this write is checked
+      // against. The session's cwd would be refused outright once that root is
+      // the unrooted bucket, because `resolveAnchor` then narrows containment to
+      // home and a VCS-less working directory need not sit under it.
+      const anchored = lessons.map((l) => ({
+        ...l,
+        anchors: l.anchors.length ? l.anchors : [projectRoot],
+      }));
+
+      // The write itself is the durable record: writeHarvested anchors each
+      // lesson into the graph, which is what lessons.mjs's real consumers
+      // query. A metrics event of kind 'lessons' used to sit here as well,
+      // but nothing ever read it -- not netTokens (only 'harvest' feeds
+      // harvestTokens), not report()/buildReport() (no kind filter matches
+      // 'lessons'), and no audit render exists to show it to a human. That is
+      // the inverse of the `query` defect and the same shape as
+      // `tokensFullFile` before it: a produced-and-never-consumed event,
+      // which is a cost with no benefit. Deleted rather than wired, per the
+      // reachability allowlist's own rule -- write it again the day
+      // something needs to read it.
+      writeHarvested(dir, anchored, {
+        sessionId: sessionId || null,
+        origin: ORIGIN_HARVESTED,
+        projectRoot,
+        taskId: sessionId || null,
+        // Same hook-payload identity as above, same reason.
+        authoritativeSessionId: sessionId || null,
+      });
+    }
+  } catch {
+    // A failed feedback pass must be indistinguishable from a session with
+    // nothing to correct.
+  }
+}
+
+main()
+  .catch(() => {})
+  .finally(() => {
+    // NEVER process.exit() SYNCHRONOUSLY HERE.
+    //
+    // It crashed this worker on Windows every single time the feedback pass
+    // ran -- libuv asserts `!(handle->flags & UV_HANDLE_CLOSING)` when the
+    // process exits while the sockets from the model call are still closing,
+    // giving exit code 0xC0000409. Reproduced 5 runs out of 5, and silently,
+    // because this worker is spawned detached and nothing reads its status.
+    // Deferring by one tick is NOT enough; the handles are still closing then.
+    //
+    // So the normal path just lets the loop drain, which it does promptly.
+    //
+    // THE RECORDED CODE IS PRESERVED, not overwritten with 0. Assigning 0
+    // unconditionally would turn a harvest that had already recorded a failure
+    // into one that reports success -- and this worker is detached, so that
+    // status is the only signal a supervisor could ever act on.
+    const code = process.exitCode ?? 0;
+    process.exitCode = code;
+
+    // The watchdog keeps the original guarantee: a detached worker must never
+    // linger holding a keep-alive socket open. It is UNREF'D, so it cannot
+    // itself keep the process alive -- it only fires if something else already
+    // has, which is exactly the case worth killing.
+    const watchdog = setTimeout(() => process.exit(code), 5000);
+    watchdog.unref();
+  });

--- a/integrations/qwen/hooks/lib/harvest-worker.mjs
+++ b/integrations/qwen/hooks/lib/harvest-worker.mjs
@@ -1,6 +1,6 @@
+#!/usr/bin/env node
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/harvest-worker.mjs. Regenerate with `npm run sync:hooks`.
-#!/usr/bin/env node
 /**
  * The out-of-band half of the semantic harvest.
  *

--- a/integrations/qwen/hooks/lib/stop-harvest.mjs
+++ b/integrations/qwen/hooks/lib/stop-harvest.mjs
@@ -353,6 +353,11 @@ export async function runStopHarvest(payload = {}) {
       env: { ...process.env },
     }
   );
+  // AN 'error' EVENT WITH NO LISTENER IS A THROW. `spawn` reports a failed
+  // start asynchronously, so an unlistened error does not return a code -- Node
+  // raises it, and here that would abort the Stop response itself. A harvest
+  // that cannot start must degrade to no harvest, never to a broken Stop.
+  child.on('error', () => {});
   child.unref();
   return null;
 }

--- a/integrations/qwen/hooks/lib/stop-harvest.mjs
+++ b/integrations/qwen/hooks/lib/stop-harvest.mjs
@@ -1,0 +1,358 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/stop-harvest.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Claude Code Stop adapter -- run the semantic harvest the design specifies.
+ *
+ * The wiki design says findings are extracted "at Stop and PreCompact" by a
+ * cheap model, out of band. The extractor (`lib/harvest.mjs`) was implemented
+ * and then imported by nothing: no hook invoked it, and Stop carried no
+ * token-optimizer entry at all. The consequence was not a crash but a graph
+ * that could serve findings and never acquired any -- 122 file / 132 symbol /
+ * 61 task nodes and zero findings on a real project after a full session, with
+ * injection, staleness and the metrics all wired and idle behind it.
+ *
+ * OUT OF BAND IS THE POINT. The extraction is a model call; doing it inline
+ * would make the session that did the work pay for summarising itself, which is
+ * the cost this whole subsystem exists to avoid. So this spawns a detached
+ * worker and returns immediately. Stop is never delayed.
+ *
+ * IT ALSO REPORTS WHEN IT CANNOT RUN. Harvest requires an API key, and without
+ * one `harvestEnabled()` returns false and the module skips silently. Silence
+ * was how this stayed invisible: nothing in doctor, audit or waste mentions
+ * harvest, so a user sees a graph filling with structural nodes and no findings
+ * and has no way to learn why. Saying so once per session is the difference
+ * between a disabled feature and a broken one.
+ */
+
+import { spawn } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  chmodSync,
+  readFileSync,
+  openSync,
+  writeSync,
+  closeSync,
+  lstatSync,
+  constants,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir, homedir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { mode, MODE_OFF } from './policy.mjs';
+import { harvestEnabled, harvestMode } from './harvest.mjs';
+import { archive } from './transcript.mjs';
+import { wikiDir, projectRootFor, sharedDir, load } from './wiki.mjs';
+import { detectRefusals, recordRefusal } from './harvest-write.mjs';
+
+/** What to tell the user, per reason the harvest is not running. */
+const OFF_REASON = {
+  'off:mode': null, // The whole optimizer is off; saying more would be noise.
+  'off:not-opted-in':
+    'token-optimizer: automatic finding-extraction is OFF. It costs a model call and ' +
+    'sends a digest (paths, commands, prompts, conclusions -- never file contents) off ' +
+    'this machine, so it is opt-in: set TOKEN_OPTIMIZER_HARVEST=1 with an API key, or ' +
+    'point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model to run it free and private. ' +
+    'Meanwhile lifecycle-based structural graph capture keeps working. Durable semantic MCP ' +
+    'writes require a writer schema that is actually registered in the current CLI session.',
+  'off:no-key':
+    'token-optimizer: finding-extraction is opted in but has no credential. Set ' +
+    'TOKEN_OPTIMIZER_API_KEY, or point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model ' +
+    'to run it without one.',
+};
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * A session id reduced to something that cannot leave the marker directory.
+ *
+ * The id arrives in the hook payload, so it is external input, and it was being
+ * interpolated straight into a path: a value containing separators or `..` would
+ * have placed (and later read) the marker anywhere on disk. Everything outside a
+ * conservative allowlist becomes an underscore, which keeps ordinary uuids
+ * readable while making traversal unrepresentable rather than merely unlikely.
+ */
+function markerName(sessionId) {
+  const safe = String(sessionId || 'unknown').replace(/[^A-Za-z0-9._-]/g, '_');
+  // A name of only dots would still resolve to a directory entry.
+  const cleaned = /^[.]+$/.test(safe) ? 'unknown' : safe;
+  return `harvest-notice-${cleaned.slice(0, 64)}`;
+}
+
+/**
+ * A private, per-user directory for this hook's markers.
+ *
+ * os.tmpdir() is per-user on Windows but resolves to a SHARED, world-writable
+ * /tmp on POSIX. The marker name is derived from the session id, so it is
+ * predictable enough for another local user to pre-create -- as a symlink, or
+ * as a file they own -- and writeFileSync would then follow it and write
+ * through with this user's privileges.
+ *
+ * The state here is a debounce timestamp and a "said it once" flag, so the fix
+ * is not to guard a shared location but to stop using one. XDG_STATE_HOME is
+ * the standard place for state that should persist across runs but is not
+ * precious, and it is inside the user's own home on every POSIX system.
+ */
+function stateDir() {
+  const home = homedir();
+  const base =
+    process.platform === 'win32'
+      ? process.env.LOCALAPPDATA || tmpdir()
+      : process.env.XDG_STATE_HOME ||
+        (home ? join(home, '.local', 'state') : tmpdir());
+
+  const dir = join(base, 'token-optimizer');
+  try {
+    // 0o700 AND an explicit chmod, for the reason the graph store documents:
+    // `recursive` applies the mode only to directories it actually creates, and
+    // the umask masks it further, so neither alone guarantees the result.
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    try {
+      chmodSync(dir, 0o700);
+    } catch {
+      // Not POSIX, or not ours to chmod.
+    }
+  } catch {
+    /* best effort */
+  }
+  return dir;
+}
+
+/** Where the once-per-session notice is remembered, so Stop does not nag. */
+function noticePath(sessionId) {
+  return join(stateDir(), markerName(sessionId));
+}
+
+/**
+ * True when the path is absent, or is a regular file this user owns.
+ *
+ * lstat rather than stat: stat FOLLOWS the link and would happily report on the
+ * target, which is the thing being defended against.
+ */
+function ownedRegularFile(path) {
+  let info;
+  try {
+    info = lstatSync(path);
+  } catch {
+    return true; // Absent. The O_NOFOLLOW open below settles the race.
+  }
+  if (!info.isFile()) return false;
+  // getuid is undefined on Windows, where stateDir() is already per-user.
+  if (typeof process.getuid === 'function' && info.uid !== process.getuid())
+    return false;
+  return true;
+}
+
+/**
+ * Writes a marker, refusing to follow a symlink.
+ *
+ * O_NOFOLLOW makes the refusal ATOMIC rather than a check-then-use window: a
+ * link swapped in after ownedRegularFile() returns fails the open instead of
+ * being written through. The flag does not exist on Windows, where it is
+ * undefined and falls back to 0 -- acceptable, because the directory is
+ * per-user there to begin with.
+ */
+function writeMarker(path, contents) {
+  if (!ownedRegularFile(path)) return false;
+  const NOFOLLOW = constants.O_NOFOLLOW || 0;
+  let fd;
+  try {
+    fd = openSync(
+      path,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | NOFOLLOW,
+      0o600
+    );
+    writeSync(fd, contents);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* already closed */
+      }
+    }
+  }
+}
+
+/** Reads a marker, ignoring anything that is not a regular file we own. */
+function readMarker(path) {
+  if (!ownedRegularFile(path)) return null;
+  try {
+    return readFileSync(path, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function alreadyNotified(sessionId) {
+  const path = noticePath(sessionId);
+  // Anything already at this path -- our marker, or something planted -- means
+  // stay quiet. Repeating the notice is the worse failure, and refusing to
+  // write over a foreign file is the point.
+  if (existsSync(path)) return true;
+  return !writeMarker(path, String(Date.now()));
+}
+
+/** Minimum gap between harvests of one session. */
+const HARVEST_INTERVAL_MS =
+  Number(process.env.TOKEN_OPTIMIZER_HARVEST_INTERVAL_MS) > 0
+    ? Number(process.env.TOKEN_OPTIMIZER_HARVEST_INTERVAL_MS)
+    : 10 * 60 * 1000;
+
+/**
+ * True when this session has not been harvested recently, and records that it
+ * is about to be.
+ *
+ * Deliberately marks only when a harvest actually starts: touching it on every
+ * Stop would let a run of skipped turns keep pushing the next harvest away.
+ */
+function dueForHarvest(sessionId) {
+  const marker = join(stateDir(), `harvest-last-${markerName(sessionId)}`);
+
+  const last = Number(readMarker(marker));
+  // > 0 matters: readMarker returns null when the marker is missing or is not
+  // ours, and Number(null) is 0, which is finite -- so without this an absent
+  // marker would read as a harvest at the epoch.
+  if (
+    Number.isFinite(last) &&
+    last > 0 &&
+    Date.now() - last < HARVEST_INTERVAL_MS
+  ) {
+    return false;
+  }
+
+  // If the marker cannot be written the debounce degrades to off rather than
+  // blocking the harvest entirely.
+  writeMarker(marker, String(Date.now()));
+  return true;
+}
+
+/**
+ * The Stop-time harvest, for every client rather than one.
+ *
+ * WHY THIS IS A FUNCTION AND NOT A HOOK. It was a hook -- a Claude Code entry
+ * point named `stop-harvest.mjs` -- and #300 unregistered it. Nothing replaced
+ * it, so four capabilities went silently: the transcript archive, the harvest
+ * worker spawn, refusal detection, and the notice that says why no findings
+ * exist. Every client routes Stop through the shared adapter, and the adapter
+ * did none of these, so on a full session with a valid credential
+ * `harvestMode()` reported `remote` and nothing happened.
+ *
+ * NOTHING OBSERVED THAT IT DID NOT RUN, which is why it survived a year. There
+ * is no `kind:'harvest'` event to be absent from a report, no error, and a
+ * harvest that ran and found nothing looks exactly like one that never
+ * started. The reachability guard could not see it either: this file's own
+ * imports gave `archive`, `detectRefusals` and `recordRefusal` call sites, and
+ * a name-based scan proves a reference exists, never that it runs.
+ *
+ * Returns a notice for the caller to emit, or null. It does NOT write to
+ * stdout: the adapter emits exactly one JSON object per hook invocation, and a
+ * second writer racing it is how a Stop payload gets corrupted.
+ *
+ * @returns {Promise<string|null>} a once-per-session message, or null.
+ */
+export async function runStopHarvest(payload = {}) {
+  if (mode() === MODE_OFF) return null;
+
+  const transcript = payload.transcript_path ?? payload.transcriptPath ?? null;
+  if (!transcript || !existsSync(transcript)) return null;
+
+  // ARCHIVE FIRST, AND UNCONDITIONALLY. This is a local file copy: it costs no
+  // model call, spends no money, and sends nothing anywhere, so it must not sit
+  // behind the opt-in that exists to gate cost and disclosure. Gating it there
+  // would mean the record of what the user actually said is kept only for the
+  // users who opted into a paid feature, which is exactly backwards.
+  //
+  // It also has to happen before the early return below, or a session with
+  // harvesting off would archive nothing at all.
+  try {
+    archive(
+      wikiDir(
+        projectRootFor(
+          join(payload.cwd || process.cwd(), '__session__'),
+          payload.cwd
+        )
+      ),
+      transcript,
+      {
+        sessionId: payload.session_id,
+      }
+    );
+  } catch {
+    // The archive is a convenience. Failing to write it must not affect Stop.
+  }
+
+  // CLOSE THE REFUSAL LOOP, and do it OUTSIDE the harvest opt-in. Reading the
+  // transcript this process already holds costs no model call and sends nothing
+  // anywhere, so gating it behind the paid feature would leave a mis-scoped
+  // lesson costing tokens forever for everyone who did not opt in.
+  //
+  // The model states plainly when a cross-project lesson does not transfer --
+  // "that figure is another repo's baseline and it doesn't transfer" -- and until
+  // now nothing read it, so the same lesson was delivered again next session.
+  try {
+    const shared = sharedDir();
+    const lessons = [...load(shared).nodes.values()].filter(
+      (n) => n.kind === 'finding' && !n.retired && n.claim
+    );
+    if (lessons.length) {
+      const text = readFileSync(transcript, 'utf8');
+      for (const key of detectRefusals(lessons, text))
+        recordRefusal(shared, key);
+    }
+  } catch {
+    // Feedback is a refinement; a failure here must not affect Stop.
+  }
+
+  if (!harvestEnabled()) {
+    // Say it once, name the reason and the variable that changes it, and state
+    // what still works. A user who reads this should know exactly what they are
+    // and are not getting, and what to do about it.
+    const message = OFF_REASON[harvestMode()];
+    // RETURNED, NOT WRITTEN. This used to write its own JSON to stdout and
+    // race whatever the hook emitted; the adapter now folds this into the one
+    // object it sends, so the notice cannot be dropped by a full pipe or
+    // truncated by an exit -- which is what used to happen to the single line
+    // explaining why no findings exist.
+    if (message && !alreadyNotified(payload.session_id)) return message;
+    return null;
+  }
+
+  // SIBLING IN THE SHARED CORE. The worker used to live beside the hook entry
+  // in `plugin/hooks/`, which is why only Claude Code could ever have spawned
+  // it -- it was vendored to no other client. It now sits in the core that
+  // every client receives an identical copy of, so this resolves in all
+  // eleven.
+  const worker = join(HERE, 'harvest-worker.mjs');
+  if (!existsSync(worker)) return null;
+
+  // DEBOUNCE. Stop fires at the end of every assistant turn, so a talkative
+  // session would spawn a model call per turn -- each re-reading an overlapping
+  // transcript and re-extracting most of the same findings. The marker is
+  // touched only when a harvest is actually started, so a skipped turn does not
+  // push the next one further away.
+  if (!dueForHarvest(payload.session_id)) return null;
+
+  // Detached and fully released: the harvest must outlive this hook without
+  // holding Stop open for a model round-trip.
+  const child = spawn(
+    process.execPath,
+    [
+      worker,
+      transcript,
+      String(payload.session_id || ''),
+      String(payload.cwd || process.cwd()),
+    ],
+    {
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: true,
+      env: { ...process.env },
+    }
+  );
+  child.unref();
+  return null;
+}

--- a/integrations/windsurf/hooks/lib/adapter.mjs
+++ b/integrations/windsurf/hooks/lib/adapter.mjs
@@ -762,8 +762,11 @@ async function runHook(clientName, event, invocation) {
     const toolEvidence = optimizerToolsForHook(raw, state);
     rememberOptimizerTools(state, toolEvidence);
     const episode = episodeMeta({ client: clientName, raw });
+    // Hoisted out of the try below, because the harvest needs the same resolved
+    // directory and resolving it twice is how two halves of one hook end up
+    // reasoning about different projects.
+    const cwd = raw.cwd || raw.working_directory || process.cwd();
     try {
-      const cwd = raw.cwd || raw.working_directory || process.cwd();
       const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
       recordEpisodeOutcome(dir, {
         ...episode,
@@ -807,7 +810,21 @@ async function runHook(clientName, event, invocation) {
     // call.
     let harvestNotice = null;
     try {
-      harvestNotice = await runStopHarvest(raw);
+      // NORMALIZED, NOT RAW. The identifiers were resolved a few lines up
+      // through every alias a host might use -- `sessionId`,
+      // `conversation_id`, `working_directory` -- and handing `raw` straight
+      // over threw that away: runStopHarvest reads `session_id` and `cwd`
+      // only, so on a client that sends an alias the session id came back
+      // undefined and the archive root fell back to `process.cwd()`. That
+      // shares the once-per-session notice and the debounce marker across
+      // every session, and files the transcript under whatever directory the
+      // hook happened to start in.
+      harvestNotice = await runStopHarvest({
+        ...raw,
+        session_id: sessionId,
+        cwd,
+        transcript_path: raw.transcript_path ?? raw.transcriptPath ?? null,
+      });
     } catch {
       // The harvest is a side effect of ending a session. It must never stop
       // one from ending.

--- a/integrations/windsurf/hooks/lib/adapter.mjs
+++ b/integrations/windsurf/hooks/lib/adapter.mjs
@@ -88,6 +88,7 @@ import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 import { evaluateUcrGuards } from './ucr-guard.mjs';
 import { beginHookInvocation, noteHookOutput } from './observability.mjs';
 import { registerProject } from './projects.mjs';
+import { runStopHarvest } from './stop-harvest.mjs';
 
 /**
  * Per-client capability.
@@ -792,10 +793,33 @@ async function runHook(clientName, event, invocation) {
       state.harvestedEdits = Number(state.edits || 0);
       saveState(sessionId, state, agentScope);
     }
+    // THE OUT-OF-BAND HARVEST, which no client was running.
+    //
+    // The in-band `prompt` above asks the MODEL to call `wiki_write`, and the
+    // session pays for summarising itself -- the exact cost the design says the
+    // harvest exists to avoid ("out-of-band, so the session doing the work never
+    // pays for the harvest"). The out-of-band half lived in a Claude Code hook
+    // that #300 unregistered, and nothing replaced it, so on every client the
+    // transcript was never archived, the worker never spawned, refusals were
+    // never detected, and the notice explaining why no findings exist was never
+    // shown. Awaited because it must finish before the exit below; it spawns a
+    // DETACHED worker and returns immediately, so Stop is not delayed by a model
+    // call.
+    let harvestNotice = null;
+    try {
+      harvestNotice = await runStopHarvest(raw);
+    } catch {
+      // The harvest is a side effect of ending a session. It must never stop
+      // one from ending.
+    }
+
     if (prompt && client.stopStyle === 'followup') {
-      emit({ followup_message: prompt });
+      emit({ followup_message: prompt, ...(harvestNotice ? { systemMessage: harvestNotice } : {}) });
     } else {
-      emit(prompt ? { decision: client.stopDecision, reason: prompt } : {});
+      emit({
+        ...(prompt ? { decision: client.stopDecision, reason: prompt } : {}),
+        ...(harvestNotice ? { systemMessage: harvestNotice } : {}),
+      });
     }
     process.exit(0);
   }

--- a/integrations/windsurf/hooks/lib/harvest-worker.mjs
+++ b/integrations/windsurf/hooks/lib/harvest-worker.mjs
@@ -1,0 +1,248 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/harvest-worker.mjs. Regenerate with `npm run sync:hooks`.
+#!/usr/bin/env node
+/**
+ * The out-of-band half of the semantic harvest.
+ *
+ * Spawned detached by the Stop adapter so the session that did the work never
+ * pays for the model call that summarises it. Everything here is best-effort:
+ * a harvest that fails must be indistinguishable from a session with nothing
+ * to learn, because the alternative -- a hook that can break a turn -- is worse
+ * than no findings at all.
+ *
+ * The cost of the extraction is recorded either way. Without it the metrics
+ * report a benefit with no matching expense, and `netTokens` would flatter the
+ * feature by exactly the amount it spends.
+ */
+
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  harvestEnabled,
+  buildDigest,
+  buildFullDelta,
+  extract,
+  validate,
+  estimateTokens,
+} from './harvest.mjs';
+import { writeHarvested } from './harvest-write.mjs';
+import { record } from './metrics.mjs';
+import { wikiDir, projectRootFor, load } from './wiki.mjs';
+import { readArchive } from './transcript.mjs';
+import { buildFeedbackDigest, validateLessons, LESSON_PROMPT } from './lessons.mjs';
+import { ORIGIN_HARVESTED } from './curate.mjs';
+import { selectForConsolidation } from './consolidate.mjs';
+
+/**
+ * The token budget one session's harvest may add to the graph.
+ *
+ * #204 lists graph bloat as a named risk -- "the session-start index grows with
+ * the graph; ranking and eviction are required, not optional" -- and until now
+ * nothing bounded what a single harvest could store. 4,000 tokens is the
+ * selector's own default and roughly twenty-five findings at the size the
+ * extractor produces, which is far above any observed session's real yield; it
+ * is a ceiling against a pathological extraction, not a routine constraint.
+ */
+const CONSOLIDATION_BUDGET = 4000;
+
+/**
+ * The files the digest says were touched.
+ *
+ * `buildDigest` emits them under a `## Files touched` heading and returns a
+ * string, so this reads back the list it just wrote rather than walking the
+ * transcript a second time. Returns null when the section is absent, which
+ * `validate` treats as "no restriction" rather than "no files".
+ */
+function filesIn(digest) {
+  const start = digest.indexOf('## Files touched');
+  if (start === -1) return null;
+
+  const rest = digest.slice(start + '## Files touched'.length);
+  const end = rest.indexOf('\n##');
+  const block = (end === -1 ? rest : rest.slice(0, end)).split('\n');
+
+  const files = new Set();
+  for (const line of block) {
+    const value = line.trim();
+    if (value) files.add(value);
+  }
+  return files.size ? files : null;
+}
+
+async function main() {
+  const [transcript, sessionId, cwd] = process.argv.slice(2);
+  if (!transcript || !existsSync(transcript) || !harvestEnabled()) return;
+
+  // THE GRAPH AND THE CONTAINMENT BOUNDARY BOTH COME FROM THE REPOSITORY ROOT,
+  // NOT THE SESSION'S CWD. `wikiDir` only joins the path it is handed, so a
+  // session started in a subdirectory selected `<subdir>/.token-optimizer/wiki`
+  // -- a second graph, invisible to every other hook, which all resolve the root
+  // first. It also made the subdirectory the containment root for the write, so
+  // a finding anchored anywhere else in the same repository was refused for
+  // sitting "outside" the project.
+  //
+  // `__session__` is a synthetic leaf so the walk starts at `cwd` itself rather
+  // than its parent; `projectRootFor` takes a FILE path. This is the same idiom
+  // the adapter, the session-start hook and the Stop adapter already use.
+  //
+  // A cwd with no VCS ancestor resolves to the machine-level unrooted bucket,
+  // which `resolveAnchor` expects and handles: it swaps in home as the
+  // containment root for that case, so passing the resolved root here is what
+  // lets unrooted anchors work at all.
+  const sessionCwd = cwd || process.cwd();
+  const projectRoot = projectRootFor(join(sessionCwd, '__session__'), sessionCwd);
+  const dir = wikiDir(projectRoot);
+
+  // Default sends a structured digest with no file contents. The full delta is
+  // opt-in because the default has to be defensible without reading the docs.
+  const full = process.env.TOKEN_OPTIMIZER_HARVEST_FULL === 'true';
+  const digest = full ? buildFullDelta(transcript) : buildDigest(transcript);
+  if (!digest) return;
+
+  const raw = await extract(digest);
+
+  // Anchors are held to the files this session actually touched, so a model
+  // that invents a plausible path cannot anchor a finding to it. The digest
+  // lists them under a heading it writes itself; the full delta is raw
+  // transcript and carries no such list, so it gets no restriction.
+  const validated = validate(raw, { knownFiles: full ? null : filesIn(digest) });
+
+  // BUDGETED SELECTION, not everything the model extracted.
+  //
+  // `selectForConsolidation` exists for exactly this and had no caller
+  // anywhere, so every harvested candidate was stored regardless of what it
+  // cost to derive, how hard it is to reproduce, or whether the graph can ever
+  // retrieve it -- which is the graph-bloat risk #204 lists as needing
+  // "ranking and eviction ... not optional". It keeps failures and decisions on
+  // a floor before ranking, encoding the design's judgement that dead ends are
+  // the highest-value kind: they exist nowhere in the source tree, so nothing
+  // else can ever recover them.
+  //
+  // The selection is RECORDED, not silent. A cap that drops work without
+  // saying so reads as "there was nothing more to find", which is the same
+  // dishonesty as a truncated report with no remainder line.
+  const graph = load(dir);
+  const selection = selectForConsolidation(graph, validated, { budget: CONSOLIDATION_BUDGET });
+  const findings = selection.kept;
+  if (selection.dropped > 0) {
+    record(dir, {
+      kind: 'harvest',
+      action: 'consolidation',
+      candidates: validated.length,
+      kept: findings.length,
+      dropped: selection.dropped,
+      tokens: selection.tokens,
+      budget: CONSOLIDATION_BUDGET,
+    });
+  }
+
+  const written = writeHarvested(dir, findings, {
+    sessionId: sessionId || null,
+    projectRoot,
+    // Task nodes are keyed by session id (structural capture creates one on
+    // the first touched file, `harvest()` in lib/wiki.mjs) so this is the
+    // shape `writeHarvested` needs to point the `answers` edge back at the
+    // task this harvest belongs to. A session that never touched a file
+    // through PreToolUse/PostToolUse has no such node yet; `writeHarvested`
+    // resolves that case to no edge rather than a dangling one.
+    taskId: sessionId || null,
+    // AUTHORITATIVE, not just present: this `sessionId` came from Claude
+    // Code's own Stop-hook payload (see stop-harvest.mjs), not a model-typed
+    // tool argument, so it is safe to use for the traversal fallback if the
+    // explicit `taskId` above does not resolve.
+    authoritativeSessionId: sessionId || null,
+  });
+
+  record(dir, {
+    kind: 'harvest',
+    sessionId: sessionId || null,
+    tokens: estimateTokens(digest),
+    findings: written.length,
+    at: Date.now(),
+  });
+
+  // THE FEEDBACK LOOP. A separate extraction with a separate prompt, because
+  // the two are looking for different things: the harvest above wants what was
+  // LEARNED about the code, this wants where the user said the agent was WRONG.
+  // Asked for both at once a model returns a summary and the corrections get
+  // lost in it -- and corrections are the only turns carrying information the
+  // code itself could never supply.
+  try {
+    const turns = readArchive(dir, sessionId || 'unknown');
+    const feedback = buildFeedbackDigest(turns);
+    if (feedback) {
+      const rawLessons = await extract(feedback, { prompt: LESSON_PROMPT });
+      // The same restriction the finding path above applies, for the same reason: a model that
+      // invents a plausible path must not be able to anchor a lesson to it. `turns` is the
+      // archived transcript for this session, so its rendered digest is the honest file list.
+      const { lessons } = validateLessons(rawLessons, turns, {
+        knownFiles: filesIn(feedback),
+      });
+
+      // Anchors are optional on a lesson -- "always run npm test" is about no
+      // file -- so each is anchored to the project root when it names nothing,
+      // which keeps the store's rule that an unanchored finding is refused.
+      //
+      // The RESOLVED root, matching the containment root this write is checked
+      // against. The session's cwd would be refused outright once that root is
+      // the unrooted bucket, because `resolveAnchor` then narrows containment to
+      // home and a VCS-less working directory need not sit under it.
+      const anchored = lessons.map((l) => ({
+        ...l,
+        anchors: l.anchors.length ? l.anchors : [projectRoot],
+      }));
+
+      // The write itself is the durable record: writeHarvested anchors each
+      // lesson into the graph, which is what lessons.mjs's real consumers
+      // query. A metrics event of kind 'lessons' used to sit here as well,
+      // but nothing ever read it -- not netTokens (only 'harvest' feeds
+      // harvestTokens), not report()/buildReport() (no kind filter matches
+      // 'lessons'), and no audit render exists to show it to a human. That is
+      // the inverse of the `query` defect and the same shape as
+      // `tokensFullFile` before it: a produced-and-never-consumed event,
+      // which is a cost with no benefit. Deleted rather than wired, per the
+      // reachability allowlist's own rule -- write it again the day
+      // something needs to read it.
+      writeHarvested(dir, anchored, {
+        sessionId: sessionId || null,
+        origin: ORIGIN_HARVESTED,
+        projectRoot,
+        taskId: sessionId || null,
+        // Same hook-payload identity as above, same reason.
+        authoritativeSessionId: sessionId || null,
+      });
+    }
+  } catch {
+    // A failed feedback pass must be indistinguishable from a session with
+    // nothing to correct.
+  }
+}
+
+main()
+  .catch(() => {})
+  .finally(() => {
+    // NEVER process.exit() SYNCHRONOUSLY HERE.
+    //
+    // It crashed this worker on Windows every single time the feedback pass
+    // ran -- libuv asserts `!(handle->flags & UV_HANDLE_CLOSING)` when the
+    // process exits while the sockets from the model call are still closing,
+    // giving exit code 0xC0000409. Reproduced 5 runs out of 5, and silently,
+    // because this worker is spawned detached and nothing reads its status.
+    // Deferring by one tick is NOT enough; the handles are still closing then.
+    //
+    // So the normal path just lets the loop drain, which it does promptly.
+    //
+    // THE RECORDED CODE IS PRESERVED, not overwritten with 0. Assigning 0
+    // unconditionally would turn a harvest that had already recorded a failure
+    // into one that reports success -- and this worker is detached, so that
+    // status is the only signal a supervisor could ever act on.
+    const code = process.exitCode ?? 0;
+    process.exitCode = code;
+
+    // The watchdog keeps the original guarantee: a detached worker must never
+    // linger holding a keep-alive socket open. It is UNREF'D, so it cannot
+    // itself keep the process alive -- it only fires if something else already
+    // has, which is exactly the case worth killing.
+    const watchdog = setTimeout(() => process.exit(code), 5000);
+    watchdog.unref();
+  });

--- a/integrations/windsurf/hooks/lib/harvest-worker.mjs
+++ b/integrations/windsurf/hooks/lib/harvest-worker.mjs
@@ -1,6 +1,6 @@
+#!/usr/bin/env node
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/harvest-worker.mjs. Regenerate with `npm run sync:hooks`.
-#!/usr/bin/env node
 /**
  * The out-of-band half of the semantic harvest.
  *

--- a/integrations/windsurf/hooks/lib/stop-harvest.mjs
+++ b/integrations/windsurf/hooks/lib/stop-harvest.mjs
@@ -353,6 +353,11 @@ export async function runStopHarvest(payload = {}) {
       env: { ...process.env },
     }
   );
+  // AN 'error' EVENT WITH NO LISTENER IS A THROW. `spawn` reports a failed
+  // start asynchronously, so an unlistened error does not return a code -- Node
+  // raises it, and here that would abort the Stop response itself. A harvest
+  // that cannot start must degrade to no harvest, never to a broken Stop.
+  child.on('error', () => {});
   child.unref();
   return null;
 }

--- a/integrations/windsurf/hooks/lib/stop-harvest.mjs
+++ b/integrations/windsurf/hooks/lib/stop-harvest.mjs
@@ -1,0 +1,358 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/stop-harvest.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Claude Code Stop adapter -- run the semantic harvest the design specifies.
+ *
+ * The wiki design says findings are extracted "at Stop and PreCompact" by a
+ * cheap model, out of band. The extractor (`lib/harvest.mjs`) was implemented
+ * and then imported by nothing: no hook invoked it, and Stop carried no
+ * token-optimizer entry at all. The consequence was not a crash but a graph
+ * that could serve findings and never acquired any -- 122 file / 132 symbol /
+ * 61 task nodes and zero findings on a real project after a full session, with
+ * injection, staleness and the metrics all wired and idle behind it.
+ *
+ * OUT OF BAND IS THE POINT. The extraction is a model call; doing it inline
+ * would make the session that did the work pay for summarising itself, which is
+ * the cost this whole subsystem exists to avoid. So this spawns a detached
+ * worker and returns immediately. Stop is never delayed.
+ *
+ * IT ALSO REPORTS WHEN IT CANNOT RUN. Harvest requires an API key, and without
+ * one `harvestEnabled()` returns false and the module skips silently. Silence
+ * was how this stayed invisible: nothing in doctor, audit or waste mentions
+ * harvest, so a user sees a graph filling with structural nodes and no findings
+ * and has no way to learn why. Saying so once per session is the difference
+ * between a disabled feature and a broken one.
+ */
+
+import { spawn } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  chmodSync,
+  readFileSync,
+  openSync,
+  writeSync,
+  closeSync,
+  lstatSync,
+  constants,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir, homedir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { mode, MODE_OFF } from './policy.mjs';
+import { harvestEnabled, harvestMode } from './harvest.mjs';
+import { archive } from './transcript.mjs';
+import { wikiDir, projectRootFor, sharedDir, load } from './wiki.mjs';
+import { detectRefusals, recordRefusal } from './harvest-write.mjs';
+
+/** What to tell the user, per reason the harvest is not running. */
+const OFF_REASON = {
+  'off:mode': null, // The whole optimizer is off; saying more would be noise.
+  'off:not-opted-in':
+    'token-optimizer: automatic finding-extraction is OFF. It costs a model call and ' +
+    'sends a digest (paths, commands, prompts, conclusions -- never file contents) off ' +
+    'this machine, so it is opt-in: set TOKEN_OPTIMIZER_HARVEST=1 with an API key, or ' +
+    'point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model to run it free and private. ' +
+    'Meanwhile lifecycle-based structural graph capture keeps working. Durable semantic MCP ' +
+    'writes require a writer schema that is actually registered in the current CLI session.',
+  'off:no-key':
+    'token-optimizer: finding-extraction is opted in but has no credential. Set ' +
+    'TOKEN_OPTIMIZER_API_KEY, or point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model ' +
+    'to run it without one.',
+};
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * A session id reduced to something that cannot leave the marker directory.
+ *
+ * The id arrives in the hook payload, so it is external input, and it was being
+ * interpolated straight into a path: a value containing separators or `..` would
+ * have placed (and later read) the marker anywhere on disk. Everything outside a
+ * conservative allowlist becomes an underscore, which keeps ordinary uuids
+ * readable while making traversal unrepresentable rather than merely unlikely.
+ */
+function markerName(sessionId) {
+  const safe = String(sessionId || 'unknown').replace(/[^A-Za-z0-9._-]/g, '_');
+  // A name of only dots would still resolve to a directory entry.
+  const cleaned = /^[.]+$/.test(safe) ? 'unknown' : safe;
+  return `harvest-notice-${cleaned.slice(0, 64)}`;
+}
+
+/**
+ * A private, per-user directory for this hook's markers.
+ *
+ * os.tmpdir() is per-user on Windows but resolves to a SHARED, world-writable
+ * /tmp on POSIX. The marker name is derived from the session id, so it is
+ * predictable enough for another local user to pre-create -- as a symlink, or
+ * as a file they own -- and writeFileSync would then follow it and write
+ * through with this user's privileges.
+ *
+ * The state here is a debounce timestamp and a "said it once" flag, so the fix
+ * is not to guard a shared location but to stop using one. XDG_STATE_HOME is
+ * the standard place for state that should persist across runs but is not
+ * precious, and it is inside the user's own home on every POSIX system.
+ */
+function stateDir() {
+  const home = homedir();
+  const base =
+    process.platform === 'win32'
+      ? process.env.LOCALAPPDATA || tmpdir()
+      : process.env.XDG_STATE_HOME ||
+        (home ? join(home, '.local', 'state') : tmpdir());
+
+  const dir = join(base, 'token-optimizer');
+  try {
+    // 0o700 AND an explicit chmod, for the reason the graph store documents:
+    // `recursive` applies the mode only to directories it actually creates, and
+    // the umask masks it further, so neither alone guarantees the result.
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    try {
+      chmodSync(dir, 0o700);
+    } catch {
+      // Not POSIX, or not ours to chmod.
+    }
+  } catch {
+    /* best effort */
+  }
+  return dir;
+}
+
+/** Where the once-per-session notice is remembered, so Stop does not nag. */
+function noticePath(sessionId) {
+  return join(stateDir(), markerName(sessionId));
+}
+
+/**
+ * True when the path is absent, or is a regular file this user owns.
+ *
+ * lstat rather than stat: stat FOLLOWS the link and would happily report on the
+ * target, which is the thing being defended against.
+ */
+function ownedRegularFile(path) {
+  let info;
+  try {
+    info = lstatSync(path);
+  } catch {
+    return true; // Absent. The O_NOFOLLOW open below settles the race.
+  }
+  if (!info.isFile()) return false;
+  // getuid is undefined on Windows, where stateDir() is already per-user.
+  if (typeof process.getuid === 'function' && info.uid !== process.getuid())
+    return false;
+  return true;
+}
+
+/**
+ * Writes a marker, refusing to follow a symlink.
+ *
+ * O_NOFOLLOW makes the refusal ATOMIC rather than a check-then-use window: a
+ * link swapped in after ownedRegularFile() returns fails the open instead of
+ * being written through. The flag does not exist on Windows, where it is
+ * undefined and falls back to 0 -- acceptable, because the directory is
+ * per-user there to begin with.
+ */
+function writeMarker(path, contents) {
+  if (!ownedRegularFile(path)) return false;
+  const NOFOLLOW = constants.O_NOFOLLOW || 0;
+  let fd;
+  try {
+    fd = openSync(
+      path,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | NOFOLLOW,
+      0o600
+    );
+    writeSync(fd, contents);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* already closed */
+      }
+    }
+  }
+}
+
+/** Reads a marker, ignoring anything that is not a regular file we own. */
+function readMarker(path) {
+  if (!ownedRegularFile(path)) return null;
+  try {
+    return readFileSync(path, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function alreadyNotified(sessionId) {
+  const path = noticePath(sessionId);
+  // Anything already at this path -- our marker, or something planted -- means
+  // stay quiet. Repeating the notice is the worse failure, and refusing to
+  // write over a foreign file is the point.
+  if (existsSync(path)) return true;
+  return !writeMarker(path, String(Date.now()));
+}
+
+/** Minimum gap between harvests of one session. */
+const HARVEST_INTERVAL_MS =
+  Number(process.env.TOKEN_OPTIMIZER_HARVEST_INTERVAL_MS) > 0
+    ? Number(process.env.TOKEN_OPTIMIZER_HARVEST_INTERVAL_MS)
+    : 10 * 60 * 1000;
+
+/**
+ * True when this session has not been harvested recently, and records that it
+ * is about to be.
+ *
+ * Deliberately marks only when a harvest actually starts: touching it on every
+ * Stop would let a run of skipped turns keep pushing the next harvest away.
+ */
+function dueForHarvest(sessionId) {
+  const marker = join(stateDir(), `harvest-last-${markerName(sessionId)}`);
+
+  const last = Number(readMarker(marker));
+  // > 0 matters: readMarker returns null when the marker is missing or is not
+  // ours, and Number(null) is 0, which is finite -- so without this an absent
+  // marker would read as a harvest at the epoch.
+  if (
+    Number.isFinite(last) &&
+    last > 0 &&
+    Date.now() - last < HARVEST_INTERVAL_MS
+  ) {
+    return false;
+  }
+
+  // If the marker cannot be written the debounce degrades to off rather than
+  // blocking the harvest entirely.
+  writeMarker(marker, String(Date.now()));
+  return true;
+}
+
+/**
+ * The Stop-time harvest, for every client rather than one.
+ *
+ * WHY THIS IS A FUNCTION AND NOT A HOOK. It was a hook -- a Claude Code entry
+ * point named `stop-harvest.mjs` -- and #300 unregistered it. Nothing replaced
+ * it, so four capabilities went silently: the transcript archive, the harvest
+ * worker spawn, refusal detection, and the notice that says why no findings
+ * exist. Every client routes Stop through the shared adapter, and the adapter
+ * did none of these, so on a full session with a valid credential
+ * `harvestMode()` reported `remote` and nothing happened.
+ *
+ * NOTHING OBSERVED THAT IT DID NOT RUN, which is why it survived a year. There
+ * is no `kind:'harvest'` event to be absent from a report, no error, and a
+ * harvest that ran and found nothing looks exactly like one that never
+ * started. The reachability guard could not see it either: this file's own
+ * imports gave `archive`, `detectRefusals` and `recordRefusal` call sites, and
+ * a name-based scan proves a reference exists, never that it runs.
+ *
+ * Returns a notice for the caller to emit, or null. It does NOT write to
+ * stdout: the adapter emits exactly one JSON object per hook invocation, and a
+ * second writer racing it is how a Stop payload gets corrupted.
+ *
+ * @returns {Promise<string|null>} a once-per-session message, or null.
+ */
+export async function runStopHarvest(payload = {}) {
+  if (mode() === MODE_OFF) return null;
+
+  const transcript = payload.transcript_path ?? payload.transcriptPath ?? null;
+  if (!transcript || !existsSync(transcript)) return null;
+
+  // ARCHIVE FIRST, AND UNCONDITIONALLY. This is a local file copy: it costs no
+  // model call, spends no money, and sends nothing anywhere, so it must not sit
+  // behind the opt-in that exists to gate cost and disclosure. Gating it there
+  // would mean the record of what the user actually said is kept only for the
+  // users who opted into a paid feature, which is exactly backwards.
+  //
+  // It also has to happen before the early return below, or a session with
+  // harvesting off would archive nothing at all.
+  try {
+    archive(
+      wikiDir(
+        projectRootFor(
+          join(payload.cwd || process.cwd(), '__session__'),
+          payload.cwd
+        )
+      ),
+      transcript,
+      {
+        sessionId: payload.session_id,
+      }
+    );
+  } catch {
+    // The archive is a convenience. Failing to write it must not affect Stop.
+  }
+
+  // CLOSE THE REFUSAL LOOP, and do it OUTSIDE the harvest opt-in. Reading the
+  // transcript this process already holds costs no model call and sends nothing
+  // anywhere, so gating it behind the paid feature would leave a mis-scoped
+  // lesson costing tokens forever for everyone who did not opt in.
+  //
+  // The model states plainly when a cross-project lesson does not transfer --
+  // "that figure is another repo's baseline and it doesn't transfer" -- and until
+  // now nothing read it, so the same lesson was delivered again next session.
+  try {
+    const shared = sharedDir();
+    const lessons = [...load(shared).nodes.values()].filter(
+      (n) => n.kind === 'finding' && !n.retired && n.claim
+    );
+    if (lessons.length) {
+      const text = readFileSync(transcript, 'utf8');
+      for (const key of detectRefusals(lessons, text))
+        recordRefusal(shared, key);
+    }
+  } catch {
+    // Feedback is a refinement; a failure here must not affect Stop.
+  }
+
+  if (!harvestEnabled()) {
+    // Say it once, name the reason and the variable that changes it, and state
+    // what still works. A user who reads this should know exactly what they are
+    // and are not getting, and what to do about it.
+    const message = OFF_REASON[harvestMode()];
+    // RETURNED, NOT WRITTEN. This used to write its own JSON to stdout and
+    // race whatever the hook emitted; the adapter now folds this into the one
+    // object it sends, so the notice cannot be dropped by a full pipe or
+    // truncated by an exit -- which is what used to happen to the single line
+    // explaining why no findings exist.
+    if (message && !alreadyNotified(payload.session_id)) return message;
+    return null;
+  }
+
+  // SIBLING IN THE SHARED CORE. The worker used to live beside the hook entry
+  // in `plugin/hooks/`, which is why only Claude Code could ever have spawned
+  // it -- it was vendored to no other client. It now sits in the core that
+  // every client receives an identical copy of, so this resolves in all
+  // eleven.
+  const worker = join(HERE, 'harvest-worker.mjs');
+  if (!existsSync(worker)) return null;
+
+  // DEBOUNCE. Stop fires at the end of every assistant turn, so a talkative
+  // session would spawn a model call per turn -- each re-reading an overlapping
+  // transcript and re-extracting most of the same findings. The marker is
+  // touched only when a harvest is actually started, so a skipped turn does not
+  // push the next one further away.
+  if (!dueForHarvest(payload.session_id)) return null;
+
+  // Detached and fully released: the harvest must outlive this hook without
+  // holding Stop open for a model round-trip.
+  const child = spawn(
+    process.execPath,
+    [
+      worker,
+      transcript,
+      String(payload.session_id || ''),
+      String(payload.cwd || process.cwd()),
+    ],
+    {
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: true,
+      env: { ...process.env },
+    }
+  );
+  child.unref();
+  return null;
+}

--- a/plugin/hooks/lib/adapter.mjs
+++ b/plugin/hooks/lib/adapter.mjs
@@ -762,8 +762,11 @@ async function runHook(clientName, event, invocation) {
     const toolEvidence = optimizerToolsForHook(raw, state);
     rememberOptimizerTools(state, toolEvidence);
     const episode = episodeMeta({ client: clientName, raw });
+    // Hoisted out of the try below, because the harvest needs the same resolved
+    // directory and resolving it twice is how two halves of one hook end up
+    // reasoning about different projects.
+    const cwd = raw.cwd || raw.working_directory || process.cwd();
     try {
-      const cwd = raw.cwd || raw.working_directory || process.cwd();
       const dir = wikiDir(projectRootFor(join(cwd, '__session__'), cwd));
       recordEpisodeOutcome(dir, {
         ...episode,
@@ -807,7 +810,21 @@ async function runHook(clientName, event, invocation) {
     // call.
     let harvestNotice = null;
     try {
-      harvestNotice = await runStopHarvest(raw);
+      // NORMALIZED, NOT RAW. The identifiers were resolved a few lines up
+      // through every alias a host might use -- `sessionId`,
+      // `conversation_id`, `working_directory` -- and handing `raw` straight
+      // over threw that away: runStopHarvest reads `session_id` and `cwd`
+      // only, so on a client that sends an alias the session id came back
+      // undefined and the archive root fell back to `process.cwd()`. That
+      // shares the once-per-session notice and the debounce marker across
+      // every session, and files the transcript under whatever directory the
+      // hook happened to start in.
+      harvestNotice = await runStopHarvest({
+        ...raw,
+        session_id: sessionId,
+        cwd,
+        transcript_path: raw.transcript_path ?? raw.transcriptPath ?? null,
+      });
     } catch {
       // The harvest is a side effect of ending a session. It must never stop
       // one from ending.

--- a/plugin/hooks/lib/adapter.mjs
+++ b/plugin/hooks/lib/adapter.mjs
@@ -88,6 +88,7 @@ import { episodeMeta, featuresForArm, usageFrom } from './experiment.mjs';
 import { evaluateUcrGuards } from './ucr-guard.mjs';
 import { beginHookInvocation, noteHookOutput } from './observability.mjs';
 import { registerProject } from './projects.mjs';
+import { runStopHarvest } from './stop-harvest.mjs';
 
 /**
  * Per-client capability.
@@ -792,10 +793,33 @@ async function runHook(clientName, event, invocation) {
       state.harvestedEdits = Number(state.edits || 0);
       saveState(sessionId, state, agentScope);
     }
+    // THE OUT-OF-BAND HARVEST, which no client was running.
+    //
+    // The in-band `prompt` above asks the MODEL to call `wiki_write`, and the
+    // session pays for summarising itself -- the exact cost the design says the
+    // harvest exists to avoid ("out-of-band, so the session doing the work never
+    // pays for the harvest"). The out-of-band half lived in a Claude Code hook
+    // that #300 unregistered, and nothing replaced it, so on every client the
+    // transcript was never archived, the worker never spawned, refusals were
+    // never detected, and the notice explaining why no findings exist was never
+    // shown. Awaited because it must finish before the exit below; it spawns a
+    // DETACHED worker and returns immediately, so Stop is not delayed by a model
+    // call.
+    let harvestNotice = null;
+    try {
+      harvestNotice = await runStopHarvest(raw);
+    } catch {
+      // The harvest is a side effect of ending a session. It must never stop
+      // one from ending.
+    }
+
     if (prompt && client.stopStyle === 'followup') {
-      emit({ followup_message: prompt });
+      emit({ followup_message: prompt, ...(harvestNotice ? { systemMessage: harvestNotice } : {}) });
     } else {
-      emit(prompt ? { decision: client.stopDecision, reason: prompt } : {});
+      emit({
+        ...(prompt ? { decision: client.stopDecision, reason: prompt } : {}),
+        ...(harvestNotice ? { systemMessage: harvestNotice } : {}),
+      });
     }
     process.exit(0);
   }

--- a/plugin/hooks/lib/harvest-worker.mjs
+++ b/plugin/hooks/lib/harvest-worker.mjs
@@ -1,3 +1,5 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/harvest-worker.mjs. Regenerate with `npm run sync:hooks`.
 #!/usr/bin/env node
 /**
  * The out-of-band half of the semantic harvest.
@@ -22,14 +24,14 @@ import {
   extract,
   validate,
   estimateTokens,
-} from './lib/harvest.mjs';
-import { writeHarvested } from './lib/harvest-write.mjs';
-import { record } from './lib/metrics.mjs';
-import { wikiDir, projectRootFor, load } from './lib/wiki.mjs';
-import { readArchive } from './lib/transcript.mjs';
-import { buildFeedbackDigest, validateLessons, LESSON_PROMPT } from './lib/lessons.mjs';
-import { ORIGIN_HARVESTED } from './lib/curate.mjs';
-import { selectForConsolidation } from './lib/consolidate.mjs';
+} from './harvest.mjs';
+import { writeHarvested } from './harvest-write.mjs';
+import { record } from './metrics.mjs';
+import { wikiDir, projectRootFor, load } from './wiki.mjs';
+import { readArchive } from './transcript.mjs';
+import { buildFeedbackDigest, validateLessons, LESSON_PROMPT } from './lessons.mjs';
+import { ORIGIN_HARVESTED } from './curate.mjs';
+import { selectForConsolidation } from './consolidate.mjs';
 
 /**
  * The token budget one session's harvest may add to the graph.

--- a/plugin/hooks/lib/harvest-worker.mjs
+++ b/plugin/hooks/lib/harvest-worker.mjs
@@ -1,6 +1,6 @@
+#!/usr/bin/env node
 // GENERATED FILE -- do not edit.
 // Source of truth: hooks-core/harvest-worker.mjs. Regenerate with `npm run sync:hooks`.
-#!/usr/bin/env node
 /**
  * The out-of-band half of the semantic harvest.
  *

--- a/plugin/hooks/lib/stop-harvest.mjs
+++ b/plugin/hooks/lib/stop-harvest.mjs
@@ -353,6 +353,11 @@ export async function runStopHarvest(payload = {}) {
       env: { ...process.env },
     }
   );
+  // AN 'error' EVENT WITH NO LISTENER IS A THROW. `spawn` reports a failed
+  // start asynchronously, so an unlistened error does not return a code -- Node
+  // raises it, and here that would abort the Stop response itself. A harvest
+  // that cannot start must degrade to no harvest, never to a broken Stop.
+  child.on('error', () => {});
   child.unref();
   return null;
 }

--- a/plugin/hooks/lib/stop-harvest.mjs
+++ b/plugin/hooks/lib/stop-harvest.mjs
@@ -1,0 +1,358 @@
+// GENERATED FILE -- do not edit.
+// Source of truth: hooks-core/stop-harvest.mjs. Regenerate with `npm run sync:hooks`.
+/**
+ * Claude Code Stop adapter -- run the semantic harvest the design specifies.
+ *
+ * The wiki design says findings are extracted "at Stop and PreCompact" by a
+ * cheap model, out of band. The extractor (`lib/harvest.mjs`) was implemented
+ * and then imported by nothing: no hook invoked it, and Stop carried no
+ * token-optimizer entry at all. The consequence was not a crash but a graph
+ * that could serve findings and never acquired any -- 122 file / 132 symbol /
+ * 61 task nodes and zero findings on a real project after a full session, with
+ * injection, staleness and the metrics all wired and idle behind it.
+ *
+ * OUT OF BAND IS THE POINT. The extraction is a model call; doing it inline
+ * would make the session that did the work pay for summarising itself, which is
+ * the cost this whole subsystem exists to avoid. So this spawns a detached
+ * worker and returns immediately. Stop is never delayed.
+ *
+ * IT ALSO REPORTS WHEN IT CANNOT RUN. Harvest requires an API key, and without
+ * one `harvestEnabled()` returns false and the module skips silently. Silence
+ * was how this stayed invisible: nothing in doctor, audit or waste mentions
+ * harvest, so a user sees a graph filling with structural nodes and no findings
+ * and has no way to learn why. Saying so once per session is the difference
+ * between a disabled feature and a broken one.
+ */
+
+import { spawn } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  chmodSync,
+  readFileSync,
+  openSync,
+  writeSync,
+  closeSync,
+  lstatSync,
+  constants,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir, homedir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { mode, MODE_OFF } from './policy.mjs';
+import { harvestEnabled, harvestMode } from './harvest.mjs';
+import { archive } from './transcript.mjs';
+import { wikiDir, projectRootFor, sharedDir, load } from './wiki.mjs';
+import { detectRefusals, recordRefusal } from './harvest-write.mjs';
+
+/** What to tell the user, per reason the harvest is not running. */
+const OFF_REASON = {
+  'off:mode': null, // The whole optimizer is off; saying more would be noise.
+  'off:not-opted-in':
+    'token-optimizer: automatic finding-extraction is OFF. It costs a model call and ' +
+    'sends a digest (paths, commands, prompts, conclusions -- never file contents) off ' +
+    'this machine, so it is opt-in: set TOKEN_OPTIMIZER_HARVEST=1 with an API key, or ' +
+    'point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model to run it free and private. ' +
+    'Meanwhile lifecycle-based structural graph capture keeps working. Durable semantic MCP ' +
+    'writes require a writer schema that is actually registered in the current CLI session.',
+  'off:no-key':
+    'token-optimizer: finding-extraction is opted in but has no credential. Set ' +
+    'TOKEN_OPTIMIZER_API_KEY, or point TOKEN_OPTIMIZER_HARVEST_ENDPOINT at a local model ' +
+    'to run it without one.',
+};
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * A session id reduced to something that cannot leave the marker directory.
+ *
+ * The id arrives in the hook payload, so it is external input, and it was being
+ * interpolated straight into a path: a value containing separators or `..` would
+ * have placed (and later read) the marker anywhere on disk. Everything outside a
+ * conservative allowlist becomes an underscore, which keeps ordinary uuids
+ * readable while making traversal unrepresentable rather than merely unlikely.
+ */
+function markerName(sessionId) {
+  const safe = String(sessionId || 'unknown').replace(/[^A-Za-z0-9._-]/g, '_');
+  // A name of only dots would still resolve to a directory entry.
+  const cleaned = /^[.]+$/.test(safe) ? 'unknown' : safe;
+  return `harvest-notice-${cleaned.slice(0, 64)}`;
+}
+
+/**
+ * A private, per-user directory for this hook's markers.
+ *
+ * os.tmpdir() is per-user on Windows but resolves to a SHARED, world-writable
+ * /tmp on POSIX. The marker name is derived from the session id, so it is
+ * predictable enough for another local user to pre-create -- as a symlink, or
+ * as a file they own -- and writeFileSync would then follow it and write
+ * through with this user's privileges.
+ *
+ * The state here is a debounce timestamp and a "said it once" flag, so the fix
+ * is not to guard a shared location but to stop using one. XDG_STATE_HOME is
+ * the standard place for state that should persist across runs but is not
+ * precious, and it is inside the user's own home on every POSIX system.
+ */
+function stateDir() {
+  const home = homedir();
+  const base =
+    process.platform === 'win32'
+      ? process.env.LOCALAPPDATA || tmpdir()
+      : process.env.XDG_STATE_HOME ||
+        (home ? join(home, '.local', 'state') : tmpdir());
+
+  const dir = join(base, 'token-optimizer');
+  try {
+    // 0o700 AND an explicit chmod, for the reason the graph store documents:
+    // `recursive` applies the mode only to directories it actually creates, and
+    // the umask masks it further, so neither alone guarantees the result.
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    try {
+      chmodSync(dir, 0o700);
+    } catch {
+      // Not POSIX, or not ours to chmod.
+    }
+  } catch {
+    /* best effort */
+  }
+  return dir;
+}
+
+/** Where the once-per-session notice is remembered, so Stop does not nag. */
+function noticePath(sessionId) {
+  return join(stateDir(), markerName(sessionId));
+}
+
+/**
+ * True when the path is absent, or is a regular file this user owns.
+ *
+ * lstat rather than stat: stat FOLLOWS the link and would happily report on the
+ * target, which is the thing being defended against.
+ */
+function ownedRegularFile(path) {
+  let info;
+  try {
+    info = lstatSync(path);
+  } catch {
+    return true; // Absent. The O_NOFOLLOW open below settles the race.
+  }
+  if (!info.isFile()) return false;
+  // getuid is undefined on Windows, where stateDir() is already per-user.
+  if (typeof process.getuid === 'function' && info.uid !== process.getuid())
+    return false;
+  return true;
+}
+
+/**
+ * Writes a marker, refusing to follow a symlink.
+ *
+ * O_NOFOLLOW makes the refusal ATOMIC rather than a check-then-use window: a
+ * link swapped in after ownedRegularFile() returns fails the open instead of
+ * being written through. The flag does not exist on Windows, where it is
+ * undefined and falls back to 0 -- acceptable, because the directory is
+ * per-user there to begin with.
+ */
+function writeMarker(path, contents) {
+  if (!ownedRegularFile(path)) return false;
+  const NOFOLLOW = constants.O_NOFOLLOW || 0;
+  let fd;
+  try {
+    fd = openSync(
+      path,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | NOFOLLOW,
+      0o600
+    );
+    writeSync(fd, contents);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* already closed */
+      }
+    }
+  }
+}
+
+/** Reads a marker, ignoring anything that is not a regular file we own. */
+function readMarker(path) {
+  if (!ownedRegularFile(path)) return null;
+  try {
+    return readFileSync(path, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function alreadyNotified(sessionId) {
+  const path = noticePath(sessionId);
+  // Anything already at this path -- our marker, or something planted -- means
+  // stay quiet. Repeating the notice is the worse failure, and refusing to
+  // write over a foreign file is the point.
+  if (existsSync(path)) return true;
+  return !writeMarker(path, String(Date.now()));
+}
+
+/** Minimum gap between harvests of one session. */
+const HARVEST_INTERVAL_MS =
+  Number(process.env.TOKEN_OPTIMIZER_HARVEST_INTERVAL_MS) > 0
+    ? Number(process.env.TOKEN_OPTIMIZER_HARVEST_INTERVAL_MS)
+    : 10 * 60 * 1000;
+
+/**
+ * True when this session has not been harvested recently, and records that it
+ * is about to be.
+ *
+ * Deliberately marks only when a harvest actually starts: touching it on every
+ * Stop would let a run of skipped turns keep pushing the next harvest away.
+ */
+function dueForHarvest(sessionId) {
+  const marker = join(stateDir(), `harvest-last-${markerName(sessionId)}`);
+
+  const last = Number(readMarker(marker));
+  // > 0 matters: readMarker returns null when the marker is missing or is not
+  // ours, and Number(null) is 0, which is finite -- so without this an absent
+  // marker would read as a harvest at the epoch.
+  if (
+    Number.isFinite(last) &&
+    last > 0 &&
+    Date.now() - last < HARVEST_INTERVAL_MS
+  ) {
+    return false;
+  }
+
+  // If the marker cannot be written the debounce degrades to off rather than
+  // blocking the harvest entirely.
+  writeMarker(marker, String(Date.now()));
+  return true;
+}
+
+/**
+ * The Stop-time harvest, for every client rather than one.
+ *
+ * WHY THIS IS A FUNCTION AND NOT A HOOK. It was a hook -- a Claude Code entry
+ * point named `stop-harvest.mjs` -- and #300 unregistered it. Nothing replaced
+ * it, so four capabilities went silently: the transcript archive, the harvest
+ * worker spawn, refusal detection, and the notice that says why no findings
+ * exist. Every client routes Stop through the shared adapter, and the adapter
+ * did none of these, so on a full session with a valid credential
+ * `harvestMode()` reported `remote` and nothing happened.
+ *
+ * NOTHING OBSERVED THAT IT DID NOT RUN, which is why it survived a year. There
+ * is no `kind:'harvest'` event to be absent from a report, no error, and a
+ * harvest that ran and found nothing looks exactly like one that never
+ * started. The reachability guard could not see it either: this file's own
+ * imports gave `archive`, `detectRefusals` and `recordRefusal` call sites, and
+ * a name-based scan proves a reference exists, never that it runs.
+ *
+ * Returns a notice for the caller to emit, or null. It does NOT write to
+ * stdout: the adapter emits exactly one JSON object per hook invocation, and a
+ * second writer racing it is how a Stop payload gets corrupted.
+ *
+ * @returns {Promise<string|null>} a once-per-session message, or null.
+ */
+export async function runStopHarvest(payload = {}) {
+  if (mode() === MODE_OFF) return null;
+
+  const transcript = payload.transcript_path ?? payload.transcriptPath ?? null;
+  if (!transcript || !existsSync(transcript)) return null;
+
+  // ARCHIVE FIRST, AND UNCONDITIONALLY. This is a local file copy: it costs no
+  // model call, spends no money, and sends nothing anywhere, so it must not sit
+  // behind the opt-in that exists to gate cost and disclosure. Gating it there
+  // would mean the record of what the user actually said is kept only for the
+  // users who opted into a paid feature, which is exactly backwards.
+  //
+  // It also has to happen before the early return below, or a session with
+  // harvesting off would archive nothing at all.
+  try {
+    archive(
+      wikiDir(
+        projectRootFor(
+          join(payload.cwd || process.cwd(), '__session__'),
+          payload.cwd
+        )
+      ),
+      transcript,
+      {
+        sessionId: payload.session_id,
+      }
+    );
+  } catch {
+    // The archive is a convenience. Failing to write it must not affect Stop.
+  }
+
+  // CLOSE THE REFUSAL LOOP, and do it OUTSIDE the harvest opt-in. Reading the
+  // transcript this process already holds costs no model call and sends nothing
+  // anywhere, so gating it behind the paid feature would leave a mis-scoped
+  // lesson costing tokens forever for everyone who did not opt in.
+  //
+  // The model states plainly when a cross-project lesson does not transfer --
+  // "that figure is another repo's baseline and it doesn't transfer" -- and until
+  // now nothing read it, so the same lesson was delivered again next session.
+  try {
+    const shared = sharedDir();
+    const lessons = [...load(shared).nodes.values()].filter(
+      (n) => n.kind === 'finding' && !n.retired && n.claim
+    );
+    if (lessons.length) {
+      const text = readFileSync(transcript, 'utf8');
+      for (const key of detectRefusals(lessons, text))
+        recordRefusal(shared, key);
+    }
+  } catch {
+    // Feedback is a refinement; a failure here must not affect Stop.
+  }
+
+  if (!harvestEnabled()) {
+    // Say it once, name the reason and the variable that changes it, and state
+    // what still works. A user who reads this should know exactly what they are
+    // and are not getting, and what to do about it.
+    const message = OFF_REASON[harvestMode()];
+    // RETURNED, NOT WRITTEN. This used to write its own JSON to stdout and
+    // race whatever the hook emitted; the adapter now folds this into the one
+    // object it sends, so the notice cannot be dropped by a full pipe or
+    // truncated by an exit -- which is what used to happen to the single line
+    // explaining why no findings exist.
+    if (message && !alreadyNotified(payload.session_id)) return message;
+    return null;
+  }
+
+  // SIBLING IN THE SHARED CORE. The worker used to live beside the hook entry
+  // in `plugin/hooks/`, which is why only Claude Code could ever have spawned
+  // it -- it was vendored to no other client. It now sits in the core that
+  // every client receives an identical copy of, so this resolves in all
+  // eleven.
+  const worker = join(HERE, 'harvest-worker.mjs');
+  if (!existsSync(worker)) return null;
+
+  // DEBOUNCE. Stop fires at the end of every assistant turn, so a talkative
+  // session would spawn a model call per turn -- each re-reading an overlapping
+  // transcript and re-extracting most of the same findings. The marker is
+  // touched only when a harvest is actually started, so a skipped turn does not
+  // push the next one further away.
+  if (!dueForHarvest(payload.session_id)) return null;
+
+  // Detached and fully released: the harvest must outlive this hook without
+  // holding Stop open for a model round-trip.
+  const child = spawn(
+    process.execPath,
+    [
+      worker,
+      transcript,
+      String(payload.session_id || ''),
+      String(payload.cwd || process.cwd()),
+    ],
+    {
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: true,
+      env: { ...process.env },
+    }
+  );
+  child.unref();
+  return null;
+}

--- a/scripts/sync-hook-core.mjs
+++ b/scripts/sync-hook-core.mjs
@@ -52,6 +52,28 @@ const banner = (name) =>
     ? `process.env.TOKEN_OPTIMIZER_VERSION = '${PACKAGE_VERSION}';\n`
     : '');
 
+/**
+ * Banners a core file, keeping any hashbang on line one.
+ *
+ * NODE ACCEPTS A HASHBANG ONLY AT BYTE ZERO. Anywhere else it is a syntax
+ * error, so prepending the banner to an executable core file produced a
+ * vendored copy that cannot parse at all -- and harvest-worker.mjs is spawned
+ * detached with stdio ignored, which means the failure is completely silent.
+ * The harvest would have gone on not running, for exactly the reason it was
+ * not running before, with a green suite on either side of it.
+ *
+ * Handled here rather than by deleting the hashbang, because the next
+ * executable added to the core would hit this again and the failure mode is
+ * invisible by construction.
+ */
+function withBanner(name, source) {
+  const text = String(source);
+  if (!text.startsWith('#!')) return banner(name) + text;
+  const newline = text.indexOf(String.fromCharCode(10));
+  if (newline === -1) return text + String.fromCharCode(10) + banner(name);
+  return text.slice(0, newline + 1) + banner(name) + text.slice(newline + 1);
+}
+
 // The EOL-safe comparison this file used to carry locally now lives in
 // scripts/lib/text.mjs, because it was needed by the other two generators and
 // having it here only meant they went without it. See that module for why.
@@ -60,7 +82,7 @@ let drifted = 0;
 
 for (const target of TARGETS) {
   for (const name of files) {
-    const contents = banner(name) + readFileSync(join(SOURCE, name), 'utf8');
+    const contents = withBanner(name, readFileSync(join(SOURCE, name), 'utf8'));
     const destination = join(target, name);
 
     if (check) {

--- a/tests/hooks/feedback-e2e.test.mjs
+++ b/tests/hooks/feedback-e2e.test.mjs
@@ -27,7 +27,7 @@ import { standingRules } from '../../hooks-core/inject.mjs';
 import { ORIGIN_HUMAN } from '../../hooks-core/curate.mjs';
 import { transcriptDir, safeName } from '../../hooks-core/transcript.mjs';
 
-const WORKER = join(process.cwd(), 'plugin', 'hooks', 'harvest-worker.mjs');
+const WORKER = join(process.cwd(), 'hooks-core', 'harvest-worker.mjs');
 const SESSION = 's-feedback-e2e';
 
 let project;
@@ -179,39 +179,39 @@ describe('the feedback loop end to end', () => {
     expect(rules).toContain('Use npm test, not npx jest.');
   }, 120_000);
 });
-
-describe('the worker reports its own status honestly', () => {
-  // The `finally` used to assign `process.exitCode = 0` unconditionally, which
-  // would turn a harvest that had already recorded a failure into one that
-  // reports success. Reported by CodeRabbit on the PR. It matters more here
-  // than it looks: the worker is spawned DETACHED, so its exit status is the
-  // only signal a supervisor could ever act on.
-  it('does not overwrite a failure code recorded before the finally', async () => {
-    const { mkdtempSync: mk, writeFileSync: wf } = await import('fs');
-    const probe = join(mkdtempSync(join(tmpdir(), 'exitcode-')), 'probe.mjs');
-    mkdirSync(join(probe, '..'), { recursive: true });
-
-    // The exact shape of the worker's tail, in isolation: a main() that records
-    // a failure, the same catch, and the same finally.
-    wf(
-      probe,
-      [
-        'async function main() { process.exitCode = 3; throw new Error("boom"); }',
-        'main()',
-        '  .catch(() => {})',
-        '  .finally(() => {',
-        '    const code = process.exitCode ?? 0;',
-        '    process.exitCode = code;',
-        '    const w = setTimeout(() => process.exit(code), 5000);',
-        '    w.unref();',
-        '  });',
-      ].join('\n')
-    );
-
-    const r = await new Promise((resolve) => {
-      const c = spawn(process.execPath, [probe]);
-      c.on('close', (code) => resolve(code));
-    });
-    expect(r).toBe(3);
-  }, 60_000);
-});
+
+describe('the worker reports its own status honestly', () => {
+  // The `finally` used to assign `process.exitCode = 0` unconditionally, which
+  // would turn a harvest that had already recorded a failure into one that
+  // reports success. Reported by CodeRabbit on the PR. It matters more here
+  // than it looks: the worker is spawned DETACHED, so its exit status is the
+  // only signal a supervisor could ever act on.
+  it('does not overwrite a failure code recorded before the finally', async () => {
+    const { mkdtempSync: mk, writeFileSync: wf } = await import('fs');
+    const probe = join(mkdtempSync(join(tmpdir(), 'exitcode-')), 'probe.mjs');
+    mkdirSync(join(probe, '..'), { recursive: true });
+
+    // The exact shape of the worker's tail, in isolation: a main() that records
+    // a failure, the same catch, and the same finally.
+    wf(
+      probe,
+      [
+        'async function main() { process.exitCode = 3; throw new Error("boom"); }',
+        'main()',
+        '  .catch(() => {})',
+        '  .finally(() => {',
+        '    const code = process.exitCode ?? 0;',
+        '    process.exitCode = code;',
+        '    const w = setTimeout(() => process.exit(code), 5000);',
+        '    w.unref();',
+        '  });',
+      ].join('\n')
+    );
+
+    const r = await new Promise((resolve) => {
+      const c = spawn(process.execPath, [probe]);
+      c.on('close', (code) => resolve(code));
+    });
+    expect(r).toBe(3);
+  }, 60_000);
+});

--- a/tests/hooks/harvest-worker-subdirectory-root.test.mjs
+++ b/tests/hooks/harvest-worker-subdirectory-root.test.mjs
@@ -25,7 +25,7 @@ import { join } from 'path';
 import { load, nodeId } from '../../hooks-core/wiki.mjs';
 import { canonicalPath } from '../../hooks-core/paths.mjs';
 
-const WORKER = join(process.cwd(), 'plugin', 'hooks', 'harvest-worker.mjs');
+const WORKER = join(process.cwd(), 'hooks-core', 'harvest-worker.mjs');
 const SESSION = 's-subdir-root';
 
 let project;

--- a/tests/hooks/stop-reaches-the-harvest.test.mjs
+++ b/tests/hooks/stop-reaches-the-harvest.test.mjs
@@ -182,4 +182,48 @@ describe('the harvest worker is reachable from every client, not one', () => {
       expect([lib, existsSync(join(lib, 'harvest-worker.mjs'))]).toEqual([lib, true]);
     }
   });
+
+  test('every vendored copy actually PARSES, not merely exists', () => {
+    // THE ASSERTION WHOSE ABSENCE LET THIS SHIP BROKEN ONCE ALREADY. The check
+    // above says the worker is there; it said so while every vendored copy was
+    // a syntax error, because the sync banner had pushed the hashbang off line
+    // one and Node accepts one only at byte zero. The worker is spawned
+    // detached with stdio ignored, so it would have failed instantly and
+    // silently -- the harvest still not running, for the same reason as before,
+    // with a green suite either side.
+    //
+    // Existence is not executability, which is this whole pull request's point
+    // applied to its own output.
+    const libs = readdirSync(join(ROOT, 'hooks-core')).filter((f) => f.endsWith('.mjs'));
+    expect(libs.length).toBeGreaterThan(20);
+
+    for (const dir of [
+      join(ROOT, 'plugin', 'hooks', 'lib'),
+      join(ROOT, 'integrations', 'codex', 'hooks', 'lib'),
+      join(ROOT, 'integrations', 'qwen', 'hooks', 'lib'),
+    ]) {
+      for (const name of libs) {
+        const file = join(dir, name);
+        const check = spawnSync(process.execPath, ['--check', file], { encoding: 'utf8' });
+        expect([file, check.status]).toEqual([file, 0]);
+      }
+    }
+  });
+
+  test('a hashbang in a core file survives vendoring on line one', () => {
+    // Pinned as a property of the generator rather than of one file, because
+    // the next executable added to hooks-core hits this again and the failure
+    // is invisible by construction.
+    const source = readFileSync(join(ROOT, 'hooks-core', 'harvest-worker.mjs'), 'utf8');
+    expect(source.startsWith('#!')).toBe(true);
+    for (const dir of [
+      join(ROOT, 'plugin', 'hooks', 'lib'),
+      join(ROOT, 'integrations', 'windsurf', 'hooks', 'lib'),
+    ]) {
+      const vendored = readFileSync(join(dir, 'harvest-worker.mjs'), 'utf8');
+      expect([dir, vendored.startsWith('#!')]).toEqual([dir, true]);
+      // And the banner is still there, on the line after.
+      expect(vendored).toContain('GENERATED FILE');
+    }
+  });
 });

--- a/tests/hooks/stop-reaches-the-harvest.test.mjs
+++ b/tests/hooks/stop-reaches-the-harvest.test.mjs
@@ -23,6 +23,7 @@
 
 import { afterEach, beforeEach, describe, expect, test } from '@jest/globals';
 import { spawnSync } from 'node:child_process';
+import vm from 'node:vm';
 import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -53,6 +54,40 @@ afterEach(() => {
     /* windows can hold a handle briefly */
   }
 });
+
+/**
+ * Every directory holding a vendored copy of the shared core.
+ *
+ * DISCOVERED, NOT LISTED. A hand-written list covered three of the twelve and
+ * still read as coverage -- and the thirteenth client, added later, would have
+ * been missed by exactly the same silence this file exists to break. Any
+ * directory named `lib` that holds an `adapter.mjs` is a vendored core by
+ * construction, because that is what `sync-hook-core` produces.
+ */
+function vendoredLibs() {
+  const found = [];
+  const walk = (dir) => {
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory() || entry.name === 'node_modules') continue;
+      const full = join(dir, entry.name);
+      if (entry.name === 'lib' && existsSync(join(full, 'adapter.mjs'))) found.push(full);
+      else walk(full);
+    }
+  };
+  walk(join(ROOT, 'plugin'));
+  walk(join(ROOT, 'integrations'));
+  // A discovery that finds nothing would pass every assertion below forever.
+  // Eleven is what sync-hook-core lists today; the floor guards a broken walk,
+  // not the exact roster, so a twelfth client raises it rather than breaking it.
+  expect(found.length).toBeGreaterThanOrEqual(11);
+  return found;
+}
 
 function runStop(env = {}, sessionId = null) {
   const merged = { ...process.env, [STATE_VAR]: state };
@@ -167,17 +202,9 @@ describe('the harvest worker is reachable from every client, not one', () => {
 
   test('is vendored beside the adapter in every client that has one', () => {
     // The adapter resolves the worker as a sibling, so this is the property the
-    // spawn depends on -- asserted per client rather than assumed from the
-    // sync script having run.
-    const libs = [
-      join(ROOT, 'plugin', 'hooks', 'lib'),
-      join(ROOT, 'integrations', 'codex', 'hooks', 'lib'),
-      join(ROOT, 'integrations', 'qwen', 'hooks', 'lib'),
-      join(ROOT, 'integrations', 'cursor', 'hooks', 'lib'),
-      join(ROOT, 'integrations', 'windsurf', 'hooks', 'lib'),
-      join(ROOT, 'integrations', 'cline', 'hooks', 'token-optimizer', 'lib'),
-    ];
-    for (const lib of libs) {
+    // spawn depends on -- asserted per client rather than assumed from the sync
+    // script having run.
+    for (const lib of vendoredLibs()) {
       expect([lib, existsSync(join(lib, 'adapter.mjs'))]).toEqual([lib, true]);
       expect([lib, existsSync(join(lib, 'harvest-worker.mjs'))]).toEqual([lib, true]);
     }
@@ -192,20 +219,27 @@ describe('the harvest worker is reachable from every client, not one', () => {
     // silently -- the harvest still not running, for the same reason as before,
     // with a green suite either side.
     //
-    // Existence is not executability, which is this whole pull request's point
+    // Existence is not executability, which is this whole change's point
     // applied to its own output.
-    const libs = readdirSync(join(ROOT, 'hooks-core')).filter((f) => f.endsWith('.mjs'));
-    expect(libs.length).toBeGreaterThan(20);
+    //
+    // EVERY DIRECTORY, and parsed IN PROCESS. The first version checked three
+    // of the twelve and spawned `node --check` per file: partial coverage that
+    // reads as coverage, and too slow to widen. `vm.SourceTextModule` compiles
+    // ESM without evaluating it, which is the same parse `--check` performs.
+    const core = readdirSync(join(ROOT, 'hooks-core')).filter((f) => f.endsWith('.mjs'));
+    expect(core.length).toBeGreaterThan(20);
 
-    for (const dir of [
-      join(ROOT, 'plugin', 'hooks', 'lib'),
-      join(ROOT, 'integrations', 'codex', 'hooks', 'lib'),
-      join(ROOT, 'integrations', 'qwen', 'hooks', 'lib'),
-    ]) {
-      for (const name of libs) {
-        const file = join(dir, name);
-        const check = spawnSync(process.execPath, ['--check', file], { encoding: 'utf8' });
-        expect([file, check.status]).toEqual([file, 0]);
+    for (const lib of vendoredLibs()) {
+      for (const name of core) {
+        const file = join(lib, name);
+        let error = null;
+        try {
+          // eslint-disable-next-line no-new
+          new vm.SourceTextModule(readFileSync(file, 'utf8'));
+        } catch (caught) {
+          error = String(caught && caught.message);
+        }
+        expect([file, error]).toEqual([file, null]);
       }
     }
   });
@@ -216,14 +250,18 @@ describe('the harvest worker is reachable from every client, not one', () => {
     // is invisible by construction.
     const source = readFileSync(join(ROOT, 'hooks-core', 'harvest-worker.mjs'), 'utf8');
     expect(source.startsWith('#!')).toBe(true);
-    for (const dir of [
-      join(ROOT, 'plugin', 'hooks', 'lib'),
-      join(ROOT, 'integrations', 'windsurf', 'hooks', 'lib'),
-    ]) {
-      const vendored = readFileSync(join(dir, 'harvest-worker.mjs'), 'utf8');
-      expect([dir, vendored.startsWith('#!')]).toEqual([dir, true]);
-      // And the banner is still there, on the line after.
-      expect(vendored).toContain('GENERATED FILE');
+
+    for (const lib of vendoredLibs()) {
+      // Trimmed per line, because the vendored copies carry CRLF on Windows and
+      // this assertion is about WHICH LINE the banner is on, not about endings.
+      const lines = readFileSync(join(lib, 'harvest-worker.mjs'), 'utf8')
+        .split(NL)
+        .map((line) => line.trim());
+      expect([lib, lines[0].startsWith('#!')]).toEqual([lib, true]);
+      // THE SECOND LINE, not merely somewhere in the file. `toContain` passed
+      // wherever the banner happened to land, which is the layout this test
+      // exists to pin.
+      expect([lib, lines[1]]).toEqual([lib, '// GENERATED FILE -- do not edit.']);
     }
   });
 });

--- a/tests/hooks/stop-reaches-the-harvest.test.mjs
+++ b/tests/hooks/stop-reaches-the-harvest.test.mjs
@@ -1,0 +1,185 @@
+/**
+ * The Stop path actually reaches the harvest.
+ *
+ * #300 unregistered `plugin/hooks/stop-harvest.mjs` and nothing replaced it, so
+ * four capabilities went silently: the transcript archive, the harvest worker
+ * spawn, refusal detection, and the notice that says why no findings exist. On
+ * a full session with a valid credential, `harvestMode()` reported `remote` and
+ * nothing happened.
+ *
+ * WHY IT SURVIVED A YEAR, and what this file is really for. Nothing observed
+ * that the harvest had not run. There is no `kind:'harvest'` event to be absent
+ * from a report, no error, and a harvest that ran and found nothing looks
+ * exactly like one that never started. The reachability guard could not see it
+ * either: the unregistered file's own imports gave `archive`, `detectRefusals`
+ * and `recordRefusal` their call sites, and a name-based scan proves a
+ * REFERENCE exists, never that it RUNS. The old marker suite even kept passing,
+ * because it spawned the removed hook directly.
+ *
+ * So these assertions are deliberately about REACHABILITY THROUGH THE REGISTERED
+ * ENTRY rather than about the harvest's internals, which have their own tests.
+ * Every one of them drives the file the host is actually configured to run.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { readFileSync } from 'node:fs';
+
+const NL = String.fromCharCode(10);
+const ROOT = process.cwd();
+const STOP = join(ROOT, 'plugin', 'hooks', 'stop.mjs');
+const HOOKS_JSON = join(ROOT, 'plugin', 'hooks', 'hooks.json');
+const STATE_VAR = process.platform === 'win32' ? 'LOCALAPPDATA' : 'XDG_STATE_HOME';
+
+let work;
+let state;
+let transcript;
+
+beforeEach(() => {
+  work = mkdtempSync(join(tmpdir(), 'stop-reach-'));
+  mkdirSync(join(work, '.git'), { recursive: true });
+  state = join(work, 'state');
+  transcript = join(work, 'transcript.jsonl');
+  writeFileSync(transcript, '{"role":"user","content":"hello"}' + NL);
+});
+
+afterEach(() => {
+  try {
+    rmSync(work, { recursive: true, force: true });
+  } catch {
+    /* windows can hold a handle briefly */
+  }
+});
+
+function runStop(env = {}, sessionId = null) {
+  const merged = { ...process.env, [STATE_VAR]: state };
+  for (const key of [
+    'TOKEN_OPTIMIZER_HARVEST',
+    'TOKEN_OPTIMIZER_HARVEST_ENDPOINT',
+    'TOKEN_OPTIMIZER_API_KEY',
+    'TOKEN_OPTIMIZER_MODE',
+  ]) {
+    delete merged[key];
+  }
+  Object.assign(merged, env);
+
+  return spawnSync(process.execPath, [STOP], {
+    input: JSON.stringify({
+      transcript_path: transcript,
+      session_id: sessionId || 'reach-' + Math.random().toString(36).slice(2),
+      cwd: work,
+    }),
+    env: merged,
+    encoding: 'utf8',
+    timeout: 30_000,
+  });
+}
+
+describe('the registered Stop entry', () => {
+  test('is the file hooks.json actually points at', () => {
+    // The defect was a registration one, so the registration is asserted
+    // directly. A hooks.json that names a file which does not exist, or that
+    // stops naming Stop at all, is exactly how this happened.
+    const config = JSON.parse(readFileSync(HOOKS_JSON, 'utf8'));
+    const stop = (config.hooks || config).Stop;
+    expect(stop).toBeTruthy();
+    const command = JSON.stringify(stop);
+    expect(command).toContain('stop.mjs');
+    expect(existsSync(STOP)).toBe(true);
+  });
+
+  test('archives the transcript, even with harvesting off', () => {
+    // ARCHIVE IS NOT GATED BY THE OPT-IN, deliberately: it is a local file copy
+    // that costs no model call and sends nothing anywhere. Gating it would keep
+    // the record of what the user said only for users who paid for a feature.
+    const result = runStop();
+    expect(result.status).toBe(0);
+
+    const graph = join(work, '.token-optimizer', 'wiki');
+    expect(existsSync(graph)).toBe(true);
+    const archived = readdirSync(graph).filter((f) => f.includes('transcript'));
+    expect(archived.length).toBeGreaterThan(0);
+  });
+
+  test('says once why no findings exist when the harvest cannot run', () => {
+    // Silence is how this stayed invisible: a user sees a graph filling with
+    // structural nodes and no findings, and has no way to learn why.
+    const result = runStop();
+    expect(result.status).toBe(0);
+    expect(result.stdout).toMatch(/token-optimizer:/);
+  });
+
+  test('emits ONE json object, with the notice folded into it', () => {
+    // The old hook wrote its own JSON to stdout beside whatever the adapter
+    // emitted. Two writers on one hook's stdout is how a Stop payload gets
+    // corrupted, so the notice is returned and merged rather than written.
+    const result = runStop();
+    expect(result.status).toBe(0);
+    expect(() => JSON.parse(result.stdout.trim())).not.toThrow();
+    expect(JSON.parse(result.stdout.trim()).systemMessage).toMatch(/token-optimizer/);
+  });
+
+  test('does not repeat the notice on the next Stop of the same session', () => {
+    // Saying it once is the difference between a disabled feature and a nag.
+    // Asserted on the shared prefix rather than one reason's wording: which
+    // OFF_REASON applies depends on the environment, and pinning the exact
+    // sentence would make this a test about the runner's env vars.
+    const first = runStop({}, 'repeat-session');
+    const second = runStop({}, 'repeat-session');
+    expect(first.status).toBe(0);
+    expect(second.status).toBe(0);
+    expect(first.stdout).toMatch(/token-optimizer:/);
+    expect(second.stdout).not.toMatch(/token-optimizer:/);
+  });
+
+  test('stays silent and succeeds when the optimizer is off entirely', () => {
+    const result = runStop({ TOKEN_OPTIMIZER_MODE: 'off' });
+    expect(result.status).toBe(0);
+    expect(result.stdout).not.toMatch(/token-optimizer:/);
+  });
+
+  test('succeeds when the transcript does not exist', () => {
+    const result = spawnSync(process.execPath, [STOP], {
+      input: JSON.stringify({
+        transcript_path: join(work, 'nope.jsonl'),
+        session_id: 'missing',
+        cwd: work,
+      }),
+      env: { ...process.env, [STATE_VAR]: state },
+      encoding: 'utf8',
+      timeout: 30_000,
+    });
+    expect(result.status).toBe(0);
+  });
+});
+
+describe('the harvest worker is reachable from every client, not one', () => {
+  test('ships in the shared core rather than beside one client entry', () => {
+    // THE REASON ONLY CLAUDE CODE COULD EVER HAVE RUN IT. The worker lived in
+    // plugin/hooks/, which is vendored to no other client, so even a correctly
+    // registered Stop on the other ten would have found no worker to spawn.
+    expect(existsSync(join(ROOT, 'hooks-core', 'harvest-worker.mjs'))).toBe(true);
+    expect(existsSync(join(ROOT, 'plugin', 'hooks', 'harvest-worker.mjs'))).toBe(false);
+  });
+
+  test('is vendored beside the adapter in every client that has one', () => {
+    // The adapter resolves the worker as a sibling, so this is the property the
+    // spawn depends on -- asserted per client rather than assumed from the
+    // sync script having run.
+    const libs = [
+      join(ROOT, 'plugin', 'hooks', 'lib'),
+      join(ROOT, 'integrations', 'codex', 'hooks', 'lib'),
+      join(ROOT, 'integrations', 'qwen', 'hooks', 'lib'),
+      join(ROOT, 'integrations', 'cursor', 'hooks', 'lib'),
+      join(ROOT, 'integrations', 'windsurf', 'hooks', 'lib'),
+      join(ROOT, 'integrations', 'cline', 'hooks', 'token-optimizer', 'lib'),
+    ];
+    for (const lib of libs) {
+      expect([lib, existsSync(join(lib, 'adapter.mjs'))]).toEqual([lib, true]);
+      expect([lib, existsSync(join(lib, 'harvest-worker.mjs'))]).toEqual([lib, true]);
+    }
+  });
+});

--- a/tests/unit/stop-harvest-markers.test.ts
+++ b/tests/unit/stop-harvest-markers.test.ts
@@ -24,7 +24,14 @@ import {
 } from 'fs';
 import { tmpdir } from 'os';
 
-const HOOK = join(process.cwd(), 'plugin', 'hooks', 'stop-harvest.mjs');
+// THE REGISTERED STOP ENTRY, not the module behind it.
+//
+// This used to spawn `plugin/hooks/stop-harvest.mjs` directly -- a file that
+// #300 removed from hooks.json, so the suite went on passing against a hook
+// nothing invoked. Driving the entry that Stop is actually wired to is what
+// makes these assertions mean anything: if the harvest stops being reachable
+// again, they fail.
+const HOOK = join(process.cwd(), 'plugin', 'hooks', 'stop.mjs');
 
 /** The env var this platform actually reads for per-user state. */
 const STATE_VAR =


### PR DESCRIPTION
Closes #322.

#300 unregistered `plugin/hooks/stop-harvest.mjs` and nothing replaced it, so four capabilities went silently: the transcript archive, the harvest worker spawn, refusal detection, and the notice that says why no findings exist. On a full session with a valid credential, `harvestMode()` reports `remote`, the user has consented by not opting out, and **nothing happens**.

## The issue understates it, and the correction changes the fix

It says the other ten adapter clients are unaffected because they reach the harvest through the shared adapter path. **They do not.** `grep` finds exactly one spawner of `harvest-worker.mjs` in the repository, and it is the unregistered file:

```
plugin/hooks/stop-harvest.mjs:318:  const worker = join(HERE, 'harvest-worker.mjs');
```

Every client routes Stop to its own generated entry, which routes to the adapter, and the adapter's stop branch only ever built the **in-band** prompt asking the model to call `wiki_write` — the very thing the design says the out-of-band harvest exists to avoid, since it makes the session pay for summarising itself. So the out-of-band harvest was dead on **all eleven clients**, not one. Qwen's Stop entry is even named `token-optimizer-semantic-harvest`.

The archive is dead on master too, not restored — `archive()` has exactly one caller and it is the same unregistered file.

## The fix

**Moved to the shared core rather than re-registered on one client.** `stop-harvest.mjs` becomes `hooks-core/stop-harvest.mjs`, exporting `runStopHarvest(payload)`, and the adapter's stop branch awaits it. Fixing only Claude Code would have left ten clients with the same dead feature.

**And the worker moved with it** — the part that made a shared fix possible at all. `harvest-worker.mjs` lived in `plugin/hooks/`, which is vendored to no other client, so even a correctly registered Stop on the other ten would have found no worker to spawn. It now sits in the core every client receives an identical copy of, and the adapter resolves it as a sibling. A test asserts that per client rather than trusting the sync script to have run.

**The notice is returned, not written.** The old hook wrote its own JSON to stdout beside whatever the hook emitted; two writers on one hook's stdout is how a Stop payload gets corrupted. The adapter folds it into the single object it emits, so the one line explaining why no findings exist can no longer be dropped by a full pipe or truncated by an exit — which is exactly what used to happen to it.

Nothing about the harvest's behaviour changes: it is still debounced, still spawns detached so Stop is never delayed by a model call, and the archive and refusal detection still run **outside** the paid opt-in, because they are local file reads that cost no model call and send nothing anywhere.

## Why it survived a year

Nothing observed that the harvest had not run. There is no `kind:'harvest'` event to be absent from a report, no error, and a harvest that ran and found nothing looks exactly like one that never started.

**The reachability guard could not see it either** — and that is worth stating plainly, because #323 shipped that guard and documented this exact limitation. The unregistered file's own imports gave `archive`, `detectRefusals` and `recordRefusal` their call sites. A name-based scan proves a *reference* exists, never that it *runs*. The existing marker suite even went on passing, because it spawned the removed hook directly; it now drives the registered entry, so it fails if the harvest becomes unreachable again.

## Verification

Nine assertions in `tests/hooks/stop-reaches-the-harvest.test.mjs`, every one through the file the host is actually configured to run. Both defects mutation-tested:

| Mutation | Result |
|---|---|
| Unwire `runStopHarvest` from the adapter | **4 of 9 fail** |
| Delete `Stop` from `hooks.json` (the #300 defect itself) | **1 fails** |

221 suites, 2706 tests, 5 skipped, 0 failed. `tsc --noEmit` clean, `npm run lint` 0 errors, `format:check` clean, `sync:hooks:check` in sync across eleven vendored directories, `validate` passes. Quality Gates run locally: `verify:clients`, `verify:certification`, `verify:harvest`, `verify:live-graph`, `verify:ui` 55/55, `verify:interactions` 64/64.

## Note for Plan 2 (#320)

Its Task 5 covers "run `derive` at Stop", and its own notes say the transcript archive was restored there. This lands in the same place — `hooks-core`'s Stop path — and restores the archive for every client, so that part of Task 5 should be dropped rather than merged twice. The in-band `wiki_write` prompt is untouched, and `derive.mjs` still has a clean seam to hook into beside `runStopHarvest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSFxBpREeR7mMkJXYb6wuX
