### PR TITLE
feat(wiki): a finding reaches every identical copy of its file

### DIFF
--- a/docs/WIKI_GRAPH.md
+++ b/docs/WIKI_GRAPH.md
@@ -156,6 +156,67 @@ The known cost: a finding unreachable by any edge is invisible to traversal.
 Lexical search is the mitigation. If measurement shows real recall loss,
 embeddings can be added later as *one more edge type* — never as the mechanism.
 
+
+## Content-addressed retrieval
+
+A vendored file is the same file wherever it sits, whatever path each copy is
+given. This repository is its own example: the shared hook core is vendored into
+eleven directories, byte-identical, so a finding recorded against
+`plugin/hooks/lib/adapter.mjs` said nothing at all to a reader touching
+`integrations/qwen/hooks/lib/adapter.mjs`.
+
+**It is an index, not a second identity.** The obvious implementation mints a
+second anchor id of the form `content:<hash>:<size>` — and a second identity for
+one file is the defect this codebase has already been burned by. `canonicalKey`
+lives *inside* `nodeId` precisely because a caller that forgot produced a second
+node for a file that already existed and split its findings invisibly.
+
+So nothing new is stored and no node is created. A file node has carried the
+sha256 of its contents since staleness needed it; content identity has been in
+the graph since P2 and was simply never read that way. There is still exactly
+one node per path and one set of `derived_from` edges per finding, so there is
+no history to split.
+
+The three remaining questions fall out rather than being decided:
+
+| Question | Answer |
+|---|---|
+| Identical content at two paths in one repository | The ordinary case, not an edge one: one content group, findings shared both ways. |
+| Does staleness follow content or path? | **Path**, exactly as before. Content identity *is* the hash, so a file whose bytes change stops matching its old group without anything having to notice. There is no such thing as a stale content anchor to invalidate. |
+| What does it do to cross-project transfer? | **Nothing.** It reads one graph, so it can only ever surface findings already in the graph being read. `fleet.mjs` and the shared tier remain the only path between projects, with their gates intact. |
+
+**The hash is 64 bits**, because `staleness.mjs` slices the sha256 to sixteen
+hex characters. Equal hashes are strong evidence of equal content and not proof
+of it, and two unrelated files sharing a digest would silently share each
+other's findings — which is why the original design carried a size beside the
+digest. `indexFile` now records one, and grouping requires both to agree when
+both are known. A node written before that field existed, or minted for an
+import target and never read, has no size; grouping is permissive there, because
+refusing would make the feature quietly stop working on every graph that
+predates it.
+
+Empty files never group: every empty file in a repository shares one hash and
+they are not the same file in any sense a reader cares about. The peer set is
+capped, because a vendored core in eleven directories is the case this exists
+for and a generated asset checked in five hundred times is the case that would
+turn one retrieval into a scan.
+
+### What this deliberately does not do
+
+The issue that asked for this wanted a finding about a vendored file to reach
+**every repository** holding it. This delivers that within one graph and not
+across machines, and the gap is a storage decision rather than an oversight.
+
+The shared tier is per-machine and holds only lessons that do not depend on any
+repository's contents. A content-anchored finding is the opposite of that by
+construction: it is a claim about specific bytes. Carrying it across projects
+would need a third tier — per-machine, content-keyed, holding
+repository-dependent claims — and that tier has a privacy posture nothing here
+has yet: a claim derived inside a private repository would surface in another
+one because both vendor the same dependency. That is a decision about what
+leaves a repository, and it belongs to whoever owns the product rather than to
+the change that made the retrieval possible.
+
 ## Injection — both layers, hard budget
 
 **SessionStart** injects a compact index: titles and ids only, so the model knows

--- a/hooks-core/staleness.mjs
+++ b/hooks-core/staleness.mjs
@@ -148,7 +148,23 @@ export function indexFile(dir, rawPath, text) {
   // staleness detection; only the diff degrades, and `serve` already states
   // plainly when evidence cannot be reconstructed.
   const snapshot = source.length <= snapshotLimit() ? source : undefined;
-  const fileNode = putNode(dir, { kind: 'file', key: path, hash: hash(source), snapshot });
+  // BYTES BESIDE THE HASH, because the hash is truncated to 64 bits and content
+  // identity is now read from it. `contentPeers` groups files by identical
+  // content, and two unrelated files sharing a 16-hex-character digest would
+  // silently share each other's findings. The deleted `contentAnchor` carried a
+  // size for exactly this reason and said so; the size is free here, since the
+  // source is already in hand.
+  //
+  // NOT THE SNAPSHOT, which would have been the obvious discriminator and is
+  // unavailable: `putNode` writes snapshots to a separate file that `load()`
+  // deliberately skips, so a loaded node never carries one.
+  const fileNode = putNode(dir, {
+    kind: 'file',
+    key: path,
+    hash: hash(source),
+    bytes: Buffer.byteLength(source),
+    snapshot,
+  });
 
   const symbols = extractSymbols(path, source);
   for (const symbol of symbols) {

--- a/hooks-core/wiki.mjs
+++ b/hooks-core/wiki.mjs
@@ -872,27 +872,135 @@ export function load(dir, { snapshots = false } = {}) {
 }
 
 /**
+ * The sha256 of nothing.
+ *
+ * Every empty file in a repository shares this hash, and they are not the same
+ * file in any sense a reader cares about -- a `.gitkeep` beside an empty
+ * `index.js` beside a placeholder test. Grouping them would make one finding
+ * about one empty file surface on every other, which is noise wearing the
+ * shape of a feature.
+ */
+const EMPTY_CONTENT_HASH = 'e3b0c44298fc1c14';
+
+/**
+ * How many identical copies of one file are followed.
+ *
+ * A vendored core in eleven directories is the case this exists for; a
+ * generated asset checked in five hundred times is the case that would turn one
+ * retrieval into a scan. The cap is far above any real vendoring and far below
+ * anything pathological, and it is applied to the PEERS rather than to the
+ * findings so the ranking below still chooses among a full candidate set.
+ */
+const MAX_CONTENT_PEERS = 32;
+
+/**
+ * Other paths in THIS graph holding byte-identical content to `anchorId`.
+ *
+ * WHY CONTENT IS NOT A SECOND IDENTITY. The obvious implementation of #319 --
+ * the deleted `contentAnchor` -- minted a second anchor id of the form
+ * `content:<hash>:<size>`, and that is the one thing this codebase has already
+ * been burned by: `canonicalKey` lives INSIDE `nodeId` precisely because a
+ * caller that forgot produced a second node for a file that already existed and
+ * split its findings invisibly. A second identity for the same file is that
+ * defect by construction.
+ *
+ * So nothing new is stored and no node is created. A file node already carries
+ * the sha256 of its contents, because staleness needs it -- content identity
+ * has been sitting in the graph since P2. This is an index over what is already
+ * there, which means it cannot split a history: there is still exactly one node
+ * per path, and a finding still has exactly one set of `derived_from` edges.
+ *
+ * STALENESS IS UNAFFECTED, and follows the path exactly as before. That falls
+ * out rather than being decided: content identity IS the hash, so a file whose
+ * bytes change simply stops matching the group and starts matching whichever
+ * group its new bytes belong to. There is no such thing as a stale content
+ * anchor to invalidate.
+ *
+ * SCOPE IS ONE GRAPH, deliberately. This can only ever surface findings that
+ * are already in the graph being read, so it opens no path between projects and
+ * changes nothing about `fleet.mjs` or the shared tier, which remain the only
+ * cross-project transfer and keep their own gates. See docs/WIKI_GRAPH.md for
+ * why the cross-repository half of #319 needs a storage decision this does not
+ * take.
+ */
+export function contentPeers(graph, anchorId) {
+  const anchor = graph.nodes.get(anchorId);
+  if (!anchor || anchor.kind !== 'file') return [];
+
+  const hash = typeof anchor.hash === 'string' ? anchor.hash : '';
+  // A file node minted for an IMPORT TARGET carries no hash at all -- see
+  // `indexFile`, which creates one for every resolved import without reading
+  // it. Grouping on a missing hash would make every unread import in the
+  // repository one content group, which is the largest possible wrong answer.
+  if (!hash || hash === EMPTY_CONTENT_HASH) return [];
+
+  const peers = [];
+  for (const node of graph.nodes.values()) {
+    if (peers.length >= MAX_CONTENT_PEERS) break;
+    if (node.kind !== 'file' || node.id === anchorId) continue;
+    if (node.hash !== hash) continue;
+
+    // THE HASH IS TRUNCATED TO 64 BITS -- `staleness.mjs` slices the sha256 to
+    // sixteen hex characters -- so equal hashes are strong evidence of equal
+    // content and not proof of it, and two unrelated files sharing a digest
+    // would silently share each other's findings. The deleted `contentAnchor`
+    // carried a size beside the digest for exactly this reason, and `indexFile`
+    // now records one.
+    //
+    // ABSENCE IS PERMISSIVE, and deliberately. A node written before `bytes`
+    // existed, or one minted for an import target and never read, has none --
+    // and refusing to group those would make the feature quietly stop working
+    // on every graph that predates it, healing only as files happen to be
+    // touched. Where both sides know their size they must agree.
+    const mine = anchor.bytes;
+    const theirs = node.bytes;
+    if (typeof mine === 'number' && typeof theirs === 'number' && mine !== theirs) continue;
+
+    peers.push(node.id);
+  }
+  return peers;
+}
+
+/**
  * Findings reachable from a file or symbol, by traversal.
  *
  * This is the retrieval primitive the whole design rests on -- no embeddings,
  * no vector index. It follows `derived_from` edges backwards from an anchor to
  * the findings that depend on it, then one hop further through `contains` so
  * that touching a file also surfaces findings about the symbols inside it.
+ *
+ * AND ACROSS IDENTICAL COPIES. A vendored file is the same file wherever it
+ * sits, whatever path each copy is given, so a finding about one copy is a
+ * finding about all of them. This repository is its own example: the shared
+ * hook core is vendored into eleven directories, byte-identical, and until now
+ * a finding recorded against one of them was invisible from the other ten.
+ * `contentPeers` explains why this is an index rather than a second identity.
  */
 export function findingsFor(graph, anchorId, { limit = 20 } = {}) {
-  const anchors = new Set([anchorId]);
+  const anchors = new Set([anchorId, ...contentPeers(graph, anchorId)]);
   for (const edge of graph.edges) {
-    if (edge.edge === 'contains' && edge.from === anchorId) anchors.add(edge.to);
+    // Symbols are expanded from every anchor, not only the one asked for: a
+    // finding about a function inside a vendored file is exactly as applicable
+    // in the copy the reader is actually touching.
+    if (edge.edge === 'contains' && anchors.has(edge.from)) anchors.add(edge.to);
   }
 
   const found = [];
+  // DEDUPED BY ID. A finding can now be reached more than once -- through a file
+  // and a symbol it contains, or through two identical copies of the same file
+  // -- and returning it twice would spend the injection budget twice on one
+  // claim and let it outrank a rival by being duplicated.
+  const seen = new Set();
   for (const edge of graph.edges) {
     if (edge.edge !== 'derived_from' || !anchors.has(edge.to)) continue;
     const node = graph.nodes.get(edge.from);
     // Retired findings are excluded at the SOURCE so no consumer has to
     // remember to filter them. A withdrawn claim reaching a model through some
     // path that forgot is the failure this centralisation prevents.
-    if (node && node.kind === 'finding' && !node.retired) found.push(node);
+    if (!node || node.kind !== 'finding' || node.retired) continue;
+    if (seen.has(node.id)) continue;
+    seen.add(node.id);
+    found.push(node);
   }
 
   // Ranked by confidence x recency, per the design. The hard token budget that

--- a/integrations/cline/hooks/token-optimizer/lib/staleness.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/staleness.mjs
@@ -150,7 +150,23 @@ export function indexFile(dir, rawPath, text) {
   // staleness detection; only the diff degrades, and `serve` already states
   // plainly when evidence cannot be reconstructed.
   const snapshot = source.length <= snapshotLimit() ? source : undefined;
-  const fileNode = putNode(dir, { kind: 'file', key: path, hash: hash(source), snapshot });
+  // BYTES BESIDE THE HASH, because the hash is truncated to 64 bits and content
+  // identity is now read from it. `contentPeers` groups files by identical
+  // content, and two unrelated files sharing a 16-hex-character digest would
+  // silently share each other's findings. The deleted `contentAnchor` carried a
+  // size for exactly this reason and said so; the size is free here, since the
+  // source is already in hand.
+  //
+  // NOT THE SNAPSHOT, which would have been the obvious discriminator and is
+  // unavailable: `putNode` writes snapshots to a separate file that `load()`
+  // deliberately skips, so a loaded node never carries one.
+  const fileNode = putNode(dir, {
+    kind: 'file',
+    key: path,
+    hash: hash(source),
+    bytes: Buffer.byteLength(source),
+    snapshot,
+  });
 
   const symbols = extractSymbols(path, source);
   for (const symbol of symbols) {

--- a/integrations/cline/hooks/token-optimizer/lib/wiki.mjs
+++ b/integrations/cline/hooks/token-optimizer/lib/wiki.mjs
@@ -874,27 +874,135 @@ export function load(dir, { snapshots = false } = {}) {
 }
 
 /**
+ * The sha256 of nothing.
+ *
+ * Every empty file in a repository shares this hash, and they are not the same
+ * file in any sense a reader cares about -- a `.gitkeep` beside an empty
+ * `index.js` beside a placeholder test. Grouping them would make one finding
+ * about one empty file surface on every other, which is noise wearing the
+ * shape of a feature.
+ */
+const EMPTY_CONTENT_HASH = 'e3b0c44298fc1c14';
+
+/**
+ * How many identical copies of one file are followed.
+ *
+ * A vendored core in eleven directories is the case this exists for; a
+ * generated asset checked in five hundred times is the case that would turn one
+ * retrieval into a scan. The cap is far above any real vendoring and far below
+ * anything pathological, and it is applied to the PEERS rather than to the
+ * findings so the ranking below still chooses among a full candidate set.
+ */
+const MAX_CONTENT_PEERS = 32;
+
+/**
+ * Other paths in THIS graph holding byte-identical content to `anchorId`.
+ *
+ * WHY CONTENT IS NOT A SECOND IDENTITY. The obvious implementation of #319 --
+ * the deleted `contentAnchor` -- minted a second anchor id of the form
+ * `content:<hash>:<size>`, and that is the one thing this codebase has already
+ * been burned by: `canonicalKey` lives INSIDE `nodeId` precisely because a
+ * caller that forgot produced a second node for a file that already existed and
+ * split its findings invisibly. A second identity for the same file is that
+ * defect by construction.
+ *
+ * So nothing new is stored and no node is created. A file node already carries
+ * the sha256 of its contents, because staleness needs it -- content identity
+ * has been sitting in the graph since P2. This is an index over what is already
+ * there, which means it cannot split a history: there is still exactly one node
+ * per path, and a finding still has exactly one set of `derived_from` edges.
+ *
+ * STALENESS IS UNAFFECTED, and follows the path exactly as before. That falls
+ * out rather than being decided: content identity IS the hash, so a file whose
+ * bytes change simply stops matching the group and starts matching whichever
+ * group its new bytes belong to. There is no such thing as a stale content
+ * anchor to invalidate.
+ *
+ * SCOPE IS ONE GRAPH, deliberately. This can only ever surface findings that
+ * are already in the graph being read, so it opens no path between projects and
+ * changes nothing about `fleet.mjs` or the shared tier, which remain the only
+ * cross-project transfer and keep their own gates. See docs/WIKI_GRAPH.md for
+ * why the cross-repository half of #319 needs a storage decision this does not
+ * take.
+ */
+export function contentPeers(graph, anchorId) {
+  const anchor = graph.nodes.get(anchorId);
+  if (!anchor || anchor.kind !== 'file') return [];
+
+  const hash = typeof anchor.hash === 'string' ? anchor.hash : '';
+  // A file node minted for an IMPORT TARGET carries no hash at all -- see
+  // `indexFile`, which creates one for every resolved import without reading
+  // it. Grouping on a missing hash would make every unread import in the
+  // repository one content group, which is the largest possible wrong answer.
+  if (!hash || hash === EMPTY_CONTENT_HASH) return [];
+
+  const peers = [];
+  for (const node of graph.nodes.values()) {
+    if (peers.length >= MAX_CONTENT_PEERS) break;
+    if (node.kind !== 'file' || node.id === anchorId) continue;
+    if (node.hash !== hash) continue;
+
+    // THE HASH IS TRUNCATED TO 64 BITS -- `staleness.mjs` slices the sha256 to
+    // sixteen hex characters -- so equal hashes are strong evidence of equal
+    // content and not proof of it, and two unrelated files sharing a digest
+    // would silently share each other's findings. The deleted `contentAnchor`
+    // carried a size beside the digest for exactly this reason, and `indexFile`
+    // now records one.
+    //
+    // ABSENCE IS PERMISSIVE, and deliberately. A node written before `bytes`
+    // existed, or one minted for an import target and never read, has none --
+    // and refusing to group those would make the feature quietly stop working
+    // on every graph that predates it, healing only as files happen to be
+    // touched. Where both sides know their size they must agree.
+    const mine = anchor.bytes;
+    const theirs = node.bytes;
+    if (typeof mine === 'number' && typeof theirs === 'number' && mine !== theirs) continue;
+
+    peers.push(node.id);
+  }
+  return peers;
+}
+
+/**
  * Findings reachable from a file or symbol, by traversal.
  *
  * This is the retrieval primitive the whole design rests on -- no embeddings,
  * no vector index. It follows `derived_from` edges backwards from an anchor to
  * the findings that depend on it, then one hop further through `contains` so
  * that touching a file also surfaces findings about the symbols inside it.
+ *
+ * AND ACROSS IDENTICAL COPIES. A vendored file is the same file wherever it
+ * sits, whatever path each copy is given, so a finding about one copy is a
+ * finding about all of them. This repository is its own example: the shared
+ * hook core is vendored into eleven directories, byte-identical, and until now
+ * a finding recorded against one of them was invisible from the other ten.
+ * `contentPeers` explains why this is an index rather than a second identity.
  */
 export function findingsFor(graph, anchorId, { limit = 20 } = {}) {
-  const anchors = new Set([anchorId]);
+  const anchors = new Set([anchorId, ...contentPeers(graph, anchorId)]);
   for (const edge of graph.edges) {
-    if (edge.edge === 'contains' && edge.from === anchorId) anchors.add(edge.to);
+    // Symbols are expanded from every anchor, not only the one asked for: a
+    // finding about a function inside a vendored file is exactly as applicable
+    // in the copy the reader is actually touching.
+    if (edge.edge === 'contains' && anchors.has(edge.from)) anchors.add(edge.to);
   }
 
   const found = [];
+  // DEDUPED BY ID. A finding can now be reached more than once -- through a file
+  // and a symbol it contains, or through two identical copies of the same file
+  // -- and returning it twice would spend the injection budget twice on one
+  // claim and let it outrank a rival by being duplicated.
+  const seen = new Set();
   for (const edge of graph.edges) {
     if (edge.edge !== 'derived_from' || !anchors.has(edge.to)) continue;
     const node = graph.nodes.get(edge.from);
     // Retired findings are excluded at the SOURCE so no consumer has to
     // remember to filter them. A withdrawn claim reaching a model through some
     // path that forgot is the failure this centralisation prevents.
-    if (node && node.kind === 'finding' && !node.retired) found.push(node);
+    if (!node || node.kind !== 'finding' || node.retired) continue;
+    if (seen.has(node.id)) continue;
+    seen.add(node.id);
+    found.push(node);
   }
 
   // Ranked by confidence x recency, per the design. The hard token budget that

--- a/integrations/codex/hooks/lib/staleness.mjs
+++ b/integrations/codex/hooks/lib/staleness.mjs
@@ -150,7 +150,23 @@ export function indexFile(dir, rawPath, text) {
   // staleness detection; only the diff degrades, and `serve` already states
   // plainly when evidence cannot be reconstructed.
   const snapshot = source.length <= snapshotLimit() ? source : undefined;
-  const fileNode = putNode(dir, { kind: 'file', key: path, hash: hash(source), snapshot });
+  // BYTES BESIDE THE HASH, because the hash is truncated to 64 bits and content
+  // identity is now read from it. `contentPeers` groups files by identical
+  // content, and two unrelated files sharing a 16-hex-character digest would
+  // silently share each other's findings. The deleted `contentAnchor` carried a
+  // size for exactly this reason and said so; the size is free here, since the
+  // source is already in hand.
+  //
+  // NOT THE SNAPSHOT, which would have been the obvious discriminator and is
+  // unavailable: `putNode` writes snapshots to a separate file that `load()`
+  // deliberately skips, so a loaded node never carries one.
+  const fileNode = putNode(dir, {
+    kind: 'file',
+    key: path,
+    hash: hash(source),
+    bytes: Buffer.byteLength(source),
+    snapshot,
+  });
 
   const symbols = extractSymbols(path, source);
   for (const symbol of symbols) {

--- a/integrations/codex/hooks/lib/wiki.mjs
+++ b/integrations/codex/hooks/lib/wiki.mjs
@@ -874,27 +874,135 @@ export function load(dir, { snapshots = false } = {}) {
 }
 
 /**
+ * The sha256 of nothing.
+ *
+ * Every empty file in a repository shares this hash, and they are not the same
+ * file in any sense a reader cares about -- a `.gitkeep` beside an empty
+ * `index.js` beside a placeholder test. Grouping them would make one finding
+ * about one empty file surface on every other, which is noise wearing the
+ * shape of a feature.
+ */
+const EMPTY_CONTENT_HASH = 'e3b0c44298fc1c14';
+
+/**
+ * How many identical copies of one file are followed.
+ *
+ * A vendored core in eleven directories is the case this exists for; a
+ * generated asset checked in five hundred times is the case that would turn one
+ * retrieval into a scan. The cap is far above any real vendoring and far below
+ * anything pathological, and it is applied to the PEERS rather than to the
+ * findings so the ranking below still chooses among a full candidate set.
+ */
+const MAX_CONTENT_PEERS = 32;
+
+/**
+ * Other paths in THIS graph holding byte-identical content to `anchorId`.
+ *
+ * WHY CONTENT IS NOT A SECOND IDENTITY. The obvious implementation of #319 --
+ * the deleted `contentAnchor` -- minted a second anchor id of the form
+ * `content:<hash>:<size>`, and that is the one thing this codebase has already
+ * been burned by: `canonicalKey` lives INSIDE `nodeId` precisely because a
+ * caller that forgot produced a second node for a file that already existed and
+ * split its findings invisibly. A second identity for the same file is that
+ * defect by construction.
+ *
+ * So nothing new is stored and no node is created. A file node already carries
+ * the sha256 of its contents, because staleness needs it -- content identity
+ * has been sitting in the graph since P2. This is an index over what is already
+ * there, which means it cannot split a history: there is still exactly one node
+ * per path, and a finding still has exactly one set of `derived_from` edges.
+ *
+ * STALENESS IS UNAFFECTED, and follows the path exactly as before. That falls
+ * out rather than being decided: content identity IS the hash, so a file whose
+ * bytes change simply stops matching the group and starts matching whichever
+ * group its new bytes belong to. There is no such thing as a stale content
+ * anchor to invalidate.
+ *
+ * SCOPE IS ONE GRAPH, deliberately. This can only ever surface findings that
+ * are already in the graph being read, so it opens no path between projects and
+ * changes nothing about `fleet.mjs` or the shared tier, which remain the only
+ * cross-project transfer and keep their own gates. See docs/WIKI_GRAPH.md for
+ * why the cross-repository half of #319 needs a storage decision this does not
+ * take.
+ */
+export function contentPeers(graph, anchorId) {
+  const anchor = graph.nodes.get(anchorId);
+  if (!anchor || anchor.kind !== 'file') return [];
+
+  const hash = typeof anchor.hash === 'string' ? anchor.hash : '';
+  // A file node minted for an IMPORT TARGET carries no hash at all -- see
+  // `indexFile`, which creates one for every resolved import without reading
+  // it. Grouping on a missing hash would make every unread import in the
+  // repository one content group, which is the largest possible wrong answer.
+  if (!hash || hash === EMPTY_CONTENT_HASH) return [];
+
+  const peers = [];
+  for (const node of graph.nodes.values()) {
+    if (peers.length >= MAX_CONTENT_PEERS) break;
+    if (node.kind !== 'file' || node.id === anchorId) continue;
+    if (node.hash !== hash) continue;
+
+    // THE HASH IS TRUNCATED TO 64 BITS -- `staleness.mjs` slices the sha256 to
+    // sixteen hex characters -- so equal hashes are strong evidence of equal
+    // content and not proof of it, and two unrelated files sharing a digest
+    // would silently share each other's findings. The deleted `contentAnchor`
+    // carried a size beside the digest for exactly this reason, and `indexFile`
+    // now records one.
+    //
+    // ABSENCE IS PERMISSIVE, and deliberately. A node written before `bytes`
+    // existed, or one minted for an import target and never read, has none --
+    // and refusing to group those would make the feature quietly stop working
+    // on every graph that predates it, healing only as files happen to be
+    // touched. Where both sides know their size they must agree.
+    const mine = anchor.bytes;
+    const theirs = node.bytes;
+    if (typeof mine === 'number' && typeof theirs === 'number' && mine !== theirs) continue;
+
+    peers.push(node.id);
+  }
+  return peers;
+}
+
+/**
  * Findings reachable from a file or symbol, by traversal.
  *
  * This is the retrieval primitive the whole design rests on -- no embeddings,
  * no vector index. It follows `derived_from` edges backwards from an anchor to
  * the findings that depend on it, then one hop further through `contains` so
  * that touching a file also surfaces findings about the symbols inside it.
+ *
+ * AND ACROSS IDENTICAL COPIES. A vendored file is the same file wherever it
+ * sits, whatever path each copy is given, so a finding about one copy is a
+ * finding about all of them. This repository is its own example: the shared
+ * hook core is vendored into eleven directories, byte-identical, and until now
+ * a finding recorded against one of them was invisible from the other ten.
+ * `contentPeers` explains why this is an index rather than a second identity.
  */
 export function findingsFor(graph, anchorId, { limit = 20 } = {}) {
-  const anchors = new Set([anchorId]);
+  const anchors = new Set([anchorId, ...contentPeers(graph, anchorId)]);
   for (const edge of graph.edges) {
-    if (edge.edge === 'contains' && edge.from === anchorId) anchors.add(edge.to);
+    // Symbols are expanded from every anchor, not only the one asked for: a
+    // finding about a function inside a vendored file is exactly as applicable
+    // in the copy the reader is actually touching.
+    if (edge.edge === 'contains' && anchors.has(edge.from)) anchors.add(edge.to);
   }
 
   const found = [];
+  // DEDUPED BY ID. A finding can now be reached more than once -- through a file
+  // and a symbol it contains, or through two identical copies of the same file
+  // -- and returning it twice would spend the injection budget twice on one
+  // claim and let it outrank a rival by being duplicated.
+  const seen = new Set();
   for (const edge of graph.edges) {
     if (edge.edge !== 'derived_from' || !anchors.has(edge.to)) continue;
     const node = graph.nodes.get(edge.from);
     // Retired findings are excluded at the SOURCE so no consumer has to
     // remember to filter them. A withdrawn claim reaching a model through some
     // path that forgot is the failure this centralisation prevents.
-    if (node && node.kind === 'finding' && !node.retired) found.push(node);
+    if (!node || node.kind !== 'finding' || node.retired) continue;
+    if (seen.has(node.id)) continue;
+    seen.add(node.id);
+    found.push(node);
   }
 
   // Ranked by confidence x recency, per the design. The hard token budget that

--- a/integrations/codex/plugin/hooks/lib/staleness.mjs
+++ b/integrations/codex/plugin/hooks/lib/staleness.mjs
@@ -150,7 +150,23 @@ export function indexFile(dir, rawPath, text) {
   // staleness detection; only the diff degrades, and `serve` already states
   // plainly when evidence cannot be reconstructed.
   const snapshot = source.length <= snapshotLimit() ? source : undefined;
-  const fileNode = putNode(dir, { kind: 'file', key: path, hash: hash(source), snapshot });
+  // BYTES BESIDE THE HASH, because the hash is truncated to 64 bits and content
+  // identity is now read from it. `contentPeers` groups files by identical
+  // content, and two unrelated files sharing a 16-hex-character digest would
+  // silently share each other's findings. The deleted `contentAnchor` carried a
+  // size for exactly this reason and said so; the size is free here, since the
+  // source is already in hand.
+  //
+  // NOT THE SNAPSHOT, which would have been the obvious discriminator and is
+  // unavailable: `putNode` writes snapshots to a separate file that `load()`
+  // deliberately skips, so a loaded node never carries one.
+  const fileNode = putNode(dir, {
+    kind: 'file',
+    key: path,
+    hash: hash(source),
+    bytes: Buffer.byteLength(source),
+    snapshot,
+  });
 
   const symbols = extractSymbols(path, source);
   for (const symbol of symbols) {

--- a/integrations/codex/plugin/hooks/lib/wiki.mjs
+++ b/integrations/codex/plugin/hooks/lib/wiki.mjs
@@ -874,27 +874,135 @@ export function load(dir, { snapshots = false } = {}) {
 }
 
 /**
+ * The sha256 of nothing.
+ *
+ * Every empty file in a repository shares this hash, and they are not the same
+ * file in any sense a reader cares about -- a `.gitkeep` beside an empty
+ * `index.js` beside a placeholder test. Grouping them would make one finding
+ * about one empty file surface on every other, which is noise wearing the
+ * shape of a feature.
+ */
+const EMPTY_CONTENT_HASH = 'e3b0c44298fc1c14';
+
+/**
+ * How many identical copies of one file are followed.
+ *
+ * A vendored core in eleven directories is the case this exists for; a
+ * generated asset checked in five hundred times is the case that would turn one
+ * retrieval into a scan. The cap is far above any real vendoring and far below
+ * anything pathological, and it is applied to the PEERS rather than to the
+ * findings so the ranking below still chooses among a full candidate set.
+ */
+const MAX_CONTENT_PEERS = 32;
+
+/**
+ * Other paths in THIS graph holding byte-identical content to `anchorId`.
+ *
+ * WHY CONTENT IS NOT A SECOND IDENTITY. The obvious implementation of #319 --
+ * the deleted `contentAnchor` -- minted a second anchor id of the form
+ * `content:<hash>:<size>`, and that is the one thing this codebase has already
+ * been burned by: `canonicalKey` lives INSIDE `nodeId` precisely because a
+ * caller that forgot produced a second node for a file that already existed and
+ * split its findings invisibly. A second identity for the same file is that
+ * defect by construction.
+ *
+ * So nothing new is stored and no node is created. A file node already carries
+ * the sha256 of its contents, because staleness needs it -- content identity
+ * has been sitting in the graph since P2. This is an index over what is already
+ * there, which means it cannot split a history: there is still exactly one node
+ * per path, and a finding still has exactly one set of `derived_from` edges.
+ *
+ * STALENESS IS UNAFFECTED, and follows the path exactly as before. That falls
+ * out rather than being decided: content identity IS the hash, so a file whose
+ * bytes change simply stops matching the group and starts matching whichever
+ * group its new bytes belong to. There is no such thing as a stale content
+ * anchor to invalidate.
+ *
+ * SCOPE IS ONE GRAPH, deliberately. This can only ever surface findings that
+ * are already in the graph being read, so it opens no path between projects and
+ * changes nothing about `fleet.mjs` or the shared tier, which remain the only
+ * cross-project transfer and keep their own gates. See docs/WIKI_GRAPH.md for
+ * why the cross-repository half of #319 needs a storage decision this does not
+ * take.
+ */
+export function contentPeers(graph, anchorId) {
+  const anchor = graph.nodes.get(anchorId);
+  if (!anchor || anchor.kind !== 'file') return [];
+
+  const hash = typeof anchor.hash === 'string' ? anchor.hash : '';
+  // A file node minted for an IMPORT TARGET carries no hash at all -- see
+  // `indexFile`, which creates one for every resolved import without reading
+  // it. Grouping on a missing hash would make every unread import in the
+  // repository one content group, which is the largest possible wrong answer.
+  if (!hash || hash === EMPTY_CONTENT_HASH) return [];
+
+  const peers = [];
+  for (const node of graph.nodes.values()) {
+    if (peers.length >= MAX_CONTENT_PEERS) break;
+    if (node.kind !== 'file' || node.id === anchorId) continue;
+    if (node.hash !== hash) continue;
+
+    // THE HASH IS TRUNCATED TO 64 BITS -- `staleness.mjs` slices the sha256 to
+    // sixteen hex characters -- so equal hashes are strong evidence of equal
+    // content and not proof of it, and two unrelated files sharing a digest
+    // would silently share each other's findings. The deleted `contentAnchor`
+    // carried a size beside the digest for exactly this reason, and `indexFile`
+    // now records one.
+    //
+    // ABSENCE IS PERMISSIVE, and deliberately. A node written before `bytes`
+    // existed, or one minted for an import target and never read, has none --
+    // and refusing to group those would make the feature quietly stop working
+    // on every graph that predates it, healing only as files happen to be
+    // touched. Where both sides know their size they must agree.
+    const mine = anchor.bytes;
+    const theirs = node.bytes;
+    if (typeof mine === 'number' && typeof theirs === 'number' && mine !== theirs) continue;
+
+    peers.push(node.id);
+  }
+  return peers;
+}
+
+/**
  * Findings reachable from a file or symbol, by traversal.
  *
  * This is the retrieval primitive the whole design rests on -- no embeddings,
  * no vector index. It follows `derived_from` edges backwards from an anchor to
  * the findings that depend on it, then one hop further through `contains` so
  * that touching a file also surfaces findings about the symbols inside it.
+ *
+ * AND ACROSS IDENTICAL COPIES. A vendored file is the same file wherever it
+ * sits, whatever path each copy is given, so a finding about one copy is a
+ * finding about all of them. This repository is its own example: the shared
+ * hook core is vendored into eleven directories, byte-identical, and until now
+ * a finding recorded against one of them was invisible from the other ten.
+ * `contentPeers` explains why this is an index rather than a second identity.
  */
 export function findingsFor(graph, anchorId, { limit = 20 } = {}) {
-  const anchors = new Set([anchorId]);
+  const anchors = new Set([anchorId, ...contentPeers(graph, anchorId)]);
   for (const edge of graph.edges) {
-    if (edge.edge === 'contains' && edge.from === anchorId) anchors.add(edge.to);
+    // Symbols are expanded from every anchor, not only the one asked for: a
+    // finding about a function inside a vendored file is exactly as applicable
+    // in the copy the reader is actually touching.
+    if (edge.edge === 'contains' && anchors.has(edge.from)) anchors.add(edge.to);
   }
 
   const found = [];
+  // DEDUPED BY ID. A finding can now be reached more than once -- through a file
+  // and a symbol it contains, or through two identical copies of the same file
+  // -- and returning it twice would spend the injection budget twice on one
+  // claim and let it outrank a rival by being duplicated.
+  const seen = new Set();
   for (const edge of graph.edges) {
     if (edge.edge !== 'derived_from' || !anchors.has(edge.to)) continue;
     const node = graph.nodes.get(edge.from);
     // Retired findings are excluded at the SOURCE so no consumer has to
     // remember to filter them. A withdrawn claim reaching a model through some
     // path that forgot is the failure this centralisation prevents.
-    if (node && node.kind === 'finding' && !node.retired) found.push(node);
+    if (!node || node.kind !== 'finding' || node.retired) continue;
+    if (seen.has(node.id)) continue;
+    seen.add(node.id);
+    found.push(node);
   }
 
   // Ranked by confidence x recency, per the design. The hard token budget that

--- a/integrations/copilot/.github/hooks/lib/staleness.mjs
+++ b/integrations/copilot/.github/hooks/lib/staleness.mjs
@@ -150,7 +150,23 @@ export function indexFile(dir, rawPath, text) {
   // staleness detection; only the diff degrades, and `serve` already states
   // plainly when evidence cannot be reconstructed.
   const snapshot = source.length <= snapshotLimit() ? source : undefined;
-  const fileNode = putNode(dir, { kind: 'file', key: path, hash: hash(source), snapshot });
+  // BYTES BESIDE THE HASH, because the hash is truncated to 64 bits and content
+  // identity is now read from it. `contentPeers` groups files by identical
+  // content, and two unrelated files sharing a 16-hex-character digest would
+  // silently share each other's findings. The deleted `contentAnchor` carried a
+  // size for exactly this reason and said so; the size is free here, since the
+  // source is already in hand.
+  //
+  // NOT THE SNAPSHOT, which would have been the obvious discriminator and is
+  // unavailable: `putNode` writes snapshots to a separate file that `load()`
+  // deliberately skips, so a loaded node never carries one.
+  const fileNode = putNode(dir, {
+    kind: 'file',
+    key: path,
+    hash: hash(source),
+    bytes: Buffer.byteLength(source),
+    snapshot,
+  });
 
   const symbols = extractSymbols(path, source);
   for (const symbol of symbols) {

--- a/integrations/copilot/.github/hooks/lib/wiki.mjs
+++ b/integrations/copilot/.github/hooks/lib/wiki.mjs
@@ -874,27 +874,135 @@ export function load(dir, { snapshots = false } = {}) {
 }
 
 /**
+ * The sha256 of nothing.
+ *
+ * Every empty file in a repository shares this hash, and they are not the same
+ * file in any sense a reader cares about -- a `.gitkeep` beside an empty
+ * `index.js` beside a placeholder test. Grouping them would make one finding
+ * about one empty file surface on every other, which is noise wearing the
+ * shape of a feature.
+ */
+const EMPTY_CONTENT_HASH = 'e3b0c44298fc1c14';
+
+/**
+ * How many identical copies of one file are followed.
+ *
+ * A vendored core in eleven directories is the case this exists for; a
+ * generated asset checked in five hundred times is the case that would turn one
+ * retrieval into a scan. The cap is far above any real vendoring and far below
+ * anything pathological, and it is applied to the PEERS rather than to the
+ * findings so the ranking below still chooses among a full candidate set.
+ */
+const MAX_CONTENT_PEERS = 32;
+
+/**
+ * Other paths in THIS graph holding byte-identical content to `anchorId`.
+ *
+ * WHY CONTENT IS NOT A SECOND IDENTITY. The obvious implementation of #319 --
+ * the deleted `contentAnchor` -- minted a second anchor id of the form
+ * `content:<hash>:<size>`, and that is the one thing this codebase has already
+ * been burned by: `canonicalKey` lives INSIDE `nodeId` precisely because a
+ * caller that forgot produced a second node for a file that already existed and
+ * split its findings invisibly. A second identity for the same file is that
+ * defect by construction.
+ *
+ * So nothing new is stored and no node is created. A file node already carries
+ * the sha256 of its contents, because staleness needs it -- content identity
+ * has been sitting in the graph since P2. This is an index over what is already
+ * there, which means it cannot split a history: there is still exactly one node
+ * per path, and a finding still has exactly one set of `derived_from` edges.
+ *
+ * STALENESS IS UNAFFECTED, and follows the path exactly as before. That falls
+ * out rather than being decided: content identity IS the hash, so a file whose
+ * bytes change simply stops matching the group and starts matching whichever
+ * group its new bytes belong to. There is no such thing as a stale content
+ * anchor to invalidate.
+ *
+ * SCOPE IS ONE GRAPH, deliberately. This can only ever surface findings that
+ * are already in the graph being read, so it opens no path between projects and
+ * changes nothing about `fleet.mjs` or the shared tier, which remain the only
+ * cross-project transfer and keep their own gates. See docs/WIKI_GRAPH.md for
+ * why the cross-repository half of #319 needs a storage decision this does not
+ * take.
+ */
+export function contentPeers(graph, anchorId) {
+  const anchor = graph.nodes.get(anchorId);
+  if (!anchor || anchor.kind !== 'file') return [];
+
+  const hash = typeof anchor.hash === 'string' ? anchor.hash : '';
+  // A file node minted for an IMPORT TARGET carries no hash at all -- see
+  // `indexFile`, which creates one for every resolved import without reading
+  // it. Grouping on a missing hash would make every unread import in the
+  // repository one content group, which is the largest possible wrong answer.
+  if (!hash || hash === EMPTY_CONTENT_HASH) return [];
+
+  const peers = [];
+  for (const node of graph.nodes.values()) {
+    if (peers.length >= MAX_CONTENT_PEERS) break;
+    if (node.kind !== 'file' || node.id === anchorId) continue;
+    if (node.hash !== hash) continue;
+
+    // THE HASH IS TRUNCATED TO 64 BITS -- `staleness.mjs` slices the sha256 to
+    // sixteen hex characters -- so equal hashes are strong evidence of equal
+    // content and not proof of it, and two unrelated files sharing a digest
+    // would silently share each other's findings. The deleted `contentAnchor`
+    // carried a size beside the digest for exactly this reason, and `indexFile`
+    // now records one.
+    //
+    // ABSENCE IS PERMISSIVE, and deliberately. A node written before `bytes`
+    // existed, or one minted for an import target and never read, has none --
+    // and refusing to group those would make the feature quietly stop working
+    // on every graph that predates it, healing only as files happen to be
+    // touched. Where both sides know their size they must agree.
+    const mine = anchor.bytes;
+    const theirs = node.bytes;
+    if (typeof mine === 'number' && typeof theirs === 'number' && mine !== theirs) continue;
+
+    peers.push(node.id);
+  }
+  return peers;
+}
+
+/**
  * Findings reachable from a file or symbol, by traversal.
  *
  * This is the retrieval primitive the whole design rests on -- no embeddings,
  * no vector index. It follows `derived_from` edges backwards from an anchor to
  * the findings that depend on it, then one hop further through `contains` so
  * that touching a file also surfaces findings about the symbols inside it.
+ *
+ * AND ACROSS IDENTICAL COPIES. A vendored file is the same file wherever it
+ * sits, whatever path each copy is given, so a finding about one copy is a
+ * finding about all of them. This repository is its own example: the shared
+ * hook core is vendored into eleven directories, byte-identical, and until now
+ * a finding recorded against one of them was invisible from the other ten.
+ * `contentPeers` explains why this is an index rather than a second identity.
  */
 export function findingsFor(graph, anchorId, { limit = 20 } = {}) {
-  const anchors = new Set([anchorId]);
+  const anchors = new Set([anchorId, ...contentPeers(graph, anchorId)]);
   for (const edge of graph.edges) {
-    if (edge.edge === 'contains' && edge.from === anchorId) anchors.add(edge.to);
+    // Symbols are expanded from every anchor, not only the one asked for: a
+    // finding about a function inside a vendored file is exactly as applicable
+    // in the copy the reader is actually touching.
+    if (edge.edge === 'contains' && anchors.has(edge.from)) anchors.add(edge.to);
   }
 
   const found = [];
+  // DEDUPED BY ID. A finding can now be reached more than once -- through a file
+  // and a symbol it contains, or through two identical copies of the same file
+  // -- and returning it twice would spend the injection budget twice on one
+  // claim and let it outrank a rival by being duplicated.
+  const seen = new Set();
   for (const edge of graph.edges) {
     if (edge.edge !== 'derived_from' || !anchors.has(edge.to)) continue;
     const node = graph.nodes.get(edge.from);
     // Retired findings are excluded at the SOURCE so no consumer has to
     // remember to filter them. A withdrawn claim reaching a model through some
     // path that forgot is the failure this centralisation prevents.
-    if (node && node.kind === 'finding' && !node.retired) found.push(node);
+    if (!node || node.kind !== 'finding' || node.retired) continue;
+    if (seen.has(node.id)) continue;
+    seen.add(node.id);
+    found.push(node);
   }
 
   // Ranked by confidence x recency, per the design. The hard token budget that

--- a/integrations/cursor/hooks/lib/staleness.mjs
+++ b/integrations/cursor/hooks/lib/staleness.mjs
@@ -150,7 +150,23 @@ export function indexFile(dir, rawPath, text) {
   // staleness detection; only the diff degrades, and `serve` already states
   // plainly when evidence cannot be reconstructed.
   const snapshot = source.length <= snapshotLimit() ? source : undefined;
-  const fileNode = putNode(dir, { kind: 'file', key: path, hash: hash(source), snapshot });
+  // BYTES BESIDE THE HASH, because the hash is truncated to 64 bits and content
+  // identity is now read from it. `contentPeers` groups files by identical
+  // content, and two unrelated files sharing a 16-hex-character digest would
+  // silently share each other's findings. The deleted `contentAnchor` carried a
+  // size for exactly this reason and said so; the size is free here, since the
+  // source is already in hand.
+  //
+  // NOT THE SNAPSHOT, which would have been the obvious discriminator and is
+  // unavailable: `putNode` writes snapshots to a separate file that `load()`
+  // deliberately skips, so a loaded node never carries one.
+  const fileNode = putNode(dir, {
+    kind: 'file',
+    key: path,
+    hash: hash(source),
+    bytes: Buffer.byteLength(source),
+    snapshot,
+  });
 
   const symbols = extractSymbols(path, source);
   for (const symbol of symbols) {

--- a/integrations/cursor/hooks/lib/wiki.mjs
+++ b/integrations/cursor/hooks/lib/wiki.mjs
@@ -874,27 +874,135 @@ export function load(dir, { snapshots = false } = {}) {
 }
 
 /**
+ * The sha256 of nothing.
+ *
+ * Every empty file in a repository shares this hash, and they are not the same
+ * file in any sense a reader cares about -- a `.gitkeep` beside an empty
+ * `index.js` beside a placeholder test. Grouping them would make one finding
+ * about one empty file surface on every other, which is noise wearing the
+ * shape of a feature.
+ */
+const EMPTY_CONTENT_HASH = 'e3b0c44298fc1c14';
+
+/**
+ * How many identical copies of one file are followed.
+ *
+ * A vendored core in eleven directories is the case this exists for; a
+ * generated asset checked in five hundred times is the case that would turn one
+ * retrieval into a scan. The cap is far above any real vendoring and far below
+ * anything pathological, and it is applied to the PEERS rather than to the
+ * findings so the ranking below still chooses among a full candidate set.
+ */
+const MAX_CONTENT_PEERS = 32;
+
+/**
+ * Other paths in THIS graph holding byte-identical content to `anchorId`.
+ *
+ * WHY CONTENT IS NOT A SECOND IDENTITY. The obvious implementation of #319 --
+ * the deleted `contentAnchor` -- minted a second anchor id of the form
+ * `content:<hash>:<size>`, and that is the one thing this codebase has already
+ * been burned by: `canonicalKey` lives INSIDE `nodeId` precisely because a
+ * caller that forgot produced a second node for a file that already existed and
+ * split its findings invisibly. A second identity for the same file is that
+ * defect by construction.
+ *
+ * So nothing new is stored and no node is created. A file node already carries
+ * the sha256 of its contents, because staleness needs it -- content identity
+ * has been sitting in the graph since P2. This is an index over what is already
+ * there, which means it cannot split a history: there is still exactly one node
+ * per path, and a finding still has exactly one set of `derived_from` edges.
+ *
+ * STALENESS IS UNAFFECTED, and follows the path exactly as before. That falls
+ * out rather than being decided: content identity IS the hash, so a file whose
+ * bytes change simply stops matching the group and starts matching whichever
+ * group its new bytes belong to. There is no such thing as a stale content
+ * anchor to invalidate.
+ *
+ * SCOPE IS ONE GRAPH, deliberately. This can only ever surface findings that
+ * are already in the graph being read, so it opens no path between projects and
+ * changes nothing about `fleet.mjs` or the shared tier, which remain the only
+ * cross-project transfer and keep their own gates. See docs/WIKI_GRAPH.md for
+ * why the cross-repository half of #319 needs a storage decision this does not
+ * take.
+ */
+export function contentPeers(graph, anchorId) {
+  const anchor = graph.nodes.get(anchorId);
+  if (!anchor || anchor.kind !== 'file') return [];
+
+  const hash = typeof anchor.hash === 'string' ? anchor.hash : '';
+  // A file node minted for an IMPORT TARGET carries no hash at all -- see
+  // `indexFile`, which creates one for every resolved import without reading
+  // it. Grouping on a missing hash would make every unread import in the
+  // repository one content group, which is the largest possible wrong answer.
+  if (!hash || hash === EMPTY_CONTENT_HASH) return [];
+
+  const peers = [];
+  for (const node of graph.nodes.values()) {
+    if (peers.length >= MAX_CONTENT_PEERS) break;
+    if (node.kind !== 'file' || node.id === anchorId) continue;
+    if (node.hash !== hash) continue;
+
+    // THE HASH IS TRUNCATED TO 64 BITS -- `staleness.mjs` slices the sha256 to
+    // sixteen hex characters -- so equal hashes are strong evidence of equal
+    // content and not proof of it, and two unrelated files sharing a digest
+    // would silently share each other's findings. The deleted `contentAnchor`
+    // carried a size beside the digest for exactly this reason, and `indexFile`
+    // now records one.
+    //
+    // ABSENCE IS PERMISSIVE, and deliberately. A node written before `bytes`
+    // existed, or one minted for an import target and never read, has none --
+    // and refusing to group those would make the feature quietly stop working
+    // on every graph that predates it, healing only as files happen to be
+    // touched. Where both sides know their size they must agree.
+    const mine = anchor.bytes;
+    const theirs = node.bytes;
+    if (typeof mine === 'number' && typeof theirs === 'number' && mine !== theirs) continue;
+
+    peers.push(node.id);
+  }
+  return peers;
+}
+
+/**
  * Findings reachable from a file or symbol, by traversal.
  *
  * This is the retrieval primitive the whole design rests on -- no embeddings,
  * no vector index. It follows `derived_from` edges backwards from an anchor to
  * the findings that depend on it, then one hop further through `contains` so
  * that touching a file also surfaces findings about the symbols inside it.
+ *
+ * AND ACROSS IDENTICAL COPIES. A vendored file is the same file wherever it
+ * sits, whatever path each copy is given, so a finding about one copy is a
+ * finding about all of them. This repository is its own example: the shared
+ * hook core is vendored into eleven directories, byte-identical, and until now
+ * a finding recorded against one of them was invisible from the other ten.
+ * `contentPeers` explains why this is an index rather than a second identity.
  */
 export function findingsFor(graph, anchorId, { limit = 20 } = {}) {
-  const anchors = new Set([anchorId]);
+  const anchors = new Set([anchorId, ...contentPeers(graph, anchorId)]);
   for (const edge of graph.edges) {
-    if (edge.edge === 'contains' && edge.from === anchorId) anchors.add(edge.to);
+    // Symbols are expanded from every anchor, not only the one asked for: a
+    // finding about a function inside a vendored file is exactly as applicable
+    // in the copy the reader is actually touching.
+    if (edge.edge === 'contains' && anchors.has(edge.from)) anchors.add(edge.to);
   }
 
   const found = [];
+  // DEDUPED BY ID. A finding can now be reached more than once -- through a file
+  // and a symbol it contains, or through two identical copies of the same file
+  // -- and returning it twice would spend the injection budget twice on one
+  // claim and let it outrank a rival by being duplicated.
+  const seen = new Set();
   for (const edge of graph.edges) {
     if (edge.edge !== 'derived_from' || !anchors.has(edge.to)) continue;
     const node = graph.nodes.get(edge.from);
     // Retired findings are excluded at the SOURCE so no consumer has to
     // remember to filter them. A withdrawn claim reaching a model through some
     // path that forgot is the failure this centralisation prevents.
-    if (node && node.kind === 'finding' && !node.retired) found.push(node);
+    if (!node || node.kind !== 'finding' || node.retired) continue;
+    if (seen.has(node.id)) continue;
+    seen.add(node.id);
+    found.push(node);
   }
 
   // Ranked by confidence x recency, per the design. The hard token budget that

--- a/integrations/gemini/hooks/lib/staleness.mjs
+++ b/integrations/gemini/hooks/lib/staleness.mjs
@@ -150,7 +150,23 @@ export function indexFile(dir, rawPath, text) {
   // staleness detection; only the diff degrades, and `serve` already states
   // plainly when evidence cannot be reconstructed.
   const snapshot = source.length <= snapshotLimit() ? source : undefined;
-  const fileNode = putNode(dir, { kind: 'file', key: path, hash: hash(source), snapshot });
+  // BYTES BESIDE THE HASH, because the hash is truncated to 64 bits and content
+  // identity is now read from it. `contentPeers` groups files by identical
+  // content, and two unrelated files sharing a 16-hex-character digest would
+  // silently share each other's findings. The deleted `contentAnchor` carried a
+  // size for exactly this reason and said so; the size is free here, since the
+  // source is already in hand.
+  //
+  // NOT THE SNAPSHOT, which would have been the obvious discriminator and is
+  // unavailable: `putNode` writes snapshots to a separate file that `load()`
+  // deliberately skips, so a loaded node never carries one.
+  const fileNode = putNode(dir, {
+    kind: 'file',
+    key: path,
+    hash: hash(source),
+    bytes: Buffer.byteLength(source),
+    snapshot,
+  });
 
   const symbols = extractSymbols(path, source);
   for (const symbol of symbols) {

--- a/integrations/gemini/hooks/lib/wiki.mjs
+++ b/integrations/gemini/hooks/lib/wiki.mjs
@@ -874,27 +874,135 @@ export function load(dir, { snapshots = false } = {}) {
 }
 
 /**
+ * The sha256 of nothing.
+ *
+ * Every empty file in a repository shares this hash, and they are not the same
+ * file in any sense a reader cares about -- a `.gitkeep` beside an empty
+ * `index.js` beside a placeholder test. Grouping them would make one finding
+ * about one empty file surface on every other, which is noise wearing the
+ * shape of a feature.
+ */
+const EMPTY_CONTENT_HASH = 'e3b0c44298fc1c14';
+
+/**
+ * How many identical copies of one file are followed.
+ *
+ * A vendored core in eleven directories is the case this exists for; a
+ * generated asset checked in five hundred times is the case that would turn one
+ * retrieval into a scan. The cap is far above any real vendoring and far below
+ * anything pathological, and it is applied to the PEERS rather than to the
+ * findings so the ranking below still chooses among a full candidate set.
+ */
+const MAX_CONTENT_PEERS = 32;
+
+/**
+ * Other paths in THIS graph holding byte-identical content to `anchorId`.
+ *
+ * WHY CONTENT IS NOT A SECOND IDENTITY. The obvious implementation of #319 --
+ * the deleted `contentAnchor` -- minted a second anchor id of the form
+ * `content:<hash>:<size>`, and that is the one thing this codebase has already
+ * been burned by: `canonicalKey` lives INSIDE `nodeId` precisely because a
+ * caller that forgot produced a second node for a file that already existed and
+ * split its findings invisibly. A second identity for the same file is that
+ * defect by construction.
+ *
+ * So nothing new is stored and no node is created. A file node already carries
+ * the sha256 of its contents, because staleness needs it -- content identity
+ * has been sitting in the graph since P2. This is an index over what is already
+ * there, which means it cannot split a history: there is still exactly one node
+ * per path, and a finding still has exactly one set of `derived_from` edges.
+ *
+ * STALENESS IS UNAFFECTED, and follows the path exactly as before. That falls
+ * out rather than being decided: content identity IS the hash, so a file whose
+ * bytes change simply stops matching the group and starts matching whichever
+ * group its new bytes belong to. There is no such thing as a stale content
+ * anchor to invalidate.
+ *
+ * SCOPE IS ONE GRAPH, deliberately. This can only ever surface findings that
+ * are already in the graph being read, so it opens no path between projects and
+ * changes nothing about `fleet.mjs` or the shared tier, which remain the only
+ * cross-project transfer and keep their own gates. See docs/WIKI_GRAPH.md for
+ * why the cross-repository half of #319 needs a storage decision this does not
+ * take.
+ */
+export function contentPeers(graph, anchorId) {
+  const anchor = graph.nodes.get(anchorId);
+  if (!anchor || anchor.kind !== 'file') return [];
+
+  const hash = typeof anchor.hash === 'string' ? anchor.hash : '';
+  // A file node minted for an IMPORT TARGET carries no hash at all -- see
+  // `indexFile`, which creates one for every resolved import without reading
+  // it. Grouping on a missing hash would make every unread import in the
+  // repository one content group, which is the largest possible wrong answer.
+  if (!hash || hash === EMPTY_CONTENT_HASH) return [];
+
+  const peers = [];
+  for (const node of graph.nodes.values()) {
+    if (peers.length >= MAX_CONTENT_PEERS) break;
+    if (node.kind !== 'file' || node.id === anchorId) continue;
+    if (node.hash !== hash) continue;
+
+    // THE HASH IS TRUNCATED TO 64 BITS -- `staleness.mjs` slices the sha256 to
+    // sixteen hex characters -- so equal hashes are strong evidence of equal
+    // content and not proof of it, and two unrelated files sharing a digest
+    // would silently share each other's findings. The deleted `contentAnchor`
+    // carried a size beside the digest for exactly this reason, and `indexFile`
+    // now records one.
+    //
+    // ABSENCE IS PERMISSIVE, and deliberately. A node written before `bytes`
+    // existed, or one minted for an import target and never read, has none --
+    // and refusing to group those would make the feature quietly stop working
+    // on every graph that predates it, healing only as files happen to be
+    // touched. Where both sides know their size they must agree.
+    const mine = anchor.bytes;
+    const theirs = node.bytes;
+    if (typeof mine === 'number' && typeof theirs === 'number' && mine !== theirs) continue;
+
+    peers.push(node.id);
+  }
+  return peers;
+}
+
+/**
  * Findings reachable from a file or symbol, by traversal.
  *
  * This is the retrieval primitive the whole design rests on -- no embeddings,
  * no vector index. It follows `derived_from` edges backwards from an anchor to
  * the findings that depend on it, then one hop further through `contains` so
  * that touching a file also surfaces findings about the symbols inside it.
+ *
+ * AND ACROSS IDENTICAL COPIES. A vendored file is the same file wherever it
+ * sits, whatever path each copy is given, so a finding about one copy is a
+ * finding about all of them. This repository is its own example: the shared
+ * hook core is vendored into eleven directories, byte-identical, and until now
+ * a finding recorded against one of them was invisible from the other ten.
+ * `contentPeers` explains why this is an index rather than a second identity.
  */
 export function findingsFor(graph, anchorId, { limit = 20 } = {}) {
-  const anchors = new Set([anchorId]);
+  const anchors = new Set([anchorId, ...contentPeers(graph, anchorId)]);
   for (const edge of graph.edges) {
-    if (edge.edge === 'contains' && edge.from === anchorId) anchors.add(edge.to);
+    // Symbols are expanded from every anchor, not only the one asked for: a
+    // finding about a function inside a vendored file is exactly as applicable
+    // in the copy the reader is actually touching.
+    if (edge.edge === 'contains' && anchors.has(edge.from)) anchors.add(edge.to);
   }
 
   const found = [];
+  // DEDUPED BY ID. A finding can now be reached more than once -- through a file
+  // and a symbol it contains, or through two identical copies of the same file
+  // -- and returning it twice would spend the injection budget twice on one
+  // claim and let it outrank a rival by being duplicated.
+  const seen = new Set();
   for (const edge of graph.edges) {
     if (edge.edge !== 'derived_from' || !anchors.has(edge.to)) continue;
     const node = graph.nodes.get(edge.from);
     // Retired findings are excluded at the SOURCE so no consumer has to
     // remember to filter them. A withdrawn claim reaching a model through some
     // path that forgot is the failure this centralisation prevents.
-    if (node && node.kind === 'finding' && !node.retired) found.push(node);
+    if (!node || node.kind !== 'finding' || node.retired) continue;
+    if (seen.has(node.id)) continue;
+    seen.add(node.id);
+    found.push(node);
   }
 
   // Ranked by confidence x recency, per the design. The hard token budget that

--- a/integrations/kilo/hooks/lib/staleness.mjs
+++ b/integrations/kilo/hooks/lib/staleness.mjs
@@ -150,7 +150,23 @@ export function indexFile(dir, rawPath, text) {
   // staleness detection; only the diff degrades, and `serve` already states
   // plainly when evidence cannot be reconstructed.
   const snapshot = source.length <= snapshotLimit() ? source : undefined;
-  const fileNode = putNode(dir, { kind: 'file', key: path, hash: hash(source), snapshot });
+  // BYTES BESIDE THE HASH, because the hash is truncated to 64 bits and content
+  // identity is now read from it. `contentPeers` groups files by identical
+  // content, and two unrelated files sharing a 16-hex-character digest would
+  // silently share each other's findings. The deleted `contentAnchor` carried a
+  // size for exactly this reason and said so; the size is free here, since the
+  // source is already in hand.
+  //
+  // NOT THE SNAPSHOT, which would have been the obvious discriminator and is
+  // unavailable: `putNode` writes snapshots to a separate file that `load()`
+  // deliberately skips, so a loaded node never carries one.
+  const fileNode = putNode(dir, {
+    kind: 'file',
+    key: path,
+    hash: hash(source),
+    bytes: Buffer.byteLength(source),
+    snapshot,
+  });
 
   const symbols = extractSymbols(path, source);
   for (const symbol of symbols) {

--- a/integrations/kilo/hooks/lib/wiki.mjs
+++ b/integrations/kilo/hooks/lib/wiki.mjs
@@ -874,27 +874,135 @@ export function load(dir, { snapshots = false } = {}) {
 }
 
 /**
+ * The sha256 of nothing.
+ *
+ * Every empty file in a repository shares this hash, and they are not the same
+ * file in any sense a reader cares about -- a `.gitkeep` beside an empty
+ * `index.js` beside a placeholder test. Grouping them would make one finding
+ * about one empty file surface on every other, which is noise wearing the
+ * shape of a feature.
+ */
+const EMPTY_CONTENT_HASH = 'e3b0c44298fc1c14';
+
+/**
+ * How many identical copies of one file are followed.
+ *
+ * A vendored core in eleven directories is the case this exists for; a
+ * generated asset checked in five hundred times is the case that would turn one
+ * retrieval into a scan. The cap is far above any real vendoring and far below
+ * anything pathological, and it is applied to the PEERS rather than to the
+ * findings so the ranking below still chooses among a full candidate set.
+ */
+const MAX_CONTENT_PEERS = 32;
+
+/**
+ * Other paths in THIS graph holding byte-identical content to `anchorId`.
+ *
+ * WHY CONTENT IS NOT A SECOND IDENTITY. The obvious implementation of #319 --
+ * the deleted `contentAnchor` -- minted a second anchor id of the form
+ * `content:<hash>:<size>`, and that is the one thing this codebase has already
+ * been burned by: `canonicalKey` lives INSIDE `nodeId` precisely because a
+ * caller that forgot produced a second node for a file that already existed and
+ * split its findings invisibly. A second identity for the same file is that
+ * defect by construction.
+ *
+ * So nothing new is stored and no node is created. A file node already carries
+ * the sha256 of its contents, because staleness needs it -- content identity
+ * has been sitting in the graph since P2. This is an index over what is already
+ * there, which means it cannot split a history: there is still exactly one node
+ * per path, and a finding still has exactly one set of `derived_from` edges.
+ *
+ * STALENESS IS UNAFFECTED, and follows the path exactly as before. That falls
+ * out rather than being decided: content identity IS the hash, so a file whose
+ * bytes change simply stops matching the group and starts matching whichever
+ * group its new bytes belong to. There is no such thing as a stale content
+ * anchor to invalidate.
+ *
+ * SCOPE IS ONE GRAPH, deliberately. This can only ever surface findings that
+ * are already in the graph being read, so it opens no path between projects and
+ * changes nothing about `fleet.mjs` or the shared tier, which remain the only
+ * cross-project transfer and keep their own gates. See docs/WIKI_GRAPH.md for
+ * why the cross-repository half of #319 needs a storage decision this does not
+ * take.
+ */
+export function contentPeers(graph, anchorId) {
+  const anchor = graph.nodes.get(anchorId);
+  if (!anchor || anchor.kind !== 'file') return [];
+
+  const hash = typeof anchor.hash === 'string' ? anchor.hash : '';
+  // A file node minted for an IMPORT TARGET carries no hash at all -- see
+  // `indexFile`, which creates one for every resolved import without reading
+  // it. Grouping on a missing hash would make every unread import in the
+  // repository one content group, which is the largest possible wrong answer.
+  if (!hash || hash === EMPTY_CONTENT_HASH) return [];
+
+  const peers = [];
+  for (const node of graph.nodes.values()) {
+    if (peers.length >= MAX_CONTENT_PEERS) break;
+    if (node.kind !== 'file' || node.id === anchorId) continue;
+    if (node.hash !== hash) continue;
+
+    // THE HASH IS TRUNCATED TO 64 BITS -- `staleness.mjs` slices the sha256 to
+    // sixteen hex characters -- so equal hashes are strong evidence of equal
+    // content and not proof of it, and two unrelated files sharing a digest
+    // would silently share each other's findings. The deleted `contentAnchor`
+    // carried a size beside the digest for exactly this reason, and `indexFile`
+    // now records one.
+    //
+    // ABSENCE IS PERMISSIVE, and deliberately. A node written before `bytes`
+    // existed, or one minted for an import target and never read, has none --
+    // and refusing to group those would make the feature quietly stop working
+    // on every graph that predates it, healing only as files happen to be
+    // touched. Where both sides know their size they must agree.
+    const mine = anchor.bytes;
+    const theirs = node.bytes;
+    if (typeof mine === 'number' && typeof theirs === 'number' && mine !== theirs) continue;
+
+    peers.push(node.id);
+  }
+  return peers;
+}
+
+/**
  * Findings reachable from a file or symbol, by traversal.
  *
  * This is the retrieval primitive the whole design rests on -- no embeddings,
  * no vector index. It follows `derived_from` edges backwards from an anchor to
  * the findings that depend on it, then one hop further through `contains` so
  * that touching a file also surfaces findings about the symbols inside it.
+ *
+ * AND ACROSS IDENTICAL COPIES. A vendored file is the same file wherever it
+ * sits, whatever path each copy is given, so a finding about one copy is a
+ * finding about all of them. This repository is its own example: the shared
+ * hook core is vendored into eleven directories, byte-identical, and until now
+ * a finding recorded against one of them was invisible from the other ten.
+ * `contentPeers` explains why this is an index rather than a second identity.
  */
 export function findingsFor(graph, anchorId, { limit = 20 } = {}) {
-  const anchors = new Set([anchorId]);
+  const anchors = new Set([anchorId, ...contentPeers(graph, anchorId)]);
   for (const edge of graph.edges) {
-    if (edge.edge === 'contains' && edge.from === anchorId) anchors.add(edge.to);
+    // Symbols are expanded from every anchor, not only the one asked for: a
+    // finding about a function inside a vendored file is exactly as applicable
+    // in the copy the reader is actually touching.
+    if (edge.edge === 'contains' && anchors.has(edge.from)) anchors.add(edge.to);
   }
 
   const found = [];
+  // DEDUPED BY ID. A finding can now be reached more than once -- through a file
+  // and a symbol it contains, or through two identical copies of the same file
+  // -- and returning it twice would spend the injection budget twice on one
+  // claim and let it outrank a rival by being duplicated.
+  const seen = new Set();
   for (const edge of graph.edges) {
     if (edge.edge !== 'derived_from' || !anchors.has(edge.to)) continue;
     const node = graph.nodes.get(edge.from);
     // Retired findings are excluded at the SOURCE so no consumer has to
     // remember to filter them. A withdrawn claim reaching a model through some
     // path that forgot is the failure this centralisation prevents.
-    if (node && node.kind === 'finding' && !node.retired) found.push(node);
+    if (!node || node.kind !== 'finding' || node.retired) continue;
+    if (seen.has(node.id)) continue;
+    seen.add(node.id);
+    found.push(node);
   }
 
   // Ranked by confidence x recency, per the design. The hard token budget that

--- a/integrations/opencode/hooks/lib/staleness.mjs
+++ b/integrations/opencode/hooks/lib/staleness.mjs
@@ -150,7 +150,23 @@ export function indexFile(dir, rawPath, text) {
   // staleness detection; only the diff degrades, and `serve` already states
   // plainly when evidence cannot be reconstructed.
   const snapshot = source.length <= snapshotLimit() ? source : undefined;
-  const fileNode = putNode(dir, { kind: 'file', key: path, hash: hash(source), snapshot });
+  // BYTES BESIDE THE HASH, because the hash is truncated to 64 bits and content
+  // identity is now read from it. `contentPeers` groups files by identical
+  // content, and two unrelated files sharing a 16-hex-character digest would
+  // silently share each other's findings. The deleted `contentAnchor` carried a
+  // size for exactly this reason and said so; the size is free here, since the
+  // source is already in hand.
+  //
+  // NOT THE SNAPSHOT, which would have been the obvious discriminator and is
+  // unavailable: `putNode` writes snapshots to a separate file that `load()`
+  // deliberately skips, so a loaded node never carries one.
+  const fileNode = putNode(dir, {
+    kind: 'file',
+    key: path,
+    hash: hash(source),
+    bytes: Buffer.byteLength(source),
+    snapshot,
+  });
 
   const symbols = extractSymbols(path, source);
   for (const symbol of symbols) {

--- a/integrations/opencode/hooks/lib/wiki.mjs
+++ b/integrations/opencode/hooks/lib/wiki.mjs
@@ -874,27 +874,135 @@ export function load(dir, { snapshots = false } = {}) {
 }
 
 /**
+ * The sha256 of nothing.
+ *
+ * Every empty file in a repository shares this hash, and they are not the same
+ * file in any sense a reader cares about -- a `.gitkeep` beside an empty
+ * `index.js` beside a placeholder test. Grouping them would make one finding
+ * about one empty file surface on every other, which is noise wearing the
+ * shape of a feature.
+ */
+const EMPTY_CONTENT_HASH = 'e3b0c44298fc1c14';
+
+/**
+ * How many identical copies of one file are followed.
+ *
+ * A vendored core in eleven directories is the case this exists for; a
+ * generated asset checked in five hundred times is the case that would turn one
+ * retrieval into a scan. The cap is far above any real vendoring and far below
+ * anything pathological, and it is applied to the PEERS rather than to the
+ * findings so the ranking below still chooses among a full candidate set.
+ */
+const MAX_CONTENT_PEERS = 32;
+
+/**
+ * Other paths in THIS graph holding byte-identical content to `anchorId`.
+ *
+ * WHY CONTENT IS NOT A SECOND IDENTITY. The obvious implementation of #319 --
+ * the deleted `contentAnchor` -- minted a second anchor id of the form
+ * `content:<hash>:<size>`, and that is the one thing this codebase has already
+ * been burned by: `canonicalKey` lives INSIDE `nodeId` precisely because a
+ * caller that forgot produced a second node for a file that already existed and
+ * split its findings invisibly. A second identity for the same file is that
+ * defect by construction.
+ *
+ * So nothing new is stored and no node is created. A file node already carries
+ * the sha256 of its contents, because staleness needs it -- content identity
+ * has been sitting in the graph since P2. This is an index over what is already
+ * there, which means it cannot split a history: there is still exactly one node
+ * per path, and a finding still has exactly one set of `derived_from` edges.
+ *
+ * STALENESS IS UNAFFECTED, and follows the path exactly as before. That falls
+ * out rather than being decided: content identity IS the hash, so a file whose
+ * bytes change simply stops matching the group and starts matching whichever
+ * group its new bytes belong to. There is no such thing as a stale content
+ * anchor to invalidate.
+ *
+ * SCOPE IS ONE GRAPH, deliberately. This can only ever surface findings that
+ * are already in the graph being read, so it opens no path between projects and
+ * changes nothing about `fleet.mjs` or the shared tier, which remain the only
+ * cross-project transfer and keep their own gates. See docs/WIKI_GRAPH.md for
+ * why the cross-repository half of #319 needs a storage decision this does not
+ * take.
+ */
+export function contentPeers(graph, anchorId) {
+  const anchor = graph.nodes.get(anchorId);
+  if (!anchor || anchor.kind !== 'file') return [];
+
+  const hash = typeof anchor.hash === 'string' ? anchor.hash : '';
+  // A file node minted for an IMPORT TARGET carries no hash at all -- see
+  // `indexFile`, which creates one for every resolved import without reading
+  // it. Grouping on a missing hash would make every unread import in the
+  // repository one content group, which is the largest possible wrong answer.
+  if (!hash || hash === EMPTY_CONTENT_HASH) return [];
+
+  const peers = [];
+  for (const node of graph.nodes.values()) {
+    if (peers.length >= MAX_CONTENT_PEERS) break;
+    if (node.kind !== 'file' || node.id === anchorId) continue;
+    if (node.hash !== hash) continue;
+
+    // THE HASH IS TRUNCATED TO 64 BITS -- `staleness.mjs` slices the sha256 to
+    // sixteen hex characters -- so equal hashes are strong evidence of equal
+    // content and not proof of it, and two unrelated files sharing a digest
+    // would silently share each other's findings. The deleted `contentAnchor`
+    // carried a size beside the digest for exactly this reason, and `indexFile`
+    // now records one.
+    //
+    // ABSENCE IS PERMISSIVE, and deliberately. A node written before `bytes`
+    // existed, or one minted for an import target and never read, has none --
+    // and refusing to group those would make the feature quietly stop working
+    // on every graph that predates it, healing only as files happen to be
+    // touched. Where both sides know their size they must agree.
+    const mine = anchor.bytes;
+    const theirs = node.bytes;
+    if (typeof mine === 'number' && typeof theirs === 'number' && mine !== theirs) continue;
+
+    peers.push(node.id);
+  }
+  return peers;
+}
+
+/**
  * Findings reachable from a file or symbol, by traversal.
  *
  * This is the retrieval primitive the whole design rests on -- no embeddings,
  * no vector index. It follows `derived_from` edges backwards from an anchor to
  * the findings that depend on it, then one hop further through `contains` so
  * that touching a file also surfaces findings about the symbols inside it.
+ *
+ * AND ACROSS IDENTICAL COPIES. A vendored file is the same file wherever it
+ * sits, whatever path each copy is given, so a finding about one copy is a
+ * finding about all of them. This repository is its own example: the shared
+ * hook core is vendored into eleven directories, byte-identical, and until now
+ * a finding recorded against one of them was invisible from the other ten.
+ * `contentPeers` explains why this is an index rather than a second identity.
  */
 export function findingsFor(graph, anchorId, { limit = 20 } = {}) {
-  const anchors = new Set([anchorId]);
+  const anchors = new Set([anchorId, ...contentPeers(graph, anchorId)]);
   for (const edge of graph.edges) {
-    if (edge.edge === 'contains' && edge.from === anchorId) anchors.add(edge.to);
+    // Symbols are expanded from every anchor, not only the one asked for: a
+    // finding about a function inside a vendored file is exactly as applicable
+    // in the copy the reader is actually touching.
+    if (edge.edge === 'contains' && anchors.has(edge.from)) anchors.add(edge.to);
   }
 
   const found = [];
+  // DEDUPED BY ID. A finding can now be reached more than once -- through a file
+  // and a symbol it contains, or through two identical copies of the same file
+  // -- and returning it twice would spend the injection budget twice on one
+  // claim and let it outrank a rival by being duplicated.
+  const seen = new Set();
   for (const edge of graph.edges) {
     if (edge.edge !== 'derived_from' || !anchors.has(edge.to)) continue;
     const node = graph.nodes.get(edge.from);
     // Retired findings are excluded at the SOURCE so no consumer has to
     // remember to filter them. A withdrawn claim reaching a model through some
     // path that forgot is the failure this centralisation prevents.
-    if (node && node.kind === 'finding' && !node.retired) found.push(node);
+    if (!node || node.kind !== 'finding' || node.retired) continue;
+    if (seen.has(node.id)) continue;
+    seen.add(node.id);
+    found.push(node);
   }
 
   // Ranked by confidence x recency, per the design. The hard token budget that

--- a/integrations/qwen/hooks/lib/staleness.mjs
+++ b/integrations/qwen/hooks/lib/staleness.mjs
@@ -150,7 +150,23 @@ export function indexFile(dir, rawPath, text) {
   // staleness detection; only the diff degrades, and `serve` already states
   // plainly when evidence cannot be reconstructed.
   const snapshot = source.length <= snapshotLimit() ? source : undefined;
-  const fileNode = putNode(dir, { kind: 'file', key: path, hash: hash(source), snapshot });
+  // BYTES BESIDE THE HASH, because the hash is truncated to 64 bits and content
+  // identity is now read from it. `contentPeers` groups files by identical
+  // content, and two unrelated files sharing a 16-hex-character digest would
+  // silently share each other's findings. The deleted `contentAnchor` carried a
+  // size for exactly this reason and said so; the size is free here, since the
+  // source is already in hand.
+  //
+  // NOT THE SNAPSHOT, which would have been the obvious discriminator and is
+  // unavailable: `putNode` writes snapshots to a separate file that `load()`
+  // deliberately skips, so a loaded node never carries one.
+  const fileNode = putNode(dir, {
+    kind: 'file',
+    key: path,
+    hash: hash(source),
+    bytes: Buffer.byteLength(source),
+    snapshot,
+  });
 
   const symbols = extractSymbols(path, source);
   for (const symbol of symbols) {

--- a/integrations/qwen/hooks/lib/wiki.mjs
+++ b/integrations/qwen/hooks/lib/wiki.mjs
@@ -874,27 +874,135 @@ export function load(dir, { snapshots = false } = {}) {
 }
 
 /**
+ * The sha256 of nothing.
+ *
+ * Every empty file in a repository shares this hash, and they are not the same
+ * file in any sense a reader cares about -- a `.gitkeep` beside an empty
+ * `index.js` beside a placeholder test. Grouping them would make one finding
+ * about one empty file surface on every other, which is noise wearing the
+ * shape of a feature.
+ */
+const EMPTY_CONTENT_HASH = 'e3b0c44298fc1c14';
+
+/**
+ * How many identical copies of one file are followed.
+ *
+ * A vendored core in eleven directories is the case this exists for; a
+ * generated asset checked in five hundred times is the case that would turn one
+ * retrieval into a scan. The cap is far above any real vendoring and far below
+ * anything pathological, and it is applied to the PEERS rather than to the
+ * findings so the ranking below still chooses among a full candidate set.
+ */
+const MAX_CONTENT_PEERS = 32;
+
+/**
+ * Other paths in THIS graph holding byte-identical content to `anchorId`.
+ *
+ * WHY CONTENT IS NOT A SECOND IDENTITY. The obvious implementation of #319 --
+ * the deleted `contentAnchor` -- minted a second anchor id of the form
+ * `content:<hash>:<size>`, and that is the one thing this codebase has already
+ * been burned by: `canonicalKey` lives INSIDE `nodeId` precisely because a
+ * caller that forgot produced a second node for a file that already existed and
+ * split its findings invisibly. A second identity for the same file is that
+ * defect by construction.
+ *
+ * So nothing new is stored and no node is created. A file node already carries
+ * the sha256 of its contents, because staleness needs it -- content identity
+ * has been sitting in the graph since P2. This is an index over what is already
+ * there, which means it cannot split a history: there is still exactly one node
+ * per path, and a finding still has exactly one set of `derived_from` edges.
+ *
+ * STALENESS IS UNAFFECTED, and follows the path exactly as before. That falls
+ * out rather than being decided: content identity IS the hash, so a file whose
+ * bytes change simply stops matching the group and starts matching whichever
+ * group its new bytes belong to. There is no such thing as a stale content
+ * anchor to invalidate.
+ *
+ * SCOPE IS ONE GRAPH, deliberately. This can only ever surface findings that
+ * are already in the graph being read, so it opens no path between projects and
+ * changes nothing about `fleet.mjs` or the shared tier, which remain the only
+ * cross-project transfer and keep their own gates. See docs/WIKI_GRAPH.md for
+ * why the cross-repository half of #319 needs a storage decision this does not
+ * take.
+ */
+export function contentPeers(graph, anchorId) {
+  const anchor = graph.nodes.get(anchorId);
+  if (!anchor || anchor.kind !== 'file') return [];
+
+  const hash = typeof anchor.hash === 'string' ? anchor.hash : '';
+  // A file node minted for an IMPORT TARGET carries no hash at all -- see
+  // `indexFile`, which creates one for every resolved import without reading
+  // it. Grouping on a missing hash would make every unread import in the
+  // repository one content group, which is the largest possible wrong answer.
+  if (!hash || hash === EMPTY_CONTENT_HASH) return [];
+
+  const peers = [];
+  for (const node of graph.nodes.values()) {
+    if (peers.length >= MAX_CONTENT_PEERS) break;
+    if (node.kind !== 'file' || node.id === anchorId) continue;
+    if (node.hash !== hash) continue;
+
+    // THE HASH IS TRUNCATED TO 64 BITS -- `staleness.mjs` slices the sha256 to
+    // sixteen hex characters -- so equal hashes are strong evidence of equal
+    // content and not proof of it, and two unrelated files sharing a digest
+    // would silently share each other's findings. The deleted `contentAnchor`
+    // carried a size beside the digest for exactly this reason, and `indexFile`
+    // now records one.
+    //
+    // ABSENCE IS PERMISSIVE, and deliberately. A node written before `bytes`
+    // existed, or one minted for an import target and never read, has none --
+    // and refusing to group those would make the feature quietly stop working
+    // on every graph that predates it, healing only as files happen to be
+    // touched. Where both sides know their size they must agree.
+    const mine = anchor.bytes;
+    const theirs = node.bytes;
+    if (typeof mine === 'number' && typeof theirs === 'number' && mine !== theirs) continue;
+
+    peers.push(node.id);
+  }
+  return peers;
+}
+
+/**
  * Findings reachable from a file or symbol, by traversal.
  *
  * This is the retrieval primitive the whole design rests on -- no embeddings,
  * no vector index. It follows `derived_from` edges backwards from an anchor to
  * the findings that depend on it, then one hop further through `contains` so
  * that touching a file also surfaces findings about the symbols inside it.
+ *
+ * AND ACROSS IDENTICAL COPIES. A vendored file is the same file wherever it
+ * sits, whatever path each copy is given, so a finding about one copy is a
+ * finding about all of them. This repository is its own example: the shared
+ * hook core is vendored into eleven directories, byte-identical, and until now
+ * a finding recorded against one of them was invisible from the other ten.
+ * `contentPeers` explains why this is an index rather than a second identity.
  */
 export function findingsFor(graph, anchorId, { limit = 20 } = {}) {
-  const anchors = new Set([anchorId]);
+  const anchors = new Set([anchorId, ...contentPeers(graph, anchorId)]);
   for (const edge of graph.edges) {
-    if (edge.edge === 'contains' && edge.from === anchorId) anchors.add(edge.to);
+    // Symbols are expanded from every anchor, not only the one asked for: a
+    // finding about a function inside a vendored file is exactly as applicable
+    // in the copy the reader is actually touching.
+    if (edge.edge === 'contains' && anchors.has(edge.from)) anchors.add(edge.to);
   }
 
   const found = [];
+  // DEDUPED BY ID. A finding can now be reached more than once -- through a file
+  // and a symbol it contains, or through two identical copies of the same file
+  // -- and returning it twice would spend the injection budget twice on one
+  // claim and let it outrank a rival by being duplicated.
+  const seen = new Set();
   for (const edge of graph.edges) {
     if (edge.edge !== 'derived_from' || !anchors.has(edge.to)) continue;
     const node = graph.nodes.get(edge.from);
     // Retired findings are excluded at the SOURCE so no consumer has to
     // remember to filter them. A withdrawn claim reaching a model through some
     // path that forgot is the failure this centralisation prevents.
-    if (node && node.kind === 'finding' && !node.retired) found.push(node);
+    if (!node || node.kind !== 'finding' || node.retired) continue;
+    if (seen.has(node.id)) continue;
+    seen.add(node.id);
+    found.push(node);
   }
 
   // Ranked by confidence x recency, per the design. The hard token budget that

--- a/integrations/windsurf/hooks/lib/staleness.mjs
+++ b/integrations/windsurf/hooks/lib/staleness.mjs
@@ -150,7 +150,23 @@ export function indexFile(dir, rawPath, text) {
   // staleness detection; only the diff degrades, and `serve` already states
   // plainly when evidence cannot be reconstructed.
   const snapshot = source.length <= snapshotLimit() ? source : undefined;
-  const fileNode = putNode(dir, { kind: 'file', key: path, hash: hash(source), snapshot });
+  // BYTES BESIDE THE HASH, because the hash is truncated to 64 bits and content
+  // identity is now read from it. `contentPeers` groups files by identical
+  // content, and two unrelated files sharing a 16-hex-character digest would
+  // silently share each other's findings. The deleted `contentAnchor` carried a
+  // size for exactly this reason and said so; the size is free here, since the
+  // source is already in hand.
+  //
+  // NOT THE SNAPSHOT, which would have been the obvious discriminator and is
+  // unavailable: `putNode` writes snapshots to a separate file that `load()`
+  // deliberately skips, so a loaded node never carries one.
+  const fileNode = putNode(dir, {
+    kind: 'file',
+    key: path,
+    hash: hash(source),
+    bytes: Buffer.byteLength(source),
+    snapshot,
+  });
 
   const symbols = extractSymbols(path, source);
   for (const symbol of symbols) {

--- a/integrations/windsurf/hooks/lib/wiki.mjs
+++ b/integrations/windsurf/hooks/lib/wiki.mjs
@@ -874,27 +874,135 @@ export function load(dir, { snapshots = false } = {}) {
 }
 
 /**
+ * The sha256 of nothing.
+ *
+ * Every empty file in a repository shares this hash, and they are not the same
+ * file in any sense a reader cares about -- a `.gitkeep` beside an empty
+ * `index.js` beside a placeholder test. Grouping them would make one finding
+ * about one empty file surface on every other, which is noise wearing the
+ * shape of a feature.
+ */
+const EMPTY_CONTENT_HASH = 'e3b0c44298fc1c14';
+
+/**
+ * How many identical copies of one file are followed.
+ *
+ * A vendored core in eleven directories is the case this exists for; a
+ * generated asset checked in five hundred times is the case that would turn one
+ * retrieval into a scan. The cap is far above any real vendoring and far below
+ * anything pathological, and it is applied to the PEERS rather than to the
+ * findings so the ranking below still chooses among a full candidate set.
+ */
+const MAX_CONTENT_PEERS = 32;
+
+/**
+ * Other paths in THIS graph holding byte-identical content to `anchorId`.
+ *
+ * WHY CONTENT IS NOT A SECOND IDENTITY. The obvious implementation of #319 --
+ * the deleted `contentAnchor` -- minted a second anchor id of the form
+ * `content:<hash>:<size>`, and that is the one thing this codebase has already
+ * been burned by: `canonicalKey` lives INSIDE `nodeId` precisely because a
+ * caller that forgot produced a second node for a file that already existed and
+ * split its findings invisibly. A second identity for the same file is that
+ * defect by construction.
+ *
+ * So nothing new is stored and no node is created. A file node already carries
+ * the sha256 of its contents, because staleness needs it -- content identity
+ * has been sitting in the graph since P2. This is an index over what is already
+ * there, which means it cannot split a history: there is still exactly one node
+ * per path, and a finding still has exactly one set of `derived_from` edges.
+ *
+ * STALENESS IS UNAFFECTED, and follows the path exactly as before. That falls
+ * out rather than being decided: content identity IS the hash, so a file whose
+ * bytes change simply stops matching the group and starts matching whichever
+ * group its new bytes belong to. There is no such thing as a stale content
+ * anchor to invalidate.
+ *
+ * SCOPE IS ONE GRAPH, deliberately. This can only ever surface findings that
+ * are already in the graph being read, so it opens no path between projects and
+ * changes nothing about `fleet.mjs` or the shared tier, which remain the only
+ * cross-project transfer and keep their own gates. See docs/WIKI_GRAPH.md for
+ * why the cross-repository half of #319 needs a storage decision this does not
+ * take.
+ */
+export function contentPeers(graph, anchorId) {
+  const anchor = graph.nodes.get(anchorId);
+  if (!anchor || anchor.kind !== 'file') return [];
+
+  const hash = typeof anchor.hash === 'string' ? anchor.hash : '';
+  // A file node minted for an IMPORT TARGET carries no hash at all -- see
+  // `indexFile`, which creates one for every resolved import without reading
+  // it. Grouping on a missing hash would make every unread import in the
+  // repository one content group, which is the largest possible wrong answer.
+  if (!hash || hash === EMPTY_CONTENT_HASH) return [];
+
+  const peers = [];
+  for (const node of graph.nodes.values()) {
+    if (peers.length >= MAX_CONTENT_PEERS) break;
+    if (node.kind !== 'file' || node.id === anchorId) continue;
+    if (node.hash !== hash) continue;
+
+    // THE HASH IS TRUNCATED TO 64 BITS -- `staleness.mjs` slices the sha256 to
+    // sixteen hex characters -- so equal hashes are strong evidence of equal
+    // content and not proof of it, and two unrelated files sharing a digest
+    // would silently share each other's findings. The deleted `contentAnchor`
+    // carried a size beside the digest for exactly this reason, and `indexFile`
+    // now records one.
+    //
+    // ABSENCE IS PERMISSIVE, and deliberately. A node written before `bytes`
+    // existed, or one minted for an import target and never read, has none --
+    // and refusing to group those would make the feature quietly stop working
+    // on every graph that predates it, healing only as files happen to be
+    // touched. Where both sides know their size they must agree.
+    const mine = anchor.bytes;
+    const theirs = node.bytes;
+    if (typeof mine === 'number' && typeof theirs === 'number' && mine !== theirs) continue;
+
+    peers.push(node.id);
+  }
+  return peers;
+}
+
+/**
  * Findings reachable from a file or symbol, by traversal.
  *
  * This is the retrieval primitive the whole design rests on -- no embeddings,
  * no vector index. It follows `derived_from` edges backwards from an anchor to
  * the findings that depend on it, then one hop further through `contains` so
  * that touching a file also surfaces findings about the symbols inside it.
+ *
+ * AND ACROSS IDENTICAL COPIES. A vendored file is the same file wherever it
+ * sits, whatever path each copy is given, so a finding about one copy is a
+ * finding about all of them. This repository is its own example: the shared
+ * hook core is vendored into eleven directories, byte-identical, and until now
+ * a finding recorded against one of them was invisible from the other ten.
+ * `contentPeers` explains why this is an index rather than a second identity.
  */
 export function findingsFor(graph, anchorId, { limit = 20 } = {}) {
-  const anchors = new Set([anchorId]);
+  const anchors = new Set([anchorId, ...contentPeers(graph, anchorId)]);
   for (const edge of graph.edges) {
-    if (edge.edge === 'contains' && edge.from === anchorId) anchors.add(edge.to);
+    // Symbols are expanded from every anchor, not only the one asked for: a
+    // finding about a function inside a vendored file is exactly as applicable
+    // in the copy the reader is actually touching.
+    if (edge.edge === 'contains' && anchors.has(edge.from)) anchors.add(edge.to);
   }
 
   const found = [];
+  // DEDUPED BY ID. A finding can now be reached more than once -- through a file
+  // and a symbol it contains, or through two identical copies of the same file
+  // -- and returning it twice would spend the injection budget twice on one
+  // claim and let it outrank a rival by being duplicated.
+  const seen = new Set();
   for (const edge of graph.edges) {
     if (edge.edge !== 'derived_from' || !anchors.has(edge.to)) continue;
     const node = graph.nodes.get(edge.from);
     // Retired findings are excluded at the SOURCE so no consumer has to
     // remember to filter them. A withdrawn claim reaching a model through some
     // path that forgot is the failure this centralisation prevents.
-    if (node && node.kind === 'finding' && !node.retired) found.push(node);
+    if (!node || node.kind !== 'finding' || node.retired) continue;
+    if (seen.has(node.id)) continue;
+    seen.add(node.id);
+    found.push(node);
   }
 
   // Ranked by confidence x recency, per the design. The hard token budget that

--- a/plugin/hooks/lib/staleness.mjs
+++ b/plugin/hooks/lib/staleness.mjs
@@ -150,7 +150,23 @@ export function indexFile(dir, rawPath, text) {
   // staleness detection; only the diff degrades, and `serve` already states
   // plainly when evidence cannot be reconstructed.
   const snapshot = source.length <= snapshotLimit() ? source : undefined;
-  const fileNode = putNode(dir, { kind: 'file', key: path, hash: hash(source), snapshot });
+  // BYTES BESIDE THE HASH, because the hash is truncated to 64 bits and content
+  // identity is now read from it. `contentPeers` groups files by identical
+  // content, and two unrelated files sharing a 16-hex-character digest would
+  // silently share each other's findings. The deleted `contentAnchor` carried a
+  // size for exactly this reason and said so; the size is free here, since the
+  // source is already in hand.
+  //
+  // NOT THE SNAPSHOT, which would have been the obvious discriminator and is
+  // unavailable: `putNode` writes snapshots to a separate file that `load()`
+  // deliberately skips, so a loaded node never carries one.
+  const fileNode = putNode(dir, {
+    kind: 'file',
+    key: path,
+    hash: hash(source),
+    bytes: Buffer.byteLength(source),
+    snapshot,
+  });
 
   const symbols = extractSymbols(path, source);
   for (const symbol of symbols) {

--- a/plugin/hooks/lib/wiki.mjs
+++ b/plugin/hooks/lib/wiki.mjs
@@ -874,27 +874,135 @@ export function load(dir, { snapshots = false } = {}) {
 }
 
 /**
+ * The sha256 of nothing.
+ *
+ * Every empty file in a repository shares this hash, and they are not the same
+ * file in any sense a reader cares about -- a `.gitkeep` beside an empty
+ * `index.js` beside a placeholder test. Grouping them would make one finding
+ * about one empty file surface on every other, which is noise wearing the
+ * shape of a feature.
+ */
+const EMPTY_CONTENT_HASH = 'e3b0c44298fc1c14';
+
+/**
+ * How many identical copies of one file are followed.
+ *
+ * A vendored core in eleven directories is the case this exists for; a
+ * generated asset checked in five hundred times is the case that would turn one
+ * retrieval into a scan. The cap is far above any real vendoring and far below
+ * anything pathological, and it is applied to the PEERS rather than to the
+ * findings so the ranking below still chooses among a full candidate set.
+ */
+const MAX_CONTENT_PEERS = 32;
+
+/**
+ * Other paths in THIS graph holding byte-identical content to `anchorId`.
+ *
+ * WHY CONTENT IS NOT A SECOND IDENTITY. The obvious implementation of #319 --
+ * the deleted `contentAnchor` -- minted a second anchor id of the form
+ * `content:<hash>:<size>`, and that is the one thing this codebase has already
+ * been burned by: `canonicalKey` lives INSIDE `nodeId` precisely because a
+ * caller that forgot produced a second node for a file that already existed and
+ * split its findings invisibly. A second identity for the same file is that
+ * defect by construction.
+ *
+ * So nothing new is stored and no node is created. A file node already carries
+ * the sha256 of its contents, because staleness needs it -- content identity
+ * has been sitting in the graph since P2. This is an index over what is already
+ * there, which means it cannot split a history: there is still exactly one node
+ * per path, and a finding still has exactly one set of `derived_from` edges.
+ *
+ * STALENESS IS UNAFFECTED, and follows the path exactly as before. That falls
+ * out rather than being decided: content identity IS the hash, so a file whose
+ * bytes change simply stops matching the group and starts matching whichever
+ * group its new bytes belong to. There is no such thing as a stale content
+ * anchor to invalidate.
+ *
+ * SCOPE IS ONE GRAPH, deliberately. This can only ever surface findings that
+ * are already in the graph being read, so it opens no path between projects and
+ * changes nothing about `fleet.mjs` or the shared tier, which remain the only
+ * cross-project transfer and keep their own gates. See docs/WIKI_GRAPH.md for
+ * why the cross-repository half of #319 needs a storage decision this does not
+ * take.
+ */
+export function contentPeers(graph, anchorId) {
+  const anchor = graph.nodes.get(anchorId);
+  if (!anchor || anchor.kind !== 'file') return [];
+
+  const hash = typeof anchor.hash === 'string' ? anchor.hash : '';
+  // A file node minted for an IMPORT TARGET carries no hash at all -- see
+  // `indexFile`, which creates one for every resolved import without reading
+  // it. Grouping on a missing hash would make every unread import in the
+  // repository one content group, which is the largest possible wrong answer.
+  if (!hash || hash === EMPTY_CONTENT_HASH) return [];
+
+  const peers = [];
+  for (const node of graph.nodes.values()) {
+    if (peers.length >= MAX_CONTENT_PEERS) break;
+    if (node.kind !== 'file' || node.id === anchorId) continue;
+    if (node.hash !== hash) continue;
+
+    // THE HASH IS TRUNCATED TO 64 BITS -- `staleness.mjs` slices the sha256 to
+    // sixteen hex characters -- so equal hashes are strong evidence of equal
+    // content and not proof of it, and two unrelated files sharing a digest
+    // would silently share each other's findings. The deleted `contentAnchor`
+    // carried a size beside the digest for exactly this reason, and `indexFile`
+    // now records one.
+    //
+    // ABSENCE IS PERMISSIVE, and deliberately. A node written before `bytes`
+    // existed, or one minted for an import target and never read, has none --
+    // and refusing to group those would make the feature quietly stop working
+    // on every graph that predates it, healing only as files happen to be
+    // touched. Where both sides know their size they must agree.
+    const mine = anchor.bytes;
+    const theirs = node.bytes;
+    if (typeof mine === 'number' && typeof theirs === 'number' && mine !== theirs) continue;
+
+    peers.push(node.id);
+  }
+  return peers;
+}
+
+/**
  * Findings reachable from a file or symbol, by traversal.
  *
  * This is the retrieval primitive the whole design rests on -- no embeddings,
  * no vector index. It follows `derived_from` edges backwards from an anchor to
  * the findings that depend on it, then one hop further through `contains` so
  * that touching a file also surfaces findings about the symbols inside it.
+ *
+ * AND ACROSS IDENTICAL COPIES. A vendored file is the same file wherever it
+ * sits, whatever path each copy is given, so a finding about one copy is a
+ * finding about all of them. This repository is its own example: the shared
+ * hook core is vendored into eleven directories, byte-identical, and until now
+ * a finding recorded against one of them was invisible from the other ten.
+ * `contentPeers` explains why this is an index rather than a second identity.
  */
 export function findingsFor(graph, anchorId, { limit = 20 } = {}) {
-  const anchors = new Set([anchorId]);
+  const anchors = new Set([anchorId, ...contentPeers(graph, anchorId)]);
   for (const edge of graph.edges) {
-    if (edge.edge === 'contains' && edge.from === anchorId) anchors.add(edge.to);
+    // Symbols are expanded from every anchor, not only the one asked for: a
+    // finding about a function inside a vendored file is exactly as applicable
+    // in the copy the reader is actually touching.
+    if (edge.edge === 'contains' && anchors.has(edge.from)) anchors.add(edge.to);
   }
 
   const found = [];
+  // DEDUPED BY ID. A finding can now be reached more than once -- through a file
+  // and a symbol it contains, or through two identical copies of the same file
+  // -- and returning it twice would spend the injection budget twice on one
+  // claim and let it outrank a rival by being duplicated.
+  const seen = new Set();
   for (const edge of graph.edges) {
     if (edge.edge !== 'derived_from' || !anchors.has(edge.to)) continue;
     const node = graph.nodes.get(edge.from);
     // Retired findings are excluded at the SOURCE so no consumer has to
     // remember to filter them. A withdrawn claim reaching a model through some
     // path that forgot is the failure this centralisation prevents.
-    if (node && node.kind === 'finding' && !node.retired) found.push(node);
+    if (!node || node.kind !== 'finding' || node.retired) continue;
+    if (seen.has(node.id)) continue;
+    seen.add(node.id);
+    found.push(node);
   }
 
   // Ranked by confidence x recency, per the design. The hard token budget that

--- a/tests/hooks/content-addressed-anchors.test.mjs
+++ b/tests/hooks/content-addressed-anchors.test.mjs
@@ -1,0 +1,274 @@
+/**
+ * A finding about a file reaches every identical copy of it.
+ *
+ * A vendored file is the same file wherever it sits, whatever path each copy is
+ * given. Until now a finding recorded against one copy was invisible from the
+ * others, and this repository is its own best example: the shared hook core is
+ * vendored into eleven directories, byte-identical, so a claim about
+ * `plugin/hooks/lib/adapter.mjs` said nothing at all when a reader touched
+ * `integrations/qwen/hooks/lib/adapter.mjs`.
+ *
+ * WHY THIS IS AN INDEX AND NOT A SECOND IDENTITY, which is the question #319
+ * asks and the reason `contentAnchor` was deleted rather than wired. That
+ * implementation minted a second anchor id, `content:<hash>:<size>`, and a
+ * second identity for one file is the defect this codebase has already been
+ * burned by -- `canonicalKey` lives inside `nodeId` precisely because a caller
+ * that forgot produced a second node for an existing file and split its
+ * findings invisibly.
+ *
+ * So nothing new is stored. A file node has carried the sha256 of its contents
+ * since staleness needed it, and this reads what is already there. One node per
+ * path, one set of `derived_from` edges per finding, no history to split.
+ *
+ * The other three questions fall out rather than being decided, and each has a
+ * test below: identical content at two paths in one repository, whether
+ * staleness follows content or path, and what this does to cross-project
+ * transfer.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  load,
+  nodeId,
+  putNode,
+  putNodeWithEdges,
+  findingsFor,
+  contentPeers,
+} from '../../hooks-core/wiki.mjs';
+import { indexFile } from '../../hooks-core/staleness.mjs';
+
+const NL = String.fromCharCode(10);
+const VENDORED = 'export function run() {' + NL + '  return 1;' + NL + '}' + NL;
+
+let project;
+let dir;
+
+beforeEach(() => {
+  project = mkdtempSync(join(tmpdir(), 'content-anchor-'));
+  mkdirSync(join(project, '.git'), { recursive: true });
+  dir = join(project, '.token-optimizer', 'wiki');
+});
+
+afterEach(() => {
+  rmSync(project, { recursive: true, force: true });
+});
+
+/** Writes a file, indexes it, and returns its path. */
+function vendor(relative, contents = VENDORED) {
+  const path = join(project, ...relative.split('/'));
+  mkdirSync(join(path, '..'), { recursive: true });
+  writeFileSync(path, contents);
+  indexFile(dir, path, contents);
+  return path;
+}
+
+/** A finding anchored to one path. */
+function findingAt(key, path, claim = 'run() returns 1, not the parsed value') {
+  return putNodeWithEdges(
+    dir,
+    { kind: 'finding', key, claim, type: 'finding', confidence: 0.9, origin: 'human' },
+    [{ edge: 'derived_from', to: nodeId('file', path) }]
+  );
+}
+
+const keysFor = (path) =>
+  findingsFor(load(dir), nodeId('file', path), { limit: 20 }).map((f) => f.key);
+
+describe('a finding reaches every identical copy', () => {
+  test('surfaces from a sibling copy the finding was never anchored to', () => {
+    const source = vendor('plugin/hooks/lib/adapter.mjs');
+    const copy = vendor('integrations/qwen/hooks/lib/adapter.mjs');
+    findingAt('adapter-returns-one', source);
+
+    // The claim was recorded against one copy and is asked for from the other.
+    expect(keysFor(copy)).toContain('adapter-returns-one');
+    // And still from the copy it was anchored to, obviously.
+    expect(keysFor(source)).toContain('adapter-returns-one');
+  });
+
+  test('reaches all of them, the way this repository actually vendors', () => {
+    // Eleven directories, byte-identical, which is the case that motivated the
+    // issue rather than a hypothetical one.
+    const paths = Array.from({ length: 11 }, (_, i) =>
+      vendor(`integrations/client-${i}/hooks/lib/adapter.mjs`)
+    );
+    findingAt('vendored-claim', paths[0]);
+
+    for (const path of paths) {
+      expect([path, keysFor(path)]).toEqual([path, expect.arrayContaining(['vendored-claim'])]);
+    }
+  });
+
+  test('returns the finding ONCE, however many anchors reach it', () => {
+    // A finding reachable through several anchors would otherwise be returned
+    // several times -- spending the injection budget repeatedly on one claim
+    // and letting it outrank a rival by being duplicated.
+    //
+    // ANCHORED TO TWO COPIES DELIBERATELY. The first version of this test
+    // anchored the finding to ONE path and passed with the dedupe removed,
+    // because the loop iterates EDGES: one edge can only be found once however
+    // many anchors are in the set. Duplication needs two edges that both land
+    // inside it, which is exactly what a finding recorded against two identical
+    // copies produces.
+    const a = vendor('a/adapter.mjs');
+    const b = vendor('b/adapter.mjs');
+    vendor('c/adapter.mjs');
+    putNodeWithEdges(
+      dir,
+      { kind: 'finding', key: 'once-only', claim: 'reached from both copies', type: 'finding', confidence: 0.9 },
+      [
+        { edge: 'derived_from', to: nodeId('file', a) },
+        { edge: 'derived_from', to: nodeId('file', b) },
+      ]
+    );
+
+    for (const path of [a, b]) {
+      const keys = keysFor(path);
+      expect([path, keys.filter((k) => k === 'once-only').length]).toEqual([path, 1]);
+    }
+  });
+
+  test('does not reach a file whose contents differ', () => {
+    const source = vendor('lib/adapter.mjs');
+    const different = vendor('lib/other.mjs', 'export const x = 2;' + NL);
+    findingAt('only-here', source);
+
+    expect(keysFor(different)).not.toContain('only-here');
+  });
+});
+
+describe('the three questions #319 asks', () => {
+  test('identical content at two paths in ONE repository is the same file', () => {
+    // The issue asks what happens here. The answer is that it is the ordinary
+    // case rather than an edge one: two paths, one content group, findings
+    // shared both ways.
+    const first = vendor('vendor/left/dep.js');
+    const second = vendor('vendor/right/dep.js');
+    findingAt('from-left', first);
+    findingAt('from-right', second, 'a second claim about the same bytes');
+
+    expect(keysFor(first)).toEqual(expect.arrayContaining(['from-left', 'from-right']));
+    expect(keysFor(second)).toEqual(expect.arrayContaining(['from-left', 'from-right']));
+  });
+
+  test('staleness follows the PATH, and the group self-corrects', () => {
+    // Content identity IS the hash, so there is no such thing as a stale
+    // content anchor to invalidate: a file whose bytes change stops matching
+    // its old group without anything having to notice.
+    const source = vendor('lib/adapter.mjs');
+    const copy = vendor('other/adapter.mjs');
+    findingAt('shared-claim', source);
+    expect(keysFor(copy)).toContain('shared-claim');
+
+    // The copy is edited. It is no longer the same file.
+    const edited = 'export function run() {' + NL + '  return 2;' + NL + '}' + NL;
+    writeFileSync(copy, edited);
+    indexFile(dir, copy, edited);
+
+    expect(keysFor(copy)).not.toContain('shared-claim');
+    // And the original is untouched -- the finding is still its own.
+    expect(keysFor(source)).toContain('shared-claim');
+  });
+
+  test('opens no path between projects: it can only read one graph', () => {
+    // This is what keeps `fleet.mjs` and the shared tier the only cross-project
+    // transfer, with their own gates intact. A finding in another project's
+    // graph is not in this graph, so no amount of matching content can reach
+    // it.
+    const source = vendor('lib/adapter.mjs');
+    findingAt('local-only', source);
+
+    const other = mkdtempSync(join(tmpdir(), 'content-anchor-other-'));
+    try {
+      const otherDir = join(other, '.token-optimizer', 'wiki');
+      const otherPath = join(other, 'lib', 'adapter.mjs');
+      mkdirSync(join(other, 'lib'), { recursive: true });
+      writeFileSync(otherPath, VENDORED);
+      indexFile(otherDir, otherPath, VENDORED);
+
+      // Byte-identical, different graph, nothing carried over.
+      const reached = findingsFor(load(otherDir), nodeId('file', otherPath), { limit: 20 });
+      expect(reached).toEqual([]);
+    } finally {
+      rmSync(other, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('what must never be grouped', () => {
+  test('empty files are not one file', () => {
+    // Every empty file in a repository shares a hash, and they are not the same
+    // file in any sense a reader cares about.
+    const keep = vendor('docs/.gitkeep', '');
+    const index = vendor('src/index.js', '');
+    findingAt('about-an-empty-file', keep);
+
+    expect(contentPeers(load(dir), nodeId('file', keep))).toEqual([]);
+    expect(keysFor(index)).not.toContain('about-an-empty-file');
+  });
+
+  test('a file node with no usable hash groups with nothing', () => {
+    // `indexFile` mints a file node for every resolved import WITHOUT reading
+    // it, so those carry no hash. Grouping on a missing or empty hash would
+    // make every unread import in the repository one content group, which is
+    // the largest possible wrong answer.
+    //
+    // ASSERTED ON THE EMPTY STRING, not on `undefined`. The first version of
+    // this test used two hashless stubs and passed with the guard removed,
+    // because `undefined === ''` is false and they could never have matched
+    // anyway. An explicitly empty hash is the value the guard actually stops.
+    const key = join(project, 'imported.ts');
+    const other = join(project, 'imported-too.ts');
+    putNode(dir, { kind: 'file', key, hash: '' });
+    putNode(dir, { kind: 'file', key: other, hash: '' });
+
+    expect(contentPeers(load(dir), nodeId('file', key))).toEqual([]);
+  });
+
+  test('an import stub with no hash at all groups with nothing either', () => {
+    const key = join(project, 'stub-a.ts');
+    putNode(dir, { kind: 'file', key });
+    putNode(dir, { kind: 'file', key: join(project, 'stub-b.ts') });
+    expect(contentPeers(load(dir), nodeId('file', key))).toEqual([]);
+  });
+
+  test('a node written before bytes existed still groups, permissively', () => {
+    // Refusing to group a node with no size would make the feature quietly stop
+    // working on every graph that predates it, healing only as files happen to
+    // be touched. Where both sides know their size they must agree; where
+    // either does not, the hash stands alone -- the same evidence staleness
+    // itself runs on.
+    const key = join(project, 'vendor', 'legacy.js');
+    const twin = join(project, 'vendor', 'legacy-copy.js');
+    const shared = 'a1b2c3d4e5f60718';
+    putNode(dir, { kind: 'file', key, hash: shared });
+    putNode(dir, { kind: 'file', key: twin, hash: shared, bytes: 4096 });
+
+    expect(contentPeers(load(dir), nodeId('file', key))).toEqual([nodeId('file', twin)]);
+  });
+
+  test('a symbol anchor is not a content group', () => {
+    const source = vendor('lib/adapter.mjs');
+    const symbol = nodeId('symbol', `${source}#run`);
+    expect(contentPeers(load(dir), symbol)).toEqual([]);
+  });
+
+  test('an unknown anchor returns nothing rather than throwing', () => {
+    expect(contentPeers(load(dir), nodeId('file', join(project, 'nope.ts')))).toEqual([]);
+  });
+});
+
+describe('the peer set is bounded', () => {
+  test('a file duplicated far beyond any real vendoring is capped', () => {
+    // A vendored core in eleven directories is what this exists for; a
+    // generated asset checked in hundreds of times is what would turn one
+    // retrieval into a scan.
+    const paths = Array.from({ length: 60 }, (_, i) => vendor(`gen/copy-${i}/asset.js`));
+    const peers = contentPeers(load(dir), nodeId('file', paths[0]));
+    expect(peers.length).toBeGreaterThan(10);
+    expect(peers.length).toBeLessThanOrEqual(32);
+  });
+});


### PR DESCRIPTION
Closes #319.

A vendored file is the same file wherever it sits, whatever path each copy is given. **This repository is its own example**: the shared hook core is vendored into eleven directories, byte-identical, so a finding recorded against `plugin/hooks/lib/adapter.mjs` said nothing at all to a reader touching `integrations/qwen/hooks/lib/adapter.mjs`.

```
plugin/hooks/lib/adapter.mjs                   5d0326b9abc30021
integrations/codex/hooks/lib/adapter.mjs       5d0326b9abc30021
integrations/qwen/hooks/lib/adapter.mjs        5d0326b9abc30021
```

## An index, not a second identity

This is the design question the issue asks, and the reason `contentAnchor` was deleted rather than wired. That implementation minted a second anchor id of the form `content:<hash>:<size>` — and **a second identity for one file is the defect this codebase has already been burned by**. `canonicalKey` lives *inside* `nodeId` precisely because a caller that forgot produced a second node for a file that already existed and split its findings invisibly.

So nothing new is stored and no node is created. A file node has carried the sha256 of its contents since staleness needed it: content identity has been in the graph since P2 and was simply never read that way. There is still exactly one node per path and one set of `derived_from` edges per finding, so **there is no history to split**. `findingsFor` expands its anchor set across the content group exactly as it already expands across `contains` edges.

## The issue's other three questions

They fall out rather than being decided, and each has a test.

| Question | Answer |
|---|---|
| Identical content at two paths in one repository | The ordinary case, not an edge one: one group, findings shared both ways. |
| Does staleness follow content or path? | **Path**, unchanged. Content identity *is* the hash, so a file whose bytes change stops matching its old group without anything having to notice — there is no stale content anchor to invalidate. |
| What does it do to cross-project transfer? | **Nothing.** It reads one graph and can only surface findings already in it. `fleet.mjs` and the shared tier remain the only path between projects, gates intact. |

## The hash is 64 bits

`staleness.mjs` slices the sha256 to sixteen hex characters, so equal hashes are strong evidence of equal content and **not proof of it** — two unrelated files sharing a digest would silently share each other's findings. The original design carried a size beside the digest for exactly this reason; `indexFile` now records one, and grouping requires both to agree where both are known. Absence is permissive, or the feature would quietly stop working on every graph predating the field, healing only as files happened to be touched.

**The first version of that guard compared snapshots** — which looked like the better discriminator and was dead code. `putNode` writes snapshots to a *separate file* that `load()` deliberately skips, so a loaded node never carries one. The test written for the guard is what caught it.

Empty files never group (every empty file shares one hash and they are not the same file in any sense a reader cares about); the peer set is capped, because eleven vendored directories is the case this exists for and a generated asset checked in five hundred times is the case that would turn one retrieval into a scan; and findings are deduped by id, since one can now be reached through several anchors.

## Verification

All six decisions mutation-tested. **Two of the tests were vacuous on the first attempt**, and both are recorded as such in their own comments:

- the dedupe test anchored its finding to **one** path — the loop iterates *edges*, so one edge can only ever be found once however many anchors are in the set. It now anchors to two identical copies, which is what actually produces a duplicate.
- the hashless test compared two `undefined` hashes, which could never have matched anyway. It now asserts on the explicitly empty string, which is the value the guard actually stops.

| Mutation | Result |
|---|---|
| Content expansion removed | 4 of 14 fail |
| Empty-hash guard removed | 1 fails |
| Size collision guard removed | 1 fails |
| Hashless guard removed | 1 fails |
| Dedupe removed | 1 fails |
| Peer cap removed | 1 fails |

223 suites, 2742 tests, 5 skipped, 0 failed. `tsc --noEmit` clean, `npm run lint` 0 errors, `format:check` clean, `sync:hooks:check` in sync across eleven vendored directories, `validate` passes. Quality Gates run locally: `verify:clients`, `verify:certification`, `verify:harvest`, `verify:live-graph`, `verify:ui` 55/55, `verify:interactions` 64/64.

## What this deliberately does not do

The issue wanted a finding about a vendored file to reach **every repository** holding it. This delivers that within one graph and not across machines, and the gap is a storage decision rather than an oversight.

The shared tier is per-machine and holds only lessons that do not depend on any repository's contents. A content-anchored finding is the opposite of that by construction — it is a claim about specific bytes. Carrying it across projects needs a third tier, per-machine and content-keyed, and that tier has a privacy posture nothing here has yet: **a claim derived inside a private repository would surface in another one** because both vendor the same dependency. That is a decision about what leaves a repository, and it is yours rather than this change's. `docs/WIKI_GRAPH.md` says so in the same words.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSFxBpREeR7mMkJXYb6wuX
